### PR TITLE
fix(dashboard): include tasks in light-mode execution API

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -252,23 +252,25 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           ("keepers", `List keepers);
         ]
       in
+      let active_tasks = List.filter (fun (t : Types.task) ->
+        match t.task_status with
+        | Types.Done _ | Types.Cancelled _ -> false
+        | _ -> true
+      ) tasks in
+      let limited_tasks = take 50 active_tasks in
+      let task_fields = [
+        ("tasks", `List (List.map task_json limited_tasks));
+        ("task_counts", `Assoc [
+          ("active", `Int (List.length active_tasks));
+          ("total", `Int (List.length tasks));
+          ("shown", `Int (List.length limited_tasks));
+        ]);
+      ] in
       if light then
-        `Assoc base_fields
+        `Assoc (base_fields @ task_fields)
       else
-        (* Full mode: include tasks, task_counts, messages *)
-        let active_tasks = List.filter (fun (t : Types.task) ->
-          match t.task_status with
-          | Types.Done _ | Types.Cancelled _ -> false
-          | _ -> true
-        ) tasks in
-        let limited_tasks = take 50 active_tasks in
+        (* Full mode: include messages in addition to tasks *)
         `Assoc
-          (base_fields @ [
-            ("tasks", `List (List.map task_json limited_tasks));
-            ("task_counts", `Assoc [
-              ("active", `Int (List.length active_tasks));
-              ("total", `Int (List.length tasks));
-              ("shown", `Int (List.length limited_tasks));
-            ]);
+          (base_fields @ task_fields @ [
             ("messages", `List (List.map message_json messages));
           ])


### PR DESCRIPTION
## Summary

- 대시보드 execution API가 `~light:true` (기본값)으로 호출되면 `tasks` 필드가 null
- 프론트엔드 `Array.isArray(null)` → `false` → 빈 배열 → 태스크 0 표시
- light 모드에서도 `tasks` + `task_counts` 포함하도록 수정
- tasks는 이미 light 모드에서 로드됨 (worker_support_briefs 계산에 필요) → 추가 I/O 비용 0

## Test plan

- [ ] `dune build --root .` 통과
- [ ] `curl .../api/v1/dashboard/execution` 에서 `tasks` 배열 반환 확인
- [ ] 대시보드에서 태스크 카운트 42 (또는 실제 수) 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)