### PR TITLE
fix(dashboard): show all keepers in continuity briefs

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -855,10 +855,7 @@ let build_continuity_briefs ~(now_ts : float) keepers session_contexts :
            let row =
              continuity_row_of_keeper ~now_ts ?related_session_id keeper
            in
-           if string_field "tone" row.json <> "ok" || row.related_session_id <> None then
-             Some row
-           else
-             None)
+           Some row)
   |> List.sort (fun (left : continuity_context) (right : continuity_context) ->
          let by_tone = Int.compare right.tone_rank left.tone_rank in
          if by_tone <> 0 then by_tone


### PR DESCRIPTION
## Summary
- `build_continuity_briefs`에서 tone=ok인 keeper를 필터링하는 로직 제거
- heartbeat로 `updated_at`이 갱신되면 `last_age_s < 3600` → tone=ok → 리스트에서 사라지는 버그 수정
- 모든 등록된 keeper가 연속성 패널에 항상 표시됨

## Root cause
```ocaml
(* before: tone ok + no session = hidden *)
if string_field "tone" row.json <> "ok" || row.related_session_id <> None then
  Some row
else
  None
```

qa-* keeper들의 `updated_at`이 heartbeat로 갱신 → `last_age_s < 3600` → tone `"ok"` → 필터링 → 대시보드에서 10분 후 사라짐

## Test plan
- [ ] 서버 재시작 후 10분+ 대기 → 모든 keeper가 연속성 패널에 유지되는지 확인
- [ ] `curl /api/v1/dashboard/execution | jq '.continuity_briefs | length'` = 등록 keeper 수와 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)