### PR TITLE
feat(keeper): voice tools — local TTS sessions, no MCP server dependency

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -493,6 +493,7 @@
    keeper_alerting
    keeper_alerting_path
    keeper_exec_tools
+   keeper_voice_local
    keeper_exec_status
    keeper_exec_persona
    keeper_exec_context

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -479,77 +479,35 @@ let execute_keeper_tool_call
                 ("agent_id", `String meta.name);
                 ("message", `String err) ]))
   | "keeper_voice_sessions" ->
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match Voice_bridge.list_voice_sessions ~sw ~clock ~net with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      (* Local session manager — no net/MCP dependency *)
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let sessions = Voice_session_manager.list_sessions mgr in
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ("session_count", `Int (List.length sessions));
+            ("sessions",
+              `List (List.map Voice_session_manager.session_to_json sessions)) ])
   | "keeper_voice_session_start" ->
-      let session_name =
+      (* Local session manager — no net/MCP dependency *)
+      let voice =
         Safe_ops.json_string_opt "session_name" args
         |> Option.map String.trim
-        |> function
-        | Some s when s <> "" -> Some s
-        | _ -> None
+        |> function Some s when s <> "" -> Some s | _ -> None
       in
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match
-            Voice_bridge.start_voice_session ~sw ~clock ~net
-              ~agent_id:meta.name ?session_name ()
-          with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("agent_id", `String meta.name);
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let session =
+        Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice ()
+      in
+      Yojson.Safe.to_string
+        (Voice_session_manager.session_to_json session)
   | "keeper_voice_session_end" ->
-      (match
-         ( Eio_context.get_switch_opt (),
-           Eio_context.get_clock_opt (),
-           Eio_context.get_net_opt () )
-       with
-      | Some sw, Some clock, Some net -> (
-          match
-            Voice_bridge.end_voice_session ~sw ~clock ~net
-              ~agent_id:meta.name
-          with
-          | Ok json -> Yojson.Safe.to_string json
-          | Error err ->
-              Yojson.Safe.to_string
-                (`Assoc
-                  [ ("status", `String "error");
-                    ("agent_id", `String meta.name);
-                    ("message", `String err) ]))
-      | _ ->
-          Yojson.Safe.to_string
-            (`Assoc
-              [ ("status", `String "error");
-                ("message", `String "net_unavailable") ]))
+      (* Local session manager — no net/MCP dependency *)
+      let mgr = Keeper_voice_local.get_session_manager () in
+      let ended = Voice_session_manager.end_session mgr ~agent_id:meta.name in
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ("status", `String (if ended then "ended" else "no_active_session"));
+            ("agent_id", `String meta.name) ])
   | "keeper_github" ->
       let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
       let gh_args = Safe_ops.json_string_list "args" args in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -417,6 +417,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                              "keeper_board_comment";
                              "keeper_fs_edit";
                              "keeper_edit";
+                             "keeper_voice_speak";
+                             "keeper_voice_session_start";
+                             "keeper_voice_session_end";
                            ])
                       all_tools_so_far
                   in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -267,7 +267,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       Safe_ops.json_string ~default:"" "policy_reward_model_path" json
     in
     let policy_voice_enabled =
-      Safe_ops.json_bool ~default:false "policy_voice_enabled" json
+      Safe_ops.json_bool ~default:(default_voice_enabled_for name) "policy_voice_enabled" json
     in
     let policy_shell_mode =
       Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -171,8 +171,11 @@ let canonical_voice_channel = function
   | "text_only" -> "text_only"
   | _ -> "voice_text"
 
-let default_voice_enabled_for name =
-  String.equal (String.lowercase_ascii (String.trim name)) "sangsu"
+let default_voice_enabled_for _name =
+  (* Voice enabled for all keepers when voice_config.json is present *)
+  match Voice_config.load () with
+  | Ok _ -> true
+  | Error _ -> false
 
 let default_voice_channel_for name =
   if default_voice_enabled_for name then "voice_text" else "text_only"

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -1,0 +1,24 @@
+(** Keeper_voice_local — Local voice session management for keepers.
+
+    Provides a singleton Voice_session_manager backed by the local filesystem,
+    eliminating the need for an external Voice MCP server for session tracking.
+    TTS (agent_speak) still uses direct HTTP endpoints (ElevenLabs, etc).
+
+    @since 2.95.0 *)
+
+let masc_base_dir () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some root when String.trim root <> "" -> Filename.concat root ".masc"
+  | _ -> ".masc"
+
+(** Singleton session manager, lazily initialized *)
+let session_manager_ref : Voice_session_manager.t option ref = ref None
+
+let get_session_manager () =
+  match !session_manager_ref with
+  | Some mgr -> mgr
+  | None ->
+    let mgr = Voice_session_manager.create ~config_path:(masc_base_dir ()) in
+    Voice_session_manager.restore mgr;
+    session_manager_ref := Some mgr;
+    mgr

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -167,42 +167,44 @@ let handle_voice_speak (ctx : 'a context) args : result =
           (Voice_bridge.agent_speak ~sw:ctx.sw ~clock:ctx.clock ~net ~agent_id
              ~message ?provider ~priority ())
 
-let handle_voice_session_start (ctx : 'a context) args : result =
+let handle_voice_session_start (_ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
-  let session_name = get_string_opt args "session_name" |> Option.map String.trim in
-  let session_name =
-    match session_name with
+  let voice = get_string_opt args "session_name" |> Option.map String.trim in
+  let voice =
+    match voice with
     | Some name when name <> "" -> Some name
     | _ -> None
   in
   if agent_id = "" then
     (false, "Error: agent_id is required")
   else
-    match require_net_or_error ctx with
-    | Error message -> (false, message)
-    | Ok net ->
-        json_string_of_result
-          (Voice_bridge.start_voice_session ~sw:ctx.sw ~clock:ctx.clock ~net
-             ~agent_id ?session_name ())
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let session =
+      Voice_session_manager.start_session mgr ~agent_id ?voice ()
+    in
+    (true, Yojson.Safe.to_string
+      (Voice_session_manager.session_to_json session))
 
-let handle_voice_session_end (ctx : 'a context) args : result =
+let handle_voice_session_end (_ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   if agent_id = "" then
     (false, "Error: agent_id is required")
   else
-    match require_net_or_error ctx with
-    | Error message -> (false, message)
-    | Ok net ->
-        json_string_of_result
-          (Voice_bridge.end_voice_session ~sw:ctx.sw ~clock:ctx.clock ~net
-             ~agent_id)
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let ended = Voice_session_manager.end_session mgr ~agent_id in
+    (true, Yojson.Safe.to_string
+      (`Assoc
+        [ ("status", `String (if ended then "ended" else "no_active_session"));
+          ("agent_id", `String agent_id) ]))
 
-let handle_voice_sessions (ctx : 'a context) _args : result =
-  match require_net_or_error ctx with
-  | Error message -> (false, message)
-  | Ok net ->
-      json_string_of_result
-        (Voice_bridge.list_voice_sessions ~sw:ctx.sw ~clock:ctx.clock ~net)
+let handle_voice_sessions (_ctx : 'a context) _args : result =
+  let mgr = Keeper_voice_local.get_session_manager () in
+  let sessions = Voice_session_manager.list_sessions mgr in
+  (true, Yojson.Safe.to_string
+    (`Assoc
+      [ ("session_count", `Int (List.length sessions));
+        ("sessions",
+          `List (List.map Voice_session_manager.session_to_json sessions)) ]))
 
 let handle_voice_agent _ctx args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
@@ -211,36 +213,14 @@ let handle_voice_agent _ctx args : result =
   else
     json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
 
-let handle_voice_transcript (ctx : 'a context) _args : result =
-  match require_net_or_error ctx with
-  | Error message -> (false, message)
-  | Ok net ->
-      json_string_of_result
-        (Voice_bridge.get_transcript ~sw:ctx.sw ~clock:ctx.clock ~net ())
+let handle_voice_transcript (_ctx : 'a context) _args : result =
+  (* Transcript requires an external STT service — not yet integrated locally *)
+  (false, Yojson.Safe.to_string
+    (`Assoc
+      [ ("status", `String "not_available");
+        ("message", `String "transcript requires STT service integration") ]))
 
-let handle_voice_conference_start (ctx : 'a context) args : result =
-  let agent_ids =
-    get_string_list args "agent_ids"
-    |> List.map String.trim
-    |> List.filter (fun item -> item <> "")
-  in
-  let conference_name = get_string_opt args "conference_name" |> Option.map String.trim in
-  let conference_name =
-    match conference_name with
-    | Some name when name <> "" -> Some name
-    | _ -> None
-  in
-  if agent_ids = [] then
-    (false, "Error: agent_ids must include at least one agent")
-  else
-    match require_net_or_error ctx with
-    | Error message -> (false, message)
-    | Ok net ->
-        json_string_of_result
-          (Voice_bridge.start_conference ~sw:ctx.sw ~clock:ctx.clock ~net
-             ~agent_ids ?conference_name ())
-
-let handle_voice_conference_end (ctx : 'a context) args : result =
+let handle_voice_conference_start (_ctx : 'a context) args : result =
   let agent_ids =
     get_string_list args "agent_ids"
     |> List.map String.trim
@@ -249,12 +229,37 @@ let handle_voice_conference_end (ctx : 'a context) args : result =
   if agent_ids = [] then
     (false, "Error: agent_ids must include at least one agent")
   else
-    match require_net_or_error ctx with
-    | Error message -> (false, message)
-    | Ok net ->
-        json_string_of_result
-          (Voice_bridge.end_conference ~sw:ctx.sw ~clock:ctx.clock ~net
-             ~agent_ids ())
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let sessions = List.map (fun agent_id ->
+      let session =
+        Voice_session_manager.start_session mgr ~agent_id ()
+      in
+      Voice_session_manager.session_to_json session
+    ) agent_ids in
+    (true, Yojson.Safe.to_string
+      (`Assoc
+        [ ("status", `String "started");
+          ("participant_count", `Int (List.length agent_ids));
+          ("sessions", `List sessions) ]))
+
+let handle_voice_conference_end (_ctx : 'a context) args : result =
+  let agent_ids =
+    get_string_list args "agent_ids"
+    |> List.map String.trim
+    |> List.filter (fun item -> item <> "")
+  in
+  if agent_ids = [] then
+    (false, "Error: agent_ids must include at least one agent")
+  else
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let ended = List.fold_left (fun count agent_id ->
+      if Voice_session_manager.end_session mgr ~agent_id then count + 1
+      else count
+    ) 0 agent_ids in
+    (true, Yojson.Safe.to_string
+      (`Assoc
+        [ ("ended", `Int ended);
+          ("total", `Int (List.length agent_ids)) ]))
 
 let dispatch (ctx : 'a context) ~name ~args : result option =
   match name with

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -185,9 +185,7 @@ let () = test "handle_heartbeat_stop_not_found" (fun () ->
       assert (String.length result > 0 (* contains emoji *)))
 )
 
-(* Voice integration in heartbeat allowed_tools tests removed:
-   Lodge_heartbeat.heartbeat_allowed_tools was deleted in the Lodge
-   deprecation refactoring (#1596, #1640). Voice tool integration
-   now lives in keeper_exec_tools.ml and capability_registry.ml. *)
-
+(* Voice integration tests removed: Lodge_heartbeat deprecated (#1596, #1640).
+   Voice tools are now verified via test_tool_shard_coverage.ml (shard/revoke)
+   and integration through keeper_exec_tools dispatch. *)
 let () = Printf.printf "\n✅ All Tool_heartbeat tests passed!\n"


### PR DESCRIPTION
## Summary

- Keeper voice tools 1→5개 확장 (speak, agent, sessions, session_start, session_end)
- Voice MCP 서버 의존 완전 제거 — 세션 관리는 로컬 Voice_session_manager
- TTS만 외부 HTTP (ElevenLabs direct) 유지
- voice_config.json 존재 시 모든 keeper 자동 활성화 (하드코딩 제거)

## 변경 범위

| 영역 | 변경 |
|------|------|
| Shard | voice shard 1→5 tools |
| Registry | 4 backend mappings + wrapped tools |
| Dispatch | keeper_exec_tools 로컬 세션 매니저 사용 |
| MCP Tools | tool_voice.ml 전체 로컬화 |
| OAS Turn | voice tools in write_done check |
| Defaults | voice_enabled = voice_config 존재 여부 |
| Rate Limit | Voice variant 추가 |
| Types | ActionVoice of string |

## 의존성

```
Before: keeper → Voice MCP Server (외부, net 필수)
After:  keeper → Voice_session_manager (로컬 파일) + TTS HTTP (speak만)
```

## Test plan

- [x] dune build
- [x] Shard tests (37 pass)
- [x] Heartbeat tests (14 pass)

Generated with [Claude Code](https://claude.com/claude-code)