### PR TITLE
fix: resolve main build errors (PreToolUse + cascade cleanup)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -103,7 +103,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
   let hooks = if config.verbose then
     { Hooks.empty with
       pre_tool_use = Some (fun event -> match event with
-        | Hooks.PreToolUse { tool_name; input } ->
+        | Hooks.PreToolUse { tool_name; input; _ } ->
           Format.eprintf "[tool] %s %s@." tool_name
             (Yojson.Safe.to_string input);
           Hooks.Continue

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -1,7 +1,7 @@
-(** Cascade — thin wrapper over OAS Cascade_config.
+(** Cascade — MASC LLM call module.
 
-    MASC defines cascade name -> model list policy (default_model_strings).
-    OAS handles config loading, model parsing, health filtering, and execution.
+    Model types, cascade profile defaults, model spec parsing,
+    and {!complete} which delegates to OAS [Cascade_config.complete_named].
 
     Public entry points:
     - {!call} — prompt-in/text-out convenience (returns cascade_result)
@@ -262,13 +262,6 @@ let llm_semaphore_available () = max_concurrent_llm - Atomic.get inflight
 let llm_permits_in_use () = Atomic.get inflight
 
 (* ================================================================ *)
-
-(** @deprecated Use {!complete} instead. *)
-type cascade_result = {
-  response : string;
-  llm_used : string;
-  duration_ms : int;
-}
 
 (** Locate config/cascade.json via CWD or ME_ROOT.
     Falls back to legacy config/llm_cascade.json if new name not found.

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -218,7 +218,7 @@ let make_pre_tool_hook
   : Agent_sdk.Hooks.hook =
   fun event ->
     match event with
-    | Agent_sdk.Hooks.PreToolUse { tool_name; input } ->
+    | Agent_sdk.Hooks.PreToolUse { tool_name; input; _ } ->
       let action_description = sprintf "tool:%s" tool_name in
       (* Skip read-only tools without calling the LLM *)
       if should_skip ~action_description then


### PR DESCRIPTION
## Summary
- main 빌드 에러 수정: OAS Hooks.PreToolUse에 새 필드 추가됨 (accumulated_cost_usd, turn)
- `verifier_oas.ml`, `agent_swarm_runner.ml`: 패턴 매치에 `; _` 추가
- `cascade.ml`: deprecated `cascade_result` 타입 삭제, 모듈 docstring 현행화

## Urgency
main 빌드 불가. 즉시 merge 필요.

## Test plan
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)