### PR TITLE
fix: agent lifecycle P0/P1 — audit trail + zombie state consistency (#1655)

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -201,7 +201,9 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
            ) in
            let _ = broadcast scoped ~from_agent:nickname
                      ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname room_id) in
-           ()
+           log_event scoped (Printf.sprintf
+             "{\"type\":\"agent_join\",\"agent\":\"%s\",\"room\":\"%s\",\"rejoin\":true,\"scoped\":true,\"ts\":\"%s\"}"
+             nickname room_id (now_iso ()))
          end
      | Error _ -> ());
     Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname room_id

--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -116,12 +116,14 @@ let cleanup_zombies config =
                     else Env_config.Zombie.threshold_seconds
                   in
                   Resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
-              zombies := agent.name :: !zombies;
               (* Stop heartbeats owned by this zombie agent *)
               let _stopped = Heartbeat.stop_by_agent ~agent_name:agent.name in
-              (* Remove agent file *)
-              (try Sys.remove path with Sys_error msg ->
-                Log.Gc.warn "failed to remove zombie agent file %s: %s" path msg)
+              (* Remove agent file — only add to zombies list on success *)
+              (try
+                Sys.remove path;
+                zombies := agent.name :: !zombies
+              with Sys_error msg ->
+                Log.Gc.warn "failed to remove zombie agent file %s: %s (agent kept in state)" path msg)
           | _ -> ()
         end
       )
@@ -129,6 +131,7 @@ let cleanup_zombies config =
 
     (* Cascade: release tasks claimed by zombie agents *)
     let released_tasks = ref [] in
+    let failed_release_agents = ref [] in
     if !zombies <> [] then begin
       let backlog = read_backlog config in
       List.iter (fun (task : task) ->
@@ -138,23 +141,30 @@ let cleanup_zombies config =
             (match !force_release_task_fn config ~agent_name:"gardener" ~task_id:task.id () with
              | Ok msg -> released_tasks := (task.id, msg) :: !released_tasks
              | Error e ->
+                 (* Track agents whose tasks failed to release — keep them in state *)
+                 if not (List.mem assignee !failed_release_agents) then
+                   failed_release_agents := assignee :: !failed_release_agents;
                  log_event config (Printf.sprintf
-                   "{\"type\":\"zombie_cascade_error\",\"task_id\":\"%s\",\"error\":\"%s\",\"ts\":\"%s\"}"
-                   task.id (Types.masc_error_to_string e) (now_iso ())))
+                   "{\"type\":\"zombie_cascade_error\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"error\":\"%s\",\"ts\":\"%s\"}"
+                   task.id assignee (Types.masc_error_to_string e) (now_iso ())))
         | _ -> ()
       ) backlog.tasks
     end;
 
-    (* Update state to remove zombie agents *)
-    if !zombies <> [] then begin
+    (* Exclude agents with failed task releases from removal *)
+    let safe_zombies = List.filter
+      (fun a -> not (List.mem a !failed_release_agents)) !zombies in
+
+    (* Update state to remove zombie agents (only those with clean release) *)
+    if safe_zombies <> [] then begin
       let _ = update_state config (fun s ->
-        { s with active_agents = List.filter (fun a -> not (List.mem a !zombies)) s.active_agents }
+        { s with active_agents = List.filter (fun a -> not (List.mem a safe_zombies)) s.active_agents }
       ) in
 
       (* Log event *)
       log_event config (Printf.sprintf
         "{\"type\":\"zombie_cleanup\",\"agents\":%s,\"released_tasks\":%d,\"ts\":\"%s\"}"
-        (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) !zombies)))
+        (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) safe_zombies)))
         (List.length !released_tasks)
         (now_iso ()));
 


### PR DESCRIPTION
## Summary

#1655의 P0/P1 3건 수정. 기록-행동 불일치(record-behavior inconsistency) 해소.

### BUG-1 (P0): Room-scoped rejoin event log 누락
- `room.ml:197-204` — inactive agent가 room scope에서 rejoin 시 event 미기록
- Fix: `log_event scoped` 추가 (default scope rejoin과 동일 패턴)

### BUG-2 (P0): Zombie 파일 삭제 실패 시 state 업데이트 계속 진행
- `room_gc.ml:122-124` — `Sys.remove` 실패해도 `zombies` 리스트에 추가됨
- Fix: 삭제 성공 시에만 `zombies`에 추가. 실패 시 로그 + state 유지

### BUG-3 (P1): Task release 실패해도 agent 제거
- `room_gc.ml:138-151` — claimed task release 실패 시 agent 여전히 `active_agents`에서 제거
- Fix: `failed_release_agents` 추적, `safe_zombies`만 state에서 제거

## Files

| File | Lines | Change |
|------|-------|--------|
| `lib/room.ml` | +3 -1 | rejoin log_event 추가 |
| `lib/room_gc.ml` | +20 -10 | 삭제 실패 가드 + release 실패 가드 |

## Test plan

- [x] `dune build --root . lib/` — 0 errors
- [ ] Zombie cleanup with permission-denied file → agent stays in state
- [ ] Zombie with stuck task → agent not removed until task released

Refs #1655