### PR TITLE
feat: bump agent_sdk >= 0.60.0 — timeout, reasoning, message fields

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.57.0))
+  (agent_sdk (>= 0.60.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.57.0"}
+  "agent_sdk" {>= "0.60.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- `agent_sdk` 의존 버전 `>= 0.57.0` → `>= 0.60.0` 범프
- OAS 0.60 breaking type changes 적용 (message `name`/`tool_call_id` 필드, Checkpoint `working_context` 필드)
- `llm_provider_dispatch.ml`에서 message 변환 시 새 필드 전파

## OAS 0.60 자동 활성화 기능 (코드 변경 불필요)
- `Cascade_config.complete_named`의 `timeout_sec` 구현 (기존에 선언만 있었음)
- OpenAI SSE의 `reasoning_content` 파싱 → `Thinking` block 자동 캡처
- Qwen3.5 thinking mode 데이터가 response에 포함됨

## 변경 파일 (12개)
- `dune-project`, `masc_mcp.opam` — 버전 범프
- `lib/` 6파일 — message/checkpoint 타입 필드 추가
- `test/` 4파일 — 테스트 message 구성 업데이트

## Test plan
- [x] `dune build --root .` 성공 (clean build)
- [ ] `make test` 전체 테스트
- [ ] heartbeat cascade 수동 실행 (timeout 동작 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)