### PR TITLE
refactor(dashboard): extract groupByKey, remove dead param, simplify dedup

### DIFF
--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { groupByKey } from '../common/collection'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type {
   CommandPlaneOrchestraResponse,
@@ -46,16 +47,6 @@ function spreadX(count: number, min: number, max: number): number[] {
   return Array.from({ length: count }, (_, idx) => Math.round(min + idx * step))
 }
 
-function groupBy<T>(items: T[], getKey: (item: T) => string): Map<string, T[]> {
-  const out = new Map<string, T[]>()
-  for (const item of items) {
-    const key = getKey(item)
-    const bucket = out.get(key) ?? []
-    bucket.push(item)
-    out.set(key, bucket)
-  }
-  return out
-}
 
 function layoutConfig(density: 'balanced' | 'compact') {
   if (density === 'compact') {
@@ -126,7 +117,7 @@ function layout(orchestra: CommandPlaneOrchestraResponse, density: 'balanced' | 
       .filter((entry): entry is readonly [string, number] => entry !== null),
   )
 
-  const workerBuckets = groupBy(workers, worker => {
+  const workerBuckets = groupByKey(workers, worker => {
     if (worker.lane_id) return `lane:${worker.lane_id}`
     if (worker.parent_id) return worker.parent_id
     return 'free'

--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -60,7 +60,6 @@ function keeperPreview(keeper: Keeper): string {
 }
 
 export function buildAgentMotion(
-  _agentName: string,
   tasks: Task[],
   messages: Message[],
   journal: JournalEntry[],

--- a/dashboard/src/components/common/collection.ts
+++ b/dashboard/src/components/common/collection.ts
@@ -1,0 +1,16 @@
+/** Group items into a Map keyed by the result of keyFn.
+ *  Items whose key is empty string, null, or undefined are skipped. */
+export function groupByKey<T>(
+  items: T[],
+  keyFn: (item: T) => string | null | undefined,
+): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyFn(item)
+    if (!key) continue
+    const arr = map.get(key)
+    if (arr) arr.push(item)
+    else map.set(key, [item])
+  }
+  return map
+}

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -43,6 +43,7 @@ import {
   normalizeKeepers,
 } from './keeper-store-normalize'
 import { buildAgentMotion, normalizeAgentKey, type AgentMotionSnapshot } from './components/common/agent-motion'
+import { groupByKey } from './components/common/collection'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
@@ -211,18 +212,6 @@ export const tasksByStatus = computed(() => {
   }
 })
 
-function groupByKey<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]> {
-  const map = new Map<string, T[]>()
-  for (const item of items) {
-    const key = keyFn(item)
-    if (!key) continue
-    const arr = map.get(key)
-    if (arr) arr.push(item)
-    else map.set(key, [item])
-  }
-  return map
-}
-
 export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = computed(() => {
   const map = new Map<string, AgentMotionSnapshot>()
   const taskList = tasks.value
@@ -248,12 +237,11 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
       ? authorJournal
       : authorJournal.length === 0
         ? agentJournal
-        : [...new Set([...agentJournal, ...authorJournal])]
+        : agentJournal.concat(authorJournal)
 
     map.set(
       key,
       buildAgentMotion(
-        agent.name,
         tasksByAgent.get(key) ?? [],
         messagesByAgent.get(key) ?? [],
         mergedJournal,


### PR DESCRIPTION
## Summary
/simplify 리뷰에서 발견한 3건 수정:

1. **groupByKey 3중 복제 제거**: `store.ts`와 `orchestra.ts`에 동일한 grouping 로직이 있었음 → `common/collection.ts`로 추출
2. **_agentName dead parameter 제거**: buildAgentMotion에서 사용하지 않는 첫 번째 파라미터 삭제
3. **Set dedup → concat**: journal merge에서 overlap 없는데 Set 생성은 불필요한 GC 압력

## Changes
- `dashboard/src/components/common/collection.ts`: 새 파일 (groupByKey 유틸)
- `dashboard/src/store.ts`: 로컬 groupByKey 삭제, import 사용, Set → concat
- `dashboard/src/components/command/orchestra.ts`: 로컬 groupBy 삭제, import 사용
- `dashboard/src/components/common/agent-motion.ts`: _agentName 파라미터 제거

## Test plan
- [x] `npm run build` 통과
- [ ] 대시보드 agent motion 카드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)