### PR TITLE
refactor: convert council/mitosis to run_named, delete dead code

### DIFF
--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -102,7 +102,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
   let max_rounds = 3 in
   let guardrails = Verifier_oas.eval_gate_to_oas_guardrails gate_config in
   match Keeper_oas_adapter.run_with_tools
-    ~config ~meta ~system_prompt
+    ~config ~meta ~cascade_name:"keeper_autonomy" ~system_prompt
     ~goal:"Execute the first step of the plan now."
     ~max_turns:max_rounds
     ~temperature:0.3

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -182,6 +182,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                       "You are " ^ meta.name
                       ^ ", a keeper agent. Respond with JSON only."
                     in
+                    (* model_specs retained for cost estimation only *)
                     let model_specs =
                       Llm_types.available_model_specs_of_strings meta.models
                     in
@@ -189,6 +190,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                       Keeper_oas_adapter.run_simple
                         ~config:ctx.config
                         ~meta
+                        ~cascade_name:"keeper_proactive"
                         ~system_prompt:system
                         ~prompt
                         ~temperature:0.3

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -252,6 +252,7 @@ let run_social_board_event_turn
           let (oas_result, total_latency_ms) = Llm_types.timed (fun () ->
               Keeper_oas_adapter.run_with_tools
                 ~config:ctx.config ~meta
+                ~cascade_name:"keeper_social"
                 ~system_prompt ~goal
                 ~max_turns:max_tool_rounds
                 ~temperature:(Keeper_config.keeper_planning_temp ())

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -1,53 +1,27 @@
-(** Keeper_oas_adapter — OAS Agent.run wrappers for keeper LLM calls.
+(** Keeper_oas_adapter — OAS wrappers for keeper LLM calls.
 
-    Delegates to [Oas_worker.run] (no tools) or [Oas_worker.run_with_masc_tools]
-    (with keeper tool dispatch).
+    Delegates to [Oas_worker.run_named] / [run_named_with_masc_tools]
+    (cascade-name-based, no model_spec construction) or to
+    [Llm_cascade.call_with_tools] for single-shot cascade calls.
 
-    @since OAS migration Phase 1 *)
+    @since OAS migration Phase 1
+    @since LLM-free cascade Phase 2 *)
 
 open Keeper_types
 open Keeper_exec_tools
 
 (* ================================================================ *)
-(* Internal: resolve model spec from keeper meta                     *)
+(* Internal: tool dispatch                                           *)
 (* ================================================================ *)
 
-let resolve_primary_model_spec (meta : keeper_meta) :
-    (Llm_types.model_spec, string) result =
-  let labels =
-    match Keeper_exec_status.active_model_of_meta meta with
-    | "" ->
-      let pool = dedupe_keep_order (meta.allowed_models @ meta.models) in
-      if pool = [] then meta.models else pool
-    | model -> [model]
-  in
-  match model_specs_of_strings labels with
-  | Error e -> Error e
-  | Ok [] -> Error "no model specs resolved"
-  | Ok (primary :: _) -> Ok primary
+(** Default context window for tool dispatch scratch context. *)
+let tool_dispatch_max_context = 8192
 
-let require_net () =
-  match Eio_context.get_net_opt () with
-  | Some net -> Ok net
-  | None -> Error "Eio net not available (keeper running outside server context)"
-
-let require_switch () =
-  match Eio_context.get_switch_opt () with
-  | Some sw -> Ok sw
-  | None -> Error "Eio switch not available (keeper running outside server context)"
-
-(* ================================================================ *)
-(* Internal: keeper tool dispatch closure for OAS                    *)
-(* ================================================================ *)
-
-(** Build a dispatch closure compatible with [Oas_worker.run_with_masc_tools].
-    Creates a minimal [Context_manager.working_context] for tool execution. *)
 let make_dispatch ~(config : Room.config) ~(meta : keeper_meta)
-    ~(model_spec : Llm_types.model_spec)
     ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
   let ctx_work = Context_manager.create
     ~system_prompt:(Printf.sprintf "Keeper %s OAS tool dispatch" meta.name)
-    ~max_tokens:model_spec.max_context
+    ~max_tokens:tool_dispatch_max_context
   in
   let tc : Llm_types.tool_call = {
     call_id = "";
@@ -77,6 +51,7 @@ type tools_run_result = {
 let run_with_tools
     ~(config : Room.config)
     ~(meta : keeper_meta)
+    ~(cascade_name : string)
     ~(system_prompt : string)
     ~(goal : string)
     ~(max_turns : int)
@@ -85,33 +60,15 @@ let run_with_tools
     ?(guardrails : Agent_sdk.Guardrails.t option)
     ()
   : (tools_run_result, string) result =
-  match resolve_primary_model_spec meta with
-  | Error e -> Error e
-  | Ok model_spec ->
-  match require_net () with
-  | Error e -> Error e
-  | Ok net ->
-  match require_switch () with
-  | Error e -> Error e
-  | Ok sw ->
   let masc_tools = keeper_allowed_llm_tools meta in
   let tools_executed_ref = ref [] in
   let dispatch ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
     tools_executed_ref := name :: !tools_executed_ref;
-    make_dispatch ~config ~meta ~model_spec ~name ~args
+    make_dispatch ~config ~meta ~name ~args
   in
-  let oas_config = { (Oas_worker.default_config
-    ~name:(Printf.sprintf "keeper-%s" meta.name)
-    ~model_spec
-    ~system_prompt
-    ~tools:[]) with
-    max_turns;
-    max_tokens;
-    temperature;
-    guardrails;
-  } in
-  match Oas_worker.run_with_masc_tools
-    ~sw ~net ~config:oas_config ~masc_tools ~dispatch goal
+  match Oas_worker.run_named_with_masc_tools
+    ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch
+    ~max_turns ~temperature ~max_tokens ?guardrails ()
   with
   | Ok oas_result ->
       Ok { oas_result; tools_executed = List.rev !tools_executed_ref }
@@ -124,31 +81,15 @@ let run_with_tools
 let run_simple
     ~(config : Room.config)
     ~(meta : keeper_meta)
+    ~(cascade_name : string)
     ~(system_prompt : string)
     ~(prompt : string)
     ~(temperature : float)
     ~(max_tokens : int)
   : (Oas_worker.run_result, string) result =
-  ignore config;
-  match resolve_primary_model_spec meta with
-  | Error e -> Error e
-  | Ok model_spec ->
-  match require_net () with
-  | Error e -> Error e
-  | Ok net ->
-  match require_switch () with
-  | Error e -> Error e
-  | Ok sw ->
-  let oas_config = { (Oas_worker.default_config
-    ~name:(Printf.sprintf "keeper-%s-simple" meta.name)
-    ~model_spec
-    ~system_prompt
-    ~tools:[]) with
-    max_turns = 1;
-    max_tokens;
-    temperature;
-  } in
-  Oas_worker.run ~sw ~net ~config:oas_config prompt
+  ignore (config, meta);
+  Oas_worker.run_named ~cascade_name ~goal:prompt ~system_prompt
+    ~max_turns:1 ~temperature ~max_tokens ()
 
 (* ================================================================ *)
 (* Public: result extractors                                         *)
@@ -164,12 +105,10 @@ let model_of_run_result (r : Oas_worker.run_result) : string =
   r.response.model
 
 (* ================================================================ *)
-(* Internal: extract OAS parameters from completion_request list    *)
+(* Internal: extract prompt from completion_request list             *)
 (* ================================================================ *)
 
-type cascade_params = {
-  primary_spec : Llm_types.model_spec;
-  fallback_specs : Llm_types.model_spec list;
+type prompt_params = {
   system_prompt : string;
   goal : string;
   temperature : float;
@@ -194,21 +133,18 @@ let messages_to_goal_text (msgs : Agent_sdk.Types.message list) : string =
   |> List.filter (fun s -> String.length s > 0)
   |> String.concat "\n"
 
-let cascade_config_of_requests
+let extract_prompt_params
     (requests : Llm_types.completion_request list)
-  : (cascade_params, string) result =
+  : (prompt_params, string) result =
   match requests with
   | [] -> Error "empty cascade request list"
-  | first :: rest ->
+  | first :: _ ->
       let sys_prompt, user_msgs = separate_system_and_user first.messages in
       let goal = messages_to_goal_text user_msgs in
       if String.length goal = 0 then
         Error "no user messages in cascade request"
       else
         Ok {
-          primary_spec = first.model;
-          fallback_specs =
-            List.map (fun (r : Llm_types.completion_request) -> r.model) rest;
           system_prompt = sys_prompt;
           goal;
           temperature = first.temperature;
@@ -216,11 +152,11 @@ let cascade_config_of_requests
         }
 
 (* ================================================================ *)
-(* Public: cascade through OAS Agent.t                              *)
+(* Public: cascade through Llm_cascade (single-shot, no Agent loop) *)
 (* ================================================================ *)
 
-let run_cascade ?timeout_sec requests =
-  match cascade_config_of_requests requests with
+let run_cascade ?(cascade_name = "keeper_turn") ?timeout_sec requests =
+  match extract_prompt_params requests with
   | Error e -> Error e
   | Ok params ->
   let messages : Llm_provider.Types.message list =
@@ -229,15 +165,13 @@ let run_cascade ?timeout_sec requests =
      else [])
     @ [ Llm_provider.Types.user_msg params.goal ]
   in
-  Llm_cascade.call_with_tools ~cascade_name:"keeper_autonomy" ~messages
+  Llm_cascade.call_with_tools ~cascade_name ~messages
     ~temperature:params.temperature ~max_tokens:params.max_tokens
     ?timeout_sec ()
 
-let run_cascade_stream ?timeout_sec ~on_event request ~fallback =
-  (* Batch fallback with synthetic SSE events.
-     All calls route through Llm_cascade. *)
+let run_cascade_stream ?(cascade_name = "keeper_turn") ?timeout_sec ~on_event request ~fallback =
   let timeout_int = Option.map int_of_float timeout_sec in
-  match run_cascade ?timeout_sec:timeout_int (request :: fallback) with
+  match run_cascade ~cascade_name ?timeout_sec:timeout_int (request :: fallback) with
   | Ok resp ->
       let text = Llm_types.text_of_response resp in
       on_event (Llm_provider.Types.MessageStart {

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -1,9 +1,11 @@
-(** Keeper_oas_adapter — OAS Agent.run wrappers for keeper LLM calls.
+(** Keeper_oas_adapter — OAS wrappers for keeper LLM calls.
 
-    Uses [Oas_worker] for agent build/run and [keeper_exec_tools] for
-    tool dispatch.
+    Uses cascade-name-based model resolution (no [model_spec] construction).
+    Delegates to [Oas_worker.run_named] for agent loops and
+    [Llm_cascade.call_with_tools] for single-shot cascade calls.
 
-    @since OAS migration Phase 1 *)
+    @since OAS migration Phase 1
+    @since LLM-free cascade Phase 2 *)
 
 open Keeper_types
 
@@ -14,11 +16,12 @@ type tools_run_result = {
 }
 
 (** Tool loop LLM call (proactive, autonomy, social board events).
-    Wraps [Oas_worker.run_with_masc_tools] with keeper tool dispatch.
-    Returns tool execution history alongside OAS result. *)
+    Wraps [Oas_worker.run_named_with_masc_tools] with keeper tool dispatch.
+    [cascade_name] selects the model cascade (e.g. "keeper_autonomy"). *)
 val run_with_tools :
   config:Room.config ->
   meta:keeper_meta ->
+  cascade_name:string ->
   system_prompt:string ->
   goal:string ->
   max_turns:int ->
@@ -29,10 +32,12 @@ val run_with_tools :
   (tools_run_result, string) result
 
 (** Tool-free LLM call (deliberation, correction, forced grounding).
-    Wraps [Oas_worker.run] without tools. *)
+    Wraps [Oas_worker.run_named] without tools. Single turn.
+    [cascade_name] selects the model cascade (e.g. "keeper_deliberation"). *)
 val run_simple :
   config:Room.config ->
   meta:keeper_meta ->
+  cascade_name:string ->
   system_prompt:string ->
   prompt:string ->
   temperature:float ->
@@ -49,40 +54,22 @@ val usage_of_run_result : Oas_worker.run_result -> Llm_types.token_usage
 (** Extract model ID string from an OAS run result. *)
 val model_of_run_result : Oas_worker.run_result -> string
 
-(** Parameters extracted from a cascade request list for OAS execution. *)
-type cascade_params = {
-  primary_spec : Llm_types.model_spec;
-  fallback_specs : Llm_types.model_spec list;
-  system_prompt : string;
-  goal : string;
-  temperature : float;
-  max_tokens : int;
-}
-
-(** Extract OAS execution parameters from a cascade request list.
-    Separates system messages into [system_prompt], remaining messages
-    into [goal] text. Returns [Error] on empty list or no user messages. *)
-val cascade_config_of_requests :
-  Llm_types.completion_request list ->
-  (cascade_params, string) result
-
-(** Cascade through OAS Agent.t — tries each model spec in order via
-    [Oas_worker.run]. Falls back to next model on failure.
-    Prefer [run_with_tools] or [run_simple] for new code. *)
+(** Cascade through [Llm_cascade.call_with_tools] — single-shot, no agent loop.
+    [cascade_name] defaults to ["keeper_turn"]. Model specs in the
+    [completion_request] list are ignored; only prompt/system/temperature
+    are extracted. *)
 val run_cascade :
+  ?cascade_name:string ->
   ?timeout_sec:int ->
   Llm_types.completion_request list ->
   (Llm_provider.Types.api_response, string) result
 
-(** Streaming cascade — batch call with synthetic SSE events.
-    Falls back to OAS batch [run_cascade] on streaming failure. *)
+(** Streaming cascade with synthetic SSE events.
+    [cascade_name] defaults to ["keeper_turn"]. *)
 val run_cascade_stream :
+  ?cascade_name:string ->
   ?timeout_sec:float ->
   on_event:(Llm_provider.Types.sse_event -> unit) ->
   Llm_types.completion_request ->
   fallback:Llm_types.completion_request list ->
   (Llm_provider.Types.api_response, string) result
-
-(** Expose model spec resolution for testing. *)
-val resolve_primary_model_spec :
-  keeper_meta -> (Llm_types.model_spec, string) result

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -128,6 +128,8 @@ let default_model_strings ~cascade_name =
   | "spawn_glm" ->
       labels_of [ ("glm", glm_model); ("glm", glm_flash) ]
       @ [ "glm:auto" ]
+  (* mitosis — cell division / handoff *)
+  | "mitosis" -> llama_glm
   (* topic extraction — fast local model, glm fallback *)
   | "topic_extraction" -> llama_glm
   (* unregistered cascade: llama + glm as safety net *)

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -87,17 +87,18 @@ let default_model_strings ~cascade_name =
   | "lodge_comment" | "lodge_agent_match" ->
       llama_glm
   (* gardener — llama first, glm fallback *)
-  | "gardener_spawn" -> llama_glm
+  | "gardener_spawn" | "gardener_retire" -> llama_glm
   (* classification — local llama, glm fallback *)
   | "classification" | "context_router" | "capability_match" -> llama_glm
   (* theory of mind — local llama, glm fallback *)
   | "tom" -> llama_glm
   (* verifier — local llama, glm fallback *)
-  | "verifier" | "code_swarm_verify" -> llama_glm
+  | "verifier" | "code_swarm_verify" | "code_swarm" -> llama_glm
   (* keeper — local llama, glm fallback *)
-  | "keeper_autonomy" -> llama_glm
+  | "keeper_autonomy" | "keeper_proactive" | "keeper_deliberation"
+  | "keeper_reply" | "keeper_social" | "keeper_turn" -> llama_glm
   (* routing — local llama, glm fallback *)
-  | "routing_judge" -> llama_glm
+  | "routing_judge" | "team_router" -> llama_glm
   (* chain — local llama, glm fallback *)
   | "chain_llm" -> llama_glm
   (* autoresearch — local llama, glm fallback *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -213,3 +213,74 @@ let run_with_masc_tools
   ) masc_tools in
   let config = { config with tools = oas_tools @ config.tools } in
   run ~sw ~net ~config goal
+
+(* ================================================================ *)
+(* Named cascade API — callers pass cascade_name, not model_spec    *)
+(* ================================================================ *)
+
+let require_eio () =
+  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+  | Some sw, Some net -> Ok (sw, net)
+  | None, _ -> Error "Eio switch not available (running outside server context)"
+  | _, None -> Error "Eio net not available (running outside server context)"
+
+let resolve_cascade ~cascade_name =
+  match Llm_cascade.get_cascade ~cascade_name () with
+  | [] ->
+    Error (Printf.sprintf "No models available for cascade '%s'" cascade_name)
+  | spec :: _ -> Ok spec
+
+let run_named
+    ~cascade_name
+    ~goal
+    ?(system_prompt = "")
+    ?(tools = [])
+    ?(max_turns = 20)
+    ?(temperature = 0.7)
+    ?(max_tokens = 4096)
+    ?guardrails
+    ()
+  : (run_result, string) result =
+  match require_eio () with
+  | Error e -> Error e
+  | Ok (sw, net) ->
+  match resolve_cascade ~cascade_name with
+  | Error e -> Error e
+  | Ok model_spec ->
+  let name = Printf.sprintf "oas-%s" cascade_name in
+  let config = { (default_config ~name ~model_spec ~system_prompt ~tools) with
+    max_turns;
+    max_tokens;
+    temperature;
+    guardrails;
+    description = Some (Printf.sprintf "cascade:%s" cascade_name);
+  } in
+  run ~sw ~net ~config goal
+
+let run_named_with_masc_tools
+    ~cascade_name
+    ~goal
+    ?(system_prompt = "")
+    ~(masc_tools : Llm_types.tool_def list)
+    ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
+    ?(max_turns = 20)
+    ?(temperature = 0.7)
+    ?(max_tokens = 4096)
+    ?guardrails
+    ()
+  : (run_result, string) result =
+  match require_eio () with
+  | Error e -> Error e
+  | Ok (sw, net) ->
+  match resolve_cascade ~cascade_name with
+  | Error e -> Error e
+  | Ok model_spec ->
+  let name = Printf.sprintf "oas-%s" cascade_name in
+  let config = { (default_config ~name ~model_spec ~system_prompt ~tools:[]) with
+    max_turns;
+    max_tokens;
+    temperature;
+    guardrails;
+    description = Some (Printf.sprintf "cascade:%s" cascade_name);
+  } in
+  run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch goal

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -54,3 +54,34 @@ val run_with_masc_tools :
   dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
   string ->
   (run_result, string) result
+
+(** {2 Named cascade API}
+
+    Callers pass a [cascade_name] string instead of constructing
+    [Llm_types.model_spec]. Model resolution is delegated to
+    [Llm_cascade.get_cascade]. *)
+
+val run_named :
+  cascade_name:string ->
+  goal:string ->
+  ?system_prompt:string ->
+  ?tools:Oas.Tool.t list ->
+  ?max_turns:int ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?guardrails:Oas.Guardrails.t ->
+  unit ->
+  (run_result, string) result
+
+val run_named_with_masc_tools :
+  cascade_name:string ->
+  goal:string ->
+  ?system_prompt:string ->
+  masc_tools:Llm_types.tool_def list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
+  ?max_turns:int ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?guardrails:Oas.Guardrails.t ->
+  unit ->
+  (run_result, string) result

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -273,56 +273,46 @@ let handle_execute _ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
-    let model_spec = Llm_types.default_local_model_spec () in
     let system_prompt =
       "You are a governance deliberation agent for the MASC multi-agent system. \
        Evaluate the following topic and produce a structured decision. \
        Include: (1) your reasoning, (2) identified risks, (3) recommended action. \
        Be concise and actionable." in
-    let config = Oas_worker.default_config
-      ~name:"council-deliberation"
-      ~model_spec ~system_prompt ~tools:[] in
-    match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-    | Some sw, Some net ->
-      (match Oas_worker.run ~sw ~net ~config topic with
-       | Ok result ->
-         json_ok (`Assoc [
-           ("topic", `String topic);
-           ("deliberation", `String (Llm_types.text_of_response result.response));
-           ("turns", `Int result.turns);
-           ("session_id", `String result.session_id);
-           ("runtime", `String "oas");
-         ])
-       | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e))
-    | _ -> json_err "Eio context (switch/net) not available for OAS execution"
+    match Oas_worker.run_named
+      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ()
+    with
+    | Ok result ->
+      json_ok (`Assoc [
+        ("topic", `String topic);
+        ("deliberation", `String (Llm_types.text_of_response result.response));
+        ("turns", `Int result.turns);
+        ("session_id", `String result.session_id);
+        ("runtime", `String "oas");
+      ])
+    | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e)
 
 let handle_execute_dry_run _ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
-    let model_spec = Llm_types.default_local_model_spec () in
     let system_prompt =
       "You are a governance analysis agent for the MASC multi-agent system (DRY RUN mode). \
        Analyze the following topic WITHOUT committing any changes. \
        Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed. \
        This is analysis only — no actions will be taken." in
-    let config = Oas_worker.default_config
-      ~name:"council-dry-run"
-      ~model_spec ~system_prompt ~tools:[] in
-    match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-    | Some sw, Some net ->
-      (match Oas_worker.run ~sw ~net ~config topic with
-       | Ok result ->
-         json_ok (`Assoc [
-           ("topic", `String topic);
-           ("analysis", `String (Llm_types.text_of_response result.response));
-           ("turns", `Int result.turns);
-           ("session_id", `String result.session_id);
-           ("dry_run", `Bool true);
-           ("runtime", `String "oas");
-         ])
-       | Error e -> json_err (Printf.sprintf "Dry-run analysis failed: %s" e))
-    | _ -> json_err "Eio context (switch/net) not available for OAS execution"
+    match Oas_worker.run_named
+      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ()
+    with
+    | Ok result ->
+      json_ok (`Assoc [
+        ("topic", `String topic);
+        ("analysis", `String (Llm_types.text_of_response result.response));
+        ("turns", `Int result.turns);
+        ("session_id", `String result.session_id);
+        ("dry_run", `Bool true);
+        ("runtime", `String "oas");
+      ])
+    | Error e -> json_err (Printf.sprintf "Dry-run analysis failed: %s" e)
 
 (* ================================================================ *)
 (* Schemas — reuse from legacy Tool_council                          *)

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -179,14 +179,9 @@ let handle_mitosis_divide ctx args : result =
   in
   let dna = Mitosis.extract_dna ~config ~parent_cell:cell ~full_context in
   let next_gen = cell.Mitosis.generation + 1 in
-  let model_spec = Llm_types.default_local_model_spec () in
-  let oas_config = Oas_worker.default_config
-    ~name:(Printf.sprintf "mitosis-child-gen%d" next_gen)
-    ~model_spec
-    ~system_prompt:(Printf.sprintf
-      "You are a continuation agent (generation %d). Previous context DNA:\n\n%s"
-      next_gen dna)
-    ~tools:[]
+  let system_prompt = Printf.sprintf
+    "You are a continuation agent (generation %d). Previous context DNA:\n\n%s"
+    next_gen dna
   in
   let goal =
     if current_task <> "" then
@@ -195,16 +190,10 @@ let handle_mitosis_divide ctx args : result =
     else
       Printf.sprintf "Continue from generation %d. Context: %s" next_gen summary
   in
-  match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
-  | None, _ -> json_err "Eio net not available for OAS agent"
-  | _, None -> json_err "Eio switch not available for OAS agent"
-  | Some net, Some sw ->
   let run_result =
-    Oas_worker.run_with_masc_tools
-      ~sw ~net ~config:oas_config
-      ~masc_tools:ctx.masc_tools
-      ~dispatch:ctx.dispatch
-      goal
+    Oas_worker.run_named_with_masc_tools
+      ~cascade_name:"mitosis" ~goal ~system_prompt
+      ~masc_tools:ctx.masc_tools ~dispatch:ctx.dispatch ()
   in
   (* Update MASC L3 state regardless of run outcome *)
   let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
@@ -260,28 +249,18 @@ let handle_mitosis_handoff ctx args : result =
     (* Phase 2: Run successor agent *)
     let target = get_string args "target_agent" "claude" in
     let next_gen = prepared_cell.Mitosis.generation + 1 in
-    let model_spec = Llm_types.default_local_model_spec () in
-    let successor_config = Oas_worker.default_config
-      ~name:(Printf.sprintf "mitosis-gen%d" next_gen)
-      ~model_spec
-      ~system_prompt:(Printf.sprintf
-        "You are generation %d. Continue from this DNA:\n\n%s"
-        next_gen dna)
-      ~tools:[]
+    let system_prompt = Printf.sprintf
+      "You are generation %d. Continue from this DNA:\n\n%s"
+      next_gen dna
     in
     let goal = Printf.sprintf
       "You are the successor agent (generation %d). Resume work from the handoff DNA above. Context ratio was %.1f%%."
       next_gen (context_ratio *. 100.0)
     in
-    let run_result = match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
-      | None, _ -> Error "Eio net not available"
-      | _, None -> Error "Eio switch not available"
-      | Some net, Some sw ->
-        Oas_worker.run_with_masc_tools
-          ~sw ~net ~config:successor_config
-          ~masc_tools:ctx.masc_tools
-          ~dispatch:ctx.dispatch
-          goal
+    let run_result =
+      Oas_worker.run_named_with_masc_tools
+        ~cascade_name:"mitosis" ~goal ~system_prompt
+        ~masc_tools:ctx.masc_tools ~dispatch:ctx.dispatch ()
     in
     (* Update state regardless of run outcome *)
     let new_cell = Mitosis.create_stem_cell ~generation:next_gen in

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -302,17 +302,6 @@ let router_judge_model () =
   | Some _ as explicit -> explicit
   | None -> inferred_lead_model ()
 
-let llama_router_model_spec model_id =
-  {
-    Llm_types.provider = Llm_types.Llama;
-    model_id;
-    max_context = 262_144;
-    api_url = Env_config.Llama.server_url;
-    api_key_env = None;
-    cost_per_1k_input = 0.0;
-    cost_per_1k_output = 0.0;
-  }
-
 let classify_risk ~task_profile ~spawn_prompt ~spawn_role =
   let text = normalized_spawn_text ~spawn_prompt ~spawn_role in
   let base = default_risk_for_profile task_profile in


### PR DESCRIPTION
## Summary

Stacked on #1730.

- `tool_council_oas.ml`: `Oas_worker.run ~config` → `Oas_worker.run_named ~cascade_name:"governance_judge"` (2곳)
- `tool_mitosis_oas.ml`: `Oas_worker.run_with_masc_tools ~config` → `Oas_worker.run_named_with_masc_tools ~cascade_name:"mitosis"` (2곳)
- `tool_team_session_routing.ml`: `llama_router_model_spec` 삭제 (dead code, 호출처 0건)
- `llm_cascade.ml`: `"mitosis"` cascade name 등록

## Impact

`Oas_worker.default_config`의 외부 호출자가 **0건**으로 감소. Phase 4 (config.model_spec 필드 deprecate) 전제조건 충족.

## Test plan

- [x] `dune build --root .` 성공
- [x] `Oas_worker.default_config` 외부 호출자 0건 확인
- [x] `model_spec` 구성이 council/mitosis에서 완전 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)