### PR TITLE
refactor: restrict Oas_worker public API to named cascade only

### DIFF
--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -128,6 +128,8 @@ let default_model_strings ~cascade_name =
   | "spawn_glm" ->
       labels_of [ ("glm", glm_model); ("glm", glm_flash) ]
       @ [ "glm:auto" ]
+  (* mitosis — cell division / handoff *)
+  | "mitosis" -> llama_glm
   (* topic extraction — fast local model, glm fallback *)
   | "topic_extraction" -> llama_glm
   (* unregistered cascade: llama + glm as safety net *)

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -1,31 +1,13 @@
 (** Oas_worker — Unified entry point for OAS-based MASC tool modules.
 
-    @since Phase 1 — MASC→OAS migration *)
+    Callers pass a [cascade_name] string; model resolution is delegated
+    to [Llm_cascade.get_cascade].  Internal [config] / [build] / [run]
+    are implementation details and not exported.
+
+    @since Phase 1 — MASC→OAS migration
+    @since Phase 4 — public API restricted to named cascade functions *)
 
 module Oas = Agent_sdk
-
-type config = {
-  name : string;
-  model_spec : Llm_types.model_spec;
-  system_prompt : string;
-  tools : Oas.Tool.t list;
-  max_turns : int;
-  max_tokens : int;
-  temperature : float;
-  hooks : Oas.Hooks.hooks option;
-  guardrails : Oas.Guardrails.t option;
-  event_bus : Oas.Event_bus.t option;
-  checkpoint_dir : string option;
-  session_id : string option;
-  description : string option;
-}
-
-val default_config :
-  name:string ->
-  model_spec:Llm_types.model_spec ->
-  system_prompt:string ->
-  tools:Oas.Tool.t list ->
-  config
 
 type run_result = {
   response : Oas.Types.api_response;
@@ -33,33 +15,6 @@ type run_result = {
   session_id : string;
   turns : int;
 }
-
-val build :
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  config:config ->
-  (Oas.Agent.t, string) result
-
-val run :
-  sw:Eio.Switch.t ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  config:config ->
-  string ->
-  (run_result, string) result
-
-val run_with_masc_tools :
-  sw:Eio.Switch.t ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  config:config ->
-  masc_tools:Llm_types.tool_def list ->
-  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
-  string ->
-  (run_result, string) result
-
-(** {2 Named cascade API}
-
-    Callers pass a [cascade_name] string instead of constructing
-    [Llm_types.model_spec]. Model resolution is delegated to
-    [Llm_cascade.get_cascade]. *)
 
 val run_named :
   cascade_name:string ->

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -273,56 +273,46 @@ let handle_execute _ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
-    let model_spec = Llm_types.default_local_model_spec () in
     let system_prompt =
       "You are a governance deliberation agent for the MASC multi-agent system. \
        Evaluate the following topic and produce a structured decision. \
        Include: (1) your reasoning, (2) identified risks, (3) recommended action. \
        Be concise and actionable." in
-    let config = Oas_worker.default_config
-      ~name:"council-deliberation"
-      ~model_spec ~system_prompt ~tools:[] in
-    match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-    | Some sw, Some net ->
-      (match Oas_worker.run ~sw ~net ~config topic with
-       | Ok result ->
-         json_ok (`Assoc [
-           ("topic", `String topic);
-           ("deliberation", `String (Llm_types.text_of_response result.response));
-           ("turns", `Int result.turns);
-           ("session_id", `String result.session_id);
-           ("runtime", `String "oas");
-         ])
-       | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e))
-    | _ -> json_err "Eio context (switch/net) not available for OAS execution"
+    match Oas_worker.run_named
+      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ()
+    with
+    | Ok result ->
+      json_ok (`Assoc [
+        ("topic", `String topic);
+        ("deliberation", `String (Llm_types.text_of_response result.response));
+        ("turns", `Int result.turns);
+        ("session_id", `String result.session_id);
+        ("runtime", `String "oas");
+      ])
+    | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e)
 
 let handle_execute_dry_run _ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
-    let model_spec = Llm_types.default_local_model_spec () in
     let system_prompt =
       "You are a governance analysis agent for the MASC multi-agent system (DRY RUN mode). \
        Analyze the following topic WITHOUT committing any changes. \
        Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed. \
        This is analysis only — no actions will be taken." in
-    let config = Oas_worker.default_config
-      ~name:"council-dry-run"
-      ~model_spec ~system_prompt ~tools:[] in
-    match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-    | Some sw, Some net ->
-      (match Oas_worker.run ~sw ~net ~config topic with
-       | Ok result ->
-         json_ok (`Assoc [
-           ("topic", `String topic);
-           ("analysis", `String (Llm_types.text_of_response result.response));
-           ("turns", `Int result.turns);
-           ("session_id", `String result.session_id);
-           ("dry_run", `Bool true);
-           ("runtime", `String "oas");
-         ])
-       | Error e -> json_err (Printf.sprintf "Dry-run analysis failed: %s" e))
-    | _ -> json_err "Eio context (switch/net) not available for OAS execution"
+    match Oas_worker.run_named
+      ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ()
+    with
+    | Ok result ->
+      json_ok (`Assoc [
+        ("topic", `String topic);
+        ("analysis", `String (Llm_types.text_of_response result.response));
+        ("turns", `Int result.turns);
+        ("session_id", `String result.session_id);
+        ("dry_run", `Bool true);
+        ("runtime", `String "oas");
+      ])
+    | Error e -> json_err (Printf.sprintf "Dry-run analysis failed: %s" e)
 
 (* ================================================================ *)
 (* Schemas — reuse from legacy Tool_council                          *)

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -179,14 +179,9 @@ let handle_mitosis_divide ctx args : result =
   in
   let dna = Mitosis.extract_dna ~config ~parent_cell:cell ~full_context in
   let next_gen = cell.Mitosis.generation + 1 in
-  let model_spec = Llm_types.default_local_model_spec () in
-  let oas_config = Oas_worker.default_config
-    ~name:(Printf.sprintf "mitosis-child-gen%d" next_gen)
-    ~model_spec
-    ~system_prompt:(Printf.sprintf
-      "You are a continuation agent (generation %d). Previous context DNA:\n\n%s"
-      next_gen dna)
-    ~tools:[]
+  let system_prompt = Printf.sprintf
+    "You are a continuation agent (generation %d). Previous context DNA:\n\n%s"
+    next_gen dna
   in
   let goal =
     if current_task <> "" then
@@ -195,16 +190,10 @@ let handle_mitosis_divide ctx args : result =
     else
       Printf.sprintf "Continue from generation %d. Context: %s" next_gen summary
   in
-  match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
-  | None, _ -> json_err "Eio net not available for OAS agent"
-  | _, None -> json_err "Eio switch not available for OAS agent"
-  | Some net, Some sw ->
   let run_result =
-    Oas_worker.run_with_masc_tools
-      ~sw ~net ~config:oas_config
-      ~masc_tools:ctx.masc_tools
-      ~dispatch:ctx.dispatch
-      goal
+    Oas_worker.run_named_with_masc_tools
+      ~cascade_name:"mitosis" ~goal ~system_prompt
+      ~masc_tools:ctx.masc_tools ~dispatch:ctx.dispatch ()
   in
   (* Update MASC L3 state regardless of run outcome *)
   let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
@@ -260,28 +249,18 @@ let handle_mitosis_handoff ctx args : result =
     (* Phase 2: Run successor agent *)
     let target = get_string args "target_agent" "claude" in
     let next_gen = prepared_cell.Mitosis.generation + 1 in
-    let model_spec = Llm_types.default_local_model_spec () in
-    let successor_config = Oas_worker.default_config
-      ~name:(Printf.sprintf "mitosis-gen%d" next_gen)
-      ~model_spec
-      ~system_prompt:(Printf.sprintf
-        "You are generation %d. Continue from this DNA:\n\n%s"
-        next_gen dna)
-      ~tools:[]
+    let system_prompt = Printf.sprintf
+      "You are generation %d. Continue from this DNA:\n\n%s"
+      next_gen dna
     in
     let goal = Printf.sprintf
       "You are the successor agent (generation %d). Resume work from the handoff DNA above. Context ratio was %.1f%%."
       next_gen (context_ratio *. 100.0)
     in
-    let run_result = match Eio_context.get_net_opt (), Eio_context.get_switch_opt () with
-      | None, _ -> Error "Eio net not available"
-      | _, None -> Error "Eio switch not available"
-      | Some net, Some sw ->
-        Oas_worker.run_with_masc_tools
-          ~sw ~net ~config:successor_config
-          ~masc_tools:ctx.masc_tools
-          ~dispatch:ctx.dispatch
-          goal
+    let run_result =
+      Oas_worker.run_named_with_masc_tools
+        ~cascade_name:"mitosis" ~goal ~system_prompt
+        ~masc_tools:ctx.masc_tools ~dispatch:ctx.dispatch ()
     in
     (* Update state regardless of run outcome *)
     let new_cell = Mitosis.create_stem_cell ~generation:next_gen in

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -302,17 +302,6 @@ let router_judge_model () =
   | Some _ as explicit -> explicit
   | None -> inferred_lead_model ()
 
-let llama_router_model_spec model_id =
-  {
-    Llm_types.provider = Llm_types.Llama;
-    model_id;
-    max_context = 262_144;
-    api_url = Env_config.Llama.server_url;
-    api_key_env = None;
-    cost_per_1k_input = 0.0;
-    cost_per_1k_output = 0.0;
-  }
-
 let classify_risk ~task_profile ~spawn_prompt ~spawn_role =
   let text = normalized_spawn_text ~spawn_prompt ~spawn_role in
   let base = default_risk_for_profile task_profile in


### PR DESCRIPTION
## Summary

Stacked on #1734 → #1730.

`.mli`에서 제거:
- `type config` (model_spec 포함)
- `val default_config`
- `val build`
- `val run`
- `val run_with_masc_tools`

Public API:
- `val run_named` — cascade_name 기반 단일 진입점
- `val run_named_with_masc_tools` — cascade_name + 도구 dispatch

## Impact

외부 모듈이 `Llm_types.model_spec`을 `Oas_worker`에 전달하는 것이 **컴파일 타임에 불가능**해졌습니다. 51줄 삭제.

## Test plan

- [x] `dune build --root .` 성공
- [x] 외부 모듈에서 config/build/run 참조 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)