### PR TITLE
fix: pg_notify returns unexpected row on Supabase Session Pooler

### DIFF
--- a/lib/backend_pg.ml
+++ b/lib/backend_pg.ml
@@ -121,9 +121,11 @@ let publish_q =
   "INSERT INTO masc_pubsub (channel, message) VALUES ($1, $2)"
 
 (* pg_notify sends real-time notification to all LISTEN clients
-   Payload limited to 8000 bytes by PostgreSQL *)
+   Payload limited to 8000 bytes by PostgreSQL.
+   NOTE: pg_notify() returns void but SELECT always produces one row.
+   Using ->! unit (expect one row, discard void value) avoids Caqti error. *)
 let notify_q =
-  (Caqti_type.(t2 string string) ->. Caqti_type.unit)
+  (Caqti_type.(t2 string string) ->! Caqti_type.unit)
   "SELECT pg_notify($1, $2)"
 
 (* PostgreSQL pg_notify payload limit (actual limit is 8000, use 7900 for safety margin) *)
@@ -397,7 +399,7 @@ let publish t ~channel ~message =
        Skip NOTIFY for large payloads - subscribers poll anyway *)
     let total_payload = String.length channel + String.length message + 1 in
     if total_payload <= pg_notify_max_payload then
-      C.exec notify_q (channel, message)
+      C.find notify_q (channel, message)
     else begin
       Log.debug ~ctx:"Pubsub" "NOTIFY skipped: payload too large (%d bytes, limit %d)"
         total_payload pg_notify_max_payload;


### PR DESCRIPTION
## Summary
`SELECT pg_notify(channel, payload)` returns one row (PostgreSQL void), but caqti query used `exec` (expects 0 rows) causing "No tuples expected" error on Supabase Session Pooler.

Fixes #2100.

## Changes
- `lib/backend_pg.ml`: `->. Caqti_type.unit` → `->! Caqti_type.unit`, `C.exec` → `C.find`
- Matches existing pattern in `lib/board/board_pg.ml:170`

## Test plan
- [x] `dune build` 통과
- [ ] `masc_join` → broadcast → 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)