### PR TITLE
fix: PG connection pool consolidation (3→10, shared pool)

### DIFF
--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -33,6 +33,7 @@ let run_cmd base_path =
   Server_runtime_bootstrap.bootstrap_server_state state;
   Server_runtime_bootstrap.bootstrap_keepers ~sw ~clock state;
   Server_runtime_bootstrap.init_task_backend ();
+  Server_runtime_bootstrap.inject_shared_pg_pool ();
   Server_runtime_bootstrap.init_memory_pg_schema ();
   ignore (Server_runtime_bootstrap.start_background_maintenance ~sw ~clock state);
   Fun.protect

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -623,8 +623,8 @@ end = struct
     | Some url ->
         let uri = Uri.of_string url in
         let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-          | Some s -> (try int_of_string s with _ -> 3)
-          | None -> 3
+          | Some s -> (try int_of_string s with _ -> 10)
+          | None -> 10
         in
         let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
         (* Caqti_eio.stdenv = < net; clock; mono_clock > *)

--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -63,6 +63,28 @@ let get_status config : Yojson.Safe.t =
   ]
 
 (* ============================================ *)
+(* Pool Statistics                              *)
+(* ============================================ *)
+
+type pool_stats = {
+  max_size: int;
+  pool_count: int;
+  shared_pool_injected: bool;
+}
+
+let pool_stats_to_yojson (s : pool_stats) : Yojson.Safe.t =
+  `Assoc [
+    ("max_size", `Int s.max_size);
+    ("pool_count", `Int s.pool_count);
+    ("shared_pool_injected", `Bool s.shared_pool_injected);
+  ]
+
+let configured_max_pool_size () =
+  match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
+  | Some s -> (try int_of_string s with _ -> 10)
+  | None -> 10
+
+(* ============================================ *)
 (* Backend Interface                            *)
 (* ============================================ *)
 

--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -671,8 +671,8 @@ module Postgres = struct
   let create ~sw ~env ~url config =
     let uri = Uri.of_string url in
     let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-      | Some s -> (try int_of_string s with _ -> 3)
-      | None -> 3
+      | Some s -> (try int_of_string s with _ -> 10)
+      | None -> 10
     in
     let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
     match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with

--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -237,17 +237,26 @@ module Q = struct
      FROM jiphyeon_records WHERE $1 = ANY(agents) ORDER BY timestamp DESC LIMIT 100"
 end
 
-(** PostgreSQL 연결 풀 *)
+(** PostgreSQL 연결 풀 — shared pool 주입 우선, fallback으로 자체 생성 *)
 let pg_pool_ref : (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t option ref = ref None
+let shared_pool_ref : (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t option ref = ref None
+
+let set_shared_pool pool =
+  shared_pool_ref := Some pool
+
+let has_shared_pool () = Option.is_some !shared_pool_ref
 
 let get_pg_pool ~sw ~env =
+  match !shared_pool_ref with
+  | Some pool -> Ok pool
+  | None ->
   match !pg_pool_ref with
   | Some pool -> Ok pool
   | None ->
     match get_postgres_url () with
     | None -> Error "DATABASE_URL not set"
     | Some url ->
-      let pool_config = Caqti_pool_config.create ~max_size:3 () in
+      let pool_config = Caqti_pool_config.create ~max_size:10 () in
       match Caqti_eio_unix.connect_pool ~sw ~pool_config (Uri.of_string url) ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;

--- a/lib/jiphyeon/archive.ml
+++ b/lib/jiphyeon/archive.ml
@@ -253,17 +253,26 @@ module Q = struct
      FROM jiphyeon_records WHERE $1 = ANY(agents) ORDER BY timestamp DESC LIMIT 100"
 end
 
-(** PostgreSQL 연결 풀 *)
+(** PostgreSQL 연결 풀 — shared pool 주입 우선, fallback으로 자체 생성 *)
 let pg_pool_ref : (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t option ref = ref None
+let shared_pool_ref : (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t option ref = ref None
+
+let set_shared_pool pool =
+  shared_pool_ref := Some pool
+
+let has_shared_pool () = Option.is_some !shared_pool_ref
 
 let get_pg_pool ~sw ~env =
+  match !shared_pool_ref with
+  | Some pool -> Ok pool
+  | None ->
   match !pg_pool_ref with
   | Some pool -> Ok pool
   | None ->
     match get_postgres_url () with
     | None -> Error "DATABASE_URL not set"
     | Some url ->
-      let pool_config = Caqti_pool_config.create ~max_size:3 () in
+      let pool_config = Caqti_pool_config.create ~max_size:10 () in
       match Caqti_eio_unix.connect_pool ~sw ~pool_config (Uri.of_string url) ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -82,6 +82,14 @@ let health_handler _request reqd =
     ("uptime", `String uptime_str);
     ("sse_clients", `Int (Sse.client_count ()));
     ("lodge", lodge_json);
+    ("pg_pool", let max_size = Backend_core.configured_max_pool_size () in
+      let shared = Council.Archive.has_shared_pool ()
+                   || Jiphyeon.Archive.has_shared_pool () in
+      Backend_core.pool_stats_to_yojson {
+        max_size;
+        pool_count = (if shared then 3 else 5);
+        shared_pool_injected = shared;
+      });
   ] in
   Http.Response.json (Yojson.Safe.to_string health_json) reqd
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -100,6 +100,15 @@ let init_task_backend () =
             (Types.show_masc_error e))
   | None -> Task_dispatch.init_jsonl ()
 
+let inject_shared_pg_pool () =
+  match Board_dispatch.get_pg_pool () with
+  | Some pool ->
+      Council.Archive.set_shared_pool pool;
+      Jiphyeon.Archive.set_shared_pool pool;
+      Log.Server.info "PG shared pool injected into council/jiphyeon archive"
+  | None ->
+      Log.Server.info "No PG pool available; council/jiphyeon will create own pools"
+
 let init_memory_pg_schema () =
   match Board_dispatch.get_pg_pool () with
   | Some pool -> (
@@ -337,6 +346,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       bootstrap_server_state state;
       bootstrap_keepers ~sw ~clock state;
       init_task_backend ();
+      inject_shared_pg_pool ();
       init_memory_pg_schema ();
       state
     in


### PR DESCRIPTION
## Summary
- Raise default PG pool size from 3 to 10 in backend.ml and backend_eio.ml
- Add shared pool injection for council/jiphyeon archive (5→3 independent pools)
- Add pool_stats type and expose in /health endpoint
- Inject shared pool in both HTTP and stdio bootstrap paths

## SLA Impact
| Metric | Before | After |
|--------|--------|-------|
| Independent PG pools | 5 | 3 |
| Max pool size (default) | 3 | 10 |
| Pool stats in /health | No | Yes |

## Test plan
- [x] `dune build` — 0 errors
- [x] `make test` — pre-existing operator.027 failure only (unrelated)
- [ ] 10 concurrent `masc_status` → timeout 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)