### PR TITLE
refactor: extract Model_spec from Cascade (Step 4a)

### DIFF
--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -1,25 +1,65 @@
 (** Cascade — MASC LLM call module.
 
-    Model types, cascade profile defaults, model spec parsing,
-    and {!complete} which delegates to OAS [Cascade_config.complete_named].
+    Cascade profile defaults and {!complete} which delegates to
+    OAS [Cascade_config.complete_named].
+
+    Model types and spec parsing live in {!Model_spec}.
 
     Public entry points:
-    - {!call} — prompt-in/text-out convenience (returns cascade_result)
-    - {!call_raw} — prompt-in, returns full api_response
-    - {!call_with_tools} — messages + tools, returns full api_response
-
-    All three route through OAS Cascade_config.complete_named.
+    - {!complete} — messages + cascade_name, returns api_response or error
 
     @since 2.114.0 — original
     @since 2.115.0 — delegated to OAS Cascade_config
-    @since 2.116.0 — call_raw, call_with_tools added *)
+    @since 2.116.0 — call_raw, call_with_tools added
+    @since 2.117.0 — model types extracted to Model_spec *)
 
 (* ================================================================ *)
-(* Model types and helpers — absorbed from Masc_model               *)
+(* Re-export Model_spec types for backward compatibility             *)
 (* ================================================================ *)
 
+type provider = Model_spec.provider =
+  | Llama
+  | Claude
+  | OpenAI
+  | Gemini
+  | Glm_cloud
+  | OpenRouter
+  | Custom of string
 
-open Printf
+type model_spec = Model_spec.model_spec = {
+  provider : provider;
+  model_id : string;
+  max_context : int;
+  api_url : string;
+  api_key_env : string option;
+  cost_per_1k_input : float;
+  cost_per_1k_output : float;
+}
+
+(* ================================================================ *)
+(* Re-export Model_spec values for backward compatibility            *)
+(* ================================================================ *)
+
+let string_of_provider = Model_spec.string_of_provider
+let llama_default = Model_spec.llama_default
+let claude_opus = Model_spec.claude_opus
+let claude_sonnet = Model_spec.claude_sonnet
+let openai_default = Model_spec.openai_default
+let glm_cloud = Model_spec.glm_cloud
+let gemini_pro = Model_spec.gemini_pro
+let model_spec_of_string = Model_spec.model_spec_of_string
+let configured_default_model_label = Model_spec.configured_default_model_label
+let default_execution_model_labels = Model_spec.default_execution_model_labels
+let default_verifier_model_labels = Model_spec.default_verifier_model_labels
+let available_model_specs_of_strings = Model_spec.available_model_specs_of_strings
+let first_available_model_spec = Model_spec.first_available_model_spec
+let default_execution_model_spec = Model_spec.default_execution_model_spec
+let default_verifier_model_spec = Model_spec.default_verifier_model_spec
+let default_local_model_spec = Model_spec.default_local_model_spec
+
+(* ================================================================ *)
+(* Helpers                                                           *)
+(* ================================================================ *)
 
 let int_of_env_default name ~default ~min_v ~max_v =
   match Sys.getenv_opt name with
@@ -31,25 +71,9 @@ let int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v v)
 
-type provider =
-  | Llama
-  | Claude
-  | OpenAI
-  | Gemini
-  | Glm_cloud
-  | OpenRouter
-  | Custom of string
-
-type model_spec = {
-  provider : provider;
-  model_id : string;
-  max_context : int;
-  api_url : string;
-  api_key_env : string option;
-  cost_per_1k_input : float;
-  cost_per_1k_output : float;
-}
-
+(* ================================================================ *)
+(* Response helpers                                                  *)
+(* ================================================================ *)
 
 (** Compute total tokens from OAS api_usage. *)
 let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens
@@ -82,75 +106,6 @@ let has_tool_use (resp : Llm_provider.Types.api_response) : bool =
   List.exists
     (function Agent_sdk.Types.ToolUse _ -> true | _ -> false)
     resp.content
-
-let string_of_provider = function
-  | Llama -> "llama"
-  | Claude -> "claude"
-  | OpenAI -> "openai"
-  | Gemini -> "gemini"
-  | Glm_cloud -> "glm_cloud"
-  | OpenRouter -> "openrouter"
-  | Custom s -> sprintf "custom(%s)" s
-
-let llama_default = {
-  provider = Llama;
-  model_id = Env_config.Llama.default_model;
-  max_context = 128000;
-  api_url = Env_config.Llama.server_url;
-  api_key_env = None;
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
-
-let claude_opus = {
-  provider = Claude;
-  model_id = Env_config.Claude.default_model;
-  max_context = 200000;
-  api_url = "https://api.anthropic.com";
-  api_key_env = Some "ANTHROPIC_API_KEY";
-  cost_per_1k_input = 0.015;
-  cost_per_1k_output = 0.075;
-}
-
-let claude_sonnet = {
-  provider = Claude;
-  model_id = Env_config.Claude.default_model;
-  max_context = 200000;
-  api_url = "https://api.anthropic.com";
-  api_key_env = Some "ANTHROPIC_API_KEY";
-  cost_per_1k_input = 0.003;
-  cost_per_1k_output = 0.015;
-}
-
-let openai_default = {
-  provider = OpenAI;
-  model_id = Env_config.OpenAI.default_model;
-  max_context = 400000;
-  api_url = "https://api.openai.com";
-  api_key_env = Some "OPENAI_API_KEY";
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
-
-let glm_cloud = {
-  provider = Glm_cloud;
-  model_id = Env_config.Llm.default_model;
-  max_context = 128000;
-  api_url = "https://api.z.ai";
-  api_key_env = Some "ZAI_API_KEY";
-  cost_per_1k_input = 0.001;
-  cost_per_1k_output = 0.002;
-}
-
-let gemini_pro = {
-  provider = Gemini;
-  model_id = Env_config.Gemini.default_model;
-  max_context = 1000000;
-  api_url = "https://generativelanguage.googleapis.com";
-  api_key_env = Some "GEMINI_API_KEY";
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
 
 let tool_msg ~name:_ ~call_id text =
   Agent_sdk.Types.tool_result_msg ~tool_use_id:call_id ~content:text ()
@@ -216,6 +171,8 @@ let inflight = Atomic.make 0
 let llm_semaphore_available () = max_concurrent_llm - Atomic.get inflight
 let llm_permits_in_use () = Atomic.get inflight
 
+(* ================================================================ *)
+(* Cascade profile defaults                                          *)
 (* ================================================================ *)
 
 (** Locate config/cascade.json via CWD or ME_ROOT.
@@ -315,172 +272,11 @@ let default_model_strings ~cascade_name =
   | _ -> llama_glm
 
 (* ================================================================ *)
-(* Model spec parsing (moved from Masc_model)                        *)
+(* Cascade orchestration                                             *)
 (* ================================================================ *)
 
-let rec model_spec_of_string s =
-  let s = String.trim s in
-  if String.equal (String.lowercase_ascii s) "default" then
-    match Provider_adapter.default_model_label_result () with
-    | Ok label -> model_spec_of_string label
-    | Error _ as e -> e
-  else if
-    String.length s > 8
-    && String.equal
-         (String.lowercase_ascii (String.sub s 0 8))
-         "default:"
-  then
-    let override_model =
-      String.sub s 8 (String.length s - 8) |> String.trim
-    in
-    (match Provider_adapter.default_model_override_label_result override_model with
-    | Ok label -> model_spec_of_string label
-    | Error _ as e -> e)
-  else
-  match String.index_opt s ':' with
-  | None ->
-    Error
-      (Printf.sprintf
-         "Cannot parse model spec: %s (expected provider:model or default[:model])"
-         s)
-  | Some idx ->
-    if idx = 0 || idx >= String.length s - 1 then
-      Error
-        (Printf.sprintf
-           "Cannot parse model spec: %s (expected provider:model or default[:model])"
-           s)
-    else
-      let provider = String.sub s 0 idx |> String.lowercase_ascii in
-      let model_id =
-        String.sub s (idx + 1) (String.length s - idx - 1)
-        |> String.trim
-      in
-      if model_id = "" then
-        Error
-          (Printf.sprintf
-             "Cannot parse model spec: %s (expected provider:model or default[:model])"
-             s)
-      else
-        match Provider_adapter.resolve_direct_adapter provider with
-        | Some adapter when adapter.canonical_name = "llama" ->
-          Ok { llama_default with model_id }
-        | Some adapter when adapter.canonical_name = "gemini-api" ->
-          if model_id = "pro" then Ok gemini_pro
-          else if model_id = "flash" then
-            let flash = Env_config_governance.Gemini.flash_model in
-            Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
-          else
-            Ok { gemini_pro with model_id }
-        | Some adapter when adapter.canonical_name = "claude-api" ->
-          if model_id = "opus" then Ok claude_opus
-          else if model_id = "sonnet" then Ok claude_sonnet
-          else Ok { claude_opus with model_id }
-        | Some adapter when adapter.canonical_name = "codex-api" ->
-          Ok { openai_default with model_id }
-        | Some adapter when adapter.canonical_name = "glm" ->
-          (* "auto" or empty -> Glm_pool selects at runtime *)
-          let effective_id = if model_id = "auto" then "" else model_id in
-          Ok { glm_cloud with model_id = effective_id }
-        | Some adapter when adapter.canonical_name = "openrouter" ->
-          Ok {
-            provider = OpenRouter;
-            model_id;
-            max_context = 128000;
-            api_url = "https://openrouter.ai/api";
-            api_key_env = Some "OPENROUTER_API_KEY";
-            cost_per_1k_input = 0.001;
-            cost_per_1k_output = 0.002;
-          }
-        | Some _ ->
-          Error (Printf.sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
-        | None ->
-          match provider with
-        | "custom" ->
-          (* Format: custom:model@http://host:port or custom:model *)
-          let actual_model, url =
-            match String.index_opt model_id '@' with
-            | Some at_idx ->
-              ( String.sub model_id 0 at_idx,
-                String.sub model_id (at_idx + 1)
-                  (String.length model_id - at_idx - 1) )
-            | None -> (model_id, Env_config_runtime.Custom_llm.default_server_url)
-          in
-          Ok {
-            provider = Custom actual_model;
-            model_id = actual_model;
-            max_context = 128000;
-            api_url = url;
-            api_key_env = None;
-            cost_per_1k_input = 0.0;
-            cost_per_1k_output = 0.0;
-          }
-        | _ ->
-          Error
-            (Printf.sprintf
-               "Cannot parse model spec: %s (unsupported provider '%s'; supported: llama, claude, gemini, glm, openrouter, custom)"
-               s provider)
-
-let configured_default_model_label () =
-  match Provider_adapter.configured_default_model_label_result () with
-  | Ok label -> Some label
-  | Error _ -> None
-
-let default_execution_model_labels () =
-  Provider_adapter.preferred_execution_model_labels ()
-
-let default_verifier_model_labels () =
-  Provider_adapter.preferred_verifier_model_labels ()
-
-let available_model_specs_of_strings model_strs =
-  model_strs
-  |> List.filter_map (fun model_str ->
-         match model_spec_of_string model_str with
-         | Error err ->
-             Log.LlmClient.warn "ignoring invalid model spec %s: %s"
-               model_str err;
-             None
-         | Ok spec -> (
-             match spec.api_key_env with
-             | Some env_name ->
-                 let value = Sys.getenv_opt env_name |> Option.value ~default:"" in
-                 if String.trim value = "" then (
-                   Log.LlmClient.debug "skipping %s: %s not set"
-                     model_str env_name;
-                   None)
-                 else Some spec
-             | None -> Some spec))
-
-let first_available_model_spec labels =
-  match available_model_specs_of_strings labels with
-  | spec :: _ -> Ok spec
-  | [] ->
-      Error
-        "No default model available. Set MASC_DEFAULT_CASCADE, \
-         MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL, or provider credentials for the \
-         preferred fallback chain, or pass an explicit model."
-
-let default_execution_model_spec () =
-  first_available_model_spec (default_execution_model_labels ())
-
-let default_verifier_model_spec () =
-  first_available_model_spec (default_verifier_model_labels ())
-
-let default_local_model_spec () =
-  match configured_default_model_label () with
-  | Some label -> (
-      match model_spec_of_string label with
-      | Ok spec -> spec
-      | Error _ -> (
-          match default_execution_model_spec () with
-          | Ok spec -> spec
-          | Error _ -> glm_cloud))
-  | None -> (
-      match default_execution_model_spec () with
-      | Ok spec -> spec
-      | Error _ -> glm_cloud)
-
 (** Backward compat: return MASC model_spec list.
-    Prefer {!call}, {!call_raw}, or {!call_with_tools} instead. *)
+    Prefer {!complete} instead. *)
 let get_cascade ?(config_path = "") ~cascade_name () :
     model_spec list =
   let defaults = default_model_strings ~cascade_name in
@@ -501,7 +297,7 @@ let get_cascade ?(config_path = "") ~cascade_name () :
         if from_file <> [] then from_file else defaults
       | None -> defaults
   in
-  let specs = available_model_specs_of_strings configured in
+  let specs = Model_spec.available_model_specs_of_strings configured in
   if specs <> [] then specs
   else
     let fallback = default_model_strings ~cascade_name in
@@ -514,10 +310,7 @@ let get_cascade ?(config_path = "") ~cascade_name () :
       Printf.eprintf
         "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!"
         cascade_name;
-      available_model_specs_of_strings fallback)
-
-(** Accept validator type: Llm_provider.Types.api_response -> bool.
-    Now that MASC validators use api_response directly, no bridging needed. *)
+      Model_spec.available_model_specs_of_strings fallback)
 
 (** Format OAS http_error as cascade error string. *)
 let format_cascade_error ~cascade_name = function
@@ -530,7 +323,6 @@ let format_cascade_error ~cascade_name = function
     Printf.sprintf "[cascade] %s: %s" cascade_name message
 
 (** Direct OAS bridge — single entry point for all LLM cascade calls.
-    Replaces {!call}, {!call_raw}, and {!call_with_tools}.
     Returns OAS [api_response] directly; error formatted as string. *)
 let complete ~cascade_name ~messages
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)

--- a/lib/dune
+++ b/lib/dune
@@ -126,6 +126,7 @@
    credits_dashboard
    cp_microarch_summary
    cp_search_fabric
+   model_spec
    cascade
    ;; WebRTC modules removed — use ocaml-webrtc library directly
    eio_context

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -1,0 +1,284 @@
+(** Model_spec — LLM provider types, preset specs, and model spec parsing.
+
+    Extracted from {!Cascade} to decouple model identity from cascade orchestration.
+
+    @since 2.117.0 *)
+
+open Printf
+
+(* ================================================================ *)
+(* Types                                                             *)
+(* ================================================================ *)
+
+type provider =
+  | Llama
+  | Claude
+  | OpenAI
+  | Gemini
+  | Glm_cloud
+  | OpenRouter
+  | Custom of string
+
+type model_spec = {
+  provider : provider;
+  model_id : string;
+  max_context : int;
+  api_url : string;
+  api_key_env : string option;
+  cost_per_1k_input : float;
+  cost_per_1k_output : float;
+}
+
+(* ================================================================ *)
+(* String conversion                                                 *)
+(* ================================================================ *)
+
+let string_of_provider = function
+  | Llama -> "llama"
+  | Claude -> "claude"
+  | OpenAI -> "openai"
+  | Gemini -> "gemini"
+  | Glm_cloud -> "glm_cloud"
+  | OpenRouter -> "openrouter"
+  | Custom s -> sprintf "custom(%s)" s
+
+(* ================================================================ *)
+(* Preset specs                                                      *)
+(* ================================================================ *)
+
+let llama_default = {
+  provider = Llama;
+  model_id = Env_config.Llama.default_model;
+  max_context = 128000;
+  api_url = Env_config.Llama.server_url;
+  api_key_env = None;
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
+}
+
+let claude_opus = {
+  provider = Claude;
+  model_id = Env_config.Claude.default_model;
+  max_context = 200000;
+  api_url = "https://api.anthropic.com";
+  api_key_env = Some "ANTHROPIC_API_KEY";
+  cost_per_1k_input = 0.015;
+  cost_per_1k_output = 0.075;
+}
+
+let claude_sonnet = {
+  provider = Claude;
+  model_id = Env_config.Claude.default_model;
+  max_context = 200000;
+  api_url = "https://api.anthropic.com";
+  api_key_env = Some "ANTHROPIC_API_KEY";
+  cost_per_1k_input = 0.003;
+  cost_per_1k_output = 0.015;
+}
+
+let openai_default = {
+  provider = OpenAI;
+  model_id = Env_config.OpenAI.default_model;
+  max_context = 400000;
+  api_url = "https://api.openai.com";
+  api_key_env = Some "OPENAI_API_KEY";
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
+}
+
+let glm_cloud = {
+  provider = Glm_cloud;
+  model_id = Env_config.Llm.default_model;
+  max_context = 128000;
+  api_url = "https://api.z.ai";
+  api_key_env = Some "ZAI_API_KEY";
+  cost_per_1k_input = 0.001;
+  cost_per_1k_output = 0.002;
+}
+
+let gemini_pro = {
+  provider = Gemini;
+  model_id = Env_config.Gemini.default_model;
+  max_context = 1000000;
+  api_url = "https://generativelanguage.googleapis.com";
+  api_key_env = Some "GEMINI_API_KEY";
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
+}
+
+(* ================================================================ *)
+(* Model spec parsing                                                *)
+(* ================================================================ *)
+
+let rec model_spec_of_string s =
+  let s = String.trim s in
+  if String.equal (String.lowercase_ascii s) "default" then
+    match Provider_adapter.default_model_label_result () with
+    | Ok label -> model_spec_of_string label
+    | Error _ as e -> e
+  else if
+    String.length s > 8
+    && String.equal
+         (String.lowercase_ascii (String.sub s 0 8))
+         "default:"
+  then
+    let override_model =
+      String.sub s 8 (String.length s - 8) |> String.trim
+    in
+    (match Provider_adapter.default_model_override_label_result override_model with
+    | Ok label -> model_spec_of_string label
+    | Error _ as e -> e)
+  else
+  match String.index_opt s ':' with
+  | None ->
+    Error
+      (Printf.sprintf
+         "Cannot parse model spec: %s (expected provider:model or default[:model])"
+         s)
+  | Some idx ->
+    if idx = 0 || idx >= String.length s - 1 then
+      Error
+        (Printf.sprintf
+           "Cannot parse model spec: %s (expected provider:model or default[:model])"
+           s)
+    else
+      let provider = String.sub s 0 idx |> String.lowercase_ascii in
+      let model_id =
+        String.sub s (idx + 1) (String.length s - idx - 1)
+        |> String.trim
+      in
+      if model_id = "" then
+        Error
+          (Printf.sprintf
+             "Cannot parse model spec: %s (expected provider:model or default[:model])"
+             s)
+      else
+        match Provider_adapter.resolve_direct_adapter provider with
+        | Some adapter when adapter.canonical_name = "llama" ->
+          Ok { llama_default with model_id }
+        | Some adapter when adapter.canonical_name = "gemini-api" ->
+          if model_id = "pro" then Ok gemini_pro
+          else if model_id = "flash" then
+            let flash = Env_config_governance.Gemini.flash_model in
+            Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
+          else
+            Ok { gemini_pro with model_id }
+        | Some adapter when adapter.canonical_name = "claude-api" ->
+          if model_id = "opus" then Ok claude_opus
+          else if model_id = "sonnet" then Ok claude_sonnet
+          else Ok { claude_opus with model_id }
+        | Some adapter when adapter.canonical_name = "codex-api" ->
+          Ok { openai_default with model_id }
+        | Some adapter when adapter.canonical_name = "glm" ->
+          (* "auto" or empty -> Glm_pool selects at runtime *)
+          let effective_id = if model_id = "auto" then "" else model_id in
+          Ok { glm_cloud with model_id = effective_id }
+        | Some adapter when adapter.canonical_name = "openrouter" ->
+          Ok {
+            provider = OpenRouter;
+            model_id;
+            max_context = 128000;
+            api_url = "https://openrouter.ai/api";
+            api_key_env = Some "OPENROUTER_API_KEY";
+            cost_per_1k_input = 0.001;
+            cost_per_1k_output = 0.002;
+          }
+        | Some _ ->
+          Error (Printf.sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
+        | None ->
+          match provider with
+        | "custom" ->
+          (* Format: custom:model@http://host:port or custom:model *)
+          let actual_model, url =
+            match String.index_opt model_id '@' with
+            | Some at_idx ->
+              ( String.sub model_id 0 at_idx,
+                String.sub model_id (at_idx + 1)
+                  (String.length model_id - at_idx - 1) )
+            | None -> (model_id, Env_config_runtime.Custom_llm.default_server_url)
+          in
+          Ok {
+            provider = Custom actual_model;
+            model_id = actual_model;
+            max_context = 128000;
+            api_url = url;
+            api_key_env = None;
+            cost_per_1k_input = 0.0;
+            cost_per_1k_output = 0.0;
+          }
+        | _ ->
+          Error
+            (Printf.sprintf
+               "Cannot parse model spec: %s (unsupported provider '%s'; supported: llama, claude, gemini, glm, openrouter, custom)"
+               s provider)
+
+(* ================================================================ *)
+(* Default model label helpers                                       *)
+(* ================================================================ *)
+
+let configured_default_model_label () =
+  match Provider_adapter.configured_default_model_label_result () with
+  | Ok label -> Some label
+  | Error _ -> None
+
+let default_execution_model_labels () =
+  Provider_adapter.preferred_execution_model_labels ()
+
+let default_verifier_model_labels () =
+  Provider_adapter.preferred_verifier_model_labels ()
+
+(* ================================================================ *)
+(* Available spec filtering                                          *)
+(* ================================================================ *)
+
+let available_model_specs_of_strings model_strs =
+  model_strs
+  |> List.filter_map (fun model_str ->
+         match model_spec_of_string model_str with
+         | Error err ->
+             Log.LlmClient.warn "ignoring invalid model spec %s: %s"
+               model_str err;
+             None
+         | Ok spec -> (
+             match spec.api_key_env with
+             | Some env_name ->
+                 let value = Sys.getenv_opt env_name |> Option.value ~default:"" in
+                 if String.trim value = "" then (
+                   Log.LlmClient.debug "skipping %s: %s not set"
+                     model_str env_name;
+                   None)
+                 else Some spec
+             | None -> Some spec))
+
+let first_available_model_spec labels =
+  match available_model_specs_of_strings labels with
+  | spec :: _ -> Ok spec
+  | [] ->
+      Error
+        "No default model available. Set MASC_DEFAULT_CASCADE, \
+         MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL, or provider credentials for the \
+         preferred fallback chain, or pass an explicit model."
+
+(* ================================================================ *)
+(* Default model spec resolvers                                      *)
+(* ================================================================ *)
+
+let default_execution_model_spec () =
+  first_available_model_spec (default_execution_model_labels ())
+
+let default_verifier_model_spec () =
+  first_available_model_spec (default_verifier_model_labels ())
+
+let default_local_model_spec () =
+  match configured_default_model_label () with
+  | Some label -> (
+      match model_spec_of_string label with
+      | Ok spec -> spec
+      | Error _ -> (
+          match default_execution_model_spec () with
+          | Ok spec -> spec
+          | Error _ -> glm_cloud))
+  | None -> (
+      match default_execution_model_spec () with
+      | Ok spec -> spec
+      | Error _ -> glm_cloud)

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -1,0 +1,73 @@
+(** Model_spec — LLM provider types, preset specs, and model spec parsing.
+
+    Extracted from {!Cascade} to decouple model identity from cascade orchestration.
+
+    @since 2.117.0 *)
+
+(** LLM provider discriminator. *)
+type provider =
+  | Llama
+  | Claude
+  | OpenAI
+  | Gemini
+  | Glm_cloud
+  | OpenRouter
+  | Custom of string
+
+(** Complete specification for an LLM endpoint. *)
+type model_spec = {
+  provider : provider;
+  model_id : string;
+  max_context : int;
+  api_url : string;
+  api_key_env : string option;
+  cost_per_1k_input : float;
+  cost_per_1k_output : float;
+}
+
+(** Human-readable provider name. *)
+val string_of_provider : provider -> string
+
+(** {2 Preset specs} *)
+
+val llama_default : model_spec
+val claude_opus : model_spec
+val claude_sonnet : model_spec
+val openai_default : model_spec
+val glm_cloud : model_spec
+val gemini_pro : model_spec
+
+(** {2 Parsing} *)
+
+(** Parse a ["provider:model"] string into a {!model_spec}.
+    Accepts ["default"] and ["default:override"] forms.
+    Returns [Error msg] on unrecognised input. *)
+val model_spec_of_string : string -> (model_spec, string) result
+
+(** {2 Default model labels} *)
+
+(** Configured default model label from env, if any. *)
+val configured_default_model_label : unit -> string option
+
+(** Preferred execution model labels (env-driven). *)
+val default_execution_model_labels : unit -> string list
+
+(** Preferred verifier model labels (env-driven). *)
+val default_verifier_model_labels : unit -> string list
+
+(** {2 Filtering and resolution} *)
+
+(** Parse a list of model strings, filter to those with available API keys. *)
+val available_model_specs_of_strings : string list -> model_spec list
+
+(** Return the first available spec from a label list, or [Error msg]. *)
+val first_available_model_spec : string list -> (model_spec, string) result
+
+(** Default execution model spec (first available from preferred chain). *)
+val default_execution_model_spec : unit -> (model_spec, string) result
+
+(** Default verifier model spec (first available from verifier chain). *)
+val default_verifier_model_spec : unit -> (model_spec, string) result
+
+(** Best-effort local model spec: configured default > execution chain > glm_cloud. *)
+val default_local_model_spec : unit -> model_spec


### PR DESCRIPTION
## Summary

`type provider`, `type model_spec`, preset specs, `model_spec_of_string` parser를
`lib/model_spec.ml`로 추출.

- cascade.ml: 556 -> 347줄 (-209)
- 새 파일: model_spec.ml (284줄), model_spec.mli (73줄)
- Re-export로 backward compat 유지 (소비자 변경 없음)

후속 PR에서 re-export 제거 + 소비자 `Model_spec.*` 직접 사용 전환 예정.

## Test plan

- [x] `dune build --root .`
- [x] `test_cascade.exe` (8/8)
- [x] `test_perpetual.exe` (193/193)
- [ ] CI green