### PR TITLE
feat(memory): OAS Memory.t bridge backed by memory_stream

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -1,0 +1,96 @@
+(** Memory_oas_bridge — Connect MASC memory systems to OAS Memory.t.
+
+    Implements [Agent_sdk.Memory.long_term_backend] using MASC's
+    [Memory_stream] and [Institution_eio] as the persistence layer.
+
+    This bridge allows OAS Agent.t to use [Memory.store ~tier:Long_term]
+    and [Memory.recall ~tier:Long_term] transparently, with MASC's
+    existing JSONL-based memory stream handling the actual persistence.
+
+    Key mapping:
+    - [persist ~key json] → [Memory_stream.add_memory] (importance from JSON or default 5)
+    - [retrieve ~key] → [Memory_stream.retrieve] with key as query (top-1)
+    - [remove ~key] → no-op (JSONL is append-only, entries decay via scoring)
+
+    @since 2.122.0 *)
+
+(** Default importance for memories stored via OAS Memory.store.
+    Configurable via MASC_MEMORY_OAS_DEFAULT_IMPORTANCE. *)
+let default_importance () =
+  match Sys.getenv_opt "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE" with
+  | Some s -> (try max 1 (min 10 (int_of_string s)) with Failure _ -> 5)
+  | None -> 5
+
+(** Extract importance from JSON value if present, else use default. *)
+let importance_of_json (json : Yojson.Safe.t) : int =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "importance" fields with
+     | Some (`Int n) -> max 1 (min 10 n)
+     | _ -> default_importance ())
+  | _ -> default_importance ()
+
+(** Extract content string from JSON value. *)
+let content_of_json (json : Yojson.Safe.t) : string =
+  match json with
+  | `String s -> s
+  | `Assoc fields ->
+    (match List.assoc_opt "content" fields with
+     | Some (`String s) -> s
+     | _ -> Yojson.Safe.to_string json)
+  | _ -> Yojson.Safe.to_string json
+
+(** Create an OAS [long_term_backend] backed by [Memory_stream] for a
+    specific agent.
+
+    Usage:
+    {[
+      let backend = Memory_oas_bridge.make_backend ~agent_name:"keeper-dm" in
+      let memory = Agent_sdk.Memory.create ~long_term:backend () in
+      (* Agent.t can now use Memory.store/recall ~tier:Long_term *)
+    ]}
+*)
+let make_backend ~(agent_name : string) : Agent_sdk.Memory.long_term_backend =
+  {
+    Agent_sdk.Memory.persist = (fun ~key json ->
+      let content = Printf.sprintf "[%s] %s" key (content_of_json json) in
+      let importance = importance_of_json json in
+      Memory_stream.add_memory
+        ~agent_name ~content ~importance
+        (Memory_stream.Observation content));
+
+    retrieve = (fun ~key ->
+      let entries = Memory_stream.retrieve ~agent_name ~query:key ~limit:1 in
+      match entries with
+      | entry :: _ ->
+        Some (`Assoc [
+          ("id", `String entry.Memory_stream.id);
+          ("content", `String entry.Memory_stream.content);
+          ("importance", `Int entry.Memory_stream.importance);
+          ("timestamp", `Float entry.Memory_stream.timestamp);
+        ])
+      | [] -> None);
+
+    remove = (fun ~key:_ ->
+      (* Memory_stream is append-only JSONL. Old entries decay naturally
+         via recency scoring. Explicit removal not supported. *)
+      ());
+  }
+
+(** Create an OAS [Memory.t] instance pre-configured with the memory_stream
+    backend for a specific agent.
+
+    This is the primary entry point for integrating OAS Memory into MASC
+    agent execution paths (gardener workers, keeper, perpetual agents). *)
+let create_memory ~(agent_name : string) : Agent_sdk.Memory.t =
+  let backend = make_backend ~agent_name in
+  Agent_sdk.Memory.create ~long_term:backend ()
+
+(** Format institutional memory as a JSON value suitable for
+    [Memory.store ~tier:Long_term "institution" value].
+
+    Loads from institution.json if present, returns None otherwise. *)
+let institution_as_json (config : Room_utils.config) : Yojson.Safe.t option =
+  let welcome = Institution_eio.load_and_format_for_welcome ~fs:() config in
+  if welcome = "" then None
+  else Some (`String welcome)


### PR DESCRIPTION
## Summary

- OAS `Agent_sdk.Memory.long_term_backend` 구현체: MASC memory_stream을 backing store로 사용
- `Memory_oas_bridge.create_memory ~agent_name` 한 줄로 OAS Memory.t 생성
- OAS Agent.t가 `Memory.store/recall ~tier:Long_term` 으로 MASC memory에 접근 가능

## Architecture

```
OAS Agent.t
  └── Memory.t
        └── long_term_backend (callback)
              ├── persist → Memory_stream.add_memory
              ├── retrieve → Memory_stream.retrieve (scored, top-1)
              └── remove → no-op (JSONL append-only, recency decay)
```

## Blocker

OAS `Builder`에 `with_memory` API가 아직 없음.
Agent.t 생성 시 Memory.t를 주입하려면 OAS PR 필요:
- `Builder.with_memory : Memory.t -> builder -> builder`
- Agent state에 `memory: Memory.t option` 추가

이 PR은 MASC 쪽 bridge만 준비. OAS PR 후 gardener_worker/keeper에서 사용 가능.

## Test plan

- [x] `dune build lib/masc_mcp.cmxa` 성공


🤖 Generated with [Claude Code](https://claude.com/claude-code)