### PR TITLE
refactor: purge all Llm_client references (99 files)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -101,7 +101,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
     Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:config.workdir ()
   in
   let agent_config = { Types.default_config with
-    model = Types.Custom provider_cfg.model_id;
+    model = provider_cfg.model_id;
     max_turns = config.max_turns;
     system_prompt = Some (Agent_swarm_prompts.solo_developer ~goal:config.goal);
   } in

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -343,7 +343,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
               let config = {
                 Types.default_config with
                 name = spec.name;
-                model = Types.Custom spec.provider.model_id;
+                model = spec.provider.model_id;
                 system_prompt = Some spec.system_prompt;
                 max_tokens =
                   Option.value spec.max_tokens

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -139,7 +139,7 @@ let run_cli_agent ~agent_type ~prompt =
 let cascade_name_for_agent_type agent_type =
   Printf.sprintf "auto_responder_%s" agent_type
 
-let llm_response_is_valid (resp : Llm_client.completion_response) =
+let llm_response_is_valid (resp : Llm_types.completion_response) =
   let s = String.trim (Llm_types.text_of_response resp) in
   let s_lower = String.lowercase_ascii s in
   let len = String.length s in

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -683,10 +683,10 @@ let generate_code_change ~goal ~baseline ~history ~insights
     ~target_file ~file_content ~llm_model =
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
-  match Llm_client.model_spec_of_string llm_model with
+  match Llm_types.model_spec_of_string llm_model with
   | Result.Error e -> Result.error (Printf.sprintf "Invalid model spec: %s" e)
   | Result.Ok model ->
-    let req : Llm_client.completion_request = {
+    let req : Llm_types.completion_request = {
       model;
       messages = [Agent_sdk.Types.user_msg prompt];
       temperature = 0.7;

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -245,7 +245,7 @@ let parse_llm_score (text : string) : float option =
       scan 0
 
 (** Validate that an LLM response contains a parseable score. *)
-let llm_score_is_valid (resp : Llm_client.completion_response) : bool =
+let llm_score_is_valid (resp : Llm_types.completion_response) : bool =
   parse_llm_score (Llm_types.text_of_response resp) <> None
 
 (** Call LLM to score agent-task compatibility.

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -116,7 +116,7 @@ let canonical_capability_id tool_name =
   | Some canonical_name -> canonical_name
   | None -> tool_name
 
-let schema_of_tool_def (tool : Llm_client.tool_def) : Types.tool_schema =
+let schema_of_tool_def (tool : Llm_types.tool_def) : Types.tool_schema =
   {
     Types.name = tool.tool_name;
     description = tool.tool_description;
@@ -423,12 +423,12 @@ let local_worker_tool_schemas ?names () :
 
 let keeper_all_tool_names : string list =
   Tool_shard.keeper_llm_tools
-  |> List.map (fun tool -> tool.Llm_client.tool_name)
+  |> List.map (fun tool -> tool.Llm_types.tool_name)
   |> unique_preserve_order
 
 let keeper_safe_tool_names : string list =
   Tool_shard.keeper_llm_tools
-  |> List.map (fun tool -> tool.Llm_client.tool_name)
+  |> List.map (fun tool -> tool.Llm_types.tool_name)
   |> List.filter (fun name -> not (List.mem name privileged_keeper_tool_names))
   |> unique_preserve_order
 

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -195,16 +195,16 @@ let llm_tool_defs_of_json = function
                  in
                  Some
                    {
-                     Llm_client.tool_name = tool_name;
+                     Llm_types.tool_name = tool_name;
                      tool_description = tool_description;
                      parameters = parameters;
                    })
   | Some _ -> []
 
-let llm_tool_calls_json (calls : Llm_client.tool_call list) =
+let llm_tool_calls_json (calls : Llm_types.tool_call list) =
   `List
     (List.map
-       (fun (call : Llm_client.tool_call) ->
+       (fun (call : Llm_types.tool_call) ->
          `Assoc
            [
              ("id", `String call.call_id);
@@ -215,7 +215,7 @@ let llm_tool_calls_json (calls : Llm_client.tool_call list) =
 
 type llm_runner =
   | Stub
-  | Direct of Llm_client.model_spec
+  | Direct of Llm_types.model_spec
   | Spawn of string (* agent name *)
   | SpawnWithModel of { agent: string; model: string }
 
@@ -223,7 +223,7 @@ let model_runner_of_string raw =
   let model = trim raw in
   let lower = String.lowercase_ascii model in
   let direct spec =
-    match Llm_client.model_spec_of_string spec with
+    match Llm_types.model_spec_of_string spec with
     | Ok parsed -> Ok (Direct parsed)
     | Error msg -> Error msg
   in
@@ -245,7 +245,7 @@ let model_runner_of_string raw =
   | "codex" -> Ok (Spawn "codex")
   | value when starts_with ~prefix:"codex:" value -> Ok (Spawn "codex")
   | value -> (
-      match Llm_client.model_spec_of_string model with
+      match Llm_types.model_spec_of_string model with
       | Ok parsed -> Ok (Direct parsed)
       | Error _ when starts_with ~prefix:"llama:" value -> direct model
       | Error _ when starts_with ~prefix:"gemini:" value -> direct model
@@ -295,7 +295,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
       in
       call_spawn_model runtime ~agent_name ~model_override ~prompt:full_prompt ~timeout_sec ()
   | Ok (Direct spec) ->
-      let req : Llm_client.completion_request =
+      let req : Llm_types.completion_request =
         {
           model = spec;
           messages =

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -333,7 +333,7 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
     }
   else
     let prompt = build_verify_prompt ~pattern ~allowed_files:worker.files diff in
-    let req : Llm_client.completion_request =
+    let req : Llm_types.completion_request =
       {
         model;
         messages = [ Agent_sdk.Types.user_msg prompt ];
@@ -387,13 +387,13 @@ let verify_plan ~base_path ~plan_id ~verify_model =
       let model =
         match verify_model with
         | Some m -> (
-            match Llm_client.model_spec_of_string m with
+            match Llm_types.model_spec_of_string m with
             | Ok spec -> spec
-            | Error _ -> Llm_client.glm_cloud)
+            | Error _ -> Llm_types.glm_cloud)
         | None -> (
-            match Llm_client.default_verifier_model_spec () with
+            match Llm_types.default_verifier_model_spec () with
             | Ok spec -> spec
-            | Error _ -> Llm_client.glm_cloud)
+            | Error _ -> Llm_types.glm_cloud)
       in
       let results =
         List.map

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -4,7 +4,7 @@
     and converts back. This is Phase 1 of migrating MASC to use OAS properly.
 
     This module is deliberately independent of Context_manager to avoid circular
-    dependency. It operates on [Llm_client.message list] directly and uses its own
+    dependency. It operates on [Llm_types.message list] directly and uses its own
     strategy enum that mirrors Context_manager.compaction_strategy.
 
     MASC has 4 roles (System, User, Assistant, Tool) while OAS has the same 4.

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -532,7 +532,7 @@ let role_of_string = function
   | "assistant" -> Agent_sdk.Types.Assistant | _ -> Agent_sdk.Types.Tool
 
 let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
-  let m = Llm_client.sanitize_message_utf8 m in
+  let m = Llm_types.sanitize_message_utf8 m in
   let base = [
     ("role", `String (role_to_string m.role));
     ("content", `String (text_of_message m));
@@ -551,7 +551,7 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
-  let text = json |> member "content" |> to_string |> Llm_client.sanitize_text_utf8 in
+  let text = json |> member "content" |> to_string |> Llm_types.sanitize_text_utf8 in
   match role with
   | Agent_sdk.Types.Tool ->
     let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
@@ -561,7 +561,7 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
-    ("system_prompt", `String (Llm_client.sanitize_text_utf8 ctx.system_prompt));
+    ("system_prompt", `String (Llm_types.sanitize_text_utf8 ctx.system_prompt));
     ("messages", `List (List.map message_to_json ctx.messages));
     ("token_count", `Int ctx.token_count);
     ("max_tokens", `Int ctx.max_tokens);
@@ -569,10 +569,10 @@ let serialize_context (ctx : working_context) : string =
   Yojson.Safe.to_string json
 
 let deserialize_context (s : string) ~max_tokens : working_context =
-  let json = Yojson.Safe.from_string (Llm_client.sanitize_text_utf8 s) in
+  let json = Yojson.Safe.from_string (Llm_types.sanitize_text_utf8 s) in
   let open Yojson.Safe.Util in
   let system_prompt =
-    json |> member "system_prompt" |> to_string |> Llm_client.sanitize_text_utf8
+    json |> member "system_prompt" |> to_string |> Llm_types.sanitize_text_utf8
   in
   let messages = json |> member "messages" |> to_list |> List.map message_of_json in
   let token_count = json |> member "token_count" |> to_int in
@@ -586,7 +586,7 @@ let create_checkpoint ctx ~generation =
     generation;
     message_count = List.length ctx.messages;
     token_count = ctx.token_count;
-    serialized = serialize_context ctx |> Llm_client.sanitize_text_utf8;
+    serialized = serialize_context ctx |> Llm_types.sanitize_text_utf8;
   }
 
 let restore_checkpoint ckpt ~max_tokens =
@@ -602,7 +602,7 @@ let create_session ~session_id ~base_dir =
   { session_id; session_dir; full_history = []; checkpoints = [] }
 
 let persist_message session msg =
-  let msg = Llm_client.sanitize_message_utf8 msg in
+  let msg = Llm_types.sanitize_message_utf8 msg in
   session.full_history <- session.full_history @ [msg];
   let path = Filename.concat session.session_dir "history.jsonl" in
   let now_ts = Time_compat.now () in
@@ -613,13 +613,13 @@ let persist_message session msg =
     | j -> j
   in
   let line =
-    (Yojson.Safe.to_string payload |> Llm_client.sanitize_text_utf8) ^ "\n"
+    (Yojson.Safe.to_string payload |> Llm_types.sanitize_text_utf8) ^ "\n"
   in
   Fs_compat.append_file path line
 
 let save_checkpoint session ckpt =
   let ckpt =
-    { ckpt with serialized = Llm_client.sanitize_text_utf8 ckpt.serialized }
+    { ckpt with serialized = Llm_types.sanitize_text_utf8 ckpt.serialized }
   in
   session.checkpoints <- session.checkpoints @ [ckpt];
   let path = Filename.concat session.session_dir
@@ -632,7 +632,7 @@ let save_checkpoint session ckpt =
     ("token_count", `Int ckpt.token_count);
     ("serialized", `String ckpt.serialized);
   ] in
-  let content = Yojson.Safe.to_string json |> Llm_client.sanitize_text_utf8 in
+  let content = Yojson.Safe.to_string json |> Llm_types.sanitize_text_utf8 in
   Fs_compat.save_file path content
 
 let load_latest_checkpoint session =
@@ -652,7 +652,7 @@ let load_latest_checkpoint session =
       let content = Fs_compat.load_file path in
       let json =
         content
-        |> Llm_client.sanitize_text_utf8
+        |> Llm_types.sanitize_text_utf8
         |> Yojson.Safe.from_string
       in
       let open Yojson.Safe.Util in
@@ -663,5 +663,5 @@ let load_latest_checkpoint session =
         message_count = json |> member "message_count" |> to_int;
         token_count = json |> member "token_count" |> to_int;
         serialized =
-          json |> member "serialized" |> to_string |> Llm_client.sanitize_text_utf8;
+          json |> member "serialized" |> to_string |> Llm_types.sanitize_text_utf8;
       }

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -14,7 +14,7 @@
 (** Working context: the message window sent to the LLM. *)
 type working_context = {
   system_prompt : string;
-  messages : Llm_client.message list;
+  messages : Llm_types.message list;
   token_count : int;                (** Estimated tokens in window *)
   max_tokens : int;                 (** Model context limit *)
   importance_scores : (int * float) list;  (** msg_index → importance 0.0-1.0 *)
@@ -37,7 +37,7 @@ type checkpoint = {
 type session_context = {
   session_id : string;
   session_dir : string;            (** Path to session JSONL files *)
-  mutable full_history : Llm_client.message list;
+  mutable full_history : Llm_types.message list;
   mutable checkpoints : checkpoint list;
 }
 
@@ -75,10 +75,10 @@ val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 
 (** Append a message to working context, updating token count. *)
-val append : working_context -> Llm_client.message -> working_context
+val append : working_context -> Llm_types.message -> working_context
 
 (** Append multiple messages. *)
-val append_many : working_context -> Llm_client.message list -> working_context
+val append_many : working_context -> Llm_types.message list -> working_context
 
 (** Score message importance (Stanford GAP formula adapted). *)
 val score_importance : working_context -> working_context
@@ -99,13 +99,13 @@ val apply_strategy : working_context -> compaction_strategy -> working_context
 val compact : working_context -> compaction_strategy list -> working_context
 
 (** Format a single message as human-readable text: "role: content". *)
-val format_message_readable : Llm_client.message -> string
+val format_message_readable : Llm_types.message -> string
 
 (** Offload messages to a markdown file in [{session_dir}/offloaded/{compaction_count}.md].
     Returns [Some path] on success, [None] on failure (fail-safe, never raises). *)
 val offload_messages :
   session_dir:string -> compaction_count:int ->
-  Llm_client.message list -> string option
+  Llm_types.message list -> string option
 
 (** Apply compaction with history offload.
     Before compaction, saves the full pre-compaction messages to a markdown file.
@@ -129,10 +129,10 @@ val oas_strategy_of_compaction : compaction_strategy -> Agent_sdk.Context_reduce
 val compact_via_oas : working_context -> compaction_strategy list -> working_context
 
 (** Convert a masc message to OAS message with role tag for lossless roundtrip. *)
-val masc_msg_to_oas_tagged : Llm_client.message -> Agent_sdk.Types.message
+val masc_msg_to_oas_tagged : Llm_types.message -> Agent_sdk.Types.message
 
 (** Recover a masc message from a tagged OAS message. *)
-val oas_msg_to_masc_tagged : Agent_sdk.Types.message -> Llm_client.message
+val oas_msg_to_masc_tagged : Agent_sdk.Types.message -> Llm_types.message
 
 (** Extract [STATE] ... [/STATE] blocks from free-form text.
     Returns the block bodies in appearance order. *)
@@ -160,7 +160,7 @@ val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
 val create_session : session_id:string -> base_dir:string -> session_context
 
 (** Persist a message to session history (append to JSONL). *)
-val persist_message : session_context -> Llm_client.message -> unit
+val persist_message : session_context -> Llm_types.message -> unit
 
 (** Save checkpoint to session directory. *)
 val save_checkpoint : session_context -> checkpoint -> unit

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -186,7 +186,7 @@ let parse_intent_response (text : string) : (query_intent * float) option =
     None
 
 (** Validate that an LLM response contains a parseable intent. *)
-let intent_response_is_valid (resp : Llm_client.completion_response) : bool =
+let intent_response_is_valid (resp : Llm_types.completion_response) : bool =
   parse_intent_response (Llm_types.text_of_response resp) <> None
 
 (** Classify query intent using LLM semantic understanding.

--- a/lib/context_scoring.mli
+++ b/lib/context_scoring.mli
@@ -21,4 +21,4 @@ val starts_with : prefix:string -> string -> bool
 
     Messages starting with [memory_summary_prefix] or [goal_prefix]
     receive a minimum score of 0.95 (sticky memory). *)
-val score_messages : Llm_client.message list -> (int * float) list
+val score_messages : Llm_types.message list -> (int * float) list

--- a/lib/dashboard_governance_judge.ml
+++ b/lib/dashboard_governance_judge.ml
@@ -287,7 +287,7 @@ let compute_judgments ~base_path:_ ~factual_json =
     let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
     let prompt = prompt_for_facts factual_json in
     match
-      Llm_client.run_prompt_cascade ~temperature:0.2 ~timeout_sec
+      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec
         ~model_specs:specs ~max_tokens:4096 ~prompt ()
     with
     | Error message -> Error message

--- a/lib/dashboard_http_keeper.ml
+++ b/lib/dashboard_http_keeper.ml
@@ -123,9 +123,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             match Keeper_types.model_specs_of_strings m.models with
             | Error _ -> `List []
             | Ok specs ->
-                `List (List.map (fun (s : Llm_client.model_spec) ->
+                `List (List.map (fun (s : Llm_types.model_spec) ->
                   `Assoc [
-                    ("provider", `String (Llm_client.string_of_provider s.provider));
+                    ("provider", `String (Llm_types.string_of_provider s.provider));
                     ("model_id", `String s.model_id);
                     ("max_context", `Int s.max_context);
                   ]
@@ -218,7 +218,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                  | Error _ -> `Assoc [("has_checkpoint", `Bool false)]
                  | Ok specs ->
                      let primary =
-                       match specs with m0 :: _ -> m0 | [] -> Llm_client.llama_default
+                       match specs with m0 :: _ -> m0 | [] -> Llm_types.llama_default
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =

--- a/lib/dashboard_http_mdal.ml
+++ b/lib/dashboard_http_mdal.ml
@@ -16,9 +16,9 @@ let perpetual_dashboard_json () : Yojson.Safe.t =
         match base with
         | `Assoc fields ->
               let models =
-              `List (List.map (fun (m : Llm_client.model_spec) ->
+              `List (List.map (fun (m : Llm_types.model_spec) ->
                 `Assoc [
-                  ("provider", `String (Llm_client.string_of_provider m.provider));
+                  ("provider", `String (Llm_types.string_of_provider m.provider));
                   ("model_id", `String m.model_id);
                   ("max_context", `Int m.max_context);
                 ]

--- a/lib/dashboard_operator_judge.ml
+++ b/lib/dashboard_operator_judge.ml
@@ -292,7 +292,7 @@ let compute_judgments ~facts_json =
     let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
     let prompt = prompt_for_facts facts_json in
     match
-      Llm_client.run_prompt_cascade ~temperature:0.2 ~timeout_sec ~model_specs:specs
+      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec ~model_specs:specs
         ~max_tokens:4096 ~prompt ()
     with
     | Error message -> Error message

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -2,7 +2,7 @@ open Env_config_core
 
 module Endpoints = struct
   (** @deprecated LLM-MCP server URL - no longer used.
-      Use {!Llm_client.run_prompt_cascade} with {!Lodge_cascade.get_cascade}
+      Use {!Llm_orchestration.run_prompt_cascade} with {!Lodge_cascade.get_cascade}
       instead. Kept for backward compatibility; will be removed in v3.0. *)
   let llm_mcp_url =
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)

--- a/lib/gardener_decisions.ml
+++ b/lib/gardener_decisions.ml
@@ -45,7 +45,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
   let model_specs = Lodge_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_client.run_prompt_cascade ~temperature:0.3
+      Llm_orchestration.run_prompt_cascade ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~model_specs ~max_tokens:200 ~prompt () with
     | Ok resp -> Llm_types.text_of_response resp
@@ -435,7 +435,7 @@ Room 내 활성 에이전트: %d
   let model_specs = Lodge_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_client.run_prompt_cascade ~temperature:0.3
+      Llm_orchestration.run_prompt_cascade ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~model_specs ~max_tokens:300 ~prompt () with
     | Ok resp -> Ok (Llm_types.text_of_response resp)

--- a/lib/keeper_alerting.ml
+++ b/lib/keeper_alerting.ml
@@ -7,8 +7,8 @@ open Keeper_memory
 let keeper_llm_tools = Tool_shard.keeper_llm_tools
 
 let merge_usage
-    (a : Llm_client.token_usage)
-    (b : Llm_client.token_usage) : Llm_client.token_usage =
+    (a : Llm_types.token_usage)
+    (b : Llm_types.token_usage) : Llm_types.token_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =

--- a/lib/keeper_autonomy.ml
+++ b/lib/keeper_autonomy.ml
@@ -167,7 +167,7 @@ let evaluate_next_action ~config ~goal_ids ~keeper_name:_ =
           StartPerpetualAgent {
             goal_id = goal.id;
             goal_title = goal.title;
-            models = Llm_client.default_execution_model_labels ();
+            models = Llm_types.default_execution_model_labels ();
             coding_mode = true;
             coding_agent = "claude";
           }
@@ -237,7 +237,7 @@ Keep it concise — max 3 sentences per step.|}
 
 let generate_action_plan ~model ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
-  let req : Llm_client.completion_request = {
+  let req : Llm_types.completion_request = {
     model;
     messages = [Agent_sdk.Types.user_msg prompt];
     temperature = 0.3;

--- a/lib/keeper_autonomy.mli
+++ b/lib/keeper_autonomy.mli
@@ -63,7 +63,7 @@ val should_auto_execute :
 
 (** Generate a concrete action plan using LLM, given a goal. *)
 val generate_action_plan :
-  model:Llm_client.model_spec ->
+  model:Llm_types.model_spec ->
   goal:Goal_store.goal ->
   keeper_context:string ->
   (string, string) result

--- a/lib/keeper_exec_autonomy.ml
+++ b/lib/keeper_exec_autonomy.ml
@@ -77,14 +77,14 @@ let autonomous_gate_config
 let execute_approved_plan
     ~(config : Room.config)
     ~(meta : keeper_meta)
-    ~(specs : Llm_client.model_spec list)
+    ~(specs : Llm_types.model_spec list)
     ~(plan : string)
     ~(pa : Keeper_autonomy.proposed_action)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     ~(trajectory_acc : Trajectory.accumulator option)
     : string * float * string list =
   let gate_config = autonomous_gate_config ~autonomy_level in
-  let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
+  let primary = match specs with p :: _ -> p | [] -> Llm_types.default_local_model_spec () in
   let system_prompt = Printf.sprintf
 {|You are a keeper agent executing an approved action plan.
 Your name: %s
@@ -102,9 +102,9 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
     ~system_prompt:(Printf.sprintf "Keeper %s autonomous execution" meta.name)
     ~max_tokens:4000 in
   let execute_tool_calls
-      (tcs : Llm_client.tool_call list) : (Llm_client.tool_call * string) list =
+      (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
     List.map
-      (fun (tc : Llm_client.tool_call) ->
+      (fun (tc : Llm_types.tool_call) ->
          let execute () =
            execute_keeper_tool_call ~config ~meta ~ctx_work tc
          in
@@ -150,7 +150,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
   let run_cascade requests = Llm_orchestration.cascade requests in
   let max_rounds = 3 in
   let initial_request =
-    { Llm_client.model = primary;
+    { Llm_types.model = primary;
       messages = [
         Agent_sdk.Types.system_msg system_prompt;
         Agent_sdk.Types.user_msg "Execute the first step of the plan now.";
@@ -161,15 +161,15 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
       response_format = `Text;
     }
   in
-  let requests = List.map (fun (spec : Llm_client.model_spec) ->
-    { initial_request with Llm_client.model = spec }
+  let requests = List.map (fun (spec : Llm_types.model_spec) ->
+    { initial_request with Llm_types.model = spec }
   ) specs in
   match run_cascade requests with
   | Error e ->
       (Printf.sprintf "LLM cascade failed: %s" e, 0.0, [])
   | Ok resp0 ->
       let rec exec_loop ~round ~acc_cost ~acc_tools ~last_resp =
-        if last_resp.Llm_client.tool_calls = [] || round > max_rounds then
+        if last_resp.Llm_types.tool_calls = [] || round > max_rounds then
           let content =
             let c = String.trim (Llm_types.text_of_response last_resp) in
             if c = "" && acc_tools <> [] then
@@ -180,11 +180,11 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
           (content, acc_cost, acc_tools)
         else
           let round_tools =
-            List.map (fun (tc : Llm_client.tool_call) -> tc.call_name)
-              last_resp.Llm_client.tool_calls
+            List.map (fun (tc : Llm_types.tool_call) -> tc.call_name)
+              last_resp.Llm_types.tool_calls
           in
           let all_tools = acc_tools @ round_tools in
-          let tool_outputs = execute_tool_calls last_resp.Llm_client.tool_calls in
+          let tool_outputs = execute_tool_calls last_resp.Llm_types.tool_calls in
           let followup_prompt =
             keeper_tool_followup_prompt
               ~user_message:"Execute the next step of the plan."
@@ -197,8 +197,8 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
             keeper_write_done all_tools
           in
           let next_tools = keeper_allowed_llm_tools ~write_done meta in
-          let followup_requests = List.map (fun (spec : Llm_client.model_spec) ->
-            { Llm_client.model = spec;
+          let followup_requests = List.map (fun (spec : Llm_types.model_spec) ->
+            { Llm_types.model = spec;
               messages = [
                 Agent_sdk.Types.system_msg system_prompt;
                 Agent_sdk.Types.user_msg followup_prompt;
@@ -235,7 +235,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
     None to fall through to regular proactive generation.
     @since 2.74.0 *)
 let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
-    ~(specs : Llm_client.model_spec list) : keeper_meta option =
+    ~(specs : Llm_types.model_spec list) : keeper_meta option =
   if not (keeper_autonomy_enabled ()) then None
   else if meta.active_goal_ids = [] then None
   else
@@ -243,9 +243,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
     | None -> None
     | Some L1_Reactive -> None
     | Some level ->
-        let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
+        let primary = match specs with p :: _ -> p | [] -> Llm_types.default_local_model_spec () in
         let verify_model =
-          match Llm_client.default_verifier_model_spec () with
+          match Llm_types.default_verifier_model_spec () with
           | Ok model -> model
           | Error _ -> primary
         in

--- a/lib/keeper_exec_context.ml
+++ b/lib/keeper_exec_context.ml
@@ -545,8 +545,8 @@ let looks_fragmentary_history_text (raw : string) : bool =
     hard_fragment || short_unterminated || trailing_connector
 
 let run_proactive_generation
-    ~(specs : Llm_client.model_spec list)
-    ~(primary : Llm_client.model_spec)
+    ~(specs : Llm_types.model_spec list)
+    ~(primary : Llm_types.model_spec)
     ~(config : Room.config)
     ~(ctx_work : Context_manager.working_context)
     ~(meta : keeper_meta)
@@ -588,9 +588,9 @@ let run_proactive_generation
   let max_tool_rounds = 3 in
   let execute_tool_calls
       ~(ctx_work : Context_manager.working_context)
-      (tcs : Llm_client.tool_call list) : (Llm_client.tool_call * string) list =
+      (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
     List.map
-      (fun (tc : Llm_client.tool_call) ->
+      (fun (tc : Llm_types.tool_call) ->
          let output =
            try execute_keeper_tool_call ~config ~meta ~ctx_work tc
            with exn ->
@@ -623,9 +623,9 @@ let run_proactive_generation
       in
       let requests =
         List.map
-          (fun (model : Llm_client.model_spec) ->
+          (fun (model : Llm_types.model_spec) ->
             ({
-               Llm_client.model;
+               Llm_types.model;
                messages =
                  (Agent_sdk.Types.system_msg turn_system_prompt)
                  :: (ctx_work.messages @ [ Agent_sdk.Types.user_msg prompt ]);
@@ -634,7 +634,7 @@ let run_proactive_generation
                tools = keeper_allowed_llm_tools meta;
                response_format = `Text;
              }
-              : Llm_client.completion_request))
+              : Llm_types.completion_request))
           specs
       in
       match run_cascade requests with
@@ -647,7 +647,7 @@ let run_proactive_generation
           let cost0 = cost_usd_of_usage resp0.usage used_model0 in
           let rec tool_loop ~round ~acc_usage ~acc_latency ~acc_cost
               ~acc_tools_used ~last_resp =
-            if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
+            if last_resp.Llm_types.tool_calls = [] || round > max_tool_rounds then
               let content =
                 let c = String.trim (Llm_types.text_of_response last_resp) in
                 if c = "" && acc_tools_used <> [] then
@@ -657,19 +657,19 @@ let run_proactive_generation
               in
               ( content,
                 acc_usage,
-                last_resp.Llm_client.model_used,
+                last_resp.Llm_types.model_used,
                 acc_latency,
                 acc_cost,
                 acc_tools_used )
             else
               let round_tools =
                 List.map
-                  (fun (tc : Llm_client.tool_call) -> tc.call_name)
-                  last_resp.Llm_client.tool_calls
+                  (fun (tc : Llm_types.tool_call) -> tc.call_name)
+                  last_resp.Llm_types.tool_calls
               in
               let all_tools_so_far = acc_tools_used @ round_tools in
               let tool_outputs =
-                execute_tool_calls ~ctx_work last_resp.Llm_client.tool_calls
+                execute_tool_calls ~ctx_work last_resp.Llm_types.tool_calls
               in
               let followup_prompt =
                 keeper_tool_followup_prompt
@@ -689,9 +689,9 @@ let run_proactive_generation
               in
               let followup_requests =
                 List.map
-                  (fun (model : Llm_client.model_spec) ->
+                  (fun (model : Llm_types.model_spec) ->
                      ({
-                        Llm_client.model;
+                        Llm_types.model;
                         messages = [
                           Agent_sdk.Types.system_msg
                             (keeper_tool_loop_system_prompt
@@ -703,14 +703,14 @@ let run_proactive_generation
                         tools = next_tools;
                         response_format = `Text;
                       }
-                       : Llm_client.completion_request))
+                       : Llm_types.completion_request))
                   specs
               in
               match run_cascade followup_requests with
               | Error _ ->
                   ( Llm_types.text_of_response last_resp,
                     acc_usage,
-                    last_resp.Llm_client.model_used,
+                    last_resp.Llm_types.model_used,
                     acc_latency,
                     acc_cost,
                     acc_tools_used @ round_tools )

--- a/lib/keeper_exec_proactive.ml
+++ b/lib/keeper_exec_proactive.ml
@@ -179,10 +179,10 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         obs
                     in
                     let model_specs =
-                      Llm_client.available_model_specs_of_strings meta.models
+                      Llm_types.available_model_specs_of_strings meta.models
                     in
                     let result =
-                      Llm_client.run_prompt_cascade
+                      Llm_orchestration.run_prompt_cascade
                         ~temperature:0.3
                         ~model_specs
                         ~max_tokens:1024
@@ -207,7 +207,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                           let primary =
                             match model_specs with
                             | p :: _ -> p
-                            | [] -> Llm_client.default_local_model_spec ()
+                            | [] -> Llm_types.default_local_model_spec ()
                           in
                           (inp *. primary.cost_per_1k_input)
                           +. (outp *. primary.cost_per_1k_output)
@@ -532,7 +532,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                let primary =
                  match specs with
                  | p :: _ -> p
-                 | [] -> Llm_client.default_local_model_spec ()
+                 | [] -> Llm_types.default_local_model_spec ()
                in
                let base_dir = session_base_dir ctx.config in
                let (session, ctx_opt) =

--- a/lib/keeper_exec_social.ml
+++ b/lib/keeper_exec_social.ml
@@ -32,7 +32,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
           let primary =
             match specs with
             | model :: _ -> model
-            | [] -> Llm_client.default_local_model_spec ()
+            | [] -> Llm_types.default_local_model_spec ()
           in
           let base_dir = session_base_dir ctx.config in
           mkdir_p base_dir;
@@ -80,15 +80,15 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
           Context_manager.persist_message session user_message;
           let requests =
             List.map
-              (fun (model : Llm_client.model_spec) ->
+              (fun (model : Llm_types.model_spec) ->
                 ({
-                  Llm_client.model;
+                  Llm_types.model;
                   messages = (Agent_sdk.Types.system_msg ctx_work.system_prompt) :: ctx_work.messages;
                   temperature = Keeper_config.keeper_reflection_temp ();
                   max_tokens = Keeper_config.keeper_explicit_reply_max_tokens ();
                   tools = [];
                   response_format = `Text;
-                } : Llm_client.completion_request))
+                } : Llm_types.completion_request))
               specs
           in
           match Llm_orchestration.cascade requests with
@@ -179,7 +179,7 @@ let run_social_board_event_turn
           let primary =
             match specs with
             | model :: _ -> model
-            | [] -> Llm_client.default_local_model_spec ()
+            | [] -> Llm_types.default_local_model_spec ()
           in
           let base_dir = session_base_dir ctx.config in
           let session, ctx_opt =
@@ -226,9 +226,9 @@ let run_social_board_event_turn
           Context_manager.persist_message session user_message;
           let execute_tool_calls
               ~(ctx_work : Context_manager.working_context)
-              (tcs : Llm_client.tool_call list) : (Llm_client.tool_call * string) list =
+              (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
             List.map
-              (fun (tc : Llm_client.tool_call) ->
+              (fun (tc : Llm_types.tool_call) ->
                  let output =
                    try execute_keeper_tool_call ~config:ctx.config ~meta ~ctx_work tc
                    with exn ->
@@ -244,9 +244,9 @@ let run_social_board_event_turn
           in
           let requests =
             List.map
-              (fun (model : Llm_client.model_spec) ->
+              (fun (model : Llm_types.model_spec) ->
                  ({
-                    Llm_client.model;
+                    Llm_types.model;
                     messages =
                       (Agent_sdk.Types.system_msg ctx_work.system_prompt)
                       :: (ctx_work.messages @ [ Agent_sdk.Types.user_msg prompt ]);
@@ -255,7 +255,7 @@ let run_social_board_event_turn
                     tools = keeper_allowed_llm_tools meta;
                     response_format = `Text;
                   }
-                   : Llm_client.completion_request))
+                   : Llm_types.completion_request))
               specs
           in
           match Llm_orchestration.cascade requests with
@@ -269,7 +269,7 @@ let run_social_board_event_turn
               let cost0 = cost_usd_of_usage resp0.usage used_model0 in
               let rec tool_loop ~round ~acc_usage ~acc_latency ~acc_cost
                   ~acc_tools_used ~last_resp =
-                if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
+                if last_resp.Llm_types.tool_calls = [] || round > max_tool_rounds then
                   let content =
                     let trimmed = String.trim (Llm_types.text_of_response last_resp) in
                     if trimmed = "" && acc_tools_used <> [] then
@@ -280,19 +280,19 @@ let run_social_board_event_turn
                   in
                   ( content,
                     acc_usage,
-                    last_resp.Llm_client.model_used,
+                    last_resp.Llm_types.model_used,
                     acc_latency,
                     acc_cost,
                     acc_tools_used )
                 else
                   let round_tools =
                     List.map
-                      (fun (tc : Llm_client.tool_call) -> tc.call_name)
-                      last_resp.Llm_client.tool_calls
+                      (fun (tc : Llm_types.tool_call) -> tc.call_name)
+                      last_resp.Llm_types.tool_calls
                   in
                   let all_tools_so_far = acc_tools_used @ round_tools in
                   let tool_outputs =
-                    execute_tool_calls ~ctx_work last_resp.Llm_client.tool_calls
+                    execute_tool_calls ~ctx_work last_resp.Llm_types.tool_calls
                   in
                   let followup_prompt =
                     keeper_tool_followup_prompt
@@ -308,9 +308,9 @@ let run_social_board_event_turn
                   in
                   let followup_requests =
                     List.map
-                      (fun (model : Llm_client.model_spec) ->
+                      (fun (model : Llm_types.model_spec) ->
                          ({
-                            Llm_client.model;
+                            Llm_types.model;
                             messages = [
                               Agent_sdk.Types.system_msg
                                 (keeper_tool_loop_system_prompt
@@ -322,14 +322,14 @@ let run_social_board_event_turn
                             tools = next_tools;
                             response_format = `Text;
                           }
-                           : Llm_client.completion_request))
+                           : Llm_types.completion_request))
                       specs
                   in
                   match Llm_orchestration.cascade followup_requests with
                   | Error _ ->
                       ( Llm_types.text_of_response last_resp,
                         acc_usage,
-                        last_resp.Llm_client.model_used,
+                        last_resp.Llm_types.model_used,
                         acc_latency,
                         acc_cost,
                         acc_tools_used @ round_tools )

--- a/lib/keeper_exec_tools.ml
+++ b/lib/keeper_exec_tools.ml
@@ -56,16 +56,16 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     match canonical_policy_action_budget meta.policy_action_budget with
     | "board" -> dedupe_tool_names (keeper_board_tool_names @ with_shell)
     | _ -> dedupe_tool_names with_shell
-  else keeper_llm_tools |> List.map (fun tool -> tool.Llm_client.tool_name)
+  else keeper_llm_tools |> List.map (fun tool -> tool.Llm_types.tool_name)
 
 let keeper_allowed_llm_tools ?(write_done = false) (meta : keeper_meta) :
-    Llm_client.tool_def list =
+    Llm_types.tool_def list =
   let allowed = keeper_allowed_tool_names ~write_done meta in
   if allowed = [] then
     []
   else
     keeper_llm_tools
-    |> List.filter (fun tool -> List.mem tool.Llm_client.tool_name allowed)
+    |> List.filter (fun tool -> List.mem tool.Llm_types.tool_name allowed)
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in
@@ -95,7 +95,7 @@ let execute_keeper_tool_call
     ~(config : Room.config)
     ~(meta : keeper_meta)
     ~(ctx_work : Context_manager.working_context)
-    (tc : Llm_client.tool_call) : string =
+    (tc : Llm_types.tool_call) : string =
   let args =
     try Yojson.Safe.from_string tc.call_arguments
     with Yojson.Json_error _ -> `Assoc []
@@ -604,11 +604,11 @@ let keeper_tool_loop_system_prompt ~(character_context : string) : string =
 let keeper_tool_followup_prompt
     ~(user_message : string)
     ~(draft_reply : string)
-    ~(tool_outputs : (Llm_client.tool_call * string) list)
+    ~(tool_outputs : (Llm_types.tool_call * string) list)
     ~(already_executed : string list) : string =
   let rendered =
     tool_outputs
-    |> List.map (fun ((tc : Llm_client.tool_call), output) ->
+    |> List.map (fun ((tc : Llm_types.tool_call), output) ->
            Printf.sprintf "- %s(%s)\n  => %s" tc.call_name tc.call_arguments
              output)
     |> String.concat "\n"

--- a/lib/keeper_exec_tools.mli
+++ b/lib/keeper_exec_tools.mli
@@ -5,13 +5,13 @@ val ensure_keeper_board_post_args :
 
 val keeper_allowed_tool_names : ?write_done:bool -> keeper_meta -> string list
 val keeper_allowed_llm_tools :
-  ?write_done:bool -> keeper_meta -> Llm_client.tool_def list
+  ?write_done:bool -> keeper_meta -> Llm_types.tool_def list
 
 val execute_keeper_tool_call :
   config:Room.config ->
   meta:keeper_meta ->
   ctx_work:Context_manager.working_context ->
-  Llm_client.tool_call ->
+  Llm_types.tool_call ->
   string
 
 val keeper_tool_loop_system_prompt : character_context:string -> string
@@ -19,7 +19,7 @@ val keeper_tool_loop_system_prompt : character_context:string -> string
 val keeper_tool_followup_prompt :
   user_message:string ->
   draft_reply:string ->
-  tool_outputs:(Llm_client.tool_call * string) list ->
+  tool_outputs:(Llm_types.tool_call * string) list ->
   already_executed:string list ->
   string
 

--- a/lib/keeper_keepalive.ml
+++ b/lib/keeper_keepalive.ml
@@ -90,7 +90,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
                  let primary_model =
                    match model_specs_of_strings meta_current.models with
                    | Ok (primary :: _) -> primary
-                   | _ -> Llm_client.default_local_model_spec ()
+                   | _ -> Llm_types.default_local_model_spec ()
                  in
                  let base_dir = session_base_dir ctx.config in
                  let _session, ctx_opt =
@@ -103,12 +103,12 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
                  | None -> ()
                  | Some c ->
                      let latest_user_message =
-                       latest_message_content_by_role ~role:Llm_client.User
+                       latest_message_content_by_role ~role:Llm_types.User
                          c.messages
                      in
                      let latest_assistant_message =
                        latest_message_content_by_role
-                         ~role:Llm_client.Assistant c.messages
+                         ~role:Llm_types.Assistant c.messages
                      in
                      let continuity_snapshot =
                        latest_state_snapshot_from_messages c.messages

--- a/lib/keeper_memory_recall.ml
+++ b/lib/keeper_memory_recall.ml
@@ -4,20 +4,20 @@ open Keeper_types
 
 include Keeper_memory_bank
 
-let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Llm_client.model_spec) : float =
+let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Llm_types.model_spec) : float =
   let input_cost = float_of_int usage.input_tokens *. model.cost_per_1k_input /. 1000.0 in
   let output_cost = float_of_int usage.output_tokens *. model.cost_per_1k_output /. 1000.0 in
   input_cost +. output_cost
 
-let model_spec_for_used (specs : Llm_client.model_spec list) (model_used : string) :
-  Llm_client.model_spec option =
+let model_spec_for_used (specs : Llm_types.model_spec list) (model_used : string) :
+  Llm_types.model_spec option =
   let used =
     if String.ends_with ~suffix:":latest" model_used then
       String.sub model_used 0 (String.length model_used - String.length ":latest")
     else
       model_used
   in
-  List.find_opt (fun (m : Llm_client.model_spec) ->
+  List.find_opt (fun (m : Llm_types.model_spec) ->
     m.model_id = model_used || m.model_id = used
   ) specs
 

--- a/lib/keeper_prompt.ml
+++ b/lib/keeper_prompt.ml
@@ -256,7 +256,7 @@ let proactive_prompt_for_keeper
 
 type proactive_generation_result = {
   reply: string;
-  usage: Llm_client.token_usage;
+  usage: Llm_types.token_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper_prompt.mli
+++ b/lib/keeper_prompt.mli
@@ -35,7 +35,7 @@ val proactive_prompt_for_keeper :
 
 type proactive_generation_result = {
   reply: string;
-  usage: Llm_client.token_usage;
+  usage: Llm_types.token_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper_status.ml
+++ b/lib/keeper_status.ml
@@ -41,7 +41,7 @@ let handle_keeper_status ctx args : tool_result =
       (match model_specs_of_strings models with
        | Error e -> (false, "❌ " ^ e)
        | Ok specs ->
-         let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
+         let primary = match specs with m0 :: _ -> m0 | [] -> Llm_types.default_local_model_spec () in
          let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
@@ -97,9 +97,9 @@ let handle_keeper_status ctx args : tool_result =
            compaction_policy_of_keeper m
          in
 
-         let models_resolved = `List (List.map (fun (s : Llm_client.model_spec) ->
+         let models_resolved = `List (List.map (fun (s : Llm_types.model_spec) ->
            `Assoc [
-             ("provider", `String (Llm_client.string_of_provider s.provider));
+             ("provider", `String (Llm_types.string_of_provider s.provider));
              ("model_id", `String s.model_id);
              ("max_context", `Int s.max_context);
              ("api_key_env", match s.api_key_env with None -> `Null | Some k -> `String k);
@@ -375,7 +375,7 @@ let handle_keeper_status ctx args : tool_result =
              (`List tail, total)
         in
         let all_internal_tools =
-          keeper_llm_tools |> List.map (fun tool -> tool.Llm_client.tool_name)
+          keeper_llm_tools |> List.map (fun tool -> tool.Llm_types.tool_name)
         in
         let allowed_tools = keeper_allowed_tool_names m in
         let blocked_internal_tools =

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -119,7 +119,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          (match ensure_api_keys specs with
           | Error e -> (false, "❌ " ^ e)
           | Ok () ->
-            let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
+            let primary = match specs with m0 :: _ -> m0 | [] -> Llm_types.default_local_model_spec () in
             let base_dir = session_base_dir ctx.config in
             mkdir_p base_dir;
             let (session, ctx_opt) = load_context_from_checkpoint
@@ -229,7 +229,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   Printf.sprintf "%s\n\n--- Turn-specific instructions ---\n%s"
                     turn_system_prompt ti
             in
-	            let user_msg = Llm_client.user_msg message in
+	            let user_msg = Llm_types.user_msg message in
 	            let ctx_work = Context_manager.append ctx_work user_msg in
 	            Context_manager.persist_message session user_msg;
             let turn_max_tokens = keeper_turn_max_tokens () in
@@ -251,18 +251,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
 
             (* Single-turn LLM call with cascade *)
             let requests =
-	              List.map (fun (model : Llm_client.model_spec) ->
+	              List.map (fun (model : Llm_types.model_spec) ->
 	                let msgs =
-	                  (Llm_client.system_msg turn_system_prompt) :: ctx_work.messages
+	                  (Llm_types.system_msg turn_system_prompt) :: ctx_work.messages
 	                in
 	                ({
-                  Llm_client.model;
+                  Llm_types.model;
                   messages = msgs;
                   temperature = 0.7;
                   max_tokens = turn_max_tokens;
                   tools = keeper_allowed_llm_tools meta;
                   response_format = `Text;
-                } : Llm_client.completion_request)
+                } : Llm_types.completion_request)
               ) specs
             in
             let run_cascade_batch requests =
@@ -288,7 +288,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     | _ -> ()
                   in
                   (match
-                     Llm_client.call_provider_stream
+                     Llm_orchestration.call_provider_stream
                        ?timeout_sec:timeout_f
                        first_req
                        ~on_event:stream_on_event
@@ -318,7 +318,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               let max_tool_rounds = 3 in
               let _trunc s n = if String.length s > n then String.sub s 0 n ^ "..." else s in
               let execute_tool_calls tcs =
-                List.map (fun (tc : Llm_client.tool_call) ->
+                List.map (fun (tc : Llm_types.tool_call) ->
                   Log.Trpg.info "Executing tool: %s args: %s"
                     tc.call_name (_trunc tc.call_arguments 200);
                   let (decision, result_opt, eval_opt, duration_ms) =
@@ -375,31 +375,31 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               let rec tool_loop ~round ~acc_usage ~acc_latency ~acc_cost
                   ~acc_tools_used ~last_resp =
-                if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
+                if last_resp.Llm_types.tool_calls = [] || round > max_tool_rounds then
                   (* Terminal: no more tool calls or hit round limit *)
                   let content =
-                    let c = String.trim (Llm_client.text_of_response last_resp) in
+                    let c = String.trim (Llm_types.text_of_response last_resp) in
                     if c = "" && acc_tools_used <> [] then
                       Printf.sprintf "(tools executed: %s)"
                         (String.concat ", " acc_tools_used)
-                    else Llm_client.text_of_response last_resp
+                    else Llm_types.text_of_response last_resp
                   in
-                  ( content, acc_usage, last_resp.Llm_client.model_used,
+                  ( content, acc_usage, last_resp.Llm_types.model_used,
                     acc_latency, acc_cost, acc_tools_used )
                 else begin
                   Log.Trpg.info "Tool round %d/%d: %d tool calls"
                     round max_tool_rounds
-                    (List.length last_resp.Llm_client.tool_calls);
+                    (List.length last_resp.Llm_types.tool_calls);
                   let round_tools =
-                    List.map (fun (tc : Llm_client.tool_call) -> tc.call_name)
-                      last_resp.Llm_client.tool_calls
+                    List.map (fun (tc : Llm_types.tool_call) -> tc.call_name)
+                      last_resp.Llm_types.tool_calls
                   in
                   let all_tools_so_far = acc_tools_used @ round_tools in
-                  let tool_outputs = execute_tool_calls last_resp.Llm_client.tool_calls in
+                  let tool_outputs = execute_tool_calls last_resp.Llm_types.tool_calls in
                   let followup_prompt =
                     keeper_tool_followup_prompt
                       ~user_message:message
-                      ~draft_reply:(Llm_client.text_of_response last_resp)
+                      ~draft_reply:(Llm_types.text_of_response last_resp)
                       ~tool_outputs
                       ~already_executed:all_tools_so_far
                   in
@@ -421,33 +421,33 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     keeper_allowed_llm_tools ~write_done meta
                   in
                   let followup_requests =
-                    List.map (fun (model : Llm_client.model_spec) ->
+                    List.map (fun (model : Llm_types.model_spec) ->
                       ({
-                        Llm_client.model;
+                        Llm_types.model;
                         messages = [
-                          Llm_client.system_msg (keeper_tool_loop_system_prompt
+                          Llm_types.system_msg (keeper_tool_loop_system_prompt
                             ~character_context:ctx_work.system_prompt);
-                          Llm_client.user_msg followup_prompt;
+                          Llm_types.user_msg followup_prompt;
                         ];
                         temperature = 0.3;
                         max_tokens = followup_max_tokens;
                         tools = next_tools;
                         response_format = `Text;
-                      } : Llm_client.completion_request)
+                      } : Llm_types.completion_request)
                     ) specs
                   in
                   match run_cascade_batch followup_requests with
                   | Error _ ->
                     (* Cascade failed — return what we have *)
-                    ( Llm_client.text_of_response last_resp, acc_usage,
-                      last_resp.Llm_client.model_used, acc_latency,
+                    ( Llm_types.text_of_response last_resp, acc_usage,
+                      last_resp.Llm_types.model_used, acc_latency,
                       acc_cost, acc_tools_used @ round_tools )
                   | Ok resp_next ->
                     Log.Trpg.info "Follow-up round %d resp: tool_calls=%d content_len=%d model=%s"
                       round
-                      (List.length resp_next.Llm_client.tool_calls)
-                      (String.length (Llm_client.text_of_response resp_next))
-                      resp_next.Llm_client.model_used;
+                      (List.length resp_next.Llm_types.tool_calls)
+                      (String.length (Llm_types.text_of_response resp_next))
+                      resp_next.Llm_types.model_used;
                     let used_model_next =
                       model_spec_for_used specs resp_next.model_used
                       |> Option.value ~default:primary
@@ -500,18 +500,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       ~expected_topic:eval0.expected_topic
                   in
                   let correction_requests =
-                    List.map (fun (model : Llm_client.model_spec) ->
+                    List.map (fun (model : Llm_types.model_spec) ->
 	                      ({
-	                        Llm_client.model;
+	                        Llm_types.model;
 	                        messages = [
-	                          Llm_client.system_msg turn_system_prompt;
-	                          Llm_client.user_msg correction_prompt;
+	                          Llm_types.system_msg turn_system_prompt;
+	                          Llm_types.user_msg correction_prompt;
 	                        ];
                         temperature = 0.2;
                         max_tokens = correction_max_tokens;
                         tools = [];
                         response_format = `Text;
-                      } : Llm_client.completion_request)
+                      } : Llm_types.completion_request)
                     ) specs
                   in
                   match run_cascade_batch correction_requests with
@@ -527,12 +527,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     let eval1 =
                       evaluate_memory_recall
                         ~user_message:message
-                        ~assistant_reply:(Llm_client.text_of_response corr)
+                        ~assistant_reply:(Llm_types.text_of_response corr)
                         ~candidates:recall_candidates
                     in
                     let evalf = { eval1 with initial_score = eval0.final_score } in
                     let merged_usage = merge_usage base_usage corr.usage in
-                    ( Llm_client.text_of_response corr, merged_usage, corr.model_used,
+                    ( Llm_types.text_of_response corr, merged_usage, corr.model_used,
                       base_latency_ms + corr.latency_ms,
                       evalf, true, evalf.passed, false, base_cost_usd +. cost1,
                       tools_used )
@@ -564,18 +564,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       ~expected_topic:eval_after_correction.expected_topic
                   in
                   let forced_requests =
-                    List.map (fun (model : Llm_client.model_spec) ->
+                    List.map (fun (model : Llm_types.model_spec) ->
 	                      ({
-	                        Llm_client.model;
+	                        Llm_types.model;
 	                        messages = [
-	                          Llm_client.system_msg turn_system_prompt;
-	                          Llm_client.user_msg forced_prompt;
+	                          Llm_types.system_msg turn_system_prompt;
+	                          Llm_types.user_msg forced_prompt;
 	                        ];
                         temperature = 0.0;
                         max_tokens = correction_max_tokens;
                         tools = [];
                         response_format = `Text;
-                      } : Llm_client.completion_request)
+                      } : Llm_types.completion_request)
                     ) specs
                   in
                   match run_cascade_batch forced_requests with
@@ -592,8 +592,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       let merged_usage = merge_usage usage_after_correction forced.usage in
                       let merged_latency = latency_after_correction + forced.latency_ms in
                       let grounded_content =
-                        let c = String.trim (Llm_client.text_of_response forced) in
-                        if c = "" then content_after_correction else Llm_client.text_of_response forced
+                        let c = String.trim (Llm_types.text_of_response forced) in
+                        if c = "" then content_after_correction else Llm_types.text_of_response forced
                       in
                       let eval2 =
                         evaluate_memory_recall
@@ -693,7 +693,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
 	              in
               let response_alignment = jaccard_similarity message safe_reply in
 
-		              let assistant_msg = Llm_client.assistant_msg safe_reply in
+		              let assistant_msg = Llm_types.assistant_msg safe_reply in
 	              let ctx_work = Context_manager.append ctx_work assistant_msg in
               Context_manager.persist_message session assistant_msg;
               let now_ts = Time_compat.now () in
@@ -736,13 +736,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 continuity_summary = continuity_summary_from_reply;
                 last_continuity_update_ts;
                 total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                total_tokens = meta.total_tokens + Llm_client.total_tokens final_usage;
+                total_tokens = meta.total_tokens + Llm_types.total_tokens final_usage;
                 total_cost_usd = meta.total_cost_usd +. total_cost_usd_turn;
                 last_turn_ts = now_ts;
                 last_model_used = final_model_used;
                 last_input_tokens = final_usage.input_tokens;
                 last_output_tokens = final_usage.output_tokens;
-                last_total_tokens = Llm_client.total_tokens final_usage;
+                last_total_tokens = Llm_types.total_tokens final_usage;
                 last_latency_ms = final_latency_ms;
                 compaction_count = meta.compaction_count + (if compacted then 1 else 0);
                 last_compaction_ts = (if compacted then now_ts else meta.last_compaction_ts);

--- a/lib/keeper_turn_lifecycle.ml
+++ b/lib/keeper_turn_lifecycle.ml
@@ -23,18 +23,18 @@ let handle_keeper_model_set ctx args : tool_result =
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (false, Printf.sprintf "❌ keeper not found: %s" name)
     | Ok (Some meta) -> (
-        match Llm_client.model_spec_of_string model with
+        match Llm_types.model_spec_of_string model with
         | Error e -> (false, "❌ " ^ e)
         | Ok spec ->
             let runtime_ok =
               match spec.provider with
-              | Llm_client.Llama -> (
+              | Llm_types.Llama -> (
                   match Tool_local_runtime.fetch_models () with
                   | Ok (_, models) -> List.mem spec.model_id models
                   | Error _ -> false)
               | _ -> true
             in
-            if spec.provider = Llm_client.Llama && not runtime_ok then
+            if spec.provider = Llm_types.Llama && not runtime_ok then
               (false, Printf.sprintf "❌ model not present in llama inventory: %s" spec.model_id)
             else
               let allowed_models =

--- a/lib/keeper_turn_response.ml
+++ b/lib/keeper_turn_response.ml
@@ -14,7 +14,7 @@ open Keeper_execution
 type turn_env = {
   meta_turn : keeper_meta;
   safe_reply : string;
-  final_usage : Llm_client.token_usage;
+  final_usage : Llm_types.token_usage;
   final_model_used : string;
   final_latency_ms : int;
   total_cost_usd_turn : float;
@@ -52,7 +52,7 @@ let build_turn_metrics_fields (env : turn_env) : (string * Yojson.Safe.t) list =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);
@@ -163,7 +163,7 @@ let build_normal_turn_response_json (env : turn_env) : Yojson.Safe.t =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);

--- a/lib/keeper_turn_setup.ml
+++ b/lib/keeper_turn_setup.ml
@@ -300,7 +300,7 @@ let ensure_keeper_exists
        (match ensure_api_keys specs with
         | Error e -> Error e
         | Ok () ->
-          let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
+          let primary = match specs with m0 :: _ -> m0 | [] -> Llm_types.default_local_model_spec () in
           let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
           let system_prompt =
             build_keeper_system_prompt

--- a/lib/keeper_turn_up.ml
+++ b/lib/keeper_turn_up.ml
@@ -374,7 +374,7 @@ let handle_keeper_up ctx args : tool_result =
              let trace_id = generate_trace_id () in
              let primary = match specs with
                | m :: _ -> m
-               | [] -> Llm_client.default_local_model_spec ()
+               | [] -> Llm_types.default_local_model_spec ()
              in
              let base_dir = session_base_dir ctx.config in
              mkdir_p base_dir;

--- a/lib/keeper_types_resident.ml
+++ b/lib/keeper_types_resident.ml
@@ -19,11 +19,11 @@ let session_base_dir_ (config : Room.config) =
   Filename.concat (Filename.concat config.base_path ".masc") "perpetual"
 
 let model_specs_of_strings (model_strs : string list) :
-    (Llm_client.model_spec list, string) result =
+    (Llm_types.model_spec list, string) result =
   let rec go acc = function
     | [] -> Ok (List.rev acc)
     | s :: rest -> (
-        match Llm_client.model_spec_of_string s with
+        match Llm_types.model_spec_of_string s with
         | Ok spec -> go (spec :: acc) rest
         | Error e -> Error (Printf.sprintf "Bad model spec %s: %s" s e))
   in
@@ -45,14 +45,14 @@ let ollama_port_listening () =
   with Unix.Unix_error _ ->
     false
 
-let model_spec_is_local_runtime (model : Llm_client.model_spec) =
+let model_spec_is_local_runtime (model : Llm_types.model_spec) =
   match model.provider with
-  | Llm_client.Llama -> true
+  | Llm_types.Llama -> true
   | _ -> false
 
-let model_spec_is_available (model : Llm_client.model_spec) =
+let model_spec_is_available (model : Llm_types.model_spec) =
   match model.provider with
-  | Llm_client.Llama -> true
+  | Llm_types.Llama -> true
   | _ -> true
 
 let keeper_fallback_model_labels () =
@@ -92,9 +92,9 @@ let maybe_append_keeper_fallback_models (models : string list) =
         in
         if extra = [] then models else models @ extra
 
-let ensure_api_keys (models : Llm_client.model_spec list) : (unit, string) result =
+let ensure_api_keys (models : Llm_types.model_spec list) : (unit, string) result =
   let missing =
-    List.filter_map (fun (m : Llm_client.model_spec) ->
+    List.filter_map (fun (m : Llm_types.model_spec) ->
       match m.api_key_env with
       | None -> None
       | Some env ->

--- a/lib/keeper_verifier.ml
+++ b/lib/keeper_verifier.ml
@@ -98,7 +98,7 @@ let risk_guard ~(autonomy_level : Keeper_autonomy.autonomy_level)
     Layer 2: Risk guard (fast, no LLM)
     Layer 3: LLM verification via verifier.ml (cheap model, 200 tokens) *)
 let verify_action
-    ~(model : Llm_client.model_spec)
+    ~(model : Llm_types.model_spec)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     (req : keeper_verification_request) : keeper_verdict =
   (* Layer 1: Cost guard *)
@@ -172,8 +172,8 @@ let run_pipeline
     ~(goal_ids : string list)
     ~(keeper_name : string)
     ~(keeper_context : string)
-    ~(plan_model : Llm_client.model_spec)
-    ~(verify_model : Llm_client.model_spec)
+    ~(plan_model : Llm_types.model_spec)
+    ~(verify_model : Llm_types.model_spec)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     : pipeline_result =
   (* Step 1: Evaluate next action *)

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -324,7 +324,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
         in
         (match result with
          | Ok resp ->
-             let masc_resp = completion_response_of_api_response resp in
+             let masc_resp = Llm_provider_dispatch.completion_response_of_api_response resp in
              let text = text_of_response masc_resp in
              if String.trim text = "" && masc_resp.tool_calls = [] then
                None  (* empty response, try batch *)
@@ -332,7 +332,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
                Some (Ok masc_resp)
          | Error http_err ->
              Log.LlmClient.warn "stream: provider error: %s"
-               (string_of_http_error http_err);
+               (Llm_provider_dispatch.string_of_http_error http_err);
              None  (* fall through to batch *))
   in
   match stream_result with

--- a/lib/llm_provider_dispatch.mli
+++ b/lib/llm_provider_dispatch.mli
@@ -30,3 +30,14 @@ val completion_response_of_api_response :
     Sets [id] to ["cached"] and [stop_reason] to [EndTurn]. *)
 val api_response_of_completion_response :
   Llm_types.completion_response -> Llm_provider.Types.api_response
+
+(** Build OAS provider config + converted messages + tool JSON from a MASC request. *)
+val provider_config_of_request :
+  Llm_types.completion_request ->
+  (Llm_provider.Provider_config.t
+   * Llm_provider.Types.message list
+   * Yojson.Safe.t list, string) result
+
+(** Human-readable string from an HTTP-level error. *)
+val string_of_http_error :
+  Llm_provider.Http_client.http_error -> string

--- a/lib/local_agent_eio_container.ml
+++ b/lib/local_agent_eio_container.ml
@@ -463,7 +463,7 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
                ~on_exec ()))
   | Error e, _ | _, Error e -> Error e
 
-let oas_provider_of_model (model : Llm_client.model_spec) : Oas.Provider.config =
+let oas_provider_of_model (model : Llm_types.model_spec) : Oas.Provider.config =
   match Llm_client.to_oas_provider model with
   | Some config -> config
   | None ->
@@ -535,7 +535,7 @@ let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
     {
       Oas.Types.default_config with
       name = worker_name;
-      model = Oas.Types.Custom model.Llm_client.model_id;
+      model = model.Llm_types.model_id;
       system_prompt = Some system_prompt;
       max_tokens = local_worker_max_tokens ();
       max_turns;

--- a/lib/local_agent_eio_runners.ml
+++ b/lib/local_agent_eio_runners.ml
@@ -5,7 +5,7 @@ open Printf
 include Local_agent_eio_container
 
 let run_worker_oas ~sw ~base_path ~worker_name
-    ~(model : Llm_client.model_spec) ~team_session_id
+    ~(model : Llm_types.model_spec) ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id
     ~role
@@ -423,9 +423,9 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 }
               in
               let model =
-                let base_model = Llm_client.default_local_model_spec () in
+                let base_model = Llm_types.default_local_model_spec () in
                 match checkpoint.model with
-                | Oas.Types.Custom model_id ->
+                | model_id when model_id <> "" ->
                     { base_model with model_id }
                 | _ ->
                     { base_model with model_id = meta.effective_model }

--- a/lib/local_agent_eio_types.ml
+++ b/lib/local_agent_eio_types.ml
@@ -346,7 +346,7 @@ let tool_defs_of_schemas schemas =
   List.map
     (fun (schema : Types.tool_schema) ->
       {
-        Llm_client.tool_name = schema.name;
+        Llm_types.tool_name = schema.name;
         tool_description = schema.description;
         parameters = schema.input_schema;
       })
@@ -360,7 +360,7 @@ let safe_text_for_followup text =
 let followup_prompt ~original_prompt ~tool_outputs ~already_used =
   let tool_lines =
     tool_outputs
-    |> List.mapi (fun idx ((tc : Llm_client.tool_call), output) ->
+    |> List.mapi (fun idx ((tc : Llm_types.tool_call), output) ->
            sprintf "%d. %s(%s)\n%s" (idx + 1) tc.call_name tc.call_arguments
              (safe_text_for_followup output))
     |> String.concat "\n\n"
@@ -500,7 +500,7 @@ let parse_text_tool_args (args_text : string) =
     in
     build [] parts
 
-let parse_text_tool_calls (content : string) : Llm_client.tool_call list =
+let parse_text_tool_calls (content : string) : Llm_types.tool_call list =
   let prefix = "mcp__masc__" in
   let prefix_len = String.length prefix in
   let len = String.length content in
@@ -556,7 +556,7 @@ let parse_text_tool_calls (content : string) : Llm_client.tool_call list =
             | Ok args_json ->
                 collect (close_idx + 1) (call_id + 1)
                   ({
-                     Llm_client.call_id = sprintf "text-fallback-%d" call_id;
+                     Llm_types.call_id = sprintf "text-fallback-%d" call_id;
                      call_name = tool_name;
                      call_arguments = Yojson.Safe.to_string args_json;
                    }
@@ -568,13 +568,13 @@ let parse_text_tool_calls (content : string) : Llm_client.tool_call list =
   in
   collect 0 1 []
 
-let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Llm_client.token_usage =
+let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Llm_types.token_usage =
   { Agent_sdk.Types.input_tokens;
     output_tokens;
     cache_creation_input_tokens = 0;
     cache_read_input_tokens = 0 }
 
-let merge_usage (a : Llm_client.token_usage) (b : Llm_client.token_usage) : Llm_client.token_usage =
+let merge_usage (a : Llm_types.token_usage) (b : Llm_types.token_usage) : Llm_types.token_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =
@@ -582,8 +582,8 @@ let merge_usage (a : Llm_client.token_usage) (b : Llm_client.token_usage) : Llm_
     cache_read_input_tokens =
       a.cache_read_input_tokens + b.cache_read_input_tokens }
 
-let estimate_cost_usd (model : Llm_client.model_spec)
-    (usage : Llm_client.token_usage) : float option =
+let estimate_cost_usd (model : Llm_types.model_spec)
+    (usage : Llm_types.token_usage) : float option =
   let input_cost =
     (float_of_int usage.input_tokens /. 1000.0) *. model.cost_per_1k_input
   in

--- a/lib/local_runtime_pool.ml
+++ b/lib/local_runtime_pool.ml
@@ -496,7 +496,7 @@ let release (lease : lease) ~success ?error ?latency_ms () =
 
 let model_spec_of_assignment (assignment : assignment) =
   {
-    Llm_client.llama_default with
+    Llm_types.llama_default with
     model_id = assignment.model_name;
     api_url = assignment.base_url;
   }

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -167,12 +167,12 @@ let read_model_strings ~config_path ~cascade_name =
           default_model_strings ~cascade_name)
 
 let get_cascade ?(config_path = "") ~cascade_name () :
-    Llm_client.model_spec list =
+    Llm_types.model_spec list =
   let path =
     if String.length config_path > 0 then config_path else default_config_path ()
   in
   let configured = read_model_strings ~config_path:path ~cascade_name in
-  let specs = Llm_client.available_model_specs_of_strings configured in
+  let specs = Llm_types.available_model_specs_of_strings configured in
   if specs <> [] then specs
   else
     let defaults = default_model_strings ~cascade_name in
@@ -185,7 +185,7 @@ let get_cascade ?(config_path = "") ~cascade_name () :
       eprintf
         "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!"
         cascade_name;
-      Llm_client.available_model_specs_of_strings defaults)
+      Llm_types.available_model_specs_of_strings defaults)
 
 (** Call LLM cascade. Routes through [Llm_orchestration.run_prompt_cascade]
     which uses OAS-inlined provider calls (no global semaphore after v2.114). *)
@@ -203,8 +203,8 @@ let call ~cascade_name ~prompt
     | Ok resp ->
         Ok
           {
-            response = Llm_client.text_of_response resp;
-            llm_used = resp.Llm_client.model_used;
-            duration_ms = resp.Llm_client.latency_ms;
+            response = Llm_types.text_of_response resp;
+            llm_used = resp.Llm_types.model_used;
+            duration_ms = resp.Llm_types.latency_ms;
           }
     | Error msg -> Error msg

--- a/lib/lodge_heartbeat_agents.ml
+++ b/lib/lodge_heartbeat_agents.ml
@@ -399,8 +399,8 @@ let heartbeat_response_is_valid ?(require_json = false) s =
   && ((not require_json) || Lodge_decision.contains_json_object s)
 
 let heartbeat_response_accepted ?(require_json = false)
-    (resp : Llm_client.completion_response) =
-  heartbeat_response_is_valid ~require_json (Llm_client.text_of_response resp)
+    (resp : Llm_types.completion_response) =
+  heartbeat_response_is_valid ~require_json (Llm_types.text_of_response resp)
 
 let run_heartbeat_llm_once ?(require_json = false) ?(temperature = 0.7) ~agent_name ~prompt () =
   let accept = heartbeat_response_accepted ~require_json in

--- a/lib/lodge_tom.ml
+++ b/lib/lodge_tom.ml
@@ -170,8 +170,8 @@ let parse_tom_response (text : string)
                     (String.sub s 0 (min 100 (String.length s)))))
 
 (** Validate that an LLM ToM response is parseable and non-trivial. *)
-let tom_response_is_valid (resp : Llm_client.completion_response) : bool =
-  match parse_tom_response (Llm_client.text_of_response resp) with
+let tom_response_is_valid (resp : Llm_types.completion_response) : bool =
+  match parse_tom_response (Llm_types.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false
 

--- a/lib/lodge_topic.ml
+++ b/lib/lodge_topic.ml
@@ -236,8 +236,8 @@ let parse_topics_response (text : string) : string list =
 (** Validate an LLM completion response for use as [~accept] predicate.
     Rejects empty, garbage, or non-array responses so the cascade retries
     with the next model. *)
-let topics_response_is_valid (result : Llm_client.completion_response) : bool =
-  let text = String.trim (Llm_client.text_of_response result) in
+let topics_response_is_valid (result : Llm_types.completion_response) : bool =
+  let text = String.trim (Llm_types.text_of_response result) in
   (* Must contain at least one bracket pair *)
   if not (String.contains text '[' && String.contains text ']') then false
   else

--- a/lib/lodge_topic.mli
+++ b/lib/lodge_topic.mli
@@ -72,7 +72,7 @@ val find_array_bounds : string -> (int * int) option
 (** Find the start and end positions of the outermost JSON array in a string.
     Uses depth tracking to handle nested brackets correctly. *)
 
-val topics_response_is_valid : Llm_client.completion_response -> bool
+val topics_response_is_valid : Llm_types.completion_response -> bool
 (** Validate an LLM completion response. Used as [~accept] predicate so
     the cascade retries with the next model on garbage/empty responses. *)
 

--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -61,13 +61,13 @@ let worker_model_spec () =
     | _ -> None
   in
   match explicit with
-  | Some spec -> Llm_client.model_spec_of_string spec
+  | Some spec -> Llm_types.model_spec_of_string spec
   | None -> (
       match Sys.getenv_opt "LLAMA_SWARM_MODEL" with
       | Some raw when String.trim raw <> "" ->
-          Llm_client.model_spec_of_string ("llama:" ^ String.trim raw)
+          Llm_types.model_spec_of_string ("llama:" ^ String.trim raw)
       | _ ->
-          Llm_client.model_spec_of_string
+          Llm_types.model_spec_of_string
             ("llama:" ^ Env_config.Llama.default_model))
 
 let base_path () =

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -329,6 +329,9 @@ module Tool_library = Tool_library
 
 (* Perpetual Agent Runtime — Infinite Context System *)
 module Llm_eio_env = Llm_eio_env
+module Llm_types = Llm_types
+module Llm_orchestration = Llm_orchestration
+module Llm_provider_dispatch = Llm_provider_dispatch
 module Llm_client = Llm_client
 module Context_scoring = Context_scoring
 module Context_compact_oas = Context_compact_oas

--- a/lib/mdal_worker.ml
+++ b/lib/mdal_worker.ml
@@ -53,36 +53,36 @@ let worker_name_for_state (state : Mdal.loop_state) =
   sprintf "mdal-%s-%02d" safe_loop (state.current_iteration + 1)
 
 let model_provider_label = function
-  | Llm_client.Llama -> "llama"
-  | Llm_client.Claude -> "claude"
-  | Llm_client.OpenAI -> "openai"
-  | Llm_client.Gemini -> "gemini"
-  | Llm_client.Glm_cloud -> "glm"
-  | Llm_client.OpenRouter -> "openrouter"
-  | Llm_client.Custom name -> "custom:" ^ name
+  | Llm_types.Llama -> "llama"
+  | Llm_types.Claude -> "claude"
+  | Llm_types.OpenAI -> "openai"
+  | Llm_types.Gemini -> "gemini"
+  | Llm_types.Glm_cloud -> "glm"
+  | Llm_types.OpenRouter -> "openrouter"
+  | Llm_types.Custom name -> "custom:" ^ name
 
-let model_label (spec : Llm_client.model_spec) =
+let model_label (spec : Llm_types.model_spec) =
   sprintf "%s:%s" (model_provider_label spec.provider) spec.model_id
 
-let validate_model_spec (spec : Llm_client.model_spec) :
-    (Llm_client.model_spec, string) result =
+let validate_model_spec (spec : Llm_types.model_spec) :
+    (Llm_types.model_spec, string) result =
   match spec.provider with
-  | Llm_client.Claude
-  | Llm_client.OpenAI
-  | Llm_client.Gemini
-  | Llm_client.Llama
-  | Llm_client.Glm_cloud -> Ok spec
-  | Llm_client.OpenRouter
-  | Llm_client.Custom _ ->
+  | Llm_types.Claude
+  | Llm_types.OpenAI
+  | Llm_types.Gemini
+  | Llm_types.Llama
+  | Llm_types.Glm_cloud -> Ok spec
+  | Llm_types.OpenRouter
+  | Llm_types.Custom _ ->
       Error
         (sprintf
            "MDAL strict worker does not support provider `%s`. Use claude, openai, gemini, llama:<model>, or glm."
            (model_provider_label spec.provider))
 
 let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
-    (Llm_client.model_spec * string, string) result =
+    (Llm_types.model_spec * string, string) result =
   let parse_worker_model raw =
-    match Llm_client.model_spec_of_string raw with
+    match Llm_types.model_spec_of_string raw with
     | Error _ as e -> e
     | Ok spec -> (
         match validate_model_spec spec with
@@ -96,14 +96,14 @@ let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
       if String.contains normalized ':' then parse_worker_model normalized
       else
         match normalized with
-        | "claude" -> Ok (Llm_client.claude_opus, model_label Llm_client.claude_opus)
+        | "claude" -> Ok (Llm_types.claude_opus, model_label Llm_types.claude_opus)
         | "openai" | "codex-api" ->
-            Ok (Llm_client.openai_default, model_label Llm_client.openai_default)
-        | "gemini" -> Ok (Llm_client.gemini_pro, model_label Llm_client.gemini_pro)
+            Ok (Llm_types.openai_default, model_label Llm_types.openai_default)
+        | "gemini" -> Ok (Llm_types.gemini_pro, model_label Llm_types.gemini_pro)
         | "ollama" ->
             Error (Provider_adapter.bare_ollama_migration_message ())
         | "glm" ->
-            Ok (Llm_client.glm_cloud, model_label Llm_client.glm_cloud)
+            Ok (Llm_types.glm_cloud, model_label Llm_types.glm_cloud)
         | "llama" ->
             Error
               "MDAL strict worker requires `worker_model` for llama providers, e.g. `llama:<model-id>`."
@@ -157,7 +157,7 @@ let run ~(sw : Eio.Switch.t) ~(config : Room.config) (state : Mdal.loop_state)
         raise (Invalid_argument message)
   in
   let model_spec =
-    match Llm_client.model_spec_of_string model_label with
+    match Llm_types.model_spec_of_string model_label with
     | Ok spec -> spec
     | Error message -> raise (Invalid_argument message)
   in

--- a/lib/mitosis_helpers.ml
+++ b/lib/mitosis_helpers.ml
@@ -180,7 +180,7 @@ let set_bool_arg args key value =
       `Assoc [ (key, `Bool value) ]
 
 let default_verifier_models =
-  Llm_client.default_verifier_model_labels ()
+  Llm_types.default_verifier_model_labels ()
 
 let default_verifier_perspectives = [
   "A: continuity archivist (value-neutral)";
@@ -435,7 +435,7 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
     let checks =
       List.mapi (fun idx model_str ->
         let perspective = perspective_at perspectives idx in
-        match Llm_client.model_spec_of_string model_str with
+        match Llm_types.model_spec_of_string model_str with
         | Error err ->
             incr warn_count;
             `Assoc [

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -17,12 +17,12 @@ let default_config ~goal ~models ?verifier ?session_dir () =
   let verifier_model = match verifier with
     | Some v -> v
     | None -> (
-        match Llm_client.default_verifier_model_spec () with
+        match Llm_types.default_verifier_model_spec () with
         | Ok model -> model
         | Error _ -> (
             match models with
             | model :: _ -> model
-            | [] -> Llm_client.glm_cloud))
+            | [] -> Llm_types.glm_cloud))
   in
   let session_base = match session_dir with
     | Some d -> d
@@ -89,20 +89,20 @@ let create_state config =
   in
   let primary_model = match config.model_cascade with
     | m :: _ -> m
-    | [] -> Llm_client.default_local_model_spec ()
+    | [] -> Llm_types.default_local_model_spec ()
   in
   let context = Context_manager.create
     ~system_prompt
     ~max_tokens:primary_model.max_context in
   (* Inject goal as first user message with sticky prefix for compaction safety *)
-  let goal_msg = Llm_client.user_msg
+  let goal_msg = Llm_types.user_msg
     (sprintf "%s %s" Context_manager.goal_prefix config.initial_goal) in
   let context = Context_manager.append context goal_msg in
   let trace_id = generate_trace_id () in
   let session = Context_manager.create_session
     ~session_id:trace_id
     ~base_dir:config.session_base_dir in
-  let zero_usage : Llm_client.token_usage = {
+  let zero_usage : Llm_types.token_usage = {
     Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
     cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
   } in
@@ -326,7 +326,7 @@ let status ~config state : Yojson.Safe.t =
     ("last_usage", `Assoc [
       ("input_tokens", `Int state.last_usage.input_tokens);
       ("output_tokens", `Int state.last_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens state.last_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens state.last_usage));
     ]);
     ("last_latency_ms", `Int state.last_latency_ms);
     ("last_heartbeat_ts", `Float state.last_heartbeat);

--- a/lib/perpetual_loop.mli
+++ b/lib/perpetual_loop.mli
@@ -29,12 +29,12 @@ type event =
 (** Loop configuration — immutable after creation. *)
 type loop_config = {
   initial_goal : string;
-  model_cascade : Llm_client.model_spec list;   (** Ordered preference *)
-  tools : Llm_client.tool_def list;
+  model_cascade : Llm_types.model_spec list;   (** Ordered preference *)
+  tools : Llm_types.tool_def list;
   heartbeat_interval_s : float;                  (** Default: 30.0 *)
   max_idle_turns : int;                          (** Stop after N turns with no progress *)
   feedback_enabled : bool;                       (** Run verifier after each action *)
-  verifier_model : Llm_client.model_spec;        (** Cheap model for verification *)
+  verifier_model : Llm_types.model_spec;        (** Cheap model for verification *)
   compact_threshold : float;                     (** Default: 0.5 *)
   prepare_threshold : float;                     (** Default: 0.7 *)
   handoff_threshold : float;                     (** Default: 0.85 *)
@@ -67,7 +67,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Llm_client.token_usage;
+  mutable last_usage : Llm_types.token_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;
@@ -104,7 +104,7 @@ val publish_to_event_bus : Agent_sdk.Event_bus.t -> event -> unit
 (** Default configuration builder. *)
 val default_config :
   goal:string ->
-  models:Llm_client.model_spec list ->
-  ?verifier:Llm_client.model_spec ->
+  models:Llm_types.model_spec list ->
+  ?verifier:Llm_types.model_spec ->
   ?session_dir:string ->
   unit -> loop_config

--- a/lib/perpetual_loop_types.ml
+++ b/lib/perpetual_loop_types.ml
@@ -20,12 +20,12 @@ type event =
 
 type loop_config = {
   initial_goal : string;
-  model_cascade : Llm_client.model_spec list;
-  tools : Llm_client.tool_def list;
+  model_cascade : Llm_types.model_spec list;
+  tools : Llm_types.tool_def list;
   heartbeat_interval_s : float;
   max_idle_turns : int;
   feedback_enabled : bool;
-  verifier_model : Llm_client.model_spec;
+  verifier_model : Llm_types.model_spec;
   compact_threshold : float;
   prepare_threshold : float;
   handoff_threshold : float;
@@ -57,7 +57,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Llm_client.token_usage;
+  mutable last_usage : Llm_types.token_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;

--- a/lib/perpetual_oas.ml
+++ b/lib/perpetual_oas.ml
@@ -132,7 +132,7 @@ let run_perpetual_via_oas
       version = 3;
       session_id = trace_id;
       agent_name = "perpetual";
-      model = Oas.Types.Custom "masc-perpetual";
+      model = "masc-perpetual";
       system_prompt = Some ctx.system_prompt;
       messages;
       usage = {

--- a/lib/perpetual_oas_build.ml
+++ b/lib/perpetual_oas_build.ml
@@ -38,11 +38,11 @@ let build_perpetual_agent
   (* Resolve OAS model from primary cascade model *)
   let primary_model = match config.model_cascade with
     | m :: _ -> m
-    | [] -> Llm_client.default_local_model_spec ()
+    | [] -> Llm_types.default_local_model_spec ()
   in
-  let oas_model = Oas.Types.Custom primary_model.model_id in
+  let oas_model = primary_model.Llm_types.model_id in
   (* Build provider via Phase 3 adapter.
-     Uses Llm_client.to_oas_provider which handles the Llm_client.model_spec
+     Uses Llm_client.to_oas_provider which handles the Llm_types.model_spec
      -> Oas.Provider.config conversion (avoiding Llm_types nominality gap). *)
   let provider = match Llm_client.to_oas_provider primary_model with
     | Some cfg -> cfg
@@ -74,7 +74,7 @@ let build_perpetual_agent
      Tool_bridge.oas_tool_of_masc creates OAS Tool.t from name/desc/schema/handler.
      For the perpetual loop adapter, each tool delegates to a no-op handler since
      actual tool dispatch remains in MASC's perpetual_loop infrastructure. *)
-  let tools = List.map (fun (td : Llm_client.tool_def) ->
+  let tools = List.map (fun (td : Llm_types.tool_def) ->
     Tool_bridge.oas_tool_of_masc
       ~name:td.tool_name
       ~description:td.tool_description

--- a/lib/perpetual_oas_hooks.ml
+++ b/lib/perpetual_oas_hooks.ml
@@ -71,7 +71,7 @@ let perpetual_hooks
         let next_model = match config.model_cascade with
           | _ :: m :: _ -> m
           | [m] -> m
-          | [] -> Llm_client.default_local_model_spec ()
+          | [] -> Llm_types.default_local_model_spec ()
         in
         Perpetual_oas_state.update_state (fun ps ->
           ps.handoff_triggered <- true;

--- a/lib/post_verifier_llm.ml
+++ b/lib/post_verifier_llm.ml
@@ -109,8 +109,8 @@ let score_to_verdict ~(dim_name : string) (score : int) : verdict =
   else Pass
 
 (** Validate that an LLM response contains parseable G-Eval scores. *)
-let geval_response_is_valid (resp : Llm_client.completion_response) : bool =
-  match parse_geval_response (Llm_client.text_of_response resp) with
+let geval_response_is_valid (resp : Llm_types.completion_response) : bool =
+  match parse_geval_response (Llm_types.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false
 

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -264,8 +264,8 @@ let get_chain_id_for_preset = function
   | "figma" -> Some "walph-figma"
   | _ -> None
 
-let walph_response_is_valid (resp : Llm_client.completion_response) =
-  let content = String.trim (Llm_client.text_of_response resp) in
+let walph_response_is_valid (resp : Llm_types.completion_response) =
+  let content = String.trim (Llm_types.text_of_response resp) in
   let lower = String.lowercase_ascii content in
   let len = String.length content in
   len > 0

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -130,7 +130,7 @@ let resolve_model_spec agent_name =
       let label_result =
         Provider_adapter.default_model_label_for_family adapter.provider_family
       in
-      Result.bind label_result Llm_client.model_spec_of_string
+      Result.bind label_result Llm_types.model_spec_of_string
 
 (** Build a spawn error result. Reduces boilerplate in spawn routing. *)
 let make_error_result ~agent_name ~start_time ~exit_code ~output ~timeout_seconds =

--- a/lib/succession.mli
+++ b/lib/succession.mli
@@ -36,7 +36,7 @@ type succession_dna = {
 
 (** Successor specification — what model the next agent uses. *)
 type successor_spec = {
-  model : Llm_client.model_spec;
+  model : Llm_types.model_spec;
   inherit_tools : bool;          (** Pass tool definitions to successor *)
   context_budget : float;        (** 0.0-1.0: how much context to transfer *)
 }
@@ -67,9 +67,9 @@ val hydrate :
     Handles provider-specific quirks (system message placement,
     tool format differences, token limit trimming). *)
 val normalize_for_model :
-  Llm_client.message list ->
-  Llm_client.model_spec ->
-  Llm_client.message list
+  Llm_types.message list ->
+  Llm_types.model_spec ->
+  Llm_types.message list
 
 (** {1 Serialization} *)
 

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -18,7 +18,7 @@
 
 open Printf
 
-let text_of_message = Llm_client.text_of_message
+let text_of_message = Llm_types.text_of_message
 
 (* ================================================================ *)
 (* Types                                                            *)
@@ -47,7 +47,7 @@ type succession_dna = {
 }
 
 type successor_spec = {
-  model : Llm_client.model_spec;
+  model : Llm_types.model_spec;
   inherit_tools : bool;
   context_budget : float;
 }
@@ -79,7 +79,7 @@ let merge_metrics a b = {
 (* ================================================================ *)
 
 (** Build a progress summary from the most recent assistant messages. *)
-let build_progress_summary (msgs : Llm_client.message list) : string =
+let build_progress_summary (msgs : Llm_types.message list) : string =
   let clip s max_len =
     if String.length s > max_len then String.sub s 0 max_len ^ "..." else s
   in
@@ -90,7 +90,7 @@ let build_progress_summary (msgs : Llm_client.message list) : string =
   let latest_state_block () =
     let rec loop = function
       | [] -> None
-      | (m : Llm_client.message) :: rest ->
+      | (m : Llm_types.message) :: rest ->
         let blocks = Context_manager.extract_state_blocks (text_of_message m) in
         (match last_opt blocks with
          | Some b -> Some b
@@ -104,8 +104,8 @@ let build_progress_summary (msgs : Llm_client.message list) : string =
     clip (Printf.sprintf "[STATE]\n%s\n[/STATE]" b) 3000
   | None ->
     (* Fallback heuristic: last assistant outputs, clipped. *)
-    let assistant_msgs = List.filter (fun (m : Llm_client.message) ->
-      m.role = Llm_client.Assistant
+    let assistant_msgs = List.filter (fun (m : Llm_types.message) ->
+      m.role = Llm_types.Assistant
     ) msgs in
     let recent = match List.length assistant_msgs with
       | n when n > 5 ->
@@ -113,13 +113,13 @@ let build_progress_summary (msgs : Llm_client.message list) : string =
         List.filteri (fun i _ -> i >= start) assistant_msgs
       | _ -> assistant_msgs
     in
-    let parts = List.map (fun (m : Llm_client.message) ->
+    let parts = List.map (fun (m : Llm_types.message) ->
       clip (text_of_message m) 200
     ) recent in
     String.concat "\n" parts
 
 (** Extract pending actions from user messages that haven't been addressed. *)
-let extract_pending_actions (msgs : Llm_client.message list) : string list =
+let extract_pending_actions (msgs : Llm_types.message list) : string list =
   let starts_with_ci ~prefix s =
     let prefix = String.lowercase_ascii prefix in
     let s = String.lowercase_ascii (String.trim s) in
@@ -155,7 +155,7 @@ let extract_pending_actions (msgs : Llm_client.message list) : string list =
   let latest_state_block () =
     let rec loop = function
       | [] -> None
-      | (m : Llm_client.message) :: rest ->
+      | (m : Llm_types.message) :: rest ->
         let blocks = Context_manager.extract_state_blocks (text_of_message m) in
         (match last_opt blocks with
          | Some b -> Some b
@@ -169,16 +169,16 @@ let extract_pending_actions (msgs : Llm_client.message list) : string list =
     if next <> [] then next else
       (match List.rev msgs with
        | [] -> []
-       | (last : Llm_client.message) :: _ when last.role = Llm_client.User -> [text_of_message last]
+       | (last : Llm_types.message) :: _ when last.role = Llm_types.User -> [text_of_message last]
        | _ -> [])
   | None ->
     (match List.rev msgs with
      | [] -> []
-     | (last : Llm_client.message) :: _ when last.role = Llm_client.User -> [text_of_message last]
+     | (last : Llm_types.message) :: _ when last.role = Llm_types.User -> [text_of_message last]
      | _ -> [])
 
 (** Extract key decisions from assistant messages containing decision markers. *)
-let extract_key_decisions (msgs : Llm_client.message list) : string list =
+let extract_key_decisions (msgs : Llm_types.message list) : string list =
   let starts_with_ci ~prefix s =
     let prefix = String.lowercase_ascii prefix in
     let s = String.lowercase_ascii (String.trim s) in
@@ -214,7 +214,7 @@ let extract_key_decisions (msgs : Llm_client.message list) : string list =
   let latest_state_block () =
     let rec loop = function
       | [] -> None
-      | (m : Llm_client.message) :: rest ->
+      | (m : Llm_types.message) :: rest ->
         let blocks = Context_manager.extract_state_blocks (text_of_message m) in
         (match last_opt blocks with
          | Some b -> Some b
@@ -229,8 +229,8 @@ let extract_key_decisions (msgs : Llm_client.message list) : string list =
   | None ->
     let decision_markers = ["decided"; "chosen"; "selected"; "using"; "approach:";
                             "strategy:"; "will use"; "going with"] in
-    List.filter_map (fun (m : Llm_client.message) ->
-      if m.role <> Llm_client.Assistant then None
+    List.filter_map (fun (m : Llm_types.message) ->
+      if m.role <> Llm_types.Assistant then None
       else
         let mc = text_of_message m in
         let lower = String.lowercase_ascii mc in
@@ -278,30 +278,30 @@ let extract_dna ~(working_ctx : Context_manager.working_context)
 (* ================================================================ *)
 
 (** Normalize messages for the target model's constraints. *)
-let normalize_for_model (msgs : Llm_client.message list)
-    (target : Llm_client.model_spec) : Llm_client.message list =
+let normalize_for_model (msgs : Llm_types.message list)
+    (target : Llm_types.model_spec) : Llm_types.message list =
   let msgs = match target.provider with
-    | Llm_client.Llama ->
+    | Llm_types.Llama ->
       (* Local llama runtimes: merge consecutive system messages, simplify tool messages *)
-      List.map (fun (m : Llm_client.message) ->
+      List.map (fun (m : Llm_types.message) ->
         match m.role with
-        | Llm_client.Tool ->
+        | Llm_types.Tool ->
           (* Convert tool messages to user messages for models without tool support *)
           let tool_id = List.find_map (function
             | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
             | _ -> None) m.content |> Option.value ~default:"unknown" in
-          { Agent_sdk.Types.role = Llm_client.User;
+          { Agent_sdk.Types.role = Llm_types.User;
                    content = [Agent_sdk.Types.Text (sprintf "[Tool result: %s]\n%s"
-                     tool_id (Llm_client.text_of_message m))] }
+                     tool_id (Llm_types.text_of_message m))] }
         | _ -> m
       ) msgs
-    | Llm_client.Claude ->
+    | Llm_types.Claude ->
       (* Claude: ensure alternating user/assistant, no consecutive same roles *)
       let rec fix_alternation = function
         | [] -> []
         | [m] -> [m]
-        | (m1 : Llm_client.message) :: ((m2 : Llm_client.message) :: rest as tail) ->
-          if m1.role = m2.role && m1.role <> Llm_client.System then
+        | (m1 : Llm_types.message) :: ((m2 : Llm_types.message) :: rest as tail) ->
+          if m1.role = m2.role && m1.role <> Llm_types.System then
             (* Merge consecutive same-role *)
             let merged = { m1 with content = [Agent_sdk.Types.Text (text_of_message m1 ^ "\n" ^ text_of_message m2)] } in
             fix_alternation (merged :: rest)
@@ -314,12 +314,12 @@ let normalize_for_model (msgs : Llm_client.message list)
   (* Trim to fit within target context budget *)
   let max_tokens = target.max_context * 8 / 10 in  (* Leave 20% for response *)
   let rec trim msgs =
-    let total = Llm_client.estimate_tokens msgs in
+    let total = Llm_types.estimate_tokens msgs in
     if total <= max_tokens || List.length msgs <= 2 then msgs
     else
       (* Remove oldest non-system message *)
       match msgs with
-      | (m : Llm_client.message) :: rest when m.role = Llm_client.System ->
+      | (m : Llm_types.message) :: rest when m.role = Llm_types.System ->
         m :: trim rest
       | _ :: rest -> trim rest
       | [] -> []
@@ -408,7 +408,7 @@ let hydrate (dna : succession_dna) (spec : successor_spec) : Context_manager.wor
       let rec take_up_to budget acc = function
         | [] -> List.rev acc
         | m :: rest ->
-          let tok = Llm_client.estimate_tokens [m] in
+          let tok = Llm_types.estimate_tokens [m] in
           if budget - tok < 0 then List.rev acc
           else take_up_to (budget - tok) (m :: acc) rest
       in
@@ -545,7 +545,7 @@ let checkpoint_of_dna
     Agent_sdk.Checkpoint.version = 3;
     session_id = sprintf "succession-%s-gen%d" dna.trace_id dna.generation;
     agent_name = "perpetual-successor";
-    model = Agent_sdk.Types.Custom "masc-perpetual";
+    model = "masc-perpetual";
     system_prompt = Some working_ctx.system_prompt;
     messages;
     usage = {

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -83,17 +83,17 @@ type result = bool * string
 (* ================================================================ *)
 
 let role_of_string = function
-  | "system" -> Llm_client.System
-  | "user" -> Llm_client.User
-  | "assistant" -> Llm_client.Assistant
-  | "tool" -> Llm_client.Tool
-  | _ -> Llm_client.User
+  | "system" -> Llm_types.System
+  | "user" -> Llm_types.User
+  | "assistant" -> Llm_types.Assistant
+  | "tool" -> Llm_types.Tool
+  | _ -> Llm_types.User
 
 let string_of_role = function
-  | Llm_client.System -> "system"
-  | Llm_client.User -> "user"
-  | Llm_client.Assistant -> "assistant"
-  | Llm_client.Tool -> "tool"
+  | Llm_types.System -> "system"
+  | Llm_types.User -> "user"
+  | Llm_types.Assistant -> "assistant"
+  | Llm_types.Tool -> "tool"
 
 let strategies_of_string = function
   | "prune_tool_outputs" -> Ok [Context_manager.PruneToolOutputs]
@@ -108,22 +108,22 @@ let strategies_of_string = function
     ]
   | s -> Error (Printf.sprintf "Unknown strategy: %s. Valid: prune_tool_outputs, merge_contiguous, drop_low_importance, summarize_old, all" s)
 
-(** Parse a JSON message object into an Llm_client.message. *)
-let parse_message (json : Yojson.Safe.t) : Llm_client.message =
+(** Parse a JSON message object into an Llm_types.message. *)
+let parse_message (json : Yojson.Safe.t) : Llm_types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
   let content = json |> member "content" |> to_string in
   match role with
-  | Llm_client.Tool ->
+  | Llm_types.Tool ->
     { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id = "compact"; content; is_error = false }] }
   | _ ->
     { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text content] }
 
-(** Serialize an Llm_client.message back to JSON. *)
-let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
+(** Serialize an Llm_types.message back to JSON. *)
+let message_to_json (m : Llm_types.message) : Yojson.Safe.t =
   `Assoc [
     ("role", `String (string_of_role m.role));
-    ("content", `String (Llm_client.text_of_message m));
+    ("content", `String (Llm_types.text_of_message m));
   ]
 
 (* ================================================================ *)

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -364,7 +364,7 @@ let env_keeper_models () =
 let default_keeper_models () =
   let from_env = env_keeper_models () in
   if from_env <> [] then from_env
-  else Llm_client.default_execution_model_labels ()
+  else Llm_types.default_execution_model_labels ()
 
 let sanitize_keeper_name s =
   let buf = Buffer.create (String.length s) in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -630,9 +630,9 @@ Call masc_listen again to continue listening.
             let spec_name =
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
-            Llm_client.model_spec_of_string spec_name
-        | _, Some _ -> Llm_client.default_execution_model_spec ()
-        | _, None -> Llm_client.default_execution_model_spec ()
+            Llm_types.model_spec_of_string spec_name
+        | _, Some _ -> Llm_types.default_execution_model_spec ()
+        | _, None -> Llm_types.default_execution_model_spec ()
       in
       let module U = Yojson.Safe.Util in
       let working_dir = match arguments |> U.member "working_dir" with

--- a/lib/tool_llm_catalog.ml
+++ b/lib/tool_llm_catalog.ml
@@ -36,8 +36,8 @@ let handle_list _ctx _args : result =
 let handle_status _ctx _args : result =
   let endpoints = D.get_cached_or_refresh () in
   let summary = Llm_provider.Discovery.summary_to_json endpoints in
-  let permits_available = Llm_client.llm_semaphore_available () in
-  let permits_in_use = Llm_client.llm_permits_in_use () in
+  let permits_available = Llm_orchestration.llm_semaphore_available () in
+  let permits_in_use = Llm_orchestration.llm_permits_in_use () in
   (true, json_ok [
     ("result", `Assoc [
       ("endpoints", `List (List.map D.endpoint_to_json endpoints));
@@ -45,7 +45,7 @@ let handle_status _ctx _args : result =
       ("masc_permits", `Assoc [
         ("available", `Int permits_available);
         ("in_use", `Int permits_in_use);
-        ("max_concurrent", `Int Llm_client.max_concurrent_llm);
+        ("max_concurrent", `Int Llm_orchestration.max_concurrent_llm);
       ]);
       ("cache_age_seconds", `Float (D.cache_age_seconds ()));
     ]);

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -160,8 +160,8 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
            acc + runtime.max_concurrency)
          0
   in
-  let configured_max_concurrent_llm = Llm_client.max_concurrent_llm in
-  let available_llm_permits = Llm_client.llm_semaphore_available () in
+  let configured_max_concurrent_llm = Llm_orchestration.max_concurrent_llm in
+  let available_llm_permits = Llm_orchestration.llm_semaphore_available () in
   let runtime_rows, provider_reachable, slot_reachable, actual_slots_total,
       active_slots_now, actual_ctxs, actual_models =
     List.fold_left
@@ -493,9 +493,9 @@ let runtime_status_json ?(include_models = true) () =
       ("source", `String "llama.cpp runtime");
       ("models", `List (List.map (fun model -> `String model) models));
       ("model_count", `Int (List.length models));
-      ("configured_max_concurrent_llm", `Int Llm_client.max_concurrent_llm);
-      ("available_llm_permits", `Int (Llm_client.llm_semaphore_available ()));
-      ("llm_permits_in_use", `Int (Llm_client.llm_permits_in_use  ()));
+      ("configured_max_concurrent_llm", `Int Llm_orchestration.max_concurrent_llm);
+      ("available_llm_permits", `Int (Llm_orchestration.llm_semaphore_available ()));
+      ("llm_permits_in_use", `Int (Llm_orchestration.llm_permits_in_use  ()));
       ("target_parallelism", `Int configured_capacity);
       ("managed_gap_to_target", `Int 0);
       ("runtime_count", `Int (List.length runtime_snapshots));
@@ -654,7 +654,7 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
         ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
         ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
         ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
-        ("configured_max_concurrent_llm", `Int Llm_client.max_concurrent_llm);
+        ("configured_max_concurrent_llm", `Int Llm_orchestration.max_concurrent_llm);
         ("configured_capacity", `Int (Local_runtime_pool.configured_capacity ()));
         ("measured_ceiling", int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
         ("per_runtime_breakdown", `List runtime_breakdown);

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -154,7 +154,7 @@ let handle_start ctx args =
   let auto_claim_cooldown = Safe_ops.json_float ~default:60.0 "auto_claim_cooldown_sec" args in
   (* Parse model specs *)
   let models = List.filter_map (fun s ->
-    match Llm_client.model_spec_of_string s with
+    match Llm_types.model_spec_of_string s with
     | Ok m -> Some m
     | Error e -> Log.Perpetual.info "Bad model spec %s: %s" s e; None
   ) model_strs in
@@ -202,7 +202,7 @@ let handle_start ctx args =
       ("trace_id", `String state.trace_id);
       ("status", `String (match ctx.start_loop with Some _ -> "started" | None -> "created"));
       ("generation", `Int 0);
-      ("models", `List (List.map (fun (m : Llm_client.model_spec) ->
+      ("models", `List (List.map (fun (m : Llm_types.model_spec) ->
         `String m.model_id) models));
     ]
   end
@@ -222,9 +222,9 @@ let handle_status args =
       (match base with
        | `Assoc fields ->
          let models =
-           `List (List.map (fun (m : Llm_client.model_spec) ->
+           `List (List.map (fun (m : Llm_types.model_spec) ->
              `Assoc [
-               ("provider", `String (Llm_client.string_of_provider m.provider));
+               ("provider", `String (Llm_types.string_of_provider m.provider));
                ("model_id", `String m.model_id);
                ("max_context", `Int m.max_context);
                ("api_key_env", match m.api_key_env with None -> `Null | Some k -> `String k);
@@ -277,7 +277,7 @@ let handle_inject args =
     match Hashtbl.find_opt active_agents id with
     | None -> `Assoc [("error", `String (Printf.sprintf "Agent %s not found" id))]
     | Some (state, _config) ->
-      let msg = Llm_client.user_msg message in
+      let msg = Llm_types.user_msg message in
       state.context <- Context_manager.append state.context msg;
       Context_manager.persist_message state.session msg;
       state.idle_turns <- 0;  (* Reset idle counter *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -8,14 +8,14 @@
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
-  tools : Llm_client.tool_def list;
+  tools : Llm_types.tool_def list;
   removable : bool;  (** true = can be revoked at runtime *)
   description : string;
 }
 
 (** Predefined shards *)
 
-let base_tools : Llm_client.tool_def list = [
+let base_tools : Llm_types.tool_def list = [
   (* Time *)
   {
     tool_name = "keeper_time_now";
@@ -49,7 +49,7 @@ let base_tools : Llm_client.tool_def list = [
   };
 ]
 
-let board_tools : Llm_client.tool_def list = [
+let board_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_board_post";
     tool_description = "Create a post on the MASC Board. Use hearth to target a topic channel.";
@@ -101,7 +101,7 @@ let board_tools : Llm_client.tool_def list = [
   };
 ]
 
-let filesystem_tools : Llm_client.tool_def list = [
+let filesystem_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_fs_read";
     tool_description = "Read a file under current project root. Use for source inspection before edits.";
@@ -129,7 +129,7 @@ let filesystem_tools : Llm_client.tool_def list = [
   };
 ]
 
-let shell_tools : Llm_client.tool_def list = [
+let shell_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_shell_readonly";
     tool_description = "Run a structured read-only project command. Supported ops: pwd, ls, cat, rg, git_status.";
@@ -171,7 +171,7 @@ let shell_tools : Llm_client.tool_def list = [
   };
 ]
 
-let voice_tools : Llm_client.tool_def list = [
+let voice_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_voice_speak";
     tool_description = "Speak a short utterance as this keeper via the voice bridge, falling back to text when voice is unavailable.";
@@ -187,7 +187,7 @@ let voice_tools : Llm_client.tool_def list = [
   };
 ]
 
-let weather_tools : Llm_client.tool_def list = [
+let weather_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_weather_note";
     tool_description = "Get weather capability note and recent weather-related questions.";
@@ -200,7 +200,7 @@ let weather_tools : Llm_client.tool_def list = [
   };
 ]
 
-let taskboard_tools : Llm_client.tool_def list = [
+let taskboard_tools : Llm_types.tool_def list = [
   {
     tool_name = "keeper_tasks_list";
     tool_description = "List tasks on the MASC backlog. Filter by status: todo, claimed, in_progress, done, cancelled.";
@@ -350,7 +350,7 @@ let get_shard (name : string) : shard option =
   Hashtbl.find_opt all_shards name
 
 (** Combine tools from multiple shard names *)
-let tools_of_shards (shard_names : string list) : Llm_client.tool_def list =
+let tools_of_shards (shard_names : string list) : Llm_types.tool_def list =
   shard_names
   |> List.filter_map (fun name -> Hashtbl.find_opt all_shards name)
   |> List.concat_map (fun (s : shard) -> s.tools)
@@ -390,7 +390,7 @@ let list_all_shards () : (string * bool * int) list =
   ) all_shards []
 
 (** Full tool set (all 11 tools) — backward compatible *)
-let keeper_llm_tools : Llm_client.tool_def list =
+let keeper_llm_tools : Llm_types.tool_def list =
   tools_of_shards default_shard_names
 
 (** {1 MCP Schemas} *)

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -5,7 +5,7 @@
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
-  tools : Llm_client.tool_def list;
+  tools : Llm_types.tool_def list;
   removable : bool;
   description : string;
 }
@@ -40,7 +40,7 @@ val all_shards : (string, shard) Hashtbl.t
 val default_shard_names : string list
 (** Default shards for a new keeper: base, board, filesystem, shell, weather. *)
 
-val tools_of_shards : string list -> Llm_client.tool_def list
+val tools_of_shards : string list -> Llm_types.tool_def list
 (** Combine tools from multiple shard names. *)
 
 (** {1 Dynamic Shard Management} *)
@@ -74,10 +74,10 @@ val set_agent_shards : string -> string list -> unit
 
 (** {1 Tool Definitions} *)
 
-val base_tools : Llm_client.tool_def list
+val base_tools : Llm_types.tool_def list
 (** Core tools: time_now, context_status, memory_search. *)
 
-val board_tools : Llm_client.tool_def list
+val board_tools : Llm_types.tool_def list
 (** Board tools: board_post, board_list, board_comment, board_vote. *)
 
 (** {1 MCP Interface} *)
@@ -89,5 +89,5 @@ val execute : string -> Yojson.Safe.t -> (bool * Yojson.Safe.t)
 (** Execute tool_shard MCP tools (grant, revoke, list).
     Agent shard state is tracked in-memory via [agent_shards] hashtable. *)
 
-val keeper_llm_tools : Llm_client.tool_def list
+val keeper_llm_tools : Llm_types.tool_def list
 (** Full tool set (all 11 tools) — backward compatible with existing code. *)

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -83,7 +83,7 @@ type prepared_spawn = Tool_team_session_step.prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Llm_client.model_spec;
+  runtime_model : Llm_types.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }
@@ -304,7 +304,7 @@ let router_judge_model () =
 
 let llama_router_model_spec model_id =
   {
-    Llm_client.provider = Llm_client.Llama;
+    Llm_types.provider = Llm_types.Llama;
     model_id;
     max_context = 262_144;
     api_url = Env_config.Llama.server_url;
@@ -465,14 +465,14 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
            worker_prompt=%S\n"
           worker_class_text role_text spawn_prompt
       in
-      let request : Llm_client.completion_request =
+      let request : Llm_types.completion_request =
         {
           model = llama_router_model_spec judge_model;
           messages =
             [
-              Llm_client.system_msg
+              Llm_types.system_msg
                 "You are a routing judge for a hybrid swarm. Output only JSON.";
-              Llm_client.user_msg prompt;
+              Llm_types.user_msg prompt;
             ];
           temperature = 0.0;
           max_tokens = 220;
@@ -485,7 +485,7 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
       with
       | Ok response -> (
           try
-            Yojson.Safe.from_string (Llm_client.text_of_response response)
+            Yojson.Safe.from_string (Llm_types.text_of_response response)
             |> parse_routing_decision_json
           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
       | Error _ -> None

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -38,7 +38,7 @@ type prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Llm_client.model_spec;
+  runtime_model : Llm_types.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -413,7 +413,7 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
         | Some model_name -> Some model_name
         | None ->
             let default_model =
-              Llm_client.default_local_model_spec ()
+              Llm_types.default_local_model_spec ()
             in
             Some default_model.model_id
       in
@@ -433,7 +433,7 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
                   Some assignment.runtime_id )
           | Error err -> Error err)
     else
-      Ok (Llm_client.default_local_model_spec (), None, None)
+      Ok (Llm_types.default_local_model_spec (), None, None)
   in
   match runtime_model with
   | Error e -> Error (spec, runtime_actor_name, e)

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -44,7 +44,7 @@ type prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Llm_client.model_spec;
+  runtime_model : Llm_types.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }

--- a/lib/trpg_dm_intent.ml
+++ b/lib/trpg_dm_intent.ml
@@ -293,8 +293,8 @@ let parse_llm_intent (text : string) : (dm_intent, string) result =
                     (String.sub s 0 (min 100 (String.length s)))))
 
 (** Validate that an LLM response contains a parseable non-Unknown intent. *)
-let llm_response_is_valid (resp : Llm_client.completion_response) : bool =
-  match parse_llm_intent (Llm_client.text_of_response resp) with
+let llm_response_is_valid (resp : Llm_types.completion_response) : bool =
+  match parse_llm_intent (Llm_types.text_of_response resp) with
   | Ok intent -> not (equal_intent_category intent.primary Unknown)
   | Error _ -> false
 

--- a/lib/trpg_harness.ml
+++ b/lib/trpg_harness.ml
@@ -104,19 +104,19 @@ let parse_tier1 (text : string) : tier1_result =
   else
     Fail "unparseable response"
 
-let tier1_check ~(model : Llm_client.model_spec) ~actor_name ~actor_persona
+let tier1_check ~(model : Llm_types.model_spec) ~actor_name ~actor_persona
     ~response_text : tier1_result =
   let prompt = build_tier1_prompt ~actor_name ~actor_persona ~response_text in
-  let req : Llm_client.completion_request = {
+  let req : Llm_types.completion_request = {
     model;
-    messages = [Llm_client.user_msg prompt];
+    messages = [Llm_types.user_msg prompt];
     temperature = 0.0;
     max_tokens = 50;
     tools = [];
     response_format = `Text;
   } in
   match Llm_orchestration.complete req with
-  | Ok resp -> parse_tier1 (Llm_client.text_of_response resp)
+  | Ok resp -> parse_tier1 (Llm_types.text_of_response resp)
   | Error e ->
     eprintf "[trpg_harness] tier1 LLM call failed: %s\n%!" e;
     Fail ("tier1_unavailable: " ^ e)
@@ -198,20 +198,20 @@ let parse_tier2 (text : string) : dimension_score list =
     find_dim Narrative_consistency "NARRATIVE_CONSISTENCY";
   ]
 
-let tier2_evaluate ~(model : Llm_client.model_spec) ~actor_name ~actor_persona
+let tier2_evaluate ~(model : Llm_types.model_spec) ~actor_name ~actor_persona
     ~actor_traits ~scene_context ~response_text : dimension_score list =
   let prompt = build_tier2_prompt ~actor_name ~actor_persona ~actor_traits
     ~scene_context ~response_text in
-  let req : Llm_client.completion_request = {
+  let req : Llm_types.completion_request = {
     model;
-    messages = [Llm_client.user_msg prompt];
+    messages = [Llm_types.user_msg prompt];
     temperature = 0.0;
     max_tokens = 200;
     tools = [];
     response_format = `Text;
   } in
   match Llm_orchestration.complete req with
-  | Ok resp -> parse_tier2 (Llm_client.text_of_response resp)
+  | Ok resp -> parse_tier2 (Llm_types.text_of_response resp)
   | Error e ->
     eprintf "[trpg_harness] tier2 LLM call failed: %s\n%!" e;
     List.map default_score all_dimensions

--- a/lib/trpg_harness.mli
+++ b/lib/trpg_harness.mli
@@ -32,20 +32,20 @@ type evaluation_result = {
 (** Tier 1 structural gate. Checks: valid JSON action, non-empty narrative,
     not out-of-character gibberish. Returns Pass or Fail with reason.
     Budget: max 50 tokens, temperature 0.0 *)
-val tier1_check : model:Llm_client.model_spec -> actor_name:string ->
+val tier1_check : model:Llm_types.model_spec -> actor_name:string ->
   actor_persona:string -> response_text:string -> tier1_result
 
 (** Tier 2 quality evaluation. Scores across 3 dimensions.
     Budget: max 200 tokens, temperature 0.0.
     Only called if tier1 passes. *)
-val tier2_evaluate : model:Llm_client.model_spec -> actor_name:string ->
+val tier2_evaluate : model:Llm_types.model_spec -> actor_name:string ->
   actor_persona:string -> actor_traits:string list -> scene_context:string ->
   response_text:string -> dimension_score list
 
 (** Full evaluation pipeline: tier1 -> tier2 (if pass) -> weighted score.
     tier1_model: cheap model (e.g., ollama:LFM2.5-1.2B-Instruct)
     tier2_model: capable model (e.g., glm:glm-4.7-flash) *)
-val evaluate : tier1_model:Llm_client.model_spec -> tier2_model:Llm_client.model_spec ->
+val evaluate : tier1_model:Llm_types.model_spec -> tier2_model:Llm_types.model_spec ->
   actor_name:string -> actor_persona:string -> actor_traits:string list ->
   scene_context:string -> response_text:string -> evaluation_result
 

--- a/lib/trpg_round_run_process.ml
+++ b/lib/trpg_round_run_process.ml
@@ -269,20 +269,20 @@ let process_one rctx ~state_json ~role ~actor_id ~keeper_name =
     | Some tier1_str ->
     try
       let tier1_model =
-        match Llm_client.model_spec_of_string tier1_str with
+        match Llm_types.model_spec_of_string tier1_str with
         | Ok m -> m
         | Error _ -> (
-            match Llm_client.default_verifier_model_spec () with
+            match Llm_types.default_verifier_model_spec () with
             | Ok model -> model
-            | Error _ -> Llm_client.glm_cloud)
+            | Error _ -> Llm_types.glm_cloud)
       in
       let tier2_model =
         match Sys.getenv_opt "TRPG_HARNESS_TIER2_MODEL" with
         | Some s -> (
-            match Llm_client.model_spec_of_string s with
+            match Llm_types.model_spec_of_string s with
             | Ok m -> m
-            | Error _ -> Llm_client.glm_cloud)
-        | None -> Llm_client.glm_cloud
+            | Error _ -> Llm_types.glm_cloud)
+        | None -> Llm_types.glm_cloud
       in
       let pctx =
         extract_prompt_context ~actor_id ~dm_persona_override state_json

--- a/lib/verifier.mli
+++ b/lib/verifier.mli
@@ -32,7 +32,7 @@ type verdict =
 (** Verify an action using the given model.
     Max 200 output tokens to keep cost low.
     @return verdict based on cheap model analysis. *)
-val verify : model:Llm_client.model_spec -> verification_request -> verdict
+val verify : model:Llm_types.model_spec -> verification_request -> verdict
 
 (** Check if an action should skip verification (read-only ops). *)
 val should_skip : action_description:string -> bool

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -148,21 +148,21 @@ One line only.|}
 (* Core: verify                                                     *)
 (* ================================================================ *)
 
-let verify ~(model : Llm_client.model_spec) (req : verification_request) : verdict =
+let verify ~(model : Llm_types.model_spec) (req : verification_request) : verdict =
   if should_skip ~action_description:req.action_description then
     Pass
   else
     let prompt = build_prompt req in
-    let completion_req : Llm_client.completion_request = {
+    let completion_req : Llm_types.completion_request = {
       model;
-      messages = [Llm_client.user_msg prompt];
+      messages = [Llm_types.user_msg prompt];
       temperature = 0.0;  (* Deterministic for verification *)
       max_tokens = 200;   (* Budget cap *)
       tools = [];
       response_format = `Text;
     } in
     match Llm_orchestration.complete completion_req with
-    | Ok resp -> parse_verdict (Llm_client.text_of_response resp)
+    | Ok resp -> parse_verdict (Llm_types.text_of_response resp)
     | Error e ->
       eprintf "[verifier] LLM call failed: %s (defaulting to WARN)\n%!" e;
       Warn ("verifier_unavailable: " ^ e)
@@ -206,7 +206,7 @@ let verdict_to_hook_decision (v : verdict) : Agent_sdk.Hooks.hook_decision =
     @param goal The current agent goal (for verification prompt context).
     @param context_summary Brief summary of agent state. *)
 let make_pre_tool_hook
-    ~(model : Llm_client.model_spec)
+    ~(model : Llm_types.model_spec)
     ~(goal : string)
     ~(context_summary : string)
   : Agent_sdk.Hooks.hook =
@@ -244,7 +244,7 @@ let make_pre_tool_hook
     @return Updated hooks record with the verifier installed in pre_tool_use. *)
 let install_hook
     ~(hooks : Agent_sdk.Hooks.hooks)
-    ~(model : Llm_client.model_spec)
+    ~(model : Llm_types.model_spec)
     ~(goal : string)
     ~(context_summary : string)
   : Agent_sdk.Hooks.hooks =

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -25,7 +25,7 @@ module Oas = Agent_sdk
     MASC workers use local Ollama/llama-server models, so all model IDs
     go through Custom. *)
 let oas_model_of_effective_model (model_id : string) : Oas.Types.model =
-  Oas.Types.Custom model_id
+  model_id
 
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.agent_config                   *)
@@ -136,7 +136,7 @@ let oas_provider_of_model = Local_agent_eio_container.oas_provider_of_model
 let build_agent
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(meta : Local_agent_eio_types.worker_container_meta)
-    ~(model : Llm_client.model_spec)
+    ~(model : Llm_types.model_spec)
     ~(system_prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(hooks : Oas.Hooks.hooks)
@@ -222,7 +222,7 @@ let run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(base_path : string)
     ~(meta : Local_agent_eio_types.worker_container_meta)
-    ~(model : Llm_client.model_spec)
+    ~(model : Llm_types.model_spec)
     ~(system_prompt : string)
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
@@ -355,7 +355,7 @@ let orchestrate_workers
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(workers : (Local_agent_eio_types.worker_container_meta
-                 * Llm_client.model_spec
+                 * Llm_types.model_spec
                  * string (* system_prompt *)
                  * Oas.Tool.t list
                  * Oas.Raw_trace.t

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -213,7 +213,7 @@ let test_auto_responder_uses_shared_llm_client () =
     (file_contains_pattern "lib/auto_responder.ml"
        {|Lodge_cascade.call ~cascade_name|});
   check bool "no direct run_prompt_cascade" false
-    (file_contains_pattern "lib/auto_responder.ml" "Llm_client.run_prompt_cascade");
+    (file_contains_pattern "lib/auto_responder.ml" "Llm_orchestration.run_prompt_cascade");
   check bool "legacy Llm_direct dispatch removed"
     false
     (file_contains_pattern "lib/auto_responder.ml" "Llm_direct.dispatch")

--- a/test/test_keeper_exec_helpers.ml
+++ b/test/test_keeper_exec_helpers.ml
@@ -166,7 +166,7 @@ let test_keeper_tool_followup_prompt_write_done_blocks_more_tools () =
       ~user_message:"post this"
       ~draft_reply:"done"
       ~tool_outputs:
-        [ ({ Masc_mcp.Llm_client.call_name = "keeper_board_post";
+        [ ({ Masc_mcp.Llm_types.call_name = "keeper_board_post";
              call_id = "1";
              call_arguments = "{}"; }, "{\"ok\":true}") ]
       ~already_executed:[ "keeper_board_post" ]
@@ -280,15 +280,15 @@ let test_execute_keeper_tool_call_readonly_branches () =
     in
     let ctx =
       Masc_mcp.Context_manager.append ctx
-        (Masc_mcp.Llm_client.user_msg "how is the weather today?")
+        (Masc_mcp.Llm_types.user_msg "how is the weather today?")
     in
     Masc_mcp.Context_manager.append ctx
-      (Masc_mcp.Llm_client.user_msg "where are we meeting?")
+      (Masc_mcp.Llm_types.user_msg "where are we meeting?")
   in
   let config = Masc_mcp.Room.default_config (Filename.get_temp_dir_name ()) in
   let run call_name args =
     Keeper_exec_tools.execute_keeper_tool_call ~config ~meta ~ctx_work
-      { Masc_mcp.Llm_client.call_id = "1"; call_name; call_arguments = args }
+      { Masc_mcp.Llm_types.call_id = "1"; call_name; call_arguments = args }
     |> Yojson.Safe.from_string
   in
   let now_json = run "keeper_time_now" "{}" in
@@ -374,11 +374,11 @@ let test_keeper_execution_compaction_helpers () =
     let ctx = Masc_mcp.Context_manager.create ~system_prompt:"system" ~max_tokens:40 in
     let ctx =
       Masc_mcp.Context_manager.append ctx
-        (Masc_mcp.Llm_client.user_msg
+        (Masc_mcp.Llm_types.user_msg
            "This is a deliberately long message that pushes the context ratio upward.")
     in
     Masc_mcp.Context_manager.append ctx
-      (Masc_mcp.Llm_client.assistant_msg
+      (Masc_mcp.Llm_types.assistant_msg
          "This is another verbose response that keeps the working set large.")
   in
   let same_ctx, reason_opt, decision =

--- a/test/test_llm_client_cascade.ml
+++ b/test/test_llm_client_cascade.ml
@@ -3,6 +3,8 @@ open Alcotest
 module Cache = Masc_mcp.Llm_response_cache
 module Env_config = Masc_mcp.Env_config
 module Llm_client = Masc_mcp.Llm_client
+module Llm_types = Masc_mcp.Llm_types
+module Llm_orchestration = Masc_mcp.Llm_orchestration
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -36,8 +38,8 @@ let with_env name value f =
 
 (** Store a cached response in OAS api_response JSON format.
     Uses MASC cache key (temperature-aware) + OAS serialization. *)
-let cache_response (req : Llm_client.completion_request) ~content ~model_used =
-  let key = Llm_client.cache_key_of_request req in
+let cache_response (req : Llm_types.completion_request) ~content ~model_used =
+  let key = Llm_orchestration.cache_key_of_request req in
   let payload =
     `Assoc
       [
@@ -62,9 +64,9 @@ let cache_response (req : Llm_client.completion_request) ~content ~model_used =
   | Error e -> fail ("set_json failed: " ^ e)
 
 let make_request model_id =
-  let model : Llm_client.model_spec =
+  let model : Llm_types.model_spec =
     {
-      provider = Llm_client.Custom "cached";
+      provider = Llm_types.Custom "cached";
       model_id;
       max_context = 4096;
       api_url = "http://127.0.0.1:1";
@@ -75,24 +77,24 @@ let make_request model_id =
   in
   ({
      model;
-     messages = [ Llm_client.user_msg ("prompt:" ^ model_id) ];
+     messages = [ Llm_types.user_msg ("prompt:" ^ model_id) ];
      temperature = 0.0;
      max_tokens = 64;
      tools = [];
      response_format = `Text;
    }
-    : Llm_client.completion_request)
+    : Llm_types.completion_request)
 
 let make_request_for_model ?(temperature = 0.0) ~model ~prompt ~max_tokens () =
   ({
      model;
-     messages = [ Llm_client.user_msg prompt ];
+     messages = [ Llm_types.user_msg prompt ];
      temperature;
      max_tokens;
      tools = [];
      response_format = `Text;
    }
-    : Llm_client.completion_request)
+    : Llm_types.completion_request)
 
 let contains_substring haystack needle =
   let h_len = String.length haystack in
@@ -111,13 +113,13 @@ let test_cascade_uses_next_cached_response_when_validator_rejects () =
       cache_response first ~content:"reject me" ~model_used:"cached-1";
       cache_response second ~content:"accept me" ~model_used:"cached-2";
       match
-        Llm_client.cascade
-          ~accept:(fun (resp : Llm_client.completion_response) ->
-            not (String.equal (Llm_client.text_of_response resp) "reject me"))
+        Llm_orchestration.cascade
+          ~accept:(fun (resp : Llm_types.completion_response) ->
+            not (String.equal (Llm_types.text_of_response resp) "reject me"))
           [ first; second ]
       with
       | Ok resp ->
-          check string "content" "accept me" (Llm_client.text_of_response resp);
+          check string "content" "accept me" (Llm_types.text_of_response resp);
           check string "winner" "cached-2" resp.model_used
       | Error e -> fail ("unexpected cascade error: " ^ e))
 
@@ -127,9 +129,9 @@ let test_cascade_returns_error_when_all_responses_rejected () =
       let first = make_request "cached-only" in
       cache_response first ~content:"reject me" ~model_used:"cached-only";
       match
-        Llm_client.cascade
-          ~accept:(fun (resp : Llm_client.completion_response) ->
-            not (String.equal (Llm_client.text_of_response resp) "reject me"))
+        Llm_orchestration.cascade
+          ~accept:(fun (resp : Llm_types.completion_response) ->
+            not (String.equal (Llm_types.text_of_response resp) "reject me"))
           [ first ]
       with
       | Ok _ -> fail "expected rejection error"
@@ -140,52 +142,52 @@ let test_cascade_returns_error_when_all_responses_rejected () =
 let test_available_model_specs_filters_invalid_and_missing_keys () =
   with_env "GEMINI_API_KEY" "" (fun () ->
       let specs =
-        Llm_client.available_model_specs_of_strings
+        Llm_types.available_model_specs_of_strings
           [ "invalid"; "gemini:gemini-2.5-pro"; "llama:qwen3.5-35b-a3b-ud-q8-xl" ]
       in
       check int "only llama survives" 1 (List.length specs);
       match specs with
       | [ only ] ->
-          check bool "provider" true (only.provider = Llm_client.Llama);
+          check bool "provider" true (only.provider = Llm_types.Llama);
           check string "model id" "qwen3.5-35b-a3b-ud-q8-xl" only.model_id
       | _ -> fail "expected one filtered model")
 
 let test_model_spec_of_string_rejects_bare_ollama_provider () =
-  match Llm_client.model_spec_of_string "ollama:glm-4.7-flash" with
+  match Llm_types.model_spec_of_string "ollama:glm-4.7-flash" with
   | Ok _ -> fail "expected ollama: prefix to be rejected"
   | Error _ -> ()
 
 let test_model_spec_of_string_parses_llama_provider () =
-  match Llm_client.model_spec_of_string "llama:glm-4.7-flash" with
+  match Llm_types.model_spec_of_string "llama:glm-4.7-flash" with
   | Ok spec ->
-      check bool "provider" true (spec.provider = Llm_client.Llama);
+      check bool "provider" true (spec.provider = Llm_types.Llama);
       check string "model id" "glm-4.7-flash" spec.model_id
   | Error e -> fail ("expected llama: provider to parse: " ^ e)
 
 let test_model_spec_of_string_resolves_default_label () =
   with_env "MASC_DEFAULT_PROVIDER" "glm" (fun () ->
       with_env "MASC_DEFAULT_MODEL" "glm-4.7" (fun () ->
-          match Llm_client.model_spec_of_string "default" with
+          match Llm_types.model_spec_of_string "default" with
           | Ok spec ->
-              check bool "provider" true (spec.provider = Llm_client.Glm_cloud);
+              check bool "provider" true (spec.provider = Llm_types.Glm_cloud);
               check string "model id" "glm-4.7" spec.model_id
           | Error e -> fail ("expected default to resolve: " ^ e)))
 
 let test_model_spec_of_string_resolves_default_override () =
   with_env "MASC_DEFAULT_PROVIDER" "gemini" (fun () ->
       with_env "MASC_DEFAULT_MODEL" "gemini-2.5-pro" (fun () ->
-          match Llm_client.model_spec_of_string "default:gemini-2.5-flash" with
+          match Llm_types.model_spec_of_string "default:gemini-2.5-flash" with
           | Ok spec ->
-              check bool "provider" true (spec.provider = Llm_client.Gemini);
+              check bool "provider" true (spec.provider = Llm_types.Gemini);
               check string "model id" "gemini-2.5-flash" spec.model_id
           | Error e -> fail ("expected default override to resolve: " ^ e)))
 
 let test_run_prompt_cascade_uses_same_request_shape () =
   with_temp_cwd (fun () ->
       Cache.clear_l1 ();
-      let model1 : Llm_client.model_spec =
+      let model1 : Llm_types.model_spec =
         {
-          provider = Llm_client.Custom "cached";
+          provider = Llm_types.Custom "cached";
           model_id = "run-prompt-1";
           max_context = 4096;
           api_url = "http://127.0.0.1:1";
@@ -203,19 +205,19 @@ let test_run_prompt_cascade_uses_same_request_shape () =
         (make_request_for_model ~model:model2 ~prompt ~max_tokens:32 ())
         ~content:"accept me" ~model_used:"run-prompt-2";
       match
-        Llm_client.run_prompt_cascade ~temperature:0.0 ~timeout_sec:30
-          ~accept:(fun (resp : Llm_client.completion_response) ->
-            not (String.equal (Llm_client.text_of_response resp) "reject me"))
+        Llm_orchestration.run_prompt_cascade ~temperature:0.0 ~timeout_sec:30
+          ~accept:(fun (resp : Llm_types.completion_response) ->
+            not (String.equal (Llm_types.text_of_response resp) "reject me"))
           ~model_specs:[ model1; model2 ] ~max_tokens:32 ~prompt ()
       with
       | Ok resp ->
-          check string "content" "accept me" (Llm_client.text_of_response resp);
+          check string "content" "accept me" (Llm_types.text_of_response resp);
           check string "winner" "run-prompt-2" resp.model_used
       | Error e -> fail ("unexpected run_prompt_cascade error: " ^ e))
 
 let test_llama_cache_key_preserves_requested_budget_below_global_cap () =
   let llama_model =
-    { Llm_client.llama_default with model_id = "qwen3.5-35b-a3b-ud-q8-xl" }
+    { Llm_types.llama_default with model_id = "qwen3.5-35b-a3b-ud-q8-xl" }
   in
   let req_short =
     make_request_for_model ~model:llama_model ~prompt:"same prompt" ~max_tokens:32 ()
@@ -225,12 +227,12 @@ let test_llama_cache_key_preserves_requested_budget_below_global_cap () =
   in
   check bool "different cache key"
     true
-    (Llm_client.cache_key_of_request req_short
-     <> Llm_client.cache_key_of_request req_long)
+    (Llm_orchestration.cache_key_of_request req_short
+     <> Llm_orchestration.cache_key_of_request req_long)
 
 let test_llama_cache_key_caps_requests_above_global_limit () =
   let llama_model =
-    { Llm_client.llama_default with model_id = "qwen3.5-35b-a3b-ud-q8-xl" }
+    { Llm_types.llama_default with model_id = "qwen3.5-35b-a3b-ud-q8-xl" }
   in
   let req_near_cap =
     make_request_for_model ~model:llama_model ~prompt:"same prompt"
@@ -241,13 +243,13 @@ let test_llama_cache_key_caps_requests_above_global_limit () =
       ~max_tokens:(Env_config.Llama.max_tokens * 2) ()
   in
   check string "same capped cache key"
-    (Llm_client.cache_key_of_request req_near_cap)
-    (Llm_client.cache_key_of_request req_far_above_cap)
+    (Llm_orchestration.cache_key_of_request req_near_cap)
+    (Llm_orchestration.cache_key_of_request req_far_above_cap)
 
 let test_non_llama_cache_key_preserves_requested_budget () =
-  let model : Llm_client.model_spec =
+  let model : Llm_types.model_spec =
     {
-      provider = Llm_client.Custom "cached";
+      provider = Llm_types.Custom "cached";
       model_id = "shape-check";
       max_context = 4096;
       api_url = "http://127.0.0.1:1";
@@ -264,8 +266,8 @@ let test_non_llama_cache_key_preserves_requested_budget () =
   in
   check bool "different cache key"
     true
-    (Llm_client.cache_key_of_request req_short
-     <> Llm_client.cache_key_of_request req_long)
+    (Llm_orchestration.cache_key_of_request req_short
+     <> Llm_orchestration.cache_key_of_request req_long)
 
 let () =
   run "llm_client_cascade"

--- a/test/test_local_agent_eio_coverage.ml
+++ b/test/test_local_agent_eio_coverage.ml
@@ -7,7 +7,7 @@ let test_parse_text_tool_calls_single () =
   in
   match Local_agent_eio.parse_text_tool_calls content with
   | [ call ] ->
-      check string "tool name" "masc_team_session_step" call.Llm_client.call_name;
+      check string "tool name" "masc_team_session_step" call.Llm_types.call_name;
       let json = Yojson.Safe.from_string call.call_arguments in
       check string "session id" "ts-123"
         Yojson.Safe.Util.(json |> member "session_id" |> to_string);
@@ -31,10 +31,10 @@ done:local64-smoke-02
   in
   match Local_agent_eio.parse_text_tool_calls content with
   | [ first; second ] ->
-      check string "first tool" "masc_heartbeat" first.Llm_client.call_name;
+      check string "first tool" "masc_heartbeat" first.Llm_types.call_name;
       check string "heartbeat args" "{}" first.call_arguments;
       check string "second tool" "masc_team_session_step"
-        second.Llm_client.call_name
+        second.Llm_types.call_name
   | _ -> fail "expected two parsed text tool calls"
 
 let () =

--- a/test/test_lodge_cascade.ml
+++ b/test/test_lodge_cascade.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module Lodge_cascade = Masc_mcp.Lodge_cascade
 module Llm_client = Masc_mcp.Llm_client
+module Llm_types = Masc_mcp.Llm_types
 
 let with_temp_json contents f =
   let path = Filename.temp_file "lodge_cascade_" ".json" in
@@ -33,9 +34,9 @@ let test_load_models_from_config () =
       check int "spec count" 2 (List.length specs);
       match specs with
       | [ first; second ] ->
-          check bool "first is llama" true (first.provider = Llm_client.Llama);
+          check bool "first is llama" true (first.provider = Llm_types.Llama);
           check string "first model" "qwen-local" first.model_id;
-          check bool "second is llama" true (second.provider = Llm_client.Llama);
+          check bool "second is llama" true (second.provider = Llm_types.Llama);
           check string "second model" "qwen-local-fallback" second.model_id
       | _ -> fail "expected two specs")
 
@@ -49,7 +50,7 @@ let test_skips_invalid_and_missing_api_key () =
           match specs with
           | [ only ] ->
               check bool "llama provider" true
-                (only.provider = Llm_client.Llama);
+                (only.provider = Llm_types.Llama);
               check string "llama model" "qwen-live" only.model_id
           | _ -> fail "expected one surviving spec"))
 
@@ -60,7 +61,7 @@ let test_missing_config_uses_defaults () =
   match specs with
   | first :: _ ->
       check bool "default starts with llama" true
-        (first.provider = Llm_client.Llama);
+        (first.provider = Llm_types.Llama);
       check string "default llama model" Masc_mcp.Env_config.Llama.default_model
         first.model_id
   | [] -> fail "expected default fallback models"

--- a/test/test_lodge_topic.ml
+++ b/test/test_lodge_topic.ml
@@ -174,7 +174,7 @@ let test_filter_empty_and_oversized () =
    ============================================ *)
 
 let make_llm_response content =
-  Llm_client.{
+  Llm_types.{
     content = [Agent_sdk.Types.Text content];
     tool_calls = [];
     usage = {

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -11,14 +11,14 @@ open Masc_mcp
 (* Helper: create MASC messages with all 4 roles                    *)
 (* ================================================================ *)
 
-let make_test_messages () : Llm_client.message list =
+let make_test_messages () : Llm_types.message list =
   [
-    Llm_client.system_msg "You are a helpful assistant.";
-    Llm_client.user_msg "Hello, what is 2+2?";
-    Llm_client.assistant_msg "The answer is 4.";
-    Llm_client.tool_msg ~name:"calculator" ~call_id:"call-1" "result: 4";
-    Llm_client.user_msg "Thanks, now solve x^2 = 9.";
-    Llm_client.assistant_msg "x = 3 or x = -3.";
+    Llm_types.system_msg "You are a helpful assistant.";
+    Llm_types.user_msg "Hello, what is 2+2?";
+    Llm_types.assistant_msg "The answer is 4.";
+    Llm_types.tool_msg ~name:"calculator" ~call_id:"call-1" "result: 4";
+    Llm_types.user_msg "Thanks, now solve x^2 = 9.";
+    Llm_types.assistant_msg "x = 3 or x = -3.";
   ]
 
 (* ================================================================ *)
@@ -26,35 +26,35 @@ let make_test_messages () : Llm_client.message list =
 (* ================================================================ *)
 
 let test_roundtrip_user_msg () =
-  let msg = Llm_client.user_msg "hello world" in
+  let msg = Llm_types.user_msg "hello world" in
   match Llm_client.to_oas_message msg with
   | None -> Alcotest.fail "user message should not be dropped"
   | Some oas ->
     let rt = Llm_client.of_oas_message oas in
     Alcotest.(check string) "role preserved" "user"
-      (match rt.role with Llm_client.User -> "user" | _ -> "other");
+      (match rt.role with Llm_types.User -> "user" | _ -> "other");
     Alcotest.(check string) "content preserved"
-      "hello world" (Llm_client.text_of_message rt)
+      "hello world" (Llm_types.text_of_message rt)
 
 let test_roundtrip_assistant_msg () =
-  let msg = Llm_client.assistant_msg "The answer is 42." in
+  let msg = Llm_types.assistant_msg "The answer is 42." in
   match Llm_client.to_oas_message msg with
   | None -> Alcotest.fail "assistant message should not be dropped"
   | Some oas ->
     let rt = Llm_client.of_oas_message oas in
     Alcotest.(check string) "role preserved" "assistant"
-      (match rt.role with Llm_client.Assistant -> "assistant" | _ -> "other");
+      (match rt.role with Llm_types.Assistant -> "assistant" | _ -> "other");
     Alcotest.(check string) "content preserved"
-      "The answer is 42." (Llm_client.text_of_message rt)
+      "The answer is 42." (Llm_types.text_of_message rt)
 
 let test_roundtrip_system_msg_dropped () =
-  let msg = Llm_client.system_msg "system prompt" in
+  let msg = Llm_types.system_msg "system prompt" in
   let result = Llm_client.to_oas_message msg in
   Alcotest.(check bool) "system message dropped (belongs in system_prompt)"
     true (Option.is_none result)
 
 let test_roundtrip_tool_msg () =
-  let msg = Llm_client.tool_msg ~name:"calc" ~call_id:"tc-1" "tool output here" in
+  let msg = Llm_types.tool_msg ~name:"calc" ~call_id:"tc-1" "tool output here" in
   match Llm_client.to_oas_message msg with
   | None -> Alcotest.fail "tool message should not be dropped"
   | Some oas ->
@@ -63,8 +63,8 @@ let test_roundtrip_tool_msg () =
        Context_compact_oas.masc_msg_to_oas uses sentinel-tagging instead. *)
     Alcotest.(check string) "tool role preserved"
       "tool"
-      (match rt.role with Llm_client.Tool -> "tool" | _ -> "other");
-    let text = Llm_client.text_of_message rt in
+      (match rt.role with Llm_types.Tool -> "tool" | _ -> "other");
+    let text = Llm_types.text_of_message rt in
     Alcotest.(check bool) "content preserved"
       true (String.length text > 0)
 
@@ -88,9 +88,9 @@ let test_compact_prune_tool_outputs () =
 let test_compact_merge_contiguous () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:4000 in
   let msgs = [
-    Llm_client.user_msg "part 1";
-    Llm_client.user_msg "part 2";
-    Llm_client.assistant_msg "response";
+    Llm_types.user_msg "part 1";
+    Llm_types.user_msg "part 2";
+    Llm_types.assistant_msg "response";
   ] in
   let ctx = List.fold_left Context_manager.append ctx msgs in
   let compacted = Context_manager.compact ctx [Context_manager.MergeContiguous] in
@@ -103,9 +103,9 @@ let test_compact_summarize_old () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:8000 in
   let msgs = List.init 12 (fun i ->
     if i mod 2 = 0 then
-      Llm_client.user_msg (Printf.sprintf "user message %d with content" i)
+      Llm_types.user_msg (Printf.sprintf "user message %d with content" i)
     else
-      Llm_client.assistant_msg (Printf.sprintf "assistant response %d" i)
+      Llm_types.assistant_msg (Printf.sprintf "assistant response %d" i)
   ) in
   let ctx = List.fold_left Context_manager.append ctx msgs in
   let compacted = Context_manager.compact ctx [Context_manager.SummarizeOld] in
@@ -118,8 +118,8 @@ let test_compact_summarize_old () =
 let test_compact_small_list_unchanged () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:4000 in
   let msgs = [
-    Llm_client.user_msg "hello";
-    Llm_client.assistant_msg "world";
+    Llm_types.user_msg "hello";
+    Llm_types.assistant_msg "world";
   ] in
   let ctx = List.fold_left Context_manager.append ctx msgs in
   let compacted = Context_manager.compact ctx [Context_manager.SummarizeOld] in
@@ -142,12 +142,12 @@ let test_restore_messages_all_roles () =
   Alcotest.(check int) "2 messages restored" 2 (List.length masc_msgs);
   let first = List.hd masc_msgs in
   Alcotest.(check string) "first is user" "user"
-    (match first.role with Llm_client.User -> "user" | _ -> "other");
+    (match first.role with Llm_types.User -> "user" | _ -> "other");
   Alcotest.(check string) "first content" "user question"
-    (Llm_client.text_of_message first);
+    (Llm_types.text_of_message first);
   let second = List.nth masc_msgs 1 in
   Alcotest.(check string) "second is assistant" "assistant"
-    (match second.role with Llm_client.Assistant -> "assistant" | _ -> "other")
+    (match second.role with Llm_types.Assistant -> "assistant" | _ -> "other")
 
 (* ================================================================ *)
 (* Runner                                                           *)

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -52,8 +52,8 @@ let test_event_bus_task_transition () =
 (* ================================================================ *)
 
 let test_message_roundtrip () =
-  let masc_msg : Llm_client.message =
-    Llm_client.assistant_msg "test content"
+  let masc_msg : Llm_types.message =
+    Llm_types.assistant_msg "test content"
   in
   let oas_msg = Llm_client.to_oas_message masc_msg in
   (match oas_msg with
@@ -62,13 +62,13 @@ let test_message_roundtrip () =
      let roundtrip = Llm_client.of_oas_message msg in
      Alcotest.(check string) "role preserved"
        "assistant"
-       (match roundtrip.role with Llm_client.Assistant -> "assistant" | _ -> "other");
+       (match roundtrip.role with Llm_types.Assistant -> "assistant" | _ -> "other");
      Alcotest.(check string) "content preserved"
-       "test content" (Llm_client.text_of_message roundtrip))
+       "test content" (Llm_types.text_of_message roundtrip))
 
 let test_system_role_dropped () =
-  let masc_msg : Llm_client.message =
-    Llm_client.system_msg "system prompt"
+  let masc_msg : Llm_types.message =
+    Llm_types.system_msg "system prompt"
   in
   let oas_msg = Llm_client.to_oas_message masc_msg in
   Alcotest.(check bool) "system message dropped (belongs in system_prompt)"
@@ -84,7 +84,7 @@ let test_restore_messages () =
   let masc_msgs = List.map Llm_client.of_oas_message oas_msgs in
   Alcotest.(check int) "2 messages" 2 (List.length masc_msgs);
   Alcotest.(check string) "first content" "hello"
-    (Llm_client.text_of_message (List.hd masc_msgs))
+    (Llm_types.text_of_message (List.hd masc_msgs))
 
 (* ================================================================ *)
 (* Context_manager OAS sync tests                                    *)
@@ -93,7 +93,7 @@ let test_restore_messages () =
 let test_oas_context_sync () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:1000 in
   let ctx = Context_manager.append ctx
-    (Llm_client.user_msg "hello") in
+    (Llm_types.user_msg "hello") in
   let ctx = Context_manager.sync_oas_context ctx in
   let msg_count =
     Context.get_scoped ctx.oas_context Context.Session "message_count" in
@@ -103,8 +103,8 @@ let test_oas_context_sync () =
 
 let test_compact_syncs_oas_context () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:1000 in
-  let ctx = Context_manager.append ctx (Llm_client.user_msg "msg1") in
-  let ctx = Context_manager.append ctx (Llm_client.assistant_msg "msg2") in
+  let ctx = Context_manager.append ctx (Llm_types.user_msg "msg1") in
+  let ctx = Context_manager.append ctx (Llm_types.assistant_msg "msg2") in
   let ctx = Context_manager.compact ctx [Context_manager.MergeContiguous] in
   let ratio =
     Context.get_scoped ctx.oas_context Context.Session "context_ratio" in

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -49,151 +49,151 @@ let test_llm_client () = group "LLM Client" (fun () ->
 
   (* 1. Provider string roundtrip *)
   assert_equal "provider_string:llama"
-    "llama" (Llm_client.string_of_provider Llama);
+    "llama" (Llm_types.string_of_provider Llama);
   assert_equal "provider_string:claude"
-    "claude" (Llm_client.string_of_provider Claude);
+    "claude" (Llm_types.string_of_provider Claude);
   assert_equal "provider_string:openai"
-    "openai" (Llm_client.string_of_provider OpenAI);
+    "openai" (Llm_types.string_of_provider OpenAI);
   assert_equal "provider_string:gemini"
-    "gemini" (Llm_client.string_of_provider Gemini);
+    "gemini" (Llm_types.string_of_provider Gemini);
 
   (* 2. Model spec parsing *)
-  (match Llm_client.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl" with
+  (match Llm_types.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl" with
    | Ok m ->
      assert_equal "parse_model:llama_local_id" "qwen3.5-35b-a3b-ud-q8-xl" m.model_id;
      assert_true "parse_model:llama_local_provider"
-       (m.provider = Llm_client.Llama)
+       (m.provider = Llm_types.Llama)
    | Error _ -> assert_true "parse_model:llama_local" false);
 
-  (match Llm_client.model_spec_of_string "claude:opus" with
+  (match Llm_types.model_spec_of_string "claude:opus" with
    | Ok m ->
      assert_equal "parse_model:claude_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:claude_provider"
-       (m.provider = Llm_client.Claude);
+       (m.provider = Llm_types.Claude);
      (* Verify opus cost tier to distinguish from sonnet routing *)
      assert_true "parse_model:claude_opus_cost"
        (m.cost_per_1k_input > 0.01)
    | Error _ -> assert_true "parse_model:claude" false);
 
-  (match Llm_client.model_spec_of_string "gemini:gemini-2.5-flash" with
+  (match Llm_types.model_spec_of_string "gemini:gemini-2.5-flash" with
    | Ok m ->
      assert_equal "parse_model:gemini_id" "gemini-2.5-flash" m.model_id;
      assert_true "parse_model:gemini_provider"
-       (m.provider = Llm_client.Gemini)
+       (m.provider = Llm_types.Gemini)
    | Error _ -> assert_true "parse_model:gemini" false);
 
-  (match Llm_client.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl:latest" with
+  (match Llm_types.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl:latest" with
    | Ok m ->
      assert_equal "parse_model:llama_tagged_id" "qwen3.5-35b-a3b-ud-q8-xl:latest" m.model_id;
      assert_true "parse_model:llama_tagged_provider"
-       (m.provider = Llm_client.Llama)
+       (m.provider = Llm_types.Llama)
    | Error _ -> assert_true "parse_model:llama_tagged" false);
 
-  (match Llm_client.model_spec_of_string "llama:qwen3.5-coder" with
+  (match Llm_types.model_spec_of_string "llama:qwen3.5-coder" with
    | Ok m ->
      assert_equal "parse_model:llama_id" "qwen3.5-coder" m.model_id;
      assert_true "parse_model:llama_provider"
-       (m.provider = Llm_client.Llama);
+       (m.provider = Llm_types.Llama);
      assert_equal "parse_model:llama_url"
        Masc_mcp.Env_config.Llama.server_url m.api_url
    | Error e -> assert_true ("parse_model:llama_failed: " ^ e) false);
 
-  (match Llm_client.model_spec_of_string "anthropic:sonnet" with
+  (match Llm_types.model_spec_of_string "anthropic:sonnet" with
    | Ok m ->
      assert_equal "parse_model:anthropic_alias_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:anthropic_alias_provider"
-       (m.provider = Llm_client.Claude)
+       (m.provider = Llm_types.Claude)
    | Error _ -> assert_true "parse_model:anthropic_alias" false);
 
-  (match Llm_client.model_spec_of_string "google:flash" with
+  (match Llm_types.model_spec_of_string "google:flash" with
    | Ok m ->
      assert_equal "parse_model:google_alias_id" Masc_mcp.Env_config.Gemini.flash_model m.model_id;
      assert_true "parse_model:google_alias_provider"
-       (m.provider = Llm_client.Gemini)
+       (m.provider = Llm_types.Gemini)
    | Error _ -> assert_true "parse_model:google_alias" false);
 
-  (match Llm_client.model_spec_of_string "claude-api:sonnet" with
+  (match Llm_types.model_spec_of_string "claude-api:sonnet" with
    | Ok m ->
      assert_equal "parse_model:claude_api_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:claude_api_provider"
-       (m.provider = Llm_client.Claude)
+       (m.provider = Llm_types.Claude)
    | Error _ -> assert_true "parse_model:claude_api" false);
 
-  (match Llm_client.model_spec_of_string "gemini-api:gemini-2.5-flash" with
+  (match Llm_types.model_spec_of_string "gemini-api:gemini-2.5-flash" with
    | Ok m ->
      assert_equal "parse_model:gemini_api_id" "gemini-2.5-flash" m.model_id;
      assert_true "parse_model:gemini_api_provider"
-       (m.provider = Llm_client.Gemini)
+       (m.provider = Llm_types.Gemini)
    | Error _ -> assert_true "parse_model:gemini_api" false);
 
-  (match Llm_client.model_spec_of_string "codex-api:gpt-5-mini" with
+  (match Llm_types.model_spec_of_string "codex-api:gpt-5-mini" with
    | Ok m ->
      assert_equal "parse_model:codex_api_id" "gpt-5-mini" m.model_id;
      assert_true "parse_model:codex_api_provider"
-       (m.provider = Llm_client.OpenAI)
+       (m.provider = Llm_types.OpenAI)
    | Error _ -> assert_true "parse_model:codex_api" false);
 
   (* 3. Invalid model spec *)
-  (match Llm_client.model_spec_of_string "invalid" with
+  (match Llm_types.model_spec_of_string "invalid" with
    | Error _ -> assert_true "parse_model:invalid" true
    | Ok _ -> assert_true "parse_model:invalid_should_fail" false);
 
-  (match Llm_client.model_spec_of_string "llama:" with
+  (match Llm_types.model_spec_of_string "llama:" with
    | Error _ -> assert_true "parse_model:empty_model_rejected" true
    | Ok _ -> assert_true "parse_model:empty_model_should_fail" false);
 
   (* 3b. MLX and Custom provider parsing *)
-  (match Llm_client.model_spec_of_string "mlx:qwen3.5-35b" with
+  (match Llm_types.model_spec_of_string "mlx:qwen3.5-35b" with
    | Ok m ->
      assert_equal "parse_model:mlx_id" "qwen3.5-35b" m.model_id;
      assert_true "parse_model:mlx_provider"
-       (m.provider = Llm_client.Custom "mlx");
+       (m.provider = Llm_types.Custom "mlx");
      assert_equal "parse_model:mlx_url" "http://127.0.0.1:8091" m.api_url
    | Error e -> assert_true ("parse_model:mlx_failed: " ^ e) false);
 
-  (match Llm_client.model_spec_of_string "custom:mymodel@http://localhost:9999" with
+  (match Llm_types.model_spec_of_string "custom:mymodel@http://localhost:9999" with
    | Ok m ->
      assert_equal "parse_model:custom_with_url_id" "mymodel" m.model_id;
      assert_true "parse_model:custom_with_url_provider"
-       (m.provider = Llm_client.Custom "mymodel");
+       (m.provider = Llm_types.Custom "mymodel");
      assert_equal "parse_model:custom_with_url_url" "http://localhost:9999" m.api_url
    | Error e -> assert_true ("parse_model:custom_url_failed: " ^ e) false);
 
-  (match Llm_client.model_spec_of_string "custom:bare-model" with
+  (match Llm_types.model_spec_of_string "custom:bare-model" with
    | Ok m ->
      assert_equal "parse_model:custom_bare_id" "bare-model" m.model_id;
      assert_true "parse_model:custom_bare_provider"
-       (m.provider = Llm_client.Custom "bare-model");
+       (m.provider = Llm_types.Custom "bare-model");
      assert_equal "parse_model:custom_bare_url" "http://127.0.0.1:8080" m.api_url
    | Error e -> assert_true ("parse_model:custom_bare_failed: " ^ e) false);
 
   (* 4. Message constructors *)
-  let msg = Llm_client.system_msg "hello" in
-  assert_true "msg:system_role" (msg.role = Llm_client.System);
-  assert_equal "msg:system_content" "hello" (Llm_client.text_of_message msg);
+  let msg = Llm_types.system_msg "hello" in
+  assert_true "msg:system_role" (msg.role = Llm_types.System);
+  assert_equal "msg:system_content" "hello" (Llm_types.text_of_message msg);
 
-  let msg2 = Llm_client.tool_msg ~name:"grep" ~call_id:"c1" "results" in
-  assert_true "msg:tool_role" (msg2.role = Llm_client.Tool);
+  let msg2 = Llm_types.tool_msg ~name:"grep" ~call_id:"c1" "results" in
+  assert_true "msg:tool_role" (msg2.role = Llm_types.Tool);
   let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult { tool_use_id = "c1"; _ } -> true | _ -> false) msg2.content in
   assert_true "msg:tool_call_id_in_content" has_tool_result;
 
   (* 5. Token estimation *)
-  let msgs = [Llm_client.user_msg "hello world"] in
-  let tokens = Llm_client.estimate_tokens msgs in
+  let msgs = [Llm_types.user_msg "hello world"] in
+  let tokens = Llm_types.estimate_tokens msgs in
   assert_true "token_estimate:positive" (tokens > 0);
   assert_true "token_estimate:reasonable" (tokens < 100);
 
   (* 6. Built-in model specs *)
   assert_true "builtin:llama_default_context"
-    (Llm_client.llama_default.max_context = 128000);
+    (Llm_types.llama_default.max_context = 128000);
   assert_true "builtin:claude_opus_cost"
-    (Llm_client.claude_opus.cost_per_1k_input > 0.0);
+    (Llm_types.claude_opus.cost_per_1k_input > 0.0);
   assert_true "builtin:gemini_pro_provider"
-    (Llm_client.gemini_pro.provider = Llm_client.Gemini);
+    (Llm_types.gemini_pro.provider = Llm_types.Gemini);
   assert_true "builtin:openai_default_provider"
-    (Llm_client.openai_default.provider = Llm_client.OpenAI);
+    (Llm_types.openai_default.provider = Llm_types.OpenAI);
   assert_true "builtin:llama_default_provider"
-    (Llm_client.llama_default.provider = Llm_client.Llama);
+    (Llm_types.llama_default.provider = Llm_types.Llama);
   (* Set env vars so default_local_model_spec resolves llama regardless of CI env *)
   let prev_provider = Sys.getenv_opt "MASC_DEFAULT_PROVIDER" in
   let prev_model = Sys.getenv_opt "MASC_DEFAULT_MODEL" in
@@ -201,9 +201,9 @@ let test_llm_client () = group "LLM Client" (fun () ->
   Unix.putenv "MASC_DEFAULT_PROVIDER" "llama";
   Unix.putenv "MASC_DEFAULT_MODEL" "default-model";
   Unix.putenv "LLAMA_DEFAULT_MODEL" "default-model";
-  let default_local = Llm_client.default_local_model_spec () in
+  let default_local = Llm_types.default_local_model_spec () in
   assert_true "builtin:default_local_provider"
-    (default_local.provider = Llm_client.Llama);
+    (default_local.provider = Llm_types.Llama);
   assert_equal "builtin:default_local_model_id"
     "default-model" default_local.model_id;
   (* Restore env vars *)
@@ -230,13 +230,13 @@ let test_context_manager () = group "Context Manager" (fun () ->
   assert_true "create:has_tokens" (ctx.token_count > 0);
 
   (* 2. Append message *)
-  let msg = Llm_client.user_msg "hello" in
+  let msg = Llm_types.user_msg "hello" in
   let ctx2 = Context_manager.append ctx msg in
   assert_equal "append:count" 1 (List.length ctx2.messages);
   assert_true "append:tokens_increased" (ctx2.token_count > ctx.token_count);
 
   (* 3. Append many *)
-  let msgs = [Llm_client.user_msg "a"; Llm_client.assistant_msg "b"] in
+  let msgs = [Llm_types.user_msg "a"; Llm_types.assistant_msg "b"] in
   let ctx3 = Context_manager.append_many ctx msgs in
   assert_equal "append_many:count" 2 (List.length ctx3.messages);
 
@@ -254,9 +254,9 @@ let test_context_manager () = group "Context Manager" (fun () ->
 
   (* 6. Importance scoring *)
   let ctx4 = Context_manager.append_many ctx [
-    Llm_client.user_msg "important question";
-    Llm_client.assistant_msg "answer";
-    Llm_client.user_msg "follow up";
+    Llm_types.user_msg "important question";
+    Llm_types.assistant_msg "answer";
+    Llm_types.user_msg "follow up";
   ] in
   let scored = Context_manager.score_importance ctx4 in
   assert_true "importance:has_scores"
@@ -267,29 +267,29 @@ let test_context_manager () = group "Context Manager" (fun () ->
   assert_true "importance:recency" (score_2 > score_0);
 
   (* 7. PruneToolOutputs *)
-  let long_tool_msg = { (Llm_client.tool_msg ~name:"t" ~call_id:"c" (String.make 1000 'x'))
-    with role = Llm_client.Tool } in
+  let long_tool_msg = { (Llm_types.tool_msg ~name:"t" ~call_id:"c" (String.make 1000 'x'))
+    with role = Llm_types.Tool } in
   let ctx5 = Context_manager.append ctx long_tool_msg in
   let pruned = Context_manager.apply_strategy ctx5 PruneToolOutputs in
   let pruned_msg = List.hd pruned.messages in
-  assert_true "prune:shorter" (String.length (Llm_client.text_of_message pruned_msg) < 1000);
+  assert_true "prune:shorter" (String.length (Llm_types.text_of_message pruned_msg) < 1000);
   assert_true "prune:has_truncated" (
-    try let _ = Str.search_forward (Str.regexp_string "truncated") (Llm_client.text_of_message pruned_msg) 0 in true
+    try let _ = Str.search_forward (Str.regexp_string "truncated") (Llm_types.text_of_message pruned_msg) 0 in true
     with Not_found -> false);
 
   (* 8. MergeContiguous *)
   let ctx6 = Context_manager.append_many ctx [
-    Llm_client.user_msg "part1";
-    Llm_client.user_msg "part2";
-    Llm_client.assistant_msg "response";
+    Llm_types.user_msg "part1";
+    Llm_types.user_msg "part2";
+    Llm_types.assistant_msg "response";
   ] in
   let merged = Context_manager.apply_strategy ctx6 MergeContiguous in
   assert_equal "merge:count" 2 (List.length merged.messages);
 
   (* 9. SummarizeOld *)
   let many_msgs = List.init 10 (fun i ->
-    if i mod 2 = 0 then Llm_client.user_msg (sprintf "q%d" i)
-    else Llm_client.assistant_msg (sprintf "a%d" i)) in
+    if i mod 2 = 0 then Llm_types.user_msg (sprintf "q%d" i)
+    else Llm_types.assistant_msg (sprintf "a%d" i)) in
   let ctx7 = Context_manager.append_many ctx many_msgs in
   let summarized = Context_manager.apply_strategy ctx7 SummarizeOld in
   assert_true "summarize:fewer_messages"
@@ -299,8 +299,8 @@ let test_context_manager () = group "Context Manager" (fun () ->
   let long_ctx = Context_manager.append_many ctx
     (List.init 10 (fun i ->
       if i mod 2 = 0
-      then Llm_client.user_msg (sprintf "detailed question %d with lots of context: %s" i (String.make 200 'x'))
-      else Llm_client.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
+      then Llm_types.user_msg (sprintf "detailed question %d with lots of context: %s" i (String.make 200 'x'))
+      else Llm_types.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
   let compacted = Context_manager.compact long_ctx
     [PruneToolOutputs; MergeContiguous; SummarizeOld] in
   assert_true "compact:reduces_tokens"
@@ -327,8 +327,8 @@ let test_context_manager () = group "Context Manager" (fun () ->
   assert_equal "restore:utf8_msg_count" 2 (List.length repaired.messages);
   assert_true "restore:utf8_content_valid"
     (List.for_all
-       (fun (msg : Llm_client.message) ->
-         let s = Llm_client.text_of_message msg in
+       (fun (msg : Llm_types.message) ->
+         let s = Llm_types.text_of_message msg in
          let rec valid_from i =
            if i >= String.length s then true
            else
@@ -342,9 +342,9 @@ let test_context_manager () = group "Context Manager" (fun () ->
   (* 13. DropLowImportance *)
   let ctx8 = Context_manager.append_many
     (Context_manager.create ~system_prompt:"test" ~max_tokens:10000) [
-    Llm_client.user_msg "important long question about architecture design";
-    Llm_client.assistant_msg "ok";  (* Short = low importance *)
-    Llm_client.user_msg "another detailed question with context";
+    Llm_types.user_msg "important long question about architecture design";
+    Llm_types.assistant_msg "ok";  (* Short = low importance *)
+    Llm_types.user_msg "another detailed question with context";
   ] in
   let dropped = Context_manager.apply_strategy ctx8 DropLowImportance in
   assert_true "drop:removes_some"
@@ -450,29 +450,29 @@ let test_succession () = group "Succession" (fun () ->
 
   (* 5. Cross-model normalization: Llama *)
   let msgs = [
-    Llm_client.user_msg "hello";
-    Llm_client.tool_msg ~name:"grep" ~call_id:"c1" "results";
-    Llm_client.assistant_msg "done";
+    Llm_types.user_msg "hello";
+    Llm_types.tool_msg ~name:"grep" ~call_id:"c1" "results";
+    Llm_types.assistant_msg "done";
   ] in
-  let normalized = Succession_oas.normalize_for_model msgs Llm_client.llama_default in
+  let normalized = Succession_oas.normalize_for_model msgs Llm_types.llama_default in
   (* Tool messages should be converted to user messages for local llama runtimes *)
-  let tool_msgs = List.filter (fun (m : Llm_client.message) ->
-    m.role = Llm_client.Tool) normalized in
+  let tool_msgs = List.filter (fun (m : Llm_types.message) ->
+    m.role = Llm_types.Tool) normalized in
   assert_equal "normalize:llama_no_tool" 0 (List.length tool_msgs);
 
   (* 6. Cross-model normalization: Claude merges consecutive *)
   let msgs2 = [
-    Llm_client.user_msg "part1";
-    Llm_client.user_msg "part2";
-    Llm_client.assistant_msg "response";
+    Llm_types.user_msg "part1";
+    Llm_types.user_msg "part2";
+    Llm_types.assistant_msg "response";
   ] in
-  let normalized2 = Succession_oas.normalize_for_model msgs2 Llm_client.claude_opus in
+  let normalized2 = Succession_oas.normalize_for_model msgs2 Llm_types.claude_opus in
   assert_true "normalize:claude_merged"
     (List.length normalized2 <= List.length msgs2);
 
   (* 7. Hydrate from DNA *)
   let spec = Succession_oas.{
-    model = Llm_client.llama_default;
+    model = Llm_types.llama_default;
     inherit_tools = true;
     context_budget = 0.3;
   } in
@@ -492,7 +492,7 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
 
   (* 1. Default config *)
   let config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Llm_client.llama_default] () in
+    ~goal:"test" ~models:[Llm_types.llama_default] () in
   assert_equal "config:goal" "test" config.initial_goal;
   assert_float_near "config:compact" 0.5 config.compact_threshold 0.01;
   assert_float_near "config:handoff" 0.85 config.handoff_threshold 0.01;
@@ -522,7 +522,7 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
 
   (* 5. Stopped state is reflected in status *)
   let fresh_config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Llm_client.llama_default] () in
+    ~goal:"test" ~models:[Llm_types.llama_default] () in
   let fresh_state = Perpetual_loop.create_state fresh_config in
   Perpetual_loop.stop fresh_state;
   assert_true "stop:running_false" (not fresh_state.running);
@@ -549,11 +549,11 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
     (String.length state2.context.system_prompt > 0);
   assert_true "context:has_goal_message"
     (List.exists
-       (fun (msg : Llm_client.message) ->
-         msg.role = Llm_client.User &&
+       (fun (msg : Llm_types.message) ->
+         msg.role = Llm_types.User &&
          Str.string_match
            (Str.regexp_string (Context_manager.goal_prefix ^ " test"))
-           (Llm_client.text_of_message msg) 0)
+           (Llm_types.text_of_message msg) 0)
        state2.context.messages);
 
   (* 8. Cost starts at zero *)
@@ -567,8 +567,8 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
     ~goal:"multi"
     ~models:
       [
-        Llm_client.llama_default;
-        { Llm_client.llama_default with model_id = "qwen3.5-9b" };
+        Llm_types.llama_default;
+        { Llm_types.llama_default with model_id = "qwen3.5-9b" };
       ]
     () in
   assert_equal "cascade:model_count" 2
@@ -625,7 +625,7 @@ let test_auto_claim () = group "Auto-Claim" (fun () ->
 
   (* 1. Auto-claim disabled when no room_config *)
   let config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Llm_client.llama_default] () in
+    ~goal:"test" ~models:[Llm_types.llama_default] () in
   assert_true "auto_claim:disabled_by_default" (config.room_config = None);
   let state = Perpetual_loop.create_state config in
   assert_true "auto_claim:no_current_task" (state.current_task_id = None);
@@ -725,10 +725,10 @@ let test_integration () = group "Integration" (fun () ->
   (* 1. Full pipeline: create → checkpoint → restore *)
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:10000 in
   let ctx = Context_manager.append_many ctx [
-    Llm_client.user_msg "question 1";
-    Llm_client.assistant_msg "answer 1";
-    Llm_client.user_msg "question 2";
-    Llm_client.assistant_msg "answer 2";
+    Llm_types.user_msg "question 1";
+    Llm_types.assistant_msg "answer 1";
+    Llm_types.user_msg "question 2";
+    Llm_types.assistant_msg "answer 2";
   ] in
   let ckpt = Context_manager.create_checkpoint ctx ~generation:0 in
   let restored = Context_manager.restore_checkpoint ckpt ~max_tokens:10000 in
@@ -749,7 +749,7 @@ let test_integration () = group "Integration" (fun () ->
   assert_equal "integration:dna_goal" "integration test" dna.goal;
 
   let spec = Succession_oas.{
-    model = Llm_client.llama_default;
+    model = Llm_types.llama_default;
     inherit_tools = true;
     context_budget = 0.5;
   } in
@@ -762,8 +762,8 @@ let test_integration () = group "Integration" (fun () ->
     (Context_manager.create ~system_prompt:"test" ~max_tokens:100000)
     (List.init 20 (fun i ->
       if i mod 2 = 0
-      then Llm_client.user_msg (sprintf "detailed question %d with context: %s" i (String.make 200 'x'))
-      else Llm_client.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
+      then Llm_types.user_msg (sprintf "detailed question %d with context: %s" i (String.make 200 'x'))
+      else Llm_types.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
   let before = big_ctx.token_count in
   let after_ctx = Context_manager.compact big_ctx
     [PruneToolOutputs; MergeContiguous; SummarizeOld] in
@@ -781,34 +781,34 @@ let test_integration () = group "Integration" (fun () ->
     (after_oas.token_count <= after_ctx.token_count * 3);
 
   (* 3c. OAS tagged roundtrip preserves role information *)
-  let tool_msg_rt = Llm_client.tool_msg ~name:"grep" ~call_id:"tc1" "search results" in
-  let sys_msg_rt = Llm_client.system_msg "you are a helper" in
-  let user_msg_rt = Llm_client.user_msg "hello" in
-  let asst_msg_rt = Llm_client.assistant_msg "hi there" in
+  let tool_msg_rt = Llm_types.tool_msg ~name:"grep" ~call_id:"tc1" "search results" in
+  let sys_msg_rt = Llm_types.system_msg "you are a helper" in
+  let user_msg_rt = Llm_types.user_msg "hello" in
+  let asst_msg_rt = Llm_types.assistant_msg "hi there" in
   List.iter (fun (label, orig_msg) ->
     let oas_msg = Context_manager.masc_msg_to_oas_tagged orig_msg in
     let back = Context_manager.oas_msg_to_masc_tagged oas_msg in
     assert_true (sprintf "roundtrip:%s:role" label) (back.role = orig_msg.role);
     assert_true (sprintf "roundtrip:%s:content" label)
-      (String.length (Llm_client.text_of_message back) > 0)
+      (String.length (Llm_types.text_of_message back) > 0)
   ) [("tool", tool_msg_rt); ("system", sys_msg_rt);
      ("user", user_msg_rt); ("assistant", asst_msg_rt)];
 
   (* 3d. compact_via_oas with tool messages preserves Tool role *)
   let ctx_with_tools = Context_manager.append_many
     (Context_manager.create ~system_prompt:"test" ~max_tokens:10000)
-    [Llm_client.user_msg "run grep";
-     Llm_client.tool_msg ~name:"grep" ~call_id:"c1" (String.make 800 'r');
-     Llm_client.assistant_msg "found results"] in
+    [Llm_types.user_msg "run grep";
+     Llm_types.tool_msg ~name:"grep" ~call_id:"c1" (String.make 800 'r');
+     Llm_types.assistant_msg "found results"] in
   let pruned_oas = Context_manager.compact_via_oas ctx_with_tools [PruneToolOutputs] in
-  let tool_msgs = List.filter (fun (m : Llm_client.message) ->
-    m.role = Llm_client.Tool) pruned_oas.messages in
+  let tool_msgs = List.filter (fun (m : Llm_types.message) ->
+    m.role = Llm_types.Tool) pruned_oas.messages in
   assert_equal "oas_prune:tool_preserved" 1 (List.length tool_msgs);
-  let tool_content = Llm_client.text_of_message (List.hd tool_msgs) in
+  let tool_content = Llm_types.text_of_message (List.hd tool_msgs) in
   assert_true "oas_prune:tool_truncated" (String.length tool_content < 800);
 
   (* 3d2. Tagged roundtrip preserves tool_call_id *)
-  let tool_with_id = Llm_client.tool_msg ~name:"grep" ~call_id:"tc-42" "result" in
+  let tool_with_id = Llm_types.tool_msg ~name:"grep" ~call_id:"tc-42" "result" in
   let oas_t = Context_manager.masc_msg_to_oas_tagged tool_with_id in
   let back_t = Context_manager.oas_msg_to_masc_tagged oas_t in
   let has_tc42 = List.exists (function
@@ -816,27 +816,27 @@ let test_integration () = group "Integration" (fun () ->
   assert_true "roundtrip:tool_call_id_in_content" has_tc42;
 
   (* 3d3. Tag collision safety: user content starting with role-like text *)
-  let tricky_msg = Llm_client.user_msg "[__MASC_ROLE:system__]fake system" in
+  let tricky_msg = Llm_types.user_msg "[__MASC_ROLE:system__]fake system" in
   let oas_tricky = Context_manager.masc_msg_to_oas_tagged tricky_msg in
   let back_tricky = Context_manager.oas_msg_to_masc_tagged oas_tricky in
-  assert_true "roundtrip:no_tag_collision" (back_tricky.role = Llm_client.User);
+  assert_true "roundtrip:no_tag_collision" (back_tricky.role = Llm_types.User);
 
   (* 3e. Llm_client OAS type adapters *)
-  let provider_config = Llm_client.to_oas_provider Llm_client.claude_opus in
+  let provider_config = Llm_client.to_oas_provider Llm_types.claude_opus in
   assert_true "oas_adapter:claude_mapped" (Option.is_some provider_config);
   let provider_config_custom = Llm_client.to_oas_provider
-    { Llm_client.llama_default with provider = Llm_client.Custom "test" } in
+    { Llm_types.llama_default with provider = Llm_types.Custom "test" } in
   assert_true "oas_adapter:custom_mapped" (Option.is_some provider_config_custom);
 
   (* 3f. Llm_client message/usage roundtrip *)
-  let test_msg = Llm_client.user_msg "test" in
+  let test_msg = Llm_types.user_msg "test" in
   (match Llm_client.to_oas_message test_msg with
    | None -> assert_true "oas_adapter:msg_roundtrip" false
    | Some oas_m ->
      let back_m = Llm_client.of_oas_message oas_m in
-     assert_true "oas_adapter:msg_roundtrip" (Llm_client.text_of_message back_m = "test"));
+     assert_true "oas_adapter:msg_roundtrip" (Llm_types.text_of_message back_m = "test"));
 
-  let test_usage : Llm_client.token_usage =
+  let test_usage : Llm_types.token_usage =
     { Agent_sdk.Types.input_tokens = 100; output_tokens = 50;
       cache_creation_input_tokens = 10; cache_read_input_tokens = 20 } in
   let oas_u = Llm_client.to_oas_usage test_usage in
@@ -855,7 +855,7 @@ let test_integration () = group "Integration" (fun () ->
 
   (* 5. Verifier + Context pipeline *)
   let ctx_v = Context_manager.create ~system_prompt:"verify test" ~max_tokens:5000 in
-  let ctx_v = Context_manager.append ctx_v (Llm_client.user_msg "do something") in
+  let ctx_v = Context_manager.append ctx_v (Llm_types.user_msg "do something") in
   let scored = Context_manager.score_importance ctx_v in
   assert_true "integration:scored"
     (List.length scored.importance_scores > 0);
@@ -870,11 +870,11 @@ let test_integration () = group "Integration" (fun () ->
 let test_history_offload () = group "History Offload" (fun () ->
 
   (* 1. format_message_readable produces role: content format *)
-  let user_msg = Llm_client.user_msg "hello world" in
+  let user_msg = Llm_types.user_msg "hello world" in
   let formatted = Context_manager.format_message_readable user_msg in
   assert_true "format:user" (formatted = "user: hello world");
 
-  let tool_msg = Llm_client.tool_msg ~name:"grep" ~call_id:"c1" "search results" in
+  let tool_msg = Llm_types.tool_msg ~name:"grep" ~call_id:"c1" "search results" in
   let formatted_tool = Context_manager.format_message_readable tool_msg in
   assert_true "format:tool_with_name"
     (String.length formatted_tool > 0
@@ -884,9 +884,9 @@ let test_history_offload () = group "History Offload" (fun () ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (sprintf "masc-offload-test-%d" (int_of_float (Unix.gettimeofday () *. 1000.0))) in
   let messages = [
-    Llm_client.user_msg "question 1";
-    Llm_client.assistant_msg "answer 1";
-    Llm_client.user_msg "question 2";
+    Llm_types.user_msg "question 1";
+    Llm_types.assistant_msg "answer 1";
+    Llm_types.user_msg "question 2";
   ] in
   let result = Context_manager.offload_messages
     ~session_dir:tmp_dir ~compaction_count:0 messages in
@@ -929,8 +929,8 @@ let test_history_offload () = group "History Offload" (fun () ->
   let ctx = Context_manager.append_many ctx
     (List.init 20 (fun i ->
       if i mod 2 = 0
-      then Llm_client.user_msg (sprintf "question %d with detail: %s" i (String.make 200 'x'))
-      else Llm_client.assistant_msg (sprintf "answer %d: %s" i (String.make 300 'y')))) in
+      then Llm_types.user_msg (sprintf "question %d with detail: %s" i (String.make 200 'x'))
+      else Llm_types.assistant_msg (sprintf "answer %d: %s" i (String.make 300 'y')))) in
   let result = Context_manager.compact_with_offload
     ~session_ctx:session ~compaction_count:1
     ctx [Context_manager.PruneToolOutputs; Context_manager.MergeContiguous;
@@ -945,8 +945,8 @@ let test_history_offload () = group "History Offload" (fun () ->
      When use_oas_reducer()=true, SummarizeOld uses Keep_first_and_last (no summary
      prefix), so annotation injection has no target — annotation is absent.
      Both behaviors are correct; verify offload file was written instead. *)
-  let has_annotation = List.exists (fun (m : Llm_client.message) ->
-    let text = Llm_client.text_of_message m in
+  let has_annotation = List.exists (fun (m : Llm_types.message) ->
+    let text = Llm_types.text_of_message m in
     try let _ = Str.search_forward
       (Str.regexp_string "[Full conversation history saved to") text 0 in true
     with Not_found -> false

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -191,7 +191,7 @@ let test_resolve_model_spec_claude () =
   match Spawn_eio.resolve_model_spec "claude" with
   | Ok spec ->
       check bool "provider is Claude" true
-        (spec.Masc_mcp.Llm_client.provider = Masc_mcp.Llm_client.Claude)
+        (spec.Masc_mcp.Llm_types.provider = Masc_mcp.Llm_types.Claude)
   | Error _ ->
       (* May fail if ANTHROPIC_API_KEY not set — that is acceptable *)
       ()
@@ -200,7 +200,7 @@ let test_resolve_model_spec_glm () =
   match Spawn_eio.resolve_model_spec "glm" with
   | Ok spec ->
       check bool "provider is Glm_cloud" true
-        (spec.Masc_mcp.Llm_client.provider = Masc_mcp.Llm_client.Glm_cloud)
+        (spec.Masc_mcp.Llm_types.provider = Masc_mcp.Llm_types.Glm_cloud)
   | Error _ ->
       (* May fail if ZAI_API_KEY not set *)
       ()
@@ -209,7 +209,7 @@ let test_resolve_model_spec_gemini () =
   match Spawn_eio.resolve_model_spec "gemini" with
   | Ok spec ->
       check bool "provider is Gemini" true
-        (spec.Masc_mcp.Llm_client.provider = Masc_mcp.Llm_client.Gemini)
+        (spec.Masc_mcp.Llm_types.provider = Masc_mcp.Llm_types.Gemini)
   | Error _ -> ()
 
 (* ============================================================

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -119,29 +119,29 @@ let test_maybe_append_keeper_fallback_models_adds_glm_when_local_only () =
         expected labels)
 
 let test_llm_client_sanitize_message_utf8_repairs_invalid_fields () =
-  let raw : Masc_mcp.Llm_client.message =
+  let raw : Masc_mcp.Llm_types.message =
     { Agent_sdk.Types.role = User;
       content = [Agent_sdk.Types.Text "hello\x80.world"] }
   in
-  let sanitized = Masc_mcp.Llm_client.sanitize_message_utf8 raw in
+  let sanitized = Masc_mcp.Llm_types.sanitize_message_utf8 raw in
   check bool "role preserved" true (sanitized.role = raw.role);
-  let sanitized_text = Masc_mcp.Llm_client.text_of_message sanitized in
-  let raw_text = Masc_mcp.Llm_client.text_of_message raw in
+  let sanitized_text = Masc_mcp.Llm_types.text_of_message sanitized in
+  let raw_text = Masc_mcp.Llm_types.text_of_message raw in
   check bool "content valid utf8" true (string_is_valid_utf8 sanitized_text);
   check bool "content changed" true (sanitized_text <> raw_text)
 
 let test_llm_client_sanitize_messages_utf8_preserves_message_count () =
   let msgs =
     [
-      Masc_mcp.Llm_client.user_msg "ok\x80";
-      Masc_mcp.Llm_client.assistant_msg "fine\xFF";
+      Masc_mcp.Llm_types.user_msg "ok\x80";
+      Masc_mcp.Llm_types.assistant_msg "fine\xFF";
     ]
   in
-  let sanitized = Masc_mcp.Llm_client.sanitize_messages_utf8 msgs in
+  let sanitized = Masc_mcp.Llm_types.sanitize_messages_utf8 msgs in
   check int "count preserved" 2 (List.length sanitized);
   check bool "all valid utf8" true
     (List.for_all
-       (fun (msg : Masc_mcp.Llm_client.message) -> string_is_valid_utf8 (Masc_mcp.Llm_client.text_of_message msg))
+       (fun (msg : Masc_mcp.Llm_types.message) -> string_is_valid_utf8 (Masc_mcp.Llm_types.text_of_message msg))
        sanitized)
 
 let test_resolved_keeper_skill_route_marks_agent_judgment () =

--- a/test/test_tool_perpetual_coverage.ml
+++ b/test/test_tool_perpetual_coverage.ml
@@ -10,6 +10,7 @@
 module Tool_perpetual = Masc_mcp.Tool_perpetual
 module Perpetual_loop = Masc_mcp.Perpetual_loop
 module Llm_client = Masc_mcp.Llm_client
+module Llm_types = Masc_mcp.Llm_types
 
 (* ============================================================
    Test Helpers
@@ -25,8 +26,8 @@ let make_ctx () : Tool_perpetual.context = {
 }
 
 (** Create a default model spec for testing. *)
-let test_model : Llm_client.model_spec = {
-  provider = Llm_client.Llama;
+let test_model : Llm_types.model_spec = {
+  provider = Llm_types.Llama;
   model_id = "test-model";
   max_context = 4000;
   api_url = "http://127.0.0.1:8085";

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -268,14 +268,14 @@ let test_schemas_names () =
    ============================================================ *)
 
 let test_base_tools_names () =
-  let names = List.map (fun (t : Masc_mcp.Llm_client.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Llm_types.tool_def) -> t.tool_name)
     Tool_shard.base_tools in
   Alcotest.(check bool) "has time_now" true (List.mem "keeper_time_now" names);
   Alcotest.(check bool) "has context_status" true (List.mem "keeper_context_status" names);
   Alcotest.(check bool) "has memory_search" true (List.mem "keeper_memory_search" names)
 
 let test_board_tools_names () =
-  let names = List.map (fun (t : Masc_mcp.Llm_client.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Llm_types.tool_def) -> t.tool_name)
     Tool_shard.board_tools in
   Alcotest.(check bool) "has board_post" true (List.mem "keeper_board_post" names);
   Alcotest.(check bool) "has board_list" true (List.mem "keeper_board_list" names);

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -319,7 +319,7 @@ let test_eio_default_dispatch_uses_shared_cascade () =
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room_walph_eio.ml" "Llm_direct.dispatch");
   check bool "no direct run_prompt_cascade" false
-    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_client.run_prompt_cascade")
+    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_orchestration.run_prompt_cascade")
 
 (* ============================================
    Test Registration


### PR DESCRIPTION
## Summary

`Llm_client.X` 참조를 canonical 모듈로 치환:
- **타입/값** → `Llm_types.X` (model_spec, message, text_of_response 등)
- **실행 함수** → `Llm_orchestration.X` (complete, cascade, run_prompt_cascade)
- **OAS adapters** → `Llm_client.X` 유지 (to_oas_provider, to_oas_message — 6곳만)

또한 기존 main의 `Types.Custom` 빌드 에러 8건 수정 (Agent_sdk.Types.model = string).

## Impact

- 99 files, 655 insertions, 637 deletions
- `Llm_client` 참조: ~400건 → 6건 (OAS adapters only)
- OAS adapter 6곳을 옮기면 `Llm_client.ml` + `Llm_client.mli` 삭제 가능

## Test plan

- [x] `dune build` passes
- [ ] Full CI
- [ ] `make test`

Progresses #1549, #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)