### PR TITLE
refactor(verifier): bypass Cascade wrapper, call OAS Cascade_config directly

### DIFF
--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -153,14 +153,27 @@ let verify (req : verification_request) : verdict =
     Pass
   else
     let prompt = build_prompt req in
+    let env = Masc_eio_env.get () in
+    let messages : Llm_provider.Types.message list =
+      [ Llm_provider.Types.user_msg prompt ]
+    in
+    let defaults = Cascade.default_model_strings ~cascade_name:"verifier" in
     match
-      Cascade.call ~cascade_name:"verifier" ~prompt
+      Llm_provider.Cascade_config.complete_named
+        ~sw:env.sw ~net:env.net ?clock:env.clock
+        ~name:"verifier" ~defaults ~messages
         ~temperature:0.0 ~max_tokens:200 ()
     with
-    | Ok r -> parse_verdict r.Cascade.response
-    | Error e ->
-      eprintf "[verifier] LLM call failed: %s (defaulting to WARN)\n%!" e;
-      Warn ("verifier_unavailable: " ^ e)
+    | Ok resp ->
+      parse_verdict (Llm_provider.Cascade_config.text_of_response resp)
+    | Error (Llm_provider.Http_client.HttpError { code; body }) ->
+      let msg = sprintf "HTTP %d: %s" code
+        (if String.length body > 200 then String.sub body 0 200 else body) in
+      eprintf "[verifier] OAS call failed: %s (defaulting to WARN)\n%!" msg;
+      Warn ("verifier_unavailable: " ^ msg)
+    | Error (Llm_provider.Http_client.NetworkError { message }) ->
+      eprintf "[verifier] OAS network error: %s (defaulting to WARN)\n%!" message;
+      Warn ("verifier_unavailable: " ^ message)
 
 (* ================================================================ *)
 (* Verdict -> Hook Decision (OAS bridge)                            *)


### PR DESCRIPTION
## Summary
`verifier_oas.verify`가 `Cascade.call` MASC 래퍼를 거치지 않고 `Llm_provider.Cascade_config.complete_named`를 직접 호출하도록 변경.

MASC가 OAS를 실제로 쓰기 위한 첫 단계. Cascade wrapper 제거로 호출 경로 단순화.

## Changes
- `Cascade.call` → `Llm_provider.Cascade_config.complete_named` 직접 호출
- `Masc_eio_env.get()` → env.sw/net/clock 전달
- `Cascade.response` string 대신 `text_of_response` 사용
- `http_error` 패턴 매치로 에러 처리

## Test plan
- [x] `dune build --root . lib/masc_mcp.cma` passes
- [ ] CI (test_gardener.ml pre-existing 빌드 실패는 별도 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)