### PR TITLE
Clean up stale keeper OAS migration surface

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -8,7 +8,7 @@
     Uses {!Keeper_tools_oas} for tool wrapping and
     {!Keeper_hooks_oas} for lifecycle hooks (checkpoint, metrics, social).
 
-    @since Phase 5 — Context_manager encapsulation *)
+    @since Phase 5 — Keeper Agent.run encapsulation *)
 
 (** Result of a single Agent.run() keeper turn. *)
 type run_result = {

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -532,13 +532,8 @@ let keeper_social_followup_max_tokens () : int =
     ~max_v:4096
 
 (* ================================================================ *)
-(* Unified Keeper Turn parameters                                    *)
+(* Unified Keeper Turn parameters                                   *)
 (* ================================================================ *)
-
-(** Feature flag: enable unified keeper turn path.
-    Env: [MASC_KEEPER_UNIFIED_TURN]. Default: false. *)
-let keeper_unified_turn_enabled () : bool =
-  bool_of_env_default "MASC_KEEPER_UNIFIED_TURN" ~default:false
 
 (** Temperature for unified keeper turns.
     Env: [MASC_KEEPER_UNIFIED_TEMP]. Default: 0.4. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -2,7 +2,8 @@
 
     Orchestrates keeper turns by building domain-specific system prompt
     configuration and delegating to {!Keeper_agent_run.run_turn} which
-    owns the full context lifecycle (checkpoint, Context_manager, Agent.run).
+    owns the full OAS-backed context lifecycle (checkpoint, prompt state,
+    Agent.run).
 
     Sub-modules:
     - Keeper_turn_up: start/reconfigure

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -8,8 +8,8 @@
     Keeper_alerting_path and Keeper_exec_tools need the working_context
     type, but Keeper_exec_context depends on those modules.
 
-    Previously these types and functions lived in Context_manager.
-    Moved here as part of the context-manager-cleanup refactoring.
+    Previously these types and functions lived in the legacy keeper context
+    module. Moved here as part of the context-manager-cleanup refactoring.
 
     @since context-manager-cleanup *)
 

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -1,6 +1,6 @@
 (** Tool_compact — Standalone MCP tool for context compaction.
 
-    Exposes Context_manager's compaction pipeline as a general-purpose
+    Exposes the OAS-backed compaction pipeline as a general-purpose
     MCP tool. Any agent can send text + strategy and receive compacted
     text back with token savings statistics.
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -201,6 +201,19 @@ let test_local_review_script_contracts () =
     (file_contains_pattern "scripts/review/local-review.sh"
        "--print-cache-key")
 
+let test_keeper_oas_cleanup_contracts () =
+  check bool "keeper config no longer exposes stale unified turn flag" true
+    (not
+       (file_contains_pattern "lib/keeper/keeper_config.ml"
+          "MASC_KEEPER_UNIFIED_TURN"));
+  check bool "keeper turn comment no longer mentions context manager" true
+    (not
+       (file_contains_pattern "lib/keeper/keeper_turn.ml"
+          "Context_manager"));
+  check bool "tool compact comment now references OAS-backed pipeline" true
+    (file_contains_pattern "lib/tool_compact.ml"
+       "OAS-backed compaction pipeline")
+
 let () =
   run "ci_hardening_source"
     [
@@ -212,5 +225,6 @@ let () =
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
+           test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
          ]);
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -250,9 +250,7 @@ let test_hooks_allowed_tools_l5 () =
 
 (* ---------- Config tests ---------- *)
 
-let test_unified_turn_config_defaults () =
-  check bool "unified disabled by default" false
-    (KC.keeper_unified_turn_enabled ());
+let test_unified_turn_runtime_defaults () =
   check (float 0.01) "unified temp default" 0.4
     (KC.keeper_unified_temperature ());
   check int "unified max_tokens default" 2048
@@ -372,7 +370,8 @@ let () =
         ] );
       ( "config",
         [
-          test_case "unified defaults" `Quick test_unified_turn_config_defaults;
+          test_case "unified runtime defaults" `Quick
+            test_unified_turn_runtime_defaults;
         ] );
       ( "metrics_observation",
         [


### PR DESCRIPTION
## Summary
- remove the dead `MASC_KEEPER_UNIFIED_TURN` config surface now that keeper keepalive already uses the unified Agent.run path unconditionally
- update stale keeper/OAS comments that still referred to the old Context_manager surface
- add source-guard coverage so the stale flag and comment drift do not reappear

## Why
- issue #1797 describes a larger Keeper -> OAS Agent.run migration, but the remaining code-level debt on `main` was mostly stale migration surface rather than an active runtime split
- this patch tightens the public/config story to match the current architecture before the next Keeper migration step

## Verification
- `dune build --root . test/test_keeper_unified.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `git diff --check`

Closes #1797