### PR TITLE
fix: board vote validation — require options, prevent duplicate votes

### DIFF
--- a/lib/room_vote.ml
+++ b/lib/room_vote.ml
@@ -24,10 +24,16 @@ let vote_status_to_string = function
 let vote_create config ~proposer ~topic ~options ~required_votes =
   ensure_initialized config;
 
+  if required_votes < 1 then
+    Printf.sprintf "❌ required_votes must be at least 1 (got %d)" required_votes
+  else if options = [] then
+    "❌ options list cannot be empty"
+  else begin
+
   mkdir_p (votes_dir config);
 
   let vote_id = Printf.sprintf "vote-%s-%d" (String.sub (now_iso ()) 0 10)
-    (Random.int 10000) in
+    (Random.int 1_000_000) in
   let vote_path = Filename.concat (votes_dir config) (vote_id ^ ".json") in
 
   let vote_json = `Assoc [
@@ -56,6 +62,8 @@ let vote_create config ~proposer ~topic ~options ~required_votes =
   Printf.sprintf "🗳️ Vote created: %s\n  Topic: %s\n  Options: %s\n  Required: %d votes"
     vote_id topic (String.concat ", " options) required_votes
 
+  end
+
 (** Cast a vote *)
 let vote_cast config ~agent_name ~vote_id ~choice =
   ensure_initialized config;
@@ -82,9 +90,12 @@ let vote_cast config ~agent_name ~vote_id ~choice =
             | _ -> []
           in
 
-          (* Add/update vote *)
-          let new_votes = (agent_name, `String choice) ::
-            (List.filter (fun (k, _) -> k <> agent_name) current_votes) in
+          (* Reject duplicate vote *)
+          if List.exists (fun (k, _) -> k = agent_name) current_votes then
+            Printf.sprintf "⚠ %s has already voted on %s" agent_name vote_id
+          else
+
+          let new_votes = (agent_name, `String choice) :: current_votes in
 
           let required = json |> member "required_votes" |> to_int in
           let vote_count = List.length new_votes in

--- a/test/dune
+++ b/test/dune
@@ -608,6 +608,11 @@
  (libraries masc_mcp alcotest eio eio_main yojson mirage-crypto-rng mirage-crypto-rng.unix))
 
 (test
+ (name test_room_vote)
+ (modules test_room_vote)
+ (libraries masc_mcp alcotest eio eio_main unix yojson mirage-crypto-rng mirage-crypto-rng.unix))
+
+(test
  (name test_task_dispatch)
  (modules test_task_dispatch)
  (libraries masc_mcp alcotest unix))

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -133,6 +133,17 @@ let test_vote_dedup () =
       | Error (Board.Already_voted _) -> ()
       | Error e -> Alcotest.fail (Board.show_board_error e)
 
+let test_vote_flip () =
+  match Board_dispatch.create_post ~author:"flip-test" ~content:"flip vote" () with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      ignore (Board_dispatch.vote ~voter:"flipper" ~post_id:pid ~direction:Board.Up);
+      match Board_dispatch.vote ~voter:"flipper" ~post_id:pid ~direction:Board.Down with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok score ->
+          Alcotest.(check int) "score after flip" (-1) score
+
 (** {1 Stats / Search / Hearth} *)
 
 let test_stats () =
@@ -229,6 +240,7 @@ let () =
     "votes", [
       Alcotest.test_case "upvote" `Quick (with_eio test_vote_post);
       Alcotest.test_case "dedup" `Quick (with_eio test_vote_dedup);
+      Alcotest.test_case "flip" `Quick (with_eio test_vote_flip);
     ];
     "misc", [
       Alcotest.test_case "stats" `Quick (with_eio test_stats);

--- a/test/test_room_vote.ml
+++ b/test/test_room_vote.ml
@@ -1,0 +1,164 @@
+(** Test Room_vote - Consensus voting input validation and core logic *)
+
+open Masc_mcp
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+(** Isolated test directory *)
+let test_base_path =
+  let dir = Filename.concat (Filename.get_temp_dir_name ()) "masc-test-room-vote" in
+  dir
+
+(** Wrap test body in Eio runtime with filesystem backend *)
+let with_eio f () =
+  Eio_main.run @@ fun _env ->
+  (* Force filesystem backend, avoid PG connection errors *)
+  Unix.putenv "MASC_BASE_PATH" test_base_path;
+  (try Unix.putenv "MASC_POSTGRES_URL" "" with _ -> ());
+  let config = Room.default_config test_base_path in
+  let _ = Room.init config ~agent_name:(Some "test-agent") in
+  f config
+
+let contains needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else loop (i + 1)
+  in
+  n = 0 || loop 0
+
+(** Helper to create a vote and extract vote_id *)
+let create_vote config ~topic ~options ~required_votes =
+  let result = Room.vote_create config ~proposer:"proposer" ~topic
+    ~options ~required_votes in
+  (* Extract vote_id from "Vote created: vote-XXXX\n..." *)
+  let parts = String.split_on_char ':' result in
+  let after_colon = List.nth parts 1 in
+  String.trim (List.hd (String.split_on_char '\n' after_colon))
+
+(** {1 vote_create validation} *)
+
+let test_vote_create_valid config =
+  let result = Room.vote_create config ~proposer:"alice" ~topic:"deploy?"
+    ~options:["yes"; "no"] ~required_votes:2 in
+  Alcotest.(check bool) "creates successfully" true (contains "Vote created" result)
+
+let test_vote_create_zero_required config =
+  let result = Room.vote_create config ~proposer:"alice" ~topic:"bad"
+    ~options:["yes"; "no"] ~required_votes:0 in
+  Alcotest.(check bool) "rejects 0 required_votes" true (contains "must be at least 1" result)
+
+let test_vote_create_negative_required config =
+  let result = Room.vote_create config ~proposer:"alice" ~topic:"bad"
+    ~options:["yes"; "no"] ~required_votes:(-1) in
+  Alcotest.(check bool) "rejects negative required_votes" true (contains "must be at least 1" result)
+
+let test_vote_create_empty_options config =
+  let result = Room.vote_create config ~proposer:"alice" ~topic:"bad"
+    ~options:[] ~required_votes:2 in
+  Alcotest.(check bool) "rejects empty options" true (contains "cannot be empty" result)
+
+(** {1 vote_cast validation} *)
+
+let test_vote_cast_not_found config =
+  let result = Room.vote_cast config ~agent_name:"bob"
+    ~vote_id:"vote-nonexistent-999" ~choice:"yes" in
+  Alcotest.(check bool) "vote not found" true (contains "not found" result)
+
+let test_vote_cast_invalid_choice config =
+  let vote_id = create_vote config ~topic:"choice test"
+    ~options:["yes"; "no"] ~required_votes:3 in
+  let result = Room.vote_cast config ~agent_name:"bob"
+    ~vote_id ~choice:"maybe" in
+  Alcotest.(check bool) "rejects invalid choice" true (contains "Invalid choice" result)
+
+let test_vote_cast_duplicate config =
+  let vote_id = create_vote config ~topic:"dup test"
+    ~options:["yes"; "no"] ~required_votes:3 in
+  let _ = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"yes" in
+  let result = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"no" in
+  Alcotest.(check bool) "rejects duplicate vote" true (contains "already voted" result)
+
+let test_vote_cast_valid config =
+  let vote_id = create_vote config ~topic:"valid cast"
+    ~options:["yes"; "no"] ~required_votes:3 in
+  let result = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"yes" in
+  Alcotest.(check bool) "cast succeeds" true (contains "Vote cast" result)
+
+(** {1 Quorum and resolution} *)
+
+let test_vote_quorum_approved config =
+  let vote_id = create_vote config ~topic:"quorum test"
+    ~options:["yes"; "no"] ~required_votes:2 in
+  let _ = Room.vote_cast config ~agent_name:"alice" ~vote_id ~choice:"yes" in
+  let result = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"yes" in
+  Alcotest.(check bool) "vote resolved" true (contains "resolved" result);
+  Alcotest.(check bool) "winner is yes" true (contains "yes" result)
+
+let test_vote_tie config =
+  let vote_id = create_vote config ~topic:"tie test"
+    ~options:["yes"; "no"] ~required_votes:2 in
+  let _ = Room.vote_cast config ~agent_name:"alice" ~vote_id ~choice:"yes" in
+  let result = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"no" in
+  Alcotest.(check bool) "vote resolved" true (contains "resolved" result);
+  Alcotest.(check bool) "result is tied" true (contains "Tied" result)
+
+let test_vote_cast_after_resolved config =
+  let vote_id = create_vote config ~topic:"resolved test"
+    ~options:["yes"; "no"] ~required_votes:1 in
+  let _ = Room.vote_cast config ~agent_name:"alice" ~vote_id ~choice:"yes" in
+  let result = Room.vote_cast config ~agent_name:"bob" ~vote_id ~choice:"no" in
+  Alcotest.(check bool) "already resolved" true (contains "already resolved" result)
+
+(** {1 vote_status and list_votes} *)
+
+let test_vote_status_not_found config =
+  let json = Room.vote_status config ~vote_id:"nonexistent-999" in
+  let has_error = match json with
+    | `Assoc fields -> List.mem_assoc "error" fields
+    | _ -> false
+  in
+  Alcotest.(check bool) "returns error for missing vote" true has_error
+
+let test_list_votes config =
+  (* Create a vote first, then list *)
+  let _ = create_vote config ~topic:"list test"
+    ~options:["a"; "b"] ~required_votes:2 in
+  let json = Room.list_votes config in
+  let count = match json with
+    | `Assoc fields ->
+        (match List.assoc_opt "count" fields with
+         | Some (`Int n) -> n
+         | _ -> -1)
+    | _ -> -1
+  in
+  Alcotest.(check bool) "has votes" true (count >= 1)
+
+(** {1 Test Runner} *)
+
+let () =
+  Alcotest.run "Room_vote" [
+    "create_validation", [
+      Alcotest.test_case "valid create" `Quick (with_eio test_vote_create_valid);
+      Alcotest.test_case "zero required_votes" `Quick (with_eio test_vote_create_zero_required);
+      Alcotest.test_case "negative required_votes" `Quick (with_eio test_vote_create_negative_required);
+      Alcotest.test_case "empty options" `Quick (with_eio test_vote_create_empty_options);
+    ];
+    "cast_validation", [
+      Alcotest.test_case "vote not found" `Quick (with_eio test_vote_cast_not_found);
+      Alcotest.test_case "invalid choice" `Quick (with_eio test_vote_cast_invalid_choice);
+      Alcotest.test_case "duplicate vote rejected" `Quick (with_eio test_vote_cast_duplicate);
+      Alcotest.test_case "valid cast" `Quick (with_eio test_vote_cast_valid);
+    ];
+    "resolution", [
+      Alcotest.test_case "quorum approved" `Quick (with_eio test_vote_quorum_approved);
+      Alcotest.test_case "tie" `Quick (with_eio test_vote_tie);
+      Alcotest.test_case "cast after resolved" `Quick (with_eio test_vote_cast_after_resolved);
+    ];
+    "status", [
+      Alcotest.test_case "not found" `Quick (with_eio test_vote_status_not_found);
+      Alcotest.test_case "list votes" `Quick (with_eio test_list_votes);
+    ];
+  ]


### PR DESCRIPTION
## Summary

- `vote_create`: reject `required_votes < 1` and empty `options` list
- `vote_cast`: prevent duplicate votes (was silently overwriting previous choice)
- Increase vote_id entropy from 10K to 1M to reduce collision probability
- Add test coverage for board dispatch

## Test plan

- [ ] `dune exec test/test_board_dispatch.exe` passes
- [ ] Manual: create vote, cast twice with same agent -> second cast rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
