### PR TITLE
refactor: delegate Model_spec to OAS Provider_registry + Pricing

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.77.0))
+  (agent_sdk (>= 0.78.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/llm_utils.ml
+++ b/lib/llm_utils.ml
@@ -27,16 +27,14 @@ let int_of_env_default name ~default ~min_v ~max_v =
 (** Compute total tokens from OAS api_usage. *)
 let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tokens
 
-(** Zero usage sentinel. *)
-let zero_usage : Agent_sdk.Types.api_usage =
-  { Agent_sdk.Types.input_tokens = 0;
-    output_tokens = 0;
-    cache_creation_input_tokens = 0;
-    cache_read_input_tokens = 0 }
+(** Zero usage sentinel — delegates to OAS Types.zero_api_usage.
+    @since 2.123.0 — delegated to OAS *)
+let zero_usage : Agent_sdk.Types.api_usage = Llm_provider.Types.zero_api_usage
 
-(** Extract usage from an api_response, defaulting to zero. *)
+(** Extract usage from an api_response, defaulting to zero.
+    @since 2.123.0 — delegates to OAS Types.usage_of_response *)
 let usage_of_response (resp : Llm_provider.Types.api_response) : Agent_sdk.Types.api_usage =
-  match resp.usage with Some u -> u | None -> zero_usage
+  Llm_provider.Types.usage_of_response resp
 
 (** Measure wall-clock latency of a thunk in milliseconds.
     Use at call sites that need per-call timing (keeper tool loops, etc.). *)

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -1,8 +1,12 @@
-(** Model_spec — LLM provider types, preset specs, and model spec parsing.
+(** Model_spec — OAS-backed model identity and resolution.
 
-    Extracted from {!Cascade} to decouple model identity from cascade orchestration.
+    Types and parsing remain for MASC-specific alias resolution
+    (Provider_adapter) and "default"/"default:override" forms.
+    Metadata (URLs, API keys, context sizes, costs) is sourced
+    from OAS Provider_registry and Pricing — single source of truth.
 
-    @since 2.117.0 *)
+    @since 2.117.0 — original extraction from Cascade
+    @since 2.123.0 — rewritten as OAS facade *)
 
 open Printf
 
@@ -43,63 +47,74 @@ let string_of_provider = function
   | Custom s -> sprintf "custom(%s)" s
 
 (* ================================================================ *)
-(* Preset specs                                                      *)
+(* OAS registry + pricing helpers                                    *)
 (* ================================================================ *)
 
-let llama_default = {
-  provider = Llama;
-  model_id = Env_config.Llama.default_model;
-  max_context = 128000;
-  api_url = Env_config.Llama.server_url;
-  api_key_env = None;
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
+let default_registry = Llm_provider.Provider_registry.default ()
 
-let claude_opus = {
-  provider = Claude;
-  model_id = Env_config.Claude.default_model;
-  max_context = 200000;
-  api_url = "https://api.anthropic.com";
-  api_key_env = Some "ANTHROPIC_API_KEY";
-  cost_per_1k_input = 0.015;
-  cost_per_1k_output = 0.075;
-}
+(** Build a model_spec from OAS registry entry + pricing. *)
+let make_of_entry
+    (entry : Llm_provider.Provider_registry.entry)
+    ~model_id ~provider : model_spec =
+  let pricing = Llm_provider.Pricing.pricing_for_model model_id in
+  let api_key_env =
+    let e = entry.defaults.api_key_env in
+    if e = "" then None else Some e
+  in
+  { provider;
+    model_id;
+    max_context = entry.max_context;
+    api_url = entry.defaults.base_url;
+    api_key_env;
+    cost_per_1k_input = pricing.input_per_million /. 1000.0;
+    cost_per_1k_output = pricing.output_per_million /. 1000.0 }
 
-let claude_sonnet = { claude_opus with
-  cost_per_1k_input = 0.003;
-  cost_per_1k_output = 0.015;
-}
+(** Build from registry name with fallback for unknown entries. *)
+let make_of_registry ~registry_name ~model_id ~provider : model_spec =
+  match Llm_provider.Provider_registry.find default_registry registry_name with
+  | Some entry -> make_of_entry entry ~model_id ~provider
+  | None ->
+    let pricing = Llm_provider.Pricing.pricing_for_model model_id in
+    { provider; model_id; max_context = 128_000;
+      api_url = "http://127.0.0.1:8085";
+      api_key_env = None;
+      cost_per_1k_input = pricing.input_per_million /. 1000.0;
+      cost_per_1k_output = pricing.output_per_million /. 1000.0 }
 
-let openai_default = {
-  provider = OpenAI;
-  model_id = Env_config.OpenAI.default_model;
-  max_context = 400000;
-  api_url = "https://api.openai.com";
-  api_key_env = Some "OPENAI_API_KEY";
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
+(* ================================================================ *)
+(* Preset specs — sourced from OAS Provider_registry + Pricing       *)
+(* ================================================================ *)
 
-let glm_cloud = {
-  provider = Glm_cloud;
-  model_id = Env_config.Llm.default_model;
-  max_context = 128000;
-  api_url = "https://api.z.ai";
-  api_key_env = Some "ZAI_API_KEY";
-  cost_per_1k_input = 0.001;
-  cost_per_1k_output = 0.002;
-}
+let llama_default =
+  make_of_registry ~registry_name:"llama"
+    ~model_id:Env_config.Llama.default_model ~provider:Llama
 
-let gemini_pro = {
-  provider = Gemini;
-  model_id = Env_config.Gemini.default_model;
-  max_context = 1000000;
-  api_url = "https://generativelanguage.googleapis.com";
-  api_key_env = Some "GEMINI_API_KEY";
-  cost_per_1k_input = 0.0;
-  cost_per_1k_output = 0.0;
-}
+let claude_opus =
+  let base = make_of_registry ~registry_name:"claude"
+    ~model_id:Env_config.Claude.default_model ~provider:Claude in
+  (* Opus pricing tier — use full wire model ID for lookup *)
+  let pricing = Llm_provider.Pricing.pricing_for_model "claude-opus-4-6" in
+  { base with
+    cost_per_1k_input = pricing.input_per_million /. 1000.0;
+    cost_per_1k_output = pricing.output_per_million /. 1000.0 }
+
+let claude_sonnet =
+  let pricing = Llm_provider.Pricing.pricing_for_model "claude-sonnet-4-6" in
+  { claude_opus with
+    cost_per_1k_input = pricing.input_per_million /. 1000.0;
+    cost_per_1k_output = pricing.output_per_million /. 1000.0 }
+
+let openai_default =
+  make_of_registry ~registry_name:"openrouter"
+    ~model_id:Env_config.OpenAI.default_model ~provider:OpenAI
+
+let glm_cloud =
+  make_of_registry ~registry_name:"glm"
+    ~model_id:Env_config.Llm.default_model ~provider:Glm_cloud
+
+let gemini_pro =
+  make_of_registry ~registry_name:"gemini"
+    ~model_id:Env_config.Gemini.default_model ~provider:Gemini
 
 (* ================================================================ *)
 (* Model spec parsing                                                *)
@@ -165,25 +180,16 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "codex-api" ->
           Ok { openai_default with model_id }
         | Some adapter when adapter.canonical_name = "glm" ->
-          (* "auto" or empty -> GLM provider selects at runtime *)
           let effective_id = if model_id = "auto" then "" else model_id in
           Ok { glm_cloud with model_id = effective_id }
         | Some adapter when adapter.canonical_name = "openrouter" ->
-          Ok {
-            provider = OpenRouter;
-            model_id;
-            max_context = 128000;
-            api_url = "https://openrouter.ai/api";
-            api_key_env = Some "OPENROUTER_API_KEY";
-            cost_per_1k_input = 0.001;
-            cost_per_1k_output = 0.002;
-          }
+          Ok (make_of_registry ~registry_name:"openrouter"
+                ~model_id ~provider:OpenRouter)
         | Some _ ->
           Error (Printf.sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
         | None ->
           match provider with
         | "custom" ->
-          (* Format: custom:model@http://host:port or custom:model *)
           let actual_model, url =
             match String.index_opt model_id '@' with
             | Some at_idx ->
@@ -192,14 +198,15 @@ let rec model_spec_of_string s =
                   (String.length model_id - at_idx - 1) )
             | None -> (model_id, Env_config_runtime.Custom_llm.default_server_url)
           in
+          let pricing = Llm_provider.Pricing.pricing_for_model actual_model in
           Ok {
             provider = Custom actual_model;
             model_id = actual_model;
-            max_context = 128000;
+            max_context = 128_000;
             api_url = url;
             api_key_env = None;
-            cost_per_1k_input = 0.0;
-            cost_per_1k_output = 0.0;
+            cost_per_1k_input = pricing.input_per_million /. 1000.0;
+            cost_per_1k_output = pricing.output_per_million /. 1000.0;
           }
         | _ ->
           Error

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.77.0"}
+  "agent_sdk" {>= "0.78.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- Model_spec의 6개 hardcoded preset specs를 OAS Provider_registry + Pricing으로 대체
- URL, API key env, max_context는 OAS Provider_registry에서 조회
- per-1K cost는 OAS Pricing에서 조회
- Llm_utils.zero_usage/usage_of_response를 OAS Types로 위임
- OAS pin >= 0.78.0

## Depends on
- jeong-sik/oas#287

## Test plan
- [x] test_perpetual.exe 193/193 통과
- [x] `dune build --root .` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)