### PR TITLE
fix(keeper): add Keep_last_n(30) to prevent 250s latency from 170 initial_messages

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -129,6 +129,7 @@ let run_turn
   ignore (Memory_oas_bridge.seed_episodes ~memory ~agent_name ~limit:30);
   ignore (Memory_oas_bridge.seed_procedures_as_oas ~memory ~agent_name ~limit:10);
   let reducer = Agent_sdk.Context_reducer.compose [
+    Agent_sdk.Context_reducer.keep_last 30;
     { Agent_sdk.Context_reducer.strategy =
         Agent_sdk.Context_reducer.Prune_tool_outputs { max_output_len = 500 } };
     { strategy = Agent_sdk.Context_reducer.Merge_contiguous };


### PR DESCRIPTION
## Summary

initial_messages 170개가 매 turn 전부 전달 → latency 250초+.
Keep_last_n(30) reducer 추가. 최근 30개만 모델에 전달.
전체 히스토리는 checkpoint에 유지.

## Test plan
- [x] dune build 성공
- [ ] keeper turn latency 250s → <30s 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)