### PR TITLE
test(verifier): follow keeper default gate config

### DIFF
--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -226,11 +226,11 @@ let test_verify_skips_readonly () =
     (Verifier_oas.verify req = Pass)
 
 (* ================================================================ *)
-(* Roundtrip: autonomous_gate_config -> guardrails                   *)
+(* Roundtrip: keeper_default_gate_config -> guardrails               *)
 (* ================================================================ *)
 
 let test_default_gate_roundtrip () =
-  let gate = Keeper_exec_autonomy.autonomous_gate_config () in
+  let gate = Tool_misc.keeper_default_gate_config () in
   let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
   Alcotest.(check bool) "default -> AllowList (strict)"
     true


### PR DESCRIPTION
## Summary
- replace the stale `Keeper_exec_autonomy.autonomous_gate_config ()` reference in `test_verifier_oas_bridge`
- use `Tool_misc.keeper_default_gate_config ()`, which matches the current keeper gate SSOT after autonomy refactors
- keep the change test-only and scoped to the failing `Health` build path

## Verification
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/verifier-oas-gate-config test/test_verifier_oas_bridge.exe`
- `./_build/default/test/test_verifier_oas_bridge.exe`
- direct `GLM-5` review on the patch: `No findings.`

## Context
This addresses `#1980` and was found while validating `#1972`.
`#1981` was a stale blocker report and has already been fixed on `main` by `#1978`.