### PR TITLE
refactor: rename Llm_discovery_cache to Discovery_cache

### DIFF
--- a/lib/discovery_cache.ml
+++ b/lib/discovery_cache.ml
@@ -1,4 +1,4 @@
-(** Llm_discovery_cache — cached wrapper over OAS [Llm_provider.Discovery].
+(** Discovery_cache — cached wrapper over OAS [Llm_provider.Discovery].
 
     All probing logic lives in OAS. This module adds:
     - TTL-based caching (30s default)
@@ -7,7 +7,7 @@
 
     No dependency on Llm_cascade.
 
-    @since 2.113.0 *)
+    @since 2.130.0 — renamed from Llm_discovery_cache *)
 
 (* ── Eio capability refs (set once at server init) ───────── *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -516,7 +516,7 @@
    ;; Perpetual Agent Runtime (infinite context system)
    llm_types
    masc_eio_env
-   llm_discovery_cache
+   discovery_cache
    oas_type_adapters
    context_scoring
    compaction_types

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -574,7 +574,7 @@ let error_handler _client_addr ?request:_ error start_response =
 
 (** Run the HTTP server with Eio *)
 let run ~sw ~net ~clock config routes =
-  Llm_discovery_cache.set_env ~sw ~net;
+  Discovery_cache.set_env ~sw ~net;
   let request_handler = make_request_handler routes in
   (* Parse IP address using Ipaddr library then convert to Eio format *)
   let ip = match Ipaddr.of_string config.host with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -301,7 +301,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
 
   (* Initialize Eio environment for LLM HTTP calls (cohttp-eio via Llm_provider) *)
   Masc_eio_env.init ~sw ~net ~clock ();
-  Llm_discovery_cache.set_env ~sw ~net;
+  Discovery_cache.set_env ~sw ~net;
 
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = make_http_config ~host ~port in

--- a/lib/tool_llm_catalog.ml
+++ b/lib/tool_llm_catalog.ml
@@ -1,5 +1,5 @@
 [@@@warning "-32-33-69"]
-(** Tool_llm_catalog — MCP tool layer over OAS Discovery (via {!Llm_discovery_cache}).
+(** Tool_llm_catalog — MCP tool layer over OAS Discovery (via {!Discovery_cache}).
 
     All probing logic is in OAS [Llm_provider.Discovery].
     This module provides the MCP tool interface for agents.
@@ -7,7 +7,7 @@
     @since 2.113.0 *)
 
 open Types
-module D = Llm_discovery_cache
+module D = Discovery_cache
 
 (* ── Types ───────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary
- Rename `Llm_discovery_cache` → `Discovery_cache`
- Move from `lib/llm/` to `lib/` top-level
- Update 3 production files (http_server_eio, server_runtime_bootstrap, tool_llm_catalog)

## Context
Part of LLM terminology purge (Train 2, PR F). Module wraps OAS Discovery
with TTL caching — the "Llm" prefix was misleading.

## Test plan
- [x] `dune build` passes (pre-existing errors only)
- [x] Zero remaining `Llm_discovery_cache` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)