### PR TITLE
chore: bump agent_sdk 0.71.0 → 0.77.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.71.0))
+  (agent_sdk (>= 0.77.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.71.0"}
+  "agent_sdk" {>= "0.77.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
Pin bump only. No code changes — OAS v0.77.0 is backward compatible.

New OAS modules available for future consumption:
- Policy, Audit, Durable (Governance layer)
- Plan (goal decomposition)
- Verified_output, Memory_access
- Gemini native backend

Build verified locally. CI will confirm full test suite.