### PR TITLE
fix(autoresearch): 6 quality fixes from post-merge review

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -29,7 +29,8 @@ type finding = {
 let confidence_to_string = function
   | High -> "high" | Medium -> "medium" | Low -> "low"
 
-let confidence_of_string = function
+let confidence_of_string s =
+  match String.lowercase_ascii (String.trim s) with
   | "high" -> High | "medium" -> Medium | "low" -> Low
   | _ -> Medium
 
@@ -101,36 +102,42 @@ let load_all_findings () : finding list =
   let path = findings_file () in
   if not (Sys.file_exists path) then []
   else
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-      let findings = ref [] in
-      (try while true do
-        let line = input_line ic in
-        if String.trim line <> "" then
-          match Yojson.Safe.from_string line |> finding_of_yojson with
-          | Ok f -> findings := f :: !findings
-          | Error _ -> ()
-      done with End_of_file -> ());
-      List.rev !findings)
+    Fs_compat.load_jsonl path
+    |> List.filter_map (fun json ->
+         match finding_of_yojson json with
+         | Ok f -> Some f
+         | Error msg ->
+           Log.Keeper.warn "Skipping malformed finding: %s" msg;
+           None)
+
+let contains_ci ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec scan i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+
+let rec take n = function
+  | [] -> []
+  | _ when n <= 0 -> []
+  | x :: rest -> x :: take (n - 1) rest
 
 let search_findings ~query ?(limit=10) () : finding list =
   let query_lower = String.lowercase_ascii query in
   load_all_findings ()
+  |> List.rev  (* most recent first — load_all returns oldest first *)
   |> List.filter (fun f ->
     let haystack = String.lowercase_ascii
       (f.goal ^ " " ^ f.hypothesis ^ " " ^ f.evidence ^ " " ^
        f.conclusion ^ " " ^ String.concat " " f.tags) in
-    let rec find_sub i =
-      if i + String.length query_lower > String.length haystack then false
-      else if String.sub haystack i (String.length query_lower) = query_lower then true
-      else find_sub (i + 1)
-    in
-    find_sub 0)
-  |> List.rev  (* most recent first *)
-  |> fun results ->
-    if List.length results > limit then
-      List.filteri (fun i _ -> i < limit) results
-    else results
+    contains_ci ~needle:query_lower haystack)
+  |> take limit
 
 (** {1 GraphQL Sync (best-effort)} *)
 

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -51,6 +51,9 @@ let keeper_autoresearch_tool_names =
   Tool_shard.autoresearch_keeper_tools
   |> List.map (fun (t : Types.tool_schema) -> t.name)
 
+let is_research_profile (meta : keeper_meta) =
+  meta.soul_profile = "research"
+
 let keeper_coding_tool_names = Tool_code_write.tool_names
 
 let dedupe_tool_names names =
@@ -71,7 +74,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
       else with_voice
     in
     let with_research =
-      if meta.soul_profile = "research" then
+      if is_research_profile meta then
         keeper_autoresearch_tool_names @ with_shell
       else with_shell
     in
@@ -84,7 +87,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
   else
     let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
     let with_research =
-      if meta.soul_profile = "research" then
+      if is_research_profile meta then
         keeper_autoresearch_tool_names @ base_names
       else base_names
     in
@@ -100,7 +103,7 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
   else
     let base = keeper_model_tools in
     let with_research =
-      if meta.soul_profile = "research" then
+      if is_research_profile meta then
         base @ Tool_shard.autoresearch_keeper_tools
       else base
     in

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -718,7 +718,9 @@ let handle_record_finding ctx args =
     let cycle_end = Safe_ops.json_int_opt "cycle_end" args in
     let cycle_range = match cycle_start, cycle_end with
       | Some a, Some b -> Some (a, b)
-      | _ -> None
+      | Some a, None -> Some (a, a)  (* single cycle *)
+      | None, Some b -> Some (b, b)
+      | None, None -> None
     in
     let finding : Autoresearch_knowledge.finding = {
       id = Autoresearch_knowledge.generate_finding_id ();


### PR DESCRIPTION
## Summary

Post-merge code review에서 발견된 Critical 2 + Important 2 + Medium 2 수정.

- **Critical**: blocking `open_in` → `Fs_compat.load_jsonl` (Eio cooperative scheduling 호환)
- **Critical**: `List.rev` 이중 적용으로 recency 역전 → 올바른 순서 + `take` 함수
- **Important**: `confidence_of_string` 대소문자 미구분 → `String.lowercase_ascii`
- **Important**: 3곳 인라인 `= "research"` → `is_research_profile` 공유 predicate
- **Medium**: partial `cycle_start` 입력 시 silent drop → `(a, a)` 단일 cycle 처리
- **Medium**: 파싱 실패 finding silent discard → `Log.Keeper.warn`

## Test plan

- [x] `test_tool_shard_coverage.exe` 42/42
- [x] `test_keeper_tools_oas.exe` 10/10
- [x] `test_autoresearch_knowledge.exe` 3/3
- [x] `dune build --root .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)