### PR TITLE
feat(dashboard): keeper config viewer API + read-only config panel

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,6 +11,7 @@ import {
 } from './board'
 import { get, post, withRetries, ROOM_TRUTH_GET_TIMEOUT_MS } from './core'
 import type {
+  KeeperConfig,
   DashboardExecutionResponse,
   DashboardGovernanceResponse,
   DashboardMemoryResponse,
@@ -422,4 +423,10 @@ export function runCommandPlaneAction(
   body: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   return post(path, body)
+}
+
+// --- Keeper config (structured read-only view) ---
+
+export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
+  return get<KeeperConfig>(`/api/v1/keepers/${encodeURIComponent(name)}/config`)
 }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1,0 +1,205 @@
+// Keeper config panel — read-only structured config viewer.
+// Fetches /api/v1/keepers/:name/config and renders grouped sections.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { fetchKeeperConfig } from '../api/dashboard'
+import type { KeeperConfig } from '../types'
+import { formatTokens } from './keeper-detail-panels'
+
+// ── State ────────────────────────────────────────────────
+
+type ConfigState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; config: KeeperConfig }
+  | { status: 'error'; message: string }
+
+const configState = signal<ConfigState>({ status: 'idle' })
+const configKeeperName = signal<string>('')
+
+export async function loadKeeperConfig(name: string): Promise<void> {
+  if (configKeeperName.value === name && configState.value.status === 'loaded') return
+  configKeeperName.value = name
+  configState.value = { status: 'loading' }
+  try {
+    const config = await fetchKeeperConfig(name)
+    configState.value = { status: 'loaded', config }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to load config'
+    configState.value = { status: 'error', message }
+  }
+}
+
+export function resetKeeperConfig(): void {
+  configState.value = { status: 'idle' }
+  configKeeperName.value = ''
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function ConfigRow({ label, value }: { label: string; value: string }) {
+  return html`
+    <div class="keeper-signal-row">
+      <span>${label}</span>
+      <strong>${value}</strong>
+    </div>
+  `
+}
+
+function SectionHeader({ title }: { title: string }) {
+  return html`
+    <div style="font-size:12px; font-weight:700; color:#a78bfa; text-transform:uppercase; letter-spacing:1px; margin-top:16px; margin-bottom:8px; padding-bottom:4px; border-bottom:1px solid rgba(167,139,250,0.2);">
+      ${title}
+    </div>
+  `
+}
+
+function BoolBadge({ value }: { value: boolean }) {
+  const color = value ? '#4ade80' : '#6b7280'
+  const text = value ? 'on' : 'off'
+  return html`<span style="color:${color}; font-weight:600;">${text}</span>`
+}
+
+function ModelList({ models }: { models: string[] }) {
+  if (models.length === 0) return html`<span style="color:#666;">none</span>`
+  return html`
+    <div style="display:flex; flex-wrap:wrap; gap:4px;">
+      ${models.map(m => html`<span class="pill" style="font-size:11px;">${m}</span>`)}
+    </div>
+  `
+}
+
+function LongText({ text }: { text: string }) {
+  if (!text || text.trim() === '') return html`<span style="color:#666;">--</span>`
+  const truncated = text.length > 200 ? text.slice(0, 200) + '...' : text
+  return html`<div style="font-size:12px; color:#ccc; white-space:pre-wrap; max-height:120px; overflow-y:auto; background:rgba(255,255,255,0.02); padding:6px 8px; border-radius:4px; margin-top:4px;">${truncated}</div>`
+}
+
+// ── Main component ───────────────────────────────────────
+
+export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
+  const state = configState.value
+
+  // Trigger load on first render or name change
+  if (configKeeperName.value !== keeperName || state.status === 'idle') {
+    void loadKeeperConfig(keeperName)
+  }
+
+  if (state.status === 'loading') {
+    return html`<div class="keeper-signal-list"><div style="color:#888; font-size:13px; padding:12px 0;">Loading config...</div></div>`
+  }
+
+  if (state.status === 'error') {
+    return html`<div class="keeper-signal-list"><div style="color:#ef4444; font-size:13px; padding:12px 0;">${state.message}</div></div>`
+  }
+
+  if (state.status !== 'loaded') return null
+
+  const c = state.config
+
+  return html`
+    <div class="keeper-signal-list">
+
+      ${'' /* --- Execution --- */}
+      <${SectionHeader} title="Execution" />
+      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
+      <${ConfigRow} label="Policy mode" value=${c.execution.policy_mode || '--'} />
+      <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
+      <div class="keeper-signal-row">
+        <span>Verify</span>
+        <strong><${BoolBadge} value=${c.execution.verify} /></strong>
+      </div>
+      <div style="margin-top:6px;">
+        <div style="font-size:11px; color:#888; margin-bottom:4px;">Models</div>
+        <${ModelList} models=${c.execution.models} />
+      </div>
+      ${c.execution.allowed_models.length > 0 ? html`
+        <div style="margin-top:6px;">
+          <div style="font-size:11px; color:#888; margin-bottom:4px;">Allowed models</div>
+          <${ModelList} models=${c.execution.allowed_models} />
+        </div>
+      ` : null}
+
+      ${'' /* --- Compaction --- */}
+      <${SectionHeader} title="Compaction" />
+      <${ConfigRow} label="Profile" value=${c.compaction.profile || '--'} />
+      <${ConfigRow} label="Ratio gate" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="Message gate" value=${String(c.compaction.message_gate)} />
+      <${ConfigRow} label="Token gate" value=${formatTokens(c.compaction.token_gate)} />
+      <${ConfigRow} label="Cooldown" value=${c.compaction.cooldown_sec + 's'} />
+
+      ${'' /* --- Proactive --- */}
+      <${SectionHeader} title="Proactive" />
+      <div class="keeper-signal-row">
+        <span>Enabled</span>
+        <strong><${BoolBadge} value=${c.proactive.enabled} /></strong>
+      </div>
+      <${ConfigRow} label="Idle trigger" value=${c.proactive.idle_sec + 's'} />
+      <${ConfigRow} label="Cooldown" value=${c.proactive.cooldown_sec + 's'} />
+
+      ${'' /* --- Drift --- */}
+      <${SectionHeader} title="Drift" />
+      <div class="keeper-signal-row">
+        <span>Enabled</span>
+        <strong><${BoolBadge} value=${c.drift.enabled} /></strong>
+      </div>
+      <${ConfigRow} label="Min turn gap" value=${String(c.drift.min_turn_gap)} />
+      <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
+      ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
+
+      ${'' /* --- Initiative --- */}
+      <${SectionHeader} title="Initiative" />
+      <div class="keeper-signal-row">
+        <span>Enabled</span>
+        <strong><${BoolBadge} value=${c.initiative.enabled} /></strong>
+      </div>
+      <${ConfigRow} label="Scope" value=${c.initiative.scope || '--'} />
+      <${ConfigRow} label="Idle trigger" value=${c.initiative.idle_sec + 's'} />
+      <${ConfigRow} label="Cooldown" value=${c.initiative.cooldown_sec + 's'} />
+      <${ConfigRow} label="Context mode" value=${c.initiative.context_mode || '--'} />
+
+      ${'' /* --- Handoff --- */}
+      <${SectionHeader} title="Handoff" />
+      <div class="keeper-signal-row">
+        <span>Auto</span>
+        <strong><${BoolBadge} value=${c.handoff.auto} /></strong>
+      </div>
+      <${ConfigRow} label="Threshold" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="Cooldown" value=${c.handoff.cooldown_sec + 's'} />
+
+      ${'' /* --- Metrics snapshot --- */}
+      <${SectionHeader} title="Metrics" />
+      <${ConfigRow} label="Generation" value=${String(c.metrics.generation)} />
+      <${ConfigRow} label="Total turns" value=${String(c.metrics.total_turns)} />
+      <${ConfigRow} label="Total tokens" value=${formatTokens(c.metrics.total_tokens)} />
+      <${ConfigRow} label="Total cost" value=${'$' + c.metrics.total_cost_usd.toFixed(4)} />
+      <${ConfigRow} label="Compactions" value=${String(c.metrics.compaction_count)} />
+
+      ${'' /* --- Prompt / Goals --- */}
+      <${SectionHeader} title="Prompt" />
+      <div style="font-size:11px; color:#888; margin-bottom:2px;">Goal</div>
+      <${LongText} text=${c.prompt.goal} />
+      ${c.prompt.short_goal ? html`
+        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Short-term goal</div>
+        <${LongText} text=${c.prompt.short_goal} />
+      ` : null}
+      ${c.prompt.mid_goal ? html`
+        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Mid-term goal</div>
+        <${LongText} text=${c.prompt.mid_goal} />
+      ` : null}
+      ${c.prompt.long_goal ? html`
+        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Long-term goal</div>
+        <${LongText} text=${c.prompt.long_goal} />
+      ` : null}
+      ${c.prompt.soul_profile ? html`
+        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Soul profile</div>
+        <${LongText} text=${c.prompt.soul_profile} />
+      ` : null}
+      ${c.prompt.instructions ? html`
+        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Instructions</div>
+        <${LongText} text=${c.prompt.instructions} />
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -31,6 +31,7 @@ import {
   KeeperNeighborhood,
   RuntimeSignals,
 } from './keeper-detail-runtime'
+import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
 
 // ── Global overlay state ──────────────────────────────────
 
@@ -43,6 +44,7 @@ export function openKeeperDetail(k: Keeper) {
 
 export function closeKeeperDetail() {
   selectedKeeper.value = null
+  resetKeeperConfig()
 }
 
 // ── Main Detail Overlay ───────────────────────────────────
@@ -217,6 +219,10 @@ export function KeeperDetailOverlay() {
 
           <${Card} title="이웃 관계 및 도구 감사">
             <${KeeperNeighborhood} keeper=${keeper} />
+          <//>
+
+          <${Card} title="Config">
+            <${KeeperConfigPanel} keeperName=${keeper.name} />
           <//>
 
           <${Card} title="메모리 및 컨텍스트">

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -407,3 +407,81 @@ export interface Keeper {
   inventory?: string[]
   relationships?: Record<string, string>
 }
+
+// --- Keeper Config (structured read-only view) ---
+
+export interface KeeperConfigPrompt {
+  goal: string
+  short_goal: string
+  mid_goal: string
+  long_goal: string
+  soul_profile: string
+  will: string
+  needs: string
+  desires: string
+  instructions: string
+}
+
+export interface KeeperConfigExecution {
+  models: string[]
+  allowed_models: string[]
+  active_model: string
+  policy_mode: string
+  policy_shell_mode: string
+  verify: boolean
+}
+
+export interface KeeperConfigCompaction {
+  profile: string
+  ratio_gate: number
+  message_gate: number
+  token_gate: number
+  cooldown_sec: number
+}
+
+export interface KeeperConfigProactive {
+  enabled: boolean
+  idle_sec: number
+  cooldown_sec: number
+}
+
+export interface KeeperConfigDrift {
+  enabled: boolean
+  min_turn_gap: number
+  count_total: number
+  last_reason: string | null
+}
+
+export interface KeeperConfigInitiative {
+  enabled: boolean
+  scope: string
+  idle_sec: number
+  cooldown_sec: number
+  context_mode: string
+}
+
+export interface KeeperConfigHandoff {
+  auto: boolean
+  threshold: number
+  cooldown_sec: number
+}
+
+export interface KeeperConfigMetrics {
+  generation: number
+  total_turns: number
+  total_tokens: number
+  total_cost_usd: number
+  compaction_count: number
+}
+
+export interface KeeperConfig {
+  name: string
+  prompt: KeeperConfigPrompt
+  execution: KeeperConfigExecution
+  compaction: KeeperConfigCompaction
+  proactive: KeeperConfigProactive
+  drift: KeeperConfigDrift
+  initiative: KeeperConfigInitiative
+  handoff: KeeperConfigHandoff
+  metrics: KeeperConfigMetrics
+}

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -450,3 +450,102 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
     ("alert_count", `Int (List.length recent_alerts));
   ]
 
+(** Build a structured config JSON for a single keeper, grouped by category.
+    Returns (http_status, json). *)
+let keeper_config_json (config : Room.config) (name : string)
+    : [ `OK | `Not_found ] * Yojson.Safe.t =
+  match Keeper_types.read_meta config name with
+  | Error msg ->
+      (`Not_found, `Assoc [ ("error", `String msg) ])
+  | Ok None ->
+      (`Not_found,
+       `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
+  | Ok (Some (m : Keeper_types.keeper_meta)) ->
+      let active_model = Keeper_exec_status.active_model_of_meta m in
+      let prompt =
+        `Assoc [
+          ("goal", `String m.goal);
+          ("short_goal", `String m.short_goal);
+          ("mid_goal", `String m.mid_goal);
+          ("long_goal", `String m.long_goal);
+          ("soul_profile", `String m.soul_profile);
+          ("will", `String m.will);
+          ("needs", `String m.needs);
+          ("desires", `String m.desires);
+          ("instructions", `String m.instructions);
+        ]
+      in
+      let execution =
+        `Assoc [
+          ("models", `List (List.map (fun s -> `String s) m.models));
+          ("allowed_models", `List (List.map (fun s -> `String s) m.allowed_models));
+          ("active_model", `String active_model);
+          ("policy_mode", `String m.policy_mode);
+          ("policy_shell_mode", `String m.policy_shell_mode);
+          ("verify", `Bool m.verify);
+        ]
+      in
+      let compaction =
+        `Assoc [
+          ("profile", `String m.compaction_profile);
+          ("ratio_gate", `Float m.compaction_ratio_gate);
+          ("message_gate", `Int m.compaction_message_gate);
+          ("token_gate", `Int m.compaction_token_gate);
+          ("cooldown_sec", `Int m.continuity_compaction_cooldown_sec);
+        ]
+      in
+      let proactive =
+        `Assoc [
+          ("enabled", `Bool m.proactive_enabled);
+          ("idle_sec", `Int m.proactive_idle_sec);
+          ("cooldown_sec", `Int m.proactive_cooldown_sec);
+        ]
+      in
+      let drift =
+        `Assoc [
+          ("enabled", `Bool m.drift_enabled);
+          ("min_turn_gap", `Int m.drift_min_turn_gap);
+          ("count_total", `Int m.drift_count_total);
+          ("last_reason",
+           if String.trim m.last_drift_reason = "" then `Null
+           else `String m.last_drift_reason);
+        ]
+      in
+      let initiative =
+        `Assoc [
+          ("enabled", `Bool m.initiative_enabled);
+          ("scope", `String m.initiative_scope);
+          ("idle_sec", `Int m.initiative_idle_sec);
+          ("cooldown_sec", `Int m.initiative_cooldown_sec);
+          ("context_mode", `String m.initiative_context_mode);
+        ]
+      in
+      let handoff =
+        `Assoc [
+          ("auto", `Bool m.auto_handoff);
+          ("threshold", `Float m.handoff_threshold);
+          ("cooldown_sec", `Int m.handoff_cooldown_sec);
+        ]
+      in
+      let metrics =
+        `Assoc [
+          ("generation", `Int m.generation);
+          ("total_turns", `Int m.total_turns);
+          ("total_tokens", `Int m.total_tokens);
+          ("total_cost_usd", `Float m.total_cost_usd);
+          ("compaction_count", `Int m.compaction_count);
+        ]
+      in
+      (`OK,
+       `Assoc [
+         ("name", `String m.name);
+         ("prompt", prompt);
+         ("execution", execution);
+         ("compaction", compaction);
+         ("proactive", proactive);
+         ("drift", drift);
+         ("initiative", initiative);
+         ("handoff", handoff);
+         ("metrics", metrics);
+       ])
+

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -144,6 +144,41 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
 
+  (* Keeper config — structured read-only config view for a single keeper *)
+  |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let req_path = Http.Request.path req in
+         let prefix = "/api/v1/keepers/" in
+         let suffix = "/config" in
+         let plen = String.length prefix in
+         let slen = String.length suffix in
+         let tlen = String.length req_path in
+         if tlen > plen + slen
+            && String.sub req_path 0 plen = prefix
+            && String.sub req_path (tlen - slen) slen = suffix
+         then
+           let name =
+             String.trim
+               (String.sub req_path plen (tlen - plen - slen))
+           in
+           if String.length name = 0 then
+             Http.Response.json ~status:`Bad_request
+               {|{"error":"keeper name is required"}|} reqd
+           else
+             let config = state.Mcp_server.room_config in
+             let (st, json) =
+               Dashboard_http_keeper.keeper_config_json config name
+             in
+             let status : Httpun.Status.t =
+               match st with `OK -> `OK | `Not_found -> `Not_found
+             in
+             Http.Response.json ~status ~compress:true ~request:req
+               (Yojson.Safe.to_string json) reqd
+         else
+           Http.Response.json ~status:`Not_found
+             {|{"error":"not found"}|} reqd
+       ) request reqd)
+
   (* Agent activity — per-agent tool call stats from telemetry *)
   |> Http.Router.get "/api/v1/agent-activity" (fun request reqd ->
        with_public_read (fun state req reqd ->


### PR DESCRIPTION
## Summary
- `GET /api/v1/keepers/:name/config` — keeper_meta를 8개 카테고리로 구조화하여 반환
- Dashboard KeeperConfigPanel — 읽기 전용 설정 뷰어 (Prompt, Execution, Compaction, Proactive, Drift, Initiative, Handoff, Metrics)
- Keeper detail overlay에 Config 카드로 통합

## 배경
에이전트 시스템 프롬프트와 설정이 OCaml에 하드코딩되어 런타임에서 확인이 불가능했다. Phase 1으로 읽기 전용 뷰어를 추가하여 가시성을 확보한다.

## 변경 파일
- `lib/dashboard/dashboard_http_keeper.ml` — `keeper_config_json` 함수
- `lib/server/server_routes_http_routes_dashboard.ml` — 라우트 등록
- `dashboard/src/components/keeper-config-panel.ts` — 신규 컴포넌트
- `dashboard/src/api/dashboard.ts` — fetchKeeperConfig
- `dashboard/src/types/core.ts` — KeeperConfig 인터페이스
- `dashboard/src/components/keeper-detail.ts` — Config 카드 통합

## Test plan
- [x] `dune build --root .` 클린 빌드
- [x] `npx tsc --noEmit` TypeScript 에러 없음
- [ ] `curl localhost:8935/api/v1/keepers/sangsu/config` 수동 테스트
- [ ] Dashboard keeper detail에서 Config 카드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)