### PR TITLE
fix: remove stale Oas.Types.Custom constructor + Auth test params (#1604)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -101,7 +101,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
     Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:config.workdir ()
   in
   let agent_config = { Types.default_config with
-    model = Types.Custom provider_cfg.model_id;
+    model = provider_cfg.model_id;
     max_turns = config.max_turns;
     system_prompt = Some (Agent_swarm_prompts.solo_developer ~goal:config.goal);
   } in

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -343,7 +343,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
               let config = {
                 Types.default_config with
                 name = spec.name;
-                model = Types.Custom spec.provider.model_id;
+                model = spec.provider.model_id;
                 system_prompt = Some spec.system_prompt;
                 max_tokens =
                   Option.value spec.max_tokens

--- a/lib/local_agent_eio_container.ml
+++ b/lib/local_agent_eio_container.ml
@@ -535,7 +535,7 @@ let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
     {
       Oas.Types.default_config with
       name = worker_name;
-      model = Oas.Types.Custom model.Llm_client.model_id;
+      model = model.Llm_client.model_id;
       system_prompt = Some system_prompt;
       max_tokens = local_worker_max_tokens ();
       max_turns;

--- a/lib/local_agent_eio_runners.ml
+++ b/lib/local_agent_eio_runners.ml
@@ -424,11 +424,11 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
               in
               let model =
                 let base_model = Llm_client.default_local_model_spec () in
-                match checkpoint.model with
-                | Oas.Types.Custom model_id ->
-                    { base_model with model_id }
-                | _ ->
-                    { base_model with model_id = meta.effective_model }
+                let model_id =
+                  if checkpoint.model <> "" then checkpoint.model
+                  else meta.effective_model
+                in
+                { base_model with model_id }
               in
               let prompt =
                 let tool_contract =

--- a/lib/perpetual_oas.ml
+++ b/lib/perpetual_oas.ml
@@ -132,7 +132,7 @@ let run_perpetual_via_oas
       version = 3;
       session_id = trace_id;
       agent_name = "perpetual";
-      model = Oas.Types.Custom "masc-perpetual";
+      model = "masc-perpetual";
       system_prompt = Some ctx.system_prompt;
       messages;
       usage = {

--- a/lib/perpetual_oas_build.ml
+++ b/lib/perpetual_oas_build.ml
@@ -40,7 +40,7 @@ let build_perpetual_agent
     | m :: _ -> m
     | [] -> Llm_client.default_local_model_spec ()
   in
-  let oas_model = Oas.Types.Custom primary_model.model_id in
+  let oas_model = primary_model.model_id in
   (* Build provider via Phase 3 adapter.
      Uses Llm_client.to_oas_provider which handles the Llm_client.model_spec
      -> Oas.Provider.config conversion (avoiding Llm_types nominality gap). *)

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -545,7 +545,7 @@ let checkpoint_of_dna
     Agent_sdk.Checkpoint.version = 3;
     session_id = sprintf "succession-%s-gen%d" dna.trace_id dna.generation;
     agent_name = "perpetual-successor";
-    model = Agent_sdk.Types.Custom "masc-perpetual";
+    model = "masc-perpetual";
     system_prompt = Some working_ctx.system_prompt;
     messages;
     usage = {

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -25,7 +25,7 @@ module Oas = Agent_sdk
     MASC workers use local Ollama/llama-server models, so all model IDs
     go through Custom. *)
 let oas_model_of_effective_model (model_id : string) : Oas.Types.model =
-  Oas.Types.Custom model_id
+  model_id
 
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.agent_config                   *)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -210,7 +210,7 @@ let test_auth_disabled_allows_all () =
 
 let test_auth_enabled_requires_token () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let result = Auth.check_permission dir ~agent_name:"claude" ~token:None ~permission:Types.CanClaimTask in
   cleanup_test_room dir;
   match result with
@@ -220,7 +220,7 @@ let test_auth_enabled_requires_token () =
 
 let test_auth_enabled_with_valid_token () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"claude" ~role:Types.Worker in
   let check_result = match create_result with
     | Ok (raw_token, _) ->
@@ -234,7 +234,7 @@ let test_auth_enabled_with_valid_token () =
 
 let test_permission_denied_for_reader () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"reader_agent" ~role:Types.Reader in
   let check_result = match create_result with
     | Ok (raw_token, _) ->
@@ -249,7 +249,7 @@ let test_permission_denied_for_reader () =
 
 let test_authorize_unknown_masc_tool_strict_worker_allowed () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
   let result =
     match create_result with
@@ -266,7 +266,7 @@ let test_authorize_unknown_masc_tool_strict_worker_allowed () =
 
 let test_authorize_unknown_masc_tool_strict_reader_denied () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"reader_agent" ~role:Types.Reader in
   let result =
     match create_result with
@@ -284,7 +284,7 @@ let test_authorize_unknown_masc_tool_strict_reader_denied () =
 
 let test_authorize_unknown_non_masc_tool_strict_denied () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
   let result =
     match create_result with
@@ -302,7 +302,7 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
 
 let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
   let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
   let result =
     match create_result with
@@ -324,7 +324,7 @@ let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
 let test_enable_disable_auth () =
   let dir = setup_test_room () in
   let initially_disabled = not (Auth.is_auth_enabled dir) in
-  let _ = Auth.enable_auth dir ~require_token:false in
+  let _ = Auth.enable_auth dir ~require_token:false ~agent_name:"test-admin" in
   let enabled = Auth.is_auth_enabled dir in
   Auth.disable_auth dir;
   let disabled_again = not (Auth.is_auth_enabled dir) in

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -440,7 +440,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   Mirage_crypto_rng_unix.use_default ();
   let supervisor_token, planner_token, implementer_a_token, implementer_b_token =
     if enable_auth then begin
-      ignore (Masc_mcp.Auth.enable_auth config.base_path ~require_token:true);
+      ignore (Masc_mcp.Auth.enable_auth config.base_path ~require_token:true ~agent_name:"test-supervisor");
       let supervisor_token =
         match
           Masc_mcp.Auth.create_token config.base_path ~agent_name:supervisor_nickname


### PR DESCRIPTION
## Summary

- OAS PR #184에서 `type model = Custom of string | ...`을 `type model = string`으로 단순화한 후, MASC 8곳에서 제거된 `Custom` 생성자를 참조하여 main 빌드가 깨짐
- `Auth.enable_auth`에 `~agent_name` 파라미터 추가(#1605)된 후 테스트 2파일에서 누락

## Changes

| 파일 | 변경 |
|------|------|
| `succession_oas.ml` | `Agent_sdk.Types.Custom "masc-perpetual"` → `"masc-perpetual"` |
| `perpetual_oas.ml` | `Oas.Types.Custom "masc-perpetual"` → `"masc-perpetual"` |
| `perpetual_oas_build.ml` | `Oas.Types.Custom primary_model.model_id` → `primary_model.model_id` |
| `agent_swarm_swarm.ml` | `Types.Custom spec.provider.model_id` → `spec.provider.model_id` |
| `agent_swarm_runner.ml` | `Types.Custom provider_cfg.model_id` → `provider_cfg.model_id` |
| `local_agent_eio_container.ml` | `Oas.Types.Custom model.Llm_client.model_id` → `model.Llm_client.model_id` |
| `local_agent_eio_runners.ml` | Pattern match on `Custom` → string comparison |
| `worker_oas.ml` | `Oas.Types.Custom model_id` → `model_id` (identity fn) |
| `test_auth.ml` | Add missing `~agent_name:"test-admin"` to 8 `enable_auth` calls |
| `test_operator_mcp_e2e.ml` | Add missing `~agent_name:"test-supervisor"` |

## Test plan

- [x] `dune build --root .` passes (0 errors)
- [x] `test_auth.exe` — 22/22 tests pass

Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)