### PR TITLE
perf(cp): add mtime-based cache to build_snapshot_state

### DIFF
--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -74,7 +74,27 @@ let topology_summary_to_json (s : topology_summary) =
       ("operation_status_counts", operation_status_counts_to_json s.operation_status_counts);
     ]
 
+(* mtime-based cache for build_snapshot_state.
+   CP files change infrequently; avoid re-reading + re-parsing on every call. *)
+let _cp_state_cache : (float * snapshot_state) option ref = ref None
+
+let cp_files_max_mtime config =
+  let paths = [
+    units_path config; operations_path config;
+    intents_path config; detachments_path config;
+    decisions_path config;
+  ] in
+  List.fold_left (fun acc path ->
+    try max acc (Unix.stat path).Unix.st_mtime
+    with Unix.Unix_error _ -> acc) 0.0 paths
+
 let build_snapshot_state ?sessions config =
+  let current_mtime = cp_files_max_mtime config in
+  (* Cache hit: same mtime and no explicit sessions override *)
+  (match sessions, !_cp_state_cache with
+   | None, Some (cached_mtime, cached_state) when cached_mtime = current_mtime ->
+       cached_state
+   | _ ->
   let agents, managed_units, units, source = topology_units config in
   let sessions =
     match sessions with
@@ -89,7 +109,7 @@ let build_snapshot_state ?sessions config =
   let status_map = agent_status_map agents in
   let child_map = children_map units in
   let unit_lookup = unit_map units in
-  {
+  let state = {
     config;
     agents;
     managed_units;
@@ -104,7 +124,9 @@ let build_snapshot_state ?sessions config =
     status_map;
     child_map;
     unit_lookup;
-  }
+  } in
+  _cp_state_cache := Some (current_mtime, state);
+  state)
 
 let topology_json_from_state (state : snapshot_state) =
   let agents = state.agents in


### PR DESCRIPTION
## Summary

- `command_plane_json`이 dashboard snapshot의 85-93% 비용 (1-7초)
- `build_snapshot_state`가 매 호출마다 5개 JSON 파일(54KB) 동기 읽기 + 파싱 + 세션 매칭
- 파일 mtime 기반 캐시 추가: mtime이 안 바뀌면 이전 결과 재사용
- 명시적 `?sessions` 전달 시 캐시 바이패스

### 기대 효과
- mission refresh (120초 간격) 내에서 여러 번 호출되는 snapshot_json이 캐시 히트
- CP 파일이 수정되지 않는 idle 기간에 즉시 응답

## Test plan
- [x] `dune build` 성공
- [ ] CI green
- [ ] 서버 재시작 후 `[snapshot_json] command_plane_json` 로그에서 latency 감소 확인

Generated with [Claude Code](https://claude.com/claude-code)