### PR TITLE
chore: remove stale swarm test stanzas from test/dune

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -222,26 +222,6 @@
  (modules test_team_session_swarm_runner)
  (libraries masc_mcp agent_sdk agent_sdk.swarm alcotest yojson unix))
 (test
- (name test_agent_swarm_unit)
- (modules test_agent_swarm_unit)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_agent_swarm_fleet)
- (modules test_agent_swarm_fleet)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_swarm_e2e)
- (modules test_swarm_e2e)
- (libraries masc_mcp agent_sdk alcotest eio eio_main unix yojson))
-
-(test
- (name test_agent_swarm_runner)
- (modules test_agent_swarm_runner)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
-
-(test
  (name test_tool_mdal)
  (modules test_tool_mdal)
  (libraries masc_mcp alcotest str yojson unix eio eio_main


### PR DESCRIPTION
## Summary

- PR #1899에서 swarm 테스트 파일 4개 삭제 시 `test/dune`의 stanza가 남아 빌드 실패
- `test_agent_swarm_unit`, `test_agent_swarm_fleet`, `test_swarm_e2e`, `test_agent_swarm_runner` stanza 제거

## Test plan

- [x] `dune build` 성공 (기존 빌드 에러 4건 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)