### PR TITLE
fix: improve dogfooding UX — workflow hints and auth bootstrap

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -25,6 +25,7 @@ let auth_dir config = Filename.concat config ".masc/auth"
 let agents_dir config = Filename.concat (auth_dir config) "agents"
 let room_secret_file config = Filename.concat (auth_dir config) "room_secret.hash"
 let auth_config_file config = Filename.concat (auth_dir config) "config.json"
+let initial_admin_file config = Filename.concat (auth_dir config) "initial_admin"
 
 (** Ensure auth directories exist *)
 let ensure_auth_dirs config =
@@ -32,6 +33,24 @@ let ensure_auth_dirs config =
   let agents = agents_dir config in
   Fs_compat.mkdir_p auth;
   Fs_compat.mkdir_p agents
+
+(** Write the initial admin agent name (bootstrap grace).
+    The agent who enables auth is always granted full permission. *)
+let write_initial_admin config agent_name =
+  ensure_auth_dirs config;
+  Out_channel.with_open_text (initial_admin_file config) (fun oc ->
+    output_string oc (String.trim agent_name))
+
+(** Read the initial admin agent name, if set. *)
+let read_initial_admin config : string option =
+  let file = initial_admin_file config in
+  if Sys.file_exists file then
+    try
+      let name = String.trim (In_channel.with_open_text file In_channel.input_all) in
+      if name = "" then None else Some name
+    with Sys_error _ -> None
+  else
+    None
 
 (* ============================================ *)
 (* Auth config management                       *)
@@ -199,6 +218,11 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
   if not auth_cfg.enabled then
     (* Auth disabled - allow everything *)
     Ok ()
+  else if (match read_initial_admin config with
+           | Some admin -> String.equal agent_name admin
+           | None -> false) then
+    (* Bootstrap grace: the agent who enabled auth always has full access *)
+    (ignore permission; Ok ())
   else if not auth_cfg.require_token then
     (* Token not required - use default role *)
     if has_permission auth_cfg.default_role permission then
@@ -386,18 +410,21 @@ let enable_auth config ~require_token ~agent_name : string * string option =
   let cfg = load_auth_config config in
   save_auth_config config { cfg with enabled = true; require_token };
   let bootstrap_token =
-    if agent_name <> "" then
+    if agent_name <> "" then begin
+      write_initial_admin config agent_name;
       match create_token config ~agent_name ~role:Admin with
       | Ok (token, _cred) -> Some token
       | Error _ -> None
-    else None
+    end else None
   in
   (secret, bootstrap_token)
 
 (** Disable authentication *)
 let disable_auth config =
   let cfg = load_auth_config config in
-  save_auth_config config { cfg with enabled = false }
+  save_auth_config config { cfg with enabled = false };
+  let file = initial_admin_file config in
+  if Sys.file_exists file then Sys.remove file
 
 (** Check if auth is enabled *)
 let is_auth_enabled config : bool =

--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -278,7 +278,7 @@ let start_operation config ~(actor : string) json =
   let assigned_unit_id =
     match get_string_opt json "assigned_unit_id" with
     | Some value -> value
-    | None -> invalid_arg "assigned_unit_id is required"
+    | None -> invalid_arg "assigned_unit_id is required. Call masc_unit_define first to create a unit."
   in
   let objective =
     match get_string_opt json "objective" with
@@ -472,7 +472,7 @@ let checkpoint_operation config ~(actor : string) json =
   let operation_id =
     match get_string_opt json "operation_id" with
     | Some value -> value
-    | None -> invalid_arg "operation_id is required"
+    | None -> invalid_arg "operation_id is required. Call masc_operation_start first."
   in
   let checkpoint_ref =
     match get_string_opt json "checkpoint_ref" with
@@ -516,7 +516,7 @@ let checkpoint_operation config ~(actor : string) json =
 
 let pause_operation_json config ~(actor : string) json =
   match get_string_opt json "operation_id" with
-  | None -> Error "operation_id is required"
+  | None -> Error "operation_id is required. Call masc_operation_start first."
   | Some operation_id ->
       Result.map operation_to_json
         (update_operation_status config ~actor ~operation_id ~status:Paused
@@ -524,7 +524,7 @@ let pause_operation_json config ~(actor : string) json =
 
 let resume_operation_json config ~(actor : string) json =
   match get_string_opt json "operation_id" with
-  | None -> Error "operation_id is required"
+  | None -> Error "operation_id is required. Call masc_operation_start first."
   | Some operation_id ->
       Result.map operation_to_json
         (update_operation_status config ~actor ~operation_id ~status:Active
@@ -532,7 +532,7 @@ let resume_operation_json config ~(actor : string) json =
 
 let stop_operation_json config ~(actor : string) json =
   match get_string_opt json "operation_id" with
-  | None -> Error "operation_id is required"
+  | None -> Error "operation_id is required. Call masc_operation_start first."
   | Some operation_id ->
       Result.map operation_to_json
         (update_operation_status config ~actor ~operation_id ~status:Cancelled
@@ -540,7 +540,7 @@ let stop_operation_json config ~(actor : string) json =
 
 let finalize_operation_json config ~(actor : string) json =
   match get_string_opt json "operation_id" with
-  | None -> Error "operation_id is required"
+  | None -> Error "operation_id is required. Call masc_operation_start first."
   | Some operation_id ->
       Result.map
         (fun operation ->

--- a/lib/command_plane/cp_lifecycle_policy.ml
+++ b/lib/command_plane/cp_lifecycle_policy.ml
@@ -4,7 +4,7 @@ let request_or_apply_assignment config ~(actor : string) ~requested_action json 
   let operation_id =
     match get_string_opt json "operation_id" with
     | Some value -> value
-    | None -> invalid_arg "operation_id is required"
+    | None -> invalid_arg "operation_id is required. Call masc_operation_start first."
   in
   let target_unit_id =
     match get_string_opt json "target_unit_id" with
@@ -88,7 +88,7 @@ let dispatch_escalate_json config ~(actor : string) json =
     let operation_id =
       match get_string_opt json "operation_id" with
       | Some value -> value
-      | None -> invalid_arg "operation_id is required"
+      | None -> invalid_arg "operation_id is required. Call masc_operation_start first."
     in
     with_operation config operation_id (fun _ current ->
         let _, _, units, _ = topology_units config in
@@ -112,7 +112,7 @@ let dispatch_escalate_json config ~(actor : string) json =
 
 let dispatch_recall_json config ~(actor : string) json =
   match get_string_opt json "operation_id" with
-  | None -> Error "operation_id is required"
+  | None -> Error "operation_id is required. Call masc_operation_start first."
   | Some operation_id ->
       Result.map
         (fun operation ->
@@ -434,7 +434,7 @@ let update_decision_status config ~(actor : string) ~decision_id ~status ?reason
 
 let policy_approve_json config ~(actor : string) json =
   match get_string_opt json "decision_id" with
-  | None -> Error "decision_id is required"
+  | None -> Error "decision_id is required. Call masc_policy_status to find pending decisions."
   | Some decision_id ->
       let decisions = read_policy_decisions config in
       (match
@@ -464,7 +464,7 @@ let policy_approve_json config ~(actor : string) json =
 
 let policy_deny_json config ~(actor : string) json =
   match get_string_opt json "decision_id" with
-  | None -> Error "decision_id is required"
+  | None -> Error "decision_id is required. Call masc_policy_status to find pending decisions."
   | Some decision_id ->
       let* updated =
         update_decision_status config ~actor ~decision_id ~status:"denied" ()

--- a/lib/keeper/keeper_feedback_tool.ml
+++ b/lib/keeper/keeper_feedback_tool.ml
@@ -13,7 +13,7 @@ let handle_keeper_feedback_record (_ctx : _ context) args : tool_result =
   if not (validate_name keeper_name) then
     (false, "invalid keeper name")
   else if decision_id = "" then
-    (false, "decision_id is required")
+    (false, "decision_id is required. Call masc_policy_status to find pending decisions.")
   else if score < -1.0 || score > 1.0 then
     (false,
      Printf.sprintf "score must be between -1.0 and 1.0, got %.2f" score)


### PR DESCRIPTION
## Summary
- **FIX 1 (#2147)**: Append workflow guidance to required-field error messages in command-plane tools (`masc_unit_define`, `masc_operation_start`, `masc_policy_status`).
- **FIX 2 (#2118)**: Write `initial_admin` file on `auth_enable` so the bootstrap agent always passes permission checks, preventing circular permission deadlock.
- **FIX 3 (#2116)**: Already merged in PR #2179. No changes.
- **FIX 4 (#2114)**: `persistent_agent_*` tools are in `Ecosystem` category. Default mode is `Full` (mode switching removed). No code change — documented as-is.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune exec --root . test/test_tool_misc_coverage.exe` — all 21 tests pass
- [ ] Manual: call `masc_operation_checkpoint` without `operation_id` — verify hint text appears
- [ ] Manual: `masc_auth_enable` then call restricted tool as the same agent — verify no permission error

Closes #2147, #2118.
Refs #2116, #2114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)