### PR TITLE
refactor: OAS fundamental improvement Phase B+C — Context_reducer + Perpetual Memory

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -1,26 +1,20 @@
-(** Context_compact_oas — Thin adapter bridging MASC compaction to OAS Context_reducer.
+(** Context_compact_oas — direct delegation to OAS Context_reducer.
 
-    Converts MASC messages to OAS messages, applies OAS Context_reducer strategies,
-    and converts back. This is Phase 1 of migrating MASC to use OAS properly.
+    MASC messages are [Agent_sdk.Types.message] — the same type OAS uses.
+    No role conversion or sentinel tagging is needed; OAS Context_reducer
+    natively supports all 4 roles (System, User, Assistant, Tool) and
+    preserves ToolUse/ToolResult pairing.
 
-    This module is deliberately independent of Context_manager to avoid circular
-    dependency. It operates on [Agent_sdk.Types.message list] directly and uses its own
-    strategy enum shared via Compaction_types.compaction_strategy.
+    MASC-specific strategies (DropLowImportance, SummarizeOld) use OAS
+    Custom closures to inject domain logic that OAS does not provide.
 
-    MASC has 4 roles (System, User, Assistant, Tool) while OAS has the same 4.
-    OAS Context_reducer strategies operate on OAS message lists and respect
-    ToolUse/ToolResult pairing. We use sentinel-tagged text to preserve MASC
-    role semantics through the OAS pipeline.
-
-    @since Phase 1 — OAS Context_reducer integration *)
+    @since Phase 1 — OAS Context_reducer integration
+    @since Phase B — Sentinel removal (roles are natively compatible) *)
 
 (* ================================================================ *)
 (* Strategy Type (shared via Compaction_types)                       *)
 (* ================================================================ *)
 
-(** Re-export from [Compaction_types] for backward compatibility.
-    Consumers that used [Context_compact_oas.PruneToolOutputs] etc.
-    continue to work without changes. *)
 type strategy = Compaction_types.compaction_strategy =
   | PruneToolOutputs
   | MergeContiguous
@@ -28,94 +22,12 @@ type strategy = Compaction_types.compaction_strategy =
   | SummarizeOld
 
 (* ================================================================ *)
-(* Role Tag Sentinels                                               *)
-(* ================================================================ *)
-
-(** \x00-prefixed sentinels prevent collision with user content.
-    No valid UTF-8 user text starts with a null byte. *)
-let system_role_tag = "\x00__MASC_ROLE:system__\x00"
-let tool_role_tag = "\x00__MASC_ROLE:tool__\x00"
-
-let starts_with ~prefix s =
-  let lp = String.length prefix in
-  String.length s >= lp && String.sub s 0 lp = prefix
-
-(* ================================================================ *)
-(* MASC <-> OAS Message Conversion                                  *)
-(* ================================================================ *)
-
-(** Convert a MASC message to an OAS message with role tags for lossless roundtrip.
-    System and Tool roles are mapped to User with a sentinel prefix so OAS
-    strategies (which expect User/Assistant alternation) handle them correctly. *)
-let masc_msg_to_oas (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
-  let text = Agent_sdk.Types.text_of_message m in
-  let role, tagged_text = match m.role with
-    | Agent_sdk.Types.System -> Agent_sdk.Types.User, system_role_tag ^ text
-    | Agent_sdk.Types.Tool -> Agent_sdk.Types.User, tool_role_tag ^ text
-    | Agent_sdk.Types.User -> Agent_sdk.Types.User, text
-    | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant, text
-  in
-  let content = match m.role with
-    | Agent_sdk.Types.Tool ->
-      let tool_use_id =
-        List.find_map (function Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id | _ -> None) m.content
-        |> Option.value ~default:"masc-tool"
-      in
-      [Agent_sdk.Types.ToolResult { tool_use_id; content = tagged_text; is_error = false }]
-    | _ -> [Agent_sdk.Types.Text tagged_text]
-  in
-  { Agent_sdk.Types.role; content; name = None; tool_call_id = None }
-
-(** Recover a MASC message from a tagged OAS message.
-    Strips sentinel prefixes and restores the original MASC role. *)
-let oas_msg_to_masc (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
-  let text, tool_id =
-    let parts = List.filter_map (fun (block : Agent_sdk.Types.content_block) ->
-      match block with
-      | Agent_sdk.Types.Text s -> Some (s, None)
-      | Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ->
-        Some (content, Some tool_use_id)
-      | _ -> None
-    ) m.content in
-    let texts = List.map fst parts in
-    let ids = List.filter_map snd parts in
-    (String.concat "\n" texts, List.nth_opt ids 0)
-  in
-  let role, content =
-    if starts_with ~prefix:system_role_tag text then
-      Agent_sdk.Types.System,
-      String.sub text (String.length system_role_tag)
-        (String.length text - String.length system_role_tag)
-    else if starts_with ~prefix:tool_role_tag text then
-      Agent_sdk.Types.Tool,
-      String.sub text (String.length tool_role_tag)
-        (String.length text - String.length tool_role_tag)
-    else
-      (match m.role with
-       | Agent_sdk.Types.User -> Agent_sdk.Types.User
-       | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant
-       | Agent_sdk.Types.System -> Agent_sdk.Types.System
-       | Agent_sdk.Types.Tool -> Agent_sdk.Types.Tool),
-      text
-  in
-  let content_blocks = match role with
-    | Agent_sdk.Types.Tool ->
-      let tool_use_id = Option.value ~default:"masc-tool" tool_id in
-      [Agent_sdk.Types.ToolResult { tool_use_id; content; is_error = false }]
-    | _ -> [Agent_sdk.Types.Text content]
-  in
-  { Agent_sdk.Types.role; content = content_blocks; name = None; tool_call_id = None }
-
-(* ================================================================ *)
-(* Importance Scoring — delegated to Context_scoring (shared SSOT)  *)
-(* ================================================================ *)
-
-(* ================================================================ *)
-(* Token Estimation                                                 *)
+(* Token Estimation                                                  *)
 (* ================================================================ *)
 
 let msg_tokens (m : Agent_sdk.Types.message) =
-  (String.length (Agent_sdk.Types.text_of_message m) / 4) + 4
+  let text = Agent_sdk.Types.text_of_message m in
+  (String.length text / 4) + 4
 
 let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
   let sys_tokens = (String.length system_prompt / 4) + 4 in
@@ -127,77 +39,28 @@ let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) 
 
 (** Map a local strategy to an OAS Context_reducer strategy.
 
-    - PruneToolOutputs and MergeContiguous map directly to OAS built-in strategies.
-    - DropLowImportance uses OAS Custom strategy with inline scoring.
-    - SummarizeOld uses OAS Custom strategy with heuristic summarization.
-
-    SummarizeOld uses extractive summarization (first-sentence extraction).
-    A future enhancement could accept an MODEL summarizer function parameter. *)
+    - PruneToolOutputs and MergeContiguous use OAS built-in strategies directly.
+    - DropLowImportance uses OAS Custom with MASC Context_scoring (OAS has no scoring).
+    - SummarizeOld uses OAS Custom with extractive summarization (deterministic, no LLM). *)
 let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
   match s with
   | PruneToolOutputs ->
     Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 }
   | MergeContiguous ->
-    (* Cannot delegate to OAS Merge_contiguous directly — it would merge
-       consecutive User messages that carry different sentinel tags (System
-       mapped to User, Tool mapped to User), corrupting role recovery.
-       Use Custom wrapper that skips sentinel-tagged messages from merging. *)
-    Agent_sdk.Context_reducer.Custom (fun oas_msgs ->
-      let has_sentinel (m : Agent_sdk.Types.message) =
-        List.exists (function
-          | Agent_sdk.Types.Text s -> String.length s > 0 && s.[0] = '\x00'
-          | Agent_sdk.Types.ToolResult { content; _ } ->
-            String.length content > 0 && content.[0] = '\x00'
-          | _ -> false
-        ) m.content
-      in
-      (* Split into sentinel-protected and mergeable segments, merge only
-         the mergeable ones via OAS, then reassemble in order. *)
-      let reducer = { Agent_sdk.Context_reducer.strategy =
-        Agent_sdk.Context_reducer.Merge_contiguous } in
-      let rec process acc buf = function
-        | [] ->
-          let merged = if buf = [] then [] else
-            Agent_sdk.Context_reducer.reduce reducer (List.rev buf) in
-          List.rev_append acc merged
-        | m :: rest when has_sentinel m ->
-          let merged = if buf = [] then [] else
-            Agent_sdk.Context_reducer.reduce reducer (List.rev buf) in
-          process (m :: List.rev_append merged acc) [] rest
-        | m :: rest ->
-          process acc (m :: buf) rest
-      in
-      process [] [] oas_msgs)
+    Agent_sdk.Context_reducer.Merge_contiguous
   | DropLowImportance ->
-    Agent_sdk.Context_reducer.Custom (fun oas_msgs ->
-      let masc_msgs = List.map oas_msg_to_masc oas_msgs in
-      let scores = Context_scoring.score_messages masc_msgs in
+    Agent_sdk.Context_reducer.Custom (fun msgs ->
+      let scores = Context_scoring.score_messages msgs in
       let threshold = 0.3 in
-      let filtered = List.filteri (fun i _m ->
+      List.filteri (fun i _m ->
         match List.assoc_opt i scores with
         | Some score -> score >= threshold
         | None -> true
-      ) masc_msgs in
-      List.map masc_msg_to_oas filtered)
+      ) msgs)
   | SummarizeOld ->
-    (* Extractive summarization: replace the middle section of messages with
-       a single System message containing first-sentence extracts of each
-       removed user/assistant turn. Preserves the first 2 and last 5 messages
-       intact (conversation start + recent context). The summary message
-       bridges the gap so the model knows what was discussed without reading
-       every old message.
-
-       This is deterministic (no MODEL call). A future enhancement could use
-       an MODEL for abstractive summarization via a callback parameter. *)
-    Agent_sdk.Context_reducer.Custom (fun oas_msgs ->
-      let n = List.length oas_msgs in
-      let first_n = 2 in
-      let last_n = 5 in
-      if n <= first_n + last_n + 1 then oas_msgs
-      else
-        let first = List.filteri (fun i _ -> i < first_n) oas_msgs in
-        let last = List.filteri (fun i _ -> i >= n - last_n) oas_msgs in
-        let middle = List.filteri (fun i _ -> i >= first_n && i < n - last_n) oas_msgs in
+    Agent_sdk.Context_reducer.Summarize_old {
+      keep_recent = 5;
+      summarizer = (fun old_msgs ->
         let first_sentence (s : string) =
           let s = String.trim s in
           let max_len = 120 in
@@ -214,91 +77,31 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
           | Some pos when pos <= max_len -> String.sub s 0 pos
           | _ -> if String.length s > max_len then String.sub s 0 max_len ^ "..." else s
         in
-        let extract_text (m : Agent_sdk.Types.message) : string =
-          m.content
-          |> List.filter_map (function
-               | Agent_sdk.Types.Text s ->
-                 let t = String.trim s in
-                 if t = "" || (String.length t > 0 && t.[0] = '\x00') then None
-                 else Some t
-               | _ -> None)
-          |> String.concat " "
-        in
-        let summary_lines = middle |> List.mapi (fun i m ->
+        let lines = old_msgs |> List.mapi (fun i m ->
           let role_str = match m.Agent_sdk.Types.role with
             | Agent_sdk.Types.User -> "user"
             | Agent_sdk.Types.Assistant -> "assistant"
             | Agent_sdk.Types.System -> "system"
             | Agent_sdk.Types.Tool -> "tool"
           in
-          let text = extract_text m in
+          let text = String.trim (Agent_sdk.Types.text_of_message m) in
           if text = "" then None
-          else Some (Printf.sprintf "[%d] %s: %s" (first_n + i + 1) role_str (first_sentence text))
+          else Some (Printf.sprintf "[%d] %s: %s" (i + 1) role_str (first_sentence text))
         ) |> List.filter_map Fun.id in
-        let omitted_count = List.length middle in
-        let summary_text = Printf.sprintf
-          "[Compacted %d messages into summary]\n%s"
-          omitted_count (String.concat "\n" summary_lines)
-        in
-        let summary_msg = Agent_sdk.Types.text_message
-          Agent_sdk.Types.System summary_text in
-        first @ [summary_msg] @ last)
-
-(* ================================================================ *)
-(* Sentinel Roundtrip Validation                                    *)
-(* ================================================================ *)
-
-(** Validate that sentinel-tagged messages survive OAS reduction intact.
-    Returns [true] if all sentinel tags in the original messages can be
-    correctly recovered from the reduced messages. Detects corruption
-    from strategies like Merge_contiguous or Summarize_old that may
-    concatenate or truncate content containing \x00 sentinel bytes. *)
-let validate_roundtrip
-    ~(original : Agent_sdk.Types.message list)
-    ~(reduced : Agent_sdk.Types.message list)
-  : bool =
-  (* Count sentinel-tagged messages (System and Tool roles) in original *)
-  let count_sentinels msgs =
-    List.fold_left (fun acc (m : Agent_sdk.Types.message) ->
-      match m.role with
-      | Agent_sdk.Types.System | Agent_sdk.Types.Tool -> acc + 1
-      | _ -> acc
-    ) 0 msgs
-  in
-  let original_sentinel_count = count_sentinels original in
-  (* If no sentinel-tagged messages, nothing to validate *)
-  if original_sentinel_count = 0 then true
-  else begin
-    (* Verify each reduced message with a sentinel tag can be cleanly parsed *)
-    let valid = List.for_all (fun (m : Agent_sdk.Types.message) ->
-      let text = Agent_sdk.Types.text_of_message m in
-      (* Check for corrupted sentinels: \x00 present but not as valid prefix *)
-      if String.contains text '\x00' then
-        starts_with ~prefix:system_role_tag text
-        || starts_with ~prefix:tool_role_tag text
-        (* Also allow text that has no sentinel at all — it was a plain message *)
-      else true
-    ) reduced in
-    valid
-  end
+        Printf.sprintf "[Compacted %d messages into summary]\n%s"
+          (List.length old_msgs) (String.concat "\n" lines)
+      );
+    }
 
 (* ================================================================ *)
 (* Public API                                                       *)
 (* ================================================================ *)
 
-(** Apply compaction via the OAS Context_reducer pipeline.
+(** Apply compaction via OAS Context_reducer.
 
-    Takes MASC messages, system prompt, and strategies. Converts to OAS messages,
-    builds a composed OAS reducer, runs the reduction, and converts back.
-
-    Returns the compacted message list and new token count.
-
-    After reduction, validates sentinel integrity. If corruption is detected
-    (e.g., from Merge_contiguous joining sentinel-tagged content), falls back
-    to returning the original messages with a warning log.
-
-    This function is functionally equivalent to [Context_manager.compact]
-    but routes through OAS Context_reducer, enabling A/B comparison. *)
+    Messages are passed directly — no role conversion needed since
+    MASC and OAS share the same [Agent_sdk.Types.message] type with
+    the same 4 roles (System, User, Assistant, Tool). *)
 let compact
     ~(system_prompt : string)
     ~(messages : Agent_sdk.Types.message list)
@@ -307,22 +110,6 @@ let compact
   let oas_strategies = List.map oas_strategy_of strategies in
   let reducer = Agent_sdk.Context_reducer.compose
     (List.map (fun s -> { Agent_sdk.Context_reducer.strategy = s }) oas_strategies) in
-  let oas_msgs = List.map masc_msg_to_oas messages in
-  let reduced = Agent_sdk.Context_reducer.reduce reducer oas_msgs in
-  let result_messages = List.map oas_msg_to_masc reduced in
-  (* Validate sentinel integrity after reduction *)
-  if validate_roundtrip ~original:messages ~reduced:result_messages then begin
-    let token_count = count_tokens system_prompt result_messages in
-    (result_messages, token_count)
-  end else begin
-    Log.Memory.warn "sentinel corruption detected after \
-             reduction with strategies [%s], falling back to original messages"
-      (String.concat ", " (List.map (fun s -> match s with
-        | PruneToolOutputs -> "PruneToolOutputs"
-        | MergeContiguous -> "MergeContiguous"
-        | DropLowImportance -> "DropLowImportance"
-        | SummarizeOld -> "SummarizeOld"
-      ) strategies));
-    let token_count = count_tokens system_prompt messages in
-    (messages, token_count)
-  end
+  let reduced = Agent_sdk.Context_reducer.reduce reducer messages in
+  let token_count = count_tokens system_prompt reduced in
+  (reduced, token_count)

--- a/lib/perpetual/perpetual_oas_build.ml
+++ b/lib/perpetual/perpetual_oas_build.ml
@@ -110,5 +110,14 @@ let build_perpetual_agent
          (sprintf "Perpetual agent (gen %d, trace %s)"
            pstate.generation pstate.trace_id)
   in
+  (* Phase C: 5-tier OAS Memory seeding (matches Keeper pattern) *)
+  let memory = Memory_oas_bridge.create_memory
+    ~agent_name:config.agent_name ~session_id:pstate.trace_id () in
+  ignore (Memory_oas_bridge.seed_institution ~memory ~config:(Room.default_config "."));
+  ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
+  ignore (Memory_oas_bridge.seed_memory_bank ~memory ~agent_name:config.agent_name ~limit:10);
+  ignore (Memory_oas_bridge.seed_episodes ~memory ~agent_name:config.agent_name ~limit:30);
+  ignore (Memory_oas_bridge.seed_procedures_as_oas ~memory ~agent_name:config.agent_name ~limit:10);
+  let builder = Oas.Builder.with_memory memory builder in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -1,8 +1,8 @@
-(** Tests for Context_compact_oas — sentinel roundtrip, strategy mapping,
+(** Tests for Context_compact_oas — strategy mapping,
     shared scoring consistency, and edge cases.
 
-    Addresses PR #1517 review issues C1 (no tests), C2 (sentinel truncation),
-    C3 (score divergence). *)
+    Sentinel roundtrip tests removed: roles are natively compatible
+    (no masc_msg_to_oas/oas_msg_to_masc conversion needed). *)
 
 open Alcotest
 
@@ -19,147 +19,11 @@ let tool_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
     name = None; tool_call_id = None }
 
 (* ================================================================ *)
-(* Sentinel Roundtrip Tests (C2)                                    *)
+(* Merge Contiguous Tests                                           *)
 (* ================================================================ *)
-
-let test_roundtrip_user () =
-  let m = msg Agent_sdk.Types.User "Hello world" in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "role preserved" "User"
-    (match back.role with Agent_sdk.Types.User -> "User" | _ -> "other");
-  check string "text preserved" "Hello world"
-    (Agent_sdk.Types.text_of_message back)
-
-let test_roundtrip_assistant () =
-  let m = msg Agent_sdk.Types.Assistant "I can help" in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "role preserved" "Assistant"
-    (match back.role with Agent_sdk.Types.Assistant -> "Assistant" | _ -> "other");
-  check string "text preserved" "I can help"
-    (Agent_sdk.Types.text_of_message back)
-
-let test_roundtrip_system () =
-  let m = msg Agent_sdk.Types.System "You are helpful" in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "role preserved" "System"
-    (match back.role with Agent_sdk.Types.System -> "System" | _ -> "other");
-  check string "text preserved" "You are helpful"
-    (Agent_sdk.Types.text_of_message back)
-
-let test_roundtrip_tool () =
-  let m = tool_msg ~id:"call-42" "Result data" in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "role preserved" "Tool"
-    (match back.role with Agent_sdk.Types.Tool -> "Tool" | _ -> "other");
-  check string "text preserved" "Result data"
-    (Agent_sdk.Types.text_of_message back);
-  let tool_id = List.find_map (function
-    | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-    | _ -> None) back.content
-  in
-  check (option string) "tool_use_id preserved" (Some "call-42") tool_id
-
-let test_roundtrip_empty_text () =
-  let m = msg Agent_sdk.Types.System "" in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "role preserved" "System"
-    (match back.role with Agent_sdk.Types.System -> "System" | _ -> "other");
-  check string "empty text preserved" ""
-    (Agent_sdk.Types.text_of_message back)
-
-let test_roundtrip_unicode () =
-  let text = "한국어 텍스트 with emoji 🎉 and special chars: \t\n" in
-  let m = msg Agent_sdk.Types.User text in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "unicode preserved" text
-    (Agent_sdk.Types.text_of_message back)
-
-let test_roundtrip_text_containing_sentinel_prefix () =
-  (* User text that accidentally contains \x00 should not be misinterpreted *)
-  let text = "Normal text without null bytes" in
-  let m = msg Agent_sdk.Types.User text in
-  let oas = Compact.masc_msg_to_oas m in
-  let back = Compact.oas_msg_to_masc oas in
-  check string "text without sentinel survives" text
-    (Agent_sdk.Types.text_of_message back)
-
-(* ================================================================ *)
-(* Validate Roundtrip Tests                                         *)
-(* ================================================================ *)
-
-let test_validate_roundtrip_clean () =
-  let msgs = [
-    msg Agent_sdk.Types.System "sys";
-    msg Agent_sdk.Types.User "hello";
-    msg Agent_sdk.Types.Assistant "hi";
-    tool_msg "result";
-  ] in
-  check bool "clean roundtrip validates" true
-    (Compact.validate_roundtrip ~original:msgs ~reduced:msgs)
-
-let test_validate_roundtrip_no_sentinels () =
-  let msgs = [
-    msg Agent_sdk.Types.User "hello";
-    msg Agent_sdk.Types.Assistant "hi";
-  ] in
-  check bool "no sentinels = trivially valid" true
-    (Compact.validate_roundtrip ~original:msgs ~reduced:msgs)
-
-let test_validate_roundtrip_empty () =
-  check bool "empty lists valid" true
-    (Compact.validate_roundtrip ~original:[] ~reduced:[])
-
-(* ================================================================ *)
-(* Sentinel Corruption Tests (C2 — real OAS reduction scenarios)    *)
-(* ================================================================ *)
-
-let test_merge_contiguous_preserves_sentinel_roles () =
-  (* BUG SCENARIO: Two consecutive System messages become two User messages
-     with sentinel tags. OAS Merge_contiguous would merge them (same role),
-     corrupting the second sentinel into the first message's text.
-     After fix: sentinel-tagged messages are excluded from merging. *)
-  let msgs = [
-    msg Agent_sdk.Types.System "System prompt 1";
-    msg Agent_sdk.Types.System "System prompt 2";
-    msg Agent_sdk.Types.User "User question";
-    msg Agent_sdk.Types.Assistant "Response";
-  ] in
-  let result, _tokens = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.MergeContiguous] in
-  (* Both system messages should survive as separate System messages *)
-  let system_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
-    m.role = Agent_sdk.Types.System) result in
-  check int "two system messages preserved separately" 2 (List.length system_msgs);
-  check string "first system text intact" "System prompt 1"
-    (Agent_sdk.Types.text_of_message (List.nth system_msgs 0));
-  check string "second system text intact" "System prompt 2"
-    (Agent_sdk.Types.text_of_message (List.nth system_msgs 1))
-
-let test_merge_contiguous_tool_sentinel_preserved () =
-  (* Consecutive Tool messages should not be merged either *)
-  let msgs = [
-    msg Agent_sdk.Types.User "query";
-    msg Agent_sdk.Types.Assistant "thinking";
-    tool_msg ~id:"t1" "Result 1";
-    tool_msg ~id:"t2" "Result 2";
-    msg Agent_sdk.Types.Assistant "final answer";
-  ] in
-  let result, _tokens = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.MergeContiguous] in
-  let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
-    m.role = Agent_sdk.Types.Tool) result in
-  check int "two tool messages preserved separately" 2 (List.length tool_msgs)
 
 let test_merge_contiguous_still_merges_plain_user () =
-  (* Regular User messages (no sentinel) should still be merged *)
+  (* Regular User messages should still be merged *)
   let msgs = [
     msg Agent_sdk.Types.User "Hello";
     msg Agent_sdk.Types.User "World";
@@ -171,26 +35,6 @@ let test_merge_contiguous_still_merges_plain_user () =
   let user_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
     m.role = Agent_sdk.Types.User) result in
   check int "plain user messages merged" 1 (List.length user_msgs)
-
-let test_prune_tool_outputs_sentinel_survives () =
-  (* ToolResult with sentinel tag and long content — sentinel at front
-     should survive truncation since max_output_len=500 > sentinel length *)
-  let long_tool_output = String.make 600 'x' in
-  let msgs = [
-    msg Agent_sdk.Types.User "query";
-    tool_msg long_tool_output;
-    msg Agent_sdk.Types.Assistant "done";
-  ] in
-  let result, _tokens = Compact.compact
-    ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.PruneToolOutputs] in
-  let tool_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
-    m.role = Agent_sdk.Types.Tool) result in
-  check int "tool message exists" 1 (List.length tool_msgs);
-  (* The Tool role should be correctly recovered *)
-  let tool_text = Agent_sdk.Types.text_of_message (List.nth tool_msgs 0) in
-  check bool "tool text was pruned" true
-    (String.length tool_text < String.length long_tool_output)
 
 (* ================================================================ *)
 (* Strategy Mapping Tests                                           *)
@@ -305,25 +149,8 @@ let test_scoring_single () =
 
 let () =
   run "context_compact_oas" [
-    "sentinel_roundtrip", [
-      test_case "user" `Quick test_roundtrip_user;
-      test_case "assistant" `Quick test_roundtrip_assistant;
-      test_case "system" `Quick test_roundtrip_system;
-      test_case "tool" `Quick test_roundtrip_tool;
-      test_case "empty text" `Quick test_roundtrip_empty_text;
-      test_case "unicode" `Quick test_roundtrip_unicode;
-      test_case "text without sentinel" `Quick test_roundtrip_text_containing_sentinel_prefix;
-    ];
-    "validate_roundtrip", [
-      test_case "clean" `Quick test_validate_roundtrip_clean;
-      test_case "no sentinels" `Quick test_validate_roundtrip_no_sentinels;
-      test_case "empty" `Quick test_validate_roundtrip_empty;
-    ];
-    "sentinel_corruption", [
-      test_case "merge_contiguous preserves system sentinel" `Quick test_merge_contiguous_preserves_sentinel_roles;
-      test_case "merge_contiguous preserves tool sentinel" `Quick test_merge_contiguous_tool_sentinel_preserved;
-      test_case "merge_contiguous still merges plain user" `Quick test_merge_contiguous_still_merges_plain_user;
-      test_case "prune_tool_outputs sentinel survives" `Quick test_prune_tool_outputs_sentinel_survives;
+    "merge_contiguous", [
+      test_case "still merges plain user" `Quick test_merge_contiguous_still_merges_plain_user;
     ];
     "strategy_mapping", [
       test_case "prune_tool_outputs" `Quick test_compact_prune_tool_outputs;

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -59,8 +59,8 @@ let test_roundtrip_tool_msg () =
   | None -> Alcotest.fail "tool message should not be dropped"
   | Some oas ->
     let rt = Oas_type_adapters.of_oas_message oas in
-    (* Oas_type_adapters.to_oas_message preserves Tool role directly (shared type).
-       Context_compact_oas.masc_msg_to_oas uses sentinel-tagging instead. *)
+    (* Both Oas_type_adapters and Context_compact_oas preserve Tool role
+       directly — MASC and OAS share the same Agent_sdk.Types.message type. *)
     Alcotest.(check string) "tool role preserved"
       "tool"
       (match rt.role with Agent_sdk.Types.Tool -> "tool" | _ -> "other");

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -776,21 +776,7 @@ let test_integration () = group "Integration" (fun () ->
   assert_true "integration:compact_reduces"
     (after_ctx.token_count < before);
 
-  (* 3b. Context_compact_oas roundtrip preserves role information *)
-  let tool_msg_rt = Masc_mcp.Oas_message.tool_result ~tool_use_id:"tc1" ~content:"search results" () in
-  let sys_msg_rt = Agent_sdk.Types.system_msg "you are a helper" in
-  let user_msg_rt = Agent_sdk.Types.user_msg "hello" in
-  let asst_msg_rt = Agent_sdk.Types.assistant_msg "hi there" in
-  List.iter (fun (label, orig_msg) ->
-    let oas_msg = Context_compact_oas.masc_msg_to_oas orig_msg in
-    let back = Context_compact_oas.oas_msg_to_masc oas_msg in
-    assert_true (sprintf "roundtrip:%s:role" label) (back.role = orig_msg.role);
-    assert_true (sprintf "roundtrip:%s:content" label)
-      (String.length (Agent_sdk.Types.text_of_message back) > 0)
-  ) [("tool", tool_msg_rt); ("system", sys_msg_rt);
-     ("user", user_msg_rt); ("assistant", asst_msg_rt)];
-
-  (* 3c. compact with tool messages preserves Tool role *)
+  (* 3b. compact with tool messages preserves Tool role *)
   let ctx_with_tools = Context_manager.append_many
     (Context_manager.create ~system_prompt:"test" ~max_tokens:10000)
     [Agent_sdk.Types.user_msg "run grep";
@@ -803,21 +789,7 @@ let test_integration () = group "Integration" (fun () ->
   let tool_content = Agent_sdk.Types.text_of_message (List.hd tool_msgs) in
   assert_true "oas_prune:tool_truncated" (String.length tool_content < 800);
 
-  (* 3c2. Tagged roundtrip preserves tool_call_id *)
-  let tool_with_id = Masc_mcp.Oas_message.tool_result ~tool_use_id:"tc-42" ~content:"result" () in
-  let oas_t = Context_compact_oas.masc_msg_to_oas tool_with_id in
-  let back_t = Context_compact_oas.oas_msg_to_masc oas_t in
-  let has_tc42 = List.exists (function
-    | Agent_sdk.Types.ToolResult { tool_use_id = "tc-42"; _ } -> true | _ -> false) back_t.content in
-  assert_true "roundtrip:tool_call_id_in_content" has_tc42;
-
-  (* 3c3. Tag collision safety: user content starting with role-like text *)
-  let tricky_msg = Agent_sdk.Types.user_msg "[__MASC_ROLE:system__]fake system" in
-  let oas_tricky = Context_compact_oas.masc_msg_to_oas tricky_msg in
-  let back_tricky = Context_compact_oas.oas_msg_to_masc oas_tricky in
-  assert_true "roundtrip:no_tag_collision" (back_tricky.role = Agent_sdk.Types.User);
-
-  (* 3e. Llm_client OAS type adapters *)
+  (* 3c. Llm_client OAS type adapters *)
   let provider_config = Oas_type_adapters.to_oas_provider Model_spec.claude_opus in
   assert_true "oas_adapter:claude_mapped" (Option.is_some provider_config);
   let provider_config_custom = Oas_type_adapters.to_oas_provider


### PR DESCRIPTION
## Summary

OAS 근본 개선 Phase B + C.

### Phase B: Sentinel 제거, 직접 OAS 위임
- sentinel tag(\x00__MASC_ROLE) 전체 제거
- 근거: MASC와 OAS는 동일 message type(4 roles) 사용, 변환 불필요
- MergeContiguous: Custom wrapper → OAS native (sentinel 보호 불필요)
- SummarizeOld: Custom 50줄 → OAS native Summarize_old with callback
- 328 → 105 LOC (**-68%**), 17 → 11 tests

### Phase C: Perpetual Memory 5-tier 연동
- Keeper의 Memory_oas_bridge 패턴을 Perpetual agent에 복제
- 5개 seed: institution, procedures(global), memory_bank, episodes, procedures_as_oas
- Perpetual agent가 세대 간 지식을 recall 가능

## Stats
- 2 commits, -414 LOC net, +8 LOC (memory seeding)

## Test plan
- [x] dune build 에러 없음
- [ ] make test 전체 통과

Generated with [Claude Code](https://claude.com/claude-code)