### PR TITLE
fix: reject chain_goal/chain_id in native orchestration mode (M-14)

### DIFF
--- a/lib/tool_command_plane_chain_common.ml
+++ b/lib/tool_command_plane_chain_common.ml
@@ -83,9 +83,12 @@ let parse_chain_launch args =
   in
   match orchestration_kind with
   | "native" ->
-      (* TODO [M-14]: chain_goal is silently ignored when orchestration_kind=native.
-         Consider: if chain_goal is set with native, either error or auto-switch to chain_dsl. *)
-      Ok None
+      let has_chain_id = get_string_opt args "chain_id" <> None in
+      let has_chain_goal = get_string_opt args "chain_goal" <> None in
+      if has_chain_id || has_chain_goal then
+        Error "chain_id/chain_goal require orchestration_kind=chain_dsl (got native)"
+      else
+        Ok None
   | "chain_dsl" ->
       let chain_id = get_string_opt args "chain_id" in
       let chain_goal = get_string_opt args "chain_goal" in


### PR DESCRIPTION
## Summary
- `orchestration_kind=native`에서 `chain_goal`/`chain_id` 전달 시 silent ignore → 명시적 에러 반환
- 사용자에게 `orchestration_kind=chain_dsl` 설정을 안내

## Test plan
- [x] `dune build --root .` 클린 빌드

🤖 Generated with [Claude Code](https://claude.com/claude-code)