### PR TITLE
fix(board): add title to search query

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -246,7 +246,8 @@ let search ~query ~limit =
         with Not_found -> false
       in
       let predicate (p : Board.post) =
-        matches_str p.content
+        matches_str p.title
+        || matches_str p.content
         || matches_str (Board.Agent_id.to_string p.author)
         || (match p.hearth with Some h -> matches_str h | None -> false)
       in

--- a/lib/board/board_pg_queries.ml
+++ b/lib/board/board_pg_queries.ml
@@ -266,7 +266,8 @@ let search_q =
   (Caqti_type.(t2 string int) ->* post_row_t)
   (Printf.sprintf
     "SELECT %s FROM masc_board_posts \
-     WHERE %s AND (content ILIKE '%%' || $1 || '%%' \
+     WHERE %s AND (title ILIKE '%%' || $1 || '%%' \
+       OR content ILIKE '%%' || $1 || '%%' \
        OR author ILIKE '%%' || $1 || '%%' \
        OR hearth ILIKE '%%' || $1 || '%%') \
      ORDER BY (votes_up - votes_down) DESC, created_at DESC \


### PR DESCRIPTION
## Summary
- `board_pg_queries.ml`: PG search에 `title ILIKE` 조건 추가
- `board_dispatch.ml`: JSONL search predicate에 `p.title` 매칭 추가

Root cause: board search가 content, author, hearth만 검색하고 title을 누락하여 제목으로 검색 시 빈 결과 반환.

Closes #1857

## Test plan
- [ ] `dune build` 통과
- [ ] post 생성 후 title keyword로 search → 해당 post 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)