### PR TITLE
fix(oas): improve bridge health follow-ups

### DIFF
--- a/docs/OAS-MIGRATION-NEXT-STEPS.md
+++ b/docs/OAS-MIGRATION-NEXT-STEPS.md
@@ -24,10 +24,10 @@ They do. The gap is that the bridge is still lossy.
 ### What remains
 
 - preserve more `planned_worker` metadata in swarm entries
-- add real per-agent telemetry instead of `get_telemetry = None`
-- replace `convergence = None` with an explicit swarm convergence policy
-- replace `max_concurrent_agents = None` with a deliberate concurrency setting
-- decide whether session-level budget should remain `no_budget` or derive from MASC session settings
+- extend telemetry beyond usage/turn_count so swarm outputs carry trace refs too
+- decide whether the current single-pass success-ratio convergence policy should become a richer multi-iteration strategy
+- replace the current room-init `resource_check` with a broader runtime-health probe if needed
+- decide whether session-level budget needs token/cost enforcement beyond the current `duration_seconds` wall-clock budget
 
 ### Success criteria
 
@@ -46,7 +46,7 @@ This pass reduced duplication, but one important path still remains outside the 
 
 ### Still remaining
 
-- local worker resume/continue path still directly resumes an OAS agent and manually handles run/checkpoint/output lifecycle
+- local worker resume/continue path still constructs resume-specific config locally before entering the shared execution tail
 
 ### Success criteria
 
@@ -99,5 +99,5 @@ These are not the next best use of time unless a concrete product need appears:
 ## Recommended Order
 
 1. team-session bridge fidelity and telemetry
-2. worker resume-path runtime consolidation
+2. worker resume-path config consolidation
 3. follow-up memory/documentation cleanup

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -47,13 +47,14 @@ The main remaining problems are no longer “missing migration” at large. They
 The bridge still throws away part of MASC session semantics:
 
 - `planned_worker` metadata is only partially projected into swarm entries
-- `get_telemetry` remains `None`
-- `convergence` and `resource_check` are still unset
-- `budget` is still `no_budget`
+- per-agent telemetry now exists, but only usage/turn_count are surfaced; `trace_ref` is still absent
+- convergence now uses a single-pass success-ratio callback, but not a richer multi-iteration swarm policy
+- `resource_check` now guards on room initialization only; it is not yet a broader runtime-health probe
+- budget now derives wall-clock time from `duration_seconds`, but there is still no richer token/cost policy
 
 This means the runner is now tool-capable, but not yet fidelity-complete.
 
-### 2. Resume path still has its own direct OAS run logic
+### 2. Resume path is only partially consolidated
 
 Direct OAS build/run sites now remain primarily in:
 
@@ -61,7 +62,7 @@ Direct OAS build/run sites now remain primarily in:
 - `worker_oas.ml`
 - `local/worker_container_runners.ml` resume/continue path
 
-That is a much smaller surface than before, but the resume path still needs the same consolidation treatment as the initial run path.
+The resume path now shares the same checkpoint/evidence/completion-log cleanup helper as the initial run path, but it still constructs resume-specific config locally before delegating into the shared execution tail.
 
 ### 3. Memory bridge scope is now honest, but not universal
 
@@ -80,6 +81,6 @@ should be treated as outdated until refreshed.
 
 ## Recommended Priorities
 
-1. Finish team-session bridge fidelity: telemetry, convergence/resource settings, and less-lossy worker/session projection.
-2. Collapse the local worker resume path onto the same shared OAS execution template used by initial runs.
+1. Finish team-session bridge fidelity: trace refs, richer runtime-health checks, and less-lossy worker/session projection.
+2. Collapse the remaining resume-config construction path onto the same shared worker execution template used by initial runs.
 3. Keep docs synced to code after each OAS migration step; the documentation drift is currently more dangerous than the remaining missing code.

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -371,63 +371,8 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
               let agent =
                 Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
               in
-              let result =
-                Oas.Agent.run ~sw agent prompt
-              in
-              let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
-              let next_checkpoint =
-                Oas.Agent.checkpoint ~session_id:meta.mcp_session_id agent
-              in
-              let tool_names =
-                List.rev !tool_names_ref |> unique_preserve_order
-              in
-              let* () =
-                save_worker_checkpoint ~base_path ~team_session_id ~worker_name
-                  next_checkpoint
-              in
-              let* () =
-                save_worker_meta ~base_path ~team_session_id ~worker_name
-                  { meta with last_run_at = Some (Time_compat.now ()) }
-              in
-              materialize_direct_evidence ~base_path ~worker_name
-                ~worker_run_id ~meta ~prompt ~workspace_path ~agent ~raw_trace;
-              Oas.Agent.close agent;
-              match result with
-              | Ok response ->
-                  let output =
-                    response.content
-                    |> List.filter_map (function
-                         | Oas.Types.Text text -> Some text
-                         | _ -> None)
-                    |> String.concat "\n"
-                  in
-                  let* () =
-                    append_worker_completion_log ~base_path ~team_session_id
-                      ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
-                  in
-                  Ok
-                    {
-                      output;
-                      model_used =
-                        (if String.trim response.model <> "" then response.model
-                         else meta.effective_model);
-                      input_tokens = Some next_checkpoint.usage.total_input_tokens;
-                      output_tokens = Some next_checkpoint.usage.total_output_tokens;
-                      cost_usd = Some next_checkpoint.usage.estimated_cost_usd;
-                      tool_call_count = List.length tool_names;
-                      tool_names;
-                      session_id = meta.mcp_session_id;
-                      raw_trace_run;
-                      api_response = Some response;
-                    }
-              | Error err ->
-                  let detail = Agent_sdk__Error.to_string err in
-                  let* () =
-                    append_worker_completion_log ~base_path ~team_session_id
-                      ~worker_name ~prompt ~tool_names ~status:"error"
-                      ~output:detail ~error:detail ()
-                  in
-                  Error detail)))
+              Worker_oas.run_existing_worker_agent ~sw ~base_path ~meta ~prompt
+                ~workspace_path ~raw_trace ?worker_run_id ~tool_names_ref agent)))
 
 let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -3,7 +3,8 @@
     Tier mapping:
     - {b Long_term} — PostgreSQL via [Memory_pg] when MASC_POSTGRES_URL is set;
                         no-op stubs otherwise
-    - {b Episodic}  — no-op (Memory_stream removed)
+    - {b Episodic}  — [seed_episodes] loads recent [Institution_eio] JSONL
+                       episodes and [flush_episodes] writes new OAS episodes back
     - {b Procedural} — [seed_procedures_as_oas] loads [Procedural_memory] entries;
                         [flush_procedures] writes back
     - {b Working/Scratchpad} — managed by OAS in-memory; no backend needed
@@ -109,10 +110,12 @@ let seed_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limi
     List.length procs
   end
 
-(** Pre-seed the keeper's memory bank.
+(** Legacy keeper memory-bank adapter.
 
-    No-op: Memory_stream has been removed.
-    Returns 0 (no entries seeded). *)
+    Historical call sites still invoke this helper, but the current 5-tier path
+    seeds episodic memory through [seed_episodes]. The removed Memory_stream
+    backend is not revived here, so this remains an intentional no-op.
+    Returns 0 to preserve legacy callers. *)
 let seed_memory_bank ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limit : int) : int =
   ignore (memory, agent_name, limit);
   0

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -212,19 +212,60 @@ let cascade_of_worker
     | first :: _ when first <> "" -> first
     | _ -> "keeper_turn"
 
+let telemetry_of_run_result (result : Oas_worker.run_result) :
+    Swarm.Swarm_types.agent_telemetry =
+  {
+    Swarm.Swarm_types.trace_ref = None;
+    usage = Option.map (Oas.Types.add_usage Oas.Types.empty_usage) result.response.usage;
+    turn_count = max 1 result.turns;
+  }
+
+let make_convergence_metric ~(entry_count : int)
+    (success_by_agent : (string, bool) Hashtbl.t) :
+    Swarm.Swarm_types.convergence_config option =
+  if entry_count <= 0 then None
+  else
+    Some
+      {
+        Swarm.Swarm_types.metric =
+          Callback
+            (fun () ->
+              let successes =
+                Hashtbl.fold
+                  (fun _ succeeded acc -> if succeeded then acc + 1 else acc)
+                  success_by_agent 0
+              in
+              float_of_int successes /. float_of_int entry_count);
+        target = 1.0;
+        max_iterations = 1;
+        patience = 1;
+        aggregate = Best_score;
+      }
+
+let budget_of_session_timeout timeout_sec =
+  match timeout_sec with
+  | Some seconds ->
+      {
+        Swarm.Swarm_types.no_budget with
+        max_total_time_sec = Some seconds;
+      }
+  | None -> Swarm.Swarm_types.no_budget
+
 (* ── planned_worker -> agent_entry ─────────────────────────────── *)
 
-let planned_worker_to_entry
+let planned_worker_to_entry_with_state
     ~(config : Room.config)
     ~(session_cascade : string list)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
+    ~(success_by_agent : (string, bool) Hashtbl.t)
     (pw : Team_session_types.planned_worker)
   : Swarm.Swarm_types.agent_entry =
   let name = pw.spawn_agent in
   let role = role_of_spawn_role ~worker_class:pw.worker_class pw.spawn_role in
   let cascade_name = cascade_of_worker ~session_cascade pw in
   let max_turns = Option.value ~default:10 pw.max_turns in
+  let telemetry_ref = ref Swarm.Swarm_types.empty_telemetry in
   let system_prompt =
     Printf.sprintf "You are agent '%s' in a team session (room: %s). Your role: %s."
       name config.base_path
@@ -242,13 +283,30 @@ let planned_worker_to_entry
         ~masc_tools ~dispatch:dispatch_with_defaults ~max_turns
         ~temperature:0.3 ~max_tokens:4096 ()
     with
-    | Ok result -> Ok result.response
+    | Ok result ->
+        Hashtbl.replace success_by_agent name true;
+        telemetry_ref := telemetry_of_run_result result;
+        Ok result.response
     | Error e ->
-      Error (Oas.Error.Config
-        (Oas.Error.InvalidConfig {
-          field = "worker"; detail = Printf.sprintf "%s: %s" name e }))
+        Hashtbl.replace success_by_agent name false;
+        telemetry_ref := Swarm.Swarm_types.empty_telemetry;
+        Error
+          (Oas.Error.Config
+             (Oas.Error.InvalidConfig
+                { field = "worker"; detail = Printf.sprintf "%s: %s" name e }))
   in
-  { name; run; role; get_telemetry = None }
+  { name; run; role; get_telemetry = Some (fun () -> !telemetry_ref) }
+
+let planned_worker_to_entry
+    ~(config : Room.config)
+    ~(session_cascade : string list)
+    ~(masc_tools : Types.tool_schema list)
+    ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
+    (pw : Team_session_types.planned_worker)
+  : Swarm.Swarm_types.agent_entry =
+  let success_by_agent = Hashtbl.create 1 in
+  planned_worker_to_entry_with_state ~config ~session_cascade ~masc_tools
+    ~dispatch ~success_by_agent pw
 
 (* ── session -> swarm_config ───────────────────────────────────── *)
 
@@ -258,28 +316,36 @@ let session_to_swarm_config
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     (session : Team_session_types.session)
   : Swarm.Swarm_types.swarm_config =
+  let success_by_agent = Hashtbl.create 8 in
   let entries =
     List.map
-      (planned_worker_to_entry ~config
-         ~session_cascade:session.model_cascade ~masc_tools ~dispatch)
+      (planned_worker_to_entry_with_state ~config
+         ~session_cascade:session.model_cascade ~masc_tools ~dispatch
+         ~success_by_agent)
       session.planned_workers
   in
+  List.iter
+    (fun (entry : Swarm.Swarm_types.agent_entry) ->
+      Hashtbl.replace success_by_agent entry.name false)
+    entries;
   let mode = mode_of_orchestration session.orchestration_mode in
   let collaboration =
     Team_context.collaboration_of_session ~base_path:config.base_path session
   in
+  let entry_count = List.length entries in
   let timeout_sec =
     if session.duration_seconds > 0 then
       Some (float_of_int session.duration_seconds)
     else None
   in
-  { entries; mode; convergence = None;
+  { entries; mode;
+    convergence = make_convergence_metric ~entry_count success_by_agent;
     max_parallel = max 1 (List.length entries);
     prompt = session.goal; timeout_sec;
-    budget = Swarm.Swarm_types.no_budget;
+    budget = budget_of_session_timeout timeout_sec;
     max_agent_retries = 1;
     collaboration = Some collaboration;
-    resource_check = None;
+    resource_check = Some (fun () -> Room.is_initialized config);
     max_concurrent_agents = Some (max 1 (List.length entries)) }
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -261,7 +261,7 @@ let make_heartbeat_callbacks
     build_resume_config + Agent.create directly.
 
     Returns a run_result on success, or an error string on failure. *)
-let run_worker_via_oas
+let rec run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(base_path : string)
     ~(meta : Worker_container_types.worker_container_meta)
@@ -323,11 +323,40 @@ let run_worker_via_oas
         | Ok _ -> ()
         | Error e -> raise (Failure ("worker join failed: " ^ e))
       in
+      let workspace_path =
+        if String.trim meta.workspace_path <> "" then meta.workspace_path
+        else base_path
+      in
+      run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
+        ~raw_trace ?worker_run_id ~tool_names_ref agent)
+
+and run_existing_worker_agent
+    ~(sw : Eio.Switch.t)
+    ~(base_path : string)
+    ~(meta : Worker_container_types.worker_container_meta)
+    ~(prompt : string)
+    ~(workspace_path : string)
+    ~(raw_trace : Oas.Raw_trace.t)
+    ?worker_run_id
+    ~(tool_names_ref : string list ref)
+    (agent : Oas.Agent.t)
+  : (Worker_container_types.run_result, string) result =
+  let ( let* ) = Result.bind in
+  let team_session_id = meta.team_session_id in
+  let worker_name = meta.worker_name in
+  let session_id = meta.mcp_session_id in
+  Fun.protect
+    ~finally:(fun () ->
+      try Oas.Agent.close agent
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+          Log.LocalWorker.warn "agent close failed for %s: %s" worker_name
+            (Printexc.to_string exn))
+    (fun () ->
       let result = Oas.Agent.run ~sw agent prompt in
       let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
-      let checkpoint =
-        Oas.Agent.checkpoint ~session_id agent
-      in
+      let checkpoint = Oas.Agent.checkpoint ~session_id agent in
       let tool_names =
         List.rev !tool_names_ref
         |> Worker_container_types.unique_preserve_order
@@ -341,51 +370,46 @@ let run_worker_via_oas
           ~team_session_id ~worker_name
           { meta with last_run_at = Some (Time_compat.now ()) }
       in
-      let workspace_path =
-        if String.trim meta.workspace_path <> "" then meta.workspace_path
-        else base_path
-      in
       Worker_container.materialize_direct_evidence
-        ~base_path ~worker_name ~worker_run_id ~meta ~prompt
-        ~workspace_path ~agent ~raw_trace;
-      Oas.Agent.close agent;
+        ~base_path ~worker_name ~worker_run_id ~meta ~prompt ~workspace_path
+        ~agent ~raw_trace;
       match result with
       | Ok response ->
-        let output =
-          response.content
-          |> List.filter_map (function
-               | Oas.Types.Text text -> Some text
-               | _ -> None)
-          |> String.concat "\n"
-        in
-        let* () =
-          Worker_container.append_worker_completion_log
-            ~base_path ~team_session_id ~worker_name ~prompt
-            ~tool_names ~status:"ok" ~output ()
-        in
-        Ok
-          {
-            Worker_container_types.output;
-            model_used =
-              (if String.trim response.model <> "" then response.model
-               else meta.effective_model);
-            input_tokens = Some checkpoint.usage.total_input_tokens;
-            output_tokens = Some checkpoint.usage.total_output_tokens;
-            cost_usd = Some checkpoint.usage.estimated_cost_usd;
-            tool_call_count = List.length tool_names;
-            tool_names;
-            session_id;
-            raw_trace_run;
-            api_response = Some response;
-          }
+          let output =
+            response.content
+            |> List.filter_map (function
+                 | Oas.Types.Text text -> Some text
+                 | _ -> None)
+            |> String.concat "\n"
+          in
+          let* () =
+            Worker_container.append_worker_completion_log
+              ~base_path ~team_session_id ~worker_name ~prompt ~tool_names
+              ~status:"ok" ~output ()
+          in
+          Ok
+            {
+              Worker_container_types.output;
+              model_used =
+                (if String.trim response.model <> "" then response.model
+                 else meta.effective_model);
+              input_tokens = Some checkpoint.usage.total_input_tokens;
+              output_tokens = Some checkpoint.usage.total_output_tokens;
+              cost_usd = Some checkpoint.usage.estimated_cost_usd;
+              tool_call_count = List.length tool_names;
+              tool_names;
+              session_id;
+              raw_trace_run;
+              api_response = Some response;
+            }
       | Error err ->
-        let detail = Oas.Error.to_string err in
-        let* () =
-          Worker_container.append_worker_completion_log
-            ~base_path ~team_session_id ~worker_name ~prompt
-            ~tool_names ~status:"error" ~output:detail ~error:detail ()
-        in
-        Error detail)
+          let detail = Oas.Error.to_string err in
+          let* () =
+            Worker_container.append_worker_completion_log
+              ~base_path ~team_session_id ~worker_name ~prompt ~tool_names
+              ~status:"error" ~output:detail ~error:detail ()
+          in
+          Error detail)
 
 (* ================================================================ *)
 (* Orchestrate Multiple Workers                                      *)

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -306,7 +306,7 @@ let test_jsonl_backend_query () =
   let result = backend.query ~prefix:"test" ~limit:10 in
   Alcotest.(check int) "query returns empty on fresh session" 0 (List.length result)
 
-let test_seed_memory_bank_noop () =
+let test_seed_memory_bank_legacy_noop () =
   let dir = setup_tmp_dir () in
   let memory = Memory_oas_bridge.create_memory ~agent_name:"test-bank" () in
   let count = Memory_oas_bridge.seed_memory_bank ~memory ~agent_name:"test-bank" ~limit:10 in
@@ -442,7 +442,8 @@ let () =
       Alcotest.test_case "persist returns Ok" `Quick test_jsonl_backend_persist;
       Alcotest.test_case "retrieve returns None" `Quick test_jsonl_backend_retrieve;
       Alcotest.test_case "query returns empty" `Quick test_jsonl_backend_query;
-      Alcotest.test_case "seed_memory_bank noop" `Quick test_seed_memory_bank_noop;
+      Alcotest.test_case "seed_memory_bank legacy noop" `Quick
+        test_seed_memory_bank_legacy_noop;
       Alcotest.test_case "seed_episodes loads recent jsonl" `Quick
         test_seed_episodes_loads_recent_jsonl;
       Alcotest.test_case "seed_episodes respects limit" `Quick

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -100,6 +100,59 @@ let make_pw ?(spawn_model = None) () : Team_session_types.planned_worker =
     routing_escalated = false;
   }
 
+let make_session ?(orchestration_mode = Team_session_types.Auto)
+    ?(duration_seconds = 600) ?(planned_workers = []) () :
+    Team_session_types.session =
+  let now = Time_compat.now () in
+  {
+    Team_session_types.session_id = "test-session";
+    goal = "test goal";
+    created_by = "test-user";
+    room_id = "test-room";
+    operation_id = None;
+    origin_kind = Team_session_types.Origin_human;
+    status = Team_session_types.Running;
+    duration_seconds;
+    execution_scope = Team_session_types.Autonomous;
+    checkpoint_interval_sec = 30;
+    min_agents = 1;
+    scale_profile = Team_session_types.Scale_standard;
+    control_profile = Team_session_types.Control_flat;
+    orchestration_mode;
+    communication_mode = Team_session_types.Comm_broadcast;
+    model_cascade = [ "llama:qwen3.5" ];
+    fallback_policy = Team_session_types.Fallback_none;
+    instruction_profile = Team_session_types.Profile_standard;
+    alert_channel = Team_session_types.Alert_broadcast;
+    auto_resume = false;
+    report_formats = [ Team_session_types.Markdown ];
+    turn_count = 0;
+    agent_names = [ "agent-1" ];
+    planned_workers;
+    broadcast_count = 0;
+    portal_count = 0;
+    cascade_attempted = 0;
+    cascade_success = 0;
+    cascade_failed = 0;
+    fallback_task_created = 0;
+    min_agents_violation_streak = 0;
+    policy_violations = [];
+    baseline_done_counts = [];
+    final_done_delta_total = None;
+    final_done_delta_by_agent = None;
+    started_at = now;
+    planned_end_at = now +. float_of_int duration_seconds;
+    stopped_at = None;
+    last_checkpoint_at = Some now;
+    last_event_at = Some now;
+    last_turn_at = None;
+    stop_reason = None;
+    generated_report = false;
+    artifacts_dir = "/tmp/masc-test";
+    created_at_iso = Types.now_iso ();
+    updated_at_iso = Types.now_iso ();
+  }
+
 let test_cascade_explicit_model () =
   let pw = make_pw ~spawn_model:(Some "glm:glm-4.5") () in
   let c = Team_session_oas_bridge.cascade_of_worker
@@ -123,6 +176,51 @@ let test_cascade_empty_model_string () =
   let c = Team_session_oas_bridge.cascade_of_worker
     ~session_cascade:["llama:qwen3.5"] pw in
   Alcotest.(check string) "empty model falls through" "llama:qwen3.5" c
+
+let test_session_to_swarm_config_health_contract () =
+  let worker_a = make_pw () in
+  let worker_b =
+    { (make_pw ()) with
+      spawn_agent = "reviewer";
+      spawn_role = Some "verify";
+      max_turns = Some 4;
+    }
+  in
+  let session = make_session ~planned_workers:[ worker_a; worker_b ] () in
+  let tmp = Filename.temp_dir "masc-test" "" in
+  let config = Room.default_config tmp in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let swarm_cfg =
+    Team_session_oas_bridge.session_to_swarm_config ~config ~masc_tools:[]
+      ~dispatch:(fun ~name:_ ~args:_ -> (false, "no"))
+      session
+  in
+  Alcotest.(check bool) "convergence present" true
+    (Option.is_some swarm_cfg.convergence);
+  Alcotest.(check bool) "resource_check present" true
+    (Option.is_some swarm_cfg.resource_check);
+  Alcotest.(check (option (float 0.001))) "budget derived from duration"
+    (Some 600.0) swarm_cfg.budget.max_total_time_sec;
+  let convergence = Option.get swarm_cfg.convergence in
+  let metric_value =
+    match convergence.metric with
+    | Swarm.Swarm_types.Callback f -> f ()
+    | Swarm.Swarm_types.Shell_command cmd ->
+        Alcotest.failf "expected callback metric, got shell command %s" cmd
+  in
+  Alcotest.(check (float 0.001)) "initial success ratio" 0.0 metric_value;
+  Alcotest.(check int) "single-pass convergence iterations" 1
+    convergence.max_iterations;
+  let first_entry = List.hd swarm_cfg.entries in
+  Alcotest.(check bool) "entry telemetry present" true
+    (Option.is_some first_entry.get_telemetry);
+  let telemetry = Option.get first_entry.get_telemetry () in
+  Alcotest.(check int) "initial telemetry turn_count" 0 telemetry.turn_count;
+  Alcotest.(check bool) "initial telemetry usage empty" true
+    (Option.is_none telemetry.usage);
+  let resource_ok = Option.get swarm_cfg.resource_check () in
+  Alcotest.(check bool) "resource check passes for initialized room" true
+    resource_ok
 
 (* ================================================================ *)
 (* Supported tool runtime tests                                     *)
@@ -209,6 +307,8 @@ let () =
         test_cascade_default;
       Alcotest.test_case "empty model string" `Quick
         test_cascade_empty_model_string;
+      Alcotest.test_case "session swarm health contract" `Quick
+        test_session_to_swarm_config_health_contract;
     ];
     "supported_tools", [
       Alcotest.test_case "schemas present" `Quick


### PR DESCRIPTION
## Summary
- add team-session swarm telemetry and explicit health defaults for convergence, resource checks, and wall-clock budget
- consolidate worker resume execution onto the shared worker_oas run tail for checkpoint, evidence, and completion logging
- refresh memory bridge comments, tests, and migration docs to match current OAS behavior

## Verification
- dune build @check
- dune exec test/test_team_session_oas_bridge.exe
- dune exec test/test_team_session_swarm_runner.exe
- dune exec test/test_memory_oas_5tier.exe