### PR TITLE
feat(dashboard): OAS worker run evidence in proof view

### DIFF
--- a/dashboard/src/components/proof-helpers.test.ts
+++ b/dashboard/src/components/proof-helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  workerRunEvidenceLabel,
+  workerRunEvidenceMeta,
+  workerRunEvidencePreview,
+  workerRunEvidenceTone,
+} from './proof-helpers'
+
+describe('workerRunEvidence helpers', () => {
+  it('marks validated raw traces as ok', () => {
+    const item = {
+      worker_run_id: 'worker-1',
+      trace_capability: 'raw',
+      trace_validated: true,
+      resolved_runtime: 'local',
+      resolved_model: 'qwen',
+      tool_call_count: 3,
+    }
+
+    expect(workerRunEvidenceTone(item)).toBe('ok')
+    expect(workerRunEvidenceLabel(item)).toBe('검증됨')
+    expect(workerRunEvidenceMeta(item)).toContain('local')
+    expect(workerRunEvidenceMeta(item)).toContain('qwen')
+    expect(workerRunEvidenceMeta(item)).toContain('도구 3')
+  })
+
+  it('prefers final text preview, then falls back to errors', () => {
+    expect(
+      workerRunEvidencePreview({
+        worker_run_id: 'worker-2',
+        final_text: 'final answer',
+        output_preview: 'preview',
+        error: 'boom',
+      }),
+    ).toBe('final answer')
+
+    expect(
+      workerRunEvidencePreview({
+        worker_run_id: 'worker-3',
+        success: false,
+        failure_reason: 'tool timeout',
+      }),
+    ).toBe('tool timeout')
+  })
+
+  it('marks failed runs as bad', () => {
+    const item = {
+      worker_run_id: 'worker-4',
+      success: false,
+      error: 'subprocess crashed',
+    }
+
+    expect(workerRunEvidenceTone(item)).toBe('bad')
+    expect(workerRunEvidenceLabel(item)).toBe('실패')
+  })
+})

--- a/dashboard/src/components/proof-helpers.ts
+++ b/dashboard/src/components/proof-helpers.ts
@@ -3,6 +3,7 @@ import type {
   DashboardProofSelection,
   DashboardProofTimelineItem,
   DashboardProofToolEvidence,
+  DashboardProofWorkerRunEvidence,
   DashboardProofVerdict,
 } from '../types'
 import { asString, asNumber, isRecord } from './common/normalize'
@@ -156,6 +157,42 @@ export function actorActivityMeta(item: DashboardProofActorContribution): string
 
 export function toolEvidenceTags(item: DashboardProofToolEvidence): string[] {
   return Array.isArray(item.tool_names) ? item.tool_names : []
+}
+
+export function workerRunEvidenceTone(item: DashboardProofWorkerRunEvidence): string {
+  if (item.trace_validated === true) return 'ok'
+  if (item.success === false || item.failure_reason || item.error) return 'bad'
+  if (item.trace_capability === 'raw') return 'ok'
+  if (item.trace_capability === 'summary_only') return 'warn'
+  return 'warn'
+}
+
+export function workerRunEvidenceLabel(item: DashboardProofWorkerRunEvidence): string {
+  if (item.trace_validated === true) return '검증됨'
+  if (item.success === false || item.failure_reason || item.error) return '실패'
+  if (item.trace_capability === 'raw') return 'raw trace'
+  if (item.trace_capability === 'summary_only') return 'summary only'
+  return item.status ?? '근거 수집'
+}
+
+export function workerRunEvidenceMeta(item: DashboardProofWorkerRunEvidence): string {
+  const parts = [
+    item.resolved_runtime ?? null,
+    item.resolved_model ?? null,
+    item.mode ?? null,
+    typeof item.tool_call_count === 'number' ? `도구 ${item.tool_call_count}` : null,
+    typeof item.record_count === 'number' ? `레코드 ${item.record_count}` : null,
+  ].filter((value): value is string => Boolean(value))
+  return parts.join(' · ')
+}
+
+export function workerRunEvidencePreview(item: DashboardProofWorkerRunEvidence): string | null {
+  return item.final_text
+    ?? item.output_preview
+    ?? item.error
+    ?? item.failure_reason
+    ?? item.stop_reason
+    ?? null
 }
 
 export function dedupeTimeline(items: DashboardProofTimelineItem[]): DedupedTimelineItem[] {

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -4,6 +4,7 @@ import type {
   DashboardProofArtifactRef,
   DashboardProofSelection,
   DashboardProofToolEvidence,
+  DashboardProofWorkerRunEvidence,
   DashboardProofVerdict,
 } from '../types'
 import { relativeTime } from './command/helpers'
@@ -16,6 +17,10 @@ import {
   selectionTone,
   timelineMetaLabel,
   toolEvidenceTags,
+  workerRunEvidenceLabel,
+  workerRunEvidenceMeta,
+  workerRunEvidencePreview,
+  workerRunEvidenceTone,
   type DedupedTimelineItem,
 } from './proof-helpers'
 
@@ -75,6 +80,48 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
             </div>`
           : null
       })()}
+    </article>
+  `
+}
+
+export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEvidence }) {
+  const preview = workerRunEvidencePreview(item)
+  const validationFailures = Array.isArray(item.validation_failures) ? item.validation_failures : []
+  const toolNames = Array.isArray(item.tool_names) ? item.tool_names : []
+  return html`
+    <article class="mission-activity-row proof-actor-row">
+      <div class="mission-activity-head">
+        <div>
+          <strong>${item.worker_name ?? item.worker_run_id}</strong>
+          <div class="mission-activity-meta">
+            <span>${item.worker_run_id}</span>
+            <span>${item.ts_iso ? relativeTime(item.ts_iso) : '기록 없음'}</span>
+          </div>
+        </div>
+        <span class="command-chip ${workerRunEvidenceTone(item)}">
+          ${workerRunEvidenceLabel(item)}
+        </span>
+      </div>
+      <div class="mission-activity-copy">
+        <span>${workerRunEvidenceMeta(item) || 'runtime/model 메타데이터 없음'}</span>
+      </div>
+      ${preview
+        ? html`<div class="proof-summary-block">
+            <strong>${item.success === false || item.error || item.failure_reason ? '실패 요약' : '출력 요약'}</strong>
+            <span>${preview}</span>
+          </div>`
+        : null}
+      ${validationFailures.length > 0
+        ? html`<div class="proof-summary-block warn">
+            <strong>검증 실패</strong>
+            <span>${validationFailures.join(' · ')}</span>
+          </div>`
+        : null}
+      ${toolNames.length > 0
+        ? html`<div class="semantic-tag-row">
+            ${toolNames.map(name => html`<span class="semantic-tag">${name}</span>`)}
+          </div>`
+        : null}
     </article>
   `
 }

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -8,6 +8,7 @@ import type {
   DashboardProofArtifactRef,
   DashboardProofTimelineItem,
   DashboardProofToolEvidence,
+  DashboardProofWorkerRunEvidence,
 } from '../types'
 import { prettyJson, relativeTime } from './command/helpers'
 import {
@@ -29,6 +30,7 @@ import {
   SelectionCard,
   TimelineRow,
   ToolEvidenceRow,
+  WorkerRunEvidenceRow,
 } from './proof-sections'
 
 export function Proof() {
@@ -63,10 +65,17 @@ export function Proof() {
   )
   const artifacts = safeArray<DashboardProofArtifactRef>(snapshot?.artifacts)
   const toolEvidence = safeArray<DashboardProofToolEvidence>(snapshot?.tool_evidence)
+  const workerRunEvidence = safeArray<DashboardProofWorkerRunEvidence>(snapshot?.worker_run_evidence)
   const verdict = snapshot?.proof_verdict ?? 'insufficient'
   const liveVerdict = summary?.live_verdict ?? verdict
   const historicalVerdict = summary?.historical_verdict ?? null
   const verdictBasis = summary?.verdict_basis ?? 'live'
+  const rawTraceRunCount =
+    summary?.raw_trace_run_count
+    ?? workerRunEvidence.filter(item => item.trace_capability === 'raw').length
+  const validatedWorkerRunCount =
+    summary?.validated_worker_run_count
+    ?? workerRunEvidence.filter(item => item.trace_validated === true).length
   const cpEvidence = snapshot?.cp_backing_evidence ?? null
   const traceCount = Array.isArray((cpEvidence as { traces?: { events?: unknown[] } } | null)?.traces?.events)
     ? ((cpEvidence as { traces?: { events?: unknown[] } }).traces?.events?.length ?? 0)
@@ -136,7 +145,7 @@ export function Proof() {
         </div>
       </div>
       <details class="mb-3">
-        <summary style="cursor: pointer; color: rgba(255,255,255,0.5); font-size: 13px; padding: 6px 0;">상세 지표 (${7}개)</summary>
+        <summary style="cursor: pointer; color: rgba(255,255,255,0.5); font-size: 13px; padding: 6px 0;">상세 지표 (${8}개)</summary>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3" class="mt-2">
           <div class="summary-stat-card rounded-xl ${verdictTone(liveVerdict)}">
             <span>Live 판정</span>
@@ -162,6 +171,11 @@ export function Proof() {
             <span>CP 트레이스</span>
             <strong>${traceCount}</strong>
             <small>관리형 backing</small>
+          </div>
+          <div class="summary-stat-card rounded-xl ${validatedWorkerRunCount > 0 ? 'ok' : rawTraceRunCount > 0 ? 'warn' : 'warn'}">
+            <span>OAS 워커 근거</span>
+            <strong>${validatedWorkerRunCount}/${Math.max(rawTraceRunCount, workerRunEvidence.length)}</strong>
+            <small>검증됨 / 수집됨</small>
           </div>
           <div class="summary-stat-card rounded-xl ${(missingArtifacts === 0 && artifacts.length > 0) ? 'ok' : 'warn'}">
             <span>산출물</span>
@@ -244,6 +258,20 @@ export function Proof() {
           </div>
         <//>
 
+        <${Card} title="OAS 워커 근거" class="mission-list-card rounded-xl">
+          <div class="mission-section-head">
+            <h3>worker run trace는 얼마나 남아 있나</h3>
+            <p>OAS worker가 남긴 raw trace, 검증 결과, 최종 출력 요약을 바로 확인합니다.</p>
+          </div>
+          <div class="mission-list-stack">
+            ${workerRunEvidence.length > 0
+              ? workerRunEvidence.map(item => html`<${WorkerRunEvidenceRow} key=${item.worker_run_id} item=${item} />`)
+              : html`<div class="empty-state">표시할 OAS worker evidence가 없습니다. raw trace 또는 summary-only evidence가 생기면 여기에 나타납니다.</div>`}
+          </div>
+        <//>
+      </div>
+
+      <div class="mission-human-grid">
         <${Card} title="실행 근거" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>실행 backing은 얼마나 남아 있나</h3>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -1,5 +1,4 @@
 import { html } from 'htm/preact'
-import type { ComponentChildren } from 'preact'
 import { connected, eventCount } from '../sse'
 import {
   refreshDashboard,
@@ -60,7 +59,6 @@ function renderResidentRuntimeCard(
 export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build
-  const residentCards: ComponentChildren[] = []
 
   return html`
     <section class="rail-card rounded-xl">
@@ -102,13 +100,6 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
       </div>
       ${build
         ? html`<div class="mt-2.5 text-xs text-[color:var(--text-muted)]">서버 빌드 · v${build.release_version} · ${shortCommit(build.commit)}</div>`
-        : null}
-      ${residentCards.length > 0
-        ? html`
-            <div style="margin-top:12px; display:flex; flex-direction:column; gap:10px;">
-              ${residentCards}
-            </div>
-          `
         : null}
     </section>
   `

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -259,6 +259,8 @@ export interface DashboardProofSummary {
   interaction_count?: number
   evidence_count?: number
   cp_trace_count?: number
+  raw_trace_run_count?: number
+  validated_worker_run_count?: number
 }
 
 export interface DashboardProofSelection {
@@ -315,6 +317,34 @@ export interface DashboardProofToolEvidence {
   timestamp?: string | null
 }
 
+export interface DashboardProofWorkerRunEvidence {
+  worker_run_id: string
+  worker_name?: string | null
+  status?: string | null
+  mode?: string | null
+  wait_mode?: string | null
+  trace_capability?: string | null
+  trace_validated?: boolean | null
+  validation_failures?: string[]
+  success?: boolean | null
+  execution_scope?: string | null
+  requested_worker_class?: string | null
+  requested_worker_size?: string | null
+  resolved_runtime?: string | null
+  resolved_model?: string | null
+  routing_reason?: string | null
+  tool_names?: string[]
+  tool_call_count?: number | null
+  output_preview?: string | null
+  record_count?: number | null
+  assistant_block_count?: number | null
+  final_text?: string | null
+  stop_reason?: string | null
+  failure_reason?: string | null
+  error?: string | null
+  ts_iso?: string | null
+}
+
 export interface DashboardProofArtifactRef {
   kind: string
   path: string
@@ -343,6 +373,7 @@ export interface DashboardProofResponse {
   actor_contributions?: DashboardProofActorContribution[]
   goal_binding?: Record<string, unknown>
   tool_evidence?: DashboardProofToolEvidence[]
+  worker_run_evidence?: DashboardProofWorkerRunEvidence[]
   cp_backing_evidence?: DashboardProofBackingEvidence | null
   artifacts?: DashboardProofArtifactRef[]
   raw_proof?: Record<string, unknown> | null


### PR DESCRIPTION
## Summary
- New proof-of-work evidence UI for individual OAS worker runs
- Type-safe evidence display with verdict classification (ok/warn/bad)
- Korean labels for validation states
- Metadata rendering (runtime, model, mode, tool count)
- Unit tests for all 4 helper functions

## Files
- `dashboard/src/types/dashboard-mission.ts` — evidence types
- `dashboard/src/components/proof-helpers.ts` — pure helper functions
- `dashboard/src/components/proof-sections.ts` — WorkerRunEvidenceRow component
- `dashboard/src/components/proof.ts` — integration into proof view
- `dashboard/src/components/proof-helpers.test.ts` — unit tests

## Test plan
- [ ] `cd dashboard && npm test` passes
- [ ] Proof view renders worker evidence rows
- [ ] Verdict chips show correct tone/color

Generated with Claude Code