### PR TITLE
fix: migrate remaining legacy metrics readers to date-split fallback

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -65,16 +65,22 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             max 0 (m.last_compaction_before_tokens - m.last_compaction_after_tokens)
           in
 
-          let metrics_path = Keeper_types.keeper_metrics_path config m.name in
+          let metrics_store = Keeper_types.keeper_metrics_store config m.name in
+          let metrics_window_max_bytes = 200000 in
+          let all_metrics_lines =
+            let n = max series_points 12000 in
+            let dated = Dated_jsonl.read_recent_lines metrics_store n in
+            if dated <> [] then dated
+            else
+              let metrics_path = Keeper_types.keeper_metrics_path config m.name in
+              Keeper_memory.read_file_tail_lines metrics_path
+                ~max_bytes:(max metrics_window_max_bytes 3000000) ~max_lines:n
+          in
           let (metrics_24h, metrics_24h_summary) =
             if compact then (`Null, `Null)
-            else keeper_metrics_24h_json ~metrics_path ~now_ts
+            else keeper_metrics_24h_json ~metrics_lines:all_metrics_lines ~now_ts
           in
-            let metrics_window_max_bytes = 200000 in
-            let metrics_lines =
-              Keeper_memory.read_file_tail_lines
-              metrics_path ~max_bytes:metrics_window_max_bytes ~max_lines:series_points
-          in
+          let metrics_lines = all_metrics_lines in
           let parsed_metrics =
             List.filter_map (fun line ->
               try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -2,8 +2,6 @@
     gen window stats, history summary, and helper utilities. *)
 
 
-open Dashboard_http_helpers
-
 let normalize_model_name s =
   let s = String.trim s in
   let s =
@@ -194,30 +192,11 @@ let create_keeper_24h_bucket_stats () : keeper_24h_bucket_stats =
   }
 
 let keeper_metrics_24h_json
-    ~(metrics_path : string)
+    ~(metrics_lines : string list)
     ~(now_ts : float) : Yojson.Safe.t * Yojson.Safe.t =
-  let max_lines =
-    int_of_env_default
-      "MASC_DASHBOARD_24H_MAX_LINES"
-      ~default:12000
-      ~min_v:200
-      ~max_v:50000
-  in
-  let max_bytes =
-    int_of_env_default
-      "MASC_DASHBOARD_24H_MAX_BYTES"
-      ~default:3000000
-      ~min_v:200000
-      ~max_v:20000000
-  in
   let window_sec = 24.0 *. 3600.0 in
   let start_ts = now_ts -. window_sec in
-  let lines =
-    Keeper_memory.read_file_tail_lines
-      metrics_path
-      ~max_bytes
-      ~max_lines
-  in
+  let lines = metrics_lines in
   let buckets : (int, keeper_24h_bucket_stats) Hashtbl.t = Hashtbl.create 64 in
   let sample_points = ref 0 in
   let proactive_points = ref 0 in
@@ -298,8 +277,7 @@ let keeper_metrics_24h_json
   let summary =
     `Assoc [
       ("window_hours", `Float 24.0);
-      ("source_max_lines", `Int max_lines);
-      ("source_max_bytes", `Int max_bytes);
+      ("source_lines", `Int (List.length metrics_lines));
       ("sample_points", `Int !sample_points);
       ("bucket_count", `Int bucket_count);
       ("from_ts_unix", `Float start_ts);

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -95,8 +95,15 @@ let recent_messages_json config =
   |> fun rows -> `List rows
 
 let latest_keeper_tools_from_metrics config keeper_name =
-  let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
-  Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
+  let store = Keeper_types.keeper_metrics_store config keeper_name in
+  let lines =
+    let dated = Dated_jsonl.read_recent_lines store 8 in
+    if dated <> [] then dated
+    else
+      let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+      Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
+  in
+  lines
   |> List.rev
   |> List.find_map (fun line ->
          try
@@ -238,10 +245,14 @@ let keepers_json ?keeper_names config =
                   ("updated_at", `String meta.updated_at);
                   ("created_at", `String meta.created_at);
                   ("recent_activity",
-                    let metrics_path = Keeper_types.keeper_metrics_path config name in
+                    let store = Keeper_types.keeper_metrics_store config name in
                     let lines =
-                      Keeper_memory.read_file_tail_lines metrics_path
-                        ~max_bytes:8000 ~max_lines:5
+                      let dated = Dated_jsonl.read_recent_lines store 5 in
+                      if dated <> [] then dated
+                      else
+                        let metrics_path = Keeper_types.keeper_metrics_path config name in
+                        Keeper_memory.read_file_tail_lines metrics_path
+                          ~max_bytes:8000 ~max_lines:5
                     in
                     `List (List.filter_map (fun line ->
                       try Some (Yojson.Safe.from_string line)


### PR DESCRIPTION
Follow-up to #1967 (merged). 3 callers of keeper_metrics_path were still reading the legacy single file directly. After date-split migration, new data only goes to YYYY-MM/DD.jsonl, so these readers would return stale/empty data after legacy file cleanup.