### PR TITLE
fix(dashboard): retry network errors + refresh data on SSE reconnect

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -165,6 +165,13 @@ function isRetryableError(err: unknown): boolean {
 
   if (!(err instanceof Error)) return false
   if (/timeout after \d+ms/i.test(err.message)) return true
+
+  // Network-level failures (server unreachable, connection reset, DNS failure).
+  // Browser fetch() throws TypeError on these — they are transient.
+  if (err instanceof TypeError && /failed to fetch|networkerror|load failed/i.test(err.message)) {
+    return true
+  }
+
   const parsedStatus = parseStatusFromMessage(err.message)
   return parsedStatus !== null && RETRYABLE_STATUS_CODES.has(parsedStatus)
 }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { route, navigate } from '../router'
-import { connected } from '../sse'
+import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot } from '../mission-store'
 import { roomTruthInitializing } from '../room-truth-store'
@@ -31,15 +31,29 @@ function lazyTabFallback(label: string) {
   return html`<div class="loading-indicator">${label} 불러오는 중...</div>`
 }
 
+function formatDisconnectDuration(): string {
+  const ts = lastDisconnectedAt.value
+  if (ts === 0) return ''
+  const sec = Math.round((Date.now() - ts) / 1000)
+  if (sec < 5) return ''
+  if (sec < 60) return ` (${sec}s)`
+  return ` (${Math.round(sec / 60)}m)`
+}
+
 export function ConnectionStatus() {
   const isConnected = connected.value
   const snap = missionSnapshot.value
   const attentionCount = snap?.attention_queue?.length ?? 0
+  const reconn = reconnectCount.value
+
+  const statusLabel = isConnected
+    ? reconn > 0 ? '재연결됨' : '연결됨'
+    : `재연결 중...${formatDisconnectDuration()}`
 
   return html`
     <div class="connection-status ${isConnected ? 'connected' : 'disconnected'}">
       <span class="status-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
-      <span class="status-text">${isConnected ? '연결됨' : '재연결 중...'}</span>
+      <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`
         <span
           class="event-count attention-badge"

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -5,7 +5,7 @@
 // and named handlers for events with custom logic (conditional hydration,
 // async imports, signal-only updates).
 
-import { lastEvent, connected } from './sse'
+import { lastEvent, connected, reconnectCount, lastDisconnectedAt } from './sse'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
@@ -15,7 +15,9 @@ import {
   refreshBoard,
   refreshMdal,
 } from './store'
+import { refreshRoomTruth } from './room-truth-store'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
+import { showToast } from './components/common/toast'
 
 // --- Refresh function registration (avoids circular imports) ---
 
@@ -149,9 +151,37 @@ async function handleGovernance(): Promise<void> {
   loadRuntimeParams()
 }
 
+// --- SSE reconnection handler ---
+
+function handleReconnect(): void {
+  const disconnectedMs = lastDisconnectedAt.value > 0
+    ? Date.now() - lastDisconnectedAt.value
+    : 0
+  const durationSec = Math.round(disconnectedMs / 1000)
+  const label = durationSec > 0 ? `${durationSec}초 단절 후 재연결됨` : '서버 연결 복구됨'
+  showToast(label, 'success', 3000)
+
+  // Refresh all data to recover events missed during disconnect
+  invalidateDashboardCache()
+  void refreshRoomTruth({ force: true })
+  refreshDashboard()
+  refreshExecution()
+  refreshBoard()
+  _refreshCommandPlaneFn?.()
+  _refreshOperatorFn?.()
+  _refreshMissionFn?.()
+}
+
 // --- SSE reaction setup ---
 
 export function setupSSEReaction(): () => void {
+  // Watch for reconnections (false -> true transitions)
+  const unsubReconnect = reconnectCount.subscribe(() => {
+    if (connected.value) {
+      handleReconnect()
+    }
+  })
+
   const unsubscribe = lastEvent.subscribe((event) => {
     if (!event) return
 
@@ -197,6 +227,7 @@ export function setupSSEReaction(): () => void {
 
   return () => {
     unsubscribe()
+    unsubReconnect()
     for (const key of Object.keys(_debounceTimers)) {
       clearTimeout(_debounceTimers[key])
       delete _debounceTimers[key]

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -22,6 +22,11 @@ export const eventCount = signal(0)
 export const lastEvent = signal<SSEEvent | null>(null)
 export const journal = signal<JournalEntry[]>([])
 
+/** Increments each time SSE reconnects after a disconnect. */
+export const reconnectCount = signal(0)
+/** Timestamp of last disconnect (0 = never disconnected). */
+export const lastDisconnectedAt = signal(0)
+
 // --- Session ID ---
 
 function getOrCreateSessionId(): string {
@@ -147,12 +152,19 @@ export function connectSSE(): void {
 
   es.onopen = () => {
     if (source !== es) return
+    const wasDisconnected = reconnectAttempts > 0
     reconnectAttempts = 0
     connected.value = true
+    if (wasDisconnected) {
+      reconnectCount.value++
+    }
   }
 
   es.onerror = () => {
     if (source !== es) return
+    if (connected.value) {
+      lastDisconnectedAt.value = Date.now()
+    }
     connected.value = false
     es.close()
     source = null


### PR DESCRIPTION
## Summary
- `TypeError: Failed to fetch` (네트워크 단절)를 retryable로 분류하여 자동 재시도
- SSE 재연결 시 놓친 이벤트를 복구하기 위해 전체 데이터 refresh (room-truth, execution, board, operator)
- 재연결 알림 toast + 단절 시간 표시

## Background
개밥먹기 중 keeper 대화 시 "Failed to fetch" 에러 발생, 서버 재시작 시 SSE 연결 끊김 후 데이터 갱신 없음.

## Changes
| File | Change |
|------|--------|
| `api/core.ts` | `isRetryableError()`에 네트워크 에러 패턴 추가 |
| `sse.ts` | `reconnectCount`, `lastDisconnectedAt` signal 추가 |
| `sse-store.ts` | 재연결 감지 → 전체 data refresh + toast |
| `dashboard-shell.ts` | 단절 시간 표시, 재연결 상태 라벨 |

## Test plan
- [ ] 서버 재시작 후 dashboard가 자동 재연결되고 데이터가 갱신되는지 확인
- [ ] 네트워크 단절 시뮬레이션 → "재연결 중... (Ns)" 표시 확인
- [ ] 재연결 후 toast "N초 단절 후 재연결됨" 표시 확인
- [ ] keeper 대화 중 fetch 실패 시 자동 재시도 확인

Generated with [Claude Code](https://claude.com/claude-code)