### PR TITLE
fix: resolve broken main build (Cascade.user_msg removed)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -153,7 +153,7 @@ let call_llm_direct_sync ~agent_type ~prompt =
   try
     match
       Cascade.complete ~cascade_name
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Llm_provider.Types.user_msg prompt]
         ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with
     | Ok resp ->

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -685,7 +685,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match
     Cascade.complete ~cascade_name:"autoresearch"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
   with
   | Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -255,7 +255,7 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
   let prompt = build_scoring_prompt agent task in
   match
     Cascade.complete ~cascade_name:"capability_match"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:15 ~max_tokens:20
       ~accept:llm_score_is_valid ()
   with

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -1,18 +1,7 @@
-(** Cascade — thin wrapper over OAS Cascade_config.
+(** Cascade — MASC LLM call module.
 
-    MASC defines cascade name -> model list policy (default_model_strings).
-    OAS handles config loading, model parsing, health filtering, and execution.
-
-    Public entry points:
-    - {!call} — prompt-in/text-out convenience (returns cascade_result)
-    - {!call_raw} — prompt-in, returns full api_response
-    - {!call_with_tools} — messages + tools, returns full api_response
-
-    All three route through OAS Cascade_config.complete_named.
-
-    @since 2.114.0 — original
-    @since 2.115.0 — delegated to OAS Cascade_config
-    @since 2.116.0 — call_raw, call_with_tools added *)
+    Model types, cascade profile defaults, model spec parsing,
+    and {!complete} which delegates to OAS [Cascade_config.complete_named]. *)
 
 (* ================================================================ *)
 (* Model types and helpers — absorbed from Masc_model               *)
@@ -262,13 +251,6 @@ let llm_semaphore_available () = max_concurrent_llm - Atomic.get inflight
 let llm_permits_in_use () = Atomic.get inflight
 
 (* ================================================================ *)
-
-(** @deprecated Use {!complete} instead. *)
-type cascade_result = {
-  response : string;
-  llm_used : string;
-  duration_ms : int;
-}
 
 (** Locate config/cascade.json via CWD or ME_ROOT.
     Falls back to legacy config/llm_cascade.json if new name not found.
@@ -603,5 +585,3 @@ let complete ~cascade_name ~messages
   | Ok resp -> Ok resp
   | Error err -> Error (format_cascade_error ~cascade_name err)
 
-(* call, call_raw, call_with_tools removed — use {!complete} directly.
-   Callers build messages and handle api_response/errors themselves. *)

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -336,7 +336,7 @@ let verify_worker ~pattern (worker : worker_plan) diff =
     let verdict =
       match
         Cascade.complete ~cascade_name:"code_swarm_verify"
-          ~messages:[Cascade.user_msg prompt]
+          ~messages:[Llm_provider.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:200 ()
       with
       | Ok resp -> Verifier_oas.parse_verdict (Cascade.text_of_response resp)

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -195,7 +195,7 @@ let classify_intent_llm (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
     Cascade.complete ~cascade_name:"context_router"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with
@@ -210,7 +210,7 @@ let classify_intent_hybrid (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
     Cascade.complete ~cascade_name:"context_router"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
   with

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -285,7 +285,7 @@ let compute_judgments ~base_path:_ ~factual_json =
   let prompt = prompt_for_facts factual_json in
   match
     Cascade.complete ~cascade_name:"governance_judge"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -290,7 +290,7 @@ let compute_judgments ~facts_json =
   let prompt = prompt_for_facts facts_json in
   match
     Cascade.complete ~cascade_name:"operator_judge"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with
   | Error message -> Error message

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -45,7 +45,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
   let response =
     match
       Cascade.complete ~cascade_name:"gardener_spawn"
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Llm_provider.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:200 () with
@@ -438,7 +438,7 @@ Room 내 활성 에이전트: %d
   let response =
     match
       Cascade.complete ~cascade_name:"gardener_spawn"
-        ~messages:[Cascade.user_msg prompt]
+        ~messages:[Llm_provider.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:300 () with

--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -239,7 +239,7 @@ let generate_action_plan ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
   match
     Cascade.complete ~cascade_name:"keeper_autonomy"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.3 ~max_tokens:500 ()
   with
   | Ok resp -> Ok (Cascade.text_of_response resp)

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -119,7 +119,7 @@ let verify_llm ~content : (verification_result, string) result =
   let prompt = build_geval_prompt ~content in
   match
     Cascade.complete ~cascade_name:"verifier"
-      ~messages:[Cascade.user_msg prompt]
+      ~messages:[Llm_provider.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec:15 ~max_tokens:150
       ~accept:geval_response_is_valid ()
   with

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -276,7 +276,7 @@ let walph_response_is_valid (resp : Llm_provider.Types.api_response) =
 let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
   match
     Cascade.complete ~cascade_name:"walph"
-      ~messages:[Cascade.user_msg prompt] ~timeout_sec
+      ~messages:[Llm_provider.Types.user_msg prompt] ~timeout_sec
       ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with
   | Ok resp -> Cascade.text_of_response resp

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -118,7 +118,7 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
     | Ok prompt ->
         let timeout = Env_config.Sentinel.llm_timeout_sec in
         (match Cascade.complete ~cascade_name
-            ~messages:[Cascade.user_msg prompt]
+            ~messages:[Llm_provider.Types.user_msg prompt]
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
         | Ok resp ->
             let text = Cascade.text_of_response resp in

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -458,8 +458,8 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
       (match
         Cascade.complete ~cascade_name:"routing_judge"
           ~messages:[
-            Cascade.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
-            Cascade.user_msg prompt]
+            Llm_provider.Types.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
+            Llm_provider.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:220
           ~timeout_sec:(router_judge_timeout_sec ()) ()
       with

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -79,7 +79,7 @@ let test_call_returns_error_when_no_models () =
           let result =
             Cascade.complete
               ~cascade_name:"heartbeat_action"
-              ~messages:[Cascade.user_msg "test"]
+              ~messages:[Llm_provider.Types.user_msg "test"]
               ~timeout_sec:1
               ~config_path:path
               ()


### PR DESCRIPTION
## Summary
- main 빌드 깨짐 수정: PR #1794 (Cascade OAS alias 제거) ↔ PR #1795 (Cascade.complete 마이그레이션) 충돌
- `Cascade.user_msg/system_msg` 14개 참조 → `Llm_provider.Types.user_msg/system_msg` 교체
- deprecated `cascade_result` 타입 삭제 (소비자 0)
- cascade.ml 모듈 docstring 현행화

## Urgency
main이 빌드 불가 상태. 즉시 merge 필요.

## Test plan
- [x] `dune build` pass (main이 이전에 실패하던 것 수정)
- [x] `test_cascade` 8 tests pass
- [x] `test_auto_responder_coverage` 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)