### PR TITLE
fix: raise keeper max_turns to allow tool use

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -56,7 +56,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 3)
+    ?(max_turns : int = 10)
     ?guardrails
     ?(temperature : float = 0.3)
     ?(max_tokens : int = 4096)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -614,7 +614,7 @@ let run_proactive_generation
       let (agent_result, attempt_latency) = timed (fun () ->
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
-            ~tools ~max_turns:3 ~temperature ~max_tokens ()) in
+            ~tools ~max_turns:10 ~temperature ~max_tokens ()) in
       match agent_result with
       | Error _ -> None
       | Ok result ->

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -195,7 +195,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         ~user_message:prompt
                         ~cascade_name:"keeper_proactive"
                         ~generation:meta.generation
-                        ~max_turns:1
+                        ~max_turns:5
                         ~temperature:0.3
                         ~max_tokens:1024 ()) in
                     match delib_result with

--- a/lib/keeper/keeper_exec_social.ml
+++ b/lib/keeper/keeper_exec_social.ml
@@ -45,7 +45,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
           ~user_message:prompt
           ~cascade_name:"keeper_turn"
           ~generation:meta.generation
-          ~max_turns:1
+          ~max_turns:5
           ~temperature:(Keeper_config.keeper_reflection_temp ())
           ~max_tokens:(Keeper_config.keeper_explicit_reply_max_tokens ())
           ()


### PR DESCRIPTION
## Summary
- `keeper_agent_run` default: 3 → 10
- `keeper_exec_context` (proactive with tools): 3 → 10
- `keeper_exec_social` (reply): 1 → 5
- `keeper_exec_proactive` (deliberation): 1 → 5

## Problem
`max_turns:3` with tools → first tool call exhausts turn budget → `Max turns exceeded (turn 3, limit 3)` → `proactive emission failed: generation returned no proactive reply`

## Approach
Turn limit is a loop safety guard, not a cost control. Cost should be controlled by `max_tokens` and `max_cost_usd`. OAS `max_idle_turns` catches stuck tool loops.

## Test plan
- [x] `dune build` clean
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)