### PR TITLE
refactor(gardener): consume OAS contract aliases

### DIFF
--- a/lib/agent_swarm_contract.ml
+++ b/lib/agent_swarm_contract.ml
@@ -490,6 +490,14 @@ let build_operation_arguments ~agent_name binding json =
           build [] binding.arg_bindings
       | _ -> Error "input must be a JSON object")
 
+let resolve_requested_tool_call ~agent_name ~requested_name ~arguments =
+  match sdk_binding_by_name requested_name with
+  | None -> Ok (requested_name, arguments)
+  | Some binding ->
+      build_operation_arguments ~agent_name binding arguments
+      |> Result.map (fun translated_arguments ->
+             (binding.canonical_operation, translated_arguments))
+
 let sdk_alias_json binding =
   let static_arguments =
     binding.arg_bindings

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -104,20 +104,18 @@ let spawned_agent_prefixed_tools : string list =
   prefixed_tool_names spawned_agent_public_tool_names
 
 (** Tool surface for Gardener-spawned OAS workers.
-    These 10 tools cover: room awareness, task lifecycle, and reporting.
-    Notably includes [masc_claim_next] and [masc_transition] for task lifecycle. *)
+    Consume the managed-agent SDK contract directly instead of re-declaring
+    canonical room/task operations in MASC-local schema copies. *)
 let gardener_worker_tool_names : string list =
   [
-    "masc_status";
-    "masc_tasks";
+    "masc_room_status";
+    "masc_list_tasks";
     "masc_claim_next";
-    "masc_transition";
+    "masc_set_current_task";
+    "masc_complete_task";
     "masc_add_task";
     "masc_broadcast";
     "masc_heartbeat";
-    "masc_memento_mori";
-    "masc_board_post";
-    "masc_board_get";
   ]
 
 let mdal_auditable_tool_names : string list =
@@ -164,6 +162,111 @@ let local_worker_public_tool_names : string list =
        "masc_board_post";
      ]
     @ mdal_auditable_tool_names)
+
+let local_worker_contract_schemas : Types.tool_schema list =
+  Agent_swarm_contract.sdk_tool_schemas
+
+let local_worker_compat_passthrough_schemas : Types.tool_schema list =
+  [
+    {
+      Types.name = "masc_status";
+      description =
+        "Get the current MASC room status including active agents and task backlog.";
+      input_schema =
+        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
+    };
+    {
+      Types.name = "masc_tasks";
+      description =
+        "List tasks in the backlog with status, assignee, and priority.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("status", `Assoc [ ("type", `String "string") ]);
+                  ("include_done", `Assoc [ ("type", `String "boolean") ]);
+                  ("include_cancelled", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+    {
+      Types.name = "masc_claim_next";
+      description =
+        "Claim the next available task automatically by priority order.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc [ ("agent_name", `Assoc [ ("type", `String "string") ]) ] );
+            ("required", `List [ `String "agent_name" ]);
+          ];
+    };
+    {
+      Types.name = "masc_transition";
+      description =
+        "Move a task through claim/start/done/cancel/release transitions.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                  ("task_id", `Assoc [ ("type", `String "string") ]);
+                  ("action", `Assoc [ ("type", `String "string") ]);
+                  ("expected_version", `Assoc [ ("type", `String "integer") ]);
+                  ("notes", `Assoc [ ("type", `String "string") ]);
+                  ("reason", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ( "required",
+              `List
+                [
+                  `String "agent_name";
+                  `String "task_id";
+                  `String "action";
+                ] );
+          ];
+    };
+    {
+      Types.name = "masc_add_task";
+      description = "Add a new task to the MASC backlog.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("title", `Assoc [ ("type", `String "string") ]);
+                  ("priority", `Assoc [ ("type", `String "integer") ]);
+                  ("description", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "title" ]);
+          ];
+    };
+    {
+      Types.name = "masc_broadcast";
+      description = "Broadcast a message to all agents in the room.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                  ("message", `Assoc [ ("type", `String "string") ]);
+                  ("format", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "agent_name"; `String "message" ]);
+          ];
+    };
+  ]
 
 let local_worker_internal_schemas : Types.tool_schema list =
   [
@@ -271,108 +374,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
                   ("limit", `Assoc [ ("type", `String "integer") ]);
                 ] );
             ("required", `List [ `String "query" ]);
-          ];
-    };
-  ]
-
-let local_worker_compat_passthrough_schemas : Types.tool_schema list =
-  [
-    {
-      Types.name = "masc_status";
-      description =
-        "Get the current MASC room status including active agents and task backlog.";
-      input_schema =
-        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-    };
-    {
-      Types.name = "masc_tasks";
-      description =
-        "List tasks in the backlog with status, assignee, and priority.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("status", `Assoc [ ("type", `String "string") ]);
-                  ("include_done", `Assoc [ ("type", `String "boolean") ]);
-                  ("include_cancelled", `Assoc [ ("type", `String "boolean") ]);
-                ] );
-          ];
-    };
-    {
-      Types.name = "masc_claim_next";
-      description =
-        "Claim the next available task automatically by priority order.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc [ ("agent_name", `Assoc [ ("type", `String "string") ]) ] );
-            ("required", `List [ `String "agent_name" ]);
-          ];
-    };
-    {
-      Types.name = "masc_transition";
-      description =
-        "Move a task through claim/start/done/cancel/release transitions.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("action", `Assoc [ ("type", `String "string") ]);
-                  ("expected_version", `Assoc [ ("type", `String "integer") ]);
-                  ("notes", `Assoc [ ("type", `String "string") ]);
-                  ("reason", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ( "required",
-              `List
-                [
-                  `String "agent_name";
-                  `String "task_id";
-                  `String "action";
-                ] );
-          ];
-    };
-    {
-      Types.name = "masc_add_task";
-      description = "Add a new task to the MASC backlog.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("title", `Assoc [ ("type", `String "string") ]);
-                  ("priority", `Assoc [ ("type", `String "integer") ]);
-                  ("description", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "title" ]);
-          ];
-    };
-    {
-      Types.name = "masc_broadcast";
-      description = "Broadcast a message to all agents in the room.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
-                  ("message", `Assoc [ ("type", `String "string") ]);
-                  ("format", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "agent_name"; `String "message" ]);
           ];
     };
   ]
@@ -611,43 +612,57 @@ let select_public_local_worker_schemas () =
   |> List.filter (fun (schema : Types.tool_schema) ->
          List.mem schema.name wanted)
 
+let resolve_named_schemas all_schemas values :
+    (Types.tool_schema list, string) result =
+  let requested =
+    values
+    |> List.map String.trim
+    |> List.filter (fun value -> value <> "")
+    |> unique_preserve_order
+  in
+  let schemas =
+    all_schemas
+    |> List.filter (fun (schema : Types.tool_schema) ->
+           List.mem schema.name requested)
+  in
+  let missing =
+    requested
+    |> List.filter (fun tool_name ->
+           not
+             (List.exists
+                (fun (schema : Types.tool_schema) ->
+                  String.equal schema.name tool_name)
+                schemas))
+  in
+  if missing <> [] then
+    Error
+      (Printf.sprintf "unknown tool schema(s): %s"
+         (String.concat ", " missing))
+  else
+    Ok schemas
+
+let gardener_worker_tool_schemas () :
+    (Types.tool_schema list, string) result =
+  let all_schemas =
+    dedupe_schemas
+      ( local_worker_internal_schemas
+      @ local_worker_contract_schemas
+      @ select_public_local_worker_schemas () )
+  in
+  resolve_named_schemas all_schemas gardener_worker_tool_names
+
 let local_worker_tool_schemas ?names () :
     (Types.tool_schema list, string) result =
   let all_schemas =
     dedupe_schemas
       ( local_worker_internal_schemas
       @ local_worker_compat_passthrough_schemas
+      @ local_worker_contract_schemas
       @ select_public_local_worker_schemas () )
   in
   match names with
   | None -> Ok all_schemas
-  | Some values ->
-      let requested =
-        values
-        |> List.map String.trim
-        |> List.filter (fun value -> value <> "")
-        |> unique_preserve_order
-      in
-      let schemas =
-        all_schemas
-        |> List.filter (fun (schema : Types.tool_schema) ->
-               List.mem schema.name requested)
-      in
-      let missing =
-        requested
-        |> List.filter (fun tool_name ->
-               not
-                 (List.exists
-                    (fun (schema : Types.tool_schema) ->
-                      String.equal schema.name tool_name)
-                    schemas))
-      in
-      if missing <> [] then
-        Error
-          (Printf.sprintf "unknown tool schema(s): %s"
-             (String.concat ", " missing))
-      else
-        Ok schemas
+  | Some values -> resolve_named_schemas all_schemas values
 
 (** Admin tool names that should be excluded from autonomous agents. *)
 let admin_tool_names : string list =

--- a/lib/gardener/gardener_worker.ml
+++ b/lib/gardener/gardener_worker.ml
@@ -2,17 +2,11 @@
     See {!gardener_worker.mli} for rationale. *)
 
 (** Build [Types.tool_schema list] from [gardener_worker_tool_names].
-    Returns an empty list on schema-lookup failure so the caller can
-    still attempt an LLM call (the model will simply have no tools). *)
-let worker_tools () : Types.tool_schema list =
-  match
-    Agent_tool_surfaces.local_worker_tool_schemas
-      ~names:Agent_tool_surfaces.gardener_worker_tool_names ()
-  with
-  | Ok schemas -> schemas
-  | Error msg ->
-      Eio.traceln "[Gardener_worker] tool schema lookup failed: %s" msg;
-      []
+    Fail fast if the worker contract cannot be materialized. *)
+let worker_tools () : (Types.tool_schema list, string) result =
+  Agent_tool_surfaces.gardener_worker_tool_schemas ()
+  |> Result.map_error (fun msg ->
+         Printf.sprintf "Gardener worker tool schema lookup failed: %s" msg)
 
 (** Dispatch closure that routes tool calls through the tag-based registry.
 
@@ -22,23 +16,53 @@ let worker_tools () : Types.tool_schema list =
     subset of [execute_tool_eio]'s tag dispatch for the tools a Gardener
     worker actually needs. *)
 let make_dispatch ~(config : Room.config) ~(agent_name : string) () ~name ~args =
-  match Tool_dispatch.lookup_tag name with
-  | Some Tool_dispatch.Mod_task ->
-      (match Tool_task.dispatch { Tool_task.config; agent_name } ~name ~args with
-       | Some result -> result
-       | None -> (false, Printf.sprintf "Unknown task tool: %s" name))
-  | Some Tool_dispatch.Mod_room ->
-      (match Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args with
-       | Some result -> result
-       | None -> (false, Printf.sprintf "Unknown room tool: %s" name))
-  | Some Tool_dispatch.Mod_heartbeat ->
-      (* Heartbeat requires sw/clock — skip in worker context, return success *)
-      (true, Printf.sprintf "Heartbeat skipped (in-process worker): %s" agent_name)
-  | Some _ ->
-      (* Tool exists in tag registry but not in the worker's supported set *)
-      (false, Printf.sprintf "Tool %s is not available in worker context" name)
-  | None ->
-      (false, Printf.sprintf "Unknown tool: %s" name)
+  match
+    Agent_swarm_contract.resolve_requested_tool_call
+      ~agent_name ~requested_name:name ~arguments:args
+  with
+  | Error msg -> (false, msg)
+  | Ok (resolved_name, resolved_args) -> (
+      match resolved_name with
+      | "masc_broadcast" ->
+          let message = Tool_args.get_string resolved_args "message" "" in
+          let trimmed = String.trim message in
+          if trimmed = "" then
+            (false, "Broadcast message cannot be empty")
+          else
+            (true, Room.broadcast config ~from_agent:agent_name ~content:message)
+      | _ -> (
+          match Tool_dispatch.lookup_tag resolved_name with
+          | Some Tool_dispatch.Mod_task ->
+              (match
+                 Tool_task.dispatch { Tool_task.config; agent_name }
+                   ~name:resolved_name ~args:resolved_args
+               with
+               | Some result -> result
+               | None ->
+                   (false, Printf.sprintf "Unknown task tool: %s" resolved_name))
+          | Some Tool_dispatch.Mod_room ->
+              (match
+                 Tool_room.dispatch { Tool_room.config; agent_name }
+                   ~name:resolved_name ~args:resolved_args
+               with
+               | Some result -> result
+               | None ->
+                   (false, Printf.sprintf "Unknown room tool: %s" resolved_name))
+          | Some Tool_dispatch.Mod_plan ->
+              (match
+                 Tool_plan.dispatch { Tool_plan.config }
+                   ~name:resolved_name ~args:resolved_args
+               with
+               | Some result -> result
+               | None ->
+                   (false, Printf.sprintf "Unknown plan tool: %s" resolved_name))
+          | Some Tool_dispatch.Mod_heartbeat ->
+              (* Heartbeat requires sw/clock — skip in worker context, return success *)
+              (true, Printf.sprintf "Heartbeat skipped (in-process worker): %s" agent_name)
+          | Some _ ->
+              (* Tool exists in tag registry but not in the worker's supported set *)
+              (false, Printf.sprintf "Tool %s is not available in worker context" resolved_name)
+          | None -> (false, Printf.sprintf "Unknown tool: %s" resolved_name)))
 
 (* Exception handling moved to Oas_worker.run internally — no run_safe needed. *)
 
@@ -48,28 +72,32 @@ let run_for_gap ~(config : Room.config) ~topic ~traits_str ~reason =
   let memory = Memory_oas_bridge.create_memory ~agent_name in
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
   ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
-  Oas_worker.run_named_with_masc_tools
-    ~cascade_name:"gardener_spawn"
-    ~system_prompt:
-      (Printf.sprintf
-         "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
-          Topic: %s\n\
-          Traits: %s\n\
-          Always include agent_name='%s' in every tool call arguments.\n\
-          1. masc_status -> room state\n\
-          2. masc_tasks -> find unclaimed work\n\
-          3. masc_claim_next -> claim a task\n\
-          4. Work on the claimed task\n\
-          5. masc_transition(task_id=..., action='done') -> mark done\n\
-          6. masc_broadcast -> report results\n\
-          Terminate after completion. Do not loop.\n\
-          %s"
-         agent_name topic traits_str agent_name institution_context)
-    ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
-    ~masc_tools:(worker_tools ())
-    ~dispatch:(make_dispatch ~config ~agent_name ())
-    ~memory
-    ~max_turns:10 ~temperature:0.3 ()
+  match worker_tools () with
+  | Error _ as error -> error
+  | Ok masc_tools ->
+      Oas_worker.run_named_with_masc_tools
+        ~cascade_name:"gardener_spawn"
+        ~system_prompt:
+          (Printf.sprintf
+             "You are a MASC Gardener worker. Your agent_name is '%s'.\n\
+              Topic: %s\n\
+              Traits: %s\n\
+              Follow each tool schema exactly. SDK tools inject agent_name automatically.\n\
+              1. masc_room_status -> room state\n\
+              2. masc_list_tasks -> find unclaimed work\n\
+              3. masc_claim_next -> claim a task\n\
+              4. masc_set_current_task(task_id=...) -> bind current task\n\
+              5. Work on the claimed task\n\
+              6. masc_complete_task(task_id=...) -> mark done\n\
+              7. masc_broadcast(message=...) -> report results\n\
+              Terminate after completion. Do not loop.\n\
+              %s"
+             agent_name topic traits_str institution_context)
+        ~goal:(Printf.sprintf "Address gap '%s': %s" topic reason)
+        ~masc_tools
+        ~dispatch:(make_dispatch ~config ~agent_name ())
+        ~memory
+        ~max_turns:10 ~temperature:0.3 ()
 
 let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_backlog_summary) =
   let agent_name = "gardener-triage-worker" in
@@ -77,25 +105,29 @@ let run_for_backlog ~(config : Room.config) ~(backlog : Gardener_types.task_back
   let memory = Memory_oas_bridge.create_memory ~agent_name in
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
   ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
-  Oas_worker.run_named_with_masc_tools
-    ~cascade_name:"gardener_spawn"
-    ~system_prompt:
-      (Printf.sprintf
-         "You are a MASC triage worker. Your agent_name is '%s'.\n\
-          Always include agent_name='%s' in every tool call arguments.\n\
-          1. masc_tasks -> review backlog\n\
-          2. masc_claim_next -> claim high-priority task\n\
-          3. Process or delegate\n\
-          4. masc_transition -> update status\n\
-          5. masc_broadcast -> report results\n\
-          Terminate after completion.\n\
-          %s"
-         agent_name agent_name institution_context)
-    ~goal:
-      (Printf.sprintf
-         "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
-         backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
-    ~masc_tools:(worker_tools ())
-    ~dispatch:(make_dispatch ~config ~agent_name ())
-    ~memory
-    ~max_turns:15 ~temperature:0.3 ()
+  match worker_tools () with
+  | Error _ as error -> error
+  | Ok masc_tools ->
+      Oas_worker.run_named_with_masc_tools
+        ~cascade_name:"gardener_spawn"
+        ~system_prompt:
+          (Printf.sprintf
+             "You are a MASC triage worker. Your agent_name is '%s'.\n\
+              Follow each tool schema exactly. SDK tools inject agent_name automatically.\n\
+              1. masc_list_tasks -> review backlog\n\
+              2. masc_claim_next -> claim high-priority task\n\
+              3. masc_set_current_task(task_id=...) -> bind current task\n\
+              4. Process or delegate\n\
+              5. masc_complete_task(task_id=...) -> update status when work is done\n\
+              6. masc_broadcast(message=...) -> report results\n\
+              Terminate after completion.\n\
+              %s"
+             agent_name institution_context)
+        ~goal:
+          (Printf.sprintf
+             "Triage backlog: %d unclaimed (%d high-pri, %d orphan)."
+             backlog.todo_count backlog.high_priority_todo backlog.orphan_count)
+        ~masc_tools
+        ~dispatch:(make_dispatch ~config ~agent_name ())
+        ~memory
+        ~max_turns:15 ~temperature:0.3 ()

--- a/lib/gardener/gardener_worker.mli
+++ b/lib/gardener/gardener_worker.mli
@@ -1,6 +1,7 @@
 (** Gardener OAS worker — 1-shot agents with real MASC tools.
 
-    Workers receive [gardener_worker_tool_names] (claim, transition, etc.)
+    Workers receive managed-agent SDK aliases from
+    [gardener_worker_tool_names] (room_status, list_tasks, complete_task, etc.)
     and terminate after completing their goal. *)
 
 (** [run_for_gap ~config ~topic ~traits_str ~reason] spawns a 1-shot OAS
@@ -18,7 +19,7 @@ val run_for_gap :
 
 (** [run_for_backlog ~config ~backlog] spawns a 1-shot OAS worker for
     backlog triage.  The worker reviews unclaimed tasks, claims high-priority
-    ones, and reports via broadcast + board. *)
+    ones, and reports via broadcast. *)
 val run_for_backlog :
   config:Room.config ->
   backlog:Gardener_types.task_backlog_summary ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -168,21 +168,12 @@ let resolve_managed_agent_call ?mcp_session_id params =
   let module U = Yojson.Safe.Util in
   let requested_name = params |> U.member "name" |> U.to_string in
   let arguments = params |> U.member "arguments" in
-  match Agent_swarm_contract.sdk_binding_by_name requested_name with
-  | None -> Ok (requested_name, arguments)
-  | Some binding ->
-      let identity =
-        Agent_registry_eio.get_or_create_identity ?mcp_session_id arguments
-      in
-      (match
-         Agent_swarm_contract.build_operation_arguments
-           ~agent_name:identity.Agent_identity.agent_name binding arguments
-       with
-      | Ok translated_arguments ->
-          Ok
-            ( binding.Agent_swarm_contract.canonical_operation,
-              translated_arguments )
-      | Error msg -> Error msg)
+  let identity =
+    Agent_registry_eio.get_or_create_identity ?mcp_session_id arguments
+  in
+  Agent_swarm_contract.resolve_requested_tool_call
+    ~agent_name:identity.Agent_identity.agent_name
+    ~requested_name ~arguments
 
 (** Handle tools/call JSON-RPC method *)
 let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications

--- a/test/test_agent_swarm_masc_tools.ml
+++ b/test/test_agent_swarm_masc_tools.ml
@@ -209,6 +209,28 @@ let test_cancel_requires_task_id () =
   | Ok _ ->
     Alcotest.fail "should fail without task_id"
 
+let test_resolve_sdk_tool_call_translates_complete_task () =
+  let arguments = `Assoc [("task_id", `String "task-123")] in
+  match
+    Agent_swarm_contract.resolve_requested_tool_call
+      ~agent_name:"gardener-worker"
+      ~requested_name:"masc_complete_task"
+      ~arguments
+  with
+  | Error msg -> Alcotest.failf "expected successful translation: %s" msg
+  | Ok (operation_id, translated) ->
+      Alcotest.(check string) "canonical op" "masc_transition" operation_id;
+      match translated with
+      | `Assoc fields ->
+          let find key = List.assoc key fields in
+          Alcotest.(check string) "task_id preserved" "task-123"
+            (Yojson.Safe.Util.to_string (find "task_id"));
+          Alcotest.(check string) "action injected" "done"
+            (Yojson.Safe.Util.to_string (find "action"));
+          Alcotest.(check string) "agent_name injected" "gardener-worker"
+            (Yojson.Safe.Util.to_string (find "agent_name"))
+      | _ -> Alcotest.fail "translated arguments should be an object"
+
 let () =
   Alcotest.run "MASC Tools" [
     "structure", [
@@ -224,5 +246,7 @@ let () =
         test_set_current_task_requires_task_id;
       Alcotest.test_case "release requires task_id" `Quick test_release_requires_task_id;
       Alcotest.test_case "cancel requires task_id" `Quick test_cancel_requires_task_id;
+      Alcotest.test_case "sdk tool call translation" `Quick
+        test_resolve_sdk_tool_call_translates_complete_task;
     ];
   ]

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -1214,12 +1214,24 @@ let suite = [
 
 (** {1 Gardener Worker Tool Surface Tests} *)
 
-let test_worker_tools_include_claim_and_transition () =
+let test_worker_tools_use_managed_aliases () =
   let names = Agent_tool_surfaces.gardener_worker_tool_names in
   check bool "claim_next present"
     true (List.mem "masc_claim_next" names);
-  check bool "transition present"
-    true (List.mem "masc_transition" names)
+  check bool "room_status present"
+    true (List.mem "masc_room_status" names);
+  check bool "list_tasks present"
+    true (List.mem "masc_list_tasks" names);
+  check bool "set_current_task present"
+    true (List.mem "masc_set_current_task" names);
+  check bool "complete_task present"
+    true (List.mem "masc_complete_task" names);
+  check bool "legacy masc_status absent"
+    false (List.mem "masc_status" names);
+  check bool "legacy masc_tasks absent"
+    false (List.mem "masc_tasks" names);
+  check bool "legacy masc_transition absent"
+    false (List.mem "masc_transition" names)
 
 let test_worker_tools_exclude_admin () =
   let names = Agent_tool_surfaces.gardener_worker_tool_names in
@@ -1236,10 +1248,7 @@ let test_worker_tool_count_bounds () =
   check bool "at most 30 tools" true (n <= 30)
 
 let test_worker_tool_names_are_resolvable () =
-  match
-    Capability_registry.local_worker_tool_schemas
-      ~names:Agent_tool_surfaces.gardener_worker_tool_names ()
-  with
+  match Agent_tool_surfaces.gardener_worker_tool_schemas () with
   | Error err -> failf "expected gardener worker schemas to resolve: %s" err
   | Ok schemas ->
       let resolved =
@@ -1262,8 +1271,8 @@ let test_run_for_gap_without_eio_returns_error () =
       | Ok _ -> fail "expected Error when Eio context is not set")
 
 let worker_suite = [
-  "worker_tools_include_claim_and_transition", `Quick,
-    test_worker_tools_include_claim_and_transition;
+  "worker_tools_use_managed_aliases", `Quick,
+    test_worker_tools_use_managed_aliases;
   "worker_tools_exclude_admin", `Quick,
     test_worker_tools_exclude_admin;
   "worker_tool_count_bounds", `Quick,


### PR DESCRIPTION
## Summary
- make Gardener worker consume managed-agent SDK aliases instead of local canonical tool copies
- share alias-to-canonical translation via Agent_swarm_contract for both managed-agent calls and Gardener dispatch
- fail fast when the Gardener worker tool contract cannot be materialized and update worker tests to assert alias-based exposure

## Validation
- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor/gardener-oas-contract _build/default/test/test_agent_swarm_masc_tools.exe`
- attempted `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor/gardener-oas-contract _build/default/test/test_gardener.exe` (no immediate failure observed, but not waited to completion)

## Notes
- local `main` is aligned with `origin/main` at `13263ccf`
- generic local worker compat passthrough is intentionally kept for now to limit blast radius while Gardener moves to the contract-backed surface