### PR TITLE
fix(team-session): prevent orphaned dirs on failed session creation

### DIFF
--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -111,7 +111,6 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     let min_agents = clamp_int ~min_v:1 ~max_v:64 min_agents in
     let now = Time_compat.now () in
     let session_id = Team_session_store.make_session_id () in
-    Team_session_store.ensure_session_dirs config session_id;
     let* () =
       match operation_id with
       | Some value -> validate_operation_attachment ~config ~operation_id:value
@@ -183,6 +182,9 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         updated_at_iso = now_iso ();
       }
     in
+    (* Create dirs only after validation succeeds — prevents orphaned
+       directories when validate_operation_attachment returns Error. *)
+    Team_session_store.ensure_session_dirs config session_id;
     Team_session_store.save_session config session;
     let* () =
       match operation_id with

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -257,7 +257,7 @@ let list_sessions ?(since_unix = 0.0) config : Team_session_types.session list =
                     in
                     has_sub snippet {|"Running"|}
                     || has_sub snippet {|"Paused"|}
-                  with Sys_error _ | End_of_file -> false)
+                  with Sys_error _ | End_of_file | Eio.Io _ -> false)
               with Unix.Unix_error _ -> true
             ) dirs
         in


### PR DESCRIPTION
## Summary
- `ensure_session_dirs`를 `validate_operation_attachment` 이후로 이동하여, validation 실패 시 고아 디렉토리(checkpoints/, worker-runs/ 만 있고 session.json 없음) 생성을 방지
- `list_sessions` filesystem fallback에서 `Eio.Io` 예외도 처리하여 dashboard WARN 반복 로그 해소

## Root Cause
`start_session`에서 `ensure_session_dirs`가 validation 전에 실행됨 → validation 실패 시 디렉토리만 남고 `session.json` 미생성 → dashboard가 주기적으로 이 파일을 읽으려다 `Eio.Io Fs Not_found` 예외 반복

## Test plan
- [x] `dune build` 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)