### PR TITLE
fix: harden local verification after quick-suite cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ build-all: build dashboard
 
 # Run tests (alias for test-unit)
 test:
-	dune test --root .
+	scripts/ci-run-tests.sh "opam exec -- dune test --root ."
 
 # Unit tests only (no server required)
 test-unit:
-	dune test --root .
+	scripts/ci-run-tests.sh "opam exec -- dune test --root ."
 
 # Contract harness (self-bootstrapping, hermetic local server)
 test-contract:

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -12,7 +12,7 @@ import {
   operatorSnapshot,
 } from '../../operator-store'
 import { ProvenanceChip } from '../common/provenance-strip'
-import { relativeTime, toneClass } from './helpers'
+import { dashboardActorName, relativeTime, toneClass } from './helpers'
 import { SwarmWorkerGrid } from './swarm-cards'
 
 function swarmLaneTone(lane: CommandPlaneSwarmLane): string {
@@ -208,6 +208,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
   const resolution = swarm.run_resolution
   if (!runId || (!recommendation && !resolution)) return null
 
+  const actor = dashboardActorName() ?? 'dashboard'
   const pendingConfirm =
     operatorSnapshot.value?.pending_confirms.find(item =>
       item.target_type === 'swarm_run' && item.target_id === runId,

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -122,15 +122,17 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     Runs alongside existing keepalive bootstrap, scanning for
     zombie fibers and restarting them with exponential backoff.
     Called once from start_existing_keepalives after bootstrap. *)
-let supervisor_sweep : Pulse.t option ref = ref None
+let supervisor_sweeps : (string, Pulse.t) Hashtbl.t =
+  Hashtbl.create 4
 
-let supervisor_sweep_running () =
-  match !supervisor_sweep with
+let supervisor_sweep_running base_path =
+  match Hashtbl.find_opt supervisor_sweeps base_path with
   | Some pulse -> Pulse.is_alive pulse
   | None -> false
 
 let start_supervisor_sweep ctx =
-  if supervisor_sweep_running () then ()
+  let base_path = ctx.config.base_path in
+  if supervisor_sweep_running base_path then ()
   else begin
     let consumer : (module Pulse.Consumer) =
       (module struct
@@ -153,7 +155,7 @@ let start_supervisor_sweep ctx =
       ~lifecycle:Perpetual
       ~consumers:[consumer]
     in
-    supervisor_sweep := Some p;
+    Hashtbl.replace supervisor_sweeps base_path p;
     Pulse.run ~sw:ctx.sw p;
     Log.Keeper.info "resident supervisor sweep started (interval %.0fs)"
       Env_config.KeeperResidentSupervisor.sweep_interval_sec

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -11,6 +11,8 @@ TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp "${TMPDIR:-/tmp}/ci-run-tests.XXXXXX.log")}"
+CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
+CI_TEST_CLEAN_RETRY_DONE=0
 
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -87,7 +89,27 @@ heartbeat() {
   done
 }
 
+test_cmd_needs_dune_sanitization() {
+  [[ "${TEST_CMD}" == *"dune "* ]] && [[ "${TEST_CMD}" != *"env -u DUNE_RPC"* ]]
+}
+
+effective_test_cmd() {
+  if test_cmd_needs_dune_sanitization; then
+    printf 'env -u DUNE_RPC %s' "${TEST_CMD}"
+  else
+    printf '%s' "${TEST_CMD}"
+  fi
+}
+
+agent_sdk_interface_mismatch_detected() {
+  [[ -f "${TEST_LOG_FILE}" ]] || return 1
+  grep -Eq \
+    'Unbound module Agent_sdk|module Oas is an alias for module Agent_sdk|inconsistent assumptions over interface Agent_sdk' \
+    "${TEST_LOG_FILE}"
+}
+
 run_with_timeout() {
+  local cmd="${1}"
   local timeout_bin=""
   if command -v timeout >/dev/null 2>&1; then
     timeout_bin="timeout"
@@ -97,17 +119,17 @@ run_with_timeout() {
 
   if [[ -n "${timeout_bin}" ]]; then
     if "${timeout_bin}" --help 2>&1 | grep -q -- '--foreground'; then
-      "${timeout_bin}" --foreground "${TEST_TIMEOUT_SEC}" bash -lc "${TEST_CMD}" \
+      "${timeout_bin}" --foreground "${TEST_TIMEOUT_SEC}" bash -lc "${cmd}" \
         > >(tee -a "${TEST_LOG_FILE}") \
         2> >(tee -a "${TEST_LOG_FILE}" >&2)
     else
-      "${timeout_bin}" "${TEST_TIMEOUT_SEC}" bash -lc "${TEST_CMD}" \
+      "${timeout_bin}" "${TEST_TIMEOUT_SEC}" bash -lc "${cmd}" \
         > >(tee -a "${TEST_LOG_FILE}") \
         2> >(tee -a "${TEST_LOG_FILE}" >&2)
     fi
   else
     echo "[ci-run] WARN: timeout command not found (timeout/gtimeout); running without enforced timeout"
-    bash -lc "${TEST_CMD}" \
+    bash -lc "${cmd}" \
       > >(tee -a "${TEST_LOG_FILE}") \
       2> >(tee -a "${TEST_LOG_FILE}" >&2)
   fi
@@ -123,6 +145,9 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[ci-run] command: ${TEST_CMD}"
+if test_cmd_needs_dune_sanitization; then
+  echo "[ci-run] sanitized_command: $(effective_test_cmd)"
+fi
 echo "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
 echo "[ci-run] started_at=$(iso_now)"
 echo "[ci-run] log_file=${TEST_LOG_FILE}"
@@ -130,10 +155,29 @@ echo "[ci-run] log_file=${TEST_LOG_FILE}"
 heartbeat &
 hb_pid="$!"
 
+effective_cmd="$(effective_test_cmd)"
+
 set +e
-run_with_timeout
+run_with_timeout "${effective_cmd}"
 status=$?
 set -e
+
+if [[ "${status}" -ne 0 ]] \
+  && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
+  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
+  && test_cmd_needs_dune_sanitization \
+  && agent_sdk_interface_mismatch_detected; then
+  CI_TEST_CLEAN_RETRY_DONE=1
+  echo "[ci-run] WARN: detected Agent_sdk interface mismatch; running dune clean and retrying once"
+  dune clean --root . \
+    > >(tee -a "${TEST_LOG_FILE}") \
+    2> >(tee -a "${TEST_LOG_FILE}" >&2)
+  echo "[ci-run] retry_started_at=$(iso_now)"
+  set +e
+  run_with_timeout "${effective_cmd}"
+  status=$?
+  set -e
+fi
 
 if [[ "${status}" -eq 124 ]]; then
   diag_dump "timeout"


### PR DESCRIPTION
## Summary
- harden `scripts/ci-run-tests.sh` for local dune runs by sanitizing `DUNE_RPC` and retrying once after `dune clean --root .` when `Agent_sdk` interface mismatch signatures are detected
- route `make test` and `make test-unit` through the hardened wrapper so the default local verification path matches CI behavior more closely
- restore dashboard typecheck cleanliness for this branch by fixing the remaining `swarm-storyboard` actor reference and keep keeper supervisor sweep tracking scoped per room config path

## Verification
- `bash -n scripts/ci-run-tests.sh`
- simulated wrapper retry path with a fake `dune` executable (mismatch -> clean -> retry success)
- `env DUNE_RPC=unix:/tmp/not-running.sock CI_TEST_TIMEOUT_SEC=120 CI_TEST_HEARTBEAT_SEC=5 CI_TEST_LOG_FILE=/tmp/ci-run-tests-smoke3.log scripts/ci-run-tests.sh "opam exec -- dune build --root . test/test_tool_permissions.exe"`
- `./_build/default/test/test_tool_permissions.exe`
- `dune build --root . test/test_operator_control.exe`
- `./_build/default/test/test_operator_control.exe`
- `cd dashboard && npm ci`
- `cd dashboard && tsc --noEmit --pretty false`

## Notes
- Issue #1943 remains open for the underlying raw `dune test` incremental mismatch root cause; this PR improves the standard verification path and leaves the root-cause issue tracked separately.
