### PR TITLE
fix(gardener): expose worker tool schemas

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -275,6 +275,108 @@ let local_worker_internal_schemas : Types.tool_schema list =
     };
   ]
 
+let local_worker_compat_passthrough_schemas : Types.tool_schema list =
+  [
+    {
+      Types.name = "masc_status";
+      description =
+        "Get the current MASC room status including active agents and task backlog.";
+      input_schema =
+        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
+    };
+    {
+      Types.name = "masc_tasks";
+      description =
+        "List tasks in the backlog with status, assignee, and priority.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("status", `Assoc [ ("type", `String "string") ]);
+                  ("include_done", `Assoc [ ("type", `String "boolean") ]);
+                  ("include_cancelled", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+    {
+      Types.name = "masc_claim_next";
+      description =
+        "Claim the next available task automatically by priority order.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc [ ("agent_name", `Assoc [ ("type", `String "string") ]) ] );
+            ("required", `List [ `String "agent_name" ]);
+          ];
+    };
+    {
+      Types.name = "masc_transition";
+      description =
+        "Move a task through claim/start/done/cancel/release transitions.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                  ("task_id", `Assoc [ ("type", `String "string") ]);
+                  ("action", `Assoc [ ("type", `String "string") ]);
+                  ("expected_version", `Assoc [ ("type", `String "integer") ]);
+                  ("notes", `Assoc [ ("type", `String "string") ]);
+                  ("reason", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ( "required",
+              `List
+                [
+                  `String "agent_name";
+                  `String "task_id";
+                  `String "action";
+                ] );
+          ];
+    };
+    {
+      Types.name = "masc_add_task";
+      description = "Add a new task to the MASC backlog.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("title", `Assoc [ ("type", `String "string") ]);
+                  ("priority", `Assoc [ ("type", `String "integer") ]);
+                  ("description", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "title" ]);
+          ];
+    };
+    {
+      Types.name = "masc_broadcast";
+      description = "Broadcast a message to all agents in the room.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                  ("message", `Assoc [ ("type", `String "string") ]);
+                  ("format", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "agent_name"; `String "message" ]);
+          ];
+    };
+  ]
+
 let local_worker_code_schemas : Types.tool_schema list =
   [
     {
@@ -512,7 +614,10 @@ let select_public_local_worker_schemas () =
 let local_worker_tool_schemas ?names () :
     (Types.tool_schema list, string) result =
   let all_schemas =
-    dedupe_schemas (local_worker_internal_schemas @ select_public_local_worker_schemas ())
+    dedupe_schemas
+      ( local_worker_internal_schemas
+      @ local_worker_compat_passthrough_schemas
+      @ select_public_local_worker_schemas () )
   in
   match names with
   | None -> Ok all_schemas

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -1235,6 +1235,22 @@ let test_worker_tool_count_bounds () =
   check bool "at least 5 tools" true (n >= 5);
   check bool "at most 30 tools" true (n <= 30)
 
+let test_worker_tool_names_are_resolvable () =
+  match
+    Capability_registry.local_worker_tool_schemas
+      ~names:Agent_tool_surfaces.gardener_worker_tool_names ()
+  with
+  | Error err -> failf "expected gardener worker schemas to resolve: %s" err
+  | Ok schemas ->
+      let resolved =
+        List.map (fun (schema : Types.tool_schema) -> schema.name) schemas
+      in
+      List.iter
+        (fun name ->
+          check bool (Printf.sprintf "%s resolvable" name) true
+            (List.mem name resolved))
+        Agent_tool_surfaces.gardener_worker_tool_names
+
 let test_run_for_gap_without_eio_returns_error () =
   let dir = test_dir () in
   Fun.protect
@@ -1252,6 +1268,8 @@ let worker_suite = [
     test_worker_tools_exclude_admin;
   "worker_tool_count_bounds", `Quick,
     test_worker_tool_count_bounds;
+  "worker_tool_names_are_resolvable", `Quick,
+    test_worker_tool_names_are_resolvable;
   "run_for_gap_without_eio_returns_error", `Quick,
     test_run_for_gap_without_eio_returns_error;
 ]


### PR DESCRIPTION
## Summary
- add the canonical MASC room/task/broadcast schemas that Gardener workers request to the local worker schema surface
- keep the fix dependency-light so Agent_tool_surfaces does not reintroduce a Tool_task/Tool_room cycle
- add a regression test that asserts every Gardener worker tool name resolves through Capability_registry.local_worker_tool_schemas

## Root cause
Gardener workers ask for canonical tools like `masc_status`, `masc_tasks`, `masc_claim_next`, `masc_transition`, `masc_add_task`, and `masc_broadcast`, but the local worker schema registry did not expose those schemas. That made schema lookup fail and the worker start with an empty tool list.

## Verification
- attempted `DUNE_BUILD_DIR=_build_codex_pr dune build --root . -j 1`
- build was started from the fresh worktree on top of `main`, but I did not wait for the full repo build to complete before opening this draft PR