### PR TITLE
feat(procedural): adaptive crystallization threshold

### DIFF
--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -1,8 +1,12 @@
 (** Procedural Memory — Patterns extracted from repeated agent behavior.
 
-    When the same pattern appears 3+ times with 70%+ positive outcomes,
-    it is crystallized into a procedure that can be injected into
-    successor agents via DNA hydration.
+    Crystallization uses adaptive thresholding:
+    - Standard: 3+ occurrences with 70%+ positive outcomes
+    - Rare-but-perfect: 2+ occurrences with 100% success rate
+    Thresholds are configurable via MASC_PROC_MIN_EVIDENCE and
+    MASC_PROC_MIN_CONFIDENCE environment variables.
+
+    Crystallized procedures are injected into successor agents via DNA hydration.
 
     Storage: .masc/procedures/{agent}/procedures.jsonl
 
@@ -152,12 +156,41 @@ let record_outcome ~agent_name ~pattern ~evidence_id ~success =
     save_procedure ~agent_name p;
     p
 
-(** Get top-N procedures by confidence (minimum 3 evidence, 70% confidence). *)
+(** Minimum evidence count required for crystallization.
+    Configurable via MASC_PROC_MIN_EVIDENCE (default: 3).
+    High-confidence patterns (100%) with fewer evidence may still qualify
+    when adaptive thresholding is enabled. *)
+let min_evidence () =
+  match Sys.getenv_opt "MASC_PROC_MIN_EVIDENCE" with
+  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 3)
+  | None -> 3
+
+(** Minimum confidence required for crystallization.
+    Configurable via MASC_PROC_MIN_CONFIDENCE (default: 0.7). *)
+let min_confidence () =
+  match Sys.getenv_opt "MASC_PROC_MIN_CONFIDENCE" with
+  | Some s -> (try max 0.0 (min 1.0 (float_of_string s)) with Failure _ -> 0.7)
+  | None -> 0.7
+
+(** Adaptive crystallization check.
+    Standard: evidence >= min_evidence AND confidence >= min_confidence.
+    Relaxed:  confidence = 1.0 AND evidence >= 2 (perfect success, rare pattern).
+    This prevents critical-but-rare patterns from being lost forever. *)
+let is_crystallized (p : procedure) : bool =
+  let min_ev = min_evidence () in
+  let min_conf = min_confidence () in
+  let evidence_count = List.length p.evidence in
+  let standard = evidence_count >= min_ev && p.confidence >= min_conf in
+  let rare_but_perfect = p.confidence >= 1.0 && evidence_count >= 2 in
+  standard || rare_but_perfect
+
+(** Get top-N crystallized procedures by confidence.
+    Uses adaptive thresholding: standard (3+ evidence, 70% confidence)
+    plus rare-but-perfect (2+ evidence, 100% confidence). *)
 let top_procedures ~agent_name ~limit : procedure list =
   let procs = load_procedures ~agent_name in
   procs
-  |> List.filter (fun p ->
-    List.length p.evidence >= 3 && p.confidence >= 0.7)
+  |> List.filter is_crystallized
   |> List.sort (fun a b -> Float.compare b.confidence a.confidence)
   |> List.filteri (fun i _ -> i < limit)
 


### PR DESCRIPTION
## Summary

- Procedural memory 결정화 임계값을 adaptive로 변경
- 기존: 3+ evidence AND 70%+ confidence (하드코딩)
- 변경: standard (3+/70%) OR rare-but-perfect (2+/100%)
- 환경변수로 설정 가능: `MASC_PROC_MIN_EVIDENCE`, `MASC_PROC_MIN_CONFIDENCE`

## Problem

특정 production 에러에 대한 workaround가 2번 발생하고 100% 성공했지만, evidence 3개 미만이라 영원히 procedure로 결정화되지 않음.

## Test plan

- [x] `dune build` 성공
- [ ] 기존 procedural memory 테스트 없음 — 별도 테스트 PR 고려


🤖 Generated with [Claude Code](https://claude.com/claude-code)