### PR TITLE
refactor: remove Cascade self-implemented types (tool_call, completion_request, aliases)

### DIFF
--- a/archive/trpg/lib/trpg_dm_intent.ml
+++ b/archive/trpg/lib/trpg_dm_intent.ml
@@ -293,7 +293,7 @@ let parse_llm_intent (text : string) : (dm_intent, string) result =
                     (String.sub s 0 (min 100 (String.length s)))))
 
 (** Validate that an LLM response contains a parseable non-Unknown intent. *)
-let llm_response_is_valid (resp : Cascade.api_response) : bool =
+let llm_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
   match parse_llm_intent (Cascade.text_of_response resp) with
   | Ok intent -> not (equal_intent_category intent.primary Unknown)
   | Error _ -> false

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -139,7 +139,7 @@ let run_cli_agent ~agent_type ~prompt =
 let cascade_name_for_agent_type agent_type =
   Printf.sprintf "auto_responder_%s" agent_type
 
-let llm_response_is_valid (resp : Cascade.api_response) =
+let llm_response_is_valid (resp : Llm_provider.Types.api_response) =
   let s = String.trim (Cascade.text_of_response resp) in
   let s_lower = String.lowercase_ascii s in
   let len = String.length s in

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -245,7 +245,7 @@ let parse_llm_score (text : string) : float option =
       scan 0
 
 (** Validate that an LLM response contains a parseable score. *)
-let llm_score_is_valid (resp : Cascade.api_response) : bool =
+let llm_score_is_valid (resp : Llm_provider.Types.api_response) : bool =
   parse_llm_score (Cascade.text_of_response resp) <> None
 
 (** Call LLM to score agent-task compatibility.

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -50,11 +50,6 @@ type model_spec = {
   cost_per_1k_output : float;
 }
 
-type role = Agent_sdk.Types.role = System | User | Assistant | Tool
-
-(** Message type — now unified with OAS. No more MASC-specific name/tool_call_id fields. *)
-type message = Agent_sdk.Types.message
-
 type tool_def = {
   tool_name : string;
   tool_description : string;
@@ -67,40 +62,31 @@ type tool_call = {
   call_arguments : string;
 }
 
-(** Token usage — now unified with OAS api_usage. Use [total_tokens] function
-    instead of the removed field. *)
-type token_usage = Agent_sdk.Types.api_usage
-
-(** Compute total tokens (was a record field, now derived). *)
-let total_tokens (u : token_usage) = u.input_tokens + u.output_tokens
+(** Compute total tokens from OAS api_usage. *)
+let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens
 
 type completion_request = {
   model : model_spec;
-  messages : message list;
+  messages : Agent_sdk.Types.message list;
   temperature : float;
   max_tokens : int;
   tools : tool_def list;
   response_format : [ `Text | `Json ];
 }
 
-(** LLM completion result — OAS api_response directly.
-    No more MASC-specific wrapper; use helpers below for field access.
-    @since Phase 2 — OAS SDK Only *)
-type api_response = Llm_provider.Types.api_response
-
-(** Zero usage sentinel for api_response with [usage = None]. *)
-let zero_usage : token_usage =
+(** Zero usage sentinel. *)
+let zero_usage : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = 0;
     output_tokens = 0;
     cache_creation_input_tokens = 0;
     cache_read_input_tokens = 0 }
 
 (** Extract usage from an api_response, defaulting to zero. *)
-let usage_of_response (resp : api_response) : token_usage =
+let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
   match resp.usage with Some u -> u | None -> zero_usage
 
 (** Extract text content from an api_response. *)
-let text_of_response (resp : api_response) : string =
+let text_of_response (resp : Llm_provider.Types.api_response) : string =
   Agent_sdk.Types.text_of_content resp.content
 
 (** Measure wall-clock latency of a thunk in milliseconds.
@@ -123,11 +109,11 @@ let tool_calls_of_content (blocks : Agent_sdk.Types.content_block list)
     blocks
 
 (** Extract tool calls from an api_response. *)
-let tool_calls_of_response (resp : api_response) : tool_call list =
+let tool_calls_of_response (resp : Llm_provider.Types.api_response) : tool_call list =
   tool_calls_of_content resp.content
 
 (** Check if an api_response has any tool calls. *)
-let has_tool_calls (resp : api_response) : bool =
+let has_tool_calls (resp : Llm_provider.Types.api_response) : bool =
   List.exists
     (function Agent_sdk.Types.ToolUse _ -> true | _ -> false)
     resp.content
@@ -150,8 +136,6 @@ let string_of_provider = function
   | Glm_cloud -> "glm_cloud"
   | OpenRouter -> "openrouter"
   | Custom s -> sprintf "custom(%s)" s
-
-let string_of_role = Agent_sdk.Types.role_to_string
 
 let llama_default = {
   provider = Llama;
@@ -213,16 +197,8 @@ let gemini_pro = {
   cost_per_1k_output = 0.0;
 }
 
-let system_msg = Agent_sdk.Types.system_msg
-let user_msg = Agent_sdk.Types.user_msg
-let assistant_msg = Agent_sdk.Types.assistant_msg
-
 let tool_msg ~name:_ ~call_id text =
   Agent_sdk.Types.tool_result_msg ~tool_use_id:call_id ~content:text ()
-
-(** Extract text content from a message.
-    Delegates to Agent_sdk.Types.text_of_content for rich content_block list. *)
-let text_of_message = Agent_sdk.Types.text_of_message
 
 (* ================================================================ *)
 (* UTF-8 Sanitization                                               *)
@@ -246,7 +222,7 @@ let sanitize_text_utf8 (s : string) : string =
   loop 0;
   Buffer.contents buf
 
-let sanitize_message_utf8 (m : message) : message =
+let sanitize_message_utf8 (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   { m with
     content = List.map (fun block ->
       match block with
@@ -260,12 +236,12 @@ let sanitize_message_utf8 (m : message) : message =
     ) m.content;
   }
 
-let sanitize_messages_utf8 (msgs : message list) : message list =
+let sanitize_messages_utf8 (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
   List.map sanitize_message_utf8 msgs
 
 (** Heuristic: ~4 characters per token (conservative estimate). *)
-let estimate_tokens (msgs : message list) =
-  List.fold_left (fun acc (m : message) -> acc + (String.length (text_of_message m) / 4) + 4) 0 msgs
+let estimate_tokens (msgs : Agent_sdk.Types.message list) =
+  List.fold_left (fun acc (m : Agent_sdk.Types.message) -> acc + (String.length (Agent_sdk.Types.text_of_message m) / 4) + 4) 0 msgs
 
 
 
@@ -591,7 +567,7 @@ let get_cascade ?(config_path = "") ~cascade_name () :
         cascade_name;
       available_model_specs_of_strings fallback)
 
-(** Accept validator type: api_response -> bool.
+(** Accept validator type: Llm_provider.Types.api_response -> bool.
     Now that MASC validators use api_response directly, no bridging needed. *)
 
 (** Format OAS http_error as cascade error string. *)

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -4,7 +4,7 @@
     and converts back. This is Phase 1 of migrating MASC to use OAS properly.
 
     This module is deliberately independent of Context_manager to avoid circular
-    dependency. It operates on [Cascade.message list] directly and uses its own
+    dependency. It operates on [Agent_sdk.Types.message list] directly and uses its own
     strategy enum that mirrors Context_manager.compaction_strategy.
 
     MASC has 4 roles (System, User, Assistant, Tool) while OAS has the same 4.

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -14,7 +14,7 @@
 (** Working context: the message window sent to the LLM. *)
 type working_context = {
   system_prompt : string;
-  messages : Cascade.message list;
+  messages : Agent_sdk.Types.message list;
   token_count : int;                (** Estimated tokens in window *)
   max_tokens : int;                 (** Model context limit *)
   importance_scores : (int * float) list;  (** msg_index → importance 0.0-1.0 *)
@@ -37,7 +37,7 @@ type checkpoint = {
 type session_context = {
   session_id : string;
   session_dir : string;            (** Path to session JSONL files *)
-  mutable full_history : Cascade.message list;
+  mutable full_history : Agent_sdk.Types.message list;
   mutable checkpoints : checkpoint list;
 }
 
@@ -75,10 +75,10 @@ val create : system_prompt:string -> max_tokens:int -> working_context
 val set_system_prompt : working_context -> system_prompt:string -> working_context
 
 (** Append a message to working context, updating token count. *)
-val append : working_context -> Cascade.message -> working_context
+val append : working_context -> Agent_sdk.Types.message -> working_context
 
 (** Append multiple messages. *)
-val append_many : working_context -> Cascade.message list -> working_context
+val append_many : working_context -> Agent_sdk.Types.message list -> working_context
 
 (** Score message importance (Stanford GAP formula adapted). *)
 val score_importance : working_context -> working_context
@@ -97,13 +97,13 @@ val goal_prefix : string
 val compact : working_context -> compaction_strategy list -> working_context
 
 (** Format a single message as human-readable text: "role: content". *)
-val format_message_readable : Cascade.message -> string
+val format_message_readable : Agent_sdk.Types.message -> string
 
 (** Offload messages to a markdown file in [{session_dir}/offloaded/{compaction_count}.md].
     Returns [Some path] on success, [None] on failure (fail-safe, never raises). *)
 val offload_messages :
   session_dir:string -> compaction_count:int ->
-  Cascade.message list -> string option
+  Agent_sdk.Types.message list -> string option
 
 (** Apply compaction with history offload.
     Before compaction, saves the full pre-compaction messages to a markdown file.
@@ -143,7 +143,7 @@ val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
 val create_session : session_id:string -> base_dir:string -> session_context
 
 (** Persist a message to session history (append to JSONL). *)
-val persist_message : session_context -> Cascade.message -> unit
+val persist_message : session_context -> Agent_sdk.Types.message -> unit
 
 (** Save checkpoint to session directory. *)
 val save_checkpoint : session_context -> checkpoint -> unit

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -186,7 +186,7 @@ let parse_intent_response (text : string) : (query_intent * float) option =
     None
 
 (** Validate that an LLM response contains a parseable intent. *)
-let intent_response_is_valid (resp : Cascade.api_response) : bool =
+let intent_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
   parse_intent_response (Cascade.text_of_response resp) <> None
 
 (** Classify query intent using LLM semantic understanding.

--- a/lib/context_scoring.mli
+++ b/lib/context_scoring.mli
@@ -21,4 +21,4 @@ val starts_with : prefix:string -> string -> bool
 
     Messages starting with [memory_summary_prefix] or [goal_prefix]
     receive a minimum score of 0.95 (sticky memory). *)
-val score_messages : Cascade.message list -> (int * float) list
+val score_messages : Agent_sdk.Types.message list -> (int * float) list

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -7,8 +7,8 @@ open Keeper_memory
 let keeper_llm_tools = Tool_shard.keeper_llm_tools
 
 let merge_usage
-    (a : Cascade.token_usage)
-    (b : Cascade.token_usage) : Cascade.token_usage =
+    (a : Agent_sdk.Types.api_usage)
+    (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -103,12 +103,12 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
                  | None -> ()
                  | Some c ->
                      let latest_user_message =
-                       latest_message_content_by_role ~role:Cascade.User
+                       latest_message_content_by_role ~role:Agent_sdk.Types.User
                          c.messages
                      in
                      let latest_assistant_message =
                        latest_message_content_by_role
-                         ~role:Cascade.Assistant c.messages
+                         ~role:Agent_sdk.Types.Assistant c.messages
                      in
                      let continuity_snapshot =
                        latest_state_snapshot_from_messages c.messages

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -160,7 +160,7 @@ let run_simple
 let text_of_run_result (r : Oas_worker.run_result) : string =
   Cascade.text_of_response r.response
 
-let usage_of_run_result (r : Oas_worker.run_result) : Cascade.token_usage =
+let usage_of_run_result (r : Oas_worker.run_result) : Agent_sdk.Types.api_usage =
   Cascade.usage_of_response r.response
 
 let model_of_run_result (r : Oas_worker.run_result) : string =
@@ -183,7 +183,7 @@ let separate_system_and_user (msgs : Agent_sdk.Types.message list) :
   let rest = ref [] in
   List.iter (fun (m : Agent_sdk.Types.message) ->
     match m.role with
-    | Agent_sdk.Types.System -> sys_parts := Cascade.text_of_message m :: !sys_parts
+    | Agent_sdk.Types.System -> sys_parts := Agent_sdk.Types.text_of_message m :: !sys_parts
     | _ -> rest := m :: !rest
   ) msgs;
   let sys = String.concat "\n" (List.rev !sys_parts) in
@@ -191,7 +191,7 @@ let separate_system_and_user (msgs : Agent_sdk.Types.message list) :
 
 let messages_to_goal_text (msgs : Agent_sdk.Types.message list) : string =
   msgs
-  |> List.map (fun (m : Agent_sdk.Types.message) -> Cascade.text_of_message m)
+  |> List.map (fun (m : Agent_sdk.Types.message) -> Agent_sdk.Types.text_of_message m)
   |> List.filter (fun s -> String.length s > 0)
   |> String.concat "\n"
 

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -73,7 +73,7 @@ val text_of_run_result : Oas_worker.run_result -> string
 
 (** Extract usage from an OAS run result.
     Returns zero usage if response has no usage data. *)
-val usage_of_run_result : Oas_worker.run_result -> Cascade.token_usage
+val usage_of_run_result : Oas_worker.run_result -> Agent_sdk.Types.api_usage
 
 (** Extract model ID string from an OAS run result. *)
 val model_of_run_result : Oas_worker.run_result -> string

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -266,7 +266,7 @@ let proactive_prompt_for_keeper
 
 type proactive_generation_result = {
   reply: string;
-  usage: Cascade.token_usage;
+  usage: Agent_sdk.Types.api_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -35,7 +35,7 @@ val proactive_prompt_for_keeper :
 
 type proactive_generation_result = {
   reply: string;
-  usage: Cascade.token_usage;
+  usage: Agent_sdk.Types.api_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;

--- a/lib/keeper/keeper_turn_response.ml
+++ b/lib/keeper/keeper_turn_response.ml
@@ -14,7 +14,7 @@ open Keeper_execution
 type turn_env = {
   meta_turn : keeper_meta;
   safe_reply : string;
-  final_usage : Cascade.token_usage;
+  final_usage : Agent_sdk.Types.api_usage;
   final_model_used : string;
   final_latency_ms : int;
   total_cost_usd_turn : float;

--- a/lib/local/local_agent_eio_types.ml
+++ b/lib/local/local_agent_eio_types.ml
@@ -568,13 +568,13 @@ let parse_text_tool_calls (content : string) : Cascade.tool_call list =
   in
   collect 0 1 []
 
-let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Cascade.token_usage =
+let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens;
     output_tokens;
     cache_creation_input_tokens = 0;
     cache_read_input_tokens = 0 }
 
-let merge_usage (a : Cascade.token_usage) (b : Cascade.token_usage) : Cascade.token_usage =
+let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
     cache_creation_input_tokens =
@@ -583,7 +583,7 @@ let merge_usage (a : Cascade.token_usage) (b : Cascade.token_usage) : Cascade.to
       a.cache_read_input_tokens + b.cache_read_input_tokens }
 
 let estimate_cost_usd (model : Cascade.model_spec)
-    (usage : Cascade.token_usage) : float option =
+    (usage : Agent_sdk.Types.api_usage) : float option =
   let input_cost =
     (float_of_int usage.input_tokens /. 1000.0) *. model.cost_per_1k_input
   in

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -1,6 +1,6 @@
 (** OAS type adapters — convert MASC model types to OAS (Agent SDK) types.
 
-    Thin wrappers bridging {!Cascade.model_spec} and {!Cascade.message}
+    Thin wrappers bridging {!Cascade.model_spec} and {!Agent_sdk.Types.message}
     to their OAS counterparts.  Most conversions are structural identity
     (shared type aliases); [to_oas_provider] performs actual mapping.
 
@@ -31,9 +31,9 @@ let to_oas_provider (spec : Cascade.model_spec) : Agent_sdk.Provider.config opti
            model_id = spec.model_id;
            api_key_env = Option.value ~default:"" spec.api_key_env }
 
-let to_oas_message (m : Cascade.message) : Agent_sdk.Types.message option =
+let to_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message option =
   match m.role with System -> None | _ -> Some m
 
-let of_oas_message (m : Agent_sdk.Types.message) : Cascade.message = m
-let of_oas_usage (u : Agent_sdk.Types.api_usage) : Cascade.token_usage = u
-let to_oas_usage (u : Cascade.token_usage) : Agent_sdk.Types.api_usage = u
+let of_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message = m
+let of_oas_usage (u : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage = u
+let to_oas_usage (u : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage = u

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -65,7 +65,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Cascade.token_usage;
+  mutable last_usage : Agent_sdk.Types.api_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;
@@ -171,7 +171,7 @@ let create_state config =
   let session = Context_manager.create_session
     ~session_id:trace_id
     ~base_dir:config.session_base_dir in
-  let zero_usage : Cascade.token_usage = {
+  let zero_usage : Agent_sdk.Types.api_usage = {
     Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
     cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
   } in

--- a/lib/perpetual/perpetual_loop.mli
+++ b/lib/perpetual/perpetual_loop.mli
@@ -67,7 +67,7 @@ type loop_state = {
   mutable started_at : float;
   mutable last_turn_ts : float;
   mutable last_model_used : string;
-  mutable last_usage : Cascade.token_usage;
+  mutable last_usage : Agent_sdk.Types.api_usage;
   mutable last_latency_ms : int;
   mutable compaction_count : int;
   mutable compaction_tokens_saved : int;

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -108,7 +108,7 @@ let score_to_verdict ~(dim_name : string) (score : int) : verdict =
   else Pass
 
 (** Validate that an LLM response contains parseable G-Eval scores. *)
-let geval_response_is_valid (resp : Cascade.api_response) : bool =
+let geval_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
   match parse_geval_response (Cascade.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -264,7 +264,7 @@ let get_chain_id_for_preset = function
   | "figma" -> Some "walph-figma"
   | _ -> None
 
-let walph_response_is_valid (resp : Cascade.api_response) =
+let walph_response_is_valid (resp : Llm_provider.Types.api_response) =
   let content = String.trim (Cascade.text_of_response resp) in
   let lower = String.lowercase_ascii content in
   let len = String.length content in

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -6,15 +6,15 @@
 
 open Alcotest
 
-module Llm = Masc_mcp.Cascade
+module Cascade = Masc_mcp.Cascade
 module Types = Agent_sdk.Types
 module Compact = Masc_mcp.Context_compact_oas
 module Scoring = Masc_mcp.Context_scoring
 
-let msg role text : Llm.message =
+let msg role text : Agent_sdk.Types.message =
   { role; content = [Types.Text text]; name = None; tool_call_id = None }
 
-let tool_msg ?(id = "tool-1") text : Llm.message =
+let tool_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
   { role = Types.Tool;
     content = [Types.ToolResult { tool_use_id = id; content = text; is_error = false }];
     name = None; tool_call_id = None }
@@ -24,40 +24,40 @@ let tool_msg ?(id = "tool-1") text : Llm.message =
 (* ================================================================ *)
 
 let test_roundtrip_user () =
-  let m = msg Llm.User "Hello world" in
+  let m = msg Agent_sdk.Types.User "Hello world" in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "role preserved" "User"
-    (match back.role with Llm.User -> "User" | _ -> "other");
+    (match back.role with Agent_sdk.Types.User -> "User" | _ -> "other");
   check string "text preserved" "Hello world"
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 let test_roundtrip_assistant () =
-  let m = msg Llm.Assistant "I can help" in
+  let m = msg Agent_sdk.Types.Assistant "I can help" in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "role preserved" "Assistant"
-    (match back.role with Llm.Assistant -> "Assistant" | _ -> "other");
+    (match back.role with Agent_sdk.Types.Assistant -> "Assistant" | _ -> "other");
   check string "text preserved" "I can help"
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 let test_roundtrip_system () =
-  let m = msg Llm.System "You are helpful" in
+  let m = msg Agent_sdk.Types.System "You are helpful" in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "role preserved" "System"
-    (match back.role with Llm.System -> "System" | _ -> "other");
+    (match back.role with Agent_sdk.Types.System -> "System" | _ -> "other");
   check string "text preserved" "You are helpful"
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 let test_roundtrip_tool () =
   let m = tool_msg ~id:"call-42" "Result data" in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "role preserved" "Tool"
-    (match back.role with Llm.Tool -> "Tool" | _ -> "other");
+    (match back.role with Agent_sdk.Types.Tool -> "Tool" | _ -> "other");
   check string "text preserved" "Result data"
-    (Llm.text_of_message back);
+    (Agent_sdk.Types.text_of_message back);
   let tool_id = List.find_map (function
     | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
     | _ -> None) back.content
@@ -65,30 +65,30 @@ let test_roundtrip_tool () =
   check (option string) "tool_use_id preserved" (Some "call-42") tool_id
 
 let test_roundtrip_empty_text () =
-  let m = msg Llm.System "" in
+  let m = msg Agent_sdk.Types.System "" in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "role preserved" "System"
-    (match back.role with Llm.System -> "System" | _ -> "other");
+    (match back.role with Agent_sdk.Types.System -> "System" | _ -> "other");
   check string "empty text preserved" ""
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 let test_roundtrip_unicode () =
   let text = "한국어 텍스트 with emoji 🎉 and special chars: \t\n" in
-  let m = msg Llm.User text in
+  let m = msg Agent_sdk.Types.User text in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "unicode preserved" text
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 let test_roundtrip_text_containing_sentinel_prefix () =
   (* User text that accidentally contains \x00 should not be misinterpreted *)
   let text = "Normal text without null bytes" in
-  let m = msg Llm.User text in
+  let m = msg Agent_sdk.Types.User text in
   let oas = Compact.masc_msg_to_oas m in
   let back = Compact.oas_msg_to_masc oas in
   check string "text without sentinel survives" text
-    (Llm.text_of_message back)
+    (Agent_sdk.Types.text_of_message back)
 
 (* ================================================================ *)
 (* Validate Roundtrip Tests                                         *)
@@ -96,9 +96,9 @@ let test_roundtrip_text_containing_sentinel_prefix () =
 
 let test_validate_roundtrip_clean () =
   let msgs = [
-    msg Llm.System "sys";
-    msg Llm.User "hello";
-    msg Llm.Assistant "hi";
+    msg Agent_sdk.Types.System "sys";
+    msg Agent_sdk.Types.User "hello";
+    msg Agent_sdk.Types.Assistant "hi";
     tool_msg "result";
   ] in
   check bool "clean roundtrip validates" true
@@ -106,8 +106,8 @@ let test_validate_roundtrip_clean () =
 
 let test_validate_roundtrip_no_sentinels () =
   let msgs = [
-    msg Llm.User "hello";
-    msg Llm.Assistant "hi";
+    msg Agent_sdk.Types.User "hello";
+    msg Agent_sdk.Types.Assistant "hi";
   ] in
   check bool "no sentinels = trivially valid" true
     (Compact.validate_roundtrip ~original:msgs ~reduced:msgs)
@@ -126,51 +126,51 @@ let test_merge_contiguous_preserves_sentinel_roles () =
      corrupting the second sentinel into the first message's text.
      After fix: sentinel-tagged messages are excluded from merging. *)
   let msgs = [
-    msg Llm.System "System prompt 1";
-    msg Llm.System "System prompt 2";
-    msg Llm.User "User question";
-    msg Llm.Assistant "Response";
+    msg Agent_sdk.Types.System "System prompt 1";
+    msg Agent_sdk.Types.System "System prompt 2";
+    msg Agent_sdk.Types.User "User question";
+    msg Agent_sdk.Types.Assistant "Response";
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous] in
   (* Both system messages should survive as separate System messages *)
-  let system_msgs = List.filter (fun (m : Llm.message) ->
-    m.role = Llm.System) result in
+  let system_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
+    m.role = Agent_sdk.Types.System) result in
   check int "two system messages preserved separately" 2 (List.length system_msgs);
   check string "first system text intact" "System prompt 1"
-    (Llm.text_of_message (List.nth system_msgs 0));
+    (Agent_sdk.Types.text_of_message (List.nth system_msgs 0));
   check string "second system text intact" "System prompt 2"
-    (Llm.text_of_message (List.nth system_msgs 1))
+    (Agent_sdk.Types.text_of_message (List.nth system_msgs 1))
 
 let test_merge_contiguous_tool_sentinel_preserved () =
   (* Consecutive Tool messages should not be merged either *)
   let msgs = [
-    msg Llm.User "query";
-    msg Llm.Assistant "thinking";
+    msg Agent_sdk.Types.User "query";
+    msg Agent_sdk.Types.Assistant "thinking";
     tool_msg ~id:"t1" "Result 1";
     tool_msg ~id:"t2" "Result 2";
-    msg Llm.Assistant "final answer";
+    msg Agent_sdk.Types.Assistant "final answer";
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous] in
-  let tool_msgs = List.filter (fun (m : Llm.message) ->
-    m.role = Llm.Tool) result in
+  let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
+    m.role = Agent_sdk.Types.Tool) result in
   check int "two tool messages preserved separately" 2 (List.length tool_msgs)
 
 let test_merge_contiguous_still_merges_plain_user () =
   (* Regular User messages (no sentinel) should still be merged *)
   let msgs = [
-    msg Llm.User "Hello";
-    msg Llm.User "World";
-    msg Llm.Assistant "Hi";
+    msg Agent_sdk.Types.User "Hello";
+    msg Agent_sdk.Types.User "World";
+    msg Agent_sdk.Types.Assistant "Hi";
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous] in
-  let user_msgs = List.filter (fun (m : Llm.message) ->
-    m.role = Llm.User) result in
+  let user_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
+    m.role = Agent_sdk.Types.User) result in
   check int "plain user messages merged" 1 (List.length user_msgs)
 
 let test_prune_tool_outputs_sentinel_survives () =
@@ -178,18 +178,18 @@ let test_prune_tool_outputs_sentinel_survives () =
      should survive truncation since max_output_len=500 > sentinel length *)
   let long_tool_output = String.make 600 'x' in
   let msgs = [
-    msg Llm.User "query";
+    msg Agent_sdk.Types.User "query";
     tool_msg long_tool_output;
-    msg Llm.Assistant "done";
+    msg Agent_sdk.Types.Assistant "done";
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.PruneToolOutputs] in
-  let tool_msgs = List.filter (fun (m : Llm.message) ->
-    m.role = Llm.Tool) result in
+  let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
+    m.role = Agent_sdk.Types.Tool) result in
   check int "tool message exists" 1 (List.length tool_msgs);
   (* The Tool role should be correctly recovered *)
-  let tool_text = Llm.text_of_message (List.nth tool_msgs 0) in
+  let tool_text = Agent_sdk.Types.text_of_message (List.nth tool_msgs 0) in
   check bool "tool text was pruned" true
     (String.length tool_text < String.length long_tool_output)
 
@@ -200,14 +200,14 @@ let test_prune_tool_outputs_sentinel_survives () =
 let test_compact_prune_tool_outputs () =
   let long_output = String.make 600 'x' in
   let msgs = [
-    msg Llm.User "query";
+    msg Agent_sdk.Types.User "query";
     tool_msg long_output;
-    msg Llm.Assistant "answer";
+    msg Agent_sdk.Types.Assistant "answer";
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.PruneToolOutputs] in
-  let tool_text = Llm.text_of_message (List.nth result 1) in
+  let tool_text = Agent_sdk.Types.text_of_message (List.nth result 1) in
   check bool "tool output was pruned" true
     (String.length tool_text < String.length long_output)
 
@@ -219,7 +219,7 @@ let test_compact_empty_messages () =
   check bool "tokens > 0 (system prompt)" true (tokens > 0)
 
 let test_compact_single_message () =
-  let msgs = [msg Llm.User "hello"] in
+  let msgs = [msg Agent_sdk.Types.User "hello"] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
     ~strategies:[Compact.MergeContiguous; Compact.DropLowImportance] in
@@ -228,10 +228,10 @@ let test_compact_single_message () =
 let test_compact_drop_low_importance () =
   (* Many short assistant messages should get low scores and be dropped *)
   let msgs =
-    (msg Llm.System "important system prompt") ::
+    (msg Agent_sdk.Types.System "important system prompt") ::
     List.init 10 (fun i ->
-      msg Llm.Assistant (Printf.sprintf "ok %d" i))
-    @ [msg Llm.User "latest question"]
+      msg Agent_sdk.Types.Assistant (Printf.sprintf "ok %d" i))
+    @ [msg Agent_sdk.Types.User "latest question"]
   in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
@@ -241,7 +241,7 @@ let test_compact_drop_low_importance () =
 
 let test_compact_summarize_old () =
   let msgs = List.init 10 (fun i ->
-    msg (if i mod 2 = 0 then Llm.User else Llm.Assistant)
+    msg (if i mod 2 = 0 then Agent_sdk.Types.User else Agent_sdk.Types.Assistant)
       (Printf.sprintf "message %d with enough content to be meaningful" i))
   in
   let result, _tokens = Compact.compact
@@ -258,9 +258,9 @@ let test_scoring_ssot () =
   (* Scoring.score_messages is now the single source of truth.
      This test verifies the function exists and produces valid output. *)
   let msgs = [
-    msg Llm.System "system";
-    msg Llm.User "user input";
-    msg Llm.Assistant "response";
+    msg Agent_sdk.Types.System "system";
+    msg Agent_sdk.Types.User "user input";
+    msg Agent_sdk.Types.Assistant "response";
     tool_msg "tool result";
   ] in
   let scores = Scoring.score_messages msgs in
@@ -272,8 +272,8 @@ let test_scoring_ssot () =
 
 let test_scoring_sticky_memory () =
   let msgs = [
-    msg Llm.Assistant "[MASC_MEMORY_SUMMARY v1] important summary";
-    msg Llm.Assistant "normal message";
+    msg Agent_sdk.Types.Assistant "[MASC_MEMORY_SUMMARY v1] important summary";
+    msg Agent_sdk.Types.Assistant "normal message";
   ] in
   let scores = Scoring.score_messages msgs in
   let summary_score = List.assoc 0 scores in
@@ -283,7 +283,7 @@ let test_scoring_sticky_memory () =
 
 let test_scoring_goal_sticky () =
   let msgs = [
-    msg Llm.User "[MASC_GOAL] Monitor CI";
+    msg Agent_sdk.Types.User "[MASC_GOAL] Monitor CI";
   ] in
   let scores = Scoring.score_messages msgs in
   let score = List.assoc 0 scores in
@@ -294,7 +294,7 @@ let test_scoring_empty () =
   check int "empty input = empty scores" 0 (List.length scores)
 
 let test_scoring_single () =
-  let msgs = [msg Llm.User "solo"] in
+  let msgs = [msg Agent_sdk.Types.User "solo"] in
   let scores = Scoring.score_messages msgs in
   check int "single message scored" 1 (List.length scores);
   let (_, score) = List.hd scores in

--- a/test/test_llm_client_coverage.ml
+++ b/test/test_llm_client_coverage.ml
@@ -1,28 +1,27 @@
 open Alcotest
 
-module Llm = Masc_mcp.Cascade
 module Cascade = Masc_mcp.Cascade
 
 let test_string_of_provider () =
-  check string "llama" "llama" (Llm.string_of_provider Llm.Llama);
-  check string "gemini" "gemini" (Llm.string_of_provider Llm.Gemini)
+  check string "llama" "llama" (Cascade.string_of_provider Cascade.Llama);
+  check string "gemini" "gemini" (Cascade.string_of_provider Cascade.Gemini)
 
 let test_message_constructors () =
-  let tool_msg = Llm.tool_msg ~name:"grep" ~call_id:"call-1" "done" in
+  let tool_msg = Cascade.tool_msg ~name:"grep" ~call_id:"call-1" "done" in
   check bool "system role" true
-    (match (Llm.system_msg "x").role with Llm.System -> true | _ -> false);
+    (match (Agent_sdk.Types.system_msg "x").role with Agent_sdk.Types.System -> true | _ -> false);
   let has_call1 = List.exists (function
     | Agent_sdk.Types.ToolResult { tool_use_id = "call-1"; _ } -> true | _ -> false) tool_msg.content in
   check bool "tool call id in content" true has_call1
 
 let test_estimate_tokens_positive () =
-  let tokens = Llm.estimate_tokens [ Llm.user_msg "hello world" ] in
+  let tokens = Cascade.estimate_tokens [ Agent_sdk.Types.user_msg "hello world" ] in
   check bool "positive" true (tokens > 0)
 
 let test_model_spec_of_string_llama () =
   match Cascade.model_spec_of_string "llama:qwen3.5-32b" with
   | Ok spec ->
-      check string "provider" "llama" (Llm.string_of_provider spec.provider);
+      check string "provider" "llama" (Cascade.string_of_provider spec.provider);
       check string "model id" "qwen3.5-32b" spec.model_id
   | Error err -> fail ("expected llama model spec, got error: " ^ err)
 
@@ -35,14 +34,14 @@ let test_model_spec_of_string_invalid () =
 
 let test_sanitize_text_utf8 () =
   let invalid = "\xffhello" in
-  let sanitized = Llm.sanitize_text_utf8 invalid in
+  let sanitized = Cascade.sanitize_text_utf8 invalid in
   check bool "keeps suffix" true (String.ends_with ~suffix:"hello" sanitized);
   check bool "not empty" true (String.length sanitized > 0)
 
 let test_available_model_specs_of_strings_llama () =
   match Cascade.available_model_specs_of_strings [ "llama:qwen3.5-32b" ] with
   | [ spec ] ->
-      check string "provider" "llama" (Llm.string_of_provider spec.provider);
+      check string "provider" "llama" (Cascade.string_of_provider spec.provider);
       check string "model id" "qwen3.5-32b" spec.model_id
   | _ -> fail "expected one available llama model"
 


### PR DESCRIPTION
## Summary

Cascade 모듈의 자체 구현 타입을 제거하고 OAS 타입을 직접 사용.

**Commit 1: alias 제거**
- `type role`, `type message`, `type token_usage`, `type api_response` 삭제
- `system_msg`, `user_msg`, `assistant_msg`, `text_of_message`, `string_of_role` 삭제
- 32파일에서 `Cascade.X` → `Agent_sdk.Types.X` / `Llm_provider.Types.X` 전환

**Commit 2: tool_call + completion_request 제거 (-198 LOC)**
- `type tool_call` + helpers (`tool_calls_of_content`, `tool_calls_of_response`, `has_tool_calls`) 삭제
- 소비자가 `ToolUse { id; name; input }` content_block을 직접 패턴 매치
- JSON string 왕복 (`Yojson.Safe.t -> string -> Yojson.Safe.t`) 제거
- `type completion_request` + `normalize_request` + `extract_prompt_params` 삭제
- `run_cascade`가 named params (`~messages ~temperature ~max_tokens`) 수용
- model, tools, response_format 사장 필드 제거

## Changes

| 삭제된 타입 | 이전 참조 수 | 대체 |
|-----------|------------|------|
| `tool_call` | 21 | `ToolUse { id; name; input }` 직접 매치 |
| `completion_request` | 13 | named params |
| `role` (alias) | - | `Agent_sdk.Types.role` |
| `message` (alias) | - | `Agent_sdk.Types.message` |
| `token_usage` (alias) | - | `Agent_sdk.Types.api_usage` |
| `api_response` (alias) | - | `Llm_provider.Types.api_response` |

## Test plan

- [x] `dune build --root .` 통과
- [x] `test_cascade.exe` (8/8 pass)
- [x] `test_perpetual.exe` (194/194 pass)
- [x] `test_local_agent_eio_coverage.exe` (2/2 pass)
- [x] `test_keeper_oas_adapter.exe` (3/3 pass)
- [ ] CI (Build and Test, Contract Harness, Lint, Health)