### PR TITLE
fix(eio): re-raise Cancelled in tool_agent bare catch

### DIFF
--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -123,7 +123,9 @@ let handle_agent_fitness ctx args =
         try
           Room.get_agents_raw ctx.config
           |> List.map (fun (a : Types.agent) -> a.name)
-        with _ -> []
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> []
       in
       List.sort_uniq String.compare (metrics_agents @ room_agents)
   in


### PR DESCRIPTION
## Summary
`tool_agent.ml:126` had `with _ -> []` wrapping `Room.get_agents_raw` (I/O operation). This swallowed `Eio.Cancel.Cancelled`, preventing graceful fiber cancellation.

## Audit result
23 `with _ ->` sites found in lib/. Only 1 wraps I/O — the rest are pure parsing (`int_of_string`, `float_of_string`, `Yojson.from_string`) which cannot raise Cancelled.

## Test plan
- [x] `dune build` passes
- [ ] CI green