### PR TITLE
fix: unbreak main — Collaboration.t + keeper helpers regression

### DIFF
--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -75,6 +75,34 @@ let run_with_tools
   | Error e -> Error e
 
 (* ================================================================ *)
+(* Internal: model spec resolution (restored from #1730 deletion)    *)
+(* ================================================================ *)
+
+let resolve_primary_model_spec (meta : keeper_meta) :
+    (Llm_types.model_spec, string) result =
+  let labels =
+    match Keeper_exec_status.active_model_of_meta meta with
+    | "" ->
+      let pool = Json_util.dedupe_keep_order (meta.allowed_models @ meta.models) in
+      if pool = [] then meta.models else pool
+    | model -> [model]
+  in
+  match Keeper_types.model_specs_of_strings labels with
+  | Error e -> Error e
+  | Ok [] -> Error "no model specs resolved"
+  | Ok (primary :: _) -> Ok primary
+
+let require_net () =
+  match Eio_context.get_net_opt () with
+  | Some net -> Ok net
+  | None -> Error "Eio net not available (keeper running outside server context)"
+
+let require_switch () =
+  match Eio_context.get_switch_opt () with
+  | Some sw -> Ok sw
+  | None -> Error "Eio switch not available (keeper running outside server context)"
+
+(* ================================================================ *)
 (* Public: run_with_custom_dispatch                                  *)
 (* ================================================================ *)
 

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -1,13 +1,11 @@
 (** Oas_worker — Unified entry point for OAS-based MASC tool modules.
 
-    Callers pass a [cascade_name] string; model resolution is delegated
-    to [Llm_cascade.get_cascade].  Internal [config] / [build] / [run]
-    are implementation details and not exported.
-
     @since Phase 1 — MASC→OAS migration
-    @since Phase 4 — public API restricted to named cascade functions *)
+    @since Phase 4 — named cascade functions preferred *)
 
 module Oas = Agent_sdk
+
+(** {1 Result type} *)
 
 type run_result = {
   response : Oas.Types.api_response;
@@ -15,6 +13,8 @@ type run_result = {
   session_id : string;
   turns : int;
 }
+
+(** {1 Named cascade API (preferred)} *)
 
 val run_named :
   cascade_name:string ->
@@ -39,4 +39,47 @@ val run_named_with_masc_tools :
   ?max_tokens:int ->
   ?guardrails:Oas.Guardrails.t ->
   unit ->
+  (run_result, string) result
+
+(** {1 Legacy model-spec API (used by keeper_oas_adapter)} *)
+
+type config = {
+  name : string;
+  model_spec : Llm_types.model_spec;
+  system_prompt : string;
+  tools : Oas.Tool.t list;
+  max_turns : int;
+  max_tokens : int;
+  temperature : float;
+  hooks : Oas.Hooks.hooks option;
+  guardrails : Oas.Guardrails.t option;
+  event_bus : Oas.Event_bus.t option;
+  checkpoint_dir : string option;
+  session_id : string option;
+  description : string option;
+}
+
+val default_config :
+  name:string ->
+  model_spec:Llm_types.model_spec ->
+  system_prompt:string ->
+  tools:Oas.Tool.t list ->
+  config
+
+val run :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+
+  string ->
+  (run_result, string) result
+
+val run_with_masc_tools :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  config:config ->
+  masc_tools:Llm_types.tool_def list ->
+  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
+
+  string ->
   (run_result, string) result

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -161,8 +161,8 @@ let planned_worker_to_participant
 (** Project a MASC team session into an OAS {!Agent_sdk.Collaboration.t}.
 
     This is a lossy projection: planned_worker (16 fields) compresses to
-    participant (6 fields).  MASC has no explicit votes or artifacts list
-    in the session record, so those are empty.
+    participant (6 fields).  MASC has no explicit contributions or artifacts
+    list in the session record, so those are empty.
 
     [shared_context] is populated from [shared_findings] if available. *)
 let collaboration_of_session
@@ -185,7 +185,7 @@ let collaboration_of_session
     participants =
       List.map planned_worker_to_participant session.planned_workers;
     artifacts = [];
-    votes = [];
+    contributions = [];
     shared_context = ctx;
     created_at = session.started_at;
     updated_at =


### PR DESCRIPTION
## Summary

main 빌드가 깨져있어서 모든 PR CI가 실패하는 상황 수정.

**두 가지 회귀:**

1. **Collaboration.t votes→contributions**: OAS v0.61.0 (PR oas#219)에서 `votes` 필드가 `contributions`로 리네임됨. `team_context.ml:188`이 구 필드명 참조.

2. **keeper_oas_adapter 삭제된 헬퍼**: PR #1730 (cascade-name API)에서 `resolve_primary_model_spec`, `require_net`, `require_switch`를 삭제했지만 `run_with_custom_dispatch` (keeper_turn.ml:460에서 호출)가 아직 의존. 헬퍼 복원 + oas_worker.mli에 legacy API 재노출.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/team_context.ml` | `votes = []` → `contributions = []` |
| `lib/keeper/keeper_oas_adapter.ml` | `resolve_primary_model_spec`, `require_net`, `require_switch` 복원 |
| `lib/oas_worker.mli` | config/default_config/run/run_with_masc_tools 재노출 |

## Test plan

- [x] `dune build` 통과 (로컬)
- [ ] CI green
- 이 PR이 머지되면 #1729, #1742, #1743 CI도 해소됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)