### PR TITLE
fix(gardener): add triage noop backoff (#1834)

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -212,10 +212,18 @@ let tick ~sw ~clock:_ ~config ~room_config : unit =
         Eio.traceln "[Gardener] Task pressure: %d TODO, %d high-pri, %d orphans"
           backlog.todo_count backlog.high_priority_todo backlog.orphan_count;
         let triage_state = get_state () in
+        let max_triage_noops = 3 in
+        if triage_state.consecutive_triage_noops >= max_triage_noops then begin
+          Eio.traceln "[Gardener] Triage backoff: %d consecutive noops (>= %d), skipping"
+            triage_state.consecutive_triage_noops max_triage_noops;
+          record_action "triage_backoff"
+            ~reason:(Printf.sprintf "skipped: %d consecutive noops" triage_state.consecutive_triage_noops)
+        end else
         (match Gardener_worker.run_for_backlog ~config:room_config ~backlog with
          | Ok result ->
              triage_state.last_triage_started_at <- Time_compat.now ();
              triage_state.last_triage_outcome <- Triage_productive;
+             triage_state.consecutive_triage_noops <- 0;
              record_action "worker_completed" ~target:result.Oas_worker.session_id
                ~reason:(Printf.sprintf "triage done in %d turns" result.Oas_worker.turns);
              Eio.traceln "[Gardener] Triage worker completed: %s (turns=%d)"
@@ -233,10 +241,12 @@ let tick ~sw ~clock:_ ~config ~room_config : unit =
          | Error err ->
              triage_state.last_triage_started_at <- Time_compat.now ();
              triage_state.last_triage_outcome <- Triage_noop;
+             triage_state.consecutive_triage_noops <- triage_state.consecutive_triage_noops + 1;
              record_action "worker_failed"
                ~reason:"triage worker failed"
                ~error:err;
-             Eio.traceln "[Gardener] Triage worker failed: %s" err;
+             Eio.traceln "[Gardener] Triage worker failed (%d/%d noops): %s"
+               triage_state.consecutive_triage_noops max_triage_noops err;
              let store = Board.global () in
              let msg =
                Printf.sprintf

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -636,6 +636,7 @@ let status_json () : Yojson.Safe.t =
                 ("room_active_agents", `Int state.last_room_active_agents);
                 ("last_triage_outcome", `String (string_of_triage_outcome state.last_triage_outcome));
                 ("last_triage_started_at", json_string_of_float_ts state.last_triage_started_at);
+                ("consecutive_triage_noops", `Int state.consecutive_triage_noops);
                 ("data_source", `String "room_filesystem");
                 ("staleness_warning", `String
                   (if state.last_health_check > 0.0 then

--- a/lib/gardener/gardener_types.ml
+++ b/lib/gardener/gardener_types.ml
@@ -336,6 +336,7 @@ type gardener_state = {
   mutable day_start: float;  (** Start of current "day" for budget tracking *)
   mutable last_triage_started_at: float;
   mutable last_triage_outcome: triage_outcome;
+  mutable consecutive_triage_noops: int;
 } [@@deriving show]
 
 let make_gardener_state () = {
@@ -367,6 +368,7 @@ let make_gardener_state () = {
   day_start = Time_compat.now ();
   last_triage_started_at = 0.0;
   last_triage_outcome = Triage_none;
+  consecutive_triage_noops = 0;
 }
 
 (** {1 Gardener Configuration} *)

--- a/lib/gardener/gardener_types.mli
+++ b/lib/gardener/gardener_types.mli
@@ -260,6 +260,7 @@ type gardener_state = {
   mutable day_start: float;  (** Start of current "day" for budget tracking *)
   mutable last_triage_started_at: float;
   mutable last_triage_outcome: triage_outcome;
+  mutable consecutive_triage_noops: int;
 }
 
 val make_gardener_state : unit -> gardener_state


### PR DESCRIPTION
## Summary
- Gardener가 매 30분마다 빈 triage team-session을 무한 반복 생성하는 버그 수정
- `consecutive_triage_noops` 카운터 추가: 3회 연속 noop/error 시 triage skip
- 성공(`Triage_productive`) 시 카운터 리셋
- health JSON에 `consecutive_triage_noops` 필드 노출 (관측 가능성)

## Root cause
`NeedWorker` → `run_for_backlog` Error → `Triage_noop` 기록만 하고 circuit breaker는 트리거하지 않음 → 다음 tick에서 같은 상황 반복

## Changes (4 files, +15/-1)
- `gardener_types.ml/.mli`: `consecutive_triage_noops` 필드
- `gardener.ml`: NeedWorker 핸들러에 backoff guard
- `gardener_decisions.ml`: health JSON 노출

## Test plan
- [x] `dune build --root .` 통과
- [x] gardener 13 tests 통과
- [ ] 서버 기동 후 `consecutive_triage_noops` 필드 확인

Closes #1834

🤖 Generated with [Claude Code](https://claude.com/claude-code)