### PR TITLE
fix(dashboard): add 30s render timeout to prevent multi-hour hangs

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -89,11 +89,11 @@ let message_json (message : Types.message) =
     ]
 
 
-let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
-  let effective_actor = Option.value ~default:"dashboard" actor in
-  match dashboard_fixture_name ?fixture () with
-  | Some "execution_smoke" -> execution_smoke_fixture_json ()
-  | _ ->
+(** Maximum wall-clock time for a single dashboard render.
+    Prevents unbounded waits when PG connections drop mid-render. *)
+let render_timeout_s = 30.0
+
+let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =
         {
           config;
@@ -284,3 +284,23 @@ let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
           (base_fields @ task_fields @ [
             ("messages", `List (List.map message_json messages));
           ])
+
+let json ?actor ?fixture ?(light = true) ~config ~sw ~clock ~proc_mgr () =
+  let effective_actor = Option.value ~default:"dashboard" actor in
+  match dashboard_fixture_name ?fixture () with
+  | Some "execution_smoke" -> execution_smoke_fixture_json ()
+  | _ ->
+    (* Guard: abort render if it exceeds render_timeout_s.
+       PG connection failures during render can block fibers for hours
+       (observed: 11,018s render on 2026-03-21). *)
+    match Eio.Time.with_timeout clock render_timeout_s (fun () ->
+      Ok (json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr ())
+    ) with
+    | Ok result -> result
+    | Error `Timeout ->
+      Log.Dashboard.error "[dashboard_execution] render timed out after %.0fs" render_timeout_s;
+      `Assoc [
+        ("generated_at", `String (Types.now_iso ()));
+        ("error", `String (Printf.sprintf "render timed out after %.0fs" render_timeout_s));
+        ("status", room_status_json config);
+      ]


### PR DESCRIPTION
## Summary
Dashboard render blocked for **11,018 seconds (3 hours)** on 2026-03-21 when Supabase PgBouncer connections dropped.

Added `Eio.Time.with_timeout` (30s) around the entire render path. On timeout, returns JSON error instead of hanging forever.

## Root Cause
PG queries inside render path (snapshot, digest, session load) hung when connections dropped mid-query. Eio cooperative scheduling meant no timeout — the fiber just waited indefinitely.

## Log evidence
```
2026-03-22 01:41:34 WARN Dashboard [dashboard_execution] slow render:
  total=11029197ms sessions=2112ms snapshot=8229ms render=11018857ms
```

## Test plan
- [x] `dune build` passes
- [ ] `dune runtest` passes
- [ ] Verify timeout fires correctly (simulate PG drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)