### PR TITLE
refactor(dashboard): split agent-detail.ts into sub-components

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -1,0 +1,30 @@
+// Agent detail journal stream — real-time activity stream filtered by agent
+
+import { html } from 'htm/preact'
+import { Card } from './common/card'
+import { TimeAgo } from './common/time-ago'
+import { agentJournalEntries, compactCopy, journalKindIcon } from './agent-detail-state'
+import type { JournalEntry } from '../types'
+
+export function AgentJournalStream({ agentName }: { agentName: string }) {
+  const entries = agentJournalEntries(agentName)
+
+  return html`
+    <${Card} title="실시간 활동 스트림">
+      ${entries.length === 0
+        ? html`<div class="empty-state">관련 이벤트 없음</div>`
+        : html`
+            <div class="agent-journal-stream">
+              ${entries.map((entry: JournalEntry, idx: number) => html`
+                <div class="agent-journal-entry" key=${idx}>
+                  <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
+                  <span class="agent-journal-type">${entry.eventType}</span>
+                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
+                  ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
+                </div>
+              `)}
+            </div>
+          `}
+    <//>
+  `
+}

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -1,0 +1,190 @@
+// Agent detail shared state, selectors, data fetching, and utility functions
+
+import { signal } from '@preact/signals'
+import { showToast } from './common/toast'
+import {
+  agents,
+  executionContinuityBriefs,
+  executionWorkerSupportBriefs,
+  keepers,
+  tasks,
+} from '../store'
+import { fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
+import { journal } from '../sse'
+import { route, navigate } from '../router'
+import { missionSnapshot } from '../mission-store'
+import type { JournalEntry } from '../types'
+import type {
+  Agent,
+  DashboardExecutionContinuityBrief,
+  DashboardMissionAgentBrief,
+  Keeper,
+  Task,
+} from '../types'
+
+const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
+
+export type TaskHistoryRow = {
+  taskId: string
+  text: string
+}
+
+// --- Signals ---
+
+export const selectedAgentName = signal<string | null>(null)
+export const loading = signal(false)
+export const detailError = signal('')
+export const roomActivity = signal<string[]>([])
+export const taskHistories = signal<TaskHistoryRow[]>([])
+export const agentTimeline = signal<AgentTimelineResponse | null>(null)
+export const mentionText = signal('')
+export const sendingMention = signal(false)
+
+// --- Selectors ---
+
+export function selectedAgent(): Agent | null {
+  const name = selectedAgentName.value
+  if (!name) return null
+  return agents.value.find(a => a.name === name) ?? null
+}
+
+export function assignedTasks(agentName: string | null): Task[] {
+  if (!agentName) return []
+  return tasks.value.filter(t => t.assignee === agentName)
+}
+
+export function keeperForAgent(agentName: string | null): Keeper | null {
+  if (!agentName) return null
+  return keepers.value.find(keeper => keeper.agent_name === agentName || keeper.name === agentName) ?? null
+}
+
+export function missionAgentBrief(agentName: string | null): DashboardMissionAgentBrief | null {
+  if (!agentName) return null
+  const mission = missionSnapshot.value
+  if (!mission) return null
+  return mission.agent_briefs.find(brief => brief.agent_name === agentName) ?? null
+}
+
+export function continuityBriefForAgent(agentName: string | null): DashboardExecutionContinuityBrief | null {
+  if (!agentName) return null
+  return executionContinuityBriefs.value.find(
+    brief => brief.agent_name === agentName || brief.name === agentName,
+  ) ?? null
+}
+
+export function workerBriefForAgent(agentName: string | null) {
+  if (!agentName) return null
+  return executionWorkerSupportBriefs.value.find(w => w.name === agentName) ?? null
+}
+
+export function agentJournalEntries(agentName: string | null): JournalEntry[] {
+  if (!agentName) return []
+  const nameLower = agentName.toLowerCase()
+  return journal.value
+    .filter((entry: JournalEntry) => {
+      const text = entry.text.toLowerCase()
+      const agent = entry.agent.toLowerCase()
+      return agent === nameLower || text.includes(nameLower) || text.includes(`@${nameLower}`)
+    })
+    .slice(0, 15)
+}
+
+// --- Actions ---
+
+export function openAgentDetail(agentName: string): void {
+  selectedAgentName.value = agentName
+  void refreshAgentDetail()
+}
+
+export function closeAgentDetail(): void {
+  selectedAgentName.value = null
+  detailError.value = ''
+  roomActivity.value = []
+  taskHistories.value = []
+  agentTimeline.value = null
+  mentionText.value = ''
+  if (route.value.tab === 'status' && route.value.params.agent) {
+    navigate('status', { section: 'agents' })
+  }
+}
+
+export async function refreshAgentDetail(): Promise<void> {
+  const agentName = selectedAgentName.value
+  if (!agentName) return
+
+  loading.value = true
+  detailError.value = ''
+  roomActivity.value = []
+  taskHistories.value = []
+  agentTimeline.value = null
+
+  try {
+    // Fetch room messages, task histories, and timeline in parallel
+    const [lines, timelineResult] = await Promise.all([
+      fetchRoomMessages(80),
+      fetchAgentTimeline(agentName, 4, 20).catch(() => null),
+    ])
+
+    roomActivity.value = lines
+      .filter(line => line.includes(agentName))
+      .slice(0, 20)
+
+    agentTimeline.value = timelineResult
+
+    const ownedTasks = assignedTasks(agentName).slice(0, 6)
+    if (ownedTasks.length === 0) return
+
+    const historyRows = await Promise.all(
+      ownedTasks.map(async task => {
+        try {
+          const text = await fetchTaskHistory(task.id, 25)
+          return { taskId: task.id, text: text.trim() }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'history load failed'
+          return { taskId: task.id, text: `Failed to load history: ${message}` }
+        }
+      }),
+    )
+    taskHistories.value = historyRows
+  } catch (err) {
+    detailError.value = err instanceof Error ? err.message : 'Failed to load agent detail'
+  } finally {
+    loading.value = false
+  }
+}
+
+export async function submitMention(): Promise<void> {
+  const target = selectedAgentName.value
+  const text = mentionText.value.trim()
+  if (!target || !text) return
+
+  const sender = localStorage.getItem(AGENT_NAME_KEY)?.trim() || 'dashboard'
+
+  sendingMention.value = true
+  try {
+    await sendBroadcast(sender, `@${target} ${text}`)
+    mentionText.value = ''
+    showToast(`Mention sent to ${target}`, 'success')
+    void refreshAgentDetail()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to send mention'
+    showToast(msg, 'error')
+  } finally {
+    sendingMention.value = false
+  }
+}
+
+// --- Helpers ---
+
+export function compactCopy(value: string | null | undefined, max = 160): string | null {
+  const text = (value ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return null
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+export function journalKindIcon(entry: JournalEntry): string {
+  if (entry.kind === 'board') return 'B'
+  if (entry.kind === 'tasks') return 'T'
+  if (entry.kind === 'keepers') return 'K'
+  return 'S'
+}

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -1,0 +1,65 @@
+// Agent detail timeline section — activity timeline with event summary
+
+import { html } from 'htm/preact'
+import { Card } from './common/card'
+import { TimeAgo } from './common/time-ago'
+import { agentTimeline, compactCopy } from './agent-detail-state'
+import type { AgentTimelineEvent } from '../api'
+
+function timelineEventIcon(type: string): string {
+  if (type === 'joined') return 'J'
+  if (type.startsWith('task_')) return 'T'
+  if (type === 'broadcast') return 'M'
+  return 'E'
+}
+
+function timelineEventLabel(type: string): string {
+  switch (type) {
+    case 'joined': return '참가'
+    case 'task_claimed': return '태스크 수임'
+    case 'task_started': return '태스크 시작'
+    case 'task_completed': return '태스크 완료'
+    case 'task_cancelled': return '태스크 취소'
+    case 'broadcast': return '브로드캐스트'
+    default: return type
+  }
+}
+
+export function AgentTimelineSection() {
+  const timeline = agentTimeline.value
+  if (!timeline) return null
+
+  const events = timeline.events ?? []
+  const summary = timeline.summary
+
+  return html`
+    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0} events)">
+      ${summary ? html`
+        <div class="agent-timeline-summary">
+          ${summary.tasks_completed > 0 ? html`<span class="pill">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="pill">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="pill">메시지 ${summary.messages_sent}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="pill">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+        </div>
+      ` : null}
+      ${events.length === 0
+        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
+        : html`
+            <div class="agent-timeline-list">
+              ${events.map((evt: AgentTimelineEvent, idx: number) => {
+                const detail = evt.detail as Record<string, string | undefined>
+                const title = detail.title ?? detail.content ?? ''
+                return html`
+                  <div class="agent-timeline-event" key=${idx}>
+                    <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
+                    <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
+                    ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}
+                    ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+                  </div>
+                `
+              })}
+            </div>
+          `}
+    <//>
+  `
+}

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -1,0 +1,48 @@
+// Agent detail worker brief — execution worker status panel
+
+import { html } from 'htm/preact'
+import { Card } from './common/card'
+import { StatusBadge } from './common/status-badge'
+import { TimeAgo } from './common/time-ago'
+import { compactCopy, workerBriefForAgent } from './agent-detail-state'
+
+export function AgentWorkerBrief({ agentName }: { agentName: string }) {
+  const worker = workerBriefForAgent(agentName)
+  if (!worker) return null
+
+  return html`
+    <${Card} title="Worker Status">
+      <div class="agent-worker-brief">
+        <div class="agent-worker-brief__row">
+          <span class="agent-worker-brief__label">State</span>
+          <${StatusBadge} status=${worker.state} />
+        </div>
+        ${worker.focus ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Focus</span>
+            <span>${worker.focus}</span>
+          </div>
+        ` : null}
+        ${worker.recent_output_preview ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Output</span>
+            <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
+          </div>
+        ` : null}
+        ${worker.related_session_id ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Session</span>
+            <span class="mono" style="font-size: 11px">${worker.related_session_id}</span>
+          </div>
+        ` : null}
+        ${worker.last_signal_at ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Signal</span>
+            <${TimeAgo} timestamp=${worker.last_signal_at} />
+            ${worker.signal_truth ? html`<span class="pill">${worker.signal_truth}</span>` : null}
+          </div>
+        ` : null}
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -1,184 +1,37 @@
-// Agent detail overlay — recent room activity + assigned task history + direct mention
+// Agent detail overlay — main component composing sub-panels
+// Sub-components: agent-detail-state, agent-detail-timeline, agent-detail-journal, agent-detail-worker
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
 import { Card } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
-import { showToast } from './common/toast'
 import { keeperIdentityHint } from './common/keeper-identity'
+import { AgentJournalStream } from './agent-detail-journal'
+import { AgentTimelineSection } from './agent-detail-timeline'
+import { AgentWorkerBrief } from './agent-detail-worker'
 import {
-  agents,
-  executionContinuityBriefs,
-  keepers,
-  tasks,
-} from '../store'
-import { fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineEvent, type AgentTimelineResponse } from '../api'
-import { journal } from '../sse'
-import { route, navigate } from '../router'
-import { missionSnapshot } from '../mission-store'
-import { executionWorkerSupportBriefs } from '../store'
-import type { JournalEntry } from '../types'
-import type {
-  Agent,
-  DashboardExecutionContinuityBrief,
-  DashboardMissionAgentBrief,
-  Keeper,
-  Task,
-} from '../types'
+  selectedAgentName,
+  loading,
+  detailError,
+  roomActivity,
+  taskHistories,
+  mentionText,
+  sendingMention,
+  selectedAgent,
+  assignedTasks,
+  keeperForAgent,
+  missionAgentBrief,
+  continuityBriefForAgent,
+  compactCopy,
+  closeAgentDetail,
+  refreshAgentDetail,
+  submitMention,
+  type TaskHistoryRow,
+} from './agent-detail-state'
+import type { Task } from '../types'
 
-const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
-
-type TaskHistoryRow = {
-  taskId: string
-  text: string
-}
-
-export const selectedAgentName = signal<string | null>(null)
-const loading = signal(false)
-const detailError = signal('')
-const roomActivity = signal<string[]>([])
-const taskHistories = signal<TaskHistoryRow[]>([])
-const agentTimeline = signal<AgentTimelineResponse | null>(null)
-const mentionText = signal('')
-const sendingMention = signal(false)
-
-export function openAgentDetail(agentName: string): void {
-  selectedAgentName.value = agentName
-  void refreshAgentDetail()
-}
-
-export function closeAgentDetail(): void {
-  selectedAgentName.value = null
-  detailError.value = ''
-  roomActivity.value = []
-  taskHistories.value = []
-  agentTimeline.value = null
-  mentionText.value = ''
-  if (route.value.tab === 'status' && route.value.params.agent) {
-    navigate('status', { section: 'agents' })
-  }
-}
-
-function selectedAgent(): Agent | null {
-  const name = selectedAgentName.value
-  if (!name) return null
-  return agents.value.find(a => a.name === name) ?? null
-}
-
-function assignedTasks(agentName: string | null): Task[] {
-  if (!agentName) return []
-  return tasks.value.filter(t => t.assignee === agentName)
-}
-
-function keeperForAgent(agentName: string | null): Keeper | null {
-  if (!agentName) return null
-  return keepers.value.find(keeper => keeper.agent_name === agentName || keeper.name === agentName) ?? null
-}
-
-function missionAgentBrief(agentName: string | null): DashboardMissionAgentBrief | null {
-  if (!agentName) return null
-  const mission = missionSnapshot.value
-  if (!mission) return null
-  return mission.agent_briefs.find(brief => brief.agent_name === agentName) ?? null
-}
-
-function continuityBriefForAgent(agentName: string | null): DashboardExecutionContinuityBrief | null {
-  if (!agentName) return null
-  return executionContinuityBriefs.value.find(
-    brief => brief.agent_name === agentName || brief.name === agentName,
-  ) ?? null
-}
-
-async function refreshAgentDetail(): Promise<void> {
-  const agentName = selectedAgentName.value
-  if (!agentName) return
-
-  loading.value = true
-  detailError.value = ''
-  roomActivity.value = []
-  taskHistories.value = []
-  agentTimeline.value = null
-
-  try {
-    // Fetch room messages, task histories, and timeline in parallel
-    const [lines, timelineResult] = await Promise.all([
-      fetchRoomMessages(80),
-      fetchAgentTimeline(agentName, 4, 20).catch(() => null),
-    ])
-
-    roomActivity.value = lines
-      .filter(line => line.includes(agentName))
-      .slice(0, 20)
-
-    agentTimeline.value = timelineResult
-
-    const ownedTasks = assignedTasks(agentName).slice(0, 6)
-    if (ownedTasks.length === 0) return
-
-    const historyRows = await Promise.all(
-      ownedTasks.map(async task => {
-        try {
-          const text = await fetchTaskHistory(task.id, 25)
-          return { taskId: task.id, text: text.trim() }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'history load failed'
-          return { taskId: task.id, text: `Failed to load history: ${message}` }
-        }
-      }),
-    )
-    taskHistories.value = historyRows
-  } catch (err) {
-    detailError.value = err instanceof Error ? err.message : 'Failed to load agent detail'
-  } finally {
-    loading.value = false
-  }
-}
-
-async function submitMention(): Promise<void> {
-  const target = selectedAgentName.value
-  const text = mentionText.value.trim()
-  if (!target || !text) return
-
-  const sender = localStorage.getItem(AGENT_NAME_KEY)?.trim() || 'dashboard'
-
-  sendingMention.value = true
-  try {
-    await sendBroadcast(sender, `@${target} ${text}`)
-    mentionText.value = ''
-    showToast(`Mention sent to ${target}`, 'success')
-    void refreshAgentDetail()
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Failed to send mention'
-    showToast(msg, 'error')
-  } finally {
-    sendingMention.value = false
-  }
-}
-
-function agentJournalEntries(agentName: string | null): JournalEntry[] {
-  if (!agentName) return []
-  const nameLower = agentName.toLowerCase()
-  return journal.value
-    .filter((entry: JournalEntry) => {
-      const text = entry.text.toLowerCase()
-      const agent = entry.agent.toLowerCase()
-      return agent === nameLower || text.includes(nameLower) || text.includes(`@${nameLower}`)
-    })
-    .slice(0, 15)
-}
-
-function workerBriefForAgent(agentName: string | null) {
-  if (!agentName) return null
-  return executionWorkerSupportBriefs.value.find(w => w.name === agentName) ?? null
-}
-
-function journalKindIcon(entry: JournalEntry): string {
-  if (entry.kind === 'board') return 'B'
-  if (entry.kind === 'tasks') return 'T'
-  if (entry.kind === 'keepers') return 'K'
-  return 'S'
-}
+// Re-export public API for external consumers
+export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-detail-state'
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
@@ -199,12 +52,6 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
       <pre class="agent-history-pre">${row.text || 'No task history yet'}</pre>
     </div>
   `
-}
-
-function compactCopy(value: string | null | undefined, max = 160): string | null {
-  const text = (value ?? '').replace(/\s+/g, ' ').trim()
-  if (!text) return null
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text
 }
 
 export function AgentDetailOverlay() {
@@ -348,127 +195,5 @@ export function AgentDetailOverlay() {
         <//>
       </div>
     </div>
-  `
-}
-
-function AgentJournalStream({ agentName }: { agentName: string }) {
-  const entries = agentJournalEntries(agentName)
-
-  return html`
-    <${Card} title="실시간 활동 스트림">
-      ${entries.length === 0
-        ? html`<div class="empty-state">관련 이벤트 없음</div>`
-        : html`
-            <div class="agent-journal-stream">
-              ${entries.map((entry: JournalEntry, idx: number) => html`
-                <div class="agent-journal-entry" key=${idx}>
-                  <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
-                  <span class="agent-journal-type">${entry.eventType}</span>
-                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
-                  ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
-                </div>
-              `)}
-            </div>
-          `}
-    <//>
-  `
-}
-
-function timelineEventIcon(type: string): string {
-  if (type === 'joined') return 'J'
-  if (type.startsWith('task_')) return 'T'
-  if (type === 'broadcast') return 'M'
-  return 'E'
-}
-
-function timelineEventLabel(type: string): string {
-  switch (type) {
-    case 'joined': return '참가'
-    case 'task_claimed': return '태스크 수임'
-    case 'task_started': return '태스크 시작'
-    case 'task_completed': return '태스크 완료'
-    case 'task_cancelled': return '태스크 취소'
-    case 'broadcast': return '브로드캐스트'
-    default: return type
-  }
-}
-
-function AgentTimelineSection() {
-  const timeline = agentTimeline.value
-  if (!timeline) return null
-
-  const events = timeline.events ?? []
-  const summary = timeline.summary
-
-  return html`
-    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0} events)">
-      ${summary ? html`
-        <div class="agent-timeline-summary">
-          ${summary.tasks_completed > 0 ? html`<span class="pill">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="pill">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="pill">메시지 ${summary.messages_sent}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="pill">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
-        </div>
-      ` : null}
-      ${events.length === 0
-        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
-        : html`
-            <div class="agent-timeline-list">
-              ${events.map((evt: AgentTimelineEvent, idx: number) => {
-                const detail = evt.detail as Record<string, string | undefined>
-                const title = detail.title ?? detail.content ?? ''
-                return html`
-                  <div class="agent-timeline-event" key=${idx}>
-                    <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
-                    <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}
-                    ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
-                  </div>
-                `
-              })}
-            </div>
-          `}
-    <//>
-  `
-}
-
-function AgentWorkerBrief({ agentName }: { agentName: string }) {
-  const worker = workerBriefForAgent(agentName)
-  if (!worker) return null
-
-  return html`
-    <${Card} title="Worker Status">
-      <div class="agent-worker-brief">
-        <div class="agent-worker-brief__row">
-          <span class="agent-worker-brief__label">State</span>
-          <${StatusBadge} status=${worker.state} />
-        </div>
-        ${worker.focus ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Focus</span>
-            <span>${worker.focus}</span>
-          </div>
-        ` : null}
-        ${worker.recent_output_preview ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Output</span>
-            <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
-          </div>
-        ` : null}
-        ${worker.related_session_id ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Session</span>
-            <span class="mono" style="font-size: 11px">${worker.related_session_id}</span>
-          </div>
-        ` : null}
-        ${worker.last_signal_at ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Signal</span>
-            <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="pill">${worker.signal_truth}</span>` : null}
-          </div>
-        ` : null}
-      </div>
-    <//>
   `
 }


### PR DESCRIPTION
## Summary
- Split 474-line `agent-detail.ts` into 5 focused modules, each under 300 lines
- `agent-detail-state.ts` (190 lines): shared signals, selectors, data fetching logic, utility helpers
- `agent-detail-timeline.ts` (65 lines): `AgentTimelineSection` component with event icon/label helpers
- `agent-detail-journal.ts` (30 lines): `AgentJournalStream` component
- `agent-detail-worker.ts` (48 lines): `AgentWorkerBrief` component
- `agent-detail.ts` (199 lines): main `AgentDetailOverlay` + re-exports public API (`openAgentDetail`, `closeAgentDetail`, `selectedAgentName`)
- All external imports remain unchanged (no breaking changes for consumers)

Closes #1518

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Verify dashboard loads and agent detail overlay opens/closes correctly
- [ ] Verify timeline, journal stream, and worker brief sections render

Generated with [Claude Code](https://claude.com/claude-code)