### PR TITLE
test(ci): follow broadcast guard source move

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -68,10 +68,10 @@ let test_route_auth_contracts () =
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)
   check bool "broadcast validates empty message" true
-    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+    (file_contains_pattern "lib/tool_inline_dispatch_comm.ml"
        {|"Broadcast message cannot be empty"|});
   check bool "broadcast trims whitespace before check" true
-    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+    (file_contains_pattern "lib/tool_inline_dispatch_comm.ml"
        {|String.trim message|});
   (* Bug #1609: cache must have automatic eviction *)
   check bool "cache has maybe_evict_expired function" true


### PR DESCRIPTION
## Summary
- update `test_ci_hardening_source` to follow the broadcast validation source move
- point the source guard at `lib/tool_inline_dispatch_comm.ml`
- keep runtime behavior unchanged by limiting the change to the stale test path

## Verification
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/ci-hardening-broadcast-path test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe` (from the worktree root)
- direct `GLM-5` review on the patch: `No findings.`

## Context
`#1955` merged before this stale source-guard fix was pushed, so this is a follow-up PR for the remaining CI failure only.