### PR TITLE
refactor: remove always-true env var gates

### DIFF
--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -6,12 +6,6 @@ open Keeper_memory
 open Keeper_exec_tools
 open Keeper_exec_context
 
-(** Check if keeper autonomy engine is enabled via environment variable. *)
-let keeper_autonomy_enabled () =
-  match Sys.getenv_opt "MASC_KEEPER_AUTONOMY_ENABLED" with
-  | Some s -> String.lowercase_ascii (String.trim s) = "true"
-  | None -> false
-
 (* ================================================================ *)
 (* Autonomous Execution Engine (Phase 5)                            *)
 (* ================================================================ *)
@@ -141,8 +135,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
     @since 2.74.0 *)
 let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(specs : Cascade.model_spec list) : keeper_meta option =
-  if not (keeper_autonomy_enabled ()) then None
-  else if meta.active_goal_ids = [] then None
+  if meta.active_goal_ids = [] then None
   else
     match Keeper_contract.parse_autonomy_level meta.autonomy_level with
     | None -> None

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -44,10 +44,7 @@ let default_metadata =
     idempotent = None;
   }
 
-let placeholder_tools_enabled () =
-  match Sys.getenv_opt "MASC_PLACEHOLDER_TOOLS_ENABLED" with
-  | Some "1" | Some "true" | Some "TRUE" | Some "yes" | Some "YES" -> true
-  | _ -> false
+let placeholder_tools_enabled () = true
 
 let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = false)
     ?(implementation_status = Adapter) reason =
@@ -296,11 +293,4 @@ let allow_direct_call name =
   | Default -> true
   | Hidden -> meta.allow_direct_call_when_hidden
 
-let hidden_placeholder_tools () =
-  if placeholder_tools_enabled () then []
-  else
-    explicit_metadata
-    |> List.filter_map (fun (name, meta) ->
-           match meta.visibility, meta.implementation_status with
-           | Hidden, Placeholder -> Some name
-           | _ -> None)
+let hidden_placeholder_tools () = []


### PR DESCRIPTION
## Summary
- `MASC_KEEPER_AUTONOMY_ENABLED` 제거 — autonomy 엔진은 항상 활성, 실제 gate는 `active_goal_ids`와 `autonomy_level`
- `MASC_PLACEHOLDER_TOOLS_ENABLED` 제거 — placeholder 도구는 항상 노출, `hidden_placeholder_tools()` 항상 `[]`

2 files, +3 / -20 lines.

## Test plan
- [x] `dune build --root .` 통과
- [ ] keeper autonomous goal turn이 env var 없이 동작 확인
- [ ] placeholder 도구가 tool catalog에서 정상 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)