### PR TITLE
fix(test): replace deleted Keeper_exec_autonomy ref in test

### DIFF
--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -230,7 +230,7 @@ let test_verify_skips_readonly () =
 (* ================================================================ *)
 
 let test_default_gate_roundtrip () =
-  let gate = Keeper_exec_autonomy.autonomous_gate_config () in
+  let gate = Tool_misc.keeper_default_gate_config () in
   let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
   Alcotest.(check bool) "default -> AllowList (strict)"
     true


### PR DESCRIPTION
## Summary
- `test_verifier_oas_bridge.ml` referenced deleted module `Keeper_exec_autonomy`
- Replaced with `Tool_misc.keeper_default_gate_config()` (identical gate config)
- This was the root cause of 2 cascading build errors on main (`@check`)

## Test plan
- [x] `dune build @check` passes with 0 errors