### PR TITLE
Deprecate masc_claim and canonicalize claim flows

### DIFF
--- a/benchmarks/benchmark.sh
+++ b/benchmarks/benchmark.sh
@@ -125,7 +125,7 @@ bench_task_lifecycle() {
     call_masc "masc_add_task" "{\"agent_name\":\"$MASC_AGENT\",\"id\":\"$task_id\",\"title\":\"Benchmark task\"}" > /dev/null
 
     # Claim task
-    call_masc "masc_claim" "{\"agent_name\":\"$MASC_AGENT\",\"task_id\":\"$task_id\"}" > /dev/null
+    call_masc "masc_transition" "{\"agent_name\":\"$MASC_AGENT\",\"task_id\":\"$task_id\",\"action\":\"claim\"}" > /dev/null
 
     # Complete task
     call_masc "masc_done" "{\"agent_name\":\"$MASC_AGENT\",\"task_id\":\"$task_id\"}" > /dev/null

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -75,8 +75,8 @@ function GuidedPanel() {
           ? {
               title: 'Task 준비도',
               tone: 'warn',
-              detail: `${actorName} 에게 배정된 claimed task가 없습니다. 먼저 claim 하거나 만들어야 합니다.`,
-              tool: tasks.value.length > 0 ? 'masc_claim' : 'masc_add_task',
+              detail: `${actorName} 에게 배정된 claimed task가 없습니다. backlog에 task가 있으면 masc_transition(action=claim)으로 집고, 없으면 새 task를 만들어야 합니다.`,
+              tool: tasks.value.length > 0 ? 'masc_transition' : 'masc_add_task',
             }
           : !currentTask
             ? {
@@ -153,7 +153,7 @@ function GuidedPanel() {
       : !actorName || !actor
         ? 'masc_join'
         : actorTasks.length === 0
-          ? (tasks.value.length > 0 ? 'masc_claim' : 'masc_add_task')
+          ? (tasks.value.length > 0 ? 'masc_transition' : 'masc_add_task')
           : !currentTask
             ? 'masc_plan_set_task'
             : heartbeatFresh === false

--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -43,7 +43,7 @@ The key split is intentional:
 |------|------------------------|--------------------|-------|
 | Canonical MCP tools | `tools/list` | `masc_transition`, `masc_team_session_step`, `decision.create`, `experiment.start`, `trpg.dice.roll` | Default surface for normal clients |
 | Managed agent MCP | `/mcp/managed` | `masc_room_status`, `masc_list_tasks`, `masc_claim_task`, `masc_set_current_task` | Internal managed-agent surface with SDK aliases + curated passthrough tools |
-| Compatibility aliases | Hidden from `tools/list` | `masc_claim`, `experiment_start`, `masc_trpg_dice_roll` | Still callable for compatibility; not part of the truthful default inventory |
+| Compatibility aliases | Deprecated and excluded from default `tools/list` | `masc_claim`, `experiment_start`, `masc_trpg_dice_roll` | Still callable for compatibility; not part of the truthful default inventory |
 | MCP prompts | `prompts/list`, `prompts/get` | `tool_help`, `team_session_proof`, `command_truth` | Explanation/proof layer, not runtime prompt registry |
 | MCP resources | `resources/list/read` | `masc://status`, `masc://tasks`, `masc://tool-help-index` | Snapshot/read layer |
 | Remote operator | `/mcp/operator` | `masc_operator_snapshot`, `masc_operator_digest` | Separate 4-tool remote-safe profile |
@@ -154,7 +154,7 @@ flowchart TD
 
 | Type | Examples | Status |
 |------|----------|--------|
-| Intentional compatibility | `masc_claim`, `experiment_start`, `masc_trpg_*` | Hidden aliases; keep if compatibility matters |
+| Intentional compatibility | `masc_claim`, `experiment_start`, `masc_trpg_*` | Deprecated/default-off aliases; keep if compatibility matters |
 | Intentional internal-only | `Prompt_registry`, `data/prompts/*.json` | Real runtime feature, not public MCP surface |
 | Experimental but documented | `SWARM-RISC`, `GAME-VIEW-PROTOCOL` draft | Keep clearly labeled as non-canonical or draft |
 | Placeholder / review-needed | none | Dead hidden placeholder removed from the MCP schema inventory |

--- a/docs/MODE-SYSTEM.md
+++ b/docs/MODE-SYSTEM.md
@@ -71,7 +71,7 @@ Essential task management. Included in all modes.
 
 ```
 masc_set_room, masc_init, masc_join, masc_leave, masc_status,
-masc_add_task, masc_claim, masc_done, masc_tasks, masc_archive_view,
+masc_add_task, masc_transition, masc_done, masc_tasks, masc_archive_view,
 masc_claim_next, masc_update_priority
 ```
 

--- a/docs/MULTI-ROOM-DESIGN.md
+++ b/docs/MULTI-ROOM-DESIGN.md
@@ -8,6 +8,7 @@ This document predates the current implementation state. Named-room support exis
 - Canonical default: repo-root room semantics via `masc_set_room`
 - Current role of named rooms: internal compatibility/helper surface
 - Public surface intent: `masc_room_*` is not part of the default `tools/list` workflow
+- Historical command references below are retained for implementation context only; they are not the recommended operator workflow.
 
 ## Problem Statement
 
@@ -19,6 +20,8 @@ Historical problem statement retained for implementation context:
 - 방 목록에서 선택해서 입장하는 UX가 없음
 
 ## Goals
+
+Historical design goals retained below. They are not the current default product surface.
 
 1. **방 목록 조회**: `masc_rooms_list` - 사용 가능한 방 목록
 2. **방 생성**: `masc_room_create` - 새 방 만들기

--- a/docs/WEBHOOK-RECEIVER-DESIGN.md
+++ b/docs/WEBHOOK-RECEIVER-DESIGN.md
@@ -268,10 +268,10 @@ let notify_room ~room_name ~task =
    → broadcast: "New task: [PR] Review #42"
 
 3. Agent가 task 확인
-   → masc_task_list --room pr-review --status pending
+   → masc_tasks --status todo
 
 4. Agent가 claim
-   → masc_claim --task-id xxx
+   → masc_transition --task-id xxx --action claim
 
 5. Agent가 작업 수행 후 완료
    → masc_done --task-id xxx --result "approved"
@@ -309,7 +309,7 @@ let masc_webhook_history ?room ?source ?limit () =
 (* 이미 있는 tools를 webhook과 연동 *)
 
 (** Task 목록 - room 필터 추가 *)
-let masc_task_list ?room ?status ?source () = ...
+let masc_tasks ?status ?include_done ?include_cancelled () = ...
 
 (** Task 상세 - webhook payload 포함 *)
 let masc_task_get ~task_id () =
@@ -411,7 +411,7 @@ curl http://localhost:8935/health
 # → tasks in rooms 확인
 
 # 4. Agent가 claim
-masc_claim --task-id <생성된 task id>
+masc_transition --task-id <생성된 task id> --action claim
 ```
 
 ---

--- a/examples/BEST-PRACTICES.md
+++ b/examples/BEST-PRACTICES.md
@@ -36,14 +36,14 @@ Human → 최종 결정
 masc_broadcast "PR #123 ready for review: feat(auth): add OAuth support"
 
 # 2. Claude가 리뷰 태스크 클레임
-masc_claim --task "review-pr-123" --agent claude
+masc_transition --task-id "review-pr-123" --action claim --agent claude
 
 # 3. Claude 리뷰 완료 후 결과 브로드캐스트
 masc_broadcast "Claude review complete: 3 suggestions, 1 concern"
 masc_done --task "review-pr-123"
 
 # 4. Gemini가 대안 제안 태스크 클레임
-masc_claim --task "suggest-pr-123" --agent gemini
+masc_transition --task-id "suggest-pr-123" --action claim --agent gemini
 
 # 5. 최종 결과 정리
 masc_broadcast "Review complete. Human decision required."
@@ -69,10 +69,11 @@ masc_broadcast "Review complete. Human decision required."
 {
   "method": "tools/call",
   "params": {
-    "name": "masc_claim",
+    "name": "masc_transition",
     "arguments": {
       "task_id": "review-pr-123",
-      "agent": "claude"
+      "agent": "claude",
+      "action": "claim"
     }
   }
 }

--- a/lib/chain/chain_executor_leaf.ml
+++ b/lib/chain/chain_executor_leaf.ml
@@ -359,23 +359,26 @@ let execute_masc_listen ctx ~clock ~tool_exec (node : node) ~filter ~timeout_sec
       record_complete ctx node.id ~duration_ms ~success:false ~node_type:"masc_listen";
       Error msg
 
-(** Execute MASC claim node - calls masc.masc_claim or masc.masc_claim_next *)
+(** Execute MASC task-acquire node.
+    Legacy [masc_claim] inputs are normalized to canonical tool calls:
+    - specific task -> [masc_transition action=claim]
+    - queue claim   -> [masc_claim_next] *)
 let execute_masc_claim ctx ~tool_exec (node : node) ~task_id ~room : (string, string) result =
   record_start ctx node.id ~node_type:"masc_claim";
   let start = Time_compat.now () in
-  (* Choose tool based on whether task_id is provided *)
+  let _ = room in
+  (* Choose canonical tool based on whether task_id is provided. *)
   let tool_name, args = match task_id with
     | Some tid ->
-        (* Specific task claim *)
-        ("masc.masc_claim", `Assoc ([
+        ("masc.masc_transition", `Assoc ([
           ("agent_name", `String (masc_agent_name ()));
           ("task_id", `String tid);
-        ] @ (match room with Some r -> [("room", `String r)] | None -> [])))
+          ("action", `String "claim");
+        ]))
     | None ->
-        (* Claim next available task *)
         ("masc.masc_claim_next", `Assoc ([
           ("agent_name", `String (masc_agent_name ()));
-        ] @ (match room with Some r -> [("room", `String r)] | None -> [])))
+        ]))
   in
   let result =
     try tool_exec ~name:tool_name ~args

--- a/lib/chain/chain_parser_parse.ml
+++ b/lib/chain/chain_parser_parse.ml
@@ -628,6 +628,27 @@ and parse_node_type (json : Yojson.Safe.t) (type_str : string) : (node_type, str
       let room = parse_string_opt json "room" in
       Ok (Masc_claim { task_id; room })
 
+  | "masc_claim_next" ->
+      let room = parse_string_opt json "room" in
+      Ok (Masc_claim { task_id = None; room })
+
+  | "masc_transition" ->
+      let action = parse_string_opt json "action" in
+      let task_id = parse_string_opt json "task_id" in
+      let room = parse_string_opt json "room" in
+      (match action with
+       | Some action when String.lowercase_ascii (String.trim action) = "claim" -> (
+           match task_id with
+           | Some _ -> Ok (Masc_claim { task_id; room })
+           | None -> Error "masc_transition claim node requires task_id")
+       | Some action ->
+           Error
+             (Printf.sprintf
+                "typed masc_transition nodes only support action=claim (got %s)"
+                action)
+       | None ->
+           Error "typed masc_transition nodes require action=claim")
+
   | "cascade" ->
       let open Yojson.Safe.Util in
       let default_threshold = match parse_float_opt json "default_threshold" with Some v -> v | None -> 0.7 in
@@ -737,4 +758,3 @@ and parse_chain_inner (json : Yojson.Safe.t) : (chain, string) result =
 (** Main entry point: Parse complete chain from JSON *)
 let parse_chain (json : Yojson.Safe.t) : (chain, string) result =
   parse_chain_inner json
-

--- a/lib/chain/chain_parser_serialize.ml
+++ b/lib/chain/chain_parser_serialize.ml
@@ -399,10 +399,16 @@ let rec node_to_json_with (include_empty_inputs : bool) (n : node) : Yojson.Safe
         ] in
         let fields = match filter with Some f -> fields @ [("filter", `String f)] | None -> fields in
         (match room with Some r -> fields @ [("room", `String r)] | None -> fields)
-    | Masc_claim { task_id; room } ->
-        let fields = [("type", `String "masc_claim")] in
-        let fields = match task_id with Some t -> fields @ [("task_id", `String t)] | None -> fields in
-        (match room with Some r -> fields @ [("room", `String r)] | None -> fields)
+    | Masc_claim { task_id; _ } ->
+        (match task_id with
+         | Some task_id ->
+             [
+               ("type", `String "masc_transition");
+               ("action", `String "claim");
+               ("task_id", `String task_id);
+             ]
+         | None ->
+             [ ("type", `String "masc_claim_next") ])
     | Cascade { tiers; confidence_prompt; max_escalations; context_mode; task_hint; default_threshold } ->
         let tier_json = `List (List.map Chain_types.cascade_tier_to_yojson tiers) in
         let fields = [

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -304,7 +304,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let quality = quality_from_result ~success ~message ~attempts in
   let workflow_guidance =
     Workflow_guide.guidance_to_json
-      (Workflow_guide.next_steps ~tool_name:name ~success)
+      (Workflow_guide.next_steps_for_call ~tool_name:name ~args:arguments ~success)
   in
   let envelope =
     `Assoc [

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -94,7 +94,7 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
 let tool_allowed_in_profile state profile tool_name =
   match profile with
   | Full ->
-      tool_schemas_for_profile state Full
+      tool_schemas_for_profile ~include_deprecated:true state Full
       |> List.exists (fun (schema : Types.tool_schema) ->
              String.equal schema.name tool_name)
   | Managed_agent ->

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -158,6 +158,7 @@ let tool_category tool_name =
 
   (* ── Core_Task: task lifecycle ── *)
   | "masc_add_task" | "masc_batch_add_tasks"
+  | "masc_claim"
   | "masc_tasks" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"
   | "masc_task_history"

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -61,6 +61,21 @@ let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = fa
     idempotent = None;
   }
 
+let deprecated_default ?canonical_name ?replacement
+    ?(implementation_status = Adapter) reason =
+  {
+    visibility = Default;
+    lifecycle = Deprecated;
+    implementation_status;
+    canonical_name;
+    replacement;
+    reason = Some reason;
+    allow_direct_call_when_hidden = false;
+    readonly = None;
+    destructive = None;
+    idempotent = None;
+  }
+
 let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden = true)
     ?(implementation_status = Real) reason =
   {
@@ -108,6 +123,11 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_votes",
       hidden_active
         "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
+    ( "masc_claim",
+      deprecated_default
+        ~canonical_name:"masc_transition"
+        ~replacement:"masc_transition(action=claim)"
+        "Compatibility alias for specific-task claim. Prefer masc_transition(action=claim) for exact task ownership; use masc_claim_next when any queued task is acceptable." );
     ( "masc_rooms_list",
       hidden_active
         "Named-room inventory is an internal compatibility surface. Repo-root room semantics remain the canonical default workflow." );

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -582,6 +582,28 @@ Tip: Look for status='todo' tasks to claim.";
     ];
   };
   {
+    name = "masc_claim";
+    description = "Deprecated compatibility alias for claiming a specific task by task_id. Prefer masc_transition with action='claim' for exact task ownership.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Your agent name");
+        ]);
+        ("task_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Task ID to claim");
+        ]);
+        ("agent_role", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional semantic role for the claim");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"; `String "task_id"]);
+    ];
+  };
+  {
     name = "masc_claim_next";
     description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level.";
     input_schema = `Assoc [
@@ -661,6 +683,7 @@ let dispatch ctx ~name ~args : result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ctx args)
+  | "masc_claim" -> Some (handle_claim ctx args)
   | "masc_claim_next" -> Some (handle_claim_next ctx args)
   | "masc_transition" -> Some (handle_transition ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ctx args)

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -24,6 +24,12 @@ let empty = { next_steps = []; preconditions = []; common_mistakes = [] }
 
 let s tool reason = { tool; reason }
 
+let transition_action args =
+  let open Yojson.Safe.Util in
+  match args |> member "action" |> to_string_option with
+  | Some action -> Some (String.lowercase_ascii (String.trim action))
+  | None -> None
+
 (* ── Golden Path 1: Room/Task Hygiene ────────────────────────────── *)
 
 let after_start ~success =
@@ -115,6 +121,51 @@ let after_transition_claim ~success =
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
           s "masc_add_task" "Create a task if none exist" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_transition_start ~success =
+  if success then
+    { next_steps =
+        [ s "masc_heartbeat" "Signal liveness before and during longer work";
+          s "masc_broadcast" "Share that you started active implementation";
+          s "masc_transition" "Mark the task complete when implementation is finished (action=done)" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check the task state before retrying the transition";
+          s "masc_workflow_guide" "Inspect your current room/task readiness" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_transition_release_or_cancel ~success =
+  if success then
+    { next_steps =
+        [ s "masc_status" "Check the remaining backlog after releasing or cancelling the task";
+          s "masc_transition" "Claim another task if work should continue (action=claim)";
+          s "masc_add_task" "Create a replacement task only if the cancelled work still needs tracking" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check task state and ownership before retrying";
+          s "masc_workflow_guide" "Inspect your current room/task readiness" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_transition_generic ~success =
+  if success then
+    { next_steps =
+        [ s "masc_status" "Refresh room state after the transition";
+          s "masc_workflow_guide" "Inspect the next recommended step for your current state" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "masc_transition follow-up depends on action. claim may require masc_plan_set_task, while done/release/cancel do not." ] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check task state before retrying the transition";
+          s "masc_workflow_guide" "Inspect your current room/task readiness" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes = [] }
 
@@ -332,7 +383,7 @@ let next_steps ~tool_name ~success =
   | "masc_plan_set_task" | "masc_set_current_task" -> after_plan_set_task ~success
   | "masc_heartbeat" -> after_heartbeat ~success
   | "masc_done" -> after_done ~success
-  | "masc_transition" -> after_transition_claim ~success
+  | "masc_transition" -> after_transition_generic ~success
   (* Golden Path 2: CPv2 *)
   | "masc_operation_start" -> after_operation_start ~success
   | "masc_dispatch_tick" -> after_dispatch_tick ~success
@@ -348,6 +399,17 @@ let next_steps ~tool_name ~success =
   | "masc_operator_digest" -> after_operator_digest ~success
   (* No guidance registered *)
   | _ -> empty
+
+let next_steps_for_call ~tool_name ~args ~success =
+  match tool_name with
+  | "masc_transition" -> (
+      match transition_action args with
+      | Some "claim" -> after_transition_claim ~success
+      | Some "start" -> after_transition_start ~success
+      | Some "done" -> after_done ~success
+      | Some ("release" | "cancel") -> after_transition_release_or_cancel ~success
+      | _ -> after_transition_generic ~success)
+  | _ -> next_steps ~tool_name ~success
 
 (* ── JSON serialisation ──────────────────────────────────────────── *)
 

--- a/lib/workflow_guide.mli
+++ b/lib/workflow_guide.mli
@@ -20,10 +20,19 @@ type guidance = {
   common_mistakes : string list;
 }
 
-(** [next_steps ~tool_name ~success] returns workflow guidance for the
-    tool that was just called.  When [success] is false the guidance
-    focuses on recovery / prerequisite steps. *)
+(** [next_steps ~tool_name ~success] returns conservative workflow guidance for the
+    tool that was just called. When argument-specific semantics matter
+    (for example [masc_transition]), this wrapper returns the generic safe path. *)
 val next_steps : tool_name:string -> success:bool -> guidance
+
+(** [next_steps_for_call ~tool_name ~args ~success] returns workflow guidance for an
+    actual tool invocation. This is the canonical path for MCP tool-call envelopes
+    because it can inspect arguments when tool semantics depend on them. *)
+val next_steps_for_call :
+  tool_name:string ->
+  args:Yojson.Safe.t ->
+  success:bool ->
+  guidance
 
 (** [guidance_to_json g] serialises guidance to a Yojson value suitable
     for embedding in the MCP response envelope. *)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -27,8 +27,8 @@ Use this before any real work:
 1. `masc_set_room`
 2. `masc_join`
 3. `masc_status`
-4. `masc_claim` or `masc_add_task`
-5. `masc_plan_set_task`
+4. `masc_transition(action=claim)` or `masc_claim_next` or `masc_add_task`
+5. `masc_plan_set_task` after `masc_transition(action=claim)`
 6. `masc_heartbeat`
 
 ### 2. Managed large-team orchestration

--- a/llms.txt
+++ b/llms.txt
@@ -8,8 +8,8 @@
    - `masc_set_room`
    - `masc_join`
    - `masc_status`
-   - `masc_claim` or `masc_add_task`
-   - `masc_plan_set_task`
+   - `masc_transition(action=claim)` or `masc_claim_next` or `masc_add_task`
+   - `masc_plan_set_task` after `masc_transition(action=claim)`
    - `masc_heartbeat`
 
 2. `CPv2 direct`

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -18,6 +18,15 @@ let test_public_visible_surface_hides_deprecated_aliases () =
   check bool "public hides masc_claim alias" false
     (List.mem "masc_claim" names)
 
+let test_include_deprecated_surface_exposes_claim_alias () =
+  let names =
+    Lib.Capability_registry.visible_public_tool_schemas_from
+      ~include_deprecated:true Lib.Config.raw_all_tool_schemas
+    |> List.map (fun (schema : Lib.Types.tool_schema) -> schema.name)
+  in
+  check bool "deprecated surface contains masc_claim" true
+    (List.mem "masc_claim" names)
+
 let test_board_post_capability_merges_public_and_keeper_projections () =
   let capability =
     Lib.Capability_registry.all_capabilities_from Lib.Config.raw_all_tool_schemas
@@ -100,6 +109,8 @@ let () =
         [
           test_case "public surface hides deprecated aliases" `Quick
             test_public_visible_surface_hides_deprecated_aliases;
+          test_case "include_deprecated exposes claim alias" `Quick
+            test_include_deprecated_surface_exposes_claim_alias;
           test_case "board capability merges public and keeper projections"
             `Quick
             test_board_post_capability_merges_public_and_keeper_projections;

--- a/test/test_chain_coverage.ml
+++ b/test/test_chain_coverage.ml
@@ -711,6 +711,38 @@ let test_adapter_transform_to_json () =
   ) transforms
 
 (* ============================================================
+   19a. parse_node / node_to_json — canonical claim wire forms
+   ============================================================ *)
+
+let test_parse_node_transition_claim_canonical () =
+  let json =
+    `Assoc
+      [
+        ("id", `String "n");
+        ("type", `String "masc_transition");
+        ("action", `String "claim");
+        ("task_id", `String "t1");
+      ]
+  in
+  match Chain_parser.parse_node json with
+  | Ok { node_type = Masc_claim { task_id = Some "t1"; _ }; _ } -> ()
+  | Ok _ -> fail "expected Masc_claim from canonical masc_transition claim"
+  | Error e -> fail e
+
+let test_parse_node_claim_next_canonical () =
+  let json =
+    `Assoc
+      [
+        ("id", `String "n");
+        ("type", `String "masc_claim_next");
+      ]
+  in
+  match Chain_parser.parse_node json with
+  | Ok { node_type = Masc_claim { task_id = None; _ }; _ } -> ()
+  | Ok _ -> fail "expected Masc_claim from canonical masc_claim_next"
+  | Error e -> fail e
+
+(* ============================================================
    19. node_to_json — all node_type variants
    ============================================================ *)
 
@@ -746,6 +778,29 @@ let test_node_to_json_cascade () =
                                      task_hint = Some "hint"; default_threshold = 0.7 }) in
   let j = Chain_parser.node_to_json n in
   (match j with `Assoc _ -> () | _ -> fail "not assoc")
+
+let test_node_to_json_specific_claim_emits_transition () =
+  let n = dummy_node "n" (Masc_claim { room = Some "ignored"; task_id = Some "t1" }) in
+  let j = Chain_parser.node_to_json n in
+  match j with
+  | `Assoc fields ->
+      check (option string) "type" (Some "masc_transition")
+        (Yojson.Safe.Util.to_string_option (List.assoc "type" fields));
+      check (option string) "action" (Some "claim")
+        (Yojson.Safe.Util.to_string_option (List.assoc "action" fields));
+      check (option string) "task_id" (Some "t1")
+        (Yojson.Safe.Util.to_string_option (List.assoc "task_id" fields))
+  | _ -> fail "not assoc"
+
+let test_node_to_json_claim_next_emits_claim_next () =
+  let n = dummy_node "n" (Masc_claim { room = Some "ignored"; task_id = None }) in
+  let j = Chain_parser.node_to_json n in
+  match j with
+  | `Assoc fields ->
+      check (option string) "type" (Some "masc_claim_next")
+        (Yojson.Safe.Util.to_string_option (List.assoc "type" fields));
+      check bool "no action field" false (List.mem_assoc "action" fields)
+  | _ -> fail "not assoc"
 
 let test_chain_to_json_string () =
   let n = dummy_node "n1" (dummy_model ()) in
@@ -1377,11 +1432,19 @@ let () =
       test_case "all variants" `Quick test_adapter_transform_to_json;
     ];
     "node_to_json", [
+      test_case "parse canonical transition claim" `Quick
+        test_parse_node_transition_claim_canonical;
+      test_case "parse canonical claim_next" `Quick
+        test_parse_node_claim_next_canonical;
       test_case "model full" `Quick test_node_to_json_model;
       test_case "tool namespaced" `Quick test_node_to_json_tool_namespaced;
       test_case "pipeline" `Quick test_node_to_json_pipeline;
       test_case "gate" `Quick test_node_to_json_gate;
       test_case "cascade" `Quick test_node_to_json_cascade;
+      test_case "specific claim emits transition" `Quick
+        test_node_to_json_specific_claim_emits_transition;
+      test_case "claim_next emits claim_next" `Quick
+        test_node_to_json_claim_next_emits_claim_next;
     ];
     "chain_to_json_string", [
       test_case "pretty" `Quick test_chain_to_json_string;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -180,6 +180,25 @@ let tool_string_field tool field =
       | _ -> Alcotest.failf "tool field missing: %s" field)
   | _ -> Alcotest.fail "tool is not an object"
 
+let result_envelope_exn response =
+  match List.assoc_opt "resultEnvelope" (result_fields_exn response) with
+  | Some (`Assoc fields) -> fields
+  | _ -> Alcotest.fail "resultEnvelope missing"
+
+let workflow_next_step_names response =
+  match List.assoc_opt "workflow_guidance" (result_envelope_exn response) with
+  | Some (`Assoc fields) -> (
+      match List.assoc_opt "next_steps" fields with
+      | Some (`List steps) ->
+          steps
+          |> List.filter_map (function
+               | `Assoc step_fields -> List.assoc_opt "tool" step_fields
+               | _ -> None)
+          |> List.filter_map (function `String value -> Some value | _ -> None)
+      | _ -> [])
+  | Some `Null | None -> []
+  | _ -> Alcotest.fail "workflow_guidance malformed"
+
 let error_code_exn response =
   match response with
   | `Assoc fields -> (
@@ -764,6 +783,169 @@ let test_handle_request_tools_call_managed_profile_sdk_alias_claim () =
     (contains_substring response_text "claimed");
   cleanup_dir base_path
 
+let test_handle_request_tools_call_transition_claim_guidance () =
+  Eio_main.run @@ fun env ->
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let sid = "mcp-transition-claim-guidance" in
+  let (ok_init, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_init" ~arguments:(`Assoc [])
+  in
+  Alcotest.(check bool) "init success" true ok_init;
+  let (ok_join, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_join"
+      ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
+  in
+  Alcotest.(check bool) "join success" true ok_join;
+  ignore
+    (Masc_mcp.Room.add_task state.room_config ~title:"transition-claim"
+       ~priority:2 ~description:"");
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 114);
+          ("method", `String "tools/call");
+          ( "params",
+            `Assoc
+              [
+                ("name", `String "masc_transition");
+                ( "arguments",
+                  `Assoc
+                    [
+                      ("task_id", `String "task-001");
+                      ("action", `String "claim");
+                    ] );
+              ] );
+        ])
+  in
+  let response =
+    Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
+  in
+  let steps = workflow_next_step_names response in
+  Alcotest.(check bool) "claim guidance includes plan_set_task" true
+    (List.mem "masc_plan_set_task" steps);
+  cleanup_dir base_path
+
+let test_handle_request_tools_call_transition_done_guidance () =
+  Eio_main.run @@ fun env ->
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let sid = "mcp-transition-done-guidance" in
+  let (ok_init, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_init" ~arguments:(`Assoc [])
+  in
+  Alcotest.(check bool) "init success" true ok_init;
+  let (ok_join, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_join"
+      ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
+  in
+  Alcotest.(check bool) "join success" true ok_join;
+  ignore
+    (Masc_mcp.Room.add_task state.room_config ~title:"transition-done"
+       ~priority:2 ~description:"");
+  let (ok_claim, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_transition"
+      ~arguments:
+        (`Assoc
+          [
+            ("task_id", `String "task-001");
+            ("action", `String "claim");
+          ])
+  in
+  Alcotest.(check bool) "claim setup success" true ok_claim;
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 115);
+          ("method", `String "tools/call");
+          ( "params",
+            `Assoc
+              [
+                ("name", `String "masc_transition");
+                ( "arguments",
+                  `Assoc
+                    [
+                      ("task_id", `String "task-001");
+                      ("action", `String "done");
+                    ] );
+              ] );
+        ])
+  in
+  let response =
+    Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
+  in
+  let steps = workflow_next_step_names response in
+  Alcotest.(check bool) "done guidance includes status" true
+    (List.mem "masc_status" steps);
+  Alcotest.(check bool) "done guidance omits plan_set_task" false
+    (List.mem "masc_plan_set_task" steps);
+  cleanup_dir base_path
+
+let test_handle_request_tools_call_deprecated_claim_alias () =
+  Eio_main.run @@ fun env ->
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let sid = "mcp-deprecated-claim-alias" in
+  let (ok_init, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_init" ~arguments:(`Assoc [])
+  in
+  Alcotest.(check bool) "init success" true ok_init;
+  let (ok_join, _) =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+      ~name:"masc_join"
+      ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
+  in
+  Alcotest.(check bool) "join success" true ok_join;
+  ignore
+    (Masc_mcp.Room.add_task state.room_config ~title:"deprecated-claim"
+       ~priority:2 ~description:"");
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 116);
+          ("method", `String "tools/call");
+          ( "params",
+            `Assoc
+              [
+                ("name", `String "masc_claim");
+                ("arguments", `Assoc [ ("task_id", `String "task-001") ]);
+              ] );
+        ])
+  in
+  let response =
+    Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
+  in
+  let response_text = Yojson.Safe.to_string response in
+  Alcotest.(check bool) "deprecated claim still callable" true
+    (contains_substring response_text "task-001");
+  Alcotest.(check bool) "deprecated claim guidance omits plan_set_task" false
+    (List.mem "masc_plan_set_task" (workflow_next_step_names response));
+  cleanup_dir base_path
+
 let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -873,6 +1055,39 @@ let test_handle_request_tools_list_include_hidden_metadata () =
          | _ -> false)
        tools);
 
+  cleanup_dir base_path
+
+let test_handle_request_tools_list_include_deprecated_claim_alias_metadata () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 219);
+          ("method", `String "tools/list");
+          ( "params",
+            `Assoc
+              [
+                ("include_deprecated", `Bool true);
+                ("names", `List [ `String "masc_claim" ]);
+              ] );
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  let tools = tools_from_response response in
+  let claim_tool = find_tool_exn tools "masc_claim" in
+  Alcotest.(check string) "claim lifecycle" "deprecated"
+    (tool_string_field claim_tool "lifecycle");
+  Alcotest.(check string) "claim canonicalName" "masc_transition"
+    (tool_string_field claim_tool "canonicalName");
+  Alcotest.(check string) "claim replacement" "masc_transition(action=claim)"
+    (tool_string_field claim_tool "replacement");
   cleanup_dir base_path
 
 let test_handle_request_tools_list_hides_team_session_turn_by_default () =
@@ -2177,6 +2392,8 @@ let eio_tests = [
   "handle tools/list with placeholder flag", `Quick, test_handle_request_tools_list_with_placeholder_flag;
   "handle tools/list include hidden metadata", `Quick,
     test_handle_request_tools_list_include_hidden_metadata;
+  "handle tools/list include deprecated claim alias metadata", `Quick,
+    test_handle_request_tools_list_include_deprecated_claim_alias_metadata;
   "handle tools/list hides team_session_turn by default", `Quick,
     test_handle_request_tools_list_hides_team_session_turn_by_default;
   "handle tools/list include usage metadata", `Quick,
@@ -2189,6 +2406,12 @@ let eio_tests = [
   test_handle_request_tools_call_operator_profile_rejects_non_operator;
   "handle tools/call managed profile sdk alias claim", `Quick,
     test_handle_request_tools_call_managed_profile_sdk_alias_claim;
+  "handle tools/call transition claim guidance", `Quick,
+    test_handle_request_tools_call_transition_claim_guidance;
+  "handle tools/call transition done guidance", `Quick,
+    test_handle_request_tools_call_transition_done_guidance;
+  "handle tools/call deprecated claim alias", `Quick,
+    test_handle_request_tools_call_deprecated_claim_alias;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -191,7 +191,7 @@ let test_tool_category_core () =
   check bool "join" true (Mode.tool_category "masc_join" = Mode.Core_Room);
   (* Core_Task *)
   check bool "status" true (Mode.tool_category "masc_status" = Mode.Core_Task);
-  check bool "claim" true (Mode.tool_category "masc_claim" = Mode.Unknown);
+  check bool "claim" true (Mode.tool_category "masc_claim" = Mode.Core_Task);
   check bool "done" true (Mode.tool_category "masc_done" = Mode.Unknown);
   check bool "tasks" true (Mode.tool_category "masc_tasks" = Mode.Core_Task);
   check bool "add_task" true (Mode.tool_category "masc_add_task" = Mode.Core_Task);

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -146,5 +146,11 @@ let () =
                   check bool (name ^ " should be visible with flag") true
                     (Tool_catalog.is_visible ~include_hidden:true name))
                 hidden_names);
+          test_case "deprecated claim alias is hidden by default but visible with include_deprecated" `Quick
+            (fun () ->
+              check bool "masc_claim hidden by default" false
+                (Tool_catalog.is_visible "masc_claim");
+              check bool "masc_claim visible with include_deprecated" true
+                (Tool_catalog.is_visible ~include_deprecated:true "masc_claim"));
         ] );
     ]

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -67,6 +67,108 @@ let test_workflow_guide_tools_exist () =
     ) g_fail.next_steps
   ) guide_tools
 
+let contains_substring haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > h_len then false
+    else if String.sub haystack i n_len = needle then true
+    else loop (i + 1)
+  in
+  n_len = 0 || loop 0
+
+let is_token_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+  | _ -> false
+
+let contains_token haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  let boundary_ok idx =
+    let before_ok =
+      idx = 0 || not (is_token_char haystack.[idx - 1])
+    in
+    let after_idx = idx + n_len in
+    let after_ok =
+      after_idx >= h_len || not (is_token_char haystack.[after_idx])
+    in
+    before_ok && after_ok
+  in
+  let rec loop i =
+    if i + n_len > h_len then false
+    else if String.sub haystack i n_len = needle && boundary_ok i then true
+    else loop (i + 1)
+  in
+  n_len = 0 || loop 0
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let repo_root () =
+  let cwd = Sys.getcwd () in
+  if Sys.file_exists (Filename.concat cwd "docs") then cwd
+  else Filename.dirname cwd
+
+let doc_path name =
+  Filename.concat (Filename.concat (repo_root ()) "docs") name
+
+let repo_path relative =
+  Filename.concat (repo_root ()) relative
+
+let test_docs_do_not_reintroduce_ghost_claim_surface () =
+  let allowed_claim_docs = [ "MCP-SURFACE-AUDIT.md" ] in
+  let docs_dir = Filename.concat (repo_root ()) "docs" in
+  Sys.readdir docs_dir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".md")
+  |> List.iter (fun name ->
+         let contents = read_file (doc_path name) in
+         if contains_substring contents "masc_task_list" then
+           Alcotest.failf "doc %s reintroduces ghost tool masc_task_list" name;
+	         if (not (List.mem name allowed_claim_docs))
+	            && contains_token contents "masc_claim"
+	         then
+	           Alcotest.failf
+	             "doc %s reintroduces normative masc_claim usage outside compatibility docs"
+	             name)
+
+let test_front_door_surfaces_do_not_reintroduce_claim_alias () =
+  let paths =
+    [
+      "llms.txt";
+      "llms-full.txt";
+      "examples/BEST-PRACTICES.md";
+      "benchmarks/benchmark.sh";
+      "dashboard/src/components/command/guided-panel.ts";
+    ]
+  in
+  List.iter
+    (fun relative ->
+      let contents = read_file (repo_path relative) in
+      if contains_token contents "masc_claim" then
+        Alcotest.failf
+          "front-door surface %s reintroduces deprecated masc_claim alias"
+          relative)
+    paths
+
+let test_multi_room_doc_keeps_historical_banner () =
+  let contents = read_file (doc_path "MULTI-ROOM-DESIGN.md") in
+  if not (contains_substring contents "Status: historical/internal compatibility note")
+  then
+    Alcotest.fail
+      "MULTI-ROOM-DESIGN.md must declare historical/internal compatibility status";
+  if not
+       (contains_substring contents
+          "Historical command references below are retained for implementation context only")
+  then
+    Alcotest.fail
+      "MULTI-ROOM-DESIGN.md must mark command references as historical-only"
+
 (* ── Test 3: No duplicate tool names in schemas ──────────────── *)
 
 let test_no_duplicate_schemas () =
@@ -97,6 +199,12 @@ let () =
             test_no_unknown_tools;
           Alcotest.test_case "workflow guide references valid tools" `Quick
             test_workflow_guide_tools_exist;
+          Alcotest.test_case "docs do not reintroduce ghost claim surface" `Quick
+            test_docs_do_not_reintroduce_ghost_claim_surface;
+          Alcotest.test_case "front-door surfaces do not reintroduce claim alias" `Quick
+            test_front_door_surfaces_do_not_reintroduce_claim_alias;
+          Alcotest.test_case "multi-room doc keeps historical banner" `Quick
+            test_multi_room_doc_keeps_historical_banner;
           Alcotest.test_case "no duplicate tool schemas" `Quick
             test_no_duplicate_schemas;
         ] );

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -159,9 +159,38 @@ let test_complete_task_removed () =
   check (list string) "removed ghost returns empty" []
     (List.map (fun (s : WG.step) -> s.tool) g.next_steps)
 
-let test_transition_routes_to_claim () =
+let test_transition_generic_is_safe () =
   let g = WG.next_steps ~tool_name:"masc_transition" ~success:true in
+  check_has_tool g.next_steps "masc_status";
+  check_has_tool g.next_steps "masc_workflow_guide"
+
+let test_transition_claim_call_guidance () =
+  let g =
+    WG.next_steps_for_call ~tool_name:"masc_transition"
+      ~args:(`Assoc [ ("action", `String "claim"); ("task_id", `String "task-001") ])
+      ~success:true
+  in
   check_has_tool g.next_steps "masc_plan_set_task"
+
+let test_transition_done_call_guidance () =
+  let g =
+    WG.next_steps_for_call ~tool_name:"masc_transition"
+      ~args:(`Assoc [ ("action", `String "done"); ("task_id", `String "task-001") ])
+      ~success:true
+  in
+  check_has_tool g.next_steps "masc_status";
+  check bool "done guidance omits plan_set_task" false
+    (List.exists (fun (s : WG.step) -> s.tool = "masc_plan_set_task") g.next_steps)
+
+let test_transition_release_call_guidance () =
+  let g =
+    WG.next_steps_for_call ~tool_name:"masc_transition"
+      ~args:(`Assoc [ ("action", `String "release"); ("task_id", `String "task-001") ])
+      ~success:true
+  in
+  check_has_tool g.next_steps "masc_status";
+  check bool "release guidance omits plan_set_task" false
+    (List.exists (fun (s : WG.step) -> s.tool = "masc_plan_set_task") g.next_steps)
 
 (* Structural: all tool names in guidance output exist in Config.all_tool_schemas *)
 let all_schema_names =
@@ -215,7 +244,10 @@ let () =
       test_case "unknown tool" `Quick test_unknown_tool;
       test_case "claim_next alias" `Quick test_claim_next_alias;
       test_case "complete_task removed" `Quick test_complete_task_removed;
-      test_case "transition routes to claim" `Quick test_transition_routes_to_claim;
+      test_case "transition generic is safe" `Quick test_transition_generic_is_safe;
+      test_case "transition claim call guidance" `Quick test_transition_claim_call_guidance;
+      test_case "transition done call guidance" `Quick test_transition_done_call_guidance;
+      test_case "transition release call guidance" `Quick test_transition_release_call_guidance;
     ];
     "structural", [
       test_case "next_steps reference real tools" `Quick test_next_steps_reference_real_tools;


### PR DESCRIPTION
## Summary
- make workflow guidance action-aware for `masc_transition` call envelopes
- deprecate `masc_claim` as a compatibility alias while keeping direct calls working
- canonicalize chain parse/serialize/execute claim paths to `masc_transition(action=claim)` or `masc_claim_next`
- remove remaining default-surface `masc_claim` references from docs, examples, benchmark flow, and dashboard guidance
- add drift guards for docs and front-door surfaces

## Verification
- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/claim-canonical-deprecation`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/claim-canonical-deprecation test/test_workflow_guide.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/claim-canonical-deprecation test/test_tool_registration_consistency.exe`
- previously in this worktree: `test_tool_exposure.exe`, `test_capability_registry.exe`, `test_mode_coverage.exe`, `test_chain_coverage.exe`, `test_mcp_server_eio.exe`

## Notes
- `dashboard/src/components/command/guided-panel.ts` was updated, but local `npx tsc --noEmit --pretty` could not be completed because `dashboard/node_modules` is absent in this worktree.