### PR TITLE
fix: agent lifecycle record-behavior consistency (6 bugs)

### DIFF
--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -122,7 +122,11 @@ let cleanup_zombies config =
     if !zombie_entries = [] then
       "✅ No zombie agents found"
     else begin
-      (* Phase 2: Transition status to Inactive + stop heartbeats *)
+      (* Phase 2: Transition status to Inactive + stop heartbeats.
+         Note: If later phases fail (task release or file deletion), the agent
+         remains in active_agents with an Inactive file. This is intentional:
+         Inactive+in-list is self-healing (next GC cycle cleans up), whereas
+         Active+dead (the old behavior) is invisible to monitoring. *)
       List.iter (fun (name, path) ->
         (try
           let json = read_json config path in


### PR DESCRIPTION
## Summary
- Fix 6 agent lifecycle bugs causing record-behavior inconsistency (#1655)
- Restructure `cleanup_zombies` into 5-phase pipeline for safe state transitions
- Add `Stdlib.Mutex` protection to heartbeat Hashtbl
- Add `agent_type` check to keeper detection (name pattern alone insufficient)

### Bug fixes
| Bug | File | Fix |
|-----|------|-----|
| BUG-1 | room.ml | Add missing `log_event` for room-scoped rejoin |
| BUG-2 | room_gc.ml | Only update state when file deletion succeeds |
| BUG-3 | room_gc.ml | Skip file removal when task release fails |
| BUG-4 | room_gc.ml | Transition zombie status to Inactive before deletion |
| BUG-5 | resilience.ml | Add `is_keeper ~name ~agent_type` dual check |
| BUG-6 | heartbeat.ml | Wrap Hashtbl with `Mutex.protect` |

## Test plan
- [x] `test_room.exe`: 79/80 PASS (1 pre-existing voting failure, unrelated)
- [x] `test_heartbeat_qw.exe`: 14/14 PASS
- [x] `test_room_coverage.exe`: 51/51 PASS
- [x] `dune build`: clean compile, no warnings
- [ ] Manual: verify zombie cleanup with simulated file permission error
- [ ] Manual: verify room-scoped rejoin event appears in event log

Closes #1655

Generated with [Claude Code](https://claude.com/claude-code)
