### PR TITLE
fix: align verification entrypoints and dashboard labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 
 # Build dashboard SPA (Vite)
 dashboard:
-	cd dashboard && npm install --prefer-offline --no-audit && npm run build
+	cd dashboard && npm ci && npm run build
 
 # Build everything (OCaml + dashboard)
 build-all: build dashboard
@@ -47,7 +47,7 @@ clean:
 coverage:
 	rm -rf _coverage
 	mkdir -p _coverage
-	BISECT_FILE=$(CURDIR)/_coverage/bisect dune test --root . --instrument-with bisect_ppx --force
+	CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 scripts/ci-run-tests.sh "BISECT_FILE=$(CURDIR)/_coverage/bisect opam exec -- dune test --root . --instrument-with bisect_ppx --force"
 
 # Print coverage summary to stdout
 coverage-summary: coverage

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "masc-dashboard",
   "private": true,
   "version": "1.0.0",
+  "packageManager": "npm@11.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -218,12 +218,6 @@ export function actionTypeLabel(value?: string | null): string {
       return '키퍼 메시지'
     case 'keeper_msg':
       return '키퍼 메시지'
-    case 'swarm_run_continue':
-      return '스웜 실행 계속'
-    case 'swarm_run_rerun':
-      return '스웜 실행 재실행'
-    case 'swarm_run_abandon':
-      return '스웜 실행 포기'
     default:
       return value?.trim() || '액션'
   }

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -387,12 +387,6 @@ export function workflowActionLabel(actionType?: string | null): string {
       return 'keeper probe'
     case 'keeper_recover':
       return 'keeper recover'
-    case 'swarm_run_continue':
-      return 'swarm run 계속'
-    case 'swarm_run_rerun':
-      return 'swarm run 재실행'
-    case 'swarm_run_abandon':
-      return 'swarm run 포기'
     default:
       return actionType?.trim() || '추천 액션'
   }

--- a/docs/PRODUCT-REVIEW.md
+++ b/docs/PRODUCT-REVIEW.md
@@ -7,7 +7,7 @@
 - 실사용 기준에서 **즉시 막히는 P0**는 3가지다.
 
 ## P0 차단 요소
-- hermetic required gate가 항상 초록이어야 한다. `dune test`, `test_sse_storm_e2e`, contract harness 중 하나라도 깨지면 internal ops 제품 기준으로는 불합격이다.
+- hermetic required gate가 항상 초록이어야 한다. `make test`, `test_sse_storm_e2e`, contract harness 중 하나라도 깨지면 internal ops 제품 기준으로는 불합격이다.
 - 인증/권한이 여전히 **opt-in strict mode** 중심이라서, 신뢰 네트워크 밖으로 나가는 순간 운영 기본값이 약하다.
 - swarm proof artifact와 live read model이 어긋나면 operator가 같은 run을 두 개의 진실로 보게 된다.
 

--- a/docs/VERIFICATION-MATRIX.md
+++ b/docs/VERIFICATION-MATRIX.md
@@ -10,6 +10,7 @@
 
 - `dune test --root .`
   - 기본 단위/통합 테스트 묶음
+  - 실행 진입점은 `make test` 또는 `scripts/ci-run-tests.sh "opam exec -- dune test"`를 기준으로 본다
 - `./_build/default/test/test_sse_storm_e2e.exe`
   - server executable 기반 SSE reconnect e2e
 - contract harness 4종
@@ -22,7 +23,7 @@
 
 ```bash
 dune build --root .
-dune test --root .
+make test
 make test-contract
 ./_build/default/test/test_sse_storm_e2e.exe
 ```
@@ -88,7 +89,7 @@ make test-contract
 
 즉, 이번 변경에서 CI 필수로 보려는 것은:
 
-- `dune test --root .`
+- `make test`
 - `test_sse_storm_e2e.exe`
 - contract harness 4종
 

--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -22,7 +22,9 @@ if ! $reuse_existing; then
   mkdir -p "$coverage_dir"
   (
     cd "$root_dir"
-    BISECT_FILE="$coverage_dir/bisect" opam exec -- dune test --root . --instrument-with bisect_ppx --force
+    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+      ./scripts/ci-run-tests.sh \
+      "BISECT_FILE='$coverage_dir/bisect' opam exec -- dune test --root . --instrument-with bisect_ppx --force"
   )
 fi
 

--- a/scripts/feedback-loop.sh
+++ b/scripts/feedback-loop.sh
@@ -36,7 +36,11 @@ for i in $(seq 1 $ITERATIONS); do
   
   # 2. Test
   echo "🧪 Testing..."
-  TEST_OUTPUT=$(opam exec -- dune test --root "$REPO_DIR" 2>&1 || true)
+  TEST_OUTPUT=$(
+    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+      "$REPO_DIR/scripts/ci-run-tests.sh" \
+      "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 || true
+  )
   TEST_PASSED=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
   TEST_FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
   

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -18,7 +18,11 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 
 # 1. Pre-check
 echo "1️⃣ Pre-check..."
-BEFORE_TESTS=$(opam exec -- dune test --root "$REPO_DIR" 2>&1 | grep -c "Test Successful" || echo "0")
+BEFORE_TESTS=$(
+  CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+    "$REPO_DIR/scripts/ci-run-tests.sh" \
+    "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 | grep -c "Test Successful" || echo "0"
+)
 echo "   Tests before: $BEFORE_TESTS passing"
 
 # 2. Build
@@ -31,7 +35,11 @@ echo "   ✅ Build OK"
 
 # 3. Test
 echo "3️⃣ Testing..."
-TEST_OUTPUT=$(opam exec -- dune test --root "$REPO_DIR" 2>&1 || true)
+TEST_OUTPUT=$(
+  CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+    "$REPO_DIR/scripts/ci-run-tests.sh" \
+    "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 || true
+)
 AFTER_TESTS=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
 FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -79,6 +79,9 @@ let () =
           Alcotest.test_case "swarm run continue removed from operator actions" `Quick
             Test_operator_control_swarm
             .test_swarm_run_continue_removed_from_operator_actions;
+          Alcotest.test_case "swarm run rerun removed from operator actions" `Quick
+            Test_operator_control_swarm
+            .test_swarm_run_rerun_removed_from_operator_actions;
           Alcotest.test_case "swarm run abandon removed from operator actions" `Quick
             Test_operator_control_swarm
             .test_swarm_run_abandon_removed_from_operator_actions;

--- a/test/test_operator_control_swarm.ml
+++ b/test/test_operator_control_swarm.ml
@@ -95,3 +95,29 @@ let test_swarm_run_abandon_removed_from_operator_actions () =
       | Error err ->
           Alcotest.(check string) "unsupported action"
             "unsupported action_type: swarm_run_abandon" err)
+
+let test_swarm_run_rerun_removed_from_operator_actions () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "dashboard"));
+      let ctx = operator_ctx env sw config "dashboard" in
+      match
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("action_type", `String "swarm_run_rerun");
+              ("target_type", `String "swarm_run");
+              ("target_id", `String "operator-swarm-rerun");
+              ("payload", `Assoc []);
+            ])
+      with
+      | Ok _ -> Alcotest.fail "swarm_run_rerun should be removed from operator actions"
+      | Error err ->
+          Alcotest.(check string) "unsupported action"
+            "unsupported action_type: swarm_run_rerun" err)


### PR DESCRIPTION
## Summary
- remove stale dashboard labels for deprecated `swarm_run_*` actions
- align local verification scripts and docs with the `ci-run-tests.sh` wrapper
- add operator regression coverage for removed `swarm_run_rerun`

## Verification
- git diff --check
- bash -n scripts/feedback-loop.sh
- bash -n scripts/improve.sh
- bash -n scripts/coverage_percent.sh
- dune build --root . test/test_operator_control.exe
- ./_build/default/test/test_operator_control.exe
- cd dashboard && npm ci
- cd dashboard && npm run build

## Notes
- follow-up after #1952 to land the remaining unmerged verification-path and dashboard-label cleanup on top of current `main`.
