### PR TITLE
fix(test): wrap heartbeat tests in Eio_main.run

### DIFF
--- a/test/test_heartbeat_qw.ml
+++ b/test/test_heartbeat_qw.ml
@@ -4,6 +4,7 @@
 open Masc_mcp
 
 let () =
+  Eio_main.run @@ fun _env ->
   (* Clear state before each test group *)
   let reset () =
     List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))


### PR DESCRIPTION
## Summary
PR #2082 converted heartbeat.ml from Stdlib.Mutex to Eio.Mutex, but the test file ran without Eio scheduler context, causing all 14 tests to fail with Effect.Unhandled.

## Fix
Wrap test entry point in `Eio_main.run`.

## Test plan
- [x] All 14 heartbeat tests pass locally
- [ ] CI green