### PR TITLE
refactor(keeper): remove dead code from legacy loop (-77 LOC)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -195,31 +195,8 @@ let float_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v v)
 
-let keeper_turn_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_TURN_MAX_TOKENS"
-    ~default:1200
-    ~min_v:256
-    ~max_v:4096
-
 let keeper_status_fast_default () : bool =
   bool_of_env_default "MASC_KEEPER_STATUS_FAST_DEFAULT" ~default:false
-
-let keeper_followup_max_tokens (turn_max_tokens : int) : int =
-  (* Thinking models (e.g. Gemini 2.5) consume internal thinking tokens
-     from this budget, so follow-up needs a generous allocation.
-     Use same budget as the initial turn since the system prompt is minimal. *)
-  clamp_int turn_max_tokens ~min_v:600 ~max_v:4096
-
-let keeper_correction_max_tokens (turn_max_tokens : int) : int =
-  clamp_int (turn_max_tokens / 2) ~min_v:280 ~max_v:900
-
-let keeper_msg_postpass_budget_ms () : int =
-  int_of_env_default
-    "MASC_KEEPER_MSG_POSTPASS_BUDGET_MS"
-    ~default:12000
-    ~min_v:0
-    ~max_v:120000
 
 let keeper_compact_ratio () : float =
   float_of_env_default

--- a/lib/keeper/keeper_oas_adapter.ml
+++ b/lib/keeper/keeper_oas_adapter.ml
@@ -105,32 +105,7 @@ let run_with_tools
   | Error e -> Error e
 
 (* ================================================================ *)
-(* Public: run_with_custom_dispatch                                  *)
-(* ================================================================ *)
-
-(** Run with a custom dispatch function and explicit tool list.
-    Uses cascade-name-based API (post-#1730).
-    [model_spec_override] is accepted for backward compat but ignored —
-    model resolution happens inside [Oas_worker.run_named_with_masc_tools]. *)
-let run_with_custom_dispatch
-    ~(meta : keeper_meta)
-    ?(model_spec_override : Cascade.model_spec option)
-    ~(system_prompt : string)
-    ~(goal : string)
-    ~(max_turns : int)
-    ~(temperature : float)
-    ~(max_tokens : int)
-    ~(masc_tools : Types.tool_schema list)
-    ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
-    ?(guardrails : Agent_sdk.Guardrails.t option)
-    ()
-  : (Oas_worker.run_result, string) result =
-  ignore model_spec_override;
-  let cascade_name = Printf.sprintf "keeper_%s" meta.name in
-  let memory = Memory_oas_bridge.create_memory ~agent_name:(Printf.sprintf "keeper-%s" meta.name) in
-  Oas_worker.run_named_with_masc_tools
-    ~cascade_name ~goal ~system_prompt ~masc_tools ~dispatch
-    ~max_turns ~temperature ~max_tokens ?guardrails ~memory ()
+(* run_with_custom_dispatch removed — Keeper uses Agent.run() via keeper_agent_run.ml *)
 
 (* ================================================================ *)
 (* Public: run_simple                                                *)

--- a/lib/keeper/keeper_oas_adapter.mli
+++ b/lib/keeper/keeper_oas_adapter.mli
@@ -34,26 +34,6 @@ val run_with_tools :
   unit ->
   (tools_run_result, string) result
 
-(** Tool loop with caller-provided dispatch closure.
-    Unlike [run_with_tools], the caller controls tool execution
-    (Eval_gate, Trajectory, custom logging). Returns raw OAS result;
-    caller manages tool tracking externally.
-    [model_spec_override] is accepted for backward compat but ignored;
-    model resolution uses cascade name derived from [meta.name]. *)
-val run_with_custom_dispatch :
-  meta:keeper_meta ->
-  ?model_spec_override:Cascade.model_spec ->
-  system_prompt:string ->
-  goal:string ->
-  max_turns:int ->
-  temperature:float ->
-  max_tokens:int ->
-  masc_tools:Types.tool_schema list ->
-  dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->
-  ?guardrails:Agent_sdk.Guardrails.t ->
-  unit ->
-  (Oas_worker.run_result, string) result
-
 (** Tool-free LLM call (deliberation, correction, forced grounding).
     Wraps [Oas_worker.run_named] without tools. Single turn.
     [cascade_name] selects the model cascade (e.g. "keeper_deliberation"). *)

--- a/lib/keeper/keeper_turn_response.ml
+++ b/lib/keeper/keeper_turn_response.ml
@@ -487,12 +487,5 @@ let finalize_handoff_turn ctx ~session ~now_ts ~specs ~primary ~base_dir
     ~new_generation:next_generation env_for_handoff in
   (true, Yojson.Safe.pretty_to_string json)
 
-(** Build the complete keeper response: emit side-effects + return JSON. *)
-let build_keeper_response ctx ~session ~now_ts ~specs ~primary ~base_dir
-    ~trajectory_acc ~gate_config ~do_handoff (env : turn_env) : tool_result =
-  if not do_handoff then
-    finalize_normal_turn ctx ~session ~now_ts ~trajectory_acc ~gate_config env
-  else
-    finalize_handoff_turn ctx ~session ~now_ts ~specs ~primary ~base_dir
-      ~trajectory_acc ~gate_config env
+(* build_keeper_response removed — keeper_turn.ml uses Agent.run() directly. *)
 


### PR DESCRIPTION
## Summary
Legacy turn loop 삭제 후 남은 dead 함수 정리.

삭제:
- keeper_config: keeper_turn_max_tokens, followup/correction_max_tokens, postpass_budget_ms
- keeper_oas_adapter: run_with_custom_dispatch
- keeper_turn_response: build_keeper_response

## Test plan
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)