### PR TITLE
fix(dashboard): restore swarm resolution actor lookup

### DIFF
--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -208,7 +208,6 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
   const resolution = swarm.run_resolution
   if (!runId || (!recommendation && !resolution)) return null
 
-  const actor = dashboardActorName() ?? 'dashboard'
   const pendingConfirm =
     operatorSnapshot.value?.pending_confirms.find(item =>
       item.target_type === 'swarm_run' && item.target_id === runId,
@@ -221,6 +220,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
         || recommendation.rerun_available
         || recommendation.abandon_available),
     )
+  const actor = dashboardActorName() ?? 'dashboard'
 
   const confirmPending = async (decision: 'confirm' | 'deny') => {
     if (!pendingConfirm) return


### PR DESCRIPTION
## Summary
- restore the actor lookup in `swarm-storyboard` by resolving `dashboardActorName()` with a safe `dashboard` fallback before calling `confirmOperatorPendingAction`
- fix the post-merge TypeScript regression introduced while syncing the earlier ops PR branch with `main`

## Verification
- ./node_modules/.bin/tsc --noEmit