### PR TITLE
refactor(dashboard): reduce noise and data duplication for observer UX

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -126,7 +126,7 @@ export function fetchDashboardMemory(
   const params = new URLSearchParams()
   params.set('sort_by', sortMode)
   if (opts?.excludeSystem) params.set('exclude_system', 'true')
-  return get(`/api/v1/dashboard/memory${params.toString() ? `?${params}` : ''}`)
+  return get(`/api/v1/dashboard/board${params.toString() ? `?${params}` : ''}`)
 }
 
 export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse> {
@@ -211,8 +211,9 @@ export function fetchDashboardSemantics(): Promise<DashboardSemanticsResponse> {
   return get('/api/v1/dashboard/semantics')
 }
 
-export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
-  return get('/api/v1/dashboard/mission')
+export function fetchDashboardMission(mode?: 'snapshot' | 'full'): Promise<DashboardMissionResponse> {
+  const query = mode ? `?mode=${mode}` : ''
+  return get(`/api/v1/dashboard/mission${query}`)
 }
 
 export function fetchDashboardMissionSession(sessionId: string): Promise<DashboardMissionSessionDetailResponse> {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -5,9 +5,8 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { route, initRouter } from './router'
 import { connectSSE, disconnectSSE } from './sse'
-import {
-  refreshDashboardSemantics,
-} from './store'
+import { dashboardSemantics } from './store'
+import { fetchDashboardSemantics } from './api'
 import { refreshRoomTruth } from './room-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForTab } from './tab-refresh'
@@ -35,7 +34,11 @@ export function App() {
     // Removed redundant refreshShell(), refreshExecution(), refreshMissionSnapshot()
     // that caused 5 concurrent API calls (server computes same data 3-6x).
     refreshRoomTruth()
-    refreshDashboardSemantics()
+
+    // Semantics: static data, fetch once and cache forever.
+    void fetchDashboardSemantics()
+      .then(data => { dashboardSemantics.value = data })
+      .catch(() => {})
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -38,11 +38,11 @@ export function App() {
     // Semantics: static data, fetch once and cache forever.
     void fetchDashboardSemantics()
       .then(data => { dashboardSemantics.value = data })
-      .catch(() => {})
+      .catch(err => { console.warn('Semantics load failed (non-critical):', err) })
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.
-    registerMissionRefresh(() => void refreshMissionSnapshot())
+    registerMissionRefresh(() => void refreshMissionSnapshot('snapshot'))
 
     // Setup SSE -> store reaction (debounced refresh on events)
     const unsubSSE = setupSSEReaction()

--- a/dashboard/src/components/common/semantic-layer.ts
+++ b/dashboard/src/components/common/semantic-layer.ts
@@ -4,7 +4,6 @@ import type {
   DashboardSemanticPanel,
 } from '../../types'
 import {
-  dashboardSemanticsLoading,
   findDashboardSemanticPanel,
 } from '../../store'
 
@@ -64,11 +63,7 @@ export function PanelSemanticDetails({
   label?: string
 }) {
   const panel = findDashboardSemanticPanel(panelId)
-  if (!panel) {
-    return dashboardSemanticsLoading.value
-      ? html`<span class="semantic-inline-state">의미 계층 불러오는 중…</span>`
-      : null
-  }
+  if (!panel) return null
   return html`
     <details class="semantic-inline ${compact ? 'compact' : ''}">
       <summary class="semantic-summary">${label}</summary>

--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -1,53 +1,49 @@
-// OAS Agent Pipeline — real-time agent lifecycle and keeper snapshot monitor.
-// Shows recent agent selection/decision/execution events from OAS Event_bus.
+// OAS Agent Pipeline — summary view with expandable raw events.
+// Shows 3-line summary + keeper context bars. Raw events behind <details> toggle.
 
 import { html } from 'htm/preact'
 import { oasAgentEvents, oasKeeperSnapshots, oasHealthSummary } from '../../store'
-
-function actionBadge(action: string | undefined): string {
-  switch (action) {
-    case 'post': return 'badge--post'
-    case 'comment': return 'badge--comment'
-    case 'upvote': return 'badge--upvote'
-    case 'skip': return 'badge--skip'
-    case 'passed': return 'badge--skip'
-    case 'skipped': return 'badge--skip'
-    default: return ''
-  }
-}
 
 function formatTs(ts: number): string {
   const d = new Date(ts * 1000)
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`
 }
 
-function OasAgentEventList() {
-  const events = oasAgentEvents.value
-  if (events.length === 0) {
-    return html`<div class="oas-empty">OAS agent event 대기 중...</div>`
+function actionBadge(action: string | undefined): string {
+  switch (action) {
+    case 'post': return 'badge--post'
+    case 'comment': return 'badge--comment'
+    case 'upvote': return 'badge--upvote'
+    case 'skip':
+    case 'passed':
+    case 'skipped': return 'badge--skip'
+    default: return ''
   }
+}
+
+function OasSummaryLines() {
+  const events = oasAgentEvents.value
+  const snapshots = oasKeeperSnapshots.value
+  const health = oasHealthSummary.value
+
+  // Count distinct active agents from recent events
+  const activeAgents = new Set(events.map(ev => ev.agent_name))
+  const firstEvent = events[0]
+  const lastEventTs = firstEvent != null ? firstEvent.timestamp : null
+  const agoMin = lastEventTs != null ? Math.round((Date.now() / 1000 - lastEventTs) / 60) : null
 
   return html`
-    <div class="oas-event-list">
-      ${events.slice(0, 15).map((ev, i) => html`
-        <div class="oas-event-row" key=${i}>
-          <span class="oas-event-ts">${formatTs(ev.timestamp)}</span>
-          <span class="oas-event-agent">${ev.agent_name}</span>
-          <span class="oas-event-type">${ev.type}</span>
-          ${ev.action ? html`<span class="oas-event-badge ${actionBadge(ev.action)}">${ev.action}</span>` : null}
-          ${ev.trigger ? html`<span class="oas-event-trigger">${ev.trigger}</span>` : null}
-          ${ev.success != null ? html`<span class="oas-event-ok ${ev.success ? 'ok' : 'fail'}">${ev.success ? 'ok' : 'fail'}</span>` : null}
-        </div>
-      `)}
+    <div class="oas-summary-lines">
+      <span>${activeAgents.size} agents active</span>
+      <span>${health.totalEvents} events${snapshots.size > 0 ? `, ${snapshots.size} keepers` : ''}</span>
+      <span>${agoMin != null ? `last ${agoMin}m ago` : 'no events yet'}</span>
     </div>
   `
 }
 
-function OasKeeperSnapshotList() {
+function OasKeeperBars() {
   const snapshots = oasKeeperSnapshots.value
-  if (snapshots.size === 0) {
-    return html`<div class="oas-empty">OAS keeper snapshot 대기 중...</div>`
-  }
+  if (snapshots.size === 0) return null
 
   const entries = [...snapshots.values()].sort((a, b) => b.timestamp - a.timestamp)
 
@@ -72,6 +68,28 @@ function OasKeeperSnapshotList() {
   `
 }
 
+function OasRawEventList() {
+  const events = oasAgentEvents.value
+  if (events.length === 0) {
+    return html`<div class="oas-empty">OAS agent event 대기 중...</div>`
+  }
+
+  return html`
+    <div class="oas-event-list">
+      ${events.slice(0, 15).map((ev, i) => html`
+        <div class="oas-event-row" key=${i}>
+          <span class="oas-event-ts">${formatTs(ev.timestamp)}</span>
+          <span class="oas-event-agent">${ev.agent_name}</span>
+          <span class="oas-event-type">${ev.type}</span>
+          ${ev.action ? html`<span class="oas-event-badge ${actionBadge(ev.action)}">${ev.action}</span>` : null}
+          ${ev.trigger ? html`<span class="oas-event-trigger">${ev.trigger}</span>` : null}
+          ${ev.success != null ? html`<span class="oas-event-ok ${ev.success ? 'ok' : 'fail'}">${ev.success ? 'ok' : 'fail'}</span>` : null}
+        </div>
+      `)}
+    </div>
+  `
+}
+
 export function OasPipeline() {
   const health = oasHealthSummary.value
 
@@ -82,15 +100,17 @@ export function OasPipeline() {
         <span class="oas-pipeline__count">${health.totalEvents} events</span>
       </div>
 
-      <div class="oas-pipeline__section">
-        <div class="oas-section-label">Agent Lifecycle</div>
-        <${OasAgentEventList} />
-      </div>
+      <${OasSummaryLines} />
 
       <div class="oas-pipeline__section">
         <div class="oas-section-label">Keeper Context</div>
-        <${OasKeeperSnapshotList} />
+        <${OasKeeperBars} />
       </div>
+
+      <details class="oas-pipeline__raw-toggle">
+        <summary>Agent Lifecycle (raw events)</summary>
+        <${OasRawEventList} />
+      </details>
     </div>
   `
 }

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -3,7 +3,6 @@ import type { ComponentChildren } from 'preact'
 import { connected, eventCount } from '../sse'
 import {
   refreshDashboard,
-  refreshDashboardSemantics,
   agents,
   tasks,
   keepers,
@@ -201,7 +200,6 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
           class="rail-refresh-btn"
           onClick=${() => {
             refreshDashboard()
-            refreshDashboardSemantics()
             refreshForTab(currentTab)
           }}
         >

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -635,11 +635,11 @@ function normalizeMissionBriefing(raw: unknown): DashboardMissionBriefingRespons
   }
 }
 
-export async function refreshMissionSnapshot(): Promise<void> {
+export async function refreshMissionSnapshot(mode?: 'snapshot' | 'full'): Promise<void> {
   missionLoading.value = true
   missionError.value = null
   try {
-    const raw = await fetchDashboardMission()
+    const raw = await fetchDashboardMission(mode ?? 'snapshot')
     missionSnapshot.value = normalizeMission(raw)
   } catch (err) {
     missionError.value = err instanceof Error ? err.message : 'Failed to load mission snapshot'

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -639,7 +639,7 @@ export async function refreshMissionSnapshot(mode?: 'snapshot' | 'full'): Promis
   missionLoading.value = true
   missionError.value = null
   try {
-    const raw = await fetchDashboardMission(mode ?? 'snapshot')
+    const raw = await fetchDashboardMission(mode)
     missionSnapshot.value = normalizeMission(raw)
   } catch (err) {
     missionError.value = err instanceof Error ? err.message : 'Failed to load mission snapshot'

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -21,6 +21,8 @@ export const roomTruthLoading = signal(false)
 export const roomTruthError = signal<string | null>(null)
 
 let inflightRoomTruthRefresh: Promise<void> | null = null
+let lastRoomTruthRefreshAt = 0
+const ROOM_TRUTH_TTL_MS = 15_000
 
 function normalizeServerStatus(raw: unknown): ServerStatus | null {
   if (!isRecord(raw)) return null
@@ -160,8 +162,9 @@ export const roomTruthInitializing = signal(false)
 const WARM_RETRY_DELAY_MS = 3_000
 const WARM_MAX_RETRIES = 10
 
-export async function refreshRoomTruth(): Promise<void> {
+export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void> {
   if (inflightRoomTruthRefresh) return inflightRoomTruthRefresh
+  if (!opts?.force && Date.now() - lastRoomTruthRefreshAt < ROOM_TRUTH_TTL_MS) return
 
   roomTruthLoading.value = true
   roomTruthError.value = null
@@ -178,6 +181,7 @@ export async function refreshRoomTruth(): Promise<void> {
       }
       roomTruthInitializing.value = false
       roomTruth.value = normalizeRoomTruth(raw)
+      lastRoomTruthRefreshAt = Date.now()
     } catch (err) {
       roomTruthError.value = err instanceof Error ? err.message : 'Failed to load room truth'
     } finally {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -29,7 +29,6 @@ import {
   fetchDashboardExecution,
   fetchDashboardMemory,
   fetchDashboardPlanning,
-  fetchDashboardSemantics,
   fetchDashboardShell,
   fetchMessagesList,
   fetchTrpgState,
@@ -188,9 +187,9 @@ export const dashboardLoading = signal(false)
 export const boardLoading = signal(false)
 export const trpgLoading = signal(false)
 export const mdalLoading = signal(false)
+
+// Semantics: loaded once on startup, never refreshed (static data).
 export const dashboardSemantics = signal<DashboardSemanticsResponse | null>(null)
-export const dashboardSemanticsLoading = signal(false)
-export const dashboardSemanticsError = signal<string | null>(null)
 
 // --- Refresh timestamps ---
 
@@ -198,7 +197,10 @@ export const lastDashboardRefreshAt = signal<string | null>(null)
 export const lastBoardRefreshAt = signal<string | null>(null)
 export const lastGoalsRefreshAt = signal<string | null>(null)
 export const lastMdalRefreshAt = signal<string | null>(null)
-export const lastDashboardSemanticsRefreshAt = signal<string | null>(null)
+
+// --- Execution TTL guard (Phase 1C) ---
+
+export const lastExecutionRefreshAt = signal<number>(0)
 
 // --- Derived state ---
 
@@ -305,22 +307,6 @@ export async function refreshDashboard(): Promise<void> {
   }
 }
 
-export async function refreshDashboardSemantics(): Promise<void> {
-  dashboardSemanticsLoading.value = true
-  dashboardSemanticsError.value = null
-  try {
-    const data = await fetchDashboardSemantics()
-    dashboardSemantics.value = data
-    lastDashboardSemanticsRefreshAt.value = new Date().toISOString()
-  } catch (err) {
-    dashboardSemanticsError.value =
-      err instanceof Error ? err.message : 'Failed to load dashboard semantics'
-  } finally {
-    dashboardSemanticsLoading.value = false
-  }
-}
-
-
 export function findDashboardSemanticPanel(panelId: string): DashboardSemanticPanel | null {
   const surfaces = dashboardSemantics.value?.surfaces ?? []
   for (const surface of surfaces) {
@@ -414,7 +400,10 @@ export async function refreshAgentActivity(): Promise<void> {
   }
 }
 
-export async function refreshExecution(): Promise<void> {
+const EXECUTION_TTL_MS = 30_000
+
+export async function refreshExecution(opts?: { force?: boolean }): Promise<void> {
+  if (!opts?.force && Date.now() - lastExecutionRefreshAt.value < EXECUTION_TTL_MS) return
   try {
     const data = await fetchDashboardExecution()
     const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
@@ -455,6 +444,7 @@ export async function refreshExecution(): Promise<void> {
       .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
     perpetualStatus.value = null
     executionLoaded.value = true
+    lastExecutionRefreshAt.value = Date.now()
     lastDashboardRefreshAt.value = new Date().toISOString()
   } catch (err) {
     console.error('Dashboard execution fetch error:', err)

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -24,7 +24,7 @@ export function refreshForTab(tab: string) {
 
   if (tab === 'situation') {
     refreshRoomTruth()
-    refreshMissionSnapshot()
+    refreshMissionSnapshot('full')
     refreshMissionBriefing()
   }
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -350,22 +350,78 @@ let start_mission_refresh_loop ~state ~sw ~clock =
     in
     loop ())
 
+(* Trim a full mission JSON to a lightweight snapshot:
+   summary, session_briefs (goal/elapsed/blocker only), attention_queue (top 5), counts.
+   Target: <20KB vs ~483KB full. *)
+let mission_snapshot_of_full (full : Yojson.Safe.t) : Yojson.Safe.t =
+  let field key = Yojson.Safe.Util.member key full in
+  let briefs =
+    match field "session_briefs" with
+    | `List items ->
+        `List
+          (List.map
+             (fun item ->
+               let f k = Yojson.Safe.Util.member k item in
+               `Assoc
+                 [
+                   ("session_id", f "session_id");
+                   ("goal", f "goal");
+                   ("status", f "status");
+                   ("health", f "health");
+                   ("elapsed_sec", f "elapsed_sec");
+                   ("blocker_summary", f "blocker_summary");
+                 ])
+             items)
+    | other -> other
+  in
+  let attention_top5 =
+    match field "attention_queue" with
+    | `List items -> `List (List.filteri (fun i _ -> i < 5) items)
+    | other -> other
+  in
+  `Assoc
+    [
+      ("generated_at", field "generated_at");
+      ("summary", field "summary");
+      ("session_briefs", briefs);
+      ("attention_queue", attention_top5);
+      ("session_count",
+       `Int
+         (match field "sessions" with `List l -> List.length l | _ -> 0));
+      ("agent_count",
+       `Int
+         (match field "agent_briefs" with
+         | `List l -> List.length l
+         | _ -> 0));
+      ("keeper_count",
+       `Int
+         (match field "keeper_briefs" with
+         | `List l -> List.length l
+         | _ -> 0));
+    ]
+
 let dashboard_mission_http_json ~state ~sw ~clock request =
   let actor = operator_actor_hint request in
-  match actor with
-  | None ->
-    (* Default: return proactively cached value immediately (0ms). *)
-    !_mission_json_ref
-  | Some _ ->
-    (* Actor-parameterized: on-demand with SWR cache. *)
-    let cache_key =
-      Printf.sprintf "mission:%s" (Option.value ~default:"" actor)
-    in
-    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
-      ~clock ~timeout_sec:30.0 (fun () ->
-      Dashboard_mission.json ?actor
-        ~config:state.Mcp_server.room_config ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ())
+  let mode = query_param request "mode" in
+  let full_json =
+    match actor with
+    | None ->
+      (* Default: return proactively cached value immediately (0ms). *)
+      !_mission_json_ref
+    | Some _ ->
+      (* Actor-parameterized: on-demand with SWR cache. *)
+      let cache_key =
+        Printf.sprintf "mission:%s" (Option.value ~default:"" actor)
+      in
+      Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
+        ~clock ~timeout_sec:30.0 (fun () ->
+        Dashboard_mission.json ?actor
+          ~config:state.Mcp_server.room_config ~sw ~clock
+          ~proc_mgr:state.Mcp_server.proc_mgr ())
+  in
+  match mode with
+  | Some "snapshot" -> mission_snapshot_of_full full_json
+  | _ -> full_json
 
 let dashboard_session_http_json ~state ~sw ~clock request =
   match query_param request "session_id" with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -426,6 +426,11 @@ let make_request_handler ~sw ~clock ~server_start_time =
           let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/board" ->
+          let json = dashboard_memory_http_json httpun_request in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
+      (* Legacy alias — kept for backward compatibility *)
       | `GET, "/api/v1/dashboard/memory" ->
           let json = dashboard_memory_http_json httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -82,6 +82,12 @@ let add_routes ~sw ~clock router =
          let json = dashboard_execution_http_json ~state ~sw ~clock request in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = dashboard_memory_http_json req in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  (* Legacy alias — kept for backward compatibility *)
   |> Http.Router.get "/api/v1/dashboard/memory" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = dashboard_memory_http_json req in


### PR DESCRIPTION
## Summary

MASC 대시보드에서 "에이전트 사회 관찰자"에게 불필요한 노이즈와 데이터 중복을 제거.

### Phase 0: Dead Weight 제거
- **0A**: semantics 엔드포인트 — 정적 데이터를 매 refresh마다 fetch하던 것을 startup 1회로 축소. loading/error signal 제거.
- **0B**: OasPipeline — 15개 raw event를 3줄 요약으로 전환 (agents active, event count, recency). Keeper bars 유지, raw events는 `<details>` 토글 뒤로.
- **0C**: `/api/v1/dashboard/memory` → `/api/v1/dashboard/board`로 이름 정리 (실제 데이터는 board posts). Legacy alias 유지.

### Phase 1: 데이터 중복 제거
- **1A**: roomTruth TTL 가드 (15초) — 탭 전환 시 5/7탭이 호출하던 중복 fetch 방지.
- **1B**: mission 2-tier — `?mode=snapshot`으로 ~20KB 경량 응답 (full은 ~483KB). Home=snapshot, Situation=full.
- **1C**: execution TTL 가드 (30초) — home 탭의 roomTruth+execution 이중 fetch 방지.

## 변경 파일 (12)

| 파일 | 변경 |
|------|------|
| `store.ts` | 0A: semantics 제거, 1C: execution TTL |
| `app.ts` | 0A: one-time semantics fetch |
| `semantic-layer.ts` | 0A: loading 참조 제거 |
| `oas-pipeline.ts` | 0B: 요약 뷰 전환 |
| `resident-runtime-rail.ts` | 0A: refresh 버튼에서 semantics 제거 |
| `api/dashboard.ts` | 0C: board URL, 1B: mission mode |
| `mission-store.ts` | 1B: snapshot/full 분기 |
| `room-truth-store.ts` | 1A: TTL 가드 |
| `tab-refresh.ts` | 1B: situation=full |
| `server_dashboard_http_core.ml` | 1B: mission_snapshot_of_full |
| `server_h2_gateway.ml` | 0C: board route alias |
| `server_routes_http_routes_dashboard.ml` | 0C: board route alias |

## Test plan

- [ ] `dune build --root .` — OCaml 빌드 통과 (확인 완료)
- [ ] `make test` — 27/27 테스트 통과 (확인 완료)
- [ ] `cd dashboard && npm run dev` → Home 탭에서 semantics fetch 1회만 발생 확인
- [ ] Network 탭: 탭 전환 시 roomTruth 15초 이내 중복 없음
- [ ] Mission endpoint: `?mode=snapshot` 응답 <20KB
- [ ] OasPipeline: 3줄 요약 표시 + details 토글 동작
- [ ] 전체 7탭 순회 — 깨진 위젯 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)