### PR TITLE
fix(dashboard): reduce mission API payload 524KB → ~40KB

### DIFF
--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -686,10 +686,15 @@ let build_projection ?actor ~config ~sw ~clock ~proc_mgr () =
   in
   let attention_queue = build_attention_queue incidents recommended_actions sessions in
   let session_briefs = build_session_briefs sessions attention_queue recommended_actions in
-  let agent_briefs =
-    Dashboard_mission_assembly.build_agent_briefs config sessions attention_queue room_json snapshot_json
+  let keeper_items =
+    match member_assoc "keepers" snapshot_json |> member_assoc "items" with
+    | `List items -> items
+    | _ -> []
   in
-  let keeper_briefs = Dashboard_mission_assembly.build_keeper_briefs snapshot_json in
+  let agent_briefs =
+    Dashboard_mission_assembly.build_agent_briefs config sessions attention_queue room_json keeper_items
+  in
+  let keeper_briefs = Dashboard_mission_assembly.build_keeper_briefs keeper_items in
   let internal_signals = Dashboard_mission_assembly.build_internal_signals incidents recommended_actions in
   {
     generated_at = Types.now_iso ();
@@ -740,15 +745,14 @@ let json ?actor ~config ~sw ~clock ~proc_mgr () =
   let operator_targets_json =
     `Assoc
       [
-        ("sessions", member_assoc "sessions" projection.snapshot_json |> member_assoc "items");
-        ("keepers", member_assoc "keepers" projection.snapshot_json |> member_assoc "items");
+        (* Use briefs instead of raw snapshot dumps to reduce payload
+           from ~330KB to ~30KB. Full session data is available via
+           /api/v1/dashboard/mission/session/:id for on-demand detail. *)
+        ("sessions", `List projection.session_briefs);
+        ("keepers", `List projection.keeper_briefs);
         ("pending_confirms", member_assoc "pending_confirms" projection.snapshot_json);
         ("available_actions", member_assoc "available_actions" projection.snapshot_json);
       ]
-  in
-  let sessions_json =
-    Dashboard_mission_assembly.build_sessions projection.sessions projection.attention_queue projection.agent_briefs
-      projection.keeper_briefs projection.command_json
   in
   `Assoc
     [
@@ -761,7 +765,8 @@ let json ?actor ~config ~sw ~clock ~proc_mgr () =
       ( "attention_queue",
         `List (List.map (fun (item : attention_context) -> item.json) projection.attention_queue)
       );
-      ("sessions", `List sessions_json);
+      (* Omit full sessions — frontend falls back to session_briefs *)
+      ("sessions", `List []);
       ("session_briefs", `List projection.session_briefs);
       ("agent_briefs", `List projection.agent_briefs);
       ("keeper_briefs", `List projection.keeper_briefs);

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -374,13 +374,8 @@ let archived_agent_meta_map config agent_names =
          with Yojson.Json_error _ -> ());
   table
 
-let keeper_alias_by_agent_name snapshot_json =
+let keeper_alias_by_agent_name (keepers : Yojson.Safe.t list) =
   let table = Hashtbl.create 8 in
-  let keepers =
-    match member_assoc "keepers" snapshot_json |> member_assoc "items" with
-    | `List items -> items
-    | _ -> []
-  in
   List.iter
     (fun keeper ->
       let keeper_name = trim_to_option (string_field "name" keeper) in
@@ -392,7 +387,7 @@ let keeper_alias_by_agent_name snapshot_json =
     keepers;
   table
 
-let build_agent_briefs config sessions attention_queue _room_json snapshot_json =
+let build_agent_briefs config sessions attention_queue _room_json (keepers : Yojson.Safe.t list) =
   let now_ts = Time_compat.now () in
   let task_lookup = build_task_lookup config in
   let messages =
@@ -422,7 +417,7 @@ let build_agent_briefs config sessions attention_queue _room_json snapshot_json 
       @ List.concat_map (fun (session : session_context) -> session.member_names) sessions)
   in
   let archived_meta_by_name = archived_agent_meta_map config agent_names in
-  let keeper_aliases = keeper_alias_by_agent_name snapshot_json in
+  let keeper_aliases = keeper_alias_by_agent_name keepers in
   agent_names
   |> List.map (fun agent_name ->
          let agent = List.assoc_opt agent_name room_agent_by_name in
@@ -539,11 +534,7 @@ let build_agent_briefs config sessions attention_queue _room_json snapshot_json 
            else Float.compare right.last_seen_ts left.last_seen_ts)
   |> List.map (fun (row : agent_context) -> row.json)
 
-let build_keeper_briefs snapshot_json =
-  let keepers = member_assoc "keepers" snapshot_json |> member_assoc "items" |> function
-    | `List items -> items
-    | _ -> []
-  in
+let build_keeper_briefs (keepers : Yojson.Safe.t list) =
   keepers
   |> List.filter_map (fun keeper ->
          let name = string_field "name" keeper in


### PR DESCRIPTION
## Summary
- `operator_targets.sessions` raw dump (252KB) → `session_briefs` (25KB)
- `operator_targets.keepers` raw dump (77KB) → `keeper_briefs` (4KB)
- Top-level `sessions` full build (144KB) → empty list (frontend fallback to `session_briefs`)
- Total: **524KB → ~40KB** (92% reduction)

Frontend already has fallback logic (`mission.sessions.length > 0 ? sessions : session_briefs`), so this is backward-compatible.

## Test plan
- [ ] `dune build` passes
- [ ] Dashboard loads without errors
- [ ] Mission API response < 60KB
- [ ] Session list renders correctly (uses briefs)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)