### PR TITLE
refactor: switch council+mitosis dispatch to OAS modules

### DIFF
--- a/bin/mitosis_cli.ml
+++ b/bin/mitosis_cli.ml
@@ -89,7 +89,7 @@ let run_validate dna_str file_path =
   Printf.printf "Validating DNA (%d chars)...\n\n" (String.length dna);
   print_dna_stats dna;
   Printf.printf "\n=== Validation Result ===\n";
-  match Tool_mitosis.validate_dna dna with
+  match Tool_mitosis_utils.validate_dna dna with
   | Ok _ ->
     Printf.printf "  Status: OK (valid DNA)\n";
     `Ok ()

--- a/lib/dune
+++ b/lib/dune
@@ -351,6 +351,7 @@
    mitosis_spawn
    tool_mitosis_utils
    tool_mitosis_handoff
+   tool_mitosis_schemas
    tool_mitosis
    tool_mitosis_oas
    tool_portal

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -144,12 +144,12 @@ let () =
   register_module_tag ~schemas:Tool_task.schemas ~tag:Mod_task;
   register_module_tag ~schemas:Tool_control.schemas ~tag:Mod_control;
   register_module_tag ~schemas:Tool_suspend.schemas ~tag:Mod_suspend;
-  register_module_tag ~schemas:Tool_council.schemas ~tag:Mod_council;
+  register_module_tag ~schemas:Tool_council_oas.schemas ~tag:Mod_council;
   register_module_tag ~schemas:Tool_cost.schemas ~tag:Mod_cost;
   register_module_tag ~schemas:Tool_rate_limit.schemas ~tag:Mod_rate_limit;
   register_module_tag ~schemas:Tool_encryption.schemas ~tag:Mod_encryption;
   register_module_tag ~schemas:Tool_relay.schemas ~tag:Mod_relay;
-  register_module_tag ~schemas:Tool_mitosis.schemas ~tag:Mod_mitosis;
+  register_module_tag ~schemas:Tool_mitosis_oas.schemas ~tag:Mod_mitosis;
   register_module_tag ~schemas:Tool_handover.schemas ~tag:Mod_handover;
   register_module_tag ~schemas:Tool_tempo.schemas ~tag:Mod_tempo;
   register_module_tag ~schemas:Tool_walph.schemas ~tag:Mod_walph;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -433,15 +433,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_tempo ->
         Tool_tempo.dispatch { Tool_tempo.config; agent_name } ~name ~args:arguments
     | Mod_mitosis ->
-        let ctx : Tool_mitosis_oas.context = {
+        let rec ctx : Tool_mitosis_oas.context = {
           config;
           agent_name;
           masc_tools = [];
           dispatch = (fun ~name:n ~args:a ->
-            match Tool_mitosis.dispatch
-              (Tool_mitosis.make_context_with_eio ~config ~sw
-                ~proc_mgr:state.Mcp_server.proc_mgr ~clock)
-              ~name:n ~args:a with
+            match Tool_mitosis_oas.dispatch ctx ~name:n ~args:a with
             | Some r -> r
             | None -> (false, Printf.sprintf "unknown tool: %s" n));
         } in

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -327,7 +327,7 @@ let handle_execute_dry_run _ctx args =
 (* Schemas — reuse from legacy Tool_council                          *)
 (* ================================================================ *)
 
-let schemas : Types.tool_schema list = Tool_council.schemas
+let schemas : Types.tool_schema list = Tool_council_internal_schemas.schemas
 
 (* ================================================================ *)
 (* Dispatch                                                          *)
@@ -359,10 +359,10 @@ let dispatch (ctx : context) ~name ~args : result option =
     | "masc_case_brief_submit" -> Some handle_case_brief_submit
     | "masc_cases" -> Some handle_cases
     | "masc_case_status" -> Some handle_case_status
-    | "masc_council_route" -> Some handle_route
-    | "masc_council_execute" -> Some handle_execute
-    | "masc_council_execute_dry_run" -> Some handle_execute_dry_run
-    | "masc_governance_petition" -> Some handle_petition_submit
+    | "masc_council_route" | "masc_route" -> Some handle_route
+    | "masc_council_execute" | "masc_execute" -> Some handle_execute
+    | "masc_council_execute_dry_run" | "masc_execute_dry_run" -> Some handle_execute_dry_run
+    | "masc_governance_petition" | "masc_petition_submit" -> Some handle_petition_submit
     | "masc_governance_status" -> Some handle_governance_status
     | "masc_governance_feed" -> Some handle_governance_feed
     | "masc_ruling_status" -> Some handle_ruling_status

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -344,7 +344,7 @@ let handle_metrics_record _ctx args : result =
 (* Schemas                                                           *)
 (* ================================================================ *)
 
-let schemas : Types.tool_schema list = Tool_mitosis.schemas
+let schemas : Types.tool_schema list = Tool_mitosis_schemas.schemas
 
 (* ================================================================ *)
 (* Dispatch                                                          *)

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -22,9 +22,9 @@ let raw_schemas : tool_schema list =
   @ Tool_cost.schemas
   @ Tool_rate_limit.schemas
   @ Tool_encryption.schemas
-  @ Tool_council.schemas
+  @ Tool_council_oas.schemas
   @ Tool_relay.schemas
-  @ Tool_mitosis.schemas
+  @ Tool_mitosis_oas.schemas
   @ Tool_handover.schemas
   @ Tool_tempo.schemas
   @ Tool_walph.schemas


### PR DESCRIPTION
All production MCP dispatch now routes through _oas replacements. Legacy modules kept as sub-module re-export hubs only. Closes #1965