### PR TITLE
fix(test): align 4 test expectations with production behavior

### DIFF
--- a/test/test_command_plane_v2_wrapper.ml
+++ b/test/test_command_plane_v2_wrapper.ml
@@ -88,6 +88,8 @@ let test_swarm_live_run_rejects_invalid_run_id () =
         Yojson.Safe.Util.(json |> member "message" |> to_string))
 
 let test_swarm_live_run_reports_sync_self_unsupported_after_preflight () =
+  (* When allow_sync_self=false the harness is forked asynchronously
+     after a successful preflight, returning (true, status:"started"). *)
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -121,13 +123,10 @@ let test_swarm_live_run_reports_sync_self_unsupported_after_preflight () =
                     ("worker_count", `Int 1);
                   ])
             in
-            Alcotest.(check bool) "sync self blocked" false ok;
+            Alcotest.(check bool) "async fork ok" true ok;
             let json = Yojson.Safe.from_string body in
-            Alcotest.(check string) "status error" "error"
+            Alcotest.(check string) "status started" "started"
               Yojson.Safe.Util.(json |> member "status" |> to_string);
-            Alcotest.(check string) "runtime blocker"
-              "sync_self_unsupported"
-              Yojson.Safe.Util.(json |> member "runtime_blocker" |> to_string);
-            Alcotest.(check bool) "doctor path included" true
-              Yojson.Safe.Util.(json |> member "runtime_doctor_path" <> `Null)))))
+            Alcotest.(check string) "run_id echoed" "sync-self-blocked"
+              Yojson.Safe.Util.(json |> member "run_id" |> to_string)))))
 

--- a/test/test_metrics_store_eio.ml
+++ b/test/test_metrics_store_eio.ml
@@ -100,8 +100,9 @@ let test_calculate_agent_metrics () =
     match Metrics_store_eio.calculate_agent_metrics config ~agent_id:"claude" ~days:1 with
     | Some metrics ->
       assert (metrics.total_tasks = 5);
-      assert (metrics.completed_tasks = 5);
-      (* 2 and 4 are successful (even numbers) *)
+      (* completed_tasks counts successful tasks: i=2 and i=4 (even numbers) *)
+      assert (metrics.completed_tasks = 2);
+      (* task_completion_rate = successful / total = 2/5 = 0.4 *)
       assert (metrics.task_completion_rate >= 0.3 && metrics.task_completion_rate <= 0.5);
       print_endline (Printf.sprintf "  Completion rate: %.1f%%" (metrics.task_completion_rate *. 100.0))
     | None -> failwith "Expected to get agent metrics"

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -142,14 +142,10 @@ let test_llm_client () = group "LLM Client" (fun () ->
    | Error _ -> assert_true "parse_model:empty_model_rejected" true
    | Ok _ -> assert_true "parse_model:empty_model_should_fail" false);
 
-  (* 3b. MLX and Custom provider parsing *)
+  (* 3b. MLX provider was removed (PR #799); parsing should fail *)
   (match Llm_types.model_spec_of_string "mlx:qwen3.5-35b" with
-   | Ok m ->
-     assert_equal "parse_model:mlx_id" "qwen3.5-35b" m.model_id;
-     assert_true "parse_model:mlx_provider"
-       (m.provider = Llm_types.Custom "mlx");
-     assert_equal "parse_model:mlx_url" "http://127.0.0.1:8091" m.api_url
-   | Error e -> assert_true ("parse_model:mlx_failed: " ^ e) false);
+   | Error _ -> assert_true "parse_model:mlx_rejected" true
+   | Ok _ -> assert_true "parse_model:mlx_should_fail" false);
 
   (match Llm_types.model_spec_of_string "custom:mymodel@http://localhost:9999" with
    | Ok m ->

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -197,10 +197,10 @@ let test_post_create_structured_payload () =
     Yojson.Safe.Util.(json |> member "post_kind" |> to_string);
   Alcotest.(check string) "source meta kept" "keeper_autonomy"
     Yojson.Safe.Util.(json |> member "meta" |> member "source" |> to_string);
-  Alcotest.(check bool) "state extracted" true
-    (String.length
-       Yojson.Safe.Util.(json |> member "meta" |> member "state_block" |> to_string)
-     > 0)
+  (* state_block is stripped by tool_board before reaching board_core,
+     so meta.state_block is absent (null) in the created post. *)
+  Alcotest.(check bool) "state_block absent after strip" true
+    (Yojson.Safe.Util.(json |> member "meta" |> member "state_block") = `Null)
 
 let test_post_create_empty_content () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary

main CI Build and Test 실패 원인 4개 수정. 모두 production 코드 변경 후 테스트 기대값 미갱신.

| 테스트 | 변경 | 원인 |
|--------|------|------|
| `test_perpetual` | Ok→Error | mlx provider 제거 (#799) |
| `test_tool_board_coverage` | state_block 있음→null | strip_state_blocks 선처리 |
| `test_command_plane_v2_wrapper` | false→true | sync_self가 async fork로 전환 |
| `test_metrics_store_eio` | 5→2 | completed_tasks = successful only |

## Test plan
- [x] `test_perpetual.exe` 194/194 pass
- [x] `test_tool_board_coverage.exe` 33/33 pass
- [x] `test_command_plane_v2.exe` 31/31 pass
- [x] `test_metrics_store_eio.exe` 8/8 pass
- [x] `dune build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)