### PR TITLE
refactor: decouple Room sub-modules from upper-layer domains (Phase 4A)

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -16,12 +16,12 @@ include Cp_lifecycle_policy
    Room_gc cannot directly reference Cp_cleanup (which depends on Room via
    Cp_io -> Cp_paths -> Room), so we use a ref-based callback. *)
 let () =
-  Room_gc.cp_cleanup_connected := true;
-  Room_gc.cp_cleanup_fn :=
+  Room_hooks.cp_cleanup_connected := true;
+  Room_hooks.cp_cleanup_fn :=
     (fun config ->
       let r = Cp_cleanup.cleanup_cp config in
       {
-        Room_gc.dead_units_removed = r.Cp_cleanup.dead_units_removed;
+        Room_hooks.dead_units_removed = r.Cp_cleanup.dead_units_removed;
         orphaned_units_removed = r.Cp_cleanup.orphaned_units_removed;
         operations_archived = r.Cp_cleanup.operations_archived;
         detachments_removed = r.Cp_cleanup.detachments_removed;

--- a/lib/dune
+++ b/lib/dune
@@ -275,6 +275,7 @@
    room_eio
    room_agent
    room_gc
+   room_hooks
    room_init
    room_lifecycle
    room_query

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -46,10 +46,77 @@ include Room_worktree
 
 (* Heartbeat & GC *)
 include Room_gc
-(* Connect the force_release_task callback for zombie cleanup *)
-let () = Room_gc.force_release_task_fn :=
+
+(* ============================================ *)
+(* Wire Room_hooks callbacks                    *)
+(* ============================================ *)
+
+(* force_release_task — zombie cleanup needs task management logic *)
+let () = Room_hooks.force_release_task_fn :=
   (fun config ~agent_name ~task_id () ->
     force_release_task_r config ~agent_name ~task_id ())
+
+(* Activity graph emit — wraps Activity_graph for room sub-modules *)
+let () = Room_hooks.activity_emit_fn :=
+  (fun config ~room_id ~actor ?subject ~kind ~payload ~tags () ->
+    ignore (Activity_graph.emit config ~room_id
+      ~actor:(Activity_graph.entity ~kind:actor.Room_hooks.kind actor.id)
+      ?subject:(Option.map (fun (s : Room_hooks.activity_entity) ->
+        Activity_graph.entity ~kind:s.kind s.id) subject)
+      ~kind ~payload ~tags ()))
+
+(* Agent economy earn — wraps Agent_economy for task completion credits *)
+let () = Room_hooks.agent_economy_earn_fn :=
+  (fun ~base_path ~agent_name ~reason ->
+    match Agent_economy.earn ~base_path ~agent_name
+      ~kind:Earn_task_done ~reason () with
+    | Ok _bal -> ()
+    | Error msg -> Log.Misc.error "task earn failed: %s" msg)
+
+(* Relation materializer — agent leave *)
+let () = Room_hooks.relation_on_leave_fn := Relation_materializer.on_agent_leave
+
+(* Relation materializer — task done *)
+let () = Room_hooks.relation_on_task_done_fn := Relation_materializer.on_task_done
+
+(* Board artifact cleanup — wraps Board_dispatch for GC *)
+let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->
+  let stale_system_daily_sec = 12.0 *. 3600.0 in
+  let board_artifact_title title =
+    let title = String.lowercase_ascii (String.trim title) in
+    String.starts_with ~prefix:"[sentinel daily]" title
+    || String.starts_with ~prefix:"[keeper daily]" title
+  in
+  let board_artifact_author author =
+    let author = String.lowercase_ascii (String.trim author) in
+    author = "auto-researcher"
+    || String.starts_with ~prefix:"qa-" author
+    || String.starts_with ~prefix:"qwen35-probe" author
+    || ((not (String.contains author ' '))
+        && String.ends_with ~suffix:"-probe" author)
+  in
+  let now = Time_compat.now () in
+  Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5200 ()
+  |> List.fold_left
+       (fun removed (post : Board.post) ->
+         let author = Board.Agent_id.to_string post.author in
+         if board_artifact_author author
+            || ((String.equal (String.lowercase_ascii author) "sentinel"
+                 || String.equal (String.lowercase_ascii author) "keeper")
+                && board_artifact_title post.title
+                && now -. post.updated_at >= stale_system_daily_sec) then
+           match Board_dispatch.delete_post
+                   ~post_id:(Board.Post_id.to_string post.id) with
+           | Ok () -> removed + 1
+           | Error _ -> removed
+         else removed)
+       0)
+
+(* Governance stale case purge — wraps Council.Governance_v2 for GC *)
+let () = Room_hooks.governance_purge_fn := (fun base_path ->
+  let test = Council.Governance_v2.purge_stale_test_cases base_path in
+  let artifact = Council.Governance_v2.purge_stale_artifact_cases base_path in
+  (test, artifact))
 
 (* Agent status, capability registration, discovery *)
 include Room_agent

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -7,80 +7,10 @@ open Types
 open Room_utils
 open Room_state
 
-(** Callback for force_release_task_r — set by Room after include.
-    This avoids a circular dependency: force_release_task_r is defined
-    in room.ml (task management section) and uses deeper task logic. *)
-let force_release_task_fn
-  : (config -> agent_name:string -> task_id:string -> unit -> string masc_result) ref
-  = ref (fun _config ~agent_name:_ ~task_id:_ () ->
-      Error (Types.TaskInvalidState "Room_gc: force_release_task_fn not connected"))
+(* Callback refs and types are now in Room_hooks. *)
 
-(** CP cleanup result type — mirrors Cp_cleanup.cleanup_result without
-    introducing a dependency on Cp_cleanup (which depends on Room). *)
-type cp_cleanup_result = {
-  dead_units_removed : int;
-  orphaned_units_removed : int;
-  operations_archived : int;
-  detachments_removed : int;
-  intents_removed : int;
-}
-
-let empty_cp_result = {
-  dead_units_removed = 0;
-  orphaned_units_removed = 0;
-  operations_archived = 0;
-  detachments_removed = 0;
-  intents_removed = 0;
-}
-
-(** Callback for CP cleanup — set by the module that connects Room_gc
-    and Cp_cleanup (e.g. command_plane_v2.ml or room.ml post-include).
-    This avoids a circular dependency: Cp_cleanup depends on Cp_io which
-    depends on Room, and Room includes Room_gc. *)
-let cp_cleanup_connected = ref false
-
-let cp_cleanup_fn
-  : (config -> cp_cleanup_result) ref
-  = ref (fun _config -> empty_cp_result)
-
-let stale_system_daily_sec = 12.0 *. 3600.0
-
-let board_artifact_title title =
-  let title = String.lowercase_ascii (String.trim title) in
-  String.starts_with ~prefix:"[sentinel daily]" title
-  || String.starts_with ~prefix:"[keeper daily]" title
-
-let board_artifact_author author =
-  let author = String.lowercase_ascii (String.trim author) in
-  author = "auto-researcher"
-  || String.starts_with ~prefix:"qa-" author
-  || String.starts_with ~prefix:"qwen35-probe" author
-  || ((not (String.contains author ' '))
-      && String.ends_with ~suffix:"-probe" author)
-
-let should_delete_board_artifact now (post : Board.post) =
-  let author = Board.Agent_id.to_string post.author in
-  board_artifact_author author
-  || ((String.equal (String.lowercase_ascii author) "sentinel"
-       || String.equal (String.lowercase_ascii author) "keeper")
-      && board_artifact_title post.title
-      && now -. post.updated_at >= stale_system_daily_sec)
-
-let cleanup_board_artifacts () =
-  let now = Time_compat.now () in
-  Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5200 ()
-  |> List.fold_left
-       (fun removed (post : Board.post) ->
-         if should_delete_board_artifact now post then
-           match
-             Board_dispatch.delete_post
-               ~post_id:(Board.Post_id.to_string post.id)
-           with
-           | Ok () -> removed + 1
-           | Error _ -> removed
-         else
-           removed)
-       0
+(* Board artifact cleanup and governance purge are now in Room_hooks callbacks.
+   The actual implementations are wired by room.ml at startup. *)
 
 
 (** Update agent heartbeat - must be called periodically.
@@ -193,7 +123,7 @@ let cleanup_zombies
         | Types.Claimed { assignee; _ }
         | Types.InProgress { assignee; _ }
           when List.exists (fun (n, _) -> n = assignee) !zombie_entries ->
-            (match !force_release_task_fn config ~agent_name:"keeper-gc" ~task_id:task.id () with
+            (match !Room_hooks.force_release_task_fn config ~agent_name:"keeper-gc" ~task_id:task.id () with
              | Ok msg -> released_tasks := (task.id, msg) :: !released_tasks
              | Error e ->
                  if not (List.mem assignee !release_failed_agents) then
@@ -460,13 +390,10 @@ let gc config ?(days=7) () =
   else
     results := "✅ No team sessions to archive" :: !results;
 
-  (* 7. Hard-delete board/governance artifacts *)
-  let board_artifact_count = cleanup_board_artifacts () in
-  let governance_test_artifact_count =
-    Council.Governance_v2.purge_stale_test_cases config.base_path
-  in
-  let governance_artifact_count =
-    Council.Governance_v2.purge_stale_artifact_cases config.base_path
+  (* 7. Hard-delete board/governance artifacts (via hooks) *)
+  let board_artifact_count = !Room_hooks.cleanup_board_artifacts_fn () in
+  let governance_test_artifact_count, governance_artifact_count =
+    !Room_hooks.governance_purge_fn config.base_path
   in
   if board_artifact_count > 0 then
     results :=
@@ -484,11 +411,11 @@ let gc config ?(days=7) () =
     results := "✅ No governance artifacts" :: !results;
 
   (* 8. CP data cleanup (dead units, stale operations, orphaned detachments) *)
-  if not !cp_cleanup_connected then
+  if not !Room_hooks.cp_cleanup_connected then
     log_event config (Printf.sprintf
       "{\"type\":\"gc_warning\",\"msg\":\"cp_cleanup_fn not connected, CP cleanup skipped\",\"ts\":\"%s\"}"
       (now_iso ()));
-  let cp_result = !cp_cleanup_fn config in
+  let cp_result = !Room_hooks.cp_cleanup_fn config in
   let cp_total =
     cp_result.dead_units_removed + cp_result.orphaned_units_removed
     + cp_result.operations_archived + cp_result.detachments_removed

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -1,0 +1,97 @@
+(** Room Hooks — Callback refs for upper-layer dependencies.
+
+    Room modules must not depend on Activity_graph, Board, Council,
+    Agent_economy, Relation_materializer, or Oas_worker directly.
+    Instead, they call these callback refs which are wired at startup
+    by room.ml (the hub module that already depends on everything).
+
+    Defaults are no-ops or error stubs. *)
+
+open Types
+
+(* ============================================ *)
+(* Types                                        *)
+(* ============================================ *)
+
+(** Activity graph entity — local mirror of Activity_graph.entity_ref
+    to avoid dependency on Activity_graph from room sub-modules. *)
+type activity_entity = { kind: string; id: string }
+
+(** CP cleanup result — mirrors Cp_cleanup.cleanup_result without
+    introducing a dependency on Cp_cleanup (which depends on Room). *)
+type cp_cleanup_result = {
+  dead_units_removed : int;
+  orphaned_units_removed : int;
+  operations_archived : int;
+  detachments_removed : int;
+  intents_removed : int;
+}
+
+let empty_cp_result = {
+  dead_units_removed = 0;
+  orphaned_units_removed = 0;
+  operations_archived = 0;
+  detachments_removed = 0;
+  intents_removed = 0;
+}
+
+(* ============================================ *)
+(* Callback refs (migrated from room_gc.ml)     *)
+(* ============================================ *)
+
+(** Force-release a task — avoids Room_gc → Room_task circular dep. *)
+let force_release_task_fn
+  : (Room_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit -> string masc_result) ref
+  = ref (fun _config ~agent_name:_ ~task_id:_ () ->
+      Error (Types.TaskInvalidState "Room_hooks: force_release_task_fn not connected"))
+
+(** CP cleanup callback — avoids Room_gc → Cp_cleanup circular dep. *)
+let cp_cleanup_connected = ref false
+
+let cp_cleanup_fn
+  : (Room_utils_backend_setup.config -> cp_cleanup_result) ref
+  = ref (fun _config -> empty_cp_result)
+
+(* ============================================ *)
+(* New callback refs (Phase 4A)                 *)
+(* ============================================ *)
+
+(** Activity graph emit — wraps Activity_graph.emit.
+    Fire-and-forget: return value is ignored by callers. *)
+let activity_emit_fn
+  : (Room_utils_backend_setup.config ->
+     room_id:string ->
+     actor:activity_entity ->
+     ?subject:activity_entity ->
+     kind:string ->
+     payload:Yojson.Safe.t ->
+     tags:string list ->
+     unit -> unit) ref
+  = ref (fun _config ~room_id:_ ~actor:_ ?subject:_ ~kind:_ ~payload:_ ~tags:_ () -> ())
+
+(** Agent economy earn — wraps Agent_economy.earn for task completion credits. *)
+let agent_economy_earn_fn
+  : (base_path:string -> agent_name:string -> reason:string -> unit) ref
+  = ref (fun ~base_path:_ ~agent_name:_ ~reason:_ -> ())
+
+(** Relation materializer: agent leave — wraps Relation_materializer.on_agent_leave. *)
+let relation_on_leave_fn
+  : (leaving_agent:string -> active_agents:string list -> unit) ref
+  = ref (fun ~leaving_agent:_ ~active_agents:_ -> ())
+
+(** Relation materializer: task done — wraps Relation_materializer.on_task_done. *)
+let relation_on_task_done_fn
+  : (assignee:string -> active_agents:string list -> unit) ref
+  = ref (fun ~assignee:_ ~active_agents:_ -> ())
+
+(** Board artifact cleanup — wraps Board_dispatch.list_posts + delete_post.
+    Returns number of deleted posts. *)
+let cleanup_board_artifacts_fn
+  : (unit -> int) ref
+  = ref (fun () -> 0)
+
+(** Governance stale case purge — wraps Council.Governance_v2.purge_*.
+    Returns (test_cases_purged, artifact_cases_purged). *)
+let governance_purge_fn
+  : (string -> int * int) ref
+  = ref (fun _base_path -> (0, 0))

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -312,8 +312,8 @@ let leave config ~agent_name =
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
 
-    (* Record co-presence relationships to Neo4j (async, non-blocking) *)
-    (try Relation_materializer.on_agent_leave
+    (* Record co-presence relationships via hook (async, non-blocking) *)
+    (try !Room_hooks.relation_on_leave_fn
            ~leaving_agent:actual_name ~active_agents:peers_before_leave
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Room.error "relation-materializer leave hook error: %s"

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -135,12 +135,11 @@ let emit_message_activity config ~from_agent ~content ~mention =
           | None -> `Null );
       ]
   in
-  let actor = Activity_graph.entity ~kind:"agent" from_agent in
+  let actor = Room_hooks.{ kind = "agent"; id = from_agent } in
   let emit ?subject ~kind ~tags () =
     try
-      ignore
-        (Activity_graph.emit config ~room_id:(activity_room_id config)
-           ~actor ?subject ~kind ~payload ~tags ())
+      !Room_hooks.activity_emit_fn config ~room_id:(activity_room_id config)
+        ~actor ?subject ~kind ~payload ~tags ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
@@ -151,7 +150,7 @@ let emit_message_activity config ~from_agent ~content ~mention =
   match mention with
   | Some target when String.trim target <> "" ->
       emit
-        ~subject:(Activity_graph.entity ~kind:"agent" target)
+        ~subject:Room_hooks.{ kind = "agent"; id = target }
         ~kind:"message.mentioned"
         ~tags:[ "message"; "mention" ] ()
   | _ -> ()

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -11,15 +11,14 @@ let activity_room_id (config : Room_utils.config) =
 
 let emit_task_activity config ~agent_name ~task_id ~kind ~payload =
   try
-    ignore
-      (Activity_graph.emit config
-         ~room_id:(activity_room_id config)
-         ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
-         ~subject:(Activity_graph.entity ~kind:"task" task_id)
-         ~kind
-         ~payload
-         ~tags:[ "task"; kind ]
-         ())
+    !Room_hooks.activity_emit_fn config
+      ~room_id:(activity_room_id config)
+      ~actor:Room_hooks.{ kind = "agent"; id = agent_name }
+      ~subject:Room_hooks.{ kind = "task"; id = task_id }
+      ~kind
+      ~payload
+      ~tags:[ "task"; kind ]
+      ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -509,10 +508,10 @@ let complete_task config ~agent_name ~task_id ~notes =
               agent_name task_id
               (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes)
               (now_iso ()));
-            (* Record task collaboration to Neo4j (async, non-blocking) *)
+            (* Record task collaboration via hook (async, non-blocking) *)
             (try
                let active = (Room_state.read_state config).active_agents in
-               Relation_materializer.on_task_done ~assignee:agent_name ~active_agents:active
+               !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active
              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.RoomTask.error "relation-materializer task hook error: %s"
                  (Printexc.to_string exn));
@@ -589,13 +588,10 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                       ("notes", if notes = "" then `Null else `String notes);
                     ]);
               log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_done"); ("agent", `String agent_name); ("task", `String task_id); ("notes", if notes = "" then `Null else `String notes); ("ts", `String (now_iso ()))]));
-              (* Agent Economy: earn credits for task completion *)
-              (match Agent_economy.earn
-                 ~base_path:config.base_path ~agent_name
-                 ~kind:Earn_task_done ~reason:(Printf.sprintf "completed %s" task_id) () with
-               | Ok _bal -> ()
-               | Error msg ->
-                 Log.Misc.error "task earn failed: %s" msg);
+              (* Agent Economy: earn credits via hook *)
+              !Room_hooks.agent_economy_earn_fn
+                ~base_path:config.base_path ~agent_name
+                ~reason:(Printf.sprintf "completed %s" task_id);
               Ok (Printf.sprintf "✅ %s completed %s" agent_name task_id)
             end
       with

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -264,23 +264,8 @@ let get_chain_id_for_preset = function
   | "figma" -> Some "walph-figma"
   | _ -> None
 
-let walph_response_is_valid (resp : Oas_response.api_response) =
-  let content = String.trim (Oas_response.text_of_response resp) in
-  let lower = String.lowercase_ascii content in
-  let len = String.length content in
-  len > 0
-  && not (len >= 5 && String.sub lower 0 5 = "error")
-  && not (len >= 14 && String.sub content 0 14 = "Empty response")
-  && not (len >= 9 && String.sub content 0 9 = "{\"error\":")
-
-let default_model_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec:_ ~max_chars () =
-  match
-    Oas_worker.run_named ~cascade_name:"walph"
-      ~goal:prompt ~max_turns:1
-      ~max_tokens:max_chars ~accept:walph_response_is_valid ()
-  with
-  | Ok result -> Oas_response.text_of_response result.Oas_worker.response
-  | Error err -> failwith err
+(* default_model_dispatch and walph_response_is_valid moved to tool_walph.ml
+   to remove Oas_worker/Oas_response dependency from Room. *)
 
 (** {1 Main Loop} *)
 
@@ -297,7 +282,7 @@ let walph_loop config ~net:_net ~clock ~agent_name
     ?(preset="drain") ?(max_iterations=10) ?target
     ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
     ?(default_model=Env_config.Glm.default_model)
-    ?(model_dispatch=default_model_dispatch) () =
+    ~model_dispatch () =
   Room.ensure_initialized config;
 
   (* Get Walph state for this specific agent *)

--- a/lib/tool_walph.ml
+++ b/lib/tool_walph.ml
@@ -9,6 +9,28 @@ type ('a, 'b) context = {
   clock: 'b Eio.Time.clock;
 }
 
+(** Walph response validator — moved from room_walph_eio.ml to remove
+    Oas_response dependency from Room sub-modules. *)
+let walph_response_is_valid (resp : Oas_response.api_response) =
+  let content = String.trim (Oas_response.text_of_response resp) in
+  let lower = String.lowercase_ascii content in
+  let len = String.length content in
+  len > 0
+  && not (len >= 5 && String.sub lower 0 5 = "error")
+  && not (len >= 14 && String.sub content 0 14 = "Empty response")
+  && not (len >= 9 && String.sub content 0 9 = "{\"error\":")
+
+(** Default model dispatch — moved from room_walph_eio.ml to remove
+    Oas_worker dependency from Room sub-modules. *)
+let default_model_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec:_ ~max_chars () =
+  match
+    Oas_worker.run_named ~cascade_name:"walph"
+      ~goal:prompt ~max_turns:1
+      ~max_tokens:max_chars ~accept:walph_response_is_valid ()
+  with
+  | Ok result -> Oas_response.text_of_response result.Oas_worker.response
+  | Error err -> failwith err
+
 (* Handle masc_walph_loop *)
 let handle_walph_loop ctx args =
   let preset = get_string args "preset" "drain" in
@@ -17,7 +39,8 @@ let handle_walph_loop ctx args =
   let error_backoff_sec = get_int args "error_backoff_sec" 2 in
   let target = get_string_opt args "target" in
   (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name
-    ~preset ~max_iterations ~max_consecutive_errors ~error_backoff_sec ?target ())
+    ~preset ~max_iterations ~max_consecutive_errors ~error_backoff_sec ?target
+    ~model_dispatch:default_model_dispatch ())
 
 (* Handle masc_walph_control *)
 let handle_walph_control ctx args =
@@ -68,13 +91,13 @@ let handle_walph_natural ctx args =
     | `Status ->
         (true, Room_walph_eio.walph_control ctx.config ~from_agent:ctx.agent_name ~command:"STATUS" ~args:"" ())
     | `Start_coverage ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"coverage" ~max_iterations:10 ())
+        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"coverage" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_refactor ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"refactor" ~max_iterations:10 ())
+        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"refactor" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_docs ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"docs" ~max_iterations:10 ())
+        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"docs" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_drain ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"drain" ~max_iterations:10 ())
+        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"drain" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
   end
 
 (* Handle masc_walph_status *)


### PR DESCRIPTION
## Summary

Room sub-module에서 상위 도메인(Activity_graph, Board, Council, OAS 등)으로의 8개 역방향 의존을 callback ref 패턴으로 제거.

**새 파일**: `lib/room/room_hooks.ml` — 중앙 집중 callback 선언, no-op 기본값, room.ml에서 wiring.

## 제거된 의존

| Room 모듈 | 제거된 의존 | Callback |
|-----------|-----------|----------|
| room_task.ml | Activity_graph | `activity_emit_fn` |
| room_state.ml | Activity_graph | `activity_emit_fn` |
| room_task.ml | Agent_economy | `agent_economy_earn_fn` |
| room_lifecycle.ml | Relation_materializer | `relation_on_leave_fn` |
| room_task.ml | Relation_materializer | `relation_on_task_done_fn` |
| room_gc.ml | Board, Board_dispatch | `cleanup_board_artifacts_fn` |
| room_gc.ml | Council.Governance_v2 | `governance_purge_fn` |
| room_walph_eio.ml | Oas_worker, Oas_response | `model_dispatch` required param |

## 남은 작업 (Phase 4B)

- `room_utils_backend_setup.ml`의 Board_dispatch 초기화 코드 (5 refs)

## Test plan

- [x] `dune build --root .` 성공
- [x] Room Coverage: 51 tests pass
- [x] Types Coverage: 187 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)