### PR TITLE
fix: protect discovery_cache with Eio.Mutex

### DIFF
--- a/lib/discovery_cache.ml
+++ b/lib/discovery_cache.ml
@@ -16,15 +16,16 @@ let set_env ~sw ~(net : [`Generic | `Unix] Eio.Net.ty Eio.Resource.t) =
   sw_ref := Some sw;
   net_ref := Some net
 
-(* ── Cache state ─────────────────────────────────────────── *)
+(* ── Cache state (Eio.Mutex-protected) ───────────────────── *)
 
 type endpoint_info = Llm_provider.Discovery.endpoint_status
 
+let cache_mu = Eio.Mutex.create ()
 let cached_endpoints : endpoint_info list ref = ref []
 let cache_updated_at : float ref = ref 0.0
 let cache_ttl = 30.0
 
-let refresh_cache () =
+let refresh_cache_unlocked () =
   match !sw_ref, !net_ref with
   | Some sw, Some net ->
     let endpoints = Llm_provider.Discovery.endpoints_from_env () in
@@ -32,14 +33,14 @@ let refresh_cache () =
     cached_endpoints := results;
     cache_updated_at := Time_compat.now ()
   | _ ->
-    (* Eio env not yet injected — return empty. Server init calls set_env. *)
     ()
 
 let get_cached_or_refresh () =
-  let now = Time_compat.now () in
-  if now -. !cache_updated_at > cache_ttl || !cached_endpoints = [] then
-    refresh_cache ();
-  !cached_endpoints
+  Eio.Mutex.use_rw ~protect:true cache_mu (fun () ->
+    let now = Time_compat.now () in
+    if now -. !cache_updated_at > cache_ttl || !cached_endpoints = [] then
+      refresh_cache_unlocked ();
+    !cached_endpoints)
 
 let cache_age_seconds () =
   Time_compat.now () -. !cache_updated_at


### PR DESCRIPTION
## Summary
- `discovery_cache.ml`의 `get_cached_or_refresh()`를 `Eio.Mutex`로 보호
- read-then-write race condition 방지: 여러 fiber가 동시에 stale TTL을 보고 중복 HTTP probe 실행하는 문제
- `generational_metrics.ml`은 이미 `with_lock` 패턴으로 보호되어 있어 수정 불필요

## Test plan
- [x] `dune build --root .` 클린 빌드

🤖 Generated with [Claude Code](https://claude.com/claude-code)