### PR TITLE
fix(dashboard): encode non-ASCII agent names in HTTP headers

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -41,7 +41,7 @@ function authHeaders(): Record<string, string> {
   const storedAgent = readStoredAgentName()
   const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
   if (token) headers['Authorization'] = `Bearer ${token}`
-  if (agent) headers['X-MASC-Agent'] = agent
+  if (agent) headers['X-MASC-Agent'] = encodeURIComponent(agent)
   return headers
 }
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -101,7 +101,7 @@ function jsonHeaders(): Record<string, string> {
   })()
   const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
   if (token) headers['Authorization'] = `Bearer ${token}`
-  if (agent) headers['X-MASC-Agent'] = agent
+  if (agent) headers['X-MASC-Agent'] = encodeURIComponent(agent)
   return headers
 }
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -165,15 +165,16 @@ let voice_config_payload () =
   | Error json -> (`Error, json)
 
 let agent_from_request request =
+  let decode v = match Uri.pct_decode v with s -> s in
   match Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent" with
-  | Some v -> Some v
+  | Some v -> Some (decode v)
   | None ->
       match Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent-name" with
-      | Some v -> Some v
+      | Some v -> Some (decode v)
       | None ->
           (match query_param request "agent" with
-           | Some v -> Some v
-           | None -> query_param request "agent_name")
+           | Some v -> Some (decode v)
+           | None -> Option.map decode (query_param request "agent_name"))
 
 let http_status_of_auth_error = function
   | Types.Unauthorized _ | Types.InvalidToken _ | Types.TokenExpired _ -> `Unauthorized


### PR DESCRIPTION
## Summary
- `X-MASC-Agent` 헤더에 한국어/이모지 에이전트 이름이 들어가면 fetch() 실패
- 원인: HTTP 헤더는 ISO-8859-1만 허용, 한국어는 범위 밖
- 수정: client `encodeURIComponent()` + server `Uri.pct_decode`

## 변경 파일
- `dashboard/src/api/core.ts` — authHeaders()
- `dashboard/src/api/keeper.ts` — jsonHeaders()
- `lib/server/server_auth.ml` — agent_from_request

## Test plan
- [ ] 한국어 에이전트 이름으로 dashboard 접속 확인
- [ ] `?agent=테스트` 쿼리 파라미터 동작 확인
- [ ] 기존 ASCII 에이전트 이름 회귀 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)