### PR TITLE
feat: wire Keeper streaming via OAS Agent.run_stream (#215)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -61,6 +61,7 @@ let run_turn
     ?(temperature : float = 0.3)
     ?(max_tokens : int = 4096)
     ?max_cost_usd
+    ?on_event
     ()
   : (run_result, string) result =
   (* 1. Ensure session directory *)
@@ -138,6 +139,7 @@ let run_turn
       ~temperature
       ~max_tokens
       ?guardrails
+      ?on_event
       ()
   with
   | Error e -> Error e

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -29,7 +29,13 @@ let handle_keeper_down = Keeper_turn_lifecycle.handle_keeper_down
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
 let handle_keeper_msg ?on_text_delta ctx args : tool_result =
-  ignore on_text_delta; (* streaming not yet wired to Agent.run() *)
+  let on_event = match on_text_delta with
+    | None -> None
+    | Some cb -> Some (fun (evt : Agent_sdk.Types.sse_event) ->
+        match evt with
+        | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } -> cb text
+        | _ -> ())
+  in
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
   if not (validate_name name) then
@@ -193,7 +199,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~build_turn_prompt
                 ~user_message:message
                 ~cascade_name:"keeper_turn"
-                ~generation:meta.generation ()
+                ~generation:meta.generation
+                ?on_event ()
             with
             | Error e ->
               (try ignore (Trajectory.finalize trajectory_acc


### PR DESCRIPTION
## Summary

- Keeper의 `on_text_delta` SSE 콜백이 `handle_keeper_msg`에서 `ignore`되던 것을 OAS `Agent.run_stream`까지 관통시킴
- `string -> unit` → `sse_event -> unit` 타입 어댑터 추가 (`ContentBlockDelta TextDelta` 패턴 매칭)
- OAS 변경 없음 — `Oas_worker.run_named`의 기존 `?on_event` 파라미터 활용

## Changes

| File | Change |
|------|--------|
| `lib/keeper/keeper_agent_run.ml` | `?on_event` optional 파라미터 추가 + `Oas_worker.run_named`에 forward (+2 lines) |
| `lib/keeper/keeper_turn.ml` | `ignore on_text_delta` 제거 → sse_event 어댑터 생성 + `run_turn`에 forward (+9 lines) |

## Test plan

- [x] `dune build` 통과
- [x] `dune runtest` 전체 통과
- [ ] E2E: `curl -N http://127.0.0.1:8935/api/v1/keeper/stream` — SSE text 청크 실시간 수신 확인

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)