### PR TITLE
fix(keeper): align storage_paths.metrics in status_detail

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -519,7 +519,8 @@ let handle_keeper_status ctx args : tool_result =
            ("compaction_history_count", `Int (snd compaction_history_tail));
            ("storage_paths", `Assoc [
              ("meta", `String (keeper_meta_path ctx.config m.name));
-             ("metrics", `String metrics_path);
+             ("metrics", `String (Dated_jsonl.base_dir metrics_store));
+             ("metrics_legacy", `String metrics_path);
              ("memory_bank", `String memory_bank_path);
              ("policy", `String (keeper_policy_log_path ctx.config m.name));
              ("feedback", `String (keeper_feedback_log_path ctx.config m.name));


### PR DESCRIPTION
## Summary

- `keeper_status_detail.ml`의 `storage_paths.metrics`를 `keeper_status.ml`(#2065)과 동일하게 date-split 디렉토리 경로로 변경
- legacy 파일 경로는 `metrics_legacy` 키로 보존

## Context

#2065 머지 후 `keeper_status.ml`은 `Dated_jsonl.base_dir`을 primary metrics 경로로 노출하지만, `keeper_status_detail.ml`은 여전히 legacy 단일 파일 경로를 노출하고 있었습니다.

## Test plan

- [x] `dune build --root .` 성공
- [x] 1 file, 2 lines changed — 단순 일관성 수정