### PR TITLE
fix: Parse Don't Validate — Tool_args required API + handler hardening

### DIFF
--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -19,18 +19,20 @@ let handle_a2a_discover ctx args =
   | Error e -> (false, Printf.sprintf "❌ Discovery failed: %s" e)
 
 let handle_a2a_query_skill ctx args =
-  let skill_agent_name = get_string args "agent_name" "" in
-  let skill_id = get_string args "skill_id" "" in
+  let ( let*! ) = Tool_args.( let*! ) in
+  let*! skill_agent_name = get_string_required args "agent_name" in
+  let*! skill_id = get_string_required args "skill_id" in
   match A2a_tools.query_skill ctx.config ~schemas:Config.raw_all_tool_schemas ~agent_name:skill_agent_name ~skill_id with
   | Ok json -> (true, Yojson.Safe.pretty_to_string json)
   | Error e -> (false, Printf.sprintf "❌ Query skill failed: %s" e)
 
 let handle_a2a_delegate ctx args =
+  let ( let*! ) = Tool_args.( let*! ) in
   (* Always use the authenticated caller's identity for the portal,
      not a user-supplied override. The caller cannot impersonate another agent. *)
   let delegate_agent_name = ctx.agent_name in
-  let target = get_string args "target_agent" "" in
-  let message = get_string args "message" "" in
+  let*! target = get_string_required args "target_agent" in
+  let*! message = get_string_required args "message" in
   let task_type_str = get_string args "task_type" "async" in
   let timeout = get_int args "timeout" 300 in
   let artifacts = match Yojson.Safe.Util.member "artifacts" args with

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -35,7 +35,8 @@ let handle_agent_update ctx args =
 
 (** Handle masc_find_by_capability *)
 let handle_find_by_capability ctx args =
-  let capability = get_string args "capability" "" in
+  let ( let*! ) = Tool_args.( let*! ) in
+  let*! capability = get_string_required args "capability" in
   let json = Room.find_agents_by_capability ctx.config ~capability in
   (true, Yojson.Safe.pretty_to_string json)
 

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -56,3 +56,26 @@ let error_result msg = (false, error_response msg)
 
 (** Convenience: [(true, ok_response fields)] *)
 let ok_result fields = (true, ok_response fields)
+
+(** {1 Parse, Don't Validate — Required Field Extractors}
+
+    Use these for required parameters instead of [get_string args key ""].
+    Returns [Ok value] on success, [Error json_string] on missing/empty input.
+    Combine with [let*!] for early-return chaining. *)
+
+(** Required non-empty string. Trims whitespace. *)
+let get_string_required args key =
+  match Safe_ops.json_string_opt key args with
+  | Some s when String.trim s <> "" -> Ok (String.trim s)
+  | Some _ -> Error (error_response (Printf.sprintf "%s must not be empty" key))
+  | None -> Error (error_response (Printf.sprintf "%s is required" key))
+
+(** Required integer. *)
+let get_int_required args key =
+  match Safe_ops.json_int_opt key args with
+  | Some i -> Ok i
+  | None -> Error (error_response (Printf.sprintf "%s is required" key))
+
+(** Monadic bind for [(ok, string) result] → [(bool * string)].
+    Chains required field extractions with early error return. *)
+let ( let*! ) r f = match r with Ok v -> f v | Error e -> (false, e)

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -61,10 +61,9 @@ let handle_pause_status ctx args =
   (true, Yojson.Safe.to_string payload)
 
 let handle_switch_mode ctx args =
-  let mode_str = get_string args "mode" "" |> String.trim |> String.lowercase_ascii in
-  if mode_str = "" then
-    (false, "mode is required (minimal|standard|parallel|coding|full|solo|custom)")
-  else
+  let ( let*! ) = Tool_args.( let*! ) in
+  let*! mode_raw = get_string_required args "mode" in
+  let mode_str = String.lowercase_ascii mode_raw in
     match Mode.mode_of_string mode_str with
     | None ->
         (false, Printf.sprintf "invalid mode: %s (minimal|standard|parallel|coding|full|solo|custom)" mode_str)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -95,6 +95,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
     | Some "" -> None
     | other -> other
   in
+  let _arg_get_string_required key =
+    Tool_args.get_string_required arguments key
+  in
   let _arg_get_int_opt _key = () in  (* unused but kept for symmetry *)
   let _arg_get_float_opt key =
     Safe_ops.json_float_opt key arguments
@@ -485,6 +488,8 @@ Call masc_listen again to continue listening.
 
   | "masc_mcp_session" ->
       let action = arg_get_string "action" "" in
+      if action = "" then Some (false, "action is required (create|get|list|delete)")
+      else
       let now = Time_compat.now () in
       let sessions = ctx.load_mcp_sessions config in
       let save sessions = ctx.save_mcp_sessions config sessions in
@@ -558,8 +563,11 @@ Call masc_listen again to continue listening.
 
   | "masc_interrupt" ->
       let task_id = arg_get_string "task_id" "" in
-      let step = arg_get_int "step" 1 in
       let action = arg_get_string "action" "" in
+      if task_id = "" || action = "" then
+        Some (false, "task_id and action are required")
+      else
+      let step = arg_get_int "step" 1 in
       let message = arg_get_string "message" "" in
       Notify.notify_interrupt ~agent:agent_name ~action;
       Some (safe_exec ["masc-checkpoint"; "--masc-dir"; Room.masc_dir config;
@@ -568,11 +576,15 @@ Call masc_listen again to continue listening.
 
   | "masc_approve" ->
       let task_id = arg_get_string "task_id" "" in
+      if task_id = "" then Some (false, "task_id is required")
+      else
       Some (safe_exec ["masc-checkpoint"; "--masc-dir"; Room.masc_dir config;
                  "--task-id"; task_id; "--approve"])
 
   | "masc_reject" ->
       let task_id = arg_get_string "task_id" "" in
+      if task_id = "" then Some (false, "task_id is required")
+      else
       let reason = arg_get_string "reason" "" in
       let args = if reason = "" then
         ["masc-checkpoint"; "--masc-dir"; Room.masc_dir config; "--task-id"; task_id; "--reject"]
@@ -619,6 +631,8 @@ Call masc_listen again to continue listening.
   | "masc_spawn" ->
       let spawn_agent_name = arg_get_string "agent_name" "" in
       let prompt = arg_get_string "prompt" "" in
+      if prompt = "" then Some (false, "prompt is required")
+      else
       let timeout_seconds = arg_get_int "timeout_seconds" 300 in
       let model_name =
         match arguments |> Yojson.Safe.Util.member "model" with

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -221,7 +221,20 @@ let handle_cancel_task ctx args =
        Log.Task.error "metrics record failed: %s" (Types.masc_error_to_string err));
   result_to_response result
 
+let transition_known_args =
+  ["task_id"; "action"; "notes"; "reason"; "expected_version"]
+
 let handle_transition ctx args =
+  let unknown = match args with
+    | `Assoc kvs ->
+      List.filter (fun (k, _) -> not (List.mem k transition_known_args)) kvs
+    | _ -> []
+  in
+  if unknown <> [] then
+    let names = String.concat ", " (List.map fst unknown) in
+    (false, Printf.sprintf "Unknown argument(s): %s. Valid: %s"
+      names (String.concat ", " transition_known_args))
+  else
   let task_id = get_string args "task_id" "" in
   match validate_task_id task_id with
   | Error e -> result_to_response (Error e)

--- a/lib/tool_vote.ml
+++ b/lib/tool_vote.ml
@@ -15,19 +15,24 @@ type result = bool * string
 
 (* Individual handlers *)
 let handle_vote_create ctx args =
+  let ( let*! ) = Tool_args.( let*! ) in
   let proposer = get_string args "proposer" ctx.agent_name in
-  let topic = get_string args "topic" "" in
+  let*! topic = get_string_required args "topic" in
   let options = get_string_list args "options" in
+  if options = [] then error_result "options must have at least one entry"
+  else
   let required_votes = get_int args "required_votes" 2 in
   (true, Room.vote_create ctx.config ~proposer ~topic ~options ~required_votes)
 
 let handle_vote_cast ctx args =
-  let vote_id = get_string args "vote_id" "" in
-  let choice = get_string args "choice" "" in
+  let ( let*! ) = Tool_args.( let*! ) in
+  let*! vote_id = get_string_required args "vote_id" in
+  let*! choice = get_string_required args "choice" in
   (true, Room.vote_cast ctx.config ~agent_name:ctx.agent_name ~vote_id ~choice)
 
 let handle_vote_status ctx args =
-  let vote_id = get_string args "vote_id" "" in
+  let ( let*! ) = Tool_args.( let*! ) in
+  let*! vote_id = get_string_required args "vote_id" in
   let json = Room.vote_status ctx.config ~vote_id in
   (true, Yojson.Safe.pretty_to_string json)
 


### PR DESCRIPTION
## Summary

MASC 도구 핸들러에 Parse Don't Validate 원칙을 시스템적으로 적용.

**Phase 1**: `Tool_args` API 확장
- `get_string_required`: 빈/누락 문자열 → `Error` 반환 (trim 포함)
- `get_int_required`: 누락 정수 → `Error` 반환
- `let*!`: required field 체이닝용 bind 연산자

**Phase 2**: 핵심 핸들러 6개에 적용
- `tool_a2a.ml`: delegate target/message, query_skill agent_name/skill_id
- `tool_agent.ml`: find_by_capability
- `tool_control.ml`: switch_mode
- `tool_inline_dispatch.ml`: mcp_session action, interrupt, approve/reject task_id, spawn prompt
- `tool_vote.ml`: vote_create topic + options, vote_cast/status vote_id/choice

**이전 PR #1623 포함**: broadcast 빈 메시지, transition unknown args, Lodge dedup

## Context

208곳의 `get_string args "key" ""` 패턴 중 핵심 도구 ~15곳을 수정. Gold Standard 패턴(`tool_social.ml`)을 `Tool_args`로 승격하여 시스템적 기반 확립.

## Test plan

- [x] `dune build --root . lib/` passes (0 errors)
- [ ] `masc_broadcast(message: "")` → error
- [ ] `masc_vote_create(topic: "")` → error
- [ ] `masc_a2a_delegate(target_agent: "")` → error
- [ ] `masc_spawn(prompt: "")` → error

Refs #1602, #1601, #1591