### PR TITLE
feat(oas_worker): add hooks + context_reducer to run_named

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -45,15 +45,21 @@ let run_turn
   : (run_result, string) result =
   let meta_ref = ref meta in
   let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
-  let _hooks = Keeper_hooks_oas.make_hooks
+  let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation () in
-  (* TODO: pass hooks to Oas_worker when it supports hooks parameter *)
+  let reducer = Agent_sdk.Context_reducer.compose [
+    { Agent_sdk.Context_reducer.strategy =
+        Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 } };
+    { strategy = Agent_sdk.Context_reducer.Merge_contiguous };
+  ] in
   match
     Oas_worker.run_named
       ~cascade_name
       ~goal:user_message
       ~system_prompt
       ~tools
+      ~hooks
+      ~context_reducer:reducer
       ~max_turns:3
       ~temperature:0.3
       ~max_tokens:4096

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -28,6 +28,7 @@ type config = {
   max_tokens : int;
   temperature : float;
   hooks : Oas.Hooks.hooks option;
+  context_reducer : Oas.Context_reducer.t option;
   guardrails : Oas.Guardrails.t option;
   event_bus : Oas.Event_bus.t option;
   checkpoint_dir : string option;
@@ -42,6 +43,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     max_tokens = 4096;
     temperature = 0.7;
     hooks = None;
+    context_reducer = None;
     guardrails = None;
     event_bus = None;
     checkpoint_dir = None;
@@ -134,6 +136,10 @@ let build
   in
   let builder = match config.hooks with
     | Some h -> Oas.Builder.with_hooks h builder
+    | None -> builder
+  in
+  let builder = match config.context_reducer with
+    | Some r -> Oas.Builder.with_context_reducer r builder
     | None -> builder
   in
   let builder = match config.description with
@@ -261,6 +267,8 @@ let run_named
     ?(temperature = 0.7)
     ?(max_tokens = 4096)
     ?guardrails
+    ?hooks
+    ?context_reducer
     ?memory
     ?on_event
     ()
@@ -277,6 +285,8 @@ let run_named
     max_tokens;
     temperature;
     guardrails;
+    hooks;
+    context_reducer;
     memory;
     description = Some (Printf.sprintf "cascade:%s" cascade_name);
   } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -25,6 +25,8 @@ val run_named :
   ?temperature:float ->
   ?max_tokens:int ->
   ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.hooks ->
+  ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->


### PR DESCRIPTION
## Summary
- Oas_worker.run_named에 ?hooks + ?context_reducer 파라미터 추가
- keeper_agent_run이 hooks(checkpoint/metrics) + context_reducer(Prune+Merge) 전달
- Agent.run()이 매 턴 전에 자동 context reduction 적용

## Changes
- oas_worker.ml: config에 context_reducer 필드, Builder.with_context_reducer 연결
- oas_worker.mli: ?hooks, ?context_reducer 시그니처 추가
- keeper_agent_run.ml: reducer 구성 + hooks/reducer 전달 (TODO 해소)

## Test plan
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)