### PR TITLE
fix(keeper): gate autoresearch on both policy paths + tests

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -72,7 +72,11 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
       else with_shell
     in
     dedupe_tool_names (keeper_board_tool_names @ with_research)
-  else keeper_model_tools |> List.map (fun tool -> tool.Types.name)
+  else
+    let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
+    if meta.soul_profile = "research" then
+      dedupe_tool_names (keeper_autoresearch_tool_names @ base_names)
+    else base_names
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     Types.tool_schema list =

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -45,6 +45,10 @@ let keeper_voice_tool_names =
 
 let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
 
+let keeper_autoresearch_tool_names =
+  Tool_shard.autoresearch_keeper_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)
 
@@ -62,7 +66,12 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
         keeper_shell_readonly_tool_names @ with_voice
       else with_voice
     in
-    dedupe_tool_names (keeper_board_tool_names @ with_shell)
+    let with_research =
+      if meta.soul_profile = "research" then
+        keeper_autoresearch_tool_names @ with_shell
+      else with_shell
+    in
+    dedupe_tool_names (keeper_board_tool_names @ with_research)
   else keeper_model_tools |> List.map (fun tool -> tool.Types.name)
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
@@ -71,7 +80,13 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
   if allowed = [] then
     []
   else
-    keeper_model_tools
+    let base = keeper_model_tools in
+    let all_tools =
+      if meta.soul_profile = "research" then
+        base @ Tool_shard.autoresearch_keeper_tools
+      else base
+    in
+    all_tools
     |> List.filter (fun tool -> List.mem tool.Types.name allowed)
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
@@ -635,6 +650,21 @@ let execute_keeper_tool_call
         let _ = Room.broadcast config ~from_agent:agent ~content:message in
         Yojson.Safe.to_string
           (`Assoc [ ("ok", `Bool true); ("broadcast", `String message) ])
+  | name when String.starts_with ~prefix:"masc_autoresearch_" name ->
+      let ctx : Tool_autoresearch.context = {
+        base_path = project_root_of_config config;
+        agent_name = Some meta.name;
+        start_operation = None;
+        start_team_session = None;
+      } in
+      (match Tool_autoresearch.dispatch ctx ~name ~args with
+      | Some (true, msg) -> msg
+      | Some (false, msg) ->
+          Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
+      | None ->
+          Yojson.Safe.to_string
+            (`Assoc [ ("error", `String "unknown_autoresearch_tool");
+                      ("tool", `String name) ]))
   | other ->
       Yojson.Safe.to_string
         (`Assoc [ ("error", `String "unknown_tool"); ("tool", `String other) ])

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -353,6 +353,19 @@ let shard_taskboard : shard = {
   description = "Task board management: list, audit, force-release, force-done, broadcast";
 }
 
+(** Autoresearch tools: filtered subset for keeper use (excludes swarm_start). *)
+let autoresearch_keeper_tools : Types.tool_schema list =
+  Tool_autoresearch_schemas.schemas
+  |> List.filter (fun (t : Types.tool_schema) ->
+       t.name <> "masc_autoresearch_swarm_start")
+
+let shard_autoresearch : shard = {
+  name = "autoresearch";
+  tools = autoresearch_keeper_tools;
+  removable = true;
+  description = "Autonomous experiment loop: start, cycle, status, inject, stop";
+}
+
 
 
 let agent_shards : (string, string list) Hashtbl.t = Hashtbl.create 32
@@ -387,6 +400,7 @@ let all_shards : (string, shard) Hashtbl.t =
     shard_weather;
     shard_voice;
     shard_taskboard;
+    shard_autoresearch;
   ];
   tbl
 

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -89,5 +89,11 @@ val execute : string -> Yojson.Safe.t -> (bool * Yojson.Safe.t)
 (** Execute tool_shard MCP tools (grant, revoke, list).
     Agent shard state is tracked in-memory via [agent_shards] hashtable. *)
 
+val autoresearch_keeper_tools : Types.tool_schema list
+(** Autoresearch tools for keeper use (excludes swarm_start). *)
+
+val shard_autoresearch : shard
+(** Autoresearch shard: start, cycle, status, inject, stop. *)
+
 val keeper_model_tools : Types.tool_schema list
 (** Full tool set (all 11 tools) — backward compatible with existing code. *)

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -69,11 +69,50 @@ let test_tool_count_matches_allowed () =
       check bool "all tools are in allowed list" true
         (List.for_all (fun name -> List.mem name allowed) tool_names))
 
+let make_research_meta () : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+    (`Assoc [("name", `String "test-researcher");
+             ("agent_name", `String "test-researcher");
+             ("trace_id", `String "test-trace-research");
+             ("soul_profile", `String "research")]) with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_research_meta failed: %s" e)
+
+let test_research_keeper_has_autoresearch_tools () =
+  let meta = make_research_meta () in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let has_cycle = List.mem "masc_autoresearch_cycle" allowed in
+  let has_start = List.mem "masc_autoresearch_start" allowed in
+  let has_status = List.mem "masc_autoresearch_status" allowed in
+  check bool "has cycle" true has_cycle;
+  check bool "has start" true has_start;
+  check bool "has status" true has_status
+
+let test_non_research_keeper_no_autoresearch () =
+  let meta = make_test_meta () in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let has_any = List.exists (fun n ->
+    String.length n > 18
+    && String.sub n 0 18 = "masc_autoresearch_") allowed in
+  check bool "no autoresearch tools" false has_any
+
+let test_research_model_tools_include_autoresearch () =
+  let meta = make_research_meta () in
+  let tools = Keeper_exec_tools.keeper_allowed_model_tools meta in
+  let has_cycle = List.exists (fun (t : Types.tool_schema) ->
+    t.name = "masc_autoresearch_cycle") tools in
+  check bool "model tools have cycle" true has_cycle
+
 let () =
   run "Keeper_tools_oas" [
     "make_tools", [
       test_case "returns nonempty" `Quick test_make_tools_returns_nonempty;
       test_case "valid schemas" `Quick test_tools_have_valid_schemas;
       test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
+    ];
+    "research_profile", [
+      test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;
+      test_case "non-research has none" `Quick test_non_research_keeper_no_autoresearch;
+      test_case "model tools include autoresearch" `Quick test_research_model_tools_include_autoresearch;
     ];
   ]

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -7,6 +7,7 @@
     Pure synchronous tests — no Eio or network required. *)
 
 module Tool_shard = Masc_mcp.Tool_shard
+module Types = Masc_mcp.Types
 
 (* ============================================================
    Predefined shard tests
@@ -61,7 +62,7 @@ let test_shard_unknown () =
 
 let test_all_shards_count () =
   let all = Tool_shard.list_all_shards () in
-  Alcotest.(check int) "7 predefined shards" 7 (List.length all)
+  Alcotest.(check int) "8 predefined shards" 8 (List.length all)
 
 (* ============================================================
    default_shard_names tests
@@ -200,7 +201,7 @@ let test_execute_tool_list () =
   let (ok, json) = Tool_shard.execute "masc_tool_list" (`Assoc []) in
   Alcotest.(check bool) "succeeds" true ok;
   let shards = Yojson.Safe.Util.(member "shards" json |> to_list) in
-  Alcotest.(check int) "7 shards in list" 7 (List.length shards)
+  Alcotest.(check int) "8 shards in list" 8 (List.length shards)
 
 let test_execute_tool_list_with_agent () =
   Hashtbl.remove Tool_shard.agent_shards "test-ex";
@@ -345,6 +346,32 @@ let () =
       Alcotest.test_case "voice" `Quick test_shard_voice_exists;
       Alcotest.test_case "unknown" `Quick test_shard_unknown;
       Alcotest.test_case "all count" `Quick test_all_shards_count;
+    ]);
+    ("autoresearch_shard", [
+      Alcotest.test_case "exists" `Quick (fun () ->
+        let s = Tool_shard.get_shard "autoresearch" in
+        Alcotest.(check bool) "found" true (s <> None));
+      Alcotest.test_case "removable" `Quick (fun () ->
+        let s = Option.get (Tool_shard.get_shard "autoresearch") in
+        Alcotest.(check bool) "removable" true s.removable);
+      Alcotest.test_case "excludes swarm_start" `Quick (fun () ->
+        let tools = Tool_shard.autoresearch_keeper_tools in
+        let has_swarm =
+          List.exists (fun (t : Types.tool_schema) ->
+            t.name = "masc_autoresearch_swarm_start") tools
+        in
+        Alcotest.(check bool) "no swarm_start" false has_swarm);
+      Alcotest.test_case "has cycle" `Quick (fun () ->
+        let tools = Tool_shard.autoresearch_keeper_tools in
+        let has_cycle =
+          List.exists (fun (t : Types.tool_schema) ->
+            t.name = "masc_autoresearch_cycle") tools
+        in
+        Alcotest.(check bool) "has cycle" true has_cycle);
+      Alcotest.test_case "not in defaults" `Quick (fun () ->
+        let defaults = Tool_shard.default_shard_names in
+        Alcotest.(check bool) "not default"
+          false (List.mem "autoresearch" defaults));
     ]);
     ("default_shard_names", [
       Alcotest.test_case "defaults" `Quick test_default_shard_names;


### PR DESCRIPTION
## Summary

- #2139 후속: policy_mode=heuristic (기본값) 경로에서도 autoresearch tools 노출
- soul_profile="research" 분기 테스트 3개 추가 (has tools, non-research has none, model tools)
- 48 tests pass (shard 42 + keeper tools 6)

## Context

#2139 는 learned policy path만 게이팅했으나, 기본 policy_mode가 heuristic이라 실제로 autoresearch tools가 노출되지 않았음. GLM-5 외부 리뷰에서 발견.

## Test plan

- [x] `test_tool_shard_coverage.exe` 42/42 pass
- [x] `test_keeper_tools_oas.exe` 6/6 pass (3 new research_profile tests)
- [x] `dune build --root .` 에러 없음
- [x] CI 7/7 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)