### PR TITLE
refactor: decouple Room/Backend from Eio_context and Env_config (Phase 3)

### DIFF
--- a/lib/backend_pg.ml
+++ b/lib/backend_pg.ml
@@ -21,6 +21,7 @@ open Backend_core
 type t = {
   pool: (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t;
   namespace: string;
+  clock: float Eio.Time.clock_ty Eio.Resource.t;
   _sw: Eio.Switch.t;  (* Keep switch alive for pool lifetime *)
 }
 
@@ -228,7 +229,7 @@ let create_eio ~sw ~env (cfg : config) : (t, error) result =
           ) pool in
           (match init_result with
            | Error err -> Error (caqti_error_to_masc err)
-           | Ok () -> Ok { pool; namespace = cfg.cluster_name; _sw = sw })
+           | Ok () -> Ok { pool; namespace = cfg.cluster_name; clock = env#clock; _sw = sw })
 
 (** Lightweight pool creation for use in a different Eio domain.
     Skips schema initialization (assumed already done by the main pool).
@@ -244,7 +245,7 @@ let[@warning "-32"] create_eio_readonly ~sw ~env (cfg : config) : (t, error) res
       match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
       | Error err -> Error (caqti_error_to_masc err)
       | Ok pool ->
-          Ok { pool; namespace = cfg.cluster_name; _sw = sw }
+          Ok { pool; namespace = cfg.cluster_name; clock = env#clock; _sw = sw }
 
 let close _t = ()
 
@@ -339,8 +340,7 @@ let acquire_lock t ~key ~ttl_seconds ~owner =
   (* Clean up expired locks with Eio cooperative timeout.
      If PG is saturated, cleanup times out after 2s instead of blocking. *)
   (try
-     let clock = Eio_context.get_clock () in
-     Eio.Time.with_timeout_exn clock cleanup_timeout_sec (fun () ->
+     Eio.Time.with_timeout_exn t.clock cleanup_timeout_sec (fun () ->
        match Caqti_eio.Pool.use (fun conn ->
          let module C = (val conn : Caqti_eio.CONNECTION) in
          C.exec cleanup_expired_q ()

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -44,7 +44,7 @@ let load room_path =
 (** Save config to file *)
 let save room_path config =
   let path = config_path room_path in
-  Room_utils.mkdir_p (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let json = to_json config in
   let content = Yojson.Safe.pretty_to_string json in
   Fs_compat.save_file path content

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -124,8 +124,13 @@ let heartbeat config ~agent_name =
   end else
     Printf.sprintf "⚠ Agent %s not found" agent_name
 
-(** Cleanup zombie agents - removes stale agents *)
-let cleanup_zombies config =
+(** Cleanup zombie agents - removes stale agents.
+    [keeper_threshold_sec] and [agent_threshold_sec] control the inactivity
+    window before an agent is considered a zombie. *)
+let cleanup_zombies
+    ?(keeper_threshold_sec = Env_config.Zombie.keeper_threshold_seconds)
+    ?(agent_threshold_sec = Env_config.Zombie.threshold_seconds)
+    config =
   ensure_initialized config;
 
   (* Single path: agents_dir derives from config.scope *)
@@ -148,8 +153,8 @@ let cleanup_zombies config =
             when (not (List.exists (fun (n, _) -> n = agent.name) !zombie_entries)) &&
                  (let threshold =
                     if Resilience.Zombie.is_keeper ~name:agent.name ~agent_type:agent.agent_type
-                    then Env_config.Zombie.keeper_threshold_seconds
-                    else Env_config.Zombie.threshold_seconds
+                    then keeper_threshold_sec
+                    else agent_threshold_sec
                   in
                   Resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
               zombie_entries := (agent.name, path) :: !zombie_entries

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -32,12 +32,9 @@ let with_scope config scope = { config with scope }
     Constructs [Caqti_eio.stdenv] from [Eio_context] globals (net/clock
     are cross-domain safe, only Switch is domain-bound).
     Returns [None] on failure. *)
-let with_domain_local_pg_backend ~sw config =
+let with_domain_local_pg_backend ~sw ~net ~clock ~mono_clock config =
   match config.backend with
   | PostgresNative _ ->
-    let net = Eio_context.get_net () in
-    let clock = Eio_context.get_clock () in
-    let mono_clock = Eio_context.get_mono_clock () in
     let env : Caqti_eio.stdenv =
       object
         method net = (net :> [`Generic] Eio.Net.ty Eio.Resource.t)

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -296,6 +296,7 @@ let default_model_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec:_ ~max_cha
 let walph_loop config ~net:_net ~clock ~agent_name
     ?(preset="drain") ?(max_iterations=10) ?target
     ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
+    ?(default_model=Env_config.Glm.default_model)
     ?(model_dispatch=default_model_dispatch) () =
   Room.ensure_initialized config;
 
@@ -491,7 +492,7 @@ let walph_loop config ~net:_net ~clock ~agent_name
 	                        try
 	                          let response = model_dispatch
 	                            ~tool_name:"glm"
-	                            ~model:Env_config.Glm.default_model
+	                            ~model:default_model
 	                            ~prompt:goal
 	                            ~timeout_sec:60
 	                            ~max_chars:4000

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -35,7 +35,7 @@ let _execution_json_ref : Yojson.Safe.t ref =
     is available, each refresh runs in a pool domain with a domain-local
     Caqti pool (the main domain's Caqti pool is domain-bound due to
     Switch capture in release).  Falls back to in-domain compute. *)
-let start_execution_refresh_loop ~state ~sw ~clock =
+let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
   let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let compute () =
@@ -43,7 +43,7 @@ let start_execution_refresh_loop ~state ~sw ~clock =
     | Some pool ->
       Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
         Eio.Switch.run @@ fun pool_sw ->
-        match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw room_config with
+        match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw ~net ~clock ~mono_clock room_config with
         | Some domain_config ->
           Dashboard_execution.json ~light:true ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ()
         | None ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -400,7 +400,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let exec_pool = Eio.Executor_pool.create ~sw ~domain_count:2 domain_mgr in
       Server_dashboard_http.set_executor_pool exec_pool;
       Log.Server.info "Executor_pool created (2 domains) for dashboard";
-      Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock;
+      Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_refresh_loop ~state ~sw ~clock;
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;


### PR DESCRIPTION
## Summary

Room+Backend sub-library 추출(Phase 4)을 위한 선행 작업.
6개 cross-module 의존을 매개변수 주입으로 제거:

1. `backend_pg.ml` — clock을 `t` 레코드에 저장, `Eio_context.get_clock()` 제거
2. `room_utils_backend_setup.ml` — `~net ~clock ~mono_clock` 매개변수로 전환
3. `config.ml` — `Room_utils.mkdir_p` → `Fs_compat.mkdir_p` (이미 sub-library)
4. `room_gc.ml` — `Env_config.Zombie.*` → optional 매개변수
5. `room_walph_eio.ml` — `Env_config.Glm.default_model` → `~default_model` 매개변수

## Why

이전 세션에서 가정한 순환 의존(Room→Backend→Eio_context→Config→Room_utils→Room)은
실제로 순환이 아닌 비순환 포레스트였음. 6개 지점을 매개변수 주입으로 끊으면
Room+Backend를 독립 sub-library로 추출 가능.

## Impact

- 7 files, +20/-17 lines
- 모든 기본값 optional param으로 보존 — 동작 변경 없음
- Phase 4(masc_room 추출)의 선행 조건 충족

## Test plan

- [x] `dune build --root .` 성공
- [ ] `make test` — CI에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)