### PR TITLE
refactor: bypass Context_manager.compact, call OAS directly

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -93,14 +93,17 @@ let compact_if_needed
       if String.starts_with ~prefix:"skipped:" reason then
         (ctx, None, reason)
       else
+        let messages, token_count =
+          Context_compact_oas.compact
+            ~system_prompt:ctx.system_prompt
+            ~messages:ctx.messages
+            ~strategies:Context_compact_oas.[
+              PruneToolOutputs; MergeContiguous;
+              DropLowImportance; SummarizeOld]
+        in
         let compacted_ctx =
-          Context_manager.compact ctx
-            Context_manager.[
-              PruneToolOutputs;
-              MergeContiguous;
-              DropLowImportance;
-              SummarizeOld;
-            ]
+          Context_manager.sync_oas_context
+            { ctx with messages; token_count; importance_scores = [] }
         in
         (compacted_ctx, Some reason, "applied:" ^ reason)
 

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -251,8 +251,13 @@ let extract_dna ~(working_ctx : Context_manager.working_context)
     ~(session_ctx : Context_manager.session_context)
     ~goal ~generation ~trace_id ~metrics =
   (* Compact the working context for transfer *)
-  let compacted = Context_manager.compact working_ctx
-    [PruneToolOutputs; MergeContiguous; SummarizeOld] in
+  let messages, token_count =
+    Context_compact_oas.compact
+      ~system_prompt:working_ctx.system_prompt
+      ~messages:working_ctx.messages
+      ~strategies:[PruneToolOutputs; MergeContiguous; SummarizeOld]
+  in
+  let compacted = { working_ctx with messages; token_count; importance_scores = [] } in
   let compressed = Context_manager.serialize_context compacted in
   let all_msgs = working_ctx.messages in
   {

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -152,7 +152,13 @@ let handle_compact args : result =
     let tokens_before = ctx.token_count in
     let msg_count_before = List.length ctx.messages in
     (* Apply compaction *)
-    let compacted = Context_manager.compact ctx strategies in
+    let messages, token_count =
+      Context_compact_oas.compact
+        ~system_prompt:ctx.system_prompt
+        ~messages:ctx.messages
+        ~strategies
+    in
+    let compacted = { ctx with messages; token_count; importance_scores = [] } in
     let tokens_after = compacted.token_count in
     let msg_count_after = List.length compacted.messages in
     let result_json = `Assoc [


### PR DESCRIPTION
## Summary
- `Context_manager.compact` 호출 3건을 `Context_compact_oas.compact` 직접 호출로 교체
- OAS Context_reducer 파이프라인을 중간 wrapper 없이 직접 사용
- `Context_manager.compact`은 이제 외부에서 호출되지 않음 (삭제 가능)

## Changed files
- `keeper_exec_context.ml`: keeper compaction policy
- `succession_oas.ml`: DNA extraction compaction
- `tool_compact.ml`: MCP tool compaction

## Context
Issue #1797 Phase 2. Keeper → OAS 마이그레이션의 compaction 경로 직접화.

## Test plan
- [x] `dune build` pass
- [x] `test_context_compact_oas_coverage` 24 tests pass
- [x] `test_perpetual` 194 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)