### PR TITLE
fix: guard Eio.Cancel.Cancelled in _eio exception handlers

### DIFF
--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -65,7 +65,8 @@ module FileSystem = struct
     let path = Eio.Path.(fs / config.base_path) in
     (* Ensure base directory exists *)
     (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 path
-     with e -> Eio.traceln "[WARN] mkdirs base failed: %s" (Printexc.to_string e));
+     with Eio.Cancel.Cancelled _ as e -> raise e
+        | e -> Eio.traceln "[WARN] mkdirs base failed: %s" (Printexc.to_string e));
     {
       config;
       fs = path;
@@ -152,7 +153,8 @@ module FileSystem = struct
             (match Eio.Path.split path with
              | Some (parent, _) ->
                  (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                  with e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                  with Eio.Cancel.Cancelled _ as e -> raise e
+                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
              | None -> ());
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
             let compressed = Compression.compress_with_header value in
@@ -231,7 +233,8 @@ module FileSystem = struct
                 (match Eio.Path.split path with
                  | Some (parent, _) ->
                      (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                      with e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                      with Eio.Cancel.Cancelled _ as e -> raise e
+                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
                  | None -> ());
                 (* Write with exclusive create *)
                 Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
@@ -293,7 +296,9 @@ module FileSystem = struct
       | Some owner, Some acquired_at, Some expires_at ->
           Some { owner; acquired_at; expires_at }
       | _ -> None
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.Misc.error "parse_lock_info failed: %s" (Printexc.to_string e);
       None
 
@@ -372,7 +377,8 @@ module FileSystem = struct
           (match Eio.Path.split path with
            | Some (parent, _) ->
                (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                with e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                with Eio.Cancel.Cancelled _ as e -> raise e
+                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
            | None -> ());
 
           (* Get the actual filesystem path string *)
@@ -458,7 +464,8 @@ module FileSystem = struct
           (match Eio.Path.split path with
            | Some (parent, _) ->
                (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                with e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                with Eio.Cancel.Cancelled _ as e -> raise e
+                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
            | None -> ());
 
           let path_str = Eio.Path.native_exn path in

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -201,8 +201,9 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
         try
           Fs_compat.save_file path content;
           Ok entry
-        with e ->
-          Error (Printexc.to_string e)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | e -> Error (Printexc.to_string e)
       end
     end else begin
       let now = Time_compat.now () in
@@ -214,8 +215,9 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
       try
         Fs_compat.save_file path content;
         Ok entry
-      with e ->
-        Error (Printexc.to_string e)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Printexc.to_string e)
     end
   end
 
@@ -244,8 +246,9 @@ let get config ~key : (cache_entry option, string) result =
           Ok (Some entry)
         end
       | None -> Ok None
-    with e ->
-      Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
 (** Delete cache entry - synchronous *)
 let delete config ~key : (bool, string) result =
@@ -256,8 +259,9 @@ let delete config ~key : (bool, string) result =
     try
       Sys.remove path;
       Ok true
-    with e ->
-      Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
 (** List all cache entries - synchronous *)
 let list config ?(tag : string option) () : cache_entry list =
@@ -310,8 +314,9 @@ let clear config : (int, string) result =
         end else acc
       ) 0 entries in
       Ok count
-    with e ->
-      Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
 (** Get cache statistics - synchronous *)
 let stats config : (int * int * float, string) result =
@@ -341,8 +346,9 @@ let stats config : (int * int * float, string) result =
         else (t, e, s)
       ) (0, 0, 0.0) entries in
       Ok (total, expired, size)
-    with e ->
-      Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
 (** Format stats for display *)
 let format_stats (total, expired, size) =

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -51,7 +51,9 @@ let error_entry_of_yojson json =
     let context = json |> member "context" |> to_string_option in
     let resolved = json |> member "resolved" |> to_bool in
     Ok { timestamp; error_type; message; context; resolved }
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let planning_context_to_yojson ctx =
   `Assoc [
@@ -83,7 +85,9 @@ let planning_context_of_yojson json =
     let created_at = json |> member "created_at" |> to_string in
     let updated_at = json |> member "updated_at" |> to_string in
     Ok { task_id; task_plan; notes; errors; deliverable; created_at; updated_at }
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (* ===== Utility Functions ===== *)
 
@@ -147,7 +151,9 @@ let init (config : Room.config) ~task_id : (planning_context, string) result =
     let json = planning_context_to_yojson ctx in
     write_file_content (Filename.concat dir "context.json") (Yojson.Safe.pretty_to_string json);
     Ok ctx
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Load planning context *)
 let load (config : Room.config) ~task_id : (planning_context, string) result =
@@ -161,7 +167,9 @@ let load (config : Room.config) ~task_id : (planning_context, string) result =
       let json = Yojson.Safe.from_string content in
       planning_context_of_yojson json
     end
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Update task plan *)
 let update_plan (config : Room.config) ~task_id ~content : (planning_context, string) result =
@@ -175,7 +183,9 @@ let update_plan (config : Room.config) ~task_id ~content : (planning_context, st
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Add note *)
 let add_note (config : Room.config) ~task_id ~note : (planning_context, string) result =
@@ -197,7 +207,9 @@ let add_note (config : Room.config) ~task_id ~note : (planning_context, string) 
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Add error - PDCA Check phase. Auto-creates planning context if none exists. *)
 let add_error (config : Room.config) ~task_id ~error_type ~message ?context () : (planning_context, string) result =
@@ -232,7 +244,9 @@ let add_error (config : Room.config) ~task_id ~error_type ~message ?context () :
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Mark error as resolved *)
 let resolve_error (config : Room.config) ~task_id ~index : (planning_context, string) result =
@@ -252,7 +266,9 @@ let resolve_error (config : Room.config) ~task_id ~index : (planning_context, st
             (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
           Ok updated
         end
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Set deliverable. Auto-creates planning context if none exists. *)
 let set_deliverable (config : Room.config) ~task_id ~content : (planning_context, string) result =
@@ -272,7 +288,9 @@ let set_deliverable (config : Room.config) ~task_id ~content : (planning_context
         write_file_content (Filename.concat dir "context.json")
           (Yojson.Safe.pretty_to_string (planning_context_to_yojson updated));
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (* ===== Session-level Context ===== *)
 

--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -233,8 +233,9 @@ let room_state_of_json json =
       paused_at = json |> member "paused_at" |> to_float_option;
       pause_reason = json |> member "pause_reason" |> to_string_option;
     }
-  with e ->
-    Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Read room state *)
 let read_state config =
@@ -243,7 +244,7 @@ let read_state config =
       (try
         let json = Yojson.Safe.from_string json_str in
         room_state_of_json json
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend_eio.NotFound _) ->
       Ok (default_room_state ())
   | Error e ->
@@ -286,7 +287,7 @@ let atomic_update_state config ~f =
       (try
         let json = Yojson.Safe.from_string json_str in
         room_state_of_json json
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error e ->
       Error (match e with
         | Backend_eio.IOError msg -> msg
@@ -313,8 +314,9 @@ let agent_state_of_json json =
       capabilities = json |> member "capabilities" |> to_list |> List.map to_string;
       status = json |> member "status" |> to_string;
     }
-  with e ->
-    Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Register agent or update heartbeat
 
@@ -376,7 +378,7 @@ let get_agent config ~name =
       (try
         let json = Yojson.Safe.from_string json_str in
         agent_state_of_json json
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend_eio.NotFound _) ->
       Error "Agent not found"
   | Error e ->
@@ -448,8 +450,9 @@ let lock_info_of_json json =
     | Some resource, Some owner, Some acquired_at, Some expires_at ->
         Ok { resource; owner; acquired_at; expires_at }
     | _ -> Error "Invalid lock metadata"
-  with e ->
-    Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Acquire lock on a resource *)
 let acquire_lock config ~resource ~owner =
@@ -522,8 +525,9 @@ let message_of_json json =
       mention = json |> member "mention" |> to_string_option;
       timestamp = json |> member "timestamp" |> to_float;
     }
-  with e ->
-    Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Extract @mention from message content
     Uses Mention module for Stateless/Stateful/Broadcast parsing *)
@@ -584,7 +588,7 @@ let get_message config ~seq =
       (try
         let json = Yojson.Safe.from_string json_str in
         message_of_json json
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend_eio.NotFound _) ->
       Error "Message not found"
   | Error e ->
@@ -648,8 +652,9 @@ let task_of_json json =
           updated_at = json |> member "updated_at" |> to_float;
           priority = json |> member "priority" |> to_int;
         }
-  with e ->
-    Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Create a new task *)
 let create_task config ~description ?(priority=1) () =
@@ -700,7 +705,7 @@ let claim_task config ~task_id ~agent =
                 Error "Task already completed"
             | Failed _ ->
                 Error "Task failed"
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
 
 (** Complete a task *)
 let complete_task config ~task_id ~agent =
@@ -731,7 +736,7 @@ let complete_task config ~task_id ~agent =
                 Error "Task already completed"
             | Failed _ ->
                 Error "Task failed"
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
 
 (** Get task by ID *)
 let get_task config ~task_id =
@@ -740,7 +745,7 @@ let get_task config ~task_id =
       (try
         let json = Yojson.Safe.from_string json_str in
         task_of_json json
-      with e -> Error (Printexc.to_string e))
+      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
   | Error (Backend_eio.NotFound _) ->
       Error "Task not found"
   | Error e ->

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -141,7 +141,9 @@ let init config ~task_id ~agent_name : (run_record, string) result =
     end;
     write_run config run;
     Ok run
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Update plan *)
 let update_plan config ~task_id ~content : (run_record, string) result =
@@ -154,7 +156,9 @@ let update_plan config ~task_id ~content : (run_record, string) result =
         write_text_file path content;
         write_run config updated;
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Append log entry *)
 let append_log config ~task_id ~note : (log_entry, string) result =
@@ -167,7 +171,9 @@ let append_log config ~task_id ~note : (log_entry, string) result =
       Fs_compat.append_jsonl file (log_entry_to_json entry)
     );
     Ok entry
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Set deliverable *)
 let set_deliverable config ~task_id ~content : (run_record, string) result =
@@ -180,7 +186,9 @@ let set_deliverable config ~task_id ~content : (run_record, string) result =
         write_text_file path content;
         write_run config updated;
         Ok updated
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Read logs (optionally tail N) *)
 let read_logs config ~task_id ?limit () : log_entry list =


### PR DESCRIPTION
## Summary
- Generic `with e ->` catches in Eio fiber context silently swallow `Eio.Cancel.Cancelled`, causing zombie fibers
- Added `Eio.Cancel.Cancelled _ as e -> raise e` guard to 37 catch sites across 5 core `_eio` files
- Matches the pattern already established in 16 other files (http_server_eio, orchestrator, etc.)

## Files Changed
| File | Sites | Risk |
|------|-------|------|
| `room_eio.ml` | 12 | JSON parsing + Backend I/O |
| `planning_eio.ml` | 9 | File I/O (write_file_content, read_file_content) |
| `cache_eio.ml` | 6 | Fs_compat.save_file, Fs_compat.load_file |
| `backend_eio.ml` | 6 | Eio.Path.mkdirs, lock parsing |
| `run_eio.ml` | 4 | File I/O (write_text_file, append_jsonl) |

## Test plan
- [x] `dune build` passes (exit code 0)
- [ ] `dune runtest` passes
- [ ] Verify no regression in room operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)