### PR TITLE
fix: clean up orphan pending confirms on lifecycle events

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -94,6 +94,9 @@ let handle_keeper_down ctx args : tool_result =
               err
       in
       Option.iter stop_linked_session m.active_team_session_id;
+      ignore
+        (Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
+           ~target_type:"keeper" ~target_id:(Some name));
       (if remove_meta then
          Safe_ops.remove_file_logged ~context:"keeper_down"
            (keeper_meta_path ctx.config name)

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -193,6 +193,27 @@ let remove_pending_confirm config token =
   in
   write_pending_confirms config remaining
 
+let remove_pending_confirms_by_target config ~target_type ~target_id =
+  let all = raw_pending_confirms config in
+  let remaining =
+    List.filter
+      (fun (entry : pending_confirm) ->
+        not
+          (String.equal entry.target_type target_type
+          && entry.target_id = target_id))
+      all
+  in
+  let removed = List.length all - List.length remaining in
+  if removed > 0 then write_pending_confirms config remaining;
+  removed
+
+let gc_expired_confirms config =
+  let all = raw_pending_confirms config in
+  let active = List.filter (fun entry -> not (pending_confirm_expired entry)) all in
+  let removed = List.length all - List.length active in
+  if removed > 0 then write_pending_confirms config active;
+  removed
+
 let normalize_pending_confirm_actor_filter = function
   | Some raw ->
       let trimmed = String.trim raw in

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -52,6 +52,9 @@ val pending_confirm_expired : pending_confirm -> bool
 val read_pending_confirms : Room.config -> pending_confirm list
 val upsert_pending_confirm : Room.config -> pending_confirm -> unit
 val remove_pending_confirm : Room.config -> string -> unit
+val remove_pending_confirms_by_target :
+  Room.config -> target_type:string -> target_id:string option -> int
+val gc_expired_confirms : Room.config -> int
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Room.config -> pending_confirm_scope

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -324,7 +324,9 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
         ("health", `String health);
         ("attention_summary", `Assoc [ ("count", `Int (if has_warn then 1 else 0)); ("provenance", `String "derived") ]);
         ("recommendation_summary", `Assoc [ ("count", `Int 0); ("provenance", `String "derived") ]);
-        ("pending_confirm_summary", Operator_control.pending_confirm_summary_json config);
+        ("pending_confirm_summary",
+          (ignore (Operator_control.gc_expired_confirms config);
+           Operator_control.pending_confirm_summary_json config));
       ]
   in
   let execution_queue =

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -284,6 +284,10 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
                 ~final_status ~reason
                 ~generate_report
         in
+        let _gc_count =
+          Operator_pending_confirm.remove_pending_confirms_by_target config
+            ~target_type:"team_session" ~target_id:(Some session_id)
+        in
         (match updated with
         | Some s -> Ok (session_status_json config s)
         | None ->


### PR DESCRIPTION
## Summary
- `pending_confirms.json`에 만료/orphan 항목이 무한 축적되는 문제 해결
- `remove_pending_confirms_by_target`: target_type + target_id 기반 일괄 제거
- `gc_expired_confirms`: 만료 항목 능동적 정리
- 세션 종료(`stop_session`), Keeper 다운(`handle_keeper_down`), Dashboard polling에서 자동 호출

## Changed files
| File | Change |
|------|--------|
| `operator_pending_confirm.ml/mli` | `remove_pending_confirms_by_target` + `gc_expired_confirms` 추가 |
| `team_session_engine_eio.ml` | `stop_session` finalize 후 team_session confirm 정리 |
| `keeper_turn_lifecycle.ml` | `handle_keeper_down`에서 keeper confirm 정리 |
| `server_dashboard_http.ml` | snapshot 경로에서 expired GC 호출 |

## Test plan
- [x] `dune build` 성공
- [x] `dune test` 통과
- [ ] 수동 검증: session stop 후 pending_confirms.json 확인
- [ ] 수동 검증: keeper down 후 orphan confirm 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)