### PR TITLE
fix(test): resolve 3 remaining CI test failures

### DIFF
--- a/lib/trace.ml
+++ b/lib/trace.ml
@@ -12,11 +12,14 @@
 (** Global Lamport clock shared by all spans *)
 let global_clock = Lamport.create ()
 
+(** Monotonic counter for ID uniqueness within the same millisecond *)
+let id_counter = Atomic.make 0
+
 (** Generate trace/span IDs *)
 let generate_id prefix =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
-  let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF in
-  Printf.sprintf "%s-%d-%06x" prefix ts hash
+  let seq = Atomic.fetch_and_add id_counter 1 in
+  Printf.sprintf "%s-%d-%06x" prefix ts (seq land 0xFFFFFF)
 
 (** Span status *)
 type span_status = Ok | Error of string
@@ -151,4 +154,5 @@ let spans_by_agent agent =
 let clear () =
   Hashtbl.clear spans;
   Queue.clear span_order;
-  Lamport.reset global_clock
+  Lamport.reset global_clock;
+  Atomic.set id_counter 0

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1015,8 +1015,8 @@ let test_execute_tool_coding_mode_allows_governance_status () =
   in
   Alcotest.(check bool) "governance status tool allowed in coding mode" true ok;
   let json = Yojson.Safe.from_string msg in
-  Alcotest.(check bool) "has cases_open field" true
-    Yojson.Safe.Util.(member "cases_open" json <> `Null);
+  Alcotest.(check bool) "has open_cases field" true
+    Yojson.Safe.Util.(member "open_cases" json <> `Null);
 
   cleanup_dir base_path
 


### PR DESCRIPTION
## Summary

main CI의 `Build and Test` 실패 원인 3건 수정:

1. **trace.ml span ID 충돌**: `Hashtbl.hash(Unix.gettimeofday())`가 동일 밀리초 내 중복 ID 생성 → `Atomic` 단조 카운터로 교체
2. **governance status 필드명**: OAS dispatch에서 `cases_open` → `open_cases`로 변경됐지만 테스트 미갱신
3. **sangsu voice defaults**: CI에 `voice_config.json` 없어서 하드코딩된 기대값 불일치 → 런타임 쿼리로 전환

#1748 (빌드 복구) 이후 테스트 green 달성 목표.

## Test plan

- [x] `dune build --root .` 성공
- [ ] CI `Build and Test` 통과 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)