### PR TITLE
fix(dashboard): show mission error state and add periodic retry

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -9,8 +9,9 @@ import {
   refreshDashboardSemantics,
 } from './store'
 import { refreshRoomTruth } from './room-truth-store'
-import { cancelPendingSSERefreshes, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
+import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForTab } from './tab-refresh'
+import { refreshMissionSnapshot } from './mission-store'
 import {
   BuildIdentityBadge,
   ConnectionStatus,
@@ -35,6 +36,10 @@ export function App() {
     // that caused 5 concurrent API calls (server computes same data 3-6x).
     refreshRoomTruth()
     refreshDashboardSemantics()
+
+    // Register mission refresh for periodic recovery from transient failures.
+    // Uses registration pattern to avoid circular imports.
+    registerMissionRefresh(() => void refreshMissionSnapshot())
 
     // Setup SSE -> store reaction (debounced refresh on events)
     const unsubSSE = setupSSEReaction()

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { HealthBeacon } from './health-beacon'
+import { missionError, missionLoading } from '../../mission-store'
 import type {
   DashboardMissionResponse,
   DashboardMissionSessionBrief,
@@ -26,7 +27,12 @@ interface SituationResult {
 type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
 
 function synthesizeSituation(snap: DashboardMissionResponse | null): SituationResult {
-  if (!snap) return { text: '데이터 로딩 중...', tone: 'ok', reasons: [] }
+  if (!snap) {
+    const error = missionError.value
+    if (error) return { text: `데이터 로드 실패: ${error}`, tone: 'warn', reasons: [] }
+    if (missionLoading.value) return { text: '데이터 로딩 중...', tone: 'ok', reasons: [] }
+    return { text: '데이터 대기 중...', tone: 'ok', reasons: [] }
+  }
 
   const sessions: SessionItem[] =
     snap.sessions.length > 0 ? snap.sessions : snap.session_briefs

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -30,6 +30,11 @@ export function registerOperatorRefresh(fn: () => void): void {
   _refreshOperatorFn = fn
 }
 
+let _refreshMissionFn: (() => void) | null = null
+export function registerMissionRefresh(fn: () => void): void {
+  _refreshMissionFn = fn
+}
+
 // --- SSE event reaction ---
 
 const _debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {}
@@ -166,6 +171,7 @@ export function startPeriodicRefresh(): void {
       invalidateDashboardCache()
     }
     refreshDashboard()
+    _refreshMissionFn?.()
   }, 30000)
 }
 

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -47,6 +47,7 @@ export function refreshForTab(tab: string) {
       refreshGovernance()
     } else if (section === 'planning') {
       refreshGoals()
+      refreshExecution()
     } else {
       refreshBoard()
     }


### PR DESCRIPTION
## Summary
- SituationBanner가 mission fetch 실패 시 "데이터 로딩 중..."에 무한 정체되던 버그 수정
- 에러/로딩/대기 3가지 상태를 구분하여 표시
- 30초 주기 갱신에 mission refresh를 포함하여 서버 일시 장애 후 자동 복구

## Changes
- `situation-banner.ts`: null snap 분기를 error/loading/waiting으로 세분화
- `sse-store.ts`: `registerMissionRefresh` 패턴 추가, periodic interval에서 호출
- `app.ts`: registration 연결 (기존 governance/operator 패턴 동일)

## Test plan
- [ ] 서버 정상 시: "진행 중인 세션 없음." 또는 세션 상태 정상 표시 확인
- [ ] 서버 다운 시: "데이터 로드 실패: ..." 메시지 + warn tone 확인
- [ ] 서버 복구 후 30초 이내 자동 갱신 확인
- [ ] 기존 탭 전환 시 mission refresh 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)