### PR TITLE
fix: narrow Stdlib.Mutex fallback to Effect.Unhandled only (#1633)

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -21,21 +21,16 @@ module FileSystemBackend : BACKEND = struct
        runs under Eio where Eio.Mutex is preferred.
        Two-phase: if Eio.Mutex fails (Effect.Unhandled), use Stdlib.Mutex.
        If f() fails inside the lock, re-raise. *)
-    let acquired = ref false in
     match
-      Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-        acquired := true;
-        f ()
-      )
+      Eio.Mutex.use_rw ~protect:true t.mutex (fun () -> f ())
     with
     | result -> result
-    | exception exn ->
-        if !acquired then raise exn  (* f() failed inside lock, propagate *)
-        else begin
-          (* Eio.Mutex unavailable — use Stdlib.Mutex for serialization *)
-          Stdlib.Mutex.lock stdlib_mutex;
-          Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
-        end
+    | exception Effect.Unhandled _ ->
+        (* No Eio runtime (e.g. tests) — fall back to Stdlib.Mutex.
+           Only catches Effect.Unhandled; Eio exceptions (Cancel, etc.)
+           propagate normally to avoid blocking the scheduler. *)
+        Stdlib.Mutex.lock stdlib_mutex;
+        Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
 
   (* Security: validate key with strict allowlist (parse, don't sanitize) *)
   let validate_key key =

--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -215,20 +215,13 @@ module MemoryBackend : BACKEND = struct
   let stdlib_mutex = Stdlib.Mutex.create ()
 
   let with_lock t f =
-    let acquired = ref false in
     match
-      Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-        acquired := true;
-        f ()
-      )
+      Eio.Mutex.use_rw ~protect:true t.mutex (fun () -> f ())
     with
     | result -> result
-    | exception exn ->
-        if !acquired then raise exn
-        else begin
-          Stdlib.Mutex.lock stdlib_mutex;
-          Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
-        end
+    | exception Effect.Unhandled _ ->
+        Stdlib.Mutex.lock stdlib_mutex;
+        Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
 
   let create (_cfg : config) : (t, error) result =
     Ok {


### PR DESCRIPTION
## Summary

`backend.ml`과 `backend_core.ml`의 `with_lock`이 모든 예외에서 `Stdlib.Mutex.lock`으로 fallback하던 문제를 수정.

**Before**: `exception exn` → acquired 체크 → Stdlib.Mutex (Eio Cancel 포함)
**After**: `exception Effect.Unhandled _` → Stdlib.Mutex (non-Eio context만)

Eio context에서 Cancel/timeout 시 Stdlib.Mutex.lock으로 빠지면 OS thread가 블록되어 scheduler starvation.

## Changes (2 files, -23/+11 LOC)

| File | Change |
|------|--------|
| `lib/backend.ml` | `exception exn` + `acquired` ref → `exception Effect.Unhandled _` |
| `lib/backend_core.ml` | 동일 패턴 |

## Test plan
- [x] `dune build --root .` clean
- [ ] CI green

Closes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)