### PR TITLE
fix: populate agent skills in a2a_discover from tool registry

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -370,7 +370,7 @@ let fetch_remote_agent_card url :
     @param capability Optional filter by capability
     @return List of agent cards
 *)
-let discover config ?(endpoint : string option) ?(capability : string option) ()
+let discover config ?(endpoint : string option) ?(capability : string option) ?(schemas : Types.tool_schema list = []) ()
     : (Yojson.Safe.t, string) result =
   match endpoint with
   | Some url ->
@@ -397,7 +397,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
         ) agents
     in
     (* Include local agent card *)
-    let local_card = Agent_card.generate_default () in
+    let local_card = Agent_card.generate_default ~schemas () in
     let agents_json = List.map (fun (a : agent) ->
       `Assoc [
         ("name", `String a.name);

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -14,7 +14,7 @@ type result = bool * string
 let handle_a2a_discover ctx args =
   let endpoint = get_string_opt args "endpoint" in
   let capability = get_string_opt args "capability" in
-  match A2a_tools.discover ctx.config ?endpoint ?capability () with
+  match A2a_tools.discover ctx.config ?endpoint ?capability ~schemas:Config.raw_all_tool_schemas () with
   | Ok json -> (true, Yojson.Safe.pretty_to_string json)
   | Error e -> (false, Printf.sprintf "❌ Discovery failed: %s" e)
 


### PR DESCRIPTION
## Summary
- `a2a_tools.ml`: `discover` 함수에 `~schemas` optional 파라미터 추가
- `tool_a2a.ml`: `handle_a2a_discover`에서 `Config.raw_all_tool_schemas` 전달

Root cause: `Agent_card.generate_default()`가 `~schemas:[]`로 호출되어 skills가 항상 빈 배열. `masc_agent_card`에서는 정상적으로 schemas를 전달하지만 `masc_a2a_discover`에서는 누락.

Closes #1854

## Test plan
- [ ] `dune build` 통과
- [ ] `masc_a2a_discover` 호출 → local_card.skills에 tool 기반 skill 목록 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)