### PR TITLE
refactor: drop Cascade re-exports, consumers use Model_spec directly (Step 4b)

### DIFF
--- a/archive/trpg/lib/trpg_harness.ml
+++ b/archive/trpg/lib/trpg_harness.ml
@@ -104,7 +104,7 @@ let parse_tier1 (text : string) : tier1_result =
   else
     Fail "unparseable response"
 
-let tier1_check ~(model : Cascade.model_spec) ~actor_name ~actor_persona
+let tier1_check ~(model : Model_spec.model_spec) ~actor_name ~actor_persona
     ~response_text : tier1_result =
   let prompt = build_tier1_prompt ~actor_name ~actor_persona ~response_text in
   let req : Cascade.completion_request = {
@@ -198,7 +198,7 @@ let parse_tier2 (text : string) : dimension_score list =
     find_dim Narrative_consistency "NARRATIVE_CONSISTENCY";
   ]
 
-let tier2_evaluate ~(model : Cascade.model_spec) ~actor_name ~actor_persona
+let tier2_evaluate ~(model : Model_spec.model_spec) ~actor_name ~actor_persona
     ~actor_traits ~scene_context ~response_text : dimension_score list =
   let prompt = build_tier2_prompt ~actor_name ~actor_persona ~actor_traits
     ~scene_context ~response_text in

--- a/archive/trpg/lib/trpg_harness.mli
+++ b/archive/trpg/lib/trpg_harness.mli
@@ -32,20 +32,20 @@ type evaluation_result = {
 (** Tier 1 structural gate. Checks: valid JSON action, non-empty narrative,
     not out-of-character gibberish. Returns Pass or Fail with reason.
     Budget: max 50 tokens, temperature 0.0 *)
-val tier1_check : model:Cascade.model_spec -> actor_name:string ->
+val tier1_check : model:Model_spec.model_spec -> actor_name:string ->
   actor_persona:string -> response_text:string -> tier1_result
 
 (** Tier 2 quality evaluation. Scores across 3 dimensions.
     Budget: max 200 tokens, temperature 0.0.
     Only called if tier1 passes. *)
-val tier2_evaluate : model:Cascade.model_spec -> actor_name:string ->
+val tier2_evaluate : model:Model_spec.model_spec -> actor_name:string ->
   actor_persona:string -> actor_traits:string list -> scene_context:string ->
   response_text:string -> dimension_score list
 
 (** Full evaluation pipeline: tier1 -> tier2 (if pass) -> weighted score.
     tier1_model: cheap model (e.g., ollama:LFM2.5-1.2B-Instruct)
     tier2_model: capable model (e.g., glm:glm-4.7-flash) *)
-val evaluate : tier1_model:Cascade.model_spec -> tier2_model:Cascade.model_spec ->
+val evaluate : tier1_model:Model_spec.model_spec -> tier2_model:Model_spec.model_spec ->
   actor_name:string -> actor_persona:string -> actor_traits:string list ->
   scene_context:string -> response_text:string -> evaluation_result
 

--- a/archive/trpg/lib/trpg_round_run_process.ml
+++ b/archive/trpg/lib/trpg_round_run_process.ml
@@ -269,20 +269,20 @@ let process_one rctx ~state_json ~role ~actor_id ~keeper_name =
     | Some tier1_str ->
     try
       let tier1_model =
-        match Cascade.model_spec_of_string tier1_str with
+        match Model_spec.model_spec_of_string tier1_str with
         | Ok m -> m
         | Error _ -> (
-            match Cascade.default_verifier_model_spec () with
+            match Model_spec.default_verifier_model_spec () with
             | Ok model -> model
-            | Error _ -> Cascade.glm_cloud)
+            | Error _ -> Model_spec.glm_cloud)
       in
       let tier2_model =
         match Sys.getenv_opt "TRPG_HARNESS_TIER2_MODEL" with
         | Some s -> (
-            match Cascade.model_spec_of_string s with
+            match Model_spec.model_spec_of_string s with
             | Ok m -> m
-            | Error _ -> Cascade.glm_cloud)
-        | None -> Cascade.glm_cloud
+            | Error _ -> Model_spec.glm_cloud)
+        | None -> Model_spec.glm_cloud
       in
       let pctx =
         extract_prompt_context ~actor_id ~dm_persona_override state_json

--- a/bin/perpetual_cli.ml
+++ b/bin/perpetual_cli.ml
@@ -144,7 +144,7 @@ let () =
 
   (* Parse model specs *)
   let models = List.filter_map (fun s ->
-    match Cascade.model_spec_of_string s with
+    match Model_spec.model_spec_of_string s with
     | Ok m ->
       (* Apply max_context override if specified *)
       let m = match args.max_context with
@@ -165,7 +165,7 @@ let () =
   let verifier =
     match args.verifier_str with
     | Some s -> (
-        match Cascade.model_spec_of_string s with
+        match Model_spec.model_spec_of_string s with
         | Ok m -> Some m
         | Error e ->
             eprintf "Bad verifier spec '%s': %s\n%!" s e;
@@ -194,8 +194,8 @@ let () =
   eprintf "Perpetual Agent CLI\n%!";
   eprintf "Goal: %s\n%!" args.goal;
   eprintf "Models: %s\n%!" (String.concat ", "
-    (List.map (fun (m : Cascade.model_spec) ->
-      sprintf "%s:%s" (Cascade.string_of_provider m.provider) m.model_id
+    (List.map (fun (m : Model_spec.model_spec) ->
+      sprintf "%s:%s" (Model_spec.string_of_provider m.provider) m.model_id
     ) models));
   eprintf "Verify: %b (model: %s)\n%!" args.verify config.verifier_model.model_id;
   eprintf "Thresholds: compact=%.0f%%, handoff=%.0f%%\n%!"

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -14,50 +14,6 @@
     @since 2.117.0 — model types extracted to Model_spec *)
 
 (* ================================================================ *)
-(* Re-export Model_spec types for backward compatibility             *)
-(* ================================================================ *)
-
-type provider = Model_spec.provider =
-  | Llama
-  | Claude
-  | OpenAI
-  | Gemini
-  | Glm_cloud
-  | OpenRouter
-  | Custom of string
-
-type model_spec = Model_spec.model_spec = {
-  provider : provider;
-  model_id : string;
-  max_context : int;
-  api_url : string;
-  api_key_env : string option;
-  cost_per_1k_input : float;
-  cost_per_1k_output : float;
-}
-
-(* ================================================================ *)
-(* Re-export Model_spec values for backward compatibility            *)
-(* ================================================================ *)
-
-let string_of_provider = Model_spec.string_of_provider
-let llama_default = Model_spec.llama_default
-let claude_opus = Model_spec.claude_opus
-let claude_sonnet = Model_spec.claude_sonnet
-let openai_default = Model_spec.openai_default
-let glm_cloud = Model_spec.glm_cloud
-let gemini_pro = Model_spec.gemini_pro
-let model_spec_of_string = Model_spec.model_spec_of_string
-let configured_default_model_label = Model_spec.configured_default_model_label
-let default_execution_model_labels = Model_spec.default_execution_model_labels
-let default_verifier_model_labels = Model_spec.default_verifier_model_labels
-let available_model_specs_of_strings = Model_spec.available_model_specs_of_strings
-let first_available_model_spec = Model_spec.first_available_model_spec
-let default_execution_model_spec = Model_spec.default_execution_model_spec
-let default_verifier_model_spec = Model_spec.default_verifier_model_spec
-let default_local_model_spec = Model_spec.default_local_model_spec
-
-(* ================================================================ *)
 (* Helpers                                                           *)
 (* ================================================================ *)
 
@@ -278,7 +234,7 @@ let default_model_strings ~cascade_name =
 (** Backward compat: return MASC model_spec list.
     Prefer {!complete} instead. *)
 let get_cascade ?(config_path = "") ~cascade_name () :
-    model_spec list =
+    Model_spec.model_spec list =
   let defaults = default_model_strings ~cascade_name in
   let configured =
     if String.length config_path > 0 then

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -216,7 +216,7 @@ let llm_tool_calls_json (blocks : Agent_sdk.Types.content_block list) =
 
 type llm_runner =
   | Stub
-  | Direct of Cascade.model_spec
+  | Direct of Model_spec.model_spec
   | Spawn of string (* agent name *)
   | SpawnWithModel of { agent: string; model: string }
 
@@ -224,7 +224,7 @@ let model_runner_of_string raw =
   let model = trim raw in
   let lower = String.lowercase_ascii model in
   let direct spec =
-    match Cascade.model_spec_of_string spec with
+    match Model_spec.model_spec_of_string spec with
     | Ok parsed -> Ok (Direct parsed)
     | Error msg -> Error msg
   in
@@ -246,7 +246,7 @@ let model_runner_of_string raw =
   | "codex" -> Ok (Spawn "codex")
   | value when starts_with ~prefix:"codex:" value -> Ok (Spawn "codex")
   | value -> (
-      match Cascade.model_spec_of_string model with
+      match Model_spec.model_spec_of_string model with
       | Ok parsed -> Ok (Direct parsed)
       | Error _ when starts_with ~prefix:"llama:" value -> direct model
       | Error _ when starts_with ~prefix:"gemini:" value -> direct model

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -123,9 +123,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             match Keeper_types.model_specs_of_strings m.models with
             | Error _ -> `List []
             | Ok specs ->
-                `List (List.map (fun (s : Cascade.model_spec) ->
+                `List (List.map (fun (s : Model_spec.model_spec) ->
                   `Assoc [
-                    ("provider", `String (Cascade.string_of_provider s.provider));
+                    ("provider", `String (Model_spec.string_of_provider s.provider));
                     ("model_id", `String s.model_id);
                     ("max_context", `Int s.max_context);
                   ]
@@ -218,7 +218,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                  | Error _ -> `Assoc [("has_checkpoint", `Bool false)]
                  | Ok specs ->
                      let primary =
-                       match specs with m0 :: _ -> m0 | [] -> Cascade.llama_default
+                       match specs with m0 :: _ -> m0 | [] -> Model_spec.llama_default
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =

--- a/lib/dashboard/dashboard_http_mdal.ml
+++ b/lib/dashboard/dashboard_http_mdal.ml
@@ -16,9 +16,9 @@ let perpetual_dashboard_json () : Yojson.Safe.t =
         match base with
         | `Assoc fields ->
               let models =
-              `List (List.map (fun (m : Cascade.model_spec) ->
+              `List (List.map (fun (m : Model_spec.model_spec) ->
                 `Assoc [
-                  ("provider", `String (Cascade.string_of_provider m.provider));
+                  ("provider", `String (Model_spec.string_of_provider m.provider));
                   ("model_id", `String m.model_id);
                   ("max_context", `Int m.max_context);
                 ]

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -471,9 +471,9 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
             else
               Ok (snapshot, model))
 
-let oas_provider_config_of_spec (spec : Cascade.model_spec) =
+let oas_provider_config_of_spec (spec : Model_spec.model_spec) =
   match spec.provider with
-  | Cascade.Gemini -> (
+  | Model_spec.Gemini -> (
       match Provider_adapter.resolve_gemini_direct_auth () with
       | Provider_adapter.Gemini_api_key -> Oas_type_adapters.to_oas_provider spec
       | Provider_adapter.Gemini_vertex_adc _ -> None
@@ -490,7 +490,7 @@ let execute_single_agent_run ~sw ~provider ~model ~prompt =
   match label_result with
   | Error _ as error -> error
   | Ok label -> (
-      match Cascade.model_spec_of_string label with
+      match Model_spec.model_spec_of_string label with
       | Error message -> Error message
       | Ok spec -> (
           match oas_provider_config_of_spec spec with

--- a/lib/keeper/keeper_autonomy.ml
+++ b/lib/keeper/keeper_autonomy.ml
@@ -167,7 +167,7 @@ let evaluate_next_action ~config ~goal_ids ~keeper_name:_ =
           StartPerpetualAgent {
             goal_id = goal.id;
             goal_title = goal.title;
-            models = Cascade.default_execution_model_labels ();
+            models = Model_spec.default_execution_model_labels ();
             coding_mode = true;
             coding_agent = "claude";
           }

--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -71,7 +71,7 @@ let autonomous_gate_config
 let execute_approved_plan
     ~(config : Room.config)
     ~(meta : keeper_meta)
-    ~(specs : Cascade.model_spec list)
+    ~(specs : Model_spec.model_spec list)
     ~(plan : string)
     ~(pa : Keeper_autonomy.proposed_action)
     ~(autonomy_level : Keeper_autonomy.autonomy_level)
@@ -79,7 +79,7 @@ let execute_approved_plan
     : string * float * string list =
   ignore trajectory_acc;
   let gate_config = autonomous_gate_config ~autonomy_level in
-  let primary = match specs with p :: _ -> p | [] -> Cascade.default_local_model_spec () in
+  let primary = match specs with p :: _ -> p | [] -> Model_spec.default_local_model_spec () in
   let system_prompt = Printf.sprintf
 {|You are a keeper agent executing an approved action plan.
 Your name: %s
@@ -134,7 +134,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
     None to fall through to regular proactive generation.
     @since 2.74.0 *)
 let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
-    ~(specs : Cascade.model_spec list) : keeper_meta option =
+    ~(specs : Model_spec.model_spec list) : keeper_meta option =
   if meta.active_goal_ids = [] then None
   else
     match Keeper_contract.parse_autonomy_level meta.autonomy_level with

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -548,8 +548,8 @@ let looks_fragmentary_history_text (raw : string) : bool =
     hard_fragment || short_unterminated || trailing_connector
 
 let run_proactive_generation
-    ~(specs : Cascade.model_spec list)
-    ~(primary : Cascade.model_spec)
+    ~(specs : Model_spec.model_spec list)
+    ~(primary : Model_spec.model_spec)
     ~(config : Room.config)
     ~(ctx_work : Context_manager.working_context)
     ~(meta : keeper_meta)

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -178,7 +178,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                     in
                     (* model_specs retained for cost estimation only *)
                     let model_specs =
-                      Cascade.available_model_specs_of_strings meta.models
+                      Model_spec.available_model_specs_of_strings meta.models
                     in
                     let (result, delib_latency) = Cascade.timed (fun () ->
                       Keeper_oas_adapter.run_simple
@@ -207,7 +207,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                           let primary =
                             match model_specs with
                             | p :: _ -> p
-                            | [] -> Cascade.default_local_model_spec ()
+                            | [] -> Model_spec.default_local_model_spec ()
                           in
                           (inp *. primary.cost_per_1k_input)
                           +. (outp *. primary.cost_per_1k_output)
@@ -515,7 +515,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
           log_proactive_failure ("api keys: " ^ msg);
           meta
       | Ok () ->
-          let specs = Cascade.available_model_specs_of_strings meta.models in
+          let specs = Model_spec.available_model_specs_of_strings meta.models in
           (match specs with
            | [] ->
                log_proactive_failure "no available model specs";
@@ -533,7 +533,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                let primary =
                  match specs with
                  | p :: _ -> p
-                 | [] -> Cascade.default_local_model_spec ()
+                 | [] -> Model_spec.default_local_model_spec ()
                in
                let base_dir = session_base_dir ctx.config in
                let (session, ctx_opt) =

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -26,11 +26,11 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
   match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
   | Ok () ->
-      let specs = Cascade.available_model_specs_of_strings model_labels in
+      let specs = Model_spec.available_model_specs_of_strings model_labels in
       let primary =
         match specs with
         | model :: _ -> model
-        | [] -> Cascade.default_local_model_spec ()
+        | [] -> Model_spec.default_local_model_spec ()
       in
           let base_dir = session_base_dir ctx.config in
           mkdir_p base_dir;
@@ -166,11 +166,11 @@ let run_social_board_event_turn
   match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
   | Ok () ->
-      let specs = Cascade.available_model_specs_of_strings model_labels in
+      let specs = Model_spec.available_model_specs_of_strings model_labels in
       let primary =
         match specs with
         | model :: _ -> model
-        | [] -> Cascade.default_local_model_spec ()
+        | [] -> Model_spec.default_local_model_spec ()
       in
           let base_dir = session_base_dir ctx.config in
           let session, ctx_opt =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -74,9 +74,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    keeper_metrics_path ctx.config meta_current.name
                  in
                  let primary_model =
-                   match Cascade.available_model_specs_of_strings meta_current.models with
+                   match Model_spec.available_model_specs_of_strings meta_current.models with
                    | primary :: _ -> primary
-                   | [] -> Cascade.default_local_model_spec ()
+                   | [] -> Model_spec.default_local_model_spec ()
                  in
                  let base_dir = session_base_dir ctx.config in
                  let _session, ctx_opt =

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -4,20 +4,20 @@ open Keeper_types
 
 include Keeper_memory_bank
 
-let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Cascade.model_spec) : float =
+let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Model_spec.model_spec) : float =
   let input_cost = float_of_int usage.input_tokens *. model.cost_per_1k_input /. 1000.0 in
   let output_cost = float_of_int usage.output_tokens *. model.cost_per_1k_output /. 1000.0 in
   input_cost +. output_cost
 
-let model_spec_for_used (specs : Cascade.model_spec list) (model_used : string) :
-  Cascade.model_spec option =
+let model_spec_for_used (specs : Model_spec.model_spec list) (model_used : string) :
+  Model_spec.model_spec option =
   let used =
     if String.ends_with ~suffix:":latest" model_used then
       String.sub model_used 0 (String.length model_used - String.length ":latest")
     else
       model_used
   in
-  List.find_opt (fun (m : Cascade.model_spec) ->
+  List.find_opt (fun (m : Model_spec.model_spec) ->
     m.model_id = model_used || m.model_id = used
   ) specs
 

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -38,8 +38,8 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = m.models in
-      let specs = Cascade.available_model_specs_of_strings models in
-      let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+      let specs = Model_spec.available_model_specs_of_strings models in
+      let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
@@ -95,9 +95,9 @@ let handle_keeper_status ctx args : tool_result =
            compaction_policy_of_keeper m
          in
 
-         let models_resolved = `List (List.map (fun (s : Cascade.model_spec) ->
+         let models_resolved = `List (List.map (fun (s : Model_spec.model_spec) ->
            `Assoc [
-             ("provider", `String (Cascade.string_of_provider s.provider));
+             ("provider", `String (Model_spec.string_of_provider s.provider));
              ("model_id", `String s.model_id);
              ("max_context", `Int s.max_context);
              ("api_key_env", match s.api_key_env with None -> `Null | Some k -> `String k);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -110,8 +110,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       (match ensure_api_keys_for_labels effective_models with
        | Error e -> (false, "❌ " ^ e)
        | Ok () ->
-         let specs = Cascade.available_model_specs_of_strings effective_models in
-         let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+         let specs = Model_spec.available_model_specs_of_strings effective_models in
+         let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
             let base_dir = session_base_dir ctx.config in
             mkdir_p base_dir;
             let (session, ctx_opt) = load_context_from_checkpoint

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -297,8 +297,8 @@ let ensure_keeper_exists
     (match ensure_api_keys_for_labels meta.models with
      | Error e -> Error e
      | Ok () ->
-       let specs = Cascade.available_model_specs_of_strings meta.models in
-       let primary = match specs with m0 :: _ -> m0 | [] -> Cascade.default_local_model_spec () in
+       let specs = Model_spec.available_model_specs_of_strings meta.models in
+       let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
        let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
        let system_prompt =
          build_keeper_system_prompt

--- a/lib/keeper/keeper_turn_up.ml
+++ b/lib/keeper/keeper_turn_up.ml
@@ -368,11 +368,11 @@ let handle_keeper_up ctx args : tool_result =
         (match ensure_api_keys_for_labels requested_models with
          | Error e -> (false, "❌ " ^ e)
          | Ok () ->
-           let specs = Cascade.available_model_specs_of_strings requested_models in
+           let specs = Model_spec.available_model_specs_of_strings requested_models in
            let trace_id = generate_trace_id () in
            let primary = match specs with
              | m :: _ -> m
-             | [] -> Cascade.default_local_model_spec ()
+             | [] -> Model_spec.default_local_model_spec ()
            in
              let base_dir = session_base_dir ctx.config in
              mkdir_p base_dir;

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -19,11 +19,11 @@ let session_base_dir_ (config : Room.config) =
   Filename.concat (Filename.concat config.base_path ".masc") "perpetual"
 
 let model_specs_of_strings (model_strs : string list) :
-    (Cascade.model_spec list, string) result =
+    (Model_spec.model_spec list, string) result =
   let rec go acc = function
     | [] -> Ok (List.rev acc)
     | s :: rest -> (
-        match Cascade.model_spec_of_string s with
+        match Model_spec.model_spec_of_string s with
         | Ok spec -> go (spec :: acc) rest
         | Error e -> Error (Printf.sprintf "Bad model spec %s: %s" s e))
   in
@@ -45,18 +45,18 @@ let ollama_port_listening () =
   with Unix.Unix_error _ ->
     false
 
-let model_spec_is_local_runtime (model : Cascade.model_spec) =
+let model_spec_is_local_runtime (model : Model_spec.model_spec) =
   match model.provider with
-  | Cascade.Llama -> true
+  | Model_spec.Llama -> true
   | _ -> false
 
 let label_is_local_runtime (label : string) =
   let l = String.lowercase_ascii (String.trim label) in
   String.length l >= 6 && String.sub l 0 6 = "llama:"
 
-let model_spec_is_available (model : Cascade.model_spec) =
+let model_spec_is_available (model : Model_spec.model_spec) =
   match model.provider with
-  | Cascade.Llama -> true
+  | Model_spec.Llama -> true
   | _ -> true
 
 (** Check whether a model label refers to an available provider.
@@ -97,9 +97,9 @@ let maybe_append_keeper_fallback_models (models : string list) =
     in
     if extra = [] then models else models @ extra
 
-let ensure_api_keys (models : Cascade.model_spec list) : (unit, string) result =
+let ensure_api_keys (models : Model_spec.model_spec list) : (unit, string) result =
   let missing =
-    List.filter_map (fun (m : Cascade.model_spec) ->
+    List.filter_map (fun (m : Model_spec.model_spec) ->
       match m.api_key_env with
       | None -> None
       | Some env ->
@@ -115,7 +115,7 @@ let ensure_api_keys (models : Cascade.model_spec list) : (unit, string) result =
 (** Check API key availability using model label strings (no model_spec needed).
     Parses labels to extract api_key_env, filtering out unparseable labels. *)
 let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
-  let specs = Cascade.available_model_specs_of_strings labels in
+  let specs = Model_spec.available_model_specs_of_strings labels in
   if specs = [] && labels <> [] then
     Error (Printf.sprintf "No valid/available model specs for labels: %s"
       (String.concat ", " labels))

--- a/lib/local/local_agent_eio_container.ml
+++ b/lib/local/local_agent_eio_container.ml
@@ -463,7 +463,7 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
                ~on_exec ()))
   | Error e, _ | _, Error e -> Error e
 
-let oas_provider_of_model (model : Cascade.model_spec) : Oas.Provider.config =
+let oas_provider_of_model (model : Model_spec.model_spec) : Oas.Provider.config =
   match Oas_type_adapters.to_oas_provider model with
   | Some config -> config
   | None ->
@@ -538,7 +538,7 @@ let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
     {
       Oas.Types.default_config with
       name = worker_name;
-      model = model.Cascade.model_id;
+      model = model.Model_spec.model_id;
       system_prompt = Some system_prompt;
       max_tokens = local_worker_max_tokens ();
       max_turns;

--- a/lib/local/local_agent_eio_runners.ml
+++ b/lib/local/local_agent_eio_runners.ml
@@ -5,7 +5,7 @@ open Printf
 include Local_agent_eio_container
 
 let run_worker_oas ~sw ~base_path ~worker_name
-    ~(model : Cascade.model_spec) ~team_session_id
+    ~(model : Model_spec.model_spec) ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id
     ~role
@@ -411,7 +411,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 }
               in
               let model =
-                let base_model = Cascade.default_local_model_spec () in
+                let base_model = Model_spec.default_local_model_spec () in
                 let model_id =
                   if checkpoint.model <> "" then checkpoint.model
                   else meta.effective_model

--- a/lib/local/local_agent_eio_types.ml
+++ b/lib/local/local_agent_eio_types.ml
@@ -576,7 +576,7 @@ let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) 
     cache_read_input_tokens =
       a.cache_read_input_tokens + b.cache_read_input_tokens }
 
-let estimate_cost_usd (model : Cascade.model_spec)
+let estimate_cost_usd (model : Model_spec.model_spec)
     (usage : Agent_sdk.Types.api_usage) : float option =
   let input_cost =
     (float_of_int usage.input_tokens /. 1000.0) *. model.cost_per_1k_input

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -496,7 +496,7 @@ let release (lease : lease) ~success ?error ?latency_ms () =
 
 let model_spec_of_assignment (assignment : assignment) =
   {
-    Cascade.llama_default with
+    Model_spec.llama_default with
     model_id = assignment.model_name;
     api_url = assignment.base_url;
   }

--- a/lib/mdal/mdal_worker.ml
+++ b/lib/mdal/mdal_worker.ml
@@ -53,36 +53,36 @@ let worker_name_for_state (state : Mdal.loop_state) =
   sprintf "mdal-%s-%02d" safe_loop (state.current_iteration + 1)
 
 let model_provider_label = function
-  | Cascade.Llama -> "llama"
-  | Cascade.Claude -> "claude"
-  | Cascade.OpenAI -> "openai"
-  | Cascade.Gemini -> "gemini"
-  | Cascade.Glm_cloud -> "glm"
-  | Cascade.OpenRouter -> "openrouter"
-  | Cascade.Custom name -> "custom:" ^ name
+  | Model_spec.Llama -> "llama"
+  | Model_spec.Claude -> "claude"
+  | Model_spec.OpenAI -> "openai"
+  | Model_spec.Gemini -> "gemini"
+  | Model_spec.Glm_cloud -> "glm"
+  | Model_spec.OpenRouter -> "openrouter"
+  | Model_spec.Custom name -> "custom:" ^ name
 
-let model_label (spec : Cascade.model_spec) =
+let model_label (spec : Model_spec.model_spec) =
   sprintf "%s:%s" (model_provider_label spec.provider) spec.model_id
 
-let validate_model_spec (spec : Cascade.model_spec) :
-    (Cascade.model_spec, string) result =
+let validate_model_spec (spec : Model_spec.model_spec) :
+    (Model_spec.model_spec, string) result =
   match spec.provider with
-  | Cascade.Claude
-  | Cascade.OpenAI
-  | Cascade.Gemini
-  | Cascade.Llama
-  | Cascade.Glm_cloud -> Ok spec
-  | Cascade.OpenRouter
-  | Cascade.Custom _ ->
+  | Model_spec.Claude
+  | Model_spec.OpenAI
+  | Model_spec.Gemini
+  | Model_spec.Llama
+  | Model_spec.Glm_cloud -> Ok spec
+  | Model_spec.OpenRouter
+  | Model_spec.Custom _ ->
       Error
         (sprintf
            "MDAL strict worker does not support provider `%s`. Use claude, openai, gemini, llama:<model>, or glm."
            (model_provider_label spec.provider))
 
 let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
-    (Cascade.model_spec * string, string) result =
+    (Model_spec.model_spec * string, string) result =
   let parse_worker_model raw =
-    match Cascade.model_spec_of_string raw with
+    match Model_spec.model_spec_of_string raw with
     | Error _ as e -> e
     | Ok spec -> (
         match validate_model_spec spec with
@@ -96,14 +96,14 @@ let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
       if String.contains normalized ':' then parse_worker_model normalized
       else
         match normalized with
-        | "claude" -> Ok (Cascade.claude_opus, model_label Cascade.claude_opus)
+        | "claude" -> Ok (Model_spec.claude_opus, model_label Model_spec.claude_opus)
         | "openai" | "codex-api" ->
-            Ok (Cascade.openai_default, model_label Cascade.openai_default)
-        | "gemini" -> Ok (Cascade.gemini_pro, model_label Cascade.gemini_pro)
+            Ok (Model_spec.openai_default, model_label Model_spec.openai_default)
+        | "gemini" -> Ok (Model_spec.gemini_pro, model_label Model_spec.gemini_pro)
         | "ollama" ->
             Error (Provider_adapter.bare_ollama_migration_message ())
         | "glm" ->
-            Ok (Cascade.glm_cloud, model_label Cascade.glm_cloud)
+            Ok (Model_spec.glm_cloud, model_label Model_spec.glm_cloud)
         | "llama" ->
             Error
               "MDAL strict worker requires `worker_model` for llama providers, e.g. `llama:<model-id>`."
@@ -157,7 +157,7 @@ let run ~(sw : Eio.Switch.t) ~(config : Room.config) (state : Mdal.loop_state)
         raise (Invalid_argument message)
   in
   let model_spec =
-    match Cascade.model_spec_of_string model_label with
+    match Model_spec.model_spec_of_string model_label with
     | Ok spec -> spec
     | Error message -> raise (Invalid_argument message)
   in

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -161,7 +161,7 @@ let set_bool_arg args key value =
       `Assoc [ (key, `Bool value) ]
 
 let default_verifier_models =
-  Cascade.default_verifier_model_labels ()
+  Model_spec.default_verifier_model_labels ()
 
 let default_verifier_perspectives = [
   "A: continuity archivist (value-neutral)";
@@ -416,7 +416,7 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
     let checks =
       List.mapi (fun idx model_str ->
         let perspective = perspective_at perspectives idx in
-        match Cascade.model_spec_of_string model_str with
+        match Model_spec.model_spec_of_string model_str with
         | Error err ->
             incr warn_count;
             `Assoc [

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -1,12 +1,12 @@
 (** OAS type adapters — convert MASC model types to OAS (Agent SDK) types.
 
-    Thin wrappers bridging {!Cascade.model_spec} and {!Agent_sdk.Types.message}
+    Thin wrappers bridging {!Model_spec.model_spec} and {!Agent_sdk.Types.message}
     to their OAS counterparts.  Most conversions are structural identity
     (shared type aliases); [to_oas_provider] performs actual mapping.
 
     @since 2.130.0 — extracted from Llm_provider_dispatch *)
 
-let to_oas_provider (spec : Cascade.model_spec) : Agent_sdk.Provider.config option =
+let to_oas_provider (spec : Model_spec.model_spec) : Agent_sdk.Provider.config option =
   match spec.provider with
   | Claude ->
     Some { Agent_sdk.Provider.provider = Anthropic;

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -67,7 +67,7 @@ type run_result = {
 (* Internal: resolve provider                                        *)
 (* ================================================================ *)
 
-let resolve_provider (spec : Cascade.model_spec) : Oas.Provider.config =
+let resolve_provider (spec : Model_spec.model_spec) : Oas.Provider.config =
   match Oas_type_adapters.to_oas_provider spec with
   | Some cfg -> cfg
   | None ->

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -28,12 +28,12 @@ type event =
 
 type loop_config = {
   initial_goal : string;
-  model_cascade : Cascade.model_spec list;
+  model_cascade : Model_spec.model_spec list;
   tools : Types.tool_schema list;
   heartbeat_interval_s : float;
   max_idle_turns : int;
   feedback_enabled : bool;
-  verifier_model : Cascade.model_spec;
+  verifier_model : Model_spec.model_spec;
   compact_threshold : float;
   prepare_threshold : float;
   handoff_threshold : float;
@@ -86,12 +86,12 @@ let default_config ~goal ~models ?verifier ?session_dir () =
   let verifier_model = match verifier with
     | Some v -> v
     | None -> (
-        match Cascade.default_verifier_model_spec () with
+        match Model_spec.default_verifier_model_spec () with
         | Ok model -> model
         | Error _ -> (
             match models with
             | model :: _ -> model
-            | [] -> Cascade.glm_cloud))
+            | [] -> Model_spec.glm_cloud))
   in
   let session_base = match session_dir with
     | Some d -> d
@@ -158,7 +158,7 @@ let create_state config =
   in
   let primary_model = match config.model_cascade with
     | m :: _ -> m
-    | [] -> Cascade.default_local_model_spec ()
+    | [] -> Model_spec.default_local_model_spec ()
   in
   let context = Context_manager.create
     ~system_prompt

--- a/lib/perpetual/perpetual_loop.mli
+++ b/lib/perpetual/perpetual_loop.mli
@@ -29,12 +29,12 @@ type event =
 (** Loop configuration — immutable after creation. *)
 type loop_config = {
   initial_goal : string;
-  model_cascade : Cascade.model_spec list;   (** Ordered preference *)
+  model_cascade : Model_spec.model_spec list;   (** Ordered preference *)
   tools : Types.tool_schema list;
   heartbeat_interval_s : float;                  (** Default: 30.0 *)
   max_idle_turns : int;                          (** Stop after N turns with no progress *)
   feedback_enabled : bool;                       (** Run verifier after each action *)
-  verifier_model : Cascade.model_spec;        (** Cheap model for verification *)
+  verifier_model : Model_spec.model_spec;        (** Cheap model for verification *)
   compact_threshold : float;                     (** Default: 0.5 *)
   prepare_threshold : float;                     (** Default: 0.7 *)
   handoff_threshold : float;                     (** Default: 0.85 *)
@@ -104,7 +104,7 @@ val publish_to_event_bus : Agent_sdk.Event_bus.t -> event -> unit
 (** Default configuration builder. *)
 val default_config :
   goal:string ->
-  models:Cascade.model_spec list ->
-  ?verifier:Cascade.model_spec ->
+  models:Model_spec.model_spec list ->
+  ?verifier:Model_spec.model_spec ->
   ?session_dir:string ->
   unit -> loop_config

--- a/lib/perpetual/perpetual_oas_build.ml
+++ b/lib/perpetual/perpetual_oas_build.ml
@@ -38,11 +38,11 @@ let build_perpetual_agent
   (* Resolve OAS model from primary cascade model *)
   let primary_model = match config.model_cascade with
     | m :: _ -> m
-    | [] -> Cascade.default_local_model_spec ()
+    | [] -> Model_spec.default_local_model_spec ()
   in
   let oas_model = primary_model.model_id in
   (* Build provider via Phase 3 adapter.
-     Uses Oas_type_adapters.to_oas_provider which handles the Cascade.model_spec
+     Uses Oas_type_adapters.to_oas_provider which handles the Model_spec.model_spec
      -> Oas.Provider.config conversion (avoiding Cascade nominality gap). *)
   let provider = match Oas_type_adapters.to_oas_provider primary_model with
     | Some cfg -> cfg

--- a/lib/perpetual/perpetual_oas_hooks.ml
+++ b/lib/perpetual/perpetual_oas_hooks.ml
@@ -71,7 +71,7 @@ let perpetual_hooks
         let next_model = match config.model_cascade with
           | _ :: m :: _ -> m
           | [m] -> m
-          | [] -> Cascade.default_local_model_spec ()
+          | [] -> Model_spec.default_local_model_spec ()
         in
         Perpetual_oas_state.update_state (fun ps ->
           ps.handoff_triggered <- true;

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -47,7 +47,7 @@ type succession_dna = {
 }
 
 type successor_spec = {
-  model : Cascade.model_spec;
+  model : Model_spec.model_spec;
   inherit_tools : bool;
   context_budget : float;
 }
@@ -284,9 +284,9 @@ let extract_dna ~(working_ctx : Context_manager.working_context)
 
 (** Normalize messages for the target model's constraints. *)
 let normalize_for_model (msgs : Agent_sdk.Types.message list)
-    (target : Cascade.model_spec) : Agent_sdk.Types.message list =
+    (target : Model_spec.model_spec) : Agent_sdk.Types.message list =
   let msgs = match target.provider with
-    | Cascade.Llama ->
+    | Model_spec.Llama ->
       (* Local llama runtimes: merge consecutive system messages, simplify tool messages *)
       List.map (fun (m : Agent_sdk.Types.message) ->
         match m.role with
@@ -301,7 +301,7 @@ let normalize_for_model (msgs : Agent_sdk.Types.message list)
                    name = None; tool_call_id = None }
         | _ -> m
       ) msgs
-    | Cascade.Claude ->
+    | Model_spec.Claude ->
       (* Claude: ensure alternating user/assistant, no consecutive same roles *)
       let rec fix_alternation = function
         | [] -> []

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -364,7 +364,7 @@ let env_keeper_models () =
 let default_keeper_models () =
   let from_env = env_keeper_models () in
   if from_env <> [] then from_env
-  else Cascade.default_execution_model_labels ()
+  else Model_spec.default_execution_model_labels ()
 
 let sanitize_keeper_name s =
   let buf = Buffer.create (String.length s) in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -652,9 +652,9 @@ Call masc_listen again to continue listening.
             let spec_name =
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
-            Cascade.model_spec_of_string spec_name
-        | _, Some _ -> Cascade.default_execution_model_spec ()
-        | _, None -> Cascade.default_execution_model_spec ()
+            Model_spec.model_spec_of_string spec_name
+        | _, Some _ -> Model_spec.default_execution_model_spec ()
+        | _, None -> Model_spec.default_execution_model_spec ()
       in
       let module U = Yojson.Safe.Util in
       let working_dir = match arguments |> U.member "working_dir" with

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -154,7 +154,7 @@ let handle_start ctx args =
   let auto_claim_cooldown = Safe_ops.json_float ~default:60.0 "auto_claim_cooldown_sec" args in
   (* Parse model specs *)
   let models = List.filter_map (fun s ->
-    match Cascade.model_spec_of_string s with
+    match Model_spec.model_spec_of_string s with
     | Ok m -> Some m
     | Error e -> Log.Perpetual.info "Bad model spec %s: %s" s e; None
   ) model_strs in
@@ -202,7 +202,7 @@ let handle_start ctx args =
       ("trace_id", `String state.trace_id);
       ("status", `String (match ctx.start_loop with Some _ -> "started" | None -> "created"));
       ("generation", `Int 0);
-      ("models", `List (List.map (fun (m : Cascade.model_spec) ->
+      ("models", `List (List.map (fun (m : Model_spec.model_spec) ->
         `String m.model_id) models));
     ]
   end
@@ -222,9 +222,9 @@ let handle_status args =
       (match base with
        | `Assoc fields ->
          let models =
-           `List (List.map (fun (m : Cascade.model_spec) ->
+           `List (List.map (fun (m : Model_spec.model_spec) ->
              `Assoc [
-               ("provider", `String (Cascade.string_of_provider m.provider));
+               ("provider", `String (Model_spec.string_of_provider m.provider));
                ("model_id", `String m.model_id);
                ("max_context", `Int m.max_context);
                ("api_key_env", match m.api_key_env with None -> `Null | Some k -> `String k);

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -84,7 +84,7 @@ type prepared_spawn = Tool_team_session_step.prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Cascade.model_spec;
+  runtime_model : Model_spec.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }

--- a/lib/tool_team_session_step.mli
+++ b/lib/tool_team_session_step.mli
@@ -39,7 +39,7 @@ type prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Cascade.model_spec;
+  runtime_model : Model_spec.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -413,7 +413,7 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
         | Some model_name -> Some model_name
         | None ->
             let default_model =
-              Cascade.default_local_model_spec ()
+              Model_spec.default_local_model_spec ()
             in
             Some default_model.model_id
       in
@@ -433,7 +433,7 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
                   Some assignment.runtime_id )
           | Error err -> Error err)
     else
-      Ok (Cascade.default_local_model_spec (), None, None)
+      Ok (Model_spec.default_local_model_spec (), None, None)
   in
   match runtime_model with
   | Error e -> Error (spec, runtime_actor_name, e)

--- a/lib/tool_team_session_step_types.ml
+++ b/lib/tool_team_session_step_types.ml
@@ -45,7 +45,7 @@ type prepared_spawn = {
   worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
-  runtime_model : Cascade.model_spec;
+  runtime_model : Model_spec.model_spec;
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -172,7 +172,7 @@ let gate_config_of_execution_scope
 let build_agent
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(meta : Local_agent_eio_types.worker_container_meta)
-    ~(model : Cascade.model_spec)
+    ~(model : Model_spec.model_spec)
     ~(system_prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(hooks : Oas.Hooks.hooks)
@@ -265,7 +265,7 @@ let run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(base_path : string)
     ~(meta : Local_agent_eio_types.worker_container_meta)
-    ~(model : Cascade.model_spec)
+    ~(model : Model_spec.model_spec)
     ~(system_prompt : string)
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
@@ -398,7 +398,7 @@ let orchestrate_workers
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(workers : (Local_agent_eio_types.worker_container_meta
-                 * Cascade.model_spec
+                 * Model_spec.model_spec
                  * string (* system_prompt *)
                  * Oas.Tool.t list
                  * Oas.Raw_trace.t

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Cascade = Masc_mcp.Cascade
+module Model_spec = Masc_mcp.Model_spec
 
 let with_temp_json contents f =
   let path = Filename.temp_file "cascade_" ".json" in
@@ -32,9 +33,9 @@ let test_load_models_from_config () =
       check int "spec count" 2 (List.length specs);
       match specs with
       | [ first; second ] ->
-          check bool "first is llama" true (first.provider = Cascade.Llama);
+          check bool "first is llama" true (first.provider = Model_spec.Llama);
           check string "first model" "qwen-local" first.model_id;
-          check bool "second is llama" true (second.provider = Cascade.Llama);
+          check bool "second is llama" true (second.provider = Model_spec.Llama);
           check string "second model" "qwen-local-fallback" second.model_id
       | _ -> fail "expected two specs")
 
@@ -48,7 +49,7 @@ let test_skips_invalid_and_missing_api_key () =
           match specs with
           | [ only ] ->
               check bool "llama provider" true
-                (only.provider = Cascade.Llama);
+                (only.provider = Model_spec.Llama);
               check string "llama model" "qwen-live" only.model_id
           | _ -> fail "expected one surviving spec"))
 
@@ -59,7 +60,7 @@ let test_missing_config_uses_defaults () =
   match specs with
   | first :: _ ->
       check bool "default starts with llama" true
-        (first.provider = Cascade.Llama);
+        (first.provider = Model_spec.Llama);
       check string "default llama model" Masc_mcp.Env_config.Llama.default_model
         first.model_id
   | [] -> fail "expected default fallback models"

--- a/test/test_llm_client_coverage.ml
+++ b/test/test_llm_client_coverage.ml
@@ -1,10 +1,11 @@
 open Alcotest
 
 module Cascade = Masc_mcp.Cascade
+module Model_spec = Masc_mcp.Model_spec
 
 let test_string_of_provider () =
-  check string "llama" "llama" (Cascade.string_of_provider Cascade.Llama);
-  check string "gemini" "gemini" (Cascade.string_of_provider Cascade.Gemini)
+  check string "llama" "llama" (Model_spec.string_of_provider Model_spec.Llama);
+  check string "gemini" "gemini" (Model_spec.string_of_provider Model_spec.Gemini)
 
 let test_message_constructors () =
   let tool_msg = Cascade.tool_msg ~name:"grep" ~call_id:"call-1" "done" in
@@ -19,14 +20,14 @@ let test_estimate_tokens_positive () =
   check bool "positive" true (tokens > 0)
 
 let test_model_spec_of_string_llama () =
-  match Cascade.model_spec_of_string "llama:qwen3.5-32b" with
+  match Model_spec.model_spec_of_string "llama:qwen3.5-32b" with
   | Ok spec ->
-      check string "provider" "llama" (Cascade.string_of_provider spec.provider);
+      check string "provider" "llama" (Model_spec.string_of_provider spec.provider);
       check string "model id" "qwen3.5-32b" spec.model_id
   | Error err -> fail ("expected llama model spec, got error: " ^ err)
 
 let test_model_spec_of_string_invalid () =
-  match Cascade.model_spec_of_string "broken" with
+  match Model_spec.model_spec_of_string "broken" with
   | Ok _ -> fail "expected parse error"
   | Error err ->
       check bool "mentions provider:model" true
@@ -39,9 +40,9 @@ let test_sanitize_text_utf8 () =
   check bool "not empty" true (String.length sanitized > 0)
 
 let test_available_model_specs_of_strings_llama () =
-  match Cascade.available_model_specs_of_strings [ "llama:qwen3.5-32b" ] with
+  match Model_spec.available_model_specs_of_strings [ "llama:qwen3.5-32b" ] with
   | [ spec ] ->
-      check string "provider" "llama" (Cascade.string_of_provider spec.provider);
+      check string "provider" "llama" (Model_spec.string_of_provider spec.provider);
       check string "model id" "qwen3.5-32b" spec.model_id
   | _ -> fail "expected one available llama model"
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -44,7 +44,7 @@ let field key json = Yojson.Safe.Util.member key json
 
 let test_default_config_fields () =
   let model_spec =
-    match Cascade.model_spec_of_string "llama:test-model" with
+    match Model_spec.model_spec_of_string "llama:test-model" with
     | Ok m -> m
     | Error e -> failwith e
   in
@@ -69,7 +69,7 @@ let test_default_config_fields () =
 
 let test_default_config_custom_values () =
   let model_spec =
-    match Cascade.model_spec_of_string "llama:custom-model" with
+    match Model_spec.model_spec_of_string "llama:custom-model" with
     | Ok m -> m
     | Error e -> failwith e
   in
@@ -98,7 +98,7 @@ let test_build_with_mock_net () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   let model_spec =
-    match Cascade.model_spec_of_string "llama:test-model" with
+    match Model_spec.model_spec_of_string "llama:test-model" with
     | Ok m -> m
     | Error e -> failwith e
   in
@@ -120,7 +120,7 @@ let test_build_invalid_config () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   let model_spec =
-    match Cascade.model_spec_of_string "llama:test-model" with
+    match Model_spec.model_spec_of_string "llama:test-model" with
     | Ok m -> m
     | Error e -> failwith e
   in
@@ -142,7 +142,7 @@ let test_build_with_tools () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
   let model_spec =
-    match Cascade.model_spec_of_string "llama:test-model" with
+    match Model_spec.model_spec_of_string "llama:test-model" with
     | Ok m -> m
     | Error e -> failwith e
   in

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -59,117 +59,117 @@ let test_llm_client () = group "LLM Client" (fun () ->
 
   (* 1. Provider string roundtrip *)
   assert_equal "provider_string:llama"
-    "llama" (Cascade.string_of_provider Llama);
+    "llama" (Model_spec.string_of_provider Llama);
   assert_equal "provider_string:claude"
-    "claude" (Cascade.string_of_provider Claude);
+    "claude" (Model_spec.string_of_provider Claude);
   assert_equal "provider_string:openai"
-    "openai" (Cascade.string_of_provider OpenAI);
+    "openai" (Model_spec.string_of_provider OpenAI);
   assert_equal "provider_string:gemini"
-    "gemini" (Cascade.string_of_provider Gemini);
+    "gemini" (Model_spec.string_of_provider Gemini);
 
   (* 2. Model spec parsing *)
-  (match Cascade.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl" with
+  (match Model_spec.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl" with
    | Ok m ->
      assert_equal "parse_model:llama_local_id" "qwen3.5-35b-a3b-ud-q8-xl" m.model_id;
      assert_true "parse_model:llama_local_provider"
-       (m.provider = Cascade.Llama)
+       (m.provider = Model_spec.Llama)
    | Error _ -> assert_true "parse_model:llama_local" false);
 
-  (match Cascade.model_spec_of_string "claude:opus" with
+  (match Model_spec.model_spec_of_string "claude:opus" with
    | Ok m ->
      assert_equal "parse_model:claude_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:claude_provider"
-       (m.provider = Cascade.Claude);
+       (m.provider = Model_spec.Claude);
      (* Verify opus cost tier to distinguish from sonnet routing *)
      assert_true "parse_model:claude_opus_cost"
        (m.cost_per_1k_input > 0.01)
    | Error _ -> assert_true "parse_model:claude" false);
 
-  (match Cascade.model_spec_of_string "gemini:gemini-2.5-flash" with
+  (match Model_spec.model_spec_of_string "gemini:gemini-2.5-flash" with
    | Ok m ->
      assert_equal "parse_model:gemini_id" "gemini-2.5-flash" m.model_id;
      assert_true "parse_model:gemini_provider"
-       (m.provider = Cascade.Gemini)
+       (m.provider = Model_spec.Gemini)
    | Error _ -> assert_true "parse_model:gemini" false);
 
-  (match Cascade.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl:latest" with
+  (match Model_spec.model_spec_of_string "llama:qwen3.5-35b-a3b-ud-q8-xl:latest" with
    | Ok m ->
      assert_equal "parse_model:llama_tagged_id" "qwen3.5-35b-a3b-ud-q8-xl:latest" m.model_id;
      assert_true "parse_model:llama_tagged_provider"
-       (m.provider = Cascade.Llama)
+       (m.provider = Model_spec.Llama)
    | Error _ -> assert_true "parse_model:llama_tagged" false);
 
-  (match Cascade.model_spec_of_string "llama:qwen3.5-coder" with
+  (match Model_spec.model_spec_of_string "llama:qwen3.5-coder" with
    | Ok m ->
      assert_equal "parse_model:llama_id" "qwen3.5-coder" m.model_id;
      assert_true "parse_model:llama_provider"
-       (m.provider = Cascade.Llama);
+       (m.provider = Model_spec.Llama);
      assert_equal "parse_model:llama_url"
        Masc_mcp.Env_config.Llama.server_url m.api_url
    | Error e -> assert_true ("parse_model:llama_failed: " ^ e) false);
 
-  (match Cascade.model_spec_of_string "anthropic:sonnet" with
+  (match Model_spec.model_spec_of_string "anthropic:sonnet" with
    | Ok m ->
      assert_equal "parse_model:anthropic_alias_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:anthropic_alias_provider"
-       (m.provider = Cascade.Claude)
+       (m.provider = Model_spec.Claude)
    | Error _ -> assert_true "parse_model:anthropic_alias" false);
 
-  (match Cascade.model_spec_of_string "google:flash" with
+  (match Model_spec.model_spec_of_string "google:flash" with
    | Ok m ->
      assert_equal "parse_model:google_alias_id" Masc_mcp.Env_config.Gemini.flash_model m.model_id;
      assert_true "parse_model:google_alias_provider"
-       (m.provider = Cascade.Gemini)
+       (m.provider = Model_spec.Gemini)
    | Error _ -> assert_true "parse_model:google_alias" false);
 
-  (match Cascade.model_spec_of_string "claude-api:sonnet" with
+  (match Model_spec.model_spec_of_string "claude-api:sonnet" with
    | Ok m ->
      assert_equal "parse_model:claude_api_id" Masc_mcp.Env_config.Claude.default_model m.model_id;
      assert_true "parse_model:claude_api_provider"
-       (m.provider = Cascade.Claude)
+       (m.provider = Model_spec.Claude)
    | Error _ -> assert_true "parse_model:claude_api" false);
 
-  (match Cascade.model_spec_of_string "gemini-api:gemini-2.5-flash" with
+  (match Model_spec.model_spec_of_string "gemini-api:gemini-2.5-flash" with
    | Ok m ->
      assert_equal "parse_model:gemini_api_id" "gemini-2.5-flash" m.model_id;
      assert_true "parse_model:gemini_api_provider"
-       (m.provider = Cascade.Gemini)
+       (m.provider = Model_spec.Gemini)
    | Error _ -> assert_true "parse_model:gemini_api" false);
 
-  (match Cascade.model_spec_of_string "codex-api:gpt-5-mini" with
+  (match Model_spec.model_spec_of_string "codex-api:gpt-5-mini" with
    | Ok m ->
      assert_equal "parse_model:codex_api_id" "gpt-5-mini" m.model_id;
      assert_true "parse_model:codex_api_provider"
-       (m.provider = Cascade.OpenAI)
+       (m.provider = Model_spec.OpenAI)
    | Error _ -> assert_true "parse_model:codex_api" false);
 
   (* 3. Invalid model spec *)
-  (match Cascade.model_spec_of_string "invalid" with
+  (match Model_spec.model_spec_of_string "invalid" with
    | Error _ -> assert_true "parse_model:invalid" true
    | Ok _ -> assert_true "parse_model:invalid_should_fail" false);
 
-  (match Cascade.model_spec_of_string "llama:" with
+  (match Model_spec.model_spec_of_string "llama:" with
    | Error _ -> assert_true "parse_model:empty_model_rejected" true
    | Ok _ -> assert_true "parse_model:empty_model_should_fail" false);
 
   (* 3b. MLX provider was removed (PR #799); parsing should fail *)
-  (match Cascade.model_spec_of_string "mlx:qwen3.5-35b" with
+  (match Model_spec.model_spec_of_string "mlx:qwen3.5-35b" with
    | Error _ -> assert_true "parse_model:mlx_rejected" true
    | Ok _ -> assert_true "parse_model:mlx_should_fail" false);
 
-  (match Cascade.model_spec_of_string "custom:mymodel@http://localhost:9999" with
+  (match Model_spec.model_spec_of_string "custom:mymodel@http://localhost:9999" with
    | Ok m ->
      assert_equal "parse_model:custom_with_url_id" "mymodel" m.model_id;
      assert_true "parse_model:custom_with_url_provider"
-       (m.provider = Cascade.Custom "mymodel");
+       (m.provider = Model_spec.Custom "mymodel");
      assert_equal "parse_model:custom_with_url_url" "http://localhost:9999" m.api_url
    | Error e -> assert_true ("parse_model:custom_url_failed: " ^ e) false);
 
-  (match Cascade.model_spec_of_string "custom:bare-model" with
+  (match Model_spec.model_spec_of_string "custom:bare-model" with
    | Ok m ->
      assert_equal "parse_model:custom_bare_id" "bare-model" m.model_id;
      assert_true "parse_model:custom_bare_provider"
-       (m.provider = Cascade.Custom "bare-model");
+       (m.provider = Model_spec.Custom "bare-model");
      assert_equal "parse_model:custom_bare_url" "http://127.0.0.1:8080" m.api_url
    | Error e -> assert_true ("parse_model:custom_bare_failed: " ^ e) false);
 
@@ -191,15 +191,15 @@ let test_llm_client () = group "LLM Client" (fun () ->
 
   (* 6. Built-in model specs *)
   assert_true "builtin:llama_default_context"
-    (Cascade.llama_default.max_context = 128000);
+    (Model_spec.llama_default.max_context = 128000);
   assert_true "builtin:claude_opus_cost"
-    (Cascade.claude_opus.cost_per_1k_input > 0.0);
+    (Model_spec.claude_opus.cost_per_1k_input > 0.0);
   assert_true "builtin:gemini_pro_provider"
-    (Cascade.gemini_pro.provider = Cascade.Gemini);
+    (Model_spec.gemini_pro.provider = Model_spec.Gemini);
   assert_true "builtin:openai_default_provider"
-    (Cascade.openai_default.provider = Cascade.OpenAI);
+    (Model_spec.openai_default.provider = Model_spec.OpenAI);
   assert_true "builtin:llama_default_provider"
-    (Cascade.llama_default.provider = Cascade.Llama);
+    (Model_spec.llama_default.provider = Model_spec.Llama);
   (* Set env vars so default_local_model_spec resolves llama regardless of CI env *)
   let prev_provider = Sys.getenv_opt "MASC_DEFAULT_PROVIDER" in
   let prev_model = Sys.getenv_opt "MASC_DEFAULT_MODEL" in
@@ -207,9 +207,9 @@ let test_llm_client () = group "LLM Client" (fun () ->
   Unix.putenv "MASC_DEFAULT_PROVIDER" "llama";
   Unix.putenv "MASC_DEFAULT_MODEL" "default-model";
   Unix.putenv "LLAMA_DEFAULT_MODEL" "default-model";
-  let default_local = Cascade.default_local_model_spec () in
+  let default_local = Model_spec.default_local_model_spec () in
   assert_true "builtin:default_local_provider"
-    (default_local.provider = Cascade.Llama);
+    (default_local.provider = Model_spec.Llama);
   assert_equal "builtin:default_local_model_id"
     "default-model" default_local.model_id;
   (* Restore env vars *)
@@ -460,7 +460,7 @@ let test_succession () = group "Succession" (fun () ->
     Cascade.tool_msg ~name:"grep" ~call_id:"c1" "results";
     Agent_sdk.Types.assistant_msg "done";
   ] in
-  let normalized = Succession_oas.normalize_for_model msgs Cascade.llama_default in
+  let normalized = Succession_oas.normalize_for_model msgs Model_spec.llama_default in
   (* Tool messages should be converted to user messages for local llama runtimes *)
   let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
     m.role = Agent_sdk.Types.Tool) normalized in
@@ -472,13 +472,13 @@ let test_succession () = group "Succession" (fun () ->
     Agent_sdk.Types.user_msg "part2";
     Agent_sdk.Types.assistant_msg "response";
   ] in
-  let normalized2 = Succession_oas.normalize_for_model msgs2 Cascade.claude_opus in
+  let normalized2 = Succession_oas.normalize_for_model msgs2 Model_spec.claude_opus in
   assert_true "normalize:claude_merged"
     (List.length normalized2 <= List.length msgs2);
 
   (* 7. Hydrate from DNA *)
   let spec = Succession_oas.{
-    model = Cascade.llama_default;
+    model = Model_spec.llama_default;
     inherit_tools = true;
     context_budget = 0.3;
   } in
@@ -498,7 +498,7 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
 
   (* 1. Default config *)
   let config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Cascade.llama_default] () in
+    ~goal:"test" ~models:[Model_spec.llama_default] () in
   assert_equal "config:goal" "test" config.initial_goal;
   assert_float_near "config:compact" 0.5 config.compact_threshold 0.01;
   assert_float_near "config:handoff" 0.85 config.handoff_threshold 0.01;
@@ -528,7 +528,7 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
 
   (* 5. Stopped state is reflected in status *)
   let fresh_config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Cascade.llama_default] () in
+    ~goal:"test" ~models:[Model_spec.llama_default] () in
   let fresh_state = Perpetual_loop.create_state fresh_config in
   Perpetual_loop.stop fresh_state;
   assert_true "stop:running_false" (not fresh_state.running);
@@ -573,8 +573,8 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
     ~goal:"multi"
     ~models:
       [
-        Cascade.llama_default;
-        { Cascade.llama_default with model_id = "qwen3.5-9b" };
+        Model_spec.llama_default;
+        { Model_spec.llama_default with model_id = "qwen3.5-9b" };
       ]
     () in
   assert_equal "cascade:model_count" 2
@@ -631,7 +631,7 @@ let test_auto_claim () = group "Auto-Claim" (fun () ->
 
   (* 1. Auto-claim disabled when no room_config *)
   let config = Perpetual_loop.default_config
-    ~goal:"test" ~models:[Cascade.llama_default] () in
+    ~goal:"test" ~models:[Model_spec.llama_default] () in
   assert_true "auto_claim:disabled_by_default" (config.room_config = None);
   let state = Perpetual_loop.create_state config in
   assert_true "auto_claim:no_current_task" (state.current_task_id = None);
@@ -755,7 +755,7 @@ let test_integration () = group "Integration" (fun () ->
   assert_equal "integration:dna_goal" "integration test" dna.goal;
 
   let spec = Succession_oas.{
-    model = Cascade.llama_default;
+    model = Model_spec.llama_default;
     inherit_tools = true;
     context_budget = 0.5;
   } in
@@ -818,10 +818,10 @@ let test_integration () = group "Integration" (fun () ->
   assert_true "roundtrip:no_tag_collision" (back_tricky.role = Agent_sdk.Types.User);
 
   (* 3e. Llm_client OAS type adapters *)
-  let provider_config = Oas_type_adapters.to_oas_provider Cascade.claude_opus in
+  let provider_config = Oas_type_adapters.to_oas_provider Model_spec.claude_opus in
   assert_true "oas_adapter:claude_mapped" (Option.is_some provider_config);
   let provider_config_custom = Oas_type_adapters.to_oas_provider
-    { Cascade.llama_default with provider = Cascade.Custom "test" } in
+    { Model_spec.llama_default with provider = Model_spec.Custom "test" } in
   assert_true "oas_adapter:custom_mapped" (Option.is_some provider_config_custom);
 
   (* 3f. Llm_client message/usage roundtrip *)

--- a/test/test_tool_perpetual_coverage.ml
+++ b/test/test_tool_perpetual_coverage.ml
@@ -10,6 +10,7 @@
 module Tool_perpetual = Masc_mcp.Tool_perpetual
 module Perpetual_loop = Masc_mcp.Perpetual_loop
 module Cascade = Masc_mcp.Cascade
+module Model_spec = Masc_mcp.Model_spec
 
 (* ============================================================
    Test Helpers
@@ -25,8 +26,8 @@ let make_ctx () : Tool_perpetual.context = {
 }
 
 (** Create a default model spec for testing. *)
-let test_model : Cascade.model_spec = {
-  provider = Cascade.Llama;
+let test_model : Model_spec.model_spec = {
+  provider = Model_spec.Llama;
   model_id = "test-model";
   max_context = 4000;
   api_url = "http://127.0.0.1:8085";


### PR DESCRIPTION
## Summary

Cascade에서 Model_spec re-export 18개(type 2 + value 16) 삭제.
40+ 파일이 `Model_spec.*`를 직접 참조하도록 전환.

- cascade.ml: 347 -> 303줄
- Cascade 모듈이 model_spec/provider 소유권을 완전히 포기
- 47파일, -41 LOC

## Test plan

- [x] `dune build --root .`
- [x] `test_cascade.exe` (8/8)
- [x] `test_perpetual.exe` (193/193)
- [x] `test_llm_client_coverage.exe` (7/7)
- [x] `test_tool_perpetual_coverage.exe` (22/22)
- [ ] CI green