### PR TITLE
fix(oas): complete bridges and enable swarm tools

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -5,57 +5,51 @@ OAS (OCaml Agent SDK)와 MASC-MCP 사이의 역할 경계를 정의한다.
 **원칙**: OAS는 MASC를 모른다. OAS의 변경은 모든 소비자에게 유익해야 한다.
 
 ```
-Claude Code (consumer) → MASC-MCP (orchestration) → OAS (agent SDK)
+consumer → MASC-MCP (coordination/orchestration) → OAS (agent runtime)
 ```
 
 ## 역할 분리
 
-| 관심사 | OAS (에이전트 수준) | MASC (조율 수준) |
-|--------|---------------------|-------------------|
-| 에이전트 실행 | `Agent.run`, turn loop | 스폰, 모니터링, 종료 결정 |
-| 도구 타입 | `Tool.t`, `tool_result` | `Tool.create`로 MASC 도구 생성, OAS 네이티브 타입 직접 사용 |
-| 단일 에이전트 상태 | `Checkpoint`, `Session`, `Context` | OAS 프리미티브 사용 (Phase 3+) |
-| 조율 상태 | 해당 없음 | Board, tasks, room, PostgreSQL |
-| 작업 메모리 | `Context` (scoped KV) | `Context_manager` (3-tier). Tier 1이 OAS Context 래핑 예정 |
-| 장기 메모리 | 해당 없음 | PostgreSQL, Neo4j, pgvector |
-| MODEL 호출 | `Api`, `Provider` | `Model_client` (프로세스 기반, curl) |
-| 멀티에이전트 | `Orchestrator`, `Event_bus` | Rooms, broadcasts, scheduling, voting |
-| 계승 | `Handoff` (MODEL 결정) | `Succession` (컨텍스트 기반 DNA) |
-| 사회성 | 해당 없음 | Board, Lodge, Gardener, Sentinel |
-| 관찰 가능성 | `Event_bus`, `Raw_trace` | SSE, Dashboard, Prometheus |
+| 관심사 | OAS | MASC |
+|--------|-----|------|
+| 단일 에이전트 실행 | `Agent.run`, `Builder`, `Hooks`, `Guardrails`, `Memory`, `Checkpoint` | 언제/왜/어떤 agent를 돌릴지 결정 |
+| 멀티에이전트 실행 | `Orchestrator`, `Agent_sdk_swarm.Runner` | room, board, workflow, policies, operator surfaces |
+| 도구 실행 | `Tool.t`, hook lifecycle, raw trace | tool schema 정의, tool dispatch, auth/join/policy semantics |
+| 컨텍스트 축약 | `Context_reducer` | 어떤 전략을 언제 적용할지 결정 |
+| 이벤트 전달 | `Event_bus` | 어떤 MASC 사건을 custom event로 publish할지 정의, SSE/dashboard에 연결 |
+| 장기 메모리 프리미티브 | `Memory.t` tiers | institutional memory, pg/jsonl backends, room/task/social semantics |
+| 조율 상태 | 없음 | room, tasks, team sessions, governance, social runtime |
 
 ## 의존 방향
 
 ```
 MASC ──depends on──→ OAS
-MASC ──does NOT──→ modify OAS
-OAS  ──does NOT──→ know about MASC
+OAS  ──does not know──→ MASC
 ```
 
-- MASC는 OAS의 공개 API(`agent_sdk.mli`)만 사용한다.
-- OAS 내부 타입이 변경되면 MASC가 따라간다 (OAS 네이티브 타입 직접 사용).
-- OAS에 MASC 전용 기능을 추가하지 않는다.
+- MASC는 OAS 공개 API를 소비한다.
+- MASC 전용 요구가 생겨도, 먼저 MASC adapter/bridge로 해결 가능한지 본다.
+- OAS에 기능을 추가하더라도 MASC 전용 개념을 새 public contract로 밀어넣지 않는다.
 
-## 통합 로드맵
+## Current Integration Status
 
-| Phase | 내용 | OAS 모듈 | MASC 모듈 | 상태 |
-|-------|------|----------|-----------|------|
-| 1 | CI 복구 + 타입 호환 | `Types.tool_result` | `agent_swarm_*` | 완료 |
-| 2 | 경계 문서 | - | 이 문서 | 완료 |
-| 3 | Context 연결 | `Context.t`, `Context_reducer` | `Context_manager` | 진행 중 |
-| 4 | Event_bus 브리지 | `Event_bus.Custom` | `Oas_events` | 계획 |
-| 5 | Checkpoint 통합 | `Checkpoint`, `Checkpoint_store` | 인라인 (`perpetual_loop.ml` / `perpetual_oas.ml`) | 완료 |
+| Area | Status | Notes |
+|------|--------|-------|
+| Context compaction | Partial complete | `context_compact_oas.ml`는 OAS `Context_reducer`를 사용한다. MASC 전체 context system이 OAS `Context.t`로 통합된 것은 아니다. |
+| Event bus bridge | Complete for current `masc:*` flow | `oas_events.ml` publishes, `oas_sse_bridge.ml` relays to dashboard SSE |
+| Checkpoint integration | Real | OAS checkpoint is used in shared worker/runtime paths |
+| Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
+| Team-session swarm | Partial complete | OAS Swarm runner is active, but bridge fidelity is still incomplete |
 
-### Oas_compat 제거 (v2.95.1)
+## What This Means Practically
 
-`Oas_compat` 어댑터 모듈을 제거했다. OAS v0.24.0의 `tool_result` 타입을 MASC에서 직접 사용한다.
-production 코드에서 호출이 없었으므로 (re-export만 존재) 영향 범위는 테스트 코드에 한정되었다.
+- “Context integration in progress” now means **broader state unification**, not compaction.
+- “Event_bus bridge planned” is no longer true for the current dashboard/SSE path.
+- “team_session pending migration” is no longer true; the correct description is **running on OAS Swarm with an incomplete bridge**.
 
-## 결정 근거
+## Boundary Rules for Future Work
 
-| 결정 | 근거 |
-|------|------|
-| OAS Context를 Tier 1 저장소로 | 구조화된 scoped KV가 flat message list보다 상태 관리에 적합 |
-| Event_bus.Custom으로 소셜 이벤트 | OAS의 기존 pub/sub 인프라를 재사용, 커스텀 이벤트 확장 가능 |
-| Checkpoint으로 perpetual loop 상태 | 원자적 파일 저장/복원이 이미 구현되어 있음 |
-| Oas_compat 제거 | production 미사용 확인, OAS v0.24.0 네이티브 타입 직접 사용으로 전환 |
+1. If the problem is “single agent execution contract”, prefer fixing `oas_worker` / `worker_oas` / OAS-facing adapters.
+2. If the problem is “room, board, governance, operator, workflow semantics”, keep it in MASC.
+3. If a bridge is lossy, fix the MASC-side adapter first before proposing OAS API expansion.
+4. Do not claim a subsystem is “migrated” if the runtime path works but key semantics are still dropped.

--- a/docs/OAS-MIGRATION-NEXT-STEPS.md
+++ b/docs/OAS-MIGRATION-NEXT-STEPS.md
@@ -1,129 +1,103 @@
-# MASC→OAS Migration — Next Steps
+# MASC → OAS Migration Next Steps
 
-v2.119.0 기준. Phase 0-3 완료, Phase 2.7 + Phase 4 남음.
+Updated: 2026-03-21
+Scope: `masc-mcp` only
 
-## 완료된 작업 (v2.118.0)
+## Current Baseline
 
-| Phase | 내용 | PR |
-|-------|------|----|
-| 0 | 616파일 감사, 분류 (485/131), OAS Issues 8건, TRPG 아카이브 | #1668 |
-| 1 | oas_worker.ml 템플릿, tool_mitosis_oas(-68%), tool_council_oas(-70%), 25 tests | #1668 |
-| 2 | dashboard_proof(-71%), keeper_alerting(skill routing 분리), keeper_turn(-86%), schemas split, autoresearch split | #1683 |
-| 3 | Random.int 40→0(ID gen), Env_config 8개 외부화, silent default 18개 Log.debug | #1699 |
-| — | OAS dispatch switchover (mitosis + council → _oas 버전), message field fix | #1717 |
+The migration is no longer blocked on “move major subsystems to OAS”.
+The important migrations are already in place:
 
-## 현재 수치
+- keeper turn execution uses OAS runtime paths
+- verifier/council/mitosis/dashboard provider runs use OAS execution helpers
+- team-session execution goes through OAS Swarm
+- OAS Event_bus custom events already flow into dashboard SSE
+- context compaction already delegates to OAS `Context_reducer`
 
-| 지표 | 시작 | 현재 | 목표 |
-|------|------|------|------|
-| LOC | 218K | ~197K | <100K |
-| God files (850+) | 31 | ~26 | <10 |
-| Random.int (ID gen) | 40 | 0 | 0 |
+The remaining work is about **completeness and consolidation**, not broad adoption theater.
 
-## 남은 작업
+## Priority 1: Finish Team-Session Fidelity
 
-### 1. Gardener → OAS Worker 전환 (P1, 가장 긴급)
+The biggest remaining product gap is not whether team sessions use OAS Swarm.
+They do. The gap is that the bridge is still lossy.
 
-**문제**: Gardener가 keeper-style 에이전트를 스폰하지만, 스폰된 에이전트가 tool 없이 heartbeat만 보내는 좀비 상태.
-- `qa-harness-drift`: turns=0, model=none, cost=$0
-- `qa-ui-smoke`: turns=0, model=none, cost=$0
-- `qa-surface-consistency`: turns=0, model=none, cost=$0
+### What remains
 
-**해결**:
-```
-현재: Gardener → spawn Keeper → heartbeat loop → idle forever
-목표: Gardener → Oas_worker.run(goal, tools) → 실행 → 결과 → 종료
-```
+- preserve more `planned_worker` metadata in swarm entries
+- add real per-agent telemetry instead of `get_telemetry = None`
+- replace `convergence = None` with an explicit swarm convergence policy
+- replace `max_concurrent_agents = None` with a deliberate concurrency setting
+- decide whether session-level budget should remain `no_budget` or derive from MASC session settings
 
-**구현**:
-1. `lib/gardener/gardener_decisions.ml`에서 spawn 경로를 `Oas_worker.run_with_masc_tools`로 변경
-2. 1회성 worker는 goal 완료 후 자동 종료 (keeper loop 불필요)
-3. 필요 시 Gardener가 주기적으로 재스폰 (cron-style)
-4. OAS Event_bus로 결과를 dashboard에 전달
+### Success criteria
 
-**검증**: 스폰된 에이전트가 turns > 0, cost > 0이면 성공.
+- background swarm workers keep working after restart and can use real supported tools
+- operator/dashboard can inspect more than just final swarm success/failure
+- team-session bridge no longer describes itself as a heavily lossy projection
 
-### 2. P2.7: team_session → OAS Swarm (가장 큰 작업)
+## Priority 2: Finish Runtime Consolidation
 
-**규모**: 20파일, 9,984 LOC, 15개 외부 의존 모듈
+This pass reduced duplication, but one important path still remains outside the shared template.
 
-**3단계 접근**:
+### Done in this pass
 
-#### 단계 1: Types 공유 인터페이스
-- `team_session_types.ml` (652줄) + `team_session_types_enums.ml` (465줄)을 OAS Swarm과 호환되는 인터페이스로 정리
-- `Swarm_types.swarm_config`와 `Team_session_types.session_config`의 교집합 정의
+- dashboard provider single-run now routes through `Oas_worker.run_model`
+- initial local worker run now routes through `Worker_oas.run_worker_via_oas`
 
-#### 단계 2: Engine 교체
-- `team_session_engine_eio.ml` (723줄) → OAS `Swarm_runner.run` 위임
-- `team_session_engine_helpers.ml` (564줄) → OAS convergence loop
-- `team_session_engine_policy.ml` (426줄) → OAS agent selection strategy
-- `team_session_engine_status.ml` (560줄) → OAS Event_bus 기반 상태 추적
+### Still remaining
 
-#### 단계 3: Tool 어댑터
-- `tool_team_session_step.ml` (857줄) → `Oas_worker` 경유
-- `tool_team_session_routing.ml` (751줄) → OAS Swarm fiber 스케줄링
-- 나머지 8개 `tool_team_session_*.ml` 파일 정규화
+- local worker resume/continue path still directly resumes an OAS agent and manually handles run/checkpoint/output lifecycle
 
-**의존 모듈 업데이트**:
-- `swarm/swarm_status_parse.ml` — Team_session_types 참조
-- `operator/operator_control.ml` — team session 상태 조회
-- `dashboard/` — session 표시
-- `worker_oas.ml` — 이미 OAS adapter (확장점)
+### Success criteria
 
-### 3. Phase 3 잔여: 활성 도구 정규화
+- initial run and resume share the same execution contract for:
+  - guardrails
+  - trace capture
+  - checkpoint persistence
+  - completion logging
+  - cleanup on error
 
-**목표**: 활성 ~100개 도구를 `oas_worker` 경유로 표준화.
+## Priority 3: Keep the Memory Bridge Honest and Complete
 
-**접근**: 카테고리별 배치 (10개씩)
-1. Keeper 도구 (40개) — keeper_turn_msg_pipeline이 이미 OAS 경로 사용
-2. Lodge 도구 (21개) — deprecated, OAS worker로 전환 또는 제거
-3. Command Plane 도구 (16개) — CPv2 direct 경로 유지, OAS 래퍼
-4. Team Session 도구 (11개) — P2.7과 동시 진행
-5. Dashboard/Agent/Misc 도구 (나머지) — 개별 평가
+The old “5-tier” claim was misleading because episodic support was a no-op.
+That is now fixed for institution episodes.
 
-### 4. Phase 4: 정리 + 문서화
+### Done in this pass
 
-1. **미사용 모듈 최종 삭제**: `reports/migration-classification-*.tsv`의 "archive" 131개 중 미삭제 파일
-2. **전 public 모듈 .mli**: 현재 부분적 → 모든 public 모듈에 API 계약
-3. **L1/L2/L3 경계 ADR**: OAS(L1 Agent Runtime + L2 Swarm) vs MASC(L3 Coordination) 경계 문서화
-4. **벤치마크**: 빌드 시간, 바이너리 크기, LOC 최종 측정
+- episodic seed/flush are real
+- `episode_limit` is real
+- duplicate write-back is prevented by persisted-ID filtering
+- the underlying `Institution_eio.load_recent_episodes_jsonl` limit bug is fixed
 
-### 5. OAS 이슈 (jeong-sik/oas)
+### Still remaining
 
-| # | 우선순위 | 제목 | 상태 |
-|---|---------|------|------|
-| #197 | P1 | Checkpoint.t working_context | Open |
-| #198 | P1 | Hook Error variant | Open |
-| #199 | P2 | Event_bus topic subscription | Open |
-| #200 | P2 | Swarm resource constraint | Open |
-| #201 | P2 | message type convergence | Open |
-| #202 | P3 | Pluggable agent selection | Open |
-| #203 | P3 | Stateful tool pattern | Open |
-| #204 | P3 | Config externalization | Open |
+- broader memory unification is still not done
+- Working/Scratchpad remain intentionally runtime-only
+- other historical memory sources are not automatically projected into OAS memory
 
-P1 (#197, #198)은 workaround(이중 저장, Event_bus bridge)로 동작 중이지만, 근본 해결이 필요.
+### Success criteria
 
-## 실행 순서 권장
+- no OAS memory helper may claim support for a tier that is still stubbed
+- all supported tiers have tests that prove seed/flush/limit behavior
 
-```
-1. Gardener → OAS Worker (1-2일)     ← 가장 시급, 좀비 해소
-2. OAS P1 이슈 해결 (#197, #198)     ← Phase 4 전 필요
-3. P2.7 team_session 단계 1 (Types)  ← 1주
-4. P2.7 team_session 단계 2 (Engine) ← 2주
-5. P2.7 team_session 단계 3 (Tools)  ← 1주
-6. Phase 3 잔여 (도구 정규화)         ← 2주
-7. Phase 4 정리                       ← 1주
-```
+## Priority 4: Stop Reintroducing Documentation Drift
 
-## 핵심 파일 참조
+The following are now stale and should not reappear in migration docs:
 
-| 파일 | 역할 |
-|------|------|
-| `lib/oas_worker.ml` | OAS Agent 통합 템플릿 (200 LOC) |
-| `lib/tool_mitosis_oas.ml` | OAS 기반 mitosis (351 LOC) |
-| `lib/tool_council_oas.ml` | OAS 기반 council (321 LOC) |
-| `lib/mcp_server_eio_execute.ml:427-454` | Dispatch switchover 지점 |
-| `lib/gardener/gardener_decisions.ml` | Gardener spawn 로직 (전환 대상) |
-| `lib/worker_oas.ml` | OAS adapter (기존, 401 LOC) |
-| `reports/magic-numbers-audit.txt` | 매직넘버 감사 (~90건) |
-| `reports/silent-defaults-audit.txt` | Silent default 감사 (697건) |
+- Gardener as an active migration target
+- “Event_bus bridge planned”
+- “team_session still pending OAS migration”
+
+## Explicit Non-Priorities
+
+These are not the next best use of time unless a concrete product need appears:
+
+- broad “unused OAS modules” adoption
+- big-bang `Model_spec` retirement
+- upstream OAS issue work as part of this `masc-mcp` pass
+
+## Recommended Order
+
+1. team-session bridge fidelity and telemetry
+2. worker resume-path runtime consolidation
+3. follow-up memory/documentation cleanup

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -1,92 +1,84 @@
 # MASC-MCP OAS Utilization Audit
 
-Date: 2026-03-20
-OAS Version: v0.77.0
-MASC-MCP: main (624d9fcc5)
+Date: 2026-03-21
+Snapshot: `fix/oas-improvements` on top of `main`
 
-## OAS Adoption Score: 55/100
+## Current Read
 
-| Area | Max | Score | Evidence |
-|------|-----|-------|----------|
-| Agent.run lifecycle | 20 | 15 | 10+ files: perpetual_oas, oas_worker, worker_oas, keeper_agent_run |
-| Types/Provider/Builder | 15 | 12 | 66 files (11.8%) reference Agent_sdk/Oas |
-| Context_reducer | 10 | 8 | context_compact_oas.ml: 4 strategies mapped |
-| Event_bus | 8 | 5 | oas_events.ml: 14 event types, oas_sse_bridge subscribes |
-| Guardrails | 7 | 5 | AllowList/DenyList/AllowAll in 5+ files |
-| Memory 3-tier | 10 | 2 | long_term_backend only. Scratchpad/Working unmapped |
-| Swarm (lib_swarm) | 15 | 0 | 22 files (5,569 lines) fully independent |
-| Advanced modules | 15 | 8 | Collaboration, Sessions, Handoff adopted. 17+ unused |
+OAS adoption in `masc-mcp` is now structurally real, but still incomplete.
+The main remaining problems are no longer “missing migration” at large. They are:
 
-## Quantitative Metrics
+1. incomplete bridge fidelity,
+2. a few remaining duplicated runtime paths,
+3. stale docs that still describe already-removed or already-migrated systems.
 
-| Metric | Value |
-|--------|-------|
-| MASC lib/ .ml files | 560 |
-| MASC lib/ total lines | 190,889 |
-| OAS-referencing files | 66 (11.8%) |
-| Agent.run call sites | 14 files |
-| Cascade.call residual | 0 (archive 1) |
-| Model_spec coupled files | 39 |
-| OAS .mli modules (total) | 144 (lib/ 138 + lib_swarm/ 6) |
-| OAS modules used by MASC | ~20 |
-| OAS modules unused | 52+ |
+## Status by Area
 
-## Strengths
+| Area | Status | Evidence |
+|------|--------|----------|
+| Single-agent runtime | Strong | `oas_worker`, keeper turn path, verifier, council, mitosis, router/judge flows use `Agent.run` through OAS wrappers |
+| Context reduction | Real | `context_compact_oas.ml` delegates directly to OAS `Context_reducer` |
+| Event bus / SSE | Real | `oas_events.ml` publishes `masc:*` events and `oas_sse_bridge.ml` relays them to SSE |
+| Memory bridge | Partial but real | `memory_oas_bridge.ml` now seeds long-term, procedural, and episodic memory; Working/Scratchpad remain runtime-only |
+| Team session swarm | Partial but real | `team_session_swarm_runner.ml` runs through OAS Swarm and now receives a real supported-tool dispatch bundle |
+| Runtime dedupe | Improving | dashboard single-run and initial local worker run now reuse shared OAS execution helpers |
 
-1. **Cascade.call fully retired** — 0 in active code
-2. **Agent.run on critical path** — perpetual_oas, oas_worker, worker_oas, keeper_agent_run
-3. **Context_reducer integrated** — 4 compaction strategies mapped via context_compact_oas.ml
-4. **Event_bus connected** — 14 event types in oas_events.ml, oas_sse_bridge subscribes
-5. **Hook system structural** — perpetual_oas_hooks.ml: 4 lifecycle hooks
-6. **Clean adapter layer** — oas_type_adapters.ml (39 lines): Model_spec -> Provider.config
-7. **Perpetual architecture is sound** — Not a dual implementation; proper 3-layer separation (types/OAS adapter/MCP dispatcher)
+## What Changed In This Pass
 
-## Critical Gaps
+- `memory_oas_bridge` is no longer lying about episodic support.
+  - `seed_episodes` now loads recent institution episodes from `institution_episodes.jsonl`
+  - `flush_episodes` now writes new OAS episodes back without duplicating already-persisted IDs
+  - `create_memory_full` now honors `episode_limit`
+- `team_session` no longer launches OAS Swarm with `masc_tools=[]` and `no dispatch`.
+  - start/recovery paths now pass a real supported local-worker tool subset
+  - bridge dispatch auto-injects worker identity fields where needed
+  - heartbeat/tool dispatch can now work in background swarm workers
+- runtime duplication was reduced.
+  - dashboard provider single-run now uses `Oas_worker.run_model`
+  - initial local worker execution now uses `Worker_oas.run_worker_via_oas`
+- this work also exposed and fixed a real pre-existing bug:
+  - `Institution_eio.load_recent_episodes_jsonl` ignored `limit` when the log was larger than the requested window
 
-### Gap 1: Swarm subsystem independent — CRITICAL
+## Remaining Gaps
 
-- lib/swarm/ (11 files, 2,750 lines) + agent_swarm_*.ml (11 files, 2,819 lines) = 22 files, 5,569 lines
-- OAS lib_swarm/runner.mli provides 3-mode (Decentralized/Supervisor/Pipeline) + convergence loop
-- MASC swarm_eio.ml (617 lines), swarm_goal_loop.ml (347 lines): independent state machines
-- agent_swarm_swarm.ml uses Agent.run per-agent but not Runner for orchestration
-- MASC swarm has features beyond OAS Runner (pheromone, emergent intelligence, custom fitness)
+### 1. Team-session bridge is still lossy
 
-### Gap 2: verifier_oas.ml Provider bypass — FIXED (this PR)
+The bridge still throws away part of MASC session semantics:
 
-- Was: direct provider cascade call (lines 160-165)
-- Now: Oas_worker.run_named — OAS-only, cascade-aware, error-formatted
+- `planned_worker` metadata is only partially projected into swarm entries
+- `get_telemetry` remains `None`
+- `convergence` and `resource_check` are still unset
+- `budget` is still `no_budget`
 
-### Gap 3: Memory bridge incomplete — MEDIUM
+This means the runner is now tool-capable, but not yet fidelity-complete.
 
-- memory_oas_bridge.ml: long_term_backend only
-- Missing: Scratchpad (per-turn), Working (session), Episodic (decay/salience), Procedural (confidence)
-- MASC has all source data (memory_stream, context_manager, procedural_memory, institution_eio)
-- Only the OAS integration glue is missing
+### 2. Resume path still has its own direct OAS run logic
 
-### Gap 4: 52+ OAS modules unused — LOW-MEDIUM
+Direct OAS build/run sites now remain primarily in:
 
-Key unused modules with potential value:
-- progressive_tools.mli — 371-tool progressive disclosure
-- durable.mli — crash-recovery persistent workflows
-- plan.mli — goal decomposition/replanning
-- verified_output.mli — phantom-type compile-time output verification
-- trajectory.mli — structured Think/Act/Observe/Respond
-- cost_tracker.mli — model cost accounting
-- otel_tracer.mli — OpenTelemetry tracing
+- `oas_worker.ml`
+- `worker_oas.ml`
+- `local/worker_container_runners.ml` resume/continue path
 
-## Migration Priorities
+That is a much smaller surface than before, but the resume path still needs the same consolidation treatment as the initial run path.
 
-| Priority | Target | Effort | Status |
-|----------|--------|--------|--------|
-| P1 | verifier_oas.ml -> Oas_worker.run_named | 1 day | DONE (this PR) |
-| P2 | Memory 3-tier completion | 3-5 days | Planned |
-| P3 | Model_spec gradual retirement | 2-3 weeks | Incremental |
-| P4 | Swarm -> OAS lib_swarm bridge | 3-4 weeks | Needs design |
-| P5 | Advanced module selective adoption | Ongoing | Optional |
+### 3. Memory bridge scope is now honest, but not universal
 
-## Corrected Findings (vs initial plan)
+The episodic source of truth is `Institution_eio` JSONL.
+That is enough for current keeper/council/mitosis usage, but it does not mean every historical MASC memory source has been unified into OAS memory.
 
-1. **Perpetual Loop**: NOT a dual implementation. Proper 3-layer: Perpetual_loop (types) -> Perpetual_oas (OAS adapter) -> Tool_perpetual (MCP dispatcher). No code duplication.
-2. **Swarm lines**: 5,569 (not 8,149 as initially estimated)
-3. **OAS reference ratio**: 11.8% (66 files, not 62)
-4. **Score**: 55/100 (up from 52, corrected for perpetual loop proper architecture)
+### 4. Some older docs are still stale by implication
+
+The worst offenders were fixed in this pass, but any document still prioritizing:
+
+- Gardener migration
+- “Event_bus bridge planned”
+- “team_session is still pre-OAS”
+
+should be treated as outdated until refreshed.
+
+## Recommended Priorities
+
+1. Finish team-session bridge fidelity: telemetry, convergence/resource settings, and less-lossy worker/session projection.
+2. Collapse the local worker resume path onto the same shared OAS execution template used by initial runs.
+3. Keep docs synced to code after each OAS migration step; the documentation drift is currently more dangerous than the remaining missing code.

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -484,7 +484,7 @@ let run_system_prompt provider =
     "You are a single MASC dashboard run using provider %s. Answer directly, keep tool use disabled, and return only the final answer."
     provider
 
-let execute_single_agent_run ~sw ~provider ~model ~prompt =
+let execute_single_agent_run ~sw:_ ~provider ~model ~prompt =
   let label_result = provider_label_for_model provider model in
   match label_result with
   | Error _ as error -> error
@@ -498,30 +498,15 @@ let execute_single_agent_run ~sw ~provider ~model ~prompt =
                 (Printf.sprintf
                    "Provider '%s' is not runnable in dashboard single-agent mode"
                    provider)
-          | Some provider_cfg -> (
-              let net = Eio_context.get_net () in
-              let builder =
-                Oas.Builder.create ~net ~model:provider_cfg.model_id
-                |> Oas.Builder.with_name "dashboard-single-run"
-                |> Oas.Builder.with_description
-                     "Dashboard-triggered single-agent execution"
-                |> Oas.Builder.with_system_prompt (run_system_prompt provider)
-                |> Oas.Builder.with_max_turns 4
-                |> Oas.Builder.with_max_tokens 2048
-                |> Oas.Builder.with_temperature 0.2
-                |> Oas.Builder.with_provider provider_cfg
-              in
-              match Oas.Builder.build_safe builder with
-              | Error error -> Error (Oas.Error.to_string error)
-              | Ok agent ->
-                  Fun.protect
-                    ~finally:(fun () ->
-                      try Oas.Agent.close agent with close_exn ->
-                        Log.Misc.warn "agent close failed: %s" (Printexc.to_string close_exn))
-                    (fun () ->
-                      match Oas.Agent.run ~sw agent prompt with
-                      | Ok response -> Ok (response_text_of_api_response response)
-                      | Error error -> Error (Oas.Error.to_string error)) )))
+          | Some _provider_cfg -> (
+              match
+                Oas_worker.run_model ~model_spec:spec ~goal:prompt
+                  ~system_prompt:(run_system_prompt provider)
+                  ~max_turns:4 ~max_tokens:2048 ~temperature:0.2 ()
+              with
+              | Ok result ->
+                  Ok (response_text_of_api_response result.response)
+              | Error error -> Error error )))
 
 let start_run ~sw ~provider ~model_opt ~prompt =
   match resolve_provider_run_request ~provider ~model_opt ~prompt with

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -668,6 +668,8 @@ let load_recent_episodes_jsonl ~limit : episode list =
   if total <= limit then all
   else
     let rec drop n = function
-      | [] -> [] | _ when n <= 0 -> all | _ :: rest -> drop (n-1) rest
+      | [] -> []
+      | remaining when n <= 0 -> remaining
+      | _ :: rest -> drop (n - 1) rest
     in
     drop (total - limit) all

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -34,11 +34,6 @@ let run_worker_oas ~sw ~base_path ~worker_name
     match worker_auth_token ~base_path ~worker_name with
     | Error e -> Error e
     | Ok auth_token ->
-        let* net =
-          match Eio_context.get_net_opt () with
-          | Some net -> Ok net
-          | None -> Error "Eio net not initialized"
-        in
         let evidence_session_id =
           evidence_session_id_of_worker_run worker_run_id
         in
@@ -124,147 +119,48 @@ let run_worker_oas ~sw ~base_path ~worker_name
         let* () =
           save_worker_meta ~base_path ~team_session_id ~worker_name meta
         in
-        let heartbeat_cbs =
-          let interval = local_worker_heartbeat_interval_sec () in
-          if interval > 0 then
-            [ { Oas.Agent_types.interval_sec = float_of_int interval;
-                callback = (fun () ->
-                  match
-                    call_masc_tool ~sw ~auth_token ~session_id:mcp_session_id
-                      ~tool_name:"masc_heartbeat" ~args:(`Assoc [])
-                  with
-                  | Ok _ -> ()
-                  | Error e ->
-                      Log.LocalWorker.warn "heartbeat error for %s: %s"
-                        worker_name e) } ]
-          else []
+        let* mcp_tools =
+          build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
+            ~worker_name ~prompt ~allowed_tools
         in
-        Fun.protect
-          ~finally:(fun () ->
-            ignore
-              (leave_worker ~sw ~auth_token ~session_id:mcp_session_id
-                 ~worker_name))
-          (fun () ->
-          let _ =
-            match join_worker ~sw ~auth_token ~session_id:mcp_session_id
-                    ~worker_name with
-            | Ok _ -> ()
-            | Error e -> raise (Failure ("worker join failed: " ^ e))
-          in
-          let* mcp_tools =
-            build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
-              ~worker_name ~prompt ~allowed_tools
-          in
-          let mcp_tools =
-            List.map (Oas.Tool.with_defaults
-              [("agent_name", `String worker_name)]) mcp_tools
-          in
-          let* shell_tools =
-            build_local_shell_tools ~room_config ~worker_name ~execution_scope
-              ~workdir:workspace_path
-          in
-          let tools = mcp_tools @ shell_tools in
-          let* raw_trace =
-            match evidence_session_id with
-            | Some trace_session_id ->
-                Oas.Raw_trace.create_for_session
-                  ~session_root:(oas_trace_session_root ~base_path)
-                  ~session_id:trace_session_id ~agent_name:worker_name ()
-                |> Result.map_error Oas.Error.to_string
-            | None -> (
-                match team_session_id with
-                | Some trace_session_id ->
-                    Oas.Raw_trace.create_for_session
-                      ~session_root:(oas_trace_session_root ~base_path)
-                      ~session_id:trace_session_id ~agent_name:worker_name ()
-                    |> Result.map_error Oas.Error.to_string
-                | None ->
-                    Oas.Raw_trace.create ~session_id:mcp_session_id
-                      ~path:
-                        (worker_raw_trace_path ~base_path
-                           ~team_session_id
-                           ~worker_name)
-                      ()
-                    |> Result.map_error Oas.Error.to_string)
-          in
-          let tool_names_ref = ref [] in
-          let hooks =
-            {
-              Oas.Hooks.empty with
-              pre_tool_use =
-                Some
-                  (function
-                    | Oas.Hooks.PreToolUse { tool_name; _ } ->
-                        tool_names_ref := tool_name :: !tool_names_ref;
-                        Oas.Hooks.Continue
-                    | _ -> Oas.Hooks.Continue);
-            }
-          in
-          let gate_config =
-            Worker_oas.gate_config_of_execution_scope meta.execution_scope
-          in
-          let* agent =
-            Worker_oas.build_agent ~net ~meta ~model ~system_prompt ~tools
-              ~hooks ~raw_trace ~heartbeat_callbacks:heartbeat_cbs
-              ~gate_config ()
-          in
-          let result =
-            Oas.Agent.run ~sw agent prompt
-          in
-          let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
-          let checkpoint =
-            Oas.Agent.checkpoint ~session_id:mcp_session_id agent
-          in
-          let tool_names =
-            List.rev !tool_names_ref |> unique_preserve_order
-          in
-          let* () =
-            save_worker_checkpoint ~base_path ~team_session_id ~worker_name
-              checkpoint
-          in
-          let* () =
-            save_worker_meta ~base_path ~team_session_id ~worker_name
-              { meta with last_run_at = Some (Time_compat.now ()) }
-          in
-          materialize_direct_evidence ~base_path ~worker_name ~worker_run_id
-            ~meta ~prompt ~workspace_path ~agent ~raw_trace;
-          Oas.Agent.close agent;
-          match result with
-          | Ok response ->
-              let output =
-                response.content
-                |> List.filter_map (function
-                     | Oas.Types.Text text -> Some text
-                     | _ -> None)
-                |> String.concat "\n"
-              in
-              let* () =
-                append_worker_completion_log ~base_path ~team_session_id
-                  ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
-              in
-              Ok
-                {
-                  output;
-                  model_used =
-                    (if String.trim response.model <> "" then response.model
-                     else model.model_id);
-                  input_tokens = Some checkpoint.usage.total_input_tokens;
-                  output_tokens = Some checkpoint.usage.total_output_tokens;
-                  cost_usd = Some checkpoint.usage.estimated_cost_usd;
-                  tool_call_count = List.length tool_names;
-                  tool_names;
-                  session_id = mcp_session_id;
-                  raw_trace_run;
-                  api_response = Some response;
-                }
-          | Error err ->
-              let detail = Agent_sdk__Error.to_string err in
-              let* () =
-                append_worker_completion_log ~base_path ~team_session_id
-                  ~worker_name ~prompt ~tool_names ~status:"error"
-                  ~output:detail ~error:detail ()
-              in
-              Error detail)
+        let mcp_tools =
+          List.map (Oas.Tool.with_defaults
+            [("agent_name", `String worker_name)]) mcp_tools
+        in
+        let* shell_tools =
+          build_local_shell_tools ~room_config ~worker_name ~execution_scope
+            ~workdir:workspace_path
+        in
+        let tools = mcp_tools @ shell_tools in
+        let* raw_trace =
+          match evidence_session_id with
+          | Some trace_session_id ->
+              Oas.Raw_trace.create_for_session
+                ~session_root:(oas_trace_session_root ~base_path)
+                ~session_id:trace_session_id ~agent_name:worker_name ()
+              |> Result.map_error Oas.Error.to_string
+          | None -> (
+              match team_session_id with
+              | Some trace_session_id ->
+                  Oas.Raw_trace.create_for_session
+                    ~session_root:(oas_trace_session_root ~base_path)
+                    ~session_id:trace_session_id ~agent_name:worker_name ()
+                  |> Result.map_error Oas.Error.to_string
+              | None ->
+                  Oas.Raw_trace.create ~session_id:mcp_session_id
+                    ~path:
+                      (worker_raw_trace_path ~base_path
+                         ~team_session_id
+                         ~worker_name)
+                    ()
+                  |> Result.map_error Oas.Error.to_string)
+        in
+        let gate_config =
+          Worker_oas.gate_config_of_execution_scope meta.execution_scope
+        in
+        Worker_oas.run_worker_via_oas ~sw ~base_path ~meta ~model
+          ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
+          ?worker_run_id ()
 
 let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
     ~(team_session_id : string) ~(prompt : string) :

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -118,25 +118,175 @@ let seed_memory_bank ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(lim
   0
 
 (* ================================================================ *)
-(* Episodic tier: no-op (Memory_stream removed)                      *)
+(* Episodic tier: Institution_eio JSONL <-> OAS episodes            *)
 (* ================================================================ *)
+
+let default_episode_salience (episode : Institution_eio.episode) =
+  let base =
+    match episode.outcome with
+    | `Success -> 0.75
+    | `Failure -> 0.95
+    | `Partial -> 0.6
+  in
+  let learning_bonus =
+    min 0.15 (float_of_int (List.length episode.learnings) *. 0.03)
+  in
+  Float.min 1.0 (base +. learning_bonus)
+
+let oas_outcome_of_institution (episode : Institution_eio.episode) =
+  match episode.outcome with
+  | `Success -> Agent_sdk.Memory.Success episode.summary
+  | `Failure -> Agent_sdk.Memory.Failure episode.summary
+  | `Partial -> Agent_sdk.Memory.Neutral
+
+let metadata_string key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+
+let metadata_string_list key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`List values) ->
+      values
+      |> List.filter_map (function
+           | `String value when String.trim value <> "" -> Some value
+           | _ -> None)
+  | _ -> []
+
+let metadata_context key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`Assoc fields) ->
+      fields
+      |> List.filter_map (function
+           | k, `String value -> Some (k, value)
+           | _ -> None)
+  | _ -> []
+
+let metadata_float key metadata =
+  match List.assoc_opt key metadata with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | Some (`Intlit value) -> Some (float_of_string value)
+  | _ -> None
+
+let institution_outcome_to_string = function
+  | `Success -> "success"
+  | `Failure -> "failure"
+  | `Partial -> "partial"
+
+let institution_outcome_of_string = function
+  | "success" -> Some `Success
+  | "failure" -> Some `Failure
+  | "partial" -> Some `Partial
+  | _ -> None
+
+let oas_episode_of_institution (episode : Institution_eio.episode) :
+    Agent_sdk.Memory.episode =
+  {
+    id = episode.id;
+    timestamp = episode.timestamp;
+    participants = episode.participants;
+    action = episode.summary;
+    outcome = oas_outcome_of_institution episode;
+    salience = default_episode_salience episode;
+    metadata =
+      [
+        ("event_type", `String episode.event_type);
+        ("institution_summary", `String episode.summary);
+        ( "institution_outcome",
+          `String (institution_outcome_to_string episode.outcome) );
+        ( "learnings",
+          `List (List.map (fun learning -> `String learning) episode.learnings)
+        );
+        ( "context",
+          `Assoc
+            (List.map (fun (key, value) -> (key, `String value)) episode.context)
+        );
+        ("source", `String "institution_jsonl");
+      ];
+  }
+
+let institution_episode_of_oas ~(agent_name : string)
+    (episode : Agent_sdk.Memory.episode) : Institution_eio.episode =
+  let summary =
+    metadata_string "institution_summary" episode.metadata
+    |> Option.value ~default:episode.action
+  in
+  let event_type =
+    metadata_string "event_type" episode.metadata
+    |> Option.value ~default:"oas_memory"
+  in
+  let learnings = metadata_string_list "learnings" episode.metadata in
+  let context = metadata_context "context" episode.metadata in
+  let outcome =
+    match
+      Option.bind
+        (metadata_string "institution_outcome" episode.metadata)
+        institution_outcome_of_string
+    with
+    | Some preserved -> preserved
+    | None -> (
+        match episode.outcome with
+        | Agent_sdk.Memory.Success _ -> `Success
+        | Agent_sdk.Memory.Failure _ -> `Failure
+        | Agent_sdk.Memory.Neutral -> `Partial)
+  in
+  let participants =
+    if episode.participants <> [] then episode.participants
+    else [ agent_name ]
+  in
+  {
+    Institution_eio.id = episode.id;
+    timestamp =
+      metadata_float "timestamp" episode.metadata
+      |> Option.value ~default:episode.timestamp;
+    participants;
+    event_type;
+    summary;
+    outcome;
+    learnings;
+    context;
+  }
+
+let persisted_episode_ids () =
+  Institution_eio.load_recent_episodes_jsonl ~limit:max_int
+  |> List.fold_left
+       (fun seen (episode : Institution_eio.episode) ->
+         if List.mem episode.id seen then seen else episode.id :: seen)
+       []
 
 (** Pre-seed the Episodic tier.
 
-    No-op: Memory_stream has been removed.
-    Returns 0 (no episodes seeded). *)
+    Loads recent institution episodes from JSONL and projects them into
+    OAS episodic memory. *)
 let seed_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string)
     ~(limit : int) : int =
-  ignore (memory, agent_name, limit);
-  0
+  ignore agent_name;
+  let episodes = Institution_eio.load_recent_episodes_jsonl ~limit in
+  List.iter
+    (fun episode ->
+      Agent_sdk.Memory.store_episode memory (oas_episode_of_institution episode))
+    episodes;
+  List.length episodes
 
 (** Flush new OAS episodes.
 
-    No-op: Memory_stream has been removed.
-    Returns 0 (no episodes flushed). *)
+    Appends newly created OAS episodes to the institution JSONL store,
+    preserving IDs and institution metadata when present. *)
 let flush_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int =
-  ignore (memory, agent_name);
-  0
+  let persisted_ids = persisted_episode_ids () in
+  let path = Institution_eio.episodes_jsonl_path () in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Agent_sdk.Memory.recall_episodes memory ~limit:max_int ()
+  |> List.fold_left
+       (fun flushed (episode : Agent_sdk.Memory.episode) ->
+         if List.mem episode.id persisted_ids then flushed
+         else (
+           Fs_compat.append_jsonl path
+             (Institution_eio.episode_to_json
+                (institution_episode_of_oas ~agent_name episode));
+           flushed + 1))
+       0
 
 (* ================================================================ *)
 (* Procedural tier: Procedural_memory <-> OAS procedures            *)
@@ -236,21 +386,23 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
 
     Seeds:
     - Long_term: PostgreSQL via [Memory_pg] when available, no-op stubs otherwise
-    - Episodic: no-op (Memory_stream removed)
+    - Episodic: recent institution episodes from JSONL
     - Procedural: top [procedure_limit] crystallized procedures
     - Working/Scratchpad: empty (managed by OAS at runtime)
 
     Optionally seeds institution to Long_term if [config] is provided.
 
-    @param episode_limit default 50 (currently unused, kept for API compat)
+    @param episode_limit default 50
     @param procedure_limit default 20 *)
 let create_memory_full ~(agent_name : string)
     ?(session_id : string option)
     ?(config : Room_utils.config option)
     ?(episode_limit = 50) ?(procedure_limit = 20)
     () : Agent_sdk.Memory.t =
-  ignore episode_limit;
   let memory = create_memory ~agent_name ?session_id () in
+  let _episode_count =
+    seed_episodes ~memory ~agent_name ~limit:episode_limit
+  in
   (* Procedural tier *)
   let _proc_count =
     seed_procedures_as_oas ~memory ~agent_name ~limit:procedure_limit
@@ -266,7 +418,6 @@ let create_memory_full ~(agent_name : string)
 (** Flush all mutable tiers back to MASC persistent storage.
 
     Call after [Agent.run] completes to persist updated procedures.
-    Episodes are no longer flushed (Memory_stream removed).
     Returns [(episodes_flushed, procedures_flushed)]. *)
 let flush_all ~(memory : Agent_sdk.Memory.t) ~(agent_name : string)
     : int * int =

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -193,9 +193,12 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
        Running and accepts manual steps via masc_team_session_step. *)
     if session.planned_workers <> [] then
       Eio.Fiber.fork ~sw (fun () ->
+        let masc_tools = Team_session_oas_bridge.supported_local_worker_tools () in
         let result =
           Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-            ~session_id ~masc_tools:[] ~dispatch:(fun ~name:_ ~args:_ -> (false, "no dispatch"))
+            ~session_id ~masc_tools
+            ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
+              ~sw ~clock ~config)
         in
         match result with
         | Ok _session ->
@@ -677,10 +680,14 @@ let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
                     @ checkpoint_detail @ event_context));
               (* Phase C-2c: reconnect also uses swarm runner *)
               Eio.Fiber.fork ~sw (fun () ->
+                let masc_tools =
+                  Team_session_oas_bridge.supported_local_worker_tools ()
+                in
                 let result =
                   Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-                    ~session_id:session.session_id ~masc_tools:[]
-                    ~dispatch:(fun ~name:_ ~args:_ -> (false, "no dispatch"))
+                    ~session_id:session.session_id ~masc_tools
+                    ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
+                      ~sw ~clock ~config)
                 in
                 match result with
                 | Ok _s ->

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -10,6 +10,162 @@
 module Swarm = Agent_sdk_swarm
 module Oas = Agent_sdk
 
+let supported_local_worker_tool_names =
+  [
+    "masc_status";
+    "masc_tasks";
+    "masc_claim_next";
+    "masc_transition";
+    "masc_add_task";
+    "masc_heartbeat";
+    "masc_board_post";
+    "masc_board_list";
+    "masc_board_get";
+    "masc_board_comment";
+    "masc_board_vote";
+    "masc_board_search";
+    "masc_code_search";
+    "masc_code_symbols";
+    "masc_code_read";
+    "masc_worktree_create";
+    "masc_worktree_remove";
+    "masc_worktree_list";
+    "masc_run_init";
+    "masc_run_plan";
+    "masc_run_log";
+    "masc_run_deliverable";
+    "masc_run_get";
+    "masc_run_list";
+  ]
+
+let supported_local_worker_tools () =
+  match
+    Agent_tool_surfaces.local_worker_tool_schemas
+      ~names:supported_local_worker_tool_names ()
+  with
+  | Ok schemas -> schemas
+  | Error msg ->
+      failwith
+        (Printf.sprintf
+           "team_session_oas_bridge: failed to resolve worker tool schemas: %s"
+           msg)
+
+let add_string_field_if_missing key value fields =
+  if String.trim value = "" || List.mem_assoc key fields then fields
+  else (key, `String value) :: fields
+
+let normalize_tool_args ~tool_name ~(agent_name : string) (args : Yojson.Safe.t)
+    : Yojson.Safe.t =
+  match args with
+  | `Assoc fields ->
+      let fields = add_string_field_if_missing "agent_name" agent_name fields in
+      let fields =
+        match tool_name with
+        | "masc_board_post" | "masc_board_comment" ->
+            add_string_field_if_missing "author" agent_name fields
+        | "masc_board_vote" ->
+            add_string_field_if_missing "voter" agent_name fields
+        | _ -> fields
+      in
+      `Assoc fields
+  | _ -> args
+
+let string_field key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> None)
+  | _ -> None
+
+let result_of_option ~tool_name = function
+  | Some result -> result
+  | None ->
+      ( false,
+        Printf.sprintf "team-session OAS runtime does not support tool '%s'"
+          tool_name )
+
+let tool_requires_presence = function
+  | "masc_claim_next"
+  | "masc_transition"
+  | "masc_heartbeat"
+  | "masc_worktree_create"
+  | "masc_worktree_remove" ->
+      true
+  | _ -> false
+
+let ensure_agent_joined ~(config : Room.config) ~(agent_name : string) =
+  try
+    if not (Room.is_initialized config) then ignore (Room.init config ~agent_name:None);
+    let joined =
+      try Room.is_agent_joined config ~agent_name
+      with Sys_error _ | Not_found | Yojson.Json_error _ -> false
+    in
+    if not joined then ignore (Room.join config ~agent_name ~capabilities:[] ());
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
+
+let dispatch_supported_tool ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
+    ~(name : string) ~(args : Yojson.Safe.t) : bool * string =
+  let agent_name =
+    match string_field "agent_name" args with
+    | Some agent_name -> agent_name
+    | None ->
+        (match string_field "author" args with
+         | Some author -> author
+         | None -> "team-session-worker")
+  in
+  let dispatch_impl () =
+    match name with
+    | "masc_status" ->
+        result_of_option ~tool_name:name
+          (Tool_room.dispatch { Tool_room.config = config; agent_name } ~name
+             ~args)
+    | "masc_tasks" | "masc_claim_next" | "masc_transition" | "masc_add_task"
+      ->
+        result_of_option ~tool_name:name
+          (Tool_task.dispatch { Tool_task.config = config; agent_name } ~name
+             ~args)
+    | "masc_code_search" | "masc_code_symbols" | "masc_code_read" ->
+        result_of_option ~tool_name:name
+          (Tool_code.dispatch { Tool_code.config = config; agent_name } ~name
+             ~args)
+    | "masc_worktree_create" | "masc_worktree_remove" | "masc_worktree_list"
+      ->
+        result_of_option ~tool_name:name
+          (Tool_worktree.dispatch
+             { Tool_worktree.config = config; agent_name }
+             ~name
+             ~args)
+    | "masc_run_init" | "masc_run_plan" | "masc_run_log"
+    | "masc_run_deliverable" | "masc_run_get" | "masc_run_list" ->
+        result_of_option ~tool_name:name
+          (Tool_run.dispatch { Tool_run.config = config } ~name ~args)
+    | "masc_heartbeat" ->
+        result_of_option ~tool_name:name
+          (Tool_heartbeat.dispatch
+             { Tool_heartbeat.config = config; agent_name; sw; clock }
+             ~name ~args)
+    | "masc_board_post" | "masc_board_list" | "masc_board_get"
+    | "masc_board_comment" | "masc_board_vote" | "masc_board_search" ->
+        Tool_board.handle_tool name args
+    | _ ->
+        ( false,
+          Printf.sprintf "team-session OAS runtime does not support tool '%s'"
+            name )
+  in
+  if tool_requires_presence name then
+    match ensure_agent_joined ~config ~agent_name with
+    | Ok () -> dispatch_impl ()
+    | Error msg ->
+        ( false,
+          Printf.sprintf "failed to prepare room presence for %s: %s" agent_name
+            msg )
+  else
+    dispatch_impl ()
+
 (* ── Role mapping ──────────────────────────────────────────────── *)
 
 let role_of_worker_class : Team_session_types.worker_class option -> Swarm.Swarm_types.agent_role =
@@ -75,10 +231,15 @@ let planned_worker_to_entry
       (match pw.spawn_role with Some r -> r | None -> "execute")
   in
   let run ~sw:_ prompt =
+    let dispatch_with_defaults ~name:(tool_name : string) ~(args : Yojson.Safe.t)
+      =
+      dispatch ~name:tool_name
+        ~args:(normalize_tool_args ~tool_name ~agent_name:name args)
+    in
     match
       Oas_worker.run_named_with_masc_tools
         ~cascade_name ~goal:prompt ~system_prompt
-        ~masc_tools ~dispatch ~max_turns
+        ~masc_tools ~dispatch:dispatch_with_defaults ~max_turns
         ~temperature:0.3 ~max_tokens:4096 ()
     with
     | Ok result -> Ok result.response
@@ -119,7 +280,7 @@ let session_to_swarm_config
     max_agent_retries = 1;
     collaboration = Some collaboration;
     resource_check = None;
-    max_concurrent_agents = None }
+    max_concurrent_agents = Some (max 1 (List.length entries)) }
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)
 

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -4,6 +4,16 @@
 
 module Swarm = Agent_sdk_swarm
 
+val supported_local_worker_tools : unit -> Types.tool_schema list
+
+val dispatch_supported_tool :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  config:Room.config ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  bool * string
+
 val role_of_worker_class :
   Team_session_types.worker_class option -> Swarm.Swarm_types.agent_role
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -270,6 +270,7 @@ let run_worker_via_oas
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(raw_trace : Oas.Raw_trace.t)
+    ?(gate_config : Eval_gate.gate_config option)
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
   let ( let* ) = Result.bind in
@@ -302,7 +303,7 @@ let run_worker_via_oas
   in
   let* agent =
     build_agent ~net ~meta ~model ~system_prompt ~tools ~hooks
-      ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ()
+      ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ?gate_config ()
   in
   let* () =
     Worker_container.save_worker_meta ~base_path

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -18,6 +18,9 @@ module Oas = Agent_sdk
 let setup_tmp_dir () =
   let dir = Filename.temp_dir "masc_mem_test" "" in
   Unix.putenv "MASC_DATA_DIR" dir;
+  Unix.putenv "MASC_WORKSPACE_ROOT" dir;
+  Unix.putenv "ME_ROOT" dir;
+  Fs_compat.mkdir_p (Filename.concat dir ".masc");
   dir
 
 let cleanup_tmp_dir dir =
@@ -88,6 +91,23 @@ let test_create_memory_full_empty () =
   Alcotest.(check int) "working empty" 0 wk;
   Alcotest.(check int) "episodic empty (no data)" 0 ep;
   Alcotest.(check int) "procedural empty (no data)" 0 pr;
+  cleanup_tmp_dir dir
+
+let test_create_memory_full_seeds_recent_episodes () =
+  let dir = setup_tmp_dir () in
+  ignore
+    (Institution_eio.record_episode_jsonl
+       ~event_type:"team_session"
+       ~summary:"worker completed setup"
+       ~participants:["worker-a"]
+       ~outcome:`Success
+       ~learnings:["seeded into memory"]);
+  let memory =
+    Memory_oas_bridge.create_memory_full ~agent_name:"test-seeded"
+      ~episode_limit:5 ~procedure_limit:5 ()
+  in
+  let (_, _, ep, _, _) = Oas.Memory.stats memory in
+  Alcotest.(check int) "episodic seeded from jsonl" 1 ep;
   cleanup_tmp_dir dir
 
 let test_memory_scratchpad_lifecycle () =
@@ -265,7 +285,7 @@ let test_stats_all_tiers () =
   cleanup_tmp_dir dir
 
 (* ================================================================ *)
-(* No-op backend verification                                        *)
+(* JSONL backend + bridge verification                                *)
 (* ================================================================ *)
 
 let test_jsonl_backend_persist () =
@@ -293,18 +313,98 @@ let test_seed_memory_bank_noop () =
   Alcotest.(check int) "seed_memory_bank returns 0" 0 count;
   cleanup_tmp_dir dir
 
-let test_seed_episodes_noop () =
+let test_seed_episodes_loads_recent_jsonl () =
   let dir = setup_tmp_dir () in
+  let first =
+    Institution_eio.record_episode_jsonl
+      ~event_type:"keeper_turn"
+      ~summary:"keeper observed drift"
+      ~participants:["keeper-a"]
+      ~outcome:`Partial
+      ~learnings:["watch alert frequency"]
+  in
+  let second =
+    Institution_eio.record_episode_jsonl
+      ~event_type:"incident"
+      ~summary:"rollback completed"
+      ~participants:["keeper-b"; "operator"]
+      ~outcome:`Success
+      ~learnings:["rollback path healthy"]
+  in
   let memory = Memory_oas_bridge.create_memory ~agent_name:"test-ep-seed" () in
   let count = Memory_oas_bridge.seed_episodes ~memory ~agent_name:"test-ep-seed" ~limit:10 in
-  Alcotest.(check int) "seed_episodes returns 0" 0 count;
+  Alcotest.(check int) "seed_episodes loads both records" 2 count;
+  let recalled = Oas.Memory.recall_episodes memory ~limit:10 () in
+  let ids = List.map (fun (episode : Oas.Memory.episode) -> episode.id) recalled in
+  Alcotest.(check bool) "first episode present" true (List.mem first.id ids);
+  Alcotest.(check bool) "second episode present" true (List.mem second.id ids);
   cleanup_tmp_dir dir
 
-let test_flush_episodes_noop () =
+let test_seed_episodes_respects_limit () =
   let dir = setup_tmp_dir () in
+  ignore
+    (Institution_eio.record_episode_jsonl
+       ~event_type:"a"
+       ~summary:"episode-a"
+       ~participants:["agent-a"]
+       ~outcome:`Partial
+       ~learnings:[]);
+  ignore
+    (Institution_eio.record_episode_jsonl
+       ~event_type:"b"
+       ~summary:"episode-b"
+       ~participants:["agent-b"]
+       ~outcome:`Success
+       ~learnings:[]);
+  ignore
+    (Institution_eio.record_episode_jsonl
+       ~event_type:"c"
+       ~summary:"episode-c"
+       ~participants:["agent-c"]
+       ~outcome:`Failure
+       ~learnings:["inspect retry budget"]);
+  let memory = Memory_oas_bridge.create_memory ~agent_name:"test-ep-limit" () in
+  let count = Memory_oas_bridge.seed_episodes ~memory ~agent_name:"test-ep-limit" ~limit:2 in
+  Alcotest.(check int) "seed_episodes limit applied" 2 count;
+  let recalled = Oas.Memory.recall_episodes memory ~limit:10 () in
+  Alcotest.(check int) "only 2 episodes recalled" 2 (List.length recalled);
+  cleanup_tmp_dir dir
+
+let test_flush_episodes_appends_only_new_records () =
+  let dir = setup_tmp_dir () in
+  let existing =
+    Institution_eio.record_episode_jsonl
+      ~event_type:"existing"
+      ~summary:"already persisted"
+      ~participants:["keeper-existing"]
+      ~outcome:`Success
+      ~learnings:["persist once"]
+  in
   let memory = Memory_oas_bridge.create_memory ~agent_name:"test-ep-flush" () in
-  let count = Memory_oas_bridge.flush_episodes ~memory ~agent_name:"test-ep-flush" in
-  Alcotest.(check int) "flush_episodes returns 0" 0 count;
+  ignore (Memory_oas_bridge.seed_episodes ~memory ~agent_name:"test-ep-flush" ~limit:10);
+  Oas.Memory.store_episode memory
+    {
+      Oas.Memory.id = "new-episode-id";
+      timestamp = Unix.gettimeofday ();
+      participants = [];
+      action = "new episode from oas";
+      outcome = Oas.Memory.Success "completed";
+      salience = 0.88;
+      metadata =
+        [
+          ("event_type", `String "oas_memory");
+          ("institution_summary", `String "new episode from oas");
+          ("institution_outcome", `String "success");
+          ("learnings", `List [`String "written back to jsonl"]);
+          ("context", `Assoc [("source", `String "unit-test")]);
+        ];
+    };
+  let flushed = Memory_oas_bridge.flush_episodes ~memory ~agent_name:"test-ep-flush" in
+  Alcotest.(check int) "only new episodes flushed" 1 flushed;
+  let persisted = Institution_eio.load_recent_episodes_jsonl ~limit:10 in
+  let ids = List.map (fun (episode : Institution_eio.episode) -> episode.id) persisted in
+  Alcotest.(check bool) "existing record preserved" true (List.mem existing.id ids);
+  Alcotest.(check bool) "new record appended" true (List.mem "new-episode-id" ids);
   cleanup_tmp_dir dir
 
 (* ================================================================ *)
@@ -319,6 +419,8 @@ let () =
     ]);
     ("create_memory_full", [
       Alcotest.test_case "empty agent" `Quick test_create_memory_full_empty;
+      Alcotest.test_case "seeds recent episodes" `Quick
+        test_create_memory_full_seeds_recent_episodes;
     ]);
     ("scratchpad_working", [
       Alcotest.test_case "scratchpad lifecycle" `Quick test_memory_scratchpad_lifecycle;
@@ -341,7 +443,11 @@ let () =
       Alcotest.test_case "retrieve returns None" `Quick test_jsonl_backend_retrieve;
       Alcotest.test_case "query returns empty" `Quick test_jsonl_backend_query;
       Alcotest.test_case "seed_memory_bank noop" `Quick test_seed_memory_bank_noop;
-      Alcotest.test_case "seed_episodes noop" `Quick test_seed_episodes_noop;
-      Alcotest.test_case "flush_episodes noop" `Quick test_flush_episodes_noop;
+      Alcotest.test_case "seed_episodes loads recent jsonl" `Quick
+        test_seed_episodes_loads_recent_jsonl;
+      Alcotest.test_case "seed_episodes respects limit" `Quick
+        test_seed_episodes_respects_limit;
+      Alcotest.test_case "flush_episodes appends only new" `Quick
+        test_flush_episodes_appends_only_new_records;
     ]);
   ]

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -125,6 +125,54 @@ let test_cascade_empty_model_string () =
   Alcotest.(check string) "empty model falls through" "llama:qwen3.5" c
 
 (* ================================================================ *)
+(* Supported tool runtime tests                                     *)
+(* ================================================================ *)
+
+let test_supported_local_worker_tools_present () =
+  let schemas = Team_session_oas_bridge.supported_local_worker_tools () in
+  let names =
+    List.map (fun (schema : Types.tool_schema) -> schema.name) schemas
+  in
+  Alcotest.(check bool) "masc_status present" true
+    (List.mem "masc_status" names);
+  Alcotest.(check bool) "masc_code_read present" true
+    (List.mem "masc_code_read" names);
+  Alcotest.(check bool) "masc_run_init present" true
+    (List.mem "masc_run_init" names)
+
+let test_dispatch_supported_tool_status () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let tmp = Filename.temp_dir "masc-test" "" in
+  let config = Room.default_config tmp in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ok, message =
+    Team_session_oas_bridge.dispatch_supported_tool
+      ~sw ~clock:(Eio.Stdenv.clock env) ~config
+      ~name:"masc_status"
+      ~args:(`Assoc [("agent_name", `String "worker-status")])
+  in
+  Alcotest.(check bool) "status dispatch succeeded" true ok;
+  Alcotest.(check bool) "status payload non-empty" true
+    (String.length message > 0)
+
+let test_dispatch_supported_tool_heartbeat_autojoin () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let tmp = Filename.temp_dir "masc-test" "" in
+  let config = Room.default_config tmp in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ok, _message =
+    Team_session_oas_bridge.dispatch_supported_tool
+      ~sw ~clock:(Eio.Stdenv.clock env) ~config
+      ~name:"masc_heartbeat"
+      ~args:(`Assoc [("agent_name", `String "worker-heartbeat")])
+  in
+  Alcotest.(check bool) "heartbeat dispatch succeeded" true ok;
+  Alcotest.(check bool) "worker auto-joined" true
+    (Room.is_agent_joined config ~agent_name:"worker-heartbeat")
+
+(* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
 
@@ -161,5 +209,13 @@ let () =
         test_cascade_default;
       Alcotest.test_case "empty model string" `Quick
         test_cascade_empty_model_string;
+    ];
+    "supported_tools", [
+      Alcotest.test_case "schemas present" `Quick
+        test_supported_local_worker_tools_present;
+      Alcotest.test_case "status dispatch" `Quick
+        test_dispatch_supported_tool_status;
+      Alcotest.test_case "heartbeat autojoin" `Quick
+        test_dispatch_supported_tool_heartbeat_autojoin;
     ];
   ]


### PR DESCRIPTION
## Summary
- complete the OAS memory bridge for institution episodic memory
- enable real supported tool dispatch for team-session OAS Swarm runs
- reduce duplicated OAS runtime paths in worker/dashboard entry points
- re-baseline OAS migration and boundary docs to current code reality

## Verification
- dune build @check
- dune exec test/test_memory_oas_5tier.exe
- dune exec test/test_team_session_oas_bridge.exe
- dune exec test/test_team_session_swarm_runner.exe
- git diff --check