### PR TITLE
refactor(keeper): encapsulate Context_manager inside run_turn

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1,14 +1,14 @@
 (** Keeper_agent_run — Run a single keeper turn via OAS Agent.run().
 
-    Replaces the manual LLM call + tool dispatch loop in keeper_turn.ml
-    with Agent.run(). Uses {!Keeper_tools_oas} for tool wrapping and
+    Owns the full context lifecycle: checkpoint loading, context creation,
+    base system prompt application, and message persistence.
+    Callers provide domain-specific system prompt logic via
+    [build_turn_prompt] callback.
+
+    Uses {!Keeper_tools_oas} for tool wrapping and
     {!Keeper_hooks_oas} for lifecycle hooks (checkpoint, metrics, social).
 
-    This is the Phase C entry point of Issue #1797.
-    Callers can switch between the old manual loop and this function
-    via [KEEPER_USE_AGENT_RUN=true] environment variable.
-
-    @since Phase 4 — Keeper → Agent.run() migration *)
+    @since Phase 5 — Context_manager encapsulation *)
 
 (** Result of a single Agent.run() keeper turn. *)
 type run_result = {
@@ -20,29 +20,85 @@ type run_result = {
 
 (** Run a single keeper turn via OAS Agent.run().
 
-    Builds OAS Tool.t from keeper tools, attaches keeper hooks
-    (checkpoint, metrics, social events), and delegates to
+    Loads checkpoint, creates working context with the base keeper system
+    prompt, then calls [build_turn_prompt] with the base prompt and message
+    history so the caller can layer skill routing, continuity context,
+    policy guards, and turn-specific instructions on top.
+
+    After the callback returns the final system prompt, appends the user
+    message, builds OAS tools + hooks, and delegates to
     [Oas_worker.run_named] which internally calls Agent.run().
 
     @param config Room configuration
     @param meta Keeper metadata
-    @param session Session context for persistence
-    @param ctx_ref Mutable ref to working context
-    @param system_prompt Full system prompt for the turn
+    @param base_dir Session base directory for checkpoints
+    @param max_context Maximum context window tokens
+    @param build_turn_prompt Callback: receives the base keeper system prompt
+           and checkpoint message history, returns the final turn system prompt
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
     @param generation Current generation counter *)
 let run_turn
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
-    ~(session : Context_manager.session_context)
-    ~(ctx_ref : Context_manager.working_context ref)
-    ~(system_prompt : string)
+    ~(base_dir : string)
+    ~(max_context : int)
+    ~(build_turn_prompt :
+        base_system_prompt:string ->
+        messages:Agent_sdk.Types.message list ->
+        string)
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
     ()
   : (run_result, string) result =
+  (* 1. Ensure session directory *)
+  Keeper_types.mkdir_p base_dir;
+  (* 2. Load checkpoint *)
+  let (session, ctx_opt) =
+    Keeper_exec_context.load_context_from_checkpoint
+      ~trace_id:meta.trace_id
+      ~primary_model_max_tokens:max_context
+      ~base_dir
+  in
+  (* 3. Build base system prompt from meta *)
+  let base_system_prompt =
+    Keeper_prompt.build_keeper_system_prompt
+      ~goal:meta.goal
+      ~short_goal:meta.short_goal
+      ~mid_goal:meta.mid_goal
+      ~long_goal:meta.long_goal
+      ~soul_profile:meta.soul_profile
+      ~will:meta.will
+      ~needs:meta.needs
+      ~desires:meta.desires
+      ~instructions:meta.instructions
+  in
+  (* 4. Create or restore working context, re-apply current prompt *)
+  let base_ctx =
+    match ctx_opt with
+    | Some c -> c
+    | None ->
+      Context_manager.create
+        ~system_prompt:base_system_prompt
+        ~max_tokens:max_context
+  in
+  let ctx_work =
+    Context_manager.set_system_prompt base_ctx
+      ~system_prompt:base_system_prompt
+  in
+  (* 5. Build final turn system prompt via caller callback *)
+  let turn_system_prompt =
+    build_turn_prompt
+      ~base_system_prompt
+      ~messages:ctx_work.messages
+  in
+  (* 6. Append user message and persist *)
+  let user_msg = Agent_sdk.Types.user_msg user_message in
+  let ctx_work = Context_manager.append ctx_work user_msg in
+  Context_manager.persist_message session user_msg;
+  (* 7. Set up agent *)
+  let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
   let meta_ref = ref meta in
   let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
@@ -56,11 +112,12 @@ let run_turn
         Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 } };
     { strategy = Agent_sdk.Context_reducer.Merge_contiguous };
   ] in
+  (* 8. Run Agent *)
   match
     Oas_worker.run_named
       ~cascade_name
       ~goal:user_message
-      ~system_prompt
+      ~system_prompt:turn_system_prompt
       ~tools
       ~hooks
       ~context_reducer:reducer
@@ -79,7 +136,6 @@ let run_turn
         | Agent_sdk.Types.ToolUse _ -> true | _ -> false)
         result.response.content)
     in
-    (* Persist assistant response to session *)
     let assistant_msg = Llm_provider.Types.assistant_msg text in
     Context_manager.persist_message session assistant_msg;
     ctx_ref := Context_manager.append !ctx_ref assistant_msg;
@@ -89,4 +145,3 @@ let run_turn
       turn_count = result.turns;
       tool_calls_made = tool_count;
     }
-

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1,5 +1,9 @@
 (** Keeper_turn -- keeper lifecycle and message-turn handlers.
 
+    Orchestrates keeper turns by building domain-specific system prompt
+    configuration and delegating to {!Keeper_agent_run.run_turn} which
+    owns the full context lifecycle (checkpoint, Context_manager, Agent.run).
+
     Sub-modules:
     - Keeper_turn_up: start/reconfigure
     - Keeper_turn_session: team-session integration
@@ -113,43 +117,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          let specs = Cascade.available_model_specs_of_strings effective_models in
          let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
             let base_dir = session_base_dir ctx.config in
-            mkdir_p base_dir;
-            let (session, ctx_opt) = load_context_from_checkpoint
-              ~trace_id:meta.trace_id ~primary_model_max_tokens:primary.max_context ~base_dir in
-            let base_ctx =
-              match ctx_opt with
-              | Some c -> c
-              | None ->
-                Context_manager.create
-                  ~system_prompt:(
-                    build_keeper_system_prompt
-                      ~goal:meta.goal
-                      ~short_goal:meta.short_goal
-                      ~mid_goal:meta.mid_goal
-                      ~long_goal:meta.long_goal
-                      ~soul_profile:meta.soul_profile
-                      ~will:meta.will
-                      ~needs:meta.needs
-                      ~desires:meta.desires
-                      ~instructions:meta.instructions)
-                  ~max_tokens:primary.max_context
-            in
-	            let ctx_work =
-	              (* Always re-apply the current keeper prompt so goal/instructions updates
-	                 actually take effect even when restoring an old checkpoint. *)
-	              Context_manager.set_system_prompt base_ctx
-                ~system_prompt:(
-                  build_keeper_system_prompt
-                    ~goal:meta.goal
-                    ~short_goal:meta.short_goal
-                    ~mid_goal:meta.mid_goal
-                    ~long_goal:meta.long_goal
-                    ~soul_profile:meta.soul_profile
-                    ~will:meta.will
-                    ~needs:meta.needs
-	                    ~desires:meta.desires
-	                    ~instructions:meta.instructions)
-            in
             let policy_mode_learned = keeper_policy_mode_is_learned meta in
             let effective_no_skill_route = no_skill_route || policy_mode_learned in
             let fallback_skill_route =
@@ -166,74 +133,68 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               if policy_mode_learned then SkillSelectHeuristic
               else keeper_skill_selection_mode ()
             in
-            let continuity_snapshot = latest_state_snapshot_from_messages ctx_work.messages in
-            let continuity_summary =
-              match continuity_snapshot with
-              | Some s -> keeper_state_snapshot_to_summary_text s
-              | None -> (
+            let build_turn_prompt ~base_system_prompt ~messages =
+              let continuity_snapshot = latest_state_snapshot_from_messages messages in
+              let continuity_summary =
+                match continuity_snapshot with
+                | Some s -> keeper_state_snapshot_to_summary_text s
+                | None ->
                   let trimmed = String.trim meta.continuity_summary in
-                  if trimmed = "" then "No continuity snapshot available." else trimmed)
-            in
-            let base_turn_system_prompt =
-              if effective_no_skill_route then
-                ctx_work.system_prompt
-              else
-                match skill_selection_mode with
-                | SkillSelectHeuristic ->
-                    skill_route_system_prompt_heuristic
-                      ~base_system_prompt:ctx_work.system_prompt
-                      ~route:fallback_skill_route
-                | SkillSelectAgent ->
-                    skill_route_system_prompt_agent
-                      ~base_system_prompt:ctx_work.system_prompt
-                      ~fallback_route:fallback_skill_route
-                      ~soul_profile:meta.soul_profile
-            in
-            let turn_system_prompt =
-              append_continuity_context_prompt
-                ~base_prompt:base_turn_system_prompt
-                continuity_snapshot
-                ~continuity_summary
-            in
-            let turn_system_prompt =
-              let policy_guards = [
-                (effective_no_skill_route,
-                 "Output guard: NEVER output lines starting with SKILL: or SKILL_REASON:.");
-                (no_state_block,
-                 "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn.");
-              ] in
-              let policy_lines =
-                List.filter_map
-                  (fun (active, line) -> if active then Some line else None)
-                  policy_guards
+                  if trimmed = "" then "No continuity snapshot available." else trimmed
               in
-              match policy_lines with
-              | [] -> turn_system_prompt
-              | _ ->
-                  Printf.sprintf "%s\n\n%s"
-                    turn_system_prompt
-                    (String.concat "\n" policy_lines)
-            in
-            let turn_system_prompt =
+              let base_turn_system_prompt =
+                if effective_no_skill_route then
+                  base_system_prompt
+                else
+                  match skill_selection_mode with
+                  | SkillSelectHeuristic ->
+                      skill_route_system_prompt_heuristic
+                        ~base_system_prompt
+                        ~route:fallback_skill_route
+                  | SkillSelectAgent ->
+                      skill_route_system_prompt_agent
+                        ~base_system_prompt
+                        ~fallback_route:fallback_skill_route
+                        ~soul_profile:meta.soul_profile
+              in
+              let prompt =
+                append_continuity_context_prompt
+                  ~base_prompt:base_turn_system_prompt
+                  continuity_snapshot
+                  ~continuity_summary
+              in
+              let prompt =
+                let policy_guards = [
+                  (effective_no_skill_route,
+                   "Output guard: NEVER output lines starting with SKILL: or SKILL_REASON:.");
+                  (no_state_block,
+                   "Output guard: NEVER output [STATE] or [/STATE] blocks in this turn.");
+                ] in
+                let policy_lines =
+                  List.filter_map
+                    (fun (active, line) -> if active then Some line else None)
+                    policy_guards
+                in
+                match policy_lines with
+                | [] -> prompt
+                | _ ->
+                    Printf.sprintf "%s\n\n%s"
+                      prompt
+                      (String.concat "\n" policy_lines)
+              in
               match turn_instructions with
-              | None -> turn_system_prompt
+              | None -> prompt
               | Some ti ->
                   Printf.sprintf "%s\n\n--- Turn-specific instructions ---\n%s"
-                    turn_system_prompt ti
+                    prompt ti
             in
-	            let user_msg = Agent_sdk.Types.user_msg message in
-	            let ctx_work = Context_manager.append ctx_work user_msg in
-	            Context_manager.persist_message session user_msg;
-
-            (* === Agent.run() === *)
-            let ctx_ref = ref ctx_work in
-            let cascade_name = "keeper_turn" in
             match
               Keeper_agent_run.run_turn
-                ~config:ctx.config ~meta ~session ~ctx_ref
-                ~system_prompt:turn_system_prompt
+                ~config:ctx.config ~meta ~base_dir
+                ~max_context:primary.max_context
+                ~build_turn_prompt
                 ~user_message:message
-                ~cascade_name
+                ~cascade_name:"keeper_turn"
                 ~generation:meta.generation ()
             with
             | Error e ->


### PR DESCRIPTION
## Summary
- `keeper_agent_run.run_turn`이 context lifecycle 전체를 소유: checkpoint 로드, context 생성/설정, 메시지 append/persist, Agent.run() 실행
- `keeper_turn.ml`은 `build_turn_prompt` callback만 제공 (skill routing, continuity, policy guards, turn instructions)
- **결과: `keeper_turn.ml`에서 Context_manager 참조 0건**

## Changes
| 파일 | 변경 |
|------|------|
| `keeper_agent_run.ml` | 새 시그니처: `~base_dir`, `~max_context`, `~build_turn_prompt` callback. 내부에서 checkpoint + context + persist 처리 |
| `keeper_turn.ml` | Context_manager.create/set_system_prompt/append/persist_message 4곳 제거. `build_turn_prompt` closure로 system prompt 구성 로직만 제공 |

## Design: Callback pattern
```
keeper_turn.ml                    keeper_agent_run.ml
┌──────────────────┐              ┌──────────────────────────┐
│ meta loading     │              │ mkdir_p base_dir         │
│ model selection  │              │ load checkpoint          │
│ skill routing    │  callback    │ create/set context       │
│ continuity       │◄────────────►│ call build_turn_prompt() │
│ policy guards    │              │ append user_msg + persist│
│ turn instructions│              │ tools + hooks + Agent.run│
└──────────────────┘              │ persist assistant_msg    │
                                  └──────────────────────────┘
```

## Test plan
- [x] `dune build` 성공
- [x] `test_tool_keeper` 8/8 pass
- [x] `test_cascade` 8/8 pass
- [ ] CI green

Closes part of #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)