### PR TITLE
fix(ops): focus session interventions on live sessions

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -2,7 +2,7 @@
 
 import { signal } from '@preact/signals'
 import { showToast } from '../common/toast'
-import { prettyJson, displayStatus } from '../../lib/status-label'
+import { prettyJson, displayStatus, statusLabel } from '../../lib/status-label'
 import type {
   OperatorAttentionItem,
   OperatorGuidanceSummary,
@@ -116,6 +116,45 @@ export interface OpsPriorityCardData {
 
 export function normalizeStatus(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+export function isSessionTerminal(session: OperatorSessionSnapshot): boolean {
+  const status = normalizeStatus(session.status)
+  return status === 'done'
+    || status === 'completed'
+    || status === 'ended'
+    || status === 'cancelled'
+    || status === 'stopped'
+    || status === 'failed'
+    || status === 'error'
+    || status === 'interrupted'
+}
+
+export function pickPreferredSession(
+  sessions: OperatorSessionSnapshot[],
+): OperatorSessionSnapshot | null {
+  return sessions.find(session => !isSessionTerminal(session)) ?? sessions[0] ?? null
+}
+
+function resolveSelectedSessionId(
+  sessions: OperatorSessionSnapshot[],
+): string {
+  if (
+    selectedSessionId.value
+    && sessions.some(session => session.session_id === selectedSessionId.value)
+  ) {
+    return selectedSessionId.value
+  }
+  return pickPreferredSession(sessions)?.session_id ?? ''
+}
+
+export function sessionHealthLabel(session: OperatorSessionSnapshot): string {
+  const health = normalizeStatus(session.team_health?.status)
+  return health ? statusLabel(health) : '상태 확인 필요'
+}
+
+export function sessionOutcomeLabel(session: OperatorSessionSnapshot): string {
+  return `${session.done_delta_total ?? 0}건 완료`
 }
 
 export function sessionPriorityTone(session: OperatorSessionSnapshot): OpsPriorityTone {
@@ -423,7 +462,7 @@ export async function submitTaskInject() {
 
 export async function submitTeamTurn() {
   const snapshot = operatorSnapshot.value
-  const sessionId = selectedSessionId.value || snapshot?.sessions[0]?.session_id || ''
+  const sessionId = resolveSelectedSessionId(snapshot?.sessions ?? [])
   if (!sessionId) {
     showToast('먼저 세션을 고르세요', 'warning')
     return
@@ -491,7 +530,7 @@ export async function submitTeamTurn() {
 
 export async function submitTeamStop() {
   const snapshot = operatorSnapshot.value
-  const sessionId = selectedSessionId.value || snapshot?.sessions[0]?.session_id || ''
+  const sessionId = resolveSelectedSessionId(snapshot?.sessions ?? [])
   if (!sessionId) {
     showToast('먼저 세션을 고르세요', 'warning')
     return

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -160,7 +160,7 @@ export function Ops() {
         <div>
           <div class="card-title-row">
             <div class="card-title">개입</div>
-            <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
+            <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} label="설명" />
           </div>
           <h2 class="ops-heading">방, 세션, 키퍼를 바로 조정하는 화면</h2>
           <p class="ops-subheading">
@@ -267,7 +267,7 @@ export function Ops() {
       <section class="card">
         <div class="monitor-section-head">
           <h2 class="monitor-headline">개입 우선순위</h2>
-          <${PanelSemanticDetails} panelId="intervene.priority_cards" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.priority_cards" compact=${true} label="설명" />
           <p class="monitor-subheadline">지금 가장 먼저 손댈 대상이 방인지, 세션인지, 키퍼인지 먼저 좁힙니다.</p>
         </div>
         <div class="ops-priority-grid">

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -48,7 +48,7 @@ export function OpsKeeperColumn() {
       <section class="card ops-panel ops-lane-panel ops-keeper-section">
         <div class="card-title-row">
           <div class="card-title">Keeper 개입</div>
-          <${PanelSemanticDetails} panelId="intervene.keeper_queue" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.keeper_queue" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">장기 실행 중인 keeper를 고르고 바로 probe나 방향 수정 메시지를 보냅니다.</p>
 
@@ -108,7 +108,7 @@ export function OpsKeeperColumn() {
       <section class="card ops-panel ops-lane-panel">
         <div class="card-title-row">
           <div class="card-title">선택한 Keeper 액션</div>
-          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">선택한 keeper에만 직접 메시지를 보내서 probe, 수정, 재지시를 합니다.</p>
 
@@ -134,7 +134,7 @@ export function OpsKeeperColumn() {
       <section class="card ops-panel">
         <div class="card-title-row">
           <div class="card-title">가능한 액션 목록</div>
-          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">백엔드가 현재 허용한다고 광고하는 액션입니다. 일부는 이 화면의 폼과 1:1로 연결됩니다.</p>
         <div class="ops-log-list">
@@ -156,7 +156,7 @@ export function OpsKeeperColumn() {
       <section class="card ops-panel">
         <div class="card-title-row">
           <div class="card-title">최근 개입 로그</div>
-          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} label="설명" />
         </div>
         <div class="ops-log-list">
           ${operatorActionLog.value.length === 0 ? html`

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -59,7 +59,7 @@ export function OpsRoomColumn() {
       <section class="card ops-panel ops-lane-panel">
         <div class="card-title-row">
           <div class="card-title">Room 개입</div>
-          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">전체 room에 영향 주는 액션입니다. 방송, 정지/재개, 작업 주입을 여기서 처리합니다.</p>
 
@@ -160,7 +160,7 @@ export function OpsRoomColumn() {
       <section class="card ops-panel">
         <div class="card-title-row">
           <div class="card-title">추천 개입</div>
-          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">백엔드 digest가 지금 가장 작은 다음 행동을 추천합니다.</p>
         <article class="ops-guidance-card ${guidanceLayerTone(guidanceLayer)}">
@@ -207,7 +207,7 @@ export function OpsRoomColumn() {
       <section class="card ops-panel ops-pending-section">
         <div class="card-title-row">
           <div class="card-title">승인 대기</div>
-          <${PanelSemanticDetails} panelId="intervene.pending_confirmations" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.pending_confirmations" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">
           ${actorFilter
@@ -262,7 +262,7 @@ export function OpsRoomColumn() {
       <section class="card ops-panel">
         <div class="card-title-row">
           <div class="card-title">최근 Room 메시지</div>
-          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.recommended_actions" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
         ${roomFeed.length > 0 ? html`

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -22,11 +22,15 @@ import {
   guidanceFreshnessLabel,
   guidanceLayerLabel,
   guidanceLayerTone,
+  isSessionTerminal,
   deliveryModeLabel,
+  pickPreferredSession,
   prettyJson,
   runtimeJudgeLabel,
   selectedSessionId,
   sessionActionLabel,
+  sessionHealthLabel,
+  sessionOutcomeLabel,
   submitTeamStop,
   submitTeamTurn,
   targetTypeLabel,
@@ -47,12 +51,18 @@ export function OpsSessionColumn() {
   const snapshot = operatorSnapshot.value
   const sessionDigest = operatorSessionDigest.value
   const sessions = snapshot?.sessions ?? []
+  const liveSessions = sessions.filter(session => !isSessionTerminal(session))
+  const archivedSessions = sessions.filter(isSessionTerminal)
   const availableSessionActions = (snapshot?.available_actions ?? []).filter(action => action.target_type === 'team_session')
-  const selectedSession = sessions.find(session => session.session_id === selectedSessionId.value) ?? sessions[0] ?? null
+  const selectedSession =
+    sessions.find(session => session.session_id === selectedSessionId.value)
+    ?? pickPreferredSession(sessions)
+  const selectedSessionActionable = selectedSession ? !isSessionTerminal(selectedSession) : false
   const activeSummary = sessionDigest?.active_summary
   const guidanceLayer = sessionDigest?.active_guidance_layer ?? 'fallback'
   const residentRuntime = sessionDigest?.resident_judge_runtime ?? snapshot?.resident_judge_runtime
-  const linkedAutoresearch = selectedSession?.linked_autoresearch ?? null
+  const linkedAutoresearch =
+    selectedSessionActionable ? selectedSession?.linked_autoresearch ?? null : null
   const busy = operatorActionBusy.value || autoresearchBusy.value
   const activeRecommendedActions =
     sessionDigest?.active_recommended_actions?.length
@@ -107,40 +117,63 @@ export function OpsSessionColumn() {
     )
   }
 
+  const renderSessionCard = (
+    session: typeof sessions[number],
+    archived = false,
+  ) => html`
+    <button
+      key=${session.session_id}
+      class="ops-entity-card ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
+      onClick=${() => { selectedSessionId.value = session.session_id }}
+    >
+      <div class="ops-entity-title-row">
+        <strong>${session.session_id}</strong>
+        <span class="status-badge ${session.status ?? 'idle'}">${displayStatus(session.status)}</span>
+      </div>
+      <div class="ops-entity-meta">
+        <span>${Math.round(session.progress_pct ?? 0)}%</span>
+        <span>${sessionOutcomeLabel(session)}</span>
+        <span>${archived ? '종료 세션' : `팀 상태 ${sessionHealthLabel(session)}`}</span>
+      </div>
+    </button>
+  `
+
   return html`
     <div class="ops-column">
       <section class="card ops-panel ops-lane-panel">
         <div class="card-title-row">
           <div class="card-title">Session 개입</div>
-          <${PanelSemanticDetails} panelId="intervene.session_queue" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.session_queue" compact=${true} label="설명" />
         </div>
-        <p class="ops-context-note">어떤 세션이 뜨거운지 고르고, 그 세션에만 노트, 작업, 중지를 적용합니다.</p>
+        <p class="ops-context-note">지금 개입 가능한 세션만 위에 두고, 종료된 세션은 아래에 접어 둡니다.</p>
 
-        <div class="ops-entity-list">
-          ${sessions.length === 0 ? html`<div class="ops-empty">지금 활성 team session이 없습니다.</div>` : sessions.map(session => html`
-            <button
-              key=${session.session_id}
-              class="ops-entity-card ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
-              onClick=${() => { selectedSessionId.value = session.session_id }}
-            >
-              <div class="ops-entity-title-row">
-                <strong>${session.session_id}</strong>
-                <span class="status-badge ${session.status ?? 'idle'}">${displayStatus(session.status)}</span>
-              </div>
-              <div class="ops-entity-meta">
-                <span>${Math.round(session.progress_pct ?? 0)}%</span>
-                <span>${session.done_delta_total ?? 0}건 완료</span>
-                <span>${session.team_health?.status ? displayStatus(String(session.team_health.status)) : '상태 확인 필요'}</span>
-              </div>
-            </button>
-          `)}
+        <div class="ops-entity-section">
+          <div class="ops-entity-section-head">
+            <strong>개입 가능한 세션</strong>
+            <span>${liveSessions.length}</span>
+          </div>
+          <div class="ops-entity-list">
+            ${liveSessions.length === 0
+              ? html`<div class="ops-empty">지금 바로 개입할 live team session이 없습니다.</div>`
+              : liveSessions.map(session => renderSessionCard(session))}
+          </div>
         </div>
+
+        ${archivedSessions.length > 0 ? html`
+          <details class="ops-archive-panel">
+            <summary class="ops-archive-summary">최근 종료 세션 ${archivedSessions.length}</summary>
+            <p class="ops-context-note">완료/중단된 세션은 읽기 전용 참고용입니다. 새 노트, 작업, 중지는 위 live 세션에만 적용하세요.</p>
+            <div class="ops-entity-list">
+              ${archivedSessions.slice(0, 8).map(session => renderSessionCard(session, true))}
+            </div>
+          </details>
+        ` : null}
       </section>
 
       <section class="card ops-panel">
         <div class="card-title-row">
           <div class="card-title">선택한 Session 요약</div>
-          <${PanelSemanticDetails} panelId="intervene.session_digest" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.session_digest" compact=${true} label="설명" />
         </div>
         <p class="ops-context-note">snapshot이 아니라 digest 기준 attention과 worker 카드를 보여줍니다.</p>
         ${selectedSession && sessionDigest ? html`
@@ -202,9 +235,13 @@ export function OpsSessionColumn() {
       <section class="card ops-panel ops-lane-panel">
         <div class="card-title-row">
           <div class="card-title">선택한 Session 액션</div>
-          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
+          <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} label="설명" />
         </div>
-        <p class="ops-context-note">선택한 세션에만 메모, 작업, 체크포인트, 중지 요청을 보냅니다.</p>
+        <p class="ops-context-note">
+          ${selectedSessionActionable
+            ? '선택한 live 세션에만 메모, 작업, 체크포인트, 중지 요청을 보냅니다.'
+            : '종료된 세션은 여기서 읽기만 하고, 실제 개입은 위 live 세션을 다시 골라서 진행합니다.'}
+        </p>
         ${availableSessionActions.length > 0 ? html`
           <div class="ops-log-list">
             ${availableSessionActions.map(action => html`
@@ -226,6 +263,7 @@ export function OpsSessionColumn() {
               <span>상태: ${displayStatus(selectedSession.status)}</span>
               <span>경과: ${selectedSession.elapsed_sec ?? 0}초</span>
               <span>남은 시간: ${selectedSession.remaining_sec ?? 0}초</span>
+              <span>${selectedSessionActionable ? `팀 상태: ${sessionHealthLabel(selectedSession)}` : '종료 세션'}</span>
             </div>
             ${selectedSession.linked_autoresearch ? html`
               <div class="ops-detail-meta">
@@ -260,6 +298,10 @@ export function OpsSessionColumn() {
             ` : null}
           </div>
         ` : html`<div class="ops-empty">먼저 세션을 하나 고르세요.</div>`}
+
+        ${selectedSession && !selectedSessionActionable ? html`
+          <div class="ops-empty">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
+        ` : null}
 
         ${linkedAutoresearch?.loop_id ? html`
           <label class="control-label" for="ops-autoresearch-hypothesis">Autoresearch 제어</label>
@@ -299,14 +341,14 @@ export function OpsSessionColumn() {
             class="control-input ops-select"
             value=${teamTurnKind.value}
             onChange=${(event: Event) => { teamTurnKind.value = (event.target as HTMLSelectElement).value as typeof teamTurnKind.value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           >
             <option value="note">노트</option>
             <option value="broadcast">방송</option>
             <option value="task">작업</option>
             <option value="worker_spawn_batch">worker 교체</option>
           </select>
-          <button class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSession}>
+          <button class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
             적용
           </button>
         </div>
@@ -318,7 +360,7 @@ export function OpsSessionColumn() {
           placeholder="세션에 남길 메시지"
           value=${teamMessage.value}
           onInput=${(event: Event) => { teamMessage.value = (event.target as HTMLTextAreaElement).value }}
-          disabled=${busy || !selectedSession}
+          disabled=${busy || !selectedSessionActionable}
         ></textarea>
 
         ${teamTurnKind.value === 'task' ? html`
@@ -328,7 +370,7 @@ export function OpsSessionColumn() {
             placeholder="주입할 작업 제목"
             value=${teamTaskTitle.value}
             onInput=${(event: Event) => { teamTaskTitle.value = (event.target as HTMLInputElement).value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           />
           <textarea
             class="control-textarea"
@@ -336,13 +378,13 @@ export function OpsSessionColumn() {
             placeholder="주입할 작업 설명"
             value=${teamTaskDescription.value}
             onInput=${(event: Event) => { teamTaskDescription.value = (event.target as HTMLTextAreaElement).value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           ></textarea>
           <select
             class="control-input ops-select"
             value=${teamTaskPriority.value}
             onChange=${(event: Event) => { teamTaskPriority.value = (event.target as HTMLSelectElement).value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           >
             <option value="1">P1</option>
             <option value="2">P2</option>
@@ -357,7 +399,7 @@ export function OpsSessionColumn() {
             placeholder='spawn_batch JSON, 예: [{"spawn_agent":"llama","spawn_prompt":"...", "spawn_role":"replacement"}]'
             value=${teamSpawnBatchJson.value}
             onInput=${(event: Event) => { teamSpawnBatchJson.value = (event.target as HTMLTextAreaElement).value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           ></textarea>
         ` : null}
 
@@ -367,9 +409,9 @@ export function OpsSessionColumn() {
             type="text"
             value=${teamStopReason.value}
             onInput=${(event: Event) => { teamStopReason.value = (event.target as HTMLInputElement).value }}
-            disabled=${busy || !selectedSession}
+            disabled=${busy || !selectedSessionActionable}
           />
-          <button class="control-btn ghost" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSession}>
+          <button class="control-btn ghost" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
             세션 중지
           </button>
         </div>

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -298,6 +298,55 @@
   gap: 8px;
 }
 
+.ops-entity-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ops-entity-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.ops-entity-section-head strong {
+  color: var(--text-strong);
+}
+
+.ops-archive-panel {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ops-archive-summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  list-style: none;
+}
+
+.ops-archive-summary::-webkit-details-marker {
+  display: none;
+}
+
+.ops-archive-summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 6px;
+  transition: transform 120ms ease;
+}
+
+.ops-archive-panel[open] .ops-archive-summary::before {
+  transform: rotate(90deg);
+}
+
 .ops-guidance-card {
   padding: 12px;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- split the ops session queue into live sessions first and archived sessions behind a collapsed section
- stop showing live team-health labels like `critical` on completed sessions and make archived sessions read-only in the action panel
- align default session targeting with the preferred live session and rename compact semantic toggles from `의미 계층` to `설명` in the ops surface

## Verification
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vite build