### PR TITLE
feat(keeper): expand voice tools from 1 to 5 for keeper agents

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -210,6 +210,10 @@ let keeper_backend_tool_name = function
   | "keeper_board_list" -> "masc_board_list"
   | "keeper_board_comment" -> "masc_board_comment"
   | "keeper_voice_speak" -> "masc_voice_speak"
+  | "keeper_voice_agent" -> "masc_voice_agent"
+  | "keeper_voice_sessions" -> "masc_voice_sessions"
+  | "keeper_voice_session_start" -> "masc_voice_session_start"
+  | "keeper_voice_session_end" -> "masc_voice_session_end"
   | "keeper_tasks_list" -> "masc_tasks"
   | "keeper_broadcast" -> "masc_broadcast"
   | other -> other
@@ -436,7 +440,10 @@ let keeper_privileged_tool_names : string list =
   privileged_keeper_tool_names
 
 let keeper_wrapped_server_tools : string list =
-  [ "masc_board_post"; "masc_board_comment"; "masc_board_list"; "masc_voice_speak"; "masc_tasks"; "masc_broadcast" ]
+  [ "masc_board_post"; "masc_board_comment"; "masc_board_list";
+    "masc_voice_speak"; "masc_voice_agent"; "masc_voice_sessions";
+    "masc_voice_session_start"; "masc_voice_session_end";
+    "masc_tasks"; "masc_broadcast" ]
 
 let keeper_wrapped_internal_tools : string list =
   keeper_all_tool_names

--- a/lib/dune
+++ b/lib/dune
@@ -511,6 +511,7 @@
    keeper_alerting
    keeper_alerting_path
    keeper_exec_tools
+   keeper_voice_local
    keeper_exec_status
    keeper_exec_persona
    keeper_exec_context

--- a/lib/keeper_exec_tools.ml
+++ b/lib/keeper_exec_tools.ml
@@ -479,77 +479,35 @@ let execute_keeper_tool_call
                 ("agent_id", `String meta.name);
                 ("message", `String err) ]))
   | "keeper_voice_sessions" ->
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match Voice_bridge.list_voice_sessions ~sw ~clock ~net with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      (* Local session manager — no net/MCP dependency *)
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let sessions = Voice_session_manager.list_sessions mgr in
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ("session_count", `Int (List.length sessions));
+            ("sessions",
+              `List (List.map Voice_session_manager.session_to_json sessions)) ])
   | "keeper_voice_session_start" ->
-      let session_name =
+      (* Local session manager — no net/MCP dependency *)
+      let voice =
         Safe_ops.json_string_opt "session_name" args
         |> Option.map String.trim
-        |> function
-        | Some s when s <> "" -> Some s
-        | _ -> None
+        |> function Some s when s <> "" -> Some s | _ -> None
       in
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match
-            Voice_bridge.start_voice_session ~sw ~clock ~net
-              ~agent_id:meta.name ?session_name ()
-          with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("agent_id", `String meta.name);
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let session =
+        Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice ()
+      in
+      Yojson.Safe.to_string
+        (Voice_session_manager.session_to_json session)
   | "keeper_voice_session_end" ->
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match
-            Voice_bridge.end_voice_session ~sw ~clock ~net
-              ~agent_id:meta.name
-          with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("agent_id", `String meta.name);
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      (* Local session manager — no net/MCP dependency *)
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ("status", `String (if ended then "ended" else "no_active_session"));
+            ("agent_id", `String meta.name) ])
   | "keeper_github" ->
       let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
       let gh_args = Safe_ops.json_string_list "args" args in

--- a/lib/keeper_exec_tools.ml
+++ b/lib/keeper_exec_tools.ml
@@ -32,7 +32,9 @@ let keeper_read_tool_names =
 let keeper_board_tool_names =
   [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list" ]
 
-let keeper_voice_tool_names = [ "keeper_voice_speak" ]
+let keeper_voice_tool_names =
+  [ "keeper_voice_speak"; "keeper_voice_agent"; "keeper_voice_sessions";
+    "keeper_voice_session_start"; "keeper_voice_session_end" ]
 
 let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
 
@@ -466,6 +468,88 @@ let execute_keeper_tool_call
         | _ ->
             Yojson.Safe.to_string
               (keeper_text_fallback_json ~agent_id:meta.name ~message))
+  | "keeper_voice_agent" ->
+      (* No net required — reads local voice config *)
+      (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
+      | Ok json -> Yojson.Safe.to_string json
+      | Error err ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [ ("status", `String "error");
+                ("agent_id", `String meta.name);
+                ("message", `String err) ]))
+  | "keeper_voice_sessions" ->
+      (match
+         ( Eio_context.get_switch_opt (),
+           Eio_context.get_clock_opt (),
+           Eio_context.get_net_opt () )
+       with
+      | Some sw, Some clock, Some net -> (
+          match Voice_bridge.list_voice_sessions ~sw ~clock ~net with
+          | Ok json -> Yojson.Safe.to_string json
+          | Error err ->
+              Yojson.Safe.to_string
+                (`Assoc
+                  [ ("status", `String "error");
+                    ("message", `String err) ]))
+      | _ ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [ ("status", `String "error");
+                ("message", `String "net_unavailable") ]))
+  | "keeper_voice_session_start" ->
+      let session_name =
+        Safe_ops.json_string_opt "session_name" args
+        |> Option.map String.trim
+        |> function
+        | Some s when s <> "" -> Some s
+        | _ -> None
+      in
+      (match
+         ( Eio_context.get_switch_opt (),
+           Eio_context.get_clock_opt (),
+           Eio_context.get_net_opt () )
+       with
+      | Some sw, Some clock, Some net -> (
+          match
+            Voice_bridge.start_voice_session ~sw ~clock ~net
+              ~agent_id:meta.name ?session_name ()
+          with
+          | Ok json -> Yojson.Safe.to_string json
+          | Error err ->
+              Yojson.Safe.to_string
+                (`Assoc
+                  [ ("status", `String "error");
+                    ("agent_id", `String meta.name);
+                    ("message", `String err) ]))
+      | _ ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [ ("status", `String "error");
+                ("message", `String "net_unavailable") ]))
+  | "keeper_voice_session_end" ->
+      (match
+         ( Eio_context.get_switch_opt (),
+           Eio_context.get_clock_opt (),
+           Eio_context.get_net_opt () )
+       with
+      | Some sw, Some clock, Some net -> (
+          match
+            Voice_bridge.end_voice_session ~sw ~clock ~net
+              ~agent_id:meta.name
+          with
+          | Ok json -> Yojson.Safe.to_string json
+          | Error err ->
+              Yojson.Safe.to_string
+                (`Assoc
+                  [ ("status", `String "error");
+                    ("agent_id", `String meta.name);
+                    ("message", `String err) ]))
+      | _ ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [ ("status", `String "error");
+                ("message", `String "net_unavailable") ]))
   | "keeper_github" ->
       let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
       let gh_args = Safe_ops.json_string_list "args" args in
@@ -624,6 +708,9 @@ let keeper_tool_followup_prompt
         "keeper_task_force_release";
         "keeper_task_force_done";
         "keeper_broadcast";
+        "keeper_voice_speak";
+        "keeper_voice_session_start";
+        "keeper_voice_session_end";
       ]
   in
   let has_write = List.exists is_write_tool already_executed in

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -1,0 +1,24 @@
+(** Keeper_voice_local — Local voice session management for keepers.
+
+    Provides a singleton Voice_session_manager backed by the local filesystem,
+    eliminating the need for an external Voice MCP server for session tracking.
+    TTS (agent_speak) still uses direct HTTP endpoints (ElevenLabs, etc).
+
+    @since 2.95.0 *)
+
+let masc_base_dir () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some root when String.trim root <> "" -> Filename.concat root ".masc"
+  | _ -> ".masc"
+
+(** Singleton session manager, lazily initialized *)
+let session_manager_ref : Voice_session_manager.t option ref = ref None
+
+let get_session_manager () =
+  match !session_manager_ref with
+  | Some mgr -> mgr
+  | None ->
+    let mgr = Voice_session_manager.create ~config_path:(masc_base_dir ()) in
+    Voice_session_manager.restore mgr;
+    session_manager_ref := Some mgr;
+    mgr

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -60,7 +60,12 @@ let select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_pos
       Lodge_reaction.generate_identity_prompt signature ~static_traits
     else load_agent_identity ~agent_name
   in
-  let allowed_tools = heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts:sorted_posts in
+  let voice_enabled =
+    match Voice_bridge.public_config_json () with
+    | Ok _ -> true
+    | Error _ -> false
+  in
+  let allowed_tools = heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts:sorted_posts ~voice_enabled () in
   let prompt =
     Lodge_decision.selection_prompt ~agent_name
       ~candidate_agents:[ (agent_name, identity_prompt) ]
@@ -234,6 +239,7 @@ let action_summary = function
   | ActionComment (post_id, content) ->
       Printf.sprintf "Commented on %s: %s" post_id (utf8_truncate content 30)
   | ActionUpvote post_id -> Printf.sprintf "Upvoted %s" post_id
+  | ActionVoice message -> Printf.sprintf "Spoke: %s" (utf8_truncate message 40)
   | ActionSkip -> "Skipped"
 
 let execute_agent_action ~agent_name ~action =
@@ -344,6 +350,13 @@ let execute_agent_action ~agent_name ~action =
            let err = Board.show_board_error e in
            Eio.traceln "   ❌ [%s] Upvote failed: %s" agent_name err;
            Skipped (Printf.sprintf "upvote_failed:%s" err))
+  | ActionVoice message ->
+      (* Voice actions are handled via the tool-loop path, not direct execution.
+         This branch exists for type exhaustiveness. *)
+      Printf.printf "   🔊 [%s] Voice action: %s\n%!" agent_name (utf8_truncate message 40);
+      record_agent_activity ~name:agent_name;
+      record_rate_action ~agent_name `Voice;
+      Acted { action; summary = action_summary action }
       
 
 (** {1 LLM call helper for Planner/Reflection} *)
@@ -579,6 +592,7 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
         | Acted { action = ActionPost _; _ } -> "post"
         | Acted { action = ActionComment _; _ } -> "comment"
         | Acted { action = ActionUpvote _; _ } -> "upvote"
+        | Acted { action = ActionVoice _; _ } -> "voice"
         | Acted { action = ActionSkip; _ } -> "skip"
         | Passed _ -> "passed"
         | Skipped _ -> "skipped"
@@ -589,6 +603,7 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
        | Acted { action = ActionComment _; _ } ->
            Lodge_selection.record_action ~agent_name:name ~action:`Comment
        | Acted { action = ActionUpvote _; _ }
+       | Acted { action = ActionVoice _; _ }
        | Acted { action = ActionSkip; _ }
        | Passed _ | Skipped _ ->
            Lodge_selection.record_action ~agent_name:name ~action:`Skip);

--- a/lib/lodge_heartbeat.mli
+++ b/lib/lodge_heartbeat.mli
@@ -194,3 +194,18 @@ val clear_gap_signals : topic:string -> unit
 
 (** Spawn a new agent from accumulated gap signals *)
 val spawn_agent_from_gap : topic:string -> signals:gap_signal_t list -> bool
+
+(** {1 Rate Limiting (delegated to Lodge_rate_limit)} *)
+
+val check_rate_limit : agent_name:string -> [< `Post | `Comment | `Vote | `Voice ] -> bool
+val record_rate_action : agent_name:string -> [< `Post | `Comment | `Vote | `Voice ] -> unit
+
+(** {1 Heartbeat Tool Surface} *)
+
+val heartbeat_allowed_tools :
+  agent_name:string ->
+  trigger:checkin_trigger ->
+  recent_posts:Board.post list ->
+  ?voice_enabled:bool ->
+  unit ->
+  string list

--- a/lib/lodge_heartbeat.mli
+++ b/lib/lodge_heartbeat.mli
@@ -51,6 +51,7 @@ and agent_action =
   | ActionPost of string
   | ActionComment of string * string
   | ActionUpvote of string
+  | ActionVoice of string
   | ActionSkip
 
 type heartbeat_result = {

--- a/lib/lodge_heartbeat_agents.ml
+++ b/lib/lodge_heartbeat_agents.ml
@@ -464,8 +464,15 @@ let heartbeat_read_tools =
     "lodge_research";
   ]
 
-let heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts =
+let heartbeat_voice_read_tools =
+  [ "masc_voice_agent"; "masc_voice_sessions" ]
+
+let heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts ?(voice_enabled = false) () =
   let tools = ref heartbeat_read_tools in
+  if voice_enabled then
+    tools := !tools @ heartbeat_voice_read_tools;
+  if voice_enabled && check_rate_limit ~agent_name `Voice then
+    tools := !tools @ [ "masc_voice_speak" ];
   if recent_posts <> [] then tools := !tools @ [ "masc_board_vote" ];
   if recent_posts <> [] && check_rate_limit ~agent_name `Comment then
     tools := !tools @ [ "masc_board_comment" ];
@@ -477,6 +484,7 @@ let classify_completion_action (completion : Lodge_worker.completion) =
   if List.mem "masc_board_post" completion.tool_names then `Post
   else if List.mem "masc_board_comment" completion.tool_names then `Comment
   else if List.mem "masc_board_vote" completion.tool_names then `Vote
+  else if List.mem "masc_voice_speak" completion.tool_names then `Voice
   else `Skip
 
 let checkin_result_of_completion ~agent_name (completion : Lodge_worker.completion) =
@@ -484,6 +492,7 @@ let checkin_result_of_completion ~agent_name (completion : Lodge_worker.completi
    | `Post -> record_rate_action ~agent_name `Post
    | `Comment -> record_rate_action ~agent_name `Comment
    | `Vote -> record_rate_action ~agent_name `Vote
+   | `Voice -> record_rate_action ~agent_name `Voice
    | `Skip -> ());
   record_agent_activity ~name:agent_name;
   match completion.status with
@@ -493,6 +502,7 @@ let checkin_result_of_completion ~agent_name (completion : Lodge_worker.completi
         | `Post -> ActionPost completion.summary
         | `Comment -> ActionComment ("tool-loop", completion.summary)
         | `Vote -> ActionUpvote "tool-loop"
+        | `Voice -> ActionVoice completion.summary
         | `Skip -> ActionSkip
       in
       Acted { action; summary = completion.summary }

--- a/lib/lodge_heartbeat_state.ml
+++ b/lib/lodge_heartbeat_state.ml
@@ -526,6 +526,7 @@ and agent_action =
   | ActionPost of string           (** content *)
   | ActionComment of string * string  (** post_id, content *)
   | ActionUpvote of string         (** post_id *)
+  | ActionVoice of string          (** message spoken *)
   | ActionSkip
 
 type llm_decision_outcome = {

--- a/lib/lodge_rate_limit.ml
+++ b/lib/lodge_rate_limit.ml
@@ -17,12 +17,14 @@ let round_robin_idx = ref 0
 
 (** {1 Per-agent Rate State} *)
 
-(** Per-agent rate state for posts/comments *)
+(** Per-agent rate state for posts/comments/voice *)
 type rate_state = {
   mutable last_post: float;
   mutable last_comment: float;
+  mutable last_voice: float;
   mutable posts_today: int;
   mutable comments_today: int;
+  mutable voice_today: int;
   mutable day_reset: float;      (** Start of current day (for daily counters) *)
 }
 
@@ -44,12 +46,14 @@ let get_rate_state ~agent_name =
     if now -. rs.day_reset > 86400.0 then begin
       rs.posts_today <- 0;
       rs.comments_today <- 0;
+      rs.voice_today <- 0;
       rs.day_reset <- day_start
     end;
     rs
   | None ->
-    let rs = { last_post = 0.0; last_comment = 0.0;
-               posts_today = 0; comments_today = 0; day_reset = day_start } in
+    let rs = { last_post = 0.0; last_comment = 0.0; last_voice = 0.0;
+               posts_today = 0; comments_today = 0; voice_today = 0;
+               day_reset = day_start } in
     Hashtbl.replace rate_states agent_name rs;
     rs
 
@@ -63,6 +67,9 @@ let check_rate_limit ~agent_name action_type =
   | `Comment ->
     now -. rs.last_comment >= min_comment_gap && rs.comments_today < max_comments_per_day
   | `Vote -> true  (* Votes are always allowed *)
+  | `Voice ->
+    (* Voice: 1 speak per heartbeat cycle, same gap as comment *)
+    now -. rs.last_voice >= min_comment_gap && rs.voice_today < max_comments_per_day
 
 (** Record that agent performed an action (update rate state) *)
 let record_rate_action ~agent_name action_type =
@@ -72,6 +79,7 @@ let record_rate_action ~agent_name action_type =
   | `Post -> rs.last_post <- now; rs.posts_today <- rs.posts_today + 1
   | `Comment -> rs.last_comment <- now; rs.comments_today <- rs.comments_today + 1
   | `Vote -> ()
+  | `Voice -> rs.last_voice <- now; rs.voice_today <- rs.voice_today + 1
 
 (** Record a check-in timestamp *)
 let record_checkin ~agent_name =

--- a/lib/lodge_rate_limit.mli
+++ b/lib/lodge_rate_limit.mli
@@ -37,10 +37,10 @@ val max_posts_per_day : unit -> int
 val max_comments_per_day : int
 
 (** Check if agent can perform the given action type. *)
-val check_rate_limit : agent_name:string -> [< `Post | `Comment | `Vote ] -> bool
+val check_rate_limit : agent_name:string -> [< `Post | `Comment | `Vote | `Voice ] -> bool
 
 (** Record that agent performed an action (update rate state). *)
-val record_rate_action : agent_name:string -> [< `Post | `Comment | `Vote ] -> unit
+val record_rate_action : agent_name:string -> [< `Post | `Comment | `Vote | `Voice ] -> unit
 
 (** {1 Per-agent-per-post Comment Tracking} *)
 

--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -130,7 +130,8 @@ let parse_completion_json (text : string) : (completion, string) result =
     }
 
 let action_tool_names =
-  [ "masc_board_post"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote" ]
+  [ "masc_board_post"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote";
+    "masc_voice_speak" ]
 
 let acted_by_tools tool_names =
   List.exists (fun name -> List.mem name action_tool_names) tool_names

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -185,6 +185,40 @@ let voice_tools : Llm_types.tool_def list = [
       ("required", `List [`String "message"]);
     ];
   };
+  {
+    tool_name = "keeper_voice_agent";
+    tool_description = "Get your own voice configuration (assigned voice, available voices). No network required.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+  {
+    tool_name = "keeper_voice_sessions";
+    tool_description = "List active voice sessions from the voice bridge.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+  {
+    tool_name = "keeper_voice_session_start";
+    tool_description = "Start a voice session for this keeper using the configured voice bridge.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("session_name", `Assoc [("type", `String "string"); ("description", `String "Optional session name")]);
+      ]);
+    ];
+  };
+  {
+    tool_name = "keeper_voice_session_end";
+    tool_description = "End the active voice session for this keeper and release bridge resources.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
 ]
 
 let weather_tools : Llm_types.tool_def list = [

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -185,4 +185,48 @@ let () = test "handle_heartbeat_stop_not_found" (fun () ->
       assert (String.length result > 0 (* contains emoji *)))
 )
 
+(* ============================================================
+   Voice integration in heartbeat allowed_tools (#4, #5)
+   ============================================================ *)
+
+let () = test "heartbeat_voice_disabled_no_voice_tools" (fun () ->
+  Eio_main.run @@ fun _env ->
+  let tools = Lodge_heartbeat.heartbeat_allowed_tools
+    ~agent_name:"test-hb-no-voice" ~trigger:Lodge_heartbeat.Scheduled
+    ~recent_posts:[] () in
+  assert (not (List.mem "masc_voice_agent" tools));
+  assert (not (List.mem "masc_voice_speak" tools));
+  assert (not (List.mem "masc_voice_sessions" tools))
+)
+
+let () = test "heartbeat_voice_enabled_has_read_tools" (fun () ->
+  Eio_main.run @@ fun _env ->
+  let tools = Lodge_heartbeat.heartbeat_allowed_tools
+    ~agent_name:"test-hb-voice-on" ~trigger:Lodge_heartbeat.Scheduled
+    ~recent_posts:[] ~voice_enabled:true () in
+  assert (List.mem "masc_voice_agent" tools);
+  assert (List.mem "masc_voice_sessions" tools)
+)
+
+let () = test "heartbeat_voice_enabled_speak_allowed_fresh" (fun () ->
+  Eio_main.run @@ fun _env ->
+  let tools = Lodge_heartbeat.heartbeat_allowed_tools
+    ~agent_name:"test-hb-voice-speak-fresh" ~trigger:Lodge_heartbeat.Scheduled
+    ~recent_posts:[] ~voice_enabled:true () in
+  assert (List.mem "masc_voice_speak" tools)
+)
+
+let () = test "heartbeat_voice_rate_limited_after_action" (fun () ->
+  Eio_main.run @@ fun _env ->
+  let agent = "test-hb-voice-rl" in
+  Lodge_heartbeat.record_rate_action ~agent_name:agent `Voice;
+  let tools = Lodge_heartbeat.heartbeat_allowed_tools
+    ~agent_name:agent ~trigger:Lodge_heartbeat.Scheduled
+    ~recent_posts:[] ~voice_enabled:true () in
+  (* voice_speak should be absent after rate limit *)
+  assert (not (List.mem "masc_voice_speak" tools));
+  (* read tools should still be present *)
+  assert (List.mem "masc_voice_agent" tools)
+)
+
 let () = Printf.printf "\n✅ All Tool_heartbeat tests passed!\n"

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -52,7 +52,7 @@ let test_shard_voice_exists () =
   match Tool_shard.get_shard "voice" with
   | Some s ->
     Alcotest.(check bool) "removable" true s.Tool_shard.removable;
-    Alcotest.(check bool) "has 1 tool" true (List.length s.Tool_shard.tools = 1)
+    Alcotest.(check bool) "has 5 tools" true (List.length s.Tool_shard.tools = 5)
   | None -> Alcotest.fail "voice shard not found"
 
 let test_shard_unknown () =
@@ -98,8 +98,8 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_llm_tools_count () =
   let tools = Tool_shard.keeper_llm_tools in
-  (* base=3 + board=4 + filesystem=2 + shell=3 + weather=1 + voice=1 = 14 *)
-  Alcotest.(check int) "14 total tools" 14 (List.length tools)
+  (* base=3 + board=4 + filesystem=2 + shell=3 + weather=1 + voice=5 = 18 *)
+  Alcotest.(check int) "18 total tools" 18 (List.length tools)
 
 (* ============================================================
    grant_shard tests

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -283,6 +283,54 @@ let test_board_tools_names () =
   Alcotest.(check bool) "has board_vote" true (List.mem "keeper_board_vote" names)
 
 (* ============================================================
+   Voice tools content tests (#3: all 5 voice tools present)
+   ============================================================ *)
+
+let test_voice_tools_names () =
+  let voice_shard = match Tool_shard.get_shard "voice" with
+    | Some s -> s | None -> Alcotest.failf "voice shard missing" in
+  let names = List.map (fun (t : Masc_mcp.Llm_types.tool_def) -> t.tool_name)
+    voice_shard.Tool_shard.tools in
+  Alcotest.(check bool) "has voice_speak" true (List.mem "keeper_voice_speak" names);
+  Alcotest.(check bool) "has voice_agent" true (List.mem "keeper_voice_agent" names);
+  Alcotest.(check bool) "has voice_sessions" true (List.mem "keeper_voice_sessions" names);
+  Alcotest.(check bool) "has voice_session_start" true (List.mem "keeper_voice_session_start" names);
+  Alcotest.(check bool) "has voice_session_end" true (List.mem "keeper_voice_session_end" names)
+
+let test_keeper_llm_has_voice_tools () =
+  let names = List.map (fun (t : Masc_mcp.Llm_types.tool_def) -> t.tool_name)
+    Tool_shard.keeper_llm_tools in
+  Alcotest.(check bool) "keeper_llm has voice_speak" true (List.mem "keeper_voice_speak" names);
+  Alcotest.(check bool) "keeper_llm has voice_agent" true (List.mem "keeper_voice_agent" names);
+  Alcotest.(check bool) "keeper_llm has voice_sessions" true (List.mem "keeper_voice_sessions" names);
+  Alcotest.(check bool) "keeper_llm has voice_session_start" true (List.mem "keeper_voice_session_start" names);
+  Alcotest.(check bool) "keeper_llm has voice_session_end" true (List.mem "keeper_voice_session_end" names)
+
+(* ============================================================
+   Shard revoke voice (#6: revoke removes all 5 voice tools)
+   ============================================================ *)
+
+let test_revoke_voice_removes_all_tools () =
+  let all_shards = Tool_shard.default_shard_names in
+  let tools_before = Tool_shard.tools_of_shards all_shards in
+  let voice_before = List.filter (fun (t : Masc_mcp.Llm_types.tool_def) ->
+    let n = t.tool_name in
+    String.length n >= 13 && String.sub n 0 13 = "keeper_voice_") tools_before in
+  Alcotest.(check int) "5 voice tools before revoke" 5 (List.length voice_before);
+  match Tool_shard.revoke_shard all_shards "voice" with
+  | Ok shards_after ->
+    let tools_after = Tool_shard.tools_of_shards shards_after in
+    let voice_after = List.filter (fun (t : Masc_mcp.Llm_types.tool_def) ->
+      let n = t.tool_name in
+      String.length n >= 13 && String.sub n 0 13 = "keeper_voice_") tools_after in
+    Alcotest.(check int) "0 voice tools after revoke" 0 (List.length voice_after)
+  | Error msg -> Alcotest.fail ("revoke should succeed: " ^ msg)
+
+(* Heartbeat voice integration (#4, #5) verified in
+   test_tool_heartbeat_coverage.ml which has Eio context and
+   direct access to Lodge_heartbeat internals. *)
+
+(* ============================================================
    Test runner
    ============================================================ *)
 
@@ -339,5 +387,10 @@ let () =
     ("tool_content", [
       Alcotest.test_case "base tools" `Quick test_base_tools_names;
       Alcotest.test_case "board tools" `Quick test_board_tools_names;
+      Alcotest.test_case "voice tools" `Quick test_voice_tools_names;
+      Alcotest.test_case "keeper_llm has voice" `Quick test_keeper_llm_has_voice_tools;
+    ]);
+    ("voice_shard_revoke", [
+      Alcotest.test_case "revoke removes all voice tools" `Quick test_revoke_voice_removes_all_tools;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Keeper voice tools 1개 → 5개 확장 (`speak`, `agent`, `sessions`, `session_start`, `session_end`)
- Voice MCP 서버 의존 완전 제거 — 세션 관리는 로컬 `Voice_session_manager` 사용
- TTS만 외부 HTTP (ElevenLabs direct) 유지
- 모든 keeper에 voice tools 자동 활성화 (`voice_config.json` 존재 시)

## 변경 범위

| 영역 | 변경 |
|------|------|
| **Shard** | voice shard 1→5 tools |
| **Registry** | 4 backend mappings + wrapped tools |
| **Dispatch** | keeper_exec_tools 4개 match case (로컬 세션 매니저) |
| **MCP Tools** | tool_voice.ml 전체 로컬화 (session/conference/transcript) |
| **OAS Turn** | voice tools in write_done check |
| **Defaults** | `voice_enabled` = voice_config 존재 여부 (하드코딩 제거) |
| **Rate Limit** | `Voice` variant 추가 (.ml + .mli) |
| **Types** | `ActionVoice of string` variant |

## 의존성 변화

```
Before: keeper → Voice_bridge → Voice MCP Server (외부, net 필수)
After:  keeper → Keeper_voice_local → Voice_session_manager (로컬 파일)
        keeper → Voice_bridge.agent_speak (TTS HTTP, speak만)
```

net 의존: 5/5 → **1/5** (speak only)

## Test plan

- [x] `dune build` — 컴파일 성공
- [x] Shard tests (37): voice tool names, count, revoke
- [x] Heartbeat tests (14): voice_enabled/disabled, rate limit
- [x] Rate limit tests (24): no regression
- [ ] Integration: keeper turn에서 voice tools LLM 제공 확인
- [ ] Integration: keeper_voice_session_start → .masc/voice_sessions/ 파일 생성

Generated with [Claude Code](https://claude.com/claude-code)