### PR TITLE
refactor(oas_worker): replace model_spec with provider+model_id in config

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -20,7 +20,8 @@ module Oas = Agent_sdk
 
 type config = {
   name : string;
-  model_spec : Llm_types.model_spec;
+  provider : Oas.Provider.config;
+  model_id : string;
   system_prompt : string;
   tools : Oas.Tool.t list;
   max_turns : int;
@@ -34,8 +35,8 @@ type config = {
   description : string option;
 }
 
-let default_config ~name ~model_spec ~system_prompt ~tools : config =
-  { name; model_spec; system_prompt; tools;
+let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
+  { name; provider; model_id; system_prompt; tools;
     max_turns = 20;
     max_tokens = 4096;
     temperature = 0.7;
@@ -108,7 +109,6 @@ let build
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
   : (Oas.Agent.t, string) result =
-  let provider = resolve_provider config.model_spec in
   let tool_names =
     List.map (fun (t : Oas.Tool.t) -> t.schema.name) config.tools in
   let guardrails = match config.guardrails with
@@ -120,13 +120,13 @@ let build
           else Oas.Guardrails.AllowAll }
   in
   let builder =
-    Oas.Builder.create ~net ~model:config.model_spec.model_id
+    Oas.Builder.create ~net ~model:config.model_id
     |> Oas.Builder.with_name config.name
     |> Oas.Builder.with_system_prompt config.system_prompt
     |> Oas.Builder.with_max_tokens config.max_tokens
     |> Oas.Builder.with_max_turns config.max_turns
     |> Oas.Builder.with_temperature config.temperature
-    |> Oas.Builder.with_provider provider
+    |> Oas.Builder.with_provider config.provider
     |> Oas.Builder.with_tools config.tools
     |> Oas.Builder.with_guardrails guardrails
   in
@@ -233,7 +233,9 @@ let resolve_cascade ~cascade_name =
   match Llm_cascade.get_cascade ~cascade_name () with
   | [] ->
     Error (Printf.sprintf "No models available for cascade '%s'" cascade_name)
-  | spec :: _ -> Ok spec
+  | spec :: _ ->
+    let provider = resolve_provider spec in
+    Ok (provider, spec.model_id)
 
 let run_named
     ~cascade_name
@@ -252,9 +254,9 @@ let run_named
   | Ok (sw, net) ->
   match resolve_cascade ~cascade_name with
   | Error e -> Error e
-  | Ok model_spec ->
+  | Ok (provider, model_id) ->
   let name = Printf.sprintf "oas-%s" cascade_name in
-  let config = { (default_config ~name ~model_spec ~system_prompt ~tools) with
+  let config = { (default_config ~name ~provider ~model_id ~system_prompt ~tools) with
     max_turns;
     max_tokens;
     temperature;
@@ -281,9 +283,9 @@ let run_named_with_masc_tools
   | Ok (sw, net) ->
   match resolve_cascade ~cascade_name with
   | Error e -> Error e
-  | Ok model_spec ->
+  | Ok (provider, model_id) ->
   let name = Printf.sprintf "oas-%s" cascade_name in
-  let config = { (default_config ~name ~model_spec ~system_prompt ~tools:[]) with
+  let config = { (default_config ~name ~provider ~model_id ~system_prompt ~tools:[]) with
     max_turns;
     max_tokens;
     temperature;


### PR DESCRIPTION
## Summary
- `Oas_worker.config.model_spec` (Llm_types.model_spec) → `provider` (OAS Provider.config) + `model_id` (string)
- `resolve_cascade` now returns `(Provider.config * string)` instead of `Llm_types.model_spec`
- No external caller impact — all use named cascade API (`run_named` / `run_named_with_masc_tools`)

## Context
Step 5 PR-A of the OAS migration plan. This is the first of 3 stacked PRs to remove `Llm_types.model_spec` from MASC.
- PR-A (this): config field replacement in oas_worker
- PR-B (next): remove parsing functions from llm_types.ml
- PR-C (final): delete Llm_types.model_spec type

## Test plan
- [x] `dune build` passes (type-safe refactoring)
- [ ] CI tests pass
- [ ] `rg "model_spec" lib/oas_worker.ml` shows only internal resolve_provider usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)