### PR TITLE
refactor(dashboard): CSS design tokens — colors, font-sizes, breakpoints

### DIFF
--- a/dashboard/src/styles/activity-graph.css
+++ b/dashboard/src/styles/activity-graph.css
@@ -26,13 +26,13 @@
   border-radius: 10px;
   background: rgba(15, 23, 42, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.2);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #e2e8f0;
   pointer-events: none;
 }
 
 .activity-graph-tooltip strong {
-  font-size: 13px;
+  font-size: var(--fs-base);
   color: var(--text-near-white);
 }
 
@@ -40,7 +40,7 @@
   padding: 2px 7px;
   border-radius: 6px;
   background: rgba(148, 163, 184, 0.15);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-slate);
 }
 
@@ -65,7 +65,7 @@
 .activity-graph-leaderboard-rank {
   width: 22px;
   text-align: center;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 700;
   color: var(--text-slate);
 }
@@ -79,7 +79,7 @@
 }
 
 .activity-graph-leaderboard-name {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: var(--text-near-white);
   white-space: nowrap;
@@ -102,7 +102,7 @@
 }
 
 .activity-graph-leaderboard-weight {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 600;
   color: var(--text-slate-light);
   min-width: 32px;
@@ -110,7 +110,7 @@
 }
 
 .activity-graph-leaderboard-status {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   padding: 2px 7px;
   border-radius: 6px;
 }
@@ -144,12 +144,12 @@
 }
 
 .activity-graph-kind-label {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-slate-light);
 }
 
 .activity-graph-kind-count {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 700;
   color: var(--text-near-white);
 }

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -35,7 +35,7 @@
 }
 
 .agent-runtime-value {
-  color: var(--text-body, #c0d2f2);
+  color: var(--text-body, var(--text-body));
   font-family: var(--font-mono, monospace);
   font-size: 12px;
 }
@@ -58,13 +58,13 @@
 
 .agent-runtime-ctx-fill {
   height: 100%;
-  background: #4ade80;
+  background: var(--ok);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
 
 .agent-runtime-ctx-fill.warn {
-  background: #fbbf24;
+  background: var(--warn);
 }
 
 .agent-runtime-ctx-fill.bad {
@@ -99,7 +99,7 @@
   border-radius: 12px;
   border: 1px solid rgba(200, 168, 78, 0.12);
   background: none;
-  color: var(--text-muted, #86a0cf);
+  color: var(--text-muted, var(--text-muted));
   font-size: 11px;
   cursor: pointer;
   transition: all 0.15s;
@@ -107,13 +107,13 @@
 
 .agent-live-chip:hover {
   border-color: rgba(200, 168, 78, 0.6);
-  color: var(--text-body, #c0d2f2);
+  color: var(--text-body, var(--text-body));
 }
 
 .agent-live-chip--active {
   background: rgba(200, 168, 78, 0.25);
-  border-color: #c8a84e;
-  color: #e8cc70;
+  border-color: var(--ff-gold);
+  color: var(--ff-gold-bright);
 }
 
 .agent-live-meta {
@@ -127,7 +127,7 @@
   font-family: var(--font-mono, monospace);
   font-size: 11px;
   font-weight: 600;
-  color: #47b8ff;
+  color: var(--accent);
   padding: 2px 8px;
   background: rgba(71, 184, 255, 0.1);
   border: 1px solid rgba(71, 184, 255, 0.2);
@@ -135,7 +135,7 @@
 }
 
 .agent-live-count {
-  color: var(--text-muted, #86a0cf);
+  color: var(--text-muted, var(--text-muted));
 }
 
 .agent-live-autoscroll {
@@ -153,7 +153,7 @@
 .agent-live-autoscroll--on {
   background: rgba(74, 222, 128, 0.1);
   border-color: rgba(74, 222, 128, 0.25);
-  color: #4ade80;
+  color: var(--ok);
 }
 
 /* Scrolling event stream */
@@ -195,17 +195,17 @@
 
 .agent-event-badge--heartbeat {
   background: rgba(74, 222, 128, 0.12);
-  color: #4ade80;
+  color: var(--ok);
 }
 
 .agent-event-badge--lifecycle {
   background: rgba(71, 184, 255, 0.12);
-  color: #47b8ff;
+  color: var(--accent);
 }
 
 .agent-event-badge--keeper {
   background: rgba(200, 168, 78, 0.15);
-  color: #e8cc70;
+  color: var(--ff-gold-bright);
 }
 
 .agent-event-badge--error {
@@ -215,22 +215,22 @@
 
 .agent-event-badge--broadcast {
   background: rgba(167, 139, 250, 0.12);
-  color: var(--purple, #a78bfa);
+  color: var(--purple, var(--purple));
 }
 
 .agent-event-badge--task {
   background: rgba(251, 191, 36, 0.12);
-  color: var(--warn, #fbbf24);
+  color: var(--warn, var(--warn));
 }
 
 .agent-event-badge--board {
   background: rgba(34, 211, 238, 0.12);
-  color: var(--cyan, #22d3ee);
+  color: var(--cyan, var(--cyan));
 }
 
 .agent-event-badge--default {
   background: rgba(138, 163, 211, 0.12);
-  color: var(--text-muted, #86a0cf);
+  color: var(--text-muted, var(--text-muted));
 }
 
 .agent-live-event-text {
@@ -244,6 +244,6 @@
 
 .agent-live-event-time {
   font-size: 10px;
-  color: var(--text-muted, #86a0cf);
+  color: var(--text-muted, var(--text-muted));
   flex-shrink: 0;
 }

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -22,11 +22,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .agent-runtime-label {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
   font-family: var(--font-mono, monospace);
   color: rgba(200, 168, 78, 0.5);
@@ -37,7 +37,7 @@
 .agent-runtime-value {
   color: var(--text-body, var(--text-body));
   font-family: var(--font-mono, monospace);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .agent-runtime-model {
@@ -100,7 +100,7 @@
   border: 1px solid rgba(200, 168, 78, 0.12);
   background: none;
   color: var(--text-muted, var(--text-muted));
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -120,12 +120,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .agent-event-rate {
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   color: var(--accent);
   padding: 2px 8px;
@@ -144,7 +144,7 @@
   border: 1px solid rgba(200, 168, 78, 0.12);
   background: none;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-family: var(--font-mono, monospace);
   cursor: pointer;
   transition: all 0.15s;
@@ -171,7 +171,7 @@
   align-items: baseline;
   gap: 6px;
   padding: 4px 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   border-radius: 4px;
   transition: background 0.1s;
 }
@@ -243,7 +243,7 @@
 }
 
 .agent-live-event-time {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: var(--text-muted, var(--text-muted));
   flex-shrink: 0;
 }

--- a/dashboard/src/styles/agent.css
+++ b/dashboard/src/styles/agent.css
@@ -20,7 +20,7 @@
   margin-bottom: 8px;
 }
 .agent-card .agent-emoji { font-size: 24px; }
-.agent-card .agent-name { font-size: 15px; font-weight: 600; }
+.agent-card .agent-name { font-size: var(--fs-lg); font-weight: 600; }
 /* ── Agent Journal Stream (Phase 2) ───────────────────────── */
 .agent-journal-stream {
   display: flex;
@@ -35,7 +35,7 @@
   align-items: baseline;
   gap: 6px;
   padding: 4px 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   border-radius: 4px;
   transition: background 0.1s;
 }
@@ -45,7 +45,7 @@
 }
 
 .agent-journal-kind {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
   font-family: var(--font-mono, monospace);
   background: rgba(138, 163, 211, 0.12);
@@ -60,7 +60,7 @@
 }
 
 .agent-journal-type {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-family: var(--font-mono, monospace);
   color: rgba(71, 184, 255, 0.7);
   flex-shrink: 0;
@@ -86,11 +86,11 @@
   display: flex;
   align-items: baseline;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .agent-worker-brief__label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   min-width: 60px;
   flex-shrink: 0;
@@ -126,7 +126,7 @@
   align-items: baseline;
   gap: 6px;
   padding: 4px 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   border-radius: 4px;
   transition: background 0.1s;
 }
@@ -136,7 +136,7 @@
 }
 
 .agent-timeline-type {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 500;
   color: var(--text-strong, #e8ecf1);
   flex-shrink: 0;
@@ -169,7 +169,7 @@
   border: 1px solid var(--card-border, rgba(255, 255, 255, 0.1));
   background: none;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -184,7 +184,7 @@
 }
 .agents-chip-count {
   display: inline-block;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   min-width: 18px;
   text-align: center;
   padding: 1px 5px;

--- a/dashboard/src/styles/animations.css
+++ b/dashboard/src/styles/animations.css
@@ -59,7 +59,7 @@ button.monitor-row.state-offline:hover {
 /* Monitor pill state variants */
 .monitor-pill.state-offline {
   background: rgba(85, 85, 85, 0.20);
-  color: #666;
+  color: var(--text-dim);
   text-decoration: line-through;
 }
 

--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -41,14 +41,14 @@
 
 .board-summary-label {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .board-summary-item strong {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--fs-md);
 }
 .board-sort-btn {
   padding: 6px 14px;
@@ -57,7 +57,7 @@
   background: var(--white-4);
   color: var(--text-dim);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   transition: all 0.2s;
 }
 .board-sort-btn:hover { background: var(--white-8); color: #ccc; }
@@ -106,7 +106,7 @@
 .vote-btn.upvote:hover, .vote-btn.upvote.active { color: #ff4500; }
 .vote-btn.downvote:hover, .vote-btn.downvote.active { color: #7193ff; }
 .vote-btn.animate { animation: votePop 0.3s ease; }
-.vote-count { font-size: 14px; font-weight: bold; color: #ccc; }
+.vote-count { font-size: var(--fs-md); font-weight: bold; color: #ccc; }
 
 /* Post content */
 .post-content {
@@ -129,7 +129,7 @@
 }
 
 .post-title {
-  font-size: 15px;
+  font-size: var(--fs-lg);
   font-weight: 650;
   line-height: 1.45;
   color: var(--text-strong);
@@ -144,7 +144,7 @@
 }
 
 .board-meta-chip {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   padding: 2px 8px;
   border-radius: 999px;
   border: 1px solid rgba(71, 184, 255, 0.3);
@@ -156,13 +156,13 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: #90a4cc;
 }
 
 .post-snippet {
   color: var(--text-body);
-  font-size: 13px;
+  font-size: var(--fs-base);
   line-height: 1.6;
 }
 
@@ -170,7 +170,7 @@
 
 /* Board detail */
 .board-detail { padding: 20px; }
-.board-detail .post-body { font-size: 14px; line-height: 1.7; margin: 15px 0; }
+.board-detail .post-body { font-size: var(--fs-md); line-height: 1.7; margin: 15px 0; }
 
 /* Board comments */
 .board-comment {
@@ -181,14 +181,14 @@
   border-left: 2px solid rgba(167,139,250,0.3);
   margin-bottom: 8px;
 }
-.board-comment .comment-author { font-size: 12px; font-weight: 600; color: var(--purple); }
-.board-comment .comment-text { font-size: 13px; margin-top: 4px; }
-.board-comment .comment-time { font-size: 11px; color: var(--text-dim); }
+.board-comment .comment-author { font-size: var(--fs-sm); font-weight: 600; color: var(--purple); }
+.board-comment .comment-text { font-size: var(--fs-base); margin-top: 4px; }
+.board-comment .comment-time { font-size: var(--fs-xs); color: var(--text-dim); }
 
 /* ── Activity Tab ──────────────────────────────────────────── */
 .activity-line {
   font-family: 'SF Mono', 'Fira Code', monospace;
-  font-size: 13px;
+  font-size: var(--fs-base);
   padding: 6px 10px;
   border-left: 2px solid var(--cyan);
   margin-bottom: 4px;
@@ -199,13 +199,13 @@
   display: flex;
   gap: 10px;
   padding: 6px 10px;
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-family: monospace;
   border-bottom: 1px solid var(--white-4);
   align-items: baseline;
 }
 .journal-type {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   min-width: 100px;
   font-weight: 600;
 }

--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -96,7 +96,7 @@
 .vote-btn {
   background: none;
   border: none;
-  color: #666;
+  color: var(--text-dim);
   cursor: pointer;
   font-size: 16px;
   padding: 2px;
@@ -183,7 +183,7 @@
 }
 .board-comment .comment-author { font-size: 12px; font-weight: 600; color: var(--purple); }
 .board-comment .comment-text { font-size: 13px; margin-top: 4px; }
-.board-comment .comment-time { font-size: 11px; color: #666; }
+.board-comment .comment-time { font-size: 11px; color: var(--text-dim); }
 
 /* ── Activity Tab ──────────────────────────────────────────── */
 .activity-line {

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -15,7 +15,7 @@
 
 .chat-empty-copy {
   color: #8ca8d5;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.6;
 }
 
@@ -81,7 +81,7 @@
   width: 30px;
   height: 30px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 700;
   letter-spacing: 0.06em;
   flex: 0 0 auto;
@@ -118,7 +118,7 @@
 
 .chat-identity-title {
   color: #f3f7ff;
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   line-height: 1.2;
 }
@@ -131,7 +131,7 @@
   align-items: center;
   border-radius: 999px;
   padding: 2px 8px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.03em;
   border: 1px solid var(--card-border);
   color: #d8e8ff;
@@ -169,7 +169,7 @@
   color: #a8c3eb;
   border-radius: 999px;
   padding: 4px 10px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
 }
 
@@ -178,12 +178,12 @@
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.68;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
 .chat-bubble-error {
   color: #ffb4b4;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
 }
 
@@ -197,7 +197,7 @@
   background:
     linear-gradient(180deg, rgba(7, 17, 37, 0.9), rgba(4, 12, 28, 0.82));
   color: #b8cae8;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .chat-detail-section {
@@ -209,7 +209,7 @@
 .chat-detail-section-title,
 .chat-detail-callout-label {
   color: #8ca8d5;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -235,21 +235,21 @@
 .chat-overview-label,
 .chat-state-label {
   color: #86a4d4;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .chat-overview-value {
   color: #eef5ff;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
   word-break: break-word;
 }
 
 .chat-state-value {
   color: #d9e7fa;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
 }
 
@@ -265,7 +265,7 @@
 
 .chat-detail-callout-value {
   color: #e9fff4;
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
 }
 
@@ -281,7 +281,7 @@
   color: #9db7e2;
   border-radius: 999px;
   padding: 4px 10px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
 }
 
@@ -290,7 +290,7 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-family: "Fira Code", monospace;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   line-height: 1.55;
   color: #95f3bc;
 }

--- a/dashboard/src/styles/command-gauge.css
+++ b/dashboard/src/styles/command-gauge.css
@@ -49,7 +49,7 @@
 
 .command-gauge-core span {
   color: rgba(148, 163, 184, 0.88);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   margin-top: 4px;
 }
 
@@ -61,7 +61,7 @@
 
 .command-gauge-copy span {
   color: rgba(191, 219, 254, 0.92);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -100,7 +100,7 @@
 
 .command-signal-copy span {
   color: rgba(148, 163, 184, 0.9);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }

--- a/dashboard/src/styles/command-swarm.css
+++ b/dashboard/src/styles/command-swarm.css
@@ -36,7 +36,7 @@
 
 .swarm-story-card strong {
   color: var(--text-near-white);
-  font-size: 15px;
+  font-size: var(--fs-lg);
   line-height: 1.3;
 }
 
@@ -60,7 +60,7 @@
   padding: 4px 8px;
   background: var(--white-6);
   color: rgba(191,219,254,0.9);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .command-swarm-layout {
@@ -184,19 +184,19 @@
 .orchestra-room-label,
 .orchestra-node-label {
   fill: var(--text-near-white);
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
 }
 
 .orchestra-node-subtitle,
 .orchestra-node-status {
   fill: rgba(226,232,240,0.62);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 
 .orchestra-node-glyph {
   fill: #7dd3fc;
-  font-size: 15px;
+  font-size: var(--fs-lg);
 }
 
 .orchestra-node.worker .orchestra-node-body {
@@ -236,7 +236,7 @@
 
 .orchestra-signal-glyph {
   fill: var(--text-near-white);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 700;
 }
 
@@ -365,7 +365,7 @@
   display: block;
   margin-bottom: 4px;
   color: rgba(125,211,252,0.78);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }

--- a/dashboard/src/styles/command.css
+++ b/dashboard/src/styles/command.css
@@ -46,7 +46,7 @@
 
 .monitor-stat-card span {
   color: rgba(255,255,255,0.6);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   word-break: keep-all;
@@ -61,7 +61,7 @@
 
 .monitor-stat-card small {
   color: rgba(255,255,255,0.5);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .command-plane-view {
@@ -132,7 +132,7 @@
 
 .command-entry-label {
   color: rgba(148, 163, 184, 0.92);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -204,7 +204,7 @@
   color: #7dd3fc;
   background: rgba(14, 116, 144, 0.22);
   border: 1px solid rgba(125, 211, 252, 0.18);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -361,7 +361,7 @@
 .command-step-tool {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: #67e8f9;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .command-doc-links {
@@ -395,7 +395,7 @@
 }
 
 .command-tab-group-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   color: rgba(255, 255, 255, 0.4);
   text-transform: uppercase;
@@ -682,7 +682,7 @@
 
 .command-card-sub {
   color: rgba(255,255,255,0.56);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   margin-top: 4px;
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -722,7 +722,7 @@
   border-top: 1px solid var(--white-8);
   color: #67e8f9;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -796,7 +796,7 @@
   align-items: center;
   padding: 3px 8px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.02em;
   background: var(--white-8);
   color: rgba(255,255,255,0.86);
@@ -833,7 +833,7 @@
   flex-wrap: wrap;
   margin-top: 8px;
   color: rgba(255,255,255,0.56);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .command-warroom-guidance {
@@ -845,7 +845,7 @@
   border: 1px solid var(--white-8);
   background: var(--white-4);
   color: rgba(255,255,255,0.84);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -917,7 +917,7 @@
   border-radius: 10px;
   background: rgba(9,12,20,0.75);
   color: rgba(224,242,254,0.92);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
   max-height: 220px;
   overflow: auto;

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -8,7 +8,7 @@
 .runtime-summary {
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   padding: 6px 0;
   list-style: none;
   user-select: none;
@@ -38,7 +38,7 @@
 
 .overview-section-collapsible > summary {
   padding: 12px 16px;
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 600;
   color: var(--text-slate-light);
   cursor: pointer;
@@ -61,7 +61,7 @@
 
 .overview-section-collapsible > summary::before {
   content: '▸';
-  font-size: 11px;
+  font-size: var(--fs-xs);
   transition: transform 0.15s;
   display: inline-block;
   color: #64748b;
@@ -84,7 +84,7 @@
   align-items: center;
   border-radius: 999px;
   padding: 3px 8px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -156,7 +156,7 @@
   border: 1px solid rgba(138, 163, 211, 0.3);
   border-radius: 8px;
   padding: 7px 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #bdd8ff;
   background: var(--white-3);
   cursor: pointer;
@@ -179,7 +179,7 @@
 
 /* ── Control Dock ─────────────────────────────────────────── */
 .control-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: #8ca8d5;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -204,7 +204,7 @@
 
 .control-status-copy {
   color: #d5e5fb;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
 }
 
@@ -220,7 +220,7 @@
   background: var(--white-4);
   color: #d3e3ff;
   padding: 8px 10px;
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-family: inherit;
 }
 
@@ -241,7 +241,7 @@
   background: rgba(71, 184, 255, 0.18);
   color: #c9ebff;
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -286,7 +286,7 @@
   border: 1px solid var(--card-border);
   background: rgba(2, 10, 24, 0.82);
   color: #9ad8b6;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
@@ -324,7 +324,7 @@
   border: 1px solid rgba(138, 163, 211, 0.22);
   background: var(--white-3);
   color: #9fb8e1;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-decoration: none;
   transition: background 0.15s;
 }
@@ -342,7 +342,7 @@
 
 .mission-collapsible-summary {
   padding: 12px 16px;
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 600;
   color: var(--text-slate-light);
   cursor: pointer;
@@ -365,7 +365,7 @@
 
 .mission-collapsible-summary::before {
   content: '\25B8';
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: #64748b;
   transition: transform 0.15s;
   display: inline-block;
@@ -436,7 +436,7 @@
   border: 1px solid var(--card-border, rgba(255, 255, 255, 0.1));
   background: none;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -458,7 +458,7 @@
   padding: 8px 12px;
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -7,7 +7,7 @@
 
 .runtime-summary {
   cursor: pointer;
-  color: #8ba2c9;
+  color: var(--text-muted);
   font-size: 12px;
   padding: 6px 0;
   list-style: none;

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -112,6 +112,15 @@
   --z-overlay-toast: 3070;
   --z-overlay-tooltip: 3080;
 
+  /* Breakpoint scale (used in @media max-width) */
+  /* 1450px: command warroom only */
+  /* 1200px: layout collapse (sidebar → stacked) */
+  /* 1100px: grid collapse (2-col → 1-col) */
+  /* 960px: compact cards */
+  /* 880px: mobile-first adaptations */
+  /* 768px: tablet/mobile */
+  /* 600px: small mobile */
+
   /* Spacing tokens */
   --space-xs: 4px;
   --space-sm: 8px;
@@ -559,7 +568,7 @@ a:hover {
   }
 }
 
-@media (max-width: 1250px) {
+@media (max-width: 1200px) {
 
   .dashboard-layout {
     grid-template-columns: 1fr;
@@ -581,7 +590,7 @@ a:hover {
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 880px) {
 
   :root {
     --header-h: 86px;
@@ -596,7 +605,7 @@ a:hover {
 
 }
 
-@media (max-width: 700px) {
+@media (max-width: 768px) {
 
   .dashboard-rail {
     grid-template-columns: 1fr;

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -76,6 +76,14 @@
   --white-8: rgba(255, 255, 255, 0.08);
   --white-10: rgba(255, 255, 255, 0.1);
 
+  /* Font-size scale */
+  --fs-2xs: 10px;
+  --fs-xs: 11px;
+  --fs-sm: 12px;
+  --fs-base: 13px;
+  --fs-md: 14px;
+  --fs-lg: 15px;
+
   /* Extended text scale */
   --text-dim: #888;
   --text-slate: #94a3b8;

--- a/dashboard/src/styles/goals.css
+++ b/dashboard/src/styles/goals.css
@@ -22,7 +22,7 @@
 }
 
 .goal-summary-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   margin-top: 2px;
 }
@@ -41,7 +41,7 @@
 }
 
 .goal-filter-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   margin-right: 4px;
 }
@@ -52,7 +52,7 @@
   color: #aaa;
   padding: 3px 10px;
   border-radius: 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -115,14 +115,14 @@
 
 .planning-loop-id {
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: var(--fs-lg);
   font-weight: 650;
   text-transform: capitalize;
 }
 
 .planning-loop-sub {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   margin-top: 2px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
@@ -138,18 +138,18 @@
   gap: 10px;
   flex-wrap: wrap;
   color: #b9c9ea;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .planning-loop-target {
   color: var(--text-body);
-  font-size: 13px;
+  font-size: var(--fs-base);
   line-height: 1.5;
 }
 
 .planning-loop-footnote {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
 }
 
@@ -166,13 +166,13 @@
 }
 
 .goal-title {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 500;
   color: #e0e0e0;
 }
 
 .goal-horizon-badge {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -183,7 +183,7 @@
   gap: 10px;
   flex-wrap: wrap;
   margin-top: 4px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
 }
 
@@ -201,7 +201,7 @@
 }
 
 .goal-review-note {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   font-style: italic;
   margin-top: 4px;
@@ -218,7 +218,7 @@
 }
 
 .goal-updated {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
 }
 
@@ -237,7 +237,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 700;
   padding: 2px 6px;
   border-radius: 4px;
@@ -282,7 +282,7 @@
 /* -- Task description preview (truncated, expandable) -- */
 
 .task-description-preview {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-muted);
   line-height: 1.5;
   margin-left: 8px;

--- a/dashboard/src/styles/goals.css
+++ b/dashboard/src/styles/goals.css
@@ -219,7 +219,7 @@
 
 .goal-updated {
   font-size: 11px;
-  color: #666;
+  color: var(--text-dim);
 }
 
 /* -- Planning toolbar (compact refresh) -- */

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -42,7 +42,7 @@
   gap: 8px;
   flex-wrap: wrap;
   color: #9ab3de;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .agent-detail-actions {
@@ -92,7 +92,7 @@
   background: var(--white-3);
   padding: 8px 10px;
   font-family: "IBM Plex Mono", "Fira Code", monospace;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #c8daf7;
   line-height: 1.4;
 }
@@ -117,7 +117,7 @@
 .agent-history-pre {
   margin: 0;
   white-space: pre-wrap;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
   color: #cfe0ff;
   font-family: "IBM Plex Mono", "Fira Code", monospace;
@@ -206,12 +206,12 @@
 }
 
 .ff-plate__sub {
-  font-size: 13px;
+  font-size: var(--fs-base);
   color: #8ca8d5;
 }
 
 .ff-plate__level {
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 700;
   color: var(--accent);
   background: rgba(71, 184, 255, 0.1);
@@ -230,7 +230,7 @@
 
 .ff-plate__model {
   font-family: "IBM Plex Mono", monospace;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: #8ca8d5;
   background: rgba(71, 184, 255, 0.08);
   border: 1px solid rgba(71, 184, 255, 0.15);
@@ -239,7 +239,7 @@
 }
 
 .ff-plate__autonomy {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--ff-gold);
   background: rgba(200, 168, 78, 0.1);
   border: 1px solid rgba(200, 168, 78, 0.2);
@@ -248,7 +248,7 @@
 }
 
 .ff-plate__signal {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
   letter-spacing: 0.5px;
   border-radius: 4px;
@@ -282,7 +282,7 @@
 }
 
 .ff-plate__bar-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 700;
   color: var(--ff-gold);
   letter-spacing: 1px;
@@ -290,7 +290,7 @@
 }
 
 .ff-plate__bar-value {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
   color: var(--text-strong);
   min-width: 36px;
@@ -306,7 +306,7 @@
 }
 
 .ff-plate__work {
-  font-size: 13px;
+  font-size: var(--fs-base);
   color: #c8daf7;
 }
 
@@ -316,7 +316,7 @@
 }
 
 .ff-plate__worker-state {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--accent);
   background: rgba(71, 184, 255, 0.08);
   padding: 1px 5px;
@@ -324,7 +324,7 @@
 }
 
 .ff-plate__worker-focus {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: #9ab3de;
 }
 
@@ -332,7 +332,7 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #8ca8d5;
 }
 
@@ -363,7 +363,7 @@
 }
 
 .ff-stat__label {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: var(--ff-gold);
   letter-spacing: 0.5px;
 }
@@ -383,7 +383,7 @@
 
 /* Timeline events - compact FF style */
 .ff-event-type {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   color: var(--ff-gold);
   min-width: 32px;
@@ -391,7 +391,7 @@
 
 .ff-event-detail {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #c8daf7;
 }
 
@@ -407,7 +407,7 @@
 }
 
 .ff-profile__mention-label {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 600;
   color: var(--ff-gold);
   white-space: nowrap;
@@ -453,19 +453,19 @@
 .ff-relation-name {
   color: var(--ff-gold);
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--fs-base);
   flex: 1;
 }
 
 .ff-relation-count {
   color: rgba(255, 255, 255, 0.5);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
 }
 
 .ff-relation-time {
   color: rgba(255, 255, 255, 0.35);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .ff-interests {
@@ -474,7 +474,7 @@
 }
 
 .ff-interests-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: rgba(255, 255, 255, 0.4);
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -492,7 +492,7 @@
   color: rgba(255, 255, 255, 0.7);
   padding: 2px 8px;
   border-radius: 3px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   border: 1px solid rgba(255, 215, 0, 0.15);
 }
 

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -417,7 +417,7 @@
   flex: 1;
 }
 
-@media (max-width: 800px) {
+@media (max-width: 768px) {
   .ff-plate {
     grid-template-columns: 1fr;
     text-align: center;

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -173,7 +173,7 @@
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 1.5px;
-  color: #c8a84e;
+  color: var(--ff-gold);
   text-transform: uppercase;
   text-align: center;
 }
@@ -195,7 +195,7 @@
 .ff-plate__name {
   margin: 0;
   font-size: 20px;
-  color: #c8a84e;
+  color: var(--ff-gold);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -213,7 +213,7 @@
 .ff-plate__level {
   font-size: 14px;
   font-weight: 700;
-  color: #47b8ff;
+  color: var(--accent);
   background: rgba(71, 184, 255, 0.1);
   border: 1px solid rgba(71, 184, 255, 0.25);
   border-radius: 4px;
@@ -240,7 +240,7 @@
 
 .ff-plate__autonomy {
   font-size: 11px;
-  color: #c8a84e;
+  color: var(--ff-gold);
   background: rgba(200, 168, 78, 0.1);
   border: 1px solid rgba(200, 168, 78, 0.2);
   border-radius: 4px;
@@ -262,13 +262,13 @@
 }
 
 .ff-plate__signal--stale {
-  color: #c8a84e;
+  color: var(--ff-gold);
   background: rgba(200, 168, 78, 0.1);
   border: 1px solid rgba(200, 168, 78, 0.2);
 }
 
 .ff-plate__signal--archived {
-  color: #8888;
+  color: var(--text-dim)8;
   background: rgba(128, 128, 128, 0.1);
   border: 1px solid rgba(128, 128, 128, 0.15);
 }
@@ -284,7 +284,7 @@
 .ff-plate__bar-label {
   font-size: 11px;
   font-weight: 700;
-  color: #c8a84e;
+  color: var(--ff-gold);
   letter-spacing: 1px;
   width: 28px;
 }
@@ -317,7 +317,7 @@
 
 .ff-plate__worker-state {
   font-size: 11px;
-  color: #47b8ff;
+  color: var(--accent);
   background: rgba(71, 184, 255, 0.08);
   padding: 1px 5px;
   border-radius: 3px;
@@ -364,7 +364,7 @@
 
 .ff-stat__label {
   font-size: 10px;
-  color: #c8a84e;
+  color: var(--ff-gold);
   letter-spacing: 0.5px;
 }
 
@@ -385,7 +385,7 @@
 .ff-event-type {
   font-size: 11px;
   font-weight: 600;
-  color: #c8a84e;
+  color: var(--ff-gold);
   min-width: 32px;
 }
 
@@ -409,7 +409,7 @@
 .ff-profile__mention-label {
   font-size: 12px;
   font-weight: 600;
-  color: #c8a84e;
+  color: var(--ff-gold);
   white-space: nowrap;
 }
 
@@ -451,7 +451,7 @@
 }
 
 .ff-relation-name {
-  color: #c8a84e;
+  color: var(--ff-gold);
   font-weight: 600;
   font-size: 13px;
   flex: 1;

--- a/dashboard/src/styles/governance-keeper.css
+++ b/dashboard/src/styles/governance-keeper.css
@@ -15,7 +15,7 @@
   border-radius: 50%;
   border: 1px solid rgba(138, 163, 211, 0.4);
   color: #9fb8e1;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   line-height: 1;
   cursor: help;
   vertical-align: middle;
@@ -43,13 +43,13 @@
 .metric-tip-pop strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #e8f2ff;
 }
 
 .metric-tip-pop span {
   display: block;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   line-height: 1.45;
   margin-top: 4px;
 }
@@ -74,7 +74,7 @@
   border: 1px solid rgba(251, 191, 36, 0.25);
   background: rgba(251, 191, 36, 0.06);
   color: rgba(251, 191, 36, 0.85);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
 }
 
@@ -97,7 +97,7 @@
 }
 
 .governance-case-topic {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 500;
   color: rgba(255, 255, 255, 0.9);
   flex: 1;
@@ -119,7 +119,7 @@
   align-items: center;
   gap: 8px;
   padding: 2px 0 2px 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .governance-event-summary {
@@ -132,7 +132,7 @@
 
 .governance-event-time {
   color: rgba(255, 255, 255, 0.35);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   flex-shrink: 0;
 }
 
@@ -146,7 +146,7 @@
 }
 
 .lifecycle-step {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   padding: 1px 6px;
   border-radius: 3px;
 }
@@ -169,7 +169,7 @@
 
 .lifecycle-arrow {
   color: rgba(255, 255, 255, 0.15);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 
 .lifecycle-arrow.done {

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -12,7 +12,7 @@
   border-radius: 8px;
   padding: 8px 10px;
   color: #f7b6b6;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .council-list {
   display: flex;
@@ -55,7 +55,7 @@ button.council-row.selected {
 
 .council-topic {
   color: #e8f0ff;
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 600;
   word-break: break-word;
 }
@@ -66,13 +66,13 @@ button.council-row.selected {
   flex-wrap: wrap;
   gap: 8px;
   color: #8ea9d6;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .council-state {
   border-radius: 999px;
   padding: 3px 9px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: lowercase;
   border: 1px solid rgba(138, 163, 211, 0.25);
   background: var(--white-6);
@@ -99,7 +99,7 @@ button.council-row.selected {
   background: rgba(0, 0, 0, 0.28);
   color: #d3e3ff;
   padding: 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
   font-family: "IBM Plex Mono", "Fira Code", monospace;
 }
@@ -146,7 +146,7 @@ button.council-row.selected {
   border: 1px solid rgba(138, 163, 211, 0.22);
   background: var(--white-6);
   color: #a9c3ee;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -160,7 +160,7 @@ button.council-row.selected {
 
 .governance-vote-meter {
   color: #8ea9d6;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .governance-chip-row {
@@ -176,7 +176,7 @@ button.council-row.selected {
   border: 1px solid var(--card-border);
   background: var(--white-5);
   color: #b8cdec;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 
 .governance-chip.ok {
@@ -239,7 +239,7 @@ button.council-row.selected {
   padding: 8px 10px;
   background: var(--white-4);
   color: #c8daf7;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .governance-summary-callout {
@@ -272,12 +272,12 @@ button.council-row.selected {
   align-items: center;
   gap: 8px;
   color: #9ab3de;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .governance-ledger-head strong {
   color: #e8f0ff;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .governance-ledger-body {
@@ -290,7 +290,7 @@ button.council-row.selected {
 .governance-badge {
   border-radius: 999px;
   padding: 2px 8px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   text-transform: lowercase;
   border: 1px solid rgba(138, 163, 211, 0.22);
   background: var(--white-5);
@@ -328,18 +328,18 @@ button.council-row.selected {
 .governance-side-block h4 {
   margin: 0;
   color: #e8f0ff;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
 .governance-side-line {
   color: #c8daf7;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
 .governance-preview {
   margin-top: 0;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   max-height: 180px;
   overflow: auto;
 }

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -355,7 +355,7 @@ button.council-row.selected {
   gap: 8px;
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1200px) {
 
   .governance-layout {
     grid-template-columns: 1fr;

--- a/dashboard/src/styles/keeper-chat.css
+++ b/dashboard/src/styles/keeper-chat.css
@@ -19,14 +19,14 @@
 }
 
 .keeper-chat__title {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: var(--ff-gold-bright, var(--ff-gold-bright));
   letter-spacing: 0.3px;
 }
 
 .keeper-chat__cancel {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--ff-hp-low, #f87171);
 }
 
@@ -43,7 +43,7 @@
 
 .keeper-chat__empty {
   color: rgba(255, 255, 255, 0.2);
-  font-size: 13px;
+  font-size: var(--fs-base);
   text-align: center;
   padding: 40px 0;
 }
@@ -64,7 +64,7 @@
 }
 
 .keeper-chat__role {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: rgba(255, 255, 255, 0.35);
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -75,7 +75,7 @@
 }
 
 .keeper-chat__text {
-  font-size: 13px;
+  font-size: var(--fs-base);
   line-height: 1.5;
   padding: 8px 12px;
   border-radius: 8px;
@@ -116,7 +116,7 @@
 
 .keeper-chat__error {
   padding: 6px 14px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--ff-hp-low, #f87171);
   background: rgba(248, 113, 113, 0.08);
   border-top: 1px solid rgba(248, 113, 113, 0.15);

--- a/dashboard/src/styles/keeper-chat.css
+++ b/dashboard/src/styles/keeper-chat.css
@@ -21,7 +21,7 @@
 .keeper-chat__title {
   font-size: 13px;
   font-weight: 600;
-  color: var(--ff-gold-bright, #e8cc70);
+  color: var(--ff-gold-bright, var(--ff-gold-bright));
   letter-spacing: 0.3px;
 }
 
@@ -86,13 +86,13 @@
 .keeper-chat__msg--user .keeper-chat__text {
   background: rgba(71, 184, 255, 0.12);
   border: 1px solid rgba(71, 184, 255, 0.2);
-  color: var(--text-body, #c0d2f2);
+  color: var(--text-body, var(--text-body));
 }
 
 .keeper-chat__msg--assistant .keeper-chat__text {
   background: rgba(200, 168, 78, 0.08);
   border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
-  color: var(--text-body, #c0d2f2);
+  color: var(--text-body, var(--text-body));
 }
 
 .keeper-chat__msg--streaming .keeper-chat__text {

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -44,7 +44,7 @@
 }
 .keeper-kpi-label { font-size: 10px; text-transform: uppercase; color: var(--text-dim); letter-spacing: 1px; }
 .keeper-kpi-value { font-size: 22px; font-weight: bold; color: var(--ok); margin-top: 4px; }
-.keeper-kpi-hint { font-size: 10px; color: #666; margin-top: 2px; }
+.keeper-kpi-hint { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
 
 /* Keeper Chart */
 

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -42,9 +42,9 @@
   text-align: center;
   border: 1px solid var(--white-6);
 }
-.keeper-kpi-label { font-size: 10px; text-transform: uppercase; color: var(--text-dim); letter-spacing: 1px; }
+.keeper-kpi-label { font-size: var(--fs-2xs); text-transform: uppercase; color: var(--text-dim); letter-spacing: 1px; }
 .keeper-kpi-value { font-size: 22px; font-weight: bold; color: var(--ok); margin-top: 4px; }
-.keeper-kpi-hint { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+.keeper-kpi-hint { font-size: var(--fs-2xs); color: var(--text-dim); margin-top: 2px; }
 
 /* Keeper Chart */
 
@@ -60,7 +60,7 @@
   border: 1px solid var(--white-10);
   border-radius: 8px;
   color: #e0e0e0;
-  font-size: 13px;
+  font-size: var(--fs-base);
   margin-bottom: 10px;
 }
 .keeper-field-search:focus { outline: none; border-color: rgba(74,222,128,0.4); }
@@ -69,10 +69,10 @@
   gap: 10px;
   padding: 6px 0;
   border-bottom: 1px solid var(--white-4);
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 .keeper-field-title { font-weight: 600; min-width: 90px; }
-.keeper-field-key { font-family: monospace; color: var(--cyan); font-size: 12px; }
+.keeper-field-key { font-family: monospace; color: var(--cyan); font-size: var(--fs-sm); }
 
 .keeper-signal-list {
   display: flex;
@@ -88,7 +88,7 @@
   border: 1px solid rgba(138, 163, 211, 0.18);
   border-radius: 8px;
   background: var(--white-3);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .keeper-signal-row strong {
@@ -103,7 +103,7 @@
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.02);
   padding: 10px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #cfe0ff;
   line-height: 1.5;
 }
@@ -119,20 +119,20 @@
   padding: 6px 10px;
   background: var(--white-3);
   border-radius: 6px;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
-.keeper-gen-label { color: var(--cyan); font-size: 11px; }
+.keeper-gen-label { color: var(--cyan); font-size: var(--fs-xs); }
 
 /* Keeper Memory */
 .keeper-memory-list { display: flex; flex-direction: column; gap: 6px; max-height: 220px; overflow-y: auto; }
 
 /* Keeper K2K */
 .keeper-k2k-list { max-height: 220px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
-.keeper-k2k-route { font-family: monospace; font-size: 11px; color: var(--text-dim); }
+.keeper-k2k-route { font-family: monospace; font-size: var(--fs-xs); color: var(--text-dim); }
 
 /* Keeper Mentions */
 .keeper-mention-chip {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   padding: 2px 8px;
   border-radius: 999px;
   background: rgba(74,222,128,0.12);
@@ -150,7 +150,7 @@
   margin: 0 0 14px;
   color: var(--cyan);
   font-family: var(--font-display, inherit);
-  font-size: 15px;
+  font-size: var(--fs-lg);
 }
 
 .keeper-comms-layout {
@@ -172,7 +172,7 @@
 .keeper-comms-diagnostics-toggle {
   cursor: pointer;
   padding: 10px 14px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: #8ca8d5;
   letter-spacing: 0.03em;
   list-style: none;
@@ -188,7 +188,7 @@
   display: inline-block;
   margin-right: 8px;
   transition: transform 0.15s ease;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .keeper-comms-diagnostics[open] > .keeper-comms-diagnostics-toggle::before {

--- a/dashboard/src/styles/layout.css
+++ b/dashboard/src/styles/layout.css
@@ -1,11 +1,11 @@
 /* ── Responsive (components) ───────────────────────────────── */
-@media (max-width: 980px) {
+@media (max-width: 960px) {
 
   .keeper-kpis { grid-template-columns: repeat(2, 1fr); }
   .agent-detail-grid { grid-template-columns: 1fr; }
 
 }
-@media (max-width: 900px) {
+@media (max-width: 880px) {
   .council-create { grid-template-columns: 1fr; }
   .control-row { grid-template-columns: 1fr; }
   .agent-mention-row { grid-template-columns: 1fr; }

--- a/dashboard/src/styles/mission.css
+++ b/dashboard/src/styles/mission.css
@@ -28,7 +28,7 @@
 
 .mission-context-item span {
   color: rgba(255,255,255,0.52);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -59,7 +59,7 @@
 
 .mission-stat-label {
   color: rgba(255,255,255,0.52);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -90,7 +90,7 @@
 
 .mission-card-target {
   color: rgba(255,255,255,0.52);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .mission-action-card {
@@ -165,7 +165,7 @@
 
 .proof-kv-grid > span {
   color: rgba(255,255,255,0.56);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -350,7 +350,7 @@
 .mission-card-disclosure summary {
   cursor: pointer;
   color: rgba(255,255,255,0.72);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .mission-link-list {
@@ -400,7 +400,7 @@
   border: 1px solid var(--white-8);
   background: var(--white-4);
   color: rgba(255,255,255,0.76);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.35;
 }
 
@@ -453,7 +453,7 @@
 
 .mission-fact-tile span {
   color: rgba(255,255,255,0.52);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -478,7 +478,7 @@
 .mission-crew-event span,
 .mission-io-item span {
   color: rgba(255,255,255,0.52);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -559,7 +559,7 @@
 
 .mission-activity-title span {
   color: rgba(255,255,255,0.62);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .mission-activity-meta,
@@ -568,7 +568,7 @@
   flex-wrap: wrap;
   gap: 10px;
   color: rgba(255,255,255,0.68);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -579,7 +579,7 @@
 
 .mission-activity-focus span {
   color: rgba(255,255,255,0.52);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -96,10 +96,10 @@
   font-weight: 500;
 }
 
-.badge--post { background: #1a3a2a; color: #4ade80; }
+.badge--post { background: #1a3a2a; color: var(--ok); }
 .badge--comment { background: #1a2a3a; color: #60a5fa; }
 .badge--upvote { background: #3a3a1a; color: #facc15; }
-.badge--skip { background: #2a2a2a; color: #888; }
+.badge--skip { background: #2a2a2a; color: var(--text-dim); }
 
 .oas-event-trigger {
   color: var(--text-muted, #666);
@@ -111,7 +111,7 @@
   font-weight: 600;
 }
 
-.oas-event-ok.ok { color: #4ade80; }
+.oas-event-ok.ok { color: var(--ok); }
 .oas-event-ok.fail { color: #f87171; }
 
 /* Keeper snapshot list */
@@ -166,7 +166,7 @@
   transition: width 0.3s ease;
 }
 
-.bar--ok { background: #4ade80; }
+.bar--ok { background: var(--ok); }
 .bar--mid { background: #facc15; }
 .bar--warn { background: #f87171; }
 

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -16,14 +16,14 @@
 }
 
 .oas-pipeline__title {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: var(--text-strong, #e0e0e0);
   letter-spacing: 0.5px;
 }
 
 .oas-pipeline__count {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted, #888);
   font-variant-numeric: tabular-nums;
 }
@@ -33,7 +33,7 @@
 }
 
 .oas-section-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 500;
   color: var(--text-muted, #888);
   text-transform: uppercase;
@@ -42,7 +42,7 @@
 }
 
 .oas-empty {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted, #666);
   padding: 8px 0;
 }
@@ -60,7 +60,7 @@
   align-items: center;
   gap: 8px;
   padding: 3px 6px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   border-radius: 4px;
 }
 
@@ -92,7 +92,7 @@
 .oas-event-badge {
   padding: 1px 6px;
   border-radius: 3px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 500;
 }
 
@@ -103,11 +103,11 @@
 
 .oas-event-trigger {
   color: var(--text-muted, #666);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 
 .oas-event-ok {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
 }
 
@@ -127,7 +127,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 6px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   border-radius: 4px;
 }
 
@@ -147,7 +147,7 @@
 
 .oas-keeper-gen {
   color: var(--text-muted, #666);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   min-width: 40px;
 }
 
@@ -179,7 +179,7 @@
 
 .oas-keeper-msgs {
   color: var(--text-muted, #666);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   min-width: 48px;
 }
 /* ── Pipeline Stage Indicator ─────────────────────────── */
@@ -215,7 +215,7 @@
 }
 
 .pipeline-stage-label {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: rgba(255, 255, 255, 0.35);
   letter-spacing: 0.04em;
   margin-left: 4px;
@@ -299,7 +299,7 @@
   gap: 4px;
   padding: 2px 8px;
   border-radius: 999px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 500;
   letter-spacing: 0.04em;
   line-height: 1;

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -586,7 +586,7 @@
   font-size: var(--fs-base);
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1200px) {
 
   .command-entry-strip,
   .ops-priority-grid {
@@ -599,7 +599,7 @@
 
 }
 
-@media (max-width: 860px) {
+@media (max-width: 880px) {
 
   .ops-header {
     flex-direction: column;

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -21,7 +21,7 @@
 .ops-subheading {
   margin-top: 6px;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--fs-base);
   max-width: 62ch;
 }
 
@@ -93,7 +93,7 @@
 
 .ops-handoff-meta {
   color: rgba(255,255,255,0.58);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .ops-workbench {
@@ -118,7 +118,7 @@
 }
 
 .ops-action-guide-title {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: rgba(255, 255, 255, 0.6);
   margin-bottom: 10px;
@@ -139,7 +139,7 @@
   border: none;
   cursor: pointer;
   text-align: left;
-  font-size: 13px;
+  font-size: var(--fs-base);
   transition: filter 0.15s;
 }
 
@@ -152,7 +152,7 @@
 }
 
 .ops-action-guide-item span {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   opacity: 0.7;
 }
 
@@ -200,7 +200,7 @@
 
 .ops-priority-label {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -213,7 +213,7 @@
 
 .ops-priority-detail {
   color: #9ab1d7;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -248,14 +248,14 @@
 
 .ops-stat span {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .ops-stat strong {
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: var(--fs-lg);
 }
 
 .ops-stat.ok {
@@ -269,7 +269,7 @@
 .ops-section-head {
   margin-top: 2px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -285,7 +285,7 @@
 .ops-context-note {
   margin-top: -2px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -310,20 +310,20 @@
 
 .ops-control-kicker {
   color: #9fe6b5;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .ops-control-summary strong {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--fs-md);
   line-height: 1.35;
 }
 
 .ops-control-summary span:last-child {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -354,7 +354,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-muted);
 }
 
@@ -373,7 +373,7 @@
 .ops-archive-summary {
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   list-style: none;
 }
 
@@ -423,7 +423,7 @@
   flex-wrap: wrap;
   gap: 8px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .ops-guidance-head strong {
@@ -454,12 +454,12 @@
   flex-wrap: wrap;
   gap: 8px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .ops-entity-goal,
 .ops-detail-goal {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   margin-top: 4px;
   white-space: nowrap;
@@ -478,7 +478,7 @@
 .ops-entity-stats {
   display: flex;
   gap: 8px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: var(--text-muted);
   margin-top: 2px;
 }
@@ -542,7 +542,7 @@
 
 .ops-token {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   word-break: break-all;
 }
@@ -554,7 +554,7 @@
   background: rgba(8, 15, 29, 0.82);
   border: 1px solid var(--white-8);
   color: #b9d6ff;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   line-height: 1.45;
   overflow-x: auto;
   white-space: pre-wrap;
@@ -583,7 +583,7 @@
   border-radius: 10px;
   border: 1px dashed rgba(255, 255, 255, 0.12);
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
 @media (max-width: 1180px) {

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -14,7 +14,7 @@
   background: rgba(10, 22, 40, 0.92);
   border: 1px solid var(--border-subtle, rgba(200, 168, 78, 0.15));
   border-left: 3px solid var(--ok);
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 500;
   color: var(--text-strong);
   line-height: 1.4;
@@ -82,7 +82,7 @@
 
 .attention-spotlight__summary {
   color: var(--text-strong);
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 500;
   line-height: 1.4;
 }
@@ -99,14 +99,14 @@
   border-radius: 999px;
   background: var(--white-6);
   border: 1px solid var(--white-8);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--warm-amber, #f5c542);
   font-weight: 500;
 }
 
 .attention-spotlight__time {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 /* ── Narrative Timeline ──────────────────────── */
@@ -128,7 +128,7 @@
   color: var(--text-muted);
   text-align: center;
   padding: 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .narrative-group {
@@ -139,7 +139,7 @@
 
 .narrative-group__label {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   padding-bottom: 2px;
@@ -158,7 +158,7 @@
 
 .narrative-event__text {
   color: var(--text-body);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -169,13 +169,13 @@
 .narrative-event__raw summary {
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }
 
 .narrative-event__raw span {
   display: block;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   padding: 4px 8px;
   background: rgba(255, 255, 255, 0.02);
   border-radius: 4px;
@@ -192,7 +192,7 @@
   border: 1px dashed var(--card-border, rgba(255, 255, 255, 0.1));
   border-radius: 6px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   cursor: pointer;
   text-align: center;
 }
@@ -215,7 +215,7 @@
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 500;
 }
 
@@ -288,7 +288,7 @@
 
 .home-section-label {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -296,12 +296,12 @@
 .home-section-copy {
   margin-top: 3px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
 .home-section-link {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--accent, #60a5fa);
   cursor: pointer;
   text-decoration: none;
@@ -349,7 +349,7 @@
 
 .hot-session-lane__title {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: var(--text-strong);
 }
@@ -364,14 +364,14 @@
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
 }
 
 .hot-session-lane__description {
   margin: 4px 0 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -383,7 +383,7 @@
   border-radius: 8px;
   border: 1px dashed rgba(138, 163, 211, 0.18);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   text-align: center;
   background: rgba(255, 255, 255, 0.02);
 }
@@ -410,7 +410,7 @@
   background: rgba(239, 68, 68, 0.06);
 }
 .hot-session-card__goal {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: var(--text-strong, #e2e8f0);
   white-space: nowrap;
@@ -419,7 +419,7 @@
 }
 .hot-session-card__context {
   margin-top: 4px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   line-height: 1.45;
   display: -webkit-box;
@@ -442,7 +442,7 @@
   border: 1px solid rgba(138, 163, 211, 0.18);
   background: rgba(138, 163, 211, 0.08);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.02em;
 }
 .hot-session-card__chip--system {
@@ -454,12 +454,12 @@
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   margin-top: 8px;
 }
 .hot-session-card__blocker {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--bad);
   margin-top: 4px;
   overflow: hidden;
@@ -512,7 +512,7 @@
   min-width: 0;
 }
 .agent-pulse-card__name {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   font-weight: 600;
   color: var(--text-strong, #e2e8f0);
   white-space: nowrap;
@@ -520,7 +520,7 @@
   text-overflow: ellipsis;
 }
 .agent-pulse-card__status {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -70,7 +70,7 @@
 }
 
 .attention-spotlight__card.ok .attention-spotlight__bar { background: var(--agent-working, var(--agent-working)); }
-.attention-spotlight__card.warn .attention-spotlight__bar { background: var(--agent-busy, #f0c060); }
+.attention-spotlight__card.warn .attention-spotlight__bar { background: var(--agent-busy, var(--agent-busy)); }
 .attention-spotlight__card.bad .attention-spotlight__bar { background: var(--bad, var(--bad)); }
 
 .attention-spotlight__body {
@@ -233,7 +233,7 @@
 }
 
 .health-beacon.warn .health-beacon__dot {
-  background: var(--agent-busy, #f0c060);
+  background: var(--agent-busy, var(--agent-busy));
   box-shadow: 0 0 8px rgba(240, 192, 96, 0.5);
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -245,7 +245,7 @@
 }
 
 .health-beacon.ok { color: var(--agent-working, var(--agent-working)); }
-.health-beacon.warn { color: var(--agent-busy, #f0c060); }
+.health-beacon.warn { color: var(--agent-busy, var(--agent-busy)); }
 .health-beacon.bad { color: var(--bad, var(--bad)); }
 
 /* ── Slim header variant for Home ──────────────── */

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -72,7 +72,7 @@
 }
 
 .pixel-avatar.signal-ring--stale {
-  box-shadow: 0 0 0 2px var(--agent-busy, #f0c060);
+  box-shadow: 0 0 0 2px var(--agent-busy, var(--agent-busy));
 }
 
 .pixel-avatar.signal-ring--archived {
@@ -112,7 +112,7 @@
 }
 
 .activity-dot--stale {
-  background: var(--agent-busy, #f0c060);
+  background: var(--agent-busy, var(--agent-busy));
 }
 
 .activity-dot--inactive {

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -135,7 +135,7 @@
   background: rgba(30, 30, 40, 0.92);
   border: 1px solid rgba(255, 255, 255, 0.12);
   color: var(--text-strong);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   line-height: 1.3;
   pointer-events: none;
   opacity: 0;
@@ -176,7 +176,7 @@
 }
 
 .pixel-avatar-name {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: var(--text-muted);
   text-align: center;
   max-width: 64px;

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -25,7 +25,7 @@
 }
 
 .agent-page__subtitle {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: rgba(255, 255, 255, 0.3);
   margin-top: 4px;
 }
@@ -43,7 +43,7 @@
   border: 1px solid rgba(200, 168, 78, 0.12);
   background: #0a1628;
   color: rgba(255, 255, 255, 0.9);
-  font-size: 13px;
+  font-size: var(--fs-base);
   width: 200px;
   transition: border-color 0.2s;
 }
@@ -69,7 +69,7 @@
   border: 1px solid rgba(200, 168, 78, 0.12);
   background: transparent;
   color: rgba(255, 255, 255, 0.45);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -176,14 +176,14 @@
 }
 
 .roster-card__name {
-  font-size: 15px;
+  font-size: var(--fs-lg);
   color: var(--ff-gold-bright);
   font-weight: 600;
   letter-spacing: 0.3px;
 }
 
 .roster-card__work {
-  font-size: 13px;
+  font-size: var(--fs-base);
   color: rgba(255, 255, 255, 0.55);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -198,7 +198,7 @@
 .roster-card__meta {
   display: flex;
   gap: var(--space-sm, 8px);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: rgba(255, 255, 255, 0.3);
 }
 
@@ -215,7 +215,7 @@
    ============================================ */
 
 .roster-badge {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   padding: 2px 8px;
   border-radius: 3px;
   font-weight: 600;
@@ -245,7 +245,7 @@
   padding: var(--space-xl, 32px);
   text-align: center;
   color: rgba(255, 255, 255, 0.2);
-  font-size: 14px;
+  font-size: var(--fs-md);
   border: 1px dashed rgba(200, 168, 78, 0.12);
   border-radius: 6px;
 }
@@ -283,7 +283,7 @@
 }
 
 .roster-card__gen {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   padding: 2px 7px;
   border-radius: 3px;
   background: rgba(74, 158, 245, 0.12);
@@ -316,7 +316,7 @@
 }
 
 .roster-card__gauge-label {
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: rgba(255, 255, 255, 0.4);
   white-space: nowrap;
   min-width: 50px;
@@ -332,7 +332,7 @@
 }
 .situation-reasons-collapse__summary {
   cursor: pointer;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted, var(--text-slate));
   padding: 4px var(--space-md, 16px);
   letter-spacing: 0.04em;
@@ -353,7 +353,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-sm, 8px);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: rgba(255, 255, 255, 0.55);
 }
 
@@ -394,7 +394,7 @@
   border-radius: 3px;
   padding: 2px 8px;
   font-weight: 600;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 /* Session triage additions */

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -18,7 +18,7 @@
 .roster-title {
   font-size: 20px;
   font-weight: 600;
-  color: #e8cc70;
+  color: var(--ff-gold-bright);
   margin: 0 0 var(--space-md, 16px) 0;
   letter-spacing: 0.5px;
   text-shadow: 0 1px 4px rgba(212, 169, 75, 0.2);
@@ -50,7 +50,7 @@
 
 .roster-search:focus {
   outline: none;
-  border-color: #c8a84e;
+  border-color: var(--ff-gold);
   box-shadow: 0 0 0 2px rgba(200, 168, 78, 0.25);
 }
 
@@ -76,14 +76,14 @@
 
 .roster-filter-btn:hover {
   background: rgba(200, 168, 78, 0.25);
-  color: #e8cc70;
+  color: var(--ff-gold-bright);
   border-color: rgba(200, 168, 78, 0.35);
 }
 
 .roster-filter-btn.active {
   background: rgba(200, 168, 78, 0.25);
-  color: #e8cc70;
-  border-color: #c8a84e;
+  color: var(--ff-gold-bright);
+  border-color: var(--ff-gold);
 }
 
 /* ============================================
@@ -115,7 +115,7 @@
   position: absolute;
   width: 8px;
   height: 8px;
-  border-color: #c8a84e;
+  border-color: var(--ff-gold);
   opacity: 0.5;
   transition: opacity 0.2s;
 }
@@ -136,7 +136,7 @@
 
 .roster-card:hover {
   background: #122040;
-  border-color: #c8a84e;
+  border-color: var(--ff-gold);
   box-shadow: 0 0 12px rgba(212, 169, 75, 0.1);
 }
 
@@ -177,7 +177,7 @@
 
 .roster-card__name {
   font-size: 15px;
-  color: #e8cc70;
+  color: var(--ff-gold-bright);
   font-weight: 600;
   letter-spacing: 0.3px;
 }
@@ -231,7 +231,7 @@
 
 .roster-badge--idle {
   background: rgba(212, 169, 75, 0.1);
-  color: #c8a84e;
+  color: var(--ff-gold);
   border: 1px solid rgba(212, 169, 75, 0.2);
 }
 
@@ -333,7 +333,7 @@
 .situation-reasons-collapse__summary {
   cursor: pointer;
   font-size: 11px;
-  color: var(--text-muted, #94a3b8);
+  color: var(--text-muted, var(--text-slate));
   padding: 4px var(--space-md, 16px);
   letter-spacing: 0.04em;
 }
@@ -362,7 +362,7 @@
 }
 
 .situation-reason--warn {
-  color: #c8a84e;
+  color: var(--ff-gold);
 }
 
 .situation-reason__tag {
@@ -389,7 +389,7 @@
 /* Attention badge — gold warning */
 .attention-badge {
   background: rgba(212, 169, 75, 0.15);
-  color: #c8a84e;
+  color: var(--ff-gold);
   border: 1px solid rgba(212, 169, 75, 0.3);
   border-radius: 3px;
   padding: 2px 8px;

--- a/dashboard/src/styles/status.css
+++ b/dashboard/src/styles/status.css
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-muted);
   white-space: nowrap;
 }
@@ -109,7 +109,7 @@
 }
 
 .pill {
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   padding: 2px 8px;
   border-radius: 999px;
   border: 1px solid rgba(71, 184, 255, 0.36);

--- a/dashboard/src/styles/tools.css
+++ b/dashboard/src/styles/tools.css
@@ -34,7 +34,7 @@
 }
 
 .tool-inventory-stat .stat-label {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-slate);
 }
 
@@ -50,7 +50,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .tool-surface-count {
@@ -61,7 +61,7 @@
   height: 18px;
   padding: 0 5px;
   border-radius: 999px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
   background: rgba(148, 163, 184, 0.18);
   color: var(--text-slate);
@@ -85,7 +85,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-slate-light);
 }
 
@@ -121,14 +121,14 @@
 }
 
 .tool-inventory-name {
-  font-size: 15px;
+  font-size: var(--fs-lg);
   font-weight: 700;
   color: var(--text-near-white);
 }
 
 .tool-inventory-desc {
   margin-top: 4px;
-  font-size: 13px;
+  font-size: var(--fs-base);
   color: var(--text-slate-light);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -152,7 +152,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-slate);
 }
 
@@ -162,7 +162,7 @@
 }
 
 .tool-inventory-reason {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--warn);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -176,7 +176,7 @@
 
 .tool-inventory-usage-hint {
   margin-bottom: 12px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: var(--text-slate);
 }
 
@@ -237,7 +237,7 @@
 }
 
 .tool-summary-heading {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   color: rgba(255, 255, 255, 0.6);
   margin: 0 0 10px 0;
@@ -262,7 +262,7 @@
 }
 
 .tool-summary-name {
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 500;
   color: #e2e8f0;
   min-width: 180px;
@@ -270,7 +270,7 @@
 }
 
 .tool-summary-desc {
-  font-size: 12px;
+  font-size: var(--fs-sm);
   color: rgba(255, 255, 255, 0.4);
   flex: 1;
   overflow: hidden;
@@ -292,7 +292,7 @@
 
 .tool-metrics-title {
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: var(--fs-lg);
   font-weight: 600;
   margin: 0;
 }
@@ -303,7 +303,7 @@
   background: rgba(239, 68, 68, 0.12);
   border: 1px solid rgba(239, 68, 68, 0.34);
   color: #fecaca;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
 /* ── Summary stats row ──────────────────────────────────── */
@@ -334,7 +334,7 @@
 
 .tool-metrics-stat .stat-label {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -348,7 +348,7 @@
 
 .tool-metrics-section h4 {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 10px;
@@ -372,14 +372,14 @@
   min-width: 72px;
   padding: 2px 8px;
   border-radius: 4px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 600;
   text-align: center;
 }
 
 .tier-dist-count {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-weight: 600;
   min-width: 36px;
   text-align: right;
@@ -387,7 +387,7 @@
 
 .tier-dist-pct {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
   min-width: 48px;
   text-align: right;
 }
@@ -420,7 +420,7 @@
   grid-template-columns: minmax(140px, 0.8fr) 68px minmax(0, 1fr) 48px;
   gap: 8px;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .tool-bar-name {
@@ -429,13 +429,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .tool-bar-tier {
   padding: 1px 6px;
   border-radius: 3px;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 600;
   text-align: center;
 }
@@ -457,7 +457,7 @@
 
 .tool-bar-count {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--fs-xs);
   text-align: right;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/dashboard/src/styles/tools.css
+++ b/dashboard/src/styles/tools.css
@@ -213,7 +213,7 @@
 }
 
 /* --- Responsive --- */
-@media (max-width: 900px) {
+@media (max-width: 880px) {
   .tool-inventory-head {
     flex-direction: column;
   }
@@ -463,7 +463,7 @@
 }
 
 /* ── Responsive ─────────────────────────────────────────── */
-@media (max-width: 860px) {
+@media (max-width: 880px) {
   .tool-metrics-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -202,7 +202,7 @@ button.agent-card:hover {
 .monitor-stat-caption {
   margin-top: 6px;
   font-size: 11px;
-  color: #8ba2c9;
+  color: var(--text-muted);
 }
 
 .monitor-section-head {
@@ -217,7 +217,7 @@ button.agent-card:hover {
 
 .monitor-subheadline {
   margin: 6px 0 0;
-  color: #8ba2c9;
+  color: var(--text-muted);
   font-size: 13px;
   line-height: 1.45;
 }
@@ -302,7 +302,7 @@ button.monitor-row.bad {
 }
 
 .monitor-sub {
-  color: #8ba2c9;
+  color: var(--text-muted);
   font-size: 12px;
 }
 
@@ -317,7 +317,7 @@ button.monitor-row.bad {
   flex-wrap: wrap;
   gap: 8px 12px;
   margin-top: 10px;
-  color: #8ba2c9;
+  color: var(--text-muted);
   font-size: 12px;
 }
 

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -12,7 +12,7 @@
 .toast {
   padding: 12px 20px;
   border-radius: 10px;
-  font-size: 13px;
+  font-size: var(--fs-base);
   animation: slideIn 0.3s ease;
   background: rgba(30,30,50,0.95);
   border: 1px solid var(--white-10);
@@ -28,14 +28,14 @@
   background: var(--white-8);
   padding: 1px 5px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .markdown-content pre {
   background: rgba(0,0,0,0.3);
   padding: 12px;
   border-radius: 8px;
   overflow-x: auto;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 .markdown-content blockquote {
   border-left: 3px solid var(--cyan);
@@ -54,7 +54,7 @@
 .think-block summary {
   cursor: pointer;
   color: var(--purple);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 /* ── SPA Refresh: class alignment + app shell tuning ─────── */
@@ -92,7 +92,7 @@
 
 .card-title {
   color: #d7e7ff;
-  font-size: 15px;
+  font-size: var(--fs-lg);
   letter-spacing: 0.05em;
   line-height: 1.35;
 }
@@ -158,21 +158,21 @@ button.agent-card:hover {
 
 .room-truth-card strong {
   color: #edf4ff;
-  font-size: 15px;
+  font-size: var(--fs-lg);
   line-height: 1.35;
 }
 
 .room-truth-card p {
   margin: 0;
   color: #96add7;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.5;
 }
 
 .room-truth-label {
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   color: #7fa5d8;
 }
 
@@ -186,7 +186,7 @@ button.agent-card:hover {
 .agent-card .agent-task {
   margin-top: 10px;
   color: #89a3cf;
-  font-size: 13px;
+  font-size: var(--fs-base);
 }
 
 .agent-card .agent-model {
@@ -201,7 +201,7 @@ button.agent-card:hover {
 
 .monitor-stat-caption {
   margin-top: 6px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
 }
 
@@ -218,7 +218,7 @@ button.agent-card:hover {
 .monitor-subheadline {
   margin: 6px 0 0;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--fs-base);
   line-height: 1.45;
 }
 
@@ -303,13 +303,13 @@ button.monitor-row.bad {
 
 .monitor-sub {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .monitor-note {
   margin-top: 4px;
   color: #9ab1d7;
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .monitor-meta {
@@ -318,20 +318,20 @@ button.monitor-row.bad {
   gap: 8px 12px;
   margin-top: 10px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: var(--fs-sm);
 }
 
 .monitor-focus {
   margin-top: 10px;
   color: #e4ecff;
-  font-size: 13px;
+  font-size: var(--fs-base);
   line-height: 1.5;
 }
 
 .monitor-footnote {
   margin-top: 8px;
   color: #7f96bd;
-  font-size: 12px;
+  font-size: var(--fs-sm);
   line-height: 1.45;
 }
 
@@ -340,7 +340,7 @@ button.monitor-row.bad {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   padding: 2px 8px;
   border-radius: 999px;
 }
@@ -369,7 +369,7 @@ button.monitor-row.bad {
   border: 1px solid var(--white-8);
 }
 .card-title {
-  font-size: 14px;
+  font-size: var(--fs-md);
   text-transform: uppercase;
   letter-spacing: 2px;
   color: var(--ok);


### PR DESCRIPTION
## Summary

대시보드 CSS를 디자인 토큰 시스템으로 정규화하는 3-Phase 작업:

### Phase 1: 색상 토큰화
- 16종 하드코딩 hex → 기존 CSS 변수 (64건 교체)
- 하드코딩 색상: 363 → 299 (-18%)

### Phase 2: Font-size 토큰화
- 6단계 scale 신규 정의 (--fs-2xs ~ --fs-lg)
- 307개 font-size 선언 토큰화 (전체의 91%)

### Phase 3: Media query 정규화
- 12개 브레이크포인트 → 7개 canonical 값 (-42%)
- 1250+1180→1200, 980→960, 900+860→880, 800+700→768

### 정규화 결과

| 항목 | Before | After |
|------|--------|-------|
| 하드코딩 색상 | 363 | 299 |
| 하드코딩 font-size | 339 | 32 |
| Breakpoints | 12 | 7 |
| 디자인 토큰 수 | ~80 | ~86 |

## Test plan
- [x] `npm run build` 성공 (매 phase)

Generated with [Claude Code](https://claude.com/claude-code)