### PR TITLE
fix: add wildcard to PreToolUse record patterns

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -103,7 +103,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
   let hooks = if config.verbose then
     { Hooks.empty with
       pre_tool_use = Some (fun event -> match event with
-        | Hooks.PreToolUse { tool_name; input } ->
+        | Hooks.PreToolUse { tool_name; input; _ } ->
           Format.eprintf "[tool] %s %s@." tool_name
             (Yojson.Safe.to_string input);
           Hooks.Continue

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -218,7 +218,7 @@ let make_pre_tool_hook
   : Agent_sdk.Hooks.hook =
   fun event ->
     match event with
-    | Agent_sdk.Hooks.PreToolUse { tool_name; input } ->
+    | Agent_sdk.Hooks.PreToolUse { tool_name; input; _ } ->
       let action_description = sprintf "tool:%s" tool_name in
       (* Skip read-only tools without calling the LLM *)
       if should_skip ~action_description then


### PR DESCRIPTION
## Summary
- Add `; _` to 2 PreToolUse pattern matches in verifier_oas.ml and agent_swarm_runner.ml
- OAS SDK added `accumulated_cost_usd` and `turn` fields to `Hooks.PreToolUse`
- Warning 9 (missing-record-field-pattern) treated as error broke main build