### PR TITLE
refactor(llm): migrate all LLM calls from Llm_orchestration to Llm_cascade

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -677,26 +677,18 @@ let parse_llm_code_response response =
             in
             Result.ok (hypothesis, trimmed)
 
-(** Generate code change by calling Llm_orchestration.complete.
+(** Generate code change via Llm_cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)
 let generate_code_change ~goal ~baseline ~history ~insights
-    ~target_file ~file_content ~llm_model =
+    ~target_file ~file_content =
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
-  match Llm_types.model_spec_of_string llm_model with
-  | Result.Error e -> Result.error (Printf.sprintf "Invalid model spec: %s" e)
-  | Result.Ok model ->
-    let req : Llm_types.completion_request = {
-      model;
-      messages = [Agent_sdk.Types.user_msg prompt];
-      temperature = 0.7;
-      max_tokens = 4096;
-      tools = [];
-      response_format = `Text;
-    } in
-    (match Llm_orchestration.complete ~timeout_sec:120 req with
-    | Result.Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
-    | Result.Ok resp -> parse_llm_code_response (Llm_types.text_of_response resp))
+  match
+    Llm_cascade.call ~cascade_name:"autoresearch" ~prompt
+      ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
+  with
+  | Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
+  | Ok r -> parse_llm_code_response r.Llm_cascade.response
 
 (* ================================================================ *)
 (* Loop State Management                                            *)

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -294,22 +294,22 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
         | _ -> prompt
       in
       call_spawn_model runtime ~agent_name ~model_override ~prompt:full_prompt ~timeout_sec ()
-  | Ok (Direct spec) ->
-      let req : Llm_types.completion_request =
-        {
-          model = spec;
-          messages =
-            (match system with
-            | Some sys when trim sys <> "" ->
-                [ Agent_sdk.Types.system_msg sys; Agent_sdk.Types.user_msg prompt ]
-            | _ -> [ Agent_sdk.Types.user_msg prompt ]);
-          temperature = 0.2;
-          max_tokens = 4096;
-          tools = llm_tool_defs_of_json tools;
-          response_format = `Text;
-        }
+  | Ok (Direct _spec) ->
+      let messages : Llm_provider.Types.message list =
+        (match system with
+        | Some sys when trim sys <> "" ->
+            [ Llm_provider.Types.system_msg sys; Llm_provider.Types.user_msg prompt ]
+        | _ -> [ Llm_provider.Types.user_msg prompt ])
       in
-      (match Llm_orchestration.complete ~timeout_sec req with
+      let tools_json = match tools with
+        | Some (`List items) -> Some items
+        | _ -> None
+      in
+      (match
+        Llm_cascade.call_with_tools ~cascade_name:"chain_llm" ~messages
+          ?tools:tools_json ~temperature:0.2 ~max_tokens:4096
+          ~timeout_sec ()
+      with
       | Ok resp when trim (Llm_types.text_of_response resp) <> "" -> Ok (Llm_types.text_of_response resp)
       | Ok resp when Llm_types.has_tool_calls resp ->
           Ok (Yojson.Safe.to_string (llm_tool_calls_json (Llm_types.tool_calls_of_response resp)))

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -322,7 +322,7 @@ FAIL: <reason> - if the diff has problems
 One line only.|}
     pattern files_str truncated_diff
 
-let verify_worker ~model ~pattern (worker : worker_plan) diff =
+let verify_worker ~pattern (worker : worker_plan) diff =
   if String.length diff = 0 then
     {
       worker_id = worker.worker_id;
@@ -333,19 +333,12 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
     }
   else
     let prompt = build_verify_prompt ~pattern ~allowed_files:worker.files diff in
-    let req : Llm_types.completion_request =
-      {
-        model;
-        messages = [ Agent_sdk.Types.user_msg prompt ];
-        temperature = 0.0;
-        max_tokens = 200;
-        tools = [];
-        response_format = `Text;
-      }
-    in
     let verdict =
-      match Llm_orchestration.complete req with
-      | Ok resp -> Verifier_oas.parse_verdict (Llm_types.text_of_response resp)
+      match
+        Llm_cascade.call ~cascade_name:"code_swarm_verify" ~prompt
+          ~temperature:0.0 ~max_tokens:200 ()
+      with
+      | Ok r -> Verifier_oas.parse_verdict r.Llm_cascade.response
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in
     let our_verdict =
@@ -380,26 +373,15 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
       issues;
     }
 
-let verify_plan ~base_path ~plan_id ~verify_model =
+let verify_plan ~base_path ~plan_id ~verify_model:_ =
   match load_plan base_path plan_id with
   | Error e -> Error e
   | Ok plan ->
-      let model =
-        match verify_model with
-        | Some m -> (
-            match Llm_types.model_spec_of_string m with
-            | Ok spec -> spec
-            | Error _ -> Llm_types.glm_cloud)
-        | None -> (
-            match Llm_types.default_verifier_model_spec () with
-            | Ok spec -> spec
-            | Error _ -> Llm_types.glm_cloud)
-      in
       let results =
         List.map
           (fun worker ->
             let diff, _changed = get_worker_diff ~base_path worker in
-            verify_worker ~model ~pattern:plan.pattern worker diff)
+            verify_worker ~pattern:plan.pattern worker diff)
           plan.workers
       in
       let pass_count =

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -281,38 +281,35 @@ let prompt_for_facts facts_json =
     (Yojson.Safe.to_string facts_json)
 
 let compute_judgments ~base_path:_ ~factual_json =
-  let specs = Llm_cascade.get_cascade ~cascade_name:"governance_judge" () in
-  if specs = [] then Error "No governance_judge model is available."
-  else
-    let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
-    let prompt = prompt_for_facts factual_json in
-    match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec
-        ~model_specs:specs ~max_tokens:4096 ~prompt ()
-    with
-    | Error message -> Error message
-    | Ok response -> (
-        try
-          let parsed = Yojson.Safe.from_string (Llm_types.text_of_response response) in
-          let generated_at = now_iso () in
-          let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
-          let items =
-            match parsed |> member "items" with
-            | `List rows -> rows
-            | _ -> []
-          in
-          let judgments =
-            items
-            |> List.filter_map
-                 (parse_item_judgment ~generated_at ~expires_at
-                    ~model_used:response.Llm_provider.Types.model)
-          in
-          Ok (response.Llm_provider.Types.model, generated_at, expires_at, judgments)
-        with
-        | Yojson.Json_error msg ->
-            Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)
-        | exn ->
-            Error (Printf.sprintf "Governance judge parse error: %s" (Printexc.to_string exn)))
+  let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
+  let prompt = prompt_for_facts factual_json in
+  match
+    Llm_cascade.call_raw ~cascade_name:"governance_judge" ~prompt
+      ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
+  with
+  | Error message -> Error message
+  | Ok response -> (
+      try
+        let parsed = Yojson.Safe.from_string (Llm_types.text_of_response response) in
+        let generated_at = now_iso () in
+        let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+        let items =
+          match parsed |> member "items" with
+          | `List rows -> rows
+          | _ -> []
+        in
+        let judgments =
+          items
+          |> List.filter_map
+               (parse_item_judgment ~generated_at ~expires_at
+                  ~model_used:response.Llm_provider.Types.model)
+        in
+        Ok (response.Llm_provider.Types.model, generated_at, expires_at, judgments)
+      with
+      | Yojson.Json_error msg ->
+          Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)
+      | exn ->
+          Error (Printf.sprintf "Governance judge parse error: %s" (Printexc.to_string exn)))
 
 let append_judgments base_path judgments =
   ensure_dir (governance_dir base_path);

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -286,23 +286,21 @@ let parse_session_judgment ~config ~generated_at ~generated_at_unix ~model_used 
   | _ -> None
 
 let compute_judgments ~facts_json =
-  let specs = Llm_cascade.get_cascade ~cascade_name:"operator_judge" () in
-  if specs = [] then Error "No operator_judge model is available."
-  else
-    let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
-    let prompt = prompt_for_facts facts_json in
-    match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.2 ~timeout_sec ~model_specs:specs
-        ~max_tokens:4096 ~prompt ()
-    with
-    | Error message -> Error message
-    | Ok response -> (
-        try Ok (response.Llm_provider.Types.model, Yojson.Safe.from_string (Llm_types.text_of_response response))
-        with
-        | Yojson.Json_error msg ->
-            Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
-        | exn ->
-            Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
+  let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
+  let prompt = prompt_for_facts facts_json in
+  match
+    Llm_cascade.call_raw ~cascade_name:"operator_judge" ~prompt
+      ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
+  with
+  | Error message -> Error message
+  | Ok response -> (
+      try Ok (response.Llm_provider.Types.model,
+              Yojson.Safe.from_string (Llm_types.text_of_response response))
+      with
+      | Yojson.Json_error msg ->
+          Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)
+      | exn ->
+          Error (Printf.sprintf "Operator judge parse error: %s" (Printexc.to_string exn)))
 
 let refresh_once ~(config : Room.config) ~build_facts =
   let st = get_state config.base_path in

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -2,8 +2,7 @@ open Env_config_core
 
 module Endpoints = struct
   (** @deprecated LLM-MCP server URL - no longer used.
-      Use {!Llm_orchestration.run_prompt_cascade} with {!Llm_cascade.get_cascade}
-      instead. Kept for backward compatibility; will be removed in v3.0. *)
+      Use {!Llm_cascade.call} instead. *)
   let llm_mcp_url =
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)
 

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -42,13 +42,13 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
     gap.maturity_hours
   in
 
-  let model_specs = Llm_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.3
+      Llm_cascade.call ~cascade_name:"gardener_spawn" ~prompt
+        ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
-        ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> Llm_types.text_of_response resp
+        ~max_tokens:200 () with
+    | Ok r -> r.Llm_cascade.response
     | Error _ -> ""
   in
 
@@ -458,13 +458,13 @@ Room 내 활성 에이전트: %d
     (health.system_error_rate *. 100.0) health.spawns_today config.max_daily_spawns
   in
 
-  let model_specs = Llm_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
     match
-      Llm_orchestration.run_prompt_cascade ~temperature:0.3
+      Llm_cascade.call ~cascade_name:"gardener_spawn" ~prompt
+        ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
-        ~model_specs ~max_tokens:300 ~prompt () with
-    | Ok resp -> Ok (Llm_types.text_of_response resp)
+        ~max_tokens:300 () with
+    | Ok r -> Ok r.Llm_cascade.response
     | Error err -> Error ("llm intervention failed: " ^ err)
   in
 

--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -235,35 +235,11 @@ Keep it concise — max 3 sentences per step.|}
      then String.sub keeper_context 0 500 ^ "..."
      else keeper_context)
 
-let generate_action_plan ~model ~goal ~keeper_context =
+let generate_action_plan ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
-  let req : Llm_types.completion_request = {
-    model;
-    messages = [Agent_sdk.Types.user_msg prompt];
-    temperature = 0.3;
-    max_tokens = 500;
-    tools = [];
-    response_format = `Text;
-  } in
-  (* Use Oas_worker.run directly to avoid dependency cycle
-     (Keeper_autonomy → Keeper_oas_adapter → ... → Keeper_autonomy).
-     Tool-free single-shot: OAS Agent with max_turns=1, no tools. *)
-  match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
-  | None, _ | _, None ->
-      (* Eio context unavailable — fall back to direct LLM call *)
-      (match Llm_orchestration.complete req with
-       | Ok resp -> Ok (Llm_types.text_of_response resp)
-       | Error e -> Error (sprintf "plan generation failed: %s" e))
-  | Some net, Some sw ->
-      let oas_config = { (Oas_worker.default_config
-        ~name:"keeper-autonomy-plan"
-        ~model_spec:model
-        ~system_prompt:"You are a planning agent. Generate concrete action plans."
-        ~tools:[]) with
-        max_turns = 1;
-        max_tokens = 500;
-        temperature = 0.3;
-      } in
-      match Oas_worker.run ~sw ~net ~config:oas_config prompt with
-      | Ok r -> Ok (Llm_types.text_of_response r.Oas_worker.response)
-      | Error e -> Error (sprintf "plan generation failed: %s" e)
+  match
+    Llm_cascade.call ~cascade_name:"keeper_autonomy" ~prompt
+      ~temperature:0.3 ~max_tokens:500 ()
+  with
+  | Ok r -> Ok r.Llm_cascade.response
+  | Error e -> Error (sprintf "plan generation failed: %s" e)

--- a/lib/keeper/keeper_autonomy.mli
+++ b/lib/keeper/keeper_autonomy.mli
@@ -61,9 +61,9 @@ val should_auto_execute :
   proposed_action ->
   bool
 
-(** Generate a concrete action plan using LLM, given a goal. *)
+(** Generate a concrete action plan using LLM, given a goal.
+    Routes through Llm_cascade "keeper_autonomy" profile. *)
 val generate_action_plan :
-  model:Llm_types.model_spec ->
   goal:Goal_store.goal ->
   keeper_context:string ->
   (string, string) result

--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -190,12 +190,6 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
     | None -> None
     | Some L1_Reactive -> None
     | Some level ->
-        let primary = match specs with p :: _ -> p | [] -> Llm_types.default_local_model_spec () in
-        let verify_model =
-          match Llm_types.default_verifier_model_spec () with
-          | Ok model -> model
-          | Error _ -> primary
-        in
         let keeper_context =
           Printf.sprintf "keeper=%s autonomy=%s turns=%d cost=$%.4f"
             meta.name (Keeper_autonomy.autonomy_level_to_string level)
@@ -281,8 +275,6 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~goal_ids:meta.active_goal_ids
               ~keeper_name:meta.name
               ~keeper_context
-              ~plan_model:primary
-              ~verify_model
               ~autonomy_level:level
             in
             (match result with

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -208,54 +208,28 @@ let run_cascade ?timeout_sec requests =
   match cascade_config_of_requests requests with
   | Error e -> Error e
   | Ok params ->
-  match require_net (), require_switch () with
-  | Error e, _ | _, Error e -> Error e
-  | Ok net, Ok sw ->
-  let all_specs = params.primary_spec :: params.fallback_specs in
-  let rec try_specs errors = function
-    | [] ->
-        let all = String.concat "; " (List.rev errors) in
-        Error (Printf.sprintf "All OAS cascade models failed: %s" all)
-    | spec :: rest ->
-        let oas_config = { (Oas_worker.default_config
-          ~name:"keeper-cascade"
-          ~model_spec:spec
-          ~system_prompt:params.system_prompt
-          ~tools:[]) with
-          max_turns = 1;
-          max_tokens = params.max_tokens;
-          temperature = params.temperature;
-        } in
-        let deadline =
-          Option.map (fun sec -> Time_compat.now () +. float_of_int sec) timeout_sec
-        in
-        let past_deadline () =
-          match deadline with
-          | None -> false
-          | Some d -> Time_compat.now () >= d
-        in
-        if past_deadline () then
-          Error "OAS cascade timeout"
-        else
-        let result = Oas_worker.run ~sw ~net ~config:oas_config params.goal in
-        (match result with
-         | Ok r ->
-             Log.Keeper.info "oas cascade: success with %s" spec.model_id;
-             Ok r.Oas_worker.response
-         | Error e ->
-             Log.Keeper.warn "oas cascade: %s failed: %s" spec.model_id e;
-             try_specs (e :: errors) rest)
+  let messages : Llm_provider.Types.message list =
+    (if String.length params.system_prompt > 0 then
+       [ Llm_provider.Types.system_msg params.system_prompt ]
+     else [])
+    @ [ Llm_provider.Types.user_msg params.goal ]
   in
-  try_specs [] all_specs
+  Llm_cascade.call_with_tools ~cascade_name:"keeper_autonomy" ~messages
+    ~temperature:params.temperature ~max_tokens:params.max_tokens
+    ?timeout_sec ()
 
 let run_cascade_stream ?timeout_sec ~on_event request ~fallback =
-  (* OAS Agent SDK does not support streaming — use Llm_orchestration
-     for the streaming path, fall back to OAS batch on failure. *)
-  match
-    Llm_orchestration.call_provider_stream ?timeout_sec request ~on_event
-  with
-  | Ok _ as ok -> ok
-  | Error e ->
-      Log.Keeper.warn "oas adapter stream failed (%s), falling back to OAS batch" e;
-      let timeout_int = Option.map int_of_float timeout_sec in
-      run_cascade ?timeout_sec:timeout_int (request :: fallback)
+  (* Batch fallback with synthetic SSE events.
+     Streaming via Llm_orchestration removed; all calls route through Llm_cascade. *)
+  let timeout_int = Option.map int_of_float timeout_sec in
+  match run_cascade ?timeout_sec:timeout_int (request :: fallback) with
+  | Ok resp ->
+      let text = Llm_types.text_of_response resp in
+      on_event (Llm_provider.Types.MessageStart {
+        id = "batch-keeper"; model = resp.Llm_provider.Types.model; usage = None });
+      if text <> "" then
+        on_event (Llm_provider.Types.ContentBlockDelta {
+          index = 0; delta = TextDelta text });
+      on_event Llm_provider.Types.MessageStop;
+      Ok resp
+  | Error _ as e -> e

--- a/lib/keeper/keeper_verifier.ml
+++ b/lib/keeper/keeper_verifier.ml
@@ -98,7 +98,6 @@ let risk_guard ~(autonomy_level : Keeper_autonomy.autonomy_level)
     Layer 2: Risk guard (fast, no LLM)
     Layer 3: LLM verification via verifier.ml (cheap model, 200 tokens) *)
 let verify_action
-    ~(model : Llm_types.model_spec)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     (req : keeper_verification_request) : keeper_verdict =
   (* Layer 1: Cost guard *)
@@ -122,7 +121,7 @@ let verify_action
       else
         req.keeper_context;
   } in
-  let verdict = Verifier_oas.verify ~model verifier_req in
+  let verdict = Verifier_oas.verify verifier_req in
   of_verifier_verdict verdict
 
 (* ================================================================ *)
@@ -172,8 +171,6 @@ let run_pipeline
     ~(goal_ids : string list)
     ~(keeper_name : string)
     ~(keeper_context : string)
-    ~(plan_model : Llm_types.model_spec)
-    ~(verify_model : Llm_types.model_spec)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     : pipeline_result =
   (* Step 1: Evaluate next action *)
@@ -190,7 +187,7 @@ let run_pipeline
       else
         (* Step 3: Generate action plan *)
         match Keeper_autonomy.generate_action_plan
-                ~model:plan_model ~goal:{ id = pa.goal_id; horizon = "short";
+                ~goal:{ id = pa.goal_id; horizon = "short";
                   title = pa.goal_title; metric = None; target_value = None;
                   due_date = None; priority = 3; status = "active";
                   parent_goal_id = None; last_review_note = None;
@@ -206,7 +203,7 @@ let run_pipeline
               action_plan = plan;
               keeper_context;
             } in
-            match verify_action ~model:verify_model ~autonomy_level req with
+            match verify_action ~autonomy_level req with
             | Proceed -> Approved (pa, plan)
             | ProceedWithCaution warning -> Cautioned (pa, plan, warning)
             | Block reason -> Rejected (pa, reason)

--- a/lib/llm/llm_orchestration.ml
+++ b/lib/llm/llm_orchestration.ml
@@ -99,10 +99,9 @@ let record_cache_bypass reason =
 (* Core: complete                                                   *)
 (* ================================================================ *)
 
-(** Single completion with MASC-level cache check/write (OAS serialization format)
-    and OAS metrics. Cache key uses MASC's temperature-aware fingerprint.
-    Cache values use OAS api_response JSON format via {!Llm_provider.Cache}.
-    Returns OAS api_response directly — no MASC wrapper. *)
+(** @deprecated Use {!Llm_cascade.call} or {!Llm_cascade.call_raw} instead.
+    Single completion with MASC-level cache check/write.
+    Bypasses OAS Cascade_config health filtering and metrics. *)
 let complete ?timeout_sec (req : completion_request)
     : (Llm_provider.Types.api_response, string) result =
   let req = normalize_request req in
@@ -199,6 +198,7 @@ let filter_by_provider_health (requests : completion_request list)
 (* Cascade: try models in order                                     *)
 (* ================================================================ *)
 
+(** @deprecated Use {!Llm_cascade.call_with_tools} instead. *)
 let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list)
     : (Llm_provider.Types.api_response, string) result =
@@ -256,6 +256,7 @@ let cascade ?(accept = fun _ -> true) ?timeout_sec
 (* run_prompt_cascade                                                *)
 (* ================================================================ *)
 
+(** @deprecated Use {!Llm_cascade.call} instead. *)
 let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec
     ?(accept = fun _ -> true) ?system ~model_specs ~max_tokens ~prompt () =
   let msgs =
@@ -283,14 +284,8 @@ let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec
 (* Streaming completion                                             *)
 (* ================================================================ *)
 
-(** Execute a streaming LLM completion using OAS provider path.
-    Each SSE event (token deltas) is delivered to [on_event] as it arrives.
-    Returns the final assembled response after the stream ends.
-
-    Streaming bypasses cache: SSE events are incremental and not cacheable.
-    No retry logic — a single attempt is made.
-    Falls back to batch completion (synthesising a single delta event)
-    when provider config is unavailable or streaming fails. *)
+(** @deprecated Streaming now handled at the keeper_oas_adapter level
+    with batch fallback via {!Llm_cascade}. *)
 let call_provider_stream ?timeout_sec (req : completion_request)
     ~(on_event : Llm_provider.Types.sse_event -> unit)
     : (Llm_provider.Types.api_response, string) result =

--- a/lib/llm/llm_orchestration.mli
+++ b/lib/llm/llm_orchestration.mli
@@ -1,8 +1,12 @@
-(** Llm_orchestration — Concurrency control, response caching, and cascade logic for LLM calls.
+(** Llm_orchestration — Concurrency diagnostics and response caching.
 
-    All functions return OAS {!Llm_provider.Types.api_response} directly.
-    Use {!Llm_types.text_of_response}, {!Llm_types.tool_calls_of_response},
-    {!Llm_types.usage_of_response} for field access. *)
+    Inference functions ([complete], [cascade], [run_prompt_cascade],
+    [call_provider_stream]) are deprecated. Use {!Llm_cascade} instead,
+    which routes all calls through OAS Cascade_config.complete_named.
+
+    Retained: concurrency counters, cache helpers, health filtering. *)
+
+(** {1 Concurrency Diagnostics (not deprecated)} *)
 
 val max_concurrent_llm : int
 
@@ -10,7 +14,11 @@ val llm_semaphore_available : unit -> int
 
 val llm_permits_in_use : unit -> int
 
+(** {1 Cache (not deprecated)} *)
+
 val cache_key_of_request : Llm_types.completion_request -> string
+
+(** {1 Health Filtering (not deprecated)} *)
 
 (** Filter cascade requests by provider health.
     Removes local (Llama) providers when all local endpoints are unhealthy,
@@ -19,17 +27,22 @@ val cache_key_of_request : Llm_types.completion_request -> string
 val filter_by_provider_health :
   Llm_types.completion_request list -> Llm_types.completion_request list
 
+(** {1 Deprecated Inference Functions} *)
+
+(** @deprecated Use {!Llm_cascade.call} or {!Llm_cascade.call_raw}. *)
 val complete :
   ?timeout_sec:int ->
   Llm_types.completion_request ->
   (Llm_types.api_response, string) result
 
+(** @deprecated Use {!Llm_cascade.call_with_tools}. *)
 val cascade :
   ?accept:(Llm_types.api_response -> bool) ->
   ?timeout_sec:int ->
   Llm_types.completion_request list ->
   (Llm_types.api_response, string) result
 
+(** @deprecated Use {!Llm_cascade.call}. *)
 val run_prompt_cascade :
   ?temperature:float ->
   ?timeout_sec:int ->
@@ -41,11 +54,7 @@ val run_prompt_cascade :
   unit ->
   (Llm_types.api_response, string) result
 
-(** Streaming completion for a single request.
-    Calls the provider in streaming mode and invokes [on_event] for each SSE
-    event as it arrives. Returns the assembled final response.
-
-    @since 2.110.0 *)
+(** @deprecated Streaming handled at adapter level with batch fallback. *)
 val call_provider_stream :
   ?timeout_sec:float ->
   Llm_types.completion_request ->

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -114,9 +114,8 @@ let default_model_strings ~cascade_name =
   (* unregistered cascade: llama + glm as safety net *)
   | _ -> llama_glm
 
-(** Backward compat: return MASC model_spec list for callers that need
-    to pass specs to Llm_orchestration directly. Uses OAS Cascade_config
-    for config loading, then maps back to Llm_types. *)
+(** Backward compat: return MASC model_spec list.
+    Prefer {!call}, {!call_raw}, or {!call_with_tools} instead. *)
 let get_cascade ?(config_path = "") ~cascade_name () :
     Llm_types.model_spec list =
   let defaults = default_model_strings ~cascade_name in

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -3,8 +3,16 @@
     MASC defines cascade name -> model list policy (default_model_strings).
     OAS handles config loading, model parsing, health filtering, and execution.
 
+    Public entry points:
+    - {!call} — prompt-in/text-out convenience (returns cascade_result)
+    - {!call_raw} — prompt-in, returns full api_response
+    - {!call_with_tools} — messages + tools, returns full api_response
+
+    All three route through OAS Cascade_config.complete_named.
+
     @since 2.114.0 — original
-    @since 2.115.0 — delegated to OAS Cascade_config *)
+    @since 2.115.0 — delegated to OAS Cascade_config
+    @since 2.116.0 — call_raw, call_with_tools added *)
 
 type cascade_result = {
   response : string;
@@ -67,7 +75,15 @@ let default_model_strings ~cascade_name =
   (* theory of mind — local llama, glm fallback *)
   | "tom" -> llama_glm
   (* verifier — local llama, glm fallback *)
-  | "verifier" -> llama_glm
+  | "verifier" | "code_swarm_verify" -> llama_glm
+  (* keeper — local llama, glm fallback *)
+  | "keeper_autonomy" -> llama_glm
+  (* routing — local llama, glm fallback *)
+  | "routing_judge" -> llama_glm
+  (* chain — local llama, glm fallback *)
+  | "chain_llm" -> llama_glm
+  (* autoresearch — local llama, glm fallback *)
+  | "autoresearch" -> llama_glm
   (* trpg — local llama, glm fallback *)
   | "trpg_intent" -> llama_glm
   (* briefing — llama first, flash-tier cloud chain, glm fallback *)
@@ -139,17 +155,40 @@ let get_cascade ?(config_path = "") ~cascade_name () :
 (** Accept validator type: api_response -> bool.
     Now that MASC validators use api_response directly, no bridging needed. *)
 
-(** Call LLM cascade. Routes directly through OAS Cascade_config.complete_named,
-    bypassing MASC's Llm_orchestration. *)
-let call ~cascade_name ~prompt
+(** Format OAS http_error as cascade error string. *)
+let format_cascade_error ~cascade_name = function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+    Printf.sprintf "[cascade] %s: HTTP %d: %s" cascade_name code
+      (if String.length body > 200
+       then String.sub body 0 200 ^ "..."
+       else body)
+  | Llm_provider.Http_client.NetworkError { message } ->
+    Printf.sprintf "[cascade] %s: %s" cascade_name message
+
+(** Internal: resolve config, call OAS complete_named, map errors to string. *)
+let complete_cascade ~cascade_name ~messages
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
   let env = Llm_eio_env.get () in
   let defaults = default_model_strings ~cascade_name in
   let config_path_opt =
     if String.length config_path > 0 then Some config_path
     else default_config_path ()
   in
+  match
+    Llm_provider.Cascade_config.complete_named
+      ~sw:env.sw ~net:env.net ?clock:env.clock
+      ?config_path:config_path_opt
+      ~name:cascade_name ~defaults ~messages
+      ?tools ~temperature ~max_tokens ~accept ~timeout_sec ()
+  with
+  | Ok resp -> Ok resp
+  | Error err -> Error (format_cascade_error ~cascade_name err)
+
+(** Prompt-in, text-out convenience. Returns {!cascade_result}. *)
+let call ~cascade_name ~prompt
+    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
   let messages : Llm_provider.Types.message list =
     (match system with
      | Some s -> [ Llm_provider.Types.system_msg s ]
@@ -158,25 +197,36 @@ let call ~cascade_name ~prompt
   in
   let t0 = Time_compat.now () in
   match
-    Llm_provider.Cascade_config.complete_named
-      ~sw:env.sw ~net:env.net ?clock:env.clock
-      ?config_path:config_path_opt
-      ~name:cascade_name ~defaults ~messages
-      ~temperature ~max_tokens ~accept ~timeout_sec ()
+    complete_cascade ~cascade_name ~messages
+      ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ()
   with
   | Ok resp ->
-    let t1 = Time_compat.now () in
-    let duration_ms = int_of_float ((t1 -. t0) *. 1000.0) in
+    let duration_ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
     Ok
       {
         response = Llm_provider.Cascade_config.text_of_response resp;
         llm_used = resp.Llm_provider.Types.model;
         duration_ms;
       }
-  | Error (Llm_provider.Http_client.HttpError { code; body }) ->
-    Error (Printf.sprintf "[cascade] %s: HTTP %d: %s" cascade_name code
-             (if String.length body > 200
-              then String.sub body 0 200 ^ "..."
-              else body))
-  | Error (Llm_provider.Http_client.NetworkError { message }) ->
-    Error (Printf.sprintf "[cascade] %s: %s" cascade_name message)
+  | Error _ as e -> e
+
+(** Prompt-in, full api_response out. Use when callers need model name,
+    tool_calls, or usage from the response. *)
+let call_raw ~cascade_name ~prompt
+    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
+  let messages : Llm_provider.Types.message list =
+    (match system with
+     | Some s -> [ Llm_provider.Types.system_msg s ]
+     | None -> [])
+    @ [ Llm_provider.Types.user_msg prompt ]
+  in
+  complete_cascade ~cascade_name ~messages
+    ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ()
+
+(** Messages + tools in, full api_response out. For tool-using LLM calls. *)
+let call_with_tools ~cascade_name ~messages
+    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
+  complete_cascade ~cascade_name ~messages
+    ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ?tools ()

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -449,7 +449,7 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
               ("recheck_status_samples", `List [`String "warn"]);
               ("recheck_stability", `Float 1.0);
             ]
-        | Ok model ->
+        | Ok _model ->
             let req = Verifier_oas.{
               action_description =
                 Printf.sprintf "masc_mitosis_handoff outcome review (%s)" perspective;
@@ -463,9 +463,9 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
                   match ctx.clock with
                   | Some (Clock clock) when judge_timeout_sec > 0.0 ->
                       Eio.Time.with_timeout_exn clock judge_timeout_sec (fun () ->
-                        Verifier_oas.verify ~model req)
+                        Verifier_oas.verify req)
                   | _ ->
-                      Verifier_oas.verify ~model req
+                      Verifier_oas.verify req
                 in
                 `Verdict verdict
               with

--- a/lib/perpetual/perpetual_oas_hooks.ml
+++ b/lib/perpetual/perpetual_oas_hooks.ml
@@ -145,7 +145,6 @@ let perpetual_hooks
   let pre_tool_use =
     if config.feedback_enabled then
       Some (Verifier_oas.make_pre_tool_hook
-        ~model:config.verifier_model
         ~goal:config.initial_goal
         ~context_summary:(sprintf "Turn %d, generation %d"
           pstate.turn_count pstate.generation))

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -57,7 +57,6 @@ type code_generator =
   history:Autoresearch.cycle_record list ->
   insights:string list ->
   target_file:string -> file_content:string ->
-  llm_model:string ->
   (string * string, string) Stdlib.result
 
 (** Per-loop code generator override (for tests). *)
@@ -535,12 +534,12 @@ let handle_cycle ctx args =
              generate ~goal:(Printf.sprintf "%s\n\nApply this hypothesis: %s" state.goal h)
                ~baseline:state.baseline
                ~history:state.history ~insights:state.insights
-               ~target_file ~file_content ~llm_model:state.llm_model
+               ~target_file ~file_content
              |> Result.map (fun (_generated_hyp, code) -> (h, code))
            | None ->
              generate ~goal:state.goal ~baseline:state.baseline
                ~history:state.history ~insights:state.insights
-               ~target_file ~file_content ~llm_model:state.llm_model)
+               ~target_file ~file_content)
         in
         match code_result with
         | Error e ->

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -443,7 +443,7 @@ let parse_routing_decision_json (json : Yojson.Safe.t) =
 let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
   match router_judge_model () with
   | None -> None
-  | Some judge_model ->
+  | Some _judge_model ->
       let worker_class_text =
         match worker_class with
         | Some kind -> Team_session_types.worker_class_to_string kind
@@ -465,30 +465,18 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
            worker_prompt=%S\n"
           worker_class_text role_text spawn_prompt
       in
-      let request : Llm_types.completion_request =
-        {
-          model = llama_router_model_spec judge_model;
-          messages =
-            [
-              Agent_sdk.Types.system_msg
-                "You are a routing judge for a hybrid swarm. Output only JSON.";
-              Agent_sdk.Types.user_msg prompt;
-            ];
-          temperature = 0.0;
-          max_tokens = 220;
-          tools = [];
-          response_format = `Json;
-        }
-      in
-      match
-        Llm_orchestration.complete ~timeout_sec:(router_judge_timeout_sec ()) request
+      (match
+        Llm_cascade.call ~cascade_name:"routing_judge" ~prompt
+          ~system:"You are a routing judge for a hybrid swarm. Output only JSON."
+          ~temperature:0.0 ~max_tokens:220
+          ~timeout_sec:(router_judge_timeout_sec ()) ()
       with
-      | Ok response -> (
+      | Ok r -> (
           try
-            Yojson.Safe.from_string (Llm_types.text_of_response response)
+            Yojson.Safe.from_string r.Llm_cascade.response
             |> parse_routing_decision_json
           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
-      | Error _ -> None
+      | Error _ -> None)
 
 let routing_summary_line (decision : routing_decision) =
   Printf.sprintf

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -148,21 +148,16 @@ One line only.|}
 (* Core: verify                                                     *)
 (* ================================================================ *)
 
-let verify ~(model : Llm_types.model_spec) (req : verification_request) : verdict =
+let verify (req : verification_request) : verdict =
   if should_skip ~action_description:req.action_description then
     Pass
   else
     let prompt = build_prompt req in
-    let completion_req : Llm_types.completion_request = {
-      model;
-      messages = [Agent_sdk.Types.user_msg prompt];
-      temperature = 0.0;  (* Deterministic for verification *)
-      max_tokens = 200;   (* Budget cap *)
-      tools = [];
-      response_format = `Text;
-    } in
-    match Llm_orchestration.complete completion_req with
-    | Ok resp -> parse_verdict (Llm_types.text_of_response resp)
+    match
+      Llm_cascade.call ~cascade_name:"verifier" ~prompt
+        ~temperature:0.0 ~max_tokens:200 ()
+    with
+    | Ok r -> parse_verdict r.Llm_cascade.response
     | Error e ->
       eprintf "[verifier] LLM call failed: %s (defaulting to WARN)\n%!" e;
       Warn ("verifier_unavailable: " ^ e)
@@ -202,11 +197,9 @@ let verdict_to_hook_decision (v : verdict) : Agent_sdk.Hooks.hook_decision =
 
     For non-PreToolUse events, returns Continue (pass-through).
 
-    @param model The cheap LLM model spec used for verification.
     @param goal The current agent goal (for verification prompt context).
     @param context_summary Brief summary of agent state. *)
 let make_pre_tool_hook
-    ~(model : Llm_types.model_spec)
     ~(goal : string)
     ~(context_summary : string)
   : Agent_sdk.Hooks.hook =
@@ -227,7 +220,7 @@ let make_pre_tool_hook
           goal;
           context_summary;
         } in
-        let verdict = verify ~model req in
+        let verdict = verify req in
         verdict_to_hook_decision verdict
     | _ -> Agent_sdk.Hooks.Continue
 
@@ -244,12 +237,11 @@ let make_pre_tool_hook
     @return Updated hooks record with the verifier installed in pre_tool_use. *)
 let install_hook
     ~(hooks : Agent_sdk.Hooks.hooks)
-    ~(model : Llm_types.model_spec)
     ~(goal : string)
     ~(context_summary : string)
   : Agent_sdk.Hooks.hooks =
   { hooks with
-    pre_tool_use = Some (make_pre_tool_hook ~model ~goal ~context_summary) }
+    pre_tool_use = Some (make_pre_tool_hook ~goal ~context_summary) }
 
 (* ================================================================ *)
 (* Read-Only Detection as OAS Guardrails.Custom                      *)


### PR DESCRIPTION
## Summary

MASC 내부의 모든 LLM inference 호출을 `Llm_orchestration` (legacy 경로) → `Llm_cascade` (OAS Cascade_config 경로)로 마이그레이션.

**Before**: 13곳에서 `Llm_orchestration.complete/cascade/run_prompt_cascade/call_provider_stream`을 직접 호출 → OAS의 timeout/health-check/cascade/metrics를 우회.

**After**: 모든 호출이 `Llm_cascade.call/call_raw/call_with_tools` → OAS `Cascade_config.complete_named` 단일 경로로 통합.

### Changes by Phase

**Phase 0: Llm_cascade API 확장**
- `complete_cascade` 내부 헬퍼 추출 (DRY error mapping)
- `call_raw`: prompt-in, full api_response out
- `call_with_tools`: messages + tools 지원
- 5개 cascade_name 등록: keeper_autonomy, routing_judge, chain_llm, autoresearch, code_swarm_verify

**Phase 1: Gardener + Dashboard (4곳)**
- gardener_decisions: 2곳 → `Llm_cascade.call`
- dashboard_operator_judge, dashboard_governance_judge: 2곳 → `Llm_cascade.call_raw`

**Phase 2: Single-shot (5곳)**
- keeper_autonomy, verifier_oas, code_swarm_plan, autoresearch, tool_team_session_routing
- `~model` 파라미터 제거, cascade_name 기반으로 전환
- caller 연쇄 업데이트 (keeper_verifier, keeper_exec_autonomy, mitosis_helpers, perpetual_oas_hooks, tool_autoresearch)

**Phase 3: Chain tools (1곳)**
- chain_native_eio: `Llm_cascade.call_with_tools` (raw JSON tool defs 직접 전달)

**Phase 4: Keeper adapter (2곳)**
- run_cascade: custom Oas_worker loop → `Llm_cascade.call_with_tools`
- run_cascade_stream: `Llm_orchestration.call_provider_stream` 제거 → batch + SSE 합성

**Phase 5: Deprecation**
- Llm_orchestration의 complete/cascade/run_prompt_cascade/call_provider_stream에 `@deprecated` 추가
- Concurrency diagnostics, cache, health filtering은 유지

### Stats
- 21 files changed
- Net ~100 lines removed
- 0 Llm_orchestration inference call sites remaining in lib/

## Test plan
- [x] `dune build lib/ bin/` — 컴파일 성공
- [x] `test_llm_cascade` — 8/8 pass
- [x] `test_gardener` — pass
- [x] `test_dashboard_governance` — pass
- [ ] 서버 실행 확인 (`./start-masc-mcp.sh`)
- [ ] Keeper heartbeat + LLM 호출 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)