### PR TITLE
fix: empty broadcast validation + cache auto-eviction (#1602, #1609)

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -82,6 +82,12 @@ let is_expired entry =
   | None -> false
   | Some exp -> Time_compat.now () > exp
 
+(** Timestamp of last batch eviction, used to throttle periodic checks. *)
+let last_batch_eviction = ref 0.0
+
+(** Minimum interval between batch evictions (seconds). *)
+let batch_eviction_interval = 60.0
+
 (** Evict all expired cache entries. Returns count of evicted entries. *)
 let evict_expired config =
   let dir = cache_dir config in
@@ -104,6 +110,47 @@ let evict_expired config =
             | _ -> count
       else count
     ) 0 entries
+
+(** Check expired ratio and evict if > 50% are expired.
+    Throttled to run at most once per [batch_eviction_interval] seconds.
+    Returns number of evicted entries (0 if skipped). *)
+let maybe_evict_expired config =
+  let now = Time_compat.now () in
+  if now -. !last_batch_eviction < batch_eviction_interval then 0
+  else begin
+    let dir = cache_dir config in
+    if not (Sys.file_exists dir) then 0
+    else
+      let files = Sys.readdir dir |> Array.to_list
+        |> List.filter (fun f -> Filename.check_suffix f ".json") in
+      let total = List.length files in
+      if total = 0 then 0
+      else begin
+        (* Sample up to 10 entries to estimate expired ratio *)
+        let sample_size = min 10 total in
+        let sample = List.filteri (fun i _ -> i < sample_size) files in
+        let expired_count = List.fold_left (fun acc filename ->
+          let path = Filename.concat dir filename in
+          match Safe_ops.read_file_safe path with
+          | Error _ -> acc
+          | Ok content ->
+            match Safe_ops.parse_json_safe ~context:"cache_maybe_evict" content with
+            | Error _ -> acc
+            | Ok json ->
+              match entry_of_json json with
+              | Some entry when is_expired entry -> acc + 1
+              | _ -> acc
+        ) 0 sample in
+        let ratio = float_of_int expired_count /. float_of_int sample_size in
+        if ratio > 0.5 then begin
+          last_batch_eviction := now;
+          evict_expired config
+        end else begin
+          last_batch_eviction := now;
+          0
+        end
+      end
+  end
 
 (** Count current number of cache entries *)
 let count_entries config =
@@ -159,11 +206,15 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
     end
   end
 
-(** Get cache entry - synchronous *)
+(** Get cache entry - synchronous.
+    Also triggers batch eviction when expired ratio > 50% (throttled). *)
 let get config ~key : (cache_entry option, string) result =
   let path = cache_file config key in
-  if not (Sys.file_exists path) then
+  if not (Sys.file_exists path) then begin
+    (* Trigger batch eviction check even on miss *)
+    let _evicted = maybe_evict_expired config in
     Ok None
+  end
   else
     try
       let content = Fs_compat.load_file path in
@@ -173,9 +224,12 @@ let get config ~key : (cache_entry option, string) result =
         if is_expired entry then begin
           (* Auto-delete expired entries *)
           Sys.remove path;
+          let _evicted = maybe_evict_expired config in
           Ok None
-        end else
+        end else begin
+          let _evicted = maybe_evict_expired config in
           Ok (Some entry)
+        end
       | None -> Ok None
     with e ->
       Error (Printexc.to_string e)

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -191,14 +191,17 @@ let make_gc_consumer config : (module Pulse.Consumer) =
     let on_beat _beat =
       try
         let result = Room.gc config ~days:gc_days () in
+        (* Periodic cache eviction — piggyback on GC cycle *)
+        let cache_evicted = Cache_eio.evict_expired config in
         last_gc_result := Some result;
         set_last last_gc;
-        log_debug (sprintf "gc: %s" result);
+        log_debug (sprintf "gc: %s (cache evicted: %d)" result cache_evicted);
         publish_event "masc:guardian:gc"
           (`Assoc [
             ("agent_name", `String "guardian");
             ("result", `String result);
             ("gc_days", `Int gc_days);
+            ("cache_evicted", `Int cache_evicted);
             ("timestamp", `Float (Time_compat.now ()));
           ]);
         Ok ()

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -405,6 +405,10 @@ let dispatch (ctx : context) ~(name : string) : result option =
 
   | "masc_broadcast" ->
       let message = arg_get_string "message" "" in
+      let trimmed = String.trim message in
+      if trimmed = "" then
+        Some (false, "Broadcast message cannot be empty")
+      else
       let allowed, wait_secs = Session.check_rate_limit registry ~agent_name in
       if not allowed then
         Some (false, Printf.sprintf "Rate limited. %d sec remaining." wait_secs)

--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -166,7 +166,78 @@ let test_expired_cleanup () =
     | Ok None -> ()  (* Auto-cleanup worked *)
     | _ -> failwith "Expected expired entry to be cleaned up"
   );
-  print_endline "✓ test_expired_cleanup passed"
+  print_endline "  test_expired_cleanup passed"
+
+let test_evict_expired_batch () =
+  with_temp_masc_dir (fun config ->
+    (* Create several expired entries *)
+    let _ = Cache_eio.set config ~key:"exp-1" ~value:"v1" ~ttl_seconds:(-1) () in
+    let _ = Cache_eio.set config ~key:"exp-2" ~value:"v2" ~ttl_seconds:(-1) () in
+    let _ = Cache_eio.set config ~key:"exp-3" ~value:"v3" ~ttl_seconds:(-1) () in
+    (* Create a valid entry *)
+    let _ = Cache_eio.set config ~key:"valid-1" ~value:"keep" ~ttl_seconds:3600 () in
+
+    (* Evict expired entries *)
+    let evicted = Cache_eio.evict_expired config in
+    assert (evicted = 3);
+
+    (* Valid entry should still exist *)
+    (match Cache_eio.get config ~key:"valid-1" with
+     | Ok (Some entry) -> assert (entry.Cache_eio.value = "keep")
+     | _ -> failwith "Expected valid entry to survive eviction");
+
+    (* Expired entries should be gone *)
+    let count = Cache_eio.count_entries config in
+    assert (count = 1)
+  );
+  print_endline "  test_evict_expired_batch passed"
+
+let test_maybe_evict_expired_triggers_when_ratio_high () =
+  with_temp_masc_dir (fun config ->
+    (* Reset last_batch_eviction to allow immediate trigger *)
+    Cache_eio.last_batch_eviction := 0.0;
+
+    (* Create 8 expired + 2 valid = 80% expired ratio > 50% threshold *)
+    for i = 1 to 8 do
+      let _ = Cache_eio.set config
+        ~key:(Printf.sprintf "exp-%d" i)
+        ~value:"expired"
+        ~ttl_seconds:(-1) () in
+      ()
+    done;
+    let _ = Cache_eio.set config ~key:"valid-a" ~value:"keep-a" ~ttl_seconds:3600 () in
+    let _ = Cache_eio.set config ~key:"valid-b" ~value:"keep-b" ~ttl_seconds:3600 () in
+
+    (* Verify we start with 10 entries *)
+    assert (Cache_eio.count_entries config = 10);
+
+    (* Access via get triggers maybe_evict_expired *)
+    let _ = Cache_eio.get config ~key:"valid-a" in
+
+    (* After batch eviction, only valid entries should remain *)
+    let remaining = Cache_eio.count_entries config in
+    assert (remaining = 2)
+  );
+  print_endline "  test_maybe_evict_expired_triggers_when_ratio_high passed"
+
+let test_maybe_evict_expired_throttled () =
+  with_temp_masc_dir (fun config ->
+    (* Set last_batch_eviction to now (prevents re-run within interval) *)
+    Cache_eio.last_batch_eviction := Unix.gettimeofday ();
+
+    (* Create expired entries *)
+    let _ = Cache_eio.set config ~key:"exp-1" ~value:"v1" ~ttl_seconds:(-1) () in
+    let _ = Cache_eio.set config ~key:"exp-2" ~value:"v2" ~ttl_seconds:(-1) () in
+
+    (* maybe_evict should be throttled (returns 0) *)
+    let evicted = Cache_eio.maybe_evict_expired config in
+    assert (evicted = 0);
+
+    (* Expired entries should still exist on disk (not evicted by batch) *)
+    (* Note: individual get will still remove the specific expired entry *)
+    assert (Cache_eio.count_entries config = 2)
+  );
+  print_endline "  test_maybe_evict_expired_throttled passed"
 
 let () =
   print_endline "\n=== Cache_eio Tests (Pure Sync) ===\n";
@@ -179,4 +250,7 @@ let () =
   test_clear ();
   test_stats ();
   test_expired_cleanup ();
-  print_endline "\n✅ All 9 Cache_eio tests passed!\n"
+  test_evict_expired_batch ();
+  test_maybe_evict_expired_triggers_when_ratio_high ();
+  test_maybe_evict_expired_throttled ();
+  print_endline "\n=== All 12 Cache_eio tests passed ===\n"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -65,6 +65,25 @@ let test_route_auth_contracts () =
     (file_contains_pattern "lib/server_h2_gateway_routes_cp.ml"
        {|h2_authorize_tool state ~tool_name:"masc_operator_confirm"|})
 
+let test_input_validation_contracts () =
+  (* Bug #1602: broadcast must reject empty messages *)
+  check bool "broadcast validates empty message" true
+    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+       {|"Broadcast message cannot be empty"|});
+  check bool "broadcast trims whitespace before check" true
+    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+       {|String.trim message|});
+  (* Bug #1609: cache must have automatic eviction *)
+  check bool "cache has maybe_evict_expired function" true
+    (file_contains_pattern "lib/cache_eio.ml"
+       "let maybe_evict_expired config");
+  check bool "cache get triggers batch eviction" true
+    (file_contains_pattern "lib/cache_eio.ml"
+       "maybe_evict_expired config");
+  check bool "guardian GC runs cache eviction" true
+    (file_contains_pattern "lib/guardian.ml"
+       "Cache_eio.evict_expired config")
+
 let () =
   run "ci_hardening_source"
     [
@@ -72,5 +91,6 @@ let () =
            test_case "sync and asset contracts" `Quick test_ci_sync_and_asset_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
+           test_case "input validation contracts" `Quick test_input_validation_contracts;
          ]);
     ]


### PR DESCRIPTION
## Summary
- **#1602**: `masc_broadcast` 빈 메시지 거부 — `String.trim` 후 empty check, `"Broadcast message cannot be empty"` 에러 반환
- **#1609**: Cache expired entry 자동 정리
  - Lazy eviction: `get` 호출 시 throttled batch eviction (60초 간격)
  - Periodic eviction: Guardian GC 루프에서 `Cache_eio.evict_expired` 호출
  - 샘플 10개 중 50% 이상 expired 시 전체 scan

## Test plan
- [x] `dune build --root .` 통과
- [x] 12개 cache 테스트 통과 (evict_expired_batch, maybe_evict 포함)
- [x] 5개 CI hardening source 테스트 통과
- [x] 빈 broadcast validation 동작 확인

Closes #1602, Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)