### PR TITLE
fix(dashboard): remove fake defaults and slim verbose responses

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -13,9 +13,9 @@ import type {
 
 const SYSTEM_BOARD_AUTHORS = new Set(['team-session'])
 
-export function toIsoTimestamp(value: unknown): string {
+export function toIsoTimestamp(value: unknown): string | null {
   if (typeof value === 'string' && value.trim()) return value
-  if (typeof value !== 'number' || Number.isNaN(value)) return new Date().toISOString()
+  if (typeof value !== 'number' || Number.isNaN(value)) return null
   const ms = value < 1_000_000_000_000 ? value * 1000 : value
   return new Date(ms).toISOString()
 }
@@ -363,8 +363,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     votes,
     vote_balance: score,
     comment_count: commentCount,
-    created_at: createdAt,
-    updated_at: updatedAt,
+    created_at: createdAt ?? '',
+    updated_at: updatedAt ?? '',
     flair: flairValue,
     hearth: asString(raw.hearth, '').trim() || null,
     visibility: asString(raw.visibility, '').trim() || undefined,
@@ -389,7 +389,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     post_id: postId,
     author,
     content: asString(raw.content, ''),
-    created_at: toIsoTimestamp(raw.created_at),
+    created_at: toIsoTimestamp(raw.created_at) ?? '',
   }
 }
 

--- a/dashboard/src/api/trpg.ts
+++ b/dashboard/src/api/trpg.ts
@@ -120,7 +120,7 @@ function normalizeEvent(value: unknown, actorNames: Map<string, string>): TrpgEv
   const type = asString(raw.type, 'event')
   return {
     type,
-    actor: actorName || actorId || 'system',
+    actor: actorName || actorId || undefined,
     actor_id: actorId || undefined,
     actor_name: actorName || undefined,
     seq: asInt(raw.seq),
@@ -130,7 +130,7 @@ function normalizeEvent(value: unknown, actorNames: Map<string, string>): TrpgEv
     visibility: asString(raw.visibility, '') || asString(payload.visibility, '') || undefined,
     event_id: asString(raw.event_id, '') || undefined,
     content: eventContent(type, payload),
-    timestamp: asString(raw.ts, '') || asString(raw.timestamp, '') || new Date().toISOString(),
+    timestamp: asString(raw.ts, '') || asString(raw.timestamp, '') || undefined,
   }
 }
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -13,14 +13,16 @@ import { formatDuration } from './mission-utils'
 
 type StatusFilter = 'all' | 'active' | 'idle' | 'offline'
 
-function statusCategory(status: string): StatusFilter {
+function statusCategory(status: string | undefined): StatusFilter {
+  if (!status) return 'idle'
   const s = status.toLowerCase()
   if (s === 'active' || s === 'busy' || s === 'listening' || s === 'working') return 'active'
   if (s === 'offline' || s === 'inactive') return 'offline'
   return 'idle'
 }
 
-function statusLabel(status: string): string {
+function statusLabel(status: string | undefined): string {
+  if (!status) return '(unknown)'
   const labels: Record<string, string> = {
     active: '활성', busy: '처리 중', listening: '대기', working: '작업 중',
     idle: '유휴', offline: '오프라인', inactive: '비활성',
@@ -28,7 +30,7 @@ function statusLabel(status: string): string {
   return labels[status.toLowerCase()] ?? status
 }
 
-function statusBadgeClass(status: string): string {
+function statusBadgeClass(status: string | undefined): string {
   const cat = statusCategory(status)
   if (cat === 'active') return 'roster-badge--active'
   if (cat === 'offline') return 'roster-badge--offline'

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -154,7 +154,7 @@ export function agentPresenceView(agent: Agent): WarRoomPresenceView {
     ].filter(Boolean).join(' · ') || '글로벌 agent roster',
     chips: [
       agent.context_ratio != null ? `ctx ${Math.round(agent.context_ratio * 100)}%` : 'ctx n/a',
-      agent.status,
+      agent.status ?? '(unknown)',
     ],
     note: agent.personalityHint ?? null,
   }

--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -73,8 +73,8 @@ export function buildAgentMotion(
   ).length
 
   const recentMessage = messages
-    .filter(message => normalizeAgentKey(message.from) === agentKey)
-    .sort((a, b) => toEpoch(b.timestamp) - toEpoch(a.timestamp))[0]
+    .filter(message => normalizeAgentKey(message.from ?? '') === agentKey)
+    .sort((a, b) => toEpoch(b.timestamp ?? '') - toEpoch(a.timestamp ?? ''))[0]
 
   const recentJournal = journal
     .filter(entry =>
@@ -91,7 +91,7 @@ export function buildAgentMotion(
     .filter(keeper => normalizeAgentKey(keeper.name) === agentKey && keeperSignalTimestamp(keeper) !== null)
     .sort((a, b) => toEpoch(keeperSignalTimestamp(b) ?? 0) - toEpoch(keeperSignalTimestamp(a) ?? 0))[0]
 
-  const messageTs = recentMessage ? toEpoch(recentMessage.timestamp) : 0
+  const messageTs = recentMessage ? toEpoch(recentMessage.timestamp ?? '') : 0
   const journalTs = recentJournal ? toEpoch(recentJournal.timestamp) : 0
   const boardTs = recentBoardPost ? toEpoch(recentBoardPost.updated_at || recentBoardPost.created_at) : 0
   const keeperTs = recentKeeper ? toEpoch(keeperSignalTimestamp(recentKeeper) ?? 0) : 0

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -8,7 +8,7 @@ export type CanonicalKeeperCardModel = {
   koreanName?: string | null
   runtimeLabel?: string | null
   emoji?: string | null
-  tone: string
+  tone?: string
   statusRaw?: string | null
   statusLabel: string
   stateClass?: string | null
@@ -61,14 +61,15 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
     || (model.recentTools?.length ?? 0) > 0
     || (model.allowedTools?.length ?? 0) > 0
 
+  const toneClass = model.tone ?? ''
   const wrapperClass =
     variant === 'mission'
-      ? `mission-activity-card ${model.tone}`
+      ? `mission-activity-card ${toneClass}`
       : 'keeper-canonical-card'
   const buttonClass =
     variant === 'mission'
       ? 'mission-card-select'
-      : `monitor-row ${model.tone}${model.stateClass ? ` state-${model.stateClass}` : ''}`
+      : `monitor-row ${toneClass}${model.stateClass ? ` state-${model.stateClass}` : ''}`
 
   return html`
     <article class=${wrapperClass}>
@@ -89,9 +90,9 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
             ? html`
                 <${MitosisRing} ratio=${model.contextRatio ?? 0} size=${34} stroke=${4} />
                 <${StatusBadge} status=${model.statusRaw ?? 'unknown'} />
-                ${model.stateLabel ? html`<span class="monitor-pill ${model.tone}">${model.stateLabel}</span>` : null}
+                ${model.stateLabel ? html`<span class="monitor-pill ${toneClass}">${model.stateLabel}</span>` : null}
               `
-            : html`<span class="command-chip ${model.tone}">${model.statusLabel}</span>`}
+            : html`<span class="command-chip ${toneClass}">${model.statusLabel}</span>`}
         </div>
 
         <div class=${variant === 'mission' ? 'mission-activity-meta' : 'monitor-meta'}>

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -24,7 +24,7 @@ export function normalizeAgentStatus(value: unknown): Agent['status'] {
   }
   if (raw === 'in_progress' || raw === 'claimed') return 'busy'
   if (raw === 'dead' || raw === 'left') return 'offline'
-  return 'offline'
+  return undefined
 }
 
 export function normalizeTaskStatus(value: unknown): Task['status'] {
@@ -33,7 +33,7 @@ export function normalizeTaskStatus(value: unknown): Task['status'] {
     return raw
   }
   if (raw === 'inprogress') return 'in_progress'
-  return 'todo'
+  return undefined
 }
 
 export function normalizeAgent(raw: unknown): Agent | null {
@@ -77,9 +77,9 @@ export function normalizeTask(raw: unknown): Task | null {
 
 export function normalizeMessage(raw: unknown): Message | null {
   if (!isRecord(raw)) return null
-  const from = asString(raw.from) ?? asString(raw.from_agent) ?? 'system'
+  const from = asString(raw.from) ?? asString(raw.from_agent)
   const content = asString(raw.content) ?? ''
-  const timestamp = asString(raw.timestamp) ?? new Date().toISOString()
+  const timestamp = asString(raw.timestamp)
   return {
     id: asString(raw.id),
     seq: asNumber(raw.seq),
@@ -93,7 +93,7 @@ export function normalizeMessage(raw: unknown): Message | null {
 export function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['severity'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
   if (raw === 'ok' || raw === 'warn' || raw === 'bad') return raw
-  return 'ok'
+  return undefined
 }
 
 export function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
@@ -337,7 +337,7 @@ export function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAct
 
 export function messageSortKey(message: Message): number {
   if (typeof message.seq === 'number' && Number.isFinite(message.seq)) return message.seq
-  const parsed = Date.parse(message.timestamp)
+  const parsed = Date.parse(message.timestamp ?? '')
   return Number.isNaN(parsed) ? 0 : parsed
 }
 
@@ -347,13 +347,13 @@ export function mergeMessages(current: Message[], incoming: Message[]): Message[
   for (const message of current) {
     const key = typeof message.seq === 'number'
       ? `seq:${message.seq}`
-      : `ts:${message.timestamp}|from:${message.from}|content:${message.content}`
+      : `ts:${message.timestamp ?? ''}|from:${message.from ?? ''}|content:${message.content}`
     byKey.set(key, message)
   }
   for (const message of incoming) {
     const key = typeof message.seq === 'number'
       ? `seq:${message.seq}`
-      : `ts:${message.timestamp}|from:${message.from}|content:${message.content}`
+      : `ts:${message.timestamp ?? ''}|from:${message.from ?? ''}|content:${message.content}`
     byKey.set(key, message)
   }
   return [...byKey.values()]

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -7,7 +7,7 @@ import type { TrpgCharacterStats } from './trpg'
 export interface Agent {
   name: string
   agent_type?: string
-  status: 'active' | 'busy' | 'listening' | 'idle' | 'inactive' | 'offline'
+  status?: 'active' | 'busy' | 'listening' | 'idle' | 'inactive' | 'offline'
   current_task: string | null
   context_ratio?: number
   joined_at?: string
@@ -28,7 +28,7 @@ export interface Agent {
 export interface Task {
   id: string
   title: string
-  status: 'todo' | 'in_progress' | 'claimed' | 'done' | 'cancelled'
+  status?: 'todo' | 'in_progress' | 'claimed' | 'done' | 'cancelled'
   priority?: number
   assignee?: string
   description?: string
@@ -39,9 +39,9 @@ export interface Task {
 export interface Message {
   id?: string
   seq?: number
-  from: string
+  from?: string
   content: string
-  timestamp: string
+  timestamp?: string
   type?: string
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -116,7 +116,7 @@ export interface DashboardExecutionHandoff {
 export interface DashboardExecutionQueueItem {
   id: string
   kind: DashboardExecutionQueueKind
-  severity: DashboardExecutionTone
+  severity?: DashboardExecutionTone
   status?: string
   summary: string
   target_type: string
@@ -174,7 +174,7 @@ export interface DashboardExecutionWorkerSupportBrief {
   name: string
   agent_name?: string
   status?: Agent['status'] | string
-  tone: DashboardExecutionTone
+  tone?: DashboardExecutionTone
   state: DashboardExecutionWorkerState
   note: string
   focus: string
@@ -196,7 +196,7 @@ export interface DashboardExecutionContinuityBrief {
   name: string
   agent_name?: string | null
   status?: string
-  tone: DashboardExecutionTone
+  tone?: DashboardExecutionTone
   state: DashboardExecutionContinuityState
   note: string
   focus: string

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -163,8 +163,6 @@ export interface BoardMonitoring {
   last_activity_age_s?: number | null
   slo_target_age_s?: number
   slo_breached?: boolean
-  warn_age_s?: number
-  bad_age_s?: number
 }
 
 export interface GovernanceMonitoring {
@@ -180,8 +178,6 @@ export interface GovernanceMonitoring {
   slo_target_case_age_s?: number
   slo_breached?: boolean
   judge_online?: boolean
-  warn_age_s?: number
-  bad_age_s?: number
 }
 
 export interface SocialRuntimeStatus {

--- a/dashboard/src/types/trpg.ts
+++ b/dashboard/src/types/trpg.ts
@@ -51,7 +51,7 @@ export interface TrpgEvent {
   event_id?: string
   content: string
   dice_roll?: DiceRoll
-  timestamp: string
+  timestamp?: string
 }
 
 export interface DiceRoll {

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -28,7 +28,6 @@ let room_status_json (config : Room.config) : Yojson.Safe.t =
       ("current_room", `String current_room);
       ("tempo_interval_s", `Float tempo.current_interval_s);
       ("paused", `Bool paused);
-      ("lodge", `Assoc [("status", `String "deprecated")]);
       ("social_runtime", social_runtime_json);
       ("version", `String Version.version);
     ]
@@ -243,8 +242,6 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           ("status", room_status_json config);
           ("social_tick", social_tick_summary);
           ("social_checkins", `List social_checkins);
-          ("lodge_tick", `Assoc [("status", `String "deprecated")]);
-          ("lodge_checkins", `List []);
           ("execution_queue", `List (List.map (fun (row : queue_context) -> row.json) limited_queue));
           ("session_briefs", `List (List.map (fun (row : session_context) -> row.json) limited_sessions));
           ("operation_briefs", `List (List.map (fun (row : operation_context) -> row.json) limited_ops));

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -45,7 +45,6 @@ let execution_smoke_fixture_json () =
             ("project", `String "execution-smoke");
             ("tempo_interval_s", `Float 300.0);
             ("paused", `Bool false);
-            ("lodge", `Assoc []);
             ( "social_runtime",
               `Assoc
                 [
@@ -74,80 +73,6 @@ let execution_smoke_fixture_json () =
             ("activity_report", `String "alpha acted, beta passed, gamma skipped");
           ] );
       ( "social_checkins",
-        `List
-          [
-            `Assoc
-              [
-                ("agent_name", `String "dreamer");
-                ("trigger", `String "scheduled");
-                ("outcome", `String "acted");
-                ("summary", `String "posted a runtime note to the board");
-                ("reason", `String "runtime pressure on the board justified a post");
-                ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_list"; `String "masc_board_post"; `String "lodge_search" ]);
-                ("used_tool_names", `List [ `String "masc_board_post" ]);
-                ("used_tool_call_count", `Int 1);
-                ("action_kind", `String "post");
-                ("tool_audit_source", `String "heartbeat_result");
-                ("tool_audit_at", `String generated_at);
-                ("checked_at", `String generated_at);
-                ("decision_reason", `String "critical board state required intervention");
-                ("worker_name", `String "local-dreamer");
-                ("failure_reason", `Null);
-              ];
-            `Assoc
-              [
-                ("agent_name", `String "historian");
-                ("trigger", `String "scheduled");
-                ("outcome", `String "passed");
-                ("summary", `Null);
-                ("reason", `String "stayed read-only after evaluating the board");
-                ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_list"; `String "lodge_profile"; `String "lodge_research" ]);
-                ("used_tool_names", `List []);
-                ("used_tool_call_count", `Null);
-                ("action_kind", `String "none");
-                ("tool_audit_source", `String "heartbeat_task");
-                ("tool_audit_at", `String generated_at);
-                ("checked_at", `String generated_at);
-                ("decision_reason", `String "not enough evidence to post");
-                ("worker_name", `Null);
-                ("failure_reason", `Null);
-              ];
-            `Assoc
-              [
-                ("agent_name", `String "connector");
-                ("trigger", `String "scheduled");
-                ("outcome", `String "skipped");
-                ("summary", `Null);
-                ("reason", `String "rate-limited after a recent board action");
-                ("allowed_tool_names", `List []);
-                ("used_tool_names", `List []);
-                ("used_tool_call_count", `Null);
-                ("action_kind", `String "none");
-                ("tool_audit_source", `Null);
-                ("tool_audit_at", `Null);
-                ("checked_at", `String generated_at);
-                ("decision_reason", `Null);
-                ("worker_name", `Null);
-                ("failure_reason", `Null);
-              ];
-          ] );
-      ( "lodge_tick",
-        `Assoc
-          [
-            ("checked", `Int 3);
-            ("acted", `Int 1);
-            ("passed", `Int 1);
-            ("skipped", `Int 1);
-            ("failed", `Int 0);
-            ("last_tick_at", `String generated_at);
-            ("last_skip_reason", `String "rate-limited after a recent board action");
-            ("last_pass_reason", `String "stayed read-only after evaluating the board");
-            ("last_system_skip_reason", `String "rate-limited after a recent board action");
-            ("strategy", `String "event_driven");
-            ("queue_depth", `Int 0);
-            ("activity_report", `String "alpha acted, beta passed, gamma skipped");
-          ] );
-      ( "lodge_checkins",
         `List
           [
             `Assoc

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -225,12 +225,19 @@ let tone_rank = function
   | _ -> 0
 
 let dashboard_fixture_name ?fixture () =
-  match fixture with
-  | Some value when String.trim value <> "" -> Some (String.trim value)
-  | _ -> (
-      match Sys.getenv_opt "MASC_DASHBOARD_FIXTURE" with
-      | Some value when String.trim value <> "" -> Some (String.trim value)
-      | _ -> None)
+  let fixtures_enabled =
+    match Sys.getenv_opt "MASC_DASHBOARD_FIXTURES_ENABLED" with
+    | Some v when String.lowercase_ascii (String.trim v) = "true" -> true
+    | _ -> false
+  in
+  if not fixtures_enabled then None
+  else
+    match fixture with
+    | Some value when String.trim value <> "" -> Some (String.trim value)
+    | _ -> (
+        match Sys.getenv_opt "MASC_DASHBOARD_FIXTURE" with
+        | Some value when String.trim value <> "" -> Some (String.trim value)
+        | _ -> None)
 
 let get_agent_identity (name : string) =
   let contains s sub =

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -20,80 +20,32 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
   let failures = ref 0 in
   let timeouts = ref 0 in
   let durations_rev = ref [] in
-  let duration_count = ref 0 in
-  let duration_sum = ref 0 in
-  let keeper_status_calls = ref 0 in
-  let keeper_status_failures = ref 0 in
-  let keeper_status_timeouts = ref 0 in
-  let keeper_msg_calls = ref 0 in
-  let keeper_msg_failures = ref 0 in
-  let keeper_msg_timeouts = ref 0 in
   List.iter
     (fun (e : Tool_audit.audit_event) ->
       if e.event_type = "tool_call" then begin
         incr total;
         if not e.success then incr failures;
-        let (tool_name, timeout_now, duration_ms_opt) =
+        let (_tool_name, timeout_now, duration_ms_opt) =
           parse_tool_call_detail e.detail
         in
         if timeout_now then incr timeouts;
         (match duration_ms_opt with
-         | Some d ->
-             incr duration_count;
-             duration_sum := !duration_sum + d;
-             durations_rev := d :: !durations_rev
-         | None -> ());
-        if tool_name = "masc_keeper_status" then begin
-          incr keeper_status_calls;
-          if not e.success then incr keeper_status_failures;
-          if timeout_now then incr keeper_status_timeouts;
-        end else if tool_name = "masc_keeper_msg" then begin
-          incr keeper_msg_calls;
-          if not e.success then incr keeper_msg_failures;
-          if timeout_now then incr keeper_msg_timeouts;
-        end
+         | Some d -> durations_rev := d :: !durations_rev
+         | None -> ())
       end)
     events;
   let total_f = float_of_int !total in
   let failure_rate =
     if !total = 0 then 0.0 else float_of_int !failures /. total_f
   in
-  let timeout_rate =
-    if !total = 0 then 0.0 else float_of_int !timeouts /. total_f
-  in
-  let avg_duration_ms =
-    if !duration_count = 0 then 0.0
-    else float_of_int !duration_sum /. float_of_int !duration_count
-  in
   let p95_duration_ms = percentile_int !durations_rev ~pct:0.95 in
-  let keeper_msg_timeout_sec =
-    int_of_env_default
-      "MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC"
-      ~default:45
-      ~min_v:10
-      ~max_v:300
-  in
   `Assoc [
     ("window_hours", `Float window_hours);
     ("tool_calls", `Int !total);
     ("failures", `Int !failures);
     ("timeouts", `Int !timeouts);
     ("failure_rate", `Float failure_rate);
-    ("timeout_rate", `Float timeout_rate);
-    ("duration_sample_count", `Int !duration_count);
-    ("avg_duration_ms", `Float avg_duration_ms);
     ("p95_duration_ms", match p95_duration_ms with Some v -> `Int v | None -> `Null);
-    ("keeper_msg_timeout_sec", `Int keeper_msg_timeout_sec);
-    ("keeper_status", `Assoc [
-      ("calls", `Int !keeper_status_calls);
-      ("failures", `Int !keeper_status_failures);
-      ("timeouts", `Int !keeper_status_timeouts);
-    ]);
-    ("keeper_msg", `Assoc [
-      ("calls", `Int !keeper_msg_calls);
-      ("failures", `Int !keeper_msg_failures);
-      ("timeouts", `Int !keeper_msg_timeouts);
-    ]);
   ]
 
 let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
@@ -166,8 +118,6 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("last_activity_age_s", json_int_opt last_activity_age_s);
       ("slo_target_age_s", `Int slo_target_age_s);
       ("slo_breached", `Bool slo_breached);
-      ("warn_age_s", `Int warn_age_s);
-      ("bad_age_s", `Int bad_age_s);
     ], true)
   with exn ->
     Log.Dashboard.error "board_monitoring_json failed: %s"
@@ -180,8 +130,6 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("last_activity_age_s", `Null);
       ("slo_target_age_s", `Int slo_target_age_s);
       ("slo_breached", `Bool false);
-      ("warn_age_s", `Int warn_age_s);
-      ("bad_age_s", `Int bad_age_s);
     ], false)
 
 let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
@@ -297,8 +245,6 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("slo_target_case_age_s", `Int slo_target_quorum_age_s);
       ("slo_breached", `Bool slo_breached);
       ("judge_online", `Bool judge_online);
-      ("warn_age_s", `Int warn_age_s);
-      ("bad_age_s", `Int bad_age_s);
     ], true)
   with exn ->
     Log.Dashboard.error "governance_monitoring_json failed: %s"
@@ -316,6 +262,4 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("slo_target_case_age_s", `Int slo_target_quorum_age_s);
       ("slo_breached", `Bool false);
       ("judge_online", `Bool false);
-      ("warn_age_s", `Int warn_age_s);
-      ("bad_age_s", `Int bad_age_s);
     ], false)

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -27,6 +27,7 @@ let test_dashboard_execution_fixture () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Lib.Room_utils.default_config dir in
+      Unix.putenv "MASC_DASHBOARD_FIXTURES_ENABLED" "true";
       Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let json =


### PR DESCRIPTION
## Summary
- **Phase 1**: Normalizer가 누락 데이터를 가짜 기본값으로 채우던 동작 제거. `undefined`/`null` 반환으로 변경하고 UI에서 `(unknown)` 표시.
- **Phase 2**: deprecated lodge 필드, 미사용 모니터링 필드(keeper_status, keeper_msg, warn_age_s 등) 응답에서 제거. 127줄 순삭.
- Fixture 응답은 `MASC_DASHBOARD_FIXTURES_ENABLED=true` 환경변수 없이 비활성화.

## Changes
| Area | File | What |
|------|------|------|
| Backend | `dashboard_execution_helpers.ml` | Fixture env var gate |
| Backend | `dashboard_execution.ml` | Remove lodge from room_status, lodge_tick/lodge_checkins from payload |
| Backend | `dashboard_execution_fixture.ml` | Remove lodge from fixture |
| Backend | `dashboard_http_monitoring.ml` | Slim tool_call_health, board, governance JSON |
| Frontend | `store-normalizers.ts` | Return undefined for unknown agent/task/message/tone |
| Frontend | `api/board.ts` | toIsoTimestamp returns null for missing |
| Frontend | `api/trpg.ts` | normalizeEvent actor/timestamp → undefined |
| Frontend | `types/*.ts` | Make status/from/timestamp/tone/severity optional |
| Frontend | UI components (4 files) | Handle undefined with safe fallbacks |

## Test plan
- [x] `dune build --root .` — OCaml 빌드 통과
- [x] `test_dashboard_execution.exe` — 5/5 테스트 통과
- [x] `npm run build` — TypeScript + Vite 빌드 통과
- [ ] `curl localhost:8935/api/v1/dashboard/execution?fixture=execution_smoke` → fixture 미노출 (MASC_DASHBOARD_FIXTURES_ENABLED 미설정 시)
- [ ] 응답에 `lodge`, `warn_age_s`, `keeper_status` 미포함 확인
- [ ] 브라우저에서 누락 데이터 "(unknown)" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)