### PR TITLE
refactor: confine Llm_provider to 2 facade modules

### DIFF
--- a/lib/discovery_cache.ml
+++ b/lib/discovery_cache.ml
@@ -1,11 +1,11 @@
-(** Discovery_cache — cached wrapper over OAS [Llm_provider.Discovery].
+(** Discovery_cache — cached wrapper over OAS Provider Discovery.
 
     All probing logic lives in OAS. This module adds:
     - TTL-based caching (30s default)
     - Convenience queries (any_local_healthy, idle/busy counts)
     - Eio capability injection (set_env at server init)
 
-    @since 2.130.0 — renamed from Llm_discovery_cache *)
+    @since 2.130.0 *)
 
 (* ── Eio capability refs (set once at server init) ───────── *)
 
@@ -67,3 +67,4 @@ let busy_slot_count () =
 (* ── JSON (delegates to OAS) ─────────────────────────────── *)
 
 let endpoint_to_json = Llm_provider.Discovery.endpoint_status_to_json
+let summary_to_json = Llm_provider.Discovery.summary_to_json

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -29,12 +29,13 @@ let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tok
 
 (** Zero usage sentinel — delegates to OAS Types.zero_api_usage.
     @since 2.123.0 — delegated to OAS *)
-let zero_usage : Agent_sdk.Types.api_usage = Llm_provider.Types.zero_api_usage
+let zero_usage : Agent_sdk.Types.api_usage =
+  { input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0 }
 
 (** Extract usage from an api_response, defaulting to zero.
-    @since 2.123.0 — delegates to OAS Types.usage_of_response *)
+    @since 2.123.0 *)
 let usage_of_response (resp : Oas_response.api_response) : Agent_sdk.Types.api_usage =
-  Llm_provider.Types.usage_of_response resp
+  match resp.usage with Some u -> u | None -> zero_usage
 
 (** Measure wall-clock latency of a thunk in milliseconds.
     Use at call sites that need per-call timing (keeper tool loops, etc.). *)

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -4,7 +4,7 @@
     The switch and net handle are needed by OAS provider completions
     which use cohttp-eio for HTTP transport.
 
-    @since 2.130.0 — renamed from Llm_eio_env *)
+    @since 2.130.0 *)
 
 type t = {
   sw : Eio.Switch.t;

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -47,7 +47,8 @@ let string_of_provider = function
   | Custom s -> sprintf "custom(%s)" s
 
 (* ================================================================ *)
-(* OAS registry + pricing helpers                                    *)
+(* OAS Provider facade                                               *)
+(* All OAS Llm_provider references are confined to this section.     *)
 (* ================================================================ *)
 
 let default_registry = Llm_provider.Provider_registry.default ()
@@ -284,3 +285,12 @@ let default_local_model_spec () =
       match default_execution_model_spec () with
       | Ok spec -> spec
       | Error _ -> glm_cloud)
+
+(* ================================================================ *)
+(* Cascade config (OAS Provider facade)                              *)
+(* ================================================================ *)
+
+(** Load cascade profile from OAS config file.
+    Returns model label strings (e.g. ["llama:qwen3.5"; "glm:glm-4.7"]). *)
+let load_cascade_profile ~config_path ~name : string list =
+  Llm_provider.Cascade_config.load_profile ~config_path ~name

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -71,3 +71,7 @@ val default_verifier_model_spec : unit -> (model_spec, string) result
 
 (** Best-effort local model spec: configured default > execution chain > glm_cloud. *)
 val default_local_model_spec : unit -> model_spec
+
+(** Load cascade profile from OAS config file.
+    Returns model label strings (e.g. ["llama:qwen3.5"; "glm:glm-4.7"]). *)
+val load_cascade_profile : config_path:string -> name:string -> string list

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -4,7 +4,7 @@
     to their OAS counterparts.  Most conversions are structural identity
     (shared type aliases); [to_oas_provider] performs actual mapping.
 
-    @since 2.130.0 — extracted from Llm_provider_dispatch *)
+    @since 2.130.0 *)
 
 let to_oas_provider (spec : Model_spec.model_spec) : Agent_sdk.Provider.config option =
   match spec.provider with

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -350,7 +350,7 @@ let resolve_cascade_specs ~cascade_name : Model_spec.model_spec list =
     match default_config_path () with
     | Some path ->
       let from_file =
-        Llm_provider.Cascade_config.load_profile ~config_path:path ~name:cascade_name
+        Model_spec.load_cascade_profile ~config_path:path ~name:cascade_name
       in
       if from_file <> [] then from_file else defaults
     | None -> defaults

--- a/lib/perpetual/perpetual_oas.ml
+++ b/lib/perpetual/perpetual_oas.ml
@@ -5,7 +5,7 @@
 
     - Phase 1: Context_compact_oas (context reduction)
     - Phase 2: Succession_oas (checkpoint/DNA)
-    - Phase 3: Llm_provider_oas (MODEL cascade)
+    - Phase 3: OAS Provider cascade
     - Phase 4: Verifier_oas (guardrails/hooks)
     - Phase 5: Worker_oas (Agent.run adapter)
 

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -1,7 +1,7 @@
 (** Post Verifier MODEL — G-Eval rubric scoring via MODEL cascade.
 
     Separated from Post_verifier to avoid dependency cycles:
-    Board -> Thompson_sampling -> Post_verifier would pull in Llm_client.
+    Board -> Thompson_sampling -> Post_verifier would pull in model client.
 
     Modes (MASC_VERIFIER_MODE env var):
     - "heuristic" (default): delegates to Post_verifier.verify

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -289,7 +289,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     init_runtime_context env
   in
 
-  (* Initialize Eio environment for MODEL HTTP calls (cohttp-eio via Llm_provider) *)
+  (* Initialize Eio environment for MODEL HTTP calls (cohttp-eio via OAS Provider) *)
   Masc_eio_env.init ~sw ~net ~clock ();
   Discovery_cache.set_env ~sw ~net;
 

--- a/lib/tool_model_catalog.ml
+++ b/lib/tool_model_catalog.ml
@@ -1,7 +1,7 @@
 [@@@warning "-32-33-69"]
 (** Tool_model_catalog — MCP tool layer over OAS Discovery (via {!Discovery_cache}).
 
-    All probing logic is in OAS [Llm_provider.Discovery].
+    All probing logic is in OAS Provider Discovery.
     This module provides the MCP tool interface for agents.
 
     @since 2.113.0 *)
@@ -35,7 +35,7 @@ let handle_list _ctx _args : result =
 
 let handle_status _ctx _args : result =
   let endpoints = D.get_cached_or_refresh () in
-  let summary = Llm_provider.Discovery.summary_to_json endpoints in
+  let summary = D.summary_to_json endpoints in
   let permits_available = Inference_utils.model_permits_available () in
   let permits_in_use = Inference_utils.model_permits_in_use () in
   (true, json_ok [
@@ -61,12 +61,11 @@ let handle_recommend _ctx args : result =
     | Some "reasoning" | Some "analysis" | Some "planning" -> true
     | _ -> false
   in
-  let open Llm_provider.Discovery in
-  let healthy = List.filter (fun (e : endpoint_status) -> e.healthy) endpoints in
-  let with_idle = List.filter (fun (e : endpoint_status) ->
+  let healthy = List.filter (fun (e : D.endpoint_info) -> e.healthy) endpoints in
+  let with_idle = List.filter (fun (e : D.endpoint_info) ->
     match e.slots with Some s -> s.idle > 0 | None -> true) healthy in
   let candidates = if with_idle <> [] then with_idle else healthy in
-  let scored = List.map (fun (e : endpoint_status) ->
+  let scored = List.map (fun (e : D.endpoint_info) ->
     let idle = match e.slots with Some s -> s.idle | None -> 0 in
     let reasoning_bonus =
       if needs_reasoning && e.capabilities.supports_reasoning then 10 else 0


### PR DESCRIPTION
## Summary
MASC는 coordination layer — LLM 내부를 알 필요 없다.

- `Llm_provider` 참조를 `model_spec.ml` + `discovery_cache.ml` 2개 파일에 격리
- `inference_utils.ml`: OAS 타입 직접 구성 (Llm_provider.Types 제거)
- `tool_model_catalog.ml`: Discovery_cache 경유 (Llm_provider.Discovery 제거)
- `oas_worker.ml`: Model_spec.load_cascade_profile 경유
- 6개 파일 코멘트에서 Llm_provider 언급 제거

**Before**: 11 files → **After**: 2 facade files

Ref #1871

## Test plan
- [ ] `dune build` 통과
- [ ] `masc_model_catalog` status/recommend 정상 동작
- [ ] cascade config 로딩 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)