### PR TITLE
feat: auto-prune old JSONL day-files on server startup

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -65,6 +65,36 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
    | exn ->
      Log.Misc.error "tool registry warm-up failed: %s"
        (Printexc.to_string exn));
+  (* Prune old date-split JSONL files on startup (default: 30 days).
+     Iterates known store directories and deletes day-files exceeding retention. *)
+  (try
+     let days =
+       Safe_ops.get_env_int_logged "MASC_JSONL_RETENTION_DAYS" ~default:30
+     in
+     let masc = Filename.concat state.room_config.base_path ".masc" in
+     let prune_dir dir =
+       if Sys.file_exists dir then
+         Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
+       else 0
+     in
+     let total =
+       prune_dir (Filename.concat masc "audit")
+       + prune_dir (Filename.concat masc "telemetry")
+       + prune_dir (Filename.concat (Filename.concat masc "governance") "judgments")
+       + (let keepers = Filename.concat masc "perpetual-keepers" in
+          if not (Sys.file_exists keepers) then 0
+          else
+            Array.fold_left (fun acc name ->
+              acc + prune_dir (Filename.concat (Filename.concat keepers name) "metrics")
+            ) 0 (Sys.readdir keepers))
+     in
+     if total > 0 then
+       Log.Misc.info "startup prune: deleted %d old JSONL day-files (retention=%dd)"
+         total days
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn));
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =


### PR DESCRIPTION
## Summary
- 서버 시작 시 date-split JSONL 저장소 4종(audit, telemetry, judgments, keeper metrics)의 오래된 day-file을 자동 정리
- 기본 보관 기간 30일, `MASC_JSONL_RETENTION_DAYS` 환경변수로 조정 가능
- `bootstrap_server_state`에 30줄 추가. 기존 `Dated_jsonl.prune` API 재사용

## Why
`Dated_jsonl.prune`이 존재하지만 호출 경로가 수동 `masc_housekeep_prune` 도구뿐이었음. 자동 정리 없이 day-file이 무한 누적되는 구조적 문제.

## Test plan
- [x] `dune build` 통과
- [x] `test_dated_jsonl.exe` 11/11 통과
- [ ] 서버 시작 후 로그에 `startup prune: deleted N old JSONL day-files` 확인
- [ ] 30일 이전 day-file이 삭제되고 최근 데이터 보존 확인