### PR TITLE
fix: disable dune-cache to bust stale dependency cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: true
+          dune-cache: false
 
       - name: Pin external dependencies
         run: |
@@ -148,7 +148,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: true
+          dune-cache: false
 
       - name: Pin external dependencies
         run: |
@@ -230,7 +230,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: true
+          dune-cache: false
 
       - name: Pin external dependencies
         run: |
@@ -297,7 +297,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: true
+          dune-cache: false
 
       - name: Pin external dependencies
         run: |
@@ -339,7 +339,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: true
+          dune-cache: false
 
       - name: Pin external dependencies
         run: |

--- a/dune
+++ b/dune
@@ -1,1 +1,1 @@
-(dirs (:standard \ .worktrees _build_codex_trpg))
+(dirs (:standard \ .worktrees _build_codex_trpg archive))

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -123,8 +123,6 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_goals.schemas
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
-    (* Tool_protocol_game_view.schemas removed — module does not exist *)
-    (* Tool_trpg.schemas removed — module does not exist *)
     @ Tool_compact.schemas
     @ Tool_async_spawn.schemas
     )

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -168,7 +168,7 @@ let () =
   register_module_tag ~schemas:Tool_async_spawn.schemas ~tag:Mod_async_spawn;
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
   register_module_tag ~schemas:Tool_llm_catalog.schemas ~tag:Mod_llm_catalog;
-  (* register_module_tag ~schemas:Tool_trpg.schemas ~tag:Mod_trpg; — module does not exist *)
+  (* Tool_trpg archived (#1668) *)
   register_module_tag ~schemas:Tool_notifications.schemas ~tag:Mod_notifications;
   (* God Schema decomposition: register modules that now own their schemas *)
   register_module_tag ~schemas:Tool_task.schemas ~tag:Mod_task;


### PR DESCRIPTION
## Summary

CI fails with false dependency cycle `Keeper_prompt -> Keeper_alerting -> Keeper_prompt` due to stale dune cache. Local clean build succeeds.

- Disable `dune-cache` in all 5 CI jobs as one-time cache bust
- Includes TRPG orphan reference cleanup from #1687

## Test plan

- [ ] CI green without dune cache
- [ ] Revert `dune-cache: true` after confirmed green

🤖 Generated with [Claude Code](https://claude.com/claude-code)