### PR TITLE
refactor: extract Proactive_refresh from dashboard refresh loops

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -91,6 +91,7 @@
    dashboard_http_keeper
    dashboard_http_mdal
    dashboard_provider_runs
+   proactive_refresh
    server_dashboard_http
    server_dashboard_http_core
    server_routes_http

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -1,0 +1,78 @@
+(** Proactive_refresh -- Reusable refresh loop with circuit breaker.
+
+    Runs a [compute] function periodically in a background fiber, storing
+    the result via [on_result].  On repeated failures the interval doubles
+    (exponential backoff, capped at [max_backoff_s]).  On recovery the
+    interval resets and a log message is emitted. *)
+
+type config = {
+  label : string;
+  interval_s : float;
+  max_backoff_s : float;
+  failure_threshold : int;
+  timeout_s : float;
+}
+
+let default_config ~label ~interval_s =
+  {
+    label;
+    interval_s;
+    max_backoff_s = 600.0;
+    failure_threshold = 3;
+    timeout_s = 10.0;
+  }
+
+let start ~sw ~clock ~config ~compute ~on_result =
+  (* --- Warm cache: run [compute] once synchronously with a timeout
+     so the server has data before the first async tick.  If it takes
+     longer than [timeout_s] the async loop will populate it. *)
+  (let t0 = Time_compat.now () in
+   try
+     match
+       Eio.Time.with_timeout clock config.timeout_s (fun () -> Ok (compute ()))
+     with
+     | Ok v ->
+       on_result v;
+       Log.Dashboard.info "%s warm cache done (%.1fs)" config.label
+         (Time_compat.now () -. t0)
+     | Error `Timeout ->
+       Log.Dashboard.warn "%s warm cache skipped (%.1fs timeout)" config.label
+         (Time_compat.now () -. t0)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Dashboard.warn "%s warm cache failed (%.1fs): %s" config.label
+       (Time_compat.now () -. t0) (Printexc.to_string exn));
+  (* --- Background refresh loop with circuit breaker. *)
+  Eio.Fiber.fork ~sw (fun () ->
+    Log.Dashboard.info "starting %s refresh loop" config.label;
+    let consecutive_failures = ref 0 in
+    let current_interval = ref config.interval_s in
+    let rec loop () =
+      let t0 = Time_compat.now () in
+      (try
+         let v = compute () in
+         on_result v;
+         let dt = Time_compat.now () -. t0 in
+         if !consecutive_failures > 0 then
+           Log.Dashboard.info "%s refresh recovered after %d failures"
+             config.label !consecutive_failures;
+         consecutive_failures := 0;
+         current_interval := config.interval_s;
+         Log.Dashboard.info "%s refreshed (%.1fs)" config.label dt
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         let dt = Time_compat.now () -. t0 in
+         consecutive_failures := !consecutive_failures + 1;
+         if !consecutive_failures >= config.failure_threshold then
+           current_interval :=
+             min config.max_backoff_s (!current_interval *. 2.0);
+         Log.Dashboard.warn
+           "%s refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
+           config.label !consecutive_failures !current_interval dt
+           (Printexc.to_string exn));
+      Eio.Time.sleep clock !current_interval;
+      loop ()
+    in
+    loop ())

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -1,0 +1,29 @@
+(** Proactive_refresh -- Reusable refresh loop with circuit breaker.
+
+    Runs a compute function periodically, with exponential backoff on
+    consecutive failures. *)
+
+type config = {
+  label : string;           (** Log prefix, e.g. "execution" or "mission". *)
+  interval_s : float;       (** Base refresh interval in seconds. *)
+  max_backoff_s : float;    (** Cap for exponential backoff. *)
+  failure_threshold : int;  (** Consecutive failures before backoff kicks in. *)
+  timeout_s : float;        (** Warm-cache timeout. *)
+}
+
+val default_config : label:string -> interval_s:float -> config
+(** [default_config ~label ~interval_s] returns a config with
+    [max_backoff_s = 600.0], [failure_threshold = 3], [timeout_s = 10.0]. *)
+
+val start :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:config ->
+  compute:(unit -> 'a) ->
+  on_result:('a -> unit) ->
+  unit
+(** Start a refresh loop with warm cache and circuit breaker.
+
+    [compute] produces a value; [on_result] stores it (typically writing
+    to a ref).  A warm-cache run executes synchronously before the async
+    loop, bounded by [config.timeout_s]. *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -31,79 +31,30 @@ let _execution_json_ref : Yojson.Safe.t ref =
     ("message", `String "Execution data is being computed. Refresh in a few seconds.");
   ])
 
-let _execution_refresh_interval_s = 60.0
-let _execution_refresh_max_backoff_s = 600.0
-
 (** Start the proactive execution refresh loop.  When an Executor_pool
     is available, each refresh runs in a pool domain with a domain-local
     Caqti pool (the main domain's Caqti pool is domain-bound due to
-    Switch capture in release).  Falls back to in-domain compute.
-
-    Circuit breaker: after 3 consecutive failures, the interval doubles
-    each time (max 600s). On success, it resets to the base interval. *)
+    Switch capture in release).  Falls back to in-domain compute. *)
 let start_execution_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.room_config in
+  let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
-  (* Warm cache with 10s timeout: do not block server startup.
-     If it takes longer, the async refresh loop will populate it. *)
-  (let t0 = Time_compat.now () in
-   try
-     match Eio.Time.with_timeout clock 10.0 (fun () ->
-       Ok (Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ())) with
-     | Ok json ->
-       _execution_json_ref := json;
-       Log.Dashboard.info "execution warm cache done (%.1fs)" (Time_compat.now () -. t0)
-     | Error `Timeout ->
-       Log.Dashboard.warn "execution warm cache skipped (%.1fs timeout)" (Time_compat.now () -. t0)
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Dashboard.warn "execution warm cache failed (%.1fs): %s"
-       (Time_compat.now () -. t0) (Printexc.to_string exn));
-  Eio.Fiber.fork ~sw (fun () ->
-    Log.Dashboard.info "starting execution refresh loop";
-    let consecutive_failures = ref 0 in
-    let current_interval = ref _execution_refresh_interval_s in
-    let rec loop () =
-      let t0 = Time_compat.now () in
-      (try
-        let json =
-          match !_executor_pool with
-          | Some pool ->
-            Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
-              Eio.Switch.run @@ fun pool_sw ->
-              match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw config with
-              | Some domain_config ->
-                Dashboard_execution.json ~light:true ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ()
-              | None ->
-                failwith "domain-local PG backend creation failed; skipping pool refresh")
-          | None ->
-            Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
-        in
-        _execution_json_ref := json;
-        let dt = Time_compat.now () -. t0 in
-        (* Success: reset circuit breaker *)
-        if !consecutive_failures > 0 then
-          Log.Dashboard.info "execution refresh recovered after %d failures"
-            !consecutive_failures;
-        consecutive_failures := 0;
-        current_interval := _execution_refresh_interval_s;
-        Log.Dashboard.info "execution refreshed (%.0fB, %.1fs, %s)"
-          (Float.of_int (String.length (Yojson.Safe.to_string json)))
-          dt
-          (if !_executor_pool <> None then "pool" else "in-domain")
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        let dt = Time_compat.now () -. t0 in
-        consecutive_failures := !consecutive_failures + 1;
-        (* Circuit breaker: backoff after 3 failures *)
-        if !consecutive_failures >= 3 then
-          current_interval :=
-            min _execution_refresh_max_backoff_s
-              (!current_interval *. 2.0);
-        Log.Dashboard.warn "execution refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
-          !consecutive_failures !current_interval dt (Printexc.to_string exn));
-      Eio.Time.sleep clock !current_interval;
-      loop ()
-    in
-    loop ())
+  let compute () =
+    match !_executor_pool with
+    | Some pool ->
+      Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
+        Eio.Switch.run @@ fun pool_sw ->
+        match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw room_config with
+        | Some domain_config ->
+          Dashboard_execution.json ~light:true ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ()
+        | None ->
+          failwith "domain-local PG backend creation failed; skipping pool refresh")
+    | None ->
+      Dashboard_execution.json ~light:true ~config:room_config ~sw ~clock ~proc_mgr ()
+  in
+  Proactive_refresh.start ~sw ~clock
+    ~config:(Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0)
+    ~compute
+    ~on_result:(fun json -> _execution_json_ref := json)
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
   let fixture = query_param request "fixture" in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -290,11 +290,11 @@ let operator_digest_http_json ~state ~sw ~clock request =
     in
     Operator_control.digest_json ?actor ?target_type ?target_id ?include_workers ctx
 
-(* --- Mission proactive refresh (same pattern as execution) ----------
-   A background fiber recomputes the mission snapshot every
-   [_mission_refresh_interval_s] seconds.  The HTTP handler returns the
-   cached ref immediately (0ms).  Actor-parameterized requests fall back
-   to on-demand compute with SWR cache. *)
+(* --- Mission proactive refresh ----------------------------------------
+   A background fiber recomputes the mission snapshot periodically.
+   The HTTP handler returns the cached ref immediately (0ms).
+   Actor-parameterized requests fall back to on-demand compute with
+   SWR cache. *)
 
 let _mission_json_ref : Yojson.Safe.t ref =
   ref (`Assoc [
@@ -312,59 +312,17 @@ let _mission_json_ref : Yojson.Safe.t ref =
     ("internal_signals", `List []);
   ])
 
-let _mission_refresh_interval_s = 120.0
-let _mission_refresh_max_backoff_s = 600.0
-
 let start_mission_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.room_config in
+  let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
-  (* Warm cache with 30s timeout: do not block server startup. *)
-  (let t0 = Time_compat.now () in
-   try
-     match Eio.Time.with_timeout clock 30.0 (fun () ->
-       Ok (Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ())) with
-     | Ok json ->
-       _mission_json_ref := json;
-       Log.Dashboard.info "mission warm cache done (%.1fs)" (Time_compat.now () -. t0)
-     | Error `Timeout ->
-       Log.Dashboard.warn "mission warm cache skipped (%.1fs timeout)" (Time_compat.now () -. t0)
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Dashboard.warn "mission warm cache failed (%.1fs): %s"
-       (Time_compat.now () -. t0) (Printexc.to_string exn));
-  Eio.Fiber.fork ~sw (fun () ->
-    Log.Dashboard.info "starting mission proactive refresh loop";
-    let consecutive_failures = ref 0 in
-    let current_interval = ref _mission_refresh_interval_s in
-    let rec loop () =
-      let t0 = Time_compat.now () in
-      (try
-        let json =
-          Dashboard_mission.json
-            ~config ~sw ~clock ~proc_mgr ()
-        in
-        _mission_json_ref := json;
-        let dt = Time_compat.now () -. t0 in
-        if !consecutive_failures > 0 then
-          Log.Dashboard.info "mission refresh recovered after %d failures"
-            !consecutive_failures;
-        consecutive_failures := 0;
-        current_interval := _mission_refresh_interval_s;
-        Log.Dashboard.info "mission refreshed (%.0fB, %.1fs)"
-          (Float.of_int (String.length (Yojson.Safe.to_string json)))
-          dt
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        let dt = Time_compat.now () -. t0 in
-        consecutive_failures := !consecutive_failures + 1;
-        if !consecutive_failures >= 3 then
-          current_interval :=
-            min _mission_refresh_max_backoff_s
-              (!current_interval *. 2.0);
-        Log.Dashboard.warn "mission refresh failed (%d consecutive, next in %.0fs, %.1fs): %s"
-          !consecutive_failures !current_interval dt (Printexc.to_string exn));
-      Eio.Time.sleep clock !current_interval;
-      loop ()
-    in
-    loop ())
+  let compute () =
+    Dashboard_mission.json ~config:room_config ~sw ~clock ~proc_mgr ()
+  in
+  Proactive_refresh.start ~sw ~clock
+    ~config:{ (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0)
+              with timeout_s = 30.0 }
+    ~compute
+    ~on_result:(fun json -> _mission_json_ref := json)
 
 (* Trim a full mission JSON to a lightweight snapshot:
    summary, session_briefs (goal/elapsed/blocker only), attention_queue (top 5), counts.


### PR DESCRIPTION
## Summary
- Extract duplicated circuit breaker pattern (consecutive failure tracking, exponential backoff, warm cache with timeout, recovery logging) from `start_execution_refresh_loop` and `start_mission_refresh_loop` into a new `Proactive_refresh` module.
- New module provides `config` record type, `default_config` constructor, and `start` function that handles the full warm-cache + background-fiber + circuit-breaker lifecycle.
- Both refresh loops now delegate to `Proactive_refresh.start` with domain-specific `compute` closures, removing ~124 lines of duplicated loop machinery.

## Changed files
| File | Change |
|------|--------|
| `lib/server/proactive_refresh.ml` | New module (79 lines) |
| `lib/server/proactive_refresh.mli` | New interface (30 lines) |
| `lib/server/server_dashboard_http.ml` | Replaced inline loop with `Proactive_refresh.start` call |
| `lib/server/server_dashboard_http_core.ml` | Replaced inline loop with `Proactive_refresh.start` call |
| `lib/dune` | Added `proactive_refresh` to module list |

## Test plan
- [x] `dune build --root . bin/main_eio.exe` compiles cleanly
- [ ] Verify dashboard execution and mission endpoints return cached data after server startup
- [ ] Confirm circuit breaker backoff behavior on simulated failures (log messages)


🤖 Generated with [Claude Code](https://claude.com/claude-code)