### PR TITLE
fix: export Keeper_oas_adapter and Oas_worker in wrapper module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -663,7 +663,6 @@
   keeper_exec_status
   keeper_exec_persona
   keeper_exec_context
-  keeper_oas_adapter
   keeper_exec_autonomy
   keeper_exec_social
   keeper_exec_proactive

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -347,6 +347,7 @@ module Keeper_learning = Keeper_learning
 module Keeper_feedback_tool = Keeper_feedback_tool
 module Keeper_keepalive = Keeper_keepalive
 module Keeper_runtime = Keeper_runtime
+module Keeper_oas_adapter = Keeper_oas_adapter
 
 (* Autonomy Adjuster — Feedback Closure (Phase 4) *)
 module Autonomy_adjuster = Autonomy_adjuster
@@ -362,3 +363,4 @@ module Compaction_types = Compaction_types
 
 (* OAS Integration — Agent SDK v0.24+ bridge *)
 module Oas_events = Oas_events
+module Oas_worker = Oas_worker

--- a/test_keeper_adapter/test_keeper_oas_adapter.ml
+++ b/test_keeper_adapter/test_keeper_oas_adapter.ml
@@ -13,6 +13,8 @@ let make_model_spec ?(model_id = "test-model") ?(provider = Llm_types.Llama) () 
   { provider;
     model_id;
     max_context = 4096;
+    api_url = "";
+    api_key_env = None;
     cost_per_1k_input = 0.0;
     cost_per_1k_output = 0.0;
   }
@@ -103,13 +105,14 @@ let test_cascade_config_preserves_temperature () =
 (* ================================================================ *)
 
 let make_run_result ?(model = "test") ?(text = "hello")
-    ?(input_tokens = 10) ?(output_tokens = 5) () : Oas_worker.run_result =
-  let open Masc_mcp in
+    ?(input_tokens = 10) ?(output_tokens = 5) () : Masc_mcp.Oas_worker.run_result =
   { response = {
       Llm_provider.Types.model;
-      content = [Llm_provider.Types.TextBlock { text }];
-      stop_reason = Some "end_turn";
-      usage = Some { input_tokens; output_tokens };
+      content = [Llm_provider.Types.Text text];
+      stop_reason = Llm_provider.Types.EndTurn;
+      usage = Some { input_tokens; output_tokens;
+                     cache_creation_input_tokens = 0;
+                     cache_read_input_tokens = 0 };
       id = "test-id";
     };
     checkpoint = None;


### PR DESCRIPTION
## Summary
- `masc_mcp.ml` wrapper에 `Keeper_oas_adapter`와 `Oas_worker` re-export 추가
- `test_keeper_oas_adapter.ml`의 타입을 현재 OAS `Llm_provider.Types`에 맞게 수정
- `lib/dune` modules 섹션의 중복 항목 제거

## Root Cause
모듈이 `lib/dune`의 `(modules ...)`에는 등록되었지만, `masc_mcp.ml` wrapper에서 re-export되지 않아 외부 테스트에서 `Unbound module Masc_mcp.Keeper_oas_adapter` 발생.

## Test plan
- [x] `dune build --root .` 성공
- [x] `dune exec test_keeper_adapter/test_keeper_oas_adapter.exe` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)