### PR TITLE
feat: add .mli for 10 high-reference modules (Phase D-3)

### DIFF
--- a/lib/config.mli
+++ b/lib/config.mli
@@ -1,0 +1,104 @@
+(** MASC Configuration Management
+
+    Persists mode settings to .masc/config.json *)
+
+(** Configuration record *)
+type t = {
+  mode : Mode.mode;
+  enabled_categories : Mode.category list;
+}
+
+val default : t
+(** Default configuration - always Full mode. *)
+
+val config_filename : string
+(** Config file name ("config.json"). *)
+
+val config_path : string -> string
+(** Get config file path given a room path. *)
+
+val to_json : t -> Yojson.Safe.t
+(** Convert config to JSON. *)
+
+val of_json : Yojson.Safe.t -> t
+(** Parse config from JSON - always returns Full mode regardless of stored value. *)
+
+val load : string -> t
+(** Load config from file. Returns default on failure. *)
+
+val save : string -> t -> unit
+(** Save config to file. *)
+
+val audit_log_path : string -> string
+(** Path to the audit log for a room. *)
+
+val json_string_option : string option -> Yojson.Safe.t
+(** Convert optional string to JSON (Null for None/empty). *)
+
+val mode_change_audit_json :
+  actor:string option ->
+  source:string option ->
+  room_path:string ->
+  previous_config:t ->
+  config:t ->
+  Yojson.Safe.t
+(** Generate audit JSON for a mode change event. *)
+
+val append_mode_change_audit :
+  actor:string option ->
+  source:string option ->
+  room_path:string ->
+  previous_config:t ->
+  config:t ->
+  unit
+(** Append a mode change audit entry to the audit log. *)
+
+val dedupe_schemas : Types.tool_schema list -> Types.tool_schema list
+(** Remove duplicate tool schemas by name, keeping the first occurrence. *)
+
+val raw_all_tool_schemas : Types.tool_schema list
+(** All tool schemas before capability filtering. *)
+
+val validate_schemas : Types.tool_schema list -> unit
+(** Validate tool schemas at module initialization time.
+    Logs warnings for duplicates, empty names/descriptions, non-object input_schema. *)
+
+val all_tool_schemas : Types.tool_schema list
+(** All tool schemas after capability filtering and validation. *)
+
+val all_tool_names : unit -> string list
+(** List of all tool names. *)
+
+val is_tool_visible : string -> bool
+(** Check if a tool is visible. *)
+
+val visible_tool_schemas :
+  ?include_hidden:bool ->
+  ?include_deprecated:bool ->
+  unit -> Types.tool_schema list
+(** Get visible tool schemas. *)
+
+val enabled_tool_schemas :
+  ?include_hidden:bool ->
+  ?include_deprecated:bool ->
+  Mode.category list -> Types.tool_schema list
+(** Get enabled tool schemas filtered by categories. *)
+
+val switch_mode :
+  ?actor:string -> ?source:string -> string -> Mode.mode -> t
+(** Switch mode - no-op, always returns Full. *)
+
+val set_categories :
+  ?actor:string -> ?source:string -> string -> Mode.category list -> t
+(** Set categories - no-op, always returns Full. *)
+
+val enable_category :
+  ?actor:string -> ?source:string -> string -> Mode.category -> t
+(** Enable a category - no-op, always returns Full. *)
+
+val disable_category :
+  ?actor:string -> ?source:string -> string -> Mode.category -> t
+(** Disable a category - no-op, always returns Full. *)
+
+val get_config_summary : string -> Yojson.Safe.t
+(** Get current config summary as JSON for tool response. *)

--- a/lib/eio_context.mli
+++ b/lib/eio_context.mli
@@ -1,0 +1,49 @@
+(** Global Eio context for shared network/clock access.
+    Set during server startup (main_eio.ml). *)
+
+type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
+
+val set_net :
+  [> `Network | `Platform of [> `Generic | `Unix ]] Eio.Resource.t -> unit
+(** Set the global Eio network handle. *)
+
+val set_clock : float Eio.Time.clock_ty Eio.Resource.t -> unit
+(** Set the global Eio clock. *)
+
+val set_mono_clock : Eio.Time.Mono.ty Eio.Resource.t -> unit
+(** Set the global Eio monotonic clock. *)
+
+val get_mono_clock : unit -> Eio.Time.Mono.ty Eio.Resource.t
+(** Get the global Eio monotonic clock.
+    @raise Invalid_argument if not initialized. *)
+
+val set_switch : Eio.Switch.t -> unit
+(** Set the global Eio switch. *)
+
+val get_net_opt : unit -> eio_net option
+(** Get the Eio network handle if available. *)
+
+val get_clock_opt : unit -> float Eio.Time.clock_ty Eio.Resource.t option
+(** Get the Eio clock if available. *)
+
+val get_switch_opt : unit -> Eio.Switch.t option
+(** Get the Eio switch if available. *)
+
+val get_net : unit -> eio_net
+(** Get the Eio network handle.
+    @raise Invalid_argument if not initialized. *)
+
+val get_clock : unit -> float Eio.Time.clock_ty Eio.Resource.t
+(** Get the Eio clock.
+    @raise Invalid_argument if not initialized. *)
+
+val get_switch : unit -> Eio.Switch.t
+(** Get the Eio switch.
+    @raise Invalid_argument if not initialized. *)
+
+val get_https_connector :
+  unit ->
+  (Uri.t ->
+   [ `Generic ] Eio.Net.stream_socket_ty Eio.Resource.t ->
+   [ `Close | `Flow | `R | `Shutdown | `Tls | `W ] Eio.Resource.t)
+(** TLS connector for Cohttp_eio HTTPS support. *)

--- a/lib/env_config.mli
+++ b/lib/env_config.mli
@@ -1,0 +1,15 @@
+(** MASC Environment Configuration
+
+    Centralized environment variable management following 12-Factor App principles.
+    All env vars use MASC_* prefix for consistency.
+
+    This module re-exports Env_config_core, Env_config_runtime,
+    Env_config_governance, and Env_config_keeper. *)
+
+include module type of Env_config_core
+include module type of Env_config_runtime
+include module type of Env_config_governance
+include module type of Env_config_keeper
+
+val print_summary : unit -> unit
+(** Print configuration summary for debugging. *)

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -1,0 +1,122 @@
+(** MASC Runtime Environment Configuration
+
+    Runtime-specific settings: zombies, locks, sessions, tempo, decisions,
+    cache, orchestrator, mitosis, spawn, local runtime, federation,
+    cancellation, neo4j, voice, custom model, network, timeouts,
+    inference defaults, control plane cleanup, message GC, chain. *)
+
+module Zombie : sig
+  val threshold_seconds : float
+  val keeper_threshold_seconds : float
+  val cleanup_interval_seconds : float
+end
+
+module Lock : sig
+  val timeout_seconds : float
+  val expiry_warning_seconds : float
+end
+
+module Session : sig
+  val max_age_seconds : float
+  val rate_limit_window_seconds : float
+end
+
+module Tempo : sig
+  val min_interval_seconds : float
+  val max_interval_seconds : float
+  val default_interval_seconds : float
+end
+
+module Decision : sig
+  val ttl_seconds : float
+end
+
+module Cache : sig
+  val max_entry_size : int
+  val max_entries : int
+end
+
+module Orchestrator : sig
+  val check_interval_seconds : float
+  val agent_name : string
+end
+
+module Mitosis : sig
+  val trigger_interval_seconds : float
+  val handoff_cooldown_seconds : float
+  val experiment_enabled : bool
+  val adaptive_thresholds_enabled : bool
+end
+
+module Spawn : sig
+  val timeout_seconds : int
+  val coding_timeout_seconds : int
+  val grace_period_seconds : int
+end
+
+module Local_runtime : sig
+  val server_url : string
+  val default_model : string
+  val max_tokens : int
+end
+
+module Llama : sig
+  val server_url : string
+  val default_model : string
+  val max_tokens : int
+end
+
+module Federation : sig
+  val timeout_seconds : float
+end
+
+module Cancellation : sig
+  val token_max_age_seconds : float
+end
+
+module Neo4j : sig
+  val uri : string
+  val http_uri : string
+  val user : string
+  val password_result : unit -> (string, string) result
+end
+
+module Voice : sig
+  val default_host : string
+  val default_port : int
+end
+
+module Custom_model : sig
+  val default_server_url : string
+end
+
+module Network : sig
+  val is_localhost : string -> bool
+end
+
+module Timeout : sig
+  val gcloud_auth_sec : float
+  val anthropic_api_sec : int
+  val openai_compat_api_sec : int
+  val model_grace_sec : float
+  val graphql_query_sec : float
+  val keeper_status_sec : float
+end
+
+module Inference_defaults : sig
+  val default_max_tokens : int
+  val sse_retry_ms : int
+  val log_truncation_len : int
+end
+
+module Cp : sig
+  val cleanup_days : int
+end
+
+module Message : sig
+  val max_count : int
+end
+
+module Chain : sig
+  val judge_model : string
+end

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -1,0 +1,98 @@
+(** Centralized error types for masc-mcp
+
+    Provides structured error types to replace string-based errors.
+
+    @since 0.4.0
+*)
+
+(** {1 Domain-Specific Errors} *)
+
+(** Room/Coordination errors *)
+type room_error =
+  | RoomNotFound of string
+  | RoomAlreadyExists of string
+  | RoomLocked of string
+  | RoomFull of int
+
+(** Task errors *)
+type task_error =
+  | TaskNotFound of string
+  | TaskAlreadyClaimed of string
+  | TaskInvalidState of string * string
+  | TaskCycleDetected
+
+(** Agent errors *)
+type agent_error =
+  | AgentNotFound of string
+  | AgentTimeout of string * int
+  | AgentHeartbeatMissing of string
+  | AgentCapabilityMismatch of string
+
+(** Federation/Portal errors *)
+type federation_error =
+  | PortalConnectionFailed of string
+  | PortalAuthFailed of string
+  | PortalTimeout of int
+  | PortalProtocolError of string
+
+(** Storage/Backend errors *)
+type storage_error =
+  | FileNotFound of string
+  | FilePermissionDenied of string
+  | FileLocked of string
+  | PostgresError of string
+  | GitError of string
+
+(** MCP Protocol errors *)
+type mcp_error =
+  | McpParseError of string
+  | McpMethodNotFound of string
+  | McpInvalidParams of string
+  | McpAuthError of string
+  | McpInternalError of string
+
+(** {1 Unified Error Type} *)
+
+(** Top-level error type combining all domains *)
+type t =
+  | Room of room_error
+  | Task of task_error
+  | Agent of agent_error
+  | Federation of federation_error
+  | Storage of storage_error
+  | Mcp of mcp_error
+  | Internal of string
+
+(** {1 Error Utilities} *)
+
+val is_recoverable : t -> bool
+(** Check if an error is recoverable (safe to retry). *)
+
+val to_string : t -> string
+(** Get a human-readable error message. *)
+
+(** {1 Result Helpers} *)
+
+type 'a result = ('a, t) Stdlib.result
+(** Shorthand for error result type. *)
+
+val fail : t -> ('a, t) Stdlib.result
+(** Create an error result. *)
+
+val ok : 'a -> ('a, t) Stdlib.result
+(** Create a success result. *)
+
+val to_string_result : ('a, t) Stdlib.result -> ('a, string) Stdlib.result
+(** Map error to string for legacy compatibility. *)
+
+val of_string : string -> t
+(** Convert string error to Internal error (for migration). *)
+
+(** {1 Logging Integration} *)
+
+type severity = Debug | Info | Warning | Error | Critical
+
+val severity_of_error : t -> severity
+(** Get error severity level. *)
+
+val string_of_severity : severity -> string

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -1,0 +1,114 @@
+(** MASC Logging System - Structured logging with levels *)
+
+(** Log levels *)
+type level =
+  | Debug
+  | Info
+  | Warn
+  | Error
+
+val level_to_string : level -> string
+(** Convert level to string representation. *)
+
+val level_to_int : level -> int
+(** Convert level to integer for comparison. *)
+
+val level_of_string : string -> level
+(** Parse level from string. Defaults to Info for unrecognized input. *)
+
+val should_log : level -> bool
+(** Check if a message at the given level should be logged. *)
+
+val set_level : level -> unit
+(** Set the global log level. *)
+
+val set_level_from_string : string -> unit
+(** Set the global log level from a string (e.g., from env var). *)
+
+val init_from_env : unit -> unit
+(** Initialize log level from MASC_LOG_LEVEL env var. *)
+
+val timestamp : unit -> string
+(** Get current timestamp as formatted string. *)
+
+val log : level -> ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+(** Log a message at the given level with optional context. *)
+
+val debug : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+val info : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+val warn : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+val error : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
+
+(** Functor for creating module-specific loggers.
+    [M.name] controls the env-var key MASC_LOG_{NAME}_LEVEL
+    and the context prefix in log output. *)
+module Make (_ : sig val name : string end) : sig
+  val debug : ('a, unit, string, unit) format4 -> 'a
+  val info : ('a, unit, string, unit) format4 -> 'a
+  val warn : ('a, unit, string, unit) format4 -> 'a
+  val error : ('a, unit, string, unit) format4 -> 'a
+end
+
+(** {1 Pre-defined module loggers} *)
+
+module Room : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Mcp : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Auth : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Retry : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Backend : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Session : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Cancel : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Sub : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Mitosis_log : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Spawn : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Pulse : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module ModelClient : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Orchestrator : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module BoardLog : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Metrics : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Dashboard : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Trpg : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Feed : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Telemetry : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Noosphere : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module CmdPlane : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Governance : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Social : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Transport : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Gc : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Reputation : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Keeper : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Memory : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Mention : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Misc : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Autoresearch : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Identity : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Institution : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Pages : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Thompson : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Chain : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Config : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Task : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Swarm : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Http : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Langfuse : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Server : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Dispatch : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module BoardPg : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module MemoryPg : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module MemoryJsonl : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module AutoResponder : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Env : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Level2 : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module RoomTask : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Inline : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Protocol : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Perpetual : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module KeeperExec : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module BoardListener : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Council : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module LocalWorker : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Sse : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Verifier : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Planner : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module CodeSwarm : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end

--- a/lib/oas_response.mli
+++ b/lib/oas_response.mli
@@ -1,0 +1,15 @@
+(** OAS response helpers.
+
+    Repo-local code should read SDK responses through this module rather than
+    reaching into provider-specific helper namespaces. *)
+
+type api_response = Agent_sdk.Types.api_response
+
+val text_of_response : api_response -> string
+(** Extract text content from an API response. *)
+
+val model_used : api_response -> string
+(** Return the model identifier used for the response. *)
+
+val usage_or_zero : api_response -> Agent_sdk.Types.api_usage
+(** Return usage stats, defaulting to zero when absent. *)

--- a/lib/resilience.mli
+++ b/lib/resilience.mli
@@ -1,0 +1,63 @@
+(** MASC Resilience - Single Source of Truth for Failure Handling *)
+
+val default_zombie_threshold : float
+(** Default zombie threshold in seconds - from Env_config. *)
+
+val default_warning_threshold : float
+(** Default inactivity warning threshold in seconds (2 minutes). *)
+
+(** Timestamp utilities for resilience checks *)
+module Time : sig
+  val now : unit -> float
+  (** Get current time as Unix float. *)
+
+  val parse_iso8601_opt : string -> float option
+  (** Parse ISO 8601 UTC timestamp ("YYYY-MM-DDTHH:MM:SSZ") to Unix epoch.
+      Returns None on parse failure. *)
+
+  val is_stale : ?threshold:float -> string -> bool
+  (** Check if a timestamp string is older than threshold.
+      Treats invalid timestamps as stale. *)
+end
+
+(** Zombie detection logic *)
+module Zombie : sig
+  val is_keeper_name : string -> bool
+  (** Check if agent name matches keeper pattern: "keeper-*-agent" (case-insensitive). *)
+
+  val is_zombie : ?threshold:float -> string -> bool
+  (** Check if an agent is a zombie based on last_seen ISO timestamp. *)
+
+  val is_keeper : name:string -> agent_type:string -> bool
+  (** Check if agent is a keeper by name pattern AND/OR agent_type field. *)
+
+  val is_zombie_for_agent : agent_name:string -> string -> bool
+  (** Check if an agent is a zombie, using keeper threshold for keeper agents. *)
+end
+
+(** {1 Zero-Zombie Protocol} *)
+
+module ZeroZombie : sig
+  type stats = {
+    mutable total_cleanups: int;
+    mutable last_cleanup_ts: float;
+    mutable last_cleaned_agents: string list;
+  }
+
+  val global_stats : stats
+  (** Global cleanup statistics. *)
+
+  val cleanup : cleanup_fn:(unit -> string list) -> string list
+  (** Run a cleanup cycle using provided cleanup function.
+      Returns list of cleaned agent names. *)
+
+  val is_benign_error : exn -> bool
+  (** Check if error is benign (e.g., not initialized - normal at startup). *)
+
+  val run_loop :
+    ?interval:float ->
+    clock:float Eio.Time.clock_ty Eio.Resource.t ->
+    cleanup_fn:(unit -> string list) ->
+    unit -> unit
+  (** Eio-native background loop for automatic cleanup. *)
+end

--- a/lib/safe_ops.mli
+++ b/lib/safe_ops.mli
@@ -1,0 +1,79 @@
+(** Safe Operations Module
+
+    Provides safe wrappers for common operations that may fail,
+    with proper error handling and logging instead of silent suppression.
+*)
+
+(** {1 Exception-Safe Wrappers} *)
+
+val try_with_log : string -> (unit -> 'a) -> 'a option
+(** Execute a function, logging exceptions and returning None on failure. *)
+
+val try_with_default : default:'a -> string -> (unit -> 'a) -> 'a
+(** Execute with default value on failure. *)
+
+(** {1 JSON Parsing} *)
+
+val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result
+(** Parse JSON with detailed error reporting. *)
+
+(** {1 File I/O} *)
+
+val read_file_safe : string -> (string, string) result
+(** Read file contents with error handling.
+    Uses Eio-native I/O via Fs_compat when available (after set_fs),
+    falls back to blocking I/O in non-Eio contexts. *)
+
+val read_json_file_safe : string -> (Yojson.Safe.t, string) result
+(** Read JSON file safely. *)
+
+val read_json_eio : string -> Yojson.Safe.t
+(** Read JSON file via Eio-native I/O (Fs_compat).
+    Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts. *)
+
+val list_dir_safe : string -> (string list, string) result
+(** List files in directory safely. *)
+
+val remove_file_logged : ?context:string -> string -> unit
+(** Remove file with logging on failure (for cleanup operations). *)
+
+val close_in_logged : in_channel -> unit
+(** Close channel with logging on failure. *)
+
+(** {1 Numeric Parsing} *)
+
+val int_of_string_safe : string -> int option
+(** Safe integer parsing. *)
+
+val int_of_string_with_default : default:int -> string -> int
+(** Integer parsing with default. *)
+
+val float_of_string_safe : string -> float option
+(** Safe float parsing. *)
+
+val float_of_string_with_default : default:float -> string -> float
+(** Float parsing with default. *)
+
+(** {1 Environment Variables} *)
+
+val get_env_int_logged : string -> default:int -> int
+(** Get environment variable as int with logging when invalid. *)
+
+val get_env_float_logged : string -> default:float -> float
+(** Get environment variable as float with logging when invalid. *)
+
+(** {1 JSON Value Extraction Helpers}
+
+    Safe extraction from Yojson.Safe.t values with proper error handling.
+    These replace [with _ -> default] patterns in JSON parsing code.
+*)
+
+val json_string : ?default:string -> string -> Yojson.Safe.t -> string
+val json_int : ?default:int -> string -> Yojson.Safe.t -> int
+val json_float : ?default:float -> string -> Yojson.Safe.t -> float
+val json_bool : ?default:bool -> string -> Yojson.Safe.t -> bool
+val json_string_list : string -> Yojson.Safe.t -> string list
+val json_string_opt : string -> Yojson.Safe.t -> string option
+val json_int_opt : string -> Yojson.Safe.t -> int option
+val json_float_opt : string -> Yojson.Safe.t -> float option
+val json_bool_opt : string -> Yojson.Safe.t -> bool option

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -1,0 +1,104 @@
+(** Central Tool Dispatch Registry - O(1) Hashtbl-based dispatch.
+
+    Replaces the 40+ sequential match chain in mcp_server_eio.ml with
+    a single Hashtbl lookup. Each Tool_X module registers a closure
+    that captures its own context, so the dispatch layer does not need
+    to know about heterogeneous context types. *)
+
+(** Unified handler type: every tool call is [name * args -> result option].
+    [None] means "this handler does not know this tool". *)
+type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
+
+(** {1 Registration} *)
+
+val register : tool_name:string -> handler:handler -> unit
+(** Register a single tool name to handler mapping. *)
+
+val register_module : schemas:Types.tool_schema list -> handler:handler -> unit
+(** Bulk-register every tool name from a schema list to the same handler. *)
+
+(** {1 Dispatch} *)
+
+val dispatch : name:string -> args:Yojson.Safe.t -> (bool * string) option
+(** O(1) dispatch. Returns [Some (success, message)] when a handler is
+    found, [None] when the tool name is unknown to the registry. *)
+
+(** {2 Dispatch Hooks}
+
+    Pre-hooks run before the handler; post-hooks run after. *)
+
+type pre_hook = name:string -> args:Yojson.Safe.t -> Tool_result.t option
+(** Pre-hook: receives tool name and args before handler runs.
+    Return [None] to proceed, [Some result] to short-circuit. *)
+
+type post_hook = Tool_result.t -> Tool_result.t
+(** Post-hook: receives result after handler completes.
+    Return the (possibly transformed) result. *)
+
+val pre_hooks : pre_hook list ref
+(** Mutable list of registered pre-hooks. *)
+
+val post_hooks : post_hook list ref
+(** Mutable list of registered post-hooks. *)
+
+val register_pre_hook : pre_hook -> unit
+val register_post_hook : post_hook -> unit
+val clear_hooks : unit -> unit
+
+val dispatch_structured : name:string -> args:Yojson.Safe.t -> Tool_result.t option
+(** Structured dispatch with hook support.
+    Execution order: pre-hooks -> handler -> post-hooks. *)
+
+(** {1 Feature Flag and Introspection} *)
+
+val v2_enabled : bool
+(** Feature flag: use the new dispatch path (default ON since v2.102). *)
+
+val registered_count : unit -> int
+(** Number of registered tool names. *)
+
+val is_registered : string -> bool
+(** Check whether a tool name is registered. *)
+
+(** {1 Read-only and Join-required Sets} *)
+
+val init_read_only_set : string list -> unit
+val init_requires_join_set : string list -> unit
+val is_read_only : string -> bool
+val is_join_required : string -> bool
+
+(** {2 Module Tag Dispatch - O(1) two-level dispatch}
+
+    Maps tool names to module tags at startup (once).
+    At call time, O(1) tag lookup determines which module's context
+    to create lazily. *)
+
+type module_tag =
+  | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
+  | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
+  | Mod_tempo | Mod_mitosis | Mod_portal | Mod_worktree
+  | Mod_code_swarm | Mod_code | Mod_vote | Mod_social
+  | Mod_council | Mod_a2a | Mod_handover
+  | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
+  | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit
+  | Mod_cost | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
+  | Mod_library | Mod_keeper | Mod_perpetual | Mod_compact | Mod_mdal
+  | Mod_notifications | Mod_inline
+  | Mod_autoresearch
+  | Mod_model_catalog
+
+val register_module_tag : schemas:Types.tool_schema list -> tag:module_tag -> unit
+(** Register tool names from a schema list with a module tag. *)
+
+val register_name_tag : tool_name:string -> tag:module_tag -> unit
+(** Register a single tool name with a tag. *)
+
+val lookup_tag : string -> module_tag option
+(** Look up the module tag for a tool name. *)
+
+val tag_registry_count : unit -> int
+(** Number of entries in the tag registry. *)
+
+val mark_tag_registry_initialized : unit -> unit
+val is_tag_registry_initialized : unit -> bool


### PR DESCRIPTION
## Summary

Phase D-3: .mli coverage expansion for the 10 most externally referenced modules.

### Added interfaces (763 LOC total)
| Module | External Refs | .mli LOC |
|--------|--------------|----------|
| log | 189 | 114 |
| safe_ops | 78 | 79 |
| env_config | 52 | 15 |
| eio_context | 21 | 49 |
| oas_response | 18 | 15 |
| config | 17 | 104 |
| error | 13 | 98 |
| resilience | 13 | 63 |
| tool_dispatch | 12 | 104 |
| env_config_runtime | 12 | 122 |

Coverage: 20.4% → 22.1% (115 → 125 .mli files).
These 10 modules account for 425+ combined external references.

## Test plan
- [x] `dune build --root .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)