### PR TITLE
chore: remove dead test references from test/dune

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -221,25 +221,8 @@
  (name test_team_session_swarm_runner)
  (modules test_team_session_swarm_runner)
  (libraries masc_mcp agent_sdk agent_sdk.swarm alcotest yojson unix))
-(test
- (name test_agent_swarm_unit)
- (modules test_agent_swarm_unit)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_agent_swarm_fleet)
- (modules test_agent_swarm_fleet)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_swarm_e2e)
- (modules test_swarm_e2e)
- (libraries masc_mcp agent_sdk alcotest eio eio_main unix yojson))
-
-(test
- (name test_agent_swarm_runner)
- (modules test_agent_swarm_runner)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
+;; test_agent_swarm_unit, test_agent_swarm_fleet, test_swarm_e2e,
+;; test_agent_swarm_runner — source files removed in #1899/#1903
 
 (test
  (name test_tool_mdal)


### PR DESCRIPTION
## Summary
- 4개 삭제된 테스트 모듈 참조 제거 (test_agent_swarm_unit, test_agent_swarm_fleet, test_swarm_e2e, test_agent_swarm_runner)
- #1899/#1903에서 소스 파일 삭제 후 test/dune 참조가 남아 `dune clean && dune build` 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)