### PR TITLE
fix: clarify dashboard home team sessions

### DIFF
--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -126,9 +126,9 @@ export function Mission() {
 
       <div class="mission-stat-grid">
         <${SummaryStat}
-          label="활성 세션"
+          label="관찰 세션"
           value=${sessionRows.length}
-          detail="session card에 표시된 협업 단위"
+          detail="실행 중 또는 최근 갱신된 팀 세션"
           tone=${focusSession?.top_attention?.severity ?? focusSession?.health ?? 'ok'}
         />
         <${SummaryStat}
@@ -194,7 +194,7 @@ export function Mission() {
         <div class="mission-list-stack">
           ${sessionRows.length > 0
             ? sessionRows.map(row => html`<${SessionBriefCard} key=${row.session_id} brief=${row} selected=${activeSessionId === row.session_id} />`)
-            : html`<div class="empty-state">지금 활성 세션이 없습니다.</div>`}
+            : html`<div class="empty-state">지금 보이는 팀 세션이 없습니다.</div>`}
         </div>
       <//>
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -7,15 +7,116 @@ import { missionSnapshot } from '../../mission-store'
 import { topActiveAgents } from '../../observatory-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
-import { formatDuration } from '../mission-utils'
+import { formatDuration, statusLabel } from '../mission-utils'
 import { SituationBanner } from './situation-banner'
 import { AttentionSpotlight } from './attention-spotlight'
 import { NarrativeTimeline } from './narrative-timeline'
 import { OasPipeline } from './oas-pipeline'
 import { AgentAvatar } from './agent-avatar'
 import type { ObservatoryAgent } from '../../observatory-store'
+import type { DashboardMissionSessionBrief } from '../../types'
 
 // --- Hot Sessions: top 3 active sessions (critical/watch first) ---
+
+function sessionStatusRank(status?: string | null): number {
+  switch ((status ?? '').trim().toLowerCase()) {
+    case 'running':
+      return 0
+    case 'paused':
+      return 1
+    case 'pending':
+      return 2
+    case 'interrupted':
+      return 3
+    case 'completed':
+    case 'done':
+      return 4
+    default:
+      return 5
+  }
+}
+
+function splitSessionGoal(goal?: string | null, fallback?: string): { primary: string; secondary: string | null } {
+  const raw = (goal ?? fallback ?? '').trim()
+  if (!raw) return { primary: fallback ?? 'session', secondary: null }
+  const parts = raw.split('·').map(part => part.trim()).filter(Boolean)
+  return {
+    primary: parts[0] ?? raw,
+    secondary: parts.length > 1 ? parts.slice(1).join(' · ') : null,
+  }
+}
+
+function isSystemSession(createdBy?: string | null): boolean {
+  const normalized = (createdBy ?? '').trim().toLowerCase()
+  if (!normalized) return false
+  const systemPrefixes = ['gardener', 'keeper', 'guardian', 'sentinel', 'dashboard', 'operator', 'system']
+  return systemPrefixes.some(prefix =>
+    normalized === prefix
+    || normalized.startsWith(`${prefix}-`)
+    || normalized.includes(`-${prefix}-`)
+  )
+}
+
+function renderSessionCard(s: DashboardMissionSessionBrief) {
+  const { primary, secondary } = splitSessionGoal(s.goal, s.session_id)
+  const creator = (s.created_by ?? '').trim()
+  const systemSession = isSystemSession(creator)
+
+  return html`
+    <div
+      class="hot-session-card ${s.blocker_summary ? 'hot-session-card--critical' : ''}"
+      key=${s.session_id}
+      onClick=${() => navigate('situation', { session_id: s.session_id })}
+    >
+      <div class="hot-session-card__goal">${primary}</div>
+      ${secondary ? html`<div class="hot-session-card__context">${secondary}</div>` : null}
+      <div class="hot-session-card__chips">
+        ${creator
+          ? html`<span class="hot-session-card__chip ${systemSession ? 'hot-session-card__chip--system' : ''}">
+              ${systemSession ? '시스템' : '주체'} · ${creator}
+            </span>`
+          : null}
+        ${s.status ? html`<span class="hot-session-card__chip">${statusLabel(s.status)}</span>` : null}
+      </div>
+      <div class="hot-session-card__meta">
+        ${s.member_names?.length ? html`
+          <span>${s.member_names.slice(0, 3).join(', ')}${s.member_names.length > 3 ? ` +${s.member_names.length - 3}` : ''}</span>
+        ` : null}
+        ${s.elapsed_sec ? html`<span>${formatDuration(s.elapsed_sec)}</span>` : null}
+      </div>
+      ${s.blocker_summary ? html`
+        <div class="hot-session-card__blocker">${s.blocker_summary}</div>
+      ` : null}
+    </div>
+  `
+}
+
+type SessionLaneProps = {
+  title: string
+  description: string
+  tone: 'human' | 'system'
+  sessions: DashboardMissionSessionBrief[]
+  emptyCopy: string
+}
+
+function SessionLane({ title, description, tone, sessions, emptyCopy }: SessionLaneProps) {
+  return html`
+    <section class="hot-session-lane hot-session-lane--${tone}">
+      <div class="hot-session-lane__header">
+        <div>
+          <div class="hot-session-lane__title-row">
+            <h3 class="hot-session-lane__title">${title}</h3>
+            <span class="hot-session-lane__count">${sessions.length}</span>
+          </div>
+          <p class="hot-session-lane__description">${description}</p>
+        </div>
+      </div>
+      ${sessions.length > 0
+        ? html`<div class="hot-sessions__grid">${sessions.map(renderSessionCard)}</div>`
+        : html`<div class="hot-session-lane__empty">${emptyCopy}</div>`}
+    </section>
+  `
+}
 
 function HotSessions() {
   const snap = missionSnapshot.value
@@ -27,35 +128,38 @@ function HotSessions() {
     const aCrit = a.blocker_summary ? 2 : (a.related_attention_count > 0 ? 1 : 0)
     const bCrit = b.blocker_summary ? 2 : (b.related_attention_count > 0 ? 1 : 0)
     if (aCrit !== bCrit) return bCrit - aCrit
+    const aStatus = sessionStatusRank(a.status)
+    const bStatus = sessionStatusRank(b.status)
+    if (aStatus !== bStatus) return aStatus - bStatus
     return (b.elapsed_sec ?? 0) - (a.elapsed_sec ?? 0)
   })
-  const top = sorted.slice(0, 3)
+  const userSessions = sorted.filter(s => !isSystemSession(s.created_by)).slice(0, 3)
+  const systemSessions = sorted.filter(s => isSystemSession(s.created_by)).slice(0, 3)
 
   return html`
     <div class="hot-sessions">
       <div class="home-section-header">
-        <span class="home-section-label">활성 세션</span>
+        <div>
+          <span class="home-section-label">팀 세션</span>
+          <div class="home-section-copy">홈에서는 사람 중심 작업과 자동 런타임을 나눠 보여줍니다.</div>
+        </div>
         <a class="home-section-link" onClick=${() => navigate('situation')}>전체 보기</a>
       </div>
-      <div class="hot-sessions__grid">
-        ${top.map(s => html`
-          <div
-            class="hot-session-card ${s.blocker_summary ? 'hot-session-card--critical' : ''}"
-            key=${s.session_id}
-            onClick=${() => navigate('situation', { session_id: s.session_id })}
-          >
-            <div class="hot-session-card__goal">${s.goal ?? s.session_id}</div>
-            <div class="hot-session-card__meta">
-              ${s.member_names?.length ? html`
-                <span>${s.member_names.slice(0, 3).join(', ')}${s.member_names.length > 3 ? ` +${s.member_names.length - 3}` : ''}</span>
-              ` : null}
-              ${s.elapsed_sec ? html`<span>${formatDuration(s.elapsed_sec)}</span>` : null}
-            </div>
-            ${s.blocker_summary ? html`
-              <div class="hot-session-card__blocker">${s.blocker_summary}</div>
-            ` : null}
-          </div>
-        `)}
+      <div class="hot-sessions__lanes">
+        <${SessionLane}
+          title="사용자 작업"
+          description="사람이 직접 연 협업 세션과 지금 손대고 있는 일입니다."
+          tone="human"
+          sessions=${userSessions}
+          emptyCopy="지금 보이는 사용자 작업 세션이 없습니다."
+        />
+        <${SessionLane}
+          title="시스템 루프"
+          description="Gardener, keeper, operator가 자동으로 유지하거나 정리하는 런타임입니다."
+          tone="system"
+          sessions=${systemSessions}
+          emptyCopy="지금 보이는 시스템 루프 세션이 없습니다."
+        />
       </div>
     </div>
   `

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -288,6 +288,7 @@ function normalizeSessionBrief(raw: unknown): DashboardMissionSessionBrief | nul
   return {
     session_id: sessionId,
     goal,
+    created_by: asString(raw.created_by) ?? null,
     room: asString(raw.room) ?? null,
     status: asString(raw.status),
     health: asString(raw.health),

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -266,9 +266,10 @@
 
 .home-section-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   margin-bottom: var(--space-xs, 4px);
+  gap: 12px;
 }
 
 .home-section-label {
@@ -276,6 +277,13 @@
   font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.home-section-copy {
+  margin-top: 3px;
+  color: var(--text-subtle, var(--text-muted));
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .home-section-link {
@@ -287,9 +295,88 @@
 .home-section-link:hover { text-decoration: underline; }
 
 /* Hot Sessions */
+.hot-sessions__lanes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.hot-session-lane {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(138, 163, 211, 0.12);
+  background: rgba(10, 22, 40, 0.44);
+}
+
+.hot-session-lane--human {
+  border-color: rgba(96, 165, 250, 0.16);
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.08), rgba(10, 22, 40, 0.44));
+}
+
+.hot-session-lane--system {
+  border-color: rgba(34, 197, 94, 0.16);
+  background: linear-gradient(180deg, rgba(34, 197, 94, 0.08), rgba(10, 22, 40, 0.44));
+}
+
+.hot-session-lane__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hot-session-lane__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hot-session-lane__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.hot-session-lane__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.hot-session-lane__description {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.hot-session-lane__empty {
+  display: grid;
+  place-items: center;
+  min-height: 116px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px dashed rgba(138, 163, 211, 0.18);
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.02);
+}
+
 .hot-sessions__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: var(--space-sm, 8px);
 }
 
@@ -316,12 +403,46 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.hot-session-card__context {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.hot-session-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.hot-session-card__chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(138, 163, 211, 0.18);
+  background: rgba(138, 163, 211, 0.08);
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+}
+.hot-session-card__chip--system {
+  border-color: rgba(34, 197, 94, 0.22);
+  background: rgba(34, 197, 94, 0.12);
+  color: #b7f3c9;
+}
 .hot-session-card__meta {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
   font-size: 11px;
   color: var(--text-muted);
-  margin-top: 4px;
+  margin-top: 8px;
 }
 .hot-session-card__blocker {
   font-size: 11px;
@@ -330,6 +451,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+@media (max-width: 960px) {
+  .hot-sessions__lanes {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Agent Pulse */

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -53,6 +53,7 @@ export interface DashboardMissionAttentionQueueItem {
 export interface DashboardMissionSessionBrief {
   session_id: string
   goal: string
+  created_by?: string | null
   room?: string | null
   status?: string
   health?: string
@@ -629,4 +630,3 @@ export interface OperatorActionLogEntry {
   message: string
   delegated_tool?: string
 }
-

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -6,6 +6,7 @@ include Dashboard_utils
 type session_context = Dashboard_mission_assembly.session_context = {
   session_id : string;
   goal : string;
+  created_by : string option;
   room : string option;
   status : string;
   health : string;
@@ -62,6 +63,17 @@ type operation_context = Dashboard_mission_assembly.operation_context = {
 type archived_agent_meta = Dashboard_mission_assembly.archived_agent_meta = {
   last_event_at : string option;
 }
+
+let active_or_recent_sessions config =
+  let cutoff_unix = Time_compat.now () -. 86400.0 in
+  let cutoff_iso = iso_of_unix cutoff_unix in
+  let is_active_or_recent (session : Team_session_types.session) =
+    match session.status with
+    | Running | Paused -> true
+    | _ -> session.updated_at_iso >= cutoff_iso
+  in
+  Team_session_store.list_sessions ~since_unix:cutoff_unix config
+  |> List.filter is_active_or_recent
 
 
 let keeper_tool_audit_json_fields keeper agent_name =
@@ -285,6 +297,7 @@ let build_session_context session_json session_cards =
         goal =
           trim_to_option (string_field "goal" meta)
           |> Option.value ~default:session_id;
+        created_by = trim_to_option (string_field "created_by" meta);
         room = trim_to_option (string_field "room_id" meta);
         status;
         health =
@@ -585,6 +598,7 @@ let build_session_briefs sessions attention_queue actions =
              [
                ("session_id", `String session.session_id);
                ("goal", `String session.goal);
+               ("created_by", json_string_option session.created_by);
                ("room", json_string_option session.room);
                ("status", `String session.status);
                ("health", `String session.health);
@@ -645,6 +659,9 @@ let build_projection ?actor ~config ~sw ~clock ~proc_mgr () =
       mcp_session_id = None;
     }
   in
+  let tracked_sessions =
+    if Room.is_initialized config then active_or_recent_sessions config else []
+  in
   let snapshot_json =
     Dashboard_cache.get_or_compute
       (Printf.sprintf "snapshot:%s" actor_name)
@@ -656,6 +673,7 @@ let build_projection ?actor ~config ~sw ~clock ~proc_mgr () =
           ~include_messages:false
           ~include_sessions:true
           ~include_keepers:true
+          ~sessions:tracked_sessions
           ctx)
   in
   let digest_json =
@@ -663,7 +681,7 @@ let build_projection ?actor ~config ~sw ~clock ~proc_mgr () =
       (Printf.sprintf "digest:%s" actor_name)
       ~ttl:5.0
       (fun () ->
-        match Operator_control.digest_json ~actor:actor_name ctx with
+        match Operator_control.digest_json ~actor:actor_name ~sessions:tracked_sessions ctx with
         | Ok json -> json
         | Error message ->
             `Assoc

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -40,6 +40,7 @@ let session_recent_events session_json = list_field "recent_events" session_json
 type session_context = {
   session_id : string;
   goal : string;
+  created_by : string option;
   room : string option;
   status : string;
   health : string;
@@ -818,6 +819,7 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs command_p
              [
                ("session_id", `String session.session_id);
                ("goal", `String session.goal);
+               ("created_by", json_string_option session.created_by);
                ("room", json_string_option session.room);
                ("status", `String session.status);
                ("health", `String session.health);

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -300,9 +300,9 @@ let persistent_agents_json ?keeper_names config =
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
-let sessions_json config =
-  let sessions =
-    Team_session_store.list_sessions config
+let sessions_json config sessions =
+  let ordered_sessions =
+    sessions
     |> List.sort (fun (a : Team_session_types.session) (b : Team_session_types.session) ->
            compare b.started_at a.started_at)
   in
@@ -321,7 +321,7 @@ let sessions_json config =
             ("status", Team_session_engine_eio.session_status_json config session);
             ("recent_events", `List recent_events);
           ])
-      sessions
+      ordered_sessions
   in
   `Assoc [ ("count", `Int (List.length items)); ("items", `List items) ]
 
@@ -480,7 +480,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
          ("provenance_summary", operator_surface_contract_json);
          ("room", room_json config);
          ( "sessions",
-           if initialized && include_sessions then sessions_json config
+           if initialized && include_sessions then sessions_json config tracked_sessions
            else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
          ( "keepers",
            if initialized && include_keepers then keepers_json ~keeper_names config
@@ -510,4 +510,3 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
   in
   _snapshot_cache := Some (cache_key, result, now);
   result)
-


### PR DESCRIPTION
## Summary
- clarify the Home dashboard session area so it no longer reads like user-only active sessions
- split Home into user work vs system loop lanes and show creator/status metadata on cards
- scope mission/home session data to running/paused plus recently updated team sessions

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/dashboard-home-active-sessions
- npm run build
  - build passes; existing TypeScript warnings remain in dashboard/src/components/agent-roster.ts and are unrelated to this change