### PR TITLE
fix: keeper shutdown delay, board mentions, dashboard cache & render

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -242,21 +242,9 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           ("continuity_briefs", `List (List.map (fun (row : continuity_context) -> row.json) continuity_rows));
           ("offline_worker_briefs", `List (List.map (fun (row : worker_context) -> row.json) offline_worker_briefs));
           ("agents", `List (List.map agent_json agents));
-          ("keepers", `List (List.map (fun k ->
-            match k with
-            | `Assoc fields when not (List.mem_assoc "pipeline_stage" fields) ->
-              let name = match List.assoc_opt "name" fields with
-                | Some (`String n) -> n | _ -> "" in
-              let stage = match Keeper_types.read_meta config name with
-                | Ok (Some m) ->
-                  let agent_status = Keeper_exec_status.parse_agent_status config ~agent_name:m.agent_name in
-                  let surface = Keeper_exec_status.keeper_surface_status
-                    ~agent_status ~diagnostic:(`Assoc []) in
-                  Keeper_exec_status.derive_pipeline_stage ~meta:m ~surface_status:surface ~now_ts
-                | _ -> "unknown" in
-              `Assoc (("pipeline_stage", `String stage) :: fields)
-            | other -> other
-          ) keepers));
+          (* pipeline_stage is now included in the snapshot keepers_json,
+             so no redundant read_meta + parse_agent_status needed here. *)
+          ("keepers", `List keepers);
         ]
       in
       let active_tasks = List.filter (fun (t : Types.task) ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -35,6 +35,20 @@ let register_keepalive name entry =
 let unregister_keepalive name =
   Hashtbl.remove keepalives name
 
+(** Sleep in short chunks so [stop_keepalive] takes effect within ~2 s
+    instead of waiting for the full 30-300 s interval. *)
+let interruptible_sleep ~clock ~stop duration =
+  let rec wait remaining =
+    if !stop then ()
+    else if remaining <= 0.0 then ()
+    else begin
+      let chunk = Float.min 2.0 remaining in
+      Eio.Time.sleep clock chunk;
+      wait (remaining -. chunk)
+    end
+  in
+  wait duration
+
 let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
     (m : keeper_meta) (stop : bool ref) : unit =
   let keepalive_started_ts = Time_compat.now () in
@@ -352,8 +366,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                 (max 30 (min 300 meta_after_proactive.presence_keepalive_sec))
             in
             let jitter = base *. 0.2 *. Random.float 1.0 in  (* intentional: jitter *)
-            Eio.Time.sleep ctx.clock (base +. jitter);
-            loop ())
+            interruptible_sleep ~clock:ctx.clock ~stop (base +. jitter);
+            if !stop then ()
+            else loop ())
   in
   loop ()
 

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -202,12 +202,17 @@ let keepers_json ?keeper_names config =
               if not agent_exists then "offline"
               else Keeper_exec_status.keeper_surface_status ~agent_status:agent_json ~diagnostic
             in
+            let pipeline_stage =
+              Keeper_exec_status.derive_pipeline_stage ~meta
+                ~surface_status:agent_status ~now_ts
+            in
             Some
               (`Assoc
                 [
                   ("runtime_class", `String "resident_keeper");
                   ("desired", `Bool true);
                   ("resident_registered", `Bool true);
+                  ("pipeline_stage", `String pipeline_stage);
                   ("name", `String meta.name);
                   ("agent_name", `String meta.agent_name);
                   ("trace_id", `String meta.trace_id);

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -172,11 +172,22 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
     ("perpetual", perpetual_dashboard_json ());
   ]
 
+(** Strip non-ASCII characters from actor string.
+    Prevents IME artifacts (e.g. Korean ㅊ) from polluting cache keys. *)
+let sanitize_actor s =
+  let buf = Buffer.create (String.length s) in
+  String.iter (fun c ->
+    match c with
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> Buffer.add_char buf c
+    | _ -> ()
+  ) s;
+  Buffer.contents buf
+
 let operator_actor_hint request =
   match agent_from_request request with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then None else Some trimmed
+      let sanitized = sanitize_actor (String.trim raw) in
+      if sanitized = "" then None else Some sanitized
   | None -> None
 
 (* --- Operator proactive refresh ---

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -310,7 +310,17 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
                   | Some id -> `String id
                   | None -> `Null );
               ])
-          ()
+          ();
+        (* Mention processing — mirror masc_broadcast pattern *)
+        let mention = Mention.extract content in
+        (match mention with
+         | Some target ->
+             Notify.notify_mention ~from_agent:author
+               ~target_agent:target ~message:content ();
+             ignore (Auto_responder.maybe_respond ~sw
+               ~base_path:config.base_path ~from_agent:author
+               ~content ~mention)
+         | None -> ())
       end;
       Some result
 
@@ -364,7 +374,17 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
                 ("post_id", `String post_id);
                 ("content", `String content);
               ])
-          ()
+          ();
+        (* Mention processing — mirror masc_broadcast pattern *)
+        let mention = Mention.extract content in
+        (match mention with
+         | Some target ->
+             Notify.notify_mention ~from_agent:author
+               ~target_agent:target ~message:content ();
+             ignore (Auto_responder.maybe_respond ~sw
+               ~base_path:config.base_path ~from_agent:author
+               ~content ~mention)
+         | None -> ())
       end;
       Some result
 


### PR DESCRIPTION
## Summary

운영 로그에서 발견된 4건의 이슈 일괄 수정.

- **Keeper shutdown 지연**: `stop_keepalive` 후 30-300초 동안 keeper가 계속 실행되던 문제. `Eio.Time.sleep`을 2초 chunk interruptible sleep으로 교체하여 ~2초 내 종료.
- **Board 멘션 미작동**: `masc_board_post`/`masc_board_comment`에서 `@mention` 파싱이 누락되어 알림/자동응답이 동작하지 않던 문제. `masc_broadcast` 패턴을 복사하여 `Mention.extract` + `Notify` + `Auto_responder` 연결.
- **Dashboard 캐시 키 오염**: IME 잔여 문자(한글 `ㅊ`)가 actor 쿼리 파라미터에 혼입되어 캐시 미스 + 반복 30초 타임아웃 발생. ASCII-only `sanitize_actor` 필터 추가.
- **Dashboard 렌더 69초**: execution 렌더 단계에서 keeper별 `read_meta` + `parse_agent_status`를 중복 호출하던 문제. snapshot 단계에서 `pipeline_stage`를 미리 계산하여 렌더 단계 중복 I/O 제거.

## Test plan

- [x] `dune build` 성공
- [x] `make test` 전체 통과 (126 tests, 86s)
- [ ] `masc_keeper_up` → `masc_keeper_down` → 로그에서 2초 내 종료 확인
- [ ] `masc_board_post` with `@claude` → mention_inbox 기록 확인
- [ ] dashboard `/api/v1/dashboard/execution` 응답 시간 < 35초

🤖 Generated with [Claude Code](https://claude.com/claude-code)