### PR TITLE
feat: OAS Durable step chain for perpetual handoff

### DIFF
--- a/lib/perpetual/perpetual_oas.ml
+++ b/lib/perpetual/perpetual_oas.ml
@@ -125,41 +125,67 @@ let run_perpetual_via_oas
   with exn ->
     Log.Perpetual.error "MASC checkpoint save failed: %s"
       (Printexc.to_string exn));
-  (* Handle handoff: extract DNA, increment generation *)
+  (* Handle handoff via OAS Durable step chain (crash-recoverable) *)
   if pstate.handoff_triggered then begin
     Log.Perpetual.info "Handoff triggered at gen %d, preparing DNA"
       pstate.generation;
-    let metrics : Succession_oas.succession_metrics = {
-      total_turns = pstate.turn_count;
-      total_tokens_used = pstate.total_tokens;
-      total_cost_usd = pstate.total_cost;
-      tasks_completed = 0;
-      errors_encountered = 0;
-      elapsed_seconds = Time_compat.now () -. state.started_at;
+    let step1 : Oas.Durable.step = {
+      name = "extract_dna";
+      execute = (fun _input ->
+        let metrics : Succession_oas.succession_metrics = {
+          total_turns = pstate.turn_count;
+          total_tokens_used = pstate.total_tokens;
+          total_cost_usd = pstate.total_cost;
+          tasks_completed = 0;
+          errors_encountered = 0;
+          elapsed_seconds = Time_compat.now () -. state.started_at;
+        } in
+        let _dna, dna_ckpt = Succession_oas.extract_dna_via_checkpoint
+          ~working_ctx:!ctx_ref
+          ~session_ctx:state.session
+          ~goal:config.initial_goal
+          ~generation:pstate.generation
+          ~trace_id
+          ~metrics
+        in
+        Ok (Oas.Checkpoint.to_json dna_ckpt));
+      retry_limit = 1;
     } in
-    (* Extract DNA via Phase 2 adapter *)
-    let _dna, dna_ckpt = Succession_oas.extract_dna_via_checkpoint
-      ~working_ctx:!ctx_ref
-      ~session_ctx:state.session
-      ~goal:config.initial_goal
-      ~generation:pstate.generation
-      ~trace_id
-      ~metrics
+    let step2 : Oas.Durable.step = {
+      name = "persist_dna";
+      execute = (fun dna_json ->
+        let dna_path = Filename.concat config.session_base_dir
+          (sprintf "%s-dna-gen%d.json" trace_id pstate.generation) in
+        Fs_compat.mkdir_p config.session_base_dir;
+        Fs_compat.save_file dna_path (Yojson.Safe.to_string dna_json);
+        Ok (`String dna_path));
+      retry_limit = 2;
+    } in
+    let step3 : Oas.Durable.step = {
+      name = "update_generation";
+      execute = (fun _input ->
+        state.generation <- pstate.generation + 1;
+        Ok (`Int (pstate.generation + 1)));
+      retry_limit = 1;
+    } in
+    let handoff_pipeline =
+      let p = Oas.Durable.create ~name:"perpetual_handoff" () in
+      let p = Oas.Durable.add_step p step1 in
+      let p = Oas.Durable.add_step p step2 in
+      Oas.Durable.add_step p step3
     in
-    (* Persist DNA checkpoint *)
-    (try
-      let dna_path = Filename.concat config.session_base_dir
-        (sprintf "%s-dna-gen%d.json" trace_id pstate.generation)
-      in
-      Fs_compat.save_file dna_path
-        (Oas.Checkpoint.to_string dna_ckpt)
-    with exn ->
-      Log.Perpetual.error "DNA checkpoint save failed: %s"
-        (Printexc.to_string exn));
-    (* Update MASC state for potential successor *)
-    state.generation <- pstate.generation + 1;
-    emit (Terminated (sprintf "Handoff complete, gen %d -> %d"
-      pstate.generation (pstate.generation + 1)))
+    let handoff_state = Oas.Durable.execute handoff_pipeline (`Null) in
+    (match handoff_state with
+    | Oas.Durable.Completed _ ->
+      emit (Terminated (sprintf "Handoff complete, gen %d -> %d"
+        pstate.generation (pstate.generation + 1)))
+    | Oas.Durable.Failed { at_step; error; _ } ->
+      Log.Perpetual.error "Handoff failed at step '%s': %s" at_step error;
+      emit (Error (sprintf "Handoff failed at %s: %s" at_step error))
+    | other ->
+      let state_json = Oas.Durable.execution_state_to_json other in
+      Log.Perpetual.warn "Handoff incomplete: %s"
+        (Yojson.Safe.to_string state_json))
   end;
   (* Sync mutable state back to MASC loop_state *)
   Perpetual_oas_state.update_state (fun _ps ->


### PR DESCRIPTION
## Summary

Perpetual agent handoff를 OAS Durable 3-step 파이프라인으로 래핑.

### Steps
1. extract_dna — DNA extraction (retry 1)
2. persist_dna — DNA checkpoint 저장 (retry 2)
3. update_generation — 세대 업데이트 (retry 1)

### 이점
- Crash recovery: 중단된 step에서 정확히 재개 가능
- Audit trail: 각 step의 input/output/timing 기록
- Retry: persist 단계에서 I/O 실패 시 재시도
- 구조화된 에러 보고 (Completed/Failed/Suspended)

## Test plan
- [x] dune build
- [ ] make test

Generated with [Claude Code](https://claude.com/claude-code)