### PR TITLE
fix: enforce LLM cascade timeout (60s dashboard stall)

### DIFF
--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -144,7 +144,6 @@ let get_cascade ?(config_path = "") ~cascade_name () :
 let call ~cascade_name ~prompt
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
-  ignore timeout_sec;
   let env = Llm_eio_env.get () in
   let defaults = default_model_strings ~cascade_name in
   let config_path_opt =
@@ -163,7 +162,7 @@ let call ~cascade_name ~prompt
       ~sw:env.sw ~net:env.net ?clock:env.clock
       ?config_path:config_path_opt
       ~name:cascade_name ~defaults ~messages
-      ~temperature ~max_tokens ~accept ()
+      ~temperature ~max_tokens ~accept ~timeout_sec ()
   with
   | Ok resp ->
     let t1 = Time_compat.now () in


### PR DESCRIPTION
## Summary
- `Llm_cascade.call`에서 `ignore timeout_sec` 제거, OAS `complete_named`에 전달
- OAS oas#208에서 추가된 `?timeout_sec` 파라미터와 연동
- LLM 호출이 30초(기본값) 후 타임아웃되어 Eio event loop 블로킹 방지

## Root Cause
`ignore timeout_sec` 한 줄 때문에 Keeper/Sentinel/Gardener의 LLM cascade 호출이 무한 대기. Eio cooperative scheduling에서 한 fiber의 블로킹이 HTTP 서버 전체에 전파되어 대시보드가 60초+ 응답 지연.

## Changes
- `lib/llm_cascade.ml`: `ignore timeout_sec` 제거, `~timeout_sec` 파라미터 전달 (2줄 변경)

## Dependencies
- **oas#208** (merged): `Cascade_config.complete_named`에 `?timeout_sec` 추가

## Test plan
- [ ] CI Build and Test 통과 (main의 trpg 빌드 에러 해결 후)
- [ ] 서버 실행 후 keeper heartbeat 중 대시보드 탭 전환 응답 시간 < 5초 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)