### PR TITLE
fix: subsystem health registry module-level init

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -125,24 +125,20 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   Sse.set_clock clock;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Agent_sdk.Event_bus.create () in
-  (* Subsystem health registry: tracks liveness of forked subsystems.
-     Maps name → (is_alive, last_crash_time option). *)
-  let subsystem_health : (string, bool * float option) Hashtbl.t = Hashtbl.create 8 in
   (* Eio fiber isolation: each subsystem runs in its own fiber.
-     If one crashes, others keep running — Eio's structured concurrency. *)
+     If one crashes, others keep running — Eio's structured concurrency.
+     Subsystem_health tracks liveness at module level (no init timing dependency). *)
   let fork_subsystem name f =
-    Hashtbl.replace subsystem_health name (true, None);
+    Subsystem_health.register name;
     Eio.Fiber.fork ~sw (fun () ->
       try f ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Hashtbl.replace subsystem_health name (false, Some (Time_compat.now ()));
+        Subsystem_health.mark_dead name;
         Log.Server.error "subsystem %s crashed: %s" name
           (Printexc.to_string exn))
   in
-  (* Expose subsystem health for /health endpoint *)
-  Subsystem_health.set_registry subsystem_health;
   (* Event_bus → SSE bridge: relay masc:* events to dashboard *)
   Oas_sse_bridge.start ~sw ~clock ~bus:event_bus;
   (* Inject Event_bus into keeper resident runtime for telemetry publishing *)

--- a/lib/subsystem_health.ml
+++ b/lib/subsystem_health.ml
@@ -1,23 +1,25 @@
 (** Subsystem health registry.
     Tracks which forked subsystems are alive or have crashed.
-    Populated by server_runtime_bootstrap, queried by /health. *)
+    Module-level Hashtbl: available from process start, no init timing dependency.
+    Called by fork_subsystem in server_runtime_bootstrap, queried by /health. *)
 
-let registry_ref : (string, bool * float option) Hashtbl.t option ref = ref None
+let registry : (string, bool * float option) Hashtbl.t = Hashtbl.create 8
 
-let set_registry tbl = registry_ref := Some tbl
+let register name =
+  Hashtbl.replace registry name (true, None)
+
+let mark_dead name =
+  Hashtbl.replace registry name (false, Some (Time_compat.now ()))
 
 let to_yojson () : Yojson.Safe.t =
-  match !registry_ref with
-  | None -> `String "not_initialized"
-  | Some tbl ->
-    let entries = Hashtbl.fold (fun name (alive, crash_time) acc ->
-      let status = if alive then "alive" else "dead" in
-      let fields = [
-        ("status", `String status);
-      ] @ (match crash_time with
-        | Some t -> [("crashed_at", `Float t)]
-        | None -> [])
-      in
-      (name, `Assoc fields) :: acc
-    ) tbl [] in
-    `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries)
+  let entries = Hashtbl.fold (fun name (alive, crash_time) acc ->
+    let status = if alive then "alive" else "dead" in
+    let fields = [
+      ("status", `String status);
+    ] @ (match crash_time with
+      | Some t -> [("crashed_at", `Float t)]
+      | None -> [])
+    in
+    (name, `Assoc fields) :: acc
+  ) registry [] in
+  `Assoc (List.sort (fun (a, _) (b, _) -> String.compare a b) entries)


### PR DESCRIPTION
## Summary
- Replace ref-cell + set_registry pattern with module-level Hashtbl
- register/mark_dead API called directly by fork_subsystem
- /health returns {} immediately instead of "not_initialized" during slow startup

## Root Cause
Registry was created inside start_resident_loops, which runs after dashboard slow render (~58s). /health responded before registry was set.

## Test plan
- [x] `dune build` — 0 errors
- [ ] Start server → immediate /health → subsystems field is `{}` (not "not_initialized")
- [ ] After subsystem fork → subsystems shows "alive" entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)