### PR TITLE
fix: normalize agent filenames to lowercase (#1629)

### DIFF
--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -53,14 +53,14 @@ let sanitize_message = sanitize_html
 let safe_filename name =
   let buf = Buffer.create (String.length name * 3) in
   String.iter (fun c ->
+    let c_lower = Char.lowercase_ascii c in
     let valid =
-      (c >= 'a' && c <= 'z') ||
-      (c >= 'A' && c <= 'Z') ||
-      (c >= '0' && c <= '9') ||
-      c = '.' || c = '_' || c = '-'
+      (c_lower >= 'a' && c_lower <= 'z') ||
+      (c_lower >= '0' && c_lower <= '9') ||
+      c_lower = '.' || c_lower = '_' || c_lower = '-'
     in
     if valid then
-      Buffer.add_char buf c
+      Buffer.add_char buf c_lower
     else
       Buffer.add_string buf (Printf.sprintf "_%02x" (Char.code c))
   ) name;


### PR DESCRIPTION
## Summary

`safe_filename`이 대소문자를 보존하여 Claude.json과 claude.json이 공존하는 문제 해결.

- macOS (APFS case-insensitive): 같은 파일을 가리키지만 이름이 다름 → 혼란
- Linux (ext4 case-sensitive): 별개 파일로 생성 → 에이전트 중복

Fix: `safe_filename`에서 모든 문자를 `Char.lowercase_ascii`로 정규화.

## Change

| File | Lines | Change |
|------|-------|--------|
| `lib/room/room_utils_ops.ml` | +5 -5 | `c` → `c_lower` 정규화 |

## Test plan

- [x] `dune build --root . lib/` — 0 errors
- [ ] `safe_filename "Claude"` = `safe_filename "claude"` = `"claude"`

Closes #1629