### PR TITLE
feat(keeper): wire Agent.run() dual-path into handle_keeper_msg

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -247,7 +247,40 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               postpass_budget_ms <= 0 || postpass_remaining_ms () > 0
             in
 
-            (* Single-turn LLM call params *)
+            (* === Dual-path: Agent.run() vs manual loop === *)
+            if Keeper_agent_run.is_enabled () then begin
+              let ctx_ref = ref ctx_work in
+              let cascade_name = "keeper_turn" in
+              match
+                Keeper_agent_run.run_turn
+                  ~config:ctx.config ~meta ~session ~ctx_ref
+                  ~system_prompt:turn_system_prompt
+                  ~user_message:message
+                  ~cascade_name
+                  ~generation:meta.generation ()
+              with
+              | Error e ->
+                (try ignore (Trajectory.finalize trajectory_acc
+                   (Trajectory.Failed e))
+                 with exn -> log_keeper_exn
+                   ~label:"trajectory finalize (agent_run error)" exn);
+                (false, Printf.sprintf "❌ Agent.run failed: %s" e)
+              | Ok result ->
+                (try ignore (Trajectory.finalize trajectory_acc
+                   Trajectory.Completed)
+                 with exn -> log_keeper_exn
+                   ~label:"trajectory finalize (agent_run ok)" exn);
+                let reply_json = `Assoc [
+                  ("reply", `String result.response_text);
+                  ("model", `String result.model_used);
+                  ("turns", `Int result.turn_count);
+                  ("tool_calls", `Int result.tool_calls_made);
+                  ("via", `String "agent_run");
+                ] in
+                (true, Yojson.Safe.to_string reply_json)
+            end else
+
+            (* Single-turn LLM call params — legacy manual loop *)
             let turn_messages =
               (Agent_sdk.Types.system_msg turn_system_prompt) :: ctx_work.messages
             in


### PR DESCRIPTION
## Summary
handle_keeper_msg에 Agent.run() dual-path 분기 추가.

KEEPER_USE_AGENT_RUN=true 시:
- Keeper_agent_run.run_turn → Oas_worker.run_named(~tools, ~hooks) → Agent.run()
- Agent.run()이 tool dispatch + idle detection + token budgeting 자동 처리
- 응답에 via:"agent_run" 마커 포함 (A/B 비교용)

기본값: disabled (기존 manual loop 그대로).

## Architecture
```
KEEPER_USE_AGENT_RUN=true?
  ├─ YES → Keeper_agent_run.run_turn
  │         ├─ Keeper_tools_oas.make_tools (tool dispatch)
  │         ├─ Keeper_hooks_oas.make_hooks (checkpoint, metrics)
  │         └─ Oas_worker.run_named(~tools, ~hooks) → Agent.run()
  └─ NO  → existing manual loop (run_cascade + gated_dispatch)
```

## Context
Issue #1797 Phase C 완료. Phase A (#1807) + Phase B+C infra (#1811) + 이 PR.

## Test plan
- [x] `dune build` pass
- [ ] Live test: KEEPER_USE_AGENT_RUN=true로 keeper 실행 후 board 상호작용

🤖 Generated with [Claude Code](https://claude.com/claude-code)