### PR TITLE
refactor: purge LLM terminology Phase 1

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -90,7 +90,7 @@ let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
 
     - PruneToolOutputs and MergeContiguous use OAS built-in strategies directly.
     - DropLowImportance uses OAS Custom with importance scoring (OAS has no scoring).
-    - SummarizeOld uses OAS Custom with extractive summarization (deterministic, no LLM). *)
+    - SummarizeOld uses OAS Custom with extractive summarization (deterministic, no model call). *)
 let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
   match s with
   | PruneToolOutputs ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2,7 +2,7 @@
 
     Replaces the 3-path dispatcher (social/proactive/autonomy) with a unified
     observe -> prompt -> Agent.run(tools, guardrails, hooks) loop.
-    The LLM decides what to do; code only enforces safety and observes results.
+    The model decides what to do; code only enforces safety and observes results.
 
     @since Unified Keeper Loop *)
 

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -2,7 +2,7 @@
 
     Replaces the 3-path dispatcher (social/proactive/autonomy) with a unified
     observe -> prompt -> Agent.run(tools, guardrails, hooks) loop.
-    The LLM decides what to do; code only enforces safety and observes results.
+    The model decides what to do; code only enforces safety and observes results.
 
     @since Unified Keeper Loop *)
 


### PR DESCRIPTION
## Summary
- Replace "LLM" with "model" / "model call" in 3 comment/docstring occurrences across `lib/`
- Files changed: `keeper_unified_turn.ml`, `keeper_unified_turn.mli`, `context_compact_oas.ml`
- No API, module, file, or public signature changes

## Test plan
- [x] `dune build --root .` passes
- [x] `grep -rn "LLM\|llm_\|_llm" lib/ --include="*.ml" --include="*.mli"` returns 0 matches

Ref #1871