### PR TITLE
perf(dashboard): split heavyweight route chunks

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit || echo '[WARN] tsc reported errors (non-blocking)' && vite build",
+    "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -88,7 +88,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const briefMap = new Map(briefs.map(b => [b.agent_name, b]))
 
   const filtered = agentList
-    .filter((a: { name: string; status: string }) => {
+    .filter((a: Agent) => {
       if (filter !== 'all' && statusCategory(a.status) !== filter) return false
       if (search && !a.name.toLowerCase().includes(search.toLowerCase())) return false
       // Keeper filter from parent chip
@@ -99,19 +99,24 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       }
       return true
     })
-    .sort((a: { status: string; name: string }, b: { status: string; name: string }) => {
-      const order: Record<string, number> = { active: 0, busy: 0, listening: 0, working: 0, idle: 1, offline: 2, inactive: 2 }
-      const aOrder = order[a.status.toLowerCase()] ?? 1
-      const bOrder = order[b.status.toLowerCase()] ?? 1
+    .sort((a: Agent, b: Agent) => {
+      const order: Record<StatusFilter, number> = {
+        all: 0,
+        active: 0,
+        idle: 1,
+        offline: 2,
+      }
+      const aOrder = order[statusCategory(a.status)]
+      const bOrder = order[statusCategory(b.status)]
       if (aOrder !== bOrder) return aOrder - bOrder
       return a.name.localeCompare(b.name)
     })
 
   const counts = {
     all: agentList.length,
-    active: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'active').length,
-    idle: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'idle').length,
-    offline: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'offline').length,
+    active: agentList.filter((a: Agent) => statusCategory(a.status) === 'active').length,
+    idle: agentList.filter((a: Agent) => statusCategory(a.status) === 'idle').length,
+    offline: agentList.filter((a: Agent) => statusCategory(a.status) === 'offline').length,
   }
 
   return html`

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { lazy, Suspense } from 'preact/compat'
 import { route, navigate } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
@@ -7,11 +8,6 @@ import { missionSnapshot } from '../mission-store'
 import { roomTruthInitializing } from '../room-truth-store'
 import { Mission } from './mission'
 import { Overview } from './overview/overview'
-import { AgentsUnified } from './agents-unified'
-import { Activity } from './activity'
-import { Work } from './work'
-import { Control } from './control'
-import { LabUnified } from './lab-unified'
 import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import {
@@ -22,6 +18,16 @@ import {
 import { InterveneRailCard, SnapshotCard } from './resident-runtime-rail'
 
 const buildIdentityOpen = signal(false)
+
+const LazyAgentsUnified = lazy(async () => ({ default: (await import('./agents-unified')).AgentsUnified }))
+const LazyActivity = lazy(async () => ({ default: (await import('./activity')).Activity }))
+const LazyWork = lazy(async () => ({ default: (await import('./work')).Work }))
+const LazyControl = lazy(async () => ({ default: (await import('./control')).Control }))
+const LazyLabUnified = lazy(async () => ({ default: (await import('./lab-unified')).LabUnified }))
+
+function lazyTabFallback(label: string) {
+  return html`<div class="loading-indicator">${label} 불러오는 중...</div>`
+}
 
 export function ConnectionStatus() {
   const isConnected = connected.value
@@ -185,15 +191,35 @@ export function TabContent() {
     case 'situation':
       return html`<${Mission} />`
     case 'agents':
-      return html`<${AgentsUnified} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('에이전트 화면')}>
+          <${LazyAgentsUnified} />
+        <//>
+      `
     case 'activity':
-      return html`<${Activity} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('활동 화면')}>
+          <${LazyActivity} />
+        <//>
+      `
     case 'work':
-      return html`<${Work} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('작업 화면')}>
+          <${LazyWork} />
+        <//>
+      `
     case 'control':
-      return html`<${Control} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('제어 화면')}>
+          <${LazyControl} />
+        <//>
+      `
     case 'lab':
-      return html`<${LabUnified} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('실험실 화면')}>
+          <${LazyLabUnified} />
+        <//>
+      `
     default:
       return html`<${Overview} />`
   }

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -11,9 +11,21 @@ import {
   refreshCommandPlaneOrchestra,
   refreshCommandPlaneSwarm,
 } from './command-store'
-import { refreshGovernance } from './components/governance'
-import { refreshTools } from './components/tools'
-import { refreshSocial } from './components/social'
+
+async function refreshGovernanceSurface(): Promise<void> {
+  const { refreshGovernance } = await import('./components/governance')
+  await refreshGovernance()
+}
+
+async function refreshToolsSurface(): Promise<void> {
+  const { refreshTools } = await import('./components/tools')
+  await refreshTools()
+}
+
+async function refreshSocialSurface(): Promise<void> {
+  const { refreshSocial } = await import('./components/social')
+  await refreshSocial()
+}
 
 export function refreshForTab(tab: string) {
   if (tab === 'home') {
@@ -36,7 +48,7 @@ export function refreshForTab(tab: string) {
 
   if (tab === 'activity') {
     refreshExecution()
-    refreshSocial()
+    void refreshSocialSurface()
   }
 
   if (tab === 'work') {
@@ -44,7 +56,7 @@ export function refreshForTab(tab: string) {
     if (section === 'evidence') {
       refreshProofSnapshot(route.value.params.session_id, route.value.params.operation_id)
     } else if (section === 'governance') {
-      refreshGovernance()
+      void refreshGovernanceSurface()
     } else if (section === 'planning') {
       refreshGoals()
       refreshExecution()
@@ -56,7 +68,7 @@ export function refreshForTab(tab: string) {
   if (tab === 'control') {
     const section = route.value.params.section
     if (section === 'tools') {
-      refreshTools()
+      void refreshToolsSurface()
     } else {
       refreshRoomTruth()
       refreshOperatorSnapshot()


### PR DESCRIPTION
## Summary
- lazy-load non-primary dashboard tabs at the route boundary
- remove static refresh imports that were pinning governance/tools/social into the main entry chunk
- keep home and situation eager for primary-path responsiveness

## Validation
- `npm run typecheck`
- `npm run build`
- main entry chunk reduced from about `594.64 kB` to `279.83 kB`

## Stacked On
- #1875
