### PR TITLE
fix: expose all registered tools — remove surface filtering

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -398,9 +398,12 @@ let public_raw_tool_schemas_from (public_tool_source_schemas : Types.tool_schema
     Types.tool_schema list =
   dedupe_schemas public_tool_source_schemas
 
+(* Surface filtering removed — all registered tools are public.
+   Previous: surface_tool_schemas_from ... Public_mcp filtered ~47 tools.
+   See #1961 for context. *)
 let public_tool_schemas_from (public_tool_source_schemas : Types.tool_schema list) :
     Types.tool_schema list =
-  surface_tool_schemas_from public_tool_source_schemas Public_mcp
+  dedupe_schemas public_tool_source_schemas
   |> Tool_help_registry.canonicalize_schemas
 
 let visible_public_tool_schemas_from

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -430,9 +430,9 @@ let list_page_size =
   match Sys.getenv_opt "MASC_LIST_PAGE_SIZE" with
   | Some raw -> (
       match int_of_string_opt (String.trim raw) with
-      | Some v when v >= 10 && v <= 256 -> v
-      | _ -> 50)
-  | None -> 50
+      | Some v when v >= 10 && v <= 1024 -> v
+      | _ -> 512)
+  | None -> 512
 
 let encode_cursor ~kind offset =
   Base64.encode_string (Printf.sprintf "%s:%d" kind offset)


### PR DESCRIPTION
## Summary
- Surface 필터링(Public_mcp)이 perpetual_start 등 47개 도구를 숨기고 있었음
- 355개 등록, 308개 노출 → 이제 전체 노출
- Pagination 기본값 50 → 512 (전체 도구를 1페이지에)

## Changes
- `capability_registry.ml`: surface_tool_schemas_from 우회, dedupe만 적용
- `mcp_server_eio_tool_profile.ml`: page size 50 → 512

## Ref
Closes #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)