### PR TITLE
feat(dashboard): keeper 상세 페이지 전용 stats + 상태 통합

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -39,6 +39,7 @@ import type {
 } from '../types'
 import { AgentRuntimeStrip } from './agent-monitor/runtime-strip'
 import { AgentLiveTimeline } from './agent-monitor/live-timeline'
+import { AutonomyMeter } from './keeper-detail-panels'
 
 const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
@@ -182,7 +183,8 @@ function CharacterPlate({ name }: { name: string }) {
 
   const displayName = brief?.display_name ?? keeper?.name ?? name
   const koreanName = agent?.koreanName ?? keeper?.koreanName
-  const headerStatus = agent?.status ?? brief?.status ?? 'unknown'
+  // Keeper heartbeat status takes priority over agent store status
+  const headerStatus = keeper?.status ?? agent?.status ?? brief?.status ?? 'unknown'
   const agentEmoji = agent?.emoji ?? keeper?.emoji
   const currentWork = brief?.current_work ?? agent?.current_task ?? null
   const lastSeenAt = agent?.last_seen ?? brief?.last_activity_at ?? null
@@ -272,7 +274,26 @@ function CharacterPlate({ name }: { name: string }) {
         ` : null}
       </div>
 
-      ${summary ? html`
+      ${isKeeper ? html`
+        <div class="ff-plate__stats ff-plate__stats--keeper">
+          <div class="ff-stat">
+            <span class="ff-stat__value">${ctxPct != null ? `${ctxPct}%` : '—'}</span>
+            <span class="ff-stat__label">CTX</span>
+          </div>
+          <div class="ff-stat">
+            <span class="ff-stat__value">${generation ?? 0}</span>
+            <span class="ff-stat__label">세대</span>
+          </div>
+          <div class="ff-stat">
+            <span class="ff-stat__value">${keeper.turn_count ?? 0}</span>
+            <span class="ff-stat__label">턴</span>
+          </div>
+          <div class="ff-stat">
+            <span class="ff-stat__value">${keeper.autonomous_action_count ?? 0}</span>
+            <span class="ff-stat__label">행동</span>
+          </div>
+        </div>
+      ` : summary ? html`
         <div class="ff-plate__stats">
           <div class="ff-stat">
             <span class="ff-stat__value">${summary.tasks_completed}</span>
@@ -306,9 +327,11 @@ export function AgentProfile({ name }: { name: string }) {
   const owned = assignedTasks(name)
   const lines = roomActivity.value
   const timeline = agentTimeline.value
+  const keeper = findKeeper(name)
+  const isKeeper = keeper != null
 
   return html`
-    <div class="ff-profile">
+    <div class="ff-profile ${isKeeper ? 'ff-profile--keeper' : ''}">
       <div class="ff-profile__toolbar">
         <button class="control-btn ghost" onClick=${() => navigate('status', { section: 'agents' })}>← 목록</button>
         <button class="control-btn ghost" onClick=${() => { void loadProfile(name) }} disabled=${loading.value}>
@@ -322,7 +345,14 @@ export function AgentProfile({ name }: { name: string }) {
 
       <${AgentRuntimeStrip} name=${name} />
 
+      ${isKeeper && keeper ? html`
+        <div class="ff-profile__keeper-panels">
+          <${AutonomyMeter} keeper=${keeper} />
+        </div>
+      ` : null}
+
       <div class="ff-profile__grid">
+        ${!isKeeper ? html`
         <${Card} title="태스크 (${owned.length})" class="ff-card">
           ${owned.length === 0
             ? html`<div class="empty-state">할당된 태스크 없음</div>`
@@ -334,6 +364,7 @@ export function AgentProfile({ name }: { name: string }) {
                 </div>
               `)}</div>`}
         <//>
+        ` : null}
 
         ${(() => {
           const rel = agentRelations.value

--- a/dashboard/src/styles/social.css
+++ b/dashboard/src/styles/social.css
@@ -1,0 +1,1 @@
+/* Social view styles — placeholder */


### PR DESCRIPTION
## Summary
- Keeper 상세 페이지의 stats grid를 keeper 전용으로 교체 (CTX%/세대/턴/행동)
- 일반 agent용 완료/수임/메시지/활동(항상 0) 카드를 keeper에서 숨김
- headerStatus에 keeper heartbeat 데이터를 우선 적용하여 offline vs 가동 중 모순 해결
- AutonomyMeter 패널 추가 (keeper-detail-panels.ts에서 재사용)

## Test plan
- [ ] `cd dashboard && npx vite build` 성공
- [ ] 브라우저 `#status?section=agents&agent=keeper-sangsu-agent` 접근
- [ ] CTX/세대/턴/행동 stats 표시 확인
- [ ] offline/가동 중 모순 해결 확인
- [ ] AutonomyMeter 렌더링 확인
- [ ] 일반 agent 프로필은 기존과 동일하게 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)