### PR TITLE
Normalize Supabase pooler PostgreSQL URLs

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -604,6 +604,13 @@ end = struct
   let caqti_error_to_masc err =
     OperationFailed (Caqti_error.show err)
 
+  let normalize_postgres_url url =
+    let uri = Uri.of_string url in
+    match Uri.host uri, Uri.port uri with
+    | Some host, Some 6543 when String.ends_with ~suffix:".pooler.supabase.com" host ->
+        Uri.to_string (Uri.with_port uri (Some 5432))
+    | _ -> url
+
   (* WARNING: create requires an Eio.Switch context!
      This is a blocking workaround - in production, create should be called
      within an Eio.Switch.run context. *)
@@ -621,7 +628,7 @@ end = struct
     match cfg.postgres_url with
     | None -> Error (ConnectionFailed "PostgreSQL URL not configured (set MASC_POSTGRES_URL)")
     | Some url ->
-        let uri = Uri.of_string url in
+        let uri = Uri.of_string (normalize_postgres_url url) in
         let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
           | Some s -> (try int_of_string s with _ -> 10)
           | None -> 10
@@ -654,7 +661,7 @@ end = struct
     match cfg.postgres_url with
     | None -> Error (ConnectionFailed "PostgreSQL URL not configured")
     | Some url ->
-        let uri = Uri.of_string url in
+        let uri = Uri.of_string (normalize_postgres_url url) in
         let pool_config = Caqti_pool_config.create ~max_size:1 () in
         match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
         | Error err -> Error (caqti_error_to_masc err)

--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -668,8 +668,15 @@ module Postgres = struct
   let caqti_error_to_masc err =
     IOError (Caqti_error.show err)
 
-  let create ~sw ~env ~url config =
+  let normalize_postgres_url url =
     let uri = Uri.of_string url in
+    match Uri.host uri, Uri.port uri with
+    | Some host, Some 6543 when String.ends_with ~suffix:".pooler.supabase.com" host ->
+        Uri.to_string (Uri.with_port uri (Some 5432))
+    | _ -> url
+
+  let create ~sw ~env ~url config =
+    let uri = Uri.of_string (normalize_postgres_url url) in
     let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
       | Some s -> (try int_of_string s with _ -> 10)
       | None -> 10

--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -93,7 +93,16 @@ let get_neo4j_url () =
   Sys.getenv_opt "RAILWAY_NEO4J_URL"
 
 let get_postgres_url () =
-  Sys.getenv_opt "DATABASE_URL"
+  let normalize_postgres_url url =
+    let uri = Uri.of_string url in
+    match Uri.host uri, Uri.port uri with
+    | Some host, Some 6543 when String.ends_with ~suffix:".pooler.supabase.com" host ->
+        Uri.to_string (Uri.with_port uri (Some 5432))
+    | _ -> url
+  in
+  match Sys.getenv_opt "DATABASE_URL" with
+  | Some url -> Some (normalize_postgres_url url)
+  | None -> None
 
 (** {1 Neo4j Operations} *)
 

--- a/lib/jiphyeon/archive.ml
+++ b/lib/jiphyeon/archive.ml
@@ -93,12 +93,20 @@ let get_neo4j_url () =
   Sys.getenv_opt "RAILWAY_NEO4J_URL"
 
 let get_postgres_url () =
+  let normalize_postgres_url url =
+    let uri = Uri.of_string url in
+    match Uri.host uri, Uri.port uri with
+    | Some host, Some 6543 when String.ends_with ~suffix:".pooler.supabase.com" host ->
+        Uri.to_string (Uri.with_port uri (Some 5432))
+    | _ -> url
+  in
   (* Try multiple env vars: DATABASE_URL, SUPABASE_DB_URL, SB_PG_URL *)
   match Sys.getenv_opt "DATABASE_URL" with
-  | Some url -> Some url
+  | Some url -> Some (normalize_postgres_url url)
   | None -> match Sys.getenv_opt "SUPABASE_DB_URL" with
-    | Some url -> Some url
-    | None -> Sys.getenv_opt "SB_PG_URL"
+    | Some url -> Some (normalize_postgres_url url)
+    | None ->
+        Option.map normalize_postgres_url (Sys.getenv_opt "SB_PG_URL")
 
 (** {1 Neo4j Operations} *)
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -114,12 +114,12 @@ let test_dashboard_component_split_contracts () =
   check bool "mission attention card exported from split file" true
     (file_contains_pattern "dashboard/src/components/mission-attention-card.ts"
        "export function AttentionCard");
-  check bool "swarm surface imports overview panel" true
+  check bool "swarm surface re-exports overview panel" true
     (file_contains_pattern "dashboard/src/components/command/swarm.ts"
-       "import { SwarmOverviewPanel } from './swarm-overview-panel'");
-  check bool "swarm surface imports live panels" true
+       "export { SwarmOverviewPanel } from './swarm-overview-panel'");
+  check bool "swarm surface re-exports live panels" true
     (file_contains_pattern "dashboard/src/components/command/swarm.ts"
-       "import { SwarmLivePanels } from './swarm-live-panels'");
+       "export { SwarmLivePanels } from './swarm-live-panels'");
   check bool "swarm overview panel exported from split file" true
     (file_contains_pattern "dashboard/src/components/command/swarm-overview-panel.ts"
        "export function SwarmOverviewPanel");
@@ -137,7 +137,19 @@ let test_dashboard_component_split_contracts () =
        "export function WarRoomHeroStrip");
   check bool "war room body exported from split file" true
     (file_contains_pattern "dashboard/src/components/command/war-room-body.ts"
-       "export function WarRoomBodyGrid")
+       "export function WarRoomBodyGrid");
+  check bool "backend normalizes postgres pooler url before connect" true
+    (file_contains_pattern "lib/backend.ml"
+       "pooler.supabase.com");
+  check bool "backend_eio normalizes postgres pooler url before connect" true
+    (file_contains_pattern "lib/backend_eio.ml"
+       "pooler.supabase.com");
+  check bool "council archive normalizes postgres url" true
+    (file_contains_pattern "lib/council/archive.ml"
+       "pooler.supabase.com");
+  check bool "jiphyeon archive normalizes postgres url" true
+    (file_contains_pattern "lib/jiphyeon/archive.ml"
+       "pooler.supabase.com")
 
 let () =
   run "ci_hardening_source"


### PR DESCRIPTION
## Summary
- normalize Supabase transaction-pooler PostgreSQL URLs to session-pooler `:5432` at every direct Caqti pool creation site
- stop council/jiphyeon archive helpers from using raw `DATABASE_URL` / `SUPABASE_DB_URL` / `SB_PG_URL` values
- refresh the source-guard expectation for the current `swarm.ts` re-export shape while pinning the new pooler normalization paths

## Testing
- `git diff --check`
- `dune exec --root . test/test_ci_hardening_source.exe`
- `dune exec --root . test/test_room_utils_coverage.exe`
- `dune build --root . test/test_council.exe bin/main_eio.exe`
- `./_build/default/test/test_council.exe`
