### PR TITLE
fix(test): update dashboard room truth fixture for blocker change

### DIFF
--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -67,11 +67,12 @@ let test_dashboard_room_truth_execution_fixture () =
         in
         let open Yojson.Safe.Util in
         check int "fixture blocked sessions"
-          1
+          0
           (json |> member "execution" |> member "summary" |> member "blocked_sessions" |> to_int);
-        check string "fixture top queue target"
-          "ts-execution-fixture-001"
-          (json |> member "execution" |> member "top_queue" |> member "target_id" |> to_string);
+        (* top_queue is null when no blocked sessions exist *)
+        check bool "fixture top queue absent when no blockers"
+          true
+          (json |> member "execution" |> member "top_queue" = `Null);
       ))
 
 let test_dashboard_room_truth_empty_room_focus_label () =


### PR DESCRIPTION
## Summary

- #1832에서 completed session의 blocker_summary를 None으로 변경
- execution_smoke fixture의 기대값 업데이트: blocked_sessions 1→0, top_queue null 검증

## Test plan

- [x] `test_dashboard_room_truth` 4/4 pass (로컬 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)