### PR TITLE
fix: dogfood round 2 — pool, lock retry, validation, param alias, retry amplification

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -93,6 +93,10 @@ let read_only_retry_limit () =
   | None -> 2
 
 let is_retryable_message message =
+  (* Tool-level timeouts must not be retried — retrying a 30s timeout
+     causes 60-90s total wait time, amplifying the original issue. *)
+  if contains_casefold message "Tool timed out" then false
+  else
   contains_casefold message "timeout" ||
   contains_casefold message "temporary" ||
   contains_casefold message "temporarily" ||


### PR DESCRIPTION
## Summary
6 fixes from 251-scenario systematic dogfooding:

1. **PG pool default 10→20** (#2112) — reduces connection exhaustion
2. **Lock retry 100×0.05s → 20×exp backoff** (#2113) — worst case 0.2s vs 5s
3. **board_post rejects empty title** (#2120)
4. **shell_mode "sandboxed" accepted** — keeper bash policy
5. **masc_transition "state" alias** (#2123) — accepts "state" as fallback for "action"
6. **Prevent retry amplification of tool timeouts** (#2117, #2148) — read-only retry was re-running 30s timeouts 2 more times (90s total)

## Root cause analysis
Tool timeout retry amplification: `is_retryable_message` matched "timeout" in "Tool timed out after 30s", causing `call_tool_with_readonly_retry` to loop 3 times × 30s = 90s.

## Test plan
- [x] `dune build --root .`
- [x] `test_multi_room` — 12 tests pass
- [x] `test_tool_misc_coverage` — all pass

Closes #2112 (partial), #2113 (partial), #2117 (partial), #2120 (partial), #2123 (partial), #2148 (partial)

Generated with [Claude Code](https://claude.com/claude-code)