### PR TITLE
fix(dashboard): humanize messages + reduce execution timeout (#1611 #1637)

### DIFF
--- a/dashboard/src/components/command/swarm.ts
+++ b/dashboard/src/components/command/swarm.ts
@@ -36,6 +36,7 @@ import {
   swarmFocusKey,
   toneClass,
 } from './helpers'
+import { formatMessageContent } from '../ops/helpers'
 import { TraceRow } from './topology'
 
 function previewText(value: unknown): string {
@@ -706,7 +707,7 @@ export function SwarmSurface() {
                       </div>
                       <div class="command-card-sub">seq ${message.seq}</div>
                     </div>
-                    <pre class="command-trace-detail">${message.content}</pre>
+                    <pre class="command-trace-detail">${formatMessageContent(message.content)}</pre>
                   </article>
                 `)}
               </div>`

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -541,3 +541,20 @@ export async function confirmPending(
     showToast(message, 'error')
   }
 }
+
+/** Format message content for human readability.
+ *  Replaces raw session/task IDs with readable labels. */
+export function formatMessageContent(content: string): string {
+  if (!content) return ''
+  return content
+    .replace(/\[team-session:ts-\d+-\w+\.\.\./g, '[session ')
+    .replace(/\[team-session:([^\]]{0,20})[^\]]*\]/g, '[session $1]')
+    .replace(/ts-\d{13,}-[a-f0-9]{4,8}/g, (match) => {
+      const ts = match.match(/ts-(\d{13,})/)
+      if (ts) {
+        const date = new Date(parseInt(ts[1]))
+        return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+      }
+      return match
+    })
+}

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -29,6 +29,7 @@ import {
   taskDescription,
   taskPriority,
   taskTitle,
+  formatMessageContent,
 } from './helpers'
 import { selectPendingConfirmState } from '../../pending-confirm'
 
@@ -272,7 +273,7 @@ export function OpsRoomColumn() {
                   <strong>${message.from}</strong>
                   <span>${message.timestamp}</span>
                 </div>
-                <div class="ops-feed-content">${message.content}</div>
+                <div class="ops-feed-content">${formatMessageContent(message.content)}</div>
               </article>
             `)}
           </div>


### PR DESCRIPTION
## Summary

Dashboard "Recent Messages"에서 `[team-session:ts-1773831553736-8...]` 같은 raw session ID가 표시되는 문제 수정.

`formatMessageContent()` 헬퍼 추가:
- `[team-session:ts-...]` → `[session ...]` (짧은 레이블)
- `ts-1773831553736-8a3f` → `23:19` (타임스탬프를 시:분으로 변환)

## Files

| File | Change |
|------|--------|
| `dashboard/src/components/ops/helpers.ts` | `formatMessageContent()` 추가 |
| `dashboard/src/components/ops/ops-room-column.ts` | room feed에 적용 |
| `dashboard/src/components/command/swarm.ts` | swarm messages에 적용 |

## Test plan

- [x] `npm run build` — Vite build 성공
- [ ] Dashboard에서 recent messages가 읽기 쉬운 형태로 표시

Closes #1611