### PR TITLE
fix: replace missed Llm_types reference in keeper_oas_adapter

### DIFF
--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -120,7 +120,7 @@ let run_with_tools
     ~max_turns ~temperature ~max_tokens ?guardrails ()
   with
   | Ok oas_result ->
-      let usage = Llm_types.usage_of_response oas_result.response in
+      let usage = Masc_model.usage_of_response oas_result.response in
       let cost_report = Some (Eval_gate.cost_report
         ~accumulated_cost:!accumulated_cost_ref
         ~api_calls:(max 1 oas_result.turns)


### PR DESCRIPTION
## Summary

- `keeper_oas_adapter.ml:123`에서 `Llm_types.usage_of_response` → `Masc_model.usage_of_response` 누락 수정
- PR #1764 rebase 과정에서 `lib/perpetual/` subdirectory 파일과 동일한 패턴으로 `find -exec grep`에서 누락됨

## Root cause

`grep -r`과 `rg --glob "*.ml"`이 특정 subdirectory 파일을 일관되게 놓침. `find -exec grep` 패턴으로 발견.

## Test plan

- [x] `dune build` — Llm_types/Llm_cascade 에러 0건
- [x] 1파일 1줄 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)