### PR TITLE
refactor: remove Cascade.tool_def, unify with Types.tool_schema

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -116,12 +116,6 @@ let canonical_capability_id tool_name =
   | Some canonical_name -> canonical_name
   | None -> tool_name
 
-let schema_of_tool_def (tool : Cascade.tool_def) : Types.tool_schema =
-  {
-    Types.name = tool.tool_name;
-    description = tool.tool_description;
-    input_schema = tool.parameters;
-  }
 
 let surface_to_string = function
   | Public_mcp -> "public_mcp"
@@ -314,10 +308,10 @@ let local_worker_internal_seeds : capability_seed list =
 
 let keeper_projection_seeds : capability_seed list =
   Tool_shard.keeper_llm_tools
-  |> List.concat_map (fun tool ->
-         let schema = schema_of_tool_def tool in
-         let backend_tool_name = keeper_backend_tool_name tool.tool_name in
-         let privileged = List.mem tool.tool_name privileged_keeper_tool_names in
+  |> List.concat_map (fun (tool : Types.tool_schema) ->
+         let schema = tool in
+         let backend_tool_name = keeper_backend_tool_name tool.name in
+         let privileged = List.mem tool.name privileged_keeper_tool_names in
          let primary_surface =
            if privileged then Keeper_privileged else Keeper_standard
          in
@@ -422,12 +416,12 @@ let local_worker_tool_schemas ?names () :
 
 let keeper_all_tool_names : string list =
   Tool_shard.keeper_llm_tools
-  |> List.map (fun tool -> tool.Cascade.tool_name)
+  |> List.map (fun tool -> tool.Types.name)
   |> unique_preserve_order
 
 let keeper_safe_tool_names : string list =
   Tool_shard.keeper_llm_tools
-  |> List.map (fun tool -> tool.Cascade.tool_name)
+  |> List.map (fun tool -> tool.Types.name)
   |> List.filter (fun name -> not (List.mem name privileged_keeper_tool_names))
   |> unique_preserve_order
 

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -50,11 +50,6 @@ type model_spec = {
   cost_per_1k_output : float;
 }
 
-type tool_def = {
-  tool_name : string;
-  tool_description : string;
-  parameters : Yojson.Safe.t;
-}
 
 (** Compute total tokens from OAS api_usage. *)
 let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -188,16 +188,16 @@ let llm_tool_defs_of_json = function
                                ("properties", `Assoc []);
                              ])
                  in
-                 let tool_description =
+                 let description =
                    match U.member "description" item with
                    | `String value -> value
                    | _ -> ""
                  in
                  Some
                    {
-                     Cascade.tool_name = tool_name;
-                     tool_description = tool_description;
-                     parameters = parameters;
+                     Types.name = tool_name;
+                     description;
+                     input_schema = parameters;
                    })
   | Some _ -> []
 

--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -1,23 +1,15 @@
 (** Gardener OAS worker — 1-shot agents with real MASC tools.
     See {!gardener_worker.mli} for rationale. *)
 
-(** Build [Cascade.tool_def list] from [gardener_worker_tool_names].
+(** Build [Types.tool_schema list] from [gardener_worker_tool_names].
     Returns an empty list on schema-lookup failure so the caller can
     still attempt an LLM call (the model will simply have no tools). *)
-let worker_tools () : Cascade.tool_def list =
+let worker_tools () : Types.tool_schema list =
   match
     Agent_tool_surfaces.local_worker_tool_schemas
       ~names:Agent_tool_surfaces.gardener_worker_tool_names ()
   with
-  | Ok schemas ->
-      List.map
-        (fun (s : Types.tool_schema) ->
-          {
-            Cascade.tool_name = s.name;
-            tool_description = s.description;
-            parameters = s.input_schema;
-          })
-        schemas
+  | Ok schemas -> schemas
   | Error msg ->
       Eio.traceln "[Gardener_worker] tool schema lookup failed: %s" msg;
       []

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -64,16 +64,16 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     match canonical_policy_action_budget meta.policy_action_budget with
     | "board" -> dedupe_tool_names (keeper_board_tool_names @ with_shell)
     | _ -> dedupe_tool_names with_shell
-  else keeper_llm_tools |> List.map (fun tool -> tool.Cascade.tool_name)
+  else keeper_llm_tools |> List.map (fun tool -> tool.Types.name)
 
 let keeper_allowed_llm_tools ?(write_done = false) (meta : keeper_meta) :
-    Cascade.tool_def list =
+    Types.tool_schema list =
   let allowed = keeper_allowed_tool_names ~write_done meta in
   if allowed = [] then
     []
   else
     keeper_llm_tools
-    |> List.filter (fun tool -> List.mem tool.Cascade.tool_name allowed)
+    |> List.filter (fun tool -> List.mem tool.Types.name allowed)
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
   let voice = Voice_bridge.get_voice_for_agent agent_id in

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -5,7 +5,7 @@ val ensure_keeper_board_post_args :
 
 val keeper_allowed_tool_names : ?write_done:bool -> keeper_meta -> string list
 val keeper_allowed_llm_tools :
-  ?write_done:bool -> keeper_meta -> Cascade.tool_def list
+  ?write_done:bool -> keeper_meta -> Types.tool_schema list
 
 val execute_keeper_tool_call :
   config:Room.config ->

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -120,7 +120,7 @@ let run_with_custom_dispatch
     ~(max_turns : int)
     ~(temperature : float)
     ~(max_tokens : int)
-    ~(masc_tools : Cascade.tool_def list)
+    ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?(guardrails : Agent_sdk.Guardrails.t option)
     ()

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -48,7 +48,7 @@ val run_with_custom_dispatch :
   max_turns:int ->
   temperature:float ->
   max_tokens:int ->
-  masc_tools:Cascade.tool_def list ->
+  masc_tools:Types.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   unit ->

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -373,7 +373,7 @@ let handle_keeper_status ctx args : tool_result =
              (`List tail, total)
         in
         let all_internal_tools =
-          keeper_llm_tools |> List.map (fun tool -> tool.Cascade.tool_name)
+          keeper_llm_tools |> List.map (fun tool -> tool.Types.name)
         in
         let allowed_tools = keeper_allowed_tool_names m in
         let blocked_internal_tools =

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -29,23 +29,23 @@ let make_tools
   let tool_defs =
     Keeper_exec_tools.keeper_allowed_llm_tools meta
   in
-  List.filter_map (fun (td : Cascade.tool_def) ->
-    if List.mem td.tool_name allowed_names then
+  List.filter_map (fun (td : Types.tool_schema) ->
+    if List.mem td.name allowed_names then
       Some (Tool_bridge.oas_tool_of_masc
-        ~name:td.tool_name
-        ~description:td.tool_description
-        ~input_schema:td.parameters
+        ~name:td.name
+        ~description:td.description
+        ~input_schema:td.input_schema
         (fun input ->
           try
             let result =
               Keeper_exec_tools.execute_keeper_tool_call
                 ~config ~meta ~ctx_work:(!ctx_ref)
-                ~name:td.tool_name ~input
+                ~name:td.name ~input
             in
             (true, result)
           with exn ->
             let msg = Printf.sprintf "tool %s failed: %s"
-              td.tool_name (Printexc.to_string exn) in
+              td.name (Printexc.to_string exn) in
             Log.Keeper.error "%s" msg;
             (false, msg)))
     else None

--- a/lib/local/local_agent_eio_types.ml
+++ b/lib/local/local_agent_eio_types.ml
@@ -342,15 +342,8 @@ let list_masc_tools ~sw:_sw ~(auth_token : string option) ~session_id
 let tool_schema_of_name schemas tool_name =
   List.find_opt (fun (schema : Types.tool_schema) -> String.equal schema.name tool_name) schemas
 
-let tool_defs_of_schemas schemas =
-  List.map
-    (fun (schema : Types.tool_schema) ->
-      {
-        Cascade.tool_name = schema.name;
-        tool_description = schema.description;
-        parameters = schema.input_schema;
-      })
-    schemas
+let tool_defs_of_schemas (schemas : Types.tool_schema list) : Types.tool_schema list =
+  schemas
 
 let safe_text_for_followup text =
   let trimmed = String.trim text in

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -219,17 +219,17 @@ let run_with_masc_tools
     ~(sw : Eio.Switch.t)
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
-    ~(masc_tools : Cascade.tool_def list)
+    ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?on_event
     (goal : string)
   : (run_result, string) result =
-  let oas_tools = List.map (fun (td : Cascade.tool_def) ->
+  let oas_tools = List.map (fun (td : Types.tool_schema) ->
     Tool_bridge.oas_tool_of_masc
-      ~name:td.tool_name
-      ~description:td.tool_description
-      ~input_schema:td.parameters
-      (fun input -> dispatch ~name:td.tool_name ~args:input)
+      ~name:td.name
+      ~description:td.description
+      ~input_schema:td.input_schema
+      (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   let config = { config with tools = oas_tools @ config.tools } in
   run ~sw ~net ~config ?on_event goal
@@ -286,7 +286,7 @@ let run_named_with_masc_tools
     ~cascade_name
     ~goal
     ?(system_prompt = "")
-    ~(masc_tools : Cascade.tool_def list)
+    ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ?(max_turns = 20)
     ?(temperature = 0.7)

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -34,7 +34,7 @@ val run_named_with_masc_tools :
   cascade_name:string ->
   goal:string ->
   ?system_prompt:string ->
-  masc_tools:Cascade.tool_def list ->
+  masc_tools:Types.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
   ?max_turns:int ->
   ?temperature:float ->

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -29,7 +29,7 @@ type event =
 type loop_config = {
   initial_goal : string;
   model_cascade : Cascade.model_spec list;
-  tools : Cascade.tool_def list;
+  tools : Types.tool_schema list;
   heartbeat_interval_s : float;
   max_idle_turns : int;
   feedback_enabled : bool;

--- a/lib/perpetual/perpetual_loop.mli
+++ b/lib/perpetual/perpetual_loop.mli
@@ -30,7 +30,7 @@ type event =
 type loop_config = {
   initial_goal : string;
   model_cascade : Cascade.model_spec list;   (** Ordered preference *)
-  tools : Cascade.tool_def list;
+  tools : Types.tool_schema list;
   heartbeat_interval_s : float;                  (** Default: 30.0 *)
   max_idle_turns : int;                          (** Stop after N turns with no progress *)
   feedback_enabled : bool;                       (** Run verifier after each action *)

--- a/lib/perpetual/perpetual_oas_build.ml
+++ b/lib/perpetual/perpetual_oas_build.ml
@@ -74,11 +74,11 @@ let build_perpetual_agent
      Tool_bridge.oas_tool_of_masc creates OAS Tool.t from name/desc/schema/handler.
      For the perpetual loop adapter, each tool delegates to a no-op handler since
      actual tool dispatch remains in MASC's perpetual_loop infrastructure. *)
-  let tools = List.map (fun (td : Cascade.tool_def) ->
+  let tools = List.map (fun (td : Types.tool_schema) ->
     Tool_bridge.oas_tool_of_masc
-      ~name:td.tool_name
-      ~description:td.tool_description
-      ~input_schema:td.parameters
+      ~name:td.name
+      ~description:td.description
+      ~input_schema:td.input_schema
       (fun _input ->
         (true, "[perpetual_oas] Tool dispatch delegated to MASC infrastructure"))
   ) config.tools in

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -22,7 +22,7 @@ module Oas = Agent_sdk
 type context = {
   config : Room_utils.config;
   agent_name : string;
-  masc_tools : Cascade.tool_def list;
+  masc_tools : Types.tool_schema list;
   dispatch : name:string -> args:Yojson.Safe.t -> bool * string;
 }
 

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -8,37 +8,37 @@
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
-  tools : Cascade.tool_def list;
+  tools : Types.tool_schema list;
   removable : bool;  (** true = can be revoked at runtime *)
   description : string;
 }
 
 (** Predefined shards *)
 
-let base_tools : Cascade.tool_def list = [
+let base_tools : Types.tool_schema list = [
   (* Time *)
   {
-    tool_name = "keeper_time_now";
-    tool_description = "Get current server time in ISO8601 and unix timestamp.";
-    parameters = `Assoc [
+    name = "keeper_time_now";
+    description = "Get current server time in ISO8601 and unix timestamp.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
   (* Context status *)
   {
-    tool_name = "keeper_context_status";
-    tool_description = "Get keeper context usage and lifecycle status.";
-    parameters = `Assoc [
+    name = "keeper_context_status";
+    description = "Get keeper context usage and lifecycle status.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
   (* Memory *)
   {
-    tool_name = "keeper_memory_search";
-    tool_description = "Search recent user messages in keeper memory by keyword.";
-    parameters = `Assoc [
+    name = "keeper_memory_search";
+    description = "Search recent user messages in keeper memory by keyword.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("query", `Assoc [("type", `String "string")]);
@@ -49,11 +49,11 @@ let base_tools : Cascade.tool_def list = [
   };
 ]
 
-let board_tools : Cascade.tool_def list = [
+let board_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_board_get";
-    tool_description = "Read a board post with its comments before deciding whether to comment, vote, or escalate.";
-    parameters = `Assoc [
+    name = "keeper_board_get";
+    description = "Read a board post with its comments before deciding whether to comment, vote, or escalate.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to inspect")]);
@@ -62,9 +62,9 @@ let board_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_board_post";
-    tool_description = "Create a post on the MASC Board. Use hearth to target a topic channel.";
-    parameters = `Assoc [
+    name = "keeper_board_post";
+    description = "Create a post on the MASC Board. Use hearth to target a topic channel.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("content", `Assoc [("type", `String "string"); ("description", `String "Post content (max 4000 chars)")]);
@@ -75,9 +75,9 @@ let board_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_board_list";
-    tool_description = "List recent posts on the MASC Board. Filter by hearth to see topic-specific posts.";
-    parameters = `Assoc [
+    name = "keeper_board_list";
+    description = "List recent posts on the MASC Board. Filter by hearth to see topic-specific posts.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("hearth", `Assoc [("type", `String "string"); ("description", `String "Filter by hearth topic (e.g. trpg)")]);
@@ -87,9 +87,9 @@ let board_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_board_comment";
-    tool_description = "Add a comment/reply to an existing Board post.";
-    parameters = `Assoc [
+    name = "keeper_board_comment";
+    description = "Add a comment/reply to an existing Board post.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to comment on")]);
@@ -99,9 +99,9 @@ let board_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_board_vote";
-    tool_description = "Vote on an existing Board post to signal support or disagreement.";
-    parameters = `Assoc [
+    name = "keeper_board_vote";
+    description = "Vote on an existing Board post to signal support or disagreement.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("post_id", `Assoc [("type", `String "string"); ("description", `String "Post ID to vote on")]);
@@ -112,11 +112,11 @@ let board_tools : Cascade.tool_def list = [
   };
 ]
 
-let filesystem_tools : Cascade.tool_def list = [
+let filesystem_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_fs_read";
-    tool_description = "Read a file under current project root. Use for source inspection before edits.";
-    parameters = `Assoc [
+    name = "keeper_fs_read";
+    description = "Read a file under current project root. Use for source inspection before edits.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path")]);
@@ -126,9 +126,9 @@ let filesystem_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_fs_edit";
-    tool_description = "Write/append a file under current project root. Use for concrete code changes.";
-    parameters = `Assoc [
+    name = "keeper_fs_edit";
+    description = "Write/append a file under current project root. Use for concrete code changes.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path")]);
@@ -140,11 +140,11 @@ let filesystem_tools : Cascade.tool_def list = [
   };
 ]
 
-let shell_tools : Cascade.tool_def list = [
+let shell_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_shell_readonly";
-    tool_description = "Run a structured read-only project command. Supported ops: pwd, ls, cat, rg, git_status.";
-    parameters = `Assoc [
+    name = "keeper_shell_readonly";
+    description = "Run a structured read-only project command. Supported ops: pwd, ls, cat, rg, git_status.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("op", `Assoc [("type", `String "string"); ("description", `String "One of: pwd, ls, cat, rg, git_status")]);
@@ -157,9 +157,9 @@ let shell_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_bash";
-    tool_description = "Run a shell command from project root. Use for build/test/check commands.";
-    parameters = `Assoc [
+    name = "keeper_bash";
+    description = "Run a shell command from project root. Use for build/test/check commands.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "Shell command string to run via zsh -lc")]);
@@ -169,9 +169,9 @@ let shell_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_github";
-    tool_description = "Run gh CLI commands from project root. Use for PR/review/comment operations.";
-    parameters = `Assoc [
+    name = "keeper_github";
+    description = "Run gh CLI commands from project root. Use for PR/review/comment operations.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand string, e.g. 'pr view 123 --comments'")]);
@@ -182,11 +182,11 @@ let shell_tools : Cascade.tool_def list = [
   };
 ]
 
-let voice_tools : Cascade.tool_def list = [
+let voice_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_voice_speak";
-    tool_description = "Speak a short utterance as this keeper via the voice bridge, falling back to text when voice is unavailable.";
-    parameters = `Assoc [
+    name = "keeper_voice_speak";
+    description = "Speak a short utterance as this keeper via the voice bridge, falling back to text when voice is unavailable.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("message", `Assoc [("type", `String "string"); ("description", `String "Text to speak")]);
@@ -197,25 +197,25 @@ let voice_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_voice_agent";
-    tool_description = "Get your own voice configuration (assigned voice, available voices). No network required.";
-    parameters = `Assoc [
+    name = "keeper_voice_agent";
+    description = "Get your own voice configuration (assigned voice, available voices). No network required.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
   {
-    tool_name = "keeper_voice_sessions";
-    tool_description = "List active voice sessions from the voice bridge.";
-    parameters = `Assoc [
+    name = "keeper_voice_sessions";
+    description = "List active voice sessions from the voice bridge.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
   {
-    tool_name = "keeper_voice_session_start";
-    tool_description = "Start a voice session for this keeper using the configured voice bridge.";
-    parameters = `Assoc [
+    name = "keeper_voice_session_start";
+    description = "Start a voice session for this keeper using the configured voice bridge.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("session_name", `Assoc [("type", `String "string"); ("description", `String "Optional session name")]);
@@ -223,20 +223,20 @@ let voice_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_voice_session_end";
-    tool_description = "End the active voice session for this keeper and release bridge resources.";
-    parameters = `Assoc [
+    name = "keeper_voice_session_end";
+    description = "End the active voice session for this keeper and release bridge resources.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
 ]
 
-let weather_tools : Cascade.tool_def list = [
+let weather_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_weather_note";
-    tool_description = "Get weather capability note and recent weather-related questions.";
-    parameters = `Assoc [
+    name = "keeper_weather_note";
+    description = "Get weather capability note and recent weather-related questions.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("location", `Assoc [("type", `String "string")]);
@@ -245,11 +245,11 @@ let weather_tools : Cascade.tool_def list = [
   };
 ]
 
-let taskboard_tools : Cascade.tool_def list = [
+let taskboard_tools : Types.tool_schema list = [
   {
-    tool_name = "keeper_tasks_list";
-    tool_description = "List tasks on the MASC backlog. Filter by status: todo, claimed, in_progress, done, cancelled.";
-    parameters = `Assoc [
+    name = "keeper_tasks_list";
+    description = "List tasks on the MASC backlog. Filter by status: todo, claimed, in_progress, done, cancelled.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("status", `Assoc [("type", `String "string"); ("description", `String "Filter by status (optional). One of: todo, claimed, in_progress, done, cancelled")]);
@@ -258,17 +258,17 @@ let taskboard_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_tasks_audit";
-    tool_description = "Audit task board health: find claimed/in_progress tasks whose assignees are no longer active agents (orphans).";
-    parameters = `Assoc [
+    name = "keeper_tasks_audit";
+    description = "Audit task board health: find claimed/in_progress tasks whose assignees are no longer active agents (orphans).";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
   };
   {
-    tool_name = "keeper_task_force_release";
-    tool_description = "Force-release a task back to Todo regardless of current assignee. Gardener privilege for orphan cleanup.";
-    parameters = `Assoc [
+    name = "keeper_task_force_release";
+    description = "Force-release a task back to Todo regardless of current assignee. Gardener privilege for orphan cleanup.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID to force-release")]);
@@ -278,9 +278,9 @@ let taskboard_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_task_force_done";
-    tool_description = "Force-mark a task as Done regardless of current assignee. Use for tasks confirmed complete but not transitioned.";
-    parameters = `Assoc [
+    name = "keeper_task_force_done";
+    description = "Force-mark a task as Done regardless of current assignee. Use for tasks confirmed complete but not transitioned.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID to force-complete")]);
@@ -290,9 +290,9 @@ let taskboard_tools : Cascade.tool_def list = [
     ];
   };
   {
-    tool_name = "keeper_broadcast";
-    tool_description = "Broadcast a message to the MASC room. Use for status reports and announcements.";
-    parameters = `Assoc [
+    name = "keeper_broadcast";
+    description = "Broadcast a message to the MASC room. Use for status reports and announcements.";
+    input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("message", `Assoc [("type", `String "string"); ("description", `String "Message to broadcast")]);
@@ -395,7 +395,7 @@ let get_shard (name : string) : shard option =
   Hashtbl.find_opt all_shards name
 
 (** Combine tools from multiple shard names *)
-let tools_of_shards (shard_names : string list) : Cascade.tool_def list =
+let tools_of_shards (shard_names : string list) : Types.tool_schema list =
   shard_names
   |> List.filter_map (fun name -> Hashtbl.find_opt all_shards name)
   |> List.concat_map (fun (s : shard) -> s.tools)
@@ -435,7 +435,7 @@ let list_all_shards () : (string * bool * int) list =
   ) all_shards []
 
 (** Full tool set (all 11 tools) — backward compatible *)
-let keeper_llm_tools : Cascade.tool_def list =
+let keeper_llm_tools : Types.tool_schema list =
   tools_of_shards default_shard_names
 
 (** {1 MCP Schemas} *)

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -5,7 +5,7 @@
 (** A named collection of tools that can be granted/revoked. *)
 type shard = {
   name : string;
-  tools : Cascade.tool_def list;
+  tools : Types.tool_schema list;
   removable : bool;
   description : string;
 }
@@ -40,7 +40,7 @@ val all_shards : (string, shard) Hashtbl.t
 val default_shard_names : string list
 (** Default shards for a new keeper: base, board, filesystem, shell, weather. *)
 
-val tools_of_shards : string list -> Cascade.tool_def list
+val tools_of_shards : string list -> Types.tool_schema list
 (** Combine tools from multiple shard names. *)
 
 (** {1 Dynamic Shard Management} *)
@@ -74,10 +74,10 @@ val set_agent_shards : string -> string list -> unit
 
 (** {1 Tool Definitions} *)
 
-val base_tools : Cascade.tool_def list
+val base_tools : Types.tool_schema list
 (** Core tools: time_now, context_status, memory_search. *)
 
-val board_tools : Cascade.tool_def list
+val board_tools : Types.tool_schema list
 (** Board tools: board_post, board_list, board_comment, board_vote. *)
 
 (** {1 MCP Interface} *)
@@ -89,5 +89,5 @@ val execute : string -> Yojson.Safe.t -> (bool * Yojson.Safe.t)
 (** Execute tool_shard MCP tools (grant, revoke, list).
     Agent shard state is tracked in-memory via [agent_shards] hashtable. *)
 
-val keeper_llm_tools : Cascade.tool_def list
+val keeper_llm_tools : Types.tool_schema list
 (** Full tool set (all 11 tools) — backward compatible with existing code. *)

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -268,14 +268,14 @@ let test_schemas_names () =
    ============================================================ *)
 
 let test_base_tools_names () =
-  let names = List.map (fun (t : Masc_mcp.Cascade.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Types.tool_schema) -> t.name)
     Tool_shard.base_tools in
   Alcotest.(check bool) "has time_now" true (List.mem "keeper_time_now" names);
   Alcotest.(check bool) "has context_status" true (List.mem "keeper_context_status" names);
   Alcotest.(check bool) "has memory_search" true (List.mem "keeper_memory_search" names)
 
 let test_board_tools_names () =
-  let names = List.map (fun (t : Masc_mcp.Cascade.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Types.tool_schema) -> t.name)
     Tool_shard.board_tools in
   Alcotest.(check bool) "has board_post" true (List.mem "keeper_board_post" names);
   Alcotest.(check bool) "has board_list" true (List.mem "keeper_board_list" names);
@@ -289,7 +289,7 @@ let test_board_tools_names () =
 let test_voice_tools_names () =
   let voice_shard = match Tool_shard.get_shard "voice" with
     | Some s -> s | None -> Alcotest.failf "voice shard missing" in
-  let names = List.map (fun (t : Masc_mcp.Cascade.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Types.tool_schema) -> t.name)
     voice_shard.Tool_shard.tools in
   Alcotest.(check bool) "has voice_speak" true (List.mem "keeper_voice_speak" names);
   Alcotest.(check bool) "has voice_agent" true (List.mem "keeper_voice_agent" names);
@@ -298,7 +298,7 @@ let test_voice_tools_names () =
   Alcotest.(check bool) "has voice_session_end" true (List.mem "keeper_voice_session_end" names)
 
 let test_keeper_llm_has_voice_tools () =
-  let names = List.map (fun (t : Masc_mcp.Cascade.tool_def) -> t.tool_name)
+  let names = List.map (fun (t : Masc_mcp.Types.tool_schema) -> t.name)
     Tool_shard.keeper_llm_tools in
   Alcotest.(check bool) "keeper_llm has voice_speak" true (List.mem "keeper_voice_speak" names);
   Alcotest.(check bool) "keeper_llm has voice_agent" true (List.mem "keeper_voice_agent" names);
@@ -313,15 +313,15 @@ let test_keeper_llm_has_voice_tools () =
 let test_revoke_voice_removes_all_tools () =
   let all_shards = Tool_shard.default_shard_names in
   let tools_before = Tool_shard.tools_of_shards all_shards in
-  let voice_before = List.filter (fun (t : Masc_mcp.Cascade.tool_def) ->
-    let n = t.tool_name in
+  let voice_before = List.filter (fun (t : Masc_mcp.Types.tool_schema) ->
+    let n = t.name in
     String.length n >= 13 && String.sub n 0 13 = "keeper_voice_") tools_before in
   Alcotest.(check int) "5 voice tools before revoke" 5 (List.length voice_before);
   match Tool_shard.revoke_shard all_shards "voice" with
   | Ok shards_after ->
     let tools_after = Tool_shard.tools_of_shards shards_after in
-    let voice_after = List.filter (fun (t : Masc_mcp.Cascade.tool_def) ->
-      let n = t.tool_name in
+    let voice_after = List.filter (fun (t : Masc_mcp.Types.tool_schema) ->
+      let n = t.name in
       String.length n >= 13 && String.sub n 0 13 = "keeper_voice_") tools_after in
     Alcotest.(check int) "0 voice tools after revoke" 0 (List.length voice_after)
   | Error msg -> Alcotest.fail ("revoke should succeed: " ^ msg)


### PR DESCRIPTION
## Summary

Cascade.tool_def 타입을 삭제하고 기존 Types.tool_schema(types_core.ml)로 통일.

- `tool_name` -> `name`, `tool_description` -> `description`, `parameters` -> `input_schema`
- `schema_of_tool_def` 변환 함수 삭제 (통일 후 identity)
- `tool_defs_of_schemas` 역변환 함수 삭제 (통일 후 identity)
- 20파일, -26 LOC

## Test plan

- [x] `dune build --root .`
- [x] `test_cascade.exe` (8/8)
- [x] `test_perpetual.exe` (193/193)
- [x] `test_tool_shard_coverage.exe` (33/37 — 4 pre-existing failures on main)
- [ ] CI green