### PR TITLE
perf: fix top dashboard performance bottlenecks

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -486,7 +486,7 @@ end = struct
 
   let get_all_q =
     (Caqti_type.string ->* Caqti_type.(t2 string string))
-    "SELECT key, value FROM masc_kv WHERE key LIKE $1 AND (expires_at IS NULL OR expires_at > NOW())"
+    "SELECT key, value FROM masc_kv WHERE key LIKE $1 AND (expires_at IS NULL OR expires_at > NOW()) ORDER BY key DESC LIMIT 200"
 
   let set_if_not_exists_q =
     (Caqti_type.(t2 string string) ->. Caqti_type.unit)

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -108,6 +108,7 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
       in
       (* Yield between heavy phases so SSE / health-check fibers can progress *)
       Eio.Fiber.yield ();
+      let t_start = Time_compat.now () in
       (* Load sessions once; pass to snapshot_json to avoid repeated filesystem scans.
          Only include active (Running/Paused) sessions plus recently finished ones
          (last 24h) to avoid loading all historical sessions on every poll. *)
@@ -133,6 +134,7 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
         | _ -> s.updated_at_iso >= cutoff_iso
       in
       let sessions = List.filter is_active_or_recent all_sessions in
+      let t_sessions = Time_compat.now () in
       Eio.Fiber.yield ();
       (* Compute directly without Dashboard_cache to avoid nested
          get_or_compute deadlock — the caller (dashboard_execution_http_json)
@@ -147,6 +149,7 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           ~sessions
           ctx
       in
+      let t_snapshot = Time_compat.now () in
       Eio.Fiber.yield ();
       let session_cards =
         if light then []
@@ -280,6 +283,21 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           ("shown", `Int (List.length limited_tasks));
         ]);
       ] in
+      let t_end = Time_compat.now () in
+      let total_ms = (t_end -. t_start) *. 1000.0 in
+      let sessions_ms = (t_sessions -. t_start) *. 1000.0 in
+      let snapshot_ms = (t_snapshot -. t_sessions) *. 1000.0 in
+      let render_ms = (t_end -. t_snapshot) *. 1000.0 in
+      if total_ms > 10000.0 then
+        Log.Dashboard.warn
+          "[dashboard_execution] slow render: total=%.0fms sessions=%.0fms snapshot=%.0fms render=%.0fms (sessions=%d keepers=%d)"
+          total_ms sessions_ms snapshot_ms render_ms
+          (List.length sessions)
+          (List.length keepers)
+      else
+        Log.Dashboard.debug
+          "[dashboard_execution] timing: total=%.0fms sessions=%.0fms snapshot=%.0fms render=%.0fms"
+          total_ms sessions_ms snapshot_ms render_ms;
       if light then
         `Assoc (base_fields @ task_fields)
       else

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -311,7 +311,7 @@ let persistent_agents_json ?keeper_names config =
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
-let sessions_json config sessions =
+let sessions_json ?(status_cache : (string, Yojson.Safe.t) Hashtbl.t option) config sessions =
   let ordered_sessions =
     sessions
     |> List.sort (fun (a : Team_session_types.session) (b : Team_session_types.session) ->
@@ -324,12 +324,23 @@ let sessions_json config sessions =
           Team_session_store.read_events ~max_events:5 config session.session_id
           |> Team_session_engine_eio.take_last 5
         in
+        let status =
+          match status_cache with
+          | Some tbl -> (
+              match Hashtbl.find_opt tbl session.session_id with
+              | Some cached -> cached
+              | None ->
+                  let s = Team_session_engine_eio.session_status_json config session in
+                  Hashtbl.replace tbl session.session_id s;
+                  s)
+          | None -> Team_session_engine_eio.session_status_json config session
+        in
         `Assoc
           [
             ("session_id", `String session.session_id);
             ("command_plane_operation_id", `String ("detachment-" ^ session.session_id));
             ("command_plane_detachment_id", `String ("detachment-" ^ session.session_id));
-            ("status", Team_session_engine_eio.session_status_json config session);
+            ("status", status);
             ("recent_events", `List recent_events);
           ])
       ordered_sessions
@@ -438,6 +449,18 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     | Summary | Messages | Full -> true
     | Sessions | Keepers -> false
   in
+  (* Pre-compute session_status_json once per session. build_session_digest
+     and sessions_json both call session_status_json for each session.
+     Caching avoids the duplicate I/O + computation. *)
+  let status_cache : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 16 in
+  let cached_session_status_json (session : Team_session_types.session) =
+    match Hashtbl.find_opt status_cache session.session_id with
+    | Some cached -> cached
+    | None ->
+        let s = Team_session_engine_eio.session_status_json config session in
+        Hashtbl.replace status_cache session.session_id s;
+        s
+  in
   let command_plane_summary =
     if initialized then
       Some (Command_plane_v2.summary_json ~sessions:tracked_sessions config)
@@ -448,7 +471,9 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
       let now = Time_compat.now () in
       let session_digests =
         tracked_sessions
-        |> List.map (fun session -> build_session_digest config session ~now)
+        |> List.map (fun session ->
+          let status_json = cached_session_status_json session in
+          build_session_digest ~status_json config session ~now)
       in
       let room_attention =
         build_room_attention_items ?command_plane_summary config
@@ -467,7 +492,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     else []
   in
   let command_plane_json =
-    if initialized then Command_plane_v2.snapshot_json config else `Assoc []
+    if initialized then Command_plane_v2.snapshot_json ~sessions:tracked_sessions config else `Assoc []
   in
   let swarm_status_json =
     if initialized then
@@ -491,7 +516,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
          ("provenance_summary", operator_surface_contract_json);
          ("room", room_json config);
          ( "sessions",
-           if initialized && include_sessions then sessions_json config tracked_sessions
+           if initialized && include_sessions then sessions_json ~status_cache config tracked_sessions
            else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
          ( "keepers",
            if initialized && include_keepers then keepers_json ~keeper_names config

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -129,6 +129,7 @@ val session_recommendations :
   recommended_action list
 
 val build_session_digest :
+  ?status_json:Yojson.Safe.t ->
   Room.config ->
   Team_session_types.session ->
   now:float ->

--- a/lib/operator/operator_digest_session.ml
+++ b/lib/operator/operator_digest_session.ml
@@ -560,8 +560,12 @@ let normalize_team_health = function
   | "critical" -> "bad"
   | other -> other
 
-let build_session_digest config (session : Team_session_types.session) ~now =
-  let status_json = Team_session_engine_eio.session_status_json config session in
+let build_session_digest ?status_json:cached_status config (session : Team_session_types.session) ~now =
+  let status_json =
+    match cached_status with
+    | Some s -> s
+    | None -> Team_session_engine_eio.session_status_json config session
+  in
   let summary = U.member "summary" status_json in
   let team_health = U.member "team_health" status_json in
   let events = Team_session_store.read_events ~max_events:2000 config session.session_id in


### PR DESCRIPTION
## Summary

- **Fix 1**: Pass `~sessions:tracked_sessions` to `Command_plane_v2.snapshot_json` in `operator_control_snapshot.ml` to avoid an unfiltered third session load from filesystem/PG.
- **Fix 2**: Add `ORDER BY key DESC LIMIT 200` to PG `get_all_q` query in `backend.ml` to prevent unbounded result sets on session prefix scans.
- **Fix 3**: Add phase timing instrumentation (sessions/snapshot/render) to `Dashboard_execution.json`. Logs WARNING with breakdown when total exceeds 10s.
- **Fix 4**: Cache `session_status_json` per session within `snapshot_json` scope. Both `build_session_digest` and `sessions_json` called it for each session; the Hashtbl cache eliminates the duplicate I/O and computation.

## Test plan

- [x] `dune build --root . bin/main_eio.exe` compiles with no errors or warnings
- [ ] Start server and verify dashboard loads without regression
- [ ] Check logs for `[dashboard_execution] timing:` entries to confirm instrumentation
- [ ] Verify session list correctness with LIMIT 200 (no missing active sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)