### PR TITLE
fix(oas): normalize structured tool payloads

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -329,13 +329,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ]
     ]
   in
-  let structured_content =
-    match name with
-    | "masc_team_session_status"
-    | "masc_operator_digest" -> (
-        try Some (Yojson.Safe.from_string message) with _ -> None)
-    | _ -> None
-  in
+  let structured_content = Tool_result.structured_payload_of_message message in
   let result_fields =
     [
       ("resultEnvelope", envelope);

--- a/lib/tool_result.ml
+++ b/lib/tool_result.ml
@@ -7,13 +7,42 @@ type t = {
   duration_ms : float;
 }
 
+let structured_payload_of_message (message : string) : Yojson.Safe.t option =
+  let parse_json raw =
+    try Some (Yojson.Safe.from_string raw)
+    with Yojson.Json_error _ -> None
+  in
+  let trimmed = String.trim message in
+  match parse_json trimmed with
+  | Some _ as json -> json
+  | None ->
+      let len = String.length message in
+      let rec loop from =
+        match String.index_from_opt message from '\n' with
+        | None -> None
+        | Some newline_idx ->
+            let suffix =
+              String.sub message (newline_idx + 1) (len - newline_idx - 1)
+              |> String.trim
+            in
+            if suffix = "" then loop (newline_idx + 1)
+            else
+              match suffix.[0] with
+              | '{' | '[' -> (
+                  match parse_json suffix with
+                  | Some _ as json -> json
+                  | None -> loop (newline_idx + 1))
+              | _ -> loop (newline_idx + 1)
+      in
+      loop 0
+
 let wrap ~tool_name ~start_time (success, message) =
   let end_time = Time_compat.now () in
   let duration_ms = (end_time -. start_time) *. 1000.0 in
   let data =
-    match Yojson.Safe.from_string message with
-    | json -> json
-    | exception Yojson.Json_error _ -> `String message
+    match structured_payload_of_message message with
+    | Some json -> json
+    | None -> `String message
   in
   { success; data; tool_name; duration_ms }
 

--- a/lib/tool_result.mli
+++ b/lib/tool_result.mli
@@ -26,6 +26,8 @@ type t = {
     @param tool_name The MCP tool name (e.g. ["masc_status"])
     @param start_time Wall-clock time when the handler started
     @param raw The [(success, message)] tuple from the handler *)
+val structured_payload_of_message : string -> Yojson.Safe.t option
+
 val wrap : tool_name:string -> start_time:float -> (bool * string) -> t
 
 (** [to_json t] serializes to JSON for logging and observability. *)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -9,6 +9,8 @@ module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
 module Mode = Masc_mcp.Mode
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
 (* ===== Test Helpers ===== *)
 
 let temp_dir () =
@@ -194,6 +196,11 @@ let result_envelope_exn response =
   match List.assoc_opt "resultEnvelope" (result_fields_exn response) with
   | Some (`Assoc fields) -> fields
   | _ -> Alcotest.fail "resultEnvelope missing"
+
+let structured_content_exn response =
+  match List.assoc_opt "structuredContent" (result_fields_exn response) with
+  | Some json -> json
+  | None -> Alcotest.fail "structuredContent missing"
 
 let workflow_next_step_names response =
   match List.assoc_opt "workflow_guidance" (result_envelope_exn response) with
@@ -1684,6 +1691,59 @@ let test_handle_request_invalid_json () =
 
   cleanup_dir base_path
 
+let test_handle_request_tools_call_cache_get_structured_content () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Room.init state.room_config ~agent_name:None);
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 116);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String "masc_cache_get");
+      ("arguments", `Assoc [ ("key", `String "missing") ]);
+    ]);
+  ]) in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  let structured = structured_content_exn response in
+  Alcotest.(check bool) "cache hit false" false
+    Yojson.Safe.Util.(structured |> member "hit" |> to_bool);
+  Alcotest.(check string) "cache key" "missing"
+    Yojson.Safe.Util.(structured |> member "key" |> to_string);
+  cleanup_dir base_path
+
+let test_handle_request_tools_call_board_post_structured_content () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Room.init state.room_config ~agent_name:None);
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 117);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String "masc_board_post");
+      ("arguments", `Assoc [
+        ("content", `String "hello board");
+        ("author", `String "tester");
+      ]);
+    ]);
+  ]) in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  let structured = structured_content_exn response in
+  Alcotest.(check string) "board content" "hello board"
+    Yojson.Safe.Util.(structured |> member "content" |> to_string);
+  Alcotest.(check string) "board author" "tester"
+    Yojson.Safe.Util.(structured |> member "author" |> to_string);
+  cleanup_dir base_path
+
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -2425,6 +2485,10 @@ let eio_tests = [
     test_handle_request_tools_call_transition_done_guidance;
   "handle tools/call deprecated claim alias", `Quick,
     test_handle_request_tools_call_deprecated_claim_alias;
+  "handle tools/call cache get structured content", `Quick,
+    test_handle_request_tools_call_cache_get_structured_content;
+  "handle tools/call board post structured content", `Quick,
+    test_handle_request_tools_call_board_post_structured_content;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -31,6 +31,21 @@ let test_wrap_plain_string () =
      Alcotest.(check string) "plain string preserved" "Something went wrong" s
    | _ -> Alcotest.fail "expected String for non-JSON input")
 
+let test_wrap_prefixed_json_response () =
+  let start = 1000.0 in
+  let raw =
+    ( true,
+      "✅ Post created:\n{\"id\":\"post-1\",\"content\":\"hello\",\"ok\":true}" )
+  in
+  let r = Tool_result.wrap ~tool_name:"masc_board_post" ~start_time:start raw in
+  match r.data with
+  | `Assoc fields ->
+      Alcotest.(check string) "id parsed" "post-1"
+        Yojson.Safe.Util.(List.assoc "id" fields |> to_string);
+      Alcotest.(check string) "content parsed" "hello"
+        Yojson.Safe.Util.(List.assoc "content" fields |> to_string)
+  | _ -> Alcotest.fail "expected parsed JSON from prefixed payload"
+
 let test_to_json () =
   let start = Time_compat.now () in
   let raw = (true, "done") in
@@ -87,6 +102,8 @@ let () =
     "wrap", [
       Alcotest.test_case "json response" `Quick test_wrap_json_response;
       Alcotest.test_case "plain string" `Quick test_wrap_plain_string;
+      Alcotest.test_case "prefixed json response" `Quick
+        test_wrap_prefixed_json_response;
     ];
     "to_json", [
       Alcotest.test_case "fields present" `Quick test_to_json;


### PR DESCRIPTION
## Summary
- infer structured payloads from raw JSON and prefixed JSON tool replies
- reuse the same structured-content inference in MCP tools/call responses instead of tool-specific special-cases
- add regression coverage for cache-get and board-post structured content

## Verification
- ./_build/default/test/test_tool_result.exe
- ./_build/default/test/test_mcp_server_eio.exe
- env XDG_CONFIG_HOME=/tmp/codex-dune-clean dune build --root .
- git diff --check