### PR TITLE
fix(dashboard): offload parameterized projection compute

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -18,12 +18,6 @@ let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =
       ("tool_usage", Tool_unified.summary_report ());
     ]
 
-(** Executor pool for offloading heavy dashboard compute to a separate
-    OS domain, bypassing Eio cooperative-scheduling starvation.
-    Set via [set_executor_pool] at server startup. *)
-let _executor_pool : Eio.Executor_pool.t option ref = ref None
-let set_executor_pool pool = _executor_pool := Some pool
-
 let _execution_json_ref : Yojson.Safe.t ref =
   ref (`Assoc [
     ("status", `String "initializing");
@@ -38,18 +32,12 @@ let _execution_json_ref : Yojson.Safe.t ref =
 let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
   let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
+  ignore net;
+  ignore mono_clock;
   let compute () =
-    match !_executor_pool with
-    | Some pool ->
-      Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
-        Eio.Switch.run @@ fun pool_sw ->
-        match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw ~net ~clock ~mono_clock room_config with
-        | Some domain_config ->
-          Dashboard_execution.json ~light:true ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ()
-        | None ->
-          failwith "domain-local PG backend creation failed; skipping pool refresh")
-    | None ->
-      Dashboard_execution.json ~light:true ~config:room_config ~sw ~clock ~proc_mgr ()
+    run_dashboard_compute ~sw ~clock ~config:room_config
+      (fun ~config ~sw ->
+        Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ())
   in
   Proactive_refresh.start ~sw ~clock
     ~config:(Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0)
@@ -76,9 +64,12 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
     in
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
       ~clock ~timeout_sec:120.0 (fun () ->
-      Dashboard_execution.json ?actor ?fixture ~light
-        ~config:state.Mcp_server.room_config ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ())
+      run_dashboard_compute ~sw ~clock
+        ~config:state.Mcp_server.room_config
+        (fun ~config ~sw ->
+          Dashboard_execution.json ?actor ?fixture ~light
+            ~config ~sw ~clock
+            ~proc_mgr:state.Mcp_server.proc_mgr ()))
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -12,21 +12,26 @@ let set_executor_pool pool = _executor_pool := Some pool
 
 let run_dashboard_compute ~sw ~clock ~(config : Room.config) compute =
   let fallback () = compute ~config ~sw in
+  let run_in_pool pool_sw =
+    match config.backend_config.Backend.backend_type with
+    | Backend.PostgresNative ->
+        let net = Eio_context.get_net () in
+        let mono_clock = Eio_context.get_mono_clock () in
+        (match
+           Room_utils_backend_setup.with_domain_local_pg_backend
+             ~sw:pool_sw ~net ~clock ~mono_clock config
+         with
+         | Some domain_config -> `Done (compute ~config:domain_config ~sw:pool_sw)
+         | None -> `Fallback)
+    | Backend.Memory | Backend.FileSystem ->
+        `Done (compute ~config ~sw:pool_sw)
+  in
   match !_executor_pool with
   | Some pool ->
       (try
-         let net = Eio_context.get_net () in
-         let mono_clock = Eio_context.get_mono_clock () in
          match
            Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
-             Eio.Switch.run @@ fun pool_sw ->
-             match
-               Room_utils_backend_setup.with_domain_local_pg_backend
-                 ~sw:pool_sw ~net ~clock ~mono_clock config
-             with
-             | Some domain_config ->
-                 `Done (compute ~config:domain_config ~sw:pool_sw)
-             | None -> `Fallback)
+             Eio.Switch.run run_in_pool)
          with
          | `Done value -> value
          | `Fallback ->

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -3,6 +3,44 @@ open Types
 open Server_utils
 open Server_auth
 
+(** Executor pool for CPU-heavy dashboard compute.  Parameterized dashboard
+    requests can otherwise monopolize the main Eio domain long enough to
+    starve unrelated MCP tool calls. *)
+let _executor_pool : Eio.Executor_pool.t option ref = ref None
+
+let set_executor_pool pool = _executor_pool := Some pool
+
+let run_dashboard_compute ~sw ~clock ~(config : Room.config) compute =
+  let fallback () = compute ~config ~sw in
+  match !_executor_pool with
+  | Some pool ->
+      (try
+         let net = Eio_context.get_net () in
+         let mono_clock = Eio_context.get_mono_clock () in
+         match
+           Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
+             Eio.Switch.run @@ fun pool_sw ->
+             match
+               Room_utils_backend_setup.with_domain_local_pg_backend
+                 ~sw:pool_sw ~net ~clock ~mono_clock config
+             with
+             | Some domain_config ->
+                 `Done (compute ~config:domain_config ~sw:pool_sw)
+             | None -> `Fallback)
+         with
+         | `Done value -> value
+         | `Fallback ->
+             Log.Dashboard.warn
+               "dashboard offload fallback: domain-local backend unavailable";
+             fallback ()
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Dashboard.warn "dashboard offload failed, using inline compute: %s"
+             (Printexc.to_string exn);
+           fallback ())
+  | None -> fallback ()
+
 (* ================================================================ *)
 (* Dashboard Data (Batch API)                                       *)
 (* ================================================================ *)
@@ -323,7 +361,8 @@ let start_mission_refresh_loop ~state ~sw ~clock =
   let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let compute () =
-    Dashboard_mission.json ~config:room_config ~sw ~clock ~proc_mgr ()
+    run_dashboard_compute ~sw ~clock ~config:room_config
+      (fun ~config ~sw -> Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ())
   in
   Proactive_refresh.start ~sw ~clock
     ~config:{ (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0)
@@ -396,9 +435,12 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
         ~clock ~timeout_sec:120.0 (fun () ->
-        Dashboard_mission.json ?actor
-          ~config:state.Mcp_server.room_config ~sw ~clock
-          ~proc_mgr:state.Mcp_server.proc_mgr ())
+        run_dashboard_compute ~sw ~clock
+          ~config:state.Mcp_server.room_config
+          (fun ~config ~sw ->
+            Dashboard_mission.json ?actor
+              ~config ~sw ~clock
+              ~proc_mgr:state.Mcp_server.proc_mgr ()))
   in
   match mode with
   | Some "snapshot" -> mission_snapshot_of_full full_json

--- a/test/dune
+++ b/test/dune
@@ -123,6 +123,11 @@
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
+ (name test_dashboard_http_core)
+ (modules test_dashboard_http_core)
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
+
+(test
  (name test_dashboard_tools)
  (modules test_dashboard_tools)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -216,6 +216,29 @@ let test_keeper_oas_cleanup_contracts () =
     (file_contains_pattern "lib/tool_compact.ml"
        "OAS-backed compaction pipeline")
 
+let test_dashboard_executor_pool_contracts () =
+  check bool "dashboard core defines executor pool helper" true
+    (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+       "let run_dashboard_compute");
+  check bool "dashboard core submits compute to executor pool" true
+    (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+       "Eio.Executor_pool.submit_exn");
+  check bool "mission refresh loop uses dashboard compute helper" true
+    (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+       "run_dashboard_compute ~sw ~clock ~config:room_config");
+  check bool "mission actor path uses dashboard compute helper" true
+    (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
+       "run_dashboard_compute ~sw ~clock");
+  check bool "execution refresh loop uses dashboard compute helper" true
+    (file_contains_pattern "lib/server/server_dashboard_http.ml"
+       "run_dashboard_compute ~sw ~clock ~config:room_config");
+  check bool "execution parameterized path uses dashboard compute helper" true
+    (file_contains_pattern "lib/server/server_dashboard_http.ml"
+       "run_dashboard_compute ~sw ~clock");
+  check bool "server bootstrap wires executor pool into dashboard" true
+    (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+       "Server_dashboard_http.set_executor_pool exec_pool")
+
 let () =
   run "ci_hardening_source"
     [
@@ -228,5 +251,7 @@ let () =
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
+           test_case "dashboard executor pool contracts" `Quick
+             test_dashboard_executor_pool_contracts;
          ]);
     ]

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1,0 +1,87 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_dashboard_http_core" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
+let with_test_env f =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      with_env "MASC_STORAGE_TYPE" "filesystem" @@ fun () ->
+      with_env "MASC_POSTGRES_URL" "" @@ fun () ->
+      with_env "DATABASE_URL" "" @@ fun () ->
+      with_env "SUPABASE_DB_URL" "" @@ fun () ->
+      with_env "SB_PG_URL" "" @@ fun () ->
+      Eio_main.run @@ fun env ->
+      let config = Lib.Room_utils.default_config dir in
+      Eio.Switch.run @@ fun sw ->
+      f ~env ~sw ~config)
+
+let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let caller_domain = Domain.self () in
+  let result_domain =
+    Lib.Server_dashboard_http_core.run_dashboard_compute
+      ~sw
+      ~clock:(Eio.Stdenv.clock env)
+      ~config
+      (fun ~config:_ ~sw:_ -> Domain.self ())
+  in
+  check bool "no pool keeps compute on caller domain" true
+    (result_domain = caller_domain)
+
+let test_run_dashboard_compute_with_pool_uses_executor_domain () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let exec_pool =
+    Eio.Executor_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+  in
+  Lib.Server_dashboard_http_core.set_executor_pool exec_pool;
+  let caller_domain = Domain.self () in
+  let result_domain =
+    Lib.Server_dashboard_http_core.run_dashboard_compute
+      ~sw
+      ~clock:(Eio.Stdenv.clock env)
+      ~config
+      (fun ~config:_ ~sw:_ -> Domain.self ())
+  in
+  check bool "executor pool runs compute off the caller domain" true
+    (result_domain <> caller_domain)
+
+let () =
+  run "dashboard_http_core"
+    [
+      ( "executor_pool",
+        [
+          test_case "no pool stays on caller domain" `Quick
+            test_run_dashboard_compute_without_pool_stays_in_current_domain;
+          test_case "pool uses executor domain" `Quick
+            test_run_dashboard_compute_with_pool_uses_executor_domain;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- move parameterized dashboard execution and mission compute onto the executor pool
- keep proactive refresh paths on the same offload helper so heavy dashboard renders do not starve MCP tool calls
- fall back to inline compute when pool offload cannot create a domain-local backend

## Verification
- env XDG_CONFIG_HOME=/tmp/codex-empty dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/plan-dashboard-timeout
- ./_build/default/test/test_tool_plan_coverage.exe
- ./_build/default/test/test_dashboard_execution.exe

## Context
This targets the observed `masc_plan_*` timeouts where dashboard eager/actor-specific projections were occupying the main Eio domain.