### PR TITLE
fix: align Collaboration.t field — votes → contributions

### DIFF
--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -185,7 +185,7 @@ let collaboration_of_session
     participants =
       List.map planned_worker_to_participant session.planned_workers;
     artifacts = [];
-    votes = [];
+    contributions = [];
     shared_context = ctx;
     created_at = session.started_at;
     updated_at =


### PR DESCRIPTION
## Summary

- `team_context.ml:188`: `votes = []` → `contributions = []`

## Root cause

OAS #220 renamed `votes: vote list` to `contributions: contribution list` in `Collaboration.t`. CI pins `agent_sdk` from `oas#main`, so the build fails with:

```
There is no field votes within type Agent_sdk.Collaboration.t
```

This single-line fix unblocks all PR CI pipelines.

## Test plan

- [x] `dune build` passes with OAS 0.60.0 (post-#220)
- [ ] CI Build and Test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)