### PR TITLE
feat: OAS Phase D+E — Checkpoint bridge + Succession delegation

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -300,6 +300,16 @@ let deserialize_context (s : string) ~max_tokens : working_context =
   { system_prompt; messages; token_count; max_tokens; importance_scores = [];
     oas_context = Agent_sdk.Context.create () }
 
+let context_to_json (ctx : working_context) : Yojson.Safe.t =
+  `Assoc [
+    ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
+    ("messages", `List (List.map message_to_json ctx.messages));
+    ("token_count", `Int ctx.token_count);
+    ("max_tokens", `Int ctx.max_tokens);
+    ("importance_scores", `List (List.map (fun (i, s) ->
+      `Assoc [("index", `Int i); ("score", `Float s)]) ctx.importance_scores));
+  ]
+
 let create_checkpoint ctx ~generation =
   {
     checkpoint_id = generate_checkpoint_id ();
@@ -308,6 +318,35 @@ let create_checkpoint ctx ~generation =
     message_count = List.length ctx.messages;
     token_count = ctx.token_count;
     serialized = serialize_context ctx |> Inference_utils.sanitize_text_utf8;
+  }
+
+let to_oas_checkpoint ~(agent_name : string) ~(session_id : string)
+    (ctx : working_context) (ckpt : checkpoint) : Agent_sdk.Checkpoint.t =
+  { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
+    session_id;
+    agent_name;
+    model = ""; (* populated by caller if known *)
+    system_prompt = Some ctx.system_prompt;
+    messages = ctx.messages;
+    usage = { total_input_tokens = 0; total_output_tokens = 0;
+              total_cache_creation_input_tokens = 0;
+              total_cache_read_input_tokens = 0;
+              api_calls = 0; estimated_cost_usd = 0.0 };
+    turn_count = ckpt.message_count;
+    created_at = ckpt.timestamp;
+    tools = [];
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    temperature = None; top_p = None; top_k = None; min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
+    context = ctx.oas_context;
+    mcp_sessions = [];
+    working_context = Some (context_to_json ctx);
   }
 
 let restore_checkpoint ckpt ~max_tokens =

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -113,11 +113,20 @@ val deserialize_context : string -> max_tokens:int -> working_context
 
 (** {1 Checkpointing} *)
 
+(** Serialize working context to JSON (for OAS Checkpoint.working_context). *)
+val context_to_json : working_context -> Yojson.Safe.t
+
 (** Create a checkpoint from current working context. *)
 val create_checkpoint : working_context -> generation:int -> checkpoint
 
 (** Restore working context from a checkpoint. *)
 val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
+
+(** Convert MASC checkpoint + context to OAS Checkpoint.t format.
+    Enables interop with OAS checkpoint persistence and resumption. *)
+val to_oas_checkpoint :
+  agent_name:string -> session_id:string ->
+  working_context -> checkpoint -> Agent_sdk.Checkpoint.t
 
 (** {1 Session Persistence} *)
 

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -24,7 +24,8 @@ let text_of_message = Agent_sdk.Types.text_of_message
 (* Types                                                            *)
 (* ================================================================ *)
 
-type succession_metrics = {
+(** Type aliases — delegate to OAS Succession module. *)
+type succession_metrics = Agent_sdk.Succession.metrics = {
   total_turns : int;
   total_tokens_used : int;
   total_cost_usd : float;
@@ -33,7 +34,7 @@ type succession_metrics = {
   elapsed_seconds : float;
 }
 
-type succession_dna = {
+type succession_dna = Agent_sdk.Succession.dna = {
   generation : int;
   trace_id : string;
   goal : string;


### PR DESCRIPTION
## Summary

### Phase D: Checkpoint Bridge (+48 LOC)
- context_to_json: working_context → Yojson.Safe.t (importance_scores 포함)
- to_oas_checkpoint: MASC checkpoint → OAS Checkpoint.t 변환
- OAS Checkpoint.working_context 필드에 MASC 전체 상태 저장

### Phase E: Succession → OAS 위임 (-61 LOC)
- Step 1: succession_metrics, succession_dna 타입 → OAS 타입 앨리어스
- Step 2: 6개 함수 위임 (empty_metrics, merge_metrics, metrics_to/of_json, dna_to/of_json)
- MASC-specific 함수 유지 (build_progress_summary, extract_*, normalize_for_model)

### 효과
- MASC succession_oas.ml 694 → 633 LOC (-9%)
- 타입 + 직렬화가 OAS와 통합 — cross-agent checkpoint 호환성 확보

## Test plan
- [x] dune build (clean) 에러 없음
- [ ] make test

Generated with [Claude Code](https://claude.com/claude-code)