### PR TITLE
fix: agent_update looks up room-scoped agents before root-scoped

### DIFF
--- a/lib/room_agent.ml
+++ b/lib/room_agent.ml
@@ -81,7 +81,16 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
     | Error e -> Error e
     | Ok _ ->
         let actual_name = resolve_agent_name config agent_name in
-        let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
+        let filename = safe_filename actual_name ^ ".json" in
+        (* Check room-scoped agents first, then root-scoped.
+           masc_join writes to room-scoped dir, but this function
+           previously only looked in root agents_dir. *)
+        let room_file = Filename.concat (agents_dir_in_room config (current_room_id config)) filename in
+        let root_file = Filename.concat (agents_dir config) filename in
+        let agent_file =
+          if Sys.file_exists room_file then room_file
+          else root_file
+        in
         if not (Sys.file_exists agent_file) then
           Error (Types.AgentNotFound actual_name)
         else


### PR DESCRIPTION
## Summary

`masc_agent_update`가 세션에 join된 에이전트를 찾지 못하는 버그 수정 (#1600).

**Root cause**: `update_agent_r`이 `agents_dir` (root-scoped)만 검색했지만, `masc_join`은 `agents_dir_in_room` (room-scoped)에 에이전트 파일을 저장. 동일 이름의 에이전트가 room 디렉토리에만 존재하면 `AgentNotFound` 에러 발생.

**Fix**: room-scoped 디렉토리를 먼저 확인하고, 없으면 root-scoped로 fallback.

## Test plan
- [ ] `masc_join` → `masc_agent_update(status: "busy")` → 정상 동작
- [ ] CI green

Closes #1600

Generated with [Claude Code](https://claude.com/claude-code)