### PR TITLE
fix: guard Eio.Cancel.Cancelled in council exception handlers

### DIFF
--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -73,7 +73,9 @@ let record_of_yojson json =
     let metadata = json |> member "metadata" |> to_assoc
       |> List.map (fun (k, v) -> (k, to_string v)) in
     Ok { id; type_; content; agents; timestamp; metadata }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "JSON parse error: %s" (Printexc.to_string e))
 
 (** {1 Utilities} *)
@@ -160,7 +162,9 @@ let execute_cypher ~sw ~env bolt_url query params =
       Ok body_str
     else
       Error (Printf.sprintf "Neo4j HTTP error: %s" body_str)
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Neo4j connection error: %s" (Printexc.to_string e))
 
 (** Neo4j에 레코드 저장 (MERGE) *)

--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -89,11 +89,15 @@ let read_file_safe path =
         (fun () -> really_input_string ic (in_channel_length ic))
     in
     Ok content
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let list_dir_safe dir =
   try Ok (Array.to_list (Sys.readdir dir))
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let consensus_dir base =
   Filename.concat (Filename.concat base ".masc") "consensus"
@@ -213,7 +217,9 @@ let vote_of_yojson (json : Yojson.Safe.t) : (vote, string) result =
           | _ -> None
         in
         Ok { agent; decision; reason; timestamp; archetype; weight }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse vote: %s" (Printexc.to_string e))
 
 let full_session_to_yojson (s : session) : Yojson.Safe.t =
@@ -271,7 +277,9 @@ let full_session_of_yojson (json : Yojson.Safe.t) : (session, string) result =
                | _ -> empty_context_ref
              in
              Ok { id; topic; initiator; votes; quorum; threshold; state; created_at; closed_at; context })
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse session: %s" (Printexc.to_string e))
 
 (** Save session to disk (write-through) *)

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -67,15 +67,21 @@ let read_file_safe path =
         (fun () -> really_input_string ic (in_channel_length ic))
     in
     Ok content
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let parse_json_safe content =
   try Ok (Yojson.Safe.from_string content)
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let list_dir_safe dir =
   try Ok (Array.to_list (Sys.readdir dir))
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** {1 Directory Management} *)
 
@@ -175,7 +181,9 @@ let turn_of_yojson (json : Yojson.Safe.t) : (turn, string) result =
     | Ok turn_type ->
         Ok { id; seq; speaker; content; turn_type; created_at; confidence; reply_to; mentions }
     | Error e -> Error e
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse turn: %s" (Printexc.to_string e))
 
 let thread_to_yojson (th : thread) : Yojson.Safe.t =
@@ -243,7 +251,9 @@ let thread_of_yojson (json : Yojson.Safe.t) : (thread, string) result =
         | Ok turns ->
             Ok { id; topic; room; status; turns; participants; started_at;
                  concluded_at; conclusion; max_turns; current_turn; floor_holder; source_post_id }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse thread: %s" (Printexc.to_string e))
 
 (** {1 File I/O - Atomic writes} *)
@@ -361,7 +371,9 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
   try
     save_thread config th;
     Ok th
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to start thread: %s" (Printexc.to_string e))
 
 let get ~config ~thread_id : thread option =
@@ -412,7 +424,9 @@ let reply ~config ~thread_id ~speaker ~content
         try
           save_thread config updated;
           Ok updated
-        with e ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | e ->
           Error (Printf.sprintf "Failed to save reply: %s" (Printexc.to_string e))
       end
 
@@ -458,7 +472,9 @@ let conclude ~config ~thread_id ~concluder ~conclusion () : (thread, string) res
         try
           save_thread config updated;
           Ok updated
-        with e ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | e ->
           Error (Printf.sprintf "Failed to conclude thread: %s" (Printexc.to_string e))
       end
 

--- a/lib/council/debate.ml
+++ b/lib/council/debate.ml
@@ -48,15 +48,21 @@ let read_file_safe path =
         (fun () -> really_input_string ic (in_channel_length ic))
     in
     Ok content
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let parse_json_safe ~context:_ content =
   try Ok (Yojson.Safe.from_string content)
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let list_dir_safe dir =
   try Ok (Array.to_list (Sys.readdir dir))
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** {1 ID Generation} *)
 
@@ -178,8 +184,9 @@ let argument_of_yojson (json : Yojson.Safe.t) : (argument, string) result =
           | _ -> None
         in
         Ok { agent; position; content; evidence; reply_to; mentions; archetype; created_at }
-  with e ->
-    Error (Printf.sprintf "Failed to parse argument: %s" (Printexc.to_string e))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printf.sprintf "Failed to parse argument: %s" (Printexc.to_string e))
 
 let debate_to_yojson (d : debate) : Yojson.Safe.t =
   let base =
@@ -234,8 +241,9 @@ let debate_of_yojson (json : Yojson.Safe.t) : (debate, string) result =
                | _ -> None
              in
              Ok { id; topic; status; arguments; context; created_at; closed_at })
-  with e ->
-    Error (Printf.sprintf "Failed to parse debate: %s" (Printexc.to_string e))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printf.sprintf "Failed to parse debate: %s" (Printexc.to_string e))
 
 (** {1 Storage Operations} *)
 
@@ -315,8 +323,9 @@ let start_debate config ~topic ?(context = empty_context_ref) ?(notify_agents=[]
       notify_fn ~agent ~message:msg
     ) notify_agents;
     Ok debate
-  with e ->
-    Error (Printf.sprintf "Failed to start debate: %s" (Printexc.to_string e))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printf.sprintf "Failed to start debate: %s" (Printexc.to_string e))
 
 (** Get a debate by ID *)
 let get_debate config ~debate_id : (debate, string) result =
@@ -378,8 +387,9 @@ let add_argument config ~debate_id ~agent ~position ~content
           (* Return with arg index for reference *)
           Printf.eprintf "[Debate] Argument #%d added by %s\n%!" arg_idx agent;
           Ok updated
-        with e ->
-          Error (Printf.sprintf "Failed to add argument: %s" (Printexc.to_string e))
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | e -> Error (Printf.sprintf "Failed to add argument: %s" (Printexc.to_string e))
       end
 
 (** Get the current status of a debate with summary *)
@@ -418,8 +428,9 @@ let close_debate config ~debate_id : (debate, string) result =
         try
           save_debate config updated;
           Ok updated
-        with e ->
-          Error (Printf.sprintf "Failed to close debate: %s" (Printexc.to_string e))
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | e -> Error (Printf.sprintf "Failed to close debate: %s" (Printexc.to_string e))
       end
 
 (** List all debates *)

--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -138,7 +138,9 @@ let execute_argv argv =
         let success = match status with Unix.WEXITED 0 -> true | _ -> false in
         let output = combine_output ~stdout ~stderr in
         { success; stdout; stderr; output; timestamp = timestamp () }
-      with e ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e ->
         let err = Printexc.to_string e in
         { success = false;
           stdout = "";

--- a/lib/council/governance_v2_serde.ml
+++ b/lib/council/governance_v2_serde.ml
@@ -21,15 +21,21 @@ let read_file_safe path =
         (fun () -> really_input_string ic (in_channel_length ic))
     in
     Ok content
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let parse_json_safe ~context content =
   try Ok (Yojson.Safe.from_string content)
-  with e -> Error (Printf.sprintf "%s: %s" context (Printexc.to_string e))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printf.sprintf "%s: %s" context (Printexc.to_string e))
 
 let list_dir_safe dir =
   try Ok (Array.to_list (Sys.readdir dir))
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 let rec ensure_dir path =
   if not (Sys.file_exists path) then (

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -358,7 +358,9 @@ let execute_cypher_raw ~cypher : (Yojson.Safe.t, string) result =
                   |> String.concat "; "
                 in
                 Error (Printf.sprintf "Neo4j error: %s" err_msg)
-            with e ->
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | e ->
               Error
                 (Printf.sprintf "Neo4j response parse error: %s"
                    (Printexc.to_string e)))
@@ -391,7 +393,9 @@ let save_to_file ~config ~(thread : Conversation.thread) : (unit, string) result
   try
     Conversation.save_thread config thread;
     Ok ()
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "File write failed: %s" (Printexc.to_string e))
 
 (** Save thread to Neo4j (fire-and-forget, best-effort) *)
@@ -473,7 +477,9 @@ let search_by_topic ~(query : string) ?(room : string option) ?(limit = 10) ()
                   with Yojson.Safe.Util.Type_error _ -> None)
         in
         Ok ids
-      with e ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e ->
         Error (Printf.sprintf "Failed to parse search results: %s" (Printexc.to_string e)))
 
 (** {1 Sync Operations} *)


### PR DESCRIPTION
## Summary
- Added `Eio.Cancel.Cancelled` re-raise guards to 26 generic catch sites across 7 council modules
- These modules perform file I/O inside try blocks; without the guard, fiber cancellation is silently swallowed
- Companion to #2078 (core _eio files)

## Files Changed
| File | Guards Added |
|------|-------------|
| `conversation.ml` | 8 |
| `debate.ml` | 8 |
| `consensus.ml` | 4 |
| `governance_v2_serde.ml` | 3 |
| `thread_persist.ml` | 3 |
| `archive.ml` | 2 |
| `executor.ml` | 1 |

## Test plan
- [x] `dune build` passes (exit code 0)
- [ ] `dune runtest` passes
- [ ] Verify no regression in council operations (debate, consensus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)