### PR TITLE
fix: plug Hashtbl memory leaks in SSE guard and MCP session tables

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -215,7 +215,21 @@ let stop_sse_session session_id =
   | None -> ()
   | Some info ->
       Hashtbl.remove sse_conn_by_session session_id;
+      Hashtbl.remove sse_connect_guard_by_session session_id;
       close_sse_conn info
+
+let is_active_sse_session session_id =
+  Hashtbl.mem sse_conn_by_session session_id
+
+let reap_stale_guards () =
+  let stale =
+    Hashtbl.fold (fun sid _ acc ->
+      if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
+      else acc
+    ) sse_connect_guard_by_session []
+  in
+  List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
+  List.length stale
 
 let close_all_sse_connections () =
   let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -17,6 +17,7 @@ val is_valid_protocol_version : string -> bool
 val remember_protocol_version : string -> string -> unit
 val remember_mcp_profile : string -> Mcp_server_eio.tool_profile -> unit
 val forget_mcp_session : string -> unit
+val reap_stale_sessions : is_active_session:(string -> bool) -> int
 val validate_mcp_session_profile :
   profile:Mcp_server_eio.tool_profile -> string -> (unit, string) result
 val validate_mcp_session_delete_profile :
@@ -53,6 +54,8 @@ val json_headers :
   deps:deps -> string -> string -> string -> (string * string) list
 val check_sse_connect_guard : string -> (unit, string * float) result
 val stop_sse_session : string -> unit
+val is_active_sse_session : string -> bool
+val reap_stale_guards : unit -> int
 val close_all_sse_connections : unit -> unit
 val handle_post_mcp :
   deps:deps ->

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -36,6 +36,22 @@ let forget_mcp_session session_id =
       Hashtbl.remove protocol_version_by_session session_id;
       Hashtbl.remove mcp_profile_by_session session_id)
 
+(** Reap session entries whose session_id has no active SSE connection.
+    Call periodically from the cleanup loop. Returns number of reaped entries. *)
+let reap_stale_sessions ~is_active_session =
+  Eio.Mutex.use_rw ~protect:true session_mutex (fun () ->
+    let stale =
+      Hashtbl.fold (fun sid _ acc ->
+        if not (is_active_session sid) then sid :: acc
+        else acc
+      ) protocol_version_by_session []
+    in
+    List.iter (fun sid ->
+      Hashtbl.remove protocol_version_by_session sid;
+      Hashtbl.remove mcp_profile_by_session sid
+    ) stale;
+    List.length stale)
+
 let profile_label = function
   | Mcp_eio.Full -> "/mcp"
   | Mcp_eio.Managed_agent -> "/mcp/managed"

--- a/lib/server/server_mcp_transport_http_sse.ml
+++ b/lib/server/server_mcp_transport_http_sse.ml
@@ -120,7 +120,21 @@ let stop_sse_session session_id =
   | None -> ()
   | Some info ->
       Hashtbl.remove sse_conn_by_session session_id;
+      Hashtbl.remove sse_connect_guard_by_session session_id;
       close_sse_conn info
+
+let is_active_sse_session session_id =
+  Hashtbl.mem sse_conn_by_session session_id
+
+let reap_stale_guards () =
+  let stale =
+    Hashtbl.fold (fun sid _ acc ->
+      if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
+      else acc
+    ) sse_connect_guard_by_session []
+  in
+  List.iter (Hashtbl.remove sse_connect_guard_by_session) stale;
+  List.length stale
 
 let close_all_sse_connections () =
   let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -211,6 +211,19 @@ let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
         let evicted = Cache_eio.evict_expired state.room_config in
         if evicted > 0 then
           Log.Server.info "Cache: evicted %d expired entries" evicted;
+        let sse_guards_reaped = Server_mcp_transport_http_sse.reap_stale_guards () in
+        let http_guards_reaped = Server_mcp_transport_http.reap_stale_guards () in
+        let is_active sid =
+          Server_mcp_transport_http_sse.is_active_sse_session sid
+          || Server_mcp_transport_http.is_active_sse_session sid
+        in
+        let sessions_reaped =
+          Server_mcp_transport_http_session.reap_stale_sessions
+            ~is_active_session:is_active
+        in
+        if sse_guards_reaped + http_guards_reaped + sessions_reaped > 0 then
+          Log.Server.info "reaped %d SSE guards + %d HTTP guards + %d stale sessions"
+            sse_guards_reaped http_guards_reaped sessions_reaped;
         loop ()
       in
       loop ());


### PR DESCRIPTION
## Summary
- `sse_connect_guard_by_session`에서 remove 호출 누락으로 세션마다 guard entry가 무한 축적되던 문제 수정
- `protocol_version_by_session`, `mcp_profile_by_session`이 SSE disconnect 시 정리되지 않던 문제 수정
- 60s cleanup loop에 `reap_stale_guards()` + `reap_stale_sessions()` 연결

## Changes
- `server_mcp_transport_http_sse.ml`: `stop_sse_session`에서 guard entry 즉시 제거 + `reap_stale_guards` 추가
- `server_mcp_transport_http.ml`: 동일 패턴 적용
- `server_mcp_transport_http_session.ml`: `reap_stale_sessions ~is_active_session` 추가 (콜백으로 순환 의존 회피)
- `server_runtime_bootstrap.ml`: 60s loop에서 3개 reap 함수 호출 + 로깅

## Test plan
- [ ] `dune build` 통과 확인
- [ ] 장시간 가동 후 `/health` 또는 로그에서 reaped 카운트 확인
- [ ] SSE 연결/해제 반복 후 guard table 크기 증가 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)