### PR TITLE
feat(keeper): expand recall candidates with history.jsonl

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -510,6 +510,49 @@ let recent_user_messages (msgs : Agent_sdk.Types.message list) ~(max_n : int) : 
        else None)
   |> take max_n
 
+(** Load user messages from a history.jsonl file (persisted across generations).
+    Each line is a JSON object with "role" and "content" fields.
+    Returns up to [max_n] user messages from the tail of the file. *)
+let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
+  let lines = read_file_tail_lines path ~max_bytes:0 ~max_lines:(max_n * 3) in
+  lines
+  |> List.filter_map (fun line ->
+       try
+         let json = Yojson.Safe.from_string line in
+         let role = Yojson.Safe.Util.(json |> member "role" |> to_string) in
+         if role = "user" then
+           let content =
+             Yojson.Safe.Util.(json |> member "content" |> to_string)
+             |> String.trim
+           in
+           if content = "" then None else Some content
+         else None
+       with _ -> None)
+  |> take max_n
+
+(** Build recall candidates by merging checkpoint messages with history.jsonl.
+    Checkpoint messages are prioritized (recent context), history.jsonl
+    provides cross-generation recall for older conversations. Deduplication
+    uses exact string match on the first 100 characters. *)
+let recall_candidates_with_history
+    ~(checkpoint_messages : Agent_sdk.Types.message list)
+    ~(history_path : string)
+    ~(max_checkpoint : int)
+    ~(max_history : int) : string list =
+  let from_checkpoint = recent_user_messages checkpoint_messages ~max_n:max_checkpoint in
+  let from_history = load_history_user_messages ~path:history_path ~max_n:max_history in
+  (* Deduplicate: checkpoint messages take priority *)
+  let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
+  let key_of s =
+    let len = min 100 (String.length s) in
+    String.sub s 0 len
+  in
+  List.iter (fun s -> Hashtbl.replace seen (key_of s) ()) from_checkpoint;
+  let unique_history =
+    List.filter (fun s -> not (Hashtbl.mem seen (key_of s))) from_history
+  in
+  from_checkpoint @ unique_history
+
 type memory_recall_eval = {
   performed: bool;
   query_kind: string;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -291,7 +291,16 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~fallback:requests
               | _ -> run_cascade_batch requests
             in
-            let recall_candidates = recent_user_messages base_ctx.messages ~max_n:32 in
+            let history_path =
+              Filename.concat (Filename.concat base_dir meta.trace_id) "history.jsonl"
+            in
+            let recall_candidates =
+              recall_candidates_with_history
+                ~checkpoint_messages:base_ctx.messages
+                ~history_path
+                ~max_checkpoint:32
+                ~max_history:64
+            in
             let (cascade_result0, latency0) = Masc_model.timed (fun () ->
                 run_cascade requests) in
             match cascade_result0 with

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Mention = Masc_mcp.Mention
 module Keeper_execution = Masc_mcp.Keeper_execution
 module Keeper_memory = Masc_mcp.Keeper_memory
+module Keeper_memory_recall = Masc_mcp.Keeper_memory_recall
 module Keeper_types = Masc_mcp.Keeper_types
 module Types = Masc_mcp.Types
 
@@ -174,6 +175,84 @@ let test_prioritized_action_to_string_all_variants () =
   check string "handoff" "handoff" (prioritized_action_to_string Act_handoff);
   check string "none" "none" (prioritized_action_to_string Act_none)
 
+(* --- history recall tests --- *)
+
+let test_tmpdir () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc-test-%d" (Unix.getpid ())) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_tmpdir dir =
+  (try
+     Array.iter (fun f -> Sys.remove (Filename.concat dir f)) (Sys.readdir dir);
+     Unix.rmdir dir
+   with _ -> ())
+
+let test_load_history_user_messages () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "history.jsonl" in
+    let lines = [
+      {|{"role":"user","content":"hello world"}|};
+      {|{"role":"assistant","content":"hi there"}|};
+      {|{"role":"user","content":"second question"}|};
+      {|{"role":"user","content":""}|};
+      {|{"role":"user","content":"third question"}|};
+    ] in
+    let oc = open_out path in
+    List.iter (fun l -> output_string oc (l ^ "\n")) lines;
+    close_out oc;
+    let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
+    check int "3 user messages" 3 (List.length result);
+    check string "first" "hello world" (List.hd result);
+    check string "last" "third question" (List.nth result 2))
+
+let test_recall_candidates_with_history_dedup () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "history.jsonl" in
+    (* history contains same message as checkpoint *)
+    let lines = [
+      {|{"role":"user","content":"hello world"}|};
+      {|{"role":"user","content":"unique from history"}|};
+    ] in
+    let oc = open_out path in
+    List.iter (fun l -> output_string oc (l ^ "\n")) lines;
+    close_out oc;
+    let checkpoint_msgs : Agent_sdk.Types.message list = [
+      Agent_sdk.Types.text_message Agent_sdk.Types.User "hello world";
+    ] in
+    let result = Keeper_memory_recall.recall_candidates_with_history
+      ~checkpoint_messages:checkpoint_msgs
+      ~history_path:path
+      ~max_checkpoint:32 ~max_history:64 in
+    (* "hello world" from checkpoint, "unique from history" from history *)
+    check int "2 total (deduped)" 2 (List.length result);
+    check string "first from checkpoint" "hello world" (List.hd result);
+    check string "second from history" "unique from history" (List.nth result 1))
+
+let test_recall_candidates_with_history_appends () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "history.jsonl" in
+    let lines = [
+      {|{"role":"user","content":"old question from 3 days ago"}|};
+      {|{"role":"user","content":"another old question"}|};
+    ] in
+    let oc = open_out path in
+    List.iter (fun l -> output_string oc (l ^ "\n")) lines;
+    close_out oc;
+    let checkpoint_msgs : Agent_sdk.Types.message list = [
+      Agent_sdk.Types.text_message Agent_sdk.Types.User "recent question";
+    ] in
+    let result = Keeper_memory_recall.recall_candidates_with_history
+      ~checkpoint_messages:checkpoint_msgs
+      ~history_path:path
+      ~max_checkpoint:32 ~max_history:64 in
+    check int "3 total" 3 (List.length result);
+    check string "checkpoint first" "recent question" (List.hd result))
+
 let () =
   run "Keeper_memory"
     [
@@ -191,6 +270,15 @@ let () =
             test_user_visible_reply_strips_skill_and_state_markers;
           test_case "user visible reply falls back to snapshot progress" `Quick
             test_user_visible_reply_falls_back_to_snapshot_progress;
+        ] );
+      ( "history_recall",
+        [
+          test_case "load_history_user_messages from jsonl" `Quick
+            test_load_history_user_messages;
+          test_case "recall_candidates_with_history deduplicates" `Quick
+            test_recall_candidates_with_history_dedup;
+          test_case "recall_candidates_with_history appends history" `Quick
+            test_recall_candidates_with_history_appends;
         ] );
       ( "prioritized_action",
         [


### PR DESCRIPTION
## Summary

- Keeper의 memory recall 후보를 checkpoint 내 32개 → checkpoint 32개 + history.jsonl 64개로 확장
- 이전 세대(generation)의 대화를 recall할 수 있게 됨
- Jaccard 기반 keyword matching은 유지 (Phase 2에서 pgvector semantic search 예정)

## Problem

Keeper가 `load_context_from_checkpoint`으로 최신 checkpoint만 로드하고, `recent_user_messages`가 checkpoint 내 메시지만 조회.
`history.jsonl`에 전체 대화가 기록되어 있지만 recall 시 읽지 않았음.

**결과**: "3일 전에 뭐 얘기했었지?"에 대답 불가.

## Changes

| File | Change |
|------|--------|
| `keeper_memory_recall.ml` | `load_history_user_messages` + `recall_candidates_with_history` 추가 |
| `keeper_turn.ml` | recall candidates를 `recall_candidates_with_history`로 교체 |
| `test_keeper_memory.ml` | history recall 테스트 3개 추가 |

## Test plan

- [x] `dune build` 성공
- [x] `history_recall` 테스트 3/3 통과
- [ ] 실제 Keeper 실행 시 cross-generation recall 동작 검증


🤖 Generated with [Claude Code](https://claude.com/claude-code)