### PR TITLE
refactor: eliminate Cascade.call wrapper, use OAS complete directly

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -152,14 +152,16 @@ let call_llm_direct_sync ~agent_type ~prompt =
   let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Cascade.call ~cascade_name ~prompt
+      Cascade.complete ~cascade_name
+        ~messages:[Cascade.user_msg prompt]
         ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with
-    | Ok result ->
+    | Ok resp ->
+        let text = Cascade.text_of_response resp in
         debug_log
-          (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s" result.llm_used
-             agent_type);
-        if String.trim result.response = "" then "no response" else result.response
+          (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s"
+             resp.Llm_provider.Types.model agent_type);
+        if String.trim text = "" then "no response" else text
     | Error err ->
         Log.AutoResponder.error "LLM cascade failed: %s" err;
         "no response"

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -684,11 +684,12 @@ let generate_code_change ~goal ~baseline ~history ~insights
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match
-    Cascade.call ~cascade_name:"autoresearch" ~prompt
+    Cascade.complete ~cascade_name:"autoresearch"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
   with
   | Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
-  | Ok r -> parse_llm_code_response r.Cascade.response
+  | Ok resp -> parse_llm_code_response (Cascade.text_of_response resp)
 
 (* ================================================================ *)
 (* Loop State Management                                            *)

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -254,14 +254,16 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
     : (float, string) result =
   let prompt = build_scoring_prompt agent task in
   match
-    Cascade.call ~cascade_name:"capability_match" ~prompt
+    Cascade.complete ~cascade_name:"capability_match"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:15 ~max_tokens:20
       ~accept:llm_score_is_valid ()
   with
-  | Ok r -> (
-      match parse_llm_score r.response with
+  | Ok resp -> (
+      let text = Cascade.text_of_response resp in
+      match parse_llm_score text with
       | Some f -> Ok f
-      | None -> Error (Printf.sprintf "unparseable LLM response: %s" r.response))
+      | None -> Error (Printf.sprintf "unparseable LLM response: %s" text))
   | Error err -> Error err
 
 (* ---------- Keyword Scoring ---------- *)

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -287,6 +287,7 @@ let llm_permits_in_use () = Atomic.get inflight
 
 (* ================================================================ *)
 
+(** @deprecated Use {!complete} instead. *)
 type cascade_result = {
   response : string;
   llm_used : string;
@@ -604,8 +605,10 @@ let format_cascade_error ~cascade_name = function
   | Llm_provider.Http_client.NetworkError { message } ->
     Printf.sprintf "[cascade] %s: %s" cascade_name message
 
-(** Internal: resolve config, call OAS complete_named, map errors to string. *)
-let complete_cascade ~cascade_name ~messages
+(** Direct OAS bridge — single entry point for all LLM cascade calls.
+    Replaces {!call}, {!call_raw}, and {!call_with_tools}.
+    Returns OAS [api_response] directly; error formatted as string. *)
+let complete ~cascade_name ~messages
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
   let env = Masc_eio_env.get () in
@@ -624,48 +627,5 @@ let complete_cascade ~cascade_name ~messages
   | Ok resp -> Ok resp
   | Error err -> Error (format_cascade_error ~cascade_name err)
 
-(** Prompt-in, text-out convenience. Returns {!cascade_result}. *)
-let call ~cascade_name ~prompt
-    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
-  let messages : Llm_provider.Types.message list =
-    (match system with
-     | Some s -> [ Llm_provider.Types.system_msg s ]
-     | None -> [])
-    @ [ Llm_provider.Types.user_msg prompt ]
-  in
-  let t0 = Time_compat.now () in
-  match
-    complete_cascade ~cascade_name ~messages
-      ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ()
-  with
-  | Ok resp ->
-    let duration_ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
-    Ok
-      {
-        response = Llm_provider.Cascade_config.text_of_response resp;
-        llm_used = resp.Llm_provider.Types.model;
-        duration_ms;
-      }
-  | Error _ as e -> e
-
-(** Prompt-in, full api_response out. Use when callers need model name,
-    tool_calls, or usage from the response. *)
-let call_raw ~cascade_name ~prompt
-    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
-  let messages : Llm_provider.Types.message list =
-    (match system with
-     | Some s -> [ Llm_provider.Types.system_msg s ]
-     | None -> [])
-    @ [ Llm_provider.Types.user_msg prompt ]
-  in
-  complete_cascade ~cascade_name ~messages
-    ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ()
-
-(** Messages + tools in, full api_response out. For tool-using LLM calls. *)
-let call_with_tools ~cascade_name ~messages
-    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
-  complete_cascade ~cascade_name ~messages
-    ~config_path ~temperature ~timeout_sec ~max_tokens ~accept ?tools ()
+(* call, call_raw, call_with_tools removed — use {!complete} directly.
+   Callers build messages and handle api_response/errors themselves. *)

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -299,7 +299,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
         | _ -> None
       in
       (match
-        Cascade.call_with_tools ~cascade_name:"chain_llm" ~messages
+        Cascade.complete ~cascade_name:"chain_llm" ~messages
           ?tools:tools_json ~temperature:0.2 ~max_tokens:4096
           ~timeout_sec ()
       with

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -335,10 +335,11 @@ let verify_worker ~pattern (worker : worker_plan) diff =
     let prompt = build_verify_prompt ~pattern ~allowed_files:worker.files diff in
     let verdict =
       match
-        Cascade.call ~cascade_name:"code_swarm_verify" ~prompt
+        Cascade.complete ~cascade_name:"code_swarm_verify"
+          ~messages:[Cascade.user_msg prompt]
           ~temperature:0.0 ~max_tokens:200 ()
       with
-      | Ok r -> Verifier_oas.parse_verdict r.Cascade.response
+      | Ok resp -> Verifier_oas.parse_verdict (Cascade.text_of_response resp)
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in
     let our_verdict =

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -194,12 +194,13 @@ let intent_response_is_valid (resp : Cascade.api_response) : bool =
 let classify_intent_llm (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Cascade.call ~cascade_name:"context_router" ~prompt
+    Cascade.complete ~cascade_name:"context_router"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with
-  | Ok r -> (
-      match parse_intent_response r.response with
+  | Ok resp -> (
+      match parse_intent_response (Cascade.text_of_response resp) with
       | Some result -> result
       | None -> (Coordination, 0.3))  (* unparseable → low-confidence fallback *)
   | Error _err -> (Coordination, 0.3)  (* LLM error → low-confidence fallback *)
@@ -208,12 +209,13 @@ let classify_intent_llm (query : string) : query_intent * float =
 let classify_intent_hybrid (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Cascade.call ~cascade_name:"context_router" ~prompt
+    Cascade.complete ~cascade_name:"context_router"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with
-  | Ok r -> (
-      match parse_intent_response r.response with
+  | Ok resp -> (
+      match parse_intent_response (Cascade.text_of_response resp) with
       | Some result -> result
       | None -> classify_intent_heuristic query)
   | Error _err -> classify_intent_heuristic query

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -284,7 +284,8 @@ let compute_judgments ~base_path:_ ~factual_json =
   let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
   let prompt = prompt_for_facts factual_json in
   match
-    Cascade.call_raw ~cascade_name:"governance_judge" ~prompt
+    Cascade.complete ~cascade_name:"governance_judge"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -289,7 +289,8 @@ let compute_judgments ~facts_json =
   let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
   let prompt = prompt_for_facts facts_json in
   match
-    Cascade.call_raw ~cascade_name:"operator_judge" ~prompt
+    Cascade.complete ~cascade_name:"operator_judge"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -2,7 +2,7 @@ open Env_config_core
 
 module Endpoints = struct
   (** @deprecated LLM-MCP server URL - no longer used.
-      Use {!Cascade.call} instead. *)
+      Use {!Cascade.complete} instead. *)
   let llm_mcp_url =
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)
 

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -44,11 +44,12 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
 
   let response =
     match
-      Cascade.call ~cascade_name:"gardener_spawn" ~prompt
+      Cascade.complete ~cascade_name:"gardener_spawn"
+        ~messages:[Cascade.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:200 () with
-    | Ok r -> r.Cascade.response
+    | Ok resp -> Cascade.text_of_response resp
     | Error _ -> ""
   in
 
@@ -436,11 +437,12 @@ Room 내 활성 에이전트: %d
 
   let response =
     match
-      Cascade.call ~cascade_name:"gardener_spawn" ~prompt
+      Cascade.complete ~cascade_name:"gardener_spawn"
+        ~messages:[Cascade.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:300 () with
-    | Ok r -> Ok r.Cascade.response
+    | Ok resp -> Ok (Cascade.text_of_response resp)
     | Error err -> Error ("llm intervention failed: " ^ err)
   in
 

--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -238,8 +238,9 @@ Keep it concise — max 3 sentences per step.|}
 let generate_action_plan ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
   match
-    Cascade.call ~cascade_name:"keeper_autonomy" ~prompt
+    Cascade.complete ~cascade_name:"keeper_autonomy"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.3 ~max_tokens:500 ()
   with
-  | Ok r -> Ok r.Cascade.response
+  | Ok resp -> Ok (Cascade.text_of_response resp)
   | Error e -> Error (sprintf "plan generation failed: %s" e)

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -2,7 +2,7 @@
 
     Delegates to [Oas_worker.run_named] / [run_named_with_masc_tools]
     (cascade-name-based, no model_spec construction) or to
-    [Cascade.call_with_tools] for single-shot cascade calls.
+    [Cascade.complete] for single-shot cascade calls.
 
     @since OAS migration Phase 1
     @since LLM-free cascade Phase 2 *)
@@ -227,7 +227,7 @@ let run_cascade ?(cascade_name = "keeper_turn") ?timeout_sec requests =
      else [])
     @ [ Llm_provider.Types.user_msg params.goal ]
   in
-  Cascade.call_with_tools ~cascade_name ~messages
+  Cascade.complete ~cascade_name ~messages
     ~temperature:params.temperature ~max_tokens:params.max_tokens
     ?timeout_sec ()
 

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -2,7 +2,7 @@
 
     Uses cascade-name-based model resolution (no [model_spec] construction).
     Delegates to [Oas_worker.run_named] for agent loops and
-    [Cascade.call_with_tools] for single-shot cascade calls.
+    [Cascade.complete] for single-shot cascade calls.
 
     @since OAS migration Phase 1
     @since LLM-free cascade Phase 2 *)
@@ -78,7 +78,7 @@ val usage_of_run_result : Oas_worker.run_result -> Cascade.token_usage
 (** Extract model ID string from an OAS run result. *)
 val model_of_run_result : Oas_worker.run_result -> string
 
-(** Cascade through [Cascade.call_with_tools] — single-shot, no agent loop.
+(** Cascade through [Cascade.complete] — single-shot, no agent loop.
     [cascade_name] defaults to ["keeper_turn"]. Model specs in the
     [completion_request] list are ignored; only prompt/system/temperature
     are extracted. *)

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -118,13 +118,14 @@ let geval_response_is_valid (resp : Cascade.api_response) : bool =
 let verify_llm ~content : (verification_result, string) result =
   let prompt = build_geval_prompt ~content in
   match
-    Cascade.call ~cascade_name:"verifier" ~prompt
+    Cascade.complete ~cascade_name:"verifier"
+      ~messages:[Cascade.user_msg prompt]
       ~temperature:0.2 ~timeout_sec:15 ~max_tokens:150
       ~accept:geval_response_is_valid ()
   with
   | Error err -> Error err
-  | Ok r -> (
-      match parse_geval_response r.response with
+  | Ok resp -> (
+      match parse_geval_response (Cascade.text_of_response resp) with
       | Error err -> Error err
       | Ok (r, q, s, _reasoning) ->
           let relevance = score_to_verdict ~dim_name:"relevance" r in

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -275,10 +275,11 @@ let walph_response_is_valid (resp : Cascade.api_response) =
 
 let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
   match
-    Cascade.call ~cascade_name:"walph" ~prompt ~timeout_sec
+    Cascade.complete ~cascade_name:"walph"
+      ~messages:[Cascade.user_msg prompt] ~timeout_sec
       ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with
-  | Ok r -> r.response
+  | Ok resp -> Cascade.text_of_response resp
   | Error err -> failwith err
 
 (** {1 Main Loop} *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -117,15 +117,19 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
         None
     | Ok prompt ->
         let timeout = Env_config.Sentinel.llm_timeout_sec in
-        (match Cascade.call ~cascade_name ~prompt
+        (match Cascade.complete ~cascade_name
+            ~messages:[Cascade.user_msg prompt]
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
-        | Ok r when String.length r.response > 5 ->
-            log_debug (sprintf "LLM response from %s (%d chars)" r.llm_used
-                   (String.length r.response));
-            parse_llm_json_safe r.response
-        | Ok r ->
-            log_warn (sprintf "LLM response too short from %s" r.llm_used);
-            None
+        | Ok resp ->
+            let text = Cascade.text_of_response resp in
+            let model = resp.Llm_provider.Types.model in
+            if String.length text > 5 then (
+              log_debug (sprintf "LLM response from %s (%d chars)" model
+                     (String.length text));
+              parse_llm_json_safe text)
+            else (
+              log_warn (sprintf "LLM response too short from %s" model);
+              None)
         | Error err ->
             log_warn (sprintf "LLM cascade %s failed: %s" cascade_name err);
             None)

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -456,14 +456,16 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
           worker_class_text role_text spawn_prompt
       in
       (match
-        Cascade.call ~cascade_name:"routing_judge" ~prompt
-          ~system:"You are a routing judge for a hybrid swarm. Output only JSON."
+        Cascade.complete ~cascade_name:"routing_judge"
+          ~messages:[
+            Cascade.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
+            Cascade.user_msg prompt]
           ~temperature:0.0 ~max_tokens:220
           ~timeout_sec:(router_judge_timeout_sec ()) ()
       with
-      | Ok r -> (
+      | Ok resp -> (
           try
-            Yojson.Safe.from_string r.Cascade.response
+            Yojson.Safe.from_string (Cascade.text_of_response resp)
             |> parse_routing_decision_json
           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
       | Error _ -> None)

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -209,9 +209,9 @@ let test_build_response_prompt_long_content () =
   check bool "handles long content" true (String.length prompt > 1000)
 
 let test_auto_responder_uses_shared_llm_client () =
-  check bool "uses Cascade.call" true
+  check bool "uses Cascade.complete" true
     (file_contains_pattern "lib/auto_responder.ml"
-       {|Cascade.call ~cascade_name|});
+       {|Cascade.complete ~cascade_name|});
   check bool "no direct run_prompt_cascade" false
     (file_contains_pattern "lib/auto_responder.ml" "Llm_orchestration.run_prompt_cascade");
   check bool "legacy Llm_direct dispatch removed"

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -77,9 +77,9 @@ let test_call_returns_error_when_no_models () =
         {|{"heartbeat_action_models":["gemini:fake-model"]}|}
         (fun path ->
           let result =
-            Cascade.call
+            Cascade.complete
               ~cascade_name:"heartbeat_action"
-              ~prompt:"test"
+              ~messages:[Cascade.user_msg "test"]
               ~timeout_sec:1
               ~config_path:path
               ()

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -4,6 +4,19 @@ open Alcotest
 open Masc_mcp
 open Masc_mcp.Gardener_types
 
+let test_dir () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_gardener_%d_%d" (Unix.getpid ())
+       (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_dir dir =
+  try Sys.readdir dir |> Array.iter (fun f ->
+    Sys.remove (Filename.concat dir f));
+    Unix.rmdir dir
+  with _ -> ()
+
 (** {1 Configuration Tests} *)
 
 let test_load_config () =
@@ -934,9 +947,14 @@ let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
     in_progress_count = 0; done_count = 1; orphan_count = 0;
     oldest_todo_age_hours = 2.0; high_priority_todo = 1;
   } in
-  match Gardener_worker.run_for_backlog ~backlog with
-  | Error _ -> ()
-  | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context"
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Room.default_config dir in
+      match Gardener_worker.run_for_backlog ~config ~backlog with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.fail "expected Error for OAS worker without Eio context")
 
 (** {1 Duplicate Task Prevention Tests (Issue #1439)} *)
 

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -313,9 +313,9 @@ let test_eio_error_cutoff () =
     (status |> member "last_stop_reason" |> to_string)
 
 let test_eio_default_dispatch_uses_shared_cascade () =
-  check bool "uses Cascade.call" true
+  check bool "uses Cascade.complete" true
     (file_contains_pattern "lib/room/room_walph_eio.ml"
-       {|Cascade.call ~cascade_name:"walph"|});
+       {|Cascade.complete ~cascade_name:"walph"|});
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room/room_walph_eio.ml" "Llm_direct.dispatch");
   check bool "no direct run_prompt_cascade" false


### PR DESCRIPTION
## Summary
- 16개 `Cascade.call`/`call_raw`/`call_with_tools` 소비자를 `Cascade.complete`로 전환
- `complete`는 OAS `api_response`를 직접 반환 (MASC 전용 `cascade_result` 래퍼 제거)
- 소비자가 직접 messages 구성 + `text_of_response`/`resp.model` 접근
- cascade.ml에서 43줄 wrapper 코드 삭제

## Motivation
SDK(OAS)를 만들어놓고 MASC가 자체 wrapper로 감싸서 OAS 타입을 숨기고 있었음.
`feedback_masc-must-use-oas-agent-run.md` 규칙: "Cascade.call 신규 사용 금지"의 후속 작업.

## Changes
- `cascade.ml`: `complete_cascade` → `complete` 승격, `call`/`call_raw`/`call_with_tools` 삭제
- 15 lib files: 16 call sites migrated
- 4 test files: source pattern checks 업데이트 + pre-existing `test_gardener` 빌드 수정

## Test plan
- [x] `dune build` 통과
- [x] `test_cascade` 8 tests passed
- [x] `test_auto_responder_coverage` 29 tests passed
- [x] `test_walph_eio` 12 tests passed
- [x] `test_gardener` 81 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)