### PR TITLE
feat(keeper): system prompt에 library 검색 힌트 추가

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -75,7 +75,9 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
      - Reply to pending mentions (use room broadcast tools)\n\
      - Work on active goals (use planning/execution tools)\n\
      - Proactive observation (post findings to board)\n\
+     - Search knowledge library (keeper_library_search/read) for research references\n\
      - Do nothing if the situation warrants it (respond with brief reasoning)\n\n\
+     When making claims or decisions, search the library first if relevant documents may exist.\n\
      Do NOT explain your decision-making process at length.\n\
      Act directly or state briefly why you chose not to act.\n";
   let system_prompt = Buffer.contents buf in


### PR DESCRIPTION
## Summary
- Keeper system prompt의 Behavior 섹션에 library 도구 사용 안내 추가
- 의사결정 시 관련 문서가 있을 수 있으면 library를 먼저 검색하도록 유도

## Changes
- `lib/keeper/keeper_unified_prompt.ml` — Possible actions에 library 항목 추가 + 검색 우선 힌트

Stacked on #2161 (keeper library tools)

Generated with Claude Code