### PR TITLE
refactor: remove Context_manager.compact from public API

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -153,7 +153,7 @@ let call_llm_direct_sync ~agent_type ~prompt =
   try
     match
       Cascade.complete ~cascade_name
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Agent_sdk.Types.user_msg prompt]
         ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with
     | Ok resp ->

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -685,7 +685,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match
     Cascade.complete ~cascade_name:"autoresearch"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
   with
   | Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -255,7 +255,7 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
   let prompt = build_scoring_prompt agent task in
   match
     Cascade.complete ~cascade_name:"capability_match"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:15 ~max_tokens:20
       ~accept:llm_score_is_valid ()
   with

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -336,7 +336,7 @@ let verify_worker ~pattern (worker : worker_plan) diff =
     let verdict =
       match
         Cascade.complete ~cascade_name:"code_swarm_verify"
-          ~messages:[Cascade.user_msg prompt]
+          ~messages:[Agent_sdk.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:200 ()
       with
       | Ok resp -> Verifier_oas.parse_verdict (Cascade.text_of_response resp)

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -5,7 +5,7 @@
 
     This module is deliberately independent of Context_manager to avoid circular
     dependency. It operates on [Agent_sdk.Types.message list] directly and uses its own
-    strategy enum that mirrors Context_manager.compaction_strategy.
+    strategy enum shared via Compaction_types.compaction_strategy.
 
     MASC has 4 roles (System, User, Assistant, Tool) while OAS has the same 4.
     OAS Context_reducer strategies operate on OAS message lists and respect

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -51,22 +51,15 @@ type compaction_strategy = Compaction_types.compaction_strategy =
   | DropLowImportance
   | SummarizeOld
 
-type compaction_result = {
-  context : working_context;
-  offloaded_path : string option;
-}
-
 (* ================================================================ *)
 (* Memory Formats                                                  *)
 (* ================================================================ *)
 
-let memory_summary_prefix = Context_scoring.memory_summary_prefix
 let goal_prefix = Context_scoring.goal_prefix
 
 let state_block_start = "[STATE]"
 let state_block_end = "[/STATE]"
 
-let starts_with = Context_scoring.starts_with
 
 let find_substring ~needle haystack ~from =
   let n_len = String.length needle in
@@ -180,16 +173,7 @@ let sync_oas_context (ctx : working_context) : working_context =
     "context_ratio" (`Float (context_ratio ctx));
   ctx
 
-let compact ctx strategies =
-  let oas_strategies = List.map (fun (s : compaction_strategy) : Context_compact_oas.strategy -> s) strategies in
-  let messages, token_count =
-    Context_compact_oas.compact
-      ~system_prompt:ctx.system_prompt
-      ~messages:ctx.messages
-      ~strategies:oas_strategies
-  in
-  let ctx = { ctx with messages; token_count; importance_scores = [] } in
-  sync_oas_context ctx
+(* compact removed — callers use Context_compact_oas.compact directly. *)
 
 (* ================================================================ *)
 (* Conversation History Offload                                     *)
@@ -249,50 +233,8 @@ let offload_messages
       (Printexc.to_string exn);
     None
 
-(** Apply compaction with history offload.
-    Messages that would be removed by compaction are saved to a markdown file
-    before compaction runs. The summary message is annotated with the offload path.
-    If offload fails, compaction proceeds normally. *)
-let compact_with_offload
-    ~(session_ctx : session_context)
-    ~(compaction_count : int)
-    (ctx : working_context)
-    (strategies : compaction_strategy list) : compaction_result =
-  (* Capture pre-compaction messages for offload *)
-  let pre_messages = ctx.messages in
-  let offloaded_path =
-    offload_messages
-      ~session_dir:session_ctx.session_dir
-      ~compaction_count
-      pre_messages
-  in
-  (* Run the compaction pipeline via OAS adapter *)
-  let compacted =
-    let oas_strategies = List.map (fun (s : compaction_strategy) : Context_compact_oas.strategy -> s) strategies in
-    let messages, token_count =
-      Context_compact_oas.compact
-        ~system_prompt:ctx.system_prompt
-        ~messages:ctx.messages
-        ~strategies:oas_strategies
-    in
-    { ctx with messages; token_count; importance_scores = [] }
-  in
-  (* If offload succeeded and SummarizeOld produced a summary, annotate it *)
-  let compacted = match offloaded_path with
-    | Some path ->
-      let annotation = sprintf "[Full conversation history saved to %s]\n\n" path in
-      let messages = List.map (fun (m : Agent_sdk.Types.message) ->
-        let mt = text_of_message m in
-        if starts_with ~prefix:memory_summary_prefix mt then
-          { m with content = [Agent_sdk.Types.Text (annotation ^ mt)] }
-        else m
-      ) compacted.messages in
-      let token_count = count_tokens compacted.system_prompt messages in
-      { compacted with messages; token_count }
-    | None -> compacted
-  in
-  let compacted = sync_oas_context compacted in
-  { context = compacted; offloaded_path }
+(* compact_with_offload removed — callers use Context_compact_oas.compact
+   + offload_messages separately. *)
 
 (* ================================================================ *)
 (* Checkpointing                                                    *)

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -51,12 +51,6 @@ type compaction_strategy = Compaction_types.compaction_strategy =
   | DropLowImportance  (** Remove messages with importance < 0.3 *)
   | SummarizeOld       (** LLM-summarize oldest 30% into 1 summary message *)
 
-(** Result of compaction with optional history offload. *)
-type compaction_result = {
-  context : working_context;
-  offloaded_path : string option;  (** Path to offloaded history markdown, if saved *)
-}
-
 (** {1 Context Ratio Thresholds} *)
 
 (** Context window usage as a ratio 0.0-1.0. *)
@@ -92,10 +86,6 @@ val score_importance : working_context -> working_context
     (preserves prompt-cache prefix). *)
 val goal_prefix : string
 
-(** Apply a pipeline of compaction strategies in order.
-    Delegates to {!Context_compact_oas.compact}. *)
-val compact : working_context -> compaction_strategy list -> working_context
-
 (** Format a single message as human-readable text: "role: content". *)
 val format_message_readable : Agent_sdk.Types.message -> string
 
@@ -104,14 +94,6 @@ val format_message_readable : Agent_sdk.Types.message -> string
 val offload_messages :
   session_dir:string -> compaction_count:int ->
   Agent_sdk.Types.message list -> string option
-
-(** Apply compaction with history offload.
-    Before compaction, saves the full pre-compaction messages to a markdown file.
-    The summary message is annotated with the offload path.
-    If offload fails, compaction proceeds normally. *)
-val compact_with_offload :
-  session_ctx:session_context -> compaction_count:int ->
-  working_context -> compaction_strategy list -> compaction_result
 
 (** Sync working context stats (message_count, token_count, context_ratio)
     into the OAS Context scoped keys. Called automatically by [compact]. *)

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -195,7 +195,7 @@ let classify_intent_llm (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
     Cascade.complete ~cascade_name:"context_router"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with
@@ -210,7 +210,7 @@ let classify_intent_hybrid (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
     Cascade.complete ~cascade_name:"context_router"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -285,7 +285,7 @@ let compute_judgments ~base_path:_ ~factual_json =
   let prompt = prompt_for_facts factual_json in
   match
     Cascade.complete ~cascade_name:"governance_judge"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -290,7 +290,7 @@ let compute_judgments ~facts_json =
   let prompt = prompt_for_facts facts_json in
   match
     Cascade.complete ~cascade_name:"operator_judge"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -45,7 +45,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
   let response =
     match
       Cascade.complete ~cascade_name:"gardener_spawn"
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Agent_sdk.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:200 () with
@@ -438,7 +438,7 @@ Room 내 활성 에이전트: %d
   let response =
     match
       Cascade.complete ~cascade_name:"gardener_spawn"
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Agent_sdk.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:300 () with

--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -239,7 +239,7 @@ let generate_action_plan ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
   match
     Cascade.complete ~cascade_name:"keeper_autonomy"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.3 ~max_tokens:500 ()
   with
   | Ok resp -> Ok (Cascade.text_of_response resp)

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -37,7 +37,7 @@ type loop_config = {
   compact_threshold : float;
   prepare_threshold : float;
   handoff_threshold : float;
-  compact_strategies : Context_manager.compaction_strategy list;
+  compact_strategies : Compaction_types.compaction_strategy list;
   session_base_dir : string;
   on_event : event -> unit;
   event_bus : Agent_sdk.Event_bus.t option;

--- a/lib/perpetual/perpetual_loop.mli
+++ b/lib/perpetual/perpetual_loop.mli
@@ -38,7 +38,7 @@ type loop_config = {
   compact_threshold : float;                     (** Default: 0.5 *)
   prepare_threshold : float;                     (** Default: 0.7 *)
   handoff_threshold : float;                     (** Default: 0.85 *)
-  compact_strategies : Context_manager.compaction_strategy list;
+  compact_strategies : Compaction_types.compaction_strategy list;
   session_base_dir : string;                     (** Where to store session data *)
   on_event : event -> unit;                      (** Callback for monitoring *)
   event_bus : Agent_sdk.Event_bus.t option;       (** OAS Event_bus for cross-system events *)

--- a/lib/perpetual/perpetual_oas_hooks.ml
+++ b/lib/perpetual/perpetual_oas_hooks.ml
@@ -42,8 +42,8 @@ let perpetual_hooks
       (* Compact threshold: apply context reduction via Phase 1 adapter *)
       if ratio >= config.compact_threshold then begin
         let before = (!ctx_ref).token_count in
-        (* Both Context_manager.compaction_strategy and Context_compact_oas.strategy
-           are now aliases for Compaction_types.compaction_strategy — no mapping needed. *)
+        (* Compaction_types.compaction_strategy and Context_compact_oas.strategy
+           are aliases — no mapping needed. *)
         let strategies = config.compact_strategies in
         let compacted_msgs, new_token_count =
           Context_compact_oas.compact

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -119,7 +119,7 @@ let verify_llm ~content : (verification_result, string) result =
   let prompt = build_geval_prompt ~content in
   match
     Cascade.complete ~cascade_name:"verifier"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec:15 ~max_tokens:150
       ~accept:geval_response_is_valid ()
   with

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -276,7 +276,7 @@ let walph_response_is_valid (resp : Llm_provider.Types.api_response) =
 let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
   match
     Cascade.complete ~cascade_name:"walph"
-      ~messages:[Cascade.user_msg prompt] ~timeout_sec
+      ~messages:[Agent_sdk.Types.user_msg prompt] ~timeout_sec
       ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with
   | Ok resp -> Cascade.text_of_response resp

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -118,7 +118,7 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
     | Ok prompt ->
         let timeout = Env_config.Sentinel.llm_timeout_sec in
         (match Cascade.complete ~cascade_name
-            ~messages:[Cascade.user_msg prompt]
+            ~messages:[Agent_sdk.Types.user_msg prompt]
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
         | Ok resp ->
             let text = Cascade.text_of_response resp in

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -458,8 +458,8 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
       (match
         Cascade.complete ~cascade_name:"routing_judge"
           ~messages:[
-            Cascade.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
-            Cascade.user_msg prompt]
+            Agent_sdk.Types.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
+            Agent_sdk.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:220
           ~timeout_sec:(router_judge_timeout_sec ()) ()
       with

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -79,7 +79,7 @@ let test_call_returns_error_when_no_models () =
           let result =
             Cascade.complete
               ~cascade_name:"heartbeat_action"
-              ~messages:[Cascade.user_msg "test"]
+              ~messages:[Agent_sdk.Types.user_msg "test"]
               ~timeout_sec:1
               ~config_path:path
               ()

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -69,13 +69,19 @@ let test_roundtrip_tool_msg () =
       true (String.length text > 0)
 
 (* ================================================================ *)
-(* Context_manager.compact tests (routes through Context_compact_oas) *)
+(* Compaction tests (via Context_compact_oas directly) *)
+
+let compact_ctx (ctx : Context_manager.working_context) strategies =
+  let messages, token_count =
+    Context_compact_oas.compact
+      ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies in
+  { ctx with Context_manager.messages; token_count; importance_scores = [] }
 (* ================================================================ *)
 
 let test_compact_prune_tool_outputs () =
   let ctx = Context_manager.create ~system_prompt:"test system" ~max_tokens:4000 in
   let ctx = List.fold_left Context_manager.append ctx (make_test_messages ()) in
-  let compacted = Context_manager.compact ctx [Context_manager.PruneToolOutputs] in
+  let compacted = compact_ctx ctx [Context_compact_oas.PruneToolOutputs] in
   (* PruneToolOutputs on short tool output should not drop messages *)
   Alcotest.(check bool) "messages preserved"
     true (List.length compacted.messages > 0);
@@ -93,7 +99,7 @@ let test_compact_merge_contiguous () =
     Agent_sdk.Types.assistant_msg "response";
   ] in
   let ctx = List.fold_left Context_manager.append ctx msgs in
-  let compacted = Context_manager.compact ctx [Context_manager.MergeContiguous] in
+  let compacted = compact_ctx ctx [Context_compact_oas.MergeContiguous] in
   (* MergeContiguous should merge the two consecutive user messages *)
   Alcotest.(check bool) "merged reduces count"
     true (List.length compacted.messages <= List.length msgs)
@@ -108,7 +114,7 @@ let test_compact_summarize_old () =
       Agent_sdk.Types.assistant_msg (Printf.sprintf "assistant response %d" i)
   ) in
   let ctx = List.fold_left Context_manager.append ctx msgs in
-  let compacted = Context_manager.compact ctx [Context_manager.SummarizeOld] in
+  let compacted = compact_ctx ctx [Context_compact_oas.SummarizeOld] in
   (* SummarizeOld with keep-first-and-last should reduce message count *)
   Alcotest.(check bool) "summarize_old reduces messages"
     true (List.length compacted.messages < List.length msgs);
@@ -122,7 +128,7 @@ let test_compact_small_list_unchanged () =
     Agent_sdk.Types.assistant_msg "world";
   ] in
   let ctx = List.fold_left Context_manager.append ctx msgs in
-  let compacted = Context_manager.compact ctx [Context_manager.SummarizeOld] in
+  let compacted = compact_ctx ctx [Context_compact_oas.SummarizeOld] in
   (* Small list (< first_n + last_n = 7) should be unchanged *)
   Alcotest.(check int) "small list unchanged"
     (List.length msgs) (List.length compacted.messages)

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -105,7 +105,12 @@ let test_compact_syncs_oas_context () =
   let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:1000 in
   let ctx = Context_manager.append ctx (Agent_sdk.Types.user_msg "msg1") in
   let ctx = Context_manager.append ctx (Agent_sdk.Types.assistant_msg "msg2") in
-  let ctx = Context_manager.compact ctx [Context_manager.MergeContiguous] in
+  let messages, token_count =
+    Context_compact_oas.compact
+      ~system_prompt:ctx.system_prompt ~messages:ctx.messages
+      ~strategies:[Context_compact_oas.MergeContiguous] in
+  let ctx = Context_manager.sync_oas_context
+    { ctx with messages; token_count; importance_scores = [] } in
   let ratio =
     Context.get_scoped ctx.oas_context Context.Session "context_ratio" in
   (match ratio with

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -17,6 +17,16 @@ open Printf
 (* Test Infrastructure                                              *)
 (* ================================================================ *)
 
+(** Compact a working_context via OAS Context_reducer directly. *)
+let compact_ctx (ctx : Context_manager.working_context)
+    (strategies : Compaction_types.compaction_strategy list)
+    : Context_manager.working_context =
+  let messages, token_count =
+    Context_compact_oas.compact
+      ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies
+  in
+  { ctx with messages; token_count; importance_scores = [] }
+
 let test_count = ref 0
 let pass_count = ref 0
 let fail_count = ref 0
@@ -266,7 +276,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
   let long_tool_msg = { (Cascade.tool_msg ~name:"t" ~call_id:"c" (String.make 1000 'x'))
     with role = Agent_sdk.Types.Tool } in
   let ctx5 = Context_manager.append ctx long_tool_msg in
-  let pruned = Context_manager.compact ctx5 [PruneToolOutputs] in
+  let pruned = compact_ctx ctx5 [PruneToolOutputs] in
   let pruned_msg = List.hd pruned.messages in
   assert_true "prune:shorter" (String.length (Agent_sdk.Types.text_of_message pruned_msg) < 1000);
   assert_true "prune:has_truncated" (
@@ -279,7 +289,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
     Agent_sdk.Types.user_msg "part2";
     Agent_sdk.Types.assistant_msg "response";
   ] in
-  let merged = Context_manager.compact ctx6 [MergeContiguous] in
+  let merged = compact_ctx ctx6 [MergeContiguous] in
   assert_equal "merge:count" 2 (List.length merged.messages);
 
   (* 9. SummarizeOld *)
@@ -287,7 +297,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
     if i mod 2 = 0 then Agent_sdk.Types.user_msg (sprintf "q%d" i)
     else Agent_sdk.Types.assistant_msg (sprintf "a%d" i)) in
   let ctx7 = Context_manager.append_many ctx many_msgs in
-  let summarized = Context_manager.compact ctx7 [SummarizeOld] in
+  let summarized = compact_ctx ctx7 [SummarizeOld] in
   assert_true "summarize:fewer_messages"
     (List.length summarized.messages < List.length ctx7.messages);
 
@@ -297,7 +307,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
       if i mod 2 = 0
       then Agent_sdk.Types.user_msg (sprintf "detailed question %d with lots of context: %s" i (String.make 200 'x'))
       else Agent_sdk.Types.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
-  let compacted = Context_manager.compact long_ctx
+  let compacted = compact_ctx long_ctx
     [PruneToolOutputs; MergeContiguous; SummarizeOld] in
   assert_true "compact:reduces_tokens"
     (compacted.token_count <= long_ctx.token_count);
@@ -342,7 +352,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
     Agent_sdk.Types.assistant_msg "ok";  (* Short = low importance *)
     Agent_sdk.Types.user_msg "another detailed question with context";
   ] in
-  let dropped = Context_manager.compact ctx8 [DropLowImportance] in
+  let dropped = compact_ctx ctx8 [DropLowImportance] in
   assert_true "drop:removes_some"
     (List.length dropped.messages <= List.length ctx8.messages);
 )
@@ -761,7 +771,7 @@ let test_integration () = group "Integration" (fun () ->
       then Agent_sdk.Types.user_msg (sprintf "detailed question %d with context: %s" i (String.make 200 'x'))
       else Agent_sdk.Types.assistant_msg (sprintf "comprehensive answer %d: %s" i (String.make 300 'y')))) in
   let before = big_ctx.token_count in
-  let after_ctx = Context_manager.compact big_ctx
+  let after_ctx = compact_ctx big_ctx
     [PruneToolOutputs; MergeContiguous; SummarizeOld] in
   assert_true "integration:compact_reduces"
     (after_ctx.token_count < before);
@@ -786,7 +796,7 @@ let test_integration () = group "Integration" (fun () ->
     [Agent_sdk.Types.user_msg "run grep";
      Cascade.tool_msg ~name:"grep" ~call_id:"c1" (String.make 800 'r');
      Agent_sdk.Types.assistant_msg "found results"] in
-  let pruned_oas = Context_manager.compact ctx_with_tools [PruneToolOutputs] in
+  let pruned_oas = compact_ctx ctx_with_tools [PruneToolOutputs] in
   let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
     m.role = Agent_sdk.Types.Tool) pruned_oas.messages in
   assert_equal "oas_prune:tool_preserved" 1 (List.length tool_msgs);
@@ -917,38 +927,18 @@ let test_history_offload () = group "History Offload" (fun () ->
       if i mod 2 = 0
       then Agent_sdk.Types.user_msg (sprintf "question %d with detail: %s" i (String.make 200 'x'))
       else Agent_sdk.Types.assistant_msg (sprintf "answer %d: %s" i (String.make 300 'y')))) in
-  let result = Context_manager.compact_with_offload
-    ~session_ctx:session ~compaction_count:1
-    ctx [Context_manager.PruneToolOutputs; Context_manager.MergeContiguous;
-         Context_manager.SummarizeOld] in
-  assert_true "compact_offload:has_path" (Option.is_some result.offloaded_path);
+  (* offload + compact separately (compact_with_offload removed) *)
+  let offloaded_path = Context_manager.offload_messages
+    ~session_dir:session.session_dir ~compaction_count:1 ctx.messages in
+  let compacted = compact_ctx ctx [PruneToolOutputs; MergeContiguous; SummarizeOld] in
+  assert_true "compact_offload:has_path" (Option.is_some offloaded_path);
   assert_true "compact_offload:context_reduced"
-    (result.context.token_count < ctx.token_count);
+    (compacted.token_count < ctx.token_count);
   assert_true "compact_offload:file_exists"
-    (Sys.file_exists (Option.get result.offloaded_path));
+    (Sys.file_exists (Option.get offloaded_path));
 
-  (* 6. Summary message contains offload path annotation.
-     When use_oas_reducer()=true, SummarizeOld uses Keep_first_and_last (no summary
-     prefix), so annotation injection has no target — annotation is absent.
-     Both behaviors are correct; verify offload file was written instead. *)
-  let has_annotation = List.exists (fun (m : Agent_sdk.Types.message) ->
-    let text = Agent_sdk.Types.text_of_message m in
-    try let _ = Str.search_forward
-      (Str.regexp_string "[Full conversation history saved to") text 0 in true
-    with Not_found -> false
-  ) result.context.messages in
-  let oas_reducer_on =
-    match Sys.getenv_opt "MASC_USE_OAS_REDUCER" with
-    | Some v -> String.lowercase_ascii (String.trim v) <> "false"
-    | None -> true in
-  if oas_reducer_on then
-    assert_true "compact_offload:offload_file_written" (Option.is_some result.offloaded_path)
-  else
-    assert_true "compact_offload:has_annotation" has_annotation;
-
-  (* 7. compact (original) still works unchanged *)
-  let orig = Context_manager.compact ctx
-    [Context_manager.PruneToolOutputs; Context_manager.SummarizeOld] in
+  (* 7. compact still works *)
+  let orig = compact_ctx ctx [PruneToolOutputs; SummarizeOld] in
   assert_true "compact:original_unchanged"
     (orig.token_count < ctx.token_count);
 


### PR DESCRIPTION
## Summary
- `Context_manager.compact`, `compact_with_offload`, `compaction_result`을 public API에서 제거
- 모든 caller가 `Context_compact_oas.compact` (OAS Context_reducer)를 직접 호출
- `compaction_strategy` 타입 참조를 `Compaction_types` 직접 참조로 전환
- Dead code 75줄 삭제

## Context
Issue #1797 Phase 2 완료. PR #1798의 후속 (squash merge로 누락된 2번째 커밋).

## Test plan
- [x] `dune build` pass
- [x] `test_perpetual` 193 tests pass
- [x] `test_oas_adapters` 9 tests pass
- [x] `test_oas_integration` 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)