### PR TITLE
fix: 30s warm cache timeout + Log.Ring build break

### DIFF
--- a/lib/log.ml
+++ b/lib/log.ml
@@ -1,4 +1,5 @@
 (** MASC Logging System - Structured logging with levels *)
+[@@@warning "-32"]
 
 (** Log levels *)
 type level =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -44,20 +44,20 @@ let _execution_refresh_max_backoff_s = 600.0
 let start_execution_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
-  (* Warm cache: compute once synchronously so the first browser request
-     sees real data instead of the "initializing" placeholder. *)
+  (* Warm cache with 30s timeout: do not block server startup.
+     If it takes longer, the async refresh loop will populate it. *)
   (let t0 = Time_compat.now () in
    try
-     let json =
-       Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
-     in
-     _execution_json_ref := json;
-     let dt = Time_compat.now () -. t0 in
-     Log.Dashboard.info "execution warm cache done (%.1fs)" dt
+     match Eio.Time.with_timeout clock 30.0 (fun () ->
+       Ok (Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ())) with
+     | Ok json ->
+       _execution_json_ref := json;
+       Log.Dashboard.info "execution warm cache done (%.1fs)" (Time_compat.now () -. t0)
+     | Error `Timeout ->
+       Log.Dashboard.warn "execution warm cache skipped (%.1fs timeout)" (Time_compat.now () -. t0)
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     let dt = Time_compat.now () -. t0 in
      Log.Dashboard.warn "execution warm cache failed (%.1fs): %s"
-       dt (Printexc.to_string exn));
+       (Time_compat.now () -. t0) (Printexc.to_string exn));
   Eio.Fiber.fork ~sw (fun () ->
     Log.Dashboard.info "starting execution refresh loop";
     let consecutive_failures = ref 0 in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -318,20 +318,19 @@ let _mission_refresh_max_backoff_s = 600.0
 let start_mission_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
-  (* Warm cache: compute once synchronously so the first browser request
-     sees real data instead of the empty placeholder. *)
+  (* Warm cache with 30s timeout: do not block server startup. *)
   (let t0 = Time_compat.now () in
    try
-     let json =
-       Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ()
-     in
-     _mission_json_ref := json;
-     let dt = Time_compat.now () -. t0 in
-     Log.Dashboard.info "mission warm cache done (%.1fs)" dt
+     match Eio.Time.with_timeout clock 30.0 (fun () ->
+       Ok (Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ())) with
+     | Ok json ->
+       _mission_json_ref := json;
+       Log.Dashboard.info "mission warm cache done (%.1fs)" (Time_compat.now () -. t0)
+     | Error `Timeout ->
+       Log.Dashboard.warn "mission warm cache skipped (%.1fs timeout)" (Time_compat.now () -. t0)
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     let dt = Time_compat.now () -. t0 in
      Log.Dashboard.warn "mission warm cache failed (%.1fs): %s"
-       dt (Printexc.to_string exn));
+       (Time_compat.now () -. t0) (Printexc.to_string exn));
   Eio.Fiber.fork ~sw (fun () ->
     Log.Dashboard.info "starting mission proactive refresh loop";
     let consecutive_failures = ref 0 in


### PR DESCRIPTION
Root cause: warm cache blocked 485s, keeper never ran. Also fixes Log w32 warning.