### PR TITLE
fix: remove stale Jiphyeon references after module retirement

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -83,8 +83,7 @@ let health_handler _request reqd =
     ("sse_clients", `Int (Sse.client_count ()));
     ("lodge", lodge_json);
     ("pg_pool", let max_size = Backend_core.configured_max_pool_size () in
-      let shared = Council.Archive.has_shared_pool ()
-                   || Jiphyeon.Archive.has_shared_pool () in
+      let shared = Council.Archive.has_shared_pool () in
       Backend_core.pool_stats_to_yojson {
         max_size;
         pool_count = (if shared then 3 else 5);

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -104,10 +104,9 @@ let inject_shared_pg_pool () =
   match Board_dispatch.get_pg_pool () with
   | Some pool ->
       Council.Archive.set_shared_pool pool;
-      Jiphyeon.Archive.set_shared_pool pool;
-      Log.Server.info "PG shared pool injected into council/jiphyeon archive"
+      Log.Server.info "PG shared pool injected into council archive"
   | None ->
-      Log.Server.info "No PG pool available; council/jiphyeon will create own pools"
+      Log.Server.info "No PG pool available; council archive will create own pool"
 
 let init_memory_pg_schema () =
   match Board_dispatch.get_pg_pool () with

--- a/lib/tool_inline_dispatch_episode.ml
+++ b/lib/tool_inline_dispatch_episode.ml
@@ -30,22 +30,6 @@ let handle_episode_flush ~config ~arguments ~(state : Mcp_server.server_state) ~
     let flushed = ref 0 in
     let failed = ref 0 in
 
-    let parse_outcome s = match s with
-      | "success" -> `Success
-      | "failure" -> `Failure
-      | _ -> `Partial
-    in
-
-    let parse_string_list = function
-      | `List l -> List.filter_map (function `String s -> Some s | _ -> None) l
-      | _ -> []
-    in
-
-    let parse_context = function
-      | `Assoc l -> List.filter_map (fun (k, v) ->
-          match v with `String s -> Some (k, s) | _ -> None) l
-      | _ -> []
-    in
 
     List.iter (fun file ->
       let file_path = Filename.concat pending_dir file in
@@ -55,31 +39,10 @@ let handle_episode_flush ~config ~arguments ~(state : Mcp_server.server_state) ~
         let module U = Yojson.Safe.Util in
         let ep_id = match Json_util.get_string json "ep_id" with Some v -> v | None -> raise Not_found in
 
-        let episode : Jiphyeon.Archive.episode = {
-          ep_id;
-          session_id = json |> U.member "session_id" |> U.to_string;
-          agent_name = json |> U.member "agent_name" |> U.to_string;
-          generation = json |> U.member "generation" |> U.to_int;
-          parent_episode = Json_util.get_string json "parent_episode";
-          event_type = json |> U.member "event_type" |> U.to_string;
-          summary = json |> U.member "summary" |> U.to_string;
-          dna = Json_util.get_string json "dna";
-          outcome = json |> U.member "outcome" |> U.to_string |> parse_outcome;
-          learnings = json |> U.member "learnings" |> parse_string_list;
-          context = json |> U.member "context" |> parse_context;
-          timestamp = json |> U.member "timestamp" |> U.to_string;
-        } in
-
-        (match state.Mcp_server.env with
-         | Some env ->
-           (match Jiphyeon.Archive.save_episode ~sw ~env episode with
-            | Ok () ->
-              Printf.printf "[EPISODE/SAVED] Episode %s saved to PostgreSQL + Neo4j\n%!" ep_id
-            | Error e ->
-              Log.Misc.error "DB save failed (file kept): %s" e)
-         | None ->
-           Log.Misc.warn "No env available, skipping DB save"
-        );
+        (* Episode DB save removed — Jiphyeon module retired (#2135).
+           Episodes are still persisted as JSONL files. *)
+        ignore (sw, state);
+        Log.Misc.info "[EPISODE/FILE] Episode %s recorded to JSONL (DB save disabled)" ep_id;
 
         let processed_dir = Filename.concat base_path ".masc/processed_episodes" in
         Fs_compat.mkdir_p processed_dir;

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -83,18 +83,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       let siblings = List.filter (fun (_, _, _) -> true) all_statuses in
 
       let cell_id = cell.Mitosis.id in
-      let episode_count, recent_episode =
-        match state.Mcp_server.env with
-        | Some env ->
-          (try
-            (match Jiphyeon.Archive.get_agent_episodes ~sw ~env cell_id 5 with
-             | Ok episodes -> (List.length episodes, List.nth_opt episodes 0)
-             | Error _ -> (0, None))
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Log.Inline.warn "%s: %s" __FUNCTION__ (Printexc.to_string exn);
-            (0, None))
-        | None -> (0, None)
-      in
+      (* Episode DB query removed — Jiphyeon module retired (#2135). *)
+      ignore (sw, state, cell_id);
+      let episode_count, recent_episode = (0, None) in
 
       let mortality_msg =
         if estimated_ratio >= 0.8 then


### PR DESCRIPTION
## Summary
#2135 deleted the Jiphyeon module but left 5 call sites, breaking the build on main.

- `tool_inline_dispatch_episode.ml`: stub episode DB save (file-based JSONL still works)
- `tool_inline_dispatch_extra.ml`: stub episode query (returns empty)
- `server_routes_http_runtime.ml`: remove duplicate `has_shared_pool` check
- `server_runtime_bootstrap.ml`: remove duplicate `set_shared_pool` call

## Test plan
- [x] `dune build` passes (was previously broken on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)