### PR TITLE
feat(recall): upgrade Jaccard with character n-gram overlap

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -104,7 +104,9 @@ let expected_topic_hint (s : string) : string option =
   else
     None
 
-let normalize_for_similarity (s : string) : string list =
+(** Strip non-alphanumeric ASCII, keep multibyte (CJK, etc.) and digits.
+    Returns a cleaned lowercase string for tokenization. *)
+let clean_for_similarity (s : string) : string =
   let s = String.lowercase_ascii s in
   let b = Bytes.of_string s in
   for i = 0 to Bytes.length b - 1 do
@@ -117,8 +119,13 @@ let normalize_for_similarity (s : string) : string list =
     in
     if not keep then Bytes.set b i ' '
   done;
+  Bytes.to_string b
+
+(** Extract unique word tokens (space-split, length >= 2). *)
+let normalize_for_similarity (s : string) : string list =
+  let cleaned = clean_for_similarity s in
   let words =
-    Bytes.to_string b
+    cleaned
     |> String.split_on_char ' '
     |> List.filter (fun w -> String.length w >= 2)
   in
@@ -128,13 +135,51 @@ let normalize_for_similarity (s : string) : string list =
     else (Hashtbl.add tbl w (); true)
   ) words
 
+(** Extract character n-grams from a cleaned string.
+    For multibyte strings (Korean, CJK), each "character" may be multiple bytes.
+    We use byte-level n-grams which naturally captures morpheme overlap
+    for UTF-8 encoded text (Korean 3 bytes/char → 3-byte-gram captures
+    individual syllables, 6-byte-gram captures 2-syllable morphemes).
+
+    Returns a deduplicated list of n-grams. *)
+let char_ngrams ~(n : int) (s : string) : string list =
+  let cleaned = clean_for_similarity s in
+  (* Remove spaces for n-gram extraction *)
+  let buf = Buffer.create (String.length cleaned) in
+  String.iter (fun c -> if c <> ' ' then Buffer.add_char buf c) cleaned;
+  let compact = Buffer.contents buf in
+  let len = String.length compact in
+  if len < n then (if len > 0 then [compact] else [])
+  else
+    let tbl : (string, unit) Hashtbl.t = Hashtbl.create 64 in
+    let acc = ref [] in
+    for i = 0 to len - n do
+      let gram = String.sub compact i n in
+      if not (Hashtbl.mem tbl gram) then begin
+        Hashtbl.add tbl gram ();
+        acc := gram :: !acc
+      end
+    done;
+    List.rev !acc
+
+(** Jaccard similarity over a combined feature set: word tokens + character n-grams.
+    Word tokens capture exact matches; n-grams capture partial/morphological overlap.
+    This is effective for Korean where "기억해" and "기억나" share the morpheme "기억"
+    but would score 0 on word-level Jaccard.
+
+    Uses 3-byte grams (captures Korean syllables) and 6-byte grams (captures
+    2-syllable Korean morphemes) alongside word tokens. *)
 let jaccard_similarity (a : string) (b : string) : float =
-  let ta = normalize_for_similarity a in
-  let tb = normalize_for_similarity b in
+  let words_a = normalize_for_similarity a in
+  let words_b = normalize_for_similarity b in
+  let ngrams_a = char_ngrams ~n:3 a @ char_ngrams ~n:6 a in
+  let ngrams_b = char_ngrams ~n:3 b @ char_ngrams ~n:6 b in
+  let ta = words_a @ ngrams_a in
+  let tb = words_b @ ngrams_b in
   if ta = [] && tb = [] then 1.0
   else if ta = [] || tb = [] then 0.0
   else
-    let h : (string, bool) Hashtbl.t = Hashtbl.create 64 in
+    let h : (string, bool) Hashtbl.t = Hashtbl.create 128 in
     List.iter (fun w -> Hashtbl.replace h w false) ta;
     let inter = ref 0 in
     let uniq_b = ref 0 in

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -120,7 +120,7 @@ let run_with_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ()
   with
   | Ok oas_result ->
-      let usage = Llm_types.usage_of_response oas_result.response in
+      let usage = Masc_model.usage_of_response oas_result.response in
       let cost_report = Some (Eval_gate.cost_report
         ~accumulated_cost:!accumulated_cost_ref
         ~api_calls:(max 1 oas_result.turns)


### PR DESCRIPTION
## Summary

- recall similarity를 word-level Jaccard → word + character n-gram Jaccard로 개선
- 한국어 형태소 부분 매칭 가능 ("기억해" vs "기억나" → "기억" 공유)
- 외부 의존 0 (embedding API, pgvector 불필요)

## Problem

기존 word-level Jaccard는 공백으로 분리한 단어 단위로만 비교. 한국어는 조사/어미가 붙으면 다른 단어로 인식되어 매칭 실패.

## Approach

UTF-8 byte-level n-gram을 feature set에 추가:
- **3-byte gram**: 한국어 1음절 (3bytes/char) 단위 매칭
- **6-byte gram**: 2음절 형태소 단위 매칭
- 기존 word tokens도 유지 (영어/숫자에 효과적)

## Test plan

- [x] `dune build` (library) 성공
- [x] keeper_memory 테스트 3/3 통과
- [ ] test_gardener.ml의 test_dir 에러는 기존 main 이슈 (이 PR과 무관)


🤖 Generated with [Claude Code](https://claude.com/claude-code)