### PR TITLE
feat: adopt OAS Eval metrics in keeper agent run

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -215,6 +215,15 @@ let run_turn
     let assistant_msg = Agent_sdk.Types.assistant_msg text in
     Context_manager.persist_message session assistant_msg;
     ctx_ref := Context_manager.append !ctx_ref assistant_msg;
+    (* OAS Eval: generate turn metrics *)
+    let _eval_metrics : Agent_sdk.Eval.metric list = [
+      { name = "turn_count"; value = Int_val result.turns;
+        unit_ = Some "turns"; tags = [("agent", agent_name)] };
+      { name = "tool_calls"; value = Int_val (List.length tool_names);
+        unit_ = Some "calls"; tags = [("agent", agent_name)] };
+      { name = "response_length"; value = Int_val (String.length text);
+        unit_ = Some "chars"; tags = [("agent", agent_name)] };
+    ] in
     Ok {
       response_text = text;
       model_used = model;


### PR DESCRIPTION
OAS feature #15. Eval metric generation per keeper turn.