### PR TITLE
feat(keeper): wrap keeper tools as OAS Tool.t (Phase A)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -490,6 +490,7 @@
    keeper_exec_persona
    keeper_exec_context
    keeper_oas_adapter
+   keeper_tools_oas
    keeper_exec_autonomy
    keeper_exec_proactive
    keeper_exec_social

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -1,0 +1,52 @@
+(** Keeper_tools_oas — Wrap keeper tools as OAS Tool.t for Agent.run().
+
+    Bridges [Keeper_exec_tools.execute_keeper_tool_call] dispatch
+    to [Agent_sdk.Tool.t] list via [Tool_bridge.oas_tool_of_masc].
+
+    Tool execution reads current context from [ctx_ref] (mutable ref),
+    enabling Agent.run() to manage messages while keeper tools
+    access the working context for status/metrics.
+
+    @since Phase 4 — Keeper → Agent.run() migration *)
+
+(** Build OAS Tool.t list from keeper's allowed tools.
+
+    Each tool delegates to [execute_keeper_tool_call] with the current
+    [ctx_ref] snapshot. Tools that raise exceptions return error results
+    instead of crashing the agent loop.
+
+    @param config Room configuration for tool dispatch
+    @param meta Keeper metadata (determines which tools are allowed)
+    @param ctx_ref Mutable ref to current working context *)
+let make_tools
+    ~(config : Room.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(ctx_ref : Context_manager.working_context ref)
+  : Agent_sdk.Tool.t list =
+  let allowed_names =
+    Keeper_exec_tools.keeper_allowed_tool_names meta
+  in
+  let tool_defs =
+    Keeper_exec_tools.keeper_allowed_llm_tools meta
+  in
+  List.filter_map (fun (td : Cascade.tool_def) ->
+    if List.mem td.tool_name allowed_names then
+      Some (Tool_bridge.oas_tool_of_masc
+        ~name:td.tool_name
+        ~description:td.tool_description
+        ~input_schema:td.parameters
+        (fun input ->
+          try
+            let result =
+              Keeper_exec_tools.execute_keeper_tool_call
+                ~config ~meta ~ctx_work:(!ctx_ref)
+                ~name:td.tool_name ~input
+            in
+            (true, result)
+          with exn ->
+            let msg = Printf.sprintf "tool %s failed: %s"
+              td.tool_name (Printexc.to_string exn) in
+            Log.Keeper.error "%s" msg;
+            (false, msg)))
+    else None
+  ) tool_defs

--- a/test/dune
+++ b/test/dune
@@ -442,6 +442,10 @@
  (modules test_tool_keeper)
  (libraries masc_mcp alcotest unix))
 (test
+ (name test_keeper_tools_oas)
+ (modules test_keeper_tools_oas)
+ (libraries masc_mcp agent_sdk alcotest unix))
+(test
  (name test_tool_council)
  (modules test_tool_council)
  (libraries masc_mcp alcotest yojson unix))

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1,0 +1,79 @@
+(** Tests for Keeper_tools_oas — OAS Tool.t wrapping of keeper tools. *)
+
+open Alcotest
+open Masc_mcp
+
+let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+    (`Assoc [("name", `String name); ("agent_name", `String name);
+             ("trace_id", `String "test-trace-001")]) with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
+
+let make_test_ctx () =
+  Context_manager.create ~system_prompt:"test" ~max_tokens:4000
+
+let test_make_tools_returns_nonempty () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      check bool "tools nonempty" true (List.length tools > 0))
+
+let test_tools_have_valid_schemas () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_schema_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      List.iter (fun (tool : Agent_sdk.Tool.t) ->
+        check bool (Printf.sprintf "tool %s has name" tool.schema.name)
+          true (String.length tool.schema.name > 0);
+        check bool (Printf.sprintf "tool %s has description" tool.schema.name)
+          true (String.length tool.schema.description > 0)
+      ) tools)
+
+let test_tool_count_matches_allowed () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_count_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+      let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
+      check bool "all tools are in allowed list" true
+        (List.for_all (fun name -> List.mem name allowed) tool_names))
+
+let () =
+  run "Keeper_tools_oas" [
+    "make_tools", [
+      test_case "returns nonempty" `Quick test_make_tools_returns_nonempty;
+      test_case "valid schemas" `Quick test_tools_have_valid_schemas;
+      test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `keeper_tools_oas.ml` 신규: keeper tool dispatch → OAS Tool.t 래핑
- `Tool_bridge.oas_tool_of_masc` 재사용, `execute_keeper_tool_call` 위임
- ctx_ref (mutable ref)로 Agent.run() 실행 중 context 접근 가능
- Exception-safe handler (tool 실패 → error result, agent loop 계속)

## Context
Issue #1797 Phase A. Keeper → Agent.run() 마이그레이션의 첫 빌딩 블록.
Phase B (hooks adapter), Phase C (turn loop 교체) 후속.

## Test plan
- [x] `dune build` pass
- [x] `test_keeper_tools_oas` 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)