### PR TITLE
fix: guard keeper empty replies

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -20,6 +20,17 @@ type run_result = {
   tools_used : string list;
 }
 
+let normalize_response_text ~(text : string) ~(tool_names : string list) :
+    (string, string) result =
+  if String.trim text <> "" then Ok text
+  else
+    match tool_names with
+    | [] -> Error "keeper turn completed with no textual reply"
+    | _ ->
+        Ok
+          (Printf.sprintf "Completed without a textual reply. Tools used: %s."
+             (String.concat ", " tool_names))
+
 (** Run a single keeper turn via OAS Agent.run().
 
     Loads checkpoint, creates working context with the base keeper system
@@ -170,14 +181,17 @@ let run_turn
         result.response.content
     in
     let usage = Keeper_exec_context.usage_of_response result.response in
-    let assistant_msg = Agent_sdk.Types.assistant_msg text in
-    Keeper_exec_context.persist_message session assistant_msg;
-    ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
-    Ok {
-      response_text = text;
-      model_used = model;
-      turn_count = result.turns;
-      tool_calls_made = List.length tool_names;
-      usage;
-      tools_used = tool_names;
-    }
+    (match normalize_response_text ~text ~tool_names with
+     | Error e -> Error e
+     | Ok response_text ->
+         let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
+         Keeper_exec_context.persist_message session assistant_msg;
+         ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
+         Ok {
+           response_text;
+           model_used = model;
+           turn_count = result.turns;
+           tool_calls_made = List.length tool_names;
+           usage;
+           tools_used = tool_names;
+         })

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3,6 +3,7 @@ open Alcotest
 module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
+module KAR = Masc_mcp.Keeper_agent_run
 (* Keeper_autonomy module removed; autonomy_level is now a plain string *)
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
@@ -333,6 +334,49 @@ let test_metrics_mixed_response () =
        with Not_found -> false
      in found)
 
+let test_normalize_response_text_passthrough () =
+  match KAR.normalize_response_text ~text:"All good." ~tool_names:[] with
+  | Ok text -> check string "keeps text" "All good." text
+  | Error e -> fail ("unexpected error: " ^ e)
+
+let test_normalize_response_text_tool_only_synthesizes () =
+  match KAR.normalize_response_text
+          ~text:""
+          ~tool_names:["keeper_board_post"; "keeper_board_comment"]
+  with
+  | Ok text ->
+      check bool "mentions no textual reply" true
+        (String.length text > 0
+         && String.contains text 'T');
+      check bool "mentions first tool" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "keeper_board_post")
+                  text 0);
+             true
+           with Not_found -> false
+         in
+         found)
+  | Error e -> fail ("unexpected error: " ^ e)
+
+let test_normalize_response_text_empty_without_tools_errors () =
+  match KAR.normalize_response_text ~text:"" ~tool_names:[] with
+  | Ok text -> fail ("expected error, got: " ^ text)
+  | Error e ->
+      check bool "error mentions textual reply" true
+        (let found =
+           try
+             ignore
+               (Str.search_forward
+                  (Str.regexp_string "no textual reply")
+                  e 0);
+             true
+           with Not_found -> false
+         in
+         found)
+
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -379,5 +423,11 @@ let () =
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
           test_case "mixed response" `Quick test_metrics_mixed_response;
+          test_case "normalize passthrough" `Quick
+            test_normalize_response_text_passthrough;
+          test_case "normalize tool only synthesizes" `Quick
+            test_normalize_response_text_tool_only_synthesizes;
+          test_case "normalize empty without tools errors" `Quick
+            test_normalize_response_text_empty_without_tools_errors;
         ] );
     ]


### PR DESCRIPTION
## Summary
- synthesize a fallback reply when keeper turns finish with tool calls but no textual response
- fail fast when a keeper turn completes with neither text nor tool output
- add regression coverage for passthrough, tool-only synthesis, and empty-without-tools error cases

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-msg-empty-reply-2194 test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `env XDG_CONFIG_HOME=/tmp/codex-dune-clean dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-msg-empty-reply-2194`
- `git diff --check`

## Issue
- fixes #2194