### PR TITLE
fix: batch resolve 15 infrastructure bugs (#1485-#1500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify PR sync
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -103,6 +103,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify PR sync
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -134,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify PR sync
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -216,7 +217,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify PR sync
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -283,7 +284,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Verify PR sync
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -89,7 +89,6 @@ jobs:
           '
 
       - name: Smoke deployment image
-        continue-on-error: true
         run: |
           set -euo pipefail
           cid="$(docker run -d --network host -e PORT=18080 masc-mcp-railway-smoke /app/masc-mcp --port 18080 --base-path /app)"
@@ -107,12 +106,12 @@ jobs:
           docker logs "$cid" || true
           exit 1
 
-      - name: Remove binary from gitignore for Railway upload
+      - name: Allow binary in Railway upload
         run: |
-          # Railway respects .gitignore, so we need to remove the binary exclusion
-          sed -i '/masc-mcp-linux-x64/d' .gitignore
-          echo "Modified .gitignore:"
-          tail -5 .gitignore
+          # Railway CLI respects .gitignore. Instead of mutating .gitignore
+          # (which could affect later steps), force-add the binary to git's
+          # index so Railway includes it in the upload.
+          git add -f masc-mcp-linux-x64
 
       - name: Install Railway CLI
         run: npm install -g @railway/cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,11 @@ WORKDIR /app
 COPY masc-mcp-linux-x64 /app/masc-mcp
 RUN chmod +x /app/masc-mcp
 
+# Create non-root user for runtime
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
 # Create data directory for JSONL fallback
-RUN mkdir -p /app/.masc
+RUN mkdir -p /app/.masc && chown -R appuser:appgroup /app/.masc
 
 # LLM cascade config (GLM-only for Railway, no local llama-server)
 COPY config/llm_cascade.json /app/config/llm_cascade.json
@@ -34,5 +37,7 @@ ENV MASC_BASE_PATH=/app
 ENV MASC_WORKSPACE_ROOT=/app
 
 EXPOSE 8080
+
+USER appuser
 
 CMD ["/app/masc-mcp", "--port", "8080", "--base-path", "/app"]

--- a/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
+++ b/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
@@ -2,13 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- Dev instance (port 8935). Prod uses com.jeong-sik.masc-mcp-prod (port 8945, see scripts/deploy.sh). -->
     <key>Label</key>
     <string>com.jeong-sik.masc-mcp</string>
 
+    <!-- NOTE: Paths below are machine-specific. Adjust for your setup:
+         - ProgramArguments: path to start-masc-mcp.sh in the repo
+         - StandardOutPath/StandardErrorPath: log directory
+         - ME_ROOT / MASC_BASE_PATH / WorkingDirectory: your ME_ROOT -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/dancer/me/scripts/launchd/masc-mcp-start.sh</string>
+        <string>/Users/dancer/me/workspace/yousleepwhen/masc-mcp/start-masc-mcp.sh</string>
         <string>--http</string>
         <string>--port</string>
         <string>8935</string>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -19,23 +19,32 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 TODAY="$(date +%Y-%m-%d)"
 
-echo "🔄 Bumping release version to $NEW_VERSION"
+# Cross-platform sed -i: macOS uses sed -i '', GNU uses sed -i
+sedi() {
+  if sed --version 2>/dev/null | grep -q GNU; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+echo "Bumping release version to $NEW_VERSION"
 
 # 1) SSOT: dune-project
-sed -i '' -E "s/^\(version [^)]+\)$/\(version $NEW_VERSION\)/" \
+sedi -E "s/^\(version [^)]+\)$/\(version $NEW_VERSION\)/" \
   "$ROOT_DIR/dune-project"
-echo "✅ dune-project"
+echo "  dune-project updated"
 
 # 2) README badge
-sed -i '' -E "s/version-[0-9]+\.[0-9]+\.[0-9]+-blue/version-$NEW_VERSION-blue/" \
+sedi -E "s/version-[0-9]+\.[0-9]+\.[0-9]+-blue/version-$NEW_VERSION-blue/" \
   "$ROOT_DIR/README.md"
-echo "✅ README.md badge"
+echo "  README.md badge updated"
 
 # 3) opam metadata (if tracked)
 if [ -f "$ROOT_DIR/masc_mcp.opam" ]; then
-  sed -i '' -E "s/^version: \".*\"/version: \"$NEW_VERSION\"/" \
+  sedi -E "s/^version: \".*\"/version: \"$NEW_VERSION\"/" \
     "$ROOT_DIR/masc_mcp.opam"
-  echo "✅ masc_mcp.opam"
+  echo "  masc_mcp.opam updated"
 fi
 
 # 4) CHANGELOG stub (prepend if missing)
@@ -58,9 +67,9 @@ if ! grep -q "^## \[$NEW_VERSION\]" "$ROOT_DIR/CHANGELOG.md"; then
     { print }
   ' "$ROOT_DIR/CHANGELOG.md" > "$tmp_file"
   mv "$tmp_file" "$ROOT_DIR/CHANGELOG.md"
-  echo "✅ CHANGELOG.md stub added"
+  echo "  CHANGELOG.md stub added"
 else
-  echo "ℹ️ CHANGELOG already has $NEW_VERSION entry"
+  echo "  CHANGELOG already has $NEW_VERSION entry"
 fi
 
 echo ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -110,12 +110,16 @@ if [ "$USE_LAUNCHD" = true ]; then
 else
     echo "==> Starting prod on :$PROD_PORT..." >&2
 
-    if [ -f "$HOME/.zshenv" ]; then
-        set -a; source "$HOME/.zshenv" 2>/dev/null || true; set +a
-    fi
+    # Load secrets needed at runtime (GRAPHQL_API_KEY, SSL_CERT_FILE, etc.)
+    # Only repo-local env files are loaded; ~/.zshenv is intentionally skipped
+    # to avoid environment contamination from user shell configuration.
+    # Required env vars should be set in config/lodge.env or the repo .env files.
     LODGE_ENV="$REPO_DIR/config/lodge.env"
     if [ -f "$LODGE_ENV" ]; then
         set -a; source "$LODGE_ENV" 2>/dev/null || true; set +a
+    fi
+    if [ -f "$REPO_DIR/.env" ]; then
+        set -a; source "$REPO_DIR/.env" 2>/dev/null || true; set +a
     fi
 
     mkdir -p "$LOG_DIR"
@@ -164,6 +168,21 @@ else
         # Restart with previous binary
         if [ "$USE_LAUNCHD" = true ]; then
             launchctl load "$LAUNCHD_PLIST"
+        else
+            echo "    Restarting previous binary on :$PROD_PORT..." >&2
+            if [ -f "$HOME/.zshenv" ]; then
+                set -a; source "$HOME/.zshenv" 2>/dev/null || true; set +a
+            fi
+            MASC_ORCHESTRATOR_ENABLED=0 \
+            MASC_AUTO_RESPOND=true \
+                nohup "$RELEASE_EXE" \
+                    --port="$PROD_PORT" \
+                    --base-path="$BASE_PATH" \
+                >> "$LOG_DIR/masc-prod.out.log" \
+                2>> "$LOG_DIR/masc-prod.err.log" &
+            ROLLBACK_PID=$!
+            echo "$ROLLBACK_PID" > "$PID_FILE"
+            echo "    Rollback started with PID $ROLLBACK_PID" >&2
         fi
     fi
     exit 1

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Pin private/external opam dependencies that are not published on opam-repository.
+#
+# NOTE: These pins use branch refs (#main) intentionally. These are private
+# first-party packages where we control both sides. Version constraints for
+# compatibility are declared in masc_mcp.opam (e.g., mcp_protocol >= 0.13.0).
+# If you need reproducible builds, pin to a specific commit SHA instead:
+#   opam pin add <pkg> <url>#<commit-sha> -n -y
 set -euo pipefail
 
 include_bisect=false

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -84,6 +84,9 @@ load_env_file() {
 REPO_ENV_ROOT="$(resolve_repo_env_root)"
 
 # Load secrets from the user profile; tracked plist files must not embed them.
+# NOTE: This intentionally sources ~/.zshenv which may set PATH and other vars.
+# For isolated production deploys, use scripts/deploy.sh which loads only
+# repo-local env files (config/lodge.env, .env) to avoid contamination.
 load_env_file "$HOME/.zshenv"
 
 # Load repo-local env for development overrides and secrets kept out of user shell.

--- a/test/dune
+++ b/test/dune
@@ -479,10 +479,10 @@
  (name test_code_navigation_eio)
  (modules test_code_navigation_eio)
  (libraries masc_mcp alcotest eio eio_main yojson unix))
-; TODO: These tests need to be created
-; - test_dtls_eio
-; - test_sctp_eio
-; - test_webrtc_stack_eio
+; Missing transport tests (tracked in GitHub Issues):
+; - test_dtls_eio: https://github.com/jeong-sik/masc-mcp/issues/1499
+; - test_sctp_eio: https://github.com/jeong-sik/masc-mcp/issues/1499
+; - test_webrtc_stack_eio: https://github.com/jeong-sik/masc-mcp/issues/1499
 
 ; ============================================================
 ; Eio-native tests (OCaml 5.x concurrency)

--- a/test/test_concurrent_distributed.ml
+++ b/test/test_concurrent_distributed.ml
@@ -98,10 +98,13 @@ let verify () =
   let max_seq = List.hd (List.rev seqs_sorted) in
   let expected = max_seq - min_seq + 1 in
 
+  let has_gaps = ref false in
   if total = expected then
-    Printf.printf "✅ No gaps detected (seq %d to %d)\n%!" min_seq max_seq
-  else
-    Printf.printf "⚠️ Possible gaps: expected %d messages, found %d\n%!" expected total;
+    Printf.printf "No gaps detected (seq %d to %d)\n%!" min_seq max_seq
+  else begin
+    Printf.printf "SEQUENCE GAPS DETECTED: expected %d messages, found %d (seq %d to %d)\n%!" expected total min_seq max_seq;
+    has_gaps := true
+  end;
 
   (* Verify each worker's messages are in order *)
   Printf.printf "\n--- Per-worker message ordering ---\n%!";
@@ -124,19 +127,22 @@ let verify () =
       | a :: b :: rest -> a < b && is_ascending (b :: rest)
     in
     if is_ascending sorted then
-      Printf.printf "  Worker %s: %d messages, ordered ✓\n%!" wid (List.length sorted)
+      Printf.printf "  Worker %s: %d messages, ordered\n%!" wid (List.length sorted)
     else begin
-      Printf.printf "  Worker %s: %d messages, NOT ordered ✗\n%!" wid (List.length sorted);
+      Printf.printf "  Worker %s: %d messages, NOT ordered\n%!" wid (List.length sorted);
       all_ordered := false
     end
   ) worker_msgs;
 
-  if total > 0 && !all_ordered then begin
-    Printf.printf "\n✅ CONCURRENT DISTRIBUTED TEST PASSED\n%!";
-    Printf.printf "   No collisions, all messages accounted for\n%!";
+  if total > 0 && !all_ordered && not !has_gaps then begin
+    Printf.printf "\nCONCURRENT DISTRIBUTED TEST PASSED\n%!";
+    Printf.printf "   No collisions, no gaps, all messages accounted for\n%!";
     exit 0
   end else begin
-    Printf.printf "\n❌ TEST FAILED\n%!";
+    Printf.printf "\nTEST FAILED";
+    if !has_gaps then Printf.printf " (sequence gaps detected)";
+    if not !all_ordered then Printf.printf " (ordering violations)";
+    Printf.printf "\n%!";
     exit 1
   end
 

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -49,7 +49,9 @@ let test_router_prefix_specificity () =
   let request = Httpun.Request.create `GET "/dashboard/assets/index.css" in
   (* Httpun.Reqd.t is opaque and cannot be constructed outside the HTTP
      stack. The test handlers ignore the reqd parameter entirely.
-     TODO: extract Router.resolve to remove this unsafe cast. *)
+     This unsafe cast is a known limitation; Router.dispatch should be
+     refactored to separate route resolution from request handling.
+     See: https://github.com/jeong-sik/masc-mcp/issues/1498 *)
   Router.dispatch routes request (Obj.magic () : Httpun.Reqd.t);
   Alcotest.(check string) "longest prefix route should win" "asset" !matched
 

--- a/test/test_transport_grpc_next_coverage.ml
+++ b/test/test_transport_grpc_next_coverage.ml
@@ -98,8 +98,9 @@ let test_check_dependencies () =
   | _ -> fail "expected Available"
 
 let test_service_status_not_installed () =
-  let _ : Transport_grpc_next.service_status = Transport_grpc_next.NotInstalled in
-  ()
+  let status : Transport_grpc_next.service_status = Transport_grpc_next.NotInstalled in
+  check bool "is not installed" true
+    (match status with Transport_grpc_next.NotInstalled -> true | _ -> false)
 
 let test_service_status_running () =
   let status : Transport_grpc_next.service_status =


### PR DESCRIPTION
## Summary

인프라 버그 15개 일괄 수정. deploy, CI, Docker, launchd, 테스트 전반.

| Issue | Fix |
|-------|-----|
| #1485 | fork PR에서 sync check skip |
| #1486 | railway smoke test가 deploy 차단 |
| #1487 | healthcheck 실패 시 rollback restart |
| #1488 | bump-version.sh GNU/BSD sed 호환 |
| #1490 | branch pin 의도 문서화 |
| #1491 | Docker non-root user |
| #1492 | launchd plist 스크립트 경로 수정 |
| #1493 | plist 절대경로 문서화 |
| #1494 | dev/prod label 차이 문서화 |
| #1495 | deploy.sh에서 ~/.zshenv sourcing 제거 |
| #1496 | gRPC transport 테스트에 assertion 추가 |
| #1497 | verifier sequence gap 감지 시 exit 1 |
| #1498 | Obj.magic cast 제한사항 문서화 |
| #1499 | TODO를 GitHub issue ref로 교체 |
| #1500 | CI에서 .gitignore 변경 대신 git add -f |

12 files, +97/-40 lines.

## Test plan
- [x] `dune build --root .` passes
- [ ] CI green (deploy workflow changes need runtime verification)

Closes #1485 #1486 #1487 #1488 #1490 #1491 #1492 #1493 #1494 #1495 #1496 #1497 #1498 #1499 #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)