### PR TITLE
fix: SSE per-client push timeout and event buffer TTL

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -113,6 +113,7 @@ let init_memory_pg_schema () =
 let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =
   Progress.set_sse_callback Sse.broadcast;
+  Sse.set_clock clock;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Agent_sdk.Event_bus.create () in
   (* Eio fiber isolation: each subsystem runs in its own fiber.
@@ -187,6 +188,9 @@ let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
         if stale_sids <> [] then
           Log.Server.info "Reaped %d stale connections (active: %d)"
             (List.length stale_sids) (Sse.client_count ());
+        let evicted_events = Sse.cleanup_expired_events () in
+        if evicted_events > 0 then
+          Log.Server.info "Evicted %d expired SSE buffer events" evicted_events;
         loop ()
       in
       loop ());

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -60,22 +60,39 @@ let client_id_counter = Atomic.make 0
 (** Global event counter for resumability *)
 let event_counter = Atomic.make 0
 
-(** Event buffer for resumability - stores (event_id, event_string) pairs *)
+(** Event buffer for resumability - stores (event_id, event_string, timestamp) *)
 let max_buffer_size = 100
-let event_buffer : (int * string) Queue.t = Queue.create ()
+let buffer_ttl_seconds = 300.0
+let event_buffer : (int * string * float) Queue.t = Queue.create ()
 
 (** Add event to buffer, maintaining max size *)
 let buffer_event event_id event_str =
   if Queue.length event_buffer >= max_buffer_size then
     ignore (Queue.pop event_buffer);
-  Queue.push (event_id, event_str) event_buffer
+  Queue.push (event_id, event_str, Time_compat.now ()) event_buffer
 
 (** Get events after given ID for replay (MCP spec MUST) *)
 let get_events_after last_id =
-  Queue.fold (fun acc (id, ev) ->
+  Queue.fold (fun acc (id, ev, _ts) ->
     if id > last_id then ev :: acc else acc
   ) [] event_buffer
   |> List.rev
+
+(** Remove events older than [buffer_ttl_seconds] from the front of the buffer.
+    Returns count of evicted events. *)
+let cleanup_expired_events () =
+  let now = Time_compat.now () in
+  let count = ref 0 in
+  let keep_popping = ref true in
+  while !keep_popping && not (Queue.is_empty event_buffer) do
+    let (_id, _ev, ts) = Queue.peek event_buffer in
+    if now -. ts > buffer_ttl_seconds then begin
+      ignore (Queue.pop event_buffer);
+      incr count
+    end else
+      keep_popping := false
+  done;
+  !count
 
 (** Format SSE event with optional ID and event type *)
 let format_event ?id ?event_type data =
@@ -169,9 +186,21 @@ let update_last_event_id session_id event_id =
         mark_seen client
     | None -> ())
 
+(** Eio clock ref for per-client push timeout.
+    Set during startup via [set_clock]. Without a clock, push has no timeout. *)
+let clock_ref : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
+
+let set_clock (clock : float Eio.Time.clock_ty Eio.Resource.t) =
+  clock_ref := Some clock
+
+(** Per-client push timeout (seconds).
+    5s is generous for a local TCP write; slow clients beyond this are dropped. *)
+let push_timeout_s = 5.0
+
 (** Broadcast event to all connected clients.
     Uses snapshot-then-act: take snapshot under lock, push outside lock.
-    Failed clients are unregistered individually afterwards. *)
+    Per-client timeout prevents a single slow client from blocking all pushes.
+    Failed/timed-out clients are unregistered individually afterwards. *)
 let broadcast json =
   let data = Yojson.Safe.to_string json in
   let current_event_id = Atomic.get event_counter + 1 in
@@ -185,11 +214,22 @@ let broadcast json =
   let failed = ref [] in
   List.iter (fun (session_id, client) ->
     if current_event_id > client.last_event_id then begin
-      match client.push event with
-      | () -> update_last_event_id session_id current_event_id
-      | exception e ->
-        Log.Server.error "Push failed for session %s: %s" session_id (Printexc.to_string e);
-        failed := session_id :: !failed
+      (try
+        (match !clock_ref with
+        | Some clock ->
+            Eio.Time.with_timeout_exn clock push_timeout_s (fun () ->
+              client.push event)
+        | None ->
+            client.push event);
+        update_last_event_id session_id current_event_id
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Eio.Time.Timeout ->
+          Log.Server.error "Push timed out for session %s (>%.0fs)" session_id push_timeout_s;
+          failed := session_id :: !failed
+      | e ->
+          Log.Server.error "Push failed for session %s: %s" session_id (Printexc.to_string e);
+          failed := session_id :: !failed)
     end
   ) clients_snapshot;
   (* Remove failed connections *)


### PR DESCRIPTION
## Summary
- Add per-client 5s push timeout via Eio.Time.with_timeout_exn in broadcast
- Inject Eio clock at startup for timeout support (graceful fallback to no-timeout)
- Add event buffer TTL (300s) with cleanup in 60s maintenance loop
- Timed-out/failed clients are unregistered and logged

## SLA Impact
| Metric | Before | After |
|--------|--------|-------|
| Broadcast blocking | Slow client blocks all | 5s timeout per client |
| Buffer cleanup | Count cap only (100) | Count cap + 300s TTL |

## Test plan
- [x] `dune build` — 0 errors
- [x] `test_sse.exe` — 3/3 pass
- [ ] Slow client simulation → broadcast completes within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)