### PR TITLE
fix(resilience): zombie detection broken by UTC double-offset

### DIFF
--- a/lib/resilience.ml
+++ b/lib/resilience.ml
@@ -11,9 +11,14 @@ module Time = struct
   (** Get current time as Unix float *)
   let now () = Time_compat.now ()
 
-  (** Parse ISO timestamp to Unix float.
-      Handles "YYYY-MM-DDTHH:MM:SSZ" format.
-      Returns None if parsing fails. *)
+  (** Parse ISO 8601 UTC timestamp ("YYYY-MM-DDTHH:MM:SSZ") to Unix epoch.
+
+      [Unix.mktime] interprets its argument as local time. To get the
+      correct UTC epoch we compute the local-UTC offset and subtract it.
+
+      The previous implementation added the offset instead of subtracting,
+      which on KST (UTC+9) made timestamps appear 9 h in the future —
+      causing [is_zombie] to always return [false]. *)
   let parse_iso8601_opt s =
     try
       Scanf.sscanf s "%04d-%02d-%02dT%02d:%02d:%02dZ"
@@ -23,11 +28,11 @@ module Time = struct
             tm_mday = day; tm_mon = mon - 1; tm_year = year - 1900;
             tm_wday = 0; tm_yday = 0; tm_isdst = false;
           } in
-          let local_time, _ = Unix.mktime tm in
-          let utc_tm = Unix.gmtime local_time in
-          let utc_time, _ = Unix.mktime utc_tm in
-          let offset = local_time -. utc_time in
-          Some (local_time +. offset))
+          let local_epoch, _ = Unix.mktime tm in
+          let utc_of_local = Unix.gmtime local_epoch in
+          let utc_as_local, _ = Unix.mktime utc_of_local in
+          let tz_offset = local_epoch -. utc_as_local in
+          Some (local_epoch -. tz_offset))
     with Scanf.Scan_failure _ | Failure _ | End_of_file ->
       Log.Misc.error "parse_iso8601_opt failed for: %S" s;
       None


### PR DESCRIPTION
## Summary

`parse_iso8601_opt`가 UTC offset을 빼야 하는데 더하고 있었다. KST(UTC+9)에서 ISO 타임스탬프가 9시간 미래로 파싱되어 `is_zombie()`가 항상 false를 반환.

## Root Cause

```ocaml
(* Before — WRONG: adds offset *)
let offset = local_time -. utc_time in
Some (local_time +. offset)

(* After — CORRECT: subtracts offset *)
let tz_offset = local_epoch -. utc_as_local in
Some (local_epoch -. tz_offset)
```

`Unix.mktime`은 입력을 로컬 시간으로 해석한다. UTC 타임스탬프 "11:28Z"를 KST 환경에서:
- `mktime(11:28)` → `11:28 KST` = `02:28 UTC` (epoch)
- 이전: `02:28 + 9h` = `11:28 UTC` → 미래 → not zombie
- 수정: `02:28 - (-9h)` = `11:28 UTC` → 과거 → zombie detected

## Impact

- 모든 zombie 감지, staleness 체크, heartbeat timeout에 영향
- #1607: 18시간 stuck agents가 zombie로 감지되지 않던 원인
- #1608: governance case 중복도 이 버그와 관련 가능성 (stale 판정 오류)

## Files changed (1)

`lib/resilience.ml` — `Time.parse_iso8601_opt` 함수 (offset 방향 수정)

## Test plan

- [x] `dune build` passes
- [ ] Unit test: parse_iso8601_opt("2026-03-18T02:28:00Z") ≈ expected UTC epoch
- [ ] Live: `masc_agents()` shows `is_zombie: true` for 18h+ stuck agents

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)