### PR TITLE
fix: auto-set current_task on claim and claim_next

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -68,6 +68,8 @@ let handle_claim ctx args =
   (* Notification harness: push claim event to all active sessions *)
   (match result with
    | Ok _ ->
+       (* Auto-set current_task so planning tools pick it up immediately *)
+       Planning_eio.set_current_task ctx.config ~task_id;
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");
          ("task_id", `String task_id);
@@ -85,7 +87,17 @@ let handle_claim_next ctx _args =
   if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
     (false, Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
   else
-  (true, Room.claim_next ctx.config ~agent_name:ctx.agent_name)
+  let result = Room.claim_next_r ctx.config ~agent_name:ctx.agent_name () in
+  let message = match result with
+    | Room_task.Claim_next_claimed { task_id; message; _ } ->
+        (* Auto-set current_task so planning tools pick it up immediately *)
+        Planning_eio.set_current_task ctx.config ~task_id;
+        message
+    | Room_task.Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
+    | Room_task.Claim_next_no_eligible _ -> "📋 No unclaimed tasks available"
+    | Room_task.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
+  in
+  (true, message)
 
 let handle_release ctx args =
   let task_id = get_string args "task_id" "" in


### PR DESCRIPTION
## Summary
- `masc_claim` 성공 시 `Planning_eio.set_current_task` 자동 호출
- `masc_claim_next` 성공 시 동일하게 자동 호출
- 별도 `masc_plan_set_task` 호출이 더 이상 필요 없음

## Problem
task를 claim하면 backlog 상태만 `Claimed`로 변경되고, 세션의 `current_task`(`.masc/current_task` 파일)는 설정되지 않았다. planning/log 도구가 "No current task set"을 반환하여 매번 `masc_plan_set_task`를 수동 호출해야 했다.

## Root cause
`claim_task`(room_task.ml)는 공유 backlog만 업데이트. `current_task`는 별도 로컬 상태(planning_eio.ml). 두 개념이 분리되어 있었으나 실사용에서는 항상 쌍으로 호출됨.

## Fix
dispatch 레이어(tool_task.ml)에서 claim 성공 시 `set_current_task`를 자동 호출. core logic(room_task.ml)은 변경 없음.

## Test plan
- [x] `dune build` — 컴파일 성공
- [x] `test_tool_task_coverage.exe` — 전부 통과
- [ ] 수동 검증: `masc_claim` → `masc_plan_get_task` → task_id 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)