### PR TITLE
feat(autoresearch): research finding persistence (JSONL + GraphQL)

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -1,0 +1,201 @@
+(** Autoresearch_knowledge — Research finding persistence (JSONL + GraphQL).
+
+    Records structured research findings from autoresearch loops.
+    Local JSONL is the primary store; GraphQL/Neo4j is best-effort sync.
+
+    @since 2.122.0 *)
+
+(** {1 Types} *)
+
+type confidence = High | Medium | Low
+
+type finding = {
+  id : string;
+  loop_id : string;
+  keeper_name : string;
+  goal : string;
+  hypothesis : string;
+  evidence : string;
+  conclusion : string;
+  confidence : confidence;
+  tags : string list;
+  related_findings : string list;
+  cycle_range : (int * int) option;  (** first_cycle, last_cycle *)
+  timestamp : float;
+}
+
+(** {1 Serialization} *)
+
+let confidence_to_string = function
+  | High -> "high" | Medium -> "medium" | Low -> "low"
+
+let confidence_of_string = function
+  | "high" -> High | "medium" -> Medium | "low" -> Low
+  | _ -> Medium
+
+let finding_to_yojson (f : finding) : Yojson.Safe.t =
+  `Assoc [
+    ("id", `String f.id);
+    ("loop_id", `String f.loop_id);
+    ("keeper_name", `String f.keeper_name);
+    ("goal", `String f.goal);
+    ("hypothesis", `String f.hypothesis);
+    ("evidence", `String f.evidence);
+    ("conclusion", `String f.conclusion);
+    ("confidence", `String (confidence_to_string f.confidence));
+    ("tags", `List (List.map (fun t -> `String t) f.tags));
+    ("related_findings", `List (List.map (fun r -> `String r) f.related_findings));
+    ("cycle_range", match f.cycle_range with
+      | None -> `Null
+      | Some (a, b) -> `List [`Int a; `Int b]);
+    ("timestamp", `Float f.timestamp);
+  ]
+
+let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
+  try
+    let open Yojson.Safe.Util in
+    let str key = member key json |> to_string in
+    let str_opt key = member key json |> to_string_option in
+    Ok {
+      id = str "id";
+      loop_id = (match str_opt "loop_id" with Some s -> s | None -> "");
+      keeper_name = (match str_opt "keeper_name" with Some s -> s | None -> "unknown");
+      goal = str "goal";
+      hypothesis = str "hypothesis";
+      evidence = str "evidence";
+      conclusion = str "conclusion";
+      confidence = confidence_of_string
+        (match str_opt "confidence" with Some s -> s | None -> "medium");
+      tags = (try member "tags" json |> to_list |> List.map to_string
+              with _ -> []);
+      related_findings = (try member "related_findings" json |> to_list |> List.map to_string
+                          with _ -> []);
+      cycle_range = (match member "cycle_range" json with
+        | `List [`Int a; `Int b] -> Some (a, b)
+        | _ -> None);
+      timestamp = (try member "timestamp" json |> to_float
+                   with _ -> Unix.gettimeofday ());
+    }
+  with exn -> Error (Printexc.to_string exn)
+
+(** {1 Storage (JSONL)} *)
+
+let findings_dir () =
+  let base = match Sys.getenv_opt "ME_ROOT" with
+    | Some r -> r | None -> Sys.getenv "HOME" ^ "/me"
+  in
+  Filename.concat base ".masc/autoresearch/findings"
+
+let findings_file () =
+  Filename.concat (findings_dir ()) "findings.jsonl"
+
+let ensure_findings_dir () =
+  Fs_compat.mkdir_p (findings_dir ())
+
+let append_finding (f : finding) : unit =
+  ensure_findings_dir ();
+  let line = Yojson.Safe.to_string (finding_to_yojson f) ^ "\n" in
+  Fs_compat.append_file (findings_file ()) line
+
+let load_all_findings () : finding list =
+  let path = findings_file () in
+  if not (Sys.file_exists path) then []
+  else
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+      let findings = ref [] in
+      (try while true do
+        let line = input_line ic in
+        if String.trim line <> "" then
+          match Yojson.Safe.from_string line |> finding_of_yojson with
+          | Ok f -> findings := f :: !findings
+          | Error _ -> ()
+      done with End_of_file -> ());
+      List.rev !findings)
+
+let search_findings ~query ?(limit=10) () : finding list =
+  let query_lower = String.lowercase_ascii query in
+  load_all_findings ()
+  |> List.filter (fun f ->
+    let haystack = String.lowercase_ascii
+      (f.goal ^ " " ^ f.hypothesis ^ " " ^ f.evidence ^ " " ^
+       f.conclusion ^ " " ^ String.concat " " f.tags) in
+    let rec find_sub i =
+      if i + String.length query_lower > String.length haystack then false
+      else if String.sub haystack i (String.length query_lower) = query_lower then true
+      else find_sub (i + 1)
+    in
+    find_sub 0)
+  |> List.rev  (* most recent first *)
+  |> fun results ->
+    if List.length results > limit then
+      List.filteri (fun i _ -> i < limit) results
+    else results
+
+(** {1 GraphQL Sync (best-effort)} *)
+
+let sync_to_graphql (f : finding) : (bool, string) result =
+  let mutation = {|
+    mutation CreateFinding(
+      $id: String!
+      $loopId: String!
+      $keeperName: String!
+      $goal: String!
+      $hypothesis: String!
+      $evidence: String!
+      $conclusion: String!
+      $confidence: String!
+      $tags: [String!]!
+    ) {
+      createFindings(input: [{
+        id: $id
+        loopId: $loopId
+        keeperName: $keeperName
+        goal: $goal
+        hypothesis: $hypothesis
+        evidence: $evidence
+        conclusion: $conclusion
+        confidence: $confidence
+        tags: $tags
+      }]) {
+        findings { id }
+      }
+    }
+  |} in
+  let variables = `Assoc [
+    ("id", `String f.id);
+    ("loopId", `String f.loop_id);
+    ("keeperName", `String f.keeper_name);
+    ("goal", `String f.goal);
+    ("hypothesis", `String f.hypothesis);
+    ("evidence", `String f.evidence);
+    ("conclusion", `String f.conclusion);
+    ("confidence", `String (confidence_to_string f.confidence));
+    ("tags", `List (List.map (fun t -> `String t) f.tags));
+  ] in
+  match Graphql_client.mutate ~timeout_sec:10.0 ~mutation ~variables () with
+  | Ok _ -> Ok true
+  | Error msg ->
+    Log.Keeper.warn "Finding GraphQL sync failed (non-fatal): %s" msg;
+    Error msg
+
+(** {1 Public API} *)
+
+let generate_finding_id () =
+  let rnd = Mirage_crypto_rng.generate 6 in
+  "fn-" ^ String.concat ""
+    (List.init (String.length rnd) (fun i ->
+      Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+
+let record_finding ~(finding : finding) : Yojson.Safe.t =
+  append_finding finding;
+  (* Best-effort GraphQL sync — local JSONL is authoritative *)
+  let graphql_ok = match sync_to_graphql finding with
+    | Ok _ -> true
+    | Error _ -> false
+  in
+  `Assoc [
+    ("ok", `Bool true);
+    ("id", `String finding.id);
+    ("graphql_synced", `Bool graphql_ok);
+  ]

--- a/lib/dune
+++ b/lib/dune
@@ -580,6 +580,7 @@
    autoresearch_git
    autoresearch_file
    autoresearch_codegen
+   autoresearch_knowledge
    tool_autoresearch_schemas
    tool_autoresearch
    ;; Anti-Fake Test Quality Scoring (harness P2)
@@ -745,6 +746,7 @@
   autoresearch_git
   autoresearch_file
   autoresearch_codegen
+  autoresearch_knowledge
   tool_autoresearch_schemas
   backend_eio_compression
   room_multi

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -698,6 +698,58 @@ let wrap_result json =
   in
   (not is_error, s)
 
+(** Handle record_finding — persist a structured research finding. *)
+let handle_record_finding ctx args =
+  let keeper_name = match ctx.agent_name with Some n -> n | None -> "unknown" in
+  let goal = Safe_ops.json_string ~default:"" "goal" args in
+  let hypothesis = Safe_ops.json_string ~default:"" "hypothesis" args in
+  let evidence = Safe_ops.json_string ~default:"" "evidence" args in
+  let conclusion = Safe_ops.json_string ~default:"" "conclusion" args in
+  if goal = "" || hypothesis = "" || evidence = "" || conclusion = "" then
+    `Assoc [("error", `String "goal, hypothesis, evidence, conclusion are required")]
+  else
+    let loop_id = Safe_ops.json_string ~default:"" "loop_id" args in
+    let confidence = Safe_ops.json_string ~default:"medium" "confidence" args in
+    let tags = match Yojson.Safe.Util.member "tags" args with
+      | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
+      | _ -> []
+    in
+    let cycle_start = Safe_ops.json_int_opt "cycle_start" args in
+    let cycle_end = Safe_ops.json_int_opt "cycle_end" args in
+    let cycle_range = match cycle_start, cycle_end with
+      | Some a, Some b -> Some (a, b)
+      | _ -> None
+    in
+    let finding : Autoresearch_knowledge.finding = {
+      id = Autoresearch_knowledge.generate_finding_id ();
+      loop_id;
+      keeper_name;
+      goal;
+      hypothesis;
+      evidence;
+      conclusion;
+      confidence = Autoresearch_knowledge.confidence_of_string confidence;
+      tags;
+      related_findings = [];
+      cycle_range;
+      timestamp = Unix.gettimeofday ();
+    } in
+    Autoresearch_knowledge.record_finding ~finding
+
+(** Handle search_findings — search previous research findings by keyword. *)
+let handle_search_findings _ctx args =
+  let query = Safe_ops.json_string ~default:"" "query" args in
+  if query = "" then
+    `Assoc [("error", `String "query is required")]
+  else
+    let limit = Safe_ops.json_int ~default:10 "limit" args in
+    let findings = Autoresearch_knowledge.search_findings ~query ~limit () in
+    `Assoc [
+      ("ok", `Bool true);
+      ("count", `Int (List.length findings));
+      ("findings", `List (List.map Autoresearch_knowledge.finding_to_yojson findings));
+    ]
+
 (** Dispatch an autoresearch tool call (standard MCP pattern). *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -708,4 +760,8 @@ let dispatch ctx ~name ~args : result option =
   | "masc_autoresearch_stop" -> Some (wrap_result (handle_stop ctx args))
   | "masc_autoresearch_inject" -> Some (wrap_result (handle_inject ctx args))
   | "masc_autoresearch_cycle" -> Some (wrap_result (handle_cycle ctx args))
+  | "masc_autoresearch_record_finding" ->
+      Some (wrap_result (handle_record_finding ctx args))
+  | "masc_autoresearch_search_findings" ->
+      Some (wrap_result (handle_search_findings ctx args))
   | _ -> None

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -178,4 +178,74 @@ Call this repeatedly to drive the autonomous loop.";
       ]);
     ];
   };
+
+  {
+    name = "masc_autoresearch_record_finding";
+    description = "Record a structured research finding from an autoresearch loop. \
+Findings are persisted to JSONL locally and synced to Neo4j (best-effort). \
+Use after synthesizing insights from multiple experiment cycles.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("loop_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Loop ID this finding belongs to (optional)");
+        ]);
+        ("goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Research goal or question being investigated");
+        ]);
+        ("hypothesis", `Assoc [
+          ("type", `String "string");
+          ("description", `String "The hypothesis that was tested");
+        ]);
+        ("evidence", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Observable evidence supporting or refuting the hypothesis");
+        ]);
+        ("conclusion", `Assoc [
+          ("type", `String "string");
+          ("description", `String "What was learned (1-3 sentences)");
+        ]);
+        ("confidence", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Confidence level: high, medium, low");
+        ]);
+        ("tags", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Topic tags for retrieval (e.g. 'attention', 'learning-rate')");
+        ]);
+        ("cycle_start", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "First cycle number this finding covers (optional)");
+        ]);
+        ("cycle_end", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Last cycle number this finding covers (optional)");
+        ]);
+      ]);
+      ("required", `List [`String "goal"; `String "hypothesis"; `String "evidence"; `String "conclusion"]);
+    ];
+  };
+
+  {
+    name = "masc_autoresearch_search_findings";
+    description = "Search previous research findings by keyword. \
+Returns findings from all loops matching the query, most recent first.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Search query (matches against goal, hypothesis, evidence, conclusion, tags)");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum results to return (default: 10)");
+        ]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  };
 ]


### PR DESCRIPTION
## Summary

- 새 모듈 `autoresearch_knowledge.ml`: finding 타입 (hypothesis/evidence/conclusion/confidence/tags)
- JSONL 로컬 저장 (authoritative) + GraphQL/Neo4j best-effort sync
- 2개 tool 추가: `record_finding`, `search_findings`
- 기존 42 shard tests + 3 keeper tools tests PASS

## Context

Phase 3 of autoresearch fork plan. 코드 최적화를 넘어 일반 지식 탐구로 확장.
Keeper가 연구 루프를 돌리며 발견한 인사이트를 구조화해서 축적. 이후 세션/keeper 간 지식 공유 기반.

## Test plan

- [x] `dune build --root .` 에러 없음
- [x] `test_tool_shard_coverage.exe` 42/42 pass
- [x] `test_keeper_tools_oas.exe` 3/3 pass
- [ ] E2E: finding record + search roundtrip
- [ ] GraphQL Finding type 스키마 추가 (second-brain-graphql 측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)