### PR TITLE
feat(keeper): load AGENT.md from persona directory into system prompt

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -75,6 +75,10 @@ let run_turn
       ~base_dir
   in
   (* 3. Build base system prompt from meta *)
+  let persona_extended =
+    Keeper_types_profile.load_persona_extended meta.name
+    |> Option.value ~default:""
+  in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
       ~goal:meta.goal
@@ -86,6 +90,8 @@ let run_turn
       ~needs:meta.needs
       ~desires:meta.desires
       ~instructions:meta.instructions
+      ~persona_extended
+      ()
   in
   (* 4. Create or restore working context, re-apply current prompt *)
   let base_ctx =

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -88,6 +88,8 @@ val build_keeper_system_prompt :
   needs:string ->
   desires:string ->
   instructions:string ->
+  ?persona_extended:string ->
+  unit ->
   string
 
 (** Append trait clause to existing trait string. *)

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -40,7 +40,7 @@ let keeper_constitution =
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~soul_profile ~will ~needs ~desires
-    ~instructions =
+    ~instructions ?(persona_extended = "") () =
   let profile =
     canonical_soul_profile soul_profile
     |> Option.value ~default:default_soul_profile
@@ -71,8 +71,14 @@ let build_keeper_system_prompt
     if s = "" then ""
     else Printf.sprintf "\nCustom instructions:\n%s\n" s
   in
+  let persona_block =
+    let s = String.trim persona_extended in
+    if s = "" then ""
+    else Printf.sprintf "<persona>\n%s\n</persona>\n\n" s
+  in
   String.concat ""
     [
+      persona_block;
       "<world>\n\
        You live in MASC (Multi-Agent Streaming Coordination).\n\
        Multiple AI agents coexist in rooms, post on a shared Board, and coordinate tasks.\n\

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -16,6 +16,8 @@ val build_keeper_system_prompt :
   needs:string ->
   desires:string ->
   instructions:string ->
+  ?persona_extended:string ->
+  unit ->
   string
 
 val append_trait_clause : base:string -> clause:string -> string

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -299,6 +299,10 @@ let ensure_keeper_exists
        let specs = Model_spec.available_model_specs_of_strings meta.models in
        let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
        let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
+       let persona_extended =
+         Keeper_types_profile.load_persona_extended name
+         |> Option.value ~default:""
+       in
        let system_prompt =
          build_keeper_system_prompt
            ~goal
@@ -310,6 +314,8 @@ let ensure_keeper_exists
            ~needs
            ~desires
            ~instructions
+           ~persona_extended
+           ()
        in
        let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary.max_context in
        (try ignore (save_checkpoint session ctx0 ~generation:0)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -282,6 +282,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
          let base_dir = session_base_dir ctx.config in
          mkdir_p base_dir;
          let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
+           let persona_extended =
+             Keeper_types_profile.load_persona_extended p.name
+             |> Option.value ~default:""
+           in
            let system_prompt =
              build_keeper_system_prompt
                ~goal
@@ -293,6 +297,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                ~needs
                ~desires
                ~instructions
+               ~persona_extended
+               ()
          in
          let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary.max_context in
          (try ignore (save_checkpoint session ctx0 ~generation:0)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -393,6 +393,23 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 
+(** Load extended persona description from AGENT.md if present.
+    Truncated to [max_chars] to avoid bloating the system prompt. *)
+let load_persona_extended ?(max_chars = 4000) name : string option =
+  match personas_root_opt () with
+  | None -> None
+  | Some root ->
+    let path = Filename.concat (Filename.concat root name) "AGENT.md" in
+    if Sys.file_exists path then
+      match Safe_ops.read_file_safe path with
+      | Error _ -> None
+      | Ok content ->
+        let trimmed = String.trim content in
+        if String.length trimmed = 0 then None
+        else if String.length trimmed <= max_chars then Some trimmed
+        else Some (String.sub trimmed 0 max_chars ^ "\n[truncated]")
+    else None
+
 let load_persona_summary name : persona_summary option =
   match persona_profile_path_opt name with
   | None -> None


### PR DESCRIPTION
## Summary
Keeper system prompt에 persona 디렉토리의 AGENT.md를 `<persona>` 블록으로 주입.

기존: `profile.json`의 `keeper.instructions` 1줄만 system prompt에 반영
변경: `$ME_ROOT/personas/<name>/AGENT.md` 전문(4000자 cap)을 system prompt 앞에 삽입

상수 같은 rich character keeper가 emotion-detector, intimacy-system 등 풍부한 설정을 활용 가능.

### 변경 파일 (7개)
- `keeper_types_profile.ml`: `load_persona_extended` 함수 추가
- `keeper_prompt.ml` + `.mli`: `?persona_extended` optional param
- `keeper_execution.mli`: re-export 시그니처 동기화
- `keeper_turn_setup.ml`: persona 로딩 + 전달
- `keeper_turn_up_create.ml`: 동일
- `keeper_agent_run.ml`: 동일

## Test plan
- [x] `dune build` passes
- [ ] keeper 재시작 후 상수 system prompt에 `<persona>` 블록 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)