### PR TITLE
feat(institution): wire institutional memory into gardener workers

### DIFF
--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -57,6 +57,7 @@ let run_safe f =
 
 let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let agent_name = Printf.sprintf "gardener-worker-%s" topic in
+  let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
   run_safe (fun () ->
     Oas_worker.run_named_with_masc_tools
       ~cascade_name:"gardener_spawn"
@@ -72,8 +73,9 @@ let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
             4. Work on the claimed task\n\
             5. masc_transition(task_id=..., action='done') -> mark done\n\
             6. masc_broadcast -> report results\n\
-            Terminate after completion. Do not loop."
-           agent_name topic traits_str agent_name)
+            Terminate after completion. Do not loop.\n\
+            %s"
+           agent_name topic traits_str agent_name institution_context)
       ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
       ~masc_tools:(worker_tools ())
       ~dispatch:(make_dispatch ~config ~agent_name ())
@@ -81,6 +83,7 @@ let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
 
 let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
   let agent_name = "gardener-triage-worker" in
+  let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
   run_safe (fun () ->
     Oas_worker.run_named_with_masc_tools
       ~cascade_name:"gardener_spawn"
@@ -93,8 +96,9 @@ let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_back
             3. Process or delegate\n\
             4. masc_transition -> update status\n\
             5. masc_broadcast -> report results\n\
-            Terminate after completion."
-           agent_name agent_name)
+            Terminate after completion.\n\
+            %s"
+           agent_name agent_name institution_context)
       ~goal:
         (Printf.sprintf
            "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."


### PR DESCRIPTION
## Summary

- `Institution_eio`의 `load_and_format_for_welcome`을 gardener worker의 system prompt에 연결
- 기존에 완전히 구현되어 있었지만 **한 번도 호출되지 않던 dead code**를 활성화
- +8/-4, 1 file

## Before/After

**Before**: Gardner worker spawn → system prompt에 tool 사용법만 포함
**After**: system prompt에 mission + cultural values + procedural tip 추가 (institution.json 존재 시)

## Design

- `load_and_format_for_welcome ~fs:() config` — Fs_compat 기반, Eio fs 불필요
- institution.json 없으면 empty string 반환 (safe no-op)
- 향후 확장: keeper DNA hydration, masc_join welcome, spawn_eio 등에도 연결 가능

## Test plan

- [x] `dune build lib/masc_mcp.cmxa` 성공
- [ ] institution.json이 있는 환경에서 worker prompt에 cultural context 포함 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)