### PR TITLE
refactor: route keeper_autonomy through OAS Agent lifecycle

### DIFF
--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -245,11 +245,25 @@ let generate_action_plan ~model ~goal ~keeper_context =
     tools = [];
     response_format = `Text;
   } in
-  (* NOTE: Llm_orchestration.complete used directly here to avoid
-     dependency cycle: Keeper_autonomy → Keeper_oas_adapter →
-     Keeper_exec_tools → ... → Keeper_autonomy.
-     This is a tool-free single-shot call, so the OAS Agent.t loop
-     is not needed. *)
-  match Llm_orchestration.complete req with
-  | Ok resp -> Ok (Llm_types.text_of_response resp)
-  | Error e -> Error (sprintf "plan generation failed: %s" e)
+  (* Use Oas_worker.run directly to avoid dependency cycle
+     (Keeper_autonomy → Keeper_oas_adapter → ... → Keeper_autonomy).
+     Tool-free single-shot: OAS Agent with max_turns=1, no tools. *)
+  match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
+  | None, _ | _, None ->
+      (* Eio context unavailable — fall back to direct LLM call *)
+      (match Llm_orchestration.complete req with
+       | Ok resp -> Ok (Llm_types.text_of_response resp)
+       | Error e -> Error (sprintf "plan generation failed: %s" e))
+  | Some net, Some sw ->
+      let oas_config = { (Oas_worker.default_config
+        ~name:"keeper-autonomy-plan"
+        ~model_spec:model
+        ~system_prompt:"You are a planning agent. Generate concrete action plans."
+        ~tools:[]) with
+        max_turns = 1;
+        max_tokens = 500;
+        temperature = 0.3;
+      } in
+      match Oas_worker.run ~sw ~net ~config:oas_config prompt with
+      | Ok r -> Ok (Llm_types.text_of_response r.Oas_worker.response)
+      | Error e -> Error (sprintf "plan generation failed: %s" e)


### PR DESCRIPTION
## Summary
`keeper_autonomy.ml`의 `generate_action_plan`에서 직접 `Llm_orchestration.complete`를 호출하던 것을 `Oas_worker.run`으로 변경.

## Problem
Keeper의 마지막 남은 직접 LLM 호출. 순환 의존 (Keeper_autonomy → Keeper_oas_adapter → ... → Keeper_autonomy) 때문에 adapter를 경유할 수 없었음.

## Fix
`Oas_worker.run`을 직접 사용하여 adapter를 우회하되, OAS Agent lifecycle(Agent.t, max_turns=1)을 통과하도록 변경.
- Eio context 있으면: OAS Agent.t lifecycle
- Eio context 없으면 (테스트 등): 기존 Llm_orchestration.complete fallback

## Test plan
- [x] `dune build lib/masc_mcp.cma` 성공 (순환 의존 없음)
- [ ] Keeper 실행 시 plan generation 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)