### PR TITLE
refactor: remove OAS-duplicate helpers from Cascade

### DIFF
--- a/archive/trpg/lib/trpg_dm_intent.ml
+++ b/archive/trpg/lib/trpg_dm_intent.ml
@@ -294,7 +294,7 @@ let parse_llm_intent (text : string) : (dm_intent, string) result =
 
 (** Validate that an LLM response contains a parseable non-Unknown intent. *)
 let llm_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
-  match parse_llm_intent (Cascade.text_of_response resp) with
+  match parse_llm_intent (Llm_provider.Types.text_of_response resp) with
   | Ok intent -> not (equal_intent_category intent.primary Unknown)
   | Error _ -> false
 

--- a/archive/trpg/lib/trpg_harness.ml
+++ b/archive/trpg/lib/trpg_harness.ml
@@ -116,7 +116,7 @@ let tier1_check ~(model : Model_spec.model_spec) ~actor_name ~actor_persona
     response_format = `Text;
   } in
   match Llm_orchestration.complete req with
-  | Ok resp -> parse_tier1 (Cascade.text_of_response resp)
+  | Ok resp -> parse_tier1 (Llm_provider.Types.text_of_response resp)
   | Error e ->
     eprintf "[trpg_harness] tier1 LLM call failed: %s\n%!" e;
     Fail ("tier1_unavailable: " ^ e)
@@ -211,7 +211,7 @@ let tier2_evaluate ~(model : Model_spec.model_spec) ~actor_name ~actor_persona
     response_format = `Text;
   } in
   match Llm_orchestration.complete req with
-  | Ok resp -> parse_tier2 (Cascade.text_of_response resp)
+  | Ok resp -> parse_tier2 (Llm_provider.Types.text_of_response resp)
   | Error e ->
     eprintf "[trpg_harness] tier2 LLM call failed: %s\n%!" e;
     List.map default_score all_dimensions

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -140,7 +140,7 @@ let cascade_name_for_agent_type agent_type =
   Printf.sprintf "auto_responder_%s" agent_type
 
 let llm_response_is_valid (resp : Llm_provider.Types.api_response) =
-  let s = String.trim (Cascade.text_of_response resp) in
+  let s = String.trim (Llm_provider.Types.text_of_response resp) in
   let s_lower = String.lowercase_ascii s in
   let len = String.length s in
   len > 0
@@ -157,7 +157,7 @@ let call_llm_direct_sync ~agent_type ~prompt =
         ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with
     | Ok resp ->
-        let text = Cascade.text_of_response resp in
+        let text = Llm_provider.Types.text_of_response resp in
         debug_log
           (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s"
              resp.Llm_provider.Types.model agent_type);

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -689,7 +689,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
       ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
   with
   | Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
-  | Ok resp -> parse_llm_code_response (Cascade.text_of_response resp)
+  | Ok resp -> parse_llm_code_response (Llm_provider.Types.text_of_response resp)
 
 (* ================================================================ *)
 (* Loop State Management                                            *)

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -246,7 +246,7 @@ let parse_llm_score (text : string) : float option =
 
 (** Validate that an LLM response contains a parseable score. *)
 let llm_score_is_valid (resp : Llm_provider.Types.api_response) : bool =
-  parse_llm_score (Cascade.text_of_response resp) <> None
+  parse_llm_score (Llm_provider.Types.text_of_response resp) <> None
 
 (** Call LLM to score agent-task compatibility.
     Returns Ok float or Error string. *)
@@ -260,7 +260,7 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
       ~accept:llm_score_is_valid ()
   with
   | Ok resp -> (
-      let text = Cascade.text_of_response resp in
+      let text = Llm_provider.Types.text_of_response resp in
       match parse_llm_score text with
       | Some f -> Ok f
       | None -> Error (Printf.sprintf "unparseable LLM response: %s" text))

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -8,10 +8,15 @@
     Public entry points:
     - {!complete} — messages + cascade_name, returns api_response or error
 
+    Response helpers ([text_of_response], [has_tool_use], [tool_msg])
+    removed — use {!Llm_provider.Types} directly.
+    [get_cascade] inlined into {!Oas_worker}.
+
     @since 2.114.0 — original
     @since 2.115.0 — delegated to OAS Cascade_config
     @since 2.116.0 — call_raw, call_with_tools added
-    @since 2.117.0 — model types extracted to Model_spec *)
+    @since 2.117.0 — model types extracted to Model_spec
+    @since 2.123.0 — OAS-duplicate helpers removed *)
 
 (* ================================================================ *)
 (* Helpers                                                           *)
@@ -28,7 +33,7 @@ let int_of_env_default name ~default ~min_v ~max_v =
       max min_v (min max_v v)
 
 (* ================================================================ *)
-(* Response helpers                                                  *)
+(* Usage helpers (no OAS equivalent — kept here)                     *)
 (* ================================================================ *)
 
 (** Compute total tokens from OAS api_usage. *)
@@ -45,10 +50,6 @@ let zero_usage : Agent_sdk.Types.api_usage =
 let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
   match resp.usage with Some u -> u | None -> zero_usage
 
-(** Extract text content from an api_response. *)
-let text_of_response (resp : Llm_provider.Types.api_response) : string =
-  Agent_sdk.Types.text_of_content resp.content
-
 (** Measure wall-clock latency of a thunk in milliseconds.
     Use at call sites that need per-call timing (keeper tool loops, etc.). *)
 let timed (f : unit -> 'a) : 'a * int =
@@ -56,15 +57,6 @@ let timed (f : unit -> 'a) : 'a * int =
   let result = f () in
   let ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
   (result, ms)
-
-(** Check if an api_response contains any ToolUse blocks. *)
-let has_tool_use (resp : Llm_provider.Types.api_response) : bool =
-  List.exists
-    (function Agent_sdk.Types.ToolUse _ -> true | _ -> false)
-    resp.content
-
-let tool_msg ~name:_ ~call_id text =
-  Agent_sdk.Types.tool_result_msg ~tool_use_id:call_id ~content:text ()
 
 (* ================================================================ *)
 (* UTF-8 Sanitization                                               *)
@@ -230,43 +222,6 @@ let default_model_strings ~cascade_name =
 (* ================================================================ *)
 (* Cascade orchestration                                             *)
 (* ================================================================ *)
-
-(** Backward compat: return MASC model_spec list.
-    Prefer {!complete} instead. *)
-let get_cascade ?(config_path = "") ~cascade_name () :
-    Model_spec.model_spec list =
-  let defaults = default_model_strings ~cascade_name in
-  let configured =
-    if String.length config_path > 0 then
-      let from_file =
-        Llm_provider.Cascade_config.load_profile
-          ~config_path ~name:cascade_name
-      in
-      if from_file <> [] then from_file else defaults
-    else
-      match default_config_path () with
-      | Some path ->
-        let from_file =
-          Llm_provider.Cascade_config.load_profile
-            ~config_path:path ~name:cascade_name
-        in
-        if from_file <> [] then from_file else defaults
-      | None -> defaults
-  in
-  let specs = Model_spec.available_model_specs_of_strings configured in
-  if specs <> [] then specs
-  else
-    let fallback = default_model_strings ~cascade_name in
-    if configured = fallback then (
-      Printf.eprintf
-        "[cascade] %s: no callable models from built-in defaults\n%!"
-        cascade_name;
-      [])
-    else (
-      Printf.eprintf
-        "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!"
-        cascade_name;
-      Model_spec.available_model_specs_of_strings fallback)
 
 (** Format OAS http_error as cascade error string. *)
 let format_cascade_error ~cascade_name = function

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -304,8 +304,8 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
           ?tools:tools_json ~temperature:0.2 ~max_tokens:4096
           ~timeout_sec ()
       with
-      | Ok resp when trim (Cascade.text_of_response resp) <> "" -> Ok (Cascade.text_of_response resp)
-      | Ok resp when Cascade.has_tool_use resp ->
+      | Ok resp when trim (Llm_provider.Types.text_of_response resp) <> "" -> Ok (Llm_provider.Types.text_of_response resp)
+      | Ok resp when List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false) resp.content ->
           Ok (Yojson.Safe.to_string (llm_tool_calls_json resp.content))
       | Ok _ -> Error "empty completion"
       | Error msg -> Error msg)

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -339,7 +339,7 @@ let verify_worker ~pattern (worker : worker_plan) diff =
           ~messages:[Agent_sdk.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:200 ()
       with
-      | Ok resp -> Verifier_oas.parse_verdict (Cascade.text_of_response resp)
+      | Ok resp -> Verifier_oas.parse_verdict (Llm_provider.Types.text_of_response resp)
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in
     let our_verdict =

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -187,7 +187,7 @@ let parse_intent_response (text : string) : (query_intent * float) option =
 
 (** Validate that an LLM response contains a parseable intent. *)
 let intent_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
-  parse_intent_response (Cascade.text_of_response resp) <> None
+  parse_intent_response (Llm_provider.Types.text_of_response resp) <> None
 
 (** Classify query intent using LLM semantic understanding.
     Returns (intent, confidence) or falls back to low-confidence default. *)
@@ -200,7 +200,7 @@ let classify_intent_llm (query : string) : query_intent * float =
       ~accept:intent_response_is_valid ()
   with
   | Ok resp -> (
-      match parse_intent_response (Cascade.text_of_response resp) with
+      match parse_intent_response (Llm_provider.Types.text_of_response resp) with
       | Some result -> result
       | None -> (Coordination, 0.3))  (* unparseable → low-confidence fallback *)
   | Error _err -> (Coordination, 0.3)  (* LLM error → low-confidence fallback *)
@@ -215,7 +215,7 @@ let classify_intent_hybrid (query : string) : query_intent * float =
       ~accept:intent_response_is_valid ()
   with
   | Ok resp -> (
-      match parse_intent_response (Cascade.text_of_response resp) with
+      match parse_intent_response (Llm_provider.Types.text_of_response resp) with
       | Some result -> result
       | None -> classify_intent_heuristic query)
   | Error _err -> classify_intent_heuristic query

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -291,7 +291,7 @@ let compute_judgments ~base_path:_ ~factual_json =
   | Error message -> Error message
   | Ok response -> (
       try
-        let parsed = Yojson.Safe.from_string (Cascade.text_of_response response) in
+        let parsed = Yojson.Safe.from_string (Llm_provider.Types.text_of_response response) in
         let generated_at = now_iso () in
         let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
         let items =

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -296,7 +296,7 @@ let compute_judgments ~facts_json =
   | Error message -> Error message
   | Ok response -> (
       try Ok (response.Llm_provider.Types.model,
-              Yojson.Safe.from_string (Cascade.text_of_response response))
+              Yojson.Safe.from_string (Llm_provider.Types.text_of_response response))
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -49,7 +49,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:200 () with
-    | Ok resp -> Cascade.text_of_response resp
+    | Ok resp -> Llm_provider.Types.text_of_response resp
     | Error _ -> ""
   in
 
@@ -442,7 +442,7 @@ Room 내 활성 에이전트: %d
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~max_tokens:300 () with
-    | Ok resp -> Ok (Cascade.text_of_response resp)
+    | Ok resp -> Ok (Llm_provider.Types.text_of_response resp)
     | Error err -> Error ("llm intervention failed: " ^ err)
   in
 

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -251,7 +251,29 @@ let require_eio () =
   | _, None -> Error "Eio net not available (running outside server context)"
 
 let resolve_cascade ~cascade_name =
-  match Cascade.get_cascade ~cascade_name () with
+  let defaults = Cascade.default_model_strings ~cascade_name in
+  let configured =
+    match Cascade.default_config_path () with
+    | Some path ->
+      let from_file =
+        Llm_provider.Cascade_config.load_profile ~config_path:path ~name:cascade_name
+      in
+      if from_file <> [] then from_file else defaults
+    | None -> defaults
+  in
+  let specs = Model_spec.available_model_specs_of_strings configured in
+  let specs =
+    if specs <> [] then specs
+    else
+      let fallback = Cascade.default_model_strings ~cascade_name in
+      if configured = fallback then (
+        Printf.eprintf "[cascade] %s: no callable models from built-in defaults\n%!" cascade_name;
+        [])
+      else (
+        Printf.eprintf "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!" cascade_name;
+        Model_spec.available_model_specs_of_strings fallback)
+  in
+  match specs with
   | [] ->
     Error (Printf.sprintf "No models available for cascade '%s'" cascade_name)
   | spec :: _ ->

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -1,7 +1,8 @@
 (** Oas_worker — Unified entry point for OAS-based MASC tool modules.
 
-    Callers pass a [cascade_name] string; model resolution is delegated
-    to [Cascade.get_cascade].  Internal [config] / [build] / [run]
+    Callers pass a [cascade_name] string; model resolution is handled
+    internally via [Cascade.default_model_strings] and
+    [Llm_provider.Cascade_config].  Internal [config] / [build] / [run]
     are implementation details and not exported.
 
     @since Phase 1 — MASC→OAS migration

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -109,7 +109,7 @@ let score_to_verdict ~(dim_name : string) (score : int) : verdict =
 
 (** Validate that an LLM response contains parseable G-Eval scores. *)
 let geval_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
-  match parse_geval_response (Cascade.text_of_response resp) with
+  match parse_geval_response (Llm_provider.Types.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false
 
@@ -125,7 +125,7 @@ let verify_llm ~content : (verification_result, string) result =
   with
   | Error err -> Error err
   | Ok resp -> (
-      match parse_geval_response (Cascade.text_of_response resp) with
+      match parse_geval_response (Llm_provider.Types.text_of_response resp) with
       | Error err -> Error err
       | Ok (r, q, s, _reasoning) ->
           let relevance = score_to_verdict ~dim_name:"relevance" r in

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -265,7 +265,7 @@ let get_chain_id_for_preset = function
   | _ -> None
 
 let walph_response_is_valid (resp : Llm_provider.Types.api_response) =
-  let content = String.trim (Cascade.text_of_response resp) in
+  let content = String.trim (Llm_provider.Types.text_of_response resp) in
   let lower = String.lowercase_ascii content in
   let len = String.length content in
   len > 0
@@ -279,7 +279,7 @@ let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars (
       ~messages:[Agent_sdk.Types.user_msg prompt] ~timeout_sec
       ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with
-  | Ok resp -> Cascade.text_of_response resp
+  | Ok resp -> Llm_provider.Types.text_of_response resp
   | Error err -> failwith err
 
 (** {1 Main Loop} *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -121,7 +121,7 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
             ~messages:[Agent_sdk.Types.user_msg prompt]
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
         | Ok resp ->
-            let text = Cascade.text_of_response resp in
+            let text = Llm_provider.Types.text_of_response resp in
             let model = resp.Llm_provider.Types.model in
             if String.length text > 5 then (
               log_debug (sprintf "LLM response from %s (%d chars)" model

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -286,7 +286,7 @@ let handle_execute _ctx args =
     | Ok result ->
       json_ok (`Assoc [
         ("topic", `String topic);
-        ("deliberation", `String (Cascade.text_of_response result.response));
+        ("deliberation", `String (Llm_provider.Types.text_of_response result.response));
         ("turns", `Int result.turns);
         ("session_id", `String result.session_id);
         ("runtime", `String "oas");
@@ -309,7 +309,7 @@ let handle_execute_dry_run _ctx args =
     | Ok result ->
       json_ok (`Assoc [
         ("topic", `String topic);
-        ("analysis", `String (Cascade.text_of_response result.response));
+        ("analysis", `String (Llm_provider.Types.text_of_response result.response));
         ("turns", `Int result.turns);
         ("session_id", `String result.session_id);
         ("dry_run", `Bool true);

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -204,7 +204,7 @@ let handle_mitosis_divide ctx args : result =
   | Error e ->
     json_err (Printf.sprintf "OAS child agent failed: %s" e)
   | Ok result ->
-    let response_text = Cascade.text_of_response result.response in
+    let response_text = Llm_provider.Types.text_of_response result.response in
     json_ok (`Assoc [
       ("divided", `Bool true);
       ("session_id", `String result.session_id);
@@ -280,7 +280,7 @@ let handle_mitosis_handoff ctx args : result =
         ("runtime", `String "oas");
       ])
     | Ok result ->
-      let response_text = Cascade.text_of_response result.response in
+      let response_text = Llm_provider.Types.text_of_response result.response in
       json_ok (`Assoc [
         ("action", `String "handoff");
         ("generation", `Int new_cell.Mitosis.generation);

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -465,7 +465,7 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
       with
       | Ok resp -> (
           try
-            Yojson.Safe.from_string (Cascade.text_of_response resp)
+            Yojson.Safe.from_string (Llm_provider.Types.text_of_response resp)
             |> parse_routing_decision_json
           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
       | Error _ -> None)

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -29,7 +29,11 @@ let test_load_models_from_config () =
   with_temp_json
     {|{"heartbeat_action_models":["llama:qwen-local","llama:qwen-local-fallback"]}|}
     (fun path ->
-      let specs = Cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+      let from_file =
+        Llm_provider.Cascade_config.load_profile ~config_path:path ~name:"heartbeat_action"
+      in
+      check int "loaded model count" 2 (List.length from_file);
+      let specs = Model_spec.available_model_specs_of_strings from_file in
       check int "spec count" 2 (List.length specs);
       match specs with
       | [ first; second ] ->
@@ -44,7 +48,10 @@ let test_skips_invalid_and_missing_api_key () =
       with_temp_json
         {|{"heartbeat_action_models":["invalid","gemini:gemini-2.5-pro","llama:qwen-live"]}|}
         (fun path ->
-          let specs = Cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+          let from_file =
+            Llm_provider.Cascade_config.load_profile ~config_path:path ~name:"heartbeat_action"
+          in
+          let specs = Model_spec.available_model_specs_of_strings from_file in
           check int "only llama survives" 1 (List.length specs);
           match specs with
           | [ only ] ->
@@ -54,8 +61,8 @@ let test_skips_invalid_and_missing_api_key () =
           | _ -> fail "expected one surviving spec"))
 
 let test_missing_config_uses_defaults () =
-  let path = Filename.concat (Filename.get_temp_dir_name ()) "missing-llm-cascade.json" in
-  let specs = Cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+  let defaults = Cascade.default_model_strings ~cascade_name:"heartbeat_action" in
+  let specs = Model_spec.available_model_specs_of_strings defaults in
   check bool "defaults available" true (List.length specs >= 1);
   match specs with
   | first :: _ ->

--- a/test/test_llm_client_coverage.ml
+++ b/test/test_llm_client_coverage.ml
@@ -8,7 +8,7 @@ let test_string_of_provider () =
   check string "gemini" "gemini" (Model_spec.string_of_provider Model_spec.Gemini)
 
 let test_message_constructors () =
-  let tool_msg = Cascade.tool_msg ~name:"grep" ~call_id:"call-1" "done" in
+  let tool_msg = Llm_provider.Types.tool_result_msg ~tool_use_id:"call-1" ~content:"done" () in
   check bool "system role" true
     (match (Agent_sdk.Types.system_msg "x").role with Agent_sdk.Types.System -> true | _ -> false);
   let has_call1 = List.exists (function

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -16,7 +16,7 @@ let make_test_messages () : Agent_sdk.Types.message list =
     Agent_sdk.Types.system_msg "You are a helpful assistant.";
     Agent_sdk.Types.user_msg "Hello, what is 2+2?";
     Agent_sdk.Types.assistant_msg "The answer is 4.";
-    Cascade.tool_msg ~name:"calculator" ~call_id:"call-1" "result: 4";
+    Llm_provider.Types.tool_result_msg ~tool_use_id:"call-1" ~content:"result: 4" ();
     Agent_sdk.Types.user_msg "Thanks, now solve x^2 = 9.";
     Agent_sdk.Types.assistant_msg "x = 3 or x = -3.";
   ]
@@ -54,7 +54,7 @@ let test_roundtrip_system_msg_dropped () =
     true (Option.is_none result)
 
 let test_roundtrip_tool_msg () =
-  let msg = Cascade.tool_msg ~name:"calc" ~call_id:"tc-1" "tool output here" in
+  let msg = Llm_provider.Types.tool_result_msg ~tool_use_id:"tc-1" ~content:"tool output here" () in
   match Oas_type_adapters.to_oas_message msg with
   | None -> Alcotest.fail "tool message should not be dropped"
   | Some oas ->

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -178,7 +178,7 @@ let test_llm_client () = group "LLM Client" (fun () ->
   assert_true "msg:system_role" (msg.role = Agent_sdk.Types.System);
   assert_equal "msg:system_content" "hello" (Agent_sdk.Types.text_of_message msg);
 
-  let msg2 = Cascade.tool_msg ~name:"grep" ~call_id:"c1" "results" in
+  let msg2 = Llm_provider.Types.tool_result_msg ~tool_use_id:"c1" ~content:"results" () in
   assert_true "msg:tool_role" (msg2.role = Agent_sdk.Types.Tool);
   let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult { tool_use_id = "c1"; _ } -> true | _ -> false) msg2.content in
   assert_true "msg:tool_call_id_in_content" has_tool_result;
@@ -273,7 +273,7 @@ let test_context_manager () = group "Context Manager" (fun () ->
   assert_true "importance:recency" (score_2 > score_0);
 
   (* 7. PruneToolOutputs *)
-  let long_tool_msg = { (Cascade.tool_msg ~name:"t" ~call_id:"c" (String.make 1000 'x'))
+  let long_tool_msg = { (Llm_provider.Types.tool_result_msg ~tool_use_id:"c" ~content:(String.make 1000 'x') ())
     with role = Agent_sdk.Types.Tool } in
   let ctx5 = Context_manager.append ctx long_tool_msg in
   let pruned = compact_ctx ctx5 [PruneToolOutputs] in
@@ -457,7 +457,7 @@ let test_succession () = group "Succession" (fun () ->
   (* 5. Cross-model normalization: Llama *)
   let msgs = [
     Agent_sdk.Types.user_msg "hello";
-    Cascade.tool_msg ~name:"grep" ~call_id:"c1" "results";
+    Llm_provider.Types.tool_result_msg ~tool_use_id:"c1" ~content:"results" ();
     Agent_sdk.Types.assistant_msg "done";
   ] in
   let normalized = Succession_oas.normalize_for_model msgs Model_spec.llama_default in
@@ -777,7 +777,7 @@ let test_integration () = group "Integration" (fun () ->
     (after_ctx.token_count < before);
 
   (* 3b. Context_compact_oas roundtrip preserves role information *)
-  let tool_msg_rt = Cascade.tool_msg ~name:"grep" ~call_id:"tc1" "search results" in
+  let tool_msg_rt = Llm_provider.Types.tool_result_msg ~tool_use_id:"tc1" ~content:"search results" () in
   let sys_msg_rt = Agent_sdk.Types.system_msg "you are a helper" in
   let user_msg_rt = Agent_sdk.Types.user_msg "hello" in
   let asst_msg_rt = Agent_sdk.Types.assistant_msg "hi there" in
@@ -794,7 +794,7 @@ let test_integration () = group "Integration" (fun () ->
   let ctx_with_tools = Context_manager.append_many
     (Context_manager.create ~system_prompt:"test" ~max_tokens:10000)
     [Agent_sdk.Types.user_msg "run grep";
-     Cascade.tool_msg ~name:"grep" ~call_id:"c1" (String.make 800 'r');
+     Llm_provider.Types.tool_result_msg ~tool_use_id:"c1" ~content:(String.make 800 'r') ();
      Agent_sdk.Types.assistant_msg "found results"] in
   let pruned_oas = compact_ctx ctx_with_tools [PruneToolOutputs] in
   let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
@@ -804,7 +804,7 @@ let test_integration () = group "Integration" (fun () ->
   assert_true "oas_prune:tool_truncated" (String.length tool_content < 800);
 
   (* 3c2. Tagged roundtrip preserves tool_call_id *)
-  let tool_with_id = Cascade.tool_msg ~name:"grep" ~call_id:"tc-42" "result" in
+  let tool_with_id = Llm_provider.Types.tool_result_msg ~tool_use_id:"tc-42" ~content:"result" () in
   let oas_t = Context_compact_oas.masc_msg_to_oas tool_with_id in
   let back_t = Context_compact_oas.oas_msg_to_masc oas_t in
   let has_tc42 = List.exists (function
@@ -870,7 +870,7 @@ let test_history_offload () = group "History Offload" (fun () ->
   let formatted = Context_manager.format_message_readable user_msg in
   assert_true "format:user" (formatted = "user: hello world");
 
-  let tool_msg = Cascade.tool_msg ~name:"grep" ~call_id:"c1" "search results" in
+  let tool_msg = Llm_provider.Types.tool_result_msg ~tool_use_id:"c1" ~content:"search results" () in
   let formatted_tool = Context_manager.format_message_readable tool_msg in
   assert_true "format:tool_with_name"
     (String.length formatted_tool > 0


### PR DESCRIPTION
## Summary

Cascade에서 OAS와 중복되는 헬퍼 4개 삭제, 소비자가 OAS 직접 사용.

- `text_of_response` (28참조) → `Llm_provider.Types.text_of_response`
- `has_tool_use` (2참조) → 인라인
- `tool_msg` (10참조) → `tool_result_msg` 직접 호출
- `get_cascade` (1참조) → `oas_worker.ml`에 인라인

cascade.ml: 303 → 258줄, 25파일, -15 LOC.

## Test plan

- [x] `dune build --root .`
- [x] `test_cascade.exe` (8/8)
- [x] `test_perpetual.exe` (193/193)
- [x] `test_oas_adapters.exe` (9/9)
- [ ] CI green