### PR TITLE
fix: add missing required parameter validation

### DIFF
--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -25,6 +25,9 @@ let handle_bounded_run (ctx : context) : result option =
     | _ -> []
   in
   let prompt = arg_get_string ctx "prompt" "" in
+  if String.trim prompt = "" then
+    Some (false, Tool_args.error_response "prompt is required")
+  else
   let constraints_json = arguments |> U.member "constraints" in
   let goal_json = arguments |> U.member "goal" in
   let constraints = Bounded.constraints_of_json constraints_json in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -196,6 +196,9 @@ let handle_done ctx args =
 
 let handle_cancel_task ctx args =
   let task_id = get_string args "task_id" "" in
+  match validate_task_id task_id with
+  | Error e -> result_to_response (Error e)
+  | Ok task_id ->
   let reason = get_string args "reason" "" in
   let tasks = Room.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks in


### PR DESCRIPTION
## Summary
- handle_cancel_task: add missing validate_task_id guard (BUG: empty task_id passed to Room.cancel_task_r)
- handle_bounded_run: add prompt empty check (returns error instead of silent empty execution)

## SLA Impact
Silent failure rate: two previously-silent failure paths now return explicit errors.

## Test plan
- [x] `dune build` — 0 errors
- [ ] Empty task_id cancel → error response with field name
- [ ] Empty prompt bounded_run → error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)