### PR TITLE
fix(keeper): pass conversation history to OAS Agent.run via initial_messages

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -140,6 +140,7 @@ let run_turn
       ~goal:user_message
       ~system_prompt:turn_system_prompt
       ~tools
+      ~initial_messages:ctx_work.messages
       ~hooks
       ~context_reducer:reducer
       ~memory

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -35,6 +35,7 @@ type config = {
   description : string option;
   memory : Oas.Memory.t option;
   named_cascade : Oas.Api.named_cascade option;
+  initial_messages : Oas.Types.message list;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -51,6 +52,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     description = None;
     memory = None;
     named_cascade = None;
+    initial_messages = [];
   }
 
 (* ================================================================ *)
@@ -154,6 +156,11 @@ let build
   let builder = match config.named_cascade with
     | Some nc -> Oas.Builder.with_named_cascade nc builder
     | None -> builder
+  in
+  let builder =
+    if config.initial_messages <> [] then
+      Oas.Builder.with_initial_messages config.initial_messages builder
+    else builder
   in
   Oas.Builder.build_safe builder
   |> Result.map_error Oas.Error.to_string
@@ -355,6 +362,7 @@ let run_named
     ~goal
     ?(system_prompt = "")
     ?(tools = [])
+    ?(initial_messages = [])
     ?(max_turns = 20)
     ?(temperature = 0.7)
     ?(max_tokens = 4096)
@@ -389,7 +397,7 @@ let run_named
       ~description:(Some (Printf.sprintf "cascade:%s" cascade_name))
       ()
   in
-  let config = { config with named_cascade = Some named_cascade } in
+  let config = { config with named_cascade = Some named_cascade; initial_messages } in
   match run ~sw ~net ~config ?on_event ?agent_ref goal with
   | Ok result when accept result.response -> Ok result
   | Ok _ -> Error (Printf.sprintf "cascade %s: response rejected by accept" cascade_name)

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -36,6 +36,7 @@ val run_named :
   goal:string ->
   ?system_prompt:string ->
   ?tools:Oas.Tool.t list ->
+  ?initial_messages:Oas.Types.message list ->
   ?max_turns:int ->
   ?temperature:float ->
   ?max_tokens:int ->


### PR DESCRIPTION
## Summary

Keeper checkpoint에 170+ 메시지가 저장되어있지만 `Oas_worker.run_named`가 현재 turn의 `goal`만 전달.
모델이 이전 대화를 모르니까 맥락 없이 매 turn 새로 시작됨.

### Root Cause
`Oas_worker.run_named`에 `initial_messages` 파라미터 없음.
OAS `Builder.with_initial_messages`는 이미 존재했지만 MASC에서 사용하지 않음.

### Fix (11줄)
- `oas_worker.ml`: config에 `initial_messages` 추가, Builder에 전달
- `keeper_agent_run.ml`: `ctx_work.messages` (checkpoint history)를 `initial_messages`로 전달

## Test plan
- [x] `dune build` 성공
- [x] keeper 테스트 98개 통과
- [ ] 서버 재시작 후 keeper가 이전 대화 맥락을 참조하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)