### PR TITLE
feat: keeper coding tools (write, edit, shell, git)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -452,6 +452,7 @@
    tool_council_json
    tool_council_schemas
    tool_code
+   tool_code_write
    code_swarm_plan
    tool_code_swarm
    tool_suspend

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -51,6 +51,8 @@ let keeper_autoresearch_tool_names =
   Tool_shard.autoresearch_keeper_tools
   |> List.map (fun (t : Types.tool_schema) -> t.name)
 
+let keeper_coding_tool_names = Tool_code_write.tool_names
+
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)
 
@@ -73,12 +75,22 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
         keeper_autoresearch_tool_names @ with_shell
       else with_shell
     in
-    dedupe_tool_names (keeper_board_tool_names @ with_research)
+    let with_coding =
+      if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
+        keeper_coding_tool_names @ with_research
+      else with_research
+    in
+    dedupe_tool_names (keeper_board_tool_names @ with_coding)
   else
     let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
-    if meta.soul_profile = "research" then
-      dedupe_tool_names (keeper_autoresearch_tool_names @ base_names)
-    else base_names
+    let with_research =
+      if meta.soul_profile = "research" then
+        keeper_autoresearch_tool_names @ base_names
+      else base_names
+    in
+    if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
+      dedupe_tool_names (keeper_coding_tool_names @ with_research)
+    else with_research
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     Types.tool_schema list =
@@ -87,10 +99,15 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     []
   else
     let base = keeper_model_tools in
-    let all_tools =
+    let with_research =
       if meta.soul_profile = "research" then
         base @ Tool_shard.autoresearch_keeper_tools
       else base
+    in
+    let all_tools =
+      if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
+        with_research @ Tool_code_write.schemas
+      else with_research
     in
     all_tools
     |> List.filter (fun tool -> List.mem tool.Types.name allowed)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -160,6 +160,7 @@ let () =
   register_module_tag ~schemas:Tool_social.schemas ~tag:Mod_social;
   register_module_tag ~schemas:Tool_vote.schemas ~tag:Mod_vote;
   register_module_tag ~schemas:Tool_code.schemas ~tag:Mod_code;
+  register_module_tag ~schemas:Tool_code_write.schemas ~tag:Mod_code_write;
   register_module_tag ~schemas:Tool_library.schemas ~tag:Mod_library;
   register_module_tag ~schemas:Tool_audit.schemas ~tag:Mod_audit;
   register_module_tag ~schemas:Tool_a2a.schemas ~tag:Mod_a2a;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -451,6 +451,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_code_swarm.dispatch { Tool_code_swarm.config; agent_name } ~name ~args:arguments
     | Mod_code ->
         Tool_code.dispatch { Tool_code.config; agent_name } ~name ~args:arguments
+    | Mod_code_write ->
+        Tool_code_write.dispatch { Tool_code_write.config; agent_name } ~name ~args:arguments
     | Mod_vote ->
         Tool_vote.dispatch { Tool_vote.config; agent_name } ~name ~args:arguments
     | Mod_social ->

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -1,0 +1,468 @@
+(** Code Write Tools — File write, edit, delete, shell, git for keeper agents.
+
+    Security model:
+    - All write operations restricted to .worktrees/ directories
+    - Shell commands restricted to allowlist
+    - Git push to main/master blocked
+    - File size limit: 1MB for writes
+    - Binary file extension check inherited from Tool_code
+
+    @since 2.128.0 *)
+
+open Types
+open Tool_args
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+}
+
+type result = bool * string
+
+let max_write_size = 1024 * 1024 (* 1MB *)
+
+(* Security: Validate path is within a .worktrees/ directory *)
+let validate_writable_path config path =
+  match Tool_code.validate_path config path with
+  | Error e -> Error e
+  | Ok abs_path ->
+    let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
+      | None -> Error (IoError "Not in a git repository")
+      | Some root -> Ok root
+    in
+    match git_root with
+    | Error e -> Error e
+    | Ok root ->
+      let worktree_prefix = Filename.concat root ".worktrees" in
+      if String.starts_with ~prefix:worktree_prefix abs_path then
+        Ok abs_path
+      else
+        Error (IoError (Printf.sprintf
+          "Write restricted to .worktrees/ directory (got: %s)" abs_path))
+
+(* Shell command allowlist *)
+let allowed_shell_commands = [
+  "dune"; "make"; "npm"; "npx"; "node";
+  "git"; "ls"; "cat"; "head"; "tail"; "wc";
+  "rg"; "find"; "diff"; "patch"; "mkdir";
+  "opam"; "ocamlfind"; "tsc";
+]
+
+(* Git action allowlist *)
+let allowed_git_actions = [
+  "add"; "commit"; "push"; "diff"; "status";
+  "log"; "branch"; "checkout"; "stash"; "fetch";
+]
+
+let max_output_bytes = 10 * 1024 (* 10KB output limit *)
+
+let truncate_output s =
+  if String.length s > max_output_bytes then
+    String.sub s 0 max_output_bytes ^ "\n... (truncated)"
+  else s
+
+(* Handler: masc_code_write — Create or overwrite a file *)
+let handle_code_write ctx args =
+  let path = get_string args "path" "" in
+  let content = get_string args "content" "" in
+  let create_dirs = get_bool args "create_dirs" false in
+
+  if path = "" then
+    (false, "path parameter required")
+  else if String.length content > max_write_size then
+    (false, Printf.sprintf "Content too large: %d bytes (max: %d)"
+       (String.length content) max_write_size)
+  else if Tool_code.is_binary_file path then
+    (false, "Binary file extension not allowed for write")
+  else begin
+    match validate_writable_path ctx.config path with
+    | Error e -> (false, Types.masc_error_to_string e)
+    | Ok abs_path ->
+      try
+        if create_dirs then begin
+          let dir = Filename.dirname abs_path in
+          Fs_compat.mkdir_p dir
+        end;
+        Fs_compat.save_file abs_path content;
+        let response = `Assoc [
+          ("status", `String "ok");
+          ("path", `String path);
+          ("bytes_written", `Int (String.length content));
+          ("agent", `String ctx.agent_name);
+        ] in
+        (true, Yojson.Safe.pretty_to_string response)
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        (false, Printf.sprintf "Write failed: %s" (Printexc.to_string exn))
+  end
+
+(* Handler: masc_code_edit — Replace old_string with new_string in a file *)
+let handle_code_edit ctx args =
+  let path = get_string args "path" "" in
+  let old_string = get_string args "old_string" "" in
+  let new_string = get_string args "new_string" "" in
+  let replace_all = get_bool args "replace_all" false in
+
+  if path = "" then (false, "path parameter required")
+  else if old_string = "" then (false, "old_string parameter required")
+  else if old_string = new_string then (false, "old_string and new_string are identical")
+  else begin
+    match validate_writable_path ctx.config path with
+    | Error e -> (false, Types.masc_error_to_string e)
+    | Ok abs_path ->
+      if not (Sys.file_exists abs_path) then
+        (false, Printf.sprintf "File not found: %s" path)
+      else begin
+        try
+          let content = Fs_compat.load_file abs_path in
+          (* Count occurrences *)
+          let count = ref 0 in
+          let pos = ref 0 in
+          let old_len = String.length old_string in
+          while !pos <= String.length content - old_len do
+            if String.sub content !pos old_len = old_string then begin
+              incr count;
+              pos := !pos + old_len
+            end else
+              incr pos
+          done;
+
+          if !count = 0 then
+            (false, "old_string not found in file")
+          else if !count > 1 && not replace_all then
+            (false, Printf.sprintf
+               "old_string found %d times. Use replace_all=true or provide more context"
+               !count)
+          else begin
+            (* Perform replacement *)
+            let new_content =
+              if replace_all then begin
+                let buf = Buffer.create (String.length content) in
+                let i = ref 0 in
+                while !i <= String.length content - old_len do
+                  if String.sub content !i old_len = old_string then begin
+                    Buffer.add_string buf new_string;
+                    i := !i + old_len
+                  end else begin
+                    Buffer.add_char buf content.[!i];
+                    incr i
+                  end
+                done;
+                (* Add remaining characters *)
+                if !i < String.length content then
+                  Buffer.add_string buf
+                    (String.sub content !i (String.length content - !i));
+                Buffer.contents buf
+              end else begin
+                (* Replace first occurrence only *)
+                let idx = ref (-1) in
+                let i = ref 0 in
+                while !idx = -1 && !i <= String.length content - old_len do
+                  if String.sub content !i old_len = old_string then
+                    idx := !i
+                  else
+                    incr i
+                done;
+                match !idx with
+                | -1 -> content (* should not happen *)
+                | pos ->
+                  String.sub content 0 pos
+                  ^ new_string
+                  ^ String.sub content (pos + old_len)
+                      (String.length content - pos - old_len)
+              end
+            in
+            Fs_compat.save_file abs_path new_content;
+            let response = `Assoc [
+              ("status", `String "ok");
+              ("path", `String path);
+              ("replacements", `Int !count);
+              ("agent", `String ctx.agent_name);
+            ] in
+            (true, Yojson.Safe.pretty_to_string response)
+          end
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+          (false, Printf.sprintf "Edit failed: %s" (Printexc.to_string exn))
+      end
+  end
+
+(* Handler: masc_code_delete — Delete a file *)
+let handle_code_delete ctx args =
+  let path = get_string args "path" "" in
+
+  if path = "" then (false, "path parameter required")
+  else begin
+    match validate_writable_path ctx.config path with
+    | Error e -> (false, Types.masc_error_to_string e)
+    | Ok abs_path ->
+      if not (Sys.file_exists abs_path) then
+        (false, Printf.sprintf "File not found: %s" path)
+      else if Sys.is_directory abs_path then
+        (false, "Cannot delete directories, only files")
+      else begin
+        try
+          Sys.remove abs_path;
+          let response = `Assoc [
+            ("status", `String "ok");
+            ("path", `String path);
+            ("agent", `String ctx.agent_name);
+          ] in
+          (true, Yojson.Safe.pretty_to_string response)
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+          (false, Printf.sprintf "Delete failed: %s" (Printexc.to_string exn))
+      end
+  end
+
+(* Handler: masc_code_shell — Bounded shell execution *)
+let handle_code_shell ctx args =
+  let command = get_string args "command" "" in
+  let cwd = get_string args "cwd" "" in
+  let timeout = get_int args "timeout" 30 in
+
+  if command = "" then (false, "command parameter required")
+  else begin
+    (* Parse first token to check allowlist *)
+    let tokens = String.split_on_char ' ' (String.trim command) in
+    let executable = match tokens with
+      | [] -> ""
+      | exe :: _ -> Filename.basename exe
+    in
+
+    if not (List.mem executable allowed_shell_commands) then
+      (false, Printf.sprintf "Command '%s' not in allowlist: %s"
+         executable (String.concat ", " allowed_shell_commands))
+    else begin
+      (* Validate cwd if provided *)
+      let cwd_result =
+        if cwd = "" then Ok None
+        else match validate_writable_path ctx.config cwd with
+          | Ok abs_cwd -> Ok (Some abs_cwd)
+          | Error e -> Error e
+      in
+      match cwd_result with
+      | Error e -> (false, Types.masc_error_to_string e)
+      | Ok cwd_opt ->
+        let safe_timeout = Float.of_int (max 5 (min 120 timeout)) in
+        let cmd_parts = ["sh"; "-c"; command] in
+        let full_cmd = match cwd_opt with
+          | None -> cmd_parts
+          | Some dir -> ["sh"; "-c"; Printf.sprintf "cd %s && %s"
+                           (Filename.quote dir) command]
+        in
+        match Process_eio.run_argv_with_status ~timeout_sec:safe_timeout full_cmd with
+        | Unix.WEXITED code, output ->
+          let response = `Assoc [
+            ("status", `String (if code = 0 then "ok" else "error"));
+            ("exit_code", `Int code);
+            ("output", `String (truncate_output output));
+            ("command", `String command);
+            ("agent", `String ctx.agent_name);
+          ] in
+          (code = 0, Yojson.Safe.pretty_to_string response)
+        | _, output ->
+          (false, Printf.sprintf "Command failed: %s" (truncate_output output))
+    end
+  end
+
+(* Handler: masc_code_git — Git operations *)
+let handle_code_git ctx args =
+  let action = get_string args "action" "" in
+  let git_args = match args with
+    | `Assoc fields ->
+      (match List.assoc_opt "args" fields with
+       | Some (`List l) ->
+         List.filter_map (function `String s -> Some s | _ -> None) l
+       | _ -> [])
+    | _ -> []
+  in
+  let cwd = get_string args "cwd" "" in
+
+  if action = "" then (false, "action parameter required")
+  else if not (List.mem action allowed_git_actions) then
+    (false, Printf.sprintf "Git action '%s' not allowed. Allowed: %s"
+       action (String.concat ", " allowed_git_actions))
+  else begin
+    (* Block dangerous operations *)
+    let is_dangerous =
+      (action = "push" && List.mem "--force" git_args) ||
+      (action = "push" && List.mem "-f" git_args) ||
+      (action = "push" && List.exists (fun a ->
+         a = "main" || a = "master" || a = "origin/main" || a = "origin/master"
+       ) git_args) ||
+      (action = "checkout" && List.mem "--" git_args &&
+       List.mem "." git_args)
+    in
+    if is_dangerous then
+      (false, "Dangerous git operation blocked (force push, main push, or checkout .)")
+    else begin
+      (* Validate cwd *)
+      let cwd_result =
+        if cwd = "" then (false, "cwd parameter required for git operations") |> fun (ok, msg) ->
+          if ok then Ok None else Error (IoError msg)
+        else match validate_writable_path ctx.config cwd with
+          | Ok abs_cwd -> Ok (Some abs_cwd)
+          | Error e -> Error e
+      in
+      match cwd_result with
+      | Error e -> (false, Types.masc_error_to_string e)
+      | Ok cwd_opt ->
+        let dir = match cwd_opt with Some d -> d | None -> "." in
+        let cmd = ["sh"; "-c";
+                   Printf.sprintf "cd %s && git %s %s"
+                     (Filename.quote dir)
+                     action
+                     (String.concat " " (List.map Filename.quote git_args))]
+        in
+        match Process_eio.run_argv_with_status ~timeout_sec:30.0 cmd with
+        | Unix.WEXITED code, output ->
+          let response = `Assoc [
+            ("status", `String (if code = 0 then "ok" else "error"));
+            ("exit_code", `Int code);
+            ("output", `String (truncate_output output));
+            ("action", `String action);
+            ("agent", `String ctx.agent_name);
+          ] in
+          (code = 0, Yojson.Safe.pretty_to_string response)
+        | _, output ->
+          (false, Printf.sprintf "Git command failed: %s" (truncate_output output))
+    end
+  end
+
+(* Dispatch *)
+let dispatch ctx ~name ~args : result option =
+  match name with
+  | "masc_code_write" -> Some (handle_code_write ctx args)
+  | "masc_code_edit" -> Some (handle_code_edit ctx args)
+  | "masc_code_delete" -> Some (handle_code_delete ctx args)
+  | "masc_code_shell" -> Some (handle_code_shell ctx args)
+  | "masc_code_git" -> Some (handle_code_git ctx args)
+  | _ -> None
+
+(* Tool schemas *)
+let schemas : Types.tool_schema list = [
+  {
+    name = "masc_code_write";
+    description = "Create or overwrite a file (restricted to .worktrees/ directories). \
+Use when generating new code files or replacing file contents entirely. \
+Pair with masc_worktree_create to set up an isolated workspace first.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File path to write (must be within .worktrees/)");
+        ]);
+        ("content", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File content to write");
+        ]);
+        ("create_dirs", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Create intermediate directories if needed (default: false)");
+          ("default", `Bool false);
+        ]);
+      ]);
+      ("required", `List [`String "path"; `String "content"]);
+    ];
+  };
+
+  {
+    name = "masc_code_edit";
+    description = "Replace a string in a file (restricted to .worktrees/ directories). \
+Use for surgical edits — changing a function body, fixing a bug, updating a value. \
+The old_string must match exactly once unless replace_all is true.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File path to edit (must be within .worktrees/)");
+        ]);
+        ("old_string", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Exact string to find and replace");
+        ]);
+        ("new_string", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Replacement string");
+        ]);
+        ("replace_all", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Replace all occurrences (default: false, requires unique match)");
+          ("default", `Bool false);
+        ]);
+      ]);
+      ("required", `List [`String "path"; `String "old_string"; `String "new_string"]);
+    ];
+  };
+
+  {
+    name = "masc_code_delete";
+    description = "Delete a file (restricted to .worktrees/ directories). \
+Cannot delete directories. Use when removing generated or obsolete files.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File path to delete (must be within .worktrees/)");
+        ]);
+      ]);
+      ("required", `List [`String "path"]);
+    ];
+  };
+
+  {
+    name = "masc_code_shell";
+    description = "Run a shell command from an allowlist (dune, make, npm, git, rg, ls, etc.). \
+Restricted to .worktrees/ working directory. Use for building, testing, and inspecting code. \
+Output truncated to 10KB. Timeout default 30s, max 120s.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("command", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Shell command to run (first token must be in allowlist)");
+        ]);
+        ("cwd", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Working directory (must be within .worktrees/)");
+        ]);
+        ("timeout", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Timeout in seconds (default: 30, max: 120)");
+          ("default", `Int 30);
+        ]);
+      ]);
+      ("required", `List [`String "command"]);
+    ];
+  };
+
+  {
+    name = "masc_code_git";
+    description = "Run git commands in a worktree (add, commit, push, diff, status, log, branch). \
+Restricted to .worktrees/ working directory. Force push and push to main/master are blocked.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("action", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Git action: add, commit, push, diff, status, log, branch, checkout, stash, fetch");
+        ]);
+        ("args", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Additional git arguments");
+        ]);
+        ("cwd", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Worktree directory (must be within .worktrees/)");
+        ]);
+      ]);
+      ("required", `List [`String "action"; `String "cwd"]);
+    ];
+  };
+]
+
+(** Tool names for keeper gating *)
+let tool_names : string list =
+  schemas |> List.map (fun (t : Types.tool_schema) -> t.name)

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -149,7 +149,7 @@ type module_tag =
   | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
   | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
   | Mod_tempo | Mod_mitosis | Mod_portal | Mod_worktree
-  | Mod_code_swarm | Mod_code | Mod_vote | Mod_social
+  | Mod_code_swarm | Mod_code | Mod_code_write | Mod_vote | Mod_social
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
   | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -77,7 +77,7 @@ type module_tag =
   | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
   | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
   | Mod_tempo | Mod_mitosis | Mod_portal | Mod_worktree
-  | Mod_code_swarm | Mod_code | Mod_vote | Mod_social
+  | Mod_code_swarm | Mod_code | Mod_code_write | Mod_vote | Mod_social
   | Mod_council | Mod_a2a | Mod_handover
   | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
   | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -77,6 +77,12 @@ let register_all () =
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
   ];
 
+  (* ── Mod_code_write: Tool_code_write ────────────────────────── *)
+  reg Mod_code_write [
+    "masc_code_write"; "masc_code_edit"; "masc_code_delete";
+    "masc_code_shell"; "masc_code_git";
+  ];
+
   (* ── Mod_vote: Tool_vote ──────────────────────────────────────── *)
   reg Mod_vote [
     "masc_vote_create"; "masc_vote_cast"; "masc_vote_status"; "masc_votes";

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -34,6 +34,7 @@ let raw_schemas : tool_schema list =
   @ Tool_social.schemas
   @ Tool_vote.schemas
   @ Tool_code.schemas
+  @ Tool_code_write.schemas
   @ Tool_library.schemas
   @ Tool_audit.schemas
   @ Tool_heartbeat.schemas


### PR DESCRIPTION
## Summary
keeper가 자율적으로 코드를 작성/수정/빌드할 수 있는 5개 MCP tool 추가.

## Tools

| Tool | 용도 |
|---|---|
| `masc_code_write` | 파일 생성/덮어쓰기 (1MB 제한) |
| `masc_code_edit` | old_string→new_string 교체 (unique match 검증) |
| `masc_code_delete` | 파일 삭제 (디렉토리 X) |
| `masc_code_shell` | bounded shell (allowlist: dune, make, npm, git, rg 등) |
| `masc_code_git` | git 조작 (add, commit, push, diff, status, log) |

## Security

- 모든 write 작업은 `.worktrees/` 디렉토리 내부로 제한
- shell command allowlist 검사
- force push, main/master push 차단
- 출력 10KB 제한, timeout 120s 상한

## Keeper Gating

`policy_shell_mode="coding"` 설정 시 이 도구들이 활성화됨. 기존 `"readonly"` 모드와 별개.

## Files Changed

- `lib/tool_code_write.ml` (신규, 468줄)
- `lib/dune`, `lib/tools.ml`, `lib/mcp_server_eio.ml`, `lib/mcp_server_eio_execute.ml` (등록)
- `lib/tool_dispatch.ml`, `lib/tool_dispatch.mli` (Mod_code_write tag)
- `lib/tool_tag_init.ml` (tag 초기화)
- `lib/keeper/keeper_exec_tools.ml` (gating)

## Test plan
- [x] `dune build --root .` 에러 없음
- [ ] `dune runtest --root .` pass
- [ ] 통합 테스트: worktree 생성 → code_write → code_shell(dune build) → code_git(commit)

## Context
- GitHub: #2162
- MASC: task-233
- TUI (#2158) full automation의 전제 조건