### PR TITLE
fix: guard Eio.Cancel.Cancelled in remaining lib/ handlers

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -193,7 +193,9 @@ let save_subscriptions () =
     let content = Yojson.Safe.pretty_to_string json in
     try
       Fs_compat.save_file !subscriptions_file content
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.Misc.error "save_subscriptions failed: %s" (Printexc.to_string e)
 
 (** Load subscriptions from file *)

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -144,7 +144,9 @@ module FileSystemBackend : BACKEND = struct
             );
             Sys.rename tmp_path path;
             Ok ()
-          with e -> Error (OperationFailed (Printexc.to_string e))
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | e -> Error (OperationFailed (Printexc.to_string e))
     )
 
   let delete t ~key =
@@ -156,7 +158,9 @@ module FileSystemBackend : BACKEND = struct
             try
               Sys.remove path;
               Ok true
-            with e -> Error (OperationFailed (Printexc.to_string e))
+            with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | e -> Error (OperationFailed (Printexc.to_string e))
           end else
             Ok false
     )
@@ -303,7 +307,9 @@ module FileSystemBackend : BACKEND = struct
                     Ok true
                 | Some _ -> Ok false  (* Different owner *)
                 | None -> Ok false    (* No valid lock *)
-              with e ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | e ->
                 Log.Misc.error "Lock operation failed: %s" (Printexc.to_string e);
                 Ok false
             in
@@ -357,7 +363,9 @@ module FileSystemBackend : BACKEND = struct
                   Ok true
                 end else
                   Ok false
-              with e ->
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | e ->
                 Log.Misc.error "Lock operation failed: %s" (Printexc.to_string e);
                 Ok false
             in
@@ -385,7 +393,9 @@ module FileSystemBackend : BACKEND = struct
       );
       Sys.remove test_path;
       Ok true
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.Misc.error "Health check failed: %s" (Printexc.to_string e);
       Ok false
 end

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -286,7 +286,9 @@ let load_persisted_posts store =
         Log.BoardLog.info "loaded %d posts from %s" !loaded path
       else
         Log.BoardLog.debug "loaded 0 posts from %s" path
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.BoardLog.error "load posts failed: %s" (Printexc.to_string e)
   end
 
@@ -313,7 +315,9 @@ let load_persisted_comments store =
         Log.BoardLog.info "loaded %d comments from %s" !loaded path
       else
         Log.BoardLog.debug "loaded 0 comments from %s" path
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.BoardLog.error "load comments failed: %s" (Printexc.to_string e)
   end
 
@@ -355,7 +359,9 @@ let load_persisted_votes store =
         Log.BoardLog.info "loaded %d vote entries from %s" !loaded path
       else
         Log.BoardLog.debug "loaded 0 vote entries from %s" path
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
   end
 

--- a/lib/chain/chain_category.ml
+++ b/lib/chain/chain_category.ml
@@ -176,7 +176,9 @@ end = struct
 
   let catch f =
     try Ok (f ())
-    with e -> Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
   let map_error f = function
     | Ok x -> Ok x

--- a/lib/chain/chain_registry.ml
+++ b/lib/chain/chain_registry.ml
@@ -310,6 +310,8 @@ let of_json (json : Yojson.Safe.t) : (int, string) result =
             Log.Chain.error "Failed to load entry: %s" msg
       ) entries;
       Ok !count
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Error (Printexc.to_string e)
   )

--- a/lib/federation_types.ml
+++ b/lib/federation_types.ml
@@ -146,7 +146,9 @@ let delegation_request_of_yojson json =
           status = json |> U.member "status" |> U.to_string;
           result = json |> U.member "result" |> U.to_string_option;
         }
-  with e -> Error (Printexc.to_string e)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e -> Error (Printexc.to_string e)
 
 (** Federation event - variant type with inline records *)
 type federation_event =

--- a/lib/jiphyeon/archive.ml
+++ b/lib/jiphyeon/archive.ml
@@ -73,7 +73,9 @@ let record_of_yojson json =
     let metadata = json |> member "metadata" |> to_assoc
       |> List.map (fun (k, v) -> (k, to_string v)) in
     Ok { id; type_; content; agents; timestamp; metadata }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "JSON parse error: %s" (Printexc.to_string e))
 
 (** {1 Utilities} *)
@@ -175,7 +177,9 @@ let execute_cypher ~sw ~env bolt_url query params =
       Ok body_str
     else
       Error (Printf.sprintf "Neo4j HTTP error: %s" body_str)
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Neo4j connection error: %s" (Printexc.to_string e))
 
 (** Neo4j에 레코드 저장 (MERGE) *)

--- a/lib/progress.ml
+++ b/lib/progress.ml
@@ -171,7 +171,9 @@ let notify ~task_id ~progress ?message ?estimated_remaining () =
   (* Read callback under lock, call outside to avoid deadlock *)
   let callback = State.with_lock (fun () -> State.global.sse_broadcast) in
   try callback json
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Misc.error "SSE broadcast failed: %s" (Printexc.to_string e)
 
 (** Wire up the forward reference

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -96,7 +96,9 @@ let room_enter config ~room_id ?(agent_name="") ~agent_type () : Yojson.Safe.t =
       (match previous_room with
        | Some prev when prev <> room_id && should_auto_leave ->
            (try ignore (leave config ~agent_name:effective_agent_name)
-            with e -> Log.Misc.error "room: auto-leave from %s failed: %s" prev (Printexc.to_string e))
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | e -> Log.Misc.error "room: auto-leave from %s failed: %s" prev (Printexc.to_string e))
        | _ -> ());
 
       (* Update current room file (for external tools) and create scoped config *)
@@ -107,7 +109,9 @@ let room_enter config ~room_id ?(agent_name="") ~agent_type () : Yojson.Safe.t =
       (* Initialize the room on first entry (no auto-join). *)
       if not (is_initialized scoped) then
         (try ignore (Room_init.init scoped ~agent_name:None)
-         with e -> Log.Misc.error "room: init failed for %s: %s" room_id (Printexc.to_string e));
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | e -> Log.Misc.error "room: init failed for %s: %s" room_id (Printexc.to_string e));
 
       (* Join the new room using scoped config *)
       let join_result = join scoped ~agent_name:effective_agent_name ~capabilities:[] () in

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -39,7 +39,9 @@ let update_priority config ~task_id ~priority =
             task_id old_priority priority (now_iso ()));
 
           Printf.sprintf "✅ Task %s priority: P%d → P%d" task_id old_priority priority
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
   )
 

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -233,7 +233,9 @@ let get_tty () =
             if String.length trimmed > 0 then Some trimmed else None
           else None
         with Unix.Unix_error _ -> None
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Misc.error "get_tty failed: %s" (Printexc.to_string e);
     None
 

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -97,7 +97,9 @@ let batch_add_tasks config tasks =
       let msg = Printf.sprintf "📋 New batch of %d quests added: %s" (List.length added_tasks) summary in
       let _ = broadcast config ~from_agent:"system" ~content:msg in
       Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Printf.sprintf "❌ Error adding batch tasks: %s" (Printexc.to_string e)
   )
 
@@ -154,7 +156,9 @@ let claim_task config ~agent_name ~task_id =
               "{\"type\":\"task_claim\",\"agent\":\"%s\",\"task\":\"%s\",\"ts\":\"%s\"}"
               agent_name task_id (now_iso ()));
             Printf.sprintf "✅ %s claimed %s" agent_name task_id
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
   )
 
@@ -229,7 +233,9 @@ let claim_task_r config ~agent_name ~task_id
                   log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_claim"); ("agent", `String agent_name); ("task", `String task_id); ("ts", `String (now_iso ()))]));
                   Ok (Printf.sprintf "✅ %s claimed %s" agent_name task_id)
           end)
-      with e -> Error (Types.IoError (Printexc.to_string e))
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Types.IoError (Printexc.to_string e))
     )
 
 (** Unified task transition (single entrypoint).
@@ -338,7 +344,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                                 (status_to_string task.task_status)
                                 (status_to_string new_status))
                      ))
-          with e -> Error (Types.IoError (Printexc.to_string e))
+          with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Types.IoError (Printexc.to_string e))
         )
 
 (** Release task back to backlog - transition wrapper *)
@@ -415,7 +423,9 @@ let complete_task config ~agent_name ~task_id ~notes =
                  (Printexc.to_string exn));
             Printf.sprintf "✅ %s completed %s" agent_name task_id
           end
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
   )
 
@@ -486,7 +496,9 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                  Log.Misc.error "task earn failed: %s" msg);
               Ok (Printf.sprintf "✅ %s completed %s" agent_name task_id)
             end
-      with e -> Error (Types.IoError (Printexc.to_string e))
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Types.IoError (Printexc.to_string e))
     )
 
 (** Cancel a task - A2A compatible *)
@@ -540,7 +552,9 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
               log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_cancelled"); ("agent", `String agent_name); ("task", `String task_id); ("reason", if reason = "" then `Null else `String reason); ("ts", `String (now_iso ()))]));
               Ok (Printf.sprintf "🚫 %s cancelled %s" agent_name task_id)
             end
-      with e -> Error (Types.IoError (Printexc.to_string e))
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Types.IoError (Printexc.to_string e))
     )
 
 (** Structured result for claim_next_r (avoids brittle string parsing). *)
@@ -769,7 +783,9 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
             released_task_id;
             message;
           }
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Claim_next_error (Printexc.to_string e)
   )
 

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -13,7 +13,9 @@
 (** Execute a function, logging exceptions and returning None on failure *)
 let try_with_log context f =
   try Some (f ())
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Misc.error "%s failed: %s" context (Printexc.to_string e);
     None
 
@@ -38,7 +40,9 @@ let read_file_safe path : (string, string) result =
     Error (Printf.sprintf "File not found: %s" path)
   else
     try Ok (Fs_compat.load_file path)
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Error (Printf.sprintf "Failed to read %s: %s" path (Printexc.to_string e))
 
 (** Safe integer parsing *)
@@ -84,19 +88,25 @@ let list_dir_safe path : (string list, string) result =
     Error (Printf.sprintf "Not a directory: %s" path)
   else
     try Ok (Sys.readdir path |> Array.to_list)
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Error (Printf.sprintf "Failed to list %s: %s" path (Printexc.to_string e))
 
 (** Remove file with logging on failure (for cleanup operations) *)
 let remove_file_logged ?(context = "cleanup") path =
   try Sys.remove path
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Misc.error "[%s] Failed to remove %s: %s" context path (Printexc.to_string e)
 
 (** Close channel with logging on failure *)
 let close_in_logged ic =
   try close_in ic
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Misc.error "Failed to close input channel: %s" (Printexc.to_string e)
 
 (** Get environment variable with logging when invalid *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -24,7 +24,9 @@ let add_routes ~sw ~clock router =
              let config = state.Mcp_server.room_config in
              let _ = Room.broadcast config ~from_agent:agent_name ~content:message in
              Http.Response.json {|{"ok":true}|} reqd
-           with e ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | e ->
              Http.Response.json
                (Printf.sprintf {|{"ok":false,"error":"%s"}|} (Printexc.to_string e))
                reqd
@@ -41,7 +43,9 @@ let add_routes ~sw ~clock router =
              let config = state.Mcp_server.room_config in
              let _ = Room.broadcast config ~from_agent:agent_name ~content:message in
              Http.Response.json {|{"ok":true}|} reqd
-           with e ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | e ->
              Http.Response.json
                (Printf.sprintf {|{"ok":false,"error":"%s"}|} (Printexc.to_string e))
                reqd

--- a/lib/social.ml
+++ b/lib/social.ml
@@ -83,7 +83,9 @@ let post_of_yojson (json : Yojson.Safe.t) : (post, string) result =
     let created_at = json |> member "created_at" |> to_float in
     let votes = json |> member "votes" |> to_int in
     Ok { id; author; content; submolt; created_at; votes }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse post: %s" (Printexc.to_string e))
 
 let comment_to_yojson (c : comment) : Yojson.Safe.t =
@@ -112,7 +114,9 @@ let comment_of_yojson (json : Yojson.Safe.t) : (comment, string) result =
     let created_at = json |> member "created_at" |> to_float in
     let votes = json |> member "votes" |> to_int in
     Ok { id; post_id; parent_id; author; content; created_at; votes }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse comment: %s" (Printexc.to_string e))
 
 let vote_record_to_yojson (v : vote_record) : Yojson.Safe.t =
@@ -132,7 +136,9 @@ let vote_record_of_yojson (json : Yojson.Safe.t) : (vote_record, string) result 
         let voted_at = json |> member "voted_at" |> to_float in
         Ok { voter; direction; voted_at }
     | Error e -> Error e
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to parse vote_record: %s" (Printexc.to_string e))
 
 (** {1 Storage Operations} *)
@@ -203,7 +209,9 @@ let create_post config ~author ~content ?submolt () =
   try
     write_json path (post_to_yojson post);
     Ok post
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "Failed to create post: %s" (Printexc.to_string e))
 
 let get_post config ~post_id : (post, string) result =
@@ -273,7 +281,9 @@ let add_comment config ~post_id ~author ~content ?parent_id () : (comment, strin
       try
         write_json path (comment_to_yojson comment);
         Ok comment
-      with e ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e ->
         Error (Printf.sprintf "Failed to add comment: %s" (Printexc.to_string e))
 
 let save_comment config (comment : comment) : unit =

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -418,7 +418,9 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
       cache_read_tokens = cache_read;
       cost_usd;
     }
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> Sys.chdir original_dir; raise e
+  | e ->
     Sys.chdir original_dir;
     {
       success = false;

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -266,7 +266,9 @@ let load_stats () =
       ) entries;
       Printf.printf "[thompson_sampling] Loaded stats for %d agents\n%!"
         (Hashtbl.length stats_table)
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.Thompson.error "Error loading stats: %s"
         (Printexc.to_string e)
   end
@@ -282,7 +284,9 @@ let save_stats () =
     Fs_compat.save_file path content;
     Printf.printf "[thompson_sampling] Saved stats for %d agents\n%!"
       (Hashtbl.length stats_table)
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Log.Thompson.error "Error saving stats: %s"
       (Printexc.to_string e)
 

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -252,7 +252,9 @@ let handle_join (ctx : context) : result option =
     let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
     (try
       Fs_compat.save_file agent_file nickname
-    with e ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e ->
       Log.Misc.error "Failed to write agent file %s: %s" agent_file (Printexc.to_string e))
   end;
   (* Cultural Inheritance: append institution welcome to join response *)

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -95,7 +95,9 @@ module JsonRpc = struct
         let method_name = json |> U.member "method" |> U.to_string in
         let params = json |> U.member "params" in
         Ok { id; method_name; params; headers = [] }
-    with e -> Error (Printexc.to_string e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | e -> Error (Printexc.to_string e)
 
   (** Serialize JSON-RPC response *)
   let serialize_response (resp : response) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary
- Added `Eio.Cancel.Cancelled` re-raise guards to 42 generic catch sites across 19 files
- Covers room/*, board/*, chain/*, social, spawn, transport, and utility modules
- spawn.ml: restores working directory before re-raising to prevent cwd corruption
- Companion to #2078 (5 core _eio files, 37 sites) and #2081 (7 council files, 26 sites)

## Combined Coverage
All three PRs together: **105 catch sites across 31 files**.

## Test plan
- [x] `dune build` passes (exit code 0)
- [ ] `dune runtest` passes
- [ ] Verify no regression in room/board/spawn operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)