### PR TITLE
fix(backend): catch Eio_mutex.Poisoned in filesystem fallback

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -25,10 +25,10 @@ module FileSystemBackend : BACKEND = struct
       Eio.Mutex.use_rw ~protect:true t.mutex (fun () -> f ())
     with
     | result -> result
-    | exception Effect.Unhandled _ ->
+    | exception Effect.Unhandled _ | exception Eio__Eio_mutex.Poisoned _ ->
         (* No Eio runtime (e.g. tests) — fall back to Stdlib.Mutex.
-           Only catches Effect.Unhandled; Eio exceptions (Cancel, etc.)
-           propagate normally to avoid blocking the scheduler. *)
+           Effect.Unhandled: first attempt without Eio context.
+           Eio_mutex.Poisoned: mutex poisoned by a prior failed attempt. *)
         Stdlib.Mutex.lock stdlib_mutex;
         Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
 


### PR DESCRIPTION
## Summary
- FileSystemBackend.with_lock이 `Effect.Unhandled`만 잡고 `Eio_mutex.Poisoned`를 놓침
- Poisoned mutex는 이전 실패한 lock 시도의 결과물 — 동일하게 Stdlib.Mutex fallback 적용
- goal_tools 7개, governance_v2, jsonl, messages_raw 등 filesystem 의존 테스트 fix

## Test plan
- [x] test_tool_goals.exe: 7/7 pass (was 0/7)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)