### PR TITLE
fix+refactor: CI green + OAS migration Phase 1-2

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -694,7 +694,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
       tools = [];
       response_format = `Text;
     } in
-    (match Llm_orchestration.complete ~timeout_sec:120 req with
+    (match Llm_cascade.complete_request ~timeout_sec:120 req with
     | Result.Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
     | Result.Ok resp -> parse_llm_code_response (Llm_types.text_of_response resp))
 

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -309,7 +309,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
           response_format = `Text;
         }
       in
-      (match Llm_orchestration.complete ~timeout_sec req with
+      (match Llm_cascade.complete_request ~timeout_sec req with
       | Ok resp when trim (Llm_types.text_of_response resp) <> "" -> Ok (Llm_types.text_of_response resp)
       | Ok resp when Llm_types.has_tool_calls resp ->
           Ok (Yojson.Safe.to_string (llm_tool_calls_json (Llm_types.tool_calls_of_response resp)))

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -344,7 +344,7 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
       }
     in
     let verdict =
-      match Llm_orchestration.complete req with
+      match Llm_cascade.complete_request req with
       | Ok resp -> Verifier_oas.parse_verdict (Llm_types.text_of_response resp)
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -281,19 +281,16 @@ let prompt_for_facts facts_json =
     (Yojson.Safe.to_string facts_json)
 
 let compute_judgments ~base_path:_ ~factual_json =
-  let specs = Llm_cascade.get_cascade ~cascade_name:"governance_judge" () in
-  if specs = [] then Error "No governance_judge model is available."
-  else
-    let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
-    let prompt = prompt_for_facts factual_json in
-    match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec
-        ~model_specs:specs ~max_tokens:4096 ~prompt ()
-    with
-    | Error message -> Error message
-    | Ok response -> (
-        try
-          let parsed = Yojson.Safe.from_string (Llm_types.text_of_response response) in
+  let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
+  let prompt = prompt_for_facts factual_json in
+  match
+    Llm_cascade.call ~cascade_name:"governance_judge" ~prompt ~temperature:0.2
+      ~timeout_sec ~max_tokens:4096 ()
+  with
+  | Error message -> Error message
+  | Ok result -> (
+      try
+        let parsed = Yojson.Safe.from_string result.Llm_cascade.response in
           let generated_at = now_iso () in
           let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
           let items =
@@ -305,9 +302,9 @@ let compute_judgments ~base_path:_ ~factual_json =
             items
             |> List.filter_map
                  (parse_item_judgment ~generated_at ~expires_at
-                    ~model_used:response.Llm_provider.Types.model)
+                    ~model_used:result.Llm_cascade.llm_used)
           in
-          Ok (response.Llm_provider.Types.model, generated_at, expires_at, judgments)
+          Ok (result.Llm_cascade.llm_used, generated_at, expires_at, judgments)
         with
         | Yojson.Json_error msg ->
             Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -286,23 +286,20 @@ let parse_session_judgment ~config ~generated_at ~generated_at_unix ~model_used 
   | _ -> None
 
 let compute_judgments ~facts_json =
-  let specs = Llm_cascade.get_cascade ~cascade_name:"operator_judge" () in
-  if specs = [] then Error "No operator_judge model is available."
-  else
-    let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
-    let prompt = prompt_for_facts facts_json in
-    match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec ~model_specs:specs
-        ~max_tokens:4096 ~prompt ()
-    with
-    | Error message -> Error message
-    | Ok response -> (
-        try Ok (response.Llm_provider.Types.model, Yojson.Safe.from_string (Llm_types.text_of_response response))
-        with
-        | Yojson.Json_error msg ->
-            Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
-        | exn ->
-            Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
+  let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
+  let prompt = prompt_for_facts facts_json in
+  match
+    Llm_cascade.call ~cascade_name:"operator_judge" ~prompt ~temperature:0.2
+      ~timeout_sec ~max_tokens:4096 ()
+  with
+  | Error message -> Error message
+  | Ok result -> (
+      try Ok (result.Llm_cascade.llm_used, Yojson.Safe.from_string result.Llm_cascade.response)
+      with
+      | Yojson.Json_error msg ->
+          Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
+      | exn ->
+          Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 
 let refresh_once ~(config : Room.config) ~build_facts =
   let st = get_state config.base_path in

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -42,13 +42,12 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
     gap.maturity_hours
   in
 
-  let model_specs = Llm_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.3
+      Llm_cascade.call ~cascade_name:"gardener_spawn" ~prompt ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
-        ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> Llm_types.text_of_response resp
+        ~max_tokens:200 () with
+    | Ok result -> result.Llm_cascade.response
     | Error _ -> ""
   in
 
@@ -458,13 +457,12 @@ Room 내 활성 에이전트: %d
     (health.system_error_rate *. 100.0) health.spawns_today config.max_daily_spawns
   in
 
-  let model_specs = Llm_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.3
+      Llm_cascade.call ~cascade_name:"gardener_spawn" ~prompt ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
-        ~model_specs ~max_tokens:300 ~prompt () with
-    | Ok resp -> Ok (Llm_types.text_of_response resp)
+        ~max_tokens:300 () with
+    | Ok result -> Ok result.Llm_cascade.response
     | Error err -> Error ("llm intervention failed: " ^ err)
   in
 

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -54,6 +54,34 @@ let process_status_to_json (st : Unix.process_status) : Yojson.Safe.t =
   | Unix.WSTOPPED sig_num ->
       `Assoc [("kind", `String "stopped"); ("signal", `Int sig_num)]
 
+let strip_state_blocks_text (s : string) : string =
+  let start_marker = "[STATE]" in
+  let end_marker = "[/STATE]" in
+  let start_re = Str.regexp_string start_marker in
+  let end_re = Str.regexp_string end_marker in
+  let len = String.length s in
+  let rec loop from (buf : Buffer.t) =
+    if from >= len then ()
+    else
+      try
+        let i = Str.search_forward start_re s from in
+        if i > from then Buffer.add_substring buf s from (i - from);
+        let block_start = i + String.length start_marker in
+        let next_from =
+          try
+            let j = Str.search_forward end_re s block_start in
+            j + String.length end_marker
+          with Not_found ->
+            len
+        in
+        loop next_from buf
+      with Not_found ->
+        Buffer.add_substring buf s from (len - from)
+  in
+  let buf = Buffer.create len in
+  loop 0 buf;
+  Buffer.contents buf
+
 let is_weather_text (s : string) : bool =
   let h = String.lowercase_ascii s in
   let n = String.lowercase_ascii "weather" in

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -291,9 +291,8 @@ let proactive_temperature attempt =
   else Keeper_config.keeper_proactive_temperature_high ()
 
 (* strip_state_blocks_text moved to Keeper_alerting_path to break
-   Keeper_prompt → Keeper_alerting → Tool_board → Keeper_prompt cycle.
-   Re-exported here via open Keeper_alerting (which includes Keeper_alerting_path). *)
-let strip_state_blocks_text = strip_state_blocks_text
+   Keeper_prompt → Keeper_alerting → Tool_board → Keeper_prompt cycle. *)
+let strip_state_blocks_text = Keeper_alerting_path.strip_state_blocks_text
 
 let trim_to_option (s : string) : string option =
   let trimmed = String.trim s in

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -290,33 +290,10 @@ let proactive_temperature attempt =
   else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
   else Keeper_config.keeper_proactive_temperature_high ()
 
-let strip_state_blocks_text (s : string) : string =
-  let start_marker = "[STATE]" in
-  let end_marker = "[/STATE]" in
-  let start_re = Str.regexp_string start_marker in
-  let end_re = Str.regexp_string end_marker in
-  let len = String.length s in
-  let rec loop from (buf : Buffer.t) =
-    if from >= len then ()
-    else
-      try
-        let i = Str.search_forward start_re s from in
-        if i > from then Buffer.add_substring buf s from (i - from);
-        let block_start = i + String.length start_marker in
-        let next_from =
-          try
-            let j = Str.search_forward end_re s block_start in
-            j + String.length end_marker
-          with Not_found ->
-            len
-        in
-        loop next_from buf
-      with Not_found ->
-        Buffer.add_substring buf s from (len - from)
-  in
-  let buf = Buffer.create len in
-  loop 0 buf;
-  Buffer.contents buf
+(* strip_state_blocks_text moved to Keeper_alerting_path to break
+   Keeper_prompt → Keeper_alerting → Tool_board → Keeper_prompt cycle.
+   Re-exported here via open Keeper_alerting (which includes Keeper_alerting_path). *)
+let strip_state_blocks_text = strip_state_blocks_text
 
 let trim_to_option (s : string) : string option =
   let trimmed = String.trim s in

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -180,3 +180,10 @@ let call ~cascade_name ~prompt
               else body))
   | Error (Llm_provider.Http_client.NetworkError { message }) ->
     Error (Printf.sprintf "[cascade] %s: %s" cascade_name message)
+
+(** Single-model completion via Llm_orchestration (cache + metrics + dispatch).
+    Thin proxy for callers migrating away from direct Llm_orchestration.complete.
+    Phase 3 will inline the logic when Llm_orchestration is deleted. *)
+let complete_request ?timeout_sec (req : Llm_types.completion_request)
+    : (Llm_provider.Types.api_response, string) result =
+  Llm_orchestration.complete ?timeout_sec req

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -348,7 +348,6 @@ module Keeper_learning = Keeper_learning
 module Keeper_feedback_tool = Keeper_feedback_tool
 module Keeper_keepalive = Keeper_keepalive
 module Keeper_runtime = Keeper_runtime
-module Keeper_oas_adapter = Keeper_oas_adapter
 
 (* Autonomy Adjuster — Feedback Closure (Phase 4) *)
 module Autonomy_adjuster = Autonomy_adjuster
@@ -364,4 +363,3 @@ module Compaction_types = Compaction_types
 
 (* OAS Integration — Agent SDK v0.24+ bridge *)
 module Oas_events = Oas_events
-module Oas_worker = Oas_worker

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -285,7 +285,7 @@ let tool_category tool_name =
   | "masc_agent_update" | "masc_agent_card"
   | "masc_get_metrics" | "masc_agent_fitness" | "masc_select_agent"
   | "masc_collaboration_graph" | "masc_consolidate_learning"
-  | "masc_self_introspect" -> Discovery
+  | "masc_self_introspect" | "masc_agent_relations" -> Discovery
 
   (* ── Voting ── *)
   | "masc_vote_create" | "masc_vote_cast" | "masc_vote_status"

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -481,7 +481,7 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
         }
       in
       match
-        Llm_orchestration.complete ~timeout_sec:(router_judge_timeout_sec ()) request
+        Llm_cascade.complete_request ~timeout_sec:(router_judge_timeout_sec ()) request
       with
       | Ok response -> (
           try

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -161,7 +161,7 @@ let verify ~(model : Llm_types.model_spec) (req : verification_request) : verdic
       tools = [];
       response_format = `Text;
     } in
-    match Llm_orchestration.complete completion_req with
+    match Llm_cascade.complete_request completion_req with
     | Ok resp -> parse_verdict (Llm_types.text_of_response resp)
     | Error e ->
       eprintf "[verifier] LLM call failed: %s (defaulting to WARN)\n%!" e;


### PR DESCRIPTION
## Summary

- Phase 1: Restore CI green (build was broken on main)
  - Remove 14 dead TRPG test stanzas, 12 dead `Server_trpg_rest` opens, TRPG HTTP routes (-570 LOC)
  - Break `Keeper_prompt ↔ Keeper_alerting` dependency cycle (move `strip_state_blocks_text` to `Keeper_alerting_path`)
  - Add `masc_agent_relations` to Mode.tool_category
- Phase 2: Migrate 8 non-keeper modules from `Llm_orchestration` to `Llm_cascade`
  - `run_prompt_cascade` callers → `Llm_cascade.call` (gardener, governance/operator judge)
  - `complete` callers → `Llm_cascade.complete_request` (autoresearch, verifier, chain, routing, swarm plan)
  - `complete_request` is a thin proxy for now; Phase 3 will inline when `Llm_orchestration` is deleted

## Pre-existing test failures (not addressed)

- `test_tool_board_coverage:post_crud` — expects `meta.state_block` field that was never extracted
- `test_voice:handlers` — network-dependent tests that fail without TTS service
- `test_perpetual:parse_model:mlx` — MLX provider removed but test expectation not updated

## Test plan

- [x] `dune build` exit 0
- [x] `test_tool_registration_consistency:linter` pass (Unknown category fix)
- [x] 8 non-keeper modules reference `Llm_cascade` instead of `Llm_orchestration`
- [ ] CI green (pre-existing failures excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)