### PR TITLE
feat(mode): add Voice category for TTS/STT tool discoverability

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -28,14 +28,15 @@ type category =
   | Plan        (* plan_*, goal_*, intent_* *)
   | Consensus   (* debate_*, consensus_*, walph_*, convo_*, decision_*, council_status *)
   | Ecosystem   (* gardener_*, keeper_*, perpetual_*, mdal_*, handover_*, library_* *)
+  | Voice       (* masc_voice_*: TTS, STT, sessions, conferences *)
   | TRPG        (* masc_trpg_*, trpg_* *)
   | Unknown     (* unmapped namespace/tool *)
 
 (** Mode presets *)
 type mode =
   | Minimal   (* core_room, core_task, health *)
-  | Standard  (* core, comm, worktree, health, plan, board, consensus *)
-  | Parallel  (* core, comm, portal, worktree, health, discovery, plan, board, consensus, voting, interrupt *)
+  | Standard  (* core, comm, worktree, health, plan, board, consensus, voice *)
+  | Parallel  (* core, comm, portal, worktree, health, discovery, plan, board, consensus, voting, interrupt, voice *)
   | Coding    (* core, worktree, code, health, plan *)
   | Full      (* all categories *)
   | Solo      (* core_room, core_task, worktree *)
@@ -65,6 +66,7 @@ let category_to_string = function
   | Plan -> "plan"
   | Consensus -> "consensus"
   | Ecosystem -> "ecosystem"
+  | Voice -> "voice"
   | TRPG -> "trpg"
   | Unknown -> "unknown"
 
@@ -91,6 +93,7 @@ let category_of_string = function
   | "plan" -> Some Plan
   | "consensus" -> Some Consensus
   | "ecosystem" -> Some Ecosystem
+  | "voice" -> Some Voice
   | "trpg" -> Some TRPG
   | _ -> None
 
@@ -125,15 +128,15 @@ let all_categories =
   core_all @ [
   Comm; Portal; Worktree; Code; Health; Discovery;
   Voting; Interrupt; Cost; Auth; RateLimit; Encryption;
-  Board; Plan; Consensus; Ecosystem; TRPG
+  Board; Plan; Consensus; Ecosystem; Voice; TRPG
 ]
 
 (** Categories for each mode preset *)
 let categories_for_mode = function
   | Minimal -> [Core_Room; Core_Task; Health]
-  | Standard -> core_all @ [Comm; Worktree; Health; Plan; Board; Consensus]
+  | Standard -> core_all @ [Comm; Worktree; Health; Plan; Board; Consensus; Voice]
   | Parallel -> core_all @ [Comm; Portal; Worktree; Health; Discovery;
-                 Plan; Board; Consensus; Voting; Interrupt]
+                 Plan; Board; Consensus; Voting; Interrupt; Voice]
   | Coding -> core_all @ [Worktree; Code; Health; Plan; Consensus]
   | Full -> all_categories
   | Solo -> [Core_Room; Core_Task; Worktree]
@@ -367,10 +370,6 @@ let tool_category tool_name =
   | "masc_persistent_agent_dataset_export"
   | "masc_persistent_agent_action_explain"
   | "masc_persistent_agent_eval_replay"
-  | "masc_voice_speak" | "masc_voice_session_start"
-  | "masc_voice_session_end" | "masc_voice_sessions"
-  | "masc_voice_agent" | "masc_voice_transcript"
-  | "masc_voice_conference_start" | "masc_voice_conference_end"
   | "masc_keeper_goals"
   | "masc_keeper_autonomy"
   | "masc_persistent_agent_goals"
@@ -392,6 +391,12 @@ let tool_category tool_name =
   (* Spawn *)
   | "masc_spawn"
   | "masc_async_spawn" | "masc_job_status" | "masc_job_list" -> Ecosystem
+
+  (* ── Voice: TTS, STT, sessions, conferences ── *)
+  | "masc_voice_speak" | "masc_voice_session_start"
+  | "masc_voice_session_end" | "masc_voice_sessions"
+  | "masc_voice_agent" | "masc_voice_transcript"
+  | "masc_voice_conference_start" | "masc_voice_conference_end" -> Voice
 
   (* ── TRPG (canonical + legacy masc_trpg_* names) ── *)
   | "trpg_roleplay"
@@ -461,8 +466,8 @@ let is_tool_enabled enabled_categories tool_name =
 (** Mode descriptions for help text *)
 let mode_description = function
   | Minimal -> "Room + task + health only (~20 tools)"
-  | Standard -> "Core, communication, worktree, health, plan, board, and consensus"
-  | Parallel -> "Multi-agent: adds portal, discovery, plan, board, consensus, voting, and interrupt"
+  | Standard -> "Core, communication, worktree, health, plan, board, consensus, and voice"
+  | Parallel -> "Multi-agent: adds portal, discovery, plan, board, consensus, voting, interrupt, and voice"
   | Coding -> "Core, worktree, code navigation, health, plan, and consensus for agent development"
   | Full -> "All categories enabled (~322 tools)"
   | Solo -> "Room + task + worktree (~23 tools)"
@@ -492,6 +497,7 @@ let category_description = function
   | Plan -> "Plan and goal management: plan_*, goal_*, intent_*"
   | Consensus -> "Multi-agent consensus: debate, WALPH, convo, decision"
   | Ecosystem -> "Agent lifecycle: gardener, keeper, perpetual, MDAL, handover, library"
+  | Voice -> "Voice bridge: TTS, STT, sessions, conferences (8 tools)"
   | TRPG -> "Tabletop RPG engine: sessions, actors, dice, quests"
   | Unknown -> "Unmapped tool (excluded from all presets)"
 

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -26,7 +26,7 @@ let schemas : tool_schema list =
     {
       name = "masc_voice_speak";
       description =
-        "Send text to the voice bridge for an agent. Returns an error unless a reachable voice backend actually accepts the request.";
+        "Send text to the voice bridge for TTS playback. Requires an active voice session (call masc_voice_session_start first). provider: optional, one of 'elevenlabs', 'openai_compat'. priority: 1=normal, higher=urgent.";
       input_schema =
         `Assoc
           [
@@ -45,7 +45,7 @@ let schemas : tool_schema list =
     {
       name = "masc_voice_session_start";
       description =
-        "Start a voice session for an agent using the configured voice bridge.";
+        "Start a voice session for an agent. Call before masc_voice_speak. Requires voice_config.json with at least one TTS endpoint configured.";
       input_schema =
         `Assoc
           [
@@ -74,7 +74,7 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_sessions";
-      description = "List active voice sessions from the voice bridge.";
+      description = "List active voice sessions. Use to check existing sessions before starting a new one or debugging.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
     };
@@ -93,14 +93,14 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_transcript";
-      description = "Get the current transcript payload from the voice bridge.";
+      description = "Get the current transcript (STT output) from the voice bridge. Requires an active voice session.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
     };
     {
       name = "masc_voice_conference_start";
       description =
-        "Start a multi-agent voice conference for the given agents.";
+        "Start a multi-agent voice conference. All agent_ids should have active voice sessions first (call masc_voice_session_start for each).";
       input_schema =
         `Assoc
           [
@@ -122,7 +122,7 @@ let schemas : tool_schema list =
     {
       name = "masc_voice_conference_end";
       description =
-        "End a multi-agent voice conference for the given agents.";
+        "End a multi-agent voice conference. Releases the shared channel; individual agent sessions remain active.";
       input_schema =
         `Assoc
           [
@@ -145,7 +145,7 @@ let schemas : tool_schema list =
 let require_net_or_error (ctx : 'a context) =
   match ctx.net with
   | Some net -> Ok net
-  | None -> Error "voice bridge requires net (server_state.net is None)"
+  | None -> Error "Voice bridge unavailable: server started without network. Restart masc-mcp with --http flag to enable voice tools."
 
 let handle_voice_speak (ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -100,7 +100,7 @@ let test_mode_roundtrip () =
    ============================================================ *)
 
 let test_all_categories_count () =
-  check int "21 categories" 21 (List.length Mode.all_categories)
+  check int "22 categories" 22 (List.length Mode.all_categories)
 
 let test_all_categories_unique () =
   let rec has_duplicates = function
@@ -130,7 +130,8 @@ let test_categories_standard () =
   check bool "has plan" true (List.mem Mode.Plan cats);
   check bool "has board" true (List.mem Mode.Board cats);
   check bool "has consensus" true (List.mem Mode.Consensus cats);
-  check int "count" 10 (List.length cats)
+  check bool "has voice" true (List.mem Mode.Voice cats);
+  check int "count" 11 (List.length cats)
 
 let test_categories_parallel () =
   let cats = Mode.categories_for_mode Mode.Parallel in
@@ -146,7 +147,8 @@ let test_categories_parallel () =
   check bool "has plan" true (List.mem Mode.Plan cats);
   check bool "has board" true (List.mem Mode.Board cats);
   check bool "has consensus" true (List.mem Mode.Consensus cats);
-  check int "count" 14 (List.length cats)
+  check bool "has voice" true (List.mem Mode.Voice cats);
+  check int "count" 15 (List.length cats)
 
 let test_categories_coding () =
   let cats = Mode.categories_for_mode Mode.Coding in
@@ -165,7 +167,7 @@ let test_categories_agent () =
 
 let test_categories_full () =
   let cats = Mode.categories_for_mode Mode.Full in
-  check int "all categories" 21 (List.length cats)
+  check int "all categories" 22 (List.length cats)
 
 let test_categories_solo () =
   let cats = Mode.categories_for_mode Mode.Solo in
@@ -285,10 +287,10 @@ let test_tool_category_code () =
 let test_tool_category_ecosystem_voice () =
   check bool "gardener_status health" true
     (Mode.tool_category "masc_gardener_status" = Mode.Health);
-  check bool "voice_speak" true (Mode.tool_category "masc_voice_speak" = Mode.Ecosystem);
-  check bool "voice_sessions" true (Mode.tool_category "masc_voice_sessions" = Mode.Ecosystem);
+  check bool "voice_speak" true (Mode.tool_category "masc_voice_speak" = Mode.Voice);
+  check bool "voice_sessions" true (Mode.tool_category "masc_voice_sessions" = Mode.Voice);
   check bool "voice_conference_start" true
-    (Mode.tool_category "masc_voice_conference_start" = Mode.Ecosystem)
+    (Mode.tool_category "masc_voice_conference_start" = Mode.Voice)
 
 let test_tool_category_namespace_mapping () =
   check bool "lodge namespace" true (Mode.tool_category "lodge_heartbeat" = Mode.Comm);

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -4,6 +4,7 @@ open Alcotest
 
 module Tool_voice = Masc_mcp.Tool_voice
 module Voice_bridge = Masc_mcp.Voice_bridge
+module Mode = Masc_mcp.Mode
 
 let contains haystack needle =
   let text = String.lowercase_ascii haystack in
@@ -576,6 +577,82 @@ let test_local_playback_argv_falls_back_to_open () =
         (Some [ open_cmd; "/tmp/sample.mp3" ])
         argv)
 
+let voice_tools =
+  [
+    "masc_voice_speak";
+    "masc_voice_session_start";
+    "masc_voice_session_end";
+    "masc_voice_sessions";
+    "masc_voice_agent";
+    "masc_voice_transcript";
+    "masc_voice_conference_start";
+    "masc_voice_conference_end";
+  ]
+
+let test_voice_tools_in_voice_category () =
+  List.iter
+    (fun name ->
+      check bool (name ^ " -> Voice") true
+        (Mode.tool_category name = Mode.Voice))
+    voice_tools
+
+let test_voice_enabled_in_standard_mode () =
+  let cats = Mode.categories_for_mode Mode.Standard in
+  List.iter
+    (fun name ->
+      check bool (name ^ " enabled in Standard") true
+        (Mode.is_tool_enabled cats name))
+    voice_tools
+
+let test_voice_enabled_in_parallel_mode () =
+  let cats = Mode.categories_for_mode Mode.Parallel in
+  List.iter
+    (fun name ->
+      check bool (name ^ " enabled in Parallel") true
+        (Mode.is_tool_enabled cats name))
+    voice_tools
+
+let test_voice_disabled_in_agent_mode () =
+  let cats = Mode.categories_for_mode Mode.Agent in
+  List.iter
+    (fun name ->
+      check bool (name ^ " disabled in Agent") false
+        (Mode.is_tool_enabled cats name))
+    voice_tools
+
+let test_voice_progressive_disclosure_in_agent_mode () =
+  let cats = Mode.categories_for_mode Mode.Agent in
+  let tool = "masc_voice_speak" in
+  check bool "disabled before enable" false
+    (Mode.is_tool_enabled cats tool);
+  Mode.tool_enable tool;
+  check bool "enabled after tool_enable" true
+    (Mode.is_tool_enabled cats tool);
+  Mode.tool_disable tool;
+  check bool "disabled after tool_disable" false
+    (Mode.is_tool_enabled cats tool)
+
+let test_error_message_contains_restart_guide () =
+  with_ctx_no_net (fun ctx ->
+      let _ok, body =
+        dispatch_exn ctx ~name:"masc_voice_speak"
+          ~args:
+            (`Assoc
+              [
+                ("agent_id", `String "test");
+                ("message", `String "hello");
+              ])
+      in
+      check bool "contains Restart" true (contains body "Restart");
+      check bool "contains --http" true (contains body "--http"))
+
+let test_voice_category_string_roundtrip () =
+  check string "to_string" "voice" (Mode.category_to_string Mode.Voice);
+  check (option string) "of_string" (Some "voice")
+    (match Mode.category_of_string "voice" with
+     | Some Mode.Voice -> Some "voice"
+     | _ -> None)
+
 let () =
   run "Tool_voice"
     [
@@ -583,6 +660,23 @@ let () =
         [
           test_case "unknown" `Quick test_dispatch_unknown;
           test_case "known tools" `Quick test_dispatch_known_tools;
+        ] );
+      ( "category",
+        [
+          test_case "voice tools in Voice category" `Quick
+            test_voice_tools_in_voice_category;
+          test_case "voice enabled in Standard" `Quick
+            test_voice_enabled_in_standard_mode;
+          test_case "voice enabled in Parallel" `Quick
+            test_voice_enabled_in_parallel_mode;
+          test_case "voice disabled in Agent" `Quick
+            test_voice_disabled_in_agent_mode;
+          test_case "progressive disclosure in Agent" `Quick
+            test_voice_progressive_disclosure_in_agent_mode;
+          test_case "category string roundtrip" `Quick
+            test_voice_category_string_roundtrip;
+          test_case "error message contains restart guide" `Quick
+            test_error_message_contains_restart_guide;
         ] );
       ( "handlers",
         [


### PR DESCRIPTION
## Summary

- Voice 도구 8개를 Ecosystem(40+ 도구)에서 별도 Voice 카테고리로 분리
- Standard, Parallel 모드에 Voice 카테고리 포함 (Agent/Solo/Minimal은 의도적 제외)
- 도구 description에 when/prerequisite 컨텍스트 추가 (PR#1418 {what/when/workflow} 패턴)
- 에러 메시지에 `--http` 재시작 가이드 포함
- 7개 새 테스트 추가 (카테고리 매핑, 모드 활성화, progressive disclosure, 에러 메시지)

## Changes

| 파일 | 변경 |
|------|------|
| `lib/mode.ml` | Voice variant + category 매핑 + Standard/Parallel preset |
| `lib/tool_voice.ml` | 6/8 description 개선 + 에러 메시지 개선 |
| `test/test_mode_coverage.ml` | 카운트 업데이트 (21→22, mode preset 수) |
| `test/test_tool_voice.ml` | 7개 category/mode 검증 테스트 추가 |

## Design decisions

- Agent 모드에는 Voice 미포함: 최소 도구 원칙 유지, `masc_tool_enable`로 개별 활성화 가능
- `test_mode_tool_count` `full equals visible` 실패는 기존 이슈 (main에서도 동일 실패)

## Test plan

- [x] `test_tool_voice.exe` 23/23 pass
- [x] `test_mode_coverage.exe` 52/52 pass
- [x] `make test` pass (기존 `full equals visible` 제외)
- [ ] 수동 검증: `masc_switch_mode(mode: "standard")` → `masc_discover_tools()` → voice 도구 8개 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)