### PR TITLE
fix(test): register orphan test, fix build failure

### DIFF
--- a/test/test_llm_client_coverage.ml
+++ b/test/test_llm_client_coverage.ml
@@ -3,7 +3,7 @@ open Alcotest
 module Llm = Masc_mcp.Llm_types
 module Llm_orch = Masc_mcp.Llm_orchestration
 
-let _sample_request provider =
+let sample_request provider =
   {
     Llm.model =
       {
@@ -91,5 +91,10 @@ let () =
           test_case "sanitize utf8" `Quick test_sanitize_text_utf8;
           test_case "available llama model spec" `Quick
             test_available_model_specs_of_strings_llama;
+        ] );
+      ( "cache",
+        [
+          test_case "cache key deterministic" `Quick
+            test_cache_key_of_request_deterministic;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `_sample_request` → `sample_request` (underscore prefix 제거, line 73에서 사용됨)
- `test_cache_key_of_request_deterministic`를 runner에 등록 (unused-value warning → 빌드 실패 원인)

## Test plan
- [x] `dune build --root .` 성공
- [x] `test_llm_client_coverage.exe` 8/8 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)