### PR TITLE
perf: reduce polling frequency and cap in-memory metrics

### DIFF
--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -212,7 +212,7 @@ export function Command() {
       if (surface === 'warroom') {
         void refreshOperatorSnapshot()
       }
-    }, 5000)
+    }, 30000)
 
     return () => {
       window.clearInterval(interval)

--- a/lib/generational_metrics.ml
+++ b/lib/generational_metrics.ml
@@ -85,6 +85,16 @@ let task_records : task_record list ref = ref []
 let handoff_records : handoff_record list ref = ref []
 let retention_tests : retention_test list ref = ref []
 
+let max_in_memory = 1000
+
+(** Keep at most [max_in_memory] entries by dropping the oldest (tail).
+    Amortized: only prunes when size exceeds 2x the cap. *)
+let prune_list r =
+  let lst = !r in
+  let len = List.length lst in
+  if len > max_in_memory * 2 then
+    r := List.filteri (fun i _ -> i < max_in_memory) lst
+
 (** {1 JSONL Persistence}
 
     Append-only JSONL backup under .masc/metrics/{agent}/
@@ -165,6 +175,7 @@ let record_task ~generation ~task_id ~completed ~duration_ms ~error_count
       timestamp = Time_compat.now ();
     } in
     task_records := record :: !task_records;
+    prune_list task_records;
     (* JSONL backup — best effort, don't fail the record *)
     (try append_jsonl ~agent_name:"_global" (task_record_to_json record)
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -182,6 +193,7 @@ let record_handoff ~from_generation ~to_generation ~dna_size ~context_ratio =
       timestamp = Time_compat.now ();
     } in
     handoff_records := record :: !handoff_records;
+    prune_list handoff_records;
     (try append_jsonl ~agent_name:"_global" (handoff_record_to_json record)
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Metrics.warn "append_jsonl handoff: %s" (Printexc.to_string exn));
@@ -193,6 +205,7 @@ let record_retention_test ~generation ~question ~expected ~actual ~confidence =
     let correct = String.lowercase_ascii expected = String.lowercase_ascii actual in
     let record = { generation; question; expected; actual; correct; confidence } in
     retention_tests := record :: !retention_tests;
+    prune_list retention_tests;
     record)
 
 (** Internal: summarize without acquiring lock (caller must hold lock) *)


### PR DESCRIPTION
## Summary
두 가지 독립적 성능 개선:

1. **Command Plane 폴링 간격 5s → 30s**: SSE EventSource가 실시간 업데이트 담당. setInterval은 fallback 역할이므로 30s로 충분. 8시간 기준 5,760 → 960 cycles.

2. **Generational Metrics 메모리 cap**: `task_records`, `handoff_records`, `retention_tests` append-only list에 `max_in_memory = 1000` 상한 적용. 2x 초과 시 amortized pruning. JSONL에 전체 이력 보존.

## Changes
- `dashboard/src/components/command/index.ts`: `setInterval` 5000 → 30000
- `lib/generational_metrics.ml`: `max_in_memory` 상수 + `prune_list` 헬퍼 + 각 mutation 후 호출

## Test plan
- [ ] `npm run build` 통과 확인
- [ ] `dune build` 통과 확인
- [ ] Command Plane SSE 실시간 업데이트 정상 동작 확인
- [ ] metrics JSONL 파일에 전체 이력 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)