### PR TITLE
fix(ci): restore resolvable agent_sdk floor

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.78.0))
+  (agent_sdk (>= 0.77.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.78.0"}
+  "agent_sdk" {>= "0.77.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- restore the `agent_sdk` minimum version to `0.77.0`
- fix CI dependency resolution on `main`
- keep the change scoped to package constraints only

## Root Cause
`masc-mcp` required `agent_sdk >= 0.78.0`, but the pinned OAS package metadata on `main` is still version `0.77.0`, so `opam install` could not solve dependencies.

## Validation
- `git diff --check`
- `opam install . --deps-only --with-test --dry-run` (solver no longer reports `agent_sdk >= 0.78.0` conflict)
