### PR TITLE
fix: restore main build — stale Llm_types ref + missing test_dir

### DIFF
--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -918,9 +918,9 @@ let test_tick_reuses_existing_backlog_triage_session () =
     in_progress_count = 1; done_count = 2; orphan_count = 1;
     oldest_todo_age_hours = 4.0; high_priority_todo = 2;
   } in
-  let dir = test_dir () in
+  let dir = Filename.temp_dir "masc_gardener" "" in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
     (fun () ->
       let config = Room.default_config dir in
       match Gardener_worker.run_for_backlog ~config ~backlog with
@@ -934,9 +934,14 @@ let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
     in_progress_count = 0; done_count = 1; orphan_count = 0;
     oldest_todo_age_hours = 2.0; high_priority_todo = 1;
   } in
-  match Gardener_worker.run_for_backlog ~backlog with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context"
+  let dir = Filename.temp_dir "masc_gardener" "" in
+  let config = Room.default_config dir in
+  Fun.protect
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+    (fun () ->
+      match Gardener_worker.run_for_backlog ~config ~backlog with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context")
 
 (** {1 Duplicate Task Prevention Tests (Issue #1439)} *)
 
@@ -1218,9 +1223,9 @@ let test_worker_tool_count_bounds () =
   check bool "at most 30 tools" true (n <= 30)
 
 let test_run_for_gap_without_eio_returns_error () =
-  let dir = test_dir () in
+  let dir = Filename.temp_dir "masc_gardener" "" in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
     (fun () ->
       let config = Room.default_config dir in
       match Gardener_worker.run_for_gap ~config ~topic:"test" ~traits_str:"a" ~reason:"r" with


### PR DESCRIPTION
## Summary
Main build is broken after #1771/#1775 merge. Two issues:

1. `keeper_oas_adapter.ml:123` — stale `Llm_types.usage_of_response` (should be `Masc_model` after rename)
2. `test_gardener.ml` — `test_dir`/`cleanup_dir` helpers removed in #1775 but still referenced at lines 921 and 1226

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)