### PR TITLE
chore: raise keeper max_turns to effectively unlimited (100 default, 10000 ceiling)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -56,7 +56,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 10)
+    ?(max_turns : int = 100)
     ?guardrails
     ?(temperature : float = 0.3)
     ?(max_tokens : int = 4096)

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -558,6 +558,6 @@ let keeper_unified_max_tokens () : int =
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:10
+    ~default:100
     ~min_v:1
-    ~max_v:30
+    ~max_v:10000


### PR DESCRIPTION
Default 10→100, max 30→10000. Override: MASC_KEEPER_UNIFIED_MAX_TURNS env var.