### PR TITLE
feat(dashboard): keeper pipeline stage indicator

### DIFF
--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import { MitosisRing } from './mitosis-ring'
 import { StatusBadge } from './status-badge'
 import { TimeAgo } from './time-ago'
+import { PipelineStageBadge } from '../keeper-pipeline-stage'
+import type { PipelineStage } from '../../types'
 
 export type CanonicalKeeperCardModel = {
   name: string
@@ -13,6 +15,7 @@ export type CanonicalKeeperCardModel = {
   statusLabel: string
   stateClass?: string | null
   stateLabel?: string | null
+  pipelineStage?: PipelineStage | null
   contextRatio?: number | null
   note?: string | null
   focus: string
@@ -90,6 +93,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
             ? html`
                 <${MitosisRing} ratio=${model.contextRatio ?? 0} size=${34} stroke=${4} />
                 <${StatusBadge} status=${model.statusRaw ?? 'unknown'} />
+                ${model.pipelineStage ? html`<${PipelineStageBadge} stage=${model.pipelineStage} />` : null}
                 ${model.stateLabel ? html`<span class="monitor-pill ${toneClass}">${model.stateLabel}</span>` : null}
               `
             : html`<span class="command-chip ${toneClass}">${model.statusLabel}</span>`}

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -60,8 +60,9 @@ export function WorkerSupportRow({
 }
 
 export function ContinuityRow({ row }: { row: DashboardExecutionContinuityBrief }) {
+  const keeper = findKeeperOrFallback(row)
   const onClick = () => {
-    openKeeperDetail(findKeeperOrFallback(row))
+    openKeeperDetail(keeper)
   }
   const runtimeLabel = keeperRuntimeLabel(row.name, row.agent_name)
   const model: CanonicalKeeperCardModel = {
@@ -74,6 +75,7 @@ export function ContinuityRow({ row }: { row: DashboardExecutionContinuityBrief 
     statusLabel: statusLabel(row.status),
     stateClass: row.state,
     stateLabel: continuityStateLabel(row.state),
+    pipelineStage: keeper.pipeline_stage ?? null,
     contextRatio: row.context_ratio ?? null,
     note: row.note,
     focus: row.focus,

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -32,6 +32,7 @@ import {
   RuntimeSignals,
 } from './keeper-detail-runtime'
 import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
+import { PipelineStageBar } from './keeper-pipeline-stage'
 
 // ── Global overlay state ──────────────────────────────────
 
@@ -137,6 +138,9 @@ export function KeeperDetailOverlay() {
             style="background:none; border:none; color:#888; cursor:pointer; font-size:20px; padding:4px 8px;"
           >✕</button>
         </div>
+
+        ${'' /* Pipeline stage indicator */}
+        <${PipelineStageBar} stage=${keeper.pipeline_stage} />
 
         ${'' /* KPIs */}
         <${KpiGrid} keeper=${keeper} />

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -1,0 +1,86 @@
+// Keeper pipeline stage indicator — shows the current lifecycle stage
+// as a horizontal bar with stage dots and labels.
+// CSS classes: .pipeline-stage-bar, .pipeline-stage-node, etc. (pipeline-stage.css)
+
+import { html } from 'htm/preact'
+import type { PipelineStage } from '../types'
+
+const STAGES: { key: PipelineStage; label: string }[] = [
+  { key: 'idle', label: 'idle' },
+  { key: 'thinking', label: 'think' },
+  { key: 'tool_use', label: 'tool' },
+  { key: 'compacting', label: 'compact' },
+  { key: 'handoff', label: 'handoff' },
+  { key: 'proactive', label: 'proactive' },
+]
+
+const STAGE_ORDER: Record<string, number> = Object.fromEntries(
+  STAGES.map((s, i) => [s.key, i]),
+)
+
+/**
+ * Full horizontal pipeline stage indicator.
+ * Shows all stages as dots connected by lines. The current stage is highlighted.
+ */
+export function PipelineStageBar({ stage }: { stage?: PipelineStage | null }) {
+  const current = stage ?? 'offline'
+  const currentIdx = STAGE_ORDER[current] ?? -1
+
+  if (current === 'offline') {
+    return html`
+      <div class="pipeline-stage-bar">
+        <div class="pipeline-stage-node active stage-offline">
+          <span class="pipeline-stage-dot"></span>
+          <span class="pipeline-stage-label">offline</span>
+        </div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="pipeline-stage-bar">
+      ${STAGES.map((s, i) => {
+        const isActive = s.key === current
+        const isPassed = i < currentIdx
+        const nodeClass = [
+          'pipeline-stage-node',
+          isActive ? 'active' : '',
+          isPassed ? 'passed' : '',
+          isActive ? `stage-${s.key}` : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+
+        return html`
+          ${i > 0 ? html`<span class="pipeline-stage-connector"></span>` : null}
+          <div class=${nodeClass}>
+            <span class="pipeline-stage-dot"></span>
+            ${isActive
+              ? html`<span class="pipeline-stage-label">${s.label}</span>`
+              : null}
+          </div>
+        `
+      })}
+    </div>
+  `
+}
+
+/**
+ * Compact badge variant for roster cards.
+ * Shows only the current stage as a small pill.
+ */
+export function PipelineStageBadge({
+  stage,
+}: {
+  stage?: PipelineStage | null
+}) {
+  const current = stage ?? 'offline'
+  const label =
+    STAGES.find((s) => s.key === current)?.label ?? current
+
+  return html`
+    <span class="pipeline-stage-badge stage-${current}">
+      ${label}
+    </span>
+  `
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -32,6 +32,7 @@ import './styles/chat.css'
 import './styles/roster.css'
 import './styles/ff-theme.css'
 import './styles/oas-pipeline.css'
+import './styles/pipeline-stage.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/pipeline-stage.css
+++ b/dashboard/src/styles/pipeline-stage.css
@@ -1,0 +1,171 @@
+/* ── Pipeline Stage Indicator ─────────────────────────── */
+
+.pipeline-stage-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  padding: 6px 0;
+}
+
+.pipeline-stage-node {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.pipeline-stage-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(100, 100, 120, 0.35);
+  border: 1.5px solid rgba(100, 100, 120, 0.5);
+  transition: all 0.3s ease;
+  flex-shrink: 0;
+}
+
+.pipeline-stage-connector {
+  width: 16px;
+  height: 2px;
+  background: rgba(100, 100, 120, 0.25);
+  flex-shrink: 0;
+}
+
+.pipeline-stage-label {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.04em;
+  margin-left: 4px;
+  white-space: nowrap;
+  transition: color 0.3s ease;
+}
+
+/* Active stage states */
+.pipeline-stage-node.active .pipeline-stage-dot {
+  width: 12px;
+  height: 12px;
+  border-width: 2px;
+}
+
+.pipeline-stage-node.active .pipeline-stage-label {
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 600;
+}
+
+/* Stage-specific colors */
+.pipeline-stage-node.active.stage-idle .pipeline-stage-dot {
+  background: rgba(148, 163, 184, 0.6);
+  border-color: rgba(148, 163, 184, 0.8);
+}
+
+.pipeline-stage-node.active.stage-thinking .pipeline-stage-dot {
+  background: rgba(96, 165, 250, 0.7);
+  border-color: rgba(96, 165, 250, 0.9);
+  animation: pipeline-pulse 1.5s ease-in-out infinite;
+}
+
+.pipeline-stage-node.active.stage-tool_use .pipeline-stage-dot {
+  background: rgba(251, 146, 60, 0.7);
+  border-color: rgba(251, 146, 60, 0.9);
+}
+
+.pipeline-stage-node.active.stage-compacting .pipeline-stage-dot {
+  background: rgba(250, 204, 21, 0.7);
+  border-color: rgba(250, 204, 21, 0.9);
+}
+
+.pipeline-stage-node.active.stage-handoff .pipeline-stage-dot {
+  background: rgba(168, 85, 247, 0.7);
+  border-color: rgba(168, 85, 247, 0.9);
+}
+
+.pipeline-stage-node.active.stage-proactive .pipeline-stage-dot {
+  background: rgba(74, 222, 128, 0.7);
+  border-color: rgba(74, 222, 128, 0.9);
+}
+
+.pipeline-stage-node.active.stage-offline .pipeline-stage-dot {
+  background: rgba(75, 75, 85, 0.6);
+  border-color: rgba(75, 75, 85, 0.8);
+}
+
+/* Passed stages get a subtle highlight */
+.pipeline-stage-node.passed .pipeline-stage-dot {
+  background: rgba(100, 100, 120, 0.5);
+  border-color: rgba(100, 100, 120, 0.7);
+}
+
+.pipeline-stage-node.passed .pipeline-stage-connector {
+  background: rgba(100, 100, 120, 0.4);
+}
+
+@keyframes pipeline-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(96, 165, 250, 0);
+  }
+  50% {
+    box-shadow: 0 0 6px 2px rgba(96, 165, 250, 0.35);
+  }
+}
+
+/* ── Compact badge variant (for roster cards) ──────────── */
+
+.pipeline-stage-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+
+.pipeline-stage-badge.stage-idle {
+  color: rgba(148, 163, 184, 0.85);
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.pipeline-stage-badge.stage-thinking {
+  color: rgba(96, 165, 250, 0.95);
+  background: rgba(96, 165, 250, 0.14);
+  border-color: rgba(96, 165, 250, 0.25);
+  animation: pipeline-badge-pulse 1.5s ease-in-out infinite;
+}
+
+.pipeline-stage-badge.stage-tool_use {
+  color: rgba(251, 146, 60, 0.95);
+  background: rgba(251, 146, 60, 0.14);
+  border-color: rgba(251, 146, 60, 0.25);
+}
+
+.pipeline-stage-badge.stage-compacting {
+  color: rgba(250, 204, 21, 0.95);
+  background: rgba(250, 204, 21, 0.14);
+  border-color: rgba(250, 204, 21, 0.25);
+}
+
+.pipeline-stage-badge.stage-handoff {
+  color: rgba(168, 85, 247, 0.95);
+  background: rgba(168, 85, 247, 0.14);
+  border-color: rgba(168, 85, 247, 0.25);
+}
+
+.pipeline-stage-badge.stage-proactive {
+  color: rgba(74, 222, 128, 0.95);
+  background: rgba(74, 222, 128, 0.14);
+  border-color: rgba(74, 222, 128, 0.25);
+}
+
+.pipeline-stage-badge.stage-offline {
+  color: rgba(100, 100, 110, 0.85);
+  background: rgba(100, 100, 110, 0.12);
+  border-color: rgba(100, 100, 110, 0.2);
+}
+
+@keyframes pipeline-badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -295,8 +295,18 @@ export interface KeeperStatusDetail {
   loadedAt: string
 }
 
+export type PipelineStage =
+  | 'idle'
+  | 'thinking'
+  | 'tool_use'
+  | 'compacting'
+  | 'handoff'
+  | 'proactive'
+  | 'offline'
+
 export interface Keeper {
   name: string
+  pipeline_stage?: PipelineStage
   runtime_class?: 'resident_keeper' | 'persistent_agent'
   desired?: boolean
   resident_registered?: boolean

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -291,6 +291,12 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               in
 	            `Assoc ([
               ("name", `String m.name);
+              ("pipeline_stage", `String
+                (Keeper_exec_status.derive_pipeline_stage
+                   ~meta:m
+                   ~surface_status:(Keeper_exec_status.keeper_surface_status
+                                      ~agent_status:agent ~diagnostic)
+                   ~now_ts));
               ("runtime_class", `String "resident_keeper");
               ("desired", `Bool true);
               ("resident_registered", `Bool true);
@@ -536,9 +542,27 @@ let keeper_config_json (config : Room.config) (name : string)
           ("compaction_count", `Int m.compaction_count);
         ]
       in
+      let now_ts = Time_compat.now () in
+      let agent_status =
+        Keeper_exec_status.parse_agent_status config ~agent_name:m.agent_name
+      in
+      let pipeline_stage =
+        let diagnostic_for_stage =
+          Keeper_exec_status.keeper_diagnostic_json
+            ~meta:m ~agent_status
+            ~keepalive_running:(Keeper_keepalive.keeper_keepalive_running m.name)
+            ~history_items:[] ~now_ts
+        in
+        let surface =
+          Keeper_exec_status.keeper_surface_status
+            ~agent_status ~diagnostic:diagnostic_for_stage
+        in
+        Keeper_exec_status.derive_pipeline_stage ~meta:m ~surface_status:surface ~now_ts
+      in
       (`OK,
        `Assoc [
          ("name", `String m.name);
+         ("pipeline_stage", `String pipeline_stage);
          ("prompt", prompt);
          ("execution", execution);
          ("compaction", compaction);

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -875,3 +875,40 @@ let keeper_diagnostic_json
       ("keepalive_running", `Bool keepalive_running);
       ("next_eligible_at_s", keeper_next_eligible_at_s ~meta ~quiet_reason ~now_ts);
     ]
+
+(** Derive pipeline stage from keeper_meta timestamps.
+    Uses recency thresholds to infer what the keeper is doing.
+    Stages: "idle" | "thinking" | "tool_use" | "compacting" | "handoff"
+            | "proactive" | "offline"
+    The 30s recency window matches the typical keeper turn duration. *)
+let derive_pipeline_stage
+    ~(meta : keeper_meta)
+    ~(surface_status : string)
+    ~(now_ts : float)
+  : string =
+  if String.equal surface_status "offline" then "offline"
+  else
+    let recency_threshold = 30.0 in
+    let turn_ago =
+      if meta.last_turn_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.last_turn_ts
+    in
+    let compaction_ago =
+      if meta.last_compaction_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.last_compaction_ts
+    in
+    let handoff_ago =
+      if meta.last_handoff_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.last_handoff_ts
+    in
+    let proactive_ago =
+      if meta.last_proactive_ts <= 0.0 then Float.infinity
+      else now_ts -. meta.last_proactive_ts
+    in
+    (* Pick the most recent activity within the recency window.
+       Priority order when multiple are recent: handoff > compacting > proactive > thinking *)
+    if handoff_ago < recency_threshold then "handoff"
+    else if compaction_ago < recency_threshold then "compacting"
+    else if proactive_ago < recency_threshold then "proactive"
+    else if turn_ago < recency_threshold then "thinking"
+    else "idle"

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -33,3 +33,9 @@ val keeper_surface_status :
   agent_status:Yojson.Safe.t ->
   diagnostic:Yojson.Safe.t ->
   string
+
+val derive_pipeline_stage :
+  meta:keeper_meta ->
+  surface_status:string ->
+  now_ts:float ->
+  string


### PR DESCRIPTION
## Summary
- `derive_pipeline_stage` — 기존 타임스탬프(last_turn_ts, last_compaction_ts 등)에서 현재 stage 추론
- keeper list + config API에 `pipeline_stage` 필드 추가
- Dashboard: PipelineStageBar (detail) + PipelineStageBadge (카드)
- Stage별 색상 + thinking 상태 pulsing 애니메이션

## Phase 3 of Agent Observability
에이전트가 지금 어떤 단계에 있는지 한눈에 파악 가능.

## Test plan
- [x] `dune build --root .` 클린 빌드
- [x] TypeScript/Vite 빌드 통과
- [ ] Dashboard keeper 카드에 stage badge 표시 확인
- [ ] Keeper detail에서 pipeline bar 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)