### PR TITLE
feat: housekeep tools for keeper world maintenance

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -377,6 +377,7 @@
    tool_encryption
    tool_auth
    tool_hat
+   tool_housekeep
    tool_audit
    tool_rate_limit
    tool_cost

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -811,5 +811,61 @@ let persistent_agent_alias_schemas =
                  description = persistent_alias_description schema;
                })
 
+let housekeep_schemas : tool_schema list = [
+  {
+    name = "masc_housekeep_scan";
+    description = "Scan .masc/ directory and list all files with size, age, and category. Use to observe the state of your world before deciding what to clean.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("category", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Filter by category: keeper_meta, keeper_metrics_legacy, keeper_memory, keeper_policy, keeper_feedback, jsonl_data, dated_split, events, other. Omit for all.");
+        ]);
+        ("min_age_days", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Only show files older than this many days. Default: 0 (all).");
+        ]);
+      ]);
+    ];
+  };
+  {
+    name = "masc_housekeep_delete";
+    description = "Delete a specific file under .masc/. Logs the deletion with timestamp and reason. Only deletes files, not directories.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Absolute path to the file to delete. Must be under .masc/.");
+        ]);
+        ("reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Why this file is being deleted (logged for audit trail).");
+        ]);
+      ]);
+      ("required", `List [`String "path"; `String "reason"]);
+    ];
+  };
+  {
+    name = "masc_housekeep_prune";
+    description = "Prune old entries from a date-split JSONL store. Removes day-files older than the specified number of days.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("store", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Store to prune: 'audit', 'telemetry', or 'keeper:<name>' (e.g. 'keeper:dm-keeper').");
+        ]);
+        ("days", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Delete entries older than this many days. Default: 30.");
+        ]);
+      ]);
+      ("required", `List [`String "store"]);
+    ];
+  };
+]
+
 let schemas : tool_schema list =
-  resident_schemas @ persistent_agent_alias_schemas
+  resident_schemas @ persistent_agent_alias_schemas @ housekeep_schemas

--- a/lib/tool_housekeep.ml
+++ b/lib/tool_housekeep.ml
@@ -1,0 +1,202 @@
+(** Housekeeping tools for keeper agents.
+
+    Gives keepers the ability to observe and maintain their own world (.masc/).
+    The keeper decides what to clean; these tools provide the means. *)
+
+open Keeper_types_resident
+
+let masc_dir config = Room_utils.masc_dir config
+
+(* ── Scan ─────────────────────────────────────────────── *)
+
+type file_entry = {
+  path : string;
+  size_bytes : int;
+  age_days : float;
+  category : string;
+}
+
+let classify_path path =
+  let base = Filename.basename path in
+  let dir = Filename.basename (Filename.dirname path) in
+  if Filename.check_suffix base ".json" && dir = "perpetual-keepers" then "keeper_meta"
+  else if Filename.check_suffix base ".metrics.jsonl" then "keeper_metrics_legacy"
+  else if Filename.check_suffix base ".memory.jsonl" then "keeper_memory"
+  else if Filename.check_suffix base ".policy.jsonl" then "keeper_policy"
+  else if Filename.check_suffix base ".feedback.jsonl" then "keeper_feedback"
+  else if Filename.check_suffix base ".jsonl" && dir = "events" then "events"
+  else if Filename.check_suffix base ".jsonl" then "jsonl_data"
+  else if dir = "metrics" || dir = "audit" || dir = "telemetry" then "dated_split"
+  else "other"
+
+let scan_dir_recursive base_path =
+  let now = Unix.gettimeofday () in
+  let entries = ref [] in
+  let rec walk dir =
+    if Sys.file_exists dir && Sys.is_directory dir then begin
+      let children =
+        try Array.to_list (Sys.readdir dir)
+        with Sys_error _ -> []
+      in
+      List.iter (fun name ->
+        let full = Filename.concat dir name in
+        if Sys.is_directory full then
+          walk full
+        else begin
+          match (try Some (Unix.stat full) with Unix.Unix_error _ -> None) with
+          | None -> ()
+          | Some st ->
+            let age_days = (now -. st.Unix.st_mtime) /. 86400.0 in
+            entries := {
+              path = full;
+              size_bytes = st.Unix.st_size;
+              age_days;
+              category = classify_path full;
+            } :: !entries
+        end
+      ) children
+    end
+  in
+  walk base_path;
+  List.rev !entries
+
+let entry_to_json e =
+  `Assoc [
+    ("path", `String e.path);
+    ("size_bytes", `Int e.size_bytes);
+    ("age_days", `Float (Float.round e.age_days *. 10.0 /. 10.0));
+    ("category", `String e.category);
+  ]
+
+let handle_housekeep_scan ctx args =
+  let category_filter =
+    match Yojson.Safe.Util.member "category" args with
+    | `String s when s <> "" -> Some s
+    | _ -> None
+  in
+  let min_age_days =
+    match Yojson.Safe.Util.member "min_age_days" args with
+    | `Int n -> float_of_int n
+    | `Float f -> f
+    | _ -> 0.0
+  in
+  let base = masc_dir ctx.config in
+  let entries = scan_dir_recursive base in
+  let filtered = entries
+    |> List.filter (fun e ->
+      e.age_days >= min_age_days
+      && (match category_filter with
+          | None -> true
+          | Some cat -> e.category = cat))
+  in
+  let total_bytes = List.fold_left (fun acc e -> acc + e.size_bytes) 0 filtered in
+  let json = `Assoc [
+    ("total_files", `Int (List.length filtered));
+    ("total_bytes", `Int total_bytes);
+    ("files", `List (List.map entry_to_json filtered));
+  ] in
+  (true, Yojson.Safe.to_string json)
+
+(* ── Delete ───────────────────────────────────────────── *)
+
+let housekeep_log_path config =
+  Filename.concat (masc_dir config) "housekeep.log"
+
+let log_deletion config ~path ~reason =
+  let ts = Time_compat.now_iso () in
+  let line = Printf.sprintf "[%s] DELETED %s reason=%s\n" ts path reason in
+  let log_path = housekeep_log_path config in
+  Fs_compat.append_file log_path line
+
+let handle_housekeep_delete ctx args =
+  let path =
+    match Yojson.Safe.Util.member "path" args with
+    | `String s -> s
+    | _ -> ""
+  in
+  let reason =
+    match Yojson.Safe.Util.member "reason" args with
+    | `String s -> s
+    | _ -> "unspecified"
+  in
+  if path = "" then
+    (false, "path is required")
+  else
+    let base = masc_dir ctx.config in
+    (* Safety: only allow deletion under .masc/ *)
+    if not (String.length path > String.length base
+            && String.sub path 0 (String.length base) = base) then
+      (false, Printf.sprintf "refused: path %s is not under %s" path base)
+    else if not (Sys.file_exists path) then
+      (false, Printf.sprintf "not found: %s" path)
+    else if Sys.is_directory path then
+      (false, Printf.sprintf "refused: %s is a directory (use prune for dated stores)" path)
+    else begin
+      let size =
+        match (try Some (Unix.stat path) with Unix.Unix_error _ -> None) with
+        | Some st -> st.Unix.st_size
+        | None -> 0
+      in
+      (try Sys.remove path with Sys_error _ -> ());
+      log_deletion ctx.config ~path ~reason;
+      let json = `Assoc [
+        ("deleted", `String path);
+        ("size_bytes", `Int size);
+        ("reason", `String reason);
+      ] in
+      (true, Yojson.Safe.to_string json)
+    end
+
+(* ── Prune ────────────────────────────────────────────── *)
+
+let handle_housekeep_prune ctx args =
+  let store_name =
+    match Yojson.Safe.Util.member "store" args with
+    | `String s -> s
+    | _ -> ""
+  in
+  let days =
+    match Yojson.Safe.Util.member "days" args with
+    | `Int n -> n
+    | _ -> 30
+  in
+  if store_name = "" then
+    (false, "store is required (audit, telemetry, or keeper:<name>)")
+  else
+    let base = masc_dir ctx.config in
+    let store_dir =
+      if store_name = "audit" then Filename.concat base "audit"
+      else if store_name = "telemetry" then Filename.concat base "telemetry"
+      else if String.length store_name > 7
+              && String.sub store_name 0 7 = "keeper:" then
+        let keeper_name = String.sub store_name 7 (String.length store_name - 7) in
+        Filename.concat (Filename.concat base "perpetual-keepers") (keeper_name ^ "/metrics")
+      else ""
+    in
+    if store_dir = "" then
+      (false, Printf.sprintf "unknown store: %s" store_name)
+    else if not (Sys.file_exists store_dir) then
+      (true, Printf.sprintf "store %s does not exist yet (nothing to prune)" store_name)
+    else begin
+      let store = Dated_jsonl.create ~base_dir:store_dir () in
+      let deleted = Dated_jsonl.prune store ~days in
+      log_deletion ctx.config
+        ~path:store_dir
+        ~reason:(Printf.sprintf "prune days=%d deleted=%d" days deleted);
+      let json = `Assoc [
+        ("store", `String store_name);
+        ("store_dir", `String store_dir);
+        ("days", `Int days);
+        ("files_deleted", `Int deleted);
+      ] in
+      (true, Yojson.Safe.to_string json)
+    end
+
+(* ── Dispatch ─────────────────────────────────────────── *)
+
+let dispatch ctx ~name ~args : (bool * string) option =
+  match name with
+  | "masc_housekeep_scan" -> Some (handle_housekeep_scan ctx args)
+  | "masc_housekeep_delete" -> Some (handle_housekeep_delete ctx args)
+  | "masc_housekeep_prune" -> Some (handle_housekeep_prune ctx args)
+  | _ -> None

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -393,6 +393,9 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_persistent_agent_goals" -> Some (Policy.handle_keeper_goals ctx args)
   | "masc_persistent_agent_trajectory" -> Some (Status.handle_keeper_trajectory ctx args)
   | "masc_persistent_agent_eval" -> Some (Status.handle_keeper_eval ctx args)
+  (* Housekeeping: keepers maintain their own world *)
+  | "masc_housekeep_scan" | "masc_housekeep_delete" | "masc_housekeep_prune" ->
+      Tool_housekeep.dispatch ctx ~name ~args
   | _ -> None
 
 (** Streaming dispatch: only handles keeper_msg with text delta forwarding.


### PR DESCRIPTION
3 MCP tools (scan/delete/prune) that give keepers autonomy over their .masc/ world. Keeper judges what to clean; tools provide the means. All deletions logged.