### PR TITLE
fix(dashboard): keeper offline 오표시 수정

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -26,7 +26,10 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const keeper = findKeeper(name)
   if (!keeper) return null
 
-  const stage = keeper.pipeline_stage
+  // Derive stage: prefer explicit pipeline_stage, fallback to heartbeat-based inference
+  const rawStage = keeper.pipeline_stage
+  const stage = rawStage
+    ?? (keeper.last_turn_ago_s != null && keeper.last_turn_ago_s < 600 ? 'idle' : rawStage)
   const ctxRatio = keeper.context_ratio
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper.generation


### PR DESCRIPTION
## Summary
- Keeper의 pipeline_stage가 null일 때 무조건 "offline"으로 표시되던 문제 수정
- last_turn_ago_s < 600s (10분)이면 "idle"로 fallback하여 실제 상태와 일치

## Root cause
PipelineStageBadge가 `stage ?? 'offline'`로 fallback. keeper가 heartbeat는 보내고 있지만 pipeline_stage 필드를 안 보내면 offline으로 표시됨.

## Test plan
- [ ] vite build 성공
- [ ] keeper 상세 페이지에서 heartbeat 활성 keeper가 "idle" 표시 확인
- [ ] pipeline_stage가 명시적으로 있는 keeper는 기존 동작 유지

Generated with Claude Code