### PR TITLE
Categorize housekeep tools in mode presets

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -274,6 +274,7 @@ let tool_category tool_name =
   | "masc_tool_stats"
   | "masc_notification_count" | "masc_check_notifications"
   | "masc_consume_notifications"
+  | "masc_housekeep_scan" | "masc_housekeep_delete" | "masc_housekeep_prune"
   (* Verification tools *)
   | "masc_verify_auto" | "masc_verify_pending"
   | "masc_verify_request" | "masc_verify_status"


### PR DESCRIPTION
## Summary
- categorize `masc_housekeep_scan`, `masc_housekeep_delete`, and `masc_housekeep_prune` under the `Health` mode bucket
- restore mode/tool-count invariants for newly registered housekeep tools
- unblock quick-suite failures that were affecting multiple open PRs

## Testing
- `git diff --check`
- `dune exec --root . test/test_tool_registration_consistency.exe`
- `dune exec --root . test/test_mode_tool_count.exe`
