### PR TITLE
fix: remove stale Jiphyeon module references

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -83,8 +83,7 @@ let health_handler _request reqd =
     ("sse_clients", `Int (Sse.client_count ()));
     ("lodge", lodge_json);
     ("pg_pool", let max_size = Backend_core.configured_max_pool_size () in
-      let shared = Council.Archive.has_shared_pool ()
-                   || Jiphyeon.Archive.has_shared_pool () in
+      let shared = Council.Archive.has_shared_pool () in
       Backend_core.pool_stats_to_yojson {
         max_size;
         pool_count = (if shared then 3 else 5);

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -104,10 +104,9 @@ let inject_shared_pg_pool () =
   match Board_dispatch.get_pg_pool () with
   | Some pool ->
       Council.Archive.set_shared_pool pool;
-      Jiphyeon.Archive.set_shared_pool pool;
-      Log.Server.info "PG shared pool injected into council/jiphyeon archive"
+      Log.Server.info "PG shared pool injected into council archive"
   | None ->
-      Log.Server.info "No PG pool available; council/jiphyeon will create own pools"
+      Log.Server.info "No PG pool available; council will create own pools"
 
 let init_memory_pg_schema () =
   match Board_dispatch.get_pg_pool () with

--- a/lib/tool_inline_dispatch_episode.ml
+++ b/lib/tool_inline_dispatch_episode.ml
@@ -55,31 +55,7 @@ let handle_episode_flush ~config ~arguments ~(state : Mcp_server.server_state) ~
         let module U = Yojson.Safe.Util in
         let ep_id = match Json_util.get_string json "ep_id" with Some v -> v | None -> raise Not_found in
 
-        let episode : Jiphyeon.Archive.episode = {
-          ep_id;
-          session_id = json |> U.member "session_id" |> U.to_string;
-          agent_name = json |> U.member "agent_name" |> U.to_string;
-          generation = json |> U.member "generation" |> U.to_int;
-          parent_episode = Json_util.get_string json "parent_episode";
-          event_type = json |> U.member "event_type" |> U.to_string;
-          summary = json |> U.member "summary" |> U.to_string;
-          dna = Json_util.get_string json "dna";
-          outcome = json |> U.member "outcome" |> U.to_string |> parse_outcome;
-          learnings = json |> U.member "learnings" |> parse_string_list;
-          context = json |> U.member "context" |> parse_context;
-          timestamp = json |> U.member "timestamp" |> U.to_string;
-        } in
-
-        (match state.Mcp_server.env with
-         | Some env ->
-           (match Jiphyeon.Archive.save_episode ~sw ~env episode with
-            | Ok () ->
-              Printf.printf "[EPISODE/SAVED] Episode %s saved to PostgreSQL + Neo4j\n%!" ep_id
-            | Error e ->
-              Log.Misc.error "DB save failed (file kept): %s" e)
-         | None ->
-           Log.Misc.warn "No env available, skipping DB save"
-        );
+        ignore (parse_outcome, parse_string_list, parse_context, state, sw);
 
         let processed_dir = Filename.concat base_path ".masc/processed_episodes" in
         Fs_compat.mkdir_p processed_dir;

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -83,18 +83,8 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       let siblings = List.filter (fun (_, _, _) -> true) all_statuses in
 
       let cell_id = cell.Mitosis.id in
-      let episode_count, recent_episode =
-        match state.Mcp_server.env with
-        | Some env ->
-          (try
-            (match Jiphyeon.Archive.get_agent_episodes ~sw ~env cell_id 5 with
-             | Ok episodes -> (List.length episodes, List.nth_opt episodes 0)
-             | Error _ -> (0, None))
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Log.Inline.warn "%s: %s" __FUNCTION__ (Printexc.to_string exn);
-            (0, None))
-        | None -> (0, None)
-      in
+      let episode_count, recent_episode = (0, None) in
+      ignore (cell_id, state, sw);
 
       let mortality_msg =
         if estimated_ratio >= 0.8 then


### PR DESCRIPTION
## Summary
#2135에서 jiphyeon 모듈을 삭제했지만 4개 파일에 참조가 남아 main CI가 `Unbound module Jiphyeon`으로 실패.

## Changes
| File | 변경 |
|------|------|
| `tool_inline_dispatch_episode.ml` | DB 저장 코드 제거 (파일 이동만 유지) |
| `server_runtime_bootstrap.ml` | `Jiphyeon.Archive.set_shared_pool` 제거 |
| `server_routes_http_runtime.ml` | `Jiphyeon.Archive.has_shared_pool()` 제거 |
| `tool_inline_dispatch_extra.ml` | `get_agent_episodes` → `(0, None)` fallback |

## Test plan
- [x] `dune build --root .` 에러 없음