### PR TITLE
fix: prevent orphan agent proliferation from sessionless requests (#1634)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -272,6 +272,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let can_auto_join =
     if (not join_required) || agent_name = "unknown" then
       false
+    else if Option.is_none mcp_session_id then
+      (* Sessionless requests (no Mcp-Session-Id header) should not auto-join.
+         Without a session, each request gets a new ephemeral agent name,
+         causing orphan agent proliferation in the room. *)
+      false
     else if not auth_enabled then
       true
     else


### PR DESCRIPTION
## Summary
Sessionless HTTP 요청이 매번 새 ephemeral agent를 room에 등록하여 고아 에이전트 증식.
`mcp_session_id`가 None이면 auto-join을 건너뛰도록 수정.

## Root Cause
`mcp_server_eio_execute.ml`의 `can_auto_join` 로직이 session 유무를 고려하지 않음.
세션 없는 요청마다 `Room.join`이 호출되어 `agent-XXXX-adjective-animal`이 room에 등록됨.

## Fix
5줄 추가: `Option.is_none mcp_session_id → can_auto_join = false`

## Impact
- Real MCP clients (Claude Code 등): 영향 없음 (항상 session ID 전송)
- Raw curl: tool 실행은 정상, room agent list에 등록만 안 됨

Closes #1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)