### PR TITLE
feat: OAS Phase 3+4 — Plan bridge + swarm_live_json stub removal

### DIFF
--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -1,8 +1,5 @@
 include Cp_lifecycle_intents
 
-(* Stub: swarm-live surface was removed. Returns empty JSON for backward compat. *)
-let swarm_live_json _config ?run_id:_ ?operation_id:_ () = `Assoc []
-
 let snapshot_json ?sessions config =
   let state = build_snapshot_state ?sessions config in
   let topology = topology_json_from_state state in

--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -509,7 +509,7 @@ let by_id rows key_field =
          | Some key -> Some (key, row)
          | None -> None)
 
-let json ?run_id ?operation_id (ctx : _ Operator_control.context) =
+let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
   let config = ctx.config in
   let actor = ctx.agent_name in
   let room = room_json config in
@@ -532,12 +532,7 @@ let json ?run_id ?operation_id (ctx : _ Operator_control.context) =
     else
       Swarm_status.empty_json
   in
-  let swarm_json =
-    if Room.is_initialized config then
-      Command_plane_v2.swarm_live_json config ?run_id ?operation_id ()
-    else
-      `Assoc []
-  in
+  let swarm_json = `Assoc [] in
   let operations_json = Command_plane_v2.operation_status_json config () in
   let operation_rows =
     list_member operations_json "operations"

--- a/lib/dune
+++ b/lib/dune
@@ -363,6 +363,7 @@
    tool_team_session_step
    tool_team_session_step_exec
    tool_team_session_step_types
+   team_session_plan
    tool_team_session_schemas
    tool_heartbeat
    tool_encryption

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -152,11 +152,8 @@ let command_plane_traces_http_json ~deps ~state request =
   Command_plane_v2.list_traces_json state.Mcp_server.room_config ?operation_id
     ~limit ()
 
-let command_plane_swarm_http_json ~deps ~state request =
-  let run_id = deps.query_param request "run_id" in
-  let operation_id = deps.query_param request "operation_id" in
-  Command_plane_v2.swarm_live_json state.Mcp_server.room_config ?run_id
-    ?operation_id ()
+let command_plane_swarm_http_json ~deps:_ ~state:_ _request =
+  `Assoc []
 
 let command_plane_orchestra_http_json ~deps ~state request =
   let actor = command_plane_actor deps request in

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -275,6 +275,8 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
             ("proof_json", `String (Team_session_store.proof_json_path config session.session_id));
           ] );
       ("linked_autoresearch", linked_autoresearch);
+      ("plan", Team_session_plan.to_json session);
+      ("plan_progress", `Float (Team_session_plan.progress session));
     ]
 
 

--- a/lib/team_session_plan.ml
+++ b/lib/team_session_plan.ml
@@ -1,0 +1,80 @@
+(** Team_session_plan — bridge from team session state to OAS Plan.t.
+
+    Computes an OAS Plan.t on-demand from session state, mapping
+    planned workers to plan steps with appropriate statuses.
+
+    @since Phase 3 — OAS feature adoption *)
+
+module Oas = Agent_sdk
+
+let worker_step_id (w : Team_session_types.planned_worker) : string =
+  match w.runtime_actor with
+  | Some actor when String.trim actor <> "" -> actor
+  | _ ->
+    Printf.sprintf "%s/%s"
+      w.spawn_agent
+      (Option.value ~default:"worker" w.spawn_role)
+
+let worker_description (w : Team_session_types.planned_worker) : string =
+  let model_part = match w.spawn_model with
+    | Some m -> Printf.sprintf " [%s]" m
+    | None -> ""
+  in
+  let role_part = match w.spawn_role with
+    | Some r -> Printf.sprintf " (%s)" r
+    | None -> ""
+  in
+  Printf.sprintf "%s%s%s" w.spawn_agent role_part model_part
+
+let step_status_of_worker
+    (active_agents : string list)
+    (session_status : Team_session_types.session_status)
+    (w : Team_session_types.planned_worker) : Oas.Plan.step_status =
+  let id = worker_step_id w in
+  let is_active = List.exists (fun a -> String.equal a id) active_agents in
+  match session_status with
+  | Completed -> Done
+  | Failed | Cancelled | Interrupted ->
+    if is_active then Failed "session terminated"
+    else Skipped
+  | Running | Paused ->
+    if is_active then Running
+    else Pending
+
+let of_session (session : Team_session_types.session) : Oas.Plan.t =
+  let plan = Oas.Plan.create
+    ~goal:session.goal
+    ~planner:session.created_by
+    ()
+  in
+  let plan = List.fold_left (fun plan w ->
+    Oas.Plan.add_step plan
+      ~id:(worker_step_id w)
+      ~description:(worker_description w)
+      ()
+  ) plan session.planned_workers in
+  let plan = Oas.Plan.start plan in
+  let plan = List.fold_left (fun plan w ->
+    let id = worker_step_id w in
+    match step_status_of_worker session.agent_names session.status w with
+    | Running -> Oas.Plan.start_step plan id
+    | Done -> Oas.Plan.complete_step plan id
+        ~result:(`Assoc [("status", `String "completed")])
+    | Failed reason -> Oas.Plan.fail_step plan id ~reason
+    | Skipped -> Oas.Plan.skip_step plan id
+    | Pending -> plan
+  ) plan session.planned_workers in
+  match session.status with
+  | Completed -> Oas.Plan.finish plan
+  | Cancelled -> Oas.Plan.abandon plan ~reason:"cancelled"
+  | Failed -> Oas.Plan.abandon plan ~reason:"failed"
+  | Interrupted -> Oas.Plan.abandon plan ~reason:"interrupted"
+  | Running | Paused -> plan
+
+let progress (session : Team_session_types.session) : float =
+  let plan = of_session session in
+  Oas.Plan.progress plan
+
+let to_json (session : Team_session_types.session) : Yojson.Safe.t =
+  let plan = of_session session in
+  Oas.Plan.to_json plan

--- a/lib/tool_command_plane_chain_query.ml
+++ b/lib/tool_command_plane_chain_query.ml
@@ -461,12 +461,8 @@ let handle_observe_alerts (ctx : (_, _) context) : result =
 let handle_observe_operations (ctx : (_, _) context) : result =
   (true, Yojson.Safe.to_string (Command_plane_v2.observe_operations_json ctx.config))
 
-let handle_observe_swarm (ctx : (_, _) context) args : result =
-  let run_id = get_string_opt args "run_id" in
-  let operation_id = get_string_opt args "operation_id" in
-  ( true,
-    Yojson.Safe.to_string
-      (Command_plane_v2.swarm_live_json ctx.config ?run_id ?operation_id ()) )
+let handle_observe_swarm (_ctx : (_, _) context) _args : result =
+  (true, Yojson.Safe.to_string (`Assoc []))
 
 let handle_observe_capacity (ctx : (_, _) context) : result =
   (true, Yojson.Safe.to_string (Command_plane_v2.observe_capacity_json ctx.config))

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -274,7 +274,7 @@ let swarm_live_error_payload config ~run_id ~message ?proc () =
   let runtime_doctor_path = swarm_live_runtime_doctor_path config run_id in
   let summary_path = swarm_live_summary_path config run_id in
   let runtime_doctor = read_json_file_opt runtime_doctor_path in
-  let detailed_json = Command_plane_v2.swarm_live_json config ~run_id () in
+  let detailed_json = `Assoc [] in
   let fields =
     [
       assoc_field "run_id" (`String run_id);

--- a/test/dune
+++ b/test/dune
@@ -222,26 +222,6 @@
  (modules test_team_session_swarm_runner)
  (libraries masc_mcp agent_sdk agent_sdk.swarm alcotest yojson unix))
 (test
- (name test_agent_swarm_unit)
- (modules test_agent_swarm_unit)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_agent_swarm_fleet)
- (modules test_agent_swarm_fleet)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson))
-
-(test
- (name test_swarm_e2e)
- (modules test_swarm_e2e)
- (libraries masc_mcp agent_sdk alcotest eio eio_main unix yojson))
-
-(test
- (name test_agent_swarm_runner)
- (modules test_agent_swarm_runner)
- (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
-
-(test
  (name test_tool_mdal)
  (modules test_tool_mdal)
  (libraries masc_mcp alcotest str yojson unix eio eio_main


### PR DESCRIPTION
## Summary

### Phase 3-C: OAS Plan.t for Team Session
- `team_session_plan.ml`: session state → OAS Plan.t on-demand 변환
  - planned_workers → plan steps, worker lifecycle → step status
  - session status → plan status (Executing/Completed/Abandoned)
- `masc_team_session_status` 응답에 `plan`(JSON) + `plan_progress`(0.0-1.0) 필드 추가

### Phase 4: swarm_live_json stub 완전 제거
- `cp_lifecycle.ml`의 stub 삭제
- 4개 호출자(`command_plane_orchestra`, `server_command_plane_http_support`, `tool_command_plane_support`, `tool_command_plane_chain_query`)를 직접 빈 JSON으로 교체
- swarm-live 데이터 surface의 마지막 흔적 제거

### 보너스: stale test/dune 정리
- PR #1899 머지에서 빠진 4개 swarm test stanza 제거

## Stats
- 2 commits, 9 files, +48 LOC net

## Test plan
- [x] dune build 에러 없음
- [ ] make test 전체 통과

Generated with [Claude Code](https://claude.com/claude-code)