### PR TITLE
fix(dashboard): add heartbeat events to agent timeline

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -389,6 +389,7 @@ function timelineEventLabel(type: string): string {
     case 'task_completed': return '태스크 완료'
     case 'task_cancelled': return '태스크 취소'
     case 'broadcast': return '브로드캐스트'
+    case 'heartbeat': return '생존'
     default: return type
   }
 }

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -178,6 +178,7 @@ function timelineEventLabel(type: string): string {
     case 'task_completed': return '완료'
     case 'task_cancelled': return '취소'
     case 'broadcast': return '방송'
+    case 'heartbeat': return '생존'
     default: return type
   }
 }

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -9,7 +9,6 @@ import {
   serverStatus,
 } from '../store'
 import { refreshForTab } from '../tab-refresh'
-import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import { navigate } from '../router'
 import { operatorSnapshot, refreshOperatorRoomDigest, refreshOperatorSnapshot } from '../operator-store'

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -59,17 +59,17 @@ let event_to_json (e : timeline_event) : Yojson.Safe.t =
       ("detail", e.detail);
     ]
 
-(* Collect agent join/status events *)
+(* Collect agent join/status + heartbeat events *)
 let agent_events (config : Room.config) ~agent_name ~room_id :
     timeline_event list =
   let agents = Room.get_agents_raw_in_room config room_id in
   agents
   |> List.filter (fun (a : Types.agent) -> String.equal a.name agent_name)
-  |> List.filter_map (fun (a : Types.agent) ->
-         match parse_iso_timestamp a.joined_at with
-         | Some ts ->
-             Some
-               {
+  |> List.concat_map (fun (a : Types.agent) ->
+         let joined =
+           match parse_iso_timestamp a.joined_at with
+           | Some ts ->
+               [{
                  ts;
                  ts_iso = a.joined_at;
                  event_type = "joined";
@@ -84,8 +84,34 @@ let agent_events (config : Room.config) ~agent_name ~room_id :
                          | Some t -> `String t
                          | None -> `Null );
                      ];
-               }
-         | None -> None)
+               }]
+           | None -> []
+         in
+         (* Emit heartbeat from last_seen if it differs from joined_at *)
+         let heartbeat =
+           if String.equal a.last_seen a.joined_at then []
+           else
+             match parse_iso_timestamp a.last_seen with
+             | Some ts ->
+                 [{
+                   ts;
+                   ts_iso = a.last_seen;
+                   event_type = "heartbeat";
+                   detail =
+                     `Assoc
+                       [
+                         ("room", `String room_id);
+                         ( "status",
+                           `String (Types.agent_status_to_string a.status) );
+                         ( "current_task",
+                           match a.current_task with
+                           | Some t -> `String t
+                           | None -> `Null );
+                       ];
+                 }]
+             | None -> []
+         in
+         joined @ heartbeat)
 
 (* Collect task-related events for an agent *)
 let task_events (config : Room.config) ~agent_name ~room_id :
@@ -272,13 +298,35 @@ let build_timeline (config : Room.config) ~agent_name ~since_hours ~limit
     List.length
       (List.filter (fun e -> String.equal e.event_type "broadcast") events)
   in
-  (* Active duration: time between first and last event *)
+  (* Active duration: time between first and last event.
+     If only one event (e.g. a heartbeat), use agent joined_at..last_seen
+     clamped to the query window as a fallback. *)
   let active_duration_minutes =
-    match (events, List.rev events) with
-    | first :: _, last :: _ ->
-        let diff = last.ts -. first.ts in
-        Float.round (diff /. 60.0)
-    | _ -> 0.0
+    let event_span =
+      match (events, List.rev events) with
+      | first :: _, last :: _ when first != last ->
+          last.ts -. first.ts
+      | _ -> 0.0
+    in
+    if event_span > 0.0 then Float.round (event_span /. 60.0)
+    else
+      (* Fallback: compute from agent file joined_at..last_seen within window *)
+      let agent_duration =
+        List.concat_map (fun room_id ->
+          Room.get_agents_raw_in_room config room_id
+          |> List.filter (fun (a : Types.agent) -> String.equal a.name agent_name)
+          |> List.filter_map (fun (a : Types.agent) ->
+            match parse_iso_timestamp a.joined_at, parse_iso_timestamp a.last_seen with
+            | Some j, Some ls ->
+                let start = Float.max j cutoff in
+                let span = ls -. start in
+                if span > 0.0 then Some span else None
+            | _ -> None)
+        ) rooms
+      in
+      match agent_duration with
+      | d :: _ -> Float.round (d /. 60.0)
+      | [] -> 0.0
   in
   let since_iso =
     let tm = Unix.gmtime cutoff in


### PR DESCRIPTION
## Summary
- Agent detail 페이지에서 통계 카드(완료/수임/메시지/활동)가 전부 0으로 표시되는 문제 수정
- Keeper가 heartbeat만 치고 broadcast/task를 만들지 않아 timeline 이벤트가 없었음
- `last_seen`을 heartbeat 이벤트로 추가하여 최소한의 활동 지표 표시

## Changes
- `Tool_agent_timeline.agent_events`: joined + heartbeat(last_seen) 이벤트 모두 수집
- `active_duration_minutes`: 이벤트 1개만 있을 때 agent joined_at~last_seen 범위에서 계산
- Dashboard: heartbeat → "생존" 라벨 추가 (agent-profile, agent-detail)
- resident-runtime-rail: 미사용 TimeAgo import 제거 (기존 빌드 에러)

## Test plan
- [ ] `curl "http://127.0.0.1:8935/api/v1/agent-timeline?agent_name=keeper-sangsu-agent&since_hours=24"` → events에 heartbeat, summary에 non-zero active_duration
- [ ] Dashboard agent detail 페이지에서 활동 시간이 0m이 아닌 값 표시
- [ ] 타임라인 섹션에 "생존" 이벤트 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)