### PR TITLE
fix(test): add missing agent_sdk deps + register 3 uncategorized tools

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -58,7 +58,7 @@
           test_code_swarm
           test_autonomy_liberation
   )
- (libraries masc_mcp alcotest str yojson mirage-crypto
+ (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))
 
 ; Runtime params + governance registry tests (requires Eio.Mutex)
@@ -315,7 +315,7 @@
 (test
  (name test_worker_container_coverage)
  (modules test_worker_container_coverage)
- (libraries masc_mcp alcotest yojson))
+ (libraries masc_mcp agent_sdk alcotest yojson))
 
 ; Resilience module tests (Time, Zombie, ZeroZombie pure functions)
 (test
@@ -411,7 +411,7 @@
 (test
  (name test_tool_keeper)
  (modules test_tool_keeper)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp agent_sdk alcotest unix))
 (test
  (name test_keeper_tools_oas)
  (modules test_keeper_tools_oas)
@@ -744,7 +744,7 @@
 (test
  (name test_perpetual)
  (modules test_perpetual)
- (libraries masc_mcp str yojson unix))
+ (libraries masc_mcp agent_sdk str yojson unix))
 
 ; TRPG tests moved to sublibrary (#1668)
 


### PR DESCRIPTION
## Summary
- 4 test stanzas directly reference `Agent_sdk.Types.*` but did not declare `agent_sdk` as an explicit dependency in `test/dune` — causes "inconsistent assumptions" on incremental builds
- 3 tools (`masc_governance_feed`, `masc_runtime_params`, `masc_set_param`) missing from `Mode.tool_category` — causes `test_tool_registration_consistency` linter failure

## Changes
1. Added `agent_sdk` to libraries of: `test_keeper_memory` (bulk block), `test_perpetual`, `test_tool_keeper`, `test_worker_container_coverage`
2. Registered 3 tools in `lib/mode.ml`: governance_feed → Consensus, runtime_params/set_param → Auth

## Test plan
- [x] `dune build` passes
- [x] `test_tool_registration_consistency` passes locally
- [ ] CI `dune test` green

Closes #1943
Ref #1936