### PR TITLE
fix: prune keeper checkpoint files (588MB dead data)

### DIFF
--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -313,6 +313,10 @@ let persist_message session msg =
   let line = Yojson.Safe.to_string payload ^ "\n" in
   Fs_compat.append_file path line
 
+(** Maximum number of checkpoint files to retain per session.
+    Only the latest N are kept; older ones are deleted after each save. *)
+let max_checkpoints_retained = 3
+
 let save_session_checkpoint session ckpt =
   session.checkpoints <- session.checkpoints @ [ckpt];
   let path = Filename.concat session.session_dir
@@ -330,7 +334,28 @@ let save_session_checkpoint session ckpt =
     ("context", context_json);
   ] in
   let content = Yojson.Safe.to_string json in
-  Fs_compat.save_file path content
+  Fs_compat.save_file path content;
+  (* Prune old checkpoints: keep only the latest max_checkpoints_retained *)
+  let dir = session.session_dir in
+  (try
+    let files = Sys.readdir dir |> Array.to_list in
+    let ckpt_files =
+      files
+      |> List.filter (fun f ->
+        let len = String.length f in
+        len > 5 && String.sub f 0 5 = "ckpt-"
+        && String.sub f (len - 5) 5 = ".json")
+      |> List.sort (fun a b -> compare b a) (* newest first *)
+    in
+    if List.length ckpt_files > max_checkpoints_retained then
+      let to_delete =
+        List.filteri (fun i _ -> i >= max_checkpoints_retained) ckpt_files
+      in
+      List.iter (fun f ->
+        let p = Filename.concat dir f in
+        (try Sys.remove p with Sys_error _ -> ())
+      ) to_delete
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
 
 let load_latest_checkpoint session =
   let dir = session.session_dir in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -95,6 +95,44 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Misc.error "startup prune failed: %s" (Printexc.to_string exn));
+  (* Prune old keeper checkpoint files: keep only latest 3 per trace session.
+     Prevents unbounded growth from AfterTurn hook saving every turn. *)
+  (try
+     let perpetual_dir =
+       Filename.concat
+         (Filename.concat state.room_config.base_path ".masc") "perpetual"
+     in
+     if Sys.file_exists perpetual_dir then begin
+       let total = ref 0 in
+       Array.iter (fun trace_name ->
+         let trace_dir = Filename.concat perpetual_dir trace_name in
+         if Sys.is_directory trace_dir then begin
+           let files = Sys.readdir trace_dir |> Array.to_list in
+           let ckpt_files =
+             files
+             |> List.filter (fun f ->
+               let len = String.length f in
+               len > 5 && String.sub f 0 5 = "ckpt-"
+               && String.sub f (len - 5) 5 = ".json")
+             |> List.sort (fun a b -> compare b a)
+           in
+           if List.length ckpt_files > 3 then
+             List.iteri (fun i f ->
+               if i >= 3 then begin
+                 (try Sys.remove (Filename.concat trace_dir f)
+                  with Sys_error _ -> ());
+                 incr total
+               end
+             ) ckpt_files
+         end
+       ) (Sys.readdir perpetual_dir);
+       if !total > 0 then
+         Log.Misc.info "startup prune: deleted %d old keeper checkpoint files" !total
+     end
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Misc.error "startup checkpoint prune failed: %s" (Printexc.to_string exn));
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =


### PR DESCRIPTION
## Summary
- `save_session_checkpoint`가 매 턴 새 `ckpt-{ts}.json`을 생성하면서 이전 파일을 삭제하지 않음
- `load_latest_checkpoint`는 최신 1개만 읽으므로 나머지는 전부 dead data
- 한 trace에 2,151개 파일 / 265MB 누적. 5개 trace 합계 588MB

## Fix
1. `save_session_checkpoint` 후 최신 3개 초과 checkpoint 즉시 삭제
2. 서버 startup 시 `perpetual/trace-*/ckpt-*.json` 전체 스캔, trace별 최신 3개만 유지

## Test plan
- [x] `dune build` 통과
- [ ] 서버 시작 후 로그에 `startup prune: deleted N old keeper checkpoint files` 확인
- [ ] keeper turn 실행 후 trace 디렉토리에 3개 이하 checkpoint 확인