### PR TITLE
fix(ci): bump agent_sdk minimum to 0.60.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.57.0))
+  (agent_sdk (>= 0.60.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))


### PR DESCRIPTION
CI가 agent_sdk 0.57.0을 받아 name/tool_call_id 필드 없이 빌드 실패. 0.60.0 이상 필수.