### PR TITLE
perf(dashboard): add signal change detection to prevent cascade re-renders

### DIFF
--- a/dashboard/src/signal-utils.test.ts
+++ b/dashboard/src/signal-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { signal } from '@preact/signals'
+import { setIfChanged, setArrayIfChanged, setArrayByKeyIfChanged } from './signal-utils'
+
+describe('setIfChanged', () => {
+  it('updates when value differs', () => {
+    const s = signal(1)
+    setIfChanged(s, 2)
+    expect(s.value).toBe(2)
+  })
+
+  it('skips when value is the same', () => {
+    const obj = { a: 1 }
+    const s = signal(obj)
+    setIfChanged(s, obj)
+    // Verify it's still the exact same reference
+    expect(s.value).toBe(obj)
+  })
+
+  it('updates when referentially different even if structurally equal', () => {
+    const s = signal({ a: 1 })
+    const newObj = { a: 1 }
+    setIfChanged(s, newObj)
+    expect(s.value).toBe(newObj)
+  })
+})
+
+describe('setArrayIfChanged', () => {
+  it('updates when length differs', () => {
+    const s = signal([1, 2, 3])
+    setArrayIfChanged(s, [1, 2])
+    expect(s.value).toEqual([1, 2])
+  })
+
+  it('updates when first element differs', () => {
+    const a = { id: 'a' }
+    const b = { id: 'b' }
+    const c = { id: 'c' }
+    const s = signal([a, b])
+    setArrayIfChanged(s, [c, b])
+    expect(s.value[0]).toBe(c)
+  })
+
+  it('updates when last element differs', () => {
+    const a = { id: 'a' }
+    const b = { id: 'b' }
+    const c = { id: 'c' }
+    const s = signal([a, b])
+    setArrayIfChanged(s, [a, c])
+    expect(s.value[1]).toBe(c)
+  })
+
+  it('skips when boundary elements are the same references', () => {
+    const a = { id: 'a' }
+    const b = { id: 'b' }
+    const arr = [a, b]
+    const s = signal(arr)
+    // Same length, same first and last references
+    setArrayIfChanged(s, [a, b])
+    expect(s.value).toBe(arr)
+  })
+
+  it('handles empty arrays', () => {
+    const empty: number[] = []
+    const s = signal(empty)
+    setArrayIfChanged(s, [])
+    expect(s.value).toBe(empty) // same length (0), no elements to compare
+  })
+})
+
+describe('setArrayByKeyIfChanged', () => {
+  const keyFn = (item: { id: string }) => item.id
+
+  it('updates when length differs', () => {
+    const s = signal([{ id: 'a' }, { id: 'b' }])
+    setArrayByKeyIfChanged(s, [{ id: 'a' }], keyFn)
+    expect(s.value).toHaveLength(1)
+  })
+
+  it('updates when first key differs', () => {
+    const original = [{ id: 'a' }, { id: 'b' }]
+    const s = signal(original)
+    const next = [{ id: 'c' }, { id: 'b' }]
+    setArrayByKeyIfChanged(s, next, keyFn)
+    expect(s.value).toBe(next)
+  })
+
+  it('updates when last key differs', () => {
+    const original = [{ id: 'a' }, { id: 'b' }]
+    const s = signal(original)
+    const next = [{ id: 'a' }, { id: 'c' }]
+    setArrayByKeyIfChanged(s, next, keyFn)
+    expect(s.value).toBe(next)
+  })
+
+  it('skips when keys at boundaries match', () => {
+    const original = [{ id: 'a' }, { id: 'b' }]
+    const s = signal(original)
+    // Different object references but same keys
+    setArrayByKeyIfChanged(s, [{ id: 'a' }, { id: 'b' }], keyFn)
+    expect(s.value).toBe(original)
+  })
+
+  it('skips empty arrays', () => {
+    const empty: { id: string }[] = []
+    const s = signal(empty)
+    setArrayByKeyIfChanged(s, [], keyFn)
+    expect(s.value).toBe(empty)
+  })
+})

--- a/dashboard/src/signal-utils.ts
+++ b/dashboard/src/signal-utils.ts
@@ -1,0 +1,54 @@
+// Signal update utilities — avoid unnecessary re-renders by skipping
+// assignments when the value has not actually changed.
+
+import type { Signal } from '@preact/signals'
+
+/** Only update signal if the new value is referentially different. */
+export function setIfChanged<T>(signal: Signal<T>, value: T): void {
+  if (signal.value !== value) {
+    signal.value = value
+  }
+}
+
+/** Only update signal if the new array differs in length or boundary elements.
+ *  Best for prepend-style buffers where elements are reused by reference. */
+export function setArrayIfChanged<T>(
+  signal: Signal<T[]>,
+  value: T[],
+): void {
+  const prev = signal.value
+  if (
+    prev.length !== value.length
+    || prev[0] !== value[0]
+    || prev[prev.length - 1] !== value[value.length - 1]
+  ) {
+    signal.value = value
+  }
+}
+
+/** Only update signal if the new array differs by length or boundary keys.
+ *  Suitable for API-fetched arrays where each element is a fresh object
+ *  but has a stable identity key (e.g., name, id). */
+export function setArrayByKeyIfChanged<T>(
+  signal: Signal<T[]>,
+  value: T[],
+  keyFn: (item: T) => string | number,
+): void {
+  const prev = signal.value
+  if (prev.length !== value.length) {
+    signal.value = value
+    return
+  }
+  if (prev.length === 0) return
+  const prevFirst = prev[0]
+  const valFirst = value[0]
+  const prevLast = prev[prev.length - 1]
+  const valLast = value[value.length - 1]
+  if (
+    prevFirst == null || valFirst == null || prevLast == null || valLast == null
+    || keyFn(prevFirst) !== keyFn(valFirst)
+    || keyFn(prevLast) !== keyFn(valLast)
+  ) {
+    signal.value = value
+  }
+}

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -112,8 +112,11 @@ const KEEPER_LIFECYCLE_EVENTS = new Set([
 
 function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void {
   if (!event.name) return
+  const newTs = event.ts_unix ? event.ts_unix * 1000 : Date.now()
+  const existingTs = keeperHeartbeats.value.get(event.name)
+  if (existingTs === newTs) return
   const next = new Map(keeperHeartbeats.value)
-  next.set(event.name, event.ts_unix ? event.ts_unix * 1000 : Date.now())
+  next.set(event.name, newTs)
   keeperHeartbeats.value = next
 }
 

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -369,7 +369,10 @@ function handleEvent(event: SSEEvent): void {
       break
     }
     case 'oas:masc:keeper:tick': {
-      oasLastKeeperTick.value = Date.now()
+      const now = Date.now()
+      if (oasLastKeeperTick.value === null || now - oasLastKeeperTick.value > 100) {
+        oasLastKeeperTick.value = now
+      }
       oasTotalEvents.value++
       break
     }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -44,6 +44,7 @@ import {
 } from './keeper-store-normalize'
 import { buildAgentMotion, normalizeAgentKey, type AgentMotionSnapshot } from './components/common/agent-motion'
 import { groupByKey } from './components/common/collection'
+import { setArrayByKeyIfChanged } from './signal-utils'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
@@ -129,6 +130,10 @@ export const oasLastKeeperTick = signal<number | null>(null)
 export const oasTotalEvents = signal(0)
 
 export function pushOasAgentEvent(event: OasAgentEvent): void {
+  const head = oasAgentEvents.value[0]
+  if (head && head.type === event.type && head.agent_name === event.agent_name && head.timestamp === event.timestamp) {
+    return
+  }
   oasAgentEvents.value = [event, ...oasAgentEvents.value].slice(0, OAS_AGENT_EVENT_BUFFER)
   oasTotalEvents.value++
 }
@@ -426,36 +431,44 @@ export async function refreshExecution(opts?: { force?: boolean }): Promise<void
       serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
     }
     const roomChanged = previousRoom != null && normalizedStatus?.room != null && previousRoom !== normalizedStatus.room
-    agents.value = (Array.isArray(data.agents) ? data.agents : [])
+    const normalizedAgents = (Array.isArray(data.agents) ? data.agents : [])
       .map(normalizeAgent)
       .filter((row): row is Agent => row !== null)
-    tasks.value = (Array.isArray(data.tasks) ? data.tasks : [])
+    setArrayByKeyIfChanged(agents, normalizedAgents, a => a.name)
+    const normalizedTasks = (Array.isArray(data.tasks) ? data.tasks : [])
       .map(normalizeTask)
       .filter((row): row is Task => row !== null)
+    setArrayByKeyIfChanged(tasks, normalizedTasks, t => t.id)
     const executionMessages = (Array.isArray(data.messages) ? data.messages : [])
       .map(normalizeMessage)
       .filter((row): row is Message => row !== null)
     messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
     keepers.value = normalizeKeepers(data.keepers)
     executionSummary.value = normalizeExecutionSummary(data.summary)
-    executionQueue.value = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
+    const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
       .map(normalizeExecutionQueueItem)
       .filter((row): row is DashboardExecutionQueueItem => row !== null)
-    executionSessionBriefs.value = (Array.isArray(data.session_briefs) ? data.session_briefs : [])
+    setArrayByKeyIfChanged(executionQueue, normalizedQueue, q => q.id)
+    const normalizedSessionBriefs = (Array.isArray(data.session_briefs) ? data.session_briefs : [])
       .map(normalizeExecutionSessionBrief)
       .filter((row): row is DashboardExecutionSessionBrief => row !== null)
-    executionOperationBriefs.value = (Array.isArray(data.operation_briefs) ? data.operation_briefs : [])
+    setArrayByKeyIfChanged(executionSessionBriefs, normalizedSessionBriefs, s => s.session_id)
+    const normalizedOpBriefs = (Array.isArray(data.operation_briefs) ? data.operation_briefs : [])
       .map(normalizeExecutionOperationBrief)
       .filter((row): row is DashboardExecutionOperationBrief => row !== null)
-    executionWorkerSupportBriefs.value = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
+    setArrayByKeyIfChanged(executionOperationBriefs, normalizedOpBriefs, o => o.operation_id)
+    const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
       .map(normalizeExecutionWorkerSupportBrief)
       .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
-    executionContinuityBriefs.value = (Array.isArray(data.continuity_briefs) ? data.continuity_briefs : [])
+    setArrayByKeyIfChanged(executionWorkerSupportBriefs, normalizedWorkerBriefs, w => w.name)
+    const normalizedContinuityBriefs = (Array.isArray(data.continuity_briefs) ? data.continuity_briefs : [])
       .map(normalizeExecutionContinuityBrief)
       .filter((row): row is DashboardExecutionContinuityBrief => row !== null)
-    executionOfflineWorkerBriefs.value = (Array.isArray(data.offline_worker_briefs) ? data.offline_worker_briefs : [])
+    setArrayByKeyIfChanged(executionContinuityBriefs, normalizedContinuityBriefs, c => c.name)
+    const normalizedOfflineBriefs = (Array.isArray(data.offline_worker_briefs) ? data.offline_worker_briefs : [])
       .map(normalizeExecutionWorkerSupportBrief)
       .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
+    setArrayByKeyIfChanged(executionOfflineWorkerBriefs, normalizedOfflineBriefs, w => w.name)
     perpetualStatus.value = null
     executionLoaded.value = true
     lastExecutionRefreshAt.value = Date.now()


### PR DESCRIPTION
## Summary
SSE 이벤트마다 signal을 무조건 갱신하여 불필요한 re-render cascade가 발생하던 문제 수정.

### Changes
- `signal-utils.ts`: 3개 유틸 (`setIfChanged`, `setArrayIfChanged`, `setArrayByKeyIfChanged`) + 13개 테스트
- `sse.ts`: `oasLastKeeperTick` 100ms debounce
- `sse-store.ts`: keeper heartbeat 타임스탬프 변경 시에만 갱신
- `store.ts`: `refreshExecution()` 8개 signal에 identity guard 적용, `pushOasAgentEvent` 중복 guard

## Test plan
- [x] `npm run build` 통과
- [x] `vitest run` — 16 테스트 통과
- [ ] Chrome DevTools Performance 탭에서 re-render 빈도 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)