### PR TITLE
perf: optimize agentMotionMap from O(N*M) to O(N+M)

### DIFF
--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -14,7 +14,7 @@ interface AgentMotionOptions {
   keepers?: Keeper[]
 }
 
-function normalizeAgentKey(value: string | null | undefined): string {
+export function normalizeAgentKey(value: string | null | undefined): string {
   return (value ?? '').trim().toLowerCase()
 }
 
@@ -60,35 +60,29 @@ function keeperPreview(keeper: Keeper): string {
 }
 
 export function buildAgentMotion(
-  agentName: string,
+  _agentName: string,
   tasks: Task[],
   messages: Message[],
   journal: JournalEntry[],
   options: AgentMotionOptions = {},
 ): AgentMotionSnapshot {
-  const agentKey = normalizeAgentKey(agentName)
+  // Callers should pre-filter arrays by agent key before calling.
+  // This function only sorts and picks the most recent entries.
   const activeAssignedCount = tasks.filter(task =>
-    normalizeAgentKey(task.assignee) === agentKey
-    && (task.status === 'claimed' || task.status === 'in_progress')
+    task.status === 'claimed' || task.status === 'in_progress'
   ).length
 
   const recentMessage = messages
-    .filter(message => normalizeAgentKey(message.from ?? '') === agentKey)
-    .sort((a, b) => toEpoch(b.timestamp ?? '') - toEpoch(a.timestamp ?? ''))[0]
+    .slice().sort((a, b) => toEpoch(b.timestamp ?? '') - toEpoch(a.timestamp ?? ''))[0]
 
   const recentJournal = journal
-    .filter(entry =>
-      normalizeAgentKey(entry.agent) === agentKey
-      || normalizeAgentKey(entry.author) === agentKey
-    )
-    .sort((a, b) => toEpoch(b.timestamp) - toEpoch(a.timestamp))[0]
+    .slice().sort((a, b) => toEpoch(b.timestamp) - toEpoch(a.timestamp))[0]
 
   const recentBoardPost = (options.boardPosts ?? [])
-    .filter(post => normalizeAgentKey(post.author) === agentKey)
-    .sort((a, b) => toEpoch(b.updated_at || b.created_at) - toEpoch(a.updated_at || a.created_at))[0]
+    .slice().sort((a, b) => toEpoch(b.updated_at || b.created_at) - toEpoch(a.updated_at || a.created_at))[0]
 
   const recentKeeper = (options.keepers ?? [])
-    .filter(keeper => normalizeAgentKey(keeper.name) === agentKey && keeperSignalTimestamp(keeper) !== null)
+    .filter(keeper => keeperSignalTimestamp(keeper) !== null)
     .sort((a, b) => toEpoch(keeperSignalTimestamp(b) ?? 0) - toEpoch(keeperSignalTimestamp(a) ?? 0))[0]
 
   const messageTs = recentMessage ? toEpoch(recentMessage.timestamp ?? '') : 0

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -41,7 +41,7 @@ import {
   keeperFreshnessTs,
   normalizeKeepers,
 } from './keeper-store-normalize'
-import { buildAgentMotion, type AgentMotionSnapshot } from './components/common/agent-motion'
+import { buildAgentMotion, normalizeAgentKey, type AgentMotionSnapshot } from './components/common/agent-motion'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
@@ -210,6 +210,18 @@ export const tasksByStatus = computed(() => {
   }
 })
 
+function groupByKey<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyFn(item)
+    if (!key) continue
+    const arr = map.get(key)
+    if (arr) arr.push(item)
+    else map.set(key, [item])
+  }
+  return map
+}
+
 export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = computed(() => {
   const map = new Map<string, AgentMotionSnapshot>()
   const taskList = tasks.value
@@ -217,15 +229,40 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
   const journalList = journal.value
   const boardPostList = boardPosts.value
   const keeperList = keepers.value
+
+  // Pre-index: one pass per array — O(N) total instead of O(N * agents)
+  const tasksByAgent = groupByKey(taskList, t => normalizeAgentKey(t.assignee))
+  const messagesByAgent = groupByKey(messageList, m => normalizeAgentKey(m.from ?? ''))
+  const journalByAgent = groupByKey(journalList, e => normalizeAgentKey(e.agent))
+  const journalByAuthor = groupByKey(journalList, e => normalizeAgentKey(e.author))
+  const boardByAgent = groupByKey(boardPostList, p => normalizeAgentKey(p.author))
+  const keepersByAgent = groupByKey(keeperList, k => normalizeAgentKey(k.name))
+
   for (const agent of agents.value) {
+    const key = normalizeAgentKey(agent.name)
+    // Merge journal entries matched by agent OR author (deduplicate)
+    const agentJournal = journalByAgent.get(key) ?? []
+    const authorJournal = journalByAuthor.get(key) ?? []
+    const mergedJournal = agentJournal.length === 0
+      ? authorJournal
+      : authorJournal.length === 0
+        ? agentJournal
+        : [...new Set([...agentJournal, ...authorJournal])]
+
     map.set(
-      agent.name.trim().toLowerCase(),
-      buildAgentMotion(agent.name, taskList, messageList, journalList, {
-        currentTask: agent.current_task,
-        lastSeen: agent.last_seen,
-        boardPosts: boardPostList,
-        keepers: keeperList,
-      }),
+      key,
+      buildAgentMotion(
+        agent.name,
+        tasksByAgent.get(key) ?? [],
+        messagesByAgent.get(key) ?? [],
+        mergedJournal,
+        {
+          currentTask: agent.current_task,
+          lastSeen: agent.last_seen,
+          boardPosts: boardByAgent.get(key) ?? [],
+          keepers: keepersByAgent.get(key) ?? [],
+        },
+      ),
     )
   }
   return map


### PR DESCRIPTION
## Summary
- `agentMotionMap` computed signal이 agent 수 x 배열 크기만큼 `.filter()` 반복하던 O(N*M) 연산을 `groupByKey` 사전 인덱싱으로 O(N+M)으로 최적화
- 10 agents x 500 items 기준 ~5,000 filter+sort ops → ~510 ops per signal tick

## Changes
- `agent-motion.ts`: `normalizeAgentKey` export, `buildAgentMotion`이 이미 필터된 배열 수신 (내부 `.filter()` 제거)
- `store.ts`: `groupByKey<T>` 헬퍼 추가, `agentMotionMap`에서 5개 배열 사전 인덱싱 후 O(1) 조회

## Test plan
- [ ] `npm run build` 통과 확인
- [ ] `vitest run` 통과 확인
- [ ] Chrome DevTools Performance 탭에서 signal 갱신 빈도 감소 확인
- [ ] Agent 카드 last activity 텍스트 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)