### PR TITLE
refactor: extract extend_turns tool to Keeper_extend_turns module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -499,6 +499,7 @@
    keeper_exec_context
    keeper_tools_oas
    keeper_hooks_oas
+   keeper_extend_turns
    keeper_agent_run
    keeper_world_observation
    keeper_unified_prompt

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -116,57 +116,7 @@ let run_turn
   let meta_ref = ref meta in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in
   let keeper_tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
-  (* extend_turns: agent self-extends turn budget within ceiling *)
-  let ceiling = max max_turns 200 in
-  let budget_current = ref max_turns in
-  let budget_extensions = ref 0 in
-  let extend_turns_tool =
-    let open Agent_sdk in
-    Tool.create
-      ~name:"extend_turns"
-      ~description:"Request additional turns when you need more time. \
-                     Guardrails check cost and idle before granting."
-      ~parameters:[
-        { Types.name = "additional_turns";
-          description = "Number of additional turns (1-20)";
-          param_type = Types.Integer; required = true };
-        { Types.name = "reason";
-          description = "Why more turns are needed";
-          param_type = Types.String; required = true };
-      ]
-      (fun input ->
-        let additional =
-          try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 5 in
-        let reason =
-          try Yojson.Safe.Util.(member "reason" input |> to_string)
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unspecified" in
-        let additional = max 1 (min additional 20) in
-        if !budget_extensions >= 10 then
-          Ok { Types.content = Printf.sprintf
-            "Denied: extension limit (10) reached. Budget: %d/%d."
-            !budget_current ceiling }
-        else
-          let new_max = min (!budget_current + additional) ceiling in
-          let granted = new_max - !budget_current in
-          if granted <= 0 then
-            Ok { Types.content = Printf.sprintf
-              "Denied: at ceiling (%d/%d)." !budget_current ceiling }
-          else begin
-            budget_current := new_max;
-            incr budget_extensions;
-            (match !agent_ref with
-             | Some agent ->
-               let state = Agent_sdk.Agent.state agent in
-               Agent_sdk.Agent.set_state agent
-                 { state with config =
-                     { state.config with max_turns = new_max } }
-             | None -> ());
-            Ok { Types.content = Printf.sprintf
-              "Granted %d turns. Budget: %d (ceiling: %d). Extensions: %d/10. Reason: %s"
-              granted new_max ceiling !budget_extensions reason }
-          end)
-  in
+  let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
   let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd

--- a/lib/keeper/keeper_extend_turns.ml
+++ b/lib/keeper/keeper_extend_turns.ml
@@ -1,0 +1,55 @@
+(** Keeper_extend_turns — Self-extending turn budget tool for keeper Agent.run.
+
+    Creates an [extend_turns] {!Agent_sdk.Tool.t} that lets the keeper request
+    more turns at runtime.  The tool enforces a per-session extension limit
+    (10 extensions) and an absolute ceiling on total turns. *)
+
+let make ~agent_ref ~max_turns ?ceiling () : Agent_sdk.Tool.t =
+  let ceiling = match ceiling with Some c -> c | None -> max max_turns 200 in
+  let budget_current = ref max_turns in
+  let budget_extensions = ref 0 in
+  let open Agent_sdk in
+  Tool.create
+    ~name:"extend_turns"
+    ~description:"Request additional turns when you need more time. \
+                   Guardrails check cost and idle before granting."
+    ~parameters:[
+      { Types.name = "additional_turns";
+        description = "Number of additional turns (1-20)";
+        param_type = Types.Integer; required = true };
+      { Types.name = "reason";
+        description = "Why more turns are needed";
+        param_type = Types.String; required = true };
+    ]
+    (fun input ->
+      let additional =
+        try Yojson.Safe.Util.(member "additional_turns" input |> to_int)
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 5 in
+      let reason =
+        try Yojson.Safe.Util.(member "reason" input |> to_string)
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "unspecified" in
+      let additional = max 1 (min additional 20) in
+      if !budget_extensions >= 10 then
+        Ok { Types.content = Printf.sprintf
+          "Denied: extension limit (10) reached. Budget: %d/%d."
+          !budget_current ceiling }
+      else
+        let new_max = min (!budget_current + additional) ceiling in
+        let granted = new_max - !budget_current in
+        if granted <= 0 then
+          Ok { Types.content = Printf.sprintf
+            "Denied: at ceiling (%d/%d)." !budget_current ceiling }
+        else begin
+          budget_current := new_max;
+          incr budget_extensions;
+          (match !agent_ref with
+           | Some agent ->
+             let state = Agent_sdk.Agent.state agent in
+             Agent_sdk.Agent.set_state agent
+               { state with config =
+                   { state.config with max_turns = new_max } }
+           | None -> ());
+          Ok { Types.content = Printf.sprintf
+            "Granted %d turns. Budget: %d (ceiling: %d). Extensions: %d/10. Reason: %s"
+            granted new_max ceiling !budget_extensions reason }
+        end)

--- a/lib/keeper/keeper_extend_turns.mli
+++ b/lib/keeper/keeper_extend_turns.mli
@@ -1,0 +1,18 @@
+(** Keeper_extend_turns — Self-extending turn budget tool for keeper Agent.run.
+
+    Creates an [extend_turns] {!Agent_sdk.Tool.t} that lets the keeper request
+    more turns at runtime.  The tool enforces a per-session extension limit
+    (10 extensions) and an absolute ceiling on total turns. *)
+
+(** Create the extend_turns tool.
+
+    @param agent_ref  Mutable ref set to [Some agent] after [Agent.create].
+                      The tool mutates the agent's [max_turns] on grant.
+    @param max_turns  Initial turn budget.
+    @param ceiling    Absolute upper bound on turns (default: [max max_turns 200]). *)
+val make :
+  agent_ref:Agent_sdk.Agent.t option ref ->
+  max_turns:int ->
+  ?ceiling:int ->
+  unit ->
+  Agent_sdk.Tool.t


### PR DESCRIPTION
## Summary
- Extract the ~50-line inline `extend_turns` tool closure from `keeper_agent_run.ml` into a dedicated `Keeper_extend_turns` module with `.ml` and `.mli` interface.
- The inline closure captured 5 mutable refs and mixed tool definition with agent lifecycle orchestration. The new module encapsulates budget tracking (current budget, extension count, ceiling) internally and exposes a single `make` factory function.
- `keeper_agent_run.ml` now calls `Keeper_extend_turns.make ~agent_ref ~max_turns ()` (1 line instead of 50).

## Test plan
- [x] `dune build --root . bin/main_eio.exe` compiles successfully
- [ ] Verify keeper agent runtime behavior is unchanged (extend_turns tool grants/denies turns as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)