### PR TITLE
refactor(keeper): reduce model_spec usage — use cascade labels

### DIFF
--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -68,18 +68,12 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
             meta.name meta.deliberation_cost_total_usd daily_budget;
           meta)
         else
-          match model_specs_of_strings meta.models with
+          match ensure_api_keys_for_labels meta.models with
           | Error msg ->
               log_proactive_failure
-                ("deliberation model specs: " ^ msg);
+                ("deliberation api keys: " ^ msg);
               meta
-          | Ok specs -> (
-              match ensure_api_keys specs with
-              | Error msg ->
-                  log_proactive_failure
-                    ("deliberation api keys: " ^ msg);
-                  meta
-              | Ok () ->
+          | Ok () ->
                   (* Parse triggers from last_triage_triggers string *)
                   let trigger_strs =
                     String.split_on_char ',' meta.last_triage_triggers
@@ -514,18 +508,19 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                               | Error msg ->
                                   Log.KeeperExec.error "write_meta failed: %s"
                                     msg);
-                             updated)))
+                             updated))
       else
-      match model_specs_of_strings meta.models with
+      match ensure_api_keys_for_labels meta.models with
       | Error msg ->
-          log_proactive_failure ("model specs: " ^ msg);
+          log_proactive_failure ("api keys: " ^ msg);
           meta
-      | Ok specs ->
-          (match ensure_api_keys specs with
-           | Error msg ->
-               log_proactive_failure ("api keys: " ^ msg);
+      | Ok () ->
+          let specs = Cascade.available_model_specs_of_strings meta.models in
+          (match specs with
+           | [] ->
+               log_proactive_failure "no available model specs";
                meta
-           | Ok () ->
+           | _ ->
                (* Phase 2: Autonomous goal turn (L2+ with active goals) *)
                (match run_autonomous_goal_turn ~config:ctx.config ~meta ~specs with
                 | Some updated_meta ->

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -23,17 +23,15 @@ let explicit_room_prompt ~(meta : keeper_meta) ~(room_id : string) (msg : Types.
 let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_id : string)
     (msg : Types.message) : (keeper_meta * string, string) result =
   let model_labels = effective_model_labels_for_turn meta ~inline_models:[] in
-  match model_specs_of_strings model_labels with
+  match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
-  | Ok specs -> (
-      match ensure_api_keys specs with
-      | Error e -> Error e
-      | Ok () ->
-          let primary =
-            match specs with
-            | model :: _ -> model
-            | [] -> Cascade.default_local_model_spec ()
-          in
+  | Ok () ->
+      let specs = Cascade.available_model_specs_of_strings model_labels in
+      let primary =
+        match specs with
+        | model :: _ -> model
+        | [] -> Cascade.default_local_model_spec ()
+      in
           let base_dir = session_base_dir ctx.config in
           mkdir_p base_dir;
           let (session, ctx_opt) =
@@ -132,7 +130,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                   last_latency_ms = cascade_latency;
                 }
               in
-              Ok (updated, reply))
+              Ok (updated, reply)
 
 let social_board_event_prompt ~(meta : keeper_meta) (event : social_board_event) : string =
   let event_kind =
@@ -173,17 +171,15 @@ let run_social_board_event_turn
     ~(meta : keeper_meta)
     ~(event : social_board_event) : (keeper_meta * social_turn_outcome, string) result =
   let model_labels = effective_model_labels_for_turn meta ~inline_models:[] in
-  match model_specs_of_strings model_labels with
+  match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
-  | Ok specs -> (
-      match ensure_api_keys specs with
-      | Error e -> Error e
-      | Ok () ->
-          let primary =
-            match specs with
-            | model :: _ -> model
-            | [] -> Cascade.default_local_model_spec ()
-          in
+  | Ok () ->
+      let specs = Cascade.available_model_specs_of_strings model_labels in
+      let primary =
+        match specs with
+        | model :: _ -> model
+        | [] -> Cascade.default_local_model_spec ()
+      in
           let base_dir = session_base_dir ctx.config in
           let session, ctx_opt =
             load_context_from_checkpoint
@@ -319,7 +315,7 @@ let run_social_board_event_turn
                     tools_used = final_tools_used;
                     decision_reason = Some assistant_text;
                     failure_reason = None;
-                  } ))
+                  } )
 
 let run_learned_policy_room_event
     (ctx : _ context)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -88,9 +88,9 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
                    keeper_metrics_path ctx.config meta_current.name
                  in
                  let primary_model =
-                   match model_specs_of_strings meta_current.models with
-                   | Ok (primary :: _) -> primary
-                   | _ -> Cascade.default_local_model_spec ()
+                   match Cascade.available_model_specs_of_strings meta_current.models with
+                   | primary :: _ -> primary
+                   | [] -> Cascade.default_local_model_spec ()
                  in
                  let base_dir = session_base_dir ctx.config in
                  let _session, ctx_opt =

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -38,11 +38,9 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = m.models in
-      (match model_specs_of_strings models with
-       | Error e -> (false, "❌ " ^ e)
-       | Ok specs ->
-         let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
-         let base_dir = session_base_dir ctx.config in
+      let specs = Cascade.available_model_specs_of_strings models in
+      let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+      let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
              let (_session, ctx_opt) =
@@ -523,7 +521,7 @@ let handle_keeper_status ctx args : tool_result =
              ("history", `String history_path);
            ]);
          ] in
-         (true, Yojson.Safe.pretty_to_string json))
+         (true, Yojson.Safe.pretty_to_string json)
 
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -113,13 +113,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           effective_models
         else maybe_append_keeper_fallback_models effective_models
       in
-      (match model_specs_of_strings effective_models with
+      (match ensure_api_keys_for_labels effective_models with
        | Error e -> (false, "❌ " ^ e)
-       | Ok specs ->
-         (match ensure_api_keys specs with
-          | Error e -> (false, "❌ " ^ e)
-          | Ok () ->
-            let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+       | Ok () ->
+         let specs = Cascade.available_model_specs_of_strings effective_models in
+         let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
             let base_dir = session_base_dir ctx.config in
             mkdir_p base_dir;
             let (session, ctx_opt) = load_context_from_checkpoint
@@ -468,7 +466,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       (fun () ->
                         Keeper_oas_adapter.run_with_custom_dispatch
                           ~meta
-                          ~model_spec_override:primary
                           ~system_prompt:(keeper_tool_loop_system_prompt
                             ~character_context:ctx_work.system_prompt)
                           ~goal:followup
@@ -983,4 +980,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 interesting_alert;
               } in
               build_keeper_response ctx ~session ~now_ts ~specs ~primary ~base_dir
-                ~trajectory_acc ~gate_config ~do_handoff turn_env))
+                ~trajectory_acc ~gate_config ~do_handoff turn_env)

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -22,20 +22,22 @@ let handle_keeper_model_set ctx args : tool_result =
     match read_meta ctx.config name with
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (false, Printf.sprintf "❌ keeper not found: %s" name)
-    | Ok (Some meta) -> (
-        match Cascade.model_spec_of_string model with
-        | Error e -> (false, "❌ " ^ e)
-        | Ok spec ->
+    | Ok (Some meta) ->
+            let is_local = label_is_local_runtime model in
             let runtime_ok =
-              match spec.provider with
-              | Cascade.Llama -> (
-                  match Tool_local_runtime.fetch_models () with
-                  | Ok (_, models) -> List.mem spec.model_id models
-                  | Error _ -> false)
-              | _ -> true
+              if is_local then (
+                let model_id =
+                  match String.index_opt model ':' with
+                  | Some i -> String.sub model (i + 1) (String.length model - i - 1)
+                  | None -> model
+                in
+                match Tool_local_runtime.fetch_models () with
+                | Ok (_, models) -> List.mem model_id models
+                | Error _ -> false)
+              else true
             in
-            if spec.provider = Cascade.Llama && not runtime_ok then
-              (false, Printf.sprintf "❌ model not present in llama inventory: %s" spec.model_id)
+            if is_local && not runtime_ok then
+              (false, Printf.sprintf "❌ model not present in llama inventory: %s" model)
             else
               let allowed_models =
                 dedupe_keep_order
@@ -66,7 +68,7 @@ let handle_keeper_model_set ctx args : tool_result =
                               (List.map (fun item -> `String item) updated.allowed_models));
                   ("room_scope", `String updated.room_scope);
                   ("trigger_mode", `String updated.trigger_mode);
-                    ]) ))
+                    ]) )
 
 
 let handle_keeper_down ctx args : tool_result =

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -294,32 +294,30 @@ let ensure_keeper_exists
     } in
     let base_dir = session_base_dir ctx.config in
     mkdir_p base_dir;
-    (match model_specs_of_strings meta.models with
+    (match ensure_api_keys_for_labels meta.models with
      | Error e -> Error e
-     | Ok specs ->
-       (match ensure_api_keys specs with
-        | Error e -> Error e
-        | Ok () ->
-          let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
-          let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
-          let system_prompt =
-            build_keeper_system_prompt
-              ~goal
-              ~short_goal
-              ~mid_goal
-              ~long_goal
-              ~soul_profile
-              ~will
-              ~needs
-              ~desires
-              ~instructions
-          in
-          let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
-          (try ignore (save_checkpoint session ctx0 ~generation:0)
-           with exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
-          match write_meta ctx.config meta with
-          | Error e -> Error e
-          | Ok () -> Ok meta))
+     | Ok () ->
+       let specs = Cascade.available_model_specs_of_strings meta.models in
+       let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+       let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
+       let system_prompt =
+         build_keeper_system_prompt
+           ~goal
+           ~short_goal
+           ~mid_goal
+           ~long_goal
+           ~soul_profile
+           ~will
+           ~needs
+           ~desires
+           ~instructions
+       in
+       let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
+       (try ignore (save_checkpoint session ctx0 ~generation:0)
+        with exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
+       match write_meta ctx.config meta with
+       | Error e -> Error e
+       | Ok () -> Ok meta)
 
 (** Apply inline settings update to keeper meta. Extracted from handle_keeper_msg. *)
 let apply_settings_update

--- a/lib/keeper/keeper_turn_up.ml
+++ b/lib/keeper/keeper_turn_up.ml
@@ -365,17 +365,15 @@ let handle_keeper_up ctx args : tool_result =
             ~fallback_message:env_message_gate
             ~fallback_token:env_token_gate
         in
-        (match model_specs_of_strings requested_models with
+        (match ensure_api_keys_for_labels requested_models with
          | Error e -> (false, "❌ " ^ e)
-         | Ok specs ->
-           (match ensure_api_keys specs with
-           | Error e -> (false, "❌ " ^ e)
-           | Ok () ->
-             let trace_id = generate_trace_id () in
-             let primary = match specs with
-               | m :: _ -> m
-               | [] -> Cascade.default_local_model_spec ()
-             in
+         | Ok () ->
+           let specs = Cascade.available_model_specs_of_strings requested_models in
+           let trace_id = generate_trace_id () in
+           let primary = match specs with
+             | m :: _ -> m
+             | [] -> Cascade.default_local_model_spec ()
+           in
              let base_dir = session_base_dir ctx.config in
              mkdir_p base_dir;
              let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
@@ -545,7 +543,7 @@ let handle_keeper_up ctx args : tool_result =
                  ("auto_handoff", `Bool meta.auto_handoff);
                  ("handoff_threshold", `Float meta.handoff_threshold);
                ] in
-               (true, Yojson.Safe.pretty_to_string json)))
+               (true, Yojson.Safe.pretty_to_string json))
     | Ok (Some old) ->
       (* Update existing keeper meta (goal/models optional) *)
       let goal_provided = Option.is_some goal_opt in

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -50,10 +50,18 @@ let model_spec_is_local_runtime (model : Cascade.model_spec) =
   | Cascade.Llama -> true
   | _ -> false
 
+let label_is_local_runtime (label : string) =
+  let l = String.lowercase_ascii (String.trim label) in
+  String.length l >= 6 && String.sub l 0 6 = "llama:"
+
 let model_spec_is_available (model : Cascade.model_spec) =
   match model.provider with
   | Cascade.Llama -> true
   | _ -> true
+
+(** Check whether a model label refers to an available provider.
+    Currently always returns true (all providers are considered available). *)
+let label_is_available (_label : string) = true
 
 let keeper_fallback_model_labels () =
   let gemini_available =
@@ -78,19 +86,16 @@ let keeper_fallback_model_labels () =
     else None)
 
 let maybe_append_keeper_fallback_models (models : string list) =
-  match model_specs_of_strings models with
-  | Error _ -> models
-  | Ok specs ->
-      let all_local = specs <> [] && List.for_all model_spec_is_local_runtime specs in
-      let any_available = List.exists model_spec_is_available specs in
-      if (not all_local) || any_available then
-        models
-      else
-        let extra =
-          keeper_fallback_model_labels ()
-          |> List.filter (fun label -> not (List.mem label models))
-        in
-        if extra = [] then models else models @ extra
+  let all_local = models <> [] && List.for_all label_is_local_runtime models in
+  let any_available = List.exists label_is_available models in
+  if (not all_local) || any_available then
+    models
+  else
+    let extra =
+      keeper_fallback_model_labels ()
+      |> List.filter (fun label -> not (List.mem label models))
+    in
+    if extra = [] then models else models @ extra
 
 let ensure_api_keys (models : Cascade.model_spec list) : (unit, string) result =
   let missing =
@@ -106,6 +111,16 @@ let ensure_api_keys (models : Cascade.model_spec list) : (unit, string) result =
   | [] -> Ok ()
   | xs ->
       Error (Printf.sprintf "Missing API key env vars: %s" (String.concat ", " xs))
+
+(** Check API key availability using model label strings (no model_spec needed).
+    Parses labels to extract api_key_env, filtering out unparseable labels. *)
+let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
+  let specs = Cascade.available_model_specs_of_strings labels in
+  if specs = [] && labels <> [] then
+    Error (Printf.sprintf "No valid/available model specs for labels: %s"
+      (String.concat ", " labels))
+  else
+    ensure_api_keys specs
 
 let keeper_metrics_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")


### PR DESCRIPTION
## Summary
- Replace `model_specs_of_strings` + `ensure_api_keys` gate pattern in 8 keeper files with label-based `ensure_api_keys_for_labels` + `Cascade.available_model_specs_of_strings`
- Add `label_is_local_runtime` / `label_is_available` for string-based provider checks without model_spec parsing
- `maybe_append_keeper_fallback_models` now works entirely with label strings (no spec parsing)
- Remove unused `model_spec_override` passage in `keeper_turn.ml` (was already `ignore`d in adapter)
- `model_specs_of_strings` and `ensure_api_keys` remain available for backward compat (used by `dashboard_http_keeper.ml`)

## Files changed
| File | What changed |
|------|-------------|
| `keeper_types_resident.ml` | Add `label_is_local_runtime`, `label_is_available`, `ensure_api_keys_for_labels`; simplify `maybe_append_keeper_fallback_models` |
| `keeper_turn.ml` | Replace `model_specs_of_strings`+`ensure_api_keys` gate; remove `model_spec_override` |
| `keeper_exec_proactive.ml` | Replace two `model_specs_of_strings`+`ensure_api_keys` gates |
| `keeper_exec_social.ml` | Replace two `model_specs_of_strings`+`ensure_api_keys` gates |
| `keeper_keepalive.ml` | Use `Cascade.available_model_specs_of_strings` directly |
| `keeper_status.ml` | Use `Cascade.available_model_specs_of_strings` directly |
| `keeper_turn_setup.ml` | Replace gate pattern |
| `keeper_turn_up.ml` | Replace gate pattern |
| `keeper_turn_lifecycle.ml` | Use `label_is_local_runtime` instead of parsing spec for provider check |

## Test plan
- [x] `dune build --root . lib/ bin/` passes (pre-existing test_gardener.ml issue on main)
- [ ] Manual keeper_up / keeper_msg smoke test
- [ ] Verify keeper status shows models_resolved correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)