### PR TITLE
fix: log silently discarded I/O errors from backend writes

### DIFF
--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -160,7 +160,13 @@ let log_event config ~event_type ~agent ~payload =
     timestamp = Time_compat.now ();
   } in
   let json_str = Yojson.Safe.to_string (event_to_json event) in
-  let _ = Backend_eio.FileSystem.set config.backend (event_key seq) json_str in
+  (match Backend_eio.FileSystem.set config.backend (event_key seq) json_str with
+   | Ok () -> ()
+   | Error e ->
+       let msg = match e with
+         | Backend_eio.IOError m -> m | Backend_eio.NotFound k -> "not found: " ^ k
+         | Backend_eio.AlreadyExists k -> "already exists: " ^ k | Backend_eio.InvalidKey k -> "invalid key: " ^ k in
+       Log.Room.warn "append_event set failed for seq %d: %s" seq msg);
   event
 
 (** Get event by sequence *)

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -83,8 +83,10 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
        write_json config agent_file_dedup (agent_to_yojson updated);
        if is_pg_backend config then begin
          let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
-         let _ = backend_set config ~key:agent_key
-                   ~value:(Yojson.Safe.to_string (agent_to_yojson updated)) in ()
+         (match backend_set config ~key:agent_key
+                   ~value:(Yojson.Safe.to_string (agent_to_yojson updated)) with
+          | Ok () -> ()
+          | Error e -> Log.Room.warn "rejoin backend_set failed for %s: %s" agent_key (Backend.show_error e))
        end;
        if is_inactive then begin
          (* Restore to active_agents on rejoin *)
@@ -130,8 +132,9 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   (* Also persist to PostgreSQL backend for HTTP state persistence (stateless requests) *)
   if is_pg_backend config then begin
     let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
-    let _ = backend_set config ~key:agent_key ~value:(Yojson.Safe.to_string agent_json) in
-    ()
+    (match backend_set config ~key:agent_key ~value:(Yojson.Safe.to_string agent_json) with
+     | Ok () -> ()
+     | Error e -> Log.Room.warn "join backend_set failed for %s: %s" agent_key (Backend.show_error e))
   end;
 
   (* Update state *)
@@ -285,10 +288,14 @@ let leave config ~agent_name =
       (* Update backend entry to Inactive as well *)
       (if in_fs then
         let updated_json = read_json config agent_file in
-        let _ = backend_set config ~key:agent_key
-                  ~value:(Yojson.Safe.to_string updated_json) in ()
+        (match backend_set config ~key:agent_key
+                  ~value:(Yojson.Safe.to_string updated_json) with
+         | Ok () -> ()
+         | Error e -> Log.Room.warn "leave backend_set failed for %s: %s" agent_key (Backend.show_error e))
       else
-        let _ = backend_delete config ~key:agent_key in ())
+        (match backend_delete config ~key:agent_key with
+         | Ok _ -> ()
+         | Error e -> Log.Room.warn "leave backend_delete failed for %s: %s" agent_key (Backend.show_error e)))
     end;
 
     (* Capture active agents before removal for relationship materialization *)

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -142,8 +142,9 @@ let write_json_root config path json =
   match root_key_of_path config path with
   | Some key ->
       let content = Yojson.Safe.pretty_to_string json in
-      let _ = backend_set config ~key ~value:content in
-      ()
+      (match backend_set config ~key ~value:content with
+       | Ok () -> ()
+       | Error e -> Log.Misc.warn "write_json_root backend_set failed for %s: %s" key (Backend.show_error e))
   | None -> write_json_local path json
 
 let delete_path_root config path =
@@ -178,8 +179,9 @@ let write_json config path json =
   match key_of_path config path with
   | Some key ->
       let content = Yojson.Safe.pretty_to_string json in
-      let _ = backend_set config ~key ~value:content in
-      ()
+      (match backend_set config ~key ~value:content with
+       | Ok () -> ()
+       | Error e -> Log.Misc.warn "write_json backend_set failed for %s: %s" key (Backend.show_error e))
   | None -> write_json_local path json
 
 let delete_path config path =

--- a/lib/swarm/swarm_checkpoint.ml
+++ b/lib/swarm/swarm_checkpoint.ml
@@ -140,8 +140,9 @@ let save config =
   (* Dual persistence: also write to PostgreSQL backend if available *)
   if Room_utils.is_pg_backend config then begin
     let json_str = Yojson.Safe.to_string json in
-    let _ = Room_utils.backend_set config ~key:"swarm:checkpoint" ~value:json_str in
-    ()
+    (match Room_utils.backend_set config ~key:"swarm:checkpoint" ~value:json_str with
+     | Ok () -> ()
+     | Error e -> Log.Misc.warn "swarm checkpoint backend_set failed: %s" (Backend.show_error e))
   end;
   Ok snapshot
 

--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -53,7 +53,9 @@ let handle_petition_submit ctx args =
                 | Error message -> (false, message)
                 | Ok bundle ->
                     let ruling = build_ruling bundle in
-                    let _ = GV2.save_ruling ctx.base_path ruling in
+                    (match GV2.save_ruling ctx.base_path ruling with
+                     | Ok _ -> ()
+                     | Error msg -> Log.Misc.warn "save_ruling failed for case %s: %s" ruling.case_id msg);
                     let json =
                       `Assoc
                         [
@@ -85,17 +87,23 @@ let handle_case_brief_submit ctx args =
             | Error message -> (false, message)
             | Ok bundle ->
                 let ruling = build_ruling bundle in
-                let _ = GV2.save_ruling ctx.base_path ruling in
+                (match GV2.save_ruling ctx.base_path ruling with
+                 | Ok _ -> ()
+                 | Error msg -> Log.Misc.warn "save_ruling failed for case %s: %s" ruling.case_id msg);
                 let order =
                   match build_execution_order bundle ruling with
                   | None -> None
                   | Some initial_order -> (
-                      let _ = GV2.save_execution_order ctx.base_path initial_order in
+                      (match GV2.save_execution_order ctx.base_path initial_order with
+                       | Ok _ -> ()
+                       | Error msg -> Log.Misc.warn "save_execution_order failed for case %s: %s" initial_order.GV2.case_id msg);
                       match initial_order.GV2.status with
                       | GV2.Queued_auto -> (
                           match execute_action ctx bundle.GV2.case_ initial_order with
                           | Ok executed_order ->
-                              let _ = GV2.update_execution_order ctx.base_path executed_order in
+                              (match GV2.update_execution_order ctx.base_path executed_order with
+                               | Ok _ -> ()
+                               | Error msg -> Log.Misc.warn "update_execution_order failed for case %s: %s" executed_order.GV2.case_id msg);
                               Some executed_order
                           | Error message ->
                               let blocked_order =
@@ -107,7 +115,9 @@ let handle_case_brief_submit ctx args =
                                   actor = Some ctx.agent_name;
                                 }
                               in
-                              let _ = GV2.update_execution_order ctx.base_path blocked_order in
+                              (match GV2.update_execution_order ctx.base_path blocked_order with
+                               | Ok _ -> ()
+                               | Error msg -> Log.Misc.warn "update_execution_order failed for blocked case %s: %s" blocked_order.GV2.case_id msg);
                               Some blocked_order)
                       | _ -> Some initial_order)
                 in


### PR DESCRIPTION
## Summary
- 11 sites used `let _ = backend_set/delete/save_ruling` discarding error results
- Write failures were completely invisible in server logs
- Now logs at warn level with key/context info for debugging

## Files Changed
| File | Fixes | Pattern |
|------|-------|---------|
| `room_lifecycle.ml` | 4 | `backend_set` (3) + `backend_delete` (1) |
| `tool_council.ml` | 5 | `save_ruling` (2) + `save/update_execution_order` (3) |
| `room_utils_ops.ml` | 2 | `backend_set` in write_json helpers |
| `room_eio.ml` | 1 | `Backend_eio.FileSystem.set` in append_event |
| `swarm_checkpoint.ml` | 1 | `backend_set` for checkpoint |

Skipped: `tool_relay.ml` — `Relay.save_checkpoint` returns a record, not a result.

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)