### PR TITLE
feat(keeper): library 검색/열람 내부 도구 추가

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -26,6 +26,8 @@ let keeper_read_tool_names =
     "keeper_read";
     "keeper_fs_read";
     "keeper_memory_search";
+    "keeper_library_search";
+    "keeper_library_read";
     "keeper_time_now";
     "keeper_context_status";
   ]
@@ -188,6 +190,20 @@ let execute_keeper_tool_call
             ("note", `String "This keeper cannot fetch live weather by itself.");
             ("recent_weather_questions", `List recent_weather_questions);
           ])
+  | "keeper_library_search" ->
+      let ok, msg = Tool_library.handle_search
+        Tool_library.{ agent_name = meta.name }
+        args
+      in
+      if ok then msg
+      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
+  | "keeper_library_read" ->
+      let ok, msg = Tool_library.handle_read
+        Tool_library.{ agent_name = meta.name }
+        args
+      in
+      if ok then msg
+      else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
   | "keeper_board_post" ->
       let author = meta.name in
       Log.Trpg.info "keeper_board_post called by %s, raw args: %s"


### PR DESCRIPTION
## Summary
- `keeper_library_search(query)` — library 문서 키워드 검색
- `keeper_library_read(topic)` — library 문서 열람
- 모든 keeper의 기본 `allowed_tools`에 포함 (keeper_read_tool_names)
- Tool_library.handle_search/handle_read 직접 호출 (LLM 미사용, 파일 I/O만)

## Context
MASC library에 논문/지식 문서가 등록되어 있지만 keeper가 자체적으로 검색/열람 불가했음.
이제 keeper가 의사결정 시 library 문서를 참조하고, Board/거버넌스에서 인용 가능.

Closes #2157

## Test plan
- [ ] `dune build --root .` 성공
- [ ] keeper가 `keeper_library_search` 호출 시 검색 결과 반환
- [ ] keeper가 `keeper_library_read` 호출 시 문서 내용 반환

Generated with Claude Code