### PR TITLE
feat: Dated_jsonl module + 4-store date-split migration

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -150,39 +150,39 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
 
 (** {1 File Operations} *)
 
-let mutex = Eio.Mutex.create ()
-
-let get_audit_path (config : Room.config) =
+(** Legacy single-file path (for fallback reads). *)
+let legacy_audit_path (config : Room.config) =
   let masc_dir = Room_utils.masc_dir config in
   Filename.concat masc_dir "audit.jsonl"
 
-(** Read all audit entries from the JSONL file *)
-let read_entries (config : Room.config) : audit_entry list =
-  let path = get_audit_path config in
-  if not (Sys.file_exists path) then []
+(** Date-split store: [.masc/audit/YYYY-MM/DD.jsonl]. *)
+let get_audit_store (config : Room.config) : Dated_jsonl.t =
+  let base = Filename.concat (Room_utils.masc_dir config) "audit" in
+  Dated_jsonl.create ~base_dir:base ()
+
+(** Read recent audit entries.
+    Tries date-split store first; falls back to legacy single file. *)
+let read_entries ?(n = 10_000) (config : Room.config) : audit_entry list =
+  let store = get_audit_store config in
+  let entries = Dated_jsonl.read_recent store n in
+  if entries <> [] then
+    List.filter_map entry_of_json entries
   else
-    let content = Fs_compat.load_file path in
-    String.split_on_char '\n' content
-    |> List.filter (fun line -> String.trim line <> "")
-    |> List.filter_map (fun line ->
-        try entry_of_json (Yojson.Safe.from_string line)
-        with Yojson.Json_error _ -> None)
+    (* Legacy fallback: single .masc/audit.jsonl *)
+    let path = legacy_audit_path config in
+    if not (Sys.file_exists path) then []
+    else
+      let content = Fs_compat.load_file path in
+      String.split_on_char '\n' content
+      |> List.filter (fun line -> String.trim line <> "")
+      |> List.filter_map (fun line ->
+          try entry_of_json (Yojson.Safe.from_string line)
+          with Yojson.Json_error _ -> None)
 
-(** Recursively create directory (no shell, safe) *)
-let ensure_dir_safe dir =
-  Fs_compat.mkdir_p dir
-
-let ensure_dir path =
-  let dir = Filename.dirname path in
-  ensure_dir_safe dir
-
-(** Append a single entry to the audit log (thread-safe) *)
+(** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : Room.config) (entry : audit_entry) =
-  Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-    let path = get_audit_path config in
-    ensure_dir path;
-    Fs_compat.append_jsonl path (entry_to_json entry)
-  )
+  let store = get_audit_store config in
+  Dated_jsonl.append store (entry_to_json entry)
 
 (** {1 Logging API} *)
 
@@ -271,28 +271,15 @@ let log_circuit_breaker config ~agent_id ~opened ~reason ?cost_estimate ?token_c
     ~details:(`Assoc [("reason", `String reason)])
     ?cost_estimate ?token_count ~outcome:Success ()
 
-(** {1 Rotation & Cleanup} *)
+(** {1 Pruning (replaces rotation)} *)
 
-let rotate_if_needed (config : Room.config) ~max_size_bytes =
-  let path = get_audit_path config in
-  if Sys.file_exists path then begin
-    let stats = Unix.stat path in
-    if stats.Unix.st_size > max_size_bytes then begin
-      (* Rotate: move current to .1, keeping only one backup *)
-      let backup_path = path ^ ".1" in
-      if Sys.file_exists backup_path then
-        Sys.remove backup_path;
-      Sys.rename path backup_path;
-      Log.Misc.info "Rotated %s (%.1f MB)" path
-        (float_of_int stats.Unix.st_size /. 1_000_000.0)
-    end
-  end
-
-(** Default max size: 10MB *)
-let default_max_size = 10_000_000
-
-let maybe_rotate config =
-  rotate_if_needed config ~max_size_bytes:default_max_size
+(** Prune audit entries older than [days] days.
+    Date-split storage makes rotation unnecessary. *)
+let prune_old (config : Room.config) ~days =
+  let store = get_audit_store config in
+  let deleted = Dated_jsonl.prune store ~days in
+  if deleted > 0 then
+    Log.Misc.info "Pruned %d old audit day-files" deleted
 
 (** {1 Statistics} *)
 
@@ -304,44 +291,25 @@ type stats = {
 }
 
 let get_stats (config : Room.config) =
-  let path = get_audit_path config in
-  if not (Sys.file_exists path) then
-    { total_entries = 0; file_size_bytes = 0; oldest_timestamp = None; newest_timestamp = None }
-  else begin
-    let size = (Unix.stat path).Unix.st_size in
-    (* Count lines and get timestamps *)
-    let content = Fs_compat.load_file path in
-    let lines = String.split_on_char '\n' content
-      |> List.filter (fun line -> String.trim line <> "") in
-    let count = ref 0 in
-    let oldest = ref None in
-    let newest = ref None in
-    List.iter (fun line ->
-      incr count;
-      (* Parse timestamp from first/last lines *)
-      if !oldest = None || !count <= 1 then begin
-        try
-          let json = Yojson.Safe.from_string line in
-          let ts = Yojson.Safe.Util.(json |> member "timestamp" |> to_float) in
-          if !oldest = None then oldest := Some ts;
-          newest := Some ts
-        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
-      end else begin
-        (* Just update newest for each line *)
-        try
-          let json = Yojson.Safe.from_string line in
-          let ts = Yojson.Safe.Util.(json |> member "timestamp" |> to_float) in
-          newest := Some ts
-        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
-      end
-    ) lines;
-    {
-      total_entries = !count;
-      file_size_bytes = size;
-      oldest_timestamp = !oldest;
-      newest_timestamp = !newest;
-    }
-  end
+  let store = get_audit_store config in
+  (* Read a large window to compute stats *)
+  let entries = Dated_jsonl.read_recent store 100_000 in
+  let count = List.length entries in
+  let oldest = ref None in
+  let newest = ref None in
+  List.iter (fun json ->
+    (try
+       let ts = Yojson.Safe.Util.(json |> member "timestamp" |> to_float) in
+       if !oldest = None then oldest := Some ts;
+       newest := Some ts
+     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ())
+  ) entries;
+  {
+    total_entries = count;
+    file_size_bytes = 0; (* no longer a single file *)
+    oldest_timestamp = !oldest;
+    newest_timestamp = !newest;
+  }
 
 let stats_to_json (s : stats) : Yojson.Safe.t =
   `Assoc [

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -155,10 +155,18 @@ let legacy_audit_path (config : Room.config) =
   let masc_dir = Room_utils.masc_dir config in
   Filename.concat masc_dir "audit.jsonl"
 
-(** Date-split store: [.masc/audit/YYYY-MM/DD.jsonl]. *)
+(** Date-split store: [.masc/audit/YYYY-MM/DD.jsonl].
+    Cached per base_dir so all callers share the same Eio.Mutex. *)
+let audit_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+
 let get_audit_store (config : Room.config) : Dated_jsonl.t =
   let base = Filename.concat (Room_utils.masc_dir config) "audit" in
-  Dated_jsonl.create ~base_dir:base ()
+  match Hashtbl.find_opt audit_store_cache base with
+  | Some store -> store
+  | None ->
+    let store = Dated_jsonl.create ~base_dir:base () in
+    Hashtbl.replace audit_store_cache base store;
+    store
 
 (** Read recent audit entries.
     Tries date-split store first; falls back to legacy single file. *)

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -27,8 +27,14 @@ type state = {
 let governance_dir base_path =
   Filename.concat (Filename.concat base_path ".masc") "governance"
 
+(** Legacy single-file path (for fallback reads). *)
 let judgments_path base_path =
   Filename.concat (governance_dir base_path) "judgments.jsonl"
+
+(** Date-split store: [.masc/governance/judgments/YYYY-MM/DD.jsonl]. *)
+let get_judgments_store base_path : Dated_jsonl.t =
+  let dir = Filename.concat (governance_dir base_path) "judgments" in
+  Dated_jsonl.create ~base_dir:dir ()
 
 let states : (string, state) Hashtbl.t = Hashtbl.create 4
 
@@ -95,29 +101,44 @@ let judgment_generated_at json =
   json |> member "generated_at" |> to_string_option |> parse_iso_opt
   |> Option.value ~default:0.0
 
+let load_judgments_into_table jsons =
+  let table = Hashtbl.create 32 in
+  List.iter (fun json ->
+    try
+      let status = json |> member "status" |> to_string_option in
+      if status = Some "active" then
+        let key = judgment_key json in
+        match Hashtbl.find_opt table key with
+        | Some current
+          when judgment_generated_at current >= judgment_generated_at json -> ()
+        | _ -> Hashtbl.replace table key json
+    with
+    | Yojson.Safe.Util.Type_error _ -> ()
+    | exn -> Log.Governance.warn "load_latest_from_disk parse: %s" (Printexc.to_string exn)
+  ) jsons;
+  table
+
+(** Load latest judgments.
+    Tries date-split store first; falls back to legacy single file. *)
 let load_latest_from_disk base_path =
-  let path = judgments_path base_path in
-  if not (Sys.file_exists path) then Hashtbl.create 32
+  let store = get_judgments_store base_path in
+  let jsons = Dated_jsonl.read_recent store 10_000 in
+  if jsons <> [] then
+    load_judgments_into_table jsons
   else
-    let table = Hashtbl.create 32 in
-    let content = Fs_compat.load_file path in
-    String.split_on_char '\n' content
-    |> List.iter (fun line ->
-           let trimmed = String.trim line in
-           if trimmed <> "" then
-             try
-               let json = Yojson.Safe.from_string trimmed in
-               let status = json |> member "status" |> to_string_option in
-               if status = Some "active" then
-                 let key = judgment_key json in
-                 match Hashtbl.find_opt table key with
-                 | Some current
-                   when judgment_generated_at current >= judgment_generated_at json -> ()
-                 | _ -> Hashtbl.replace table key json
-             with
-             | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ()
-             | exn -> Log.Governance.warn "load_latest_from_disk parse: %s" (Printexc.to_string exn));
-    table
+    (* Legacy fallback *)
+    let path = judgments_path base_path in
+    if not (Sys.file_exists path) then Hashtbl.create 32
+    else
+      let content = Fs_compat.load_file path in
+      let legacy_jsons =
+        String.split_on_char '\n' content
+        |> List.filter (fun line -> String.trim line <> "")
+        |> List.filter_map (fun line ->
+            try Some (Yojson.Safe.from_string line)
+            with Yojson.Json_error _ -> None)
+      in
+      load_judgments_into_table legacy_jsons
 
 let latest_judgments base_path =
   let st = get_state base_path in
@@ -313,12 +334,11 @@ let compute_judgments ~base_path:_ ~factual_json =
       | exn ->
           Error (Printf.sprintf "Governance judge parse error: %s" (Printexc.to_string exn)))
 
+(** Append judgments to date-split store.
+    Thread-safe via Dated_jsonl internal mutex. *)
 let append_judgments base_path judgments =
-  ensure_dir (governance_dir base_path);
-  let path = judgments_path base_path in
-  List.iter
-    (fun json -> Fs_compat.append_jsonl path json)
-    judgments
+  let store = get_judgments_store base_path in
+  List.iter (fun json -> Dated_jsonl.append store json) judgments
 
 let refresh_once ~base_path ~build_facts =
   let st = get_state base_path in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -31,10 +31,18 @@ let governance_dir base_path =
 let judgments_path base_path =
   Filename.concat (governance_dir base_path) "judgments.jsonl"
 
-(** Date-split store: [.masc/governance/judgments/YYYY-MM/DD.jsonl]. *)
+(** Date-split store: [.masc/governance/judgments/YYYY-MM/DD.jsonl].
+    Cached per base_dir so all callers share the same Eio.Mutex. *)
+let judgments_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+
 let get_judgments_store base_path : Dated_jsonl.t =
   let dir = Filename.concat (governance_dir base_path) "judgments" in
-  Dated_jsonl.create ~base_dir:dir ()
+  match Hashtbl.find_opt judgments_store_cache dir with
+  | Some store -> store
+  | None ->
+    let store = Dated_jsonl.create ~base_dir:dir () in
+    Hashtbl.replace judgments_store_cache dir store;
+    store
 
 let states : (string, state) Hashtbl.t = Hashtbl.create 4
 

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -1,0 +1,226 @@
+(** Date-split JSONL storage.
+
+    Extracts the [YYYY-MM/DD.jsonl] pattern originally used by
+    {!Room_utils_ops.log_event} into a reusable module.
+
+    Layout:
+    {v
+      base_dir/
+        2026-03/
+          20.jsonl
+          21.jsonl
+        2026-04/
+          01.jsonl
+    v}
+*)
+
+type t = {
+  base_dir : string;
+  mutex : Eio.Mutex.t;
+}
+
+let create ~base_dir ?mutex () =
+  let mutex = match mutex with Some m -> m | None -> Eio.Mutex.create () in
+  { base_dir; mutex }
+
+let base_dir t = t.base_dir
+
+(* ── Date helpers ─────────────────────────────────────── *)
+
+(** Current UTC date decomposed into (month_dir, day_file). *)
+let today_parts () =
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  (month, day)
+
+(** Full path for today's JSONL file, creating dirs as needed. *)
+let today_path t =
+  let month, day = today_parts () in
+  let dir = Filename.concat t.base_dir month in
+  Fs_compat.mkdir_p dir;
+  Filename.concat dir day
+
+(** Parse ["YYYY-MM-DD"] into [("YYYY-MM", "DD")].
+    Returns [None] for malformed strings. *)
+let parse_date s =
+  if String.length s < 10 then None
+  else
+    let month = String.sub s 0 7 in
+    let day = String.sub s 8 2 in
+    Some (month, day)
+
+(* ── Directory listing (sorted descending) ────────────── *)
+
+let list_subdirs path =
+  if not (Sys.file_exists path) then []
+  else
+    try
+      Sys.readdir path
+      |> Array.to_list
+      |> List.sort (fun a b -> String.compare b a)
+    with Sys_error _ -> []
+
+(** Month directories matching [YYYY-MM] pattern, newest first. *)
+let list_month_dirs base_dir =
+  list_subdirs base_dir
+  |> List.filter (fun d ->
+    String.length d = 7
+    && d.[4] = '-'
+    && (try ignore (int_of_string (String.sub d 0 4)); true with Failure _ -> false))
+
+(** Day files matching [DD.jsonl], newest first. *)
+let list_day_files month_path =
+  list_subdirs month_path
+  |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
+
+(* ── Lines from a single file ─────────────────────────── *)
+
+let load_lines path =
+  if not (Fs_compat.file_exists path) then []
+  else
+    try
+      Fs_compat.load_file path
+      |> String.split_on_char '\n'
+      |> List.filter (fun l -> String.trim l <> "")
+    with Sys_error _ -> []
+
+(* ── Public API ───────────────────────────────────────── *)
+
+let append t json =
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    let path = today_path t in
+    Fs_compat.append_jsonl path json)
+
+let read_recent t n =
+  if n <= 0 then []
+  else begin
+    let collected = ref [] in
+    let count = ref 0 in
+    let months = list_month_dirs t.base_dir in
+    let exception Done in
+    (try
+       List.iter (fun m ->
+         let month_path = Filename.concat t.base_dir m in
+         let days = list_day_files month_path in
+         List.iter (fun d ->
+           if !count >= n then raise_notrace Done;
+           let path = Filename.concat month_path d in
+           let lines = load_lines path in
+           (* Lines are chronological in file; take from the end *)
+           let rev_lines = List.rev lines in
+           List.iter (fun line ->
+             if !count < n then begin
+               (try
+                  let json = Yojson.Safe.from_string line in
+                  collected := json :: !collected;
+                  incr count
+                with Yojson.Json_error _ -> ())
+             end
+           ) rev_lines
+         ) days
+       ) months
+     with Done -> ());
+    (* collected is already chronological:
+       we scan newest-first and prepend, so oldest ends up at the head *)
+    !collected
+  end
+
+let read_recent_lines t n =
+  if n <= 0 then []
+  else begin
+    let collected = ref [] in
+    let count = ref 0 in
+    let months = list_month_dirs t.base_dir in
+    let exception Done in
+    (try
+       List.iter (fun m ->
+         let month_path = Filename.concat t.base_dir m in
+         let days = list_day_files month_path in
+         List.iter (fun d ->
+           if !count >= n then raise_notrace Done;
+           let path = Filename.concat month_path d in
+           let lines = load_lines path in
+           let rev_lines = List.rev lines in
+           List.iter (fun line ->
+             if !count < n then begin
+               collected := line :: !collected;
+               incr count
+             end
+           ) rev_lines
+         ) days
+       ) months
+     with Done -> ());
+    !collected
+  end
+
+let read_range t ~since ~until =
+  match parse_date since, parse_date until with
+  | None, _ | _, None -> []
+  | Some (since_month, since_day), Some (until_month, until_day) ->
+    let collected = ref [] in
+    let months = list_month_dirs t.base_dir |> List.rev in (* ascending *)
+    List.iter (fun m ->
+      if String.compare m since_month >= 0
+         && String.compare m until_month <= 0 then begin
+        let month_path = Filename.concat t.base_dir m in
+        let days = list_day_files month_path |> List.rev in (* ascending *)
+        List.iter (fun d ->
+          let day_num = Filename.remove_extension d in
+          let dominated =
+            (m = since_month && String.compare day_num since_day < 0)
+            || (m = until_month && String.compare day_num until_day > 0)
+          in
+          if not dominated then begin
+            let path = Filename.concat month_path d in
+            let lines = load_lines path in
+            List.iter (fun line ->
+              (try
+                 let json = Yojson.Safe.from_string line in
+                 collected := json :: !collected
+               with Yojson.Json_error _ -> ())
+            ) lines
+          end
+        ) days
+      end
+    ) months;
+    List.rev !collected
+
+let prune t ~days =
+  if days <= 0 then 0
+  else begin
+    let now = Unix.gettimeofday () in
+    let cutoff = now -. (float_of_int days *. 86400.0) in
+    let cutoff_tm = Unix.gmtime cutoff in
+    let cutoff_month =
+      Printf.sprintf "%04d-%02d"
+        (cutoff_tm.Unix.tm_year + 1900)
+        (cutoff_tm.Unix.tm_mon + 1)
+    in
+    let cutoff_day = Printf.sprintf "%02d" cutoff_tm.Unix.tm_mday in
+    let deleted = ref 0 in
+    let months = list_month_dirs t.base_dir in
+    List.iter (fun m ->
+      let month_path = Filename.concat t.base_dir m in
+      if String.compare m cutoff_month < 0 then begin
+        (* Entire month is before cutoff — remove all files *)
+        let day_files = list_day_files month_path in
+        List.iter (fun d ->
+          (try Sys.remove (Filename.concat month_path d) with Sys_error _ -> ());
+          incr deleted
+        ) day_files;
+        (try Unix.rmdir month_path with Unix.Unix_error _ -> ())
+      end else if m = cutoff_month then begin
+        let day_files = list_day_files month_path in
+        List.iter (fun d ->
+          let day_num = Filename.remove_extension d in
+          if String.compare day_num cutoff_day < 0 then begin
+            (try Sys.remove (Filename.concat month_path d) with Sys_error _ -> ());
+            incr deleted
+          end
+        ) day_files
+      end
+    ) months;
+    !deleted
+  end

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -1,0 +1,35 @@
+(** Date-split JSONL storage.
+
+    Organises JSONL records into [base_dir/YYYY-MM/DD.jsonl] files.
+    Each instance carries its own {!Eio.Mutex.t} for concurrent-safe appends. *)
+
+type t
+(** Opaque handle.  Holds [base_dir] and a per-store mutex. *)
+
+val create : base_dir:string -> ?mutex:Eio.Mutex.t -> unit -> t
+(** [create ~base_dir ()] builds a store rooted at [base_dir].
+    An optional [mutex] can be injected (useful for testing). *)
+
+val base_dir : t -> string
+(** Return the base directory of this store. *)
+
+val append : t -> Yojson.Safe.t -> unit
+(** Append [json] to today's [DD.jsonl] inside [YYYY-MM/].
+    Creates directories as needed.  Thread-safe via internal mutex. *)
+
+val read_recent : t -> int -> Yojson.Safe.t list
+(** [read_recent t n] returns the newest [n] entries in chronological order
+    (oldest first).  Scans day-files from newest to oldest, stops early. *)
+
+val read_recent_lines : t -> int -> string list
+(** Like {!read_recent} but returns raw JSONL strings (no parse).
+    Useful for tail-readers that do their own parsing. *)
+
+val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
+(** [read_range t ~since ~until] returns entries whose day-file falls
+    within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).
+    Result is in chronological order. *)
+
+val prune : t -> days:int -> int
+(** [prune t ~days] deletes day-files older than [days] days ago.
+    Returns the number of files deleted.  Removes empty month directories. *)

--- a/lib/dated_jsonl/dune
+++ b/lib/dated_jsonl/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+(library
+ (name dated_jsonl)
+ (public_name masc_mcp.dated_jsonl)
+ (libraries fs_compat eio unix yojson))

--- a/lib/dune
+++ b/lib/dune
@@ -772,6 +772,8 @@
    time_compat
    ;; Filesystem compatibility (Eio-native with Unix fallback)
    fs_compat
+   ;; Date-split JSONL storage (YYYY-MM/DD.jsonl)
+   dated_jsonl
    ;; Council - multi-agent governance
    council
    ;; Jiphyeon - Episode storage for Agent Being Protocol

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,4 +3,4 @@
  (name fs_compat)
  (public_name masc_mcp.fs_compat)
  (modules fs_compat)
- (libraries eio yojson))
+ (libraries eio unix yojson))

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -72,8 +72,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
             then (
               (try
-                 let metrics_path =
-                   keeper_metrics_path ctx.config meta_current.name
+                 let metrics_store =
+                   keeper_metrics_store ctx.config meta_current.name
                  in
                  let primary_model =
                    match Model_spec.available_model_specs_of_strings meta_current.models with
@@ -193,7 +193,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                            ("handoff", `Assoc [ ("performed", `Bool false) ]);
                          ]
                      in
-                     append_jsonl_line metrics_path snapshot;
+                     Dated_jsonl.append metrics_store snapshot;
                      (try
                         Sse.broadcast
                           (`Assoc

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -115,6 +115,7 @@ let build_keeper_system_prompt
      Reply in the user's language. Keep replies concise.\n\
      </continuity>"
     goal short_goal mid_goal long_goal will needs desires custom
+    will needs desires
     profile_policy
 
 let append_trait_clause ~(base : string) ~(clause : string) : string =

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -104,6 +104,7 @@ let handle_keeper_status ctx args : tool_result =
            ]
          ) specs) in
 
+         let metrics_store = keeper_metrics_store ctx.config m.name in
          let metrics_path = keeper_metrics_path ctx.config m.name in
          let memory_bank_path = keeper_memory_bank_path ctx.config m.name in
          let session_dir = keeper_session_dir ctx.config m.trace_id in
@@ -111,9 +112,10 @@ let handle_keeper_status ctx args : tool_result =
 
          let metrics_tail =
            let lines =
-             read_file_tail_lines metrics_path
-               ~max_bytes:tail_bytes
-               ~max_lines:tail_turns
+             let dated = Dated_jsonl.read_recent_lines metrics_store tail_turns in
+             if dated <> [] then dated
+             else read_file_tail_lines metrics_path
+                    ~max_bytes:tail_bytes ~max_lines:tail_turns
            in
            `List
              (List.filter_map
@@ -123,9 +125,11 @@ let handle_keeper_status ctx args : tool_result =
          in
          let metrics_window_lines =
            if include_metrics_overview then
-             read_file_tail_lines metrics_path
-               ~max_bytes:tail_bytes
-               ~max_lines:(max tail_turns 200)
+             let n = max tail_turns 200 in
+             let dated = Dated_jsonl.read_recent_lines metrics_store n in
+             if dated <> [] then dated
+             else read_file_tail_lines metrics_path
+                    ~max_bytes:tail_bytes ~max_lines:n
            else
              []
          in
@@ -295,10 +299,12 @@ let handle_keeper_status ctx args : tool_result =
            if not include_compaction_history then
              (`List [], 0)
            else
+             let n = max 200 (tail_compactions * 20) in
              let lines =
-               read_file_tail_lines metrics_path
-                 ~max_bytes:tail_bytes
-                 ~max_lines:(max 200 (tail_compactions * 20))
+               let dated = Dated_jsonl.read_recent_lines metrics_store n in
+               if dated <> [] then dated
+               else read_file_tail_lines metrics_path
+                      ~max_bytes:tail_bytes ~max_lines:n
              in
              let events_rev =
                List.fold_left

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -126,10 +126,18 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
 let keeper_metrics_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")
 
-(** Date-split metrics store: [.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl]. *)
+(** Date-split metrics store: [.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl].
+    Cached per keeper name so all callers share the same Eio.Mutex. *)
+let metrics_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
+
 let keeper_metrics_store config name : Dated_jsonl.t =
   let dir = Filename.concat (keeper_dir_ config) (name ^ "/metrics") in
-  Dated_jsonl.create ~base_dir:dir ()
+  match Hashtbl.find_opt metrics_store_cache dir with
+  | Some store -> store
+  | None ->
+    let store = Dated_jsonl.create ~base_dir:dir () in
+    Hashtbl.replace metrics_store_cache dir store;
+    store
 
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -122,8 +122,14 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
   else
     ensure_api_keys specs
 
+(** Legacy single-file metrics path (for fallback reads). *)
 let keeper_metrics_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")
+
+(** Date-split metrics store: [.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl]. *)
+let keeper_metrics_store config name : Dated_jsonl.t =
+  let dir = Filename.concat (keeper_dir_ config) (name ^ "/metrics") in
+  Dated_jsonl.create ~base_dir:dir ()
 
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -83,10 +83,18 @@ let update_tool_usage stats_by_tool ~tool_name ~success ~timestamp =
 let telemetry_file config =
   Filename.concat (Room_utils.masc_dir config) "telemetry.jsonl"
 
-(** Date-split store: [.masc/telemetry/YYYY-MM/DD.jsonl]. *)
+(** Date-split store: [.masc/telemetry/YYYY-MM/DD.jsonl].
+    Cached per base_dir so all callers share the same Eio.Mutex. *)
+let telemetry_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+
 let get_telemetry_store config : Dated_jsonl.t =
   let base = Filename.concat (Room_utils.masc_dir config) "telemetry" in
-  Dated_jsonl.create ~base_dir:base ()
+  match Hashtbl.find_opt telemetry_store_cache base with
+  | Some store -> store
+  | None ->
+    let store = Dated_jsonl.create ~base_dir:base () in
+    Hashtbl.replace telemetry_store_cache base store;
+    store
 
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
   List.filter_map (fun json ->

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -79,8 +79,21 @@ let update_tool_usage stats_by_tool ~tool_name ~success ~timestamp =
   } in
   Hashtbl.replace stats_by_tool tool_name updated
 
+(** Legacy single-file path (for fallback reads). *)
 let telemetry_file config =
   Filename.concat (Room_utils.masc_dir config) "telemetry.jsonl"
+
+(** Date-split store: [.masc/telemetry/YYYY-MM/DD.jsonl]. *)
+let get_telemetry_store config : Dated_jsonl.t =
+  let base = Filename.concat (Room_utils.masc_dir config) "telemetry" in
+  Dated_jsonl.create ~base_dir:base ()
+
+let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
+  List.filter_map (fun json ->
+    match event_record_of_yojson json with
+    | Ok record -> Some record
+    | Error _ -> None
+  ) jsons
 
 let read_all_events_from_path (file : string) : event_record list =
   if not (Sys.file_exists file) then
@@ -96,57 +109,42 @@ let read_all_events_from_path (file : string) : event_record list =
           | Error _ -> None
         with Yojson.Json_error _ -> None)
 
-let ensure_masc_dir fs config =
-  let dir = Room_utils.masc_dir config in
-  let path = Eio.Path.(fs / dir) in
-  Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 path
-
 let event_to_json event =
   let record = {
     timestamp = Time_compat.now ();
     event;
   } in
-  Yojson.Safe.to_string (event_record_to_yojson record)
+  event_record_to_yojson record
 
-(** Track an event - appends to telemetry.jsonl *)
-let track ~fs config event : unit =
-  ensure_masc_dir fs config;
-  let file = telemetry_file config in
-  let json_line = event_to_json event ^ "\n" in
+(** Track an event - appends to date-split telemetry store.
+    Thread-safe via Dated_jsonl internal mutex. *)
+let track ~fs:_ config event : unit =
+  let store = get_telemetry_store config in
+  Dated_jsonl.append store (event_to_json event)
 
-  (* Use Room_utils.with_file_lock for concurrent safety *)
-  Room_utils.with_file_lock config file (fun () ->
-    let path = Eio.Path.(fs / file) in
-    Eio.Path.save ~append:true ~create:(`If_missing 0o600) path json_line
-  )
-
-(** Read all events from telemetry file *)
-let read_all_events ~fs config : event_record list =
-  let file = telemetry_file config in
-  let path = Eio.Path.(fs / file) in
-  try
-    let content = Eio.Path.load path in
-    let lines = String.split_on_char '\n' content
-                |> List.filter (fun s -> String.trim s <> "") in
-    List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        match event_record_of_yojson json with
-        | Ok record -> Some record
-        | Error _ -> None
-      with Yojson.Json_error _ -> None
-    ) lines
-  with Sys_error _ | Eio.Io _ -> []
+(** Read all events.
+    Tries date-split store first; falls back to legacy single file. *)
+let read_all_events ~fs:_ config : event_record list =
+  let store = get_telemetry_store config in
+  let jsons = Dated_jsonl.read_recent store 100_000 in
+  if jsons <> [] then
+    parse_event_records jsons
+  else
+    read_all_events_from_path (telemetry_file config)
 
 let summarize_tool_usage ?fs config : tool_usage_summary =
   let telemetry_path = telemetry_file config in
-  let telemetry_available = Sys.file_exists telemetry_path in
+  let store = get_telemetry_store config in
+  let telemetry_available =
+    Sys.file_exists telemetry_path
+    || Sys.file_exists (Dated_jsonl.base_dir store)
+  in
   let stats_by_tool = Hashtbl.create 32 in
   let total_calls = ref 0 in
   let records =
     match fs with
-    | Some fs when telemetry_available -> read_all_events ~fs config
-    | _ -> read_all_events_from_path telemetry_path
+    | Some fs -> read_all_events ~fs config
+    | None -> read_all_events_from_path telemetry_path
   in
   List.iter (fun (record : event_record) ->
     match record.event with
@@ -225,7 +223,8 @@ let tool_usage_fields summary tool_name =
      | None -> `Null);
   ]
 
-(** Read events since a timestamp *)
+(** Read events since a timestamp.
+    With date-split storage, reads recent entries and filters by timestamp. *)
 let read_events_since ~fs config ~since : event_record list =
   let all = read_all_events ~fs config in
   List.filter (fun r -> r.timestamp >= since) all
@@ -338,20 +337,8 @@ let track_error ~fs config ~code ~message ~context =
 let track_tool_called ~fs config ~tool_name ~success ~duration_ms ?agent_id () =
   track ~fs config (Tool_called { tool_name; success; duration_ms; agent_id })
 
-(** Rotate telemetry file *)
-let rotate ~fs config ~max_age_days : unit =
-  let now = Time_compat.now () in
-  let cutoff = now -. (float_of_int max_age_days *. 86400.0) in
-  let all = read_all_events ~fs config in
-  let recent = List.filter (fun r -> r.timestamp >= cutoff) all in
-
-  let file = telemetry_file config in
-  let tmp_file = file ^ ".tmp" in
-  let content = 
-    List.map (fun record -> Yojson.Safe.to_string (event_record_to_yojson record)) recent
-    |> String.concat "\n"
-    |> (fun s -> if s = "" then "" else s ^ "\n")
-  in
-  let tmp_path = Eio.Path.(fs / tmp_file) in
-  Eio.Path.save ~create:(`Or_truncate 0o600) tmp_path content;
-  Unix.rename tmp_file file
+(** Prune telemetry entries older than [max_age_days] days.
+    Replaces the old rotate function; date-split makes rewriting unnecessary. *)
+let rotate ~fs:_ config ~max_age_days : unit =
+  let store = get_telemetry_store config in
+  ignore (Dated_jsonl.prune store ~days:max_age_days)

--- a/test/dune
+++ b/test/dune
@@ -130,6 +130,12 @@
  (modules test_dashboard_governance)
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
+; Date-split JSONL storage tests
+(test
+ (name test_dated_jsonl)
+ (modules test_dated_jsonl)
+ (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
+
 (test
  (name test_dashboard_labels)
  (modules test_dashboard_labels)

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -1,0 +1,212 @@
+(** Tests for Dated_jsonl date-split JSONL storage. *)
+
+open Alcotest
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir = Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s_%d_%d_%.0f" prefix !counter (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
+
+let make_json i =
+  `Assoc [("i", `Int i); ("ts", `Float (Unix.gettimeofday ()))]
+
+(* ── append creates YYYY-MM/DD.jsonl ──────────────────── *)
+
+let test_append_creates_dated_file () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_append" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store (make_json 1);
+  Dated_jsonl.append store (make_json 2);
+  (* Verify directory structure exists *)
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let month_dir = Filename.concat dir month in
+  let file = Filename.concat month_dir day in
+  check bool "month dir exists" true (Sys.file_exists month_dir);
+  check bool "day file exists" true (Sys.file_exists file);
+  (* Verify file content *)
+  let content = Fs_compat.load_file file in
+  let lines = String.split_on_char '\n' content
+    |> List.filter (fun l -> String.trim l <> "") in
+  check int "two lines" 2 (List.length lines)
+
+(* ── read_recent returns newest N in chronological order ─ *)
+
+let test_read_recent () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_recent" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  for i = 1 to 5 do
+    Dated_jsonl.append store (make_json i)
+  done;
+  let result = Dated_jsonl.read_recent store 3 in
+  check int "returns 3" 3 (List.length result);
+  (* Should be chronological: 3, 4, 5 *)
+  let values = List.map (fun j ->
+    Yojson.Safe.Util.(j |> member "i" |> to_int)
+  ) result in
+  check (list int) "newest 3 chronological" [3; 4; 5] values
+
+let test_read_recent_zero () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_zero" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store (make_json 1);
+  let result = Dated_jsonl.read_recent store 0 in
+  check int "returns 0" 0 (List.length result)
+
+let test_read_recent_more_than_exists () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_overflow" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store (make_json 1);
+  Dated_jsonl.append store (make_json 2);
+  let result = Dated_jsonl.read_recent store 100 in
+  check int "returns all 2" 2 (List.length result)
+
+(* ── read_recent_lines returns raw strings ─────────────── *)
+
+let test_read_recent_lines () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_lines" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  for i = 1 to 4 do
+    Dated_jsonl.append store (make_json i)
+  done;
+  let lines = Dated_jsonl.read_recent_lines store 2 in
+  check int "returns 2 lines" 2 (List.length lines);
+  (* Lines should be valid JSON *)
+  List.iter (fun line ->
+    check bool "parseable json" true
+      (try ignore (Yojson.Safe.from_string line); true
+       with Yojson.Json_error _ -> false)
+  ) lines
+
+(* ── read_range filters by date ────────────────────────── *)
+
+let test_read_range () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_range" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store (make_json 1);
+  (* Read today's range *)
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let today = Printf.sprintf "%04d-%02d-%02d"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday in
+  let result = Dated_jsonl.read_range store ~since:today ~until:today in
+  check bool "non-empty for today" true (List.length result > 0);
+  (* Far future range should be empty *)
+  let result2 = Dated_jsonl.read_range store ~since:"2099-01-01" ~until:"2099-12-31" in
+  check int "empty for future" 0 (List.length result2)
+
+let test_read_range_malformed () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_badrange" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let result = Dated_jsonl.read_range store ~since:"bad" ~until:"dates" in
+  check int "malformed dates return empty" 0 (List.length result)
+
+(* ── prune removes old files ───────────────────────────── *)
+
+let test_prune () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_prune" in
+  (* Create a fake old month dir with a day file *)
+  let old_month = Filename.concat dir "2020-01" in
+  Fs_compat.mkdir_p old_month;
+  Fs_compat.append_file (Filename.concat old_month "15.jsonl")
+    "{\"old\":true}\n";
+  (* Also add today's data *)
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  Dated_jsonl.append store (make_json 1);
+  (* Prune data older than 30 days *)
+  let deleted = Dated_jsonl.prune store ~days:30 in
+  check bool "deleted at least 1" true (deleted >= 1);
+  check bool "old file removed" false
+    (Sys.file_exists (Filename.concat old_month "15.jsonl"));
+  (* Today's data should survive *)
+  let result = Dated_jsonl.read_recent store 10 in
+  check bool "today survives prune" true (List.length result > 0)
+
+let test_prune_zero_days () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_prune0" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let deleted = Dated_jsonl.prune store ~days:0 in
+  check int "zero days prunes nothing" 0 deleted
+
+(* ── concurrent append safety ──────────────────────────── *)
+
+let test_concurrent_append () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_concurrent" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let n = 50 in
+  Eio.Fiber.all (
+    List.init n (fun i ->
+      fun () ->
+        Dated_jsonl.append store (make_json i)
+    )
+  );
+  let result = Dated_jsonl.read_recent store n in
+  check int "all entries written" n (List.length result)
+
+(* ── empty store ───────────────────────────────────────── *)
+
+let test_empty_store () =
+  Eio_main.run @@ fun _env ->
+  let dir = tmpdir "dated_jsonl_empty" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let result = Dated_jsonl.read_recent store 10 in
+  check int "empty read" 0 (List.length result);
+  let lines = Dated_jsonl.read_recent_lines store 10 in
+  check int "empty lines" 0 (List.length lines)
+
+(* ── Test Suite ───────────────────────────────────────── *)
+
+let () =
+  run "Dated_jsonl"
+    [
+      ( "append",
+        [
+          test_case "creates dated file" `Quick test_append_creates_dated_file;
+        ] );
+      ( "read_recent",
+        [
+          test_case "returns newest N chronological" `Quick test_read_recent;
+          test_case "returns 0 for n=0" `Quick test_read_recent_zero;
+          test_case "returns all when n > count" `Quick test_read_recent_more_than_exists;
+        ] );
+      ( "read_recent_lines",
+        [
+          test_case "returns raw strings" `Quick test_read_recent_lines;
+        ] );
+      ( "read_range",
+        [
+          test_case "today range non-empty" `Quick test_read_range;
+          test_case "malformed dates safe" `Quick test_read_range_malformed;
+        ] );
+      ( "prune",
+        [
+          test_case "removes old files" `Quick test_prune;
+          test_case "zero days safe" `Quick test_prune_zero_days;
+        ] );
+      ( "concurrent",
+        [
+          test_case "concurrent append" `Quick test_concurrent_append;
+        ] );
+      ( "empty",
+        [
+          test_case "empty store" `Quick test_empty_store;
+        ] );
+    ]

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -174,7 +174,8 @@ let test_event_to_json_agent_joined () =
     agent_id = "test";
     capabilities = ["a"; "b"];
   } in
-  let json_str = Telemetry_eio.event_to_json e in
+  let json = Telemetry_eio.event_to_json e in
+  let json_str = Yojson.Safe.to_string json in
   check bool "nonempty" true (String.length json_str > 0);
   check bool "is json" true (String.contains json_str '{')
 
@@ -184,7 +185,8 @@ let test_event_to_json_task_completed () =
     duration_ms = 100;
     success = true;
   } in
-  let json_str = Telemetry_eio.event_to_json e in
+  let json = Telemetry_eio.event_to_json e in
+  let json_str = Yojson.Safe.to_string json in
   check bool "nonempty" true (String.length json_str > 0);
   check bool "contains timestamp" true (String.length json_str > 10)
 


### PR DESCRIPTION
## Summary

- **New `Dated_jsonl` library** (`lib/dated_jsonl/`): reusable `YYYY-MM/DD.jsonl` date-split storage with per-instance `Eio.Mutex`, extracted from `Room_utils_ops.log_event` pattern
- **Migrate 4 JSONL stores** from single-file infinite-append to date-split:
  - `audit_log.ml` → `.masc/audit/YYYY-MM/DD.jsonl` (was 1.8MB)
  - `telemetry_eio.ml` → `.masc/telemetry/YYYY-MM/DD.jsonl` (was 848KB)
  - `dashboard_governance_judge.ml` → `.masc/governance/judgments/YYYY-MM/DD.jsonl` (was 3MB)
  - `keeper_keepalive.ml` + `keeper_status.ml` → `.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl` (was 29.5MB)
- **Legacy fallback**: all readers try date-split first, fall back to single file
- **Rotation → Prune**: `rotate_if_needed` replaced by `Dated_jsonl.prune ~days`
- **Bug fixes**: governance judge race condition (added mutex), `keeper_prompt.ml` sprintf arg mismatch

## Data Cleanup (post-merge, manual)

```bash
rm .masc/audit.jsonl
rm .masc/telemetry.jsonl
rm .masc/governance/judgments.jsonl
rm .masc/perpetual-keepers/*.metrics.jsonl
rm .masc/clusters/me/telemetry.jsonl
```

## Test plan

- [x] `test_dated_jsonl.exe` — 11 tests (append, read_recent, read_recent_lines, read_range, prune, concurrent, empty)
- [x] `test_telemetry_eio_coverage.exe` — 32 tests pass
- [x] `dune build` clean (only pre-existing dashboard_mission failure)
- [ ] Manual: start server, verify keeper heartbeat writes to new path
- [ ] Manual: run data cleanup commands after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)