### PR TITLE
refactor: migrate council Stdlib I/O to Fs_compat (-36 LOC)

### DIFF
--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -82,13 +82,7 @@ let sessions : (string, session) Hashtbl.t = Hashtbl.create 16
 let _base_path : string option ref = ref None
 
 let read_file_safe path =
-  try
-    let ic = open_in path in
-    let content =
-      Fun.protect ~finally:(fun () -> close_in_noerr ic)
-        (fun () -> really_input_string ic (in_channel_length ic))
-    in
-    Ok content
+  try Ok (Fs_compat.load_file path)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
@@ -120,19 +114,17 @@ let write_json path json =
   let dir = Filename.dirname path in
   let base_name = Filename.basename path in
   let tmp_path = Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base_name (Unix.getpid ())) in
-  let oc = open_out tmp_path in
-  let closed = ref false in
-  Fun.protect ~finally:(fun () ->
-    if not !closed then (try close_out oc with Sys_error _ -> ());
-    if Sys.file_exists tmp_path then
-      try Sys.remove tmp_path with Sys_error _ -> ()
-  ) (fun () ->
-    output_string oc content;
-    flush oc;
-    close_out oc;
-    closed := true;
+  match
+    Fs_compat.save_file tmp_path content;
     Sys.rename tmp_path path
-  )
+  with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as e) ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise e
+  | exception exn ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise exn
 
 (** {1 JSON Serialization (full, for persistence)} *)
 

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -60,13 +60,7 @@ type config = {
 (** {1 Helper Functions} *)
 
 let read_file_safe path =
-  try
-    let ic = open_in path in
-    let content =
-      Fun.protect ~finally:(fun () -> close_in_noerr ic)
-        (fun () -> really_input_string ic (in_channel_length ic))
-    in
-    Ok content
+  try Ok (Fs_compat.load_file path)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
@@ -264,19 +258,17 @@ let write_json path json =
   let dir = Filename.dirname path in
   let base = Filename.basename path in
   let tmp_path = Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base (Unix.getpid ())) in
-  let oc = open_out tmp_path in
-  let closed = ref false in
-  Fun.protect ~finally:(fun () ->
-    if not !closed then (try close_out oc with Sys_error _ -> ());
-    if Sys.file_exists tmp_path then
-      try Sys.remove tmp_path with Sys_error _ -> ()
-  ) (fun () ->
-    output_string oc content;
-    flush oc;
-    close_out oc;
-    closed := true;
+  match
+    Fs_compat.save_file tmp_path content;
     Sys.rename tmp_path path
-  )
+  with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as e) ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise e
+  | exception exn ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise exn
 
 (** Read JSON from file *)
 let read_json path =

--- a/lib/council/debate.ml
+++ b/lib/council/debate.ml
@@ -41,13 +41,7 @@ type debate = {
 (** {1 Helper Functions} *)
 
 let read_file_safe path =
-  try
-    let ic = open_in path in
-    let content =
-      Fun.protect ~finally:(fun () -> close_in_noerr ic)
-        (fun () -> really_input_string ic (in_channel_length ic))
-    in
-    Ok content
+  try Ok (Fs_compat.load_file path)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
@@ -274,19 +268,17 @@ let write_json path json =
   let dir = Filename.dirname path in
   let base = Filename.basename path in
   let tmp_path = Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base (Unix.getpid ())) in
-  let oc = open_out tmp_path in
-  let closed = ref false in
-  Fun.protect ~finally:(fun () ->
-    if not !closed then (try close_out oc with Sys_error _ -> ());
-    if Sys.file_exists tmp_path then
-      try Sys.remove tmp_path with Sys_error _ -> ()
-  ) (fun () ->
-    output_string oc content;
-    flush oc;
-    close_out oc;
-    closed := true;
+  match
+    Fs_compat.save_file tmp_path content;
     Sys.rename tmp_path path
-  )
+  with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as e) ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise e
+  | exception exn ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise exn
 
 (** Read JSON from file *)
 let read_json path =

--- a/lib/council/dune
+++ b/lib/council/dune
@@ -3,5 +3,5 @@
  (name council)
  (public_name masc_mcp.council)
  (modules router debate consensus balance archive executor conversation governance_v2 governance_v2_types governance_v2_serde loop_guard thread_persist council)
- (libraries str yojson base64 unix eio caqti caqti-eio caqti-eio.unix caqti-driver-postgresql cohttp cohttp-eio uuidm time_compat masc_log)
+ (libraries str yojson base64 unix eio caqti caqti-eio caqti-eio.unix caqti-driver-postgresql cohttp cohttp-eio uuidm time_compat masc_log fs_compat)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -179,11 +179,9 @@ let execute_config_change key value =
     (* Ensure directory exists *)
     ensure_dir config_dir;
     (* Write JSON config *)
-    let json = `Assoc [("key", `String key); ("value", `String value); 
+    let json = `Assoc [("key", `String key); ("value", `String value);
                        ("updated_at", `Float (Time_compat.now ()))] in
-    let oc = open_out config_file in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-      output_string oc (Yojson.Safe.pretty_to_string json));
+    Fs_compat.save_file config_file (Yojson.Safe.pretty_to_string json);
     let msg = Printf.sprintf "Config written: %s = %s → %s" key value config_file in
     { success = true;
       stdout = msg;
@@ -207,9 +205,7 @@ let execute_notification target message =
       ("message", `String message);
       ("timestamp", `Float (Time_compat.now ()))
     ] in
-    let oc = open_out_gen [Open_append; Open_creat] 0o644 notify_file in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-      output_string oc (Yojson.Safe.to_string json ^ "\n"));
+    Fs_compat.append_file notify_file (Yojson.Safe.to_string json ^ "\n");
     (* Also log to stderr for visibility *)
     Log.Misc.info "[Council] %s: %s" target message;
     let msg = Printf.sprintf "Notified %s: %s" target message in

--- a/lib/council/governance_v2_serde.ml
+++ b/lib/council/governance_v2_serde.ml
@@ -14,13 +14,7 @@ include Governance_v2_types
 (* ================================================================ *)
 
 let read_file_safe path =
-  try
-    let ic = open_in path in
-    let content =
-      Fun.protect ~finally:(fun () -> close_in_noerr ic)
-        (fun () -> really_input_string ic (in_channel_length ic))
-    in
-    Ok content
+  try Ok (Fs_compat.load_file path)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
@@ -61,19 +55,17 @@ let write_json path json =
   let tmp_path =
     Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base (Unix.getpid ()))
   in
-  let oc = open_out tmp_path in
-  let closed = ref false in
-  Fun.protect
-    ~finally:(fun () ->
-      if not !closed then (try close_out oc with Sys_error _ -> ());
-      if Sys.file_exists tmp_path then
-        try Sys.remove tmp_path with Sys_error _ -> ())
-    (fun () ->
-      output_string oc content;
-      flush oc;
-      close_out oc;
-      closed := true;
-      Sys.rename tmp_path path)
+  match
+    Fs_compat.save_file tmp_path content;
+    Sys.rename tmp_path path
+  with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as e) ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise e
+  | exception exn ->
+      (try Sys.remove tmp_path with Sys_error _ -> ());
+      raise exn
 
 let read_json path =
   match read_file_safe path with


### PR DESCRIPTION
## Summary
- Replaced 10 manual `open_in/open_out` + `Fun.protect` patterns with `Fs_compat` calls
- Net -36 LOC: boilerplate channel management removed
- `Fs_compat` uses Eio.Path when available, Stdlib fallback otherwise
- Atomic writes preserve cleanup-on-failure with `Eio.Cancel.Cancelled` safety

## Changes
| File | Read | Write | Total |
|------|------|-------|-------|
| `debate.ml` | 1 | 1 | 2 |
| `consensus.ml` | 1 | 1 | 2 |
| `governance_v2_serde.ml` | 1 | 1 | 2 |
| `conversation.ml` | 1 | 1 | 2 |
| `executor.ml` | 0 | 2 | 2 |
| `dune` | +fs_compat dep | | |

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)