### PR TITLE
refactor(keeper): deduplicate coordination → exec_context

### DIFF
--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -1,123 +1,24 @@
-(** Keeper_coordination — Room presence, compaction policy, checkpoint persistence, and error logging for keeper agents. MASC coordination domain. *)
+(** Keeper_coordination — Room presence, model selection, and room cursor management.
+
+    Checkpoint/compaction/logging functions are delegated to {!Keeper_exec_context}
+    (single source of truth) and re-exported here for backward compatibility
+    with [include Keeper_coordination] in {!Keeper_execution}. *)
 
 open Keeper_types
-open Keeper_memory [@@warning "-33"]
 
-(** Log a keeper error with [UNEXPECTED] tag for unrecognized exceptions.
-    Known IO/parse exceptions get a plain log; anything else is tagged for triage.
-    No re-raise — side-effect-only patterns must not change control flow. *)
-let log_keeper_exn ~label exn =
-  let tag = match exn with
-    | Sys_error _ | Failure _ | Not_found
-    | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
-    | _ -> "[UNEXPECTED] "
-  in
-  Log.Keeper.info "%s%s: %s" tag label (Printexc.to_string exn)
+(* ================================================================ *)
+(* Re-exports from Keeper_exec_context — single source of truth     *)
+(* ================================================================ *)
 
-let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
-  let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
-  let latest_ckpt =
-    try Context_manager.load_latest_checkpoint session
-    with ex ->
-      Log.Keeper.error "keeper:%s checkpoint load failed: %s"
-        trace_id
-        (Printexc.to_string ex);
-      None
-  in
-  match latest_ckpt with
-  | None -> (session, None)
-  | Some ckpt ->
-      (try
-         let ctx =
-           Context_manager.restore_checkpoint ckpt
-             ~max_tokens:primary_model_max_tokens
-         in
-         (session, Some ctx)
-       with ex ->
-         Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
-           trace_id
-           (Printexc.to_string ex);
-         (session, None))
-
-let save_checkpoint session (ctx : Context_manager.working_context) ~generation =
-  let ckpt = Context_manager.create_checkpoint ctx ~generation in
-  Context_manager.save_checkpoint session ckpt;
-  ckpt
-
-let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
-  (meta.compaction_ratio_gate, meta.compaction_message_gate, meta.compaction_token_gate)
-
-let compact_if_needed
-    ~(meta : keeper_meta)
-    ~(now_ts : float)
-    (ctx : Context_manager.working_context) :
-    Context_manager.working_context * string option * string =
-  let ratio = Context_manager.context_ratio ctx in
-  let message_count = List.length ctx.messages in
-  let token_count = ctx.token_count in
-  let ratio_gate, message_gate, token_gate = compaction_policy_of_keeper meta in
-  let cooldown = Float.of_int meta.continuity_compaction_cooldown_sec in
-  let last_reflection_ts = max meta.last_continuity_update_ts meta.last_proactive_ts in
-  let reflection_ready =
-    last_reflection_ts > 0.0 && now_ts -. last_reflection_ts >= cooldown
-  in
-  let hold_s =
-    if cooldown <= 0.0 then 0.0
-    else if last_reflection_ts <= 0.0 then
-      Float.of_int meta.continuity_compaction_cooldown_sec
-    else
-      max
-        0.0
-        (Float.of_int meta.continuity_compaction_cooldown_sec
-       -. (now_ts -. last_reflection_ts))
-  in
-  let trigger_reason =
-    if not reflection_ready then
-      Some
-        (Printf.sprintf
-           "skipped:continuity_reflection(%0.0fs<%ds)"
-           hold_s meta.continuity_compaction_cooldown_sec)
-    else if ratio >= ratio_gate then
-      Some (Printf.sprintf "ratio(%.4f>=%.4f)" ratio ratio_gate)
-    else if message_gate > 0 && message_count >= message_gate then
-      Some (Printf.sprintf "messages(%d>=%d)" message_count message_gate)
-    else if token_gate > 0 && token_count >= token_gate then
-      Some (Printf.sprintf "tokens(%d>=%d)" token_count token_gate)
-    else None
-  in
-  match trigger_reason with
-  | None -> (ctx, None, "blocked:below_thresholds")
-  | Some reason ->
-      if String.starts_with ~prefix:"skipped:" reason then
-        (ctx, None, reason)
-      else
-        let compacted_ctx =
-          Context_manager.compact ctx
-            Context_manager.[
-              PruneToolOutputs;
-              MergeContiguous;
-              DropLowImportance;
-              SummarizeOld;
-            ]
-        in
-        (compacted_ctx, Some reason, "applied:" ^ reason)
-
-let generate_trace_id () =
-  let ts = int_of_float (Time_compat.now () *. 1000.0) in
-  let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFF in
-  Printf.sprintf "trace-%d-%05x" ts hash
-
-let keeper_board_write_tool_names =
-  [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
-
-let keeper_write_done tool_names =
-  List.exists (fun name -> List.mem name keeper_board_write_tool_names) tool_names
-
-let keeper_action_kind_of_tool_names tool_names =
-  if List.mem "keeper_board_post" tool_names then "post"
-  else if List.mem "keeper_board_comment" tool_names then "comment"
-  else if List.mem "keeper_board_vote" tool_names then "vote"
-  else "none"
+let log_keeper_exn = Keeper_exec_context.log_keeper_exn
+let load_context_from_checkpoint = Keeper_exec_context.load_context_from_checkpoint
+let save_checkpoint = Keeper_exec_context.save_checkpoint
+let compaction_policy_of_keeper = Keeper_exec_context.compaction_policy_of_keeper
+let compact_if_needed = Keeper_exec_context.compact_if_needed
+let generate_trace_id = Keeper_exec_context.generate_trace_id
+let keeper_board_write_tool_names = Keeper_exec_context.keeper_board_write_tool_names
+let keeper_write_done = Keeper_exec_context.keeper_write_done
+let keeper_action_kind_of_tool_names = Keeper_exec_context.keeper_action_kind_of_tool_names
 
 let effective_model_labels_for_turn
     (m : keeper_meta)


### PR DESCRIPTION
## Summary
- `keeper_coordination.ml`의 116줄 중복 코드를 `Keeper_exec_context`로 위임
- checkpoint/compaction/logging/trace_id/board_tool_names 함수들이 단일 소스로 통합
- `include Keeper_coordination` 경로는 re-export로 유지 (하위 호환)

## Context
Keeper → OAS Agent.run 마이그레이션의 첫 단계. Context_manager 의존 해소를 위한 사전 정리.
전체 로드맵은 #1796 참조.

## Test plan
- [x] `dune build` pass
- [x] `test_keeper_oas_adapter` 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)