### PR TITLE
fix: masc_set_room resolves worktree paths to shared .masc/

### DIFF
--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -282,13 +282,21 @@ let dispatch (ctx : context) ~(name : string) : result option =
       if not (Sys.file_exists expanded && Sys.is_directory expanded) then
         Some (false, Printf.sprintf "Directory not found: %s" expanded)
       else
-        let masc_dir = Filename.concat expanded ".masc" in
+        (* Resolve to git root so worktree paths find the shared .masc/ directory *)
+        let resolved = Room_utils_backend_setup.resolve_masc_base_path expanded in
+        let masc_dir = Filename.concat resolved ".masc" in
         if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then
-          Some (false, Printf.sprintf "No .masc/ directory found in: %s\nRun masc_init to initialize, or choose a MASC-enabled directory." expanded)
+          Some (false, Printf.sprintf "No .masc/ directory found in: %s\nRun masc_init to initialize, or choose a MASC-enabled directory." resolved)
         else begin
           state.Mcp_server.room_config <- Room.default_config expanded;
-          let status = if Room.is_initialized state.Mcp_server.room_config then "ok" else "(not initialized)" in
-          Some (true, Printf.sprintf "MASC room set to: %s\n   .masc/ status: %s" expanded status)
+          let rc = state.Mcp_server.room_config in
+          let status = if Room.is_initialized rc then "ok" else "(not initialized)" in
+          let workspace_note =
+            if rc.workspace_path <> rc.base_path then
+              Printf.sprintf "\n   workspace: %s (worktree)" rc.workspace_path
+            else ""
+          in
+          Some (true, Printf.sprintf "MASC room set to: %s\n   .masc/ status: %s%s" rc.base_path status workspace_note)
         end
 
   | "masc_join" ->


### PR DESCRIPTION
## Summary
- `masc_set_room`에 worktree 경로를 넣으면 git root의 `.masc/`를 찾지 못해 실패하던 문제 수정
- `resolve_masc_base_path`로 git root를 먼저 resolve한 뒤 `.masc/` 존재 여부 확인
- 응답에 room path(git root)와 workspace path(worktree)를 구분해서 표시

## Problem
```
masc_set_room(path="/repo/.worktrees/my-task")
→ "No .masc/ directory found in: /repo/.worktrees/my-task"
```
worktree에는 `.masc/`가 없으므로 항상 실패. 에이전트가 repo root를 직접 지정해야 했음.

## Root cause
`masc_set_room` 핸들러가 인자로 받은 경로에서 직접 `.masc/`를 찾았음. worktree는 git root와 `.masc/`를 공유하는데, 핸들러가 이를 고려하지 않았음.

## Fix
`Room_utils_backend_setup.resolve_masc_base_path`로 git root를 resolve한 뒤 `.masc/` 확인. `Room.default_config`는 이미 `base_path`=git root, `workspace_path`=원래경로를 올바르게 분리하므로, 핸들러만 수정.

## After
```
masc_set_room(path="/repo/.worktrees/my-task")
→ "MASC room set to: /repo
     .masc/ status: ok
     workspace: /repo/.worktrees/my-task (worktree)"
```

## Test plan
- [x] `dune build` 성공
- [x] `test_room_utils_coverage.exe` — 75/75 pass
- [ ] 수동 검증: worktree 경로로 `masc_set_room` 호출 → 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)