### PR TITLE
fix: restore main build — 2 post-merge breakages

### DIFF
--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -78,6 +78,10 @@ let run_with_tools
 (* Public: run_with_custom_dispatch                                  *)
 (* ================================================================ *)
 
+(** Run with a custom dispatch function and explicit tool list.
+    Uses cascade-name-based API (post-#1730).
+    [model_spec_override] is accepted for backward compat but ignored —
+    model resolution happens inside [Oas_worker.run_named_with_masc_tools]. *)
 let run_with_custom_dispatch
     ~(meta : keeper_meta)
     ?(model_spec_override : Llm_types.model_spec option)
@@ -91,31 +95,11 @@ let run_with_custom_dispatch
     ?(guardrails : Agent_sdk.Guardrails.t option)
     ()
   : (Oas_worker.run_result, string) result =
-  let model_spec_r = match model_spec_override with
-    | Some spec -> Ok spec
-    | None -> resolve_primary_model_spec meta
-  in
-  match model_spec_r with
-  | Error e -> Error e
-  | Ok model_spec ->
-  match require_net () with
-  | Error e -> Error e
-  | Ok net ->
-  match require_switch () with
-  | Error e -> Error e
-  | Ok sw ->
-  let oas_config = { (Oas_worker.default_config
-    ~name:(Printf.sprintf "keeper-%s-turn" meta.name)
-    ~model_spec
-    ~system_prompt
-    ~tools:[]) with
-    max_turns;
-    max_tokens;
-    temperature;
-    guardrails;
-  } in
-  Oas_worker.run_with_masc_tools
-    ~sw ~net ~config:oas_config ~masc_tools ~dispatch goal
+  ignore model_spec_override;
+  let cascade_name = Printf.sprintf "keeper_%s" meta.name in
+  Oas_worker.run_named_with_masc_tools
+    ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch
+    ~max_turns ~temperature ~max_tokens ?guardrails ()
 
 (* ================================================================ *)
 (* Public: run_simple                                                *)

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -185,7 +185,7 @@ let collaboration_of_session
     participants =
       List.map planned_worker_to_participant session.planned_workers;
     artifacts = [];
-    votes = [];
+    contributions = [];
     shared_context = ctx;
     created_at = session.started_at;
     updated_at =


### PR DESCRIPTION
## Summary

main이 빌드 불가 상태 — 최근 리팩토링 PR 병합 후 2건의 breakage:

1. **keeper_oas_adapter.ml**: `resolve_primary_model_spec` / `require_net` / `require_switch`가 #1730에서 삭제됐지만 `run_with_custom_dispatch`가 계속 호출. cascade-name 기반 `Oas_worker.run_named_with_masc_tools`로 전환.

2. **team_context.ml**: `Agent_sdk.Collaboration.t`에서 `votes` 필드 제거, `contributions` 필드 추가됨 (OAS SDK 업데이트). 레코드 리터럴 동기화.

## Test plan

- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)