### PR TITLE
fix: reduce default PG pool_size 10 -> 5 to avoid Supabase MaxClients

### DIFF
--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -81,8 +81,8 @@ let pool_stats_to_yojson (s : pool_stats) : Yojson.Safe.t =
 
 let configured_max_pool_size () =
   match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-  | Some s -> (try int_of_string s with _ -> 10)
-  | None -> 10
+  | Some s -> (try int_of_string s with _ -> 5)
+  | None -> 5
 
 (* ============================================ *)
 (* Backend Interface                            *)

--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -269,7 +269,11 @@ let get_pg_pool ~sw ~env =
     match get_postgres_url () with
     | None -> Error "DATABASE_URL not set"
     | Some url ->
-      let pool_config = Caqti_pool_config.create ~max_size:10 () in
+      let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
+        | Some s -> (try int_of_string s with _ -> 5)
+        | None -> 5
+      in
+      let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
       match Caqti_eio_unix.connect_pool ~sw ~pool_config (Uri.of_string url) ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;


### PR DESCRIPTION
## Summary

- MASC가 3개 독립 Caqti 풀을 생성, 각각 max_size=10 → 총 31 커넥션
- Supabase PgBouncer Session Pooler pool_size 초과 → `MaxClientsInSessionMode` 에러
- 기본값 10 → 5로 축소 (총 11 커넥션)
- `council/archive.ml`의 하드코딩 10도 `MASC_PG_POOL_SIZE` 환경변수로 통일

### 변경 전/후
| 풀 | Before | After |
|----|--------|-------|
| backend_pg main | 10 | 5 |
| backend_eio_pg | 10 | 5 |
| backend_pg readonly | 1 | 1 |
| council/archive | 10 (하드코딩) | 5 (env) |
| **합계** | **31** | **16** |

## Test plan
- [x] `dune build` 성공
- [x] `make test` — pre-existing operator.027 실패만 (main과 동일)
- [ ] MASC 서버 재시작 후 `MaxClientsInSessionMode` 에러 해소 확인

Generated with [Claude Code](https://claude.com/claude-code)