### PR TITLE
feat: wire memory + hooks into keeper Agent.run path

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -43,10 +43,14 @@ let run_turn
     ~(generation : int)
     ()
   : (run_result, string) result =
+  let agent_name = Printf.sprintf "keeper-%s" meta.name in
   let meta_ref = ref meta in
   let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
   let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation () in
+  let memory = Memory_oas_bridge.create_memory ~agent_name in
+  ignore (Memory_oas_bridge.seed_institution ~memory ~config);
+  ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
   let reducer = Agent_sdk.Context_reducer.compose [
     { Agent_sdk.Context_reducer.strategy =
         Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 } };
@@ -60,6 +64,7 @@ let run_turn
       ~tools
       ~hooks
       ~context_reducer:reducer
+      ~memory
       ~max_turns:3
       ~temperature:0.3
       ~max_tokens:4096

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -302,6 +302,7 @@ let run_named_with_masc_tools
     ?(temperature = 0.7)
     ?(max_tokens = 4096)
     ?guardrails
+    ?hooks
     ?memory
     ?on_event
     ()
@@ -318,6 +319,7 @@ let run_named_with_masc_tools
     max_tokens;
     temperature;
     guardrails;
+    hooks;
     memory;
     description = Some (Printf.sprintf "cascade:%s" cascade_name);
   } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -42,6 +42,7 @@ val run_named_with_masc_tools :
   ?temperature:float ->
   ?max_tokens:int ->
   ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->


### PR DESCRIPTION
## Summary
- `keeper_agent_run.ml`: Memory_oas_bridge 주입 (memory + institution + procedures)
- `run_named_with_masc_tools`: `?hooks` 파라미터 추가 (run_named과 동일)

## Changes
3 files, 8 lines:
- `keeper_agent_run.ml`: `~memory` + seed_institution + seed_procedures
- `oas_worker.ml`: `?hooks` param in `run_named_with_masc_tools`
- `oas_worker.mli`: signature update

## Context
Keeper Agent.run() path (#1807/#1811)에 OAS Memory.t + hooks 완전 연결.
이제 `KEEPER_USE_AGENT_RUN=true` 시 memory, hooks, context_reducer 모두 동작.

Generated with [Claude Code](https://claude.com/claude-code)