### PR TITLE
feat: wire 5-tier memory into all callers + flush

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -120,6 +120,9 @@ let run_turn
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
   ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
   ignore (Memory_oas_bridge.seed_memory_bank ~memory ~agent_name ~limit:10);
+  (* 5-tier: Episodic + Procedural seeding (in addition to Long_term above) *)
+  ignore (Memory_oas_bridge.seed_episodes ~memory ~agent_name ~limit:30);
+  ignore (Memory_oas_bridge.seed_procedures_as_oas ~memory ~agent_name ~limit:10);
   let reducer = Agent_sdk.Context_reducer.compose [
     { Agent_sdk.Context_reducer.strategy =
         Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 } };
@@ -144,6 +147,7 @@ let run_turn
   with
   | Error e -> Error e
   | Ok result ->
+    let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
     let text = Agent_sdk.Types.text_of_content result.response.content in
     let model = result.response.Llm_provider.Types.model in
     let tool_names =

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -279,11 +279,13 @@ let handle_execute _ctx args =
        Evaluate the following topic and produce a structured decision. \
        Include: (1) your reasoning, (2) identified risks, (3) recommended action. \
        Be concise and actionable." in
-    let memory = Memory_oas_bridge.create_memory ~agent_name:"council-deliberation" in
+    let agent_name = "council-deliberation" in
+    let memory = Memory_oas_bridge.create_memory_full ~agent_name () in
     match Oas_worker.run_named
       ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
     with
     | Ok result ->
+      let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
       json_ok (`Assoc [
         ("topic", `String topic);
         ("deliberation", `String (Llm_provider.Types.text_of_response result.response));
@@ -302,11 +304,13 @@ let handle_execute_dry_run _ctx args =
        Analyze the following topic WITHOUT committing any changes. \
        Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed. \
        This is analysis only — no actions will be taken." in
-    let memory = Memory_oas_bridge.create_memory ~agent_name:"council-dry-run" in
+    let agent_name = "council-dry-run" in
+    let memory = Memory_oas_bridge.create_memory_full ~agent_name () in
     match Oas_worker.run_named
       ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
     with
     | Ok result ->
+      let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
       json_ok (`Assoc [
         ("topic", `String topic);
         ("analysis", `String (Llm_provider.Types.text_of_response result.response));

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -190,7 +190,7 @@ let handle_mitosis_divide ctx args : result =
     else
       Printf.sprintf "Continue from generation %d. Context: %s" next_gen summary
   in
-  let memory = Memory_oas_bridge.create_memory ~agent_name:ctx.agent_name in
+  let memory = Memory_oas_bridge.create_memory_full ~agent_name:ctx.agent_name () in
   let run_result =
     Oas_worker.run_named_with_masc_tools
       ~cascade_name:"mitosis" ~goal ~system_prompt
@@ -200,6 +200,7 @@ let handle_mitosis_divide ctx args : result =
   let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
   Mcp_server.current_cell := new_cell;
   Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:new_cell ~config;
+  let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name:ctx.agent_name in
   match run_result with
   | Error e ->
     json_err (Printf.sprintf "OAS child agent failed: %s" e)
@@ -258,7 +259,7 @@ let handle_mitosis_handoff ctx args : result =
       "You are the successor agent (generation %d). Resume work from the handoff DNA above. Context ratio was %.1f%%."
       next_gen (context_ratio *. 100.0)
     in
-    let memory = Memory_oas_bridge.create_memory ~agent_name:ctx.agent_name in
+    let memory = Memory_oas_bridge.create_memory_full ~agent_name:ctx.agent_name () in
     let run_result =
       Oas_worker.run_named_with_masc_tools
         ~cascade_name:"mitosis" ~goal ~system_prompt
@@ -268,6 +269,7 @@ let handle_mitosis_handoff ctx args : result =
     let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
     Mcp_server.current_cell := new_cell;
     Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:new_cell ~config:config_m;
+    let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name:ctx.agent_name in
     match run_result with
     | Error e ->
       json_ok (`Assoc [


### PR DESCRIPTION
## Summary
- 모든 Memory_oas_bridge.create_memory 호출자를 5-tier로 전환
- Agent.run 완료 후 flush_all로 학습된 episode/procedure 영속화

## Changes (3 files, +14/-4)
- `tool_council_oas.ml`: create_memory_full + flush_all (deliberation + dry-run)
- `tool_mitosis_oas.ml`: create_memory_full + flush_all (divide + handoff)
- `keeper_agent_run.ml`: 기존 Long_term seed 유지 + seed_episodes + seed_procedures_as_oas + flush_all

## Why
#1873에서 5-tier bridge를 구현했지만 호출자가 여전히 `create_memory`(Long_term only)를 사용. 이 PR로 모든 에이전트 실행 경로에서 Episodic + Procedural tier가 활성화됨.

## Keeper 특수 처리
Keeper는 `_global` agent_name으로 procedures를 seed하는 기존 패턴 유지. `create_memory_full`로 대체하지 않고 Episodic/Procedural seed를 추가.

## Test plan
- [x] `test_memory_oas_5tier.exe` 15/15 pass
- [x] `test_verifier_oas_bridge.exe` 25/25 pass
- [x] `dune build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)