### PR TITLE
fix: Eio.Cancel.Cancelled guards round 3 (52 catches, 33 files)

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -579,7 +579,7 @@ let apply_code_change ~workdir ~target_file ~new_content =
       Fs_compat.save_file tmp_path new_content;
       Unix.rename tmp_path abs_path;
       Result.ok original
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       (try Sys.remove tmp_path with Sys_error _ -> ());
       Result.error (Printf.sprintf "Failed to write %s: %s"
         target_file (Printexc.to_string exn)))

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -288,7 +288,7 @@ let maybe_sweep store =
   let now = Time_compat.now () in
   if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then
     (try ignore (sweep store)
-     with exn -> Log.BoardLog.warn "sweep failed: %s" (Printexc.to_string exn));
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.BoardLog.warn "sweep failed: %s" (Printexc.to_string exn));
   if now -. store.last_flush > flush_interval_sec then
     !deferred_flush_fn store
 

--- a/lib/board/board_pg_queries.ml
+++ b/lib/board/board_pg_queries.ml
@@ -39,7 +39,7 @@ let post_of_row
       in
       let meta_json =
         match meta_raw with
-        | Some raw -> (try Some (Yojson.Safe.from_string raw) with exn ->
+        | Some raw -> (try Some (Yojson.Safe.from_string raw) with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.BoardPg.warn "meta_json parse failed: %s (raw=%s)" (Printexc.to_string exn) raw;
             None)
         | None -> None

--- a/lib/chain/chain_executor_complex.ml
+++ b/lib/chain/chain_executor_complex.ml
@@ -426,7 +426,7 @@ let execute_stream_merge ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : ex
                  Eio.Mutex.use_rw count_mutex ~protect:true (fun () ->
                    incr completed_count);
                  safe_stream_add (Some (node.id, Error msg))
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              let err = Printexc.to_string exn in
              Eio.Mutex.use_rw count_mutex ~protect:true (fun () ->
                incr completed_count);

--- a/lib/chain/chain_executor_leaf.ml
+++ b/lib/chain/chain_executor_leaf.ml
@@ -262,7 +262,7 @@ let execute_masc_broadcast ctx ~tool_exec (node : node) ~message ~room ~mention 
   (* Call masc.masc_broadcast via tool_exec *)
   let result =
     try tool_exec ~name:"masc.masc_broadcast" ~args
-    with exn -> Error (Printexc.to_string exn)
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
   in
   let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
   match result with
@@ -382,7 +382,7 @@ let execute_masc_claim ctx ~tool_exec (node : node) ~task_id ~room : (string, st
   in
   let result =
     try tool_exec ~name:tool_name ~args
-    with exn -> Error (Printexc.to_string exn)
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
   in
   let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
   match result with
@@ -404,7 +404,7 @@ let execute_tool_node ctx ~tool_exec ~(node : node) (tool : node_type) : (string
       let resolved_args = substitute_json ctx args in
       let result =
         try tool_exec ~name ~args:resolved_args
-        with exn -> Error (Printexc.to_string exn)
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
       in
       let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
       (match result with

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -107,7 +107,7 @@ let load_prompt_dir dir =
                | Error msg ->
                    Log.Chain.warn "prompt parse failed for %s: %s"
                      path msg
-             with exn ->
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.Chain.error "prompt load failed for %s: %s"
                  path (Printexc.to_string exn)))
 

--- a/lib/chain/chain_orchestrator_eio.ml
+++ b/lib/chain/chain_orchestrator_eio.ml
@@ -315,7 +315,7 @@ let orchestrate
   in
   let notify_chain_designed (chain : chain) =
     try on_chain_designed chain
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Chain_log.warn "orchestrator" "on_chain_designed failed for %s: %s"
         chain.id (Printexc.to_string exn)
   in

--- a/lib/chain/chain_registry.ml
+++ b/lib/chain/chain_registry.ml
@@ -84,7 +84,7 @@ let init ?persist_dir () =
                    }
                | Error msg ->
                    Log.Chain.error "Failed to parse %s: %s" path msg)
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Chain.info "Exception loading %s: %s" path (Printexc.to_string exn)
           end
         ) files
@@ -149,7 +149,7 @@ let load_from_dir (dir : string) : (int * (string * string) list) =
               incr loaded
           | Error msg ->
               errors := (path, msg) :: !errors
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           errors := (path, Printexc.to_string exn) :: !errors
       end
     ) files;

--- a/lib/chain/chain_run_store.ml
+++ b/lib/chain/chain_run_store.ml
@@ -296,7 +296,7 @@ let run_record_to_json (r : run_record) : Yojson.Safe.t =
 
 let persist_run_record (r : run_record) =
   try append_persistent_json (run_record_to_json r)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Chain.error "persist failed: %s"
       (Printexc.to_string exn)
 

--- a/lib/chain/chain_telemetry.ml
+++ b/lib/chain/chain_telemetry.ml
@@ -45,7 +45,7 @@ let history_file () =
 let append_history (json : Yojson.Safe.t) =
   try
     Fs_compat.append_jsonl (history_file ()) json
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     (* Log telemetry write errors for debugging - non-critical *)
     Log.Telemetry.error "Write error to %s: %s" (history_file ())
       (Printexc.to_string exn)
@@ -228,7 +228,7 @@ let emit event =
   (* Call handlers outside of lock to avoid deadlocks *)
   List.iter (fun handler ->
     try handler event
-    with exn -> Log.Chain.warn "chain_telemetry: event handler failed: %s" (Printexc.to_string exn)
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Chain.warn "chain_telemetry: event handler failed: %s" (Printexc.to_string exn)
   ) handlers
 
 (** {1 Subscription API} *)

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -321,7 +321,7 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
             with Not_found -> List.rev acc
           in
           collect 0 []
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Printf.eprintf "[Council] mention extraction failed: %s\n%!"
             (Printexc.to_string exn);
           []

--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -188,7 +188,7 @@ let execute_config_change key value =
       stderr = "";
       output = msg;
       timestamp = Time_compat.now () }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     let msg = Printf.sprintf "Config error: %s" (Printexc.to_string exn) in
     { success = false;
       stdout = "";
@@ -216,7 +216,7 @@ let execute_notification target message =
       stderr = "";
       output = msg;
       timestamp = Time_compat.now () }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     let msg = Printf.sprintf "Notification error: %s" (Printexc.to_string exn) in
     { success = false;
       stdout = "";

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -630,7 +630,7 @@ let list_org_rooms ~org_id : Yojson.Safe.t =
               ("success", `Bool false);
               ("error", `String (Printf.sprintf "Fetch stopped: %s" rooms_url));
             ]
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.Misc.error "federation: remote room list error: %s" (Printexc.to_string exn);
           `Assoc [
             ("success", `Bool false);

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -413,7 +413,7 @@ let gc config ?(days=7) () =
                  Log.Misc.error "failed to archive session %s" session_id);
               incr session_archive_count
             end
-          with exn ->
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.Gc.warn "session archive %s failed: %s" session_id (Printexc.to_string exn)
       end
     )

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -410,7 +410,7 @@ let complete_task config ~agent_name ~task_id ~notes =
             (try
                let active = (Room_state.read_state config).active_agents in
                Relation_materializer.on_task_done ~assignee:agent_name ~active_agents:active
-             with exn ->
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.RoomTask.error "relation-materializer task hook error: %s"
                  (Printexc.to_string exn));
             Printf.sprintf "✅ %s completed %s" agent_name task_id

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -499,7 +499,7 @@ let walph_loop config ~net:_net ~clock ~agent_name
 	                          in
 	                          if response = "" then Error "Empty MODEL response"
 	                          else Ok response
-	                        with exn -> Error (Printexc.to_string exn)
+	                        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 	                    in
 
 	                    (match chain_result with

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -63,7 +63,7 @@ let handle_a2a_subscribe _ctx args =
     match A2a_tools.subscribe ?agent_filter ~events () with
     | Ok json -> (true, Yojson.Safe.pretty_to_string json)
     | Error e -> (false, Printf.sprintf "❌ Subscribe failed: %s" e)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     (false, Printf.sprintf "❌ Subscribe exception: %s" (Printexc.to_string exn)))
 
 let handle_a2a_unsubscribe _ctx args =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -89,7 +89,7 @@ let broadcast_cycle_result (state : Autoresearch.loop_state) (record : Autoresea
     ("delta", `Float record.delta);
     ("baseline", `Float state.baseline);
     ("best_score", `Float state.best_score);
-  ]) with exn ->
+  ]) with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Autoresearch.warn "broadcast_cycle_result failed: %s" (Printexc.to_string exn)
 
 (* ================================================================ *)
@@ -441,7 +441,7 @@ let handle_stop ctx args =
                        ("reason", `String reason);
                        ("status", `String (Autoresearch.status_to_string state.status));
                      ])
-             with exn ->
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.Autoresearch.warn "stop event append failed: %s" (Printexc.to_string exn))
         | None -> ());
         `Assoc [
@@ -662,7 +662,7 @@ let handle_cycle ctx args =
                                    ("baseline", `Float state.baseline);
                                    ("best_score", `Float state.best_score);
                                  ])
-                         with exn ->
+                         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                            Log.Autoresearch.warn "cycle event append failed: %s" (Printexc.to_string exn))
                     | None -> ());
                     (* 10. SSE broadcast *)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -189,7 +189,7 @@ let handle_post_create args =
       (match !board_event_hook with
        | Some cb -> (
            try cb.on_post_created post
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.BoardLog.error "on_post_created callback failed: %s"
                (Printexc.to_string exn))
        | None -> ());
@@ -320,7 +320,7 @@ let handle_comment_add args =
       (match !board_event_hook with
        | Some cb -> (
            try cb.on_comment_created comment
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.BoardLog.error "on_comment_created callback failed: %s"
                (Printexc.to_string exn))
        | None -> ());

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -225,7 +225,7 @@ let handle_code_symbols ctx args =
                 ("symbols", `List symbols_json);
               ] in
               (true, Yojson.Safe.pretty_to_string response)
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               (false, Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn))
           end
         end
@@ -280,7 +280,7 @@ let handle_code_read ctx args =
                 ("lines", `List (List.map (fun s -> `String s) result_lines));
               ] in
               (true, Yojson.Safe.pretty_to_string response)
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               (false, Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn))
           end
         end

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -112,7 +112,7 @@ let json_string_member_opt json key =
 let read_json_file_opt path =
   if Sys.file_exists path then
     (try Some (Safe_ops.read_json_eio path)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.CmdPlane.warn "read_json_file_opt %s: %s" path (Printexc.to_string exn);
        None)
   else
@@ -201,9 +201,9 @@ let run_process_with_timeout ~clock_opt ~timeout_sec ~prog ~argv ~env =
   let finalize exit_code =
     let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
     let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in
-    (try Sys.remove stdout_path with exn ->
+    (try Sys.remove stdout_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.CmdPlane.warn "failed to remove stdout tmpfile %s: %s" stdout_path (Printexc.to_string exn));
-    (try Sys.remove stderr_path with exn ->
+    (try Sys.remove stderr_path with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.CmdPlane.warn "failed to remove stderr tmpfile %s: %s" stderr_path (Printexc.to_string exn));
     { exit_code; stdout; stderr }
   in

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -38,7 +38,7 @@ let dispatch ~name ~args : (bool * string) option =
   match Hashtbl.find_opt registry name with
   | Some handler -> (
       try handler ~name ~args
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Some
           ( false,
             Printf.sprintf "dispatch_v2 handler error for %s: %s" name

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -422,7 +422,7 @@ let add_fallback_task ctx node err =
         node.Goal_orchestrator.node_id node.Goal_orchestrator.depth err
     in
     try Some (Room.add_task ctx.config ~title ~priority:2 ~description:desc)
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.error "add_fallback_task failed: %s" (Printexc.to_string exn);
       None
 

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -75,11 +75,11 @@ let handle_heartbeat_start ctx args =
           (* Keep agent liveness fresh so zombie cleanup does not remove active heartbeat owners. *)
           (try
              ignore (Room.heartbeat ctx.config ~agent_name:ctx.agent_name)
-           with exn -> log_non_cancelled "[Heartbeat] keepalive error" exn);
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_non_cancelled "[Heartbeat] keepalive error" exn);
           if should_send then begin
             (try
                ignore (Room.broadcast ctx.config ~from_agent:ctx.agent_name ~content:message)
-             with exn -> log_non_cancelled "[Heartbeat] broadcast error" exn);
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_non_cancelled "[Heartbeat] broadcast error" exn);
             last_heartbeat := Time_compat.now ()
           end;
           (* Sleep for base interval (smart mode adjusts internally) *)
@@ -88,7 +88,7 @@ let handle_heartbeat_start ctx args =
       | _ -> ()
     in
     try loop ()
-    with exn -> log_non_cancelled "[Heartbeat] loop error" exn
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_non_cancelled "[Heartbeat] loop error" exn
   );
   let mode_str = if smart then " [SMART]" else "" in
   (true, Printf.sprintf "✅ Heartbeat started: %s (interval: %ds, message: %s)%s" hb_id interval message mode_str)

--- a/lib/tool_inline_dispatch_episode.ml
+++ b/lib/tool_inline_dispatch_episode.ml
@@ -87,7 +87,7 @@ let handle_episode_flush ~config ~arguments ~(state : Mcp_server.server_state) ~
         Sys.rename file_path new_path;
         Printf.printf "[EPISODE/FLUSH] Processed episode %s -> %s\n%!" ep_id new_path;
         incr flushed
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Misc.error "Failed to flush %s: %s" file (Printexc.to_string exn);
         incr failed
     ) pending_files;

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -59,7 +59,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
             (match Jiphyeon.Archive.get_agent_episodes ~sw ~env cell_id 5 with
              | Ok episodes -> (List.length episodes, List.nth_opt episodes 0)
              | Error _ -> (0, None))
-          with exn ->
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.Inline.warn "%s: %s" __FUNCTION__ (Printexc.to_string exn);
             (0, None))
         | None -> (0, None)

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -64,7 +64,7 @@ let handle_start (ctx : context) : result option =
       try
         let _msg = Room.join active_config ~agent_name ~capabilities:[] () in
         Ok ()
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let msg = Printexc.to_string exn in
         if String.length msg > 0 then Error msg else Error "join failed"
     in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -352,7 +352,7 @@ let handle_persistent_agent_create_from_persona ctx args : tool_result =
 let dispatch ctx ~name ~args : tool_result option =
   (* Resident keepers are bootstrapped lazily on tool use as a fallback.
      Server startup also calls bootstrap_existing_keepers for always-on presence. *)
-  (try start_existing_keepalives ctx with exn ->
+  (try start_existing_keepalives ctx with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Keeper.error "start_existing_keepalives failed: %s" (Printexc.to_string exn));
   match name with
   | "masc_persona_list" -> Some (Persona.handle_persona_list ctx args)
@@ -399,7 +399,7 @@ let dispatch ctx ~name ~args : tool_result option =
     Returns None for all other tool names.
     Called from server_routes_http_keeper_stream. *)
 let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
-  (try start_existing_keepalives ctx with exn ->
+  (try start_existing_keepalives ctx with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Keeper.error "start_existing_keepalives failed: %s" (Printexc.to_string exn));
   match name with
   | "masc_keeper_msg" ->

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -157,7 +157,7 @@ let handle_read _ctx args =
         try
           let content = In_channel.with_open_text path In_channel.input_all in
           (true, sprintf "## %s\n\n%s" (Filename.basename path) content)
-        with exn -> (false, sprintf "Read error: %s" (Printexc.to_string exn))
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Read error: %s" (Printexc.to_string exn))
   end
 
 (* Add document *)
@@ -214,7 +214,7 @@ verified_by: []
         Out_channel.with_open_text filepath (fun oc -> Out_channel.output_string oc full_content);
         let status = if confidence < 0.5 then "candidate (needs verification)" else "library" in
         (true, sprintf "Document added to %s: %s" status filepath)
-      with exn -> (false, sprintf "Write error: %s" (Printexc.to_string exn))
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Write error: %s" (Printexc.to_string exn))
     end
   end
 
@@ -252,7 +252,7 @@ let handle_promote ctx args =
           Out_channel.with_open_text dest_path (fun oc -> Out_channel.output_string oc with_verifier);
           Sys.remove src_path;
           (true, sprintf "Promoted to library: %s (confidence: %.2f)" dest_path new_confidence)
-        with exn -> (false, sprintf "Promote error: %s" (Printexc.to_string exn))
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Promote error: %s" (Printexc.to_string exn))
   end
 
 (* Search documents *)

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -384,7 +384,7 @@ let raw_completion_at ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec () 
           latency_ms;
           error = Some (Printf.sprintf "curl stopped %d" sig_num);
         }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     {
       success = false;
       latency_ms =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -641,7 +641,7 @@ let handle_gc ctx args =
   (* Also expire pending decisions past TTL *)
   let expired =
     try Cp_lifecycle.check_expired_decisions ctx.config
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.warn "check_expired_decisions failed: %s" (Printexc.to_string exn);
       0
   in

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -57,7 +57,7 @@ let force_leave config ~agent_id ~reason =
   (* Broadcast the forced leave *)
   let message = Printf.sprintf "[SYSTEM] Agent '%s' forcibly removed: %s" agent_id reason in
   (try ignore (Room.broadcast config ~from_agent:"system" ~content:message)
-   with exn -> Log.Misc.error "broadcast (force leave) failed: %s" (Printexc.to_string exn))
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.error "broadcast (force leave) failed: %s" (Printexc.to_string exn))
 
 (** {1 Tool Handlers} *)
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -181,7 +181,7 @@ let handle_done ctx args =
          handoff_to = None;
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
-        with exn -> Log.Task.error "Metrics_store_eio.record(done) failed: %s" (Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(done) failed: %s" (Printexc.to_string exn));
        (* Feed success into Thompson Sampling quality signal *)
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
        (* Prometheus: record task completion *)
@@ -225,7 +225,7 @@ let handle_cancel_task ctx args =
          handoff_to = None;
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
-        with exn -> Log.Task.error "Metrics_store_eio.record(cancel) failed: %s" (Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(cancel) failed: %s" (Printexc.to_string exn));
        (* Feed failure into Thompson Sampling quality signal *)
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
        (* Prometheus: record task failure *)
@@ -358,7 +358,7 @@ let handle_transition ctx args =
          handoff_to = None;
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
-        with exn -> Log.Task.error "Metrics_store_eio.record(transition-done) failed: %s" (Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-done) failed: %s" (Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
        Prometheus.record_task_completed ()
    | Ok _, "cancel" ->
@@ -375,7 +375,7 @@ let handle_transition ctx args =
          handoff_to = None;
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
-        with exn -> Log.Task.error "Metrics_store_eio.record(transition-cancel) failed: %s" (Printexc.to_string exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Task.error "Metrics_store_eio.record(transition-cancel) failed: %s" (Printexc.to_string exn));
        Thompson_sampling.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
        Prometheus.record_task_failed ()
    | _ -> ());


### PR DESCRIPTION
Round 3: tool_*, chain/, room/, board/, council/, federation, autoresearch. Combined R1+R2+R3: 164 total catches guarded. Build passes.