### PR TITLE
fix: adapt memory_oas_bridge to OAS v0.77.0 long_term_backend

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -57,7 +57,8 @@ let make_backend ~(agent_name : string) : Agent_sdk.Memory.long_term_backend =
       let importance = importance_of_json json in
       Memory_stream.add_memory
         ~agent_name ~content ~importance
-        (Memory_stream.Observation content));
+        (Memory_stream.Observation content);
+      Ok ());
 
     retrieve = (fun ~key ->
       let entries = Memory_stream.retrieve ~agent_name ~query:key ~limit:1 in
@@ -74,7 +75,28 @@ let make_backend ~(agent_name : string) : Agent_sdk.Memory.long_term_backend =
     remove = (fun ~key:_ ->
       (* Memory_stream is append-only JSONL. Old entries decay naturally
          via recency scoring. Explicit removal not supported. *)
-      ());
+      Ok ());
+
+    batch_persist = (fun pairs ->
+      List.iter (fun (key, json) ->
+        let content = Printf.sprintf "[%s] %s" key (content_of_json json) in
+        let importance = importance_of_json json in
+        Memory_stream.add_memory
+          ~agent_name ~content ~importance
+          (Memory_stream.Observation content)
+      ) pairs;
+      Ok ());
+
+    query = (fun ~prefix ~limit ->
+      let entries = Memory_stream.retrieve ~agent_name ~query:prefix ~limit in
+      List.map (fun (e : Memory_stream.memory_entry) ->
+        (e.Memory_stream.id,
+         `Assoc [
+           ("content", `String e.Memory_stream.content);
+           ("importance", `Int e.Memory_stream.importance);
+           ("timestamp", `Float e.Memory_stream.timestamp);
+         ])
+      ) entries);
   }
 
 (** Create an OAS [Memory.t] instance pre-configured with the memory_stream


### PR DESCRIPTION
## Summary

- OAS v0.77.0 (#1845)에서 `Memory.long_term_backend` 타입 변경:
  - `persist`/`remove` 반환: `unit` → `(unit, string) result`
  - 새 필드: `batch_persist`, `query`
- `memory_oas_bridge.ml`을 새 타입에 맞게 수정

## Test plan

- [ ] `dune build --root .` 통과 (로컬 확인 완료)
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)