### PR TITLE
feat: integrate Eval_gate into OAS keeper tool dispatch

### DIFF
--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -107,6 +107,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
     ~max_turns:max_rounds
     ~temperature:0.3
     ~max_tokens:1024
+    ~gate_config
     ~guardrails
     ()
   with

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -18,26 +18,58 @@ open Keeper_exec_tools
 let tool_dispatch_max_context = 8192
 
 let make_dispatch ~(config : Room.config) ~(meta : keeper_meta)
+    ~(gate_config : Eval_gate.gate_config option)
+    ~(accumulated_cost_ref : float ref)
     ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
   let ctx_work = Context_manager.create
     ~system_prompt:(Printf.sprintf "Keeper %s OAS tool dispatch" meta.name)
     ~max_tokens:tool_dispatch_max_context
   in
-  let tc : Llm_types.tool_call = {
-    call_id = "";
-    call_name = name;
-    call_arguments = Yojson.Safe.to_string args;
-  } in
-  try
-    let output = execute_keeper_tool_call ~config ~meta ~ctx_work tc in
-    (true, output)
-  with exn ->
-    Log.Keeper.error "oas adapter tool %s failed: %s" name (Printexc.to_string exn);
-    (false, Yojson.Safe.to_string
-       (`Assoc [
-         ("error", `String "Tool execution failed");
-         ("tool", `String name);
-       ]))
+  let args_json = Yojson.Safe.to_string args in
+  let execute () =
+    let tc : Llm_types.tool_call = {
+      call_id = "";
+      call_name = name;
+      call_arguments = args_json;
+    } in
+    execute_keeper_tool_call ~config ~meta ~ctx_work tc
+  in
+  match gate_config with
+  | None ->
+    (try (true, execute ())
+     with exn ->
+       Log.Keeper.error "oas adapter tool %s failed: %s"
+         name (Printexc.to_string exn);
+       (false, Yojson.Safe.to_string
+          (`Assoc [("error", `String "Tool execution failed");
+                   ("tool", `String name)])))
+  | Some gate ->
+    let (decision, result_opt, eval_opt, _duration) =
+      Eval_gate.guarded_execute
+        ~config:gate
+        ~accumulated_cost:!accumulated_cost_ref
+        ~trajectory_acc:None
+        ~tool_name:name
+        ~args_json
+        ~execute
+    in
+    (match decision with
+     | Trajectory.Reject reason ->
+       Log.Keeper.warn "eval_gate rejected %s: %s" name reason;
+       (false, Yojson.Safe.to_string
+          (`Assoc [("error", `String ("Gate rejected: " ^ reason));
+                   ("tool", `String name)]))
+     | Trajectory.Pass ->
+       let output = Option.value ~default:"{}" result_opt in
+       (match eval_opt with
+        | Some eval ->
+          accumulated_cost_ref :=
+            !accumulated_cost_ref +. eval.Eval_gate.cost_usd;
+          if eval.Eval_gate.should_warn then
+            Log.Keeper.warn "eval_gate warning for %s: %s"
+              name (Option.value ~default:"" eval.Eval_gate.warning)
+        | None -> ());
+       (true, output))
 
 (* ================================================================ *)
 (* Public: run_with_tools                                            *)
@@ -57,14 +89,16 @@ let run_with_tools
     ~(max_turns : int)
     ~(temperature : float)
     ~(max_tokens : int)
+    ?(gate_config : Eval_gate.gate_config option)
     ?(guardrails : Agent_sdk.Guardrails.t option)
     ()
   : (tools_run_result, string) result =
   let masc_tools = keeper_allowed_llm_tools meta in
   let tools_executed_ref = ref [] in
+  let accumulated_cost_ref = ref 0.0 in
   let dispatch ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
     tools_executed_ref := name :: !tools_executed_ref;
-    make_dispatch ~config ~meta ~name ~args
+    make_dispatch ~config ~meta ~gate_config ~accumulated_cost_ref ~name ~args
   in
   match Oas_worker.run_named_with_masc_tools
     ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -17,7 +17,9 @@ type tools_run_result = {
 
 (** Tool loop LLM call (proactive, autonomy, social board events).
     Wraps [Oas_worker.run_named_with_masc_tools] with keeper tool dispatch.
-    [cascade_name] selects the model cascade (e.g. "keeper_autonomy"). *)
+    [cascade_name] selects the model cascade (e.g. "keeper_autonomy").
+    When [gate_config] is provided, each tool call is wrapped with
+    [Eval_gate.guarded_execute] for cost/entropy/destructive checks. *)
 val run_with_tools :
   config:Room.config ->
   meta:keeper_meta ->
@@ -27,6 +29,7 @@ val run_with_tools :
   max_turns:int ->
   temperature:float ->
   max_tokens:int ->
+  ?gate_config:Eval_gate.gate_config ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   unit ->
   (tools_run_result, string) result


### PR DESCRIPTION
## Summary

`make_dispatch`에 `?gate_config` 추가. 제공 시 `Eval_gate.guarded_execute`로 각 tool call을 감싸 cost/entropy/destructive 패턴 검증.

- `run_with_tools`에 `?gate_config:Eval_gate.gate_config` 파라미터 추가
- `keeper_exec_autonomy`가 autonomy-level gate를 `run_with_tools`에 전달
- gate 없으면 기존 동작 유지 (direct execution)

## Two-layer safety

| Layer | 검증 | 시점 |
|-------|------|------|
| **OAS guardrails** | tool allowlist/denylist, max_calls_per_turn | LLM prompt 생성 전 |
| **Eval_gate dispatch** | cost budget, entropy, destructive patterns | tool 실행 직전 |

## Test plan

- [x] `dune build --root .` 성공
- [ ] L3+ autonomy에서 cost budget 초과 시 tool rejection 확인
- [ ] gate 없는 경로 (social, proactive) 기존 동작 유지

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)