### PR TITLE
fix: validate board and cache inputs

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -146,7 +146,14 @@ let handle_post_create args =
   let body = get_string_opt args "body" |> Option.map strip_state_blocks_text in
   let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
   let content = strip_state_blocks_text raw_content in
-  if String.length content > Board.Limits.max_content_length then
+  let title_is_empty =
+    match title with
+    | Some value -> String.trim value = ""
+    | None -> false
+  in
+  if title_is_empty then
+    (false, "❌ title is required")
+  else if String.length content > Board.Limits.max_content_length then
     (false, Printf.sprintf "Content exceeds max length (%d > %d chars)"
        (String.length content) Board.Limits.max_content_length)
   else
@@ -192,6 +199,15 @@ let sort_order_of_string = function
   | "discussed" | "comments" -> Discussed
   | _ -> Hot  (* default *)
 
+let parse_sort_order value =
+  match String.lowercase_ascii (String.trim value) with
+  | "hot" -> Ok Hot
+  | "trending" -> Ok Trending
+  | "recent" | "new" -> Ok Recent
+  | "updated" | "active" -> Ok Updated
+  | "discussed" | "comments" -> Ok Discussed
+  | _ -> Error "invalid sort. Valid: hot, trending, recent, updated, discussed"
+
 let dispatch_sort_of sort_by =
   match sort_by with
   | Hot -> Board_dispatch.Hot
@@ -206,7 +222,11 @@ let handle_post_list args =
   let hearth = get_string_opt args "hearth" in
   let random = get_bool args "random" false in
   let offset = get_int args "offset" 0 in
-  let sort_by = get_string args "sort_by" "hot" |> sort_order_of_string in
+  let sort_arg =
+    match get_string_opt args "sort_by" with
+    | Some _ as value -> value
+    | None -> get_string_opt args "sort"
+  in
   let exclude_system = get_bool args "exclude_system" false in
   let exclude_automation = get_bool args "exclude_automation" false in
   let since = get_float_opt args "since" in
@@ -215,61 +235,68 @@ let handle_post_list args =
     | Some s -> visibility_of_string s
     | None -> None
   in
-
-  let all_posts = Board_dispatch.list_posts ~visibility_filter ?hearth
-    ~exclude_automation
-    ~sort_by:(dispatch_sort_of sort_by) ~limit:(limit + offset + 100) () in
-
-  (* Filter out system posts when exclude_system is true *)
-  let all_posts = if exclude_system then
-    List.filter (fun (p : Board.post) ->
-      Board.classify_post_kind p <> Board.System_post
-      && Board.Agent_id.to_string p.author <> "system"
-    ) all_posts
-  else all_posts
+  let sort_by_result =
+    match sort_arg with
+    | None -> Ok Hot
+    | Some value -> parse_sort_order value
   in
+  match sort_by_result with
+  | Error msg -> (false, Printf.sprintf "❌ %s" msg)
+  | Ok sort_by ->
+      let all_posts = Board_dispatch.list_posts ~visibility_filter ?hearth
+        ~exclude_automation
+        ~sort_by:(dispatch_sort_of sort_by) ~limit:(limit + offset + 100) () in
 
-  (* Sorting is already handled by Board_dispatch *)
-  let sorted_posts = all_posts in
+      (* Filter out system posts when exclude_system is true *)
+      let all_posts = if exclude_system then
+        List.filter (fun (p : Board.post) ->
+          Board.classify_post_kind p <> Board.System_post
+          && Board.Agent_id.to_string p.author <> "system"
+        ) all_posts
+      else all_posts
+      in
 
-  let posts =
-    if random then
-      (* Shuffle via random-key sort (unbiased, unlike comparator trick) *)
-      let shuffled = List.map (fun p -> (Random.bits (), p)) sorted_posts
-        |> List.sort (fun (a, _) (b, _) -> compare a b)
-        |> List.map snd in
-      List.filteri (fun i _ -> i < limit) shuffled
-    else if offset > 0 then
-      (* Skip offset, take limit *)
-      List.filteri (fun i _ -> i >= offset && i < offset + limit) sorted_posts
-    else
-      List.filteri (fun i _ -> i < limit) sorted_posts
-  in
-  if posts = [] then
-    (true, "📭 No posts found.")
-  else
-    (* Check for new activity since timestamp *)
-    let has_new_activity (p : Board.post) =
-      match since with
-      | None -> false
-      | Some ts ->
-          (* Post itself is new *)
-          p.created_at > ts || p.updated_at > ts
-    in
-    let format_post_with_indicator p =
-      let indicator = if has_new_activity p then " 🔔" else "" in
-      format_post p ^ indicator
-    in
-    let formatted = List.map format_post_with_indicator posts in
-    let sort_label = match sort_by with
-      | Hot -> "🔥 Hot"
-      | Trending -> "📈 Trending"
-      | Recent -> "🕐 Recent"
-      | Updated -> "🔄 Recently Updated"
-      | Discussed -> "💬 Most Discussed"
-    in
-    let header = Printf.sprintf "📋 Posts (%d) — %s:" (List.length posts) sort_label in
-    (true, header ^ "\n\n" ^ String.concat "\n\n---\n\n" formatted)
+      (* Sorting is already handled by Board_dispatch *)
+      let sorted_posts = all_posts in
+
+      let posts =
+        if random then
+          (* Shuffle via random-key sort (unbiased, unlike comparator trick) *)
+          let shuffled = List.map (fun p -> (Random.bits (), p)) sorted_posts
+            |> List.sort (fun (a, _) (b, _) -> compare a b)
+            |> List.map snd in
+          List.filteri (fun i _ -> i < limit) shuffled
+        else if offset > 0 then
+          (* Skip offset, take limit *)
+          List.filteri (fun i _ -> i >= offset && i < offset + limit) sorted_posts
+        else
+          List.filteri (fun i _ -> i < limit) sorted_posts
+      in
+      if posts = [] then
+        (true, "📭 No posts found.")
+      else
+        (* Check for new activity since timestamp *)
+        let has_new_activity (p : Board.post) =
+          match since with
+          | None -> false
+          | Some ts ->
+              (* Post itself is new *)
+              p.created_at > ts || p.updated_at > ts
+        in
+        let format_post_with_indicator p =
+          let indicator = if has_new_activity p then " 🔔" else "" in
+          format_post p ^ indicator
+        in
+        let formatted = List.map format_post_with_indicator posts in
+        let sort_label = match sort_by with
+          | Hot -> "🔥 Hot"
+          | Trending -> "📈 Trending"
+          | Recent -> "🕐 Recent"
+          | Updated -> "🔄 Recently Updated"
+          | Discussed -> "💬 Most Discussed"
+        in
+        let header = Printf.sprintf "📋 Posts (%d) — %s:" (List.length posts) sort_label in
+        (true, header ^ "\n\n" ^ String.concat "\n\n---\n\n" formatted)
 
 let handle_post_get args =
   let post_id = get_string args "post_id" "" in

--- a/lib/tool_cache.ml
+++ b/lib/tool_cache.ml
@@ -36,9 +36,10 @@ let handle_cache_get ctx args : result =
         ("entry", Cache_eio.entry_to_json entry);
       ]))
   | Ok None ->
-      (true, Yojson.Safe.pretty_to_string (`Assoc [
+      (false, Yojson.Safe.pretty_to_string (`Assoc [
         ("hit", `Bool false);
         ("key", `String key);
+        ("error", `String "cache entry not found");
       ]))
   | Error e ->
       (false, Printf.sprintf "❌ Cache get failed: %s" e)

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -213,6 +213,17 @@ let test_post_create_empty_content () =
     Alcotest.(check bool) "error mentions reason" true
       (String.length body > 0)
 
+let test_post_create_empty_title_rejected () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_post"
+    (make_args
+       [ ("title", `String "   "); ("content", `String "Hello board");
+         ("author", `String "tester") ]) in
+  Alcotest.(check bool) "empty title rejected" false ok;
+  Alcotest.(check bool) "error mentions title" true
+    (contains_substring body "title is required")
+
 let test_post_list_empty () =
   Eio_main.run @@ fun _env ->
   cleanup ();
@@ -276,6 +287,17 @@ let test_post_list_sort_orders () =
     Alcotest.(check bool) (Printf.sprintf "sort %s ok" s) true ok;
     Alcotest.(check bool) (Printf.sprintf "sort %s has content" s) true (String.length body > 0)
   ) sorts
+
+let test_post_list_invalid_sort_rejected () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  ignore (dispatch "masc_board_post"
+    (make_args [("content", `String "sort test"); ("author", `String "a")]));
+  let ok, body = dispatch "masc_board_list"
+    (make_args [("sort", `String "invalid_xyz")]) in
+  Alcotest.(check bool) "invalid sort rejected" false ok;
+  Alcotest.(check bool) "error mentions valid sorts" true
+    (contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
 
 let test_post_get_success () =
   Eio_main.run @@ fun _env ->
@@ -457,12 +479,16 @@ let () =
           Alcotest.test_case "create structured payload" `Quick
             test_post_create_structured_payload;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;
+          Alcotest.test_case "create empty title rejected" `Quick
+            test_post_create_empty_title_rejected;
           Alcotest.test_case "list empty" `Quick test_post_list_empty;
           Alcotest.test_case "cleanup clears persisted jsonl" `Quick
             test_cleanup_clears_persisted_jsonl;
           Alcotest.test_case "list with posts" `Quick test_post_list_with_posts;
           Alcotest.test_case "list limit clamping" `Quick test_post_list_limit_clamping;
           Alcotest.test_case "list sort orders" `Quick test_post_list_sort_orders;
+          Alcotest.test_case "list invalid sort rejected" `Quick
+            test_post_list_invalid_sort_rejected;
           Alcotest.test_case "get success" `Quick test_post_get_success;
           Alcotest.test_case "get not found" `Quick test_post_get_not_found;
         ] );

--- a/test/test_tool_cache_coverage.ml
+++ b/test/test_tool_cache_coverage.ml
@@ -82,6 +82,18 @@ let test_dispatch_cache_get () =
     | None -> fail "expected Some"
   with _ -> ()
 
+let test_dispatch_cache_get_miss_rejected () =
+  let ctx = make_ctx () in
+  let args = `Assoc [("key", `String "missing")] in
+  match Tool_cache.dispatch ctx ~name:"masc_cache_get" ~args with
+  | Some (success, body) ->
+      check bool "cache miss rejected" false success;
+      let json = Yojson.Safe.from_string body in
+      check bool "hit false" false Yojson.Safe.Util.(json |> member "hit" |> to_bool);
+      check string "error message" "cache entry not found"
+        Yojson.Safe.Util.(json |> member "error" |> to_string)
+  | None -> fail "expected Some"
+
 let test_dispatch_cache_delete () =
   let ctx = make_ctx () in
   let args = `Assoc [("key", `String "k1")] in
@@ -150,6 +162,7 @@ let () =
     "dispatch", [
       test_case "cache_set" `Quick test_dispatch_cache_set;
       test_case "cache_get" `Quick test_dispatch_cache_get;
+      test_case "cache_get miss rejected" `Quick test_dispatch_cache_get_miss_rejected;
       test_case "cache_delete" `Quick test_dispatch_cache_delete;
       test_case "cache_list" `Quick test_dispatch_cache_list;
       test_case "cache_clear" `Quick test_dispatch_cache_clear;


### PR DESCRIPTION
## Summary
- reject explicitly empty `masc_board_post.title`
- reject invalid `masc_board_list` sort keys instead of silently defaulting to hot
- return a not-found failure envelope for `masc_cache_get` misses

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/input-validation-2120 test/test_tool_board_coverage.exe test/test_tool_cache_coverage.exe`
- `./_build/default/test/test_tool_board_coverage.exe`
- `./_build/default/test/test_tool_cache_coverage.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/input-validation-2120`
- `git diff --check`

## Issue
- fixes #2120