### PR TITLE
fix(dashboard): resolve navigation double-click bug

### DIFF
--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -162,7 +162,15 @@ export function navigate(tab: AnyTabId, params?: Record<string, string>): void {
     ? { ...redirect.params, ...(params ?? {}) }
     : params ?? {}
   const next = { tab: resolvedTab, params: resolvedParams, postId: null } satisfies RouteState
-  window.location.hash = toHash(next)
+  const nextHash = toHash(next)
+  // Update signal synchronously so Preact re-renders immediately.
+  // Without this, clicking the same surface twice is needed because
+  // hashchange fires asynchronously and may be skipped if the hash
+  // is identical to the current value.
+  route.value = next
+  if (window.location.hash !== nextHash) {
+    window.location.hash = nextHash
+  }
 }
 
 export function navigateToPost(postId: string): void {


### PR DESCRIPTION
## Summary
- `navigate()` now sets `route.value` synchronously before `window.location.hash`
- Prevents double-click needed when navigating (especially to #lab)
- Guards against no-op when hash is already identical

## Root cause
`hashchange` event is async and skipped entirely when the new hash equals the current hash. The route signal only updated via hashchange listener, so the first click sometimes appeared to do nothing.

## Test plan
- [ ] Dashboard builds (`npm run build`)
- [ ] Navigate to each tab with single click
- [ ] #lab tab works on first click
- [ ] Back/forward browser buttons still work
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)