### PR TITLE
feat(memory): seed procedural memory into OAS Memory.t

### DIFF
--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -55,6 +55,7 @@ let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
   let memory = Memory_oas_bridge.create_memory ~agent_name in
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
+  ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:
@@ -83,6 +84,7 @@ let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_back
   let institution_context = Institution_eio.load_and_format_for_welcome ~fs:() config in
   let memory = Memory_oas_bridge.create_memory ~agent_name in
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
+  ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
   Oas_worker.run_named_with_masc_tools
     ~cascade_name:"gardener_spawn"
     ~system_prompt:

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -106,3 +106,20 @@ let seed_institution ~(memory : Agent_sdk.Memory.t) ~(config : Room_utils.config
     Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "institution" json;
     true
   | None -> false
+
+(** Pre-seed crystallized procedural memory into a [Memory.t] instance.
+
+    Loads top-N procedures (adaptive threshold: standard 3+/70% OR rare 2+/100%)
+    and stores as a single Long_term entry.  Returns the number of procedures seeded. *)
+let seed_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limit : int) : int =
+  let procs = Procedural_memory.top_procedures ~agent_name ~limit in
+  if procs = [] then 0
+  else begin
+    let json = `Assoc [
+      ("agent_name", `String agent_name);
+      ("procedures", `List (List.map Procedural_memory.to_json procs));
+      ("count", `Int (List.length procs));
+    ] in
+    Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "procedures" json;
+    List.length procs
+  end


### PR DESCRIPTION
## Summary
Crystallized procedural memory를 OAS Memory.t에 pre-seed. Agent 시작 시 top-5 procedures를 memory_stream에 기록.

## Changes
- `memory_oas_bridge.ml`: `seed_procedures` 함수 추가
- `gardener_worker.ml`: gap + triage worker에서 `seed_procedures` 호출

## Test plan
- [x] `dune build` 성공

Generated with [Claude Code](https://claude.com/claude-code)