### PR TITLE
fix(dashboard): resolve keeper/agent detail click failures

### DIFF
--- a/dashboard/src/components/execution/shared.ts
+++ b/dashboard/src/components/execution/shared.ts
@@ -50,6 +50,24 @@ export function findKeeper(name?: string | null): Keeper | null {
   return keepers.value.find(keeper => keeper.name === name || keeper.agent_name === name) ?? null
 }
 
+/** Build a minimal Keeper from a continuity brief when the full Keeper object is not in the store.
+ *  This prevents silent click failures on keeper cards. */
+export function keeperFromBrief(brief: DashboardExecutionContinuityBrief): Keeper {
+  return {
+    name: brief.name,
+    agent_name: brief.agent_name ?? brief.name,
+    status: brief.status ?? 'unknown',
+    emoji: brief.emoji ?? '',
+    koreanName: brief.korean_name ?? null,
+    context_ratio: brief.context_ratio ?? null,
+  } as Keeper
+}
+
+/** Find a full Keeper from the store, or fall back to constructing one from a continuity brief. */
+export function findKeeperOrFallback(brief: DashboardExecutionContinuityBrief): Keeper {
+  return findKeeper(brief.name) ?? keeperFromBrief(brief)
+}
+
 export function agentStateLabel(state: DashboardExecutionWorkerSupportBrief['state']): string {
   switch (state) {
     case 'working': return '작업 중'

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -17,7 +17,7 @@ import {
   signalTruthLabel,
   evidenceSourceLabel,
   continuityStateLabel,
-  findKeeper,
+  findKeeperOrFallback,
 } from './shared'
 
 export function WorkerSupportRow({
@@ -61,8 +61,7 @@ export function WorkerSupportRow({
 
 export function ContinuityRow({ row }: { row: DashboardExecutionContinuityBrief }) {
   const onClick = () => {
-    const keeper = findKeeper(row.name)
-    if (keeper) openKeeperDetail(keeper)
+    openKeeperDetail(findKeeperOrFallback(row))
   }
   const runtimeLabel = keeperRuntimeLabel(row.name, row.agent_name)
   const model: CanonicalKeeperCardModel = {

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -1,7 +1,8 @@
 // Focus Sidebar — active agents with task info and pressure gauge
 
 import { html } from 'htm/preact'
-import { focusAgents, selectedAgent, selectAgent } from '../../live-store'
+import { focusAgents } from '../../live-store'
+import { openAgentDetail, selectedAgentName } from '../agent-detail'
 import { TimeAgo } from '../common/time-ago'
 
 function pressureClass(pressure: 'calm' | 'normal' | 'hot'): string {
@@ -22,7 +23,7 @@ function pressureLabel(pressure: 'calm' | 'normal' | 'hot'): string {
 
 export function FocusSidebar() {
   const list = focusAgents.value
-  const selected = selectedAgent.value
+  const selected = selectedAgentName.value
 
   return html`
     <div class="focus-sidebar">
@@ -37,7 +38,7 @@ export function FocusSidebar() {
             <div
               key=${agent.name}
               class="focus-agent-card ${selected === agent.name ? 'focus-agent-selected' : ''}"
-              onClick=${() => selectAgent(selected === agent.name ? null : agent.name)}
+              onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
                 <span class="focus-agent-name">

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -1,7 +1,8 @@
 // Pulse Strip — horizontal agent bubble bar with state-driven colors and animation
 
 import { html } from 'htm/preact'
-import { agentPulses, selectAgent, selectedAgent, type PulseState } from '../../live-store'
+import { agentPulses, type PulseState } from '../../live-store'
+import { openAgentDetail, selectedAgentName } from '../agent-detail'
 
 function pulseStateClass(state: PulseState): string {
   switch (state) {
@@ -13,7 +14,7 @@ function pulseStateClass(state: PulseState): string {
 
 export function PulseStrip() {
   const pulses = agentPulses.value
-  const selected = selectedAgent.value
+  const selected = selectedAgentName.value
 
   if (pulses.length === 0) {
     return html`
@@ -29,7 +30,7 @@ export function PulseStrip() {
         <button
           key=${p.name}
           class="pulse-bubble ${pulseStateClass(p.state)} ${selected === p.name ? 'pulse-selected' : ''}"
-          onClick=${() => selectAgent(selected === p.name ? null : p.name)}
+          onClick=${() => openAgentDetail(p.name)}
           title="${p.koreanName ? `${p.name} (${p.koreanName})` : p.name}${p.currentTask ? ` — ${p.currentTask}` : ''}"
         >
           <span class="pulse-emoji">${p.emoji || p.name.charAt(0).toUpperCase()}</span>

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -18,6 +18,7 @@ import type {
   DashboardMissionSessionBrief,
   DashboardMissionSessionCard,
   DashboardMissionSessionDetailResponse,
+  Keeper,
 } from '../types'
 import {
   type EnrichedAgentRow,
@@ -620,7 +621,15 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
 
   return html`
     <article class="mission-activity-card ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
-      <button class="mission-card-select" onClick=${() => { if (row.keeper) openKeeperDetail(row.keeper) }}>
+      <button class="mission-card-select" onClick=${() => {
+        const keeper: Keeper = row.keeper ?? {
+          name: row.brief.name,
+          agent_name: row.brief.agent_name ?? row.brief.name,
+          status: row.brief.status ?? 'unknown',
+          context_ratio: row.brief.context_ratio ?? null,
+        } as Keeper
+        openKeeperDetail(keeper)
+      }}>
         <div class="mission-activity-head">
           <div class="mission-activity-title">
             <div class="mission-status-dot ${liveStateClass(row.brief.status, row.keeper?.status)}"></div>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -3,10 +3,13 @@
 import { html } from 'htm/preact'
 import { PanelSemanticDetails } from '../common/semantic-layer'
 import { KeeperConversationPanel } from '../keeper-shared'
+import { openKeeperDetail } from '../keeper-detail'
+import { findKeeper } from '../execution/shared'
 import {
   operatorActionLog,
   operatorSnapshot,
 } from '../../operator-store'
+import type { Keeper, OperatorKeeperSnapshot } from '../../types'
 import {
   actionTypeLabel,
   deliveryModeLabel,
@@ -18,6 +21,19 @@ import {
 
 function truncateGoal(goal: string, maxLen = 60): string {
   return goal.length > maxLen ? goal.slice(0, maxLen) + '...' : goal
+}
+
+function openOpsKeeperDetail(opsKeeper: OperatorKeeperSnapshot): void {
+  const full = findKeeper(opsKeeper.name)
+  const keeper: Keeper = full ?? {
+    name: opsKeeper.name,
+    agent_name: opsKeeper.agent_name ?? opsKeeper.name,
+    status: opsKeeper.status ?? 'unknown',
+    context_ratio: opsKeeper.context_ratio ?? null,
+    model: opsKeeper.model ?? null,
+    goal: opsKeeper.goal ?? null,
+  } as Keeper
+  openKeeperDetail(keeper)
 }
 
 export function OpsKeeperColumn() {
@@ -46,6 +62,12 @@ export function OpsKeeperColumn() {
               <div class="ops-entity-title-row">
                 <strong>${keeper.name}</strong>
                 <span class="status-badge ${keeper.status ?? 'idle'}">${displayStatus(keeper.status)}</span>
+                <span
+                  class="ops-detail-link"
+                  title="키퍼 상세 보기"
+                  style="cursor:pointer; font-size:12px; opacity:0.6; margin-left:auto;"
+                  onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
+                >상세</span>
               </div>
               <div class="ops-entity-meta">
                 <span>${keeper.last_model_used ?? keeper.model ?? 'model 확인 필요'}</span>


### PR DESCRIPTION
## Summary

- Keeper 카드 클릭 시 `findKeeper()` null 반환으로 인한 silent failure 해소
- `findKeeperOrFallback()` 추가: store 미스 시 continuity brief로 minimal Keeper 구성
- Ops panel keeper 카드에 "상세" 링크 추가 (기존 인-패널 선택 유지)
- Live tab의 focus-sidebar/pulse-strip agent 클릭 시 detail overlay 열기 (기존에는 highlight만)

## Test plan

- [ ] Situation 탭에서 keeper brief 카드 클릭 → detail overlay 열림 확인
- [ ] Agents 탭 execution view에서 continuity row 클릭 → detail overlay 열림
- [ ] Control(ops) 탭에서 keeper 카드의 "상세" 클릭 → detail overlay 열림
- [ ] Control 탭에서 keeper 카드 본체 클릭 → 기존 인-패널 선택 유지
- [ ] Activity(live) 탭에서 focus-sidebar agent 클릭 → agent detail overlay 열림
- [ ] Activity 탭에서 pulse-strip agent bubble 클릭 → agent detail overlay 열림
- [ ] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)