### PR TITLE
feat: inject extend_turns tool into keeper Agent.run

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -113,7 +113,60 @@ let run_turn
   let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
   let meta_ref = ref meta in
-  let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+  let agent_ref : Agent_sdk.Agent.t option ref = ref None in
+  let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+  (* extend_turns: agent self-extends turn budget within ceiling *)
+  let ceiling = max max_turns 200 in
+  let budget_current = ref max_turns in
+  let budget_extensions = ref 0 in
+  let extend_turns_tool =
+    let open Agent_sdk in
+    Tool.create
+      ~name:"extend_turns"
+      ~description:"Request additional turns when you need more time. \
+                     Guardrails check cost and idle before granting."
+      ~parameters:[
+        { Types.name = "additional_turns";
+          description = "Number of additional turns (1-20)";
+          param_type = Types.Integer; required = true };
+        { Types.name = "reason";
+          description = "Why more turns are needed";
+          param_type = Types.String; required = true };
+      ]
+      (fun input ->
+        let additional =
+          try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
+          with _ -> 5 in
+        let reason =
+          try Yojson.Safe.Util.(member "reason" input |> to_string)
+          with _ -> "unspecified" in
+        let additional = max 1 (min additional 20) in
+        if !budget_extensions >= 10 then
+          Ok { Types.content = Printf.sprintf
+            "Denied: extension limit (10) reached. Budget: %d/%d."
+            !budget_current ceiling }
+        else
+          let new_max = min (!budget_current + additional) ceiling in
+          let granted = new_max - !budget_current in
+          if granted <= 0 then
+            Ok { Types.content = Printf.sprintf
+              "Denied: at ceiling (%d/%d)." !budget_current ceiling }
+          else begin
+            budget_current := new_max;
+            incr budget_extensions;
+            (match !agent_ref with
+             | Some agent ->
+               let state = Agent_sdk.Agent.state agent in
+               Agent_sdk.Agent.set_state agent
+                 { state with config =
+                     { state.config with max_turns = new_max } }
+             | None -> ());
+            Ok { Types.content = Printf.sprintf
+              "Granted %d turns. Budget: %d (ceiling: %d). Extensions: %d/10. Reason: %s"
+              granted new_max ceiling !budget_extensions reason }
+          end)
+  in
+  let tools = extend_turns_tool :: keeper_tools in
   let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd () in
   let memory = Memory_oas_bridge.create_memory ~agent_name ~session_id:meta.trace_id () in
@@ -143,6 +196,7 @@ let run_turn
       ~max_tokens
       ?guardrails
       ?on_event
+      ~agent_ref
       ()
   with
   | Error e -> Error e

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -168,6 +168,7 @@ let run
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
     ?(on_event : (Oas.Types.sse_event -> unit) option)
+    ?(agent_ref : Oas.Agent.t option ref option)
     (goal : string)
   : (run_result, string) result =
   let session_id = match config.session_id with
@@ -188,6 +189,8 @@ let run
     ) config.event_bus;
     Error (Printf.sprintf "Agent build failed: %s" e)
   | Ok agent ->
+  (* Set agent_ref for tools that need post-creation agent access (e.g. extend_turns) *)
+  (match agent_ref with Some r -> r := Some agent | None -> ());
   (* Wrap agent execution so Eio/network exceptions become Error results,
      honouring the (run_result, string) result return type promised by .mli.
      Eio.Cancel.Cancelled is re-raised for structured-concurrency safety. *)
@@ -362,6 +365,7 @@ let run_named
     ?context_reducer
     ?memory
     ?on_event
+    ?agent_ref
     ()
   : (run_result, string) result =
   match require_eio () with
@@ -387,7 +391,7 @@ let run_named
       ()
   in
   let config = { config with named_cascade = Some named_cascade } in
-  match run ~sw ~net ~config ?on_event goal with
+  match run ~sw ~net ~config ?on_event ?agent_ref goal with
   | Ok result when accept result.response -> Ok result
   | Ok _ -> Error (Printf.sprintf "cascade %s: response rejected by accept" cascade_name)
   | Error e -> Error e

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -45,6 +45,7 @@ val run_named :
   ?context_reducer:Oas.Context_reducer.t ->
   ?memory:Oas.Memory.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
+  ?agent_ref:Oas.Agent.t option ref ->
   unit ->
   (run_result, string) result
 


### PR DESCRIPTION
## Summary
- Keeper가 자기 판단으로 턴 예산을 확장하는 extend_turns tool 주입
- oas_worker에 ?agent_ref plumbing 추가 (Agent build 후 ref 설정)
- Guardrails: ceiling 200, per-extend 20, max 10 extensions

## Context
PR #1942의 후속 — 기본 autonomy(Agent.run 전환)는 이미 머지됨. 이 PR은 self-extend 기능 추가.
OAS Agent_turn_budget (#303) 머지 완료. MASC 로컬 구현은 추후 OAS 모듈로 교체 가능.

## Test plan
- [x] `dune build` clean
- [ ] 서버 재시작 → keeper extend_turns tool 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)