### PR TITLE
refactor: rename Llm_eio_env to Masc_eio_env

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -515,7 +515,7 @@
    autonomy_adjuster
    ;; Perpetual Agent Runtime (infinite context system)
    llm_types
-   llm_eio_env
+   masc_eio_env
    llm_discovery_cache
    oas_type_adapters
    context_scoring

--- a/lib/llm_cascade.ml
+++ b/lib/llm_cascade.ml
@@ -189,7 +189,7 @@ let format_cascade_error ~cascade_name = function
 let complete_cascade ~cascade_name ~messages
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
-  let env = Llm_eio_env.get () in
+  let env = Masc_eio_env.get () in
   let defaults = default_model_strings ~cascade_name in
   let config_path_opt =
     if String.length config_path > 0 then Some config_path

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -1,10 +1,10 @@
-(** Module-level Eio environment for LLM HTTP calls via Llm_provider.
+(** Module-level Eio environment for OAS HTTP calls.
     Set once at server startup via {!init}.
 
-    The switch and net handle are needed by [Llm_provider.Complete.complete]
-    which uses cohttp-eio for HTTP transport.
+    The switch and net handle are needed by OAS provider completions
+    which use cohttp-eio for HTTP transport.
 
-    @since 2.103.0 — v0.49 curl-subprocess replacement *)
+    @since 2.130.0 — renamed from Llm_eio_env *)
 
 type t = {
   sw : Eio.Switch.t;
@@ -19,6 +19,6 @@ let init ~sw ~net ?clock () = Atomic.set env (Some { sw; net; clock })
 let get () =
   match Atomic.get env with
   | Some e -> e
-  | None -> failwith "Llm_eio_env not initialized: call init at server startup"
+  | None -> failwith "Masc_eio_env not initialized: call init at server startup"
 
 let get_opt () = Atomic.get env

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -300,7 +300,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   in
 
   (* Initialize Eio environment for LLM HTTP calls (cohttp-eio via Llm_provider) *)
-  Llm_eio_env.init ~sw ~net ~clock ();
+  Masc_eio_env.init ~sw ~net ~clock ();
   Llm_discovery_cache.set_env ~sw ~net;
 
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -262,7 +262,7 @@ let test_homeostatic_score_at_maximum () =
 let test_spawn_decision_returns_valid () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
+  Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
   (* Use propose_spawn which internally calculates health from real data *)
   let decision = Gardener.propose_spawn ~topic:"test-topic" ~reason:"test" ~urgency:High in
   (* Verify decision is one of the valid ADT variants *)

--- a/test/test_llm_cascade.ml
+++ b/test/test_llm_cascade.ml
@@ -71,7 +71,7 @@ let test_call_returns_error_when_no_models () =
      requires a missing API key. *)
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  Masc_mcp.Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
+  Masc_mcp.Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
   with_env "ZAI_API_KEY" "" (fun () ->
     with_env "GEMINI_API_KEY" "" (fun () ->
       with_temp_json


### PR DESCRIPTION
## Summary
- Rename `Llm_eio_env` → `Masc_eio_env` (holds Eio switch/net/clock, no LLM-specific logic)
- Move from `lib/llm/` to `lib/` (top-level, reflects MASC ownership)
- Update 3 production files + 2 test files

## Context
Part of LLM terminology purge (Train 2, PR E). The module holds Eio context
for cohttp-eio HTTP transport — naming it "Llm" was misleading after OAS migration.

## Test plan
- [x] `dune build` passes (pre-existing errors only)
- [x] Zero remaining `Llm_eio_env` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)