### PR TITLE
feat(dashboard): keeper config editor — runtime agent behavior tuning

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -214,6 +214,31 @@ export async function post<T>(
   return res.json() as Promise<T>
 }
 
+export async function patch<T>(
+  path: string,
+  body: unknown,
+  extraHeaders?: Record<string, string>,
+  timeoutMs = DEFAULT_POST_TIMEOUT_MS,
+): Promise<T> {
+  const res = await fetchWithTimeout(path, {
+    method: 'POST',
+    headers: {
+      ...jsonHeaders(),
+      ...(extraHeaders ?? {}),
+    },
+    body: JSON.stringify(body),
+  }, timeoutMs)
+  if (!res.ok) {
+    throw new ApiRequestError({
+      method: 'PATCH',
+      path,
+      status: res.status,
+      statusText: res.statusText,
+    })
+  }
+  return res.json() as Promise<T>
+}
+
 export async function postRaw(
   path: string,
   body: unknown,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -9,7 +9,7 @@ import {
   normalizeGovernanceJudgeSummary,
   normalizePendingConfirmation,
 } from './board'
-import { get, post, withRetries, ROOM_TRUTH_GET_TIMEOUT_MS } from './core'
+import { get, post, patch, withRetries, ROOM_TRUTH_GET_TIMEOUT_MS } from './core'
 import type {
   KeeperConfig,
   DashboardExecutionResponse,
@@ -429,4 +429,28 @@ export function runCommandPlaneAction(
 
 export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
   return get<KeeperConfig>(`/api/v1/keepers/${encodeURIComponent(name)}/config`)
+}
+
+export type KeeperConfigUpdatePayload = {
+  new_goal?: string
+  new_short_goal?: string
+  new_mid_goal?: string
+  new_long_goal?: string
+  new_soul_profile?: string
+  new_will?: string
+  new_needs?: string
+  new_desires?: string
+  new_instructions?: string
+  new_drift_enabled?: boolean
+  new_drift_min_turn_gap?: number
+}
+
+export function patchKeeperConfig(
+  name: string,
+  payload: KeeperConfigUpdatePayload,
+): Promise<KeeperConfig> {
+  return patch<KeeperConfig>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/config`,
+    payload,
+  )
 }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1,9 +1,12 @@
-// Keeper config panel — read-only structured config viewer.
+// Keeper config panel — structured config viewer with inline editing.
 // Fetches /api/v1/keepers/:name/config and renders grouped sections.
+// Edit mode enables PATCH for prompt-related fields (goal, soul, will, needs,
+// desires, instructions, drift).
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { fetchKeeperConfig } from '../api/dashboard'
+import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
+import type { KeeperConfigUpdatePayload } from '../api/dashboard'
 import type { KeeperConfig } from '../types'
 import { formatTokens } from './keeper-detail-panels'
 
@@ -17,6 +20,58 @@ type ConfigState =
 
 const configState = signal<ConfigState>({ status: 'idle' })
 const configKeeperName = signal<string>('')
+const editMode = signal(false)
+const saving = signal(false)
+const saveError = signal<string | null>(null)
+
+// Draft values for editable fields (only used in edit mode)
+type EditDraft = {
+  goal: string
+  short_goal: string
+  mid_goal: string
+  long_goal: string
+  soul_profile: string
+  will: string
+  needs: string
+  desires: string
+  instructions: string
+  drift_enabled: boolean
+  drift_min_turn_gap: number
+}
+
+const editDraft = signal<EditDraft | null>(null)
+
+function initDraftFromConfig(c: KeeperConfig): EditDraft {
+  return {
+    goal: c.prompt.goal,
+    short_goal: c.prompt.short_goal,
+    mid_goal: c.prompt.mid_goal,
+    long_goal: c.prompt.long_goal,
+    soul_profile: c.prompt.soul_profile,
+    will: c.prompt.will,
+    needs: c.prompt.needs,
+    desires: c.prompt.desires,
+    instructions: c.prompt.instructions,
+    drift_enabled: c.drift.enabled,
+    drift_min_turn_gap: c.drift.min_turn_gap,
+  }
+}
+
+function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdatePayload {
+  const payload: KeeperConfigUpdatePayload = {}
+  if (draft.goal !== orig.prompt.goal) payload.new_goal = draft.goal
+  if (draft.short_goal !== orig.prompt.short_goal) payload.new_short_goal = draft.short_goal
+  if (draft.mid_goal !== orig.prompt.mid_goal) payload.new_mid_goal = draft.mid_goal
+  if (draft.long_goal !== orig.prompt.long_goal) payload.new_long_goal = draft.long_goal
+  if (draft.soul_profile !== orig.prompt.soul_profile) payload.new_soul_profile = draft.soul_profile
+  if (draft.will !== orig.prompt.will) payload.new_will = draft.will
+  if (draft.needs !== orig.prompt.needs) payload.new_needs = draft.needs
+  if (draft.desires !== orig.prompt.desires) payload.new_desires = draft.desires
+  if (draft.instructions !== orig.prompt.instructions) payload.new_instructions = draft.instructions
+  if (draft.drift_enabled !== orig.drift.enabled) payload.new_drift_enabled = draft.drift_enabled
+  if (draft.drift_min_turn_gap !== orig.drift.min_turn_gap) payload.new_drift_min_turn_gap = draft.drift_min_turn_gap
+  return payload
+}
 
 export async function loadKeeperConfig(name: string): Promise<void> {
   if (configKeeperName.value === name && configState.value.status === 'loaded') return
@@ -34,6 +89,9 @@ export async function loadKeeperConfig(name: string): Promise<void> {
 export function resetKeeperConfig(): void {
   configState.value = { status: 'idle' }
   configKeeperName.value = ''
+  editMode.value = false
+  editDraft.value = null
+  saveError.value = null
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -76,6 +134,92 @@ function LongText({ text }: { text: string }) {
   return html`<div style="font-size:12px; color:#ccc; white-space:pre-wrap; max-height:120px; overflow-y:auto; background:rgba(255,255,255,0.02); padding:6px 8px; border-radius:4px; margin-top:4px;">${truncated}</div>`
 }
 
+const SOUL_PROFILES = ['balanced', 'safety', 'delivery', 'research', 'relationship', 'minimal'] as const
+
+const fieldStyle = 'width:100%; background:#1a1a2e; color:#ccc; border:1px solid #333; border-radius:4px; padding:6px 8px; font-size:12px; font-family:inherit; resize:vertical;'
+const btnBase = 'border:none; border-radius:4px; padding:4px 12px; font-size:12px; cursor:pointer; font-weight:600;'
+
+// ── Edit field components ────────────────────────────────
+
+function updateDraft(field: keyof EditDraft, value: string | boolean | number) {
+  const d = editDraft.value
+  if (!d) return
+  editDraft.value = { ...d, [field]: value }
+}
+
+function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; label: string; rows?: number }) {
+  const d = editDraft.value
+  if (!d) return null
+  const val = d[field] as string
+  return html`
+    <div style="margin-top:8px;">
+      <div style="font-size:11px; color:#888; margin-bottom:2px;">${label}</div>
+      <textarea
+        style=${fieldStyle}
+        rows=${rows}
+        value=${val}
+        onInput=${(e: Event) => updateDraft(field, (e.target as HTMLTextAreaElement).value)}
+      />
+    </div>
+  `
+}
+
+function EditSelect({ field, label, options }: { field: keyof EditDraft; label: string; options: readonly string[] }) {
+  const d = editDraft.value
+  if (!d) return null
+  const val = d[field] as string
+  return html`
+    <div style="margin-top:8px;">
+      <div style="font-size:11px; color:#888; margin-bottom:2px;">${label}</div>
+      <select
+        style=${fieldStyle}
+        value=${val}
+        onChange=${(e: Event) => updateDraft(field, (e.target as HTMLSelectElement).value)}
+      >
+        ${options.map(o => html`<option value=${o}>${o}</option>`)}
+      </select>
+    </div>
+  `
+}
+
+function EditCheckbox({ field, label }: { field: keyof EditDraft; label: string }) {
+  const d = editDraft.value
+  if (!d) return null
+  const val = d[field] as boolean
+  return html`
+    <div class="keeper-signal-row" style="margin-top:4px;">
+      <span>${label}</span>
+      <input
+        type="checkbox"
+        checked=${val}
+        onChange=${(e: Event) => updateDraft(field, (e.target as HTMLInputElement).checked)}
+      />
+    </div>
+  `
+}
+
+function EditNumber({ field, label, min, max }: { field: keyof EditDraft; label: string; min: number; max: number }) {
+  const d = editDraft.value
+  if (!d) return null
+  const val = d[field] as number
+  return html`
+    <div class="keeper-signal-row" style="margin-top:4px;">
+      <span>${label}</span>
+      <input
+        type="number"
+        style="width:60px; background:#1a1a2e; color:#ccc; border:1px solid #333; border-radius:4px; padding:4px 6px; font-size:12px;"
+        value=${val}
+        min=${min}
+        max=${max}
+        onInput=${(e: Event) => {
+          const n = parseInt((e.target as HTMLInputElement).value, 10)
+          if (!Number.isNaN(n)) updateDraft(field, Math.max(min, Math.min(max, n)))
+        }}
+      />
+    </div>
+  `
+}
+
 // ── Main component ───────────────────────────────────────
 
 export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
@@ -97,11 +241,129 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   if (state.status !== 'loaded') return null
 
   const c = state.config
+  const isEditing = editMode.value
+  const isSaving = saving.value
+
+  function enterEditMode() {
+    editDraft.value = initDraftFromConfig(c)
+    saveError.value = null
+    editMode.value = true
+  }
+
+  function cancelEdit() {
+    editMode.value = false
+    editDraft.value = null
+    saveError.value = null
+  }
+
+  async function saveConfig() {
+    const draft = editDraft.value
+    if (!draft) return
+    const payload = buildPayload(draft, c)
+    if (Object.keys(payload).length === 0) {
+      cancelEdit()
+      return
+    }
+    saving.value = true
+    saveError.value = null
+    try {
+      const updated = await patchKeeperConfig(keeperName, payload)
+      configState.value = { status: 'loaded', config: updated }
+      editMode.value = false
+      editDraft.value = null
+    } catch (err) {
+      saveError.value = err instanceof Error ? err.message : 'Save failed'
+    } finally {
+      saving.value = false
+    }
+  }
+
+  // --- Toolbar ---
+  const toolbar = html`
+    <div style="display:flex; gap:6px; align-items:center; margin-bottom:8px;">
+      ${isEditing ? html`
+        <button
+          style="${btnBase} background:#4ade80; color:#000;"
+          onClick=${saveConfig}
+          disabled=${isSaving}
+        >${isSaving ? 'Saving...' : 'Save'}</button>
+        <button
+          style="${btnBase} background:#444; color:#ccc;"
+          onClick=${cancelEdit}
+          disabled=${isSaving}
+        >Cancel</button>
+      ` : html`
+        <button
+          style="${btnBase} background:#a78bfa; color:#000;"
+          onClick=${enterEditMode}
+        >Edit</button>
+      `}
+      ${saveError.value ? html`<span style="color:#ef4444; font-size:12px;">${saveError.value}</span>` : null}
+    </div>
+  `
+
+  // --- Prompt section (editable) ---
+  const promptSection = isEditing ? html`
+    <${SectionHeader} title="Prompt (editing)" />
+    <${EditTextarea} field="goal" label="Goal" rows=${3} />
+    <${EditTextarea} field="short_goal" label="Short-term goal" rows=${2} />
+    <${EditTextarea} field="mid_goal" label="Mid-term goal" rows=${2} />
+    <${EditTextarea} field="long_goal" label="Long-term goal" rows=${2} />
+    <${EditSelect} field="soul_profile" label="Soul profile" options=${SOUL_PROFILES} />
+    <${EditTextarea} field="will" label="Will" rows=${2} />
+    <${EditTextarea} field="needs" label="Needs" rows=${2} />
+    <${EditTextarea} field="desires" label="Desires" rows=${2} />
+    <${EditTextarea} field="instructions" label="Instructions" rows=${4} />
+  ` : html`
+    <${SectionHeader} title="Prompt" />
+    <div style="font-size:11px; color:#888; margin-bottom:2px;">Goal</div>
+    <${LongText} text=${c.prompt.goal} />
+    ${c.prompt.short_goal ? html`
+      <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Short-term goal</div>
+      <${LongText} text=${c.prompt.short_goal} />
+    ` : null}
+    ${c.prompt.mid_goal ? html`
+      <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Mid-term goal</div>
+      <${LongText} text=${c.prompt.mid_goal} />
+    ` : null}
+    ${c.prompt.long_goal ? html`
+      <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Long-term goal</div>
+      <${LongText} text=${c.prompt.long_goal} />
+    ` : null}
+    ${c.prompt.soul_profile ? html`
+      <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Soul profile</div>
+      <${LongText} text=${c.prompt.soul_profile} />
+    ` : null}
+    ${c.prompt.instructions ? html`
+      <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Instructions</div>
+      <${LongText} text=${c.prompt.instructions} />
+    ` : null}
+  `
+
+  // --- Drift section (editable) ---
+  const driftSection = isEditing ? html`
+    <${SectionHeader} title="Drift (editing)" />
+    <${EditCheckbox} field="drift_enabled" label="Enabled" />
+    <${EditNumber} field="drift_min_turn_gap" label="Min turn gap" min=${1} max=${50} />
+    <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
+    ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
+  ` : html`
+    <${SectionHeader} title="Drift" />
+    <div class="keeper-signal-row">
+      <span>Enabled</span>
+      <strong><${BoolBadge} value=${c.drift.enabled} /></strong>
+    </div>
+    <${ConfigRow} label="Min turn gap" value=${String(c.drift.min_turn_gap)} />
+    <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
+    ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
+  `
 
   return html`
     <div class="keeper-signal-list">
 
-      ${'' /* --- Execution --- */}
+      ${toolbar}
+
+      ${'' /* --- Execution (read-only) --- */}
       <${SectionHeader} title="Execution" />
       <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="Policy mode" value=${c.execution.policy_mode || '--'} />
@@ -121,7 +383,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         </div>
       ` : null}
 
-      ${'' /* --- Compaction --- */}
+      ${'' /* --- Compaction (read-only) --- */}
       <${SectionHeader} title="Compaction" />
       <${ConfigRow} label="Profile" value=${c.compaction.profile || '--'} />
       <${ConfigRow} label="Ratio gate" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
@@ -129,7 +391,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Token gate" value=${formatTokens(c.compaction.token_gate)} />
       <${ConfigRow} label="Cooldown" value=${c.compaction.cooldown_sec + 's'} />
 
-      ${'' /* --- Proactive --- */}
+      ${'' /* --- Proactive (read-only) --- */}
       <${SectionHeader} title="Proactive" />
       <div class="keeper-signal-row">
         <span>Enabled</span>
@@ -138,17 +400,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Idle trigger" value=${c.proactive.idle_sec + 's'} />
       <${ConfigRow} label="Cooldown" value=${c.proactive.cooldown_sec + 's'} />
 
-      ${'' /* --- Drift --- */}
-      <${SectionHeader} title="Drift" />
-      <div class="keeper-signal-row">
-        <span>Enabled</span>
-        <strong><${BoolBadge} value=${c.drift.enabled} /></strong>
-      </div>
-      <${ConfigRow} label="Min turn gap" value=${String(c.drift.min_turn_gap)} />
-      <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
-      ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
+      ${'' /* --- Drift (editable) --- */}
+      ${driftSection}
 
-      ${'' /* --- Initiative --- */}
+      ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="Initiative" />
       <div class="keeper-signal-row">
         <span>Enabled</span>
@@ -159,7 +414,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Cooldown" value=${c.initiative.cooldown_sec + 's'} />
       <${ConfigRow} label="Context mode" value=${c.initiative.context_mode || '--'} />
 
-      ${'' /* --- Handoff --- */}
+      ${'' /* --- Handoff (read-only) --- */}
       <${SectionHeader} title="Handoff" />
       <div class="keeper-signal-row">
         <span>Auto</span>
@@ -168,7 +423,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Threshold" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
       <${ConfigRow} label="Cooldown" value=${c.handoff.cooldown_sec + 's'} />
 
-      ${'' /* --- Metrics snapshot --- */}
+      ${'' /* --- Metrics (read-only) --- */}
       <${SectionHeader} title="Metrics" />
       <${ConfigRow} label="Generation" value=${String(c.metrics.generation)} />
       <${ConfigRow} label="Total turns" value=${String(c.metrics.total_turns)} />
@@ -176,30 +431,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Total cost" value=${'$' + c.metrics.total_cost_usd.toFixed(4)} />
       <${ConfigRow} label="Compactions" value=${String(c.metrics.compaction_count)} />
 
-      ${'' /* --- Prompt / Goals --- */}
-      <${SectionHeader} title="Prompt" />
-      <div style="font-size:11px; color:#888; margin-bottom:2px;">Goal</div>
-      <${LongText} text=${c.prompt.goal} />
-      ${c.prompt.short_goal ? html`
-        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Short-term goal</div>
-        <${LongText} text=${c.prompt.short_goal} />
-      ` : null}
-      ${c.prompt.mid_goal ? html`
-        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Mid-term goal</div>
-        <${LongText} text=${c.prompt.mid_goal} />
-      ` : null}
-      ${c.prompt.long_goal ? html`
-        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Long-term goal</div>
-        <${LongText} text=${c.prompt.long_goal} />
-      ` : null}
-      ${c.prompt.soul_profile ? html`
-        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Soul profile</div>
-        <${LongText} text=${c.prompt.soul_profile} />
-      ` : null}
-      ${c.prompt.instructions ? html`
-        <div style="font-size:11px; color:#888; margin-top:8px; margin-bottom:2px;">Instructions</div>
-        <${LongText} text=${c.prompt.instructions} />
-      ` : null}
+      ${'' /* --- Prompt (editable) --- */}
+      ${promptSection}
     </div>
   `
 }

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -395,6 +395,9 @@ module Router = struct
   let prefix_get prefix handler routes =
     add ~path:("PREFIX:" ^ prefix) ~methods:[`GET] ~handler routes
 
+  let prefix_post prefix handler routes =
+    add ~path:("PREFIX:" ^ prefix) ~methods:[`POST] ~handler routes
+
   let dispatch routes request reqd =
     let req_path = Request.path request in
     let req_method = Request.method_ request in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -179,6 +179,98 @@ let add_routes ~sw ~clock router =
              {|{"error":"not found"}|} reqd
        ) request reqd)
 
+  (* Keeper config update — POST (PATCH semantic) to update prompt/drift fields *)
+  |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
+       with_read_auth (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           let req_path = Http.Request.path req in
+           let prefix = "/api/v1/keepers/" in
+           let suffix = "/config" in
+           let plen = String.length prefix in
+           let slen = String.length suffix in
+           let tlen = String.length req_path in
+           if tlen > plen + slen
+              && String.sub req_path 0 plen = prefix
+              && String.sub req_path (tlen - slen) slen = suffix
+           then
+             let name =
+               String.trim
+                 (String.sub req_path plen (tlen - plen - slen))
+             in
+             if String.length name = 0 then
+               Http.Response.json ~status:`Bad_request
+                 {|{"error":"keeper name is required"}|} reqd
+             else
+               let config = state.Mcp_server.room_config in
+               match Keeper_types.read_meta config name with
+               | Error msg ->
+                   Http.Response.json ~status:`Not_found
+                     (Printf.sprintf {|{"error":"%s"}|}
+                        (String.escaped msg))
+                     reqd
+               | Ok None ->
+                   Http.Response.json ~status:`Not_found
+                     (Printf.sprintf {|{"error":"keeper %S not found"}|} name)
+                     reqd
+               | Ok (Some meta0) ->
+                   (try
+                      let args = Yojson.Safe.from_string body_str in
+                      let new_soul_profile_res =
+                        Keeper_config.parse_soul_profile_opt args "new_soul_profile"
+                      in
+                      match new_soul_profile_res with
+                      | Error e ->
+                          Http.Response.json ~status:`Bad_request
+                            (Printf.sprintf {|{"error":"%s"}|} (String.escaped e))
+                            reqd
+                      | Ok new_soul_profile ->
+                          let new_short_goal =
+                            Keeper_config.parse_goal_horizon_opt args "new_short_goal"
+                          in
+                          let new_mid_goal =
+                            Keeper_config.parse_goal_horizon_opt args "new_mid_goal"
+                          in
+                          let new_long_goal =
+                            Keeper_config.parse_goal_horizon_opt args "new_long_goal"
+                          in
+                          let new_will =
+                            Keeper_config.parse_self_model_opt args "new_will"
+                          in
+                          let new_needs =
+                            Keeper_config.parse_self_model_opt args "new_needs"
+                          in
+                          let new_desires =
+                            Keeper_config.parse_self_model_opt args "new_desires"
+                          in
+                          let new_drift_enabled_opt =
+                            Tool_args.get_bool_opt args "new_drift_enabled"
+                          in
+                          let new_drift_min_turn_gap_opt =
+                            Safe_ops.json_int_opt "new_drift_min_turn_gap" args
+                          in
+                          let _updated =
+                            Keeper_turn_setup.apply_settings_update
+                              ~args ~meta0 ~new_short_goal ~new_mid_goal
+                              ~new_long_goal ~new_soul_profile ~new_will
+                              ~new_needs ~new_desires ~new_drift_enabled_opt
+                              ~new_drift_min_turn_gap_opt ~config
+                          in
+                          let (_st, json) =
+                            Dashboard_http_keeper.keeper_config_json config name
+                          in
+                          Http.Response.json ~compress:true ~request:req
+                            (Yojson.Safe.to_string json) reqd
+                    with Yojson.Json_error e ->
+                      Http.Response.json ~status:`Bad_request
+                        (Printf.sprintf {|{"error":"invalid json: %s"}|}
+                           (String.escaped e))
+                        reqd)
+           else
+             Http.Response.json ~status:`Not_found
+               {|{"error":"not found"}|} reqd
+         )
+       ) request reqd)
+
   (* Agent activity — per-agent tool call stats from telemetry *)
   |> Http.Router.get "/api/v1/agent-activity" (fun request reqd ->
        with_public_read (fun state req reqd ->


### PR DESCRIPTION
## Summary
- `POST /api/v1/keepers/:name/config` — keeper 설정을 런타임에서 변경 (apply_settings_update 위임)
- Dashboard KeeperConfigPanel에 Edit/Save/Cancel 토글 추가
- 편집 가능 필드: goal, soul_profile (6종 dropdown), will/needs/desires, instructions, drift

## Phase 2 of Agent Observability
Phase 1(#1939)의 읽기 전용 뷰어를 편집 가능으로 확장.
에이전트 프롬프트와 행동 설정을 OCaml 재빌드 없이 대시보드에서 변경 가능.

## Test plan
- [x] `dune build --root .` 클린 빌드
- [ ] `curl -X POST localhost:8935/api/v1/keepers/sangsu/config -d '{"new_soul_profile":"safety"}'` 수동 테스트
- [ ] Dashboard에서 Edit → 변경 → Save → 값 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)