### PR TITLE
refactor: remove Masc_model type aliases and trivial helpers (Phase 1)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -140,7 +140,7 @@ let cascade_name_for_agent_type agent_type =
   Printf.sprintf "auto_responder_%s" agent_type
 
 let llm_response_is_valid (resp : Masc_model.api_response) =
-  let s = String.trim (Masc_model.text_of_response resp) in
+  let s = String.trim (Agent_sdk.Types.text_of_content resp.content) in
   let s_lower = String.lowercase_ascii s in
   let len = String.length s in
   len > 0

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -246,7 +246,7 @@ let parse_llm_score (text : string) : float option =
 
 (** Validate that an LLM response contains a parseable score. *)
 let llm_score_is_valid (resp : Masc_model.api_response) : bool =
-  parse_llm_score (Masc_model.text_of_response resp) <> None
+  parse_llm_score (Agent_sdk.Types.text_of_content resp.content) <> None
 
 (** Call LLM to score agent-task compatibility.
     Returns Ok float or Error string. *)

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -304,8 +304,8 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
           ~timeout_sec ()
       with
       | Ok resp when trim (Agent_sdk.Types.text_of_content resp.content) <> "" -> Ok (Agent_sdk.Types.text_of_content resp.content)
-      | Ok resp when Masc_model.has_tool_calls resp ->
-          Ok (Yojson.Safe.to_string (llm_tool_calls_json (Masc_model.tool_calls_of_response resp)))
+      | Ok resp when List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) resp.content ->
+          Ok (Yojson.Safe.to_string (llm_tool_calls_json (Masc_model.tool_calls_of_content resp.content)))
       | Ok _ -> Error "empty completion"
       | Error msg -> Error msg)
 

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -303,7 +303,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
           ?tools:tools_json ~temperature:0.2 ~max_tokens:4096
           ~timeout_sec ()
       with
-      | Ok resp when trim (Masc_model.text_of_response resp) <> "" -> Ok (Masc_model.text_of_response resp)
+      | Ok resp when trim (Agent_sdk.Types.text_of_content resp.content) <> "" -> Ok (Agent_sdk.Types.text_of_content resp.content)
       | Ok resp when Masc_model.has_tool_calls resp ->
           Ok (Yojson.Safe.to_string (llm_tool_calls_json (Masc_model.tool_calls_of_response resp)))
       | Ok _ -> Error "empty completion"

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -4,7 +4,7 @@
     and converts back. This is Phase 1 of migrating MASC to use OAS properly.
 
     This module is deliberately independent of Context_manager to avoid circular
-    dependency. It operates on [Masc_model.message list] directly and uses its own
+    dependency. It operates on [Agent_sdk.Types.message list] directly and uses its own
     strategy enum that mirrors Context_manager.compaction_strategy.
 
     MASC has 4 roles (System, User, Assistant, Tool) while OAS has the same 4.

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -14,7 +14,7 @@
 (** Working context: the message window sent to the LLM. *)
 type working_context = {
   system_prompt : string;
-  messages : Masc_model.message list;
+  messages : Agent_sdk.Types.message list;
   token_count : int;                (** Estimated tokens in window *)
   max_tokens : int;                 (** Model context limit *)
   importance_scores : (int * float) list;  (** msg_index → importance 0.0-1.0 *)
@@ -37,7 +37,7 @@ type checkpoint = {
 type session_context = {
   session_id : string;
   session_dir : string;            (** Path to session JSONL files *)
-  mutable full_history : Masc_model.message list;
+  mutable full_history : Agent_sdk.Types.message list;
   mutable checkpoints : checkpoint list;
 }
 
@@ -75,10 +75,10 @@ val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 
 (** Append a message to working context, updating token count. *)
-val append : working_context -> Masc_model.message -> working_context
+val append : working_context -> Agent_sdk.Types.message -> working_context
 
 (** Append multiple messages. *)
-val append_many : working_context -> Masc_model.message list -> working_context
+val append_many : working_context -> Agent_sdk.Types.message list -> working_context
 
 (** Score message importance (Stanford GAP formula adapted). *)
 val score_importance : working_context -> working_context
@@ -97,13 +97,13 @@ val goal_prefix : string
 val compact : working_context -> compaction_strategy list -> working_context
 
 (** Format a single message as human-readable text: "role: content". *)
-val format_message_readable : Masc_model.message -> string
+val format_message_readable : Agent_sdk.Types.message -> string
 
 (** Offload messages to a markdown file in [{session_dir}/offloaded/{compaction_count}.md].
     Returns [Some path] on success, [None] on failure (fail-safe, never raises). *)
 val offload_messages :
   session_dir:string -> compaction_count:int ->
-  Masc_model.message list -> string option
+  Agent_sdk.Types.message list -> string option
 
 (** Apply compaction with history offload.
     Before compaction, saves the full pre-compaction messages to a markdown file.
@@ -143,7 +143,7 @@ val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
 val create_session : session_id:string -> base_dir:string -> session_context
 
 (** Persist a message to session history (append to JSONL). *)
-val persist_message : session_context -> Masc_model.message -> unit
+val persist_message : session_context -> Agent_sdk.Types.message -> unit
 
 (** Save checkpoint to session directory. *)
 val save_checkpoint : session_context -> checkpoint -> unit

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -187,7 +187,7 @@ let parse_intent_response (text : string) : (query_intent * float) option =
 
 (** Validate that an LLM response contains a parseable intent. *)
 let intent_response_is_valid (resp : Masc_model.api_response) : bool =
-  parse_intent_response (Masc_model.text_of_response resp) <> None
+  parse_intent_response (Agent_sdk.Types.text_of_content resp.content) <> None
 
 (** Classify query intent using LLM semantic understanding.
     Returns (intent, confidence) or falls back to low-confidence default. *)

--- a/lib/context_scoring.mli
+++ b/lib/context_scoring.mli
@@ -21,4 +21,4 @@ val starts_with : prefix:string -> string -> bool
 
     Messages starting with [memory_summary_prefix] or [goal_prefix]
     receive a minimum score of 0.95 (sticky memory). *)
-val score_messages : Masc_model.message list -> (int * float) list
+val score_messages : Agent_sdk.Types.message list -> (int * float) list

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -290,7 +290,7 @@ let compute_judgments ~base_path:_ ~factual_json =
   | Error message -> Error message
   | Ok response -> (
       try
-        let parsed = Yojson.Safe.from_string (Masc_model.text_of_response response) in
+        let parsed = Yojson.Safe.from_string (Agent_sdk.Types.text_of_content response.content) in
         let generated_at = now_iso () in
         let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
         let items =

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -295,7 +295,7 @@ let compute_judgments ~facts_json =
   | Error message -> Error message
   | Ok response -> (
       try Ok (response.Llm_provider.Types.model,
-              Yojson.Safe.from_string (Masc_model.text_of_response response))
+              Yojson.Safe.from_string (Agent_sdk.Types.text_of_content response.content))
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)

--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -48,61 +48,54 @@ let make_dispatch ~(config : Room.config) ~(agent_name : string) () ~name ~args 
   | None ->
       (false, Printf.sprintf "Unknown tool: %s" name)
 
-(** Wrap OAS worker calls so Eio exceptions (Mutex.Poisoned from LLM
-    connection failure, etc.) become [Error] results instead of crashing. *)
-let run_safe f =
-  try f ()
-  with exn ->
-    Error (Printf.sprintf "OAS worker exception: %s" (Printexc.to_string exn))
+(* Exception handling moved to Oas_worker.run internally — no run_safe needed. *)
 
 let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let agent_name = Printf.sprintf "gardener-worker-%s" topic in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
-  run_safe (fun () ->
-    Oas_worker.run_named_with_masc_tools
-      ~cascade_name:"gardener_spawn"
-      ~system_prompt:
-        (Printf.sprintf
-           "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
-            Topic: %s\n\
-            Traits: %s\n\
-            Always include agent_name='%s' in every tool call arguments.\n\
-            1. masc_status -> room state\n\
-            2. masc_tasks -> find unclaimed work\n\
-            3. masc_claim_next -> claim a task\n\
-            4. Work on the claimed task\n\
-            5. masc_transition(task_id=..., action='done') -> mark done\n\
-            6. masc_broadcast -> report results\n\
-            Terminate after completion. Do not loop.\n\
-            %s"
-           agent_name topic traits_str agent_name institution_context)
-      ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
-      ~masc_tools:(worker_tools ())
-      ~dispatch:(make_dispatch ~config ~agent_name ())
-      ~max_turns:10 ~temperature:0.3 ())
+  Oas_worker.run_named_with_masc_tools
+    ~cascade_name:"gardener_spawn"
+    ~system_prompt:
+      (Printf.sprintf
+         "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
+          Topic: %s\n\
+          Traits: %s\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
+          1. masc_status -> room state\n\
+          2. masc_tasks -> find unclaimed work\n\
+          3. masc_claim_next -> claim a task\n\
+          4. Work on the claimed task\n\
+          5. masc_transition(task_id=..., action='done') -> mark done\n\
+          6. masc_broadcast -> report results\n\
+          Terminate after completion. Do not loop.\n\
+          %s"
+         agent_name topic traits_str agent_name institution_context)
+    ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
+    ~masc_tools:(worker_tools ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~max_turns:10 ~temperature:0.3 ()
 
 let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
   let agent_name = "gardener-triage-worker" in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
-  run_safe (fun () ->
-    Oas_worker.run_named_with_masc_tools
-      ~cascade_name:"gardener_spawn"
-      ~system_prompt:
-        (Printf.sprintf
-           "You are a MASC triage worker. Your agent_name is '%s'.\n\
-            Always include agent_name='%s' in every tool call arguments.\n\
-            1. masc_tasks -> review backlog\n\
-            2. masc_claim_next -> claim high-priority task\n\
-            3. Process or delegate\n\
-            4. masc_transition -> update status\n\
-            5. masc_broadcast -> report results\n\
-            Terminate after completion.\n\
-            %s"
-           agent_name agent_name institution_context)
-      ~goal:
-        (Printf.sprintf
-           "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
-           backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
-      ~masc_tools:(worker_tools ())
-      ~dispatch:(make_dispatch ~config ~agent_name ())
-      ~max_turns:15 ~temperature:0.3 ())
+  Oas_worker.run_named_with_masc_tools
+    ~cascade_name:"gardener_spawn"
+    ~system_prompt:
+      (Printf.sprintf
+         "You are a MASC triage worker. Your agent_name is '%s'.\n\
+          Always include agent_name='%s' in every tool call arguments.\n\
+          1. masc_tasks -> review backlog\n\
+          2. masc_claim_next -> claim high-priority task\n\
+          3. Process or delegate\n\
+          4. masc_transition -> update status\n\
+          5. masc_broadcast -> report results\n\
+          Terminate after completion.\n\
+          %s"
+         agent_name agent_name institution_context)
+    ~goal:
+      (Printf.sprintf
+         "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
+         backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
+    ~masc_tools:(worker_tools ())
+    ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~max_turns:15 ~temperature:0.3 ()

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -7,8 +7,8 @@ open Keeper_memory
 let keeper_llm_tools = Tool_shard.keeper_llm_tools
 
 let merge_usage
-    (a : Masc_model.token_usage)
-    (b : Masc_model.token_usage) : Masc_model.token_usage =
+    (a : Agent_sdk.Types.api_usage)
+    (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =

--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -127,7 +127,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
       let cost = cost_usd_of_usage usage used_model_spec in
       (* OAS handles tool dispatch internally; extract tool names from response *)
       let tools_used =
-        Masc_model.tool_calls_of_response run_result.response
+        Masc_model.tool_calls_of_content run_result.response.content
         |> List.map (fun (tc : Masc_model.tool_call) -> tc.call_name)
       in
       (content, cost, tools_used)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -657,7 +657,7 @@ let run_proactive_generation
           let cost0 = cost_usd_of_usage (usage_of_response resp0) used_model0 in
           let rec tool_loop ~round ~acc_usage ~acc_latency ~acc_cost
               ~acc_tools_used ~last_resp =
-            if not (Masc_model.has_tool_calls last_resp) || round > max_tool_rounds then
+            if not (List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) last_resp.Llm_provider.Types.content) || round > max_tool_rounds then
               let content =
                 let c = String.trim (Agent_sdk.Types.text_of_content last_resp.content) in
                 if c = "" && acc_tools_used <> [] then
@@ -672,7 +672,7 @@ let run_proactive_generation
                 acc_cost,
                 acc_tools_used )
             else
-              let last_resp_tool_calls = Masc_model.tool_calls_of_response last_resp in
+              let last_resp_tool_calls = Masc_model.tool_calls_of_content last_resp.content in
               let round_tools =
                 List.map
                   (fun (tc : Masc_model.tool_call) -> tc.call_name)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -8,6 +8,13 @@ open Keeper_alerting
 open Keeper_exec_tools
 open Keeper_exec_status
 
+let zero_usage : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
+
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
+  match resp.usage with Some u -> u | None -> zero_usage
+
 let log_keeper_exn ~label exn =
   let tag = match exn with
     | Sys_error _ | Failure _ | Not_found
@@ -647,16 +654,16 @@ let run_proactive_generation
             model_spec_for_used specs resp0.Llm_provider.Types.model
             |> Option.value ~default:primary
           in
-          let cost0 = cost_usd_of_usage (Masc_model.usage_of_response resp0) used_model0 in
+          let cost0 = cost_usd_of_usage (usage_of_response resp0) used_model0 in
           let rec tool_loop ~round ~acc_usage ~acc_latency ~acc_cost
               ~acc_tools_used ~last_resp =
             if not (Masc_model.has_tool_calls last_resp) || round > max_tool_rounds then
               let content =
-                let c = String.trim (Masc_model.text_of_response last_resp) in
+                let c = String.trim (Agent_sdk.Types.text_of_content last_resp.content) in
                 if c = "" && acc_tools_used <> [] then
                   Printf.sprintf "(tools executed: %s)"
                     (String.concat ", " acc_tools_used)
-                else Masc_model.text_of_response last_resp
+                else Agent_sdk.Types.text_of_content last_resp.content
               in
               ( content,
                 acc_usage,
@@ -678,7 +685,7 @@ let run_proactive_generation
               let followup_prompt =
                 keeper_tool_followup_prompt
                   ~user_message:prompt
-                  ~draft_reply:(Masc_model.text_of_response last_resp)
+                  ~draft_reply:(Agent_sdk.Types.text_of_content last_resp.content)
                   ~tool_outputs
                   ~already_executed:all_tools_so_far
               in
@@ -714,7 +721,7 @@ let run_proactive_generation
                   run_cascade followup_requests) in
               match followup_result with
               | Error _ ->
-                  ( Masc_model.text_of_response last_resp,
+                  ( Agent_sdk.Types.text_of_content last_resp.content,
                     acc_usage,
                     last_resp.Llm_provider.Types.model,
                     acc_latency,
@@ -725,7 +732,7 @@ let run_proactive_generation
                     model_spec_for_used specs resp_next.Llm_provider.Types.model
                     |> Option.value ~default:primary
                   in
-                  let resp_next_usage = Masc_model.usage_of_response resp_next in
+                  let resp_next_usage = usage_of_response resp_next in
                   let cost_next = cost_usd_of_usage resp_next_usage used_model_next in
                   tool_loop
                     ~round:(round + 1)
@@ -739,7 +746,7 @@ let run_proactive_generation
                attempt_cost_usd, attempt_tools_used) =
             tool_loop
               ~round:1
-              ~acc_usage:(Masc_model.usage_of_response resp0)
+              ~acc_usage:(usage_of_response resp0)
               ~acc_latency:latency0
               ~acc_cost:cost0
               ~acc_tools_used:[]

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -7,6 +7,13 @@ open Keeper_alerting
 open Keeper_exec_context
 open Keeper_exec_autonomy
 
+let zero_usage : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
+
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
+  match resp.usage with Some u -> u | None -> zero_usage
+
 let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
   let log_proactive_failure reason =
     Log.Keeper.error "proactive emission failed: %s" reason
@@ -202,7 +209,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         meta
                     | Ok run_result ->
                         let response = run_result.Oas_worker.response in
-                        let response_usage = Masc_model.usage_of_response response in
+                        let response_usage = usage_of_response response in
                         let turn_cost =
                           let inp =
                             float_of_int response_usage.input_tokens /. 1000.0
@@ -220,12 +227,12 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         in
                         (match
                            Keeper_deliberation.parse_deliberation_response
-                             (Masc_model.text_of_response response)
+                             (Agent_sdk.Types.text_of_content response.content)
                          with
                          | Error msg ->
                              Log.KeeperExec.error "%s parse failed: %s (raw: %s)"
                                meta.name msg
-                               (Keeper_types.short_preview (Masc_model.text_of_response response));
+                               (Keeper_types.short_preview (Agent_sdk.Types.text_of_content response.content));
                              (* Update meta with cost even on parse failure *)
                              let updated =
                                { meta with

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -493,7 +493,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                    + response_usage.output_tokens;
                                  total_tokens =
                                    meta.total_tokens
-                                   + Masc_model.total_tokens response_usage;
+                                   + (response_usage.input_tokens + response_usage.output_tokens);
                                  total_cost_usd =
                                    meta.total_cost_usd +. turn_cost;
                                  last_turn_ts = now_ts;
@@ -503,7 +503,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                  last_output_tokens =
                                    response_usage.output_tokens;
                                  last_total_tokens =
-                                   Masc_model.total_tokens response_usage;
+                                   (response_usage.input_tokens + response_usage.output_tokens);
                                  last_latency_ms = delib_latency;
                                  last_proactive_ts = now_ts;
                                  last_proactive_reason =
@@ -644,13 +644,13 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                              meta.total_input_tokens + generated.usage.input_tokens;
                            total_output_tokens =
                              meta.total_output_tokens + generated.usage.output_tokens;
-                           total_tokens = meta.total_tokens + Masc_model.total_tokens generated.usage;
+                           total_tokens = meta.total_tokens + (generated.usage.input_tokens + generated.usage.output_tokens);
                            total_cost_usd = meta.total_cost_usd +. turn_cost;
                            last_turn_ts = now_ts;
                            last_model_used = model_used;
                            last_input_tokens = generated.usage.input_tokens;
                            last_output_tokens = generated.usage.output_tokens;
-                           last_total_tokens = Masc_model.total_tokens generated.usage;
+                           last_total_tokens = (generated.usage.input_tokens + generated.usage.output_tokens);
                            last_latency_ms = generated.latency_ms;
                            compaction_count =
                              meta.compaction_count + if compacted then 1 else 0;
@@ -697,7 +697,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                     [
                                       ("input_tokens", `Int generated.usage.input_tokens);
                                       ("output_tokens", `Int generated.usage.output_tokens);
-                                      ("total_tokens", `Int (Masc_model.total_tokens generated.usage));
+                                      ("total_tokens", `Int ((generated.usage.input_tokens + generated.usage.output_tokens)));
                                     ] );
                                 ("latency_ms", `Int generated.latency_ms);
                                 ("cost_usd", `Float turn_cost);

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -7,6 +7,13 @@ open Keeper_alerting [@@warning "-33"]
 open Keeper_exec_tools [@@warning "-33"]
 open Keeper_exec_context
 
+let zero_usage : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
+
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
+  match resp.usage with Some u -> u | None -> zero_usage
+
 let explicit_room_prompt ~(meta : keeper_meta) ~(room_id : string) (msg : Types.message) : string =
   Printf.sprintf
     "You were explicitly mentioned in room '%s' by %s.\n\
@@ -99,7 +106,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
               let used_model =
                 model_spec_for_used specs resp.Llm_provider.Types.model |> Option.value ~default:primary
               in
-              let reply_raw = String.trim (Masc_model.text_of_response resp) in
+              let reply_raw = String.trim (Agent_sdk.Types.text_of_content resp.content) in
               let reply =
                 if reply_raw = "" then
                   Printf.sprintf "@%s 야, 다시 한 번만 말해봐." msg.from_agent
@@ -112,7 +119,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
               (try ignore (save_checkpoint session ctx_work ~generation:meta.generation)
                with exn ->
                  log_keeper_exn ~label:"save_checkpoint (explicit room reply) failed" exn);
-              let usage = Masc_model.usage_of_response resp in
+              let usage = usage_of_response resp in
               let now_ts = Time_compat.now () in
               let updated =
                 {
@@ -254,13 +261,13 @@ let run_social_board_event_turn
                  Keeper_oas_adapter.tools_executed = final_tools_used } ->
               let final_resp = run_result.Oas_worker.response in
               let final_content =
-                let trimmed = String.trim (Masc_model.text_of_response final_resp) in
+                let trimmed = String.trim (Agent_sdk.Types.text_of_content final_resp.content) in
                 if trimmed = "" && final_tools_used <> [] then
                   Printf.sprintf "(tools executed: %s)" (String.concat ", " final_tools_used)
                 else if trimmed = "" then trimmed
                 else trimmed
               in
-              let final_usage = Masc_model.usage_of_response final_resp in
+              let final_usage = usage_of_response final_resp in
               let final_model_used = final_resp.Llm_provider.Types.model in
               let final_latency_ms = total_latency_ms in
               let final_cost_usd =

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -128,14 +128,14 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + usage.output_tokens;
-                  total_tokens = meta.total_tokens + Masc_model.total_tokens usage;
+                  total_tokens = meta.total_tokens + (usage.input_tokens + usage.output_tokens);
                   total_cost_usd =
                     meta.total_cost_usd +. cost_usd_of_usage usage used_model;
                   last_turn_ts = now_ts;
                   last_model_used = resp.Llm_provider.Types.model;
                   last_input_tokens = usage.input_tokens;
                   last_output_tokens = usage.output_tokens;
-                  last_total_tokens = Masc_model.total_tokens usage;
+                  last_total_tokens = (usage.input_tokens + usage.output_tokens);
                   last_latency_ms = cascade_latency;
                 }
               in
@@ -302,13 +302,13 @@ let run_social_board_event_turn
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + final_usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                  total_tokens = meta.total_tokens + Masc_model.total_tokens final_usage;
+                  total_tokens = meta.total_tokens + (final_usage.input_tokens + final_usage.output_tokens);
                   total_cost_usd = meta.total_cost_usd +. final_cost_usd;
                   last_turn_ts = now_ts;
                   last_model_used = final_model_used;
                   last_input_tokens = final_usage.input_tokens;
                   last_output_tokens = final_usage.output_tokens;
-                  last_total_tokens = Masc_model.total_tokens final_usage;
+                  last_total_tokens = (final_usage.input_tokens + final_usage.output_tokens);
                   last_latency_ms = final_latency_ms;
                   last_autonomous_action_at =
                     (if action_kind = "none" then meta.last_autonomous_action_at else now_iso ());

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -10,6 +10,13 @@
 open Keeper_types
 open Keeper_exec_tools
 
+let zero_usage : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
+
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
+  match resp.usage with Some u -> u | None -> zero_usage
+
 (* ================================================================ *)
 (* Internal: tool dispatch                                           *)
 (* ================================================================ *)
@@ -158,10 +165,10 @@ let run_simple
 (* ================================================================ *)
 
 let text_of_run_result (r : Oas_worker.run_result) : string =
-  Masc_model.text_of_response r.response
+  Agent_sdk.Types.text_of_content r.response.content
 
-let usage_of_run_result (r : Oas_worker.run_result) : Masc_model.token_usage =
-  Masc_model.usage_of_response r.response
+let usage_of_run_result (r : Oas_worker.run_result) : Agent_sdk.Types.api_usage =
+  usage_of_response r.response
 
 let model_of_run_result (r : Oas_worker.run_result) : string =
   r.response.model
@@ -235,7 +242,7 @@ let run_cascade_stream ?(cascade_name = "keeper_turn") ?timeout_sec ~on_event re
   let timeout_int = Option.map int_of_float timeout_sec in
   match run_cascade ~cascade_name ?timeout_sec:timeout_int (request :: fallback) with
   | Ok resp ->
-      let text = Masc_model.text_of_response resp in
+      let text = Agent_sdk.Types.text_of_content resp.content in
       on_event (Llm_provider.Types.MessageStart {
         id = "batch-keeper"; model = resp.Llm_provider.Types.model; usage = None });
       if text <> "" then

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -73,7 +73,7 @@ val text_of_run_result : Oas_worker.run_result -> string
 
 (** Extract usage from an OAS run result.
     Returns zero usage if response has no usage data. *)
-val usage_of_run_result : Oas_worker.run_result -> Masc_model.token_usage
+val usage_of_run_result : Oas_worker.run_result -> Agent_sdk.Types.api_usage
 
 (** Extract model ID string from an OAS run result. *)
 val model_of_run_result : Oas_worker.run_result -> string

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -266,7 +266,7 @@ let proactive_prompt_for_keeper
 
 type proactive_generation_result = {
   reply: string;
-  usage: Masc_model.token_usage;
+  usage: Agent_sdk.Types.api_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -35,7 +35,7 @@ val proactive_prompt_for_keeper :
 
 type proactive_generation_result = {
   reply: string;
-  usage: Masc_model.token_usage;
+  usage: Agent_sdk.Types.api_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -18,6 +18,13 @@ open Keeper_turn_session
 open Keeper_turn_response
 open Keeper_turn_setup
 
+let zero_usage : Agent_sdk.Types.api_usage =
+  { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
+
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
+  match resp.usage with Some u -> u | None -> zero_usage
+
 type tool_result = Keeper_types.tool_result
 
 let handle_keeper_up = Keeper_turn_up.handle_keeper_up
@@ -313,7 +320,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 model_spec_for_used specs resp0.Llm_provider.Types.model
                 |> Option.value ~default:primary
               in
-              let cost0 = cost_usd_of_usage (Masc_model.usage_of_response resp0) used_model0 in
+              let cost0 = cost_usd_of_usage (usage_of_response resp0) used_model0 in
               (* Multi-round tool calling: gated dispatch + OAS lifecycle *)
               let max_tool_rounds = 3 in
               let _trunc s n = if String.length s > n then String.sub s 0 n ^ "..." else s in
@@ -411,8 +418,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                    base_cost_usd, tools_used) =
                 if not (Masc_model.has_tool_calls resp0) then
                   (* No tool calls — return initial response directly *)
-                  (Masc_model.text_of_response resp0,
-                   Masc_model.usage_of_response resp0,
+                  (Agent_sdk.Types.text_of_content resp0.content,
+                   usage_of_response resp0,
                    resp0.Llm_provider.Types.model,
                    latency0, cost0, [])
                 else begin
@@ -442,21 +449,21 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     (* Write done or single round — return first-round result *)
                     let content =
                       let c =
-                        String.trim (Masc_model.text_of_response resp0)
+                        String.trim (Agent_sdk.Types.text_of_content resp0.content)
                       in
                       if c = "" then
                         Printf.sprintf "(tools executed: %s)"
                           (String.concat ", " first_tools)
                       else c
                     in
-                    (content, Masc_model.usage_of_response resp0,
+                    (content, usage_of_response resp0,
                      resp0.Llm_provider.Types.model,
                      latency0, cost0, first_tools)
                   end else begin
                     (* Remaining rounds: delegate to OAS lifecycle *)
                     let followup = keeper_tool_followup_prompt
                       ~user_message:message
-                      ~draft_reply:(Masc_model.text_of_response resp0)
+                      ~draft_reply:(Agent_sdk.Types.text_of_content resp0.content)
                       ~tool_outputs:first_outputs
                       ~already_executed:first_tools
                     in
@@ -488,14 +495,14 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                         _e;
                       let content =
                         let c =
-                          String.trim (Masc_model.text_of_response resp0)
+                          String.trim (Agent_sdk.Types.text_of_content resp0.content)
                         in
                         if c = "" then
                           Printf.sprintf "(tools executed: %s)"
                             (String.concat ", " first_tools)
                         else c
                       in
-                      (content, Masc_model.usage_of_response resp0,
+                      (content, usage_of_response resp0,
                        resp0.Llm_provider.Types.model,
                        latency0, cost0, all_tools)
                     | Ok run_result ->
@@ -504,15 +511,15 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       in
                       let oas_content =
                         let c =
-                          String.trim (Masc_model.text_of_response oas_resp)
+                          String.trim (Agent_sdk.Types.text_of_content oas_resp.content)
                         in
                         if c = "" then
                           Printf.sprintf "(tools executed: %s)"
                             (String.concat ", " all_tools)
-                        else Masc_model.text_of_response oas_resp
+                        else Agent_sdk.Types.text_of_content oas_resp.content
                       in
                       let oas_usage =
-                        Masc_model.usage_of_response oas_resp
+                        usage_of_response oas_resp
                       in
                       let oas_model =
                         oas_resp.Llm_provider.Types.model
@@ -526,7 +533,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       in
                       (oas_content,
                        merge_usage
-                         (Masc_model.usage_of_response resp0) oas_usage,
+                         (usage_of_response resp0) oas_usage,
                        oas_model,
                        latency0 + oas_latency,
                        cost0 +. oas_cost,
@@ -589,17 +596,17 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       model_spec_for_used specs corr.Llm_provider.Types.model
                       |> Option.value ~default:primary
                     in
-                    let corr_usage = Masc_model.usage_of_response corr in
+                    let corr_usage = usage_of_response corr in
                     let cost1 = cost_usd_of_usage corr_usage used_model1 in
                     let eval1 =
                       evaluate_memory_recall
                         ~user_message:message
-                        ~assistant_reply:(Masc_model.text_of_response corr)
+                        ~assistant_reply:(Agent_sdk.Types.text_of_content corr.content)
                         ~candidates:recall_candidates
                     in
                     let evalf = { eval1 with initial_score = eval0.final_score } in
                     let merged_usage = merge_usage base_usage corr_usage in
-                    ( Masc_model.text_of_response corr, merged_usage, corr.Llm_provider.Types.model,
+                    ( Agent_sdk.Types.text_of_content corr.content, merged_usage, corr.Llm_provider.Types.model,
                       base_latency_ms + corr_latency,
                       evalf, true, evalf.passed, false, base_cost_usd +. cost1,
                       tools_used )
@@ -657,13 +664,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                         model_spec_for_used specs forced.Llm_provider.Types.model
                         |> Option.value ~default:primary
                       in
-                      let forced_usage = Masc_model.usage_of_response forced in
+                      let forced_usage = usage_of_response forced in
                       let cost2 = cost_usd_of_usage forced_usage used_model2 in
                       let merged_usage = merge_usage usage_after_correction forced_usage in
                       let merged_latency = latency_after_correction + forced_latency in
                       let grounded_content =
-                        let c = String.trim (Masc_model.text_of_response forced) in
-                        if c = "" then content_after_correction else Masc_model.text_of_response forced
+                        let c = String.trim (Agent_sdk.Types.text_of_content forced.content) in
+                        if c = "" then content_after_correction else Agent_sdk.Types.text_of_content forced.content
                       in
                       let eval2 =
                         evaluate_memory_recall

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -416,7 +416,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               Trajectory.increment_turn trajectory_acc;
               let (base_content, base_usage, base_model_used, base_latency_ms,
                    base_cost_usd, tools_used) =
-                if not (Masc_model.has_tool_calls resp0) then
+                if not (List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) resp0.content) then
                   (* No tool calls — return initial response directly *)
                   (Agent_sdk.Types.text_of_content resp0.content,
                    usage_of_response resp0,
@@ -425,7 +425,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 else begin
                   (* First round: execute tool calls from initial response *)
                   let first_tcs =
-                    Masc_model.tool_calls_of_response resp0
+                    Masc_model.tool_calls_of_content resp0.content
                   in
                   Log.Trpg.info "Tool round 1/%d: %d tool calls"
                     max_tool_rounds (List.length first_tcs);
@@ -813,13 +813,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 continuity_summary = continuity_summary_from_reply;
                 last_continuity_update_ts;
                 total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                total_tokens = meta.total_tokens + Masc_model.total_tokens final_usage;
+                total_tokens = meta.total_tokens + (final_usage.input_tokens + final_usage.output_tokens);
                 total_cost_usd = meta.total_cost_usd +. total_cost_usd_turn;
                 last_turn_ts = now_ts;
                 last_model_used = final_model_used;
                 last_input_tokens = final_usage.input_tokens;
                 last_output_tokens = final_usage.output_tokens;
-                last_total_tokens = Masc_model.total_tokens final_usage;
+                last_total_tokens = (final_usage.input_tokens + final_usage.output_tokens);
                 last_latency_ms = final_latency_ms;
                 compaction_count = meta.compaction_count + (if compacted then 1 else 0);
                 last_compaction_ts = (if compacted then now_ts else meta.last_compaction_ts);

--- a/lib/keeper/keeper_turn_response.ml
+++ b/lib/keeper/keeper_turn_response.ml
@@ -14,7 +14,7 @@ open Keeper_execution
 type turn_env = {
   meta_turn : keeper_meta;
   safe_reply : string;
-  final_usage : Masc_model.token_usage;
+  final_usage : Agent_sdk.Types.api_usage;
   final_model_used : string;
   final_latency_ms : int;
   total_cost_usd_turn : float;
@@ -52,7 +52,7 @@ let build_turn_metrics_fields (env : turn_env) : (string * Yojson.Safe.t) list =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Masc_model.total_tokens env.final_usage));
+      ("total_tokens", `Int ((env.final_usage.input_tokens + env.final_usage.output_tokens)));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);
@@ -163,7 +163,7 @@ let build_normal_turn_response_json (env : turn_env) : Yojson.Safe.t =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Masc_model.total_tokens env.final_usage));
+      ("total_tokens", `Int ((env.final_usage.input_tokens + env.final_usage.output_tokens)));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);

--- a/lib/local/local_agent_eio_types.ml
+++ b/lib/local/local_agent_eio_types.ml
@@ -568,13 +568,13 @@ let parse_text_tool_calls (content : string) : Masc_model.tool_call list =
   in
   collect 0 1 []
 
-let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Masc_model.token_usage =
+let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens;
     output_tokens;
     cache_creation_input_tokens = 0;
     cache_read_input_tokens = 0 }
 
-let merge_usage (a : Masc_model.token_usage) (b : Masc_model.token_usage) : Masc_model.token_usage =
+let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =
@@ -583,7 +583,7 @@ let merge_usage (a : Masc_model.token_usage) (b : Masc_model.token_usage) : Masc
       a.cache_read_input_tokens + b.cache_read_input_tokens }
 
 let estimate_cost_usd (model : Masc_model.model_spec)
-    (usage : Masc_model.token_usage) : float option =
+    (usage : Agent_sdk.Types.api_usage) : float option =
   let input_cost =
     (float_of_int usage.input_tokens /. 1000.0) *. model.cost_per_1k_input
   in

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -1,6 +1,6 @@
 (** OAS type adapters — convert MASC model types to OAS (Agent SDK) types.
 
-    Thin wrappers bridging {!Masc_model.model_spec} and {!Masc_model.message}
+    Thin wrappers bridging {!Masc_model.model_spec} and {!Agent_sdk.Types.message}
     to their OAS counterparts.  Most conversions are structural identity
     (shared type aliases); [to_oas_provider] performs actual mapping.
 
@@ -31,9 +31,9 @@ let to_oas_provider (spec : Masc_model.model_spec) : Agent_sdk.Provider.config o
            model_id = spec.model_id;
            api_key_env = Option.value ~default:"" spec.api_key_env }
 
-let to_oas_message (m : Masc_model.message) : Agent_sdk.Types.message option =
+let to_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message option =
   match m.role with System -> None | _ -> Some m
 
-let of_oas_message (m : Agent_sdk.Types.message) : Masc_model.message = m
-let of_oas_usage (u : Agent_sdk.Types.api_usage) : Masc_model.token_usage = u
-let to_oas_usage (u : Masc_model.token_usage) : Agent_sdk.Types.api_usage = u
+let of_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message = m
+let of_oas_usage (u : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage = u
+let to_oas_usage (u : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage = u

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -170,31 +170,40 @@ let run
     ) config.event_bus;
     Error (Printf.sprintf "Agent build failed: %s" e)
   | Ok agent ->
-  let result = match on_event with
-    | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
-    | None -> Oas.Agent.run ~sw agent goal
-  in
-  let checkpoint = match config.checkpoint_dir with
-    | Some dir ->
-      let ckpt = Oas.Agent.checkpoint ~session_id agent in
-      (try persist_checkpoint ~dir ~session_id ckpt
-       with exn ->
-         Printf.eprintf "[oas_worker] Checkpoint save failed: %s\n%!"
-           (Printexc.to_string exn));
-      Some ckpt
-    | None -> None
-  in
-  Option.iter (fun bus ->
-    let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
-    publish_lifecycle bus ~name:config.name ~event:status
-      ~detail:(Printf.sprintf "session=%s" session_id)
-  ) config.event_bus;
-  let turns = (Oas.Agent.state agent).turn_count in
-  Oas.Agent.close agent;
-  match result with
-  | Ok response -> Ok { response; checkpoint; session_id; turns }
-  | Error err ->
-    Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err))
+  (* Wrap agent execution so Eio/network exceptions become Error results,
+     honouring the (run_result, string) result return type promised by .mli.
+     Eio.Cancel.Cancelled is re-raised for structured-concurrency safety. *)
+  (try
+    let result = match on_event with
+      | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
+      | None -> Oas.Agent.run ~sw agent goal
+    in
+    let checkpoint = match config.checkpoint_dir with
+      | Some dir ->
+        let ckpt = Oas.Agent.checkpoint ~session_id agent in
+        (try persist_checkpoint ~dir ~session_id ckpt
+         with exn ->
+           Printf.eprintf "[oas_worker] Checkpoint save failed: %s\n%!"
+             (Printexc.to_string exn));
+        Some ckpt
+      | None -> None
+    in
+    Option.iter (fun bus ->
+      let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
+      publish_lifecycle bus ~name:config.name ~event:status
+        ~detail:(Printf.sprintf "session=%s" session_id)
+    ) config.event_bus;
+    let turns = (Oas.Agent.state agent).turn_count in
+    Oas.Agent.close agent;
+    (match result with
+    | Ok response -> Ok { response; checkpoint; session_id; turns }
+    | Error err ->
+      Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    (try Oas.Agent.close agent with _ -> ());
+    Error (Printf.sprintf "Agent execution exception: %s" (Printexc.to_string exn)))
 
 (* ================================================================ *)
 (* Convenience: run_with_masc_tools                                  *)

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -65,7 +65,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Masc_model.token_usage;
+  mutable last_usage : Agent_sdk.Types.api_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;
@@ -171,7 +171,7 @@ let create_state config =
   let session = Context_manager.create_session
     ~session_id:trace_id
     ~base_dir:config.session_base_dir in
-  let zero_usage : Masc_model.token_usage = {
+  let zero_usage : Agent_sdk.Types.api_usage = {
     Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
     cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
   } in
@@ -395,7 +395,7 @@ let status ~config state : Yojson.Safe.t =
     ("last_usage", `Assoc [
       ("input_tokens", `Int state.last_usage.input_tokens);
       ("output_tokens", `Int state.last_usage.output_tokens);
-      ("total_tokens", `Int (Masc_model.total_tokens state.last_usage));
+      ("total_tokens", `Int (state.last_usage.input_tokens + state.last_usage.output_tokens));
     ]);
     ("last_latency_ms", `Int state.last_latency_ms);
     ("last_heartbeat_ts", `Float state.last_heartbeat);

--- a/lib/perpetual/perpetual_loop.mli
+++ b/lib/perpetual/perpetual_loop.mli
@@ -67,7 +67,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Masc_model.token_usage;
+  mutable last_usage : Agent_sdk.Types.api_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -109,7 +109,7 @@ let score_to_verdict ~(dim_name : string) (score : int) : verdict =
 
 (** Validate that an LLM response contains parseable G-Eval scores. *)
 let geval_response_is_valid (resp : Masc_model.api_response) : bool =
-  match parse_geval_response (Masc_model.text_of_response resp) with
+  match parse_geval_response (Agent_sdk.Types.text_of_content resp.content) with
   | Ok _ -> true
   | Error _ -> false
 

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -265,7 +265,7 @@ let get_chain_id_for_preset = function
   | _ -> None
 
 let walph_response_is_valid (resp : Masc_model.api_response) =
-  let content = String.trim (Masc_model.text_of_response resp) in
+  let content = String.trim (Agent_sdk.Types.text_of_content resp.content) in
   let lower = String.lowercase_ascii content in
   let len = String.length content in
   len > 0

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -285,7 +285,7 @@ let handle_execute _ctx args =
     | Ok result ->
       json_ok (`Assoc [
         ("topic", `String topic);
-        ("deliberation", `String (Masc_model.text_of_response result.response));
+        ("deliberation", `String (Agent_sdk.Types.text_of_content result.response.content));
         ("turns", `Int result.turns);
         ("session_id", `String result.session_id);
         ("runtime", `String "oas");
@@ -307,7 +307,7 @@ let handle_execute_dry_run _ctx args =
     | Ok result ->
       json_ok (`Assoc [
         ("topic", `String topic);
-        ("analysis", `String (Masc_model.text_of_response result.response));
+        ("analysis", `String (Agent_sdk.Types.text_of_content result.response.content));
         ("turns", `Int result.turns);
         ("session_id", `String result.session_id);
         ("dry_run", `Bool true);

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -203,7 +203,7 @@ let handle_mitosis_divide ctx args : result =
   | Error e ->
     json_err (Printf.sprintf "OAS child agent failed: %s" e)
   | Ok result ->
-    let response_text = Masc_model.text_of_response result.response in
+    let response_text = Agent_sdk.Types.text_of_content result.response.content in
     json_ok (`Assoc [
       ("divided", `Bool true);
       ("session_id", `String result.session_id);
@@ -278,7 +278,7 @@ let handle_mitosis_handoff ctx args : result =
         ("runtime", `String "oas");
       ])
     | Ok result ->
-      let response_text = Masc_model.text_of_response result.response in
+      let response_text = Agent_sdk.Types.text_of_content result.response.content in
       json_ok (`Assoc [
         ("action", `String "handoff");
         ("generation", `Int new_cell.Mitosis.generation);

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -4,6 +4,23 @@ open Alcotest
 open Masc_mcp
 open Masc_mcp.Gardener_types
 
+let test_dir () =
+  let tmp = Filename.temp_file "masc_gardener_test" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
 (** {1 Configuration Tests} *)
 
 let test_load_config () =
@@ -934,9 +951,14 @@ let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
     in_progress_count = 0; done_count = 1; orphan_count = 0;
     oldest_todo_age_hours = 2.0; high_priority_todo = 1;
   } in
-  match Gardener_worker.run_for_backlog ~backlog with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context"
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Room.default_config dir in
+      match Gardener_worker.run_for_backlog ~config ~backlog with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context")
 
 (** {1 Duplicate Task Prevention Tests (Issue #1439)} *)
 


### PR DESCRIPTION
## Summary

Masc_model 제거 Phase 1: OAS SDK 타입을 직접 사용하도록 전환.

- `text_of_response` (33 sites, 15 files) → `Agent_sdk.Types.text_of_content resp.content`
- `usage_of_response` (16 sites, 5 files) → module-local helpers
- `keeper_oas_adapter.mli`: `Masc_model.token_usage` → `Agent_sdk.Types.api_usage`

Stacked on #1778.

## Context

`Masc_model`은 OAS SDK 타입의 1줄 wrapper를 252줄에 걸쳐 제공하는 불필요한 indirection layer.
56개 파일이 의존하므로 단계적으로 제거:
- **Phase 1** (이 PR): type alias + trivial helper 제거
- **Phase 2**: model_spec/provider/빌트인 스펙 → Cascade로 이동
- **Phase 3**: masc_model.ml 삭제

## Test plan

- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)