### PR TITLE
feat(dashboard): real-time agent monitor (Phase 4)

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -1,0 +1,171 @@
+// AgentLiveTimeline — enhanced per-agent event timeline with filter chips,
+// event rate, auto-scroll toggle, and color-coded event badges.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect, useRef, useMemo } from 'preact/hooks'
+import { TimeAgo } from '../common/time-ago'
+import { journal } from '../../sse'
+import type { JournalEntry, JournalEventType } from '../../types'
+
+type FilterKind = 'all' | 'heartbeat' | 'turn' | 'tool' | 'error' | 'lifecycle'
+
+const activeFilter = signal<FilterKind>('all')
+const autoScroll = signal(true)
+
+const FILTER_CHIPS: { key: FilterKind; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'heartbeat', label: 'Heartbeat' },
+  { key: 'turn', label: 'Turn' },
+  { key: 'tool', label: 'Tool' },
+  { key: 'error', label: 'Error' },
+  { key: 'lifecycle', label: 'Lifecycle' },
+]
+
+function eventMatchesFilter(entry: JournalEntry, filter: FilterKind): boolean {
+  if (filter === 'all') return true
+  const et = entry.eventType ?? 'unknown'
+  switch (filter) {
+    case 'heartbeat':
+      return et === 'keeper_heartbeat' || et === 'oas_keeper_snapshot'
+    case 'turn':
+      return et === 'broadcast' || et === 'board_post' || et === 'board_comment'
+    case 'tool':
+      return entry.text.toLowerCase().includes('tool')
+    case 'error':
+      return et === 'keeper_guardrail' || entry.text.toLowerCase().includes('error')
+    case 'lifecycle':
+      return et === 'agent_joined' || et === 'agent_left' || et === 'keeper_handoff' || et === 'keeper_compaction'
+    default:
+      return true
+  }
+}
+
+function eventKindBadgeClass(eventType: JournalEventType | undefined): string {
+  switch (eventType) {
+    case 'keeper_heartbeat':
+    case 'oas_keeper_snapshot':
+      return 'agent-event-badge--heartbeat'
+    case 'agent_joined':
+    case 'agent_left':
+      return 'agent-event-badge--lifecycle'
+    case 'keeper_handoff':
+    case 'keeper_compaction':
+      return 'agent-event-badge--keeper'
+    case 'keeper_guardrail':
+      return 'agent-event-badge--error'
+    case 'broadcast':
+      return 'agent-event-badge--broadcast'
+    case 'task_update':
+      return 'agent-event-badge--task'
+    case 'board_post':
+    case 'board_comment':
+      return 'agent-event-badge--board'
+    default:
+      return 'agent-event-badge--default'
+  }
+}
+
+function eventKindLabel(eventType: JournalEventType | undefined): string {
+  switch (eventType) {
+    case 'keeper_heartbeat': return 'HB'
+    case 'oas_keeper_snapshot': return 'OAS'
+    case 'agent_joined': return 'JOIN'
+    case 'agent_left': return 'LEFT'
+    case 'keeper_handoff': return 'HAND'
+    case 'keeper_compaction': return 'COMP'
+    case 'keeper_guardrail': return 'GUARD'
+    case 'broadcast': return 'CAST'
+    case 'task_update': return 'TASK'
+    case 'board_post': return 'POST'
+    case 'board_comment': return 'CMNT'
+    case 'unknown': return 'SYS'
+    default: return 'EVT'
+  }
+}
+
+function compactText(value: string | null | undefined, max = 120): string {
+  const text = (value ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return ''
+  return text.length > max ? `${text.slice(0, max - 1)}...` : text
+}
+
+function getAgentJournalEntries(name: string): JournalEntry[] {
+  const lower = name.toLowerCase()
+  return journal.value
+    .filter((e: JournalEntry) => {
+      const text = e.text.toLowerCase()
+      const agent = e.agent.toLowerCase()
+      return agent === lower || text.includes(lower) || text.includes(`@${lower}`)
+    })
+    .slice(0, 50)
+}
+
+export function AgentLiveTimeline({ name }: { name: string }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const allEntries = getAgentJournalEntries(name)
+
+  const filtered = useMemo(() => {
+    const f = activeFilter.value
+    return allEntries.filter(e => eventMatchesFilter(e, f))
+  }, [allEntries, activeFilter.value])
+
+  // events/min calculation: count events in the last 60 seconds
+  const eventsPerMin = useMemo(() => {
+    const now = Date.now()
+    const cutoff = now - 60_000
+    const recentCount = allEntries.filter(e => e.timestamp > cutoff).length
+    return recentCount
+  }, [allEntries])
+
+  useEffect(() => {
+    if (autoScroll.value && scrollRef.current) {
+      scrollRef.current.scrollTop = 0
+    }
+  }, [filtered.length])
+
+  return html`
+    <div class="agent-live-timeline">
+      <div class="agent-live-header">
+        <div class="agent-live-filter-bar">
+          ${FILTER_CHIPS.map(chip => html`
+            <button
+              key=${chip.key}
+              class="agent-live-chip ${activeFilter.value === chip.key ? 'agent-live-chip--active' : ''}"
+              onClick=${() => { activeFilter.value = chip.key }}
+            >
+              ${chip.label}
+            </button>
+          `)}
+        </div>
+        <div class="agent-live-meta">
+          <span class="agent-event-rate">${eventsPerMin}/min</span>
+          <span class="agent-live-count">${filtered.length} events</span>
+          <button
+            class="agent-live-autoscroll ${autoScroll.value ? 'agent-live-autoscroll--on' : ''}"
+            onClick=${() => { autoScroll.value = !autoScroll.value }}
+            title=${autoScroll.value ? 'Auto-scroll ON' : 'Auto-scroll OFF'}
+          >
+            ${autoScroll.value ? 'AUTO' : 'MANUAL'}
+          </button>
+        </div>
+      </div>
+
+      <div class="agent-live-stream" ref=${scrollRef}>
+        ${filtered.length === 0
+          ? html`<div class="empty-state">No events matching filter</div>`
+          : filtered.map((entry: JournalEntry, idx: number) => html`
+              <div class="agent-live-event" key=${idx}>
+                <span class="agent-event-badge ${eventKindBadgeClass(entry.eventType)}">
+                  ${eventKindLabel(entry.eventType)}
+                </span>
+                <span class="agent-live-event-text">${compactText(entry.text)}</span>
+                ${entry.timestamp ? html`
+                  <span class="agent-live-event-time"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                ` : null}
+              </div>
+            `)}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -1,0 +1,77 @@
+// AgentRuntimeStrip — compact horizontal strip showing keeper live metrics.
+// Renders pipeline stage badge, context ratio bar, generation, active model, last turn age.
+// Only renders if the agent has a linked keeper.
+
+import { html } from 'htm/preact'
+import { PipelineStageBadge } from '../keeper-pipeline-stage'
+import { keepers } from '../../store'
+import { formatDuration } from '../mission-utils'
+import type { Keeper } from '../../types'
+
+function findKeeper(name: string): Keeper | null {
+  return keepers.value.find(
+    k => k.agent_name === name || k.name === name,
+  ) ?? null
+}
+
+function ctxBarClass(ratio: number | null | undefined): string {
+  if (ratio == null) return ''
+  const pct = ratio * 100
+  if (pct < 50) return ''
+  if (pct < 70) return 'warn'
+  return 'bad'
+}
+
+export function AgentRuntimeStrip({ name }: { name: string }) {
+  const keeper = findKeeper(name)
+  if (!keeper) return null
+
+  const stage = keeper.pipeline_stage
+  const ctxRatio = keeper.context_ratio
+  const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
+  const generation = keeper.generation
+  const model = keeper.active_model ?? keeper.model ?? null
+  const lastTurnAge = keeper.last_turn_ago_s
+
+  return html`
+    <div class="agent-runtime-strip">
+      <div class="agent-runtime-metric">
+        <${PipelineStageBadge} stage=${stage} />
+      </div>
+
+      ${ctxPct != null ? html`
+        <div class="agent-runtime-metric">
+          <span class="agent-runtime-label">CTX</span>
+          <div class="agent-runtime-ctx-bar">
+            <div
+              class="agent-runtime-ctx-fill ${ctxBarClass(ctxRatio)}"
+              style=${{ width: `${ctxPct}%` }}
+            ></div>
+          </div>
+          <span class="agent-runtime-value">${ctxPct}%</span>
+        </div>
+      ` : null}
+
+      ${generation != null ? html`
+        <div class="agent-runtime-metric">
+          <span class="agent-runtime-label">GEN</span>
+          <span class="agent-runtime-value">${generation}</span>
+        </div>
+      ` : null}
+
+      ${model ? html`
+        <div class="agent-runtime-metric">
+          <span class="agent-runtime-label">MODEL</span>
+          <span class="agent-runtime-value agent-runtime-model">${model}</span>
+        </div>
+      ` : null}
+
+      ${lastTurnAge != null ? html`
+        <div class="agent-runtime-metric">
+          <span class="agent-runtime-label">TURN</span>
+          <span class="agent-runtime-value">${formatDuration(lastTurnAge)} ago</span>
+        </div>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -27,11 +27,9 @@ import {
   type AgentTimelineResponse,
   type AgentRelationsResponse,
 } from '../api'
-import { journal } from '../sse'
 import { missionSnapshot } from '../mission-store'
 import { navigate } from '../router'
 import { formatDuration } from './mission-utils'
-import type { JournalEntry } from '../types'
 import type {
   Agent,
   DashboardExecutionContinuityBrief,
@@ -39,6 +37,8 @@ import type {
   Keeper,
   Task,
 } from '../types'
+import { AgentRuntimeStrip } from './agent-monitor/runtime-strip'
+import { AgentLiveTimeline } from './agent-monitor/live-timeline'
 
 const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
@@ -81,17 +81,6 @@ function continuityBrief(name: string): DashboardExecutionContinuityBrief | null
 
 function workerBrief(name: string) {
   return executionWorkerSupportBriefs.value.find(w => w.name === name) ?? null
-}
-
-function agentJournalEntries(name: string): JournalEntry[] {
-  const lower = name.toLowerCase()
-  return journal.value
-    .filter((e: JournalEntry) => {
-      const text = e.text.toLowerCase()
-      const agent = e.agent.toLowerCase()
-      return agent === lower || text.includes(lower) || text.includes(`@${lower}`)
-    })
-    .slice(0, 15)
 }
 
 function compactCopy(value: string | null | undefined, max = 160): string | null {
@@ -180,13 +169,6 @@ function timelineEventLabel(type: string): string {
     case 'broadcast': return '방송'
     default: return type
   }
-}
-
-function journalKindIcon(entry: JournalEntry): string {
-  if (entry.kind === 'board') return 'B'
-  if (entry.kind === 'tasks') return 'T'
-  if (entry.kind === 'keepers') return 'K'
-  return 'S'
 }
 
 // --- FF Character Plate ---
@@ -324,7 +306,6 @@ export function AgentProfile({ name }: { name: string }) {
   const owned = assignedTasks(name)
   const lines = roomActivity.value
   const timeline = agentTimeline.value
-  const journalEntries = agentJournalEntries(name)
 
   return html`
     <div class="ff-profile">
@@ -338,6 +319,8 @@ export function AgentProfile({ name }: { name: string }) {
       ${profileError.value ? html`<div class="council-error">${profileError.value}</div>` : null}
 
       <${CharacterPlate} name=${name} />
+
+      <${AgentRuntimeStrip} name=${name} />
 
       <div class="ff-profile__grid">
         <${Card} title="태스크 (${owned.length})" class="ff-card">
@@ -404,17 +387,8 @@ export function AgentProfile({ name }: { name: string }) {
               })}</div>`}
         <//>
 
-        <${Card} title="실시간 (${journalEntries.length})" class="ff-card">
-          ${journalEntries.length === 0
-            ? html`<div class="empty-state">이벤트 없음</div>`
-            : html`<div class="agent-journal-stream">${journalEntries.map((entry: JournalEntry, idx: number) => html`
-                <div class="agent-journal-entry" key=${idx}>
-                  <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
-                  <span class="agent-journal-type">${entry.eventType}</span>
-                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
-                  ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
-                </div>
-              `)}</div>`}
+        <${Card} title="실시간" class="ff-card">
+          <${AgentLiveTimeline} name=${name} />
         <//>
 
         <${Card} title="Room 활동" class="ff-card">

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -33,6 +33,7 @@ import './styles/roster.css'
 import './styles/ff-theme.css'
 import './styles/oas-pipeline.css'
 import './styles/pipeline-stage.css'
+import './styles/agent-monitor.css'
 import './styles/logs.css'
 
 import { render } from 'preact'

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -1,0 +1,249 @@
+/* ── Agent Monitor — runtime strip + live timeline ──────────── */
+
+/* ── Runtime Strip ─────────────────────────────────────────── */
+
+.agent-runtime-strip {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: linear-gradient(
+    90deg,
+    rgba(10, 22, 40, 0.85) 0%,
+    rgba(16, 28, 48, 0.7) 100%
+  );
+  border: 1px solid var(--ff-border-subtle);
+  border-radius: var(--radius-sm, 10px);
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.agent-runtime-metric {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.agent-runtime-label {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--font-mono, monospace);
+  color: var(--ff-gold-dim, rgba(200, 168, 78, 0.5));
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.agent-runtime-value {
+  color: var(--text-body, #c0d2f2);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+}
+
+.agent-runtime-model {
+  max-width: 160px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Context ratio mini bar */
+.agent-runtime-ctx-bar {
+  width: 60px;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.agent-runtime-ctx-fill {
+  height: 100%;
+  background: var(--ff-hp-full, #4ade80);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.agent-runtime-ctx-fill.warn {
+  background: var(--ff-hp-mid, #fbbf24);
+}
+
+.agent-runtime-ctx-fill.bad {
+  background: var(--ff-hp-low, #f87171);
+}
+
+/* ── Live Timeline ─────────────────────────────────────────── */
+
+.agent-live-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-live-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Filter chips row */
+.agent-live-filter-bar {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.agent-live-chip {
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--ff-border-subtle);
+  background: none;
+  color: var(--text-muted, #86a0cf);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.agent-live-chip:hover {
+  border-color: var(--ff-border-hover, rgba(200, 168, 78, 0.6));
+  color: var(--text-body, #c0d2f2);
+}
+
+.agent-live-chip--active {
+  background: var(--ff-gold-dim, rgba(200, 168, 78, 0.25));
+  border-color: var(--ff-gold, #c8a84e);
+  color: var(--ff-gold-bright, #e8cc70);
+}
+
+.agent-live-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.agent-event-rate {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ff-crystal, #47b8ff);
+  padding: 2px 8px;
+  background: rgba(71, 184, 255, 0.1);
+  border: 1px solid rgba(71, 184, 255, 0.2);
+  border-radius: 8px;
+}
+
+.agent-live-count {
+  color: var(--text-muted, #86a0cf);
+}
+
+.agent-live-autoscroll {
+  padding: 2px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--ff-border-subtle);
+  background: none;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.agent-live-autoscroll--on {
+  background: rgba(74, 222, 128, 0.1);
+  border-color: rgba(74, 222, 128, 0.25);
+  color: var(--ff-hp-full, #4ade80);
+}
+
+/* Scrolling event stream */
+.agent-live-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* Event row */
+.agent-live-event {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 4px;
+  transition: background 0.1s;
+}
+
+.agent-live-event:hover {
+  background: var(--white-4, rgba(255, 255, 255, 0.04));
+}
+
+/* Event kind badge */
+.agent-event-badge {
+  font-size: 9px;
+  font-weight: 700;
+  font-family: var(--font-mono, monospace);
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  min-width: 32px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.agent-event-badge--heartbeat {
+  background: rgba(74, 222, 128, 0.12);
+  color: var(--ff-hp-full, #4ade80);
+}
+
+.agent-event-badge--lifecycle {
+  background: rgba(71, 184, 255, 0.12);
+  color: var(--ff-crystal, #47b8ff);
+}
+
+.agent-event-badge--keeper {
+  background: rgba(200, 168, 78, 0.15);
+  color: var(--ff-gold-bright, #e8cc70);
+}
+
+.agent-event-badge--error {
+  background: rgba(248, 113, 113, 0.14);
+  color: var(--ff-hp-low, #f87171);
+}
+
+.agent-event-badge--broadcast {
+  background: rgba(167, 139, 250, 0.12);
+  color: var(--purple, #a78bfa);
+}
+
+.agent-event-badge--task {
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--warn, #fbbf24);
+}
+
+.agent-event-badge--board {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--cyan, #22d3ee);
+}
+
+.agent-event-badge--default {
+  background: rgba(138, 163, 211, 0.12);
+  color: var(--text-muted, #86a0cf);
+}
+
+.agent-live-event-text {
+  color: var(--text-body, #b0bec5);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.agent-live-event-time {
+  font-size: 10px;
+  color: var(--text-muted, #86a0cf);
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
Agent observability Phase 4 완성.

- **AgentRuntimeStrip**: keeper 연결 시 pipeline stage + context% + generation + model + last turn age
- **AgentLiveTimeline**: 필터 토글(6종) + events/min + auto-scroll + 색상 코딩
- agent-profile.ts의 기존 journal 섹션 교체

## Phase 1-4 완성
1. Config viewer (GET API)
2. Config editor (POST API + edit UI)
3. Pipeline stage indicator (derive + bar/badge)
4. **Real-time monitor (runtime strip + live timeline)**

## Test plan
- [x] TypeScript 빌드 통과
- [ ] Dashboard agent 클릭 → RuntimeStrip 표시
- [ ] Live timeline 필터 토글 동작
- [ ] events/min 실시간 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)