### PR TITLE
fix(test): align dashboard tests with async briefing and social rename

### DIFF
--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -44,17 +44,11 @@ let test_dashboard_execution_fixture () =
         let session_briefs = json |> member "session_briefs" |> to_list in
         let operation_briefs = json |> member "operation_briefs" |> to_list in
         let worker_briefs = json |> member "worker_support_briefs" |> to_list in
-        let social_tick = json |> member "social_tick" in
-        let social_checkins = json |> member "social_checkins" |> to_list in
         let continuity_briefs = json |> member "continuity_briefs" |> to_list in
         let offline_worker_briefs = json |> member "offline_worker_briefs" |> to_list in
         check bool "summary removed from execution payload" true
           (json |> member "summary" = `Null);
-        check int "social checked count" 3 (social_tick |> member "checked" |> to_int);
-        check int "social checkins" 3 (List.length social_checkins);
-        (* lodge_tick / lodge_checkins assertions removed — Lodge deprecated #1596 *)
-        check bool "social runtime present" true
-          (json |> member "status" |> member "social_runtime" <> `Null);
+        (* social_tick / social_checkins / social_runtime removed — social renamed to activity #2093 *)
         check string "top queue kind" "session"
           (execution_queue |> List.hd |> member "kind" |> to_string);
         check string "top queue target" "ts-execution-fixture-001"

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -67,7 +67,9 @@ let iso_of_unix ts =
     (tm.Unix.tm_mon + 1)
     tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
-let test_briefing_is_model_free_and_synchronous () =
+let test_briefing_cold_call_returns_pending () =
+  (* After #2094, cold calls (no cache) return "pending" and trigger async refresh.
+     This avoids blocking the dashboard on cold-start computation. *)
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
@@ -85,18 +87,10 @@ let test_briefing_is_model_free_and_synchronous () =
           ~config ~sw ~clock ~proc_mgr:None ()
       in
       let open Yojson.Safe.Util in
-      check string "status" "ok"
+      check string "cold call returns pending" "pending"
         (json |> member "status" |> to_string);
-      check bool "refreshing false" false
-        (json |> member "refreshing" |> to_bool);
-      check string "model" "deterministic"
-        (json |> member "model" |> to_string);
-      check string "provenance" "narrative"
-        (json |> member "provenance" |> to_string);
-      check bool "not authoritative" false
-        (json |> member "authoritative" |> to_bool);
-      check int "section count" 3
-        (json |> member "sections" |> to_list |> List.length))
+      check bool "refreshing true on cold call" true
+        (json |> member "refreshing" |> to_bool))
 
 let test_force_refresh_without_cache_returns_pending () =
   Eio_main.run @@ fun env ->
@@ -455,8 +449,8 @@ let () =
     [
       ( "deterministic",
         [
-          test_case "briefing is model-free and synchronous" `Quick
-            test_briefing_is_model_free_and_synchronous;
+          test_case "cold call returns pending" `Quick
+            test_briefing_cold_call_returns_pending;
           test_case "force refresh without cache returns pending" `Quick
             test_force_refresh_without_cache_returns_pending;
           test_case "force refresh with cache returns stale cached payload" `Quick

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -206,6 +206,7 @@ let test_current_room_after_enter () =
 (* ============================================ *)
 
 let test_room_enter_moves_agent () =
+  Eio_main.run @@ fun _env ->
   let (config, test_dir) = setup_test_room () in
   Fun.protect ~finally:(fun () -> cleanup_test_room test_dir) (fun () ->
     ignore (Room.init config ~agent_name:None);

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -60,6 +60,7 @@ let () = test "heartbeat_generate_id" (fun () ->
 )
 
 let () = test "heartbeat_start_stop" (fun () ->
+  Eio_main.run @@ fun _env ->
   let hb_id = Heartbeat.start ~agent_name:"test" ~interval:30 ~message:"ping" in
   assert (String.length hb_id > 0);
 
@@ -79,6 +80,7 @@ let () = test "heartbeat_start_stop" (fun () ->
 )
 
 let () = test "heartbeat_get" (fun () ->
+  Eio_main.run @@ fun _env ->
   let hb_id = Heartbeat.start ~agent_name:"getter" ~interval:60 ~message:"test" in
 
   match Heartbeat.get hb_id with
@@ -96,6 +98,7 @@ let () = test "heartbeat_get_missing" (fun () ->
 )
 
 let () = test "heartbeat_list_multiple" (fun () ->
+  Eio_main.run @@ fun _env ->
   let id1 = Heartbeat.start ~agent_name:"a1" ~interval:10 ~message:"m1" in
   let id2 = Heartbeat.start ~agent_name:"a2" ~interval:20 ~message:"m2" in
 

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -111,8 +111,9 @@ let () = test "dispatch_dashboard_invalid_scope" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
-(* Test dispatch gc *)
+(* Test dispatch gc — needs Eio context for Eio.Mutex in gc path *)
 let () = test "dispatch_gc" (fun () ->
+  Eio_main.run @@ fun _env ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("days", `Int 7)] in
   match Tool_misc.dispatch ctx ~name:"masc_gc" ~args with
@@ -124,6 +125,7 @@ let () = test "dispatch_gc" (fun () ->
 
 (* Test dispatch gc with default days *)
 let () = test "dispatch_gc_default" (fun () ->
+  Eio_main.run @@ fun _env ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_gc" ~args with


### PR DESCRIPTION
## Summary
- **Briefing test**: `test_briefing_is_model_free_and_synchronous` → `test_briefing_cold_call_returns_pending`. After #2094 switched to async-first briefing, cold calls correctly return `"pending"` instead of `"ok"`.
- **Execution test**: Remove `social_tick`/`social_checkins`/`social_runtime` assertions. These fields were removed in #2093 (social → activity rename) but the test was not updated.

Fixes CI failures on `main` (both `deterministic` and `read_model` test suites).

## Test plan
- [x] `test_dashboard_mission_briefing` — 11/11 pass
- [x] `test_dashboard_execution` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)