### PR TITLE
fix: route verifier through Oas_worker.complete_single

### DIFF
--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -1,0 +1,92 @@
+# MASC-MCP OAS Utilization Audit
+
+Date: 2026-03-20
+OAS Version: v0.77.0
+MASC-MCP: main (624d9fcc5)
+
+## OAS Adoption Score: 55/100
+
+| Area | Max | Score | Evidence |
+|------|-----|-------|----------|
+| Agent.run lifecycle | 20 | 15 | 10+ files: perpetual_oas, oas_worker, worker_oas, keeper_agent_run |
+| Types/Provider/Builder | 15 | 12 | 66 files (11.8%) reference Agent_sdk/Oas |
+| Context_reducer | 10 | 8 | context_compact_oas.ml: 4 strategies mapped |
+| Event_bus | 8 | 5 | oas_events.ml: 14 event types, oas_sse_bridge subscribes |
+| Guardrails | 7 | 5 | AllowList/DenyList/AllowAll in 5+ files |
+| Memory 3-tier | 10 | 2 | long_term_backend only. Scratchpad/Working unmapped |
+| Swarm (lib_swarm) | 15 | 0 | 22 files (5,569 lines) fully independent |
+| Advanced modules | 15 | 8 | Collaboration, Sessions, Handoff adopted. 17+ unused |
+
+## Quantitative Metrics
+
+| Metric | Value |
+|--------|-------|
+| MASC lib/ .ml files | 560 |
+| MASC lib/ total lines | 190,889 |
+| OAS-referencing files | 66 (11.8%) |
+| Agent.run call sites | 14 files |
+| Cascade.call residual | 0 (archive 1) |
+| Model_spec coupled files | 39 |
+| OAS .mli modules (total) | 144 (lib/ 138 + lib_swarm/ 6) |
+| OAS modules used by MASC | ~20 |
+| OAS modules unused | 52+ |
+
+## Strengths
+
+1. **Cascade.call fully retired** — 0 in active code
+2. **Agent.run on critical path** — perpetual_oas, oas_worker, worker_oas, keeper_agent_run
+3. **Context_reducer integrated** — 4 compaction strategies mapped via context_compact_oas.ml
+4. **Event_bus connected** — 14 event types in oas_events.ml, oas_sse_bridge subscribes
+5. **Hook system structural** — perpetual_oas_hooks.ml: 4 lifecycle hooks
+6. **Clean adapter layer** — oas_type_adapters.ml (39 lines): Model_spec -> Provider.config
+7. **Perpetual architecture is sound** — Not a dual implementation; proper 3-layer separation (types/OAS adapter/MCP dispatcher)
+
+## Critical Gaps
+
+### Gap 1: Swarm subsystem independent — CRITICAL
+
+- lib/swarm/ (11 files, 2,750 lines) + agent_swarm_*.ml (11 files, 2,819 lines) = 22 files, 5,569 lines
+- OAS lib_swarm/runner.mli provides 3-mode (Decentralized/Supervisor/Pipeline) + convergence loop
+- MASC swarm_eio.ml (617 lines), swarm_goal_loop.ml (347 lines): independent state machines
+- agent_swarm_swarm.ml uses Agent.run per-agent but not Runner for orchestration
+- MASC swarm has features beyond OAS Runner (pheromone, emergent intelligence, custom fitness)
+
+### Gap 2: verifier_oas.ml Provider bypass — FIXED (this PR)
+
+- Was: direct Llm_provider.Cascade_config.complete_named call (lines 160-165)
+- Now: Oas_worker.complete_single — cascade-aware, config-path-resolved, error-formatted
+
+### Gap 3: Memory bridge incomplete — MEDIUM
+
+- memory_oas_bridge.ml: long_term_backend only
+- Missing: Scratchpad (per-turn), Working (session), Episodic (decay/salience), Procedural (confidence)
+- MASC has all source data (memory_stream, context_manager, procedural_memory, institution_eio)
+- Only the OAS integration glue is missing
+
+### Gap 4: 52+ OAS modules unused — LOW-MEDIUM
+
+Key unused modules with potential value:
+- progressive_tools.mli — 371-tool progressive disclosure
+- durable.mli — crash-recovery persistent workflows
+- plan.mli — goal decomposition/replanning
+- verified_output.mli — phantom-type compile-time output verification
+- trajectory.mli — structured Think/Act/Observe/Respond
+- cost_tracker.mli — LLM cost accounting
+- otel_tracer.mli — OpenTelemetry tracing
+
+## Migration Priorities
+
+| Priority | Target | Effort | Status |
+|----------|--------|--------|--------|
+| P1 | verifier_oas.ml -> Oas_worker.complete_single | 1 day | DONE (this PR) |
+| P2 | Memory 3-tier completion | 3-5 days | Planned |
+| P3 | Model_spec gradual retirement | 2-3 weeks | Incremental |
+| P4 | Swarm -> OAS lib_swarm bridge | 3-4 weeks | Needs design |
+| P5 | Advanced module selective adoption | Ongoing | Optional |
+
+## Corrected Findings (vs initial plan)
+
+1. **Perpetual Loop**: NOT a dual implementation. Proper 3-layer: Perpetual_loop (types) -> Perpetual_oas (OAS adapter) -> Tool_perpetual (MCP dispatcher). No code duplication.
+2. **Swarm lines**: 5,569 (not 8,149 as initially estimated)
+3. **OAS reference ratio**: 11.8% (66 files, not 62)
+4. **Score**: 55/100 (up from 52, corrected for perpetual loop proper architecture)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -153,27 +153,19 @@ let verify (req : verification_request) : verdict =
     Pass
   else
     let prompt = build_prompt req in
-    let env = Masc_eio_env.get () in
     let messages : Llm_provider.Types.message list =
       [ Llm_provider.Types.user_msg prompt ]
     in
-    let defaults = Oas_worker.default_model_strings ~cascade_name:"verifier" in
     match
-      Llm_provider.Cascade_config.complete_named
-        ~sw:env.sw ~net:env.net ?clock:env.clock
-        ~name:"verifier" ~defaults ~messages
+      Oas_worker.complete_single
+        ~cascade_name:"verifier" ~messages
         ~temperature:0.0 ~max_tokens:200 ()
     with
     | Ok resp ->
-      parse_verdict (Llm_provider.Cascade_config.text_of_response resp)
-    | Error (Llm_provider.Http_client.HttpError { code; body }) ->
-      let msg = sprintf "HTTP %d: %s" code
-        (if String.length body > 200 then String.sub body 0 200 else body) in
-      eprintf "[verifier] OAS call failed: %s (defaulting to WARN)\n%!" msg;
+      parse_verdict (Llm_provider.Types.text_of_response resp)
+    | Error msg ->
+      eprintf "[verifier] cascade call failed: %s (defaulting to WARN)\n%!" msg;
       Warn ("verifier_unavailable: " ^ msg)
-    | Error (Llm_provider.Http_client.NetworkError { message }) ->
-      eprintf "[verifier] OAS network error: %s (defaulting to WARN)\n%!" message;
-      Warn ("verifier_unavailable: " ^ message)
 
 (* ================================================================ *)
 (* Verdict -> Hook Decision (OAS bridge)                            *)

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -173,6 +173,59 @@ let test_write_tools_are_not_readonly () =
   ) write_tools
 
 (* ================================================================ *)
+(* parse_verdict                                                     *)
+(* ================================================================ *)
+
+let test_parse_verdict_pass () =
+  Alcotest.(check bool) "PASS" true
+    (Verifier_oas.parse_verdict "PASS" = Pass)
+
+let test_parse_verdict_pass_with_trailing () =
+  Alcotest.(check bool) "PASS with trailing" true
+    (Verifier_oas.parse_verdict "PASS - looks good" = Pass)
+
+let test_parse_verdict_warn () =
+  match Verifier_oas.parse_verdict "WARN: minor issue" with
+  | Warn reason ->
+    Alcotest.(check bool) "reason preserved" true
+      (String.length reason > 0)
+  | _ -> Alcotest.fail "expected Warn"
+
+let test_parse_verdict_fail () =
+  match Verifier_oas.parse_verdict "FAIL: critical error" with
+  | Fail reason ->
+    Alcotest.(check bool) "reason preserved" true
+      (String.length reason > 0)
+  | _ -> Alcotest.fail "expected Fail"
+
+let test_parse_verdict_case_insensitive () =
+  Alcotest.(check bool) "pass lowercase" true
+    (Verifier_oas.parse_verdict "pass" = Pass)
+
+let test_parse_verdict_unknown_defaults_to_warn () =
+  match Verifier_oas.parse_verdict "something unexpected" with
+  | Warn _ -> ()
+  | _ -> Alcotest.fail "unknown text should default to Warn"
+
+let test_parse_verdict_empty_defaults_to_pass () =
+  Alcotest.(check bool) "empty -> Pass" true
+    (Verifier_oas.parse_verdict "" = Pass)
+
+(* ================================================================ *)
+(* should_skip (verify fast path)                                    *)
+(* ================================================================ *)
+
+let test_verify_skips_readonly () =
+  let req : Verifier_oas.verification_request = {
+    action_description = "read file contents";
+    action_result = "some data";
+    goal = "test goal";
+    context_summary = "test context";
+  } in
+  Alcotest.(check bool) "read-only skips to Pass" true
+    (Verifier_oas.verify req = Pass)
+
+(* ================================================================ *)
 (* Roundtrip: autonomous_gate_config -> guardrails                   *)
 (* ================================================================ *)
 
@@ -287,6 +340,22 @@ let () =
     ("read_only_predicate", [
       Alcotest.test_case "read tools" `Quick test_read_tools_are_readonly;
       Alcotest.test_case "write tools" `Quick test_write_tools_are_not_readonly;
+    ]);
+    ("parse_verdict", [
+      Alcotest.test_case "PASS" `Quick test_parse_verdict_pass;
+      Alcotest.test_case "PASS with trailing" `Quick
+        test_parse_verdict_pass_with_trailing;
+      Alcotest.test_case "WARN" `Quick test_parse_verdict_warn;
+      Alcotest.test_case "FAIL" `Quick test_parse_verdict_fail;
+      Alcotest.test_case "case insensitive" `Quick
+        test_parse_verdict_case_insensitive;
+      Alcotest.test_case "unknown -> Warn" `Quick
+        test_parse_verdict_unknown_defaults_to_warn;
+      Alcotest.test_case "empty -> Pass" `Quick
+        test_parse_verdict_empty_defaults_to_pass;
+    ]);
+    ("verify_skip", [
+      Alcotest.test_case "read-only skips" `Quick test_verify_skips_readonly;
     ]);
     ("autonomous_gate roundtrip", [
       Alcotest.test_case "L3 -> AllowList (strict)" `Quick test_l3_gate_roundtrip;


### PR DESCRIPTION
## Summary
- verifier_oas.ml의 직접 `Llm_provider.Cascade_config.complete_named` 호출을 `Oas_worker.complete_single`로 전환
- OAS 감사 보고서 추가 (55/100점)
- parse_verdict + verify skip 테스트 8개 추가

## Changes
- `lib/verifier_oas.ml`: `Masc_eio_env.get()` + `default_model_strings` 수동 호출 제거, `Oas_worker.complete_single`이 내부 처리
- `test/test_verifier_oas_bridge.ml`: parse_verdict 7개 + verify_skip 1개 테스트 추가 (17→25)
- `docs/OAS-UTILIZATION-AUDIT.md`: OAS 활용도 정량 감사 보고서

## Why
verifier는 `Oas_worker.complete_single`이 제공하는 config path 해석, cascade defaults, 에러 포맷팅을 우회하고 있었다. 이 변경으로 cascade 정책 변경 시 verifier도 자동 반영된다.

## Test plan
- [x] `test_verifier_oas_bridge.exe` 25/25 pass
- [x] `test_post_verifier.exe` 21/21 pass
- [x] `dune build` clean (0 warnings)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)