### PR TITLE
fix: remove stale TRPG module references after archival

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http
 

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http
 open Server_h2_gateway_helpers

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -11,7 +11,6 @@ let make_routes ~port ~host ~sw ~clock =
   Http.Router.empty
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes
-  |> Server_routes_http_routes_trpg.add_routes
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
   |> Server_routes_http_routes_command_plane_read.add_routes
   |> Server_routes_http_routes_command_plane_write.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 
 module Http = Http_server_eio

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 
 module Mcp_eio = Mcp_server_eio

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 
 module Http = Http_server_eio

--- a/lib/server/server_routes_http_routes_command_plane_read.ml
+++ b/lib/server/server_routes_http_routes_command_plane_read.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_routes_command_plane_write.ml
+++ b/lib/server/server_routes_http_routes_command_plane_write.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_routes_social.ml
+++ b/lib/server/server_routes_http_routes_social.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 open Server_routes_http_common
 open Server_routes_http_pages

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -4,7 +4,6 @@ open Types
 open Server_utils
 open Server_auth
 open Server_tts_proxy
-open Server_trpg_rest
 open Server_dashboard_http
 
 open Server_routes_http_common

--- a/test/dune
+++ b/test/dune
@@ -356,49 +356,7 @@
  (modules test_room_messages_raw)
  (libraries masc_mcp alcotest unix))
 
-; TRPG engine state machine tests
-(test
- (name test_trpg_engine_state_machine)
- (modules test_trpg_engine_state_machine)
- (libraries masc_mcp alcotest))
-
-(test
- (name test_trpg_engine_store)
- (modules test_trpg_engine_store)
- (libraries masc_mcp alcotest unix))
-
-(test
- (name test_trpg_rule_dnd5e_lite)
- (modules test_trpg_rule_dnd5e_lite)
- (libraries masc_mcp alcotest yojson))
-
-; NPC Bestiary tests (12 archetypes, scaling, deterministic damage)
-(test
- (name test_trpg_npc_bestiary)
- (modules test_trpg_npc_bestiary)
- (libraries masc_mcp alcotest yojson))
-
-; NPC combat integration tests (spawn -> counterattack -> event store)
-(test
- (name test_trpg_npc_integration)
- (modules test_trpg_npc_integration)
- (libraries masc_mcp alcotest yojson unix))
-
-(test
- (name test_trpg_engine_store_sqlite)
- (modules test_trpg_engine_store_sqlite)
- (libraries masc_mcp alcotest unix))
-
-(test
- (name test_tool_trpg_coverage)
- (modules test_tool_trpg_coverage)
- (libraries masc_mcp alcotest yojson unix eio eio_main))
-
-; Narrative Intelligence tests (inventory, relationships, dedup, JSON recovery)
-(test
- (name test_narrative_intelligence)
- (modules test_narrative_intelligence)
- (libraries masc_mcp alcotest yojson))
+; (TRPG tests archived — modules moved to archive/trpg/)
 
 (test
  (name test_tool_goals)
@@ -472,10 +430,7 @@
  (modules test_local_runtime_pool)
  (libraries masc_mcp alcotest unix))
 
-(test
- (name test_protocol_game_view)
- (modules test_protocol_game_view)
- (libraries masc_mcp alcotest yojson unix eio eio_main))
+; (test_protocol_game_view archived with TRPG)
 
 (test
  (name test_tool_keeper)
@@ -733,13 +688,6 @@
  (libraries alcotest yojson unix)
  (deps ../bin/main_eio.exe))
 
-; TRPG actor API endpoint-level integration tests
-(test
- (name test_trpg_actor_api_e2e)
- (modules test_trpg_actor_api_e2e)
- (libraries alcotest yojson unix)
- (deps ../bin/main_eio.exe))
-
 ; Operator MCP endpoint-level supervision tests
 (test
  (name test_operator_mcp_e2e)
@@ -828,29 +776,7 @@
  (modules test_perpetual)
  (libraries masc_mcp str yojson unix))
 
-; TRPG Keeper Intelligence — BDI Memory Module
-(test
- (name test_trpg_bdi)
- (modules test_trpg_bdi)
- (libraries masc_mcp alcotest yojson unix))
-
-; TRPG Keeper Intelligence — DM Intent Extraction
-(test
- (name test_trpg_dm_intent)
- (modules test_trpg_dm_intent)
- (libraries masc_mcp alcotest yojson))
-
-; TRPG Keeper Intelligence — Actor-Keeper Compatibility
-(test
- (name test_trpg_actor_match)
- (modules test_trpg_actor_match)
- (libraries masc_mcp alcotest yojson))
-
-; TRPG Keeper Intelligence — Evaluation Harness (parsers + scoring)
-(test
- (name test_trpg_harness)
- (modules test_trpg_harness)
- (libraries masc_mcp alcotest yojson))
+; (TRPG Keeper Intelligence tests archived)
 
 ; ============================================================
 ; Keeper Agent Harness tests (trajectory + eval gates + scenarios)


### PR DESCRIPTION
## Summary
TRPG 모듈 아카이빙 후 남은 12개 `open Server_trpg_rest` 제거 + test/dune에서 11개 TRPG 테스트 항목 제거 + HTTP router에서 TRPG 라우트 제거.

## Remaining
`Keeper_prompt ↔ Keeper_alerting` 순환 의존은 #1683에서 도입됨. 별도 PR로 분리.

## Test plan
- [x] test/dune 파싱 에러 해소
- [x] `open Server_trpg_rest` 컴파일 에러 해소
- [ ] 순환 의존 해소 후 `dune build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)