### PR TITLE
fix(dashboard): restore proof evidence render

### DIFF
--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -332,7 +332,7 @@ function ActorContributionRow({ item }: { item: DashboardProofActorContribution 
   const lastSeen = item.last_active_at ?? item.recent_request_at ?? null
   const isPlanned = item.activity_state === 'planned_only'
   return html`
-    <article class="mission-activity-row proof-actor-row" style="${isPlanned ? 'opacity: 0.45;' : ''}"
+    <article class="mission-activity-row proof-actor-row" style="${isPlanned ? 'opacity: 0.45;' : ''}">
       <div class="mission-activity-head">
         <div>
           <strong>${item.actor}</strong>


### PR DESCRIPTION
## Summary
- fix the proof surface HTM markup so actor contribution cards render again
- verify the evidence tab no longer crashes with l.push is not a function
- smoke the main dashboard surfaces to check for similar render crashes

## Validation
- npm run build
- browser smoke on home, situation, agents, activity, work(board/governance/evidence/planning), control, control?section=tools, lab

## Notes
- npm run typecheck still fails on pre-existing dashboard/src/components/agent-roster.ts typing errors unrelated to this fix
