### PR TITLE
refactor(dashboard): remove semantic layer UI + judgment panels

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -5,8 +5,6 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { route, initRouter } from './router'
 import { connectSSE, disconnectSSE } from './sse'
-import { dashboardSemantics } from './store'
-import { fetchDashboardSemantics } from './api'
 import { refreshRoomTruth } from './room-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForTab } from './tab-refresh'
@@ -34,11 +32,6 @@ export function App() {
     // Removed redundant refreshShell(), refreshExecution(), refreshMissionSnapshot()
     // that caused 5 concurrent API calls (server computes same data 3-6x).
     refreshRoomTruth()
-
-    // Semantics: static data, fetch once and cache forever.
-    void fetchDashboardSemantics()
-      .then(data => { dashboardSemantics.value = data })
-      .catch(err => { console.warn('Semantics load failed (non-critical):', err) })
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.

--- a/dashboard/src/components/common/semantic-layer.ts
+++ b/dashboard/src/components/common/semantic-layer.ts
@@ -1,74 +1,12 @@
-import { html } from 'htm/preact'
-import type {
-  DashboardSemanticMetric,
-  DashboardSemanticPanel,
-} from '../../types'
-import {
-  findDashboardSemanticPanel,
-} from '../../store'
+// Semantic layer panels removed from dashboard UI.
+// This metadata is for AI agents and belongs in tool descriptions,
+// not in the human-facing operator dashboard.
+// Keeping the export signature so 71 call sites don't need changes.
 
-function SemanticMetricRow({ metric }: { metric: DashboardSemanticMetric }) {
-  return html`
-    <article class="semantic-metric-row">
-      <div class="semantic-metric-head">
-        <strong>${metric.label}</strong>
-        <span class="semantic-code">${metric.id}</span>
-      </div>
-      <p>${metric.what_it_measures}</p>
-      <div class="semantic-grid compact">
-        <span>이유</span><span>${metric.why_it_exists}</span>
-        <span>근거 경로</span><span>${metric.source_path}</span>
-        <span>갱신 조건</span><span>${metric.update_trigger}</span>
-        <span>에이전트 영향</span><span>${metric.agent_behavior_effect}</span>
-        <span>생태계 영향</span><span>${metric.ecosystem_effect}</span>
-        <span>해석</span><span>${metric.interpretation}</span>
-        <span>나쁜 냄새</span><span>${metric.bad_smell}</span>
-        <span>다음 액션</span><span>${metric.next_action}</span>
-      </div>
-    </article>
-  `
-}
-
-function SemanticPanelBody({ panel }: { panel: DashboardSemanticPanel }) {
-  return html`
-    <div class="semantic-body">
-      <div class="semantic-grid">
-        <span>목적</span><span>${panel.purpose}</span>
-        <span>무엇을 푸나</span><span>${panel.problem_solved}</span>
-        <span>언제 보나</span><span>${panel.when_active}</span>
-        <span>에이전트 역할</span><span>${panel.agent_role}</span>
-        <span>생태계 기능</span><span>${panel.ecosystem_function}</span>
-      </div>
-      ${panel.related_tools.length > 0
-        ? html`<div class="semantic-tag-row">
-            ${panel.related_tools.map(tool => html`<span class="semantic-tag">${tool}</span>`)}
-          </div>`
-        : null}
-      ${panel.metrics.length > 0
-        ? html`<div class="semantic-metric-list">
-            ${panel.metrics.map(metric => html`<${SemanticMetricRow} key=${metric.id} metric=${metric} />`)}
-          </div>`
-        : null}
-    </div>
-  `
-}
-
-export function PanelSemanticDetails({
-  panelId,
-  compact = false,
-  label = '의미 계층',
-}: {
+export function PanelSemanticDetails(_props: {
   panelId: string
   compact?: boolean
   label?: string
 }) {
-  const panel = findDashboardSemanticPanel(panelId)
-  if (!panel) return null
-  return html`
-    <details class="semantic-inline ${compact ? 'compact' : ''}">
-      <summary class="semantic-summary">${label}</summary>
-      <${SemanticPanelBody} panel=${panel} />
-    </details>
-  `
+  return null
 }
-

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -24,7 +24,6 @@ import {
 import {
   MissionContextBar,
   SummaryStat,
-  MissionBriefingCard,
   AttentionCard,
   SessionBriefCard,
   SessionDetailCard,
@@ -281,25 +280,14 @@ export function Mission() {
         <//>
       </details>
 
-      <div class="mission-human-grid">
-        <${MissionBriefingCard} />
-
-        <${Card} title="운영 보조 진단" class="mission-list-card" semanticId="mission.internal_signals">
-          <div class="mission-section-head">
-            <h3>시스템 진단</h3>
-            <p>artifact scope drift 같은 내부 신호는 사회 흐름을 읽은 뒤에만 참고하도록 아래 보조 면으로 둡니다.</p>
-            <${ProvenanceStrip} items=${[{ kind: 'derived' }]} />
+      ${internalSignals.length > 0 ? html`
+        <details class="mission-card-disclosure" style="margin-top: 12px;">
+          <summary>내부 신호 ${internalSignals.length}</summary>
+          <div class="mission-list-stack">
+            ${internalSignals.map(item => html`<${InternalSignalCard} key=${item.id} item=${item} />`)}
           </div>
-          <details class="mission-card-disclosure">
-            <summary>내부 신호 ${internalSignals.length}</summary>
-            <div class="mission-list-stack">
-              ${internalSignals.length > 0
-                ? internalSignals.map(item => html`<${InternalSignalCard} key=${item.id} item=${item} />`)
-                : html`<div class="empty-state">지금은 내부 진단 경고가 없습니다.</div>`}
-            </div>
-          </details>
-        <//>
-      </div>
+        </details>
+      ` : null}
     </section>
   `
 }


### PR DESCRIPTION
## Summary
- 대시보드에서 "의미 계층" 버튼 71개 비활성화 (PanelSemanticDetails -> return null)
- "판단 레이어" 패널 제거 (MissionBriefingCard)
- "운영 보조 진단" 패널 제거 (내부 신호는 접이식으로 유지)
- semantics API fetch 제거 (앱 초기화 시 불필요한 네트워크 호출 1건 제거)

## Rationale
semantic layer 정보는 AI 에이전트용 메타데이터. tool description과 CLAUDE.md에 이미 존재.
인간 운영자 대시보드에 렌더링하면 시각적 노이즈만 추가.

## Test plan
- [ ] `npm run build` 통과
- [ ] sessions 페이지에서 "판단 레이어" / "운영 보조 진단" 패널 사라짐 확인
- [ ] 각 패널의 "의미 계층" 버튼이 더 이상 표시되지 않음 확인
- [ ] 내부 신호가 있을 때 접이식 패널로 표시됨 확인

Generated with [Claude Code](https://claude.com/claude-code)