### PR TITLE
fix(dashboard): clean keeper chat metadata and unlock stream

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -135,6 +135,10 @@ function parseSseEvent(frame: string): KeeperChatStreamEvent | null {
   }
 }
 
+function isTerminalKeeperStreamEvent(event: KeeperChatStreamEvent): boolean {
+  return event.type === 'RUN_FINISHED' || event.type === 'RUN_ERROR'
+}
+
 export async function streamKeeperMessage(
   name: string,
   message: string,
@@ -189,7 +193,16 @@ export async function streamKeeperMessage(
       buffer = rest
       for (const frame of frames) {
         const event = parseSseEvent(frame)
-        if (event) onEvent(event)
+        if (!event) continue
+        onEvent(event)
+        if (isTerminalKeeperStreamEvent(event)) {
+          try {
+            await reader.cancel()
+          } catch {
+            // Ignore stream cancellation errors after terminal events.
+          }
+          return
+        }
       }
       if (done) break
     }

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -94,13 +94,26 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
   ].filter((row): row is { label: string; value: string } => Boolean(row))
 }
 
-export function ChatMessageBubble({ entry }: { entry: KeeperConversationEntry }) {
+export function ChatMessageBubble({
+  entry,
+  showMetadata = true,
+}: {
+  entry: KeeperConversationEntry
+  showMetadata?: boolean
+}) {
   const [expanded, setExpanded] = useState(false)
   const [rawExpanded, setRawExpanded] = useState(false)
   const detailItems = detailSummary(entry.details)
-  const canExpand = !!entry.details
+  const canExpand = showMetadata && !!entry.details
   const overview = entry.details ? overviewRows(entry.details) : []
   const state = stateRows(entry.details?.stateBlock)
+
+  useEffect(() => {
+    if (!showMetadata) {
+      setExpanded(false)
+      setRawExpanded(false)
+    }
+  }, [showMetadata])
 
   return html`
     <article class=${`chat-bubble ${bubbleTone(entry)}`}>
@@ -129,7 +142,7 @@ export function ChatMessageBubble({ entry }: { entry: KeeperConversationEntry })
           : null}
       </div>
 
-      ${detailItems.length > 0
+      ${showMetadata && detailItems.length > 0
         ? html`<div class="chat-detail-chip-row">
             ${detailItems.map(item => html`<span class="chat-detail-chip">${item}</span>`)}
           </div>`
@@ -205,9 +218,11 @@ export function ChatMessageBubble({ entry }: { entry: KeeperConversationEntry })
 export function ChatTranscript({
   entries,
   emptyText,
+  showMetadata,
 }: {
   entries: KeeperConversationEntry[]
   emptyText: string
+  showMetadata?: boolean
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const lastSignature = entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}`).join('|')
@@ -222,7 +237,7 @@ export function ChatTranscript({
     <div class="chat-transcript" ref=${scrollerRef}>
       ${entries.length === 0
         ? html`<div class="chat-empty-copy">${emptyText}</div>`
-        : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} />`)}
+        : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} />`)}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -19,6 +19,24 @@ import {
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 
+const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
+
+function readKeeperChatMetadataVisible(): boolean {
+  try {
+    return localStorage.getItem(KEEPER_CHAT_METADATA_VISIBLE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function writeKeeperChatMetadataVisible(value: boolean): void {
+  try {
+    localStorage.setItem(KEEPER_CHAT_METADATA_VISIBLE_KEY, value ? 'true' : 'false')
+  } catch {
+    // Ignore persistence failures.
+  }
+}
+
 function quietReasonLabel(reason?: string | null): string {
   switch (reason) {
     case 'quiet_hours':
@@ -149,12 +167,17 @@ export function KeeperConversationPanel({
   placeholder: string
 }) {
   const [draft, setDraft] = useState('')
+  const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
 
   useEffect(() => {
     if (keeperName) {
       void hydrateKeeperStatus(keeperName)
     }
   }, [keeperName])
+
+  useEffect(() => {
+    writeKeeperChatMetadataVisible(showMetadata)
+  }, [showMetadata])
 
   const rawThread = keeperThreads.value[keeperName] ?? []
   // Filter out system/tool messages — only show user and assistant conversation
@@ -179,9 +202,19 @@ export function KeeperConversationPanel({
 
   return html`
     <div class="keeper-conversation-shell">
+      <div class="keeper-conversation-toolbar">
+        <button
+          type="button"
+          class="control-btn ghost"
+          onClick=${() => { setShowMetadata(!showMetadata) }}
+        >
+          ${showMetadata ? '메타 숨기기' : '메타 표시'}
+        </button>
+      </div>
       <${ChatTranscript}
         entries=${thread}
         emptyText="아직 직접 대화 기록이 없습니다."
+        showMetadata=${showMetadata}
       />
       <${ChatComposer}
         draft=${draft}

--- a/dashboard/src/keeper-message.ts
+++ b/dashboard/src/keeper-message.ts
@@ -30,7 +30,7 @@ function stripSkillRouteLines(text: string): string {
     .split('\n')
     .filter(line => {
       const trimmed = line.trim()
-      return !trimmed.startsWith('SKILL:') && !trimmed.startsWith('SKILL_REASON:')
+      return !trimmed.startsWith('SKILL')
     })
     .join('\n')
 }
@@ -69,6 +69,7 @@ export function normalizeKeeperConversationDetails(raw: unknown): KeeperConversa
     skillPrimary: asString(payload.skill_primary) ?? null,
     skillReason: asString(payload.skill_reason) ?? null,
     stateBlock,
+    replyText: reply || null,
     rawPayload: payload,
   }
 }

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -239,6 +239,7 @@ function normalizeHistoryEntry(raw: unknown, index: number): KeeperConversationE
     role,
     label: roleLabel(role),
     text,
+    rawText,
     timestamp,
     delivery: 'history',
     streamState: null,
@@ -299,7 +300,8 @@ function setAssistantStreamState(
 function appendAssistantDelta(name: string, entryId: string, delta: string): void {
   updateThreadEntry(name, entryId, entry => ({
     ...entry,
-    text: `${entry.text}${delta}`,
+    rawText: `${entry.rawText ?? entry.text}${delta}`,
+    text: formatKeeperVisibleReply(`${entry.rawText ?? entry.text}${delta}`),
     streamState: 'streaming',
     delivery: 'streaming',
   }))
@@ -393,6 +395,7 @@ export function abortKeeperThreadMessage(name: string): void {
   }
   clearActiveStream(keeperName)
   setRecordValue(keeperSending, keeperName, false)
+  setRecordValue(keeperStreamStartedAt, keeperName, null)
 }
 
 function applyKeeperStreamEvent(
@@ -419,7 +422,16 @@ function applyKeeperStreamEvent(
       if (event.name === 'KEEPER_REPLY_DETAILS') {
         const details = normalizeKeeperConversationDetails(event.value)
         if (details) {
-          finalizeAssistantEntry(keeperName, assistantEntryId, { details })
+          updateThreadEntry(keeperName, assistantEntryId, entry => {
+            const rawText = details.replyText ?? entry.rawText ?? entry.text
+            const text = formatKeeperVisibleReply(rawText)
+            return {
+              ...entry,
+              details,
+              rawText,
+              text,
+            }
+          })
         }
       }
       return null
@@ -503,6 +515,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
     role: 'assistant',
     label: keeperName,
     text: '',
+    rawText: '',
     timestamp: null,
     delivery: 'sending',
     streamState: 'opening',
@@ -580,6 +593,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
         const reply = await sendKeeperMessageDetailed(keeperName, message)
         finalizeAssistantEntry(keeperName, assistantId, {
           text: reply.text.trim() || '(empty reply)',
+          rawText: reply.details?.replyText ?? (reply.text.trim() || '(empty reply)'),
           delivery: 'delivered',
           streamState: null,
           details: reply.details,

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -228,3 +228,8 @@
   flex-direction: column;
   gap: 10px;
 }
+
+.keeper-conversation-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -263,6 +263,7 @@ export interface KeeperConversationDetails {
   skillPrimary?: string | null
   skillReason?: string | null
   stateBlock?: string | null
+  replyText?: string | null
   rawPayload?: unknown
 }
 
@@ -277,6 +278,7 @@ export interface KeeperConversationEntry {
   role: KeeperConversationRole
   label: string
   text: string
+  rawText?: string | null
   timestamp?: string | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
@@ -405,4 +407,3 @@ export interface Keeper {
   inventory?: string[]
   relationships?: Record<string, string>
 }
-


### PR DESCRIPTION
## Summary
- hide keeper chat metadata behind a persisted toggle instead of showing it by default
- sanitize streamed keeper replies so SKILL/STATE control text does not leak into the visible chat bubble
- treat terminal SSE events as stream completion so the composer unlocks as soon as the run finishes

## Validation
- npm run build
- npm run typecheck *(fails on pre-existing dashboard/src/components/agent-roster.ts errors unrelated to this change)*