### PR TITLE
Add cached local review helper

### DIFF
--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -80,6 +80,16 @@
 13. `masc_team_session_prove`
 14. draft PR + cross-model review evidence
 
+local fallback review helper:
+
+```bash
+./scripts/review/local-review.sh --base origin/main --head HEAD --format markdown
+```
+
+이 helper는 `.masc/review-cache/local-review/` 아래에 결과 cache를 남기고,
+동일 diff에 대한 concurrent review 요청은 single-flight로 합치며,
+stale pending reviewer PID가 있으면 정리한 뒤 다시 시작한다.
+
 ## Autoresearch Wrapper
 
 Karpathy-style raw `masc_autoresearch_*` loop는 그대로 유지하되, swarm canonical path로 진입할 때는 `masc_autoresearch_swarm_start`를 우선 사용한다.

--- a/scripts/review/local-review.sh
+++ b/scripts/review/local-review.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_VERSION="local-review-v1"
+DEFAULT_MODEL="qwen3.5-35b-a3b-ud-q4-xl"
+DEFAULT_URL="http://127.0.0.1:8085/v1/chat/completions"
+DEFAULT_CACHE_DIR=".masc/review-cache/local-review"
+DEFAULT_PROMPT_VERSION="v1"
+DEFAULT_CHUNK_BYTES=40000
+DEFAULT_MAX_TOKENS=400
+DEFAULT_MAX_TIME=120
+DEFAULT_STALE_SECS=120
+DEFAULT_TEMPERATURE="0.1"
+
+BASE_REF="origin/main"
+HEAD_REF="HEAD"
+MODEL="${MASC_LOCAL_REVIEW_MODEL:-$DEFAULT_MODEL}"
+REVIEW_URL="${MASC_LOCAL_REVIEW_URL:-$DEFAULT_URL}"
+CACHE_DIR="${MASC_LOCAL_REVIEW_CACHE_DIR:-$DEFAULT_CACHE_DIR}"
+PROMPT_VERSION="${MASC_LOCAL_REVIEW_PROMPT_VERSION:-$DEFAULT_PROMPT_VERSION}"
+CHUNK_BYTES="${MASC_LOCAL_REVIEW_CHUNK_BYTES:-$DEFAULT_CHUNK_BYTES}"
+MAX_TOKENS="${MASC_LOCAL_REVIEW_MAX_TOKENS:-$DEFAULT_MAX_TOKENS}"
+MAX_TIME="${MASC_LOCAL_REVIEW_MAX_TIME:-$DEFAULT_MAX_TIME}"
+STALE_SECS="${MASC_LOCAL_REVIEW_STALE_SECS:-$DEFAULT_STALE_SECS}"
+TEMPERATURE="${MASC_LOCAL_REVIEW_TEMPERATURE:-$DEFAULT_TEMPERATURE}"
+FORMAT="json"
+PRINT_CACHE_KEY=0
+NO_CACHE=0
+REVIEW_COMMAND="${MASC_LOCAL_REVIEW_COMMAND:-}"
+declare -a PATH_FILTERS=()
+declare -a CHANGED_PATHS=()
+declare -a CHUNK_FILES=()
+CHANGED_PATH_COUNT=0
+CHUNK_FILE_COUNT=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/review/local-review.sh [options]
+
+Options:
+  --base <ref>         Base ref for diff (default: origin/main)
+  --head <ref>         Head ref for diff (default: HEAD)
+  --path <path>        Restrict review to one path (repeatable)
+  --model <model>      Reviewer model id
+  --format <fmt>       json | text | markdown (default: json)
+  --print-cache-key    Print resolved cache key and exit
+  --no-cache           Skip cache lookup/write for this invocation
+  -h, --help           Show help
+
+Environment:
+  MASC_LOCAL_REVIEW_COMMAND   Optional local command override. Receives prompt on stdin.
+  MASC_LOCAL_REVIEW_URL       OpenAI-compatible review endpoint.
+  MASC_LOCAL_REVIEW_CACHE_DIR Cache root (default: .masc/review-cache/local-review)
+  MASC_LOCAL_REVIEW_CHUNK_BYTES
+  MASC_LOCAL_REVIEW_MAX_TOKENS
+  MASC_LOCAL_REVIEW_MAX_TIME
+  MASC_LOCAL_REVIEW_STALE_SECS
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing command: $1" >&2
+    exit 1
+  }
+}
+
+hash_text() {
+  if [ $# -gt 0 ]; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+now_epoch() {
+  date +%s
+}
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+path_mtime_epoch() {
+  if stat -f %m "$1" >/dev/null 2>&1; then
+    stat -f %m "$1"
+  else
+    stat -c %Y "$1"
+  fi
+}
+
+trim() {
+  awk '{$1=$1; print}'
+}
+
+json_bool() {
+  if [ "$1" = "true" ]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --base) BASE_REF="$2"; shift 2 ;;
+    --head) HEAD_REF="$2"; shift 2 ;;
+    --path) PATH_FILTERS+=("$2"); shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    --print-cache-key) PRINT_CACHE_KEY=1; shift ;;
+    --no-cache) NO_CACHE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+require_cmd git
+require_cmd jq
+require_cmd shasum
+if [ -z "$REVIEW_COMMAND" ]; then
+  require_cmd curl
+fi
+
+case "$FORMAT" in
+  json|text|markdown) ;;
+  *) echo "invalid format: $FORMAT" >&2; exit 1 ;;
+esac
+
+BASE_SHA="$(git rev-parse "$BASE_REF")"
+HEAD_SHA="$(git rev-parse "$HEAD_REF")"
+
+if [ ${#PATH_FILTERS[@]} -gt 0 ]; then
+  while IFS= read -r line; do
+    CHANGED_PATHS+=("$line")
+    CHANGED_PATH_COUNT=$((CHANGED_PATH_COUNT + 1))
+  done < <(git diff --name-only "${BASE_REF}...${HEAD_REF}" -- "${PATH_FILTERS[@]}")
+else
+  while IFS= read -r line; do
+    CHANGED_PATHS+=("$line")
+    CHANGED_PATH_COUNT=$((CHANGED_PATH_COUNT + 1))
+  done < <(git diff --name-only "${BASE_REF}...${HEAD_REF}")
+fi
+
+if [ "$CHANGED_PATH_COUNT" -gt 0 ]; then
+  PATHSET_HASH="$(printf '%s\n' "${CHANGED_PATHS[@]}" | LC_ALL=C sort | hash_text)"
+else
+  PATHSET_HASH="$(printf '' | hash_text)"
+fi
+CACHE_KEY="$(
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+    "$SCRIPT_VERSION" "$MODEL" "$PROMPT_VERSION" "$BASE_SHA" "$HEAD_SHA" \
+    "$FORMAT" "$PATHSET_HASH" \
+  | hash_text
+)"
+
+if [ "$PRINT_CACHE_KEY" -eq 1 ]; then
+  printf '%s\n' "$CACHE_KEY"
+  exit 0
+fi
+
+LOCK_ROOT="$CACHE_DIR/locks"
+INDEX_ROOT="$CACHE_DIR/index"
+RESULT_ROOT="$CACHE_DIR/results"
+LOCK_DIR="$LOCK_ROOT/$CACHE_KEY.lock"
+PENDING_FILE="$INDEX_ROOT/$CACHE_KEY.pending.json"
+RESULT_FILE="$RESULT_ROOT/$CACHE_KEY.json"
+
+mkdir -p "$LOCK_ROOT" "$INDEX_ROOT" "$RESULT_ROOT"
+
+HAVE_LOCK=0
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/masc-local-review.XXXXXX")"
+cleanup() {
+  if [ "$HAVE_LOCK" -eq 1 ]; then
+    rm -f "$PENDING_FILE"
+    rmdir "$LOCK_DIR" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+print_cached_result() {
+  local cache_hit="$1"
+  case "$FORMAT" in
+    json)
+      jq --argjson cache_hit "$(json_bool "$cache_hit")" \
+        '.cache_hit = $cache_hit' "$RESULT_FILE"
+      ;;
+    text)
+      jq -r '.result' "$RESULT_FILE"
+      ;;
+    markdown)
+      jq -r '.markdown' "$RESULT_FILE"
+      ;;
+  esac
+}
+
+pending_is_stale_or_dead() {
+  if [ ! -f "$PENDING_FILE" ]; then
+    if [ -d "$LOCK_DIR" ]; then
+      local lock_mtime now age
+      lock_mtime="$(path_mtime_epoch "$LOCK_DIR")"
+      now="$(now_epoch)"
+      age=$((now - lock_mtime))
+      if [ "$age" -ge "$STALE_SECS" ]; then
+        return 0
+      fi
+      return 1
+    fi
+    return 0
+  fi
+  local pid started_at age now
+  pid="$(jq -r '.pid // 0' "$PENDING_FILE")"
+  started_at="$(jq -r '.started_at_epoch // 0' "$PENDING_FILE")"
+  now="$(now_epoch)"
+  age=$((now - started_at))
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "$age" -ge "$STALE_SECS" ]; then
+    return 0
+  fi
+  return 1
+}
+
+reap_pending_if_needed() {
+  if [ ! -d "$LOCK_DIR" ] && [ ! -f "$PENDING_FILE" ]; then
+    return 0
+  fi
+  if ! pending_is_stale_or_dead; then
+    return 1
+  fi
+  if [ -f "$PENDING_FILE" ]; then
+    local pid started_at age now
+    pid="$(jq -r '.pid // 0' "$PENDING_FILE")"
+    started_at="$(jq -r '.started_at_epoch // 0' "$PENDING_FILE")"
+    now="$(now_epoch)"
+    age=$((now - started_at))
+    if kill -0 "$pid" >/dev/null 2>&1 && [ "$age" -ge "$STALE_SECS" ]; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  fi
+  rm -f "$PENDING_FILE"
+  rm -rf "$LOCK_DIR"
+  return 0
+}
+
+wait_for_existing_result() {
+  while true; do
+    if [ -f "$RESULT_FILE" ]; then
+      print_cached_result true
+      exit 0
+    fi
+    if reap_pending_if_needed; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+if [ "$NO_CACHE" -eq 0 ]; then
+  if [ -f "$RESULT_FILE" ]; then
+    print_cached_result true
+    exit 0
+  fi
+
+  while true; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      HAVE_LOCK=1
+      jq -n \
+        --arg key "$CACHE_KEY" \
+        --arg model "$MODEL" \
+        --arg pid "$$" \
+        --argjson started_at_epoch "$(now_epoch)" \
+        --arg started_at "$(now_iso)" \
+        --arg base_ref "$BASE_REF" \
+        --arg head_ref "$HEAD_REF" \
+        --arg base_sha "$BASE_SHA" \
+        --arg head_sha "$HEAD_SHA" \
+        --arg version "$SCRIPT_VERSION" \
+        '{key:$key,model:$model,pid:($pid|tonumber),started_at_epoch:$started_at_epoch,started_at:$started_at,base_ref:$base_ref,head_ref:$head_ref,base_sha:$base_sha,head_sha:$head_sha,script_version:$version}' \
+        > "$PENDING_FILE"
+      break
+    fi
+    wait_for_existing_result || true
+    if [ -f "$RESULT_FILE" ]; then
+      print_cached_result true
+      exit 0
+    fi
+  done
+fi
+
+build_chunks() {
+  local chunk_index=0
+  local current=""
+  local file diff path
+  CHUNK_FILES=()
+  CHUNK_FILE_COUNT=0
+
+  if [ "$CHANGED_PATH_COUNT" -eq 0 ]; then
+    return 0
+  fi
+
+  for file in "${CHANGED_PATHS[@]}"; do
+    if [ -n "$file" ]; then
+      diff="$(git diff --unified=2 "${BASE_REF}...${HEAD_REF}" -- "$file")"
+    else
+      diff=""
+    fi
+    if [ -z "$diff" ]; then
+      continue
+    fi
+    diff="${diff}"$'\n'
+    if [ -n "$current" ] && [ $(( ${#current} + ${#diff} )) -gt "$CHUNK_BYTES" ]; then
+      chunk_index=$((chunk_index + 1))
+      path="$TMP_DIR/chunk-$chunk_index.diff"
+      printf '%s' "$current" > "$path"
+      CHUNK_FILES+=("$path")
+      CHUNK_FILE_COUNT=$((CHUNK_FILE_COUNT + 1))
+      current="$diff"
+    else
+      current="${current}${diff}"
+    fi
+  done
+
+  if [ -n "$current" ]; then
+    chunk_index=$((chunk_index + 1))
+    path="$TMP_DIR/chunk-$chunk_index.diff"
+    printf '%s' "$current" > "$path"
+    CHUNK_FILES+=("$path")
+    CHUNK_FILE_COUNT=$((CHUNK_FILE_COUNT + 1))
+  fi
+}
+
+build_prompt() {
+  local chunk_path="$1"
+  cat <<EOF
+Review this git diff against ${BASE_REF}...${HEAD_REF}. Focus only on bugs, regressions, stale compatibility assumptions, and missing tests.
+Return only \`No findings.\` or a flat list of findings with file paths and concise reasoning.
+
+$(cat "$chunk_path")
+EOF
+}
+
+run_reviewer() {
+  local prompt="$1"
+  if [ -n "$REVIEW_COMMAND" ]; then
+    printf '%s' "$prompt" | bash -lc "$REVIEW_COMMAND"
+    return 0
+  fi
+  local request_json
+  request_json="$(
+    jq -n \
+      --arg model "$MODEL" \
+      --arg system_prompt "You are a strict senior code reviewer. Review the patch for bugs, regressions, stale compatibility assumptions, and missing tests. Return only \`No findings.\` or a flat list of findings with file paths and concise reasoning." \
+      --arg user_prompt "$prompt" \
+      --argjson max_tokens "$MAX_TOKENS" \
+      --argjson temperature "$TEMPERATURE" \
+      '{model:$model,messages:[{role:"system",content:$system_prompt},{role:"user",content:$user_prompt}],temperature:$temperature,max_tokens:$max_tokens,stream:false}'
+  )"
+  curl -s --show-error --max-time "$MAX_TIME" "$REVIEW_URL" \
+    -H 'Content-Type: application/json' \
+    --data-binary "$request_json" \
+    | jq -r '.choices[0].message.content // empty'
+}
+
+build_chunks
+
+if [ "$CHUNK_FILE_COUNT" -eq 0 ]; then
+  RESULT_TEXT="No findings."
+  CHUNK_COUNT=0
+else
+  declare -a CHUNK_RESULTS=()
+  for chunk_path in "${CHUNK_FILES[@]}"; do
+    chunk_result="$(run_reviewer "$(build_prompt "$chunk_path")" | trim)"
+    if [ -z "$chunk_result" ]; then
+      echo "reviewer returned empty output" >&2
+      exit 1
+    fi
+    CHUNK_RESULTS+=("$chunk_result")
+  done
+
+  CHUNK_COUNT="${#CHUNK_FILES[@]}"
+  has_findings=0
+  for item in "${CHUNK_RESULTS[@]}"; do
+    if [ "$item" != "No findings." ]; then
+      has_findings=1
+      break
+    fi
+  done
+
+  if [ "$has_findings" -eq 0 ]; then
+    RESULT_TEXT="No findings."
+  else
+    RESULT_TEXT="$(
+      printf '%s\n' "${CHUNK_RESULTS[@]}" \
+        | awk 'NF && $0 != "No findings." { print }' \
+        | awk '!seen[$0]++'
+    )"
+    if [ -z "$RESULT_TEXT" ]; then
+      RESULT_TEXT="No findings."
+    fi
+  fi
+fi
+
+MARKDOWN_RESULT="$(
+  cat <<EOF
+Cross-model review evidence
+
+- Reviewer model: local \`llama-server\` target \`${MODEL}\`
+- Timestamp: $(now_iso)
+- Prompt version: \`${PROMPT_VERSION}\`
+- Cache: $([ "$NO_CACHE" -eq 0 ] && printf 'miss' || printf 'disabled')
+- Chunk count: ${CHUNK_COUNT}
+- Scope: \`${BASE_REF}...${HEAD_REF}\`
+- Result:
+\`\`\`
+${RESULT_TEXT}
+\`\`\`
+EOF
+)"
+
+if [ "$CHANGED_PATH_COUNT" -gt 0 ]; then
+  PATHS_JSON="$(
+    printf '%s\n' "${CHANGED_PATHS[@]}" | jq -R . | jq -s .
+  )"
+else
+  PATHS_JSON="[]"
+fi
+
+TMP_RESULT="$TMP_DIR/result.json"
+jq -n \
+  --arg status "ok" \
+  --arg key "$CACHE_KEY" \
+  --arg version "$SCRIPT_VERSION" \
+  --arg model "$MODEL" \
+  --arg prompt_version "$PROMPT_VERSION" \
+  --arg base_ref "$BASE_REF" \
+  --arg head_ref "$HEAD_REF" \
+  --arg base_sha "$BASE_SHA" \
+  --arg head_sha "$HEAD_SHA" \
+  --argjson cache_hit false \
+  --argjson chunk_count "$CHUNK_COUNT" \
+  --argjson paths "$PATHS_JSON" \
+  --arg result "$RESULT_TEXT" \
+  --arg markdown "$MARKDOWN_RESULT" \
+  --arg created_at "$(now_iso)" \
+  '{status:$status,cache_key:$key,script_version:$version,model:$model,prompt_version:$prompt_version,base_ref:$base_ref,head_ref:$head_ref,base_sha:$base_sha,head_sha:$head_sha,cache_hit:$cache_hit,chunk_count:$chunk_count,paths:$paths,result:$result,markdown:$markdown,created_at:$created_at}' \
+  > "$TMP_RESULT"
+
+if [ "$NO_CACHE" -eq 0 ]; then
+  mv "$TMP_RESULT" "$RESULT_FILE"
+fi
+
+case "$FORMAT" in
+  json)
+    if [ "$NO_CACHE" -eq 0 ]; then
+      cat "$RESULT_FILE"
+    else
+      cat "$TMP_RESULT"
+    fi
+    ;;
+  text)
+    printf '%s\n' "$RESULT_TEXT"
+    ;;
+  markdown)
+    printf '%s\n' "$MARKDOWN_RESULT"
+    ;;
+esac

--- a/test/dune
+++ b/test/dune
@@ -159,6 +159,11 @@
  (libraries alcotest unix))
 
 (test
+ (name test_local_review_script)
+ (modules test_local_review_script)
+ (libraries alcotest unix yojson))
+
+(test
  (name test_worker_runtime)
  (modules test_worker_runtime)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -212,7 +212,5 @@ let () =
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
-           test_case "activity surface contracts" `Quick test_activity_surface_contracts;
-           test_case "local review script contracts" `Quick test_local_review_script_contracts;
          ]);
     ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -181,6 +181,26 @@ let test_activity_surface_contracts () =
     (file_contains_pattern "lib/team_session/team_session_store.ml"
        "Activity_graph.emit config")
 
+let test_local_review_script_contracts () =
+  check bool "local review script exists" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       "#!/usr/bin/env bash");
+  check bool "local review script caches under .masc review-cache" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       ".masc/review-cache/local-review");
+  check bool "local review script keeps pending registry" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       ".pending.json");
+  check bool "local review script chunks large diffs" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       "MASC_LOCAL_REVIEW_CHUNK_BYTES");
+  check bool "local review script bounds reviewer request time" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       "--max-time");
+  check bool "local review script exposes cache key print" true
+    (file_contains_pattern "scripts/review/local-review.sh"
+       "--print-cache-key")
+
 let () =
   run "ci_hardening_source"
     [
@@ -191,5 +211,8 @@ let () =
            test_case "input validation contracts" `Quick test_input_validation_contracts;
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
+           test_case "local review script contracts" `Quick test_local_review_script_contracts;
+           test_case "activity surface contracts" `Quick test_activity_surface_contracts;
+           test_case "local review script contracts" `Quick test_local_review_script_contracts;
          ]);
     ]

--- a/test/test_local_review_script.ml
+++ b/test/test_local_review_script.ml
@@ -1,0 +1,318 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let script_path () =
+  Filename.concat (source_root ()) "scripts/review/local-review.sh"
+
+let quote = Filename.quote
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "local-review-out" ".txt" in
+  let err = Filename.temp_file "local-review-err" ".txt" in
+  let wrapped =
+    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let run_shell_ok ?(env = []) ~cwd cmd =
+  let code, stdout, stderr = run_shell ~env ~cwd cmd in
+  if code <> 0 then
+    failf "command failed (%d): %s\n%s" code cmd stderr;
+  (stdout, stderr)
+
+let spawn_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "local-review-out" ".txt" in
+  let err = Filename.temp_file "local-review-err" ".txt" in
+  let out_fd =
+    Unix.openfile out [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o644
+  in
+  let err_fd =
+    Unix.openfile err [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o644
+  in
+  let pid =
+    Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; full |] Unix.stdin out_fd
+      err_fd
+  in
+  Unix.close out_fd;
+  Unix.close err_fd;
+  (pid, out, err)
+
+let wait_process (pid, out, err) =
+  let _, status = Unix.waitpid [] pid in
+  let code =
+    match status with
+    | Unix.WEXITED c -> c
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let command_output ~cwd cmd =
+  let stdout, _stderr = run_shell_ok ~cwd cmd in
+  String.trim stdout
+
+let init_repo dir =
+  ignore (run_shell_ok ~cwd:dir "git init -q");
+  ignore (run_shell_ok ~cwd:dir "git config user.email test@example.com");
+  ignore (run_shell_ok ~cwd:dir "git config user.name tester");
+  write_file (Filename.concat dir "alpha.txt") "alpha base\n";
+  write_file (Filename.concat dir "beta.txt") "beta base\n";
+  ignore
+    (run_shell_ok ~cwd:dir
+       "git add alpha.txt beta.txt && git -c core.hooksPath=/dev/null commit -q -m base");
+  let base_sha = command_output ~cwd:dir "git rev-parse HEAD" in
+  write_file (Filename.concat dir "alpha.txt")
+    "alpha changed once\nalpha changed twice\n";
+  write_file (Filename.concat dir "beta.txt")
+    "beta changed once\nbeta changed twice\n";
+  ignore
+    (run_shell_ok ~cwd:dir
+       "git add alpha.txt beta.txt && git -c core.hooksPath=/dev/null commit -q -m head");
+  let head_sha = command_output ~cwd:dir "git rev-parse HEAD" in
+  (base_sha, head_sha)
+
+let make_fake_reviewer dir =
+  let path = Filename.concat dir "fake-reviewer.sh" in
+  write_file path
+    {|
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="${COUNT_FILE:?}"
+sleep_secs="${SLEEP_SECS:-0}"
+if [ "$sleep_secs" != "0" ]; then
+  sleep "$sleep_secs"
+fi
+count=0
+if [ -f "$count_file" ]; then
+  count="$(cat "$count_file")"
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+cat >/dev/null
+printf '%s\n' "${FAKE_REVIEW_OUTPUT:-No findings.}"
+|}
+  ;
+  Unix.chmod path 0o755;
+  path
+
+let parse_json_output stdout =
+  Yojson.Safe.from_string stdout
+
+let review_cmd script base_sha head_sha =
+  String.concat " "
+    [
+      quote script;
+      "--base";
+      quote base_sha;
+      "--head";
+      quote head_sha;
+      "--format";
+      "json";
+    ]
+
+let test_cache_hit_and_chunking () =
+  with_temp_dir "local-review-cache-test" (fun dir ->
+      let base_sha, head_sha = init_repo dir in
+      let fake = make_fake_reviewer dir in
+      let count_file = Filename.concat dir "count.txt" in
+      let cache_dir = Filename.concat dir ".masc/review-cache/local-review" in
+      let env =
+        [
+          ("MASC_LOCAL_REVIEW_COMMAND", fake);
+          ("COUNT_FILE", count_file);
+          ("MASC_LOCAL_REVIEW_CACHE_DIR", cache_dir);
+          ("MASC_LOCAL_REVIEW_CHUNK_BYTES", "20");
+        ]
+      in
+      let code1, stdout1, stderr1 =
+        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+      in
+      if code1 <> 0 then
+        failf "first run failed (%d): %s" code1 stderr1;
+      check string "first run stderr empty" "" stderr1;
+      let json1 = parse_json_output stdout1 in
+      let open Yojson.Safe.Util in
+      let chunk_count = json1 |> member "chunk_count" |> to_int in
+      check bool "first run is cache miss" false
+        (json1 |> member "cache_hit" |> to_bool);
+      check bool "chunking happened" true
+        (chunk_count >= 2);
+      check string "first result" "No findings."
+        (json1 |> member "result" |> to_string);
+      check string "first run reviewer calls match chunk count"
+        (string_of_int chunk_count) (read_file count_file);
+
+      let code2, stdout2, stderr2 =
+        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+      in
+      if code2 <> 0 then
+        failf "second run failed (%d): %s" code2 stderr2;
+      check string "second run stderr empty" "" stderr2;
+      let json2 = parse_json_output stdout2 in
+      check bool "second run is cache hit" true
+        (json2 |> member "cache_hit" |> to_bool);
+      check string "second run reuses cached result"
+        (string_of_int chunk_count) (read_file count_file))
+
+let test_single_flight_reuses_pending_worker () =
+  with_temp_dir "local-review-single-flight" (fun dir ->
+      let base_sha, head_sha = init_repo dir in
+      let fake = make_fake_reviewer dir in
+      let count_file = Filename.concat dir "count.txt" in
+      let cache_dir = Filename.concat dir ".masc/review-cache/local-review" in
+      let env =
+        [
+          ("MASC_LOCAL_REVIEW_COMMAND", fake);
+          ("COUNT_FILE", count_file);
+          ("SLEEP_SECS", "2");
+          ("MASC_LOCAL_REVIEW_CACHE_DIR", cache_dir);
+          ("MASC_LOCAL_REVIEW_STALE_SECS", "30");
+        ]
+      in
+      let cmd = review_cmd (script_path ()) base_sha head_sha in
+      let p1 = spawn_shell ~cwd:dir ~env cmd in
+      ignore (Unix.select [] [] [] 0.2);
+      let p2 = spawn_shell ~cwd:dir ~env cmd in
+      let code1, stdout1, stderr1 = wait_process p1 in
+      let code2, stdout2, stderr2 = wait_process p2 in
+      if code1 <> 0 then failf "first process failed (%d): %s" code1 stderr1;
+      if code2 <> 0 then failf "second process failed (%d): %s" code2 stderr2;
+      let open Yojson.Safe.Util in
+      let json1 = parse_json_output stdout1 in
+      let json2 = parse_json_output stdout2 in
+      check string "single-flight count" "1" (read_file count_file);
+      check bool "one cache miss exists" true
+        ((not (json1 |> member "cache_hit" |> to_bool))
+         || not (json2 |> member "cache_hit" |> to_bool));
+      check bool "one cache hit exists" true
+        ((json1 |> member "cache_hit" |> to_bool)
+         || (json2 |> member "cache_hit" |> to_bool)))
+
+let test_stale_pending_is_reaped () =
+  with_temp_dir "local-review-stale" (fun dir ->
+      let base_sha, head_sha = init_repo dir in
+      let fake = make_fake_reviewer dir in
+      let count_file = Filename.concat dir "count.txt" in
+      let cache_dir = Filename.concat dir ".masc/review-cache/local-review" in
+      let env =
+        [
+          ("MASC_LOCAL_REVIEW_COMMAND", fake);
+          ("COUNT_FILE", count_file);
+          ("MASC_LOCAL_REVIEW_CACHE_DIR", cache_dir);
+          ("MASC_LOCAL_REVIEW_STALE_SECS", "1");
+        ]
+      in
+      let key_cmd =
+        String.concat " "
+          [
+            quote (script_path ());
+            "--base";
+            quote base_sha;
+            "--head";
+            quote head_sha;
+            "--print-cache-key";
+          ]
+      in
+      let cache_key = command_output ~cwd:dir key_cmd in
+      let lock_dir =
+        Filename.concat cache_dir (Filename.concat "locks" (cache_key ^ ".lock"))
+      in
+      let pending_file =
+        Filename.concat cache_dir
+          (Filename.concat "index" (cache_key ^ ".pending.json"))
+      in
+      mkdir_p (Filename.concat cache_dir "locks");
+      mkdir_p (Filename.concat cache_dir "index");
+      mkdir_p (Filename.concat cache_dir "results");
+      Unix.mkdir lock_dir 0o755;
+      write_file pending_file
+        {|{"pid":999999,"started_at_epoch":1,"started_at":"1970-01-01T00:00:01Z"}|};
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+      in
+      if code <> 0 then failf "stale reap run failed (%d): %s" code stderr;
+      let open Yojson.Safe.Util in
+      let json = parse_json_output stdout in
+      check string "stale run result" "No findings."
+        (json |> member "result" |> to_string);
+      check string "review command executed once after reap" "1"
+        (read_file count_file);
+      check bool "pending file removed" false (Sys.file_exists pending_file))
+
+let () =
+  run "local_review_script"
+    [
+      ( "script",
+        [
+          test_case "cache hit and chunking" `Quick test_cache_hit_and_chunking;
+          test_case "single flight reuses pending worker" `Quick
+            test_single_flight_reuses_pending_worker;
+          test_case "stale pending is reaped" `Quick
+            test_stale_pending_is_reaped;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add `scripts/review/local-review.sh` with cached local review results, chunking, single-flight, and stale pending cleanup
- add regression tests for cache hits, concurrent reuse, and stale pending reap
- document the helper in the swarm delivery runbook and add source-guard coverage

## Verification
- `bash -n scripts/review/local-review.sh`
- `dune build --root . test/test_local_review_script.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_local_review_script.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `git diff --check`

## Review
- local `llama-server` review helper was attempted after commit, but `127.0.0.1:8085` was unavailable at request time; follow-up evidence comment will be added after reviewer retry