### PR TITLE
fix(eio): replace Stdlib.Mutex with Eio.Mutex in heartbeat.ml

### DIFF
--- a/lib/heartbeat.ml
+++ b/lib/heartbeat.ml
@@ -14,21 +14,21 @@ type t = {
 
 let heartbeats : (string, t) Hashtbl.t = Hashtbl.create 16
 let heartbeat_counter = Atomic.make 0
-let mu = Mutex.create ()
+let mu = Eio.Mutex.create ()
 
 let generate_id () =
   Atomic.incr heartbeat_counter;
   Printf.sprintf "hb-%d-%d" (int_of_float (Time_compat.now ())) (Atomic.get heartbeat_counter)
 
 let start ~agent_name ~interval ~message =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
     let id = generate_id () in
     let hb = { id; agent_name; interval; message; active = true; created_at = Time_compat.now () } in
     Hashtbl.add heartbeats id hb;
     id)
 
 let stop id =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
     match Hashtbl.find_opt heartbeats id with
     | Some hb ->
         hb.active <- false;
@@ -37,15 +37,15 @@ let stop id =
     | None -> false)
 
 let list () =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_ro mu (fun () ->
     Hashtbl.fold (fun _ hb acc -> hb :: acc) heartbeats [])
 
 let get id =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_ro mu (fun () ->
     Hashtbl.find_opt heartbeats id)
 
 let stop_by_agent ~agent_name =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
     let ids_to_remove =
       Hashtbl.fold (fun id hb acc ->
         if hb.agent_name = agent_name then id :: acc else acc


### PR DESCRIPTION
## Summary
Stdlib.Mutex blocks the OS thread in Eio cooperative scheduler, starving all other fibers on the same domain. Heartbeat module is called from Eio MCP tool handlers, so this causes fiber starvation under concurrent heartbeat operations.

## Changes
- `lib/heartbeat.ml`: `Mutex.create()` → `Eio.Mutex.create()`, `Mutex.protect` → `Eio.Mutex.use_rw`/`use_ro`

## Note
`backend_core.ml` and `backend.ml` also have Stdlib.Mutex fallback patterns, but those are intentionally dual-mode (Eio + test context). They need a different approach (separate PR).

## Test plan
- [x] `dune build` passes
- [ ] CI green