### PR TITLE
chore: deduplicate Llm_utils + dead cascade entries + SDK 0.77 compat

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -8,28 +8,10 @@ open Keeper_alerting
 open Keeper_exec_tools [@@warning "-33"]
 open Keeper_exec_status
 
-(* ================================================================ *)
-(* Inline utilities (formerly timed/total_tokens/usage_of)  *)
-(* ================================================================ *)
-
-let timed (f : unit -> 'a) : 'a * int =
-  let t0 = Time_compat.now () in
-  let result = f () in
-  let ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
-  (result, ms)
-
-let zero_usage : Agent_sdk.Types.api_usage =
-  { input_tokens = 0; output_tokens = 0;
-    cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
-
-let usage_of_response (resp : Llm_provider.Types.api_response)
-    : Agent_sdk.Types.api_usage =
-  match resp.usage with Some u -> u | None -> zero_usage
-
-let total_tokens (u : Agent_sdk.Types.api_usage) : int =
-  u.input_tokens + u.output_tokens
-
-(* ================================================================ *)
+let timed = Llm_utils.timed
+let zero_usage = Llm_utils.zero_usage
+let usage_of_response = Llm_utils.usage_of_response
+let total_tokens = Llm_utils.total_tokens
 
 let log_keeper_exn ~label exn =
   let tag = match exn with
@@ -581,10 +563,6 @@ let run_proactive_generation
     ~(idle_seconds : int) : proactive_generation_result option =
   let base_prompt =
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
-  in
-  let zero_usage : Agent_sdk.Types.api_usage =
-    { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
-      cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
   in
   let max_attempts = 3 in
   let previous_preview = String.trim meta.last_proactive_preview in

--- a/lib/llm_utils.ml
+++ b/lib/llm_utils.ml
@@ -96,9 +96,20 @@ let sanitize_message_utf8 (m : Agent_sdk.Types.message) : Agent_sdk.Types.messag
 let sanitize_messages_utf8 (msgs : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
   List.map sanitize_message_utf8 msgs
 
-(** Heuristic: ~4 characters per token (conservative estimate). *)
+(** Heuristic token estimate: ~4 chars per token.
+    Calculates length from content blocks directly to avoid
+    allocating intermediate concatenated strings. *)
 let estimate_tokens (msgs : Agent_sdk.Types.message list) =
-  List.fold_left (fun acc (m : Agent_sdk.Types.message) -> acc + (String.length (Agent_sdk.Types.text_of_message m) / 4) + 4) 0 msgs
+  let block_length = function
+    | Agent_sdk.Types.Text s -> String.length s
+    | Agent_sdk.Types.ToolResult { content; _ } -> String.length content
+    | Agent_sdk.Types.ToolUse { input; _ } ->
+        String.length (Yojson.Safe.to_string input)
+    | _ -> 0
+  in
+  List.fold_left (fun acc (m : Agent_sdk.Types.message) ->
+    let content_len = List.fold_left (fun sum b -> sum + block_length b) 0 m.content in
+    acc + (content_len / 4) + 4) 0 msgs
 
 (* ================================================================ *)
 (* Concurrency diagnostics (observability only, no throttling)       *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -285,14 +285,10 @@ let default_model_strings ~cascade_name =
   match cascade_name with
   (* heartbeat — llama first, glm fallback *)
   | "heartbeat_action" | "heartbeat_wake" -> llama_glm
-  (* sentinel — llama first, glm fallback *)
-  | "sentinel_board" | "sentinel_task" | "sentinel_keeper" -> llama_glm
   (* lodge subsystems — llama first, glm fallback *)
   | "lodge_direct" | "lodge_context_rewrite" | "lodge_trait_gen"
   | "lodge_comment" | "lodge_agent_match" ->
       llama_glm
-  (* gardener — llama first, glm fallback *)
-  | "gardener_spawn" | "gardener_retire" -> llama_glm
   (* classification — local llama, glm fallback *)
   | "classification" | "context_router" | "capability_match" -> llama_glm
   (* theory of mind — local llama, glm fallback *)


### PR DESCRIPTION
## Summary
- `keeper_exec_context.ml`의 4개 중복 함수를 `Llm_utils` import로 교체 (-20 LOC)
- `default_model_strings`에서 삭제된 subsystem 5개 엔트리 제거 (sentinel, gardener)
- `estimate_tokens`에서 불필요한 string 할당 제거 (block 단위 length 계산)
- `memory_oas_bridge.ml` agent_sdk 0.77.0 Memory.t 호환 (persist/remove → result, batch_persist + query 추가)

## Motivation
/simplify 리뷰 에이전트 3개 병렬 실행 결과 발견된 이슈:
1. `keeper_exec_context.ml`과 `llm_utils.ml` 간 byte-for-byte 동일 함수 4개
2. PR #1843에서 삭제된 sentinel/gardener 모듈의 cascade_name 엔트리 잔존
3. `estimate_tokens`가 매 호출마다 `text_of_message`로 임시 문자열 할당

## Test plan
- [x] `dune build lib/ --root .` 통과
- [ ] CI green (agent_sdk pin이 test linker에서 충돌 — 별도 해결 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)