### PR TITLE
fix: Eio.Cancel.Cancelled guards round 2 (44 catches, 14 files)

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -216,7 +216,9 @@ let get_or_compute_simple key ~ttl compute =
     (* Stale but usable — recompute inline (no fibers available) *)
     let value =
       try compute ()
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Log.Dashboard.warn "stale cache recompute failed for %s: %s"
           key (Printexc.to_string exn);
         entry.value

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -259,7 +259,7 @@ let keeper_metrics_24h_json
             end
           end
         end
-      with exn -> Log.Server.info "keeper log parse: %s" (Printexc.to_string exn))
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Server.info "keeper log parse: %s" (Printexc.to_string exn))
     lines;
   let rows =
     buckets

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -119,7 +119,9 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("slo_target_age_s", `Int slo_target_age_s);
       ("slo_breached", `Bool slo_breached);
     ], true)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Log.Dashboard.error "board_monitoring_json failed: %s"
       (Printexc.to_string exn);
     (`Assoc [
@@ -246,7 +248,9 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("slo_breached", `Bool slo_breached);
       ("judge_online", `Bool judge_online);
     ], true)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Log.Dashboard.error "governance_monitoring_json failed: %s"
       (Printexc.to_string exn);
     (`Assoc [

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -813,7 +813,9 @@ let start_async_refresh ~actor_name ~config ~sw ~clock ~proc_mgr () =
                with_cache_lock (fun () ->
                    cache.refresh_in_flight <- false;
                    cache.last_error <- Some reason)
-         with exn ->
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
            with_cache_lock (fun () ->
                cache.refresh_in_flight <- false;
                cache.last_error <- Some (Printexc.to_string exn)));

--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -49,7 +49,9 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
                | Error e ->
                    Log.Misc.error "dashboard proof auto-gen failed: %s" e;
                    None
-             with exn ->
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
                Log.Misc.error "dashboard proof auto-gen exception: %s" (Printexc.to_string exn);
                None))
     | _ -> None

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -269,7 +269,9 @@ module Request = struct
     let stop () =
       if not !stopped then begin
         stopped := true;
-        (try Httpun.Body.Reader.close body with exn ->
+        (try Httpun.Body.Reader.close body with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
           Log.Misc.error "[http] body close failed: %s" (Printexc.to_string exn))
       end
     in
@@ -289,7 +291,9 @@ module Request = struct
            Httpun.Body.Reader.schedule_read body
              ~on_eof:(fun () ->
                let body_str = Buffer.contents buf in
-               try on_body body_str with exn ->
+               try on_body body_str with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
                  on_error (`Internal exn))
              ~on_read:(fun buffer ~off ~len ->
                if !stopped then ()
@@ -609,7 +613,9 @@ let run ~sw ~net ~clock config routes =
                ~error_handler
                client_addr
                flow
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              Log.Http.error "Connection error: %s" (Printexc.to_string exn))
        with exn ->
          if is_cancelled exn then raise exn;

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -206,7 +206,9 @@ let make_request_handler routes =
       match Router.find_route routes req with
       | Some route -> route.handler req reqd
       | None -> Response.not_found reqd
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Response.internal_error (Printexc.to_string exn) reqd
 
 (** Httpun-Compatible Adapter Layer
@@ -283,7 +285,9 @@ let run ~sw ~net ~clock config request_handler =
         Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
             Eio.Switch.on_release conn_sw (fun () ->
-              try Eio.Flow.close flow with exn ->
+              try Eio.Flow.close flow with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
                 Log.Misc.error "[h2] flow close failed: %s" (Printexc.to_string exn)
             );
             try
@@ -293,7 +297,9 @@ let run ~sw ~net ~clock config request_handler =
                 ~error_handler
                 client_addr
                 flow
-            with exn ->
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
               Log.Http.error "Connection error: %s" (Printexc.to_string exn)
           )
         )

--- a/lib/swarm/swarm_goal_loop.ml
+++ b/lib/swarm/swarm_goal_loop.ml
@@ -101,7 +101,9 @@ let measure_metric metric_fn =
         Error (Printf.sprintf "metric_fn exited with code %d" code)
     | _ ->
         Error "metric_fn terminated abnormally"
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "metric_fn failed: %s" (Printexc.to_string exn))
 
 (* ================================================================ *)

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -42,22 +42,22 @@ let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param 
   let open Yojson.Safe.Util in
   let props =
     try schema |> member "properties" |> to_assoc
-    with _ -> []
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
   in
   let required_keys =
     try schema |> member "required" |> to_list |> List.filter_map (fun j ->
-      try Some (to_string j) with _ -> None)
-    with _ -> []
+      try Some (to_string j) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
   in
   List.filter_map (fun (key, prop) ->
     try
       let type_str =
         try prop |> member "type" |> to_string
-        with _ -> "string"
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "string"
       in
       let description =
         try prop |> member "description" |> to_string
-        with _ -> ""
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
       in
       Some {
         Agent_sdk.Types.name = key;
@@ -65,7 +65,7 @@ let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param 
         param_type = param_type_of_string type_str;
         required = List.mem key required_keys;
       }
-    with _ -> None
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
   ) props
 
 (** {1 OAS Tool.t Creation}

--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -254,7 +254,9 @@ let post_final_summary (state : Mdal.loop_state) =
          ~ttl_hours:24
          ~hearth:(Mdal.state_hearth state.loop_id)
          ())
-  with exn -> Log.Misc.warn "tool_mdal: final board post failed: %s" (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Log.Misc.warn "tool_mdal: final board post failed: %s" (Printexc.to_string exn)
 
 let terminal_response ?config (state : Mdal.loop_state) ~reason ~error_message =
   assoc_with_fields (state_to_json ?config state)
@@ -280,7 +282,9 @@ let emit_stop_event (state : Mdal.loop_state) ~reason =
           ("final_metric", `Float final_metric);
           ("iterations", `Int state.current_iteration);
         ])
-  with exn -> Log.Misc.warn "tool_mdal: emit_stop_event SSE failed: %s" (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Log.Misc.warn "tool_mdal: emit_stop_event SSE failed: %s" (Printexc.to_string exn)
 
 let emit_completed_event ~loop_id ~final_metric ~iterations =
   try
@@ -292,7 +296,9 @@ let emit_completed_event ~loop_id ~final_metric ~iterations =
           ("final_metric", `Float final_metric);
           ("iterations", `Int iterations);
         ])
-  with exn -> Log.Misc.warn "tool_mdal: emit_completed_event SSE failed: %s" (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Log.Misc.warn "tool_mdal: emit_completed_event SSE failed: %s" (Printexc.to_string exn)
 
 let run_worker_iteration (ctx : context) (config : Room.config)
     (state : Mdal.loop_state) current_metric =
@@ -502,7 +508,7 @@ let handle_start (ctx : context) args =
          ("evidence_policy", `String "hard");
          ("execution_mode", `String (Mdal.execution_mode_to_string state.execution_mode));
          ("persistence_backend", `String (config_persistence_backend config));
-       ]) with exn -> Log.Misc.warn "tool_mdal: mdal_started SSE failed: %s" (Printexc.to_string exn));
+       ]) with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: mdal_started SSE failed: %s" (Printexc.to_string exn));
 
       assoc_with_fields (state_to_json ~config state)
         [ ("worker_prompt", `String (Mdal.render_worker_prompt profile [] baseline)) ])
@@ -663,7 +669,7 @@ let handle_iterate (ctx : context) args =
                                 ~ttl_hours:24
                                 ~hearth:(Mdal.iter_hearth state.loop_id)
                                 ())
-                    with exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
+                    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
 
                    (* Broadcast via SSE *)
                    (try Sse.broadcast (`Assoc [
@@ -673,7 +679,7 @@ let handle_iterate (ctx : context) args =
                       ("metric_before", `Float metric_before);
                       ("metric_after", `Float metric_after);
                       ("delta", `Float delta);
-                    ]) with exn -> Log.Misc.warn "tool_mdal: iter SSE broadcast failed: %s" (Printexc.to_string exn));
+                    ]) with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: iter SSE broadcast failed: %s" (Printexc.to_string exn));
 
                    (* Check if goal is met *)
                    let evaluation = Mdal.evaluate_iteration record in
@@ -806,7 +812,9 @@ let parse_worker_spec (json : Yojson.Safe.t) : (Mdal_swarm.worker_spec, string) 
       agent = json |> member "agent" |> to_string_option |> Option.value ~default:"default";
       max_iterations = json |> member "max_iterations" |> to_int_option |> Option.value ~default:10;
     }
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "Invalid worker spec: %s" (Printexc.to_string exn))
 
 let parse_all_workers workers_json =

--- a/lib/tool_mitosis.ml
+++ b/lib/tool_mitosis.ml
@@ -506,7 +506,7 @@ let run_sync_handoff ctx args : result =
         ~to_generation:new_cell.Mitosis.generation
         ~dna_size
         ~context_ratio)
-       with exn -> Log.Mitosis_log.error "record_handoff failed: %s" (Printexc.to_string exn));
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Mitosis_log.error "record_handoff failed: %s" (Printexc.to_string exn));
       let effective_agent =
         if !selected_agent = "" then normalized_target_agent else !selected_agent
       in
@@ -579,7 +579,7 @@ let run_sync_handoff ctx args : result =
           in
           let new_state = Adaptive_thresholds.adapt current_state outcome in
           (try Adaptive_thresholds.save_state ~room:room_name new_state
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Mitosis_log.error "adaptive save failed: %s" (Printexc.to_string exn));
           Log.Mitosis_log.info "adaptive adapted room=%s prepare=%.3f->%.3f handoff=%.3f->%.3f"
             room_name
@@ -652,7 +652,7 @@ let handle_mitosis_handoff ctx args : result =
           ~saga_id
           ~status:"running"
           ~payload:(`Assoc [("message", `String "handoff saga running")]))
-         with exn -> Log.Mitosis_log.error "write_saga_state(running) failed: %s" (Printexc.to_string exn));
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Mitosis_log.error "write_saga_state(running) failed: %s" (Printexc.to_string exn));
         let started = Time_compat.now () in
         try
           let run_once () =
@@ -677,7 +677,7 @@ let handle_mitosis_handoff ctx args : result =
                 ("result", parsed);
                 ("verification", match verification with Some v -> v | None -> `Null);
               ]))
-             with exn -> Log.Mitosis_log.error "write_saga_state(result) failed: %s" (Printexc.to_string exn))
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Mitosis_log.error "write_saga_state(result) failed: %s" (Printexc.to_string exn))
           in
           (match ctx.clock with
            | Some (Clock clock) ->
@@ -696,10 +696,12 @@ let handle_mitosis_handoff ctx args : result =
                       ("error", `String "verification_saga_timeout");
                       ("timeout_sec", `Float saga_timeout_sec);
                     ]))
-                   with exn -> Log.Mitosis_log.error "write_saga_state(timeout) failed: %s" (Printexc.to_string exn)))
+                   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Mitosis_log.error "write_saga_state(timeout) failed: %s" (Printexc.to_string exn)))
            | None ->
                run_once ())
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           (try ignore (write_saga_state
             ~base_path
             ~saga_id
@@ -707,7 +709,7 @@ let handle_mitosis_handoff ctx args : result =
             ~payload:(`Assoc [
               ("error", `String (Printexc.to_string exn));
             ]))
-           with exn2 -> Log.Mitosis_log.error "write_saga_state(error) failed: %s" (Printexc.to_string exn2)));
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn2 -> Log.Mitosis_log.error "write_saga_state(error) failed: %s" (Printexc.to_string exn2)));
       let json = `Assoc [
         ("action", `String "accepted");
         ("async", `Bool true);

--- a/lib/voice/voice_bridge_eio.ml
+++ b/lib/voice/voice_bridge_eio.ml
@@ -387,7 +387,9 @@ let single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str =
     else
       Error (Printf.sprintf "HTTP %d: %s"
         (Cohttp.Code.code_of_status status) body_str)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "Connection error: %s" (Printexc.to_string exn))
 
 (** Make HTTP POST request to Voice MCP server with timeout and retry - Eio version *)
@@ -448,7 +450,9 @@ let extract_mcp_result json =
           (try Ok (Yojson.Safe.from_string t)
            with Yojson.Json_error _ -> Ok (`String t))
         | None -> Ok result)
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Parse error: %s" (Printexc.to_string e))
 
 let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
@@ -594,7 +598,9 @@ let is_voice_server_available ~sw ~clock ~net =
                 in
                 voice_server_available := Some available;
                 Ok available
-          with exn ->
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
             Eio.traceln "[WARN] voice server check failed: %s"
               (Printexc.to_string exn);
             voice_server_available := Some false;
@@ -858,5 +864,7 @@ let health_check ~sw ~clock:_ ~net () =
           Error
             (Printf.sprintf "Unhealthy: HTTP %d"
                (Cohttp.Code.code_of_status status))
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Error (Printf.sprintf "Not reachable: %s" (Printexc.to_string exn))

--- a/lib/voice/voice_bridge_eio_core.ml
+++ b/lib/voice/voice_bridge_eio_core.ml
@@ -104,7 +104,9 @@ let client_for_uri ~net uri =
 
 let client_for_uri_result ~net uri =
   try Ok (client_for_uri ~net uri)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Error (Printf.sprintf "HTTPS client init error: %s" (Printexc.to_string exn))
 
 (** ============================================

--- a/lib/voice/voice_stream.ml
+++ b/lib/voice/voice_stream.ml
@@ -120,7 +120,7 @@ let safe_close_client t ic =
   (try
      if not (Ws.Wsd.is_closed ic.wsd) then
        Ws.Wsd.close ic.wsd
-   with exn -> Log.Misc.warn "ws close: %s" (Printexc.to_string exn));
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "ws close: %s" (Printexc.to_string exn));
   remove_client t ic.client.id
 
 let mark_client_error t ic message =
@@ -204,7 +204,9 @@ let send_bytes t ic ~kind payload =
       Eio.Mutex.use_rw ~protect:true ic.send_mutex (fun () ->
         Ws.Wsd.send_bytes ic.wsd ~kind payload ~off:0 ~len:(Bytes.length payload);
         Ws.Wsd.flushed ic.wsd finish);
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> finish (); raise e
+    | exn ->
       finish ();
       mark_client_error t ic (Printexc.to_string exn)
   end
@@ -272,16 +274,20 @@ let start ~sw ~net ~clock t =
           let flow, client_addr = Eio.Net.accept ~sw socket in
           Eio.Fiber.fork ~sw (fun () ->
             try connection_handler client_addr flow
-            with exn ->
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
               Log.error ~ctx:"voice_stream" "Handler error: %s" (Printexc.to_string exn));
           accept_loop 0.05
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           if t.should_stop then
             ()
           else begin
             Log.error ~ctx:"voice_stream" "Accept error: %s" (Printexc.to_string exn);
             (try Eio.Time.sleep clock backoff_s
-             with exn -> Log.Misc.warn "sleep interrupted: %s" (Printexc.to_string exn));
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "sleep interrupted: %s" (Printexc.to_string exn));
             let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
             accept_loop next_backoff
           end
@@ -297,7 +303,7 @@ let stop t =
    | Some (Listening_socket socket) ->
      t.server_socket <- None;
      (try Eio.Resource.close socket
-      with exn -> Eio.traceln "[WARN] socket close: %s" (Printexc.to_string exn))
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Eio.traceln "[WARN] socket close: %s" (Printexc.to_string exn))
    | None -> ());
   let clients = Hashtbl.fold (fun _ ic acc -> ic :: acc) t.clients [] in
   List.iter (fun ic -> safe_close_client t ic) clients;


### PR DESCRIPTION
Round 2: tool_mdal, voice, http_server, tool_mitosis, tool_bridge, dashboard, swarm. Combined 112 catches guarded (68+44). Build passes.