### PR TITLE
fix: add Eio.Cancel.Cancelled re-raise guards (68 catches)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -166,7 +166,9 @@ let call_model_direct_sync ~agent_type ~prompt =
     | Error err ->
         Log.AutoResponder.error "MODEL cascade failed: %s" err;
         "no response"
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Log.AutoResponder.error "MODEL call failed: %s" (Printexc.to_string exn);
     "no response"
 
@@ -209,10 +211,14 @@ let masc_call ~sw ~tool_name ~(args : Yojson.Safe.t) : (string, string) result =
               | [] -> raise (Failure "empty content list")
             in
             Ok txt
-          with exn ->
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
             Log.Misc.warn "auto_responder: MCP response parse failed: %s" (Printexc.to_string exn);
             Ok body_str
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Error (Printexc.to_string exn)
 
 let extract_nickname (response_text : string) : string option =
@@ -261,10 +267,14 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
             let msg = Printf.sprintf "@%s %s" mention response in
             let broadcast_args = `Assoc [("agent_name", `String nickname); ("message", `String msg)] in
             (try ignore (masc_call ~sw ~tool_name:"masc_broadcast" ~args:broadcast_args)
-             with exn -> Log.AutoResponder.error "broadcast failed: %s" (Printexc.to_string exn));
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn -> Log.AutoResponder.error "broadcast failed: %s" (Printexc.to_string exn));
             let leave_args = `Assoc [("agent_name", `String nickname)] in
             (try ignore (masc_call ~sw ~tool_name:"masc_leave" ~args:leave_args)
-             with exn -> Log.AutoResponder.error "leave failed: %s" (Printexc.to_string exn));
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn -> Log.AutoResponder.error "leave failed: %s" (Printexc.to_string exn));
             let short_resp = if String.length response > 50 then String.sub response 0 50 ^ "..." else response in
             Log.AutoResponder.info "%s: %s" nickname short_resp
       )
@@ -331,7 +341,9 @@ let maybe_respond ~sw ~base_path:_ ~from_agent ~content ~mention =
                   Log.AutoResponder.info "Spawning %s for @%s from %s" mention_base m from_agent;
                   run_cli_agent ~agent_type:mention_base ~prompt
                 )
-          with exn ->
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
             debug_log (Printf.sprintf "ERROR: %s" (Printexc.to_string exn))
         );
         Some task_id

--- a/lib/keeper/keeper_exec_autonomy.ml
+++ b/lib/keeper/keeper_exec_autonomy.ml
@@ -209,6 +209,7 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                   | (true, _) -> ()
                   | (false, err) ->
                       Log.KeeperExec.error "%s L2 perpetual board post failed: %s" meta.name err
+                  | exception (Eio.Cancel.Cancelled _ as e) -> raise e
                   | exception exn ->
                       log_keeper_exn ~label:(Printf.sprintf "autonomy %s L2 board post error" meta.name) exn);
                  Some { meta with
@@ -260,7 +261,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                       (try ignore (Goal_store.review_goal config
                         ~goal_id:req.goal_id ~outcome:"progress"
                         ~note:(Printf.sprintf "Perpetual agent started (models: %s)"
-                          (String.concat ", " req.models)) ()) with exn ->
+                          (String.concat ", " req.models)) ()) with
+                        | Eio.Cancel.Cancelled _ as e -> raise e
+                        | exn ->
                         log_keeper_exn ~label:"goal review failed" exn);
                       (* Post to Board *)
                       let board_args = `Assoc [
@@ -285,6 +288,7 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                        | (true, _) -> ()
                        | (false, err) ->
                            Log.KeeperExec.error "%s: board post failed: %s" meta.name err
+                       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
                        | exception exn ->
                            log_keeper_exn ~label:(Printf.sprintf "autonomy %s board post error" meta.name) exn);
                       Some { meta with
@@ -317,7 +321,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    ("goal_id", `String pa.goal_id);
                    ("action", `String pa.action_description);
                    ("autonomy_level", `String (Keeper_autonomy.autonomy_level_to_string level));
-                 ]) with exn ->
+                 ]) with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                    log_keeper_exn ~label:"SSE keeper_autonomy_start broadcast failed" exn);
                  (* 5-2: Execute the approved plan *)
                  let (summary, exec_cost, tools_used) =
@@ -325,7 +331,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                      ~autonomy_level:level ~trajectory_acc:(Some traj_acc) in
                  (* 5-3: Finalize trajectory *)
                  (try ignore (Trajectory.finalize traj_acc Trajectory.Completed)
-                  with exn -> log_keeper_exn ~label:"trajectory finalize failed" exn);
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn -> log_keeper_exn ~label:"trajectory finalize failed" exn);
                  (* 5-3: Update goal progress *)
                  let outcome = if tools_used <> [] then "progress" else "blocked" in
                  let review_note = Printf.sprintf
@@ -335,7 +343,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    (String.concat ", " tools_used)
                    exec_cost in
                  (try ignore (Goal_store.review_goal config
-                   ~goal_id:pa.goal_id ~outcome ~note:review_note ()) with exn ->
+                   ~goal_id:pa.goal_id ~outcome ~note:review_note ()) with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
                    log_keeper_exn ~label:"goal review failed" exn);
                  (* 5-4: Post execution report to Board *)
                  let report_args = `Assoc [
@@ -366,7 +376,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    ("result", `String outcome);
                    ("tools_used", `List (List.map (fun t -> `String t) tools_used));
                    ("cost_usd", `Float exec_cost);
-                 ]) with exn ->
+                 ]) with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                    log_keeper_exn ~label:"SSE keeper_autonomy_complete broadcast failed" exn);
                  Some { meta with
                    last_autonomous_action_at = now_iso ();
@@ -407,14 +419,18 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    ("action", `String pa.action_description);
                    ("autonomy_level", `String (Keeper_autonomy.autonomy_level_to_string level));
                    ("caution", `String warning);
-                 ]) with exn ->
+                 ]) with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                    log_keeper_exn ~label:"SSE keeper_autonomy_start (cautioned) broadcast failed" exn);
                  (* 5-2: Execute despite caution *)
                  let (summary, exec_cost, tools_used) =
                    execute_approved_plan ~config ~meta ~specs ~plan ~pa
                      ~autonomy_level:level ~trajectory_acc:(Some traj_acc) in
                  (try ignore (Trajectory.finalize traj_acc Trajectory.Completed)
-                  with exn -> log_keeper_exn ~label:"trajectory finalize (cautioned) failed" exn);
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn -> log_keeper_exn ~label:"trajectory finalize (cautioned) failed" exn);
                  (* 5-3: Update goal progress *)
                  let outcome = if tools_used <> [] then "progress" else "blocked" in
                  let review_note = Printf.sprintf
@@ -424,7 +440,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    (String.concat ", " tools_used)
                    exec_cost in
                  (try ignore (Goal_store.review_goal config
-                   ~goal_id:pa.goal_id ~outcome ~note:review_note ()) with exn ->
+                   ~goal_id:pa.goal_id ~outcome ~note:review_note ()) with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
                    log_keeper_exn ~label:"goal review (cautioned) failed" exn);
                  (* 5-4: Board report + SSE complete *)
                  let report_args = `Assoc [
@@ -457,7 +475,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    ("tools_used", `List (List.map (fun t -> `String t) tools_used));
                    ("cost_usd", `Float exec_cost);
                    ("warning", `String warning);
-                 ]) with exn ->
+                 ]) with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                    log_keeper_exn ~label:"SSE keeper_autonomy_complete (cautioned) broadcast failed" exn);
                  Some { meta with
                    last_autonomous_action_at = now_iso ();

--- a/lib/keeper/keeper_exec_proactive.ml
+++ b/lib/keeper/keeper_exec_proactive.ml
@@ -137,13 +137,17 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                 backlog.tasks)
                          in
                          (unclaimed, failed)
-                       with exn ->
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
                          Log.Keeper.warn "proactive: task count query failed: %s" (Printexc.to_string exn);
                          (0, 0))
                     in
                     let active_agents =
                       (try List.length (Room.get_agents_raw ctx.config)
-                       with exn ->
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
                          Log.Keeper.warn "proactive: agent count query failed: %s" (Printexc.to_string exn);
                          0)
                     in
@@ -267,7 +271,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                           ~room_id:target_room
                                           ~from_agent:meta.agent_name
                                           ~content)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation reply_in_room failed" exn)
                               | Keeper_deliberation.Broadcast { message } ->
                                   (try
@@ -275,7 +281,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                        (Room.broadcast ctx.config
                                           ~from_agent:meta.agent_name
                                           ~content:message)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation broadcast failed" exn)
                               | Keeper_deliberation.TaskClaim { task_id; reason = _ } ->
                                   (try
@@ -286,7 +294,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                      in
                                      Log.KeeperExec.info "task_claim result: %s"
                                        result
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation task_claim failed" exn)
                               | Keeper_deliberation.BoardPost { content; hearth } ->
                                   (try
@@ -296,7 +306,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                           ~content
                                           ?hearth
                                           ())
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation board_post failed" exn)
                               | Keeper_deliberation.BoardComment { post_id; content } ->
                                   (try
@@ -306,7 +318,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                           ~author:meta.agent_name
                                           ~content
                                           ())
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation board_comment failed" exn)
                               | Keeper_deliberation.BoardVote { post_id; direction } ->
                                   (try
@@ -320,7 +334,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                           ~voter:meta.agent_name
                                           ~post_id
                                           ~direction:dir)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation board_vote failed" exn)
                               | Keeper_deliberation.ProposeSpawn { topic; reason } ->
                                   (try
@@ -333,7 +349,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                        (Room.broadcast ctx.config
                                           ~from_agent:meta.agent_name
                                           ~content:msg)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation propose_spawn failed" exn)
                               | Keeper_deliberation.StartDiscussion { topic; context } ->
                                   (try
@@ -346,7 +364,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                        (Room.broadcast ctx.config
                                           ~from_agent:meta.agent_name
                                           ~content:msg)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation start_discussion failed" exn)
                               | Keeper_deliberation.ShareFinding { finding; source } ->
                                   (try
@@ -359,7 +379,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                        (Room.broadcast ctx.config
                                           ~from_agent:meta.agent_name
                                           ~content:msg)
-                                   with exn ->
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e -> raise e
+                                   | exn ->
                                      log_keeper_exn ~label:"deliberation share_finding failed" exn)
                               | Keeper_deliberation.MultiStep actions ->
                                   let max_steps = 5 in
@@ -466,7 +488,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                            | Keeper_deliberation.MultiStep _ ->
                                                Log.KeeperExec.info "%s nested multi_step skipped"
                                                  meta.name
-                                         with exn ->
+                                         with
+                                         | Eio.Cancel.Cancelled _ as e -> raise e
+                                         | exn ->
                                            log_keeper_exn ~label:(Printf.sprintf "deliberation %s multi_step %d failed" meta.name !step_count) exn;
                                            stop := true)))
                                     steps_to_run);
@@ -620,7 +644,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                        let after_compact_tokens = ctx_work.token_count in
                        let compacted = after_compact_tokens < before_compact_tokens in
                        (try ignore (save_checkpoint session ctx_work ~generation:meta.generation)
-                        with exn -> log_keeper_exn ~label:"save_checkpoint (tool_loop) failed" exn);
+                        with
+                        | Eio.Cancel.Cancelled _ as e -> raise e
+                        | exn -> log_keeper_exn ~label:"save_checkpoint (tool_loop) failed" exn);
                        let turn_cost = generated.total_cost_usd in
                        let proactive_reason =
                          Printf.sprintf
@@ -737,7 +763,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                               ]
                           in
                           append_jsonl_line metrics_path metrics_json
-                       with exn ->
+                       with
+                       | Eio.Cancel.Cancelled _ as e -> raise e
+                       | exn ->
                          log_keeper_exn ~label:"metrics JSONL write failed" exn);
                        updated))
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -58,7 +58,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             (try
                let synced = ensure_keeper_room_presence ctx.config meta_current in
                ignore (write_meta ctx.config synced)
-             with exn ->
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
                Log.Keeper.error "room heartbeat failed: %s"
                  (Printexc.to_string exn));
             let meta_current =
@@ -203,7 +205,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                                 `Float (Context_manager.context_ratio c) );
                               ("ts_unix", `Float now_ts);
                             ])
-                      with exn ->
+                      with
+                      | Eio.Cancel.Cancelled _ as e -> raise e
+                      | exn ->
                         Log.Keeper.error "heartbeat SSE broadcast failed: %s"
                           (Printexc.to_string exn));
                      (* OAS: publish keeper snapshot event *)
@@ -215,7 +219,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                             ~context_ratio:(Context_manager.context_ratio c)
                             ~message_count:(List.length c.messages)
                       | None -> ()))
-               with exn ->
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
                  Log.Keeper.error "heartbeat snapshot write failed: %s"
                    (Printexc.to_string exn));
               last_snapshot_ts := now_ts);
@@ -250,14 +256,18 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                             backlog.tasks)
                      in
                      (unclaimed, failed)
-                   with exn ->
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
                      Log.Keeper.warn "keepalive: task count query failed: %s" (Printexc.to_string exn);
                      (0, 0))
                 in
                 let current_agent_count =
                   (try
                      List.length (Room.get_agents_raw ctx.config)
-                   with exn ->
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
                      Log.Keeper.warn "keepalive: agent count query failed: %s" (Printexc.to_string exn);
                      0)
                 in
@@ -321,7 +331,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                      |> Keeper_contract.trigger_mode_is_explicit_only
                    then maybe_emit_explicit_room_replies ctx meta_after_triage
                    else maybe_emit_proactive ctx meta_after_triage
-                 with exn ->
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                    Log.Keeper.error "proactive emission failed: %s"
                      (Printexc.to_string exn);
                    meta_after_triage)
@@ -349,13 +361,17 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     (try
        if not (Room_utils.is_initialized ctx.config) then
          ignore (Room.init ctx.config ~agent_name:None)
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
        Log.Keeper.error "room init failed: %s"
          (Printexc.to_string exn));
     (try
        let synced = ensure_keeper_room_presence ctx.config m in
        ignore (write_meta ctx.config synced)
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
        Log.Keeper.error "room presence bootstrap failed: %s"
          (Printexc.to_string exn));
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -238,7 +238,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           let file = Printf.sprintf "/tmp/.masc_agent_%s" sid in
           (try
             Fs_compat.save_file file nickname
-          with e ->
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | e ->
             Log.Misc.error "Failed to write agent file %s: %s"
               file (Printexc.to_string e))
   in
@@ -312,13 +314,17 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         write_mcp_session_agent nickname;
         write_term_session_agent nickname;
         (try ignore (Session.register registry ~agent_name:nickname)
-         with exn -> log_mcp_exn ~label:"session register (nickname) failed" exn);
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> log_mcp_exn ~label:"session register (nickname) failed" exn);
         (* Prometheus + Telemetry: track auto-join *)
         Prometheus.inc_gauge "masc_active_agents" ();
         (match state.Mcp_server.fs with
          | Some fs ->
              (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
-              with exn ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
                 Log.Telemetry.debug "track_agent_joined (auto): %s" (Printexc.to_string exn))
          | None -> ());
         nickname
@@ -330,7 +336,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* Auto-register session for non-read-only tools *)
   if agent_name <> "unknown" && not is_read_only then
     (try ignore (Session.register registry ~agent_name)
-     with exn -> log_mcp_exn ~label:"session register (tool) failed" exn);
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn -> log_mcp_exn ~label:"session register (tool) failed" exn);
 
   (* Log tool call *)
   Log.Mcp.debug "[%s] %s" agent_name name;
@@ -515,7 +523,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           start_loop = Some (fun loop_state loop_config ->
             Eio.Fiber.fork ~sw (fun () ->
               try Perpetual_oas.run ~sw ~config:loop_config ~state:loop_state
-              with exn ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
                 log_mcp_exn ~label:(Printf.sprintf "perpetual loop crashed for %s"
                   loop_state.Perpetual_loop.trace_id) exn));
           sw = Some sw; proc_mgr = state.Mcp_server.proc_mgr;

--- a/lib/server/server_command_plane_http_stream.ml
+++ b/lib/server/server_command_plane_http_stream.ml
@@ -82,7 +82,9 @@ let stream_native_chain_events_http ~deps ~request reqd =
                Eio.Time.sleep (deps.get_clock ()) Env_config_governance.Timeouts.sse_keepalive_sec;
                if not (send_raw ": keepalive\n\n") then close_stream ()
              done
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              close_stream
                ~reason:
                  (Printf.sprintf "keepalive loop failed: %s"
@@ -90,7 +92,9 @@ let stream_native_chain_events_http ~deps ~request reqd =
                ())
      else
        close_stream ~reason:"initial stream write failed" ()
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
      close_stream
        ~reason:
          (Printf.sprintf "subscription setup failed: %s"
@@ -186,7 +190,9 @@ let stream_native_chain_events_h2 ~deps ~request h2_reqd =
                Eio.Time.sleep (deps.get_clock ()) Env_config_governance.Timeouts.sse_keepalive_sec;
                if not (send_raw ": keepalive\n\n") then close_stream ()
              done
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              close_stream
                ~reason:
                  (Printf.sprintf "keepalive loop failed: %s"
@@ -194,7 +200,9 @@ let stream_native_chain_events_h2 ~deps ~request h2_reqd =
                ())
      else
        close_stream ~reason:"initial stream write failed" ()
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
      close_stream
        ~reason:
          (Printf.sprintf "subscription setup failed: %s"

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -204,7 +204,9 @@ let close_sse_conn info =
     info.closed <- true;
     info.stop := true;
     (try Httpun.Body.Writer.close info.writer
-     with exn ->
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
        Log.Misc.debug "close_sse_conn: %s"
          (Printexc.to_string exn));
     Sse.unregister_if_current info.session_id info.client_id)
@@ -233,7 +235,9 @@ let send_raw info data =
           Httpun.Body.Writer.flush info.writer (fun _ -> ()));
       Sse.touch info.session_id;
       true
-    with _exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _exn ->
       close_sse_conn info;
       false
 
@@ -445,7 +449,9 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                                   in
                                   let response = Httpun.Response.create ~headers `OK in
                                   Httpun.Reqd.respond_with_string reqd response body
-                      with exn ->
+                      with
+                      | Eio.Cancel.Cancelled _ as e -> raise e
+                      | exn ->
                         let protocol_version =
                           get_protocol_version_for_session ~session_id request
                         in
@@ -761,6 +767,7 @@ let ag_ui_event_of_masc_event ~room_id event =
     | None -> event
   with
   | Yojson.Json_error _ -> event
+  | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       Log.Transport.warn "ag_ui_event_of_masc_event failed: %s" (Printexc.to_string exn);
       event

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -107,7 +107,9 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
         (try
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms ()
-         with exn ->
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
            Log.Misc.error "telemetry tracking failed: %s"
              (Printexc.to_string exn))
     | None -> ()
@@ -217,7 +219,9 @@ let keeper_stream_send_raw writer mutex closed data =
           Httpun.Body.Writer.write_string writer data;
           Httpun.Body.Writer.flush writer (fun _ -> ()));
       true
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Log.Keeper.warn "keeper_stream_send_raw write failed: %s" (Printexc.to_string exn);
       closed := true;
       false
@@ -294,7 +298,9 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
              ~duration_ms ()
-         with exn ->
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
            Log.Misc.error "telemetry tracking failed: %s"
              (Printexc.to_string exn))
     | None -> ());
@@ -374,7 +380,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
     if not !closed then begin
       closed := true;
       (try Httpun.Body.Writer.close writer
-       with exn ->
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
          Log.Misc.warn "keeper_stream writer close: %s"
            (Printexc.to_string exn))
     end
@@ -439,7 +447,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                 (execute_keeper_stream_tool_streaming ~sw ~clock
                    ?auth_token:(auth_token_from_request request)
                    state ~agent_name ~arguments:args ~on_text_delta)
-            with exn ->
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
               Log.Keeper.warn
                 "keeper_stream: streaming dispatch raised: %s"
                 (Printexc.to_string exn);
@@ -449,7 +459,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                    (execute_keeper_stream_tool ~sw ~clock
                       ?auth_token:(auth_token_from_request request)
                       state ~agent_name ~arguments:args)
-               with exn2 -> Error (Printexc.to_string exn2))
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn2 -> Error (Printexc.to_string exn2))
           in
           match dispatch_result with
           | Error err ->
@@ -487,7 +499,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                  | None -> ());
                 send_keeper_stream_finish writer mutex closed ~thread_id
                   ~run_id ~message_id
-              with exn ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
                 send_keeper_error writer mutex closed ~thread_id ~run_id
                   (Printexc.to_string exn))))
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -48,7 +48,9 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
   ignore (Room.init state.room_config ~agent_name:None);
   Chain_native_eio.ensure_bootstrap state.room_config;
   (try Tool_command_plane.backfill_chain_overlays state.room_config
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
      Log.Misc.error "startup backfill failed: %s"
        (Printexc.to_string exn));
   (* Warm up Tool_registry from persistent telemetry.jsonl *)
@@ -60,7 +62,9 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
        let n = Tool_registry.warm_up summary in
        Log.Misc.info "tool registry: warmed up %d tools (%d calls) from telemetry"
          n summary.total_calls
-   with exn ->
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
      Log.Misc.error "tool registry warm-up failed: %s"
        (Printexc.to_string exn));
   Mcp_server.set_sse_callback state Sse.broadcast
@@ -80,7 +84,9 @@ let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =
     if stats.enabled then
       Log.Keeper.info "scanned=%d started=%d stale=%d recovering=%d"
         stats.scanned stats.started stats.stale stats.recovering
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Log.Server.error "keeper bootstrap failed: %s"
       (Printexc.to_string exn)
 
@@ -115,7 +121,9 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   let fork_subsystem name f =
     Eio.Fiber.fork ~sw (fun () ->
       try f ()
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Log.Server.error "subsystem %s crashed: %s" name
           (Printexc.to_string exn))
   in
@@ -129,7 +137,9 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.room_config
     in
     Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Log.Server.error "subsystem orchestrator failed to start: %s"
       (Printexc.to_string exn));
   fork_subsystem "social_runtime" (fun () ->
@@ -253,7 +263,9 @@ let serve ~sw ~clock ~socket ~request_handler =
           Eio.Switch.run (fun conn_sw ->
               Eio.Switch.on_release conn_sw (fun () ->
                   try Eio.Flow.close flow
-                  with exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn));
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn));
               try
                 let conn_handler =
                   Httpun_eio.Server.create_connection_handler ~sw:conn_sw
@@ -277,7 +289,9 @@ let serve ~sw ~clock ~socket ~request_handler =
                       Httpun.Body.Writer.close body)
                 in
                 conn_handler client_addr flow
-              with exn ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
                 Log.Misc.error "Connection error: %s"
                   (Printexc.to_string exn)))
       ;
@@ -287,7 +301,9 @@ let serve ~sw ~clock ~socket ~request_handler =
       else begin
         Log.Misc.error "Accept error: %s" (Printexc.to_string exn);
         (try Eio.Time.sleep clock backoff_s
-         with exn -> Log.Misc.warn "backoff sleep: %s" (Printexc.to_string exn));
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> Log.Misc.warn "backoff sleep: %s" (Printexc.to_string exn));
         accept_loop (Float.min 2.0 (backoff_s *. 1.5))
       end
   in
@@ -360,7 +376,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_dashboard_http.start_operator_refresh_loop ~state ~sw ~clock;
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
       start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Log.Server.error "Background init failed (HTTP still serving): %s"
         (Printexc.to_string exn));
 


### PR DESCRIPTION
Eio fiber에서 broad catch가 Cancel.Cancelled를 삼키면 structured concurrency가 깨진다. 9파일 68개 catch site에 re-raise guard 추가. Build passes.