### PR TITLE
Fix local dune test RPC lock retry

### DIFF
--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -23,6 +23,10 @@ START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
 CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
 CI_TEST_CLEAN_RETRY_DONE=0
+CI_TEST_ALLOW_RPC_RETRY="${CI_TEST_ALLOW_RPC_RETRY:-1}"
+CI_TEST_RPC_RETRY_DONE=0
+CI_TEST_ISOLATED_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR:-.ci_build}"
+ACTIVE_TEST_BUILD_DIR="${DUNE_BUILD_DIR:-_build}"
 
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -48,6 +52,7 @@ diag_dump() {
   echo "[ci-diag] elapsed_sec=$(elapsed_sec)"
   echo "[ci-diag] pwd=$(pwd)"
   echo "[ci-diag] log_file=${TEST_LOG_FILE}"
+  echo "[ci-diag] build_dir=${ACTIVE_TEST_BUILD_DIR}"
 
   echo "[ci-diag] process snapshot (dune/ocaml/test):"
   ps -eo pid,ppid,etime,%cpu,%mem,comm,args \
@@ -66,7 +71,7 @@ diag_dump() {
     tail -n 120 "${TEST_LOG_FILE}" || true
   fi
 
-  local tests_root="_build/default/test/_build/_tests"
+  local tests_root="${ACTIVE_TEST_BUILD_DIR%/}/default/test/_build/_tests"
   if [[ -d "${tests_root}" ]]; then
     # Sort by file mtime so diagnostic tail follows the most recently updated test.
     local -a output_files=()
@@ -107,6 +112,10 @@ test_cmd_needs_dune_sanitization() {
   [[ "${TEST_CMD}" == *"dune "* ]] && [[ "${TEST_CMD}" != *"env -u DUNE_RPC"* ]]
 }
 
+test_cmd_has_explicit_build_dir() {
+  [[ "${TEST_CMD}" == *"--build-dir"* ]] || [[ "${TEST_CMD}" == *"DUNE_BUILD_DIR="* ]]
+}
+
 effective_test_cmd() {
   if test_cmd_needs_dune_sanitization; then
     printf 'env -u DUNE_RPC %s' "${TEST_CMD}"
@@ -115,11 +124,33 @@ effective_test_cmd() {
   fi
 }
 
+isolated_build_dir_cmd() {
+  local cmd="${1}"
+  printf 'env DUNE_BUILD_DIR=%q %s' "${CI_TEST_ISOLATED_BUILD_DIR}" "${cmd}"
+}
+
 agent_sdk_interface_mismatch_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
   grep -Eq \
     'Unbound module Agent_sdk|module Oas is an alias for module Agent_sdk|inconsistent assumptions over interface Agent_sdk' \
     "${TEST_LOG_FILE}"
+}
+
+rpc_server_not_running_detected() {
+  [[ -f "${TEST_LOG_FILE}" ]] || return 1
+  grep -Eq 'RPC server not running\.|has locked the build directory\.' "${TEST_LOG_FILE}"
+}
+
+clean_current_build_dir() {
+  if [[ "${ACTIVE_TEST_BUILD_DIR}" != "_build" ]]; then
+    env DUNE_BUILD_DIR="${ACTIVE_TEST_BUILD_DIR}" dune clean --root . \
+      > >(tee -a "${TEST_LOG_FILE}") \
+      2> >(tee -a "${TEST_LOG_FILE}" >&2)
+  else
+    dune clean --root . \
+      > >(tee -a "${TEST_LOG_FILE}") \
+      2> >(tee -a "${TEST_LOG_FILE}" >&2)
+  fi
 }
 
 run_with_timeout() {
@@ -170,11 +201,30 @@ heartbeat &
 hb_pid="$!"
 
 effective_cmd="$(effective_test_cmd)"
+run_cmd="${effective_cmd}"
 
 set +e
-run_with_timeout "${effective_cmd}"
+run_with_timeout "${run_cmd}"
 status=$?
 set -e
+
+if [[ "${status}" -ne 0 ]] \
+  && [[ "${CI_TEST_ALLOW_RPC_RETRY}" = "1" ]] \
+  && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
+  && test_cmd_needs_dune_sanitization \
+  && ! test_cmd_has_explicit_build_dir \
+  && rpc_server_not_running_detected; then
+  CI_TEST_RPC_RETRY_DONE=1
+  ACTIVE_TEST_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR}"
+  run_cmd="$(isolated_build_dir_cmd "${effective_cmd}")"
+  echo "[ci-run] WARN: detected dune RPC/lock failure; retrying once with isolated build dir ${ACTIVE_TEST_BUILD_DIR}"
+  echo "[ci-run] isolated_command: ${run_cmd}"
+  echo "[ci-run] retry_started_at=$(iso_now)"
+  set +e
+  run_with_timeout "${run_cmd}"
+  status=$?
+  set -e
+fi
 
 if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
@@ -183,12 +233,10 @@ if [[ "${status}" -ne 0 ]] \
   && agent_sdk_interface_mismatch_detected; then
   CI_TEST_CLEAN_RETRY_DONE=1
   echo "[ci-run] WARN: detected Agent_sdk interface mismatch; running dune clean and retrying once"
-  dune clean --root . \
-    > >(tee -a "${TEST_LOG_FILE}") \
-    2> >(tee -a "${TEST_LOG_FILE}" >&2)
+  clean_current_build_dir
   echo "[ci-run] retry_started_at=$(iso_now)"
   set +e
-  run_with_timeout "${effective_cmd}"
+  run_with_timeout "${run_cmd}"
   status=$?
   set -e
 fi

--- a/test/dune
+++ b/test/dune
@@ -164,6 +164,11 @@
  (libraries alcotest unix yojson))
 
 (test
+ (name test_ci_run_tests_script)
+ (modules test_ci_run_tests_script)
+ (libraries alcotest unix))
+
+(test
  (name test_worker_runtime)
  (modules test_worker_runtime)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -149,7 +149,6 @@ let test_dashboard_component_split_contracts () =
   check bool "council archive normalizes postgres url" true
     (file_contains_pattern "lib/council/archive.ml"
        "pooler.supabase.com")
-  (* jiphyeon module removed in #2135 — assertion removed *)
 
 let test_activity_surface_contracts () =
   check bool "activity tab exposes activity graph label" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -40,7 +40,12 @@ let test_health_and_ci_runner_diagnostics () =
   check bool "ci runner captures log file" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "TEST_LOG_FILE=");
   check bool "ci runner prints failure markers" true
-    (file_contains_pattern "scripts/ci-run-tests.sh" "failure markers (latest 20)")
+    (file_contains_pattern "scripts/ci-run-tests.sh" "failure markers (latest 20)");
+  check bool "ci runner retries dune rpc lock failures in isolated build dir" true
+    (file_contains_pattern "scripts/ci-run-tests.sh"
+       "detected dune RPC/lock failure; retrying once with isolated build dir");
+  check bool "ci runner tracks active build dir for diagnostics" true
+    (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR")
 
 let test_route_auth_contracts () =
   check bool "http command-plane units use tool auth" true

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -1,0 +1,150 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let script_path () =
+  Filename.concat (source_root ()) "scripts/ci-run-tests.sh"
+
+let quote = Filename.quote
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "ci-run-tests-out" ".txt" in
+  let err = Filename.temp_file "ci-run-tests-err" ".txt" in
+  let wrapped =
+    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let make_fake_dune dir =
+  let bin_dir = Filename.concat dir "bin" in
+  Unix.mkdir bin_dir 0o755;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+printf '%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" >>"$log_file"
+if [ "${1:-}" = "--version" ]; then
+  printf '3.21.0\n'
+  exit 0
+fi
+if [ "${1:-}" = "clean" ]; then
+  exit 0
+fi
+if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
+  printf 'Error: RPC server not running.\n' >&2
+  exit 1
+fi
+mkdir -p "${DUNE_BUILD_DIR}/default/test/_build/_tests"
+printf 'fake ok\n' > "${DUNE_BUILD_DIR}/default/test/_build/_tests/fake.output"
+printf 'Testing `fake`.\n'
+exit 0
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  bin_dir
+
+let test_rpc_retry_uses_isolated_build_dir () =
+  with_temp_dir "ci-run-tests-retry" (fun dir ->
+      let fake_log = Filename.concat dir "fake-dune.log" in
+      let fake_bin = make_fake_dune dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_DUNE_LOG", fake_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+        ]
+      in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env
+          (Printf.sprintf "%s %s" (quote (script_path ()))
+             (quote "dune test --root ."))
+      in
+      if code <> 0 then
+        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check bool "retry warning present" true
+        (contains_substring stdout
+           "detected dune RPC/lock failure; retrying once with isolated build dir .ci_build");
+      check bool "isolated command exports build dir" true
+        (contains_substring stdout "isolated_command: env DUNE_BUILD_DIR=.ci_build");
+      check bool "success message present" true
+        (contains_substring stdout "tests completed successfully");
+      let log_lines =
+        read_file fake_log
+        |> String.split_on_char '\n'
+        |> List.filter (fun line -> String.trim line <> "")
+      in
+      match log_lines with
+      | [ first; second ] ->
+          check string "first attempt uses default build dir" "test|"
+            first;
+          check string "second attempt uses isolated build dir"
+            "test|.ci_build" second
+      | _ ->
+          failf "expected exactly two dune invocations, got:\n%s"
+            (String.concat "\n" log_lines))
+
+let () =
+  run "ci_run_tests_script"
+    [
+      ( "script",
+        [
+          test_case "rpc retry uses isolated build dir" `Quick
+            test_rpc_retry_uses_isolated_build_dir;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- retry local `dune test` commands once in an isolated build dir when `_build` RPC/lock attach fails
- add a fake-`dune` regression test for the retry path and update CI source guards
- document the stale `#2122` symptom in the PR context: the real failure is local `make test`/`dune test` RPC lock contention, not `tool_council_oas`

## Verification
- `bash -n scripts/ci-run-tests.sh`
- `git diff --check`
- `dune build --root . --build-dir .ci_build_script_tests test/test_ci_run_tests_script.exe test/test_ci_hardening_source.exe`
- `./.ci_build_script_tests/default/test/test_ci_run_tests_script.exe`
- `./.ci_build_script_tests/default/test/test_ci_hardening_source.exe`
