### PR TITLE
fix(oas_worker): catch exceptions in run to honour Result return type

### DIFF
--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -48,61 +48,54 @@ let make_dispatch ~(config : Room.config) ~(agent_name : string) () ~name ~args 
   | None ->
       (false, Printf.sprintf "Unknown tool: %s" name)
 
-(** Wrap OAS worker calls so Eio exceptions (Mutex.Poisoned from LLM
-    connection failure, etc.) become [Error] results instead of crashing. *)
-let run_safe f =
-  try f ()
-  with exn ->
-    Error (Printf.sprintf "OAS worker exception: %s" (Printexc.to_string exn))
+(* Exception handling moved to Oas_worker.run internally — no run_safe needed. *)
 
 let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let agent_name = Printf.sprintf "gardener-worker-%s" topic in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
-  run_safe (fun () ->
-    Oas_worker.run_named_with_masc_tools
-      ~cascade_name:"gardener_spawn"
-      ~system_prompt:
-        (Printf.sprintf
-           "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
-            Topic: %s\n\
-            Traits: %s\n\
-            Always include agent_name='%s' in every tool call arguments.\n\
-            1. masc_status -> room state\n\
-            2. masc_tasks -> find unclaimed work\n\
-            3. masc_claim_next -> claim a task\n\
-            4. Work on the claimed task\n\
-            5. masc_transition(task_id=..., action='done') -> mark done\n\
-            6. masc_broadcast -> report results\n\
-            Terminate after completion. Do not loop.\n\
-            %s"
-           agent_name topic traits_str agent_name institution_context)
-      ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
-      ~masc_tools:(worker_tools ())
-      ~dispatch:(make_dispatch ~config ~agent_name ())
-      ~max_turns:10 ~temperature:0.3 ())
+  Oas_worker.run_named_with_masc_tools
+    ~cascade_name:"gardener_spawn"
+    ~system_prompt:
+      (Printf.sprintf
+         "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
+          Topic: %s\n\
+          Traits: %s\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
+          1. masc_status -> room state\n\
+          2. masc_tasks -> find unclaimed work\n\
+          3. masc_claim_next -> claim a task\n\
+          4. Work on the claimed task\n\
+          5. masc_transition(task_id=..., action='done') -> mark done\n\
+          6. masc_broadcast -> report results\n\
+          Terminate after completion. Do not loop.\n\
+          %s"
+         agent_name topic traits_str agent_name institution_context)
+    ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
+    ~masc_tools:(worker_tools ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~max_turns:10 ~temperature:0.3 ()
 
 let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
   let agent_name = "gardener-triage-worker" in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
-  run_safe (fun () ->
-    Oas_worker.run_named_with_masc_tools
-      ~cascade_name:"gardener_spawn"
-      ~system_prompt:
-        (Printf.sprintf
-           "You are a MASC triage worker. Your agent_name is '%s'.\n\
-            Always include agent_name='%s' in every tool call arguments.\n\
-            1. masc_tasks -> review backlog\n\
-            2. masc_claim_next -> claim high-priority task\n\
-            3. Process or delegate\n\
-            4. masc_transition -> update status\n\
-            5. masc_broadcast -> report results\n\
-            Terminate after completion.\n\
-            %s"
-           agent_name agent_name institution_context)
-      ~goal:
-        (Printf.sprintf
-           "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
-           backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
-      ~masc_tools:(worker_tools ())
-      ~dispatch:(make_dispatch ~config ~agent_name ())
-      ~max_turns:15 ~temperature:0.3 ())
+  Oas_worker.run_named_with_masc_tools
+    ~cascade_name:"gardener_spawn"
+    ~system_prompt:
+      (Printf.sprintf
+         "You are a MASC triage worker. Your agent_name is '%s'.\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
+          1. masc_tasks -> review backlog\n\
+          2. masc_claim_next -> claim high-priority task\n\
+          3. Process or delegate\n\
+          4. masc_transition -> update status\n\
+          5. masc_broadcast -> report results\n\
+          Terminate after completion.\n\
+          %s"
+         agent_name agent_name institution_context)
+    ~goal:
+      (Printf.sprintf
+         "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
+         backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
+    ~masc_tools:(worker_tools ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~max_turns:15 ~temperature:0.3 ()

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -170,31 +170,40 @@ let run
     ) config.event_bus;
     Error (Printf.sprintf "Agent build failed: %s" e)
   | Ok agent ->
-  let result = match on_event with
-    | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
-    | None -> Oas.Agent.run ~sw agent goal
-  in
-  let checkpoint = match config.checkpoint_dir with
-    | Some dir ->
-      let ckpt = Oas.Agent.checkpoint ~session_id agent in
-      (try persist_checkpoint ~dir ~session_id ckpt
-       with exn ->
-         Printf.eprintf "[oas_worker] Checkpoint save failed: %s\n%!"
-           (Printexc.to_string exn));
-      Some ckpt
-    | None -> None
-  in
-  Option.iter (fun bus ->
-    let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
-    publish_lifecycle bus ~name:config.name ~event:status
-      ~detail:(Printf.sprintf "session=%s" session_id)
-  ) config.event_bus;
-  let turns = (Oas.Agent.state agent).turn_count in
-  Oas.Agent.close agent;
-  match result with
-  | Ok response -> Ok { response; checkpoint; session_id; turns }
-  | Error err ->
-    Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err))
+  (* Wrap agent execution so Eio/network exceptions become Error results,
+     honouring the (run_result, string) result return type promised by .mli.
+     Eio.Cancel.Cancelled is re-raised for structured-concurrency safety. *)
+  (try
+    let result = match on_event with
+      | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
+      | None -> Oas.Agent.run ~sw agent goal
+    in
+    let checkpoint = match config.checkpoint_dir with
+      | Some dir ->
+        let ckpt = Oas.Agent.checkpoint ~session_id agent in
+        (try persist_checkpoint ~dir ~session_id ckpt
+         with exn ->
+           Printf.eprintf "[oas_worker] Checkpoint save failed: %s\n%!"
+             (Printexc.to_string exn));
+        Some ckpt
+      | None -> None
+    in
+    Option.iter (fun bus ->
+      let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
+      publish_lifecycle bus ~name:config.name ~event:status
+        ~detail:(Printf.sprintf "session=%s" session_id)
+    ) config.event_bus;
+    let turns = (Oas.Agent.state agent).turn_count in
+    Oas.Agent.close agent;
+    (match result with
+    | Ok response -> Ok { response; checkpoint; session_id; turns }
+    | Error err ->
+      Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    (try Oas.Agent.close agent with _ -> ());
+    Error (Printf.sprintf "Agent execution exception: %s" (Printexc.to_string exn)))
 
 (* ================================================================ *)
 (* Convenience: run_with_masc_tools                                  *)


### PR DESCRIPTION
## Summary

- `oas_worker.run`의 `.mli` 시그니처는 `(run_result, string) result`를 약속하지만, `Oas.Agent.run`이 Eio/네트워크 예외를 던지면 Result로 변환되지 않고 그대로 전파됨
- agent 실행 단계를 `try-with`로 감싸서 예외를 `Error`로 변환
- `Eio.Cancel.Cancelled`는 re-raise하여 structured concurrency 취소 전파 보존
- 예외 발생 시 `Oas.Agent.close`로 best-effort cleanup
- `gardener_worker.run_safe` 제거 (OAS worker 내부에서 처리하므로 불필요)

Supersedes the symptom-level fix in #1773. Root cause is in `oas_worker.ml`, not in individual callers.

## Test plan

- [ ] `dune build` passes (lib 컴파일 확인)
- [ ] CI gardener tests pass (LLM 없는 환경에서 예외가 Error로 변환)
- [ ] 기존 OAS worker callers (keeper, perpetual 등) 동작 불변

🤖 Generated with [Claude Code](https://claude.com/claude-code)