### PR TITLE
feat(keeper): enable voice tools for all keepers

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -41,6 +41,7 @@ let allowed_tools_for_autonomy_level
     "keeper_memory_search";
     "keeper_time_now"; "keeper_context_status";
     "extend_turns";
+    "keeper_voice_speak"; "keeper_voice_agent";
   ] in
   match String.lowercase_ascii (String.trim level) with
   | "l4_autonomous" -> Some ("keeper_bash" :: base_safe)


### PR DESCRIPTION
## Summary
- `keeper_voice_speak`, `keeper_voice_agent`를 `base_safe` autonomy allowlist에 추가
- L1-L3 keeper가 proactive turn에서 ElevenLabs TTS로 음성 출력 가능

## Background
Voice tool은 이미 구현되어 있었지만 (`keeper_exec_tools.ml`, `voice_bridge_eio.ml`), autonomy gate의 `base_safe` 목록에 없어서 L1-L3 keeper가 사용 불가.

`voice_config.json` 존재 시 `default_voice_enabled_for`가 `true` 반환하여 tool 목록에는 포함되지만, `keeper_hooks_oas.ml`의 allowlist에서 차단됨.

## Changes
| File | Change |
|------|--------|
| `keeper_hooks_oas.ml` | `base_safe`에 `keeper_voice_speak`, `keeper_voice_agent` 추가 (+1 line) |

## What is NOT changed
- `keeper_voice_sessions`, `session_start`, `session_end`는 voice MCP server 의존이므로 base_safe 제외
- `keeper_voice_speak`는 HTTP direct (ElevenLabs API)로 동작하여 세션 서버 없이도 사용 가능

## Test plan
- [ ] `dune build` 통과 확인
- [ ] 서버 재시작 후 keeper가 `keeper_voice_speak` tool 호출 가능 확인
- [ ] ElevenLabs API key 설정 확인 (`ELEVENLABS_API_KEY` in env)
- [ ] keeper proactive turn에서 voice tool이 tool 목록에 포함되는지 확인

Generated with [Claude Code](https://claude.com/claude-code)