### PR TITLE
fix(keeper): pass conversation history in proactive generation path

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -493,7 +493,8 @@ let run_proactive_generation
       let (agent_result, attempt_latency) = timed (fun () ->
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
-            ~tools ~max_turns:10 ~temperature ~max_tokens ()) in
+            ~tools ~initial_messages:ctx_work.messages
+            ~max_turns:10 ~temperature ~max_tokens ()) in
       match agent_result with
       | Error _ -> None
       | Ok result ->


### PR DESCRIPTION
## Summary

#2058과 동일 버그 — proactive generation 경로. `ctx_work.messages` 접근 가능하지만 `initial_messages`로 미전달.

25개 `Oas_worker` 호출 전수 감사 결과 이것이 마지막 누락.

## Test plan
- [x] `dune build` 성공
- [ ] proactive turn에서 이전 대화 맥락 참조 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)