### PR TITLE
fix: simplify review — sanitize fast-path, dedup resolve, reduce preset duplication

### DIFF
--- a/lib/llm_utils.ml
+++ b/lib/llm_utils.ml
@@ -52,21 +52,32 @@ let timed (f : unit -> 'a) : 'a * int =
 
 let sanitize_text_utf8 (s : string) : string =
   let len = String.length s in
-  let buf = Buffer.create len in
-  let rec loop i =
-    if i >= len then ()
+  (* Fast path: scan for invalid UTF-8 without allocating *)
+  let rec has_invalid i =
+    if i >= len then false
     else
       let dec = String.get_utf_8_uchar s i in
       let dlen = Uchar.utf_decode_length dec in
-      if dlen > 0 && Uchar.utf_decode_is_valid dec then (
-        Buffer.add_substring buf s i dlen;
-        loop (i + dlen))
-      else (
-        Buffer.add_string buf "\xEF\xBF\xBD";
-        loop (i + 1))
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then has_invalid (i + dlen)
+      else true
   in
-  loop 0;
-  Buffer.contents buf
+  if not (has_invalid 0) then s
+  else
+    let buf = Buffer.create len in
+    let rec loop i =
+      if i >= len then ()
+      else
+        let dec = String.get_utf_8_uchar s i in
+        let dlen = Uchar.utf_decode_length dec in
+        if dlen > 0 && Uchar.utf_decode_is_valid dec then (
+          Buffer.add_substring buf s i dlen;
+          loop (i + dlen))
+        else (
+          Buffer.add_string buf "\xEF\xBF\xBD";
+          loop (i + 1))
+    in
+    loop 0;
+    Buffer.contents buf
 
 let sanitize_message_utf8 (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   { m with

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -66,12 +66,7 @@ let claude_opus = {
   cost_per_1k_output = 0.075;
 }
 
-let claude_sonnet = {
-  provider = Claude;
-  model_id = Env_config.Claude.default_model;
-  max_context = 200000;
-  api_url = "https://api.anthropic.com";
-  api_key_env = Some "ANTHROPIC_API_KEY";
+let claude_sonnet = { claude_opus with
   cost_per_1k_input = 0.003;
   cost_per_1k_output = 0.015;
 }

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -401,14 +401,12 @@ let resolve_cascade_specs ~cascade_name : Model_spec.model_spec list =
   in
   let specs = Model_spec.available_model_specs_of_strings configured in
   if specs <> [] then specs
-  else
-    let fallback = default_model_strings ~cascade_name in
-    if configured = fallback then (
+  else if configured = defaults then (
       Printf.eprintf "[cascade] %s: no callable models from built-in defaults\n%!" cascade_name;
       [])
     else (
       Printf.eprintf "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!" cascade_name;
-      Model_spec.available_model_specs_of_strings fallback)
+      Model_spec.available_model_specs_of_strings defaults)
 
 (** Run a single Agent.run() call with cascade model fallback.
 


### PR DESCRIPTION
## Summary

/simplify 리뷰 결과 수정:

1. `sanitize_text_utf8`: 유효 UTF-8이면 Buffer 할당 없이 원본 반환 (fast path)
2. `resolve_cascade_specs`: `default_model_strings` 2회 호출 → 1회로 축소
3. `claude_sonnet`: `{ claude_opus with cost_per_1k_* }` — 5줄 중복 제거

3파일, +4 LOC net (fast-path 추가로 증가하지만 실행 시 할당 감소).

## Test plan

- [x] 변경 파일 빌드 에러 없음
- [ ] CI green (main에 memory_oas_bridge.ml 빌드 깨짐 있어 별도 수정 필요)