### PR TITLE
refactor(keeper): complete Dated_jsonl migration for keeper_status metrics

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -63,9 +63,12 @@ let handle_keeper_list ctx args : tool_result =
             let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
               compaction_policy_of_keeper m
             in
+	            let metrics_store = keeper_metrics_store ctx.config m.name in
 	            let metrics_path = keeper_metrics_path ctx.config m.name in
 	            let metrics_window_lines =
-	              read_file_tail_lines metrics_path ~max_bytes:120000 ~max_lines:120
+	              let dated = Dated_jsonl.read_recent_lines metrics_store 120 in
+	              if dated <> [] then dated
+	              else read_file_tail_lines metrics_path ~max_bytes:120000 ~max_lines:120
 	            in
 	            let last_metrics =
 	              match List.rev metrics_window_lines with
@@ -259,7 +262,8 @@ let handle_keeper_list ctx args : tool_result =
 	              ("memory_bank", memory_summary_to_json memory_bank_summary);
               ("storage_paths", `Assoc [
                 ("meta", `String (keeper_meta_path ctx.config m.name));
-                ("metrics", `String metrics_path);
+                ("metrics", `String (Dated_jsonl.base_dir metrics_store));
+                ("metrics_legacy", `String metrics_path);
                 ("memory_bank", `String (keeper_memory_bank_path ctx.config m.name));
                 ("policy", `String (keeper_policy_log_path ctx.config m.name));
                 ("feedback", `String (keeper_feedback_log_path ctx.config m.name));

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -352,7 +352,8 @@ let gc config ?(days=7) () =
    | Error e ->
        results := Printf.sprintf "⚠️ Backend pubsub cleanup failed: %s" (Backend.show_error e) :: !results);
 
-  (* 5. Cleanup orphan keeper sidecar files (.metrics.jsonl/.memory.jsonl without .json) *)
+  (* 5. Cleanup orphan keeper sidecar files (.metrics.jsonl/.memory.jsonl without .json)
+        and orphan date-split metrics directories (<name>/metrics/ without <name>.json) *)
   let keeper_orphan_count = ref 0 in
   let pk_dir = Filename.concat (Filename.concat config.base_path ".masc") "perpetual-keepers" in
   if Sys.file_exists pk_dir then begin
@@ -363,7 +364,7 @@ let gc config ?(days=7) () =
         Some (Filename.chop_suffix name ".json")
       else None
     ) entries in
-    (* Find and remove orphan sidecar files *)
+    (* Find and remove orphan legacy sidecar files *)
     List.iter (fun name ->
       (* Skip global files starting with _ (e.g. _alerts.jsonl) *)
       if String.length name > 0 && name.[0] <> '_' then begin
@@ -375,6 +376,37 @@ let gc config ?(days=7) () =
           if not (List.mem base active_keepers) then begin
             (try Sys.remove (Filename.concat pk_dir name)
              with Sys_error _ -> ());
+            incr keeper_orphan_count
+          end
+        end
+      end
+    ) entries;
+    (* Find and remove orphan date-split metrics directories *)
+    let rec rmdir_recursive path =
+      if Sys.file_exists path && Sys.is_directory path then begin
+        Array.iter (fun child ->
+          let child_path = Filename.concat path child in
+          if Sys.is_directory child_path then rmdir_recursive child_path
+          else (try Sys.remove child_path with Sys_error _ -> ())
+        ) (Sys.readdir path);
+        (try Unix.rmdir path with Unix.Unix_error _ -> ())
+      end
+    in
+    List.iter (fun name ->
+      if String.length name > 0 && name.[0] <> '_'
+         && not (Filename.check_suffix name ".json")
+         && not (Filename.check_suffix name ".jsonl") then begin
+        let dir_path = Filename.concat pk_dir name in
+        if Sys.file_exists dir_path && Sys.is_directory dir_path then begin
+          let metrics_dir = Filename.concat dir_path "metrics" in
+          if not (List.mem name active_keepers)
+             && Sys.file_exists metrics_dir && Sys.is_directory metrics_dir then begin
+            rmdir_recursive metrics_dir;
+            (* Remove the keeper dir itself if now empty *)
+            (try
+               if Array.length (Sys.readdir dir_path) = 0 then
+                 Unix.rmdir dir_path
+             with Sys_error _ | Unix.Unix_error _ -> ());
             incr keeper_orphan_count
           end
         end


### PR DESCRIPTION
## Summary

- `keeper_status.ml`의 마지막 legacy-only metrics reader를 `Dated_jsonl.read_recent_lines` + legacy fallback 패턴으로 전환
- `room_gc.ml` orphan cleanup에 date-split metrics 디렉토리(`<name>/metrics/YYYY-MM/DD.jsonl`) 정리 추가
- `storage_paths` 출력에 date-split 경로를 primary로, legacy 경로를 `metrics_legacy`로 분리

## Context

`.masc/perpetual-keepers/*.metrics.jsonl` 단일 파일(합계 ~29.5MB)에서 `Dated_jsonl` date-split으로의 migration이 진행 중이었으나, `keeper_status.ml`만 legacy reader를 유지하고 있었습니다. 이 PR로 모든 keeper metrics reader가 date-split을 우선 사용하게 됩니다.

### Migration 상태 (이 PR 이후 모두 완료)

| 파일 | Writer | Reader | 상태 |
|------|--------|--------|------|
| `keeper_keepalive.ml` | `Dated_jsonl.append` | - | 이전에 완료 |
| `keeper_status_detail.ml` | - | date-split + fallback | 이전에 완료 |
| `dashboard_http_keeper.ml` | - | date-split + fallback | 이전에 완료 |
| `operator_control_snapshot.ml` | - | date-split + fallback | 이전에 완료 |
| **`keeper_status.ml`** | - | **date-split + fallback** | **이 PR** |

## Test plan

- [x] `dune build --root .` 성공
- [x] `test/test_dated_jsonl.exe` 11/11 PASS
- [x] `make test` — 기존 pre-existing failure(`dispatch_gc` Eio context)만 발생, 새 실패 없음
- [ ] 라이브 keeper 실행 후 `masc_keeper_status --detailed` 응답에 `metrics` 경로가 date-split 디렉토리를 가리키는지 확인