### PR TITLE
fix: restore latency tracking via call-site timed measurement

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -638,7 +638,9 @@ let run_proactive_generation
               : Llm_types.completion_request))
           specs
       in
-      match run_cascade requests with
+      let (cascade_result0, latency0) = Llm_types.timed (fun () ->
+          run_cascade requests) in
+      match cascade_result0 with
       | Error _ -> None
       | Ok resp0 ->
           let used_model0 =
@@ -708,7 +710,9 @@ let run_proactive_generation
                        : Llm_types.completion_request))
                   specs
               in
-              match run_cascade followup_requests with
+              let (followup_result, round_latency) = Llm_types.timed (fun () ->
+                  run_cascade followup_requests) in
+              match followup_result with
               | Error _ ->
                   ( Llm_types.text_of_response last_resp,
                     acc_usage,
@@ -726,7 +730,7 @@ let run_proactive_generation
                   tool_loop
                     ~round:(round + 1)
                     ~acc_usage:(merge_usage acc_usage resp_next_usage)
-                    ~acc_latency
+                    ~acc_latency:(acc_latency + round_latency)
                     ~acc_cost:(acc_cost +. cost_next)
                     ~acc_tools_used:(acc_tools_used @ round_tools)
                     ~last_resp:resp_next
@@ -736,7 +740,7 @@ let run_proactive_generation
             tool_loop
               ~round:1
               ~acc_usage:(Llm_types.usage_of_response resp0)
-              ~acc_latency:0
+              ~acc_latency:latency0
               ~acc_cost:cost0
               ~acc_tools_used:[]
               ~last_resp:resp0

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -181,7 +181,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                     let model_specs =
                       Llm_types.available_model_specs_of_strings meta.models
                     in
-                    let result =
+                    let (result, delib_latency) = Llm_types.timed (fun () ->
                       Llm_orchestration.run_prompt_cascade
                         ~temperature:0.3
                         ~model_specs
@@ -189,8 +189,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         ~prompt
                         ~system:("You are " ^ meta.name
                                  ^ ", a keeper agent. Respond with JSON only.")
-                        ()
-                    in
+                        ()) in
                     match result with
                     | Error msg ->
                         Log.KeeperExec.error "%s LLM call failed: %s"
@@ -492,7 +491,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                    response_usage.output_tokens;
                                  last_total_tokens =
                                    Llm_types.total_tokens response_usage;
-                                 last_latency_ms = 0;
+                                 last_latency_ms = delib_latency;
                                  last_proactive_ts = now_ts;
                                  last_proactive_reason =
                                    Printf.sprintf

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -91,7 +91,9 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                 } : Llm_types.completion_request))
               specs
           in
-          match Llm_orchestration.cascade requests with
+          let (cascade_result, cascade_latency) = Llm_types.timed (fun () ->
+              Llm_orchestration.cascade requests) in
+          match cascade_result with
           | Error e -> Error e
           | Ok resp ->
               let used_model =
@@ -127,7 +129,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                   last_input_tokens = usage.input_tokens;
                   last_output_tokens = usage.output_tokens;
                   last_total_tokens = Llm_types.total_tokens usage;
-                  last_latency_ms = 0;
+                  last_latency_ms = cascade_latency;
                 }
               in
               Ok (updated, reply))
@@ -259,7 +261,9 @@ let run_social_board_event_turn
                    : Llm_types.completion_request))
               specs
           in
-          match Llm_orchestration.cascade requests with
+          let (cascade_result0, latency0) = Llm_types.timed (fun () ->
+              Llm_orchestration.cascade requests) in
+          match cascade_result0 with
           | Error e -> Error e
           | Ok resp0 ->
               let max_tool_rounds = Keeper_config.keeper_max_tool_rounds () in
@@ -327,7 +331,9 @@ let run_social_board_event_turn
                            : Llm_types.completion_request))
                       specs
                   in
-                  match Llm_orchestration.cascade followup_requests with
+                  let (followup_result, round_latency) = Llm_types.timed (fun () ->
+                      Llm_orchestration.cascade followup_requests) in
+                  match followup_result with
                   | Error _ ->
                       ( Llm_types.text_of_response last_resp,
                         acc_usage,
@@ -345,7 +351,7 @@ let run_social_board_event_turn
                       tool_loop
                         ~round:(round + 1)
                         ~acc_usage:(merge_usage acc_usage resp_next_usage)
-                        ~acc_latency
+                        ~acc_latency:(acc_latency + round_latency)
                         ~acc_cost:(acc_cost +. cost_next)
                         ~acc_tools_used:(acc_tools_used @ round_tools)
                         ~last_resp:resp_next
@@ -355,7 +361,7 @@ let run_social_board_event_turn
                 tool_loop
                   ~round:1
                   ~acc_usage:(Llm_types.usage_of_response resp0)
-                  ~acc_latency:0
+                  ~acc_latency:latency0
                   ~acc_cost:cost0
                   ~acc_tools_used:[]
                   ~last_resp:resp0

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -303,7 +303,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               | _ -> run_cascade_batch requests
             in
             let recall_candidates = recent_user_messages base_ctx.messages ~max_n:32 in
-            match run_cascade requests with
+            let (cascade_result0, latency0) = Llm_types.timed (fun () ->
+                run_cascade requests) in
+            match cascade_result0 with
             | Error e ->
               (try ignore (Trajectory.finalize trajectory_acc (Trajectory.Failed e))
                with exn -> log_keeper_exn ~label:"trajectory finalize (error path) failed" exn);
@@ -437,7 +439,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       } : Llm_types.completion_request)
                     ) specs
                   in
-                  match run_cascade_batch followup_requests with
+                  let (followup_result, round_latency) = Llm_types.timed (fun () ->
+                      run_cascade_batch followup_requests) in
+                  match followup_result with
                   | Error _ ->
                     (* Cascade failed — return what we have *)
                     ( Llm_types.text_of_response last_resp, acc_usage,
@@ -459,7 +463,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     tool_loop
                       ~round:(round + 1)
                       ~acc_usage:(merge_usage acc_usage resp_next_usage)
-                      ~acc_latency
+                      ~acc_latency:(acc_latency + round_latency)
                       ~acc_cost:(acc_cost +. cost_next)
                       ~acc_tools_used:(acc_tools_used @ round_tools)
                       ~last_resp:resp_next
@@ -470,7 +474,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               let (base_content, base_usage, base_model_used, base_latency_ms,
                    base_cost_usd, tools_used) =
                 tool_loop ~round:1 ~acc_usage:(Llm_types.usage_of_response resp0)
-                  ~acc_latency:0 ~acc_cost:cost0
+                  ~acc_latency:latency0 ~acc_cost:cost0
                   ~acc_tools_used:[] ~last_resp:resp0
               in
               let eval0 =
@@ -517,7 +521,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       } : Llm_types.completion_request)
                     ) specs
                   in
-                  match run_cascade_batch correction_requests with
+                  let (corr_result, corr_latency) = Llm_types.timed (fun () ->
+                      run_cascade_batch correction_requests) in
+                  match corr_result with
                   | Error _ ->
                     ( base_content, base_usage, base_model_used, base_latency_ms,
                       eval0, true, false, false, base_cost_usd, tools_used )
@@ -537,7 +543,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     let evalf = { eval1 with initial_score = eval0.final_score } in
                     let merged_usage = merge_usage base_usage corr_usage in
                     ( Llm_types.text_of_response corr, merged_usage, corr.Llm_provider.Types.model,
-                      base_latency_ms,
+                      base_latency_ms + corr_latency,
                       evalf, true, evalf.passed, false, base_cost_usd +. cost1,
                       tools_used )
               in
@@ -582,7 +588,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       } : Llm_types.completion_request)
                     ) specs
                   in
-                  match run_cascade_batch forced_requests with
+                  let (forced_result, forced_latency) = Llm_types.timed (fun () ->
+                      run_cascade_batch forced_requests) in
+                  match forced_result with
                   | Error _ ->
                       ( content_after_correction, usage_after_correction,
                         model_after_correction, latency_after_correction,
@@ -595,7 +603,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       let forced_usage = Llm_types.usage_of_response forced in
                       let cost2 = cost_usd_of_usage forced_usage used_model2 in
                       let merged_usage = merge_usage usage_after_correction forced_usage in
-                      let merged_latency = latency_after_correction in
+                      let merged_latency = latency_after_correction + forced_latency in
                       let grounded_content =
                         let c = String.trim (Llm_types.text_of_response forced) in
                         if c = "" then content_after_correction else Llm_types.text_of_response forced

--- a/lib/llm/llm_types.ml
+++ b/lib/llm/llm_types.ml
@@ -84,6 +84,14 @@ let usage_of_response (resp : api_response) : token_usage =
 let text_of_response (resp : api_response) : string =
   Agent_sdk.Types.text_of_content resp.content
 
+(** Measure wall-clock latency of a thunk in milliseconds.
+    Use at call sites that need per-call timing (keeper tool loops, etc.). *)
+let timed (f : unit -> 'a) : 'a * int =
+  let t0 = Time_compat.now () in
+  let result = f () in
+  let ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+  (result, ms)
+
 (** Extract tool calls from content blocks. *)
 let tool_calls_of_content (blocks : Agent_sdk.Types.content_block list)
     : tool_call list =

--- a/lib/llm/llm_types.mli
+++ b/lib/llm/llm_types.mli
@@ -86,6 +86,10 @@ val usage_of_response : api_response -> token_usage
 (** Extract text content from an api_response. *)
 val text_of_response : api_response -> string
 
+(** Measure wall-clock latency of a thunk in milliseconds.
+    Use at call sites that need per-call timing (keeper tool loops, etc.). *)
+val timed : (unit -> 'a) -> 'a * int
+
 (** Extract tool calls from content blocks. *)
 val tool_calls_of_content : Agent_sdk.Types.content_block list -> tool_call list
 


### PR DESCRIPTION
## Summary

Follow-up to #1654 (OAS SDK Phase 2 Step A). GLM external review flagged the latency tracking removal as CRITICAL — keepers used `latency_ms` for observability diagnostics.

### Fix
- Add `Llm_types.timed : (unit -> 'a) -> 'a * int` helper for wall-clock measurement
- Wrap cascade/complete calls in keeper tool loops with `timed()` to restore per-round latency accumulation

### Why call-site measurement is better
- Old: `complete` measured internal time (provider call only)
- New: keeper measures full wall-clock time (including cache lookup)
- More accurate for the keeper's actual concern: "how long did this round take?"

### Files
- `llm_types.ml/mli` — add `timed` helper
- `keeper_exec_context.ml` — 2 call sites
- `keeper_exec_social.ml` — 3 call sites
- `keeper_turn.ml` — 4 call sites (incl. correction + forced grounding)
- `keeper_exec_proactive.ml` — 1 call site

## Test plan
- [x] `dune build` passes
- [x] `test_llm_client_cascade` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)