### PR TITLE
fix(gardener): wire worker dispatch through tag-based registry

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -212,7 +212,7 @@ let tick ~sw ~clock:_ ~config ~room_config : unit =
         Eio.traceln "[Gardener] Task pressure: %d TODO, %d high-pri, %d orphans"
           backlog.todo_count backlog.high_priority_todo backlog.orphan_count;
         let triage_state = get_state () in
-        (match Gardener_worker.run_for_backlog ~backlog with
+        (match Gardener_worker.run_for_backlog ~config:room_config ~backlog with
          | Ok result ->
              triage_state.last_triage_started_at <- Time_compat.now ();
              triage_state.last_triage_outcome <- Triage_productive;

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -229,27 +229,31 @@ let decide_retire ~config ~health ~(agent_stats : agent_stats) : retirement_deci
 let execute_spawn ?sw ?room_config ~(decision : spawn_decision) () : (string, string) result =
   match decision with
   | SpawnApproved { topic; proposed_traits; proposed_hours = _; reason; _ } ->
-      ignore (sw, room_config);
+      ignore sw;
       Eio.traceln "[Gardener] Executing OAS worker spawn: %s (reason: %s)" topic reason;
       let config = load_config () in
       let traits_str = String.concat ", " proposed_traits in
-      (match Gardener_worker.run_for_gap ~topic ~traits_str ~reason with
-       | Ok result ->
-           record_spawn ();
-           reset_circuit ();
-           let msg = Printf.sprintf
-             "OAS worker completed for '%s' (turns=%d, session=%s)"
-             topic result.Oas_worker.turns result.Oas_worker.session_id in
-           let store = Board.global () in
-           (try ignore (Board.create_post store ~author:"gardener"
-             ~content:(Printf.sprintf "Worker completed: %s\nTopic: %s\nReason: %s\nTurns: %d"
-               result.Oas_worker.session_id topic reason result.Oas_worker.turns)
-             ~ttl_hours:24 ())
-            with exn -> Log.Spawn.error "Board.create_post failed: %s" (Printexc.to_string exn));
-           Ok msg
-       | Error e ->
-           trip_circuit ~config;
-           Error (Printf.sprintf "OAS worker failed: %s" e))
+      (match room_config with
+       | None ->
+           Error "room_config required for OAS worker spawn (call from tick loop)"
+       | Some room_cfg ->
+           (match Gardener_worker.run_for_gap ~config:room_cfg ~topic ~traits_str ~reason with
+            | Ok result ->
+                record_spawn ();
+                reset_circuit ();
+                let msg = Printf.sprintf
+                  "OAS worker completed for '%s' (turns=%d, session=%s)"
+                  topic result.Oas_worker.turns result.Oas_worker.session_id in
+                let store = Board.global () in
+                (try ignore (Board.create_post store ~author:"gardener"
+                  ~content:(Printf.sprintf "Worker completed: %s\nTopic: %s\nReason: %s\nTurns: %d"
+                    result.Oas_worker.session_id topic reason result.Oas_worker.turns)
+                  ~ttl_hours:24 ())
+                 with exn -> Log.Spawn.error "Board.create_post failed: %s" (Printexc.to_string exn));
+                Ok msg
+            | Error e ->
+                trip_circuit ~config;
+                Error (Printf.sprintf "OAS worker failed: %s" e)))
   | SpawnDeferred { topic = _; reason; _ } ->
       Error (Printf.sprintf "Spawn deferred: %s" reason)
   | SpawnRejected { topic; reason } ->

--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -22,47 +22,74 @@ let worker_tools () : Llm_types.tool_def list =
       Eio.traceln "[Gardener_worker] tool schema lookup failed: %s" msg;
       []
 
-(** Dispatch closure that routes tool calls through the global registry. *)
-let make_dispatch () ~name ~args =
-  match Tool_dispatch.dispatch ~name ~args with
-  | Some result -> result
-  | None -> (false, Printf.sprintf "Unknown tool: %s" name)
+(** Dispatch closure that routes tool calls through the tag-based registry.
 
-let run_for_gap ~topic ~traits_str ~reason =
+    The old [Tool_dispatch.dispatch] path uses a handler Hashtbl that is never
+    populated — all real handlers live behind [Tool_dispatch.lookup_tag] and
+    module-specific dispatch functions.  This closure mirrors the lightweight
+    subset of [execute_tool_eio]'s tag dispatch for the tools a Gardener
+    worker actually needs. *)
+let make_dispatch ~(config : Room.config) ~(agent_name : string) () ~name ~args =
+  match Tool_dispatch.lookup_tag name with
+  | Some Tool_dispatch.Mod_task ->
+      (match Tool_task.dispatch { Tool_task.config; agent_name } ~name ~args with
+       | Some result -> result
+       | None -> (false, Printf.sprintf "Unknown task tool: %s" name))
+  | Some Tool_dispatch.Mod_room ->
+      (match Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args with
+       | Some result -> result
+       | None -> (false, Printf.sprintf "Unknown room tool: %s" name))
+  | Some Tool_dispatch.Mod_heartbeat ->
+      (* Heartbeat requires sw/clock — skip in worker context, return success *)
+      (true, Printf.sprintf "Heartbeat skipped (in-process worker): %s" agent_name)
+  | Some _ ->
+      (* Tool exists in tag registry but not in the worker's supported set *)
+      (false, Printf.sprintf "Tool %s is not available in worker context" name)
+  | None ->
+      (false, Printf.sprintf "Unknown tool: %s" name)
+
+let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
+  let agent_name = Printf.sprintf "gardener-worker-%s" topic in
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:
       (Printf.sprintf
-         "You are a MASC Gardener worker. Address: %s\n\
+         "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
+          Topic: %s\n\
           Traits: %s\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
           1. masc_status -> room state\n\
           2. masc_tasks -> find unclaimed work\n\
           3. masc_claim_next -> claim a task\n\
           4. Work on the claimed task\n\
-          5. masc_transition -> mark done\n\
+          5. masc_transition(task_id=..., action='done') -> mark done\n\
           6. masc_broadcast -> report results\n\
           Terminate after completion. Do not loop."
-         topic traits_str)
+         agent_name topic traits_str agent_name)
     ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
     ~masc_tools:(worker_tools ())
-    ~dispatch:(make_dispatch ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
     ~max_turns:10 ~temperature:0.3 ()
 
-let run_for_backlog ~(backlog : Gardener_types.task_backlog_summary) =
+let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
+  let agent_name = "gardener-triage-worker" in
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:
-      "You are a MASC triage worker.\n\
-       1. masc_tasks -> review backlog\n\
-       2. masc_claim_next -> claim high-priority task\n\
-       3. Process or delegate\n\
-       4. masc_transition -> update status\n\
-       5. masc_broadcast -> report results\n\
-       Terminate after completion."
+      (Printf.sprintf
+         "You are a MASC triage worker. Your agent_name is '%s'.\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
+          1. masc_tasks -> review backlog\n\
+          2. masc_claim_next -> claim high-priority task\n\
+          3. Process or delegate\n\
+          4. masc_transition -> update status\n\
+          5. masc_broadcast -> report results\n\
+          Terminate after completion."
+         agent_name agent_name)
     ~goal:
       (Printf.sprintf
          "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
          backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
     ~masc_tools:(worker_tools ())
-    ~dispatch:(make_dispatch ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
     ~max_turns:15 ~temperature:0.3 ()

--- a/lib/gardener/gardener_worker.mli
+++ b/lib/gardener/gardener_worker.mli
@@ -3,18 +3,23 @@
     Workers receive [gardener_worker_tool_names] (claim, transition, etc.)
     and terminate after completing their goal. *)
 
-(** [run_for_gap ~topic ~traits_str ~reason] spawns a 1-shot OAS worker
-    to address a detected ecosystem gap.  The worker will claim a pending
-    task, work on it, and terminate. *)
+(** [run_for_gap ~config ~topic ~traits_str ~reason] spawns a 1-shot OAS
+    worker to address a detected ecosystem gap.  The worker will claim a
+    pending task, work on it, and terminate.
+
+    [config] is the room configuration, required so the worker can dispatch
+    tool calls through the tag-based registry with proper context. *)
 val run_for_gap :
+  config:Room.config ->
   topic:string ->
   traits_str:string ->
   reason:string ->
   (Oas_worker.run_result, string) result
 
-(** [run_for_backlog ~backlog] spawns a 1-shot OAS worker for backlog
-    triage.  The worker reviews unclaimed tasks, claims high-priority
+(** [run_for_backlog ~config ~backlog] spawns a 1-shot OAS worker for
+    backlog triage.  The worker reviews unclaimed tasks, claims high-priority
     ones, and reports via broadcast + board. *)
 val run_for_backlog :
+  config:Room.config ->
   backlog:Gardener_types.task_backlog_summary ->
   (Oas_worker.run_result, string) result

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -940,9 +940,14 @@ let test_tick_reuses_existing_backlog_triage_session () =
     in_progress_count = 1; done_count = 2; orphan_count = 1;
     oldest_todo_age_hours = 4.0; high_priority_todo = 2;
   } in
-  match Gardener_worker.run_for_backlog ~backlog with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context"
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Room.default_config dir in
+      match Gardener_worker.run_for_backlog ~config ~backlog with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context")
 
 (* Tick with inactive joined agent should still attempt OAS worker *)
 let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
@@ -1275,9 +1280,14 @@ let test_worker_tool_count_bounds () =
   check bool "at most 30 tools" true (n <= 30)
 
 let test_run_for_gap_without_eio_returns_error () =
-  match Gardener_worker.run_for_gap ~topic:"test" ~traits_str:"a" ~reason:"r" with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error when Eio context is not set"
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Room.default_config dir in
+      match Gardener_worker.run_for_gap ~config ~topic:"test" ~traits_str:"a" ~reason:"r" with
+      | Error _ -> ()
+      | Ok _ -> fail "expected Error when Eio context is not set")
 
 let worker_suite = [
   "worker_tools_include_claim_and_transition", `Quick,


### PR DESCRIPTION
## Summary

- Gardener worker의 tool dispatch가 빈 registry를 조회하여 모든 tool call이 "Unknown tool"로 실패하던 근본 버그 수정
- `Tool_dispatch.dispatch` (비어있는 handler Hashtbl) → `Tool_dispatch.lookup_tag` (실제 등록된 tag registry) 기반으로 전환
- `Room.config`를 worker에 전달하여 `Tool_task.dispatch`가 올바른 context로 동작

## Root Cause

MASC에는 2개의 dispatch 시스템이 공존:
1. `Tool_dispatch.registry` (handler Hashtbl) — **등록 코드 없음, 비어있음**
2. `Tool_dispatch.tag_registry` — `mcp_server_eio.ml`에서 등록, **실제 사용됨**

Worker는 1번을 호출하고 있어서 모든 tool이 "Unknown tool"로 실패.

**증거**: audit.jsonl에서 task_done 0건, backlog 38개 중 36개 todo, 마지막 worker 활동 join/leave만.

## Changes

| File | Change |
|------|--------|
| `gardener_worker.ml` | `make_dispatch`를 tag-based routing으로 교체 (Mod_task, Mod_room, Mod_heartbeat) |
| `gardener_worker.mli` | `~config:Room.config` 파라미터 추가 |
| `gardener_decisions.ml` | `execute_spawn`에서 `room_config` 전달, None이면 Error 반환 |
| `gardener.ml` | `run_for_backlog`에 `~config:room_config` 전달 |
| `test_gardener.ml` | 테스트에 Room.config 전달 |

## Test plan

- [x] `dune build` 성공
- [x] `gardener_worker` 테스트 4/4 통과
- [ ] 실제 gardener spawn → worker task claim → done e2e 검증 (서버 재시작 후)


🤖 Generated with [Claude Code](https://claude.com/claude-code)