### PR TITLE
fix: replace silent catch-all handlers with logging/narrow catches

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -32,7 +32,7 @@ let activity_log_file () =
 let debug_log msg =
   let line = Printf.sprintf "[%f] %s\n" (Time_compat.now ()) msg in
   try Fs_compat.append_file "/tmp/auto_debug.log" line
-  with _ -> ()
+  with Sys_error _ | Unix.Unix_error _ -> ()
 
 let activity_log ~mode ~from_agent ~mention ~status ~detail =
   let log_file = activity_log_file () in
@@ -50,7 +50,7 @@ let activity_log ~mode ~from_agent ~mention ~status ~detail =
   let line = Printf.sprintf "[%s] [%s] %s → @%s | %s | %s\n"
     timestamp mode_str from_agent mention status detail in
   try Fs_compat.append_file log_file line
-  with _ -> ()
+  with Sys_error _ | Unix.Unix_error _ -> ()
 
 (* --- Loop prevention / throttling --- *)
 

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -580,7 +580,7 @@ let apply_code_change ~workdir ~target_file ~new_content =
       Unix.rename tmp_path abs_path;
       Result.ok original
     with exn ->
-      (try Sys.remove tmp_path with _ -> ());
+      (try Sys.remove tmp_path with Sys_error _ -> ());
       Result.error (Printf.sprintf "Failed to write %s: %s"
         target_file (Printexc.to_string exn)))
 

--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -183,7 +183,8 @@ module Pubsub_mem = struct
     | None -> Ok 0
     | Some callbacks ->
         List.iter (fun cb ->
-          try cb message with _ -> ()
+          try cb message with exn ->
+            Log.Backend.warn "subscriber callback failed: %s" (Printexc.to_string exn)
         ) callbacks;
         Ok (List.length callbacks)
 

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -387,7 +387,8 @@ let load_neo4j_identity_cache () =
                   }
               end)
             edges
-        with _ -> ())
+        with exn ->
+          Log.Dashboard.warn "neo4j identity cache update failed: %s" (Printexc.to_string exn))
   end
 
 (** Merge two profiles: prefer non-default values from [overlay] over [base]. *)

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -517,7 +517,8 @@ let execute_single_agent_run ~sw ~provider ~model ~prompt =
               | Ok agent ->
                   Fun.protect
                     ~finally:(fun () ->
-                      try Oas.Agent.close agent with _ -> ())
+                      try Oas.Agent.close agent with close_exn ->
+                        Log.Misc.warn "agent close failed: %s" (Printexc.to_string close_exn))
                     (fun () ->
                       match Oas.Agent.run ~sw agent prompt with
                       | Ok response -> Ok (response_text_of_api_response response)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -214,7 +214,8 @@ let run
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    (try Oas.Agent.close agent with _ -> ());
+    (try Oas.Agent.close agent with close_exn ->
+      Log.Misc.warn "agent close failed during cleanup: %s" (Printexc.to_string close_exn));
     Error (Printf.sprintf "Agent execution exception: %s" (Printexc.to_string exn)))
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary
- 6파일에서 `with _ -> ()` 패턴을 Log 경고 또는 좁은 예외 매칭으로 교체
- Silent swallow → Log.warn: backend_core(콜백), oas_worker/dashboard_provider_runs(Agent.close), dashboard_execution_helpers(Neo4j 캐시)
- Broad catch → Narrow: auto_responder(Sys_error|Unix_error), autoresearch(Sys_error)

디버깅 블랙홀 제거. fault-tolerant 동작은 유지.

## Test plan
- [x] `dune build --root .` 클린 빌드

🤖 Generated with [Claude Code](https://claude.com/claude-code)