### PR TITLE
refactor: move Cascade.complete to Oas_worker.complete_single

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -152,7 +152,7 @@ let call_llm_direct_sync ~agent_type ~prompt =
   let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Cascade.complete ~cascade_name
+      Oas_worker.complete_single ~cascade_name
         ~messages:[Agent_sdk.Types.user_msg prompt]
         ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -684,7 +684,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
   let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
     ~file_content ~target_file in
   match
-    Cascade.complete ~cascade_name:"autoresearch"
+    Oas_worker.complete_single ~cascade_name:"autoresearch"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.7 ~max_tokens:4096 ~timeout_sec:120 ()
   with

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -254,7 +254,7 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
     : (float, string) result =
   let prompt = build_scoring_prompt agent task in
   match
-    Cascade.complete ~cascade_name:"capability_match"
+    Oas_worker.complete_single ~cascade_name:"capability_match"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:15 ~max_tokens:20
       ~accept:llm_score_is_valid ()

--- a/lib/cascade.ml
+++ b/lib/cascade.ml
@@ -1,22 +1,19 @@
-(** Cascade — MASC LLM call module.
+(** Cascade — MASC LLM cascade policy module.
 
-    Cascade profile defaults and {!complete} which delegates to
-    OAS [Cascade_config.complete_named].
+    Holds cascade profile defaults ({!default_model_strings}),
+    config path resolution ({!default_config_path}), usage helpers,
+    concurrency diagnostics, and UTF-8 sanitization.
+
+    LLM execution moved to {!Oas_worker.complete_single} (single-shot)
+    and {!Oas_worker.run_named} (multi-turn).
 
     Model types and spec parsing live in {!Model_spec}.
 
-    Public entry points:
-    - {!complete} — messages + cascade_name, returns api_response or error
-
-    Response helpers ([text_of_response], [has_tool_use], [tool_msg])
-    removed — use {!Llm_provider.Types} directly.
-    [get_cascade] inlined into {!Oas_worker}.
-
     @since 2.114.0 — original
     @since 2.115.0 — delegated to OAS Cascade_config
-    @since 2.116.0 — call_raw, call_with_tools added
     @since 2.117.0 — model types extracted to Model_spec
-    @since 2.123.0 — OAS-duplicate helpers removed *)
+    @since 2.123.0 — OAS-duplicate helpers removed
+    @since 2.124.0 — complete/format_cascade_error moved to Oas_worker *)
 
 (* ================================================================ *)
 (* Helpers                                                           *)
@@ -219,40 +216,5 @@ let default_model_strings ~cascade_name =
   (* unregistered cascade: llama + glm as safety net *)
   | _ -> llama_glm
 
-(* ================================================================ *)
-(* Cascade orchestration                                             *)
-(* ================================================================ *)
-
-(** Format OAS http_error as cascade error string. *)
-let format_cascade_error ~cascade_name = function
-  | Llm_provider.Http_client.HttpError { code; body } ->
-    Printf.sprintf "[cascade] %s: HTTP %d: %s" cascade_name code
-      (if String.length body > 200
-       then String.sub body 0 200 ^ "..."
-       else body)
-  | Llm_provider.Http_client.NetworkError { message } ->
-    Printf.sprintf "[cascade] %s: %s" cascade_name message
-
-(** Direct OAS bridge — single entry point for all LLM cascade calls.
-    Returns OAS [api_response] directly; error formatted as string. *)
-let complete ~cascade_name ~messages
-    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
-  let env = Masc_eio_env.get () in
-  let defaults = default_model_strings ~cascade_name in
-  let config_path_opt =
-    if String.length config_path > 0 then Some config_path
-    else default_config_path ()
-  in
-  match
-    Llm_provider.Cascade_config.complete_named
-      ~sw:env.sw ~net:env.net ?clock:env.clock
-      ?config_path:config_path_opt
-      ~name:cascade_name ~defaults ~messages
-      ?tools ~temperature ~max_tokens ~accept ~timeout_sec ()
-  with
-  | Ok resp -> Ok resp
-  | Error err -> Error (format_cascade_error ~cascade_name err)
-
-(* call, call_raw, call_with_tools removed — use {!complete} directly.
-   Callers build messages and handle api_response/errors themselves. *)
+(* complete, format_cascade_error removed — use {!Oas_worker.complete_single}.
+   call, call_raw, call_with_tools were removed earlier. *)

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -300,7 +300,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
         | _ -> None
       in
       (match
-        Cascade.complete ~cascade_name:"chain_llm" ~messages
+        Oas_worker.complete_single ~cascade_name:"chain_llm" ~messages
           ?tools:tools_json ~temperature:0.2 ~max_tokens:4096
           ~timeout_sec ()
       with

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -335,7 +335,7 @@ let verify_worker ~pattern (worker : worker_plan) diff =
     let prompt = build_verify_prompt ~pattern ~allowed_files:worker.files diff in
     let verdict =
       match
-        Cascade.complete ~cascade_name:"code_swarm_verify"
+        Oas_worker.complete_single ~cascade_name:"code_swarm_verify"
           ~messages:[Agent_sdk.Types.user_msg prompt]
           ~temperature:0.0 ~max_tokens:200 ()
       with

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -194,7 +194,7 @@ let intent_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
 let classify_intent_llm (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Cascade.complete ~cascade_name:"context_router"
+    Oas_worker.complete_single ~cascade_name:"context_router"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()
@@ -209,7 +209,7 @@ let classify_intent_llm (query : string) : query_intent * float =
 let classify_intent_hybrid (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Cascade.complete ~cascade_name:"context_router"
+    Oas_worker.complete_single ~cascade_name:"context_router"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
       ~accept:intent_response_is_valid ()

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -284,7 +284,7 @@ let compute_judgments ~base_path:_ ~factual_json =
   let timeout_sec = Env_config.Llm.dashboard_governance_judge_timeout_seconds in
   let prompt = prompt_for_facts factual_json in
   match
-    Cascade.complete ~cascade_name:"governance_judge"
+    Oas_worker.complete_single ~cascade_name:"governance_judge"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -289,7 +289,7 @@ let compute_judgments ~facts_json =
   let timeout_sec = Env_config.Llm.operator_judge_timeout_seconds in
   let prompt = prompt_for_facts facts_json in
   match
-    Cascade.complete ~cascade_name:"operator_judge"
+    Oas_worker.complete_single ~cascade_name:"operator_judge"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec ~max_tokens:4096 ()
   with

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -2,7 +2,7 @@ open Env_config_core
 
 module Endpoints = struct
   (** @deprecated LLM-MCP server URL - no longer used.
-      Use {!Cascade.complete} instead. *)
+      Use {!Oas_worker.complete_single} instead. *)
   let llm_mcp_url =
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)
 

--- a/lib/gardener/gardener_decisions.ml
+++ b/lib/gardener/gardener_decisions.ml
@@ -44,7 +44,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
 
   let response =
     match
-      Cascade.complete ~cascade_name:"gardener_spawn"
+      Oas_worker.complete_single ~cascade_name:"gardener_spawn"
         ~messages:[Agent_sdk.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
@@ -437,7 +437,7 @@ Room 내 활성 에이전트: %d
 
   let response =
     match
-      Cascade.complete ~cascade_name:"gardener_spawn"
+      Oas_worker.complete_single ~cascade_name:"gardener_spawn"
         ~messages:[Agent_sdk.Types.user_msg prompt]
         ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -241,6 +241,43 @@ let run_with_masc_tools
   run ~sw ~net ~config ?on_event goal
 
 (* ================================================================ *)
+(* Single-shot cascade call (replaces Cascade.complete)              *)
+(* ================================================================ *)
+
+(** Format OAS http_error as cascade error string. *)
+let format_cascade_error ~cascade_name = function
+  | Llm_provider.Http_client.HttpError { code; body } ->
+    Printf.sprintf "[cascade] %s: HTTP %d: %s" cascade_name code
+      (if String.length body > 200
+       then String.sub body 0 200 ^ "..."
+       else body)
+  | Llm_provider.Http_client.NetworkError { message } ->
+    Printf.sprintf "[cascade] %s: %s" cascade_name message
+
+(** Single-shot LLM call via cascade policy.
+    Drop-in replacement for the former [Cascade.complete].
+    Policy (model selection, config path) is read from {!Cascade};
+    execution goes through [Llm_provider.Cascade_config.complete_named]. *)
+let complete_single ~cascade_name ~messages
+    ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
+  let env = Masc_eio_env.get () in
+  let defaults = Cascade.default_model_strings ~cascade_name in
+  let config_path_opt =
+    if String.length config_path > 0 then Some config_path
+    else Cascade.default_config_path ()
+  in
+  match
+    Llm_provider.Cascade_config.complete_named
+      ~sw:env.sw ~net:env.net ?clock:env.clock
+      ?config_path:config_path_opt
+      ~name:cascade_name ~defaults ~messages
+      ?tools ~temperature ~max_tokens ~accept ~timeout_sec ()
+  with
+  | Ok resp -> Ok resp
+  | Error err -> Error (format_cascade_error ~cascade_name err)
+
+(* ================================================================ *)
 (* Named cascade API — callers pass cascade_name, not model_spec    *)
 (* ================================================================ *)
 

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -5,8 +5,12 @@
     [Llm_provider.Cascade_config].  Internal [config] / [build] / [run]
     are implementation details and not exported.
 
+    Single-shot calls use {!complete_single}.  Multi-turn agent loops
+    use {!run_named} or {!run_named_with_masc_tools}.
+
     @since Phase 1 — MASC→OAS migration
-    @since Phase 4 — public API restricted to named cascade functions *)
+    @since Phase 4 — public API restricted to named cascade functions
+    @since Phase 5 — complete_single moved here from Cascade *)
 
 module Oas = Agent_sdk
 
@@ -16,6 +20,21 @@ type run_result = {
   session_id : string;
   turns : int;
 }
+
+(** Single-shot LLM call via cascade policy.
+    Drop-in replacement for the former [Cascade.complete].
+    Returns OAS [api_response] directly; error formatted as string. *)
+val complete_single :
+  cascade_name:string ->
+  messages:Oas.Types.message list ->
+  ?config_path:string ->
+  ?temperature:float ->
+  ?timeout_sec:int ->
+  ?max_tokens:int ->
+  ?accept:(Llm_provider.Types.api_response -> bool) ->
+  ?tools:Yojson.Safe.t list ->
+  unit ->
+  (Llm_provider.Types.api_response, string) result
 
 val run_named :
   cascade_name:string ->

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -118,7 +118,7 @@ let geval_response_is_valid (resp : Llm_provider.Types.api_response) : bool =
 let verify_llm ~content : (verification_result, string) result =
   let prompt = build_geval_prompt ~content in
   match
-    Cascade.complete ~cascade_name:"verifier"
+    Oas_worker.complete_single ~cascade_name:"verifier"
       ~messages:[Agent_sdk.Types.user_msg prompt]
       ~temperature:0.2 ~timeout_sec:15 ~max_tokens:150
       ~accept:geval_response_is_valid ()

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -275,7 +275,7 @@ let walph_response_is_valid (resp : Llm_provider.Types.api_response) =
 
 let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
   match
-    Cascade.complete ~cascade_name:"walph"
+    Oas_worker.complete_single ~cascade_name:"walph"
       ~messages:[Agent_sdk.Types.user_msg prompt] ~timeout_sec
       ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -117,7 +117,7 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
         None
     | Ok prompt ->
         let timeout = Env_config.Sentinel.llm_timeout_sec in
-        (match Cascade.complete ~cascade_name
+        (match Oas_worker.complete_single ~cascade_name
             ~messages:[Agent_sdk.Types.user_msg prompt]
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
         | Ok resp ->

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -456,7 +456,7 @@ let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
           worker_class_text role_text spawn_prompt
       in
       (match
-        Cascade.complete ~cascade_name:"routing_judge"
+        Oas_worker.complete_single ~cascade_name:"routing_judge"
           ~messages:[
             Agent_sdk.Types.system_msg "You are a routing judge for a hybrid swarm. Output only JSON.";
             Agent_sdk.Types.user_msg prompt]

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -209,9 +209,9 @@ let test_build_response_prompt_long_content () =
   check bool "handles long content" true (String.length prompt > 1000)
 
 let test_auto_responder_uses_shared_llm_client () =
-  check bool "uses Cascade.complete" true
+  check bool "uses Oas_worker.complete_single" true
     (file_contains_pattern "lib/auto_responder.ml"
-       {|Cascade.complete ~cascade_name|});
+       {|Oas_worker.complete_single ~cascade_name|});
   check bool "no direct run_prompt_cascade" false
     (file_contains_pattern "lib/auto_responder.ml" "Llm_orchestration.run_prompt_cascade");
   check bool "legacy Llm_direct dispatch removed"

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module Cascade = Masc_mcp.Cascade
 module Model_spec = Masc_mcp.Model_spec
+module Oas_worker = Masc_mcp.Oas_worker
 
 let with_temp_json contents f =
   let path = Filename.temp_file "cascade_" ".json" in
@@ -85,7 +86,7 @@ let test_call_returns_error_when_no_models () =
         {|{"heartbeat_action_models":["gemini:fake-model"]}|}
         (fun path ->
           let result =
-            Cascade.complete
+            Oas_worker.complete_single
               ~cascade_name:"heartbeat_action"
               ~messages:[Agent_sdk.Types.user_msg "test"]
               ~timeout_sec:1

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -313,9 +313,9 @@ let test_eio_error_cutoff () =
     (status |> member "last_stop_reason" |> to_string)
 
 let test_eio_default_dispatch_uses_shared_cascade () =
-  check bool "uses Cascade.complete" true
+  check bool "uses Oas_worker.complete_single" true
     (file_contains_pattern "lib/room/room_walph_eio.ml"
-       {|Cascade.complete ~cascade_name:"walph"|});
+       {|Oas_worker.complete_single ~cascade_name:"walph"|});
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room/room_walph_eio.ml" "Llm_direct.dispatch");
   check bool "no direct run_prompt_cascade" false


### PR DESCRIPTION
## Summary

Cascade.complete를 Oas_worker.complete_single로 이동.
Cascade 모듈은 이제 정책(cascade profile)만 담당.

- `Cascade.complete` → `Oas_worker.complete_single` (16 소비자 전환)
- `format_cascade_error` 함께 이동
- cascade.ml: 258 → 220줄
- 20파일

Oas_worker가 LLM 실행 계층의 단일 진입점:
- `complete_single`: 단발 cascade 호출
- `run_named`: 다회전 Agent.run()

## Test plan

- [x] `dune build --root .`
- [x] test_cascade (8), test_perpetual (193), test_auto_responder (29), test_walph (12), test_gardener (82) 등
- [ ] CI green