### PR TITLE
fix: remove orphan TRPG references breaking main build

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,1 @@
-(dirs (:standard \ .worktrees _build_codex_trpg))
+(dirs (:standard \ .worktrees _build_codex_trpg archive))

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -123,8 +123,6 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_goals.schemas
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
-    (* Tool_protocol_game_view.schemas removed — module does not exist *)
-    (* Tool_trpg.schemas removed — module does not exist *)
     @ Tool_compact.schemas
     @ Tool_async_spawn.schemas
     )

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -168,7 +168,7 @@ let () =
   register_module_tag ~schemas:Tool_async_spawn.schemas ~tag:Mod_async_spawn;
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
   register_module_tag ~schemas:Tool_llm_catalog.schemas ~tag:Mod_llm_catalog;
-  (* register_module_tag ~schemas:Tool_trpg.schemas ~tag:Mod_trpg; — module does not exist *)
+  (* Tool_trpg archived (#1668) *)
   register_module_tag ~schemas:Tool_notifications.schemas ~tag:Mod_notifications;
   (* God Schema decomposition: register modules that now own their schemas *)
   register_module_tag ~schemas:Tool_task.schemas ~tag:Mod_task;


### PR DESCRIPTION
## Summary

- root `dune`에 `archive` 디렉토리 제외 추가 (순환 의존성 해결)
- `Server_trpg_rest`, `Tool_trpg`, `Tool_protocol_game_view` 삭제된 모듈의 dangling 참조 제거
- 12개 서버 파일에서 `open Server_trpg_rest` 제거
- `server_h2_gateway_routes_extra.ml`에서 TRPG 라우트 match arm 제거
- `server_h2_gateway.ml`에서 TRPG auth guard dead code 제거
- `config.ml`, `mcp_server_eio.ml`에서 삭제된 모듈 스키마 참조 제거
- TRPG 관련 test stanza 주석 처리

## Test plan

- [x] `dune build lib/` green (순환 의존성 + Unbound module 해결됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)