### PR TITLE
fix: social guardrails propagation + keeper adapter test fix

### DIFF
--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -226,26 +226,14 @@ let run_social_board_event_turn
           let user_message = Agent_sdk.Types.user_msg prompt in
           let ctx_work = Context_manager.append ctx_work user_message in
           Context_manager.persist_message session user_message;
-          let _execute_tool_calls
-              ~(ctx_work : Context_manager.working_context)
-              (tcs : Llm_types.tool_call list) : (Llm_types.tool_call * string) list =
-            List.map
-              (fun (tc : Llm_types.tool_call) ->
-                 let output =
-                   try execute_keeper_tool_call ~config:ctx.config ~meta ~ctx_work tc
-                   with exn ->
-                     Log.Keeper.error "social tool %s failed: %s" tc.call_name (Printexc.to_string exn);
-                     Yojson.Safe.to_string
-                       (`Assoc
-                         [
-                           ("error", `String "Tool execution failed (internal error)");
-                           ("tool", `String tc.call_name);
-                         ])
-                 in
-                 (tc, output))
-              tcs
+          (* Social context: L3-equivalent guardrails (read + board tools) *)
+          let social_gate =
+            Keeper_exec_autonomy.autonomous_gate_config
+              ~autonomy_level:Keeper_autonomy.L3_Guided
           in
-          (* OAS Agent lifecycle: run_with_tools replaces manual tool loop *)
+          let guardrails =
+            Verifier_oas.eval_gate_to_oas_guardrails social_gate
+          in
           let max_tool_rounds = Keeper_config.keeper_max_tool_rounds () in
           let system_prompt = ctx_work.system_prompt in
           let goal = prompt in
@@ -255,7 +243,8 @@ let run_social_board_event_turn
                 ~system_prompt ~goal
                 ~max_turns:max_tool_rounds
                 ~temperature:(Keeper_config.keeper_planning_temp ())
-                ~max_tokens:(Keeper_config.keeper_social_initial_max_tokens ()) ())
+                ~max_tokens:(Keeper_config.keeper_social_initial_max_tokens ())
+                ~guardrails ())
           in
           match oas_result with
           | Error e -> Error e

--- a/lib/local/local_agent_eio_container.ml
+++ b/lib/local/local_agent_eio_container.ml
@@ -532,7 +532,8 @@ let append_worker_completion_log ~base_path ~team_session_id ~worker_name
 (** Build (config, options) for Agent.resume — the continue_worker path.
     New workers use Worker_oas.build_agent (Builder pattern) instead. *)
 let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
-    ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = []) () =
+    ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
+    ?(guardrails : Oas.Guardrails.t option) () =
   let config =
     {
       Oas.Types.default_config with
@@ -549,17 +550,21 @@ let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
       tool_choice = Some Oas.Types.Auto;
     }
   in
+  let effective_guardrails =
+    match guardrails with
+    | Some g -> g
+    | None ->
+        { Oas.Guardrails.tool_filter =
+            Oas.Guardrails.AllowList (oas_tool_names tools);
+          max_tool_calls_per_turn = Some 12;
+        }
+  in
   let options =
     {
       Oas.Agent.default_options with
       provider = Some (oas_provider_of_model model);
       hooks;
-      guardrails =
-        {
-          Oas.Guardrails.tool_filter =
-            Oas.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some 12;
-        };
+      guardrails = effective_guardrails;
       raw_trace = Some raw_trace;
       periodic_callbacks;
     }

--- a/lib/local/local_agent_eio_runners.ml
+++ b/lib/local/local_agent_eio_runners.ml
@@ -455,6 +455,12 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
               let thinking_enabled =
                 Option.value ~default:false meta.thinking_enabled
               in
+              let resume_guardrails =
+                let gate =
+                  Worker_oas.gate_config_of_execution_scope meta.execution_scope
+                in
+                Verifier_oas.eval_gate_to_oas_guardrails gate
+              in
               let config, options =
                 build_resume_config ~worker_name ~model
                   ~system_prompt:
@@ -462,7 +468,8 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                        ?session_id:meta.team_session_id ?role:meta.role
                        ?selection_note:meta.selection_note ())
                   ~tools ~max_turns ~thinking_enabled ~hooks ~raw_trace
-                  ~periodic_callbacks:heartbeat_cbs ()
+                  ~periodic_callbacks:heartbeat_cbs
+                  ~guardrails:resume_guardrails ()
               in
               let agent =
                 Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()

--- a/test_keeper_adapter/dune
+++ b/test_keeper_adapter/dune
@@ -1,5 +1,4 @@
-; Disabled: Keeper_oas_adapter is in private_modules — needs .mli visibility fix
-; (test
-;  (name test_keeper_oas_adapter)
-;  (modules test_keeper_oas_adapter)
-;  (libraries masc_mcp agent_sdk alcotest yojson eio eio_main))
+(test
+ (name test_keeper_oas_adapter)
+ (modules test_keeper_oas_adapter)
+ (libraries masc_mcp agent_sdk alcotest yojson eio eio_main))

--- a/test_keeper_adapter/test_keeper_oas_adapter.ml
+++ b/test_keeper_adapter/test_keeper_oas_adapter.ml
@@ -14,12 +14,10 @@ let make_model_spec ?(model_id = "test-model") ?(provider = Llm_types.Llama) () 
   { provider;
     model_id;
     max_context = 4096;
-    api_url = "";
+    api_url = "http://127.0.0.1:8085";
     api_key_env = None;
     cost_per_1k_input = 0.0;
     cost_per_1k_output = 0.0;
-    api_url = "http://127.0.0.1:8085";
-    api_key_env = None;
   }
 
 let make_request ?(model_id = "test-model") ?(provider = Llm_types.Llama)


### PR DESCRIPTION
## Summary

- `keeper_exec_social`: `run_with_tools`에 L3 guardrails 전달 (AllowList: read + board tools). dead `_execute_tool_calls` 16 LOC 제거
- `test_keeper_oas_adapter`: 중복 `api_url`/`api_key_env` 필드 수정, test stanza 활성화 (11 tests)

이로써 `Keeper_oas_adapter.run_with_tools`의 모든 호출부(autonomy, social)가 guardrails를 전달합니다.

## Test plan

- [x] `test_keeper_oas_adapter` 11/11 pass (re-enabled)
- [x] `test_verifier_oas_bridge` 17/17 pass (no regression)
- [x] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)