### PR TITLE
fix: Eio.Cancel.Cancelled guards — 100% coverage (197 catches, 106 files)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -355,7 +355,7 @@ let fetch_remote_agent_card url :
                 (Printf.sprintf "Fetch killed by signal %d: %s" sig_num well_known)
           | Unix.WSTOPPED _ ->
               Stdlib.Error (Printf.sprintf "Fetch stopped: %s" well_known)
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Stdlib.Error
             (Printf.sprintf "Remote discovery error (%s): %s" well_known
                (Printexc.to_string exn))

--- a/lib/adaptive_thresholds.ml
+++ b/lib/adaptive_thresholds.ml
@@ -157,7 +157,7 @@ let load_state ~(room : string) : adaptive_state option =
       let content = Fs_compat.load_file path in
       let json = Yojson.Safe.from_string content in
       state_of_json json
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.warn "adaptive_thresholds: state load failed: %s" (Printexc.to_string exn);
       None
   else None

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -144,7 +144,7 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
       with Yojson.Safe.Util.Type_error _ -> None
     in
     Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "audit_log: entry parse failed: %s" (Printexc.to_string exn);
     None
 

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -250,7 +250,7 @@ let load_json_file path =
     try
       let content = Fs_compat.load_file path in
       Some (Yojson.Safe.from_string content)
-    with _ -> None
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
 
 let load_swarm_link_by_loop ~base_path loop_id =
   load_json_file (loop_link_file ~base_path loop_id)

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -263,7 +263,7 @@ module FileSystemBackend : BACKEND = struct
                     Out_channel.output_string oc (Yojson.Safe.to_string json)
                   );
                   Ok true
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Error (OperationFailed (Printexc.to_string exn))
           in
           release_flock fd;

--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -183,7 +183,7 @@ module Pubsub_mem = struct
     | None -> Ok 0
     | Some callbacks ->
         List.iter (fun cb ->
-          try cb message with exn ->
+          try cb message with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.Backend.warn "subscriber callback failed: %s" (Printexc.to_string exn)
         ) callbacks;
         Ok (List.length callbacks)

--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -418,7 +418,7 @@ module FileSystem = struct
           let _ = Unix.write_substring fd new_str 0 (String.length new_str) in
 
           Ok new_value
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Error (IOError (Printf.sprintf "atomic_increment failed: %s" (Printexc.to_string exn)))
 
   (** Atomically get the current counter value without incrementing *)
@@ -439,7 +439,7 @@ module FileSystem = struct
             let n = Unix.read fd buf 0 32 in
             if n = 0 then Ok 0
             else Ok (Safe_ops.int_of_string_with_default ~default:0 (String.trim (Bytes.sub_string buf 0 n)))
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Error (IOError (Printf.sprintf "atomic_get failed: %s" (Printexc.to_string exn)))
 
   (** Atomically update a file with a transform function.
@@ -511,7 +511,7 @@ module FileSystem = struct
           let _ = Unix.write_substring fd compressed 0 (String.length compressed) in
 
           Ok new_content
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Error (IOError (Printf.sprintf "atomic_update failed: %s" (Printexc.to_string exn)))
 
   (** {2 Health Check} *)

--- a/lib/backoff.ml
+++ b/lib/backoff.ml
@@ -109,7 +109,7 @@ let retry ~clock ~(policy : policy) (f : unit -> ('a, string) result) : 'a retry
 let retry_exn ~clock ~(policy : policy) (f : unit -> 'a) : 'a retry_result =
   retry ~clock ~policy (fun () ->
     try Ok (f ())
-    with exn -> Error (Printexc.to_string exn))
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn))
 
 (** {1 Pure Delay Sequence (no Eio dependency)} *)
 

--- a/lib/cancellation.ml
+++ b/lib/cancellation.ml
@@ -128,7 +128,7 @@ module TokenStore = struct
         if not t.cancelled then begin
           t.cancelled <- true;
           List.iter (fun cb ->
-            try cb () with exn ->
+            try cb () with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Cancel.error "Callback failed: %s" (Printexc.to_string exn)
           ) t.callbacks
         end
@@ -147,7 +147,7 @@ let cancel ?(reason : string option) (token : token) : unit =
     token.reason <- reason;
     (* Execute callbacks in reverse order (LIFO) *)
     List.iter (fun cb ->
-      try cb () with exn ->
+      try cb () with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Cancel.error "Callback failed: %s" (Printexc.to_string exn)
     ) token.callbacks
   end

--- a/lib/chain/chain_executor_complex.ml
+++ b/lib/chain/chain_executor_complex.ml
@@ -406,7 +406,7 @@ let execute_stream_merge ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : ex
     let safe_stream_add value =
       try
         Eio.Stream.add stream value
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         if is_cancelled exn then raise exn;
         Log.Chain.error "stream add error: %s"
           (Printexc.to_string exn)
@@ -432,14 +432,14 @@ let execute_stream_merge ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : ex
                incr completed_count);
              safe_stream_add (Some (node.id, Error err))
        ) nodes)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        if is_cancelled exn then raise exn;
        Log.Chain.info "producer crashed: %s"
          (Printexc.to_string exn));
     (* Signal completion after all producers done *)
     (try
        safe_stream_add None
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        if is_cancelled exn then raise exn;
        Log.Chain.error "completion signal error: %s"
          (Printexc.to_string exn))

--- a/lib/chain/chain_executor_resilience.ml
+++ b/lib/chain/chain_executor_resilience.ml
@@ -248,7 +248,7 @@ let execute_chain_exec ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : exec
       (* Parse the chain JSON *)
       let chain_json = try
         Ok (Yojson.Safe.from_string chain_json_str)
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Error (Printf.sprintf "ChainExec: invalid JSON from '%s': %s" chain_source (Printexc.to_string exn))
       in
       match chain_json with

--- a/lib/chain/chain_run_store.ml
+++ b/lib/chain/chain_run_store.ml
@@ -360,7 +360,7 @@ let read_persisted_run_json ~(run_id : string) : Yojson.Safe.t option =
                match Yojson.Safe.Util.member "run_id" json with
                | `String value when String.equal value run_id -> Some json
                | _ -> None
-             with exn ->
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.Chain.warn "chain_run_store: run entry parse failed: %s" (Printexc.to_string exn);
                None)
 

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -110,7 +110,7 @@ let checkpoint_of_json (json : Yojson.Safe.t) : (checkpoint, string) result =
         | Error _ -> None
     in
     Ok { run_id; chain_id; node_id; outputs; traces; timestamp; total_tokens }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Failed to parse checkpoint: %s" (Printexc.to_string exn))
 
 (** Save a checkpoint to disk using Eio *)
@@ -139,7 +139,7 @@ let save (store : checkpoint_store) (cp : checkpoint) : (unit, string) result =
       output_string oc content
     );
     Ok ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Failed to save checkpoint: %s" (Printexc.to_string exn))
 
 (** Load a checkpoint from disk using Eio *)

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -141,7 +141,7 @@ let load_plan base_path plan_id : (swarm_plan, string) result =
           created_at = json |> member "created_at" |> to_float;
           base_path = json |> member "base_path" |> to_string;
         }
-    with exn -> Error (sprintf "Failed to load plan: %s" (Printexc.to_string exn))
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (sprintf "Failed to load plan: %s" (Printexc.to_string exn))
 
 (* ================================================================ *)
 (* Plan — grep + split                                              *)
@@ -155,7 +155,7 @@ let grep_matches ~base_path ~pattern ~file_glob ~exclude_files =
   in
   let output =
     try Process_eio.run_argv ~timeout_sec:30.0 argv
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.CodeSwarm.error "grep failed: %s" (Printexc.to_string exn);
       ""
   in

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -228,7 +228,7 @@ let offload_messages
     Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
       let _ = Unix.write_substring fd content 0 (String.length content) in ());
     Some path
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Memory.error "offload_messages failed: %s"
       (Printexc.to_string exn);
     None
@@ -381,7 +381,7 @@ let save_checkpoint session ckpt =
      This avoids JSON-in-JSON double encoding that corrupts multi-byte UTF-8. *)
   let context_json =
     try Yojson.Safe.from_string ckpt.serialized
-    with _ -> `String ckpt.serialized
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> `String ckpt.serialized
   in
   let json = `Assoc [
     ("checkpoint_id", `String ckpt.checkpoint_id);
@@ -421,7 +421,7 @@ let load_latest_checkpoint session =
           let ctx = json |> member "context" in
           if ctx = `Null then raise Not_found;
           Yojson.Safe.to_string ctx
-        with _ ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ ->
           json |> member "serialized" |> to_string
       in
       Some {

--- a/lib/dashboard/dashboard_agent_relations.ml
+++ b/lib/dashboard/dashboard_agent_relations.ml
@@ -62,7 +62,7 @@ let json ~agent_name () : Yojson.Safe.t =
     | Some agent ->
       let open Yojson.Safe.Util in
       (try agent |> member "interests" |> to_list
-       with _ -> [])
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> [])
     | None -> []
   in
   let relations = match agent_data with
@@ -89,7 +89,7 @@ let json ~agent_name () : Yojson.Safe.t =
             ("note", member "note" node);
             ("participants", `List participants);
           ])
-       with _ -> [])
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> [])
     | None -> []
   in
   `Assoc [

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -271,7 +271,7 @@ let extract_persona_name (agent_name : string) : string =
 let load_persona_profile (persona_name : string) : agent_profile option =
   let me_root =
     try Env_config.me_root ()
-    with _ -> (
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (
       match Sys.getenv_opt "HOME" with
       | Some home -> Filename.concat home "me"
       | None -> "/tmp")
@@ -288,21 +288,21 @@ let load_persona_profile (persona_name : string) : agent_profile option =
     | Ok json ->
         let open Yojson.Safe.Util in
         let name_val =
-          (try Some (json |> member "name" |> to_string) with _ -> None)
+          (try Some (json |> member "name" |> to_string) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
           |> Option.value ~default:persona_name
         in
         let keeper_json =
-          try Some (json |> member "keeper") with _ -> None
+          try Some (json |> member "keeper") with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
         in
         let model =
           match keeper_json with
           | Some kj -> (
               try Some (kj |> member "active_model" |> to_string)
-              with _ -> None)
+              with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
           | None -> None
         in
         let trait =
-          try Some (json |> member "trait" |> to_string) with _ -> None
+          try Some (json |> member "trait" |> to_string) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
         in
         let traits = match trait with Some t -> [t] | None -> [] in
         Some
@@ -341,39 +341,39 @@ let load_neo4j_identity_cache () =
             (fun edge ->
               let node = edge |> member "node" in
               let name =
-                try node |> member "name" |> to_string with _ -> ""
+                try node |> member "name" |> to_string with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
               in
               if name <> "" then begin
                 let emoji =
                   (try Some (node |> member "emoji" |> to_string)
-                   with _ -> None)
+                   with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
                   |> Option.value ~default:"🤖"
                 in
                 let korean_name =
                   (try Some (node |> member "koreanName" |> to_string)
-                   with _ -> None)
+                   with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
                   |> Option.value ~default:name
                 in
                 let model =
                   try Some (node |> member "model" |> to_string)
-                  with _ -> None
+                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
                 in
                 let traits =
                   try node |> member "traits" |> to_list |> List.map to_string
-                  with _ -> []
+                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
                 in
                 let interests =
                   try
                     node |> member "interests" |> to_list |> List.map to_string
-                  with _ -> []
+                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
                 in
                 let activity_level =
                   try Some (node |> member "activityLevel" |> to_float)
-                  with _ -> None
+                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
                 in
                 let primary_value =
                   try Some (node |> member "primaryValue" |> to_string)
-                  with _ -> None
+                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
                 in
                 Hashtbl.replace neo4j_identity_cache name
                   {
@@ -387,7 +387,7 @@ let load_neo4j_identity_cache () =
                   }
               end)
             edges
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.Dashboard.warn "neo4j identity cache update failed: %s" (Printexc.to_string exn))
   end
 

--- a/lib/debate.ml
+++ b/lib/debate.ml
@@ -140,7 +140,7 @@ let write_json path json =
   (try
      Fs_compat.save_file tmp_path content;
      Sys.rename tmp_path path
-   with exn ->
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      (if Sys.file_exists tmp_path then
         Safe_ops.remove_file_logged ~context:"debate" tmp_path);
      raise exn)

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -326,7 +326,7 @@ let guarded_execute
       let t0 = Time_compat.now () in
       let result =
         try execute ()
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.info "eval_gate tool %s failed: %s" tool_name (Printexc.to_string exn);
           Yojson.Safe.to_string (`Assoc [
             ("error", `String "Tool execution failed (internal error)");

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -424,7 +424,7 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       max_cost_usd = float_opt "max_cost_usd" 0.10;
       tags = str_list "tags";
     }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Failed to parse scenario: %s" (Printexc.to_string exn))
 
 (** Load scenarios from a JSON file containing an array of scenario objects. *)
@@ -449,7 +449,7 @@ let load_scenarios_from_file (path : string) : (scenario list, string) result =
            | Ok s -> Ok [s]
            | Error e -> Error e)
       | _ -> Error "Expected JSON array or object"
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Error (Printf.sprintf "Failed to load scenarios: %s" (Printexc.to_string exn))
 
 (* ================================================================ *)

--- a/lib/generational_metrics.ml
+++ b/lib/generational_metrics.ml
@@ -167,7 +167,7 @@ let record_task ~generation ~task_id ~completed ~duration_ms ~error_count
     task_records := record :: !task_records;
     (* JSONL backup — best effort, don't fail the record *)
     (try append_jsonl ~agent_name:"_global" (task_record_to_json record)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Metrics.warn "append_jsonl task: %s" (Printexc.to_string exn));
     record)
 
@@ -183,7 +183,7 @@ let record_handoff ~from_generation ~to_generation ~dna_size ~context_ratio =
     } in
     handoff_records := record :: !handoff_records;
     (try append_jsonl ~agent_name:"_global" (handoff_record_to_json record)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Metrics.warn "append_jsonl handoff: %s" (Printexc.to_string exn));
     record)
 
@@ -201,7 +201,7 @@ let summarize_generation_unlocked generation =
   let all_tasks =
     if !task_records = [] then
       (try load_task_records_from_jsonl ~agent_name:"_global"
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Log.Metrics.warn "load_task_records fallback: %s" (Printexc.to_string exn);
          [])
     else !task_records

--- a/lib/goal/goal_orchestrator.ml
+++ b/lib/goal/goal_orchestrator.ml
@@ -108,7 +108,7 @@ let add_task_safe config ~title ~description =
   try
     let response = Room.add_task config ~title ~priority:3 ~description in
     Ok response
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let execute_plan config ~agent_name:_ plan =
   let created = ref [] in

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -291,7 +291,7 @@ let parse_yyyy_mm_dd s =
         let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
         let tz_offset = local_epoch -. utc_as_local in
         Some (local_epoch +. tz_offset))
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s" (Printexc.to_string exn);
     None
 

--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -69,7 +69,7 @@ let request_curl ~timeout_sec body =
             (try
                let output = Process_eio.run_argv ~timeout_sec argv in
                ensure_json_response output
-             with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
           else
             (* Unix fallback when Eio loop not started *)
             (try
@@ -80,7 +80,7 @@ let request_curl ~timeout_sec body =
                    (fun () -> In_channel.input_all ic)
                in
                ensure_json_response output
-             with exn -> Error (Printexc.to_string exn))))
+             with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn))))
 
 (** Cohttp_eio primary transport with curl fallback. *)
 let request ?(timeout_sec=10.0) body : (string, string) result =
@@ -126,9 +126,9 @@ let request ?(timeout_sec=10.0) body : (string, string) result =
       match Eio_context.get_clock_opt () with
       | Some clock ->
         (try Eio.Time.with_timeout_exn clock timeout_sec run
-         with exn -> Error (Printexc.to_string exn))
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn))
       | None ->
-        (try run () with exn -> Error (Printexc.to_string exn))
+        (try run () with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn))
   in
   match cohttp_result with
   | Ok _ as success -> success

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -127,7 +127,7 @@ let synapse_of_json json : synapse option =
       last_updated = json |> member "last_updated" |> to_float;
       created_at = json |> member "created_at" |> to_float;
     }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "Failed to parse synapse: %s" (Printexc.to_string exn);
     None
 
@@ -146,7 +146,7 @@ let graph_of_json json : synapse_graph =
       |> List.filter_map synapse_of_json in
     let last_consolidation = json |> member "last_consolidation" |> to_float in
     { synapses; last_consolidation }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "Failed to parse graph: %s" (Printexc.to_string exn);
     { synapses = []; last_consolidation = 0.0 }
 
@@ -160,7 +160,7 @@ let load_graph config : synapse_graph =
       let content = Fs_compat.load_file file in
       let json = Yojson.Safe.from_string content in
       graph_of_json json
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.error "Failed to load graph from %s: %s" file (Printexc.to_string exn);
       { synapses = []; last_consolidation = 0.0 }
 

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -620,7 +620,7 @@ let run ~sw ~net ~clock config routes =
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->
              Log.Http.error "Connection error: %s" (Printexc.to_string exn))
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if is_cancelled exn then raise exn;
          let delay = !backoff_s in
          Log.Http.error "Accept error: %s (backoff %.2fs)"
@@ -628,7 +628,7 @@ let run ~sw ~net ~clock config routes =
          Eio.Time.sleep clock delay;
          bump_backoff ());
       accept_loop ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       if is_cancelled exn then ()
       else
         let delay = !backoff_s in

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -303,7 +303,7 @@ let run ~sw ~net ~clock config request_handler =
               Log.Http.error "Connection error: %s" (Printexc.to_string exn)
           )
         )
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         if is_cancelled exn then raise exn;
         let delay = !backoff_s in
         Log.Http.error "Accept error: %s (backoff %.2fs)"
@@ -311,7 +311,7 @@ let run ~sw ~net ~clock config request_handler =
         Eio.Time.sleep clock delay;
         bump_backoff ());
       accept_loop ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       if is_cancelled exn then ()
       else begin
         let delay = !backoff_s in

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -647,7 +647,7 @@ let record_episode_jsonl ~event_type ~summary ~participants ~outcome ~learnings 
   let path = episodes_jsonl_path () in
   (try
     Fs_compat.append_jsonl path (episode_to_json episode)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Institution.error "JSONL episode write failed: %s"
       (Printexc.to_string exn));
   episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -137,10 +137,10 @@ let run_turn
       (fun input ->
         let additional =
           try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
-          with _ -> 5 in
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 5 in
         let reason =
           try Yojson.Safe.Util.(member "reason" input |> to_string)
-          with _ -> "unspecified" in
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unspecified" in
         let additional = max 1 (min additional 20) in
         if !budget_extensions >= 10 then
           Ok { Types.content = Printf.sprintf

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -309,7 +309,7 @@ let slack_api_post_json
   | Unix.WEXITED 0 ->
       (try
          Ok (Yojson.Safe.from_string out)
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Error (Printf.sprintf "json_parse_failed: %s" (Printexc.to_string exn)))
   | Unix.WEXITED n ->
       Error (Printf.sprintf "curl_exit_%d: %s" n (short_preview ~max_len:220 out))
@@ -480,7 +480,7 @@ let maybe_emit_interesting_alert
           ("reply_preview", `String (short_preview ~max_len:360 reply));
         ]
       in
-      (try append_jsonl_line (keeper_alerts_path ctx.config) alert_json with exn ->
+      (try append_jsonl_line (keeper_alerts_path ctx.config) alert_json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Keeper.error "alert JSONL write failed: %s" (Printexc.to_string exn));
       let board_result =
         run_alert_channel_with_retry ctx
@@ -552,7 +552,7 @@ let maybe_emit_interesting_alert
                 ("failed_channels",
                   `List (List.map alert_channel_result_to_json attempted_failures));
               ])
-         with exn ->
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Keeper.error "failed-channels JSONL write failed: %s" (Printexc.to_string exn));
       if deadlettered then
         (try
@@ -566,7 +566,7 @@ let maybe_emit_interesting_alert
                 ("channels",
                   `List (List.map alert_channel_result_to_json channels));
               ])
-         with exn ->
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Keeper.error "deadletter JSONL write failed: %s" (Printexc.to_string exn));
       {
         enabled = true;

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -82,7 +82,7 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
           ignore
             (Room.heartbeat_in_room config ~room_id ~agent_name:meta.agent_name);
           room_id :: acc
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           log_keeper_exn ~label:(Printf.sprintf "room presence sync failed for %s in %s" meta.name room_id) exn;
           acc)
       [] room_ids

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -211,7 +211,7 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
           ignore
             (Room.heartbeat_in_room config ~room_id ~agent_name:meta.agent_name);
           room_id :: acc
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           log_keeper_exn ~label:(Printf.sprintf "room presence sync failed for %s in %s" meta.name room_id) exn;
           acc)
       [] room_ids

--- a/lib/keeper/keeper_learning.ml
+++ b/lib/keeper/keeper_learning.ml
@@ -88,7 +88,7 @@ let decision_record_of_json (json : Yojson.Safe.t) : decision_record option =
           feedback_comment =
             Safe_ops.json_string ~default:"" "feedback_comment" json;
         }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "keeper_learning: decision record parse failed: %s" (Printexc.to_string exn);
     None
 

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -197,7 +197,7 @@ let write_memory_bank_rows
     Fs_compat.save_file tmp content;
     Sys.rename tmp path;
     Ok ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Safe_ops.remove_file_logged ~context:"memory_compaction" tmp;
     Error (Printf.sprintf "failed to rewrite memory bank: %s" (Printexc.to_string exn))
 

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -572,7 +572,7 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
            in
            if content = "" then None else Some content
          else None
-       with _ -> None)
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
   |> take max_n
 
 (** Build recall candidates by merging checkpoint messages with history.jsonl.

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -143,14 +143,14 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (try
        if not (Room_utils.is_initialized ctx.config) then
          ignore (Room.init ctx.config ~agent_name:None)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Keeper.error "supervisor room init failed: %s"
          (Printexc.to_string exn));
     (* Presence sync *)
     (try
        let synced = ensure_keeper_room_presence ctx.config meta in
        ignore (write_meta ctx.config synced)
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Keeper.error "supervisor presence sync failed: %s"
          (Printexc.to_string exn));
     publish_lifecycle "started" meta.name "supervised";

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -140,7 +140,7 @@ let start_supervisor_sweep ctx =
         let should_act _beat = true
         let on_beat _beat =
           (try Keeper_resident_supervisor.sweep_and_recover ctx
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Keeper.error "supervisor sweep failed: %s"
                (Printexc.to_string exn));
           Ok ()
@@ -180,7 +180,7 @@ let start_existing_keepalives ctx =
           stats.enabled stats.scanned stats.started stats.stale
           stats.recovering;
       maybe_start_supervisor_sweep ctx stats
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       (* Retry bootstrap on next keeper tool call if this attempt failed. *)
       Hashtbl.remove existing_keepalive_bootstrap_done base_path;
       raise exn

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -43,7 +43,7 @@ let make_tools
                 ~name:td.name ~input
             in
             (true, result)
-          with exn ->
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             let msg = Printf.sprintf "tool %s failed: %s"
               td.name (Printexc.to_string exn) in
             Log.Keeper.error "%s" msg;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -205,13 +205,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             | Error e ->
               (try ignore (Trajectory.finalize trajectory_acc
                  (Trajectory.Failed e))
-               with exn -> log_keeper_exn
+               with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run error)" exn);
               (false, Printf.sprintf "❌ Agent.run failed: %s" e)
             | Ok result ->
               (try ignore (Trajectory.finalize trajectory_acc
                  Trajectory.Completed)
-               with exn -> log_keeper_exn
+               with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run ok)" exn);
               let reply_json = `Assoc [
                 ("reply", `String result.response_text);

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -121,7 +121,7 @@ let handle_keeper_down ctx args : tool_result =
         in
         if validate_name m.trace_id then (
           let dir = Filename.concat (session_base_dir ctx.config) m.trace_id in
-          try rm_rf dir with exn ->
+          try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             Log.Keeper.error "session dir cleanup failed: %s"
               (Printexc.to_string exn)));
       let json = `Assoc [

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -313,7 +313,7 @@ let ensure_keeper_exists
        in
        let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
        (try ignore (save_checkpoint session ctx0 ~generation:0)
-        with exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
        match write_meta ctx.config meta with
        | Error e -> Error e
        | Ok () -> Ok meta)
@@ -420,6 +420,6 @@ let apply_settings_update
       updated_at = now_iso ();
     } in
     (try ignore (write_meta config updated)
-     with exn -> log_keeper_exn ~label:"write_meta (settings) failed" exn);
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"write_meta (settings) failed" exn);
     updated
 

--- a/lib/keeper/keeper_turn_up.ml
+++ b/lib/keeper/keeper_turn_up.ml
@@ -391,7 +391,7 @@ let handle_keeper_up ctx args : tool_result =
              in
              let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
              (try ignore (save_checkpoint session ctx0 ~generation:0)
-              with exn -> log_keeper_exn ~label:"save_checkpoint (init) failed" exn);
+              with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (init) failed" exn);
              let meta = {
                name;
                agent_name = keeper_agent_name name;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -564,7 +564,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           last_deliberation_ts;
           last_triage_triggers;
         }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
 
 type resident_keeper_spec = {
@@ -668,7 +668,7 @@ let write_resident_keeper config (spec : resident_keeper_spec) :
   try
     Fs_compat.save_file path content;
     Ok ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error
       (Printf.sprintf "failed to write resident keeper %s: %s" path
          (Printexc.to_string exn))
@@ -682,7 +682,7 @@ let read_resident_keeper config name : (resident_keeper_spec option, string) res
       match resident_keeper_of_json json with
       | Ok spec -> Ok (Some spec)
       | Error msg -> Error msg
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Error
         (Printf.sprintf "failed to read resident keeper %s: %s" path
            (Printexc.to_string exn))
@@ -759,7 +759,7 @@ let write_meta config (m : keeper_meta) : (unit, string) result =
   try
     Fs_compat.save_file path content;
     Ok ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
 
 let read_meta config name : (keeper_meta option, string) result =

--- a/lib/langfuse.ml
+++ b/lib/langfuse.ml
@@ -236,7 +236,7 @@ let send_to_langfuse ~endpoint ~body () =
       let n = try Unix.read sock buf 0 256 with Unix.Unix_error _ -> 0 in
       Log.Langfuse.info "Response (%d bytes): %s" n (Bytes.sub_string buf 0 (min n 100));
       Unix.close sock
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Langfuse.error "Error: %s" (Printexc.to_string exn)
   end
 

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -447,7 +447,7 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
             try
               Telemetry_eio.track_tool_called ~fs config ~tool_name ~success
                 ~duration_ms ~agent_id:worker_name ()
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.LocalWorker.warn "telemetry error for %s/%s: %s"
                 worker_name tool_name (Printexc.to_string exn))
         | _ -> ());

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -230,7 +230,7 @@ let post_json_via_eio ~sw ~(auth_token : string option) ~session_id
         in
         if Cohttp.Code.is_success status then Ok raw_body
         else Error (sprintf "MASC HTTP %d: %s" status raw_body)
-      with exn -> Error (Printexc.to_string exn)
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : string)
     ~(params : Yojson.Safe.t) : (Yojson.Safe.t, string) result =
@@ -285,7 +285,7 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
           Error (sprintf "curl signaled: %d" code)
       | Unix.WSTOPPED code ->
           Error (sprintf "curl stopped: %d" code)
-    with exn -> Error (Printexc.to_string exn)
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
   in
   let perform_request () =
     match Eio_context.get_net_opt () with

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -46,12 +46,12 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net ~base_path =
     ~net:(net :> Eio_context.eio_net) ~base_path in
   (try Team_session_engine_eio.recover_running_sessions ~sw ~clock
          ~config:state.Mcp_server.room_config
-   with exn -> log_mcp_exn ~label:"team_session recovery skipped" exn);
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_mcp_exn ~label:"team_session recovery skipped" exn);
   (* Reconcile Prometheus active_agents gauge with existing agent files *)
   (try
      let masc_dir = Filename.concat state.Mcp_server.room_config.base_path ".masc" in
      Prometheus.reconcile_active_agents_gauge masc_dir
-   with exn -> log_mcp_exn ~label:"prometheus agent reconciliation skipped" exn);
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_mcp_exn ~label:"prometheus agent reconciliation skipped" exn);
   state
 
 (** {1 Re-exported Mcp_server Functions} *)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -222,7 +222,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                   "Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_DEFAULT_SEC or MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
                   timeout_sec
                   name))
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in
        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
@@ -267,7 +267,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      | Some fs ->
          (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms ()
-          with exn ->
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             log_mcp_exn ~label:"telemetry tracking failed" exn)
      | None -> ());
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -177,12 +177,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
                 resolved
               else
                 agent_name
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               log_mcp_exn ~label:"is_agent_joined" exn;
               agent_name)
           else
             agent_name
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           log_mcp_exn ~label:__FUNCTION__ exn;
           agent_name
       else

--- a/lib/mcp_server_eio_helpers.ml
+++ b/lib/mcp_server_eio_helpers.ml
@@ -21,7 +21,7 @@ let wait_for_message_eio ~clock (registry : Session.registry) ~agent_name ~timeo
    | Some _ -> ()
    | None ->
        (try ignore (Session.register registry ~agent_name)
-        with exn -> log_mcp_exn ~label:"session register (SSE) failed" exn));
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_mcp_exn ~label:"session register (SSE) failed" exn));
   Session.update_activity registry ~agent_name ~is_listening:(Some true) ();
   let rec wait_loop () =
     let elapsed = Time_compat.now () -. start_time in
@@ -39,7 +39,7 @@ let wait_for_message_eio ~clock (registry : Session.registry) ~agent_name ~timeo
     end
   in
   try wait_loop ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     log_mcp_exn ~label:"listen wait_loop interrupted" exn;
     Session.update_activity registry ~agent_name ~is_listening:(Some false) ();
     None

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -387,7 +387,7 @@ let handle_request
   try
     let json =
       try Ok (Yojson.Safe.from_string request_str)
-      with exn -> Error (Printexc.to_string exn)
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
     in
     match json with
     | Error msg ->

--- a/lib/mdal/mdal_swarm.ml
+++ b/lib/mdal/mdal_swarm.ml
@@ -94,7 +94,7 @@ let measure_metric_shell ?timeout_sec cmd =
         Error (Printf.sprintf "Terminated by signal %d" signal)
     | Unix.WSTOPPED signal ->
         Error (Printf.sprintf "Stopped by signal %d" signal)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Shell error: %s" (Printexc.to_string exn))
 
 let evaluate_aggregate strategy ~aggregate_goal_expr metrics =

--- a/lib/memory/memory_jsonl.ml
+++ b/lib/memory/memory_jsonl.ml
@@ -127,7 +127,7 @@ let make_backend ~base_dir ~agent_name ~session_id
       let line = encode_line ~key ~value:(Some json) in
       Fs_compat.append_file path line;
       Ok ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       let msg = Printf.sprintf "memory_jsonl persist(%s) failed: %s"
           key (Printexc.to_string exn) in
       Log.Memory.error "%s" msg;
@@ -147,7 +147,7 @@ let make_backend ~base_dir ~agent_name ~session_id
       | Some (Some v) -> Some v
       | Some None -> None  (* tombstone *)
       | None -> None       (* key never written *)
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Memory.error "memory_jsonl retrieve(%s) failed: %s"
         key (Printexc.to_string exn);
       None
@@ -159,7 +159,7 @@ let make_backend ~base_dir ~agent_name ~session_id
       let line = encode_line ~key ~value:None in
       Fs_compat.append_file path line;
       Ok ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       let msg = Printf.sprintf "memory_jsonl remove(%s) failed: %s"
           key (Printexc.to_string exn) in
       Log.Memory.error "%s" msg;
@@ -209,7 +209,7 @@ let make_backend ~base_dir ~agent_name ~session_id
         | (k, v, _ts) :: rest -> take (n - 1) ((k, v) :: acc) rest
       in
       take limit [] sorted
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Memory.error "memory_jsonl query(%s) failed: %s"
         prefix (Printexc.to_string exn);
       []

--- a/lib/memory/memory_pg.ml
+++ b/lib/memory/memory_pg.ml
@@ -106,7 +106,7 @@ let make_backend ~(pool : pool) ~(agent_name : string)
     ) pool with
     | Ok (Some json_str) ->
       (try Some (Yojson.Safe.from_string json_str)
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Log.MemoryPg.warn "retrieve(%s/%s) JSON parse failed: %s"
            agent_name key (Printexc.to_string exn);
          None)
@@ -151,7 +151,7 @@ let make_backend ~(pool : pool) ~(agent_name : string)
     | Ok rows ->
       List.filter_map (fun (key, json_str) ->
         try Some (key, Yojson.Safe.from_string json_str)
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.MemoryPg.warn "query(%s/%s) JSON parse failed: %s"
             agent_name key (Printexc.to_string exn);
           None

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -81,9 +81,9 @@ let record config (metric : task_metric) : unit =
   (* Security: 0o600 - only owner can read/write metrics data *)
   (* FD leak fix: ensure fd is always closed with Fun.protect *)
   let fd = Unix.openfile file [Unix.O_WRONLY; Unix.O_APPEND; Unix.O_CREAT] 0o600 in
-  Fun.protect ~finally:(fun () -> try Unix.close fd with exn -> (try Log.Misc.error "fd close failed: %s" (Printexc.to_string exn) with exn2 -> ignore (Printexc.to_string exn2))) (fun () ->
+  Fun.protect ~finally:(fun () -> try Unix.close fd with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (try Log.Misc.error "fd close failed: %s" (Printexc.to_string exn) with exn2 -> ignore (Printexc.to_string exn2))) (fun () ->
     Unix.lockf fd Unix.F_LOCK 0;
-    Fun.protect ~finally:(fun () -> try Unix.lockf fd Unix.F_ULOCK 0 with exn -> (try Log.Misc.error "fd unlock failed: %s" (Printexc.to_string exn) with exn2 -> ignore (Printexc.to_string exn2))) (fun () ->
+    Fun.protect ~finally:(fun () -> try Unix.lockf fd Unix.F_ULOCK 0 with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (try Log.Misc.error "fd unlock failed: %s" (Printexc.to_string exn) with exn2 -> ignore (Printexc.to_string exn2))) (fun () ->
       let _ = Unix.write_substring fd line 0 (String.length line) in
       ()
     )
@@ -130,7 +130,7 @@ let read_metrics_file file : task_metric list =
           let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
           Log.Metrics.error "Failed to parse metric: %s (line: %s)" e preview;
           None
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
         Log.Metrics.error "JSON parse error: %s (line: %s)"
           (Printexc.to_string exn) preview;

--- a/lib/mitosis.ml
+++ b/lib/mitosis.ml
@@ -436,7 +436,7 @@ let write_status ~base_path ~cell ~config =
   if Sys.file_exists masc_dir && Sys.is_directory masc_dir then begin
     try
       Fs_compat.save_file status_file (Yojson.Safe.pretty_to_string json ^ "\n")
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Mitosis_log.error "Failed to write status: %s" (Printexc.to_string exn)
   end
 
@@ -471,7 +471,7 @@ let write_status_with_backend ~room_config ~cell ~config =
   if Sys.file_exists masc_dir && Sys.is_directory masc_dir then begin
     try
       Fs_compat.save_file status_file (Yojson.Safe.pretty_to_string json ^ "\n")
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Mitosis_log.error "Failed to write status file: %s"
         (Printexc.to_string exn)
   end;

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -97,7 +97,7 @@ let queue_episode ~base_path ~session_id ~agent_name ~generation
     Fs_compat.save_file file (Yojson.Safe.pretty_to_string json);
     Printf.printf "[EPISODE/QUEUE] Queued episode %s (gen %d) → %s\n%!" ep_id generation file;
     Some ep_id
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "episode queue failed: %s" (Printexc.to_string exn);
     None
 
@@ -126,7 +126,7 @@ let write_saga_state ~base_path ~saga_id ~status ~payload : string option =
   try
     Fs_compat.save_file file (Yojson.Safe.pretty_to_string json);
     Some file
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "mitosis saga write failed %s: %s" file (Printexc.to_string exn);
     None
 

--- a/lib/mitosis/mitosis_spawn.ml
+++ b/lib/mitosis/mitosis_spawn.ml
@@ -183,7 +183,7 @@ let spawn_with_cascade ~ctx ~preferred_agent ~total_timeout_seconds ~prompt =
                   (try ignore (Circuit_breaker.record_failure_global
                     ~agent_id:(breaker_agent_id agent)
                     ~reason)
-                   with exn -> Log.Spawn.error "circuit_breaker record_failure failed: %s" (Printexc.to_string exn));
+                   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Spawn.error "circuit_breaker record_failure failed: %s" (Printexc.to_string exn));
                   let result = failed_spawn_result ~msg:reason ~exit_code:125 in
                   let attempts' = (agent, result) :: attempts in
                   loop attempts' (attempts_agent_left - 1) rest
@@ -205,12 +205,12 @@ let spawn_with_cascade ~ctx ~preferred_agent ~total_timeout_seconds ~prompt =
                   if result.Spawn.success then
                     (try ignore (Circuit_breaker.record_success_global
                       ~agent_id:(breaker_agent_id agent))
-                     with exn -> Log.Spawn.error "circuit_breaker record_success failed: %s" (Printexc.to_string exn))
+                     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Spawn.error "circuit_breaker record_success failed: %s" (Printexc.to_string exn))
                   else if should_penalize_failure result then
                     (try ignore (Circuit_breaker.record_failure_global
                       ~agent_id:(breaker_agent_id agent)
                       ~reason:(normalized_spawn_reason result))
-                     with exn -> Log.Spawn.error "circuit_breaker record_failure (spawn) failed: %s" (Printexc.to_string exn));
+                     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Spawn.error "circuit_breaker record_failure (spawn) failed: %s" (Printexc.to_string exn));
                   let attempts' = (agent, result) :: attempts in
                   if result.Spawn.success then
                     (result, agent, List.rev attempts')

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -27,7 +27,7 @@ let run_argv_line argv =
 
 let run_argv_ignore argv =
   (try ignore (Process_eio.run_argv_with_status ~timeout_sec:60.0 argv)
-   with exn -> Log.Misc.error "run_argv_ignore failed: %s" (Printexc.to_string exn))
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.error "run_argv_ignore failed: %s" (Printexc.to_string exn))
 
 (** Get non-empty environment variable *)
 let getenv_nonempty name =
@@ -190,7 +190,7 @@ let send_notification ?(sound=false) ?focus_cmd ~title ~subtitle ~message () =
   else begin
     send_via_osascript ~title ~subtitle ~message;
     (try ignore (focus_on_osascript ())
-     with exn -> Log.Misc.error "focus_on_osascript failed: %s" (Printexc.to_string exn));
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.error "focus_on_osascript failed: %s" (Printexc.to_string exn));
     (* NOTE: For osascript fallback, we intentionally do not execute focus_cmd.
        focus_cmd can contain arbitrary shell snippets (user-configured) and would
        require `sh -c` execution. terminal-notifier handles click actions. *)

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -22,7 +22,7 @@ let relay_event = function
         ("ts_unix", `Float (Time_compat.now ()));
       ] in
       (try Sse.broadcast sse_json
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Log.Server.error "oas_sse_bridge: broadcast failed: %s"
            (Printexc.to_string exn))
   | _ -> ()

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -203,7 +203,7 @@ let run
       | Some dir ->
         let ckpt = Oas.Agent.checkpoint ~session_id agent in
         (try persist_checkpoint ~dir ~session_id ckpt
-         with exn ->
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Misc.error "oas_worker: Checkpoint save failed: %s"
              (Printexc.to_string exn));
         Some ckpt

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -167,7 +167,7 @@ let load_all config =
            match of_yojson json with
            | Ok value -> Some value
            | Error _ -> None
-         with exn ->
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Governance.warn "operator judgment parse: %s" (Printexc.to_string exn);
            None)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -169,10 +169,10 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
           Eio.Fiber.fork ~sw (fun () ->
             try
               ignore (spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config)
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Orchestrator.error "spawn failed: %s" (Printexc.to_string exn));
         Ok ()
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let msg = Printf.sprintf "orchestrator check error: %s" (Printexc.to_string exn) in
         Log.Orchestrator.warn "%s (recovering...)" msg;
         Error msg
@@ -195,7 +195,7 @@ let make_zero_zombie_consumer ~room_config
             try
               String.sub status_trimmed 0 (min 4 (String.length status_trimmed)) = "\xf0\x9f\xa7\x9f" ||
               String.length status_trimmed >= 7 && String.sub status_trimmed 0 7 = "Cleaned"
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
               false
           in
@@ -203,7 +203,7 @@ let make_zero_zombie_consumer ~room_config
             Log.Orchestrator.info "[zombie] %s" status_trimmed
         end;
         Ok ()
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         if Resilience.ZeroZombie.is_benign_error exn then
           Ok ()
         else begin

--- a/lib/perpetual/perpetual_oas.ml
+++ b/lib/perpetual/perpetual_oas.ml
@@ -109,7 +109,7 @@ let run_perpetual_via_oas
     Fs_compat.mkdir_p config.session_base_dir;
     Fs_compat.save_file checkpoint_path
       (Oas.Checkpoint.to_string oas_ckpt)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Perpetual.error "Checkpoint save failed: %s"
       (Printexc.to_string exn));
   (* Save MASC-format checkpoint via Phase D bridge (to_oas_checkpoint) *)
@@ -122,7 +122,7 @@ let run_perpetual_via_oas
     let ckpt_path2 = Filename.concat config.session_base_dir
       (trace_id ^ "-masc.json") in
     Fs_compat.save_file ckpt_path2 (Oas.Checkpoint.to_string masc_oas_ckpt)
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Perpetual.error "MASC checkpoint save failed: %s"
       (Printexc.to_string exn));
   (* Handle handoff via OAS Durable step chain (crash-recoverable) *)

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -96,7 +96,7 @@ let parse_geval_response (text : string) :
          else
            Error
              (Printf.sprintf "scores out of range: r=%d q=%d s=%d" r q s)
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Error
            (Printf.sprintf "missing fields: %s" (Printexc.to_string exn)))
 

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -134,7 +134,7 @@ let init ?persist_dir () =
                   Hashtbl.replace version_index entry.id versions
               | Error msg ->
                 Log.Misc.error "Failed to parse %s: %s" file msg
-            with exn ->
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Misc.error "Failed to parse %s: %s" file (Printexc.to_string exn)
           end
         ) files

--- a/lib/reflection.ml
+++ b/lib/reflection.ml
@@ -42,7 +42,7 @@ let load_meta ~agent_name : float =
       let content = Fs_compat.load_file path in
       let json = Yojson.Safe.from_string content in
       Json_util.get_float json "last_reflection" |> Option.value ~default:0.0
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.warn "reflection: meta load failed: %s" (Printexc.to_string exn);
       0.0
   end

--- a/lib/resilience.ml
+++ b/lib/resilience.ml
@@ -123,19 +123,19 @@ module ZeroZombie = struct
     in
     let rec loop () =
       (try Eio.Time.sleep clock interval
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if is_cancelled exn then raise exn;
          Log.Misc.error "sleep error: %s" (Printexc.to_string exn));
       (try
          ignore (cleanup ~cleanup_fn)
-       with exn ->
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if is_cancelled exn then raise exn;
          (* Silently ignore benign errors like "not initialized" *)
          if not (is_benign_error exn) then
            Log.Misc.error "cleanup error: %s" (Printexc.to_string exn));
       loop ()
     in
-    try loop () with exn ->
+    try loop () with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       if is_cancelled exn then raise exn
       else if not (is_benign_error exn) then
         Log.Misc.error "loop error: %s" (Printexc.to_string exn)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -309,7 +309,7 @@ let leave config ~agent_name =
     (* Record co-presence relationships to Neo4j (async, non-blocking) *)
     (try Relation_materializer.on_agent_leave
            ~leaving_agent:actual_name ~active_agents:peers_before_leave
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Room.error "relation-materializer leave hook error: %s"
          (Printexc.to_string exn));
 

--- a/lib/run_log_eio.ml
+++ b/lib/run_log_eio.ml
@@ -149,9 +149,9 @@ let record_event
          | Some f -> append_jsonl_unlocked ~fs:f json
          | None -> append_jsonl_sys json;
          if stream_enabled () then
-           (try Sse.broadcast json with exn ->
+           (try Sse.broadcast json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Misc.error "SSE broadcast failed: %s" (Printexc.to_string exn)))
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Misc.error "Write failed: %s" (Printexc.to_string exn))
 
 (** Record a tool execution to the run log *)

--- a/lib/runtime_params.ml
+++ b/lib/runtime_params.ml
@@ -152,7 +152,7 @@ let persist ~base_path =
     let tmp = path ^ ".tmp" in
     Fs_compat.save_file tmp (Yojson.Safe.pretty_to_string json);
     Sys.rename tmp path
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Config.error "Runtime_params.persist: %s" (Printexc.to_string exn)
 
 let restore ~base_path =
@@ -176,7 +176,7 @@ let restore ~base_path =
               pairs)
       | _ ->
           Log.Config.warn "Runtime_params.restore: invalid JSON in %s" path
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Config.error "Runtime_params.restore: %s" (Printexc.to_string exn))
 
 (* ── audit ───────────────────────────────────────────────────── *)

--- a/lib/safe_parse.ml
+++ b/lib/safe_parse.ml
@@ -156,7 +156,7 @@ let json_of_string ~context ~default s =
     Use for encoding/compression where fallback is always safe. *)
 let try_or ~context ~fallback f =
   try f ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     if warn_enabled () then
       Log.Misc.error "%s failed: %s, using fallback" context (Printexc.to_string exn);
     fallback ()
@@ -164,7 +164,7 @@ let try_or ~context ~fallback f =
 (** Try operation, return None on any exception. Logs when warn enabled. *)
 let try_opt ~context f =
   try Some (f ())
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     if warn_enabled () then
       Log.Misc.error "%s failed: %s" context (Printexc.to_string exn);
     None

--- a/lib/server/server_checkpoint.ml
+++ b/lib/server/server_checkpoint.ml
@@ -185,7 +185,7 @@ let save (c : checkpoint) : (unit, string) result =
     Log.Server.debug "[Checkpoint] saved to %s (%.0f bytes)"
       path (float_of_int (String.length json_str));
     Ok ()
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     let msg = Printf.sprintf "checkpoint save failed: %s" (Printexc.to_string exn) in
     Log.Server.warn "[Checkpoint] %s" msg;
     Error msg
@@ -208,7 +208,7 @@ let load () : checkpoint option =
       | None ->
           Log.Server.warn "[Checkpoint] invalid checkpoint at %s, ignoring" path;
           None
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Server.warn "[Checkpoint] load failed: %s" (Printexc.to_string exn);
       None
 

--- a/lib/server/server_command_plane_http_stream.ml
+++ b/lib/server/server_command_plane_http_stream.ml
@@ -49,7 +49,7 @@ let stream_native_chain_events_http ~deps ~request reqd =
               Httpun.Body.Writer.write_string writer frame;
               Httpun.Body.Writer.flush writer (fun _ -> ());
               `Sent
-            with exn -> `Error exn)
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn -> `Error exn)
     in
     match write_result with
     | `Sent -> true
@@ -157,7 +157,7 @@ let stream_native_chain_events_h2 ~deps ~request h2_reqd =
               H2.Body.Writer.write_string writer frame;
               H2.Body.Writer.flush writer (fun _ -> ());
               `Sent
-            with exn -> `Error exn)
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn -> `Error exn)
     in
     match write_result with
     | `Sent -> true

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -79,7 +79,7 @@ let start_cp_summary_refresh_loop ~state ~sw ~clock =
         _cp_summary_ref := compute_cp_summary ~state;
         let dt = Time_compat.now () -. t0 in
         Log.CmdPlane.info "cp-summary refreshed (%.1fs)" dt
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let dt = Time_compat.now () -. t0 in
         Log.CmdPlane.warn "cp-summary refresh failed (%.1fs): %s"
           dt (Printexc.to_string exn));

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -50,7 +50,7 @@ let start_execution_refresh_loop ~state ~sw ~clock =
      _execution_json_ref := json;
      let dt = Time_compat.now () -. t0 in
      Log.Dashboard.info "execution warm cache done (%.1fs)" dt
-   with exn ->
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      let dt = Time_compat.now () -. t0 in
      Log.Dashboard.warn "execution warm cache failed (%.1fs): %s"
        dt (Printexc.to_string exn));
@@ -80,7 +80,7 @@ let start_execution_refresh_loop ~state ~sw ~clock =
           (Float.of_int (String.length (Yojson.Safe.to_string json)))
           dt
           (if !_executor_pool <> None then "pool" else "in-domain")
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let dt = Time_compat.now () -. t0 in
         Log.Dashboard.warn "execution refresh failed (%.1fs): %s"
           dt (Printexc.to_string exn));
@@ -284,7 +284,7 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       try
         Dashboard_cache.get_or_compute "command_summary" ~ttl:3.0 (fun () ->
           Server_command_plane_http.command_plane_summary_http_json ~state)
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Dashboard.warn "command_plane_summary: %s" (Printexc.to_string exn);
         `Assoc []
     else

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -212,7 +212,7 @@ let start_operator_refresh_loop ~state ~sw ~clock =
          | Error _ -> ());
         let dt = Time_compat.now () -. t0 in
         Log.Dashboard.info "operator refreshed (%.1fs)" dt
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let dt = Time_compat.now () -. t0 in
         Log.Dashboard.warn "operator refresh failed (%.1fs): %s"
           dt (Printexc.to_string exn));
@@ -327,7 +327,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
      _mission_json_ref := json;
      let dt = Time_compat.now () -. t0 in
      Log.Dashboard.info "mission warm cache done (%.1fs)" dt
-   with exn ->
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      let dt = Time_compat.now () -. t0 in
      Log.Dashboard.warn "mission warm cache failed (%.1fs): %s"
        dt (Printexc.to_string exn));
@@ -345,7 +345,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
         Log.Dashboard.info "mission refreshed (%.0fB, %.1fs)"
           (Float.of_int (String.length (Yojson.Safe.to_string json)))
           dt
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         let dt = Time_compat.now () -. t0 in
         Log.Dashboard.warn "mission refresh failed (%.1fs): %s"
           dt (Printexc.to_string exn));

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -709,7 +709,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
     in
     try
       dispatch_h2_route ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       let msg = Printexc.to_string exn in
       Log.Http.error "Handler error: %s" msg;
       h2_respond_text h2_reqd ("500 Internal Server Error: " ^ msg) ~status:`Internal_server_error ~extra_headers:cors

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -560,7 +560,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
                   let rec loop () =
                     if not !(info.stop) then (
                       (try Eio.Time.sleep clock sse_ping_interval_s
-                       with exn ->
+                       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                          if is_cancelled exn then raise exn;
                          Log.Server.error "ping sleep error: %s"
                            (Printexc.to_string exn));
@@ -569,14 +569,14 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
                            stop_sse_session info.session_id
                          else if not !(info.stop) then
                            ignore (send_raw info ": ping\n\n")
-                       with exn ->
+                       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                          if is_cancelled exn then raise exn;
                          Log.Server.error "ping send error: %s"
                            (Printexc.to_string exn);
                          stop_sse_session info.session_id);
                       loop ())
                   in
-                  try loop () with exn ->
+                  try loop () with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                     if is_cancelled exn then ()
                     else
                       Log.Server.error "ping loop error: %s"

--- a/lib/server/server_mcp_transport_http_mcp_handlers.ml
+++ b/lib/server/server_mcp_transport_http_mcp_handlers.ml
@@ -224,7 +224,7 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
                                       protocol_version origin
                                   in
                                   respond_json `OK body headers
-                      with exn ->
+                      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                         let protocol_version =
                           Server_mcp_transport_http_session
                           .get_protocol_version_for_session ~session_id request
@@ -373,7 +373,7 @@ let handle_get_mcp ~(deps : deps) ?legacy_messages_endpoint
                              Eio.Time.sleep clock
                                Server_mcp_transport_http_headers
                                .sse_ping_interval_s
-                           with exn ->
+                           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                              if is_cancelled exn then raise exn;
                              Log.Server.error "ping sleep error: %s"
                                (Printexc.to_string exn));
@@ -385,7 +385,7 @@ let handle_get_mcp ~(deps : deps) ?legacy_messages_endpoint
                                ignore
                                  (Server_mcp_transport_http_sse.send_raw info
                                     ": ping\n\n")
-                           with exn ->
+                           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                              if is_cancelled exn then raise exn;
                              Log.Server.error "ping send error: %s"
                                (Printexc.to_string exn);
@@ -393,7 +393,7 @@ let handle_get_mcp ~(deps : deps) ?legacy_messages_endpoint
                                info.session_id);
                           loop ())
                       in
-                      try loop () with exn ->
+                      try loop () with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                         if is_cancelled exn then ()
                         else
                           Log.Server.error "ping loop error: %s"

--- a/lib/server/server_mcp_transport_http_sse.ml
+++ b/lib/server/server_mcp_transport_http_sse.ml
@@ -110,7 +110,7 @@ let close_sse_conn info =
     info.closed <- true;
     info.stop := true;
     (try Httpun.Body.Writer.close info.writer
-     with exn ->
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Misc.debug "close_sse_conn: %s"
          (Printexc.to_string exn));
     Sse.unregister_if_current info.session_id info.client_id)

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -204,7 +204,7 @@ let asset_content_type name =
 
 let read_file path =
   try Ok (In_channel.with_open_bin path In_channel.input_all)
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let serve_graphiql_asset name _request reqd =
   let path = graphiql_asset_path name in

--- a/lib/server/server_routes_http_routes_social.ml
+++ b/lib/server/server_routes_http_routes_social.ml
@@ -159,7 +159,7 @@ let add_routes router =
                (Yojson.Safe.to_string (`Assoc [
                  ("ok", `Bool ok); ("message", `String msg)
                ]))
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              respond_json_with_cors ~status:`Bad_request request reqd
                (Yojson.Safe.to_string (`Assoc [
                  ("ok", `Bool false);
@@ -179,7 +179,7 @@ let add_routes router =
                (Yojson.Safe.to_string (`Assoc [
                  ("ok", `Bool ok); ("message", `String msg)
                ]))
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              respond_json_with_cors ~status:`Bad_request request reqd
                (Yojson.Safe.to_string (`Assoc [
                  ("ok", `Bool false);

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -295,7 +295,7 @@ let serve ~sw ~clock ~socket ~request_handler =
                   (Printexc.to_string exn)))
       ;
       accept_loop 0.05
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       if is_cancelled exn then ()
       else begin
         Log.Misc.error "Accept error: %s" (Printexc.to_string exn);

--- a/lib/server/server_social_http.ml
+++ b/lib/server/server_social_http.ml
@@ -103,7 +103,7 @@ let send_raw info data =
           Httpun.Body.Writer.write_string info.writer data;
           Httpun.Body.Writer.flush info.writer (fun _ -> ());
           true
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.Social.warn "send_raw write failed: %s" (Printexc.to_string exn);
           info.closed <- true;
           false)
@@ -177,14 +177,14 @@ let handle_stream ~deps ~state request reqd =
           let rec loop () =
             if not !(info.stop) then begin
               (try Eio.Time.sleep clock keepalive_interval_s
-               with exn -> if is_cancelled exn then raise exn);
+               with Eio.Cancel.Cancelled _ as e -> raise e | exn -> if is_cancelled exn then raise exn);
               if not !(info.stop) then
                 ignore (send_raw info ": keepalive\n\n");
               loop ()
             end
           in
           try loop ()
-          with exn ->
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             if not (is_cancelled exn) then close_stream info;
             Social_motion.unregister_if_current info.session_id info.client_id)
   | _ -> ());

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -335,7 +335,7 @@ let wait_for_message registry ~agent_name ~timeout =
 
   let result =
     try wait_loop ()
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Misc.warn "session listen interrupted: %s" (Printexc.to_string exn);
       None
   in

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -126,7 +126,7 @@ let phase_cleanup state ~clock =
         try
           hook.action ();
           Log.Server.debug "[Shutdown] hook '%s' completed" hook.name
-        with exn ->
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.Server.warn "[Shutdown] hook '%s' failed: %s" hook.name (Printexc.to_string exn)
       ) all_hooks)
   with Eio.Time.Timeout ->

--- a/lib/spawn_registry.ml
+++ b/lib/spawn_registry.ml
@@ -168,7 +168,7 @@ let maybe_sweep reg =
   let now = Time_compat.now () in
   if now -. reg.last_sweep > float_of_int Limits.sweeper_interval_sec then
     (try ignore (sweep reg)
-     with exn -> Log.Spawn.error "sweep failed: %s" (Printexc.to_string exn))
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Spawn.error "sweep failed: %s" (Printexc.to_string exn))
 
 (** {1 Cooldown Management} *)
 

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -136,7 +136,7 @@ let _parse_error () =
   let dispatch_request (handler : request_handler) request =
     try
       handler request
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       error_response
         ~id:(extract_id request)
         ~code:(-32603)

--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -162,7 +162,7 @@ let push_event_to_sessions (event : Yojson.Safe.t) : unit =
   match !session_registry_ref with
   | Some push_fn ->
       (try ignore (push_fn event)
-       with exn -> Log.Sub.error "push_event failed: %s" (Printexc.to_string exn))
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Sub.error "push_event failed: %s" (Printexc.to_string exn))
   | None ->
       Log.Sub.info "push_event_to_sessions: registry not wired"
 
@@ -194,7 +194,7 @@ let notify_change ~(resource : resource_type) ~(change : change_type)
          ("timestamp", `Float now);
        ] in
        (try ignore (push_fn event)
-        with exn -> Log.Sub.error "push_sub_event failed: %s" (Printexc.to_string exn))
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Sub.error "push_sub_event failed: %s" (Printexc.to_string exn))
    | None -> ());
   List.length subs
 

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -387,7 +387,7 @@ let hydrate (dna : succession_dna) (spec : successor_spec) : Context_manager.wor
     else
       try Some (Context_manager.deserialize_context
                   dna.compressed_context ~max_tokens:spec.model.max_context)
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Misc.warn "succession: context deserialize failed: %s" (Printexc.to_string exn);
         None
   in
@@ -484,7 +484,7 @@ let dna_of_json json =
       warnings = json |> member "warnings" |> str_list_of_json;
       metrics = json |> member "metrics" |> metrics_of_json;
     }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (sprintf "DNA parse error: %s" (Printexc.to_string exn))
 
 (* ================================================================ *)
@@ -608,7 +608,7 @@ let get_metrics ctx : succession_metrics =
         errors_encountered = json |> member "errors_encountered" |> to_int;
         elapsed_seconds = json |> member "elapsed_seconds" |> to_number;
       }
-    with _ -> empty_metrics)
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> empty_metrics)
   | _ -> empty_metrics
 
 (** Read a scoped string, returning a default if missing. *)

--- a/lib/supervisor.ml
+++ b/lib/supervisor.ml
@@ -79,7 +79,7 @@ let rec start_child ~sw ~clock cs =
         cs.spec.start ();
         cs.running <- false;
         Log.Server.info "[Supervisor] child %s exited normally" name
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         cs.running <- false;
         let msg = Printexc.to_string exn in
         Log.Server.warn "[Supervisor] child %s crashed: %s" name msg;

--- a/lib/task_pg.ml
+++ b/lib/task_pg.ml
@@ -234,7 +234,7 @@ let row_to_task (((id, title, description), (priority, status, assignee),
     match Yojson.Safe.from_string files_json with
     | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
     | _ -> []
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "task_pg: files JSON parse failed: %s" (Printexc.to_string exn);
     [] in
   let required_role = Agent_identity.role_of_string required_role_str in

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -227,7 +227,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
               (Team_session_types.control_profile_to_string control_profile) );
           ("model_cascade", `List (List.map (fun m -> `String m) model_cascade));
         ])
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let refresh_duration_expired_session ~(config : Room.config) ~(session_id : string)
     (session : Team_session_types.session) : Team_session_types.session =

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -442,7 +442,7 @@ let list_sessions ~(config : Room.config) ~(requester_agent : string option)
           ("count", `Int (List.length items));
           ("sessions", `List items);
         ])
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let compare_sessions ~(config : Room.config) ~(requester_agent : string option)
     ~(base_session_id : string) ~(target_session_id : string) :

--- a/lib/team_session/team_session_report_core.ml
+++ b/lib/team_session/team_session_report_core.ml
@@ -861,5 +861,5 @@ let generate config (session : Team_session_types.session) :
     in
     Team_session_store.write_text_file report_md_path markdown;
     Ok (report_json, markdown)
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 

--- a/lib/team_session/team_session_report_proof.ml
+++ b/lib/team_session/team_session_report_proof.ml
@@ -416,4 +416,4 @@ let generate_proof ?(proof_level = default_proof_level) config
         ~proof_generated_at_iso:generated_at_iso
     in
     Ok (proof_json, markdown)
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -181,7 +181,7 @@ let load_latest_checkpoint config session_id : Team_session_types.checkpoint opt
         | Error e ->
             Log.Session.error "checkpoint parse error (%s): %s" latest e;
             None
-      with exn ->
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Session.error "checkpoint load error (%s): %s" latest
           (Printexc.to_string exn);
         None)
@@ -196,7 +196,7 @@ let read_recent_events config session_id ~max_count :
         | Ok e -> Some e
         | Error _ -> None)
       raw
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Session.error "read_recent_events error (%s): %s"
       session_id (Printexc.to_string exn);
     []

--- a/lib/team_session/team_session_types.ml
+++ b/lib/team_session/team_session_types.ml
@@ -638,7 +638,7 @@ let session_of_yojson json =
         created_at_iso = json |> member "created_at_iso" |> to_string_option |> Option.value ~default:(Types.now_iso ());
         updated_at_iso = json |> member "updated_at_iso" |> to_string_option |> Option.value ~default:(Types.now_iso ());
       }
-  with exn ->
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Session.error "session_of_yojson parse failed: %s"
       (Printexc.to_string exn);
     None
@@ -669,7 +669,7 @@ let checkpoint_of_yojson (json : Yojson.Safe.t) : (checkpoint, string) result =
         active_agents =
           json |> member "active_agents" |> to_list |> List.map to_string;
       }
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let event_entry_of_yojson (json : Yojson.Safe.t) : (event_entry, string) result =
   try
@@ -680,7 +680,7 @@ let event_entry_of_yojson (json : Yojson.Safe.t) : (event_entry, string) result 
         event_type = json |> member "event_type" |> to_string;
         detail = json |> member "detail";
       }
-  with exn -> Error (Printexc.to_string exn)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
 
 let checkpoint_to_yojson (c : checkpoint) =
   `Assoc

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -137,10 +137,10 @@ let handle_compact args : result =
     let strategy_str = args |> member "strategy" |> to_string in
     let max_tokens =
       (try args |> member "max_tokens" |> to_int
-       with _ -> 128_000) in
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 128_000) in
     let system_prompt =
       (try args |> member "system_prompt" |> to_string
-       with _ -> "") in
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "") in
     let strategies = match strategies_of_string strategy_str with
       | Ok s -> s
       | Error msg -> raise (Invalid_argument msg)

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -88,7 +88,7 @@ let handle_start (ctx : context) : result option =
             let start = !idx + String.length prefix in
             let end_idx = try String.index_from add_result start ':' with Not_found -> String.length add_result in
             String.sub add_result start (end_idx - start)
-          with _ -> ""
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
         in
         if task_id = "" then
           Some (true, Printf.sprintf "masc_start partial: joined as %s, but task creation failed: %s" agent_name add_result)

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -211,7 +211,7 @@ let record_entry (acc : accumulator) (entry : tool_call_entry) : unit =
   (* Persist immediately for crash recovery *)
   (try append_entry ~masc_root:acc.masc_root ~keeper_name:acc.keeper_name
        ~trace_id:acc.trace_id entry
-   with exn -> Log.Keeper.error "Failed to persist entry for %s: %s" acc.trace_id (Printexc.to_string exn))
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Keeper.error "Failed to persist entry for %s: %s" acc.trace_id (Printexc.to_string exn))
 
 let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
   let traj = {
@@ -229,7 +229,7 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
   } in
   (try append_summary ~masc_root:acc.masc_root ~keeper_name:acc.keeper_name
        ~trace_id:acc.trace_id traj
-   with exn -> Log.Keeper.error "Failed to persist summary for %s: %s" acc.trace_id (Printexc.to_string exn));
+   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Keeper.error "Failed to persist summary for %s: %s" acc.trace_id (Printexc.to_string exn));
   traj
 
 (* ================================================================ *)

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -604,7 +604,7 @@ let start_server ~sw ~env config room_config : server =
   Eio.Fiber.fork ~sw (fun () ->
     try
       Grpc_eio.Server.serve ~sw ~env grpc_server
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Transport.info "serve crashed: %s" (Printexc.to_string exn)
   );
 

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -287,7 +287,7 @@ let load_request base_path req_id =
     try
       let json = Safe_ops.read_json_eio path in
       request_of_yojson json
-    with exn ->
+    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Error (Printf.sprintf "Failed to load verification %s: %s" req_id (Printexc.to_string exn))
   else
     Error (Printf.sprintf "Verification %s not found" req_id)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -219,7 +219,7 @@ let make_pre_tool_hook
       else
         let input_str =
           try Yojson.Safe.to_string input
-          with _ -> "{}" in
+          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "{}" in
         let req : verification_request = {
           action_description;
           action_result = input_str;

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -321,7 +321,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
                    ~success:(Result.is_ok result) ~duration_ms)
                on_exec;
              result
-           with exn ->
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              let duration_ms = 0 in
              Option.iter
                (fun f -> f ~tool_name:"shell_exec" ~success:false ~duration_ms)


### PR DESCRIPTION
Final round: 197 catches across 106 files. Total 347 guards in lib/. 20 remaining are pure stdlib parsers (int_of_string etc) that cannot raise Eio.Cancel.Cancelled. Build passes.