### PR TITLE
fix(dashboard): avoid render-phase signal mutations

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
 import { route } from '../router'
 import { agents, keepers } from '../store'
 import { missionSnapshot } from '../mission-store'
@@ -13,10 +14,6 @@ import { Execution } from './agents'
 type AgentsView = 'all' | 'agents' | 'keepers' | 'sessions'
 
 const activeView = signal<AgentsView>('all')
-
-function chipClass(view: AgentsView): string {
-  return `agents-chip ${activeView.value === view ? 'agents-chip--active' : ''}`
-}
 
 /** Determine which agents have keeper runtime from keepers store + mission snapshot. */
 function keeperNameSet(): Set<string> {
@@ -50,15 +47,18 @@ export function AgentsUnified() {
     return html`<${AgentProfile} name=${agentParam} />`
   }
 
-  // Sync from route params if present
   const viewParam = route.value.params.view as string | undefined
-  if (viewParam === 'sessions' && activeView.value !== 'sessions') {
-    activeView.value = 'sessions'
-  } else if (viewParam === 'keepers' && activeView.value !== 'keepers') {
-    activeView.value = 'keepers'
-  } else if (viewParam === 'agents' && activeView.value !== 'agents') {
-    activeView.value = 'agents'
-  }
+  const routeView =
+    viewParam === 'sessions' || viewParam === 'keepers' || viewParam === 'agents'
+      ? viewParam
+      : null
+  const currentView = routeView ?? activeView.value
+
+  useEffect(() => {
+    if (routeView && activeView.value !== routeView) {
+      activeView.value = routeView
+    }
+  }, [routeView])
 
   // Compute counts for chip badges
   const kNames = keeperNameSet()
@@ -73,7 +73,7 @@ export function AgentsUnified() {
         ${CHIPS.map(c => html`
           <button
             key=${c.id}
-            class=${chipClass(c.id)}
+            class=${`agents-chip ${currentView === c.id ? 'agents-chip--active' : ''}`}
             onClick=${() => { activeView.value = c.id }}
           >
             ${c.label}
@@ -84,11 +84,11 @@ export function AgentsUnified() {
         `)}
       </div>
 
-      ${activeView.value === 'sessions'
+      ${currentView === 'sessions'
         ? html`<${Execution} />`
         : html`<${AgentRoster}
-            keeperFilter=${activeView.value === 'keepers' ? 'keeper-only'
-              : activeView.value === 'agents' ? 'agent-only'
+            keeperFilter=${currentView === 'keepers' ? 'keeper-only'
+              : currentView === 'agents' ? 'agent-only'
               : 'all'}
           />`
       }

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -1,6 +1,7 @@
 // 실행 표면 — 세션/작전 중심 실행 진단
 
 import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { RoomTruthStrip } from './common/room-truth-strip'
 import {
@@ -33,29 +34,44 @@ export function Execution() {
   const continuityAll = executionContinuityBriefs.value
   const offlineRowsAll = executionOfflineWorkerBriefs.value
 
-  if (selectedQueueId.value && !queueRows.some(item => item.id === selectedQueueId.value)) {
-    selectedQueueId.value = null
-  }
-  if (selectedSessionId.value && !sessionRowsAll.some(item => item.session_id === selectedSessionId.value)) {
-    selectedSessionId.value = null
-  }
-  if (selectedOperationId.value && !operationRowsAll.some(item => item.operation_id === selectedOperationId.value)) {
-    selectedOperationId.value = null
-  }
+  const activeQueueId =
+    selectedQueueId.value && queueRows.some(item => item.id === selectedQueueId.value)
+      ? selectedQueueId.value
+      : null
+  const activeSelectedSessionId =
+    selectedSessionId.value && sessionRowsAll.some(item => item.session_id === selectedSessionId.value)
+      ? selectedSessionId.value
+      : null
+  const activeSelectedOperationId =
+    selectedOperationId.value && operationRowsAll.some(item => item.operation_id === selectedOperationId.value)
+      ? selectedOperationId.value
+      : null
 
-  const activeQueue = selectedQueueId.value
-    ? queueRows.find(item => item.id === selectedQueueId.value) ?? null
+  useEffect(() => {
+    if (selectedQueueId.value !== activeQueueId) {
+      selectedQueueId.value = activeQueueId
+    }
+    if (selectedSessionId.value !== activeSelectedSessionId) {
+      selectedSessionId.value = activeSelectedSessionId
+    }
+    if (selectedOperationId.value !== activeSelectedOperationId) {
+      selectedOperationId.value = activeSelectedOperationId
+    }
+  }, [activeQueueId, activeSelectedSessionId, activeSelectedOperationId])
+
+  const activeQueue = activeQueueId
+    ? queueRows.find(item => item.id === activeQueueId) ?? null
     : null
 
   const activeSessionId = (() => {
-    if (selectedSessionId.value) return selectedSessionId.value
+    if (activeSelectedSessionId) return activeSelectedSessionId
     if (!activeQueue) return null
     if (activeQueue.kind === 'session') return activeQueue.target_id
     return activeQueue.linked_session_id ?? null
   })()
 
   const activeOperationId = (() => {
-    if (selectedOperationId.value) return selectedOperationId.value
+    if (activeSelectedOperationId) return activeSelectedOperationId
     if (!activeQueue) return null
     if (activeQueue.kind === 'operation') return activeQueue.target_id
     return activeQueue.linked_operation_id ?? null

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -8,6 +8,7 @@ import { missionSnapshot } from '../mission-store'
 import { roomTruthInitializing } from '../room-truth-store'
 import { Mission } from './mission'
 import { Overview } from './overview/overview'
+import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import {
@@ -229,7 +230,23 @@ export function DashboardMain() {
   if (roomTruthInitializing.value) {
     return html`<div class="loading-indicator">서버가 데이터를 준비하고 있습니다. 잠시 후 자동으로 새로고침됩니다...</div>`
   }
-  return dashboardLoading.value && !connected.value
-    ? html`<div class="loading-indicator">대시보드 불러오는 중...</div>`
-    : html`<${TabContent} />`
+  if (dashboardLoading.value && !connected.value) {
+    return html`<div class="loading-indicator">대시보드 불러오는 중...</div>`
+  }
+
+  const routeLabel = [
+    route.value.tab,
+    route.value.params.section,
+    route.value.params.surface,
+    route.value.params.session_id,
+    route.value.params.operation_id,
+  ]
+    .filter(Boolean)
+    .join(':')
+
+  return html`
+    <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
+      <${TabContent} />
+    <//>
+  `
 }

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -45,19 +45,29 @@ export function Mission() {
     return html`<div class="empty-state">상황판 스냅샷이 아직 없습니다.</div>`
   }
 
-  if (selectedAttentionId.value && !mission.attention_queue.some(item => item.id === selectedAttentionId.value)) {
-    selectedAttentionId.value = null
-  }
-
   const sessionRows = mission.sessions
-  if (selectedSessionId.value && !sessionRows.some(item => item.session_id === selectedSessionId.value)) {
-    selectedSessionId.value = null
-  }
+  const activeSelectedAttentionId =
+    selectedAttentionId.value && mission.attention_queue.some(item => item.id === selectedAttentionId.value)
+      ? selectedAttentionId.value
+      : null
+  const activeSelectedSessionId =
+    selectedSessionId.value && sessionRows.some(item => item.session_id === selectedSessionId.value)
+      ? selectedSessionId.value
+      : null
 
-  const activeAttention = mission.attention_queue.find(item => item.id === selectedAttentionId.value) ?? null
+  useEffect(() => {
+    if (selectedAttentionId.value !== activeSelectedAttentionId) {
+      selectedAttentionId.value = activeSelectedAttentionId
+    }
+    if (selectedSessionId.value !== activeSelectedSessionId) {
+      selectedSessionId.value = activeSelectedSessionId
+    }
+  }, [activeSelectedAttentionId, activeSelectedSessionId])
+
+  const activeAttention = mission.attention_queue.find(item => item.id === activeSelectedAttentionId) ?? null
   const attentionSessionId =
     activeAttention?.related_session_ids.find(id => sessionRows.some(item => item.session_id === id)) ?? null
-  const activeSessionId = selectedSessionId.value ?? attentionSessionId ?? sessionRows[0]?.session_id ?? null
+  const activeSessionId = activeSelectedSessionId ?? attentionSessionId ?? sessionRows[0]?.session_id ?? null
   const sessionLookup = sessionLookupById()
   const focusSession = sessionRows.find(item => item.session_id === activeSessionId) ?? null
   const keeperRows = mission.keeper_briefs.slice(0, 6).map(enrichedKeeperRow)
@@ -265,7 +275,7 @@ export function Mission() {
           </div>
           <div class="mission-lane-stack">
             ${attentionQueue.length > 0
-              ? attentionQueue.map(item => html`<${AttentionCard} key=${item.id} item=${item} selected=${selectedAttentionId.value === item.id} sessionLookup=${sessionLookup} />`)
+              ? attentionQueue.map(item => html`<${AttentionCard} key=${item.id} item=${item} selected=${activeSelectedAttentionId === item.id} sessionLookup=${sessionLookup} />`)
               : html`<div class="empty-state">지금 세션 단위 주의 대기열은 비어 있습니다.</div>`}
           </div>
         <//>


### PR DESCRIPTION
## Summary
- move route/state reconciliation for dashboard surfaces out of render and into effects
- use safe local selections in agents and mission views so invalid route state no longer mutates signals during render
- keep the main dashboard tab content behind a route-keyed error boundary so a single surface failure does not white-screen the whole dashboard

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build
- manual route sweep on localhost:8935 across situation, agents sessions, work planning, control, and lab surfaces without an ErrorBoundary trip