### PR TITLE
fix(ci): remove stale push trigger from deploy-railway workflow

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,8 +1,6 @@
 name: Deploy to Railway
 
 on:
-  push:
-    branches: [release/v2.94.0]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
deploy-railway.yml이 `release/v2.94.0` 브랜치에 하드코딩되어 있어 33버전 뒤처진 dead workflow. push 트리거를 제거하고 `workflow_dispatch` 전용으로 전환.

## Changes
- `.github/workflows/deploy-railway.yml`: push trigger 삭제

## Test plan
- [x] YAML 문법 유효
- [ ] workflow_dispatch 수동 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)