### PR TITLE
fix: return JSON-RPC error when Mcp-Session-Id missing (#2116)

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -203,6 +203,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
          MCP Endpoints
          ───────────────────────────────────────────────────────────────────── *)
       | `POST, "/mcp" | `POST, "/" | `POST, "/mcp/managed" | `POST, "/mcp/operator" ->
+          let session_was_provided = Option.is_some session_id_opt in
           let session_id = match session_id_opt with
             | Some id -> id
             | None -> Mcp_session.generate ()
@@ -245,6 +246,20 @@ let make_request_handler ~sw ~clock ~server_start_time =
                          h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
                      | Ok _cred_opt ->
                          h2_read_body h2_reqd (fun body_str ->
+                             match
+                               Server_mcp_transport_http
+                               .validate_session_requirement
+                                 ~session_was_provided body_str
+                             with
+                             | Error msg ->
+                                 let body = json_rpc_error (-32600) msg in
+                                 h2_respond_json h2_reqd body
+                                   ~status:`Bad_request
+                                   ~extra_headers:
+                                     (cors
+                                     @ mcp_headers session_id
+                                         protocol_version)
+                             | Ok () ->
                              let accept_mode =
                                Server_mcp_transport_http_headers
                                .classify_mcp_accept_for_body httpun_request body_str

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -255,8 +255,10 @@ let send_raw info data =
       false
 
 let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
+  let session_id_opt = get_session_id_any request in
+  let session_was_provided = Option.is_some session_id_opt in
   let session_id =
-    match get_session_id_any request with
+    match session_id_opt with
     | Some sid -> sid
     | None -> Mcp_session.generate ()
   in
@@ -328,6 +330,25 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                 ~protocol_version msg
           | Ok () ->
               Http.Request.read_body_async reqd (fun body_str ->
+                  match
+                    validate_session_requirement ~session_was_provided body_str
+                  with
+                  | Error msg ->
+                      let body =
+                        Printf.sprintf
+                          {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+                          (Yojson.Safe.to_string (`String msg))
+                      in
+                      let headers =
+                        Httpun.Headers.of_list
+                          (("content-length", string_of_int (String.length body))
+                          :: json_headers ~deps session_id protocol_version
+                               origin)
+                      in
+                      Httpun.Reqd.respond_with_string reqd
+                        (Httpun.Response.create ~headers `Bad_request)
+                        body
+                  | Ok () ->
                   let accept_mode =
                     Server_mcp_transport_http_headers.classify_mcp_accept_for_body
                       request body_str

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -22,6 +22,9 @@ val validate_mcp_session_profile :
   profile:Mcp_server_eio.tool_profile -> string -> (unit, string) result
 val validate_mcp_session_delete_profile :
   profile:Mcp_server_eio.tool_profile -> string -> (unit, string) result
+val method_from_body : string -> string option
+val validate_session_requirement :
+  session_was_provided:bool -> string -> (unit, string) result
 val protocol_version_from_body : string -> string option
 val get_session_id_query : string -> string option
 val get_header_any_case : Httpun.Headers.t -> string -> string option

--- a/lib/server/server_mcp_transport_http_mcp_handlers.ml
+++ b/lib/server/server_mcp_transport_http_mcp_handlers.ml
@@ -5,8 +5,12 @@ module Http_negotiation = Mcp_protocol.Http_negotiation
 type deps = Server_mcp_transport_http_types.deps
 
 let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
+  let session_id_opt =
+    Server_mcp_transport_http_session.get_session_id_any request
+  in
+  let session_was_provided = Option.is_some session_id_opt in
   let session_id =
-    match Server_mcp_transport_http_session.get_session_id_any request with
+    match session_id_opt with
     | Some sid -> sid
     | None -> Mcp_session.generate ()
   in
@@ -74,6 +78,27 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
                 request reqd ~session_id ~protocol_version msg
           | Ok () ->
               Http.Request.read_body_async reqd (fun body_str ->
+                  match
+                    Server_mcp_transport_http_protocol
+                    .validate_session_requirement ~session_was_provided body_str
+                  with
+                  | Error msg ->
+                      let body =
+                        Printf.sprintf
+                          {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+                          (Yojson.Safe.to_string (`String msg))
+                      in
+                      let headers =
+                        Httpun.Headers.of_list
+                          (("content-length",
+                            string_of_int (String.length body))
+                          :: Server_mcp_transport_http_headers.json_headers
+                               ~deps session_id protocol_version origin)
+                      in
+                      Httpun.Reqd.respond_with_string reqd
+                        (Httpun.Response.create ~headers `Bad_request)
+                        body
+                  | Ok () ->
                   let accept_mode =
                     Server_mcp_transport_http_headers.classify_mcp_accept_for_body
                       request body_str

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -22,6 +22,28 @@ type deps = {
     base_path:string -> Httpun.Request.t -> (unit, string) result;
 }
 
+let method_from_body body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    match json with
+    | `Assoc fields -> (
+        match List.assoc_opt "method" fields with
+        | Some (`String m) -> Some m
+        | _ -> None)
+    | _ -> None
+  with Yojson.Json_error _ -> None
+
+let validate_session_requirement ~session_was_provided body_str =
+  if session_was_provided then Ok ()
+  else
+    match method_from_body body_str with
+    | Some "initialize" | Some "notifications/initialized" | Some "ping" ->
+        Ok ()
+    | Some _ | None ->
+        Error
+          "Mcp-Session-Id header required. Call initialize first to obtain a \
+           session."
+
 let protocol_version_from_body body_str =
   try
     let json = Yojson.Safe.from_string body_str in

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -11,6 +11,7 @@
 open Alcotest
 
 module Mcp_session = Masc_mcp.Mcp_session
+module Http_transport = Masc_mcp.Server_mcp_transport_http
 
 (* ============================================================
    base62_chars Tests
@@ -179,5 +180,76 @@ let () =
       test_case "valid" `Quick test_get_or_generate_valid;
       test_case "invalid space" `Quick test_get_or_generate_invalid_space;
       test_case "empty" `Quick test_get_or_generate_empty;
+    ];
+    "method_from_body", [
+      test_case "tools/call" `Quick (fun () ->
+        check (option string) "extracts method" (Some "tools/call")
+          (Http_transport.method_from_body
+             {|{"jsonrpc":"2.0","method":"tools/call","params":{},"id":1}|}));
+      test_case "initialize" `Quick (fun () ->
+        check (option string) "extracts initialize" (Some "initialize")
+          (Http_transport.method_from_body
+             {|{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}|}));
+      test_case "invalid json" `Quick (fun () ->
+        check (option string) "returns None" None
+          (Http_transport.method_from_body "not json"));
+      test_case "no method field" `Quick (fun () ->
+        check (option string) "returns None" None
+          (Http_transport.method_from_body {|{"jsonrpc":"2.0","id":1}|}));
+    ];
+    "validate_session_requirement", [
+      test_case "session provided -> ok" `Quick (fun () ->
+        check bool "ok" true
+          (Result.is_ok
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:true
+                {|{"jsonrpc":"2.0","method":"tools/call","params":{},"id":1}|})));
+      test_case "initialize without session -> ok" `Quick (fun () ->
+        check bool "ok" true
+          (Result.is_ok
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false
+                {|{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}|})));
+      test_case "ping without session -> ok" `Quick (fun () ->
+        check bool "ok" true
+          (Result.is_ok
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false
+                {|{"jsonrpc":"2.0","method":"ping","params":{},"id":1}|})));
+      test_case "notifications/initialized without session -> ok" `Quick (fun () ->
+        check bool "ok" true
+          (Result.is_ok
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false
+                {|{"jsonrpc":"2.0","method":"notifications/initialized"}|})));
+      test_case "tools/call without session -> error" `Quick (fun () ->
+        check bool "error" true
+          (Result.is_error
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false
+                {|{"jsonrpc":"2.0","method":"tools/call","params":{},"id":1}|})));
+      test_case "tools/list without session -> error" `Quick (fun () ->
+        check bool "error" true
+          (Result.is_error
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false
+                {|{"jsonrpc":"2.0","method":"tools/list","id":1}|})));
+      test_case "invalid json without session -> error" `Quick (fun () ->
+        check bool "error" true
+          (Result.is_error
+             (Http_transport.validate_session_requirement
+                ~session_was_provided:false "not json")));
+      test_case "error message content" `Quick (fun () ->
+        match
+          Http_transport.validate_session_requirement
+            ~session_was_provided:false
+            {|{"jsonrpc":"2.0","method":"tools/call","params":{},"id":1}|}
+        with
+        | Error msg ->
+            check bool "mentions session" true
+              (String.length msg > 0
+              && (try ignore (String.index msg 'S'); true
+                  with Not_found -> false))
+        | Ok () -> fail "expected error");
     ];
   ]


### PR DESCRIPTION
## Summary
- Session ID 없이 stateful method 호출 시 silent empty SSE 대신 JSON-RPC -32600 에러 반환
- `initialize`, `ping`, `notifications/initialized`는 session 없이 허용
- HTTP/1.1 main + HTTP/1.1 mcp_handlers + H2 gateway 3개 transport 모두 수정

## Changes
- `method_from_body`: body JSON에서 method 이름 추출
- `validate_session_requirement`: session 필요 여부 판단
- 3개 handler에서 body 파싱 후 session 검증 삽입

## Test plan
- [x] 12 new tests (method_from_body 4 + validate_session_requirement 8)
- [x] 41/41 session tests pass (0.006s)
- [x] Build clean (no new errors)
- [ ] Manual: `curl -X POST http://localhost:8935/mcp -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_status"},"id":1}'` → should return error

Closes #2116

🤖 Generated with [Claude Code](https://claude.com/claude-code)