### PR TITLE
refactor(swarm): migrate Agent.create to Builder pattern with Guardrails

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -100,11 +100,6 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
   let dev_tools =
     Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:config.workdir ()
   in
-  let agent_config = { Types.default_config with
-    model = provider_cfg.model_id;
-    max_turns = config.max_turns;
-    system_prompt = Some (Agent_swarm_prompts.solo_developer ~goal:config.goal);
-  } in
   let hooks = if config.verbose then
     { Hooks.empty with
       pre_tool_use = Some (fun event -> match event with
@@ -114,10 +109,27 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
           Hooks.Continue
         | _ -> Hooks.Continue) }
   else Hooks.empty in
-  let agent = Agent.create ~net ~config:agent_config ~tools:dev_tools
-    ~options:{ Agent.default_options with
-               base_url; provider = Some provider_cfg; hooks } () in
-  Agent.run ~sw agent config.goal
+  let tool_names =
+    List.map (fun (tool : Tool.t) -> tool.schema.name) dev_tools
+  in
+  let builder =
+    Builder.create ~net ~model:provider_cfg.model_id
+    |> Builder.with_max_turns config.max_turns
+    |> Builder.with_system_prompt
+         (Agent_swarm_prompts.solo_developer ~goal:config.goal)
+    |> Builder.with_base_url base_url
+    |> Builder.with_provider provider_cfg
+    |> Builder.with_tools dev_tools
+    |> Builder.with_hooks hooks
+    |> Builder.with_guardrails
+         {
+           Guardrails.tool_filter = AllowList tool_names;
+           max_tool_calls_per_turn = Some 12;
+         }
+  in
+  match Builder.build_safe builder with
+  | Error err -> Error err
+  | Ok agent -> Agent.run ~sw agent config.goal
 
 let run_fleet ~sw ~net ~clock ~proc_mgr config =
   let provider_cfg = match resolve_provider config.provider_name with

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -340,23 +340,32 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
                   []
               in
               let all_tools = spec.tools @ masc_tools @ extra_tools in
-              let config = {
-                Types.default_config with
-                name = spec.name;
-                model = spec.provider.model_id;
-                system_prompt = Some spec.system_prompt;
-                max_tokens =
-                  Option.value spec.max_tokens
-                    ~default:Types.default_config.max_tokens;
-                max_turns = spec.max_turns;
-                temperature = spec.temperature;
-              } in
-              let agent =
-                Agent.create ~net ~config ~tools:all_tools
-                  ~options:{ Agent.default_options with
-                             provider = Some spec.provider } ()
+              let tool_names =
+                List.map (fun (tool : Tool.t) -> tool.schema.name) all_tools
               in
-              Agent.run ~sw:inner_sw agent goal
+              let builder =
+                Builder.create ~net ~model:spec.provider.model_id
+                |> Builder.with_name spec.name
+                |> Builder.with_system_prompt spec.system_prompt
+                |> Builder.with_max_tokens
+                     (Option.value spec.max_tokens
+                        ~default:Types.default_config.max_tokens)
+                |> Builder.with_max_turns spec.max_turns
+                |> (fun b ->
+                     match spec.temperature with
+                     | Some t -> Builder.with_temperature t b
+                     | None -> b)
+                |> Builder.with_provider spec.provider
+                |> Builder.with_tools all_tools
+                |> Builder.with_guardrails
+                     {
+                       Guardrails.tool_filter = AllowList tool_names;
+                       max_tool_calls_per_turn = Some 12;
+                     }
+              in
+              match Builder.build_safe builder with
+              | Error err -> Error err
+              | Ok agent -> Agent.run ~sw:inner_sw agent goal
             )
           in
           let result =


### PR DESCRIPTION
## Summary

- `agent_swarm_swarm.ml` (`run_agent`): `Agent.create ~config ~options` → `Builder.create` pipeline + `build_safe`
- `agent_swarm_runner.ml` (`run_solo`): same migration for standalone CLI agent
- Both paths gain `AllowList` guardrails (tool filtering) and `max_tool_calls_per_turn = 12`
- Reference pattern: `worker_oas.ml:136-177`

## Context

Part of OAS Integration Gaps plan (PR 1/3). Remaining paths:
- PR 2: `local_agent_eio_container.ml` Builder consolidation
- PR 3: `Eval_gate → OAS Guardrails` bridge

## Test plan

- [x] `dune build --root . lib/agent_swarm_swarm.ml lib/agent_swarm_runner.ml` — compiles
- [ ] Full build blocked by pre-existing `Server_trpg_rest` archive issue (see #1680)
- [ ] Swarm integration test with live MASC server

🤖 Generated with [Claude Code](https://claude.com/claude-code)