### PR TITLE
feat(oas): add Eval_gate → OAS Guardrails bridge

### DIFF
--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -288,3 +288,41 @@ let guardrails_with_read_only_tag
     guardrails pipelines for conditional verification bypass. *)
 let read_only_predicate (schema : Agent_sdk.Types.tool_schema) : bool =
   should_skip ~action_description:schema.name
+
+(* ================================================================ *)
+(* Eval_gate -> OAS Guardrails bridge                               *)
+(* ================================================================ *)
+
+(** Convert Eval_gate.gate_config to OAS Guardrails.t.
+
+    Maps the static tool-filtering portion of the gate config:
+    - [allowlist_enabled] + [allowed_tools] -> AllowList
+    - [denied_tools] only -> DenyList
+    - Both enabled -> AllowList (stricter; deny is redundant)
+    - Neither -> AllowAll
+
+    Dynamic runtime checks (cost budget, entropy, destructive patterns)
+    remain in Eval_gate. OAS Guardrails handles static pre-filtering;
+    Eval_gate handles stateful per-call checks. Together they form
+    defense-in-depth.
+
+    @since Phase 6 — OAS Guardrails bridge *)
+let eval_gate_to_oas_guardrails (gate : Eval_gate.gate_config) :
+    Agent_sdk.Guardrails.t =
+  let tool_filter =
+    match (gate.allowlist_enabled, gate.allowed_tools, gate.denied_tools) with
+    | true, (_ :: _ as allowed), _ ->
+        (* AllowList is the stricter filter; deny is handled at runtime *)
+        Agent_sdk.Guardrails.AllowList allowed
+    | true, [], _ ->
+        (* Allowlist enabled but empty = deny all tools *)
+        Agent_sdk.Guardrails.AllowList []
+    | false, _, (_ :: _ as denied) ->
+        Agent_sdk.Guardrails.DenyList denied
+    | false, _, [] ->
+        Agent_sdk.Guardrails.AllowAll
+  in
+  {
+    Agent_sdk.Guardrails.tool_filter;
+    max_tool_calls_per_turn = Some gate.max_tool_calls_per_turn;
+  }

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -142,11 +142,22 @@ let build_agent
     ~(hooks : Oas.Hooks.hooks)
     ~(raw_trace : Oas.Raw_trace.t)
     ~(heartbeat_callbacks : Oas.Agent.periodic_callback list)
+    ?(gate_config : Eval_gate.gate_config option)
     () : (Oas.Agent.t, string) result =
   let config = agent_config_of_worker_meta meta ~system_prompt in
   let provider = oas_provider_of_model model in
   let tool_names =
     List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
+  in
+  let guardrails =
+    match gate_config with
+    | Some gate ->
+        Verifier_oas.eval_gate_to_oas_guardrails gate
+    | None ->
+        {
+          Oas.Guardrails.tool_filter = AllowList tool_names;
+          max_tool_calls_per_turn = Some 12;
+        }
   in
   let builder =
     Oas.Builder.create ~net ~model:config.model
@@ -164,11 +175,7 @@ let build_agent
     |> Oas.Builder.with_provider provider
     |> Oas.Builder.with_tools tools
     |> Oas.Builder.with_hooks hooks
-    |> Oas.Builder.with_guardrails
-         {
-           Oas.Guardrails.tool_filter = AllowList tool_names;
-           max_tool_calls_per_turn = Some 12;
-         }
+    |> Oas.Builder.with_guardrails guardrails
     |> Oas.Builder.with_raw_trace raw_trace
     |> Oas.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Oas.Builder.with_description (description_of_meta meta)


### PR DESCRIPTION
## Summary

- `verifier_oas.ml`: new `eval_gate_to_oas_guardrails` bridge function
  - `allowlist_enabled + allowed_tools` → `AllowList`
  - `denied_tools` only → `DenyList`
  - `max_tool_calls_per_turn` mapped directly
  - Dynamic checks (cost, entropy, destructive) stay in Eval_gate (defense-in-depth)
- `worker_oas.ml`: `build_agent` accepts optional `~gate_config`
  - When provided, uses bridge for guardrails instead of default AllowList
  - Backward-compatible: existing callers unaffected (optional param)

## Context

Part of OAS Integration Gaps plan (PR 3/3).
- PR 1: #1682 (swarm Builder migration)
- PR 2: #1684 (local agent Builder consolidation)

## Design: Defense-in-Depth

```
OAS Guardrails (static)    Eval_gate (dynamic)
├── AllowList/DenyList      ├── cost budget check
├── max_tool_calls cap      ├── entropy detection
└── applied at Builder      ├── destructive pattern scan
    construction time        └── applied at each tool call
```

## Test plan

- [x] `dune build --root . lib/verifier_oas.ml lib/worker_oas.ml` — compiles
- [ ] Full build blocked by pre-existing `Server_trpg_rest` archive issue
- [ ] Unit test for eval_gate_to_oas_guardrails mapping
- [ ] Keeper autonomous execution with gate_config → guardrails

🤖 Generated with [Claude Code](https://claude.com/claude-code)