### PR TITLE
fix: replace blocking F_RLOCK with non-blocking retry in atomic_get

### DIFF
--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -415,8 +415,23 @@ module FileSystem = struct
           else
             let fd = Unix.openfile path_str [Unix.O_RDONLY] 0o644 in
             Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.close fd) @@ fun () ->
-            (* Shared lock for reading *)
-            Unix.lockf fd Unix.F_RLOCK 0;
+            (* Non-blocking lock with retry to avoid blocking the Eio domain.
+               Uses F_TLOCK (exclusive try) since F_TRLOCK is not available in OCaml.
+               Read-only access still gets exclusive lock — acceptable for short reads. *)
+            let max_retries = 50 in
+            let rec try_lock retries =
+              if retries <= 0 then
+                raise (Failure "atomic_get: failed to acquire lock after max retries")
+              else
+                try Unix.lockf fd Unix.F_TLOCK 0
+                with Unix.Unix_error (Unix.EAGAIN, _, _)
+                   | Unix.Unix_error (Unix.EACCES, _, _) ->
+                  (match Process_eio.get_clock () with
+                   | Ok clk -> Eio.Time.sleep clk 0.001
+                   | Error _ -> Eio.Fiber.yield ());
+                  try_lock (retries - 1)
+            in
+            try_lock max_retries;
             Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
             let buf = Bytes.create 32 in
             let n = Unix.read fd buf 0 32 in


### PR DESCRIPTION
## Summary
- `atomic_get` used `Unix.lockf F_RLOCK` which blocks the Eio domain if a writer holds the lock
- Replaced with `F_TLOCK` + 1ms backoff retry (max 50), matching `atomic_increment` and `atomic_update`
- OCaml lacks `F_TRLOCK` (non-blocking shared lock), so uses exclusive lock for reads — acceptable for 32-byte counter reads

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)