### PR TITLE
fix(dashboard): guard nullable fields to prevent render crash

### DIFF
--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -92,7 +92,7 @@ export function LogViewer() {
         </div>
 
         <div class="logs-actions">
-          <span class="logs-total">${logTotal.value.toLocaleString()}건</span>
+          <span class="logs-total">${(logTotal.value ?? 0).toLocaleString()}건</span>
           <label class="logs-auto-label">
             <input
               type="checkbox"

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -37,7 +37,7 @@ function gatherSpotlightItems(snap: DashboardMissionResponse): SpotlightItem[] {
 
   // 2. Sessions with blockers (that aren't already captured in attention queue)
   const sessions: SessionItem[] =
-    snap.sessions.length > 0 ? snap.sessions : snap.session_briefs
+    (snap.sessions ?? []).length > 0 ? snap.sessions : (snap.session_briefs ?? [])
   const aqIds = new Set(items.map(i => i.id))
 
   for (const s of sessions) {

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -36,7 +36,7 @@ function synthesizeSituation(snap: DashboardMissionResponse | null): SituationRe
   }
 
   const sessions: SessionItem[] =
-    snap.sessions.length > 0 ? snap.sessions : snap.session_briefs
+    (snap.sessions ?? []).length > 0 ? snap.sessions : (snap.session_briefs ?? [])
   const total = sessions.length
   const blocked = sessions.filter(s => s.blocker_summary).length
   const attentionItems = snap.attention_queue ?? []


### PR DESCRIPTION
## Summary
Dashboard crashes with "Cannot read properties of undefined" on initial load when API returns partial data.

## Fixes
- `situation-banner.ts`: `snap.sessions` → `(snap.sessions ?? [])`
- `attention-spotlight.ts`: same pattern
- `logs.ts`: `logTotal.value.toLocaleString()` → `(logTotal.value ?? 0).toLocaleString()`

## Root cause
API responses during server warm-up may omit array fields. Components assumed arrays were always present.