### PR TITLE
refactor: remove lodge dashboard surface

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -319,7 +319,7 @@ let local_worker_internal_schemas : Types.tool_schema list =
     };
     {
       Types.name = "lodge_research";
-      description = "Research a topic using the MODEL and share findings with the lodge.";
+      description = "Research a topic using the MODEL and share findings with the board.";
       input_schema =
         `Assoc
           [
@@ -335,7 +335,7 @@ let local_worker_internal_schemas : Types.tool_schema list =
     };
     {
       Types.name = "lodge_profile";
-      description = "Get an agent profile including recent lodge activity, stats, and interests. Use when reviewing an agent's contributions before collaboration or mentioning them.";
+      description = "Get an agent profile including recent board activity, stats, and interests. Use when reviewing an agent's contributions before collaboration or mentioning them.";
       input_schema =
         `Assoc
           [
@@ -347,7 +347,7 @@ let local_worker_internal_schemas : Types.tool_schema list =
     };
     {
       Types.name = "lodge_search";
-      description = "Search lodge content (posts, comments, code snippets) and agents by keyword. Use when looking for prior discussions on a topic or finding agents with relevant expertise.";
+      description = "Search board content (posts, comments, code snippets) and agents by keyword. Use when looking for prior discussions on a topic or finding agents with relevant expertise.";
       input_schema =
         `Assoc
           [

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -434,7 +434,7 @@ let get_agent_profile (name : string) : agent_profile =
         if contains normalized "claude" then ("🧠", "클로드")
         else if contains normalized "gemini" then ("💎", "제미나이")
         else if contains normalized "codex" then ("🤖", "코덱스")
-        else if contains normalized "lodge" then ("🏠", "롯지 키퍼")
+        else if contains normalized "lodge" then ("👥", "소셜 에이전트")
         else if contains normalized "gardener" then ("🌿", "정원사")
         else if contains normalized "review" then ("🔍", "리뷰어")
         else if contains normalized "test" then ("🧪", "테스터")
@@ -473,4 +473,3 @@ let handoff_json ~surface ?command_surface ?operation_id ~label ~target_type ~ta
     match operation_id with
     | Some value -> [ ("operation_id", `String value) ]
     | None -> [])
-

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -165,7 +165,7 @@ let prompt_for_facts facts_json =
      Read only the factual operator snapshot JSON below.\n\
      Produce concise, operational judgments for the room and any team sessions that need attention.\n\
      Do not repeat raw facts. Do not invent evidence, ids, or actions. Omit entries when you are not confident.\n\
-     Allowed action_type values: broadcast, room_pause, room_resume, social_sweep, lodge_tick, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.\n\
+     Allowed action_type values: broadcast, room_pause, room_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.\n\
      Output strict JSON only with this shape:\n\
      {\n\
        \"room\": {\n\

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -312,7 +312,7 @@ let keeper_diagnostic_summary ~health_state ~quiet_reason =
   | _ -> (
       match quiet_reason with
       | Some "quiet_hours" ->
-          "Lodge quiet hours are active. Direct messages still work, but scheduled social ticks may look asleep."
+          "Quiet hours are active. Direct messages still work, but scheduled social ticks may look asleep."
       | Some "min_gap" ->
           "Keeper is inside its proactive cooldown window. Direct messages work now; autonomous check-ins will wait."
       | Some "never_started" ->

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -116,7 +116,7 @@ let resident_schemas : tool_schema list = [
       ("properties", `Assoc [
         ("name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Keeper handle (stable). Example: 'lodge-helper'");
+          ("description", `String "Keeper handle (stable). Example: 'keeper-helper'");
         ]);
         ("goal", `Assoc [
           ("type", `String "string");

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -36,7 +36,6 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
   let tasks = Room.get_tasks_raw_in_room config room_id in
   let agents = Room.get_agents_raw_in_room config room_id in
   let msgs = Room.get_messages_raw_in_room config ~room_id ~since_seq:0 ~limit:20 in
-  let lodge_json = `Assoc [("status", `String "deprecated")] in
   let now_ts = Time_compat.now () in
   let (board_monitor_json, board_contract_ok) = board_monitoring_json ~now_ts in
   let (governance_monitor_json, governance_feed_ok) =
@@ -101,7 +100,6 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("board", board_monitor_json);
         ("governance", governance_monitor_json);
       ]);
-      ("lodge", lodge_json);
       ("data_quality", `Assoc [
         ("board_contract_ok", `Bool board_contract_ok);
         ("governance_feed_ok", `Bool governance_feed_ok);
@@ -443,7 +441,6 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
     Room.read_current_room config |> Option.value ~default:"default"
   in
   let tempo = Tempo.get_tempo config in
-  let lodge_json = `Assoc [("status", `String "deprecated")] in
   let build = Build_identity.current () in
   `Assoc
     [
@@ -456,7 +453,6 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
       ("project", `String room_state.project);
       ("tempo_interval_s", `Float tempo.current_interval_s);
       ("paused", `Bool room_state.paused);
-      ("lodge", lodge_json);
       ("version", `String build.release_version);
       ("build", Build_identity.to_yojson build);
     ]
@@ -542,4 +538,3 @@ let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
           ] );
       ("providers", provider_capacity_json ());
       ])
-

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -159,7 +159,6 @@ let make_request_handler ~sw ~clock ~server_start_time =
           in
           let _state = get_server_state () in
           let build = Build_identity.current () in
-          let lodge_json = `Assoc [("status", `String "deprecated")] in
           let health_json = `Assoc [
             ("status", `String "ok");
             ("server", `String "masc-mcp");
@@ -169,7 +168,6 @@ let make_request_handler ~sw ~clock ~server_start_time =
             ("protocol", `String "h2");
             ("uptime", `String uptime_str);
             ("sse_clients", `Int (Sse.client_count ()));
-            ("lodge", lodge_json);
           ] in
           let body = Yojson.Safe.to_string health_json in
           h2_respond_json h2_reqd body ~extra_headers:cors
@@ -353,10 +351,6 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `GET, "/dashboard/credits" ->
           h2_respond_html h2_reqd (Credits_dashboard.html ()) ~extra_headers:cors
-
-      | `GET, "/dashboard/lodge" ->
-          let body = {|<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=/dashboard"></head><body>Redirecting to dashboard...</body></html>|} in
-          h2_respond_html h2_reqd body ~extra_headers:cors
 
       | `GET, p when is_dashboard_spa_deep_link p ->
           h2_respond_dashboard_index ()

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -27,12 +27,6 @@ let add_routes ~port ~host router =
        with_public_read (fun _state _req reqd ->
          Http.Response.html (Credits_dashboard.html ()) reqd
        ) request reqd)
-  |> Http.Router.get "/dashboard/lodge" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
-         Http.Response.html
-           {|<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=/dashboard"></head><body>Redirecting to dashboard...</body></html>|}
-           reqd
-       ) request reqd)
   |> Http.Router.get "/favicon.ico" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          serve_favicon req reqd

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -10,7 +10,6 @@ let is_dashboard_spa_deep_link path =
   starts_with ~prefix:"/dashboard/" path
   && not (starts_with ~prefix:"/dashboard/assets/" path)
   && path <> "/dashboard/credits"
-  && path <> "/dashboard/lodge"
 
 (** CORS preflight response headers *)
 let cors_preflight_headers origin =
@@ -58,7 +57,6 @@ let health_handler _request reqd =
     else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
   in
   let build = Build_identity.current () in
-  let lodge_json = `Assoc [("status", `String "deprecated")] in
   let health_json = `Assoc [
     ("status", `String "ok");
     ("server", `String "masc-mcp");
@@ -81,7 +79,6 @@ let health_handler _request reqd =
         ] );
     ("uptime", `String uptime_str);
     ("sse_clients", `Int (Sse.client_count ()));
-    ("lodge", lodge_json);
     ("pg_pool", let max_size = Backend_core.configured_max_pool_size () in
       let shared = Council.Archive.has_shared_pool ()
                    || Jiphyeon.Archive.has_shared_pool () in

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -20,7 +20,6 @@ let strict_action_enums =
     `String "room_pause";
     `String "room_resume";
     `String "social_sweep";
-    `String "lodge_tick";
     `String "team_note";
     `String "team_broadcast";
     `String "team_task_inject";
@@ -105,9 +104,9 @@ let action_schema ~remote =
     name = "masc_operator_action";
     description =
       if remote then
-        "Preview or run a structured operator action. Use this when you need to broadcast, steer a team session, pause a room, or message a keeper through the remote operator surface. Use social_sweep for immediate public-square social processing. lodge_tick remains a compatibility alias."
+        "Preview or run a structured operator action. Use this when you need to broadcast, steer a team session, pause a room, or message a keeper through the remote operator surface. Use social_sweep for immediate public-square social processing."
       else
-        "Run a structured operator action against the room, a team session, or a keeper. Use this when you need guided control with preview-confirm safety for disruptive actions. Use social_sweep for immediate public-square social processing. lodge_tick remains a compatibility alias.";
+        "Run a structured operator action against the room, a team session, or a keeper. Use this when you need guided control with preview-confirm safety for disruptive actions. Use social_sweep for immediate public-square social processing.";
     input_schema =
       `Assoc
         [

--- a/lib/tool_schemas_a2a.ml
+++ b/lib/tool_schemas_a2a.ml
@@ -162,7 +162,7 @@ Reports tool usage and decision metadata. Pair with masc_heartbeat_start to init
         ]);
         ("agent", `Assoc [
           ("type", `String "string");
-          ("description", `String "Original Lodge agent name (e.g., 'dreamer')");
+          ("description", `String "Original source agent name (e.g., 'dreamer')");
         ]);
         ("status", `Assoc [
           ("type", `String "string");

--- a/lib/tool_schemas_agent.ml
+++ b/lib/tool_schemas_agent.ml
@@ -155,7 +155,7 @@ Pair with masc_heartbeat_start on the orchestrator side. MASC records but does n
         ]);
         ("agent", `Assoc [
           ("type", `String "string");
-          ("description", `String "Original Lodge agent name (e.g., 'dreamer')");
+          ("description", `String "Original source agent name (e.g., 'dreamer')");
         ]);
         ("status", `Assoc [
           ("type", `String "string");


### PR DESCRIPTION
## Summary
- remove the deprecated `lodge` slot from dashboard batch, shell status, and health payloads
- drop the public `/dashboard/lodge` route and stop exposing Lodge-specific labels in dashboard-facing copy
- rewrite remaining public schema/descriptive text to use board or source-agent wording instead of Lodge terminology

## Verification
- `git diff --check`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-professional-redesign-recover/_build/default/test/test_runtime_params.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-professional-redesign-recover/_build/default/test/test_operator_control.exe`

## Notes
- focused on public dashboard and operator-facing surface removal; internal compatibility aliases and skill routing remain unchanged in this PR
