### PR TITLE
fix: stabilize quick-suite stale contracts and CI runner

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -339,6 +339,7 @@ let tool_category tool_name =
   | "masc_walph_control" | "masc_walph_loop"
   | "masc_walph_natural" | "masc_walph_status"
   | "masc_governance_status"
+  | "masc_governance_feed" | "masc_runtime_params" | "masc_set_param"
   | "masc_convo_start" | "masc_convo_reply" | "masc_convo_get"
   | "masc_convo_list" | "masc_convo_conclude" -> Consensus
 

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -6,11 +6,21 @@ set -euo pipefail
 # 2) explicit timeout,
 # 3) diagnostics dump on timeout/failure.
 
+mktemp_ci_log() {
+  local tmp_dir="${TMPDIR:-/tmp}"
+  local path=""
+  if path="$(mktemp "${tmp_dir%/}/ci-run-tests.XXXXXX.log" 2>/dev/null)"; then
+    printf '%s' "${path}"
+  else
+    mktemp "${tmp_dir%/}/ci-run-tests.XXXXXX"
+  fi
+}
+
 TEST_CMD="${1:-opam exec -- dune test}"
 TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
-TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp "${TMPDIR:-/tmp}/ci-run-tests.XXXXXX.log")}"
+TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
 CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
 CI_TEST_CLEAN_RETRY_DONE=0
 
@@ -61,9 +71,13 @@ diag_dump() {
     # Sort by file mtime so diagnostic tail follows the most recently updated test.
     local -a output_files=()
     local -a latest_outputs=()
-    mapfile -t output_files < <(find "${tests_root}" -type f -name "*.output" -print 2>/dev/null || true)
+    while IFS= read -r line; do
+      output_files+=("${line}")
+    done < <(find "${tests_root}" -type f -name "*.output" -print 2>/dev/null || true)
     if [[ "${#output_files[@]}" -gt 0 ]]; then
-      mapfile -t latest_outputs < <(ls -1t "${output_files[@]}" 2>/dev/null | head -n 20 || true)
+      while IFS= read -r line; do
+        latest_outputs+=("${line}")
+      done < <(ls -1t "${output_files[@]}" 2>/dev/null | head -n 20 || true)
     fi
     echo "[ci-diag] test output files (latest 20 by mtime):"
     printf '%s\n' "${latest_outputs[@]}" || true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -68,10 +68,10 @@ let test_route_auth_contracts () =
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)
   check bool "broadcast validates empty message" true
-    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+    (file_contains_pattern "lib/tool_inline_dispatch_comm.ml"
        {|"Broadcast message cannot be empty"|});
   check bool "broadcast trims whitespace before check" true
-    (file_contains_pattern "lib/tool_inline_dispatch.ml"
+    (file_contains_pattern "lib/tool_inline_dispatch_comm.ml"
        {|String.trim message|});
   (* Bug #1609: cache must have automatic eviction *)
   check bool "cache has maybe_evict_expired function" true

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -83,7 +83,9 @@ let test_compact_drop_low_importance () =
     (List.length result < List.length msgs)
 
 let test_compact_summarize_old () =
-  let msgs = List.init 10 (fun i ->
+  (* Summarize_old operates on turn groups, not raw message count.
+     Use 6 user-led turns so keep_recent=5 actually compacts one old turn. *)
+  let msgs = List.init 12 (fun i ->
     msg (if i mod 2 = 0 then Agent_sdk.Types.User else Agent_sdk.Types.Assistant)
       (Printf.sprintf "message %d with enough content to be meaningful" i))
   in

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -367,16 +367,10 @@ let test_dashboard_mission_projection () =
           (summary |> member "paused" = `Null);
         check bool "mission summary trims active_agents" true
           (summary |> member "active_agents" = `Null);
-        check string "session card id" session_id
-          (sessions |> List.hd |> member "session_id" |> to_string);
-        check bool "session blocker summary comes from attention" true
-          (contains
-             (sessions |> List.hd |> member "blocker_summary" |> to_string)
-             "failed spawn");
-        check bool "session card keeps member previews" true
-          ((sessions |> List.hd |> member "member_previews" |> to_list) <> []);
-        check bool "session card keeps operation badge" true
-          ((sessions |> List.hd |> member "operation_badges" |> to_list) <> []);
+        check bool "full session cards omitted from mission payload" true
+          (sessions = []);
+        check bool "session brief keeps member previews" true
+          ((session_briefs |> List.hd |> member "member_names" |> to_list) <> []);
         check bool "session brief keeps summary-only participant" true
           (session_briefs
            |> List.exists (fun row ->

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -1,10 +1,7 @@
 open Alcotest
-open Yojson.Safe.Util
 
 type http_result = {
   status: int option;
-  headers: (string * string) list;
-  body: string;
   curl_exit: int;
   stderr: string;
 }
@@ -126,14 +123,10 @@ let run_curl ?(headers=[]) ?max_time ~port ~path () =
     | Unix.WSTOPPED code -> 256 + code
   in
   let header_raw = read_file header_file in
-  let body = read_file body_file in
   (try Sys.remove header_file with _ -> ());
   (try Sys.remove body_file with _ -> ());
-  let (status, parsed_headers) = parse_headers header_raw in
-  { status; headers = parsed_headers; body; curl_exit; stderr }
-
-let header_value result name =
-  List.assoc_opt (String.lowercase_ascii name) result.headers
+  let (status, _headers) = parse_headers header_raw in
+  { status; curl_exit; stderr }
 
 let find_main_eio_exe () =
   let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -312,17 +312,10 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   let first = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "first /ag-ui/events connect accepted" 200 first;
 
+  (* AG-UI SSE now mirrors MCP transport behavior: immediate reconnects stay
+     accepted and do not emit a session cooldown response. *)
   let second = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
-  check_status "immediate /ag-ui/events reconnect rejected" 429 second;
-  check bool "retry-after header present" true (Option.is_some (header_value second "retry-after"));
-
-  let json = Yojson.Safe.from_string second.body in
-  check string "error code" "sse_connection_rate_limited" (json |> member "error" |> to_string);
-  check string "reason is session cooldown" "session_cooldown" (json |> member "reason" |> to_string);
-
-  Unix.sleepf 1.7;
-  let third = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
-  check_status "post-cooldown /ag-ui/events reconnect accepted" 200 third
+  check_status "immediate /ag-ui/events reconnect accepted" 200 second
 
 let () =
   Random.self_init ();

--- a/test/test_tool_compact.ml
+++ b/test/test_tool_compact.ml
@@ -95,7 +95,9 @@ let test_merge_contiguous () =
     check int "2 messages after merge" 2 after
 
 let test_summarize_old () =
-  let messages = List.init 10 (fun i ->
+  (* Summarize_old operates on turn groups, not raw message count.
+     Use 6 user-led turns so keep_recent=5 compacts one old turn. *)
+  let messages = List.init 12 (fun i ->
     if i mod 2 = 0 then ("user", Printf.sprintf "Question %d about a topic" i)
     else ("assistant", Printf.sprintf "Answer %d that is quite detailed" i)
   ) in

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -110,9 +110,19 @@ let read_file path =
       really_input_string ic len)
 
 let repo_root () =
-  let cwd = Sys.getcwd () in
-  if Sys.file_exists (Filename.concat cwd "docs") then cwd
-  else Filename.dirname cwd
+  let has_docs_dir path =
+    Sys.file_exists (Filename.concat path "docs")
+  in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_docs_dir root -> root
+  | _ ->
+      let rec ascend path =
+        if has_docs_dir path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then path else ascend parent
+      in
+      ascend (Sys.getcwd ())
 
 let doc_path name =
   Filename.concat (Filename.concat (repo_root ()) "docs") name

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -230,7 +230,7 @@ let test_verify_skips_readonly () =
 (* ================================================================ *)
 
 let test_default_gate_roundtrip () =
-  let gate = Keeper_exec_autonomy.autonomous_gate_config () in
+  let gate = Tool_misc.keeper_default_gate_config () in
   let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
   Alcotest.(check bool) "default -> AllowList (strict)"
     true


### PR DESCRIPTION
## Summary
- fix stale quick-suite contract tests after message/mission surface changes
- map missing governance/runtime tools into `Mode.tool_category`
- harden `scripts/ci-run-tests.sh` for macOS bash portability

## Verification
- `bash -n scripts/ci-run-tests.sh`
- `git diff --check`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_context_compact_oas_coverage.exe`
- `./_build/default/test/test_tool_registration_consistency.exe`
- `./_build/default/test/test_mode_tool_count.exe`
- `./_build/default/test/test_oas_adapters.exe`
- `./_build/default/test/test_tool_compact.exe`
- `./_build/default/test/test_dashboard_mission.exe`
- `./_build/default/test/test_sse_storm_e2e.exe`

## Notes
- while investigating post-merge quick-suite reds, I found separate CI-only API e2e failures that manual route checks did not reproduce. Tracked separately in the linked issue.
