### PR TITLE
fix: cache truncation, board profile match, agent schema, batch validation

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -42,11 +42,20 @@ let sanitize_key key =
 let cache_file config key =
   Filename.concat (cache_dir config) (sanitize_key key ^ ".json")
 
-(** Entry to JSON *)
+(** Entry to JSON — truncates value at 512 bytes for listing responses *)
+let max_list_value_len = 512
+
 let entry_to_json (entry : cache_entry) : Yojson.Safe.t =
+  let value_len = String.length entry.value in
+  let display_value =
+    if value_len > max_list_value_len then
+      String.sub entry.value 0 max_list_value_len ^ "...(truncated)"
+    else entry.value
+  in
   `Assoc [
     ("key", `String entry.key);
-    ("value", `String entry.value);
+    ("value", `String display_value);
+    ("value_size", `Int value_len);
     ("created_at", `Float entry.created_at);
     ("expires_at", match entry.expires_at with
       | Some t -> `Float t

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -412,10 +412,12 @@ let handle_profile args =
   if agent = "" then (false, "❌ agent required")
   else
     let all_posts : Board.post list = Board_dispatch.list_posts ~limit:1000 () in
-    let agent_posts = List.filter (fun (p : Board.post) -> Board.Agent_id.to_string p.author = agent) all_posts in
+    let norm s = String.lowercase_ascii (String.trim s) in
+    let agent_norm = norm agent in
+    let agent_posts = List.filter (fun (p : Board.post) -> norm (Board.Agent_id.to_string p.author) = agent_norm) all_posts in
     let post_votes = List.fold_left (fun acc (p : Board.post) -> acc + p.votes_up - p.votes_down) 0 agent_posts in
     let all_comments : Board.comment list = Board_dispatch.list_comments () in
-    let agent_comments = List.filter (fun (c : Board.comment) -> Board.Agent_id.to_string c.author = agent) all_comments in
+    let agent_comments = List.filter (fun (c : Board.comment) -> norm (Board.Agent_id.to_string c.author) = agent_norm) all_comments in
     let comment_votes = List.fold_left (fun acc (c : Board.comment) -> acc + c.votes_up - c.votes_down) 0 agent_comments in
     (true, Printf.sprintf "📊 **%s** 프로필\n📝 게시물: %d개 (%+d점)\n💬 코멘트: %d개 (%+d점)\n⭐ 총: %+d점"
       agent (List.length agent_posts) post_votes (List.length agent_comments) comment_votes (post_votes + comment_votes))

--- a/lib/tool_schemas_agent.ml
+++ b/lib/tool_schemas_agent.ml
@@ -107,16 +107,12 @@ Pair with masc_cleanup_zombies to remove stale agents or masc_find_by_capability
   };
   {
     name = "masc_agent_update";
-    description = "Update an agent's metadata (status or capabilities) with transition guards. \
-Use when you need to correct an external agent's state or change your own status to busy/listening. \
-Pair with masc_agents to verify the update or masc_register_capabilities for capability-only changes.";
+    description = "Update your own agent metadata (status or capabilities) with transition guards. \
+Use when you need to change your status to busy/listening or update capabilities. \
+Only modifies the calling agent's own record. Pair with masc_agents to verify the update.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Agent name or nickname");
-        ]);
         ("status", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional status: active | busy | listening | inactive");
@@ -127,7 +123,6 @@ Pair with masc_agents to verify the update or masc_register_capabilities for cap
           ("description", `String "Optional capability list (overwrites existing)");
         ]);
       ]);
-      ("required", `List [`String "agent_name"]);
     ];
   };
   {

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -44,13 +44,26 @@ let handle_batch_add_tasks ctx args =
     | `List l -> l
     | _ -> []
   in
-  let tasks = List.map (fun t ->
-    let title = t |> member "title" |> to_string in
+  if tasks_json = [] then
+    (false, "tasks array is empty or missing")
+  else
+  let validated = List.mapi (fun idx t ->
+    let title = String.trim (t |> member "title" |> to_string) in
     let priority = t |> member "priority" |> to_int_option |> Option.value ~default:3 in
     let description = t |> member "description" |> to_string_option |> Option.value ~default:"" in
-    (title, priority, description)
+    if title = "" then
+      Error (Printf.sprintf "item[%d]: title cannot be empty" idx)
+    else if priority < 1 || priority > 5 then
+      Error (Printf.sprintf "item[%d]: priority must be 1-5, got %d" idx priority)
+    else
+      Ok (title, priority, description)
   ) tasks_json in
-  (true, Room.batch_add_tasks ctx.config tasks)
+  let errors = List.filter_map (function Error e -> Some e | Ok _ -> None) validated in
+  if errors <> [] then
+    (false, Printf.sprintf "Validation failed:\n%s" (String.concat "\n" errors))
+  else
+    let tasks = List.filter_map (function Ok t -> Some t | Error _ -> None) validated in
+    (true, Room.batch_add_tasks ctx.config tasks)
 
 let handle_claim ctx args =
   if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then


### PR DESCRIPTION
## Summary
- `cache_eio.ml`: `entry_to_json`에서 512바이트 초과 value 잘라내기 + `value_size` 필드 추가 (#1850)
- `tool_board.ml`: `handle_profile`에서 agent name 비교 시 trim+lowercase 정규화 (#1853)
- `tool_schemas_agent.ml`: `masc_agent_update` schema에서 미사용 `agent_name` 파라미터 제거. handler는 이미 `ctx.agent_name`만 사용 (#1858)
- `tool_task.ml`: `batch_add_tasks` per-item 검증 추가. 실패 항목에 index+reason 반환 (#1860)

Closes #1850, closes #1853, closes #1858, closes #1860

## Test plan
- [ ] `dune build` 통과
- [ ] cache: 512B+ value → truncated + value_size 표시
- [ ] board profile: 대소문자/공백 차이 있는 agent name으로 조회 → 정상 매칭
- [ ] agent_update: agent_name 파라미터 없이 호출 가능
- [ ] batch_add: 빈 title 항목 포함 시 → 전체 거부 + 실패 인덱스 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)