### PR TITLE
fix: repair tool_housekeep build errors

### DIFF
--- a/lib/tool_housekeep.ml
+++ b/lib/tool_housekeep.ml
@@ -3,7 +3,7 @@
     Gives keepers the ability to observe and maintain their own world (.masc/).
     The keeper decides what to clean; these tools provide the means. *)
 
-open Keeper_types_resident
+open Keeper_types
 
 let masc_dir config = Room_utils.masc_dir config
 
@@ -103,7 +103,7 @@ let housekeep_log_path config =
   Filename.concat (masc_dir config) "housekeep.log"
 
 let log_deletion config ~path ~reason =
-  let ts = Time_compat.now_iso () in
+  let ts = Types.now_iso () in
   let line = Printf.sprintf "[%s] DELETED %s reason=%s\n" ts path reason in
   let log_path = housekeep_log_path config in
   Fs_compat.append_file log_path line


### PR DESCRIPTION
## Summary
- `Time_compat.now_iso` → `Types.now_iso` (존재하지 않는 모듈 참조)
- `open Keeper_types_resident` → `open Keeper_types` (ctx.config 접근에 필요한 타입)
- 자동 생성 PR에서 깨진 채 머지된 파일 복구

## Test plan
- [x] `dune build` 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)