### PR TITLE
refactor: move Cascade helpers to natural owners

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -14,6 +14,47 @@ open Printf
 let text_of_message = Agent_sdk.Types.text_of_message
 
 (* ================================================================ *)
+(* UTF-8 sanitization (moved from Cascade)                          *)
+(* ================================================================ *)
+
+let sanitize_text_utf8 (s : string) : string =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec loop i =
+    if i >= len then ()
+    else
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then (
+        Buffer.add_substring buf s i dlen;
+        loop (i + dlen))
+      else (
+        Buffer.add_string buf "\xEF\xBF\xBD";
+        loop (i + 1))
+  in
+  loop 0;
+  Buffer.contents buf
+
+let sanitize_message_utf8 (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
+  { m with
+    content = List.map (fun block ->
+      match block with
+      | Agent_sdk.Types.Text s -> Agent_sdk.Types.Text (sanitize_text_utf8 s)
+      | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error } ->
+          Agent_sdk.Types.ToolResult {
+            tool_use_id = sanitize_text_utf8 tool_use_id;
+            content = sanitize_text_utf8 content;
+            is_error }
+      | other -> other
+    ) m.content;
+  }
+
+(** Heuristic token estimate: ~4 chars per token. *)
+let estimate_tokens (msgs : Agent_sdk.Types.message list) =
+  List.fold_left (fun acc (m : Agent_sdk.Types.message) ->
+    acc + (String.length (Agent_sdk.Types.text_of_message m) / 4) + 4) 0 msgs
+
+(* ================================================================ *)
 (* Types                                                            *)
 (* ================================================================ *)
 
@@ -253,7 +294,7 @@ let role_of_string = function
   | "assistant" -> Agent_sdk.Types.Assistant | _ -> Agent_sdk.Types.Tool
 
 let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
-  let m = Cascade.sanitize_message_utf8 m in
+  let m = sanitize_message_utf8 m in
   let base = [
     ("role", `String (role_to_string m.role));
     ("content", `String (text_of_message m));
@@ -272,7 +313,7 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
-  let text = json |> member "content" |> to_string |> Cascade.sanitize_text_utf8 in
+  let text = json |> member "content" |> to_string |> sanitize_text_utf8 in
   match role with
   | Agent_sdk.Types.Tool ->
     let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
@@ -282,7 +323,7 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
-    ("system_prompt", `String (Cascade.sanitize_text_utf8 ctx.system_prompt));
+    ("system_prompt", `String (sanitize_text_utf8 ctx.system_prompt));
     ("messages", `List (List.map message_to_json ctx.messages));
     ("token_count", `Int ctx.token_count);
     ("max_tokens", `Int ctx.max_tokens);
@@ -290,10 +331,10 @@ let serialize_context (ctx : working_context) : string =
   Yojson.Safe.to_string json
 
 let deserialize_context (s : string) ~max_tokens : working_context =
-  let json = Yojson.Safe.from_string (Cascade.sanitize_text_utf8 s) in
+  let json = Yojson.Safe.from_string (sanitize_text_utf8 s) in
   let open Yojson.Safe.Util in
   let system_prompt =
-    json |> member "system_prompt" |> to_string |> Cascade.sanitize_text_utf8
+    json |> member "system_prompt" |> to_string |> sanitize_text_utf8
   in
   let messages = json |> member "messages" |> to_list |> List.map message_of_json in
   let token_count = json |> member "token_count" |> to_int in
@@ -307,7 +348,7 @@ let create_checkpoint ctx ~generation =
     generation;
     message_count = List.length ctx.messages;
     token_count = ctx.token_count;
-    serialized = serialize_context ctx |> Cascade.sanitize_text_utf8;
+    serialized = serialize_context ctx |> sanitize_text_utf8;
   }
 
 let restore_checkpoint ckpt ~max_tokens =
@@ -323,7 +364,7 @@ let create_session ~session_id ~base_dir =
   { session_id; session_dir; full_history = []; checkpoints = [] }
 
 let persist_message session msg =
-  let msg = Cascade.sanitize_message_utf8 msg in
+  let msg = sanitize_message_utf8 msg in
   session.full_history <- session.full_history @ [msg];
   let path = Filename.concat session.session_dir "history.jsonl" in
   let now_ts = Time_compat.now () in
@@ -334,13 +375,13 @@ let persist_message session msg =
     | j -> j
   in
   let line =
-    (Yojson.Safe.to_string payload |> Cascade.sanitize_text_utf8) ^ "\n"
+    (Yojson.Safe.to_string payload |> sanitize_text_utf8) ^ "\n"
   in
   Fs_compat.append_file path line
 
 let save_checkpoint session ckpt =
   let ckpt =
-    { ckpt with serialized = Cascade.sanitize_text_utf8 ckpt.serialized }
+    { ckpt with serialized = sanitize_text_utf8 ckpt.serialized }
   in
   session.checkpoints <- session.checkpoints @ [ckpt];
   let path = Filename.concat session.session_dir
@@ -353,7 +394,7 @@ let save_checkpoint session ckpt =
     ("token_count", `Int ckpt.token_count);
     ("serialized", `String ckpt.serialized);
   ] in
-  let content = Yojson.Safe.to_string json |> Cascade.sanitize_text_utf8 in
+  let content = Yojson.Safe.to_string json |> sanitize_text_utf8 in
   Fs_compat.save_file path content
 
 let load_latest_checkpoint session =
@@ -373,7 +414,7 @@ let load_latest_checkpoint session =
       let content = Fs_compat.load_file path in
       let json =
         content
-        |> Cascade.sanitize_text_utf8
+        |> sanitize_text_utf8
         |> Yojson.Safe.from_string
       in
       let open Yojson.Safe.Util in
@@ -384,5 +425,5 @@ let load_latest_checkpoint session =
         message_count = json |> member "message_count" |> to_int;
         token_count = json |> member "token_count" |> to_int;
         serialized =
-          json |> member "serialized" |> to_string |> Cascade.sanitize_text_utf8;
+          json |> member "serialized" |> to_string |> sanitize_text_utf8;
       }

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -9,6 +9,17 @@
 
     @since 2.61.0 *)
 
+(** {1 UTF-8 Sanitization} *)
+
+(** Replace invalid UTF-8 bytes with U+FFFD replacement character. *)
+val sanitize_text_utf8 : string -> string
+
+(** Sanitize all text content in a message. *)
+val sanitize_message_utf8 : Agent_sdk.Types.message -> Agent_sdk.Types.message
+
+(** Heuristic token estimate: ~4 chars per token. *)
+val estimate_tokens : Agent_sdk.Types.message list -> int
+
 (** {1 Working Context} *)
 
 (** Working context: the message window sent to the LLM. *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -15,6 +15,99 @@
 module Oas = Agent_sdk
 
 (* ================================================================ *)
+(* Cascade profile helpers (moved from Cascade)                      *)
+(* ================================================================ *)
+
+let int_of_env_default name ~default ~min_v ~max_v =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+      let v =
+        try int_of_string (String.trim raw)
+        with Failure _ -> default
+      in
+      max min_v (min max_v v)
+
+(** Locate config/cascade.json via CWD or ME_ROOT. *)
+let default_config_path () : string option =
+  let base dir name = Filename.concat (Filename.concat dir "config") name in
+  let cwd = Sys.getcwd () in
+  let me_root =
+    Sys.getenv_opt "ME_ROOT"
+    |> Option.value
+         ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
+  in
+  let masc_root = Filename.concat me_root "workspace/yousleepwhen/masc-mcp" in
+  let candidates =
+    [ base cwd "cascade.json";
+      base masc_root "cascade.json";
+      base cwd "llm_cascade.json";
+      base masc_root "llm_cascade.json" ]
+  in
+  List.find_opt Sys.file_exists candidates
+
+let cascade_label provider model =
+  if model = "" then None
+  else Some (Printf.sprintf "%s:%s" provider model)
+
+let cascade_labels_of pairs =
+  List.filter_map (fun (p, m) -> cascade_label p m) pairs
+
+let default_model_strings ~cascade_name =
+  let llama_model = Env_config.Llama.default_model in
+  let glm_model = Env_config.Llm.default_model in
+  let glm_flash = Env_config.Llm.flash_model in
+  let llama_glm =
+    (if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else [])
+    @ [ "glm:auto" ]
+  in
+  match cascade_name with
+  | "heartbeat_action" | "heartbeat_wake" -> llama_glm
+  | "sentinel_board" | "sentinel_task" | "sentinel_keeper" -> llama_glm
+  | "lodge_direct" | "lodge_context_rewrite" | "lodge_trait_gen"
+  | "lodge_comment" | "lodge_agent_match" -> llama_glm
+  | "gardener_spawn" | "gardener_retire" -> llama_glm
+  | "classification" | "context_router" | "capability_match" -> llama_glm
+  | "tom" -> llama_glm
+  | "verifier" | "code_swarm_verify" | "code_swarm" -> llama_glm
+  | "keeper_autonomy" | "keeper_proactive" | "keeper_deliberation"
+  | "keeper_reply" | "keeper_social" | "keeper_turn" -> llama_glm
+  | "routing_judge" | "team_router" -> llama_glm
+  | "chain_llm" -> llama_glm
+  | "autoresearch" -> llama_glm
+  | "trpg_intent" -> llama_glm
+  | "briefing" ->
+      (if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else [])
+      @ cascade_labels_of [ ("glm", glm_flash); ("gemini", Env_config.Gemini.flash_model) ]
+      @ [ "glm:auto" ]
+  | "governance_judge" | "operator_judge" -> llama_glm
+  | "walph" -> llama_glm
+  | "auto_responder_claude" ->
+      cascade_labels_of [ ("claude", Env_config.Claude.default_model) ]
+      @ [ "glm:auto" ]
+  | "auto_responder_gemini" ->
+      cascade_labels_of [ ("gemini", Env_config.Gemini.flash_model) ]
+      @ [ "glm:auto" ]
+  | "auto_responder_glm" ->
+      cascade_labels_of [ ("glm", glm_model) ]
+      @ [ "glm:auto" ]
+  | "auto_responder" -> llama_glm
+  | "spawn_glm" ->
+      cascade_labels_of [ ("glm", glm_model); ("glm", glm_flash) ]
+      @ [ "glm:auto" ]
+  | "mitosis" -> llama_glm
+  | "topic_extraction" -> llama_glm
+  | _ -> llama_glm
+
+(** Max concurrent LLM calls — observability only, no throttling. *)
+let max_concurrent_llm =
+  int_of_env_default "MASC_MAX_CONCURRENT_LLM" ~default:8 ~min_v:1 ~max_v:128
+
+let inflight = Atomic.make 0
+let llm_semaphore_available () = max_concurrent_llm - Atomic.get inflight
+let llm_permits_in_use () = Atomic.get inflight
+
+(* ================================================================ *)
 (* Configuration                                                     *)
 (* ================================================================ *)
 
@@ -262,10 +355,10 @@ let complete_single ~cascade_name ~messages
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?tools () =
   let env = Masc_eio_env.get () in
-  let defaults = Cascade.default_model_strings ~cascade_name in
+  let defaults = default_model_strings ~cascade_name in
   let config_path_opt =
     if String.length config_path > 0 then Some config_path
-    else Cascade.default_config_path ()
+    else default_config_path ()
   in
   match
     Llm_provider.Cascade_config.complete_named
@@ -289,9 +382,9 @@ let require_eio () =
 
 (** Resolve cascade model specs from config + defaults. *)
 let resolve_cascade_specs ~cascade_name : Model_spec.model_spec list =
-  let defaults = Cascade.default_model_strings ~cascade_name in
+  let defaults = default_model_strings ~cascade_name in
   let configured =
-    match Cascade.default_config_path () with
+    match default_config_path () with
     | Some path ->
       let from_file =
         Llm_provider.Cascade_config.load_profile ~config_path:path ~name:cascade_name
@@ -302,7 +395,7 @@ let resolve_cascade_specs ~cascade_name : Model_spec.model_spec list =
   let specs = Model_spec.available_model_specs_of_strings configured in
   if specs <> [] then specs
   else
-    let fallback = Cascade.default_model_strings ~cascade_name in
+    let fallback = default_model_strings ~cascade_name in
     if configured = fallback then (
       Printf.eprintf "[cascade] %s: no callable models from built-in defaults\n%!" cascade_name;
       [])

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -1,7 +1,7 @@
 (** Oas_worker — Unified entry point for OAS-based MASC tool modules.
 
     Callers pass a [cascade_name] string; model resolution is handled
-    internally via [Cascade.default_model_strings] and
+    internally via [default_model_strings] and
     [Llm_provider.Cascade_config].  Internal [config] / [build] / [run]
     are implementation details and not exported.
 
@@ -10,9 +10,34 @@
 
     @since Phase 1 — MASC→OAS migration
     @since Phase 4 — public API restricted to named cascade functions
-    @since Phase 5 — complete_single moved here from Cascade *)
+    @since Phase 5 — complete_single moved here from Cascade
+    @since Phase 6 — cascade profile helpers + diagnostics moved here *)
 
 module Oas = Agent_sdk
+
+(** {1 Cascade Profile Helpers} *)
+
+(** Locate config/cascade.json via CWD or ME_ROOT. *)
+val default_config_path : unit -> string option
+
+(** Built-in model string defaults for a cascade profile name. *)
+val default_model_strings : cascade_name:string -> string list
+
+(** {1 Concurrency Diagnostics} *)
+
+(** Maximum concurrent LLM calls (from MASC_MAX_CONCURRENT_LLM env). *)
+val max_concurrent_llm : int
+
+(** Number of currently available LLM permits. *)
+val llm_semaphore_available : unit -> int
+
+(** Number of LLM permits currently in use. *)
+val llm_permits_in_use : unit -> int
+
+(** Atomic counter tracking in-flight LLM calls. *)
+val inflight : int Atomic.t
+
+(** {1 Run Results} *)
 
 type run_result = {
   response : Oas.Types.api_response;

--- a/lib/perpetual/perpetual_loop.ml
+++ b/lib/perpetual/perpetual_loop.ml
@@ -395,7 +395,7 @@ let status ~config state : Yojson.Safe.t =
     ("last_usage", `Assoc [
       ("input_tokens", `Int state.last_usage.input_tokens);
       ("output_tokens", `Int state.last_usage.output_tokens);
-      ("total_tokens", `Int (Cascade.total_tokens state.last_usage));
+      ("total_tokens", `Int (state.last_usage.input_tokens + state.last_usage.output_tokens));
     ]);
     ("last_latency_ms", `Int state.last_latency_ms);
     ("last_heartbeat_ts", `Float state.last_heartbeat);

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -7,7 +7,7 @@
     - Task hygiene (orphaned/stuck task warnings) — LLM-driven
     - Keeper health monitoring — LLM-driven
 
-    LLM judgment layer via Prompt_registry + Cascade.
+    LLM judgment layer via Prompt_registry + Oas_worker cascade.
     When LLM is unavailable, judgment consumers skip silently.
 
     OAS integration: exports Agent Card, publishes events via Event_bus.
@@ -107,7 +107,7 @@ let parse_llm_json_safe s =
     else None
 
 (** Call sentinel LLM via cascade: render prompt from registry, run through
-    model specs from Cascade. Returns parsed JSON or None on failure. *)
+    model specs from Oas_worker cascade. Returns parsed JSON or None on failure. *)
 let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
   if not Env_config.Sentinel.llm_enabled then None
   else

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -320,7 +320,7 @@ let normalize_for_model (msgs : Agent_sdk.Types.message list)
   (* Trim to fit within target context budget *)
   let max_tokens = target.max_context * 8 / 10 in  (* Leave 20% for response *)
   let rec trim msgs =
-    let total = Cascade.estimate_tokens msgs in
+    let total = Context_manager.estimate_tokens msgs in
     if total <= max_tokens || List.length msgs <= 2 then msgs
     else
       (* Remove oldest non-system message *)
@@ -414,7 +414,7 @@ let hydrate (dna : succession_dna) (spec : successor_spec) : Context_manager.wor
       let rec take_up_to budget acc = function
         | [] -> List.rev acc
         | m :: rest ->
-          let tok = Cascade.estimate_tokens [m] in
+          let tok = Context_manager.estimate_tokens [m] in
           if budget - tok < 0 then List.rev acc
           else take_up_to (budget - tok) (m :: acc) rest
       in

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -160,8 +160,8 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
            acc + runtime.max_concurrency)
          0
   in
-  let configured_max_concurrent_llm = Cascade.max_concurrent_llm in
-  let available_llm_permits = Cascade.llm_semaphore_available () in
+  let configured_max_concurrent_llm = Oas_worker.max_concurrent_llm in
+  let available_llm_permits = Oas_worker.llm_semaphore_available () in
   let runtime_rows, provider_reachable, slot_reachable, actual_slots_total,
       active_slots_now, actual_ctxs, actual_models =
     List.fold_left
@@ -493,9 +493,9 @@ let runtime_status_json ?(include_models = true) () =
       ("source", `String "llama.cpp runtime");
       ("models", `List (List.map (fun model -> `String model) models));
       ("model_count", `Int (List.length models));
-      ("configured_max_concurrent_llm", `Int Cascade.max_concurrent_llm);
-      ("available_llm_permits", `Int (Cascade.llm_semaphore_available ()));
-      ("llm_permits_in_use", `Int (Cascade.llm_permits_in_use  ()));
+      ("configured_max_concurrent_llm", `Int Oas_worker.max_concurrent_llm);
+      ("available_llm_permits", `Int (Oas_worker.llm_semaphore_available ()));
+      ("llm_permits_in_use", `Int (Oas_worker.llm_permits_in_use  ()));
       ("target_parallelism", `Int configured_capacity);
       ("managed_gap_to_target", `Int 0);
       ("runtime_count", `Int (List.length runtime_snapshots));
@@ -654,7 +654,7 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
         ("p50_latency_ms", int_opt_to_json (pctl 0.50 latencies));
         ("p95_latency_ms", int_opt_to_json (pctl 0.95 latencies));
         ("max_latency_ms", int_opt_to_json (pctl 1.0 latencies));
-        ("configured_max_concurrent_llm", `Int Cascade.max_concurrent_llm);
+        ("configured_max_concurrent_llm", `Int Oas_worker.max_concurrent_llm);
         ("configured_capacity", `Int (Local_runtime_pool.configured_capacity ()));
         ("measured_ceiling", int_opt_to_json (Local_runtime_pool.measured_ceiling ()));
         ("per_runtime_breakdown", `List runtime_breakdown);

--- a/lib/tool_model_catalog.ml
+++ b/lib/tool_model_catalog.ml
@@ -36,8 +36,8 @@ let handle_list _ctx _args : result =
 let handle_status _ctx _args : result =
   let endpoints = D.get_cached_or_refresh () in
   let summary = Llm_provider.Discovery.summary_to_json endpoints in
-  let permits_available = Cascade.llm_semaphore_available () in
-  let permits_in_use = Cascade.llm_permits_in_use () in
+  let permits_available = Oas_worker.llm_semaphore_available () in
+  let permits_in_use = Oas_worker.llm_permits_in_use () in
   (true, json_ok [
     ("result", `Assoc [
       ("endpoints", `List (List.map D.endpoint_to_json endpoints));
@@ -45,7 +45,7 @@ let handle_status _ctx _args : result =
       ("masc_permits", `Assoc [
         ("available", `Int permits_available);
         ("in_use", `Int permits_in_use);
-        ("max_concurrent", `Int Cascade.max_concurrent_llm);
+        ("max_concurrent", `Int Oas_worker.max_concurrent_llm);
       ]);
       ("cache_age_seconds", `Float (D.cache_age_seconds ()));
     ]);


### PR DESCRIPTION
## Summary
- `Cascade` 모듈의 모든 함수를 자연스러운 소유자 모듈로 이동
- `cascade.ml`은 외부 호출자 0건인 dead module 상태가 됨 (다음 PR에서 삭제 예정)

### 이동 맵

| 함수 | 출발 | 도착 | 이유 |
|------|------|------|------|
| `sanitize_text_utf8`, `sanitize_message_utf8` | Cascade | Context_manager | 유일한 소비자 (12곳) |
| `estimate_tokens` | Cascade | Context_manager | 토큰 관리 모듈 |
| `default_config_path`, `default_model_strings` | Cascade | Oas_worker | 유일한 소비자 |
| `label`, `labels_of` | Cascade | Oas_worker (`cascade_label`, `cascade_labels_of`) | 내부 헬퍼 |
| `max_concurrent_llm`, `inflight`, `llm_*` | Cascade | Oas_worker | LLM 실행 레이어 |
| `int_of_env_default` | Cascade | Oas_worker | 내부 헬퍼 |
| `total_tokens` (perpetual_loop) | Cascade.total_tokens | 인라인 | one-liner |

### 변경 파일 (9개)
- `context_manager.ml/mli` — sanitize + estimate_tokens 추가
- `oas_worker.ml/mli` — cascade profile + diagnostics 추가
- `succession_oas.ml` — `Cascade.estimate_tokens` → `Context_manager.estimate_tokens`
- `perpetual_loop.ml` — `Cascade.total_tokens` → 인라인
- `tool_model_catalog.ml`, `tool_local_runtime.ml` — `Cascade.llm_*` → `Oas_worker.llm_*`
- `sentinel.ml` — docstring 업데이트

## Test plan
- [x] `dune build --root .` 통과
- [x] `test_cascade` 8 tests 통과
- [ ] CI green 확인
- [ ] 후속 PR: `cascade.ml` 삭제 + dune 모듈 목록 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)