### PR TITLE
fix: board/:id HTTP/1.1 route + permanent board posts (TTL=0)

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -206,7 +206,7 @@ let normalize_initiative_cooldown_sec (v : int) : int =
   clamp_int v ~min_v:3600 ~max_v:604800
 
 let normalize_initiative_post_ttl_hours (v : int) : int =
-  clamp_int v ~min_v:1 ~max_v:168
+  clamp_int v ~min_v:0 ~max_v:168
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)

--- a/lib/server/server_routes_http_routes_social.ml
+++ b/lib/server/server_routes_http_routes_social.ml
@@ -146,6 +146,21 @@ let add_routes router =
        let json = `Assoc [("flairs", `List flairs)] in
        Http.Response.json (Yojson.Safe.to_string json) reqd)
 
+  |> Http.Router.prefix_get "/api/v1/board/" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let path = Http.Request.path request in
+         (match extract_path_param ~prefix:"/api/v1/board/" path with
+          | None ->
+              Http.Response.json
+                (Yojson.Safe.to_string (`Assoc [("error", `String "post_id is required")]))
+                ~status:`Bad_request reqd
+          | Some post_id ->
+              let format =
+                query_param req "format" |> Option.value ~default:"nested"
+              in
+              let (status, body) = board_post_detail_json ~response_format:format ~post_id in
+              respond_json_with_cors ~status request reqd body)
+       ) request reqd)
 
   (* Board write APIs — used by Bevy Viewer *)
   |> Http.Router.post "/api/v1/tools/masc_board_vote" (fun request reqd ->


### PR DESCRIPTION
board 개밥먹기 2건: (1) single-post detail HTTP/1.1 누락 (2) keeper TTL=1h→0 (96% 데이터 유실 근본 원인)