### PR TITLE
refactor(dashboard): server API safety + SSE routing

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -1,5 +1,9 @@
 // SSE event reaction and periodic refresh — extracted from store.ts
 // Routes SSE events to the minimal refresh function needed.
+//
+// Event routing uses a declarative map for simple refresh-only events,
+// and named handlers for events with custom logic (conditional hydration,
+// async imports, signal-only updates).
 
 import { lastEvent, connected } from './sse'
 import {
@@ -13,7 +17,7 @@ import {
 } from './store'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 
-// --- Governance/CommandPlane/Operator refresh registration (avoids circular import) ---
+// --- Refresh function registration (avoids circular imports) ---
 
 let _refreshGovernanceFn: (() => void) | null = null
 export function registerGovernanceRefresh(fn: () => void): void {
@@ -35,7 +39,7 @@ export function registerMissionRefresh(fn: () => void): void {
   _refreshMissionFn = fn
 }
 
-// --- SSE event reaction ---
+// --- Debounced scheduling ---
 
 const _debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {}
 let _fetchDebounce: ReturnType<typeof setTimeout> | null = null
@@ -48,106 +52,146 @@ function scheduleRefresh(key: string, fn: () => void, delayMs = 500): void {
   }, delayMs)
 }
 
+// --- Declarative event routing ---
+// Simple events that map directly to a debounced refresh target.
+// Complex events (conditional logic, async imports) use named handlers below.
+
+type RefreshTarget = 'execution' | 'board' | 'mdal' | 'operator'
+
+interface SimpleRoute {
+  target: RefreshTarget
+  debounceMs?: number
+}
+
+const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
+  // Agent lifecycle
+  agent_joined:   { target: 'execution' },
+  agent_left:     { target: 'execution' },
+  // Broadcasts
+  broadcast:      { target: 'execution' },
+  // Keeper lifecycle (also triggers operator refresh via handler)
+  keeper_handoff:       { target: 'execution' },
+  keeper_compaction:    { target: 'execution' },
+  keeper_guardrail:     { target: 'execution' },
+  // Client input
+  client_input_approved:  { target: 'operator', debounceMs: 300 },
+  client_input_rejected:  { target: 'operator', debounceMs: 300 },
+  client_input_updated:   { target: 'operator', debounceMs: 300 },
+  // Board
+  board_post:           { target: 'board' },
+  'masc/board_post':    { target: 'board' },
+  board_comment:        { target: 'board' },
+  'masc/board_comment': { target: 'board' },
+  // MDAL
+  mdal_started:    { target: 'mdal', debounceMs: 350 },
+  mdal_iteration:  { target: 'mdal', debounceMs: 350 },
+  mdal_completed:  { target: 'mdal', debounceMs: 350 },
+  mdal_stopped:    { target: 'mdal', debounceMs: 350 },
+}
+
+// Prefix patterns for events that use startsWith matching
+const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
+  { prefix: 'task_',      target: 'execution' },
+  { prefix: 'masc/task_', target: 'execution' },
+]
+
+const REFRESH_FNS: Record<RefreshTarget, () => void> = {
+  execution: refreshExecution,
+  board:     refreshBoard,
+  mdal:      refreshMdal,
+  operator:  () => _refreshOperatorFn?.(),
+}
+
+// --- Named handlers for complex events ---
+
+const KEEPER_LIFECYCLE_EVENTS = new Set([
+  'keeper_handoff', 'keeper_compaction', 'keeper_guardrail', 'keeper_turn_complete',
+])
+
+function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void {
+  if (!event.name) return
+  const next = new Map(keeperHeartbeats.value)
+  next.set(event.name, event.ts_unix ? event.ts_unix * 1000 : Date.now())
+  keeperHeartbeats.value = next
+}
+
+function handleKeeperLifecycle(event: { type: string; name?: string }): void {
+  // All keeper lifecycle events trigger operator refresh
+  scheduleRefresh('operator', () => _refreshOperatorFn?.(), 600)
+
+  // keeper_turn_complete: re-hydrate active keeper's conversation thread
+  if (event.type === 'keeper_turn_complete') {
+    const keeperName = event.name ?? ''
+    const viewing = activeKeeperName.value
+    if (keeperName && keeperName === viewing) {
+      scheduleRefresh(`keeper_thread_${keeperName}`, () => {
+        void hydrateKeeperStatus(keeperName, true)
+      }, 800)
+    }
+  }
+}
+
+function handleDashboardRefresh(): void {
+  invalidateDashboardCache()
+  if (!_fetchDebounce) {
+    _fetchDebounce = setTimeout(() => {
+      refreshDashboard()
+      _refreshCommandPlaneFn?.()
+      _refreshOperatorFn?.()
+      _fetchDebounce = null
+    }, 500)
+  }
+}
+
+async function handleGovernance(): Promise<void> {
+  _refreshGovernanceFn?.()
+  const { loadRuntimeParams } = await import('./components/governance')
+  loadRuntimeParams()
+}
+
+// --- SSE reaction setup ---
+
 export function setupSSEReaction(): () => void {
   const unsubscribe = lastEvent.subscribe((event) => {
     if (!event) return
 
-    // Keeper heartbeat — update signal directly, zero network calls
-    if (event.type === 'keeper_heartbeat' && event.name) {
-      const next = new Map(keeperHeartbeats.value)
-      next.set(event.name, event.ts_unix ? event.ts_unix * 1000 : Date.now())
-      keeperHeartbeats.value = next
+    // 1. Keeper heartbeat — signal-only, zero network calls
+    if (event.type === 'keeper_heartbeat') {
+      handleKeeperHeartbeat(event)
       return
     }
 
-    // Agent events → execution surface refresh
-    if (event.type === 'agent_joined' || event.type === 'agent_left') {
-      scheduleRefresh('execution', refreshExecution)
-    }
-
-    // Dashboard data events — debounced full refresh
+    // 2. Dashboard-wide data events — debounced full refresh
     if (isDashboardRefreshEvent(event.type)) {
-      invalidateDashboardCache()
-      if (!_fetchDebounce) {
-        _fetchDebounce = setTimeout(() => {
-          refreshDashboard()
-          _refreshCommandPlaneFn?.()
-          _refreshOperatorFn?.()
-          _fetchDebounce = null
-        }, 500)
+      handleDashboardRefresh()
+    }
+
+    // 3. Simple route: exact match
+    const simpleRoute = SIMPLE_ROUTES[event.type]
+    if (simpleRoute) {
+      scheduleRefresh(
+        simpleRoute.target,
+        REFRESH_FNS[simpleRoute.target],
+        simpleRoute.debounceMs,
+      )
+    }
+
+    // 4. Simple route: prefix match
+    for (const { prefix, target } of PREFIX_ROUTES) {
+      if (event.type.startsWith(prefix)) {
+        scheduleRefresh(target, REFRESH_FNS[target])
+        break
       }
     }
 
-    // Task events → execution surface refresh
-    if (event.type.startsWith('task_') || event.type.startsWith('masc/task_')) {
-      scheduleRefresh('execution', refreshExecution)
+    // 5. Keeper lifecycle — additional operator refresh + thread hydration
+    if (KEEPER_LIFECYCLE_EVENTS.has(event.type)) {
+      handleKeeperLifecycle(event)
     }
 
-    // Broadcast → execution timeline refresh
-    if (event.type === 'broadcast') {
-      scheduleRefresh('execution', refreshExecution)
-    }
-
-    // Keeper lifecycle events → execution + operator refresh
-    if (
-      event.type === 'keeper_handoff'
-      || event.type === 'keeper_compaction'
-      || event.type === 'keeper_guardrail'
-      || event.type === 'keeper_turn_complete'
-    ) {
-      scheduleRefresh('execution', refreshExecution)
-      scheduleRefresh('operator', () => _refreshOperatorFn?.(), 600)
-
-      // Re-hydrate conversation thread for the active keeper so chat
-      // updates without a manual page refresh.
-      if (event.type === 'keeper_turn_complete') {
-        const keeperName = event.name ?? ''
-        const viewing = activeKeeperName.value
-        if (keeperName && keeperName === viewing) {
-          scheduleRefresh(`keeper_thread_${keeperName}`, () => {
-            void hydrateKeeperStatus(keeperName, true)
-          }, 800)
-        }
-      }
-    }
-
-    // Client input approval/rejection → operator refresh
-    if (
-      event.type === 'client_input_approved'
-      || event.type === 'client_input_rejected'
-      || event.type === 'client_input_updated'
-    ) {
-      scheduleRefresh('operator', () => _refreshOperatorFn?.(), 300)
-    }
-
-    // Board events → board refresh only
-    if (
-      event.type === 'board_post'
-      || event.type === 'masc/board_post'
-      || event.type === 'board_comment'
-      || event.type === 'masc/board_comment'
-    ) {
-      scheduleRefresh('board', refreshBoard)
-    }
-
-    // Governance events (including param changes from governance enforcement)
+    // 6. Governance events
     if (event.type.startsWith('decision_') || event.type === 'governance_param_changed') {
-      scheduleRefresh('governance', async () => {
-        _refreshGovernanceFn?.()
-        // Also refresh runtime params panel so it reflects param changes immediately
-        const { loadRuntimeParams } = await import('./components/governance')
-        loadRuntimeParams()
-      })
-    }
-
-    // MDAL events
-    if (
-      event.type === 'mdal_started'
-      || event.type === 'mdal_iteration'
-      || event.type === 'mdal_completed'
-      || event.type === 'mdal_stopped'
-    ) {
-      scheduleRefresh('mdal', refreshMdal, 350)
+      scheduleRefresh('governance', () => void handleGovernance())
     }
   })
 
@@ -160,7 +204,13 @@ export function setupSSEReaction(): () => void {
   }
 }
 
-// --- Periodic refresh (for keeper presence heartbeats that don't emit SSE) ---
+// --- Periodic refresh ---
+
+const PERIODIC_REFRESH_MS =
+  typeof import.meta !== 'undefined' && (import.meta as Record<string, unknown>).env
+    && ((import.meta as Record<string, Record<string, unknown>>).env).DEV
+    ? 90_000
+    : 30_000
 
 let _periodicId: ReturnType<typeof setInterval> | null = null
 
@@ -172,7 +222,7 @@ export function startPeriodicRefresh(): void {
     }
     refreshDashboard()
     _refreshMissionFn?.()
-  }, 30000)
+  }, PERIODIC_REFRESH_MS)
 }
 
 export function stopPeriodicRefresh(): void {
@@ -184,7 +234,7 @@ export function stopPeriodicRefresh(): void {
 
 /** Cancel all pending SSE-triggered refresh timers.
  *  Call on route change to prevent stale fetches from firing after the user
- *  navigates to a different tab (fixes C-4/M-12 race condition). */
+ *  navigates to a different tab. */
 export function cancelPendingSSERefreshes(): void {
   for (const key of Object.keys(_debounceTimers)) {
     clearTimeout(_debounceTimers[key])

--- a/lib/server/server_routes_http_routes_command_plane_read.ml
+++ b/lib/server/server_routes_http_routes_command_plane_read.ml
@@ -129,17 +129,18 @@ let add_routes router =
   |> Http.Router.prefix_get "/api/v1/chains/runs/" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let req_path = Http.Request.path req in
-         let prefix = "/api/v1/chains/runs/" in
-         let run_id =
-           String.sub req_path (String.length prefix)
-             (String.length req_path - String.length prefix)
-         in
-         match command_plane_chain_run_http_json ~state req run_id with
-         | Ok json ->
-             Http.Response.json ~compress:true ~request:req
-               (Yojson.Safe.to_string json) reqd
-         | Error message ->
-             Http.Response.json ~status:(chain_http_error_status message) ~request:req
-               (Yojson.Safe.to_string (command_plane_error_json message))
-               reqd
+         (match extract_path_param ~prefix:"/api/v1/chains/runs/" req_path with
+          | None ->
+              Http.Response.json ~status:`Bad_request ~request:req
+                (Yojson.Safe.to_string (command_plane_error_json "run_id is required"))
+                reqd
+          | Some run_id ->
+              (match command_plane_chain_run_http_json ~state req run_id with
+               | Ok json ->
+                   Http.Response.json ~compress:true ~request:req
+                     (Yojson.Safe.to_string json) reqd
+               | Error message ->
+                   Http.Response.json ~status:(chain_http_error_status message) ~request:req
+                     (Yojson.Safe.to_string (command_plane_error_json message))
+                     reqd))
        ) request reqd)

--- a/lib/server/server_routes_http_routes_social.ml
+++ b/lib/server/server_routes_http_routes_social.ml
@@ -64,13 +64,14 @@ let add_routes router =
        with_public_read (fun state _req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in
          let path = Http.Request.path request in
-         let prefix = "/api/v1/governance/cases/" in
-         let case_id =
-           String.sub path (String.length prefix)
-             (String.length path - String.length prefix)
-         in
-         let (status, json) = governance_case_detail_json ~base_path ~case_id in
-         respond_json_with_cors ~status request reqd (Yojson.Safe.to_string json)
+         (match extract_path_param ~prefix:"/api/v1/governance/cases/" path with
+          | None ->
+              Http.Response.json
+                (Yojson.Safe.to_string (`Assoc [("error", `String "case_id is required")]))
+                ~status:`Bad_request reqd
+          | Some case_id ->
+              let (status, json) = governance_case_detail_json ~base_path ~case_id in
+              respond_json_with_cors ~status request reqd (Yojson.Safe.to_string json))
        ) request reqd)
 
   |> Http.Router.get "/api/v1/governance/feed" (fun request reqd ->
@@ -203,44 +204,46 @@ let add_routes router =
   |> Http.Router.prefix_get "/api/v1/mentions/" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          let path = Http.Request.path request in
-         let prefix = "/api/v1/mentions/" in
-         let agent_name =
-           String.sub path (String.length prefix)
-             (String.length path - String.length prefix)
-         in
-         let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
-         let mentions =
-           Mention_inbox.read_mentions state.Mcp_server.room_config
-             ~target_agent:agent_name ~limit
-         in
-         let unread =
-           Mention_inbox.unread_count state.Mcp_server.room_config
-             ~target_agent:agent_name
-         in
-         let json = `Assoc [
-           ("agent", `String agent_name);
-           ("unread_count", `Int unread);
-           ("mentions", `List (List.map Mention_inbox.mention_record_to_json mentions));
-         ] in
-         Http.Response.json (Yojson.Safe.to_string json) reqd
+         (match extract_path_param ~prefix:"/api/v1/mentions/" path with
+          | None ->
+              Http.Response.json
+                (Yojson.Safe.to_string (`Assoc [("error", `String "agent_name is required")]))
+                ~status:`Bad_request reqd
+          | Some agent_name ->
+              let limit = standard_limit request in
+              let mentions =
+                Mention_inbox.read_mentions state.Mcp_server.room_config
+                  ~target_agent:agent_name ~limit
+              in
+              let unread =
+                Mention_inbox.unread_count state.Mcp_server.room_config
+                  ~target_agent:agent_name
+              in
+              let json = `Assoc [
+                ("agent", `String agent_name);
+                ("unread_count", `Int unread);
+                ("mentions", `List (List.map Mention_inbox.mention_record_to_json mentions));
+              ] in
+              Http.Response.json (Yojson.Safe.to_string json) reqd)
        ) request reqd)
 
   (* Agent Reputation API *)
   |> Http.Router.prefix_get "/api/v1/reputation/" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          let path = Http.Request.path request in
-         let prefix = "/api/v1/reputation/" in
-         let agent_name =
-           String.sub path (String.length prefix)
-             (String.length path - String.length prefix)
-         in
-         let rep =
-           Agent_reputation.compute_reputation
-             state.Mcp_server.room_config ~agent_name
-         in
-         Http.Response.json
-           (Yojson.Safe.to_string (Agent_reputation.reputation_to_json rep))
-           reqd
+         (match extract_path_param ~prefix:"/api/v1/reputation/" path with
+          | None ->
+              Http.Response.json
+                (Yojson.Safe.to_string (`Assoc [("error", `String "agent_name is required")]))
+                ~status:`Bad_request reqd
+          | Some agent_name ->
+              let rep =
+                Agent_reputation.compute_reputation
+                  state.Mcp_server.room_config ~agent_name
+              in
+              Http.Response.json
+                (Yojson.Safe.to_string (Agent_reputation.reputation_to_json rep))
+                reqd)
        ) request reqd)
 
   (* Activity Feed API *)

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -117,3 +117,22 @@ let dashboard_compact_mode request =
   | Some s -> String.equal "compact" (String.lowercase_ascii (String.trim s))
   | None -> false
 
+(** Extract a path parameter after a known prefix.
+    Returns None if the path doesn't start with prefix or the parameter is empty.
+    Prevents String.sub crash from bounds violations. *)
+let extract_path_param ~prefix path =
+  let plen = String.length prefix in
+  let plen_total = String.length path in
+  if plen_total > plen && String.sub path 0 plen = prefix then
+    let param = String.trim (String.sub path plen (plen_total - plen)) in
+    if String.length param > 0 then Some param else None
+  else None
+
+(** Standard query param: limit with default 50, clamped 1..200. *)
+let standard_limit request =
+  int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200
+
+(** Standard query param: offset with default 0, min 0. *)
+let standard_offset request =
+  int_query_param request "offset" ~default:0 |> max 0
+


### PR DESCRIPTION
## Summary

- **Server**: `String.sub` 경로 추출 4곳에 bounds check 추가. crash → 400 응답 전환.
  - `extract_path_param` 헬퍼 도입 (server_utils.ml)
  - `standard_limit`/`standard_offset` query param 중앙화
- **Frontend**: SSE 이벤트 라우팅을 if/else 체인에서 선언적 `SIMPLE_ROUTES` 맵으로 리팩토링
  - 복잡 이벤트는 named handler로 분리 (keeper lifecycle, governance)
  - dev 모드 주기 갱신 90초 (prod 30초)

## Test plan

- [x] `dune build --root .` 성공
- [ ] `npm run build` (dashboard) 성공
- [ ] 브라우저에서 SSE 이벤트 수신 + 탭 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)