### PR TITLE
refactor(local-agent): delegate run_worker_oas to Worker_oas.build_agent

### DIFF
--- a/lib/local/local_agent_eio_runners.ml
+++ b/lib/local/local_agent_eio_runners.ml
@@ -200,26 +200,10 @@ let run_worker_oas ~sw ~base_path ~worker_name
                     | _ -> Oas.Hooks.Continue);
             }
           in
-          let max_turn_cap =
-            match execution_scope with
-            | Team_session_types.Limited_code_change -> 20
-            | Team_session_types.Observe_only -> 12
-            | Team_session_types.Autonomous -> 30
+          let* agent =
+            Worker_oas.build_agent ~net ~meta ~model ~system_prompt ~tools
+              ~hooks ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ()
           in
-          let max_turns =
-            match max_turns with
-            | Some value -> max 1 (min max_turn_cap value)
-            | None -> max 2 (min max_turn_cap (max 2 (timeout_sec / 20)))
-          in
-          let thinking_enabled =
-            Option.value ~default:false thinking_enabled
-          in
-          let config, options =
-            build_oas_agent ~worker_name ~model ~system_prompt ~tools
-              ~max_turns ~thinking_enabled ~hooks ~raw_trace
-              ~periodic_callbacks:heartbeat_cbs ()
-          in
-          let agent = Oas.Agent.create ~net ~config ~tools ~options () in
           let result =
             Oas.Agent.run ~sw agent prompt
           in


### PR DESCRIPTION
## Summary

- `run_worker_oas`: replaced `build_oas_agent` + `Agent.create` with `Worker_oas.build_agent`
- Removes 16 lines of redundant max_turns/thinking_enabled computation
- `Worker_oas.build_agent` uses Builder pattern with `build_safe` validation + AllowList guardrails
- `continue_worker` retains `build_oas_agent` for `Agent.resume` (needs config+options separately)

## Context

Part of OAS Integration Gaps plan (PR 2/3). Depends on PR 1 (#1682) conceptually but no code dependency.
- PR 3: `Eval_gate → OAS Guardrails` bridge

## Test plan

- [x] `dune build --root . lib/local/local_agent_eio_runners.ml` — compiles
- [ ] Full build blocked by pre-existing `Server_trpg_rest` archive issue
- [ ] Team session worker integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)