### PR TITLE
fix(dashboard): add missing logs section to navigation config

### DIFF
--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -205,6 +205,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       params: { section: 'avatars' },
     },
   ],
+  logs: [],
 }
 
 function validSectionIds(tab: NonHomeTabId): SurfaceSectionId[] {


### PR DESCRIPTION
## Summary
- `DASHBOARD_SECTION_ITEMS`에 `logs` 키 누락으로 TS2741 빌드 에러 수정
- `DASHBOARD_SURFACES`에 logs 탭이 추가되었지만 `Record<NonHomeTabId, ...>`에 logs 키가 빠져있었음

## Test plan
- [x] `npm run build` 성공 (TS2741 해소)

🤖 Generated with [Claude Code](https://claude.com/claude-code)