### PR TITLE
feat(board): expose Board+Comm to Agent mode

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -134,6 +134,7 @@ type social_board_event = {
   post_id : string;
   comment_id : string option;
   author : string;
+  post_author : string option;
   content : string;
   created_at : float;
 }

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -61,9 +61,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
         keeper_shell_readonly_tool_names @ with_voice
       else with_voice
     in
-    match canonical_policy_action_budget meta.policy_action_budget with
-    | "board" -> dedupe_tool_names (keeper_board_tool_names @ with_shell)
-    | _ -> dedupe_tool_names with_shell
+    dedupe_tool_names (keeper_board_tool_names @ with_shell)
   else keeper_model_tools |> List.map (fun tool -> tool.Types.name)
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -24,6 +24,7 @@ type social_board_event = Keeper_exec_context.social_board_event = {
   post_id : string;
   comment_id : string option;
   author : string;
+  post_author : string option;
   content : string;
   created_at : float;
 }

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -140,7 +140,7 @@ let categories_for_mode = function
   | Coding -> core_all @ [Worktree; Code; Health; Plan; Consensus]
   | Full -> all_categories
   | Solo -> [Core_Room; Core_Task; Worktree]
-  | Agent -> [Core_Room; Core_Task; Worktree]
+  | Agent -> [Core_Room; Core_Task; Worktree; Board; Comm]
   | Custom -> [] (* Will be loaded from config *)
 
 (** Tool name to category mapping.
@@ -465,7 +465,7 @@ let mode_description = function
   | Coding -> "Core, worktree, code navigation, health, plan, and consensus for agent development"
   | Full -> "All categories enabled (~322 tools)"
   | Solo -> "Room + task + worktree (~23 tools)"
-  | Agent -> "Focused agent: room + task + worktree (~20 tools, PR #814 sweet spot)"
+  | Agent -> "Focused agent: room + task + worktree + board + comm (~30 tools)"
   | Custom -> "User-defined category set"
 
 (** Category descriptions *)

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -161,9 +161,11 @@ let test_categories_agent () =
   check bool "has core_room" true (List.mem Mode.Core_Room cats);
   check bool "has core_task" true (List.mem Mode.Core_Task cats);
   check bool "has worktree" true (List.mem Mode.Worktree cats);
+  check bool "has board" true (List.mem Mode.Board cats);
+  check bool "has comm" true (List.mem Mode.Comm cats);
   check bool "no core_session" false (List.mem Mode.Core_Session cats);
   check bool "no core_ops" false (List.mem Mode.Core_Ops cats);
-  check int "count" 3 (List.length cats)
+  check int "count" 5 (List.length cats)
 
 let test_categories_full () =
   let cats = Mode.categories_for_mode Mode.Full in


### PR DESCRIPTION
## Summary
- Agent 모드에 Board + Comm 카테고리 추가 (3→5 카테고리). 외부 에이전트(Claude Code, Codex)가 board tool에 접근 가능
- Keeper board tool의 `action_budget="board"` 게이트 제거. learned-mode keeper는 항상 board tool 사용 가능
- PG에서 테스트/자동화 쓰레기 글 3건 삭제 (tester, mdal, team-session)

## Changes

| 파일 | 변경 | 이유 |
|------|------|------|
| `lib/mode.ml` | Agent 모드에 Board, Comm 추가 | 외부 agent board 접근 |
| `lib/keeper/keeper_exec_tools.ml` | board tool 항상 포함 | keeper board 접근 |
| `test/test_mode_coverage.ml` | Agent 카테고리 count 3→5 | 테스트 업데이트 |
| `masc_mcp.opam` | dune build 재생성 | dune-project 2.123.0 반영 |

## Context
Board가 만들어졌지만 Agent 모드에 Board 카테고리가 누락되어 외부 에이전트가 접근 불가. Keeper도 `policy_action_budget = "board"`가 기본값이 아니라서 board tool이 비활성 상태.

## Test plan
- [x] `test_mode_coverage.exe` — 52 tests pass (Agent 카테고리 5개 검증)
- [x] `test_mode_tool_count.exe` — 18 tests pass (monotonic ordering, range checks)
- [x] PG 보드 데이터 정리 확인 (`SELECT count(*) FROM masc_board_posts` = 0)
- [ ] `make test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)