### PR TITLE
fix(board): permanent comments lost on restart (expires_at=0.0)

### DIFF
--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -299,7 +299,7 @@ let load_persisted_comments store =
       let lines = Fs_compat.load_jsonl path in
       List.iter (fun json ->
         match comment_of_yojson json with
-        | Some c when c.expires_at > now ->
+        | Some c when c.expires_at = 0.0 || c.expires_at > now ->
             let cid = Comment_id.to_string c.id in
             Hashtbl.replace store.comments cid c;
             (* Build comments_by_post index *)


### PR DESCRIPTION
## Summary
board_comments.jsonl이 서버 재시작마다 0바이트로 리셋되는 버그 수정.

## Root Cause
`load_persisted_comments`에서 `c.expires_at > now` 조건이 영구 댓글(expires_at=0.0)을 필터링.
posts 로더는 `p.expires_at = 0.0 ||` 가드가 있었지만 comments 로더에 누락됨 (복붙 누락).

## Fix
`c.expires_at = 0.0 || c.expires_at > now` — sweeper와 동일한 패턴 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)