### PR TITLE
fix: keeper system prompt format string mismatch

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -117,7 +117,6 @@ let build_keeper_system_prompt
     goal short_goal mid_goal long_goal will needs desires custom
     will needs desires
     profile_policy
-    will needs desires
 
 let append_trait_clause ~(base : string) ~(clause : string) : string =
   let b = String.trim base in


### PR DESCRIPTION
Remove duplicate will/needs/desires args (15 values for 12 %s).