### PR TITLE
fix: strip [STATE] blocks from board posts (server + client)

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -4,6 +4,7 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
+import { stripStateBlocks } from '../keeper-message'
 import {
   boardPosts,
   boardSortMode,
@@ -280,7 +281,7 @@ function PostCard({ post }: { post: BoardPost }) {
             <span>투표 ${post.votes ?? 0}</span>
           </div>
         </div>
-        <div class="post-snippet">${previewText(post.body)}</div>
+        <div class="post-snippet">${previewText(stripStateBlocks(post.body))}</div>
       </div>
     </div>
   `
@@ -345,7 +346,7 @@ function PostDetail({ post }: { post: BoardPost }) {
       <${Card} title=${post.title} semanticId="memory.feed">
         <div class="board-detail">
           <div class="post-body">
-            <${Markdown} text=${post.body} />
+            <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
           <div class="post-meta" style="margin-top:12px;">
             <span>${post.author}</span>

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -14,7 +14,7 @@ function extractStateBlock(text: string): string | null {
   return state || null
 }
 
-function stripStateBlocks(text: string): string {
+export function stripStateBlocks(text: string): string {
   let next = text
   for (;;) {
     const start = next.indexOf(STATE_START)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -122,8 +122,9 @@ let format_comment_tree ?(max_depth=5) (comments : Board.comment list) =
 
 let handle_post_create args =
   let title = get_string_opt args "title" in
-  let body = get_string_opt args "body" in
-  let content = match body with Some value -> value | None -> get_string args "content" "" in
+  let body = get_string_opt args "body" |> Option.map Keeper_prompt.strip_state_blocks_text in
+  let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
+  let content = Keeper_prompt.strip_state_blocks_text raw_content in
   let author = get_string args "author" "anonymous" in
   let ttl_hours = get_int args "ttl_hours" Board.Limits.default_ttl_hours in
   let visibility_str = get_string args "visibility" "internal" in


### PR DESCRIPTION
## Summary
- **서버**: `tool_board.ml`에서 `Keeper_prompt.strip_state_blocks_text`로 `[STATE]...[/STATE]` 블록 제거 후 저장
- **클라이언트**: `memory.ts`에서 `stripStateBlocks()`로 렌더링 시 제거 (방어적 보완)
- `keeper-message.ts`의 `stripStateBlocks` 함수를 export

## Problem
Keeper가 LLM 응답의 `[STATE]...[/STATE]` 내부 상태 블록을 포함한 채 Board에 포스트. 대시보드에서 사용자에게 그대로 노출됨.

## Fix
- 서버 (근본): 포스트 저장 전 content/body에서 STATE 블록 제거
- 클라이언트 (방어): 렌더링 시에도 제거 (기존 DB에 이미 저장된 데이터 대응)

## Note
현재 main HEAD에 순환 의존 빌드 에러 있음 (Keeper_prompt→Keeper_alerting 순환, Tool_protocol_game_view 누락). 이 PR의 변경과 무관. main 수정 후 CI가 통과할 것으로 예상.

## Test plan
- [ ] main 빌드 복구 후 `dune build` 확인
- [ ] 대시보드에서 기존 STATE 블록 포함 포스트가 깨끗하게 렌더링되는지 확인
- [ ] 새 포스트 생성 시 STATE 블록이 저장되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)