### PR TITLE
feat: subsystem health tracking and cache eviction

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -322,6 +322,7 @@
    spawn_registry
    sse
    streamable_http
+   subsystem_health
    subscriptions
    swarm_status
    swarm_status_types

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -90,6 +90,7 @@ let health_handler _request reqd =
         pool_count = (if shared then 3 else 5);
         shared_pool_injected = shared;
       });
+    ("subsystems", Subsystem_health.to_yojson ());
   ] in
   Http.Response.json (Yojson.Safe.to_string health_json) reqd
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -125,17 +125,24 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   Sse.set_clock clock;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Agent_sdk.Event_bus.create () in
+  (* Subsystem health registry: tracks liveness of forked subsystems.
+     Maps name → (is_alive, last_crash_time option). *)
+  let subsystem_health : (string, bool * float option) Hashtbl.t = Hashtbl.create 8 in
   (* Eio fiber isolation: each subsystem runs in its own fiber.
      If one crashes, others keep running — Eio's structured concurrency. *)
   let fork_subsystem name f =
+    Hashtbl.replace subsystem_health name (true, None);
     Eio.Fiber.fork ~sw (fun () ->
       try f ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
+        Hashtbl.replace subsystem_health name (false, Some (Time_compat.now ()));
         Log.Server.error "subsystem %s crashed: %s" name
           (Printexc.to_string exn))
   in
+  (* Expose subsystem health for /health endpoint *)
+  Subsystem_health.set_registry subsystem_health;
   (* Event_bus → SSE bridge: relay masc:* events to dashboard *)
   Oas_sse_bridge.start ~sw ~clock ~bus:event_bus;
   (* Inject Event_bus into keeper resident runtime for telemetry publishing *)
@@ -200,6 +207,10 @@ let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
         let evicted_events = Sse.cleanup_expired_events () in
         if evicted_events > 0 then
           Log.Server.info "Evicted %d expired SSE buffer events" evicted_events;
+        (* Cache eviction: remove expired entries *)
+        let evicted = Cache_eio.evict_expired state.room_config in
+        if evicted > 0 then
+          Log.Server.info "Cache: evicted %d expired entries" evicted;
         loop ()
       in
       loop ());

--- a/lib/subsystem_health.ml
+++ b/lib/subsystem_health.ml
@@ -1,0 +1,23 @@
+(** Subsystem health registry.
+    Tracks which forked subsystems are alive or have crashed.
+    Populated by server_runtime_bootstrap, queried by /health. *)
+
+let registry_ref : (string, bool * float option) Hashtbl.t option ref = ref None
+
+let set_registry tbl = registry_ref := Some tbl
+
+let to_yojson () : Yojson.Safe.t =
+  match !registry_ref with
+  | None -> `String "not_initialized"
+  | Some tbl ->
+    let entries = Hashtbl.fold (fun name (alive, crash_time) acc ->
+      let status = if alive then "alive" else "dead" in
+      let fields = [
+        ("status", `String status);
+      ] @ (match crash_time with
+        | Some t -> [("crashed_at", `Float t)]
+        | None -> [])
+      in
+      (name, `Assoc fields) :: acc
+    ) tbl [] in
+    `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries)


### PR DESCRIPTION
## Summary
- Add subsystem_health.ml: registry tracking alive/dead subsystems with crash timestamps
- fork_subsystem now records crash state on failure
- Expose subsystem liveness in /health endpoint (JSON object per subsystem)
- Add Cache_eio.evict_expired to 60s maintenance loop

## SLA Impact
| Metric | Before | After |
|--------|--------|-------|
| Subsystem crash detection | Log only | /health visible |
| Cache cleanup | On-demand (maybe_evict) | Every 60s + on-demand |

## Test plan
- [x] `dune build` — 0 errors
- [ ] Subsystem crash → /health shows "dead" + crash timestamp
- [ ] Expired cache entries → evicted within 60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)