### PR TITLE
fix(swarm): guard Yojson.Util.member against Null JSON

### DIFF
--- a/lib/swarm/swarm_status_build.ml
+++ b/lib/swarm/swarm_status_build.ml
@@ -157,8 +157,8 @@ let build_json_from_inputs ~timeline_limit_override ~now
                ("provenance", `String "derived");
              ])
     |> List.sort (fun left right ->
-           let left_severity = left |> U.member "severity" |> U.to_string in
-           let right_severity = right |> U.member "severity" |> U.to_string in
+           let left_severity = match U.member "severity" left with `String s -> s | _ -> "unknown" in
+           let right_severity = match U.member "severity" right with `String s -> s | _ -> "unknown" in
            Int.compare (severity_sort left_severity) (severity_sort right_severity))
   in
   let present_lanes = List.filter (fun (lane : lane) -> lane.present) lanes in

--- a/lib/swarm/swarm_status_json.ml
+++ b/lib/swarm/swarm_status_json.ml
@@ -123,10 +123,13 @@ let list_member json key =
   | _ -> []
 
 let get_detail_string json key =
-  match U.member "detail" json |> U.member key with
-  | `String value ->
-      let trimmed = String.trim value in
-      if trimmed = "" then None else Some trimmed
+  match U.member "detail" json with
+  | `Assoc _ as detail -> (
+      match U.member key detail with
+      | `String value ->
+          let trimmed = String.trim value in
+          if trimmed = "" then None else Some trimmed
+      | _ -> None)
   | _ -> None
 
 let first_some left right =


### PR DESCRIPTION
## Summary
- `swarm_status_json.ml:126`: `U.member "detail" json |> U.member key` — detail이 Null이면 crash. match guard 추가.
- `swarm_status_build.ml:160-161`: sort 비교자에서 severity 없으면 crash. pattern match fallback 추가.

## Context
`Yojson.Safe.Util.member`는 `Assoc`에서만 동작하고 `Null`에서는 `Type_error` 예외 발생.
dashboard room-truth 500 에러(PR #2019)와 동일한 패턴.

## Test plan
- [x] `dune build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)