### PR TITLE
fix: mask stack traces and DB details in MCP responses (#1630)

### DIFF
--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -543,7 +543,7 @@ let stats t =
       ]
   | Error err ->
       Log.BoardPg.error "stats error: %s" (Caqti_error.show err);
-      `Assoc [("error", `String (Caqti_error.show err))]
+      `Assoc [("error", `String "Database operation failed")]
 
 (** {1 Search} *)
 

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -327,8 +327,9 @@ let guarded_execute
       let result =
         try execute ()
         with exn ->
+          Log.info "eval_gate tool %s failed: %s" tool_name (Printexc.to_string exn);
           Yojson.Safe.to_string (`Assoc [
-            ("error", `String (Printexc.to_string exn));
+            ("error", `String "Tool execution failed (internal error)");
             ("tool", `String tool_name);
           ])
       in

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -632,9 +632,10 @@ let list_org_rooms ~org_id : Yojson.Safe.t =
               ("error", `String (Printf.sprintf "Fetch stopped: %s" rooms_url));
             ]
         with exn ->
+          Log.Misc.error "federation: remote room list error: %s" (Printexc.to_string exn);
           `Assoc [
             ("success", `Bool false);
-            ("error", `String (Printf.sprintf "Remote room list error: %s" (Printexc.to_string exn)));
+            ("error", `String "Remote room list error (internal error)");
           ])
 
 (** Cross-room message type *)

--- a/lib/keeper_exec_context.ml
+++ b/lib/keeper_exec_context.ml
@@ -594,9 +594,10 @@ let run_proactive_generation
          let output =
            try execute_keeper_tool_call ~config ~meta ~ctx_work tc
            with exn ->
+             Log.Keeper.error "tool %s failed: %s" tc.call_name (Printexc.to_string exn);
              Yojson.Safe.to_string
                (`Assoc [
-                 ("error", `String (Printexc.to_string exn));
+                 ("error", `String "Tool execution failed (internal error)");
                  ("tool", `String tc.call_name);
                ])
          in

--- a/lib/keeper_exec_social.ml
+++ b/lib/keeper_exec_social.ml
@@ -232,10 +232,11 @@ let run_social_board_event_turn
                  let output =
                    try execute_keeper_tool_call ~config:ctx.config ~meta ~ctx_work tc
                    with exn ->
+                     Log.Keeper.error "social tool %s failed: %s" tc.call_name (Printexc.to_string exn);
                      Yojson.Safe.to_string
                        (`Assoc
                          [
-                           ("error", `String (Printexc.to_string exn));
+                           ("error", `String "Tool execution failed (internal error)");
                            ("tool", `String tc.call_name);
                          ])
                  in


### PR DESCRIPTION
## Summary

MCP tool 응답에 `Printexc.to_string`과 `Caqti_error.show`로 내부 경로, 함수명, DB 연결 정보가 노출되던 보안 문제 수정.

서버 로그에는 full trace를 유지하고, 외부 응답에는 generic 메시지를 반환.

## Changes (5 files, +9/-5 LOC)

| File | Before | After |
|------|--------|-------|
| `keeper_exec_context.ml` | `Printexc.to_string exn` | log + "Tool execution failed" |
| `keeper_exec_social.ml` | `Printexc.to_string exn` | log + "Tool execution failed" |
| `eval_gate.ml` | `Printexc.to_string exn` | log + "Tool execution failed" |
| `federation.ml` | `Printexc.to_string exn` in JSON | log + "Remote room list error" |
| `board_pg.ml` | `Caqti_error.show err` in JSON | "Database operation failed" |

## Test plan
- [x] `dune build --root .` clean
- [ ] CI green

Closes #1630

🤖 Generated with [Claude Code](https://claude.com/claude-code)