### PR TITLE
feat(keeper): run_cascade through OAS Agent.t + tests

### DIFF
--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -149,18 +149,113 @@ let model_of_run_result (r : Oas_worker.run_result) : string =
   r.response.model
 
 (* ================================================================ *)
-(* Public: cascade compatibility wrappers                           *)
+(* Internal: extract OAS parameters from completion_request list    *)
+(* ================================================================ *)
+
+type cascade_params = {
+  primary_spec : Llm_types.model_spec;
+  fallback_specs : Llm_types.model_spec list;
+  system_prompt : string;
+  goal : string;
+  temperature : float;
+  max_tokens : int;
+}
+
+let separate_system_and_user (msgs : Agent_sdk.Types.message list) :
+    string * Agent_sdk.Types.message list =
+  let sys_parts = ref [] in
+  let rest = ref [] in
+  List.iter (fun (m : Agent_sdk.Types.message) ->
+    match m.role with
+    | Agent_sdk.Types.System -> sys_parts := Llm_types.text_of_message m :: !sys_parts
+    | _ -> rest := m :: !rest
+  ) msgs;
+  let sys = String.concat "\n" (List.rev !sys_parts) in
+  (sys, List.rev !rest)
+
+let messages_to_goal_text (msgs : Agent_sdk.Types.message list) : string =
+  msgs
+  |> List.map (fun (m : Agent_sdk.Types.message) -> Llm_types.text_of_message m)
+  |> List.filter (fun s -> String.length s > 0)
+  |> String.concat "\n"
+
+let cascade_config_of_requests
+    (requests : Llm_types.completion_request list)
+  : (cascade_params, string) result =
+  match requests with
+  | [] -> Error "empty cascade request list"
+  | first :: rest ->
+      let sys_prompt, user_msgs = separate_system_and_user first.messages in
+      let goal = messages_to_goal_text user_msgs in
+      if String.length goal = 0 then
+        Error "no user messages in cascade request"
+      else
+        Ok {
+          primary_spec = first.model;
+          fallback_specs =
+            List.map (fun (r : Llm_types.completion_request) -> r.model) rest;
+          system_prompt = sys_prompt;
+          goal;
+          temperature = first.temperature;
+          max_tokens = first.max_tokens;
+        }
+
+(* ================================================================ *)
+(* Public: cascade through OAS Agent.t                              *)
 (* ================================================================ *)
 
 let run_cascade ?timeout_sec requests =
-  Llm_orchestration.cascade ?timeout_sec requests
+  match cascade_config_of_requests requests with
+  | Error e -> Error e
+  | Ok params ->
+  match require_net (), require_switch () with
+  | Error e, _ | _, Error e -> Error e
+  | Ok net, Ok sw ->
+  let all_specs = params.primary_spec :: params.fallback_specs in
+  let rec try_specs errors = function
+    | [] ->
+        let all = String.concat "; " (List.rev errors) in
+        Error (Printf.sprintf "All OAS cascade models failed: %s" all)
+    | spec :: rest ->
+        let oas_config = { (Oas_worker.default_config
+          ~name:"keeper-cascade"
+          ~model_spec:spec
+          ~system_prompt:params.system_prompt
+          ~tools:[]) with
+          max_turns = 1;
+          max_tokens = params.max_tokens;
+          temperature = params.temperature;
+        } in
+        let deadline =
+          Option.map (fun sec -> Time_compat.now () +. float_of_int sec) timeout_sec
+        in
+        let past_deadline () =
+          match deadline with
+          | None -> false
+          | Some d -> Time_compat.now () >= d
+        in
+        if past_deadline () then
+          Error "OAS cascade timeout"
+        else
+        let result = Oas_worker.run ~sw ~net ~config:oas_config params.goal in
+        (match result with
+         | Ok r ->
+             Log.Keeper.info "oas cascade: success with %s" spec.model_id;
+             Ok r.Oas_worker.response
+         | Error e ->
+             Log.Keeper.warn "oas cascade: %s failed: %s" spec.model_id e;
+             try_specs (e :: errors) rest)
+  in
+  try_specs [] all_specs
 
 let run_cascade_stream ?timeout_sec ~on_event request ~fallback =
+  (* OAS Agent SDK does not support streaming — use Llm_orchestration
+     for the streaming path, fall back to OAS batch on failure. *)
   match
     Llm_orchestration.call_provider_stream ?timeout_sec request ~on_event
   with
   | Ok _ as ok -> ok
   | Error e ->
-      Log.Keeper.warn "oas adapter stream failed (%s), falling back to batch" e;
+      Log.Keeper.warn "oas adapter stream failed (%s), falling back to OAS batch" e;
       let timeout_int = Option.map int_of_float timeout_sec in
-      Llm_orchestration.cascade ?timeout_sec:timeout_int fallback
+      run_cascade ?timeout_sec:timeout_int (request :: fallback)

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -42,22 +42,41 @@ val usage_of_run_result : Oas_worker.run_result -> Llm_types.token_usage
 (** Extract model ID string from an OAS run result. *)
 val model_of_run_result : Oas_worker.run_result -> string
 
-(** Cascade through OAS provider — compatibility wrapper for call sites
-    that already construct [completion_request list].
-    Routes through [Llm_orchestration.cascade] which uses OAS provider
-    internally. This is a transitional API: prefer [run_with_tools] or
-    [run_simple] for new code. *)
+(** Parameters extracted from a cascade request list for OAS execution. *)
+type cascade_params = {
+  primary_spec : Llm_types.model_spec;
+  fallback_specs : Llm_types.model_spec list;
+  system_prompt : string;
+  goal : string;
+  temperature : float;
+  max_tokens : int;
+}
+
+(** Extract OAS execution parameters from a cascade request list.
+    Separates system messages into [system_prompt], remaining messages
+    into [goal] text. Returns [Error] on empty list or no user messages. *)
+val cascade_config_of_requests :
+  Llm_types.completion_request list ->
+  (cascade_params, string) result
+
+(** Cascade through OAS Agent.t — tries each model spec in order via
+    [Oas_worker.run]. Falls back to next model on failure.
+    Prefer [run_with_tools] or [run_simple] for new code. *)
 val run_cascade :
   ?timeout_sec:int ->
   Llm_types.completion_request list ->
   (Llm_provider.Types.api_response, string) result
 
-(** Streaming cascade through OAS provider — compatibility wrapper for
-    call sites that need SSE text deltas. Falls back to batch cascade
-    on streaming failure. *)
+(** Streaming cascade — uses [Llm_orchestration.call_provider_stream]
+    for streaming (OAS Agent SDK lacks streaming API). Falls back to
+    OAS batch [run_cascade] on streaming failure. *)
 val run_cascade_stream :
   ?timeout_sec:float ->
   on_event:(Llm_provider.Types.sse_event -> unit) ->
   Llm_types.completion_request ->
   fallback:Llm_types.completion_request list ->
   (Llm_provider.Types.api_response, string) result
+
+(** Expose model spec resolution for testing. *)
+val resolve_primary_model_spec :
+  keeper_meta -> (Llm_types.model_spec, string) result

--- a/test_keeper_adapter/dune
+++ b/test_keeper_adapter/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_oas_adapter)
+ (modules test_keeper_oas_adapter)
+ (libraries masc_mcp agent_sdk alcotest yojson eio eio_main))

--- a/test_keeper_adapter/test_keeper_oas_adapter.ml
+++ b/test_keeper_adapter/test_keeper_oas_adapter.ml
@@ -1,0 +1,179 @@
+open Alcotest
+
+module Adapter = Masc_mcp.Keeper_oas_adapter
+module Llm_types = Masc_mcp.Llm_types
+module Types = Agent_sdk.Types
+
+(* ================================================================ *)
+(* Helper: build a minimal completion_request                       *)
+(* ================================================================ *)
+
+let make_model_spec ?(model_id = "test-model") ?(provider = Llm_types.Llama) () :
+    Llm_types.model_spec =
+  { provider;
+    model_id;
+    max_context = 4096;
+    cost_per_1k_input = 0.0;
+    cost_per_1k_output = 0.0;
+  }
+
+let make_request ?(model_id = "test-model") ?(provider = Llm_types.Llama)
+    ?(temperature = 0.7) ?(max_tokens = 1024) ?(tools = [])
+    (messages : Types.message list) : Llm_types.completion_request =
+  { model = make_model_spec ~model_id ~provider ();
+    messages;
+    temperature;
+    max_tokens;
+    tools;
+    response_format = `Text;
+  }
+
+(* ================================================================ *)
+(* Group 1: cascade_config_of_requests                              *)
+(* ================================================================ *)
+
+let test_cascade_config_empty_list () =
+  match Adapter.cascade_config_of_requests [] with
+  | Error msg ->
+      check bool "contains 'empty'" true
+        (String.length msg > 0)
+  | Ok _ -> fail "expected Error for empty list"
+
+let test_cascade_config_single_request () =
+  let req = make_request [
+    Types.system_msg "You are a keeper.";
+    Types.user_msg "What is the status?";
+  ] in
+  match Adapter.cascade_config_of_requests [req] with
+  | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
+  | Ok params ->
+      check string "system_prompt" "You are a keeper." params.system_prompt;
+      check bool "goal contains status" true
+        (String.length params.goal > 0);
+      check string "primary model" "test-model" params.primary_spec.model_id;
+      check (list string) "no fallbacks" []
+        (List.map (fun (s : Llm_types.model_spec) -> s.model_id) params.fallback_specs)
+
+let test_cascade_config_multiple_requests () =
+  let req1 = make_request ~model_id:"primary"
+    [Types.system_msg "sys"; Types.user_msg "goal"] in
+  let req2 = make_request ~model_id:"fallback1"
+    [Types.user_msg "goal"] in
+  let req3 = make_request ~model_id:"fallback2"
+    [Types.user_msg "goal"] in
+  match Adapter.cascade_config_of_requests [req1; req2; req3] with
+  | Error e -> fail e
+  | Ok params ->
+      check string "primary" "primary" params.primary_spec.model_id;
+      check int "fallback count" 2 (List.length params.fallback_specs);
+      check string "fallback1" "fallback1"
+        (List.nth params.fallback_specs 0).model_id;
+      check string "fallback2" "fallback2"
+        (List.nth params.fallback_specs 1).model_id
+
+let test_cascade_config_no_system_message () =
+  let req = make_request [Types.user_msg "just a question"] in
+  match Adapter.cascade_config_of_requests [req] with
+  | Error _ -> fail "should succeed even without system message"
+  | Ok params ->
+      check string "empty system prompt" "" params.system_prompt;
+      check bool "goal present" true (String.length params.goal > 0)
+
+let test_cascade_config_no_user_messages () =
+  let req = make_request [Types.system_msg "system only"] in
+  match Adapter.cascade_config_of_requests [req] with
+  | Error msg ->
+      check bool "mentions user messages" true
+        (String.length msg > 0)
+  | Ok _ -> fail "expected Error when no user messages"
+
+let test_cascade_config_preserves_temperature () =
+  let req = make_request ~temperature:0.3 ~max_tokens:512
+    [Types.system_msg "s"; Types.user_msg "g"] in
+  match Adapter.cascade_config_of_requests [req] with
+  | Error e -> fail e
+  | Ok params ->
+      let epsilon = 0.001 in
+      check bool "temperature" true
+        (Float.abs (params.temperature -. 0.3) < epsilon);
+      check int "max_tokens" 512 params.max_tokens
+
+(* ================================================================ *)
+(* Group 2: result extractors                                       *)
+(* ================================================================ *)
+
+let make_run_result ?(model = "test") ?(text = "hello")
+    ?(input_tokens = 10) ?(output_tokens = 5) () : Oas_worker.run_result =
+  let open Masc_mcp in
+  { response = {
+      Llm_provider.Types.model;
+      content = [Llm_provider.Types.TextBlock { text }];
+      stop_reason = Some "end_turn";
+      usage = Some { input_tokens; output_tokens };
+      id = "test-id";
+    };
+    checkpoint = None;
+    session_id = "test-session";
+    turns = 1;
+  }
+
+let test_text_of_run_result () =
+  let r = make_run_result ~text:"world" () in
+  check string "text" "world" (Adapter.text_of_run_result r)
+
+let test_usage_of_run_result () =
+  let r = make_run_result ~input_tokens:100 ~output_tokens:50 () in
+  let usage = Adapter.usage_of_run_result r in
+  check int "input" 100 usage.input_tokens;
+  check int "output" 50 usage.output_tokens
+
+let test_model_of_run_result () =
+  let r = make_run_result ~model:"qwen3.5" () in
+  check string "model" "qwen3.5" (Adapter.model_of_run_result r)
+
+(* ================================================================ *)
+(* Group 3: run_cascade error paths (no Eio context needed)         *)
+(* ================================================================ *)
+
+let test_run_cascade_empty_requests () =
+  match Adapter.run_cascade [] with
+  | Error msg ->
+      check bool "error message present" true (String.length msg > 0)
+  | Ok _ -> fail "expected Error for empty requests"
+
+let test_run_cascade_no_user_messages () =
+  let req = make_request [Types.system_msg "system only"] in
+  match Adapter.run_cascade [req] with
+  | Error _ -> () (* expected: no user messages *)
+  | Ok _ -> fail "expected Error for request with no user messages"
+
+(* ================================================================ *)
+(* Registration                                                     *)
+(* ================================================================ *)
+
+let () =
+  run "Keeper_oas_adapter" [
+    ("cascade_config", [
+      test_case "empty list returns error" `Quick
+        test_cascade_config_empty_list;
+      test_case "single request extracts params" `Quick
+        test_cascade_config_single_request;
+      test_case "multiple requests with fallbacks" `Quick
+        test_cascade_config_multiple_requests;
+      test_case "no system message" `Quick
+        test_cascade_config_no_system_message;
+      test_case "no user messages returns error" `Quick
+        test_cascade_config_no_user_messages;
+      test_case "preserves temperature and max_tokens" `Quick
+        test_cascade_config_preserves_temperature;
+    ]);
+    ("extractors", [
+      test_case "text_of_run_result" `Quick test_text_of_run_result;
+      test_case "usage_of_run_result" `Quick test_usage_of_run_result;
+      test_case "model_of_run_result" `Quick test_model_of_run_result;
+    ]);
+    ("run_cascade_errors", [
+      test_case "empty requests" `Quick test_run_cascade_empty_requests;
+      test_case "no user messages" `Quick test_run_cascade_no_user_messages;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- `run_cascade`를 `Llm_orchestration.cascade` wrapper에서 **실제 OAS Agent.t** 경유로 전환
- `cascade_config_of_requests`: completion_request list → (model_spec, system_prompt, goal) 추출
- cascade retry: primary → fallback 순서로 `Oas_worker.run` 시도, deadline timeout
- streaming: OAS SDK에 streaming API 없음 → `Llm_orchestration.call_provider_stream` 유지, batch fallback은 OAS 경유
- `resolve_primary_model_spec` .mli 노출 (testability)
- 11 unit tests: cascade config (6), extractors (3), error paths (2)

## 이전 PR 관계
- #1676 (MERGED): routing layer — keeper 9곳을 Keeper_oas_adapter로 교체
- 이 PR: adapter 내부를 실제 OAS Agent.t로 전환

## Test plan
- [ ] `test_keeper_adapter/test_keeper_oas_adapter.exe` 11 tests pass
- [ ] lib 빌드 성공 (기존 TRPG/Keeper_prompt cycle은 별도 이슈)
- [ ] keeper chat API: `curl -X POST localhost:8935/api/v1/keepers/chat/stream -d '{"name":"sangsu","message":"hello"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)