### PR TITLE
fix(dashboard): drop mission mode and avoid briefing cold-start timeout

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -241,9 +241,8 @@ export function fetchDashboardSemantics(): Promise<DashboardSemanticsResponse> {
   return get('/api/v1/dashboard/semantics')
 }
 
-export function fetchDashboardMission(mode?: 'snapshot' | 'full'): Promise<DashboardMissionResponse> {
-  const query = mode ? `?mode=${mode}` : ''
-  return get(`/api/v1/dashboard/mission${query}`)
+export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
+  return get('/api/v1/dashboard/mission')
 }
 
 export function fetchDashboardMissionSession(sessionId: string): Promise<DashboardMissionSessionDetailResponse> {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -42,7 +42,7 @@ export function App() {
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.
-    registerMissionRefresh(() => void refreshMissionSnapshot('snapshot'))
+    registerMissionRefresh(() => void refreshMissionSnapshot())
 
     // Setup SSE -> store reaction (debounced refresh on events)
     const unsubSSE = setupSSEReaction()

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -22,11 +22,11 @@ import {
   normalizeMissionBriefing,
 } from './mission-normalizers'
 
-export async function refreshMissionSnapshot(mode?: 'snapshot' | 'full'): Promise<void> {
+export async function refreshMissionSnapshot(): Promise<void> {
   missionLoading.value = true
   missionError.value = null
   try {
-    const raw = await fetchDashboardMission(mode)
+    const raw = await fetchDashboardMission()
     missionSnapshot.value = normalizeMission(raw)
   } catch (err) {
     missionError.value = err instanceof Error ? err.message : 'Failed to load mission snapshot'

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -45,7 +45,7 @@ export function refreshForTab(tab: string) {
       refreshMissionSnapshot()
     } else {
       refreshRoomTruth()
-      refreshMissionSnapshot('full')
+      refreshMissionSnapshot()
       refreshMissionBriefing()
     }
   }

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -77,26 +77,6 @@ end
 
 (* ── Response envelope builders ─────────────────────────────────── *)
 
-let error_json ~now ~reason =
-  `Assoc
-    [
-      ("generated_at", `String now);
-      ("cached", `Bool false);
-      ("stale", `Bool false);
-      ("refreshing", `Bool false);
-      ("status", `String "error");
-      ("summary", `String "Mission briefing refresh failed. Retry to request a fresh judgment.");
-      ("provenance", `String "narrative");
-      ("authoritative", `Bool false);
-      ("provenance_summary", mission_briefing_surface_contract_json);
-      ("model", `Null);
-      ("ttl_sec", `Int (int_of_float cache_ttl_sec));
-      ("criteria", criteria_json ());
-      ("sections", `List []);
-      ("error", `String reason);
-      ("last_error", option_string_json (Some reason));
-    ]
-
 let pending_json ~now ~last_error =
   `Assoc
     [
@@ -318,14 +298,7 @@ let json ?actor ?(force = false) ~config ~sw ~clock ~proc_mgr () =
         if not refresh_in_flight then
           start_async_refresh ~actor_name ~config ~sw ~clock ~proc_mgr ();
         pending_json ~now:now_iso ~last_error)
-      else
-        match compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () with
-        | Ok result_json ->
-            with_cache_lock (fun () ->
-                cache.cached_json <- Some result_json;
-                cache.cached_at <- Unix.gettimeofday ();
-                cache.last_error <- None);
-            result_json
-        | Error reason ->
-            with_cache_lock (fun () -> cache.last_error <- Some reason);
-            error_json ~now:now_iso ~reason
+      else (
+        if not refresh_in_flight then
+          start_async_refresh ~actor_name ~config ~sw ~clock ~proc_mgr ();
+        pending_json ~now:now_iso ~last_error)


### PR DESCRIPTION
## Summary
- remove the deprecated `mode` query handling from dashboard mission refresh calls
- return `pending` immediately on mission briefing cold cache miss and refresh in the background
- keep the mission surface responsive while briefing catches up

## Verification
- `./dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `dune build --root .`
- manual check: `GET /api/v1/dashboard/mission/briefing` now returns `pending` immediately instead of timing out on cold start

## Notes
- frontend dev server binds at `localhost`/IPv6 in local verification
- local worktree uses a symlinked `dashboard/node_modules` for verification only and it is not committed

<!-- sync poke -->
