### PR TITLE
chore: bump version to 2.117.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.116.0)
+(version 2.117.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
Gardener OAS direct spawn (#1705) + anti-pattern audits.