### PR TITLE
Split war room surface panels

### DIFF
--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -1,0 +1,282 @@
+import { html } from 'htm/preact'
+import type {
+  CommandPlaneChainOverlay,
+  CommandPlaneSwarmBlocker,
+  CommandPlaneSwarmLane,
+  CommandPlaneSwarmResponse,
+  OperatorLinkedAutoresearch,
+  OperatorSessionSnapshot,
+  PendingConfirmation,
+} from '../../types'
+import {
+  deadlineLabel,
+  displayStatus,
+  formatElapsed,
+  relativeTime,
+  sessionStatusTone,
+  toneClass,
+} from './helpers'
+import { PanelSemanticDetails } from '../common/semantic-layer'
+import {
+  SwarmBlockerCard,
+  SwarmHealthBar,
+  SwarmRunResolutionCard,
+  SwarmStoryboard,
+} from './swarm'
+import { TraceRow } from './topology'
+import {
+  WarRoomFeedCard,
+  WarRoomPresenceCard,
+  WarRoomWorkerCard,
+} from './war-room-panels'
+import type {
+  WarRoomFeedItem,
+  WarRoomPresenceView,
+  WarRoomWorkerView,
+} from './war-room-panels'
+import { WarRoomOrchestrationRail } from './war-room-metrics'
+
+type WarRoomBodyProps = {
+  wallboard: boolean
+  liveLanes: CommandPlaneSwarmLane[]
+  selectedSession: OperatorSessionSnapshot | null
+  chainOverlay: CommandPlaneChainOverlay | null
+  linkedAutoresearch?: OperatorLinkedAutoresearch | null
+  workers: WarRoomWorkerView[]
+  feedItems: WarRoomFeedItem[]
+  swarm?: CommandPlaneSwarmResponse | null
+  agentViews: WarRoomPresenceView[]
+  keeperViews: WarRoomPresenceView[]
+  swarmHasEvidence: boolean
+  blockers: CommandPlaneSwarmBlocker[]
+  pendingApprovals: number
+  pendingConfirmTotal: number
+  pendingConfirmVisible: number
+  pendingConfirmHidden: number
+  pendingConfirms: PendingConfirmation[]
+  activeLane: CommandPlaneSwarmLane | null
+}
+
+export function WarRoomBodyGrid({
+  wallboard,
+  liveLanes,
+  selectedSession,
+  chainOverlay,
+  linkedAutoresearch,
+  workers,
+  feedItems,
+  swarm,
+  agentViews,
+  keeperViews,
+  swarmHasEvidence,
+  blockers,
+  pendingApprovals,
+  pendingConfirmTotal,
+  pendingConfirmVisible,
+  pendingConfirmHidden,
+  pendingConfirms,
+  activeLane,
+}: WarRoomBodyProps) {
+  return html`
+    <div class="command-warroom-grid ${wallboard ? 'wallboard' : ''}">
+      <div class="command-warroom-column">
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">실행 흐름</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          ${liveLanes.length > 0
+            ? html`
+                <${SwarmStoryboard} lanes=${liveLanes} />
+                <${SwarmHealthBar} lanes=${liveLanes} />
+              `
+            : selectedSession
+              ? html`
+                  <article class="command-guide-card">
+                    <div class="command-guide-head">
+                      <strong>${selectedSession.session_id}</strong>
+                      <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                    </div>
+                    <p>스웜 실시간 증거는 아직 약합니다. 이 카드는 세션 요약과 워커 기록을 기준으로 유지합니다.</p>
+                    <div class="command-card-grid">
+                      <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
+                      <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
+                      <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>
+                    </div>
+                  </article>
+                `
+              : html`<div class="empty-state">보이는 레인이 아직 없습니다.</div>`}
+        </section>
+
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">오케스트레이션</div>
+            <${PanelSemanticDetails} panelId="command.chains" compact=${true} />
+          </div>
+          <${WarRoomOrchestrationRail} chainOverlay=${chainOverlay} linkedAutoresearch=${linkedAutoresearch} />
+        </section>
+
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">워커 현황</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          ${workers.length > 0
+            ? html`<div class="command-card-stack">
+                ${workers.map(worker => html`<${WarRoomWorkerCard} worker=${worker} />`)}
+              </div>`
+            : html`<div class="empty-state">활성 워커 카드가 아직 없습니다.</div>`}
+        </section>
+      </div>
+
+      <div class="command-warroom-column">
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">상황 피드</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          ${feedItems.length > 0
+            ? html`<div class="command-trace-stack">
+                ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
+              </div>`
+            : html`<div class="empty-state">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
+        </section>
+
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">트레이스 흐름</div>
+            <${PanelSemanticDetails} panelId="command.trace" compact=${true} />
+          </div>
+          ${swarm && swarm.recent_trace_events.length > 0
+            ? html`<div class="command-trace-stack">
+                ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
+              </div>`
+            : html`<div class="empty-state">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
+        </section>
+      </div>
+
+      <div class="command-warroom-column">
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">Agents</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          ${agentViews.length > 0
+            ? html`<div class="warroom-presence-grid">
+                ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
+              </div>`
+            : html`<div class="empty-state">가시적인 active agent가 아직 없습니다.</div>`}
+        </section>
+
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">Keepers</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          ${keeperViews.length > 0
+            ? html`<div class="warroom-presence-grid">
+                ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
+              </div>`
+            : html`<div class="empty-state">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
+        </section>
+
+        <section class="card command-section">
+          <div class="card-title-row">
+            <div class="card-title">압력</div>
+            <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
+          </div>
+          <div class="command-card-stack">
+            ${swarmHasEvidence && swarm ? html`<${SwarmRunResolutionCard} swarm=${swarm} />` : null}
+            ${blockers.length > 0
+              ? blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)
+              : html`<div class="command-guide-card ok"><p>지금 보이는 blocker는 없습니다.</p></div>`}
+            ${pendingApprovals > 0
+              ? html`
+                  <article class="command-guide-card warn">
+                    <div class="command-guide-head">
+                      <strong>승인 대기</strong>
+                      <span class="command-chip warn">${pendingApprovals}</span>
+                    </div>
+                    <p>엄격 액션이 묶여 있습니다. 실제 승인 처리는 제어 표면에서 합니다.</p>
+                  </article>
+                `
+              : null}
+            ${pendingConfirmTotal > 0
+              ? html`
+                  <article class="command-guide-card warn">
+                    <div class="command-guide-head">
+                      <strong>확인 대기</strong>
+                      <span class="command-chip warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
+                    </div>
+                    <p>
+                      운영자 미리보기가 사람 확인을 기다리고 있습니다.
+                      ${pendingConfirmHidden > 0 ? ` 현재 actor 기준으로는 ${pendingConfirmVisible}건만 보입니다.` : ''}
+                    </p>
+                    <div class="command-tag-row">
+                      ${pendingConfirms.slice(0, 3).map(item => html`<span class="command-tag">${item.confirm_token}</span>`)}
+                    </div>
+                  </article>
+                `
+              : null}
+            ${activeLane
+              ? html`
+                  <article class="command-card compact">
+                    <div class="command-card-head">
+                      <div>
+                        <strong>${activeLane.label}</strong>
+                        <div class="command-card-sub">${activeLane.kind} · ${activeLane.phase}</div>
+                      </div>
+                      <span class="command-chip ${toneClass(sessionStatusTone(activeLane.motion_state))}">${displayStatus(activeLane.motion_state)}</span>
+                    </div>
+                    <div class="command-card-grid">
+                      <span>현재 단계</span><span>${activeLane.current_step}</span>
+                      <span>이동 사유</span><span>${activeLane.movement_reason}</span>
+                      <span>막힘 수</span><span>${activeLane.blockers.length}</span>
+                      <span>최근 이동</span><span>${relativeTime(activeLane.last_movement_at)}</span>
+                    </div>
+                  </article>
+                `
+              : null}
+            ${swarmHasEvidence && swarm?.detachment
+              ? html`
+                  <article class="command-card compact">
+                    <div class="command-card-head">
+                      <div>
+                        <strong>${swarm.detachment.detachment_id}</strong>
+                        <div class="command-card-sub">${swarm.detachment.assigned_unit_id}</div>
+                      </div>
+                      <span class="command-chip ${toneClass(sessionStatusTone(swarm.detachment.status))}">${displayStatus(swarm.detachment.status ?? 'active')}</span>
+                    </div>
+                    <div class="command-card-grid">
+                      <span>리더</span><span>${swarm.detachment.leader_id ?? '미지정'}</span>
+                      <span>편성</span><span>${swarm.detachment.roster.length}</span>
+                      <span>세션</span><span>${swarm.detachment.session_id ?? '연결 없음'}</span>
+                      <span>하트비트</span><span>${deadlineLabel(swarm.detachment.heartbeat_deadline)}</span>
+                    </div>
+                  </article>
+                `
+              : selectedSession
+                ? html`
+                    <article class="command-card compact">
+                      <div class="command-card-head">
+                        <div>
+                          <strong>${selectedSession.session_id}</strong>
+                          <div class="command-card-sub">현재 세션 기준</div>
+                        </div>
+                        <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                      </div>
+                      <div class="command-card-grid">
+                        <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
+                        <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
+                        <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>
+                        <span>완료 변화량</span><span>${selectedSession.done_delta_total ?? 0}</span>
+                      </div>
+                    </article>
+                  `
+                : null}
+          </div>
+        </section>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -1,0 +1,170 @@
+import { html } from 'htm/preact'
+import type {
+  CommandPlaneChainOverlay,
+  CommandPlaneSwarmLane,
+  CommandPlaneSwarmResponse,
+  OperatorGuidanceSummary,
+  OperatorResidentJudgeRuntime,
+  OperatorSessionSnapshot,
+} from '../../types'
+import { navigate } from '../../router'
+import { setCommandPlaneSurface } from '../../command-store'
+import {
+  displayStatus,
+  relativeTime,
+  surfaceRouteParams,
+  toneClass,
+} from './helpers'
+import {
+  guidanceFreshnessLabel,
+  guidanceLayerLabel,
+  guidanceLayerTone,
+  runtimeJudgeLabel,
+} from '../ops/helpers'
+import { WarRoomJumpButton } from './war-room-metrics'
+
+type WarRoomHeroProps = {
+  wallboard: boolean
+  stickyTone: 'ok' | 'warn' | 'bad'
+  heroTitle: string
+  heroSummary: string
+  swarmHasEvidence: boolean
+  swarm?: CommandPlaneSwarmResponse | null
+  selectedSession: OperatorSessionSnapshot | null
+  activeLane: CommandPlaneSwarmLane | null
+  activeSummary?: OperatorGuidanceSummary | null
+  guidanceLayer: string
+  fullscreenActive: boolean
+  workerJoined?: number | null
+  workerExpected?: number | null
+  workerCardCount: number
+  blockersCount: number
+  pendingApprovals: number
+  pendingConfirmTotal: number
+  pendingConfirmVisible: number
+  pendingConfirmHidden: number
+  residentRuntime?: OperatorResidentJudgeRuntime | null
+  latestSignal?: string | null
+  latestMessage?: string | null
+  latestTrace?: string | null
+  chainOverlay: CommandPlaneChainOverlay | null
+  onRefresh: () => void
+  onToggleFullscreen: () => void
+}
+
+function standardView() {
+  if (document.fullscreenElement) {
+    void document.exitFullscreen?.()
+  }
+  setCommandPlaneSurface('warroom')
+  navigate('operations', surfaceRouteParams('warroom'))
+}
+
+export function WarRoomHeroStrip({
+  wallboard,
+  stickyTone,
+  heroTitle,
+  heroSummary,
+  swarmHasEvidence,
+  swarm,
+  selectedSession,
+  activeLane,
+  activeSummary,
+  guidanceLayer,
+  fullscreenActive,
+  workerJoined,
+  workerExpected,
+  workerCardCount,
+  blockersCount,
+  pendingApprovals,
+  pendingConfirmTotal,
+  pendingConfirmVisible,
+  pendingConfirmHidden,
+  residentRuntime,
+  latestSignal,
+  latestMessage,
+  latestTrace,
+  chainOverlay,
+  onRefresh,
+  onToggleFullscreen,
+}: WarRoomHeroProps) {
+  return html`
+    <section class="command-warroom-strip ${toneClass(stickyTone)} ${wallboard ? 'wallboard' : ''}">
+      <div class="command-warroom-strip-head">
+        <div>
+          <span class="command-hero-kicker">${wallboard ? 'War Room Wallboard' : '실시간 워룸'}</span>
+          <strong>${heroTitle}</strong>
+          <div class="command-card-sub">
+            ${swarmHasEvidence ? (swarm?.operation?.operation_id ?? '작전 정보 없음') : '세션 기준값'}
+            ${selectedSession?.session_id ? ` · 세션 ${selectedSession.session_id}` : ''}
+            ${swarmHasEvidence && swarm?.detachment?.detachment_id ? ` · 분견대 ${swarm.detachment.detachment_id}` : ''}
+            ${activeLane ? ` · 대표 레인 ${activeLane.label}` : ''}
+          </div>
+          <div class="command-warroom-summary">${heroSummary}</div>
+          ${activeSummary?.summary
+            ? html`<div class="command-warroom-guidance ${guidanceLayerTone(guidanceLayer)}">
+                <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
+                <span>${activeSummary.summary}</span>
+              </div>`
+            : null}
+        </div>
+        <div class="command-warroom-hero-actions">
+          <button class="control-btn ghost" onClick=${onRefresh}>새로고침</button>
+          ${wallboard
+            ? html`
+                <button class="control-btn ghost" onClick=${onToggleFullscreen}>
+                  ${fullscreenActive ? '전체 화면 해제' : '전체 화면'}
+                </button>
+                <button class="control-btn ghost" onClick=${standardView}>
+                  표준 보기
+                </button>
+              `
+            : null}
+          <${WarRoomJumpButton}
+            label="스웜 상세"
+            surface="swarm"
+            params=${{
+              ...(swarmHasEvidence && swarm?.operation?.operation_id ? { operation_id: swarm.operation.operation_id } : {}),
+              ...(swarmHasEvidence && swarm?.run_id ? { run_id: swarm.run_id } : {}),
+            }}
+          />
+          ${chainOverlay
+            ? html`<${WarRoomJumpButton}
+                label="체인"
+                surface="chains"
+                params=${{ operation: chainOverlay.operation.operation_id }}
+              />`
+            : null}
+          <${WarRoomJumpButton} label="개입" />
+        </div>
+      </div>
+      <div class="command-warroom-strip-stats">
+        <div class="monitor-stat-card">
+          <span>워커</span>
+          <strong>${workerJoined ?? 0}/${workerExpected ?? 0}</strong>
+          <small>${swarmHasEvidence ? (swarm?.summary?.completed_workers ?? 0) : 0} 완료 · ${workerCardCount} 카드</small>
+        </div>
+        <div class="monitor-stat-card">
+          <span>런타임</span>
+          <strong>${swarmHasEvidence ? (swarm?.provider?.runtime_blocker ? '막힘' : swarm?.provider?.provider_reachable ? '준비됨' : selectedSession ? displayStatus(selectedSession.status) : '확인 필요') : (selectedSession ? displayStatus(selectedSession.status) : '확인 필요')}</strong>
+          <small>${swarmHasEvidence ? `설정 ${swarm?.provider?.configured_capacity ?? 'n/a'} · 실제 ${swarm?.provider?.actual_slots ?? swarm?.provider?.total_slots ?? 0} · hot ${swarm?.summary?.peak_hot_slots ?? swarm?.provider?.peak_active_slots ?? 0}` : `세션 워커 ${workerCardCount}`}</small>
+        </div>
+        <div class="monitor-stat-card ${toneClass(blockersCount > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')}">
+          <span>압력</span>
+          <strong>${blockersCount + pendingApprovals + pendingConfirmTotal}</strong>
+          <small>막힘 ${blockersCount} · 승인 ${pendingApprovals} · 확인 ${pendingConfirmVisible}${pendingConfirmHidden > 0 ? `/${pendingConfirmTotal}` : ''}</small>
+        </div>
+        <div class="monitor-stat-card ${toneClass(guidanceLayerTone(guidanceLayer))}">
+          <span>상주 판정기</span>
+          <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
+          <small>${guidanceFreshnessLabel(activeSummary)}${residentRuntime?.model_used ? ` · ${residentRuntime.model_used}` : ''}</small>
+        </div>
+        <div class="monitor-stat-card">
+          <span>마지막 신호</span>
+          <strong>${relativeTime(latestSignal)}</strong>
+          <small>${latestMessage ? '메시지' : latestTrace ? '트레이스' : '대기 중'}</small>
+        </div>
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -2,7 +2,6 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type {
   CommandPlaneSwarmLane,
-  PendingConfirmation,
 } from '../../types'
 import {
   commandPlaneChainSummary,
@@ -10,7 +9,6 @@ import {
   commandPlaneSwarmLoading,
   refreshCommandPlaneChainSummary,
   refreshCommandPlaneSwarm,
-  setCommandPlaneSurface,
 } from '../../command-store'
 import {
   operatorLoading,
@@ -19,31 +17,14 @@ import {
   refreshOperatorSessionDigest,
   refreshOperatorSnapshot,
 } from '../../operator-store'
-import { navigate } from '../../router'
 import { agents, keepers } from '../../store'
 import { PanelSemanticDetails } from '../common/semantic-layer'
 import {
   currentCommandPlaneSummary,
-  deadlineLabel,
-  displayStatus,
-  formatElapsed,
   hasSwarmActivity,
   pickWarRoomSession,
-  relativeTime,
-  sessionStatusTone,
-  surfaceRouteParams,
-  toneClass,
 } from './helpers'
 import { selectPendingConfirmState } from '../../pending-confirm'
-import {
-  guidanceFreshnessLabel,
-  guidanceLayerLabel,
-  guidanceLayerTone,
-  runtimeJudgeLabel,
-} from '../ops/helpers'
-import { SwarmBlockerCard, SwarmHealthBar, SwarmRunResolutionCard, SwarmStoryboard } from './swarm'
-import { TraceRow } from './topology'
-import { WarRoomWorkerCard, WarRoomPresenceCard, WarRoomFeedCard } from './war-room-panels'
 import type { WarRoomPresenceView } from './war-room-panels'
 import {
   agentPresenceView,
@@ -54,8 +35,9 @@ import {
   swarmWorkerView,
   timestampSortValue,
   WarRoomJumpButton,
-  WarRoomOrchestrationRail,
 } from './war-room-metrics'
+import { WarRoomHeroStrip } from './war-room-hero'
+import { WarRoomBodyGrid } from './war-room-body'
 
 export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
   const summary = currentCommandPlaneSummary()
@@ -233,293 +215,54 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
 
   return html`
     <div class="command-section-stack ${wallboard ? 'wallboard' : ''}">
-      <section class="command-warroom-strip ${toneClass(stickyTone)} ${wallboard ? 'wallboard' : ''}">
-        <div class="command-warroom-strip-head">
-          <div>
-            <span class="command-hero-kicker">${wallboard ? 'War Room Wallboard' : '실시간 워룸'}</span>
-            <strong>${heroTitle}</strong>
-            <div class="command-card-sub">
-              ${swarmHasEvidence ? (swarm?.operation?.operation_id ?? '작전 정보 없음') : '세션 기준값'}
-              ${selectedSession?.session_id ? ` · 세션 ${selectedSession.session_id}` : ''}
-              ${swarmHasEvidence && swarm?.detachment?.detachment_id ? ` · 분견대 ${swarm.detachment.detachment_id}` : ''}
-              ${activeLane ? ` · 대표 레인 ${activeLane.label}` : ''}
-            </div>
-            <div class="command-warroom-summary">${heroSummary}</div>
-            ${activeSummary?.summary
-              ? html`<div class="command-warroom-guidance ${guidanceLayerTone(guidanceLayer)}">
-                  <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
-                  <span>${activeSummary.summary}</span>
-                </div>`
-              : null}
-          </div>
-          <div class="command-warroom-hero-actions">
-            <button class="control-btn ghost" onClick=${refreshWallboard}>새로고침</button>
-            ${wallboard
-              ? html`
-                  <button class="control-btn ghost" onClick=${toggleFullscreen}>
-                    ${fullscreenActive ? '전체 화면 해제' : '전체 화면'}
-                  </button>
-                  <button
-                    class="control-btn ghost"
-                    onClick=${() => {
-                      if (document.fullscreenElement) {
-                        void document.exitFullscreen?.()
-                      }
-                      setCommandPlaneSurface('warroom')
-                      navigate('operations', surfaceRouteParams('warroom'))
-                    }}
-                  >
-                    표준 보기
-                  </button>
-                `
-              : null}
-            <${WarRoomJumpButton}
-              label="스웜 상세"
-              surface="swarm"
-              params=${{
-                ...(swarmHasEvidence && swarm?.operation?.operation_id ? { operation_id: swarm.operation.operation_id } : {}),
-                ...(swarmHasEvidence && swarm?.run_id ? { run_id: swarm.run_id } : {}),
-              }}
-            />
-            ${chainOverlay
-              ? html`<${WarRoomJumpButton}
-                  label="체인"
-                  surface="chains"
-                  params=${{ operation: chainOverlay.operation.operation_id }}
-                />`
-              : null}
-            <${WarRoomJumpButton} label="개입" />
-          </div>
-        </div>
-        <div class="command-warroom-strip-stats">
-          <div class="monitor-stat-card">
-            <span>워커</span>
-            <strong>${workerJoined ?? 0}/${workerExpected ?? 0}</strong>
-            <small>${swarmHasEvidence ? (swarm?.summary?.completed_workers ?? 0) : 0} 완료 · ${workers.length} 카드</small>
-          </div>
-          <div class="monitor-stat-card">
-            <span>런타임</span>
-            <strong>${swarmHasEvidence ? (swarm?.provider?.runtime_blocker ? '막힘' : swarm?.provider?.provider_reachable ? '준비됨' : selectedSession ? displayStatus(selectedSession.status) : '확인 필요') : (selectedSession ? displayStatus(selectedSession.status) : '확인 필요')}</strong>
-            <small>${swarmHasEvidence ? `설정 ${swarm?.provider?.configured_capacity ?? 'n/a'} · 실제 ${swarm?.provider?.actual_slots ?? swarm?.provider?.total_slots ?? 0} · hot ${swarm?.summary?.peak_hot_slots ?? swarm?.provider?.peak_active_slots ?? 0}` : `세션 워커 ${sessionDigest?.worker_cards.length ?? 0}`}</small>
-          </div>
-          <div class="monitor-stat-card ${toneClass(blockers.length > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')}">
-            <span>압력</span>
-            <strong>${blockers.length + pendingApprovals + pendingConfirmTotal}</strong>
-            <small>막힘 ${blockers.length} · 승인 ${pendingApprovals} · 확인 ${pendingConfirmVisible}${pendingConfirmHidden > 0 ? `/${pendingConfirmTotal}` : ''}</small>
-          </div>
-          <div class="monitor-stat-card ${toneClass(guidanceLayerTone(guidanceLayer))}">
-            <span>상주 판정기</span>
-            <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
-            <small>${guidanceFreshnessLabel(activeSummary)}${residentRuntime?.model_used ? ` · ${residentRuntime.model_used}` : ''}</small>
-          </div>
-          <div class="monitor-stat-card">
-            <span>마지막 신호</span>
-            <strong>${relativeTime(latestSignal)}</strong>
-            <small>${latestMessage ? '메시지' : latestTrace ? '트레이스' : '대기 중'}</small>
-          </div>
-        </div>
-      </section>
-
-      <div class="command-warroom-grid ${wallboard ? 'wallboard' : ''}">
-        <div class="command-warroom-column">
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">실행 흐름</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            ${liveLanes.length > 0
-              ? html`
-                  <${SwarmStoryboard} lanes=${liveLanes} />
-                  <${SwarmHealthBar} lanes=${liveLanes} />
-                `
-              : selectedSession
-                ? html`
-                    <article class="command-guide-card">
-                      <div class="command-guide-head">
-                        <strong>${selectedSession.session_id}</strong>
-                        <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
-                      </div>
-                      <p>스웜 실시간 증거는 아직 약합니다. 이 카드는 세션 요약과 워커 기록을 기준으로 유지합니다.</p>
-                      <div class="command-card-grid">
-                        <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
-                        <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
-                        <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>
-                      </div>
-                    </article>
-                  `
-                : html`<div class="empty-state">보이는 레인이 아직 없습니다.</div>`}
-          </section>
-
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">오케스트레이션</div>
-              <${PanelSemanticDetails} panelId="command.chains" compact=${true} />
-            </div>
-            <${WarRoomOrchestrationRail} chainOverlay=${chainOverlay} linkedAutoresearch=${linkedAutoresearch} />
-          </section>
-
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">워커 현황</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            ${workers.length > 0
-              ? html`<div class="command-card-stack">
-                  ${workers.map(worker => html`<${WarRoomWorkerCard} worker=${worker} />`)}
-                </div>`
-              : html`<div class="empty-state">활성 워커 카드가 아직 없습니다.</div>`}
-          </section>
-        </div>
-
-        <div class="command-warroom-column">
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">상황 피드</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            ${feedItems.length > 0
-              ? html`<div class="command-trace-stack">
-                  ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
-                </div>`
-              : html`<div class="empty-state">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
-          </section>
-
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">트레이스 흐름</div>
-              <${PanelSemanticDetails} panelId="command.trace" compact=${true} />
-            </div>
-            ${swarm && swarm.recent_trace_events.length > 0
-              ? html`<div class="command-trace-stack">
-                  ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
-                </div>`
-              : html`<div class="empty-state">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
-          </section>
-        </div>
-
-        <div class="command-warroom-column">
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">Agents</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            ${agentViews.length > 0
-              ? html`<div class="warroom-presence-grid">
-                  ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
-                </div>`
-              : html`<div class="empty-state">가시적인 active agent가 아직 없습니다.</div>`}
-          </section>
-
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">Keepers</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            ${keeperViews.length > 0
-              ? html`<div class="warroom-presence-grid">
-                  ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
-                </div>`
-              : html`<div class="empty-state">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
-          </section>
-
-          <section class="card command-section">
-            <div class="card-title-row">
-              <div class="card-title">압력</div>
-              <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
-            </div>
-            <div class="command-card-stack">
-              ${swarmHasEvidence && swarm ? html`<${SwarmRunResolutionCard} swarm=${swarm} />` : null}
-              ${blockers.length > 0
-                ? blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)
-                : html`<div class="command-guide-card ok"><p>지금 보이는 blocker는 없습니다.</p></div>`}
-              ${pendingApprovals > 0
-                ? html`
-                    <article class="command-guide-card warn">
-                      <div class="command-guide-head">
-                        <strong>승인 대기</strong>
-                        <span class="command-chip warn">${pendingApprovals}</span>
-                      </div>
-                      <p>엄격 액션이 묶여 있습니다. 실제 승인 처리는 제어 표면에서 합니다.</p>
-                    </article>
-                  `
-                : null}
-              ${pendingConfirmTotal > 0
-                ? html`
-                    <article class="command-guide-card warn">
-                      <div class="command-guide-head">
-                        <strong>확인 대기</strong>
-                        <span class="command-chip warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
-                      </div>
-                      <p>
-                        운영자 미리보기가 사람 확인을 기다리고 있습니다.
-                        ${pendingConfirmHidden > 0 ? ` 현재 actor 기준으로는 ${pendingConfirmVisible}건만 보입니다.` : ''}
-                      </p>
-                      <div class="command-tag-row">
-                        ${pendingConfirms.slice(0, 3).map((item: PendingConfirmation) => html`<span class="command-tag">${item.confirm_token}</span>`)}
-                      </div>
-                    </article>
-                  `
-                : null}
-              ${activeLane
-                ? html`
-                    <article class="command-card compact">
-                      <div class="command-card-head">
-                        <div>
-                          <strong>${activeLane.label}</strong>
-                          <div class="command-card-sub">${activeLane.kind} · ${activeLane.phase}</div>
-                        </div>
-                        <span class="command-chip ${toneClass(sessionStatusTone(activeLane.motion_state))}">${displayStatus(activeLane.motion_state)}</span>
-                      </div>
-                      <div class="command-card-grid">
-                        <span>현재 단계</span><span>${activeLane.current_step}</span>
-                        <span>이동 사유</span><span>${activeLane.movement_reason}</span>
-                        <span>막힘 수</span><span>${activeLane.blockers.length}</span>
-                        <span>최근 이동</span><span>${relativeTime(activeLane.last_movement_at)}</span>
-                      </div>
-                    </article>
-                  `
-                : null}
-              ${swarmHasEvidence && swarm?.detachment
-                ? html`
-                    <article class="command-card compact">
-                      <div class="command-card-head">
-                        <div>
-                          <strong>${swarm.detachment.detachment_id}</strong>
-                          <div class="command-card-sub">${swarm.detachment.assigned_unit_id}</div>
-                        </div>
-                        <span class="command-chip ${toneClass(sessionStatusTone(swarm.detachment.status))}">${displayStatus(swarm.detachment.status ?? 'active')}</span>
-                      </div>
-                      <div class="command-card-grid">
-                        <span>리더</span><span>${swarm.detachment.leader_id ?? '미지정'}</span>
-                        <span>편성</span><span>${swarm.detachment.roster.length}</span>
-                        <span>세션</span><span>${swarm.detachment.session_id ?? '연결 없음'}</span>
-                        <span>하트비트</span><span>${deadlineLabel(swarm.detachment.heartbeat_deadline)}</span>
-                      </div>
-                    </article>
-                  `
-                : selectedSession
-                  ? html`
-                      <article class="command-card compact">
-                        <div class="command-card-head">
-                          <div>
-                            <strong>${selectedSession.session_id}</strong>
-                            <div class="command-card-sub">현재 세션 기준</div>
-                          </div>
-                          <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
-                        </div>
-                        <div class="command-card-grid">
-                          <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
-                          <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
-                          <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>
-                          <span>완료 변화량</span><span>${selectedSession.done_delta_total ?? 0}</span>
-                        </div>
-                      </article>
-                    `
-                  : null}
-            </div>
-          </section>
-        </div>
-      </div>
+      <${WarRoomHeroStrip}
+        wallboard=${wallboard}
+        stickyTone=${stickyTone}
+        heroTitle=${heroTitle}
+        heroSummary=${heroSummary}
+        swarmHasEvidence=${swarmHasEvidence}
+        swarm=${swarm}
+        selectedSession=${selectedSession}
+        activeLane=${activeLane}
+        activeSummary=${activeSummary}
+        guidanceLayer=${guidanceLayer}
+        fullscreenActive=${fullscreenActive}
+        workerJoined=${workerJoined}
+        workerExpected=${workerExpected}
+        workerCardCount=${workers.length}
+        blockersCount=${blockers.length}
+        pendingApprovals=${pendingApprovals}
+        pendingConfirmTotal=${pendingConfirmTotal}
+        pendingConfirmVisible=${pendingConfirmVisible}
+        pendingConfirmHidden=${pendingConfirmHidden}
+        residentRuntime=${residentRuntime}
+        latestSignal=${latestSignal}
+        latestMessage=${latestMessage}
+        latestTrace=${latestTrace}
+        chainOverlay=${chainOverlay}
+        onRefresh=${refreshWallboard}
+        onToggleFullscreen=${toggleFullscreen}
+      />
+      <${WarRoomBodyGrid}
+        wallboard=${wallboard}
+        liveLanes=${liveLanes}
+        selectedSession=${selectedSession}
+        chainOverlay=${chainOverlay}
+        linkedAutoresearch=${linkedAutoresearch}
+        workers=${workers}
+        feedItems=${feedItems}
+        swarm=${swarm}
+        agentViews=${agentViews}
+        keeperViews=${keeperViews}
+        swarmHasEvidence=${swarmHasEvidence}
+        blockers=${blockers}
+        pendingApprovals=${pendingApprovals}
+        pendingConfirmTotal=${pendingConfirmTotal}
+        pendingConfirmVisible=${pendingConfirmVisible}
+        pendingConfirmHidden=${pendingConfirmHidden}
+        pendingConfirms=${pendingConfirms}
+        activeLane=${activeLane}
+      />
     </div>
   `
 }

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -125,7 +125,19 @@ let test_dashboard_component_split_contracts () =
        "export function SwarmOverviewPanel");
   check bool "swarm live panels exported from split file" true
     (file_contains_pattern "dashboard/src/components/command/swarm-live-panels.ts"
-       "export function SwarmLivePanels")
+       "export function SwarmLivePanels");
+  check bool "war room surface imports hero strip" true
+    (file_contains_pattern "dashboard/src/components/command/war-room.ts"
+       "import { WarRoomHeroStrip } from './war-room-hero'");
+  check bool "war room surface imports body grid" true
+    (file_contains_pattern "dashboard/src/components/command/war-room.ts"
+       "import { WarRoomBodyGrid } from './war-room-body'");
+  check bool "war room hero exported from split file" true
+    (file_contains_pattern "dashboard/src/components/command/war-room-hero.ts"
+       "export function WarRoomHeroStrip");
+  check bool "war room body exported from split file" true
+    (file_contains_pattern "dashboard/src/components/command/war-room-body.ts"
+       "export function WarRoomBodyGrid")
 
 let () =
   run "ci_hardening_source"


### PR DESCRIPTION
## Summary
- split `dashboard/src/components/command/war-room.ts` into dedicated hero-strip and body-grid modules
- keep `war-room.ts` focused on state derivation, hooks, and empty-state routing
- extend the dashboard source-guard test to lock the new import/export split points

## Testing
- `git diff --check`
- `dune build --root . test/test_ci_hardening_source.exe && ./_build/default/test/test_ci_hardening_source.exe`
- `cd dashboard && ./node_modules/.bin/tsc --noEmit --pretty false`
- `cd dashboard && npm run build`

## Notes
- dashboard validation used a temporary `dashboard/node_modules` symlink to the root repo dashboard install, then removed it after the checks
