### PR TITLE
fix: input validation guards for board, cache, a2a, and check tools

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -474,6 +474,10 @@ let delegate config ~agent_name ~target ~message
     ?(artifacts : artifact list = [])
     ?(timeout = 300)
     () : (Yojson.Safe.t, string) result =
+  (* BUG: Prevent self-delegation — creates blocking self-portal *)
+  if String.equal agent_name target then
+    Error (Printf.sprintf "Self-delegation not allowed: agent '%s' cannot delegate to itself" agent_name)
+  else
   (* Timeout is stored and returned in response for client-side enforcement *)
   let timeout_ms = timeout * 1000 in
   let deadline = Time_compat.now () +. (float_of_int timeout) in

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -164,6 +164,10 @@ let count_entries config =
 (** Set cache entry - synchronous *)
 let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []) ()
     : (cache_entry, string) result =
+  (* BUG-016: Reject empty key *)
+  if String.length (String.trim key) = 0 then
+    Error "Cache key must not be empty"
+  else
   (* BUG-013: Per-entry size limit *)
   let max_size = Env_config.Cache.max_entry_size in
   if String.length value > max_size then

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -155,6 +155,10 @@ let handle_post_create args =
   let body = get_string_opt args "body" |> Option.map strip_state_blocks_text in
   let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
   let content = strip_state_blocks_text raw_content in
+  if String.length content > Board.Limits.max_content_length then
+    (false, Printf.sprintf "Content exceeds max length (%d > %d chars)"
+       (String.length content) Board.Limits.max_content_length)
+  else
   let author = get_string args "author" "anonymous" in
   let ttl_hours = get_int args "ttl_hours" Board.Limits.default_ttl_hours in
   let visibility_str = get_string args "visibility" "internal" in

--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -504,8 +504,10 @@ let execute_action ctx (case_ : GV2.case_record) (order : GV2.execution_order) =
       | action_type ->
           Error
             (Printf.sprintf
-               "unsupported execution action_type for governance v2: %s"
-               action_type))
+               "unsupported execution action_type for governance v2: '%s'. \
+                Supported: add_task, start_operation, set_param, release_task, \
+                flag_post, restart_keeper"
+               (String.trim action_type)))
 
 (* TODO(M-13): V1 governance tools (debate, consensus, sessions) are deprecated.
    Full removal requires auditing all callers and cleaning up the Debate/Consensus

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -226,7 +226,7 @@ let check_assertion st assertion =
          "Call masc_join to register your agent in the room")
     | "task_claimed" ->
         (st.task_claimed,
-         "Call masc_claim_next or masc_transition(action=claim) to get a task")
+         "Call masc_claim to get a task")
     | "current_task_set" ->
         (st.current_task_set,
          "Call masc_plan_set_task after claiming a task")


### PR DESCRIPTION
## Summary
- `tool_room.ml`: fix_hint이 존재하지 않는 `masc_claim_next`, `masc_transition`을 참조 → `masc_claim`으로 교체 (#1852)
- `tool_board.ml`: `handle_post_create`에 `Board.Limits.max_content_length` (4000자) 초과 시 거부 추가 (#1855)
- `cache_eio.ml`: `set`에 빈 키/공백만 있는 키 거부 추가 (#1856)
- `a2a_tools.ml`: `delegate`에 self-delegation (`agent_name = target`) 방지 추가 (#1859)
- `tool_council.ml`: governance v2 catch-all 에러 메시지에 지원 action_type 목록 + `String.trim` 적용 (#1851)

Closes #1851, closes #1852, closes #1855, closes #1856, closes #1859

## Test plan
- [ ] `dune build` 통과
- [ ] `make test` 통과
- [ ] cache: empty key → Error 반환 확인
- [ ] board: 4000자 초과 content → false 반환 확인
- [ ] a2a: self-delegation → Error 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)