### PR TITLE
fix: remove 4 stale test references from test/dune

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -222,26 +222,6 @@
  (modules test_team_session_swarm_runner)
  (libraries masc_mcp agent_sdk agent_sdk.swarm alcotest yojson unix))
 (test
- (name test_agent_swarm_unit)
- (modules test_agent_swarm_unit)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_agent_swarm_fleet)
- (modules test_agent_swarm_fleet)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_swarm_e2e)
- (modules test_swarm_e2e)
- (libraries masc_mcp agent_sdk alcotest eio eio_main unix yojson))
-
-(test
- (name test_agent_swarm_runner)
- (modules test_agent_swarm_runner)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
-
-(test
  (name test_tool_mdal)
  (modules test_tool_mdal)
  (libraries masc_mcp alcotest str yojson unix eio eio_main


### PR DESCRIPTION
## Summary

PR #1899 (OAS rename) deleted 4 swarm test files but left their dune registrations, breaking `dune build`.

Removed stale entries:
- `test_agent_swarm_unit`
- `test_agent_swarm_fleet`
- `test_swarm_e2e`
- `test_agent_swarm_runner`

## Test plan
- [x] `dune build --root .` — now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)