### PR TITLE
fix: remove stale voice bridge references post-migration

### DIFF
--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -11,7 +11,13 @@ let masc_base_dir () =
   | Some root when String.trim root <> "" -> Filename.concat root ".masc"
   | _ -> ".masc"
 
-(** Singleton session manager, lazily initialized *)
+(** Singleton session manager, lazily initialized.
+    Thread-safety: safe under single Eio domain — all fibers share one
+    OS thread, so [ref] read/write cannot race. No Eio.Mutex needed.
+    Voice_session_manager.restore is called once on first access;
+    subsequent calls to [get_session_manager] return the cached value.
+    Zombie session cleanup happens inside Voice_session_manager at
+    session-start time (expired sessions are reaped lazily). *)
 let session_manager_ref : Voice_session_manager.t option ref = ref None
 
 let get_session_manager () =

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -26,7 +26,7 @@ let schemas : tool_schema list =
     {
       name = "masc_voice_speak";
       description =
-        "Send text to the voice bridge for TTS playback. Requires an active voice session (call masc_voice_session_start first). provider: optional, one of 'elevenlabs', 'openai_compat'. priority: 1=normal, higher=urgent.";
+        "Send text to the TTS layer for audio playback. Requires an active voice session (call masc_voice_session_start first). provider: optional, one of 'elevenlabs', 'openai_compat'. priority: 1=normal, higher=urgent.";
       input_schema =
         `Assoc
           [
@@ -61,7 +61,7 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_session_end";
-      description = "End the active voice session for an agent and release bridge resources. Use when the agent's voice interaction is complete or the session needs cleanup.";
+      description = "End the active voice session for an agent and release session resources. Use when the agent's voice interaction is complete or the session needs cleanup.";
       input_schema =
         `Assoc
           [
@@ -93,7 +93,7 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_transcript";
-      description = "Get the current transcript (STT output) from the voice bridge. Requires an active voice session.";
+      description = "Get the current transcript (STT output). Requires STT service integration and an active voice session.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
     };
@@ -145,8 +145,16 @@ let schemas : tool_schema list =
 let require_net_or_error (ctx : 'a context) =
   match ctx.net with
   | Some net -> Ok net
-  | None -> Error "Voice bridge unavailable: server started without network. Restart masc-mcp with --http flag to enable voice tools."
+  | None -> Error "TTS service unavailable: server started without network. Restart masc-mcp with --http flag to enable voice tools."
 
+(* --- Handler categories ---
+   All handlers receive [ctx] for dispatch signature consistency.
+   Category A (net required): speak, agent — call Voice_bridge over HTTP.
+   Category B (local only):   session_start/end, sessions, conference_start/end
+                               — use Keeper_voice_local / Voice_session_manager.
+   Category C (stub):         transcript — STT service not yet integrated. *)
+
+(* Category A: requires network for TTS endpoint *)
 let handle_voice_speak (ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   let message = get_string args "message" "" in
@@ -167,6 +175,7 @@ let handle_voice_speak (ctx : 'a context) args : result =
           (Voice_bridge.agent_speak ~sw:ctx.sw ~clock:ctx.clock ~net ~agent_id
              ~message ?provider ~priority ())
 
+(* Category B: local session via Voice_session_manager *)
 let handle_voice_session_start (_ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   let voice = get_string_opt args "session_name" |> Option.map String.trim in
@@ -206,6 +215,7 @@ let handle_voice_sessions (_ctx : 'a context) _args : result =
         ("sessions",
           `List (List.map Voice_session_manager.session_to_json sessions)) ]))
 
+(* Category A: reads agent voice config via Voice_bridge *)
 let handle_voice_agent _ctx args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   if agent_id = "" then
@@ -213,6 +223,7 @@ let handle_voice_agent _ctx args : result =
   else
     json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
 
+(* Category C: STT stub — returns not_available until service is integrated *)
 let handle_voice_transcript (_ctx : 'a context) _args : result =
   (* Transcript requires an external STT service — not yet integrated locally *)
   (false, Yojson.Safe.to_string
@@ -220,6 +231,9 @@ let handle_voice_transcript (_ctx : 'a context) _args : result =
       [ ("status", `String "not_available");
         ("message", `String "transcript requires STT service integration") ]))
 
+(* Category B: conference = batch start of local sessions for multiple agents.
+   Each agent_id gets its own Voice_session_manager session; the "conference"
+   is a convenience grouping, not a shared audio channel. *)
 let handle_voice_conference_start (_ctx : 'a context) args : result =
   let agent_ids =
     get_string_list args "agent_ids"
@@ -242,6 +256,7 @@ let handle_voice_conference_start (_ctx : 'a context) args : result =
           ("participant_count", `Int (List.length agent_ids));
           ("sessions", `List sessions) ]))
 
+(* Category B: batch end — tears down each agent's session individually *)
 let handle_voice_conference_end (_ctx : 'a context) args : result =
   let agent_ids =
     get_string_list args "agent_ids"


### PR DESCRIPTION
## Summary

- tool description 3곳, 에러 메시지 1곳에서 "voice bridge" → "TTS layer/service" 용어 정리
- 8개 핸들러에 Category A(net)/B(local)/C(stub) 패턴 주석 추가
- conference_start/end가 batch session start/end임을 명시
- keeper_voice_local.ml에 단일 Eio domain thread-safety 주석 추가

#1673 이후 구 Voice MCP 아키텍처 용어 잔존물 정리.

## Test plan

- [x] `dune build --root .` 성공
- [x] `test_tool_shard_coverage.exe` 37/37 통과
- [x] `grep 'voice bridge' lib/tool_voice.ml` → 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)