### PR TITLE
fix: remove Oas.Types.Custom — unbreak main build

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -24,7 +24,7 @@ module Oas = Agent_sdk
 (** Convert an effective_model string to an OAS model identifier.
     MASC workers use local Ollama/llama-server models, so all model IDs
     go through Custom. *)
-let oas_model_of_effective_model (model_id : string) : Oas.Types.model =
+let oas_model_of_effective_model (model_id : string) : string =
   model_id
 
 (* ================================================================ *)


### PR DESCRIPTION
## Problem

Main build broken: OAS 0.57.0 changed `type model` from variant to `string`, removing the `Custom` constructor. 8 call sites still used it.

## Fix

Replace `Types.Custom model_id` → `model_id` in 8 files. Minimal, surgical fix.

Closes #1604

## Test plan

- [x] `dune build` passes (lib/)
- [ ] `make test` (2 pre-existing test warnings from #1605 Auth.enable_auth change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)