### PR TITLE
fix(notifications): return pure JSON, remove human-text prefix

### DIFF
--- a/lib/tool_notifications.ml
+++ b/lib/tool_notifications.ml
@@ -70,8 +70,7 @@ let handle_notification_count (registry : Session.registry) ~agent_name : result
     | Some session -> List.length session.message_queue
     | None -> 0
   ) in
-  (true, Printf.sprintf "Pending notifications: %d\n---\n%s"
-     count (Yojson.Safe.to_string (`Assoc [("count", `Int count)])))
+  (true, Yojson.Safe.to_string (`Assoc [("count", `Int count)]))
 
 let handle_check_notifications (registry : Session.registry) ~agent_name args : result =
   let limit = max 0 (get_int args "limit" 10) in
@@ -89,8 +88,7 @@ let handle_check_notifications (registry : Session.registry) ~agent_name args : 
     ("count", `Int (List.length notifications));
     ("notifications", `List notifications);
   ] in
-  (true, Printf.sprintf "Checked %d notification(s) for %s\n---\n%s"
-     (List.length notifications) agent_name (Yojson.Safe.pretty_to_string json))
+  (true, Yojson.Safe.to_string json)
 
 let handle_consume_notifications (registry : Session.registry) ~agent_name args : result =
   let limit = max 0 (get_int args "limit" 10) in
@@ -114,8 +112,7 @@ let handle_consume_notifications (registry : Session.registry) ~agent_name args 
     ("remaining", `Int remaining_count);
     ("notifications", `List consumed);
   ] in
-  (true, Printf.sprintf "Consumed %d notification(s), %d remaining\n---\n%s"
-     (List.length consumed) remaining_count (Yojson.Safe.pretty_to_string json))
+  (true, Yojson.Safe.to_string json)
 
 (** Dispatch tool call by name *)
 let dispatch registry ~agent_name ~name args : result option =

--- a/test/test_notifications.ml
+++ b/test/test_notifications.ml
@@ -38,18 +38,8 @@ let queue_length registry ~agent_name =
     | None -> 0
   )
 
-(** Extract JSON from response body that may have "summary\n---\n{json}" format *)
-let extract_json body =
-  match String.split_on_char '-' body with
-  | _ ->
-    (* Find the first '{' and parse from there *)
-    let len = String.length body in
-    let rec find_brace i =
-      if i >= len then body
-      else if body.[i] = '{' then String.sub body i (len - i)
-      else find_brace (i + 1)
-    in
-    Yojson.Safe.from_string (find_brace 0)
+(** Parse JSON response body *)
+let extract_json body = Yojson.Safe.from_string body
 
 (* Run a test function inside Eio runtime *)
 let with_eio f () =


### PR DESCRIPTION
## Summary

- Notification handler가 `"Pending notifications: 0\n---\n{\"count\":0}"` 혼합 형식 반환
- 테스트의 `extract_json`이 CI(Linux/io_uring)에서 `{` 검색 실패 → 11개 테스트 실패
- 3개 handler 모두 순수 JSON 반환으로 전환
- `extract_json` → `Yojson.Safe.from_string` 직접 호출

## Test plan
- [x] `dune build` 성공
- [x] notification 15/15 tests pass (로컬)
- [ ] CI green (Linux io_uring 환경에서 확인 필요)

Generated with [Claude Code](https://claude.com/claude-code)