### PR TITLE
fix: UTC timezone offset in 4 additional parsers (#1628)

### DIFF
--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -100,7 +100,10 @@ let task_activities (config : Room.config) : activity_item list =
                      tm_mday = d; tm_mon = m - 1; tm_year = y - 1900;
                      tm_wday = 0; tm_yday = 0; tm_isdst = false;
                    } in
-                   let (t, _) = Unix.mktime tm in t)
+                   let local_epoch, _ = Unix.mktime tm in
+                   let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+                   let tz_offset = local_epoch -. utc_as_local in
+                   local_epoch +. tz_offset)
             with
             | Scanf.Scan_failure _ | Failure _ | End_of_file -> 0.0
             | exn ->

--- a/lib/cp_search_fabric.ml
+++ b/lib/cp_search_fabric.ml
@@ -273,7 +273,10 @@ let parse_iso_timestamp iso =
             Unix.tm_isdst = false;
           }
         in
-        Some (fst (Unix.mktime tm)))
+        let local_epoch, _ = Unix.mktime tm in
+        let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+        let tz_offset = local_epoch -. utc_as_local in
+        Some (local_epoch +. tz_offset))
   with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
 
 let stop_words =

--- a/lib/goal_store.ml
+++ b/lib/goal_store.ml
@@ -287,8 +287,10 @@ let parse_yyyy_mm_dd s =
             tm_isdst = false;
           }
         in
-        let ts, _ = Unix.mktime tm in
-        Some ts)
+        let local_epoch, _ = Unix.mktime tm in
+        let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+        let tz_offset = local_epoch -. utc_as_local in
+        Some (local_epoch +. tz_offset))
   with exn ->
     Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s" (Printexc.to_string exn);
     None

--- a/lib/room_task.ml
+++ b/lib/room_task.ml
@@ -606,7 +606,10 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
               let tm = { Unix.tm_sec = 0; tm_min = mi; tm_hour = h;
                          tm_mday = d; tm_mon = mo - 1; tm_year = y - 1900;
                          tm_wday = 0; tm_yday = 0; tm_isdst = false } in
-              Some (fst (Unix.mktime tm)))
+              let local_epoch, _ = Unix.mktime tm in
+              let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
+              let tz_offset = local_epoch -. utc_as_local in
+              Some (local_epoch +. tz_offset))
         with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
       in
       let effective_priority (task : Types.task) =


### PR DESCRIPTION
## Summary

#1621 (resilience.ml) 과 동일한 `Unix.mktime` UTC 오프셋 버그가 4개 파일에 추가로 존재.
KST(UTC+9) 호스트에서 모든 시간 비교가 9시간 차이 발생.

## Changes (4 files, +16/-5 LOC)

| File | Impact |
|------|--------|
| `activity_feed.ml` | Activity feed 시간순 정렬 |
| `cp_search_fabric.ml` | CP task 생성 시각 |
| `room_task.ml` | Task starvation 우선순위 (>24h 대기) |
| `goal_store.ml` | 날짜 경계 (today/tomorrow) |

## Fix pattern

```ocaml
(* Before *)
fst (Unix.mktime tm)

(* After — same as #1621 *)
let local_epoch, _ = Unix.mktime tm in
let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
let tz_offset = local_epoch -. utc_as_local in
local_epoch +. tz_offset
```

## Test plan
- [x] `dune build --root .` clean
- [ ] CI green

Closes #1628

🤖 Generated with [Claude Code](https://claude.com/claude-code)