### PR TITLE
fix(test): use current keeper gate config helper

### DIFF
--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -226,11 +226,11 @@ let test_verify_skips_readonly () =
     (Verifier_oas.verify req = Pass)
 
 (* ================================================================ *)
-(* Roundtrip: autonomous_gate_config -> guardrails                   *)
+(* Roundtrip: keeper_default_gate_config -> guardrails               *)
 (* ================================================================ *)
 
 let test_default_gate_roundtrip () =
-  let gate = Keeper_exec_autonomy.autonomous_gate_config () in
+  let gate = Tool_misc.keeper_default_gate_config () in
   let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
   Alcotest.(check bool) "default -> AllowList (strict)"
     true


### PR DESCRIPTION
## Summary
- replace the stale `Keeper_exec_autonomy.autonomous_gate_config` reference in `test_verifier_oas_bridge`
- point the roundtrip assertion at the current keeper default gate config helper
- restore `dune build --root . @check` on current main

## Testing
- dune build --root . @check
