### PR TITLE
feat(oas): wire Eval_gate → OAS Guardrails + test coverage + dead code removal

### DIFF
--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -83,6 +83,7 @@ let execute_approved_plan
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
     ~(trajectory_acc : Trajectory.accumulator option)
     : string * float * string list =
+  ignore trajectory_acc;
   let gate_config = autonomous_gate_config ~autonomy_level in
   let primary = match specs with p :: _ -> p | [] -> Llm_types.default_local_model_spec () in
   let system_prompt = Printf.sprintf
@@ -97,58 +98,6 @@ Execute step 1 of this plan using the available tools.
 Be concise. Only use tools that directly advance the plan.
 Do NOT use destructive tools (bash rm, edit, delete).|}
     meta.name pa.goal_title pa.goal_id plan
-  in
-  let ctx_work = Context_manager.create
-    ~system_prompt:(Printf.sprintf "Keeper %s autonomous execution" meta.name)
-    ~max_tokens:4000 in
-  (* gate_config is now passed to OAS guardrails via run_with_tools.
-     The _execute_tool_calls below is dead code (kept as reference
-     for Eval_gate.guarded_execute pattern, remove in next PR). *)
-  let _execute_tool_calls
-      (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
-    List.map
-      (fun (tc : Llm_types.tool_call) ->
-         let execute () =
-           execute_keeper_tool_call ~config ~meta ~ctx_work tc
-         in
-         let (decision, result_opt, _post_eval, duration_ms) =
-           Eval_gate.guarded_execute
-             ~config:gate_config
-             ~accumulated_cost:0.0
-             ~trajectory_acc
-             ~tool_name:tc.call_name
-             ~args_json:tc.call_arguments
-             ~execute
-         in
-         let result = match decision, result_opt with
-           | Trajectory.Reject reason, _ ->
-               Log.KeeperExec.info "GATE BLOCKED %s: %s"
-                 tc.call_name reason;
-               Yojson.Safe.to_string (`Assoc [("gate_blocked", `String tc.call_name); ("reason", `String reason)])
-           | _, Some r -> r
-           | _, None -> "{\"error\":\"no result\"}"
-         in
-         (* Record to trajectory *)
-         (match trajectory_acc with
-          | Some acc ->
-              Trajectory.record_entry acc {
-                ts = Time_compat.now ();
-                ts_iso = Types.now_iso ();
-                turn = acc.Trajectory.turn;
-                round = 0;
-                tool_name = tc.call_name;
-                args_json = tc.call_arguments;
-                gate_decision = decision;
-                result = Some (if String.length result > 500
-                          then String.sub result 0 500 ^ "..."
-                          else result);
-                duration_ms;
-                error = None;
-                cost_usd = 0.0;
-              }
-          | None -> ());
-         (tc, result))
-      tcs
   in
   let max_rounds = 3 in
   let guardrails = Verifier_oas.eval_gate_to_oas_guardrails gate_config in

--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -101,8 +101,9 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
   let ctx_work = Context_manager.create
     ~system_prompt:(Printf.sprintf "Keeper %s autonomous execution" meta.name)
     ~max_tokens:4000 in
-  (* TODO: migrate Eval_gate logic into OAS guardrails when
-     run_with_tools fully replaces the manual tool loop. *)
+  (* gate_config is now passed to OAS guardrails via run_with_tools.
+     The _execute_tool_calls below is dead code (kept as reference
+     for Eval_gate.guarded_execute pattern, remove in next PR). *)
   let _execute_tool_calls
       (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
     List.map
@@ -150,12 +151,15 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
       tcs
   in
   let max_rounds = 3 in
+  let guardrails = Verifier_oas.eval_gate_to_oas_guardrails gate_config in
   match Keeper_oas_adapter.run_with_tools
     ~config ~meta ~system_prompt
     ~goal:"Execute the first step of the plan now."
     ~max_turns:max_rounds
     ~temperature:0.3
     ~max_tokens:1024
+    ~guardrails
+    ()
   with
   | Error e ->
       (Printf.sprintf "OAS agent failed: %s" e, 0.0, [])

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -78,6 +78,8 @@ let run_with_tools
     ~(max_turns : int)
     ~(temperature : float)
     ~(max_tokens : int)
+    ?(guardrails : Agent_sdk.Guardrails.t option)
+    ()
   : (Oas_worker.run_result, string) result =
   match resolve_primary_model_spec meta with
   | Error e -> Error e
@@ -98,6 +100,7 @@ let run_with_tools
     max_turns;
     max_tokens;
     temperature;
+    guardrails;
   } in
   Oas_worker.run_with_masc_tools
     ~sw ~net ~config:oas_config ~masc_tools ~dispatch goal

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -19,6 +19,8 @@ val run_with_tools :
   max_turns:int ->
   temperature:float ->
   max_tokens:int ->
+  ?guardrails:Agent_sdk.Guardrails.t ->
+  unit ->
   (Oas_worker.run_result, string) result
 
 (** Tool-free LLM call (deliberation, correction, forced grounding).

--- a/lib/local/local_agent_eio_container.ml
+++ b/lib/local/local_agent_eio_container.ml
@@ -529,7 +529,9 @@ let append_worker_completion_log ~base_path ~team_session_id ~worker_name
           Option.fold ~none:`Null ~some:(fun value -> `String value) error );
       ])
 
-let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
+(** Build (config, options) for Agent.resume — the continue_worker path.
+    New workers use Worker_oas.build_agent (Builder pattern) instead. *)
+let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
     ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = []) () =
   let config =
     {

--- a/lib/local/local_agent_eio_runners.ml
+++ b/lib/local/local_agent_eio_runners.ml
@@ -200,9 +200,13 @@ let run_worker_oas ~sw ~base_path ~worker_name
                     | _ -> Oas.Hooks.Continue);
             }
           in
+          let gate_config =
+            Worker_oas.gate_config_of_execution_scope meta.execution_scope
+          in
           let* agent =
             Worker_oas.build_agent ~net ~meta ~model ~system_prompt ~tools
-              ~hooks ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ()
+              ~hooks ~raw_trace ~heartbeat_callbacks:heartbeat_cbs
+              ~gate_config ()
           in
           let result =
             Oas.Agent.run ~sw agent prompt

--- a/lib/local/local_agent_eio_runners.ml
+++ b/lib/local/local_agent_eio_runners.ml
@@ -452,7 +452,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 Option.value ~default:false meta.thinking_enabled
               in
               let config, options =
-                build_oas_agent ~worker_name ~model
+                build_resume_config ~worker_name ~model
                   ~system_prompt:
                     (default_system_prompt ~worker_name ~model_id:model.model_id
                        ?session_id:meta.team_session_id ?role:meta.role

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -334,6 +334,8 @@ module Anti_fake = Anti_fake
 
 (* Keeper Autonomy Engine (Phase 2: autonomy slider + verifier) *)
 module Keeper_autonomy = Keeper_autonomy
+module Keeper_exec_autonomy = Keeper_exec_autonomy
+module Keeper_oas_adapter = Keeper_oas_adapter
 module Keeper_verifier = Keeper_verifier
 module Keeper_contract = Keeper_contract
 module Keeper_deliberation = Keeper_deliberation

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -319,6 +319,7 @@ module Context_scoring = Context_scoring
 module Context_compact_oas = Context_compact_oas
 module Context_manager = Context_manager
 module Verifier_oas = Verifier_oas
+module Worker_oas = Worker_oas
 module Succession_oas = Succession_oas
 module Perpetual_loop = Perpetual_loop
 module Perpetual_oas = Perpetual_oas

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -122,6 +122,42 @@ let description_of_meta (meta : Local_agent_eio_types.worker_container_meta) : s
 let oas_provider_of_model = Local_agent_eio_container.oas_provider_of_model
 
 (* ================================================================ *)
+(* execution_scope -> gate_config                                    *)
+(* ================================================================ *)
+
+(** Derive Eval_gate.gate_config from execution_scope.
+    Observe_only: strict allowlist (read-only tools), low budget.
+    Limited_code_change: moderate budget, deny destructive bash.
+    Autonomous: permissive, higher budget. *)
+let gate_config_of_execution_scope
+    (scope : Team_session_types.execution_scope) : Eval_gate.gate_config =
+  match scope with
+  | Observe_only ->
+      { Eval_gate.default_config with
+        allowlist_enabled = true;
+        allowed_tools = [
+          "file_read"; "shell_exec"; "list_dir"; "glob"; "grep";
+          "search"; "git_status"; "git_log"; "git_diff";
+        ];
+        max_tool_calls_per_turn = 8;
+        max_cost_usd = 0.05;
+      }
+  | Limited_code_change ->
+      { Eval_gate.default_config with
+        destructive_check_enabled = true;
+        denied_tools = [
+          "shell_exec_dangerous"; "git_push_force"; "rm_rf";
+        ];
+        max_tool_calls_per_turn = 12;
+        max_cost_usd = 0.20;
+      }
+  | Autonomous ->
+      { Eval_gate.default_config with
+        max_tool_calls_per_turn = 20;
+        max_cost_usd = 0.50;
+      }
+
+(* ================================================================ *)
 (* Build OAS Agent.t via Builder                                     *)
 (* ================================================================ *)
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -222,7 +222,7 @@ let make_heartbeat_callbacks
 
     This function mirrors run_worker_oas in local_agent_eio_runners.ml,
     but constructs the agent using the Builder pattern instead of
-    build_oas_agent + Agent.create directly.
+    build_resume_config + Agent.create directly.
 
     Returns a run_result on success, or an error string on failure. *)
 let run_worker_via_oas

--- a/test/dune
+++ b/test/dune
@@ -188,6 +188,12 @@
  (modules test_oas_integration)
  (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
 
+; Verifier_oas bridge tests (eval_gate→guardrails, verdict→hook, read-only)
+(test
+ (name test_verifier_oas_bridge)
+ (modules test_verifier_oas_bridge)
+ (libraries masc_mcp agent_sdk alcotest yojson))
+
 ; OAS adapter tests (sentinel roundtrip, context_compact_oas strategies)
 (test
  (name test_oas_adapters)

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -1,0 +1,252 @@
+(** test_verifier_oas_bridge — Pure tests for Verifier_oas bridge functions.
+
+    Covers eval_gate_to_oas_guardrails, verdict_to_hook_decision,
+    and read_only_predicate without any LLM or network calls.
+
+    @since OAS Integration Phase 2 *)
+
+open Masc_mcp
+
+module Oas = Agent_sdk
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
+
+let make_gate
+    ?(max_cost = 0.50)
+    ?(max_calls = 10)
+    ?(entropy = 3)
+    ?(destructive = true)
+    ?(allowlist_enabled = false)
+    ?(allowed = [])
+    ?(denied = [])
+    () : Eval_gate.gate_config =
+  {
+    max_cost_usd = max_cost;
+    max_tool_calls_per_turn = max_calls;
+    entropy_threshold = entropy;
+    destructive_check_enabled = destructive;
+    allowlist_enabled;
+    allowed_tools = allowed;
+    denied_tools = denied;
+  }
+
+let make_schema name : Oas.Types.tool_schema =
+  { name; description = ""; parameters = [] }
+
+(* ================================================================ *)
+(* eval_gate_to_oas_guardrails                                       *)
+(* ================================================================ *)
+
+let test_allowlist_maps_to_allowlist () =
+  let gate =
+    make_gate ~allowlist_enabled:true
+      ~allowed:["keeper_read"; "keeper_bash"]
+      ~denied:["keeper_edit"]
+      ()
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "allowlist takes priority"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList names ->
+         List.sort String.compare names
+         = List.sort String.compare ["keeper_read"; "keeper_bash"]
+     | _ -> false);
+  Alcotest.(check (option int)) "max_tool_calls preserved"
+    (Some 10) g.max_tool_calls_per_turn
+
+let test_denylist_maps_to_denylist () =
+  let gate =
+    make_gate ~allowlist_enabled:false
+      ~denied:["keeper_bash"; "keeper_edit"]
+      ()
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "denied only -> DenyList"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.DenyList names ->
+         List.sort String.compare names
+         = List.sort String.compare ["keeper_bash"; "keeper_edit"]
+     | _ -> false)
+
+let test_neither_maps_to_allowall () =
+  let gate =
+    make_gate ~allowlist_enabled:false ~allowed:[] ~denied:[] ()
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "neither -> AllowAll"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowAll -> true
+     | _ -> false)
+
+let test_empty_allowlist_maps_to_empty_allowlist () =
+  let gate =
+    make_gate ~allowlist_enabled:true ~allowed:[] ()
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "empty allowlist -> AllowList []"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList [] -> true
+     | _ -> false)
+
+let test_max_tool_calls_preserved () =
+  let gate = make_gate ~max_calls:5 () in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check (option int)) "max_tool_calls = 5"
+    (Some 5) g.max_tool_calls_per_turn
+
+let test_allowlist_ignores_denied_when_both () =
+  let gate =
+    make_gate ~allowlist_enabled:true
+      ~allowed:["keeper_read"]
+      ~denied:["keeper_bash"]
+      ()
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "allowlist wins over denylist"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList ["keeper_read"] -> true
+     | _ -> false)
+
+(* ================================================================ *)
+(* verdict_to_hook_decision                                          *)
+(* ================================================================ *)
+
+let test_pass_to_continue () =
+  let decision = Verifier_oas.verdict_to_hook_decision Pass in
+  Alcotest.(check bool) "Pass -> Continue"
+    true
+    (decision = Oas.Hooks.Continue)
+
+let test_warn_to_continue () =
+  let decision = Verifier_oas.verdict_to_hook_decision (Warn "minor issue") in
+  Alcotest.(check bool) "Warn -> Continue"
+    true
+    (decision = Oas.Hooks.Continue)
+
+let test_fail_to_skip () =
+  let decision = Verifier_oas.verdict_to_hook_decision (Fail "critical error") in
+  Alcotest.(check bool) "Fail -> Skip"
+    true
+    (decision = Oas.Hooks.Skip)
+
+(* ================================================================ *)
+(* read_only_predicate                                               *)
+(* ================================================================ *)
+
+let test_read_tools_are_readonly () =
+  (* Word boundary matching: underscore IS a word char, so "keeper_read"
+     does NOT match "read". Only tools with standalone patterns match. *)
+  let read_tools = [
+    "read file"; "grep code"; "search files";
+    "find module"; "list dir"; "ls output";
+    "git status"; "git log"; "git diff";
+    "view file"; "get status";
+    "fetch data"; "query db";
+  ] in
+  List.iter (fun name ->
+    let schema = make_schema name in
+    Alcotest.(check bool) (Printf.sprintf "%s is read-only" name)
+      true
+      (Verifier_oas.read_only_predicate schema)
+  ) read_tools
+
+let test_write_tools_are_not_readonly () =
+  let write_tools = [
+    "keeper_bash"; "keeper_edit";
+    "keeper_fs_edit"; "keeper_github";
+    "write_file"; "delete_node";
+    (* underscore-joined: "read" is NOT at word boundary *)
+    "keeper_read"; "bulk_search";
+  ] in
+  List.iter (fun name ->
+    let schema = make_schema name in
+    Alcotest.(check bool) (Printf.sprintf "%s is NOT read-only" name)
+      false
+      (Verifier_oas.read_only_predicate schema)
+  ) write_tools
+
+(* ================================================================ *)
+(* Roundtrip: autonomous_gate_config -> guardrails                   *)
+(* ================================================================ *)
+
+let test_l3_gate_roundtrip () =
+  let gate =
+    Keeper_exec_autonomy.autonomous_gate_config
+      ~autonomy_level:Keeper_autonomy.L3_Guided
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "L3 -> AllowList (strict)"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList names -> List.length names > 0
+     | _ -> false);
+  Alcotest.(check (option int)) "L3 max_tool_calls = 5"
+    (Some 5) g.max_tool_calls_per_turn
+
+let test_l4_gate_roundtrip () =
+  let gate =
+    Keeper_exec_autonomy.autonomous_gate_config
+      ~autonomy_level:Keeper_autonomy.L4_Autonomous
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "L4 -> AllowList (includes bash)"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList names ->
+         List.mem "keeper_bash" names
+     | _ -> false)
+
+let test_l5_gate_roundtrip () =
+  let gate =
+    Keeper_exec_autonomy.autonomous_gate_config
+      ~autonomy_level:Keeper_autonomy.L5_Independent
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "L5 -> AllowAll"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowAll -> true
+     | _ -> false)
+
+(* ================================================================ *)
+(* Test Suite                                                        *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "verifier_oas_bridge" [
+    ("eval_gate_to_oas_guardrails", [
+      Alcotest.test_case "allowlist -> AllowList" `Quick
+        test_allowlist_maps_to_allowlist;
+      Alcotest.test_case "denylist -> DenyList" `Quick
+        test_denylist_maps_to_denylist;
+      Alcotest.test_case "neither -> AllowAll" `Quick
+        test_neither_maps_to_allowall;
+      Alcotest.test_case "empty allowlist -> AllowList []" `Quick
+        test_empty_allowlist_maps_to_empty_allowlist;
+      Alcotest.test_case "max_tool_calls preserved" `Quick
+        test_max_tool_calls_preserved;
+      Alcotest.test_case "allowlist ignores denied" `Quick
+        test_allowlist_ignores_denied_when_both;
+    ]);
+    ("verdict_to_hook_decision", [
+      Alcotest.test_case "Pass -> Continue" `Quick test_pass_to_continue;
+      Alcotest.test_case "Warn -> Continue" `Quick test_warn_to_continue;
+      Alcotest.test_case "Fail -> Skip" `Quick test_fail_to_skip;
+    ]);
+    ("read_only_predicate", [
+      Alcotest.test_case "read tools" `Quick test_read_tools_are_readonly;
+      Alcotest.test_case "write tools" `Quick test_write_tools_are_not_readonly;
+    ]);
+    ("autonomous_gate roundtrip", [
+      Alcotest.test_case "L3 -> AllowList (strict)" `Quick test_l3_gate_roundtrip;
+      Alcotest.test_case "L4 -> AllowList (with bash)" `Quick test_l4_gate_roundtrip;
+      Alcotest.test_case "L5 -> AllowAll" `Quick test_l5_gate_roundtrip;
+    ]);
+  ]

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -216,6 +216,50 @@ let test_l5_gate_roundtrip () =
      | _ -> false)
 
 (* ================================================================ *)
+(* execution_scope -> gate_config -> guardrails roundtrip             *)
+(* ================================================================ *)
+
+let test_observe_only_roundtrip () =
+  let gate =
+    Worker_oas.gate_config_of_execution_scope
+      Team_session_types.Observe_only
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "Observe_only -> AllowList (read-only)"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowList names -> List.length names > 0
+     | _ -> false);
+  Alcotest.(check (option int)) "Observe_only max_calls = 8"
+    (Some 8) g.max_tool_calls_per_turn
+
+let test_limited_code_change_roundtrip () =
+  let gate =
+    Worker_oas.gate_config_of_execution_scope
+      Team_session_types.Limited_code_change
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "Limited -> DenyList"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.DenyList names -> List.length names > 0
+     | _ -> false)
+
+let test_autonomous_roundtrip () =
+  let gate =
+    Worker_oas.gate_config_of_execution_scope
+      Team_session_types.Autonomous
+  in
+  let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
+  Alcotest.(check bool) "Autonomous -> AllowAll"
+    true
+    (match g.tool_filter with
+     | Oas.Guardrails.AllowAll -> true
+     | _ -> false);
+  Alcotest.(check (option int)) "Autonomous max_calls = 20"
+    (Some 20) g.max_tool_calls_per_turn
+
+(* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
 
@@ -248,5 +292,13 @@ let () =
       Alcotest.test_case "L3 -> AllowList (strict)" `Quick test_l3_gate_roundtrip;
       Alcotest.test_case "L4 -> AllowList (with bash)" `Quick test_l4_gate_roundtrip;
       Alcotest.test_case "L5 -> AllowAll" `Quick test_l5_gate_roundtrip;
+    ]);
+    ("execution_scope roundtrip", [
+      Alcotest.test_case "Observe_only -> AllowList" `Quick
+        test_observe_only_roundtrip;
+      Alcotest.test_case "Limited -> DenyList" `Quick
+        test_limited_code_change_roundtrip;
+      Alcotest.test_case "Autonomous -> AllowAll" `Quick
+        test_autonomous_roundtrip;
     ]);
   ]


### PR DESCRIPTION
## Summary

OAS Integration Phase 2: bridge 함수가 존재하지만 아무도 호출하지 않던 문제를 해결.

- **test**: eval_gate bridge 함수 17개 pure 테스트 추가 (LLM 불필요)
- **feat(keeper)**: `autonomous_gate_config` → `eval_gate_to_oas_guardrails` → `run_with_tools ~guardrails` 연결
- **refactor**: `build_oas_agent` → `build_resume_config` 이름 변경 + dead `_execute_tool_calls` 48 LOC 제거
- **feat(worker)**: `execution_scope` → `gate_config` → OAS Guardrails 연결 (Observe_only/Limited/Autonomous)

### Defense-in-Depth 구조

| 레이어 | 역할 | 위치 |
|--------|------|------|
| OAS Guardrails (static) | tool allow/deny 사전 필터링 | Agent.t 빌드 시 설정 |
| Eval_gate (dynamic) | cost, entropy, destructive 런타임 체크 | tool call 시점 |

Net: +368/-55 LOC (304 테스트, +64 실 코드, -55 dead code)

## Test plan

- [x] `dune build --root .` 컴파일 확인
- [x] `test_verifier_oas_bridge.exe` 17/17 pass
- [x] 기존 테스트 regression 없음
- [x] `build_oas_agent` grep 결과 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)