### PR TITLE
chore: remove deleted test references from test/dune

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -221,25 +221,7 @@
  (name test_team_session_swarm_runner)
  (modules test_team_session_swarm_runner)
  (libraries masc_mcp agent_sdk agent_sdk.swarm alcotest yojson unix))
-(test
- (name test_agent_swarm_unit)
- (modules test_agent_swarm_unit)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_agent_swarm_fleet)
- (modules test_agent_swarm_fleet)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_swarm_e2e)
- (modules test_swarm_e2e)
- (libraries masc_mcp agent_sdk alcotest eio eio_main unix yojson))
-
-(test
- (name test_agent_swarm_runner)
- (modules test_agent_swarm_runner)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
+; Agent swarm tests removed (#1903 — migrated to OAS Swarm Runner)
 
 (test
  (name test_tool_mdal)


### PR DESCRIPTION
## Summary
- #1903 (OAS Swarm Runner 마이그레이션)에서 4개 테스트 파일 삭제했으나 test/dune stanza가 남아 빌드 실패
- test_agent_swarm_unit, test_agent_swarm_fleet, test_swarm_e2e, test_agent_swarm_runner 제거

## Test plan
- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)