### PR TITLE
fix: break Keeper_prompt ↔ Keeper_alerting cycle (#1690)

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -4,7 +4,17 @@
 
 open Keeper_types
 open Keeper_memory
-open Keeper_alerting
+open Keeper_skill_routing
+
+(** Case-insensitive substring check. Local copy to break
+    Keeper_prompt -> Keeper_alerting -> Keeper_prompt cycle. *)
+let contains_ci (haystack : string) (needle : string) : bool =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  if n = "" then false
+  else
+    try ignore (Str.search_forward (Str.regexp_string n) h 0); true
+    with Not_found -> false
 
 let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =


### PR DESCRIPTION
## Summary

`dune build` on main fails with dependency cycle:
```
Keeper_prompt -> Keeper_alerting -> Keeper_prompt
```

Root cause: `keeper_prompt.ml` opened `Keeper_alerting` just for `contains_ci` (case-insensitive substring check). Fix: local copy of the 6-line helper + direct `open Keeper_skill_routing` for `strip_skill_route_lines`.

1 file, +11/-1 lines.

Closes #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)