### PR TITLE
fix: Gardener spawns OAS workers directly (#1645)

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -416,7 +416,7 @@ let tick ~sw ~clock ~config ~room_config : unit =
     | NeedSpawn gap ->
         Eio.traceln "[Gardener] Intervention needed: spawn %s" gap.topic;
         let spawn_decision = decide_spawn ~config ~health ~gap in
-        (match execute_spawn ~decision:spawn_decision with
+        (match execute_spawn ~sw ~room_config ~decision:spawn_decision () with
          | Ok name ->
              record_action "spawned" ~target:name
                ~reason:(Printf.sprintf "spawned from gap '%s'" gap.topic);
@@ -551,6 +551,7 @@ let start_sentinel_reactor_fiber ~sw ~clock ~sub =
 let start ?bus ~sw ~clock ~room_config () =
   let config = load_config () in
   room_config_ref := Some room_config;
+  sw_ref := Some sw;
   bus_ref := bus;
   if config.enabled then begin
     gardener_lock := Some (Eio.Mutex.create ());

--- a/lib/gardener.mli
+++ b/lib/gardener.mli
@@ -104,11 +104,20 @@ val decide_retire :
 
 (** {1 Execution} *)
 
-(** Execute an approved spawn decision.
+(** Execute an approved spawn decision via OAS worker agent.
 
-    Creates agent in Neo4j, posts announcement, updates budgets.
-    @return [Ok agent_name] on success, [Error reason] otherwise *)
-val execute_spawn : decision:spawn_decision -> (string, string) result
+    Spawns a real OAS agent using [Spawn_eio.spawn]. When called from the
+    background tick loop, pass [~sw] and [~room_config] explicitly. When
+    called from the MCP tool layer, omit them to use the module-level refs
+    set during {!start}.
+
+    @return [Ok message] on success, [Error reason] otherwise *)
+val execute_spawn :
+  ?sw:Eio.Switch.t ->
+  ?room_config:Room_utils.config ->
+  decision:spawn_decision ->
+  unit ->
+  (string, string) result
 
 (** Execute an approved retirement decision.
 

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -225,15 +225,59 @@ let decide_retire ~config ~health ~(agent_stats : agent_stats) : retirement_deci
 
 (** {1 Spawn Execution} *)
 
-(** Execute an approved spawn *)
-let execute_spawn ~(decision : spawn_decision) : (string, string) result =
+(** Execute an approved spawn via OAS worker agent (Spawn_eio).
+
+    When called from the background tick loop, [~sw] and [~room_config] are
+    passed explicitly. When called from the MCP tool layer (which has no
+    Eio.Switch in scope), the function falls back to the module-level refs
+    set during [Gardener.start]. *)
+let execute_spawn ?sw ?room_config ~(decision : spawn_decision) () : (string, string) result =
   match decision with
-  | SpawnApproved { topic; proposed_traits = _; proposed_hours = _; reason; _ } ->
-      Eio.traceln "[Gardener] Executing spawn: %s (reason: %s)" topic reason;
-      (* Lodge heartbeat spawn removed (#1596). Use Gardener Neo4j spawn directly. *)
+  | SpawnApproved { topic; proposed_traits; proposed_hours = _; reason; _ } ->
+      Eio.traceln "[Gardener] Executing OAS spawn: %s (reason: %s)" topic reason;
       let config = load_config () in
-      trip_circuit ~config;
-      Error "spawn_agent_from_gap not available (Lodge removed)"
+      let resolved_sw = match sw with Some s -> Some s | None -> !sw_ref in
+      let resolved_rc = match room_config with Some rc -> Some rc | None -> !room_config_ref in
+      (match resolved_sw, resolved_rc with
+       | None, _ ->
+           trip_circuit ~config;
+           Error "execute_spawn: no Eio.Switch available (gardener not started?)"
+       | _, None ->
+           trip_circuit ~config;
+           Error "execute_spawn: no room_config available (gardener not started?)"
+       | Some sw, Some room_config ->
+      let traits_str = String.concat ", " proposed_traits in
+      let prompt = Printf.sprintf
+        "You are a MASC agent spawned by Gardener to address: %s\n\
+         Traits: %s\n\
+         Your task: Check the room for pending tasks (masc_status), claim one (masc_claim_next), and work on it.\n\
+         When done, broadcast your results and leave the room."
+        topic traits_str
+      in
+      let agent_name = Printf.sprintf "gardener-worker-%s"
+        (String.sub (Digest.to_hex (Digest.string topic)) 0 8) in
+      (try
+        let result = Spawn_eio.spawn ~sw ~agent_name ~prompt
+          ~room_config ~timeout_seconds:300 () in
+        if result.Spawn_eio.success then begin
+          record_spawn ();
+          reset_circuit ();
+          let msg = Printf.sprintf "OAS worker '%s' spawned for '%s' (elapsed: %dms)"
+            agent_name topic result.Spawn_eio.elapsed_ms in
+          let store = Board.global () in
+          (try ignore (Board.create_post store ~author:"gardener"
+            ~content:(Printf.sprintf "New agent deployed: %s\nTopic: %s\nReason: %s" agent_name topic reason)
+            ~ttl_hours:24 ())
+           with exn -> Log.Spawn.error "Board.create_post failed: %s" (Printexc.to_string exn));
+          Ok msg
+        end else begin
+          trip_circuit ~config;
+          Error (Printf.sprintf "OAS spawn failed: %s"
+            (String.sub result.Spawn_eio.output 0 (min 200 (String.length result.Spawn_eio.output))))
+        end
+      with exn ->
+        trip_circuit ~config;
+        Error (Printf.sprintf "OAS spawn exception: %s" (Printexc.to_string exn))))
   | SpawnDeferred { topic = _; reason; _ } ->
       Error (Printf.sprintf "Spawn deferred: %s" reason)
   | SpawnRejected { topic; reason } ->

--- a/lib/gardener/gardener_state.ml
+++ b/lib/gardener/gardener_state.ml
@@ -28,6 +28,7 @@ let load_config () : gardener_config = {
 let gardener_state_ref : gardener_state option ref = ref None
 let gardener_lock : Eio.Mutex.t option ref = ref None
 let room_config_ref : Room_utils.config option ref = ref None
+let sw_ref : Eio.Switch.t option ref = ref None
 
 (** Execute [f] with lock if available, otherwise directly.
     Safe for single-threaded test scenarios (no Eio runtime). *)

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -202,7 +202,7 @@ let handle_execute_spawn _ctx args : result =
       (* Then execute if approved *)
       match decision with
       | SpawnApproved _ ->
-          (match Gardener.execute_spawn ~decision with
+          (match Gardener.execute_spawn ~decision () with
            | Ok name ->
                let json = `Assoc [
                  ("status", `String "ok");


### PR DESCRIPTION
## Summary

Gardener가 Lodge 의존 없이 OAS worker를 직접 spawn.

기존: Gardener triage → plan worker → (Lodge 필요) → 실행 불가 → 무한 루프
변경: Gardener triage → `Spawn_eio.spawn` → OAS worker 실행 → 완료

- `execute_spawn`의 "Lodge removed" stub을 실제 OAS spawn으로 교체
- 5 files, +69/-14 lines
- gap signal의 topic/traits를 prompt로 변환하여 worker에 전달
- 성공 시 Board 공지, 실패 시 circuit breaker trip

## Test plan

- [x] `dune build --root .` 통과
- [x] 76/77 test 통과 (1 pre-existing LLM connectivity failure)
- [ ] Gardener enabled 상태에서 서버 기동 + gap signal 발생 시 worker spawn 확인

Closes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)