### PR TITLE
feat(memory): wire OAS Memory.t into gardener workers and keeper

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.68.0))
+  (agent_sdk (>= 0.71.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/dune
+++ b/lib/dune
@@ -213,6 +213,8 @@
    log
    thompson_sampling
    memory_stream
+   memory_stream_sync
+   memory_oas_bridge
    agent_planner
    reflection
    relation_materializer

--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -53,6 +53,7 @@ let make_dispatch ~(config : Room.config) ~(agent_name : string) () ~name ~args 
 let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let agent_name = Printf.sprintf "gardener-worker-%s" topic in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
+  let memory = Memory_oas_bridge.create_memory ~agent_name in
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:
@@ -73,11 +74,13 @@ let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
     ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
     ~masc_tools:(worker_tools ())
     ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~memory
     ~max_turns:10 ~temperature:0.3 ()
 
 let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
   let agent_name = "gardener-triage-worker" in
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
+  let memory = Memory_oas_bridge.create_memory ~agent_name in
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:
@@ -98,4 +101,5 @@ let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_back
          backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
     ~masc_tools:(worker_tools ())
     ~dispatch:(make_dispatch ~config ~agent_name ())
+    ~memory
     ~max_turns:15 ~temperature:0.3 ()

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -95,9 +95,10 @@ let run_with_tools
     tools_executed_ref := name :: !tools_executed_ref;
     make_dispatch ~config ~meta ~gate_config ~accumulated_cost_ref ~name ~args
   in
+  let memory = Memory_oas_bridge.create_memory ~agent_name:(Printf.sprintf "keeper-%s" meta.name) in
   match Oas_worker.run_named_with_masc_tools
     ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch
-    ~max_turns ~temperature ~max_tokens ?guardrails ()
+    ~max_turns ~temperature ~max_tokens ?guardrails ~memory ()
   with
   | Ok oas_result ->
       Ok { oas_result; tools_executed = List.rev !tools_executed_ref }
@@ -126,9 +127,10 @@ let run_with_custom_dispatch
   : (Oas_worker.run_result, string) result =
   ignore model_spec_override;
   let cascade_name = Printf.sprintf "keeper_%s" meta.name in
+  let memory = Memory_oas_bridge.create_memory ~agent_name:(Printf.sprintf "keeper-%s" meta.name) in
   Oas_worker.run_named_with_masc_tools
     ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch
-    ~max_turns ~temperature ~max_tokens ?guardrails ()
+    ~max_turns ~temperature ~max_tokens ?guardrails ~memory ()
 
 (* ================================================================ *)
 (* Public: run_simple                                                *)
@@ -144,9 +146,10 @@ let run_simple
     ~(max_tokens : int)
     ()
   : (Oas_worker.run_result, string) result =
-  ignore (config, meta);
+  ignore config;
+  let memory = Memory_oas_bridge.create_memory ~agent_name:(Printf.sprintf "keeper-%s" meta.name) in
   Oas_worker.run_named ~cascade_name ~goal:prompt ~system_prompt
-    ~max_turns:1 ~temperature ~max_tokens ()
+    ~max_turns:1 ~temperature ~max_tokens ~memory ()
 
 (* ================================================================ *)
 (* Public: result extractors                                         *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -33,6 +33,7 @@ type config = {
   checkpoint_dir : string option;
   session_id : string option;
   description : string option;
+  memory : Oas.Memory.t option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -46,6 +47,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     checkpoint_dir = None;
     session_id = None;
     description = None;
+    memory = None;
   }
 
 (* ================================================================ *)
@@ -136,6 +138,10 @@ let build
   in
   let builder = match config.description with
     | Some d -> Oas.Builder.with_description d builder
+    | None -> builder
+  in
+  let builder = match config.memory with
+    | Some m -> Oas.Builder.with_memory m builder
     | None -> builder
   in
   Oas.Builder.build_safe builder
@@ -255,6 +261,7 @@ let run_named
     ?(temperature = 0.7)
     ?(max_tokens = 4096)
     ?guardrails
+    ?memory
     ?on_event
     ()
   : (run_result, string) result =
@@ -270,6 +277,7 @@ let run_named
     max_tokens;
     temperature;
     guardrails;
+    memory;
     description = Some (Printf.sprintf "cascade:%s" cascade_name);
   } in
   run ~sw ~net ~config ?on_event goal
@@ -284,6 +292,7 @@ let run_named_with_masc_tools
     ?(temperature = 0.7)
     ?(max_tokens = 4096)
     ?guardrails
+    ?memory
     ?on_event
     ()
   : (run_result, string) result =
@@ -299,6 +308,7 @@ let run_named_with_masc_tools
     max_tokens;
     temperature;
     guardrails;
+    memory;
     description = Some (Printf.sprintf "cascade:%s" cascade_name);
   } in
   run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch ?on_event goal

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -25,6 +25,7 @@ val run_named :
   ?temperature:float ->
   ?max_tokens:int ->
   ?guardrails:Oas.Guardrails.t ->
+  ?memory:Oas.Memory.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->
   (run_result, string) result
@@ -39,6 +40,7 @@ val run_named_with_masc_tools :
   ?temperature:float ->
   ?max_tokens:int ->
   ?guardrails:Oas.Guardrails.t ->
+  ?memory:Oas.Memory.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->
   (run_result, string) result

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.68.0"}
+  "agent_sdk" {>= "0.71.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- Gardener workers와 Keeper가 OAS `Memory.t`를 통해 `memory_stream` 기반 장기 기억 사용
- `Oas_worker.config`에 `memory` 필드 추가, `Builder.with_memory`로 Agent.t에 주입
- PR #1794 빌드 깨짐 수정 (`Cascade.user_msg` → `Llm_provider.Types.user_msg` 일괄 교체)
- OAS 의존 버전 0.68.0 → 0.71.0 (Builder.with_memory 포함)

## Changes
- `oas_worker.ml/mli`: `?memory` param 추가, build에서 `Builder.with_memory` 연결
- `gardener_worker.ml`: `Memory_oas_bridge.create_memory ~agent_name` 주입
- `keeper_oas_adapter.ml`: run_with_tools/custom_dispatch/simple 3곳에 memory 주입
- `lib/dune`: `memory_oas_bridge`, `memory_stream_sync` 모듈 등록
- 13개 파일: `Cascade.user_msg/system_msg` → `Llm_provider.Types.*` (빌드 수정)
- 2개 파일: PreToolUse 레코드 패턴에 `; _` 추가 (OAS 0.71.0 필드 추가 대응)

## Test plan
- [x] `dune build` 성공
- [x] `make test` 31 tests pass
- [ ] Runtime 검증: gardener worker 스폰 시 memory_stream에 기록 확인

## Architecture
```
Gardener Worker / Keeper
  ↓ Memory_oas_bridge.create_memory ~agent_name
  ↓ Oas_worker.run_named_with_masc_tools ~memory
  ↓ Builder.with_memory (OAS 0.71.0)
  ↓ Agent.t.memory = Some Memory.t
  ↓ Agent가 Memory.store/recall ~tier:Long_term 사용 가능
  ↓ long_term_backend → memory_stream.add_memory / retrieve
```

Generated with [Claude Code](https://claude.com/claude-code)