### PR TITLE
fix(dashboard): remove unused resident-runtime-rail helpers (TS6133)

### DIFF
--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -19,44 +19,6 @@ function shortCommit(commit: string | null | undefined): string {
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
-function residentStatusLabel(
-  status: 'live' | 'quiet' | 'starting' | 'idle' | 'disabled',
-) {
-  if (status === 'live') return '가동 중'
-  if (status === 'quiet') return '조용함'
-  if (status === 'starting') return '기동 중'
-  if (status === 'idle') return '대기 중'
-  return '비활성'
-}
-
-function renderRuntimeStat(label: string, value: ComponentChildren) {
-  return html`
-    <div class="build-badge-row">
-      <span>${label}</span>
-      <strong>${value}</strong>
-    </div>
-  `
-}
-
-function renderResidentRuntimeCard(
-  title: string,
-  statusLabel: string,
-  tone: 'ok' | 'warn' | 'bad',
-  rows: ComponentChildren[],
-  hint?: ComponentChildren,
-) {
-  return html`
-    <div style="padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
-      <div class="rail-card-head" class="m-0">
-        <h3 class="text-xs">${title}</h3>
-        <span class="rail-section-chip ${tone}">${statusLabel}</span>
-      </div>
-      ${rows}
-      ${hint ? html`<div class="rail-build-hint">${hint}</div>` : null}
-    </div>
-  `
-}
-
 export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build


### PR DESCRIPTION
## Summary
- Remove three unexported, unreferenced functions (`residentStatusLabel`, `renderRuntimeStat`, `renderResidentRuntimeCard`) from `resident-runtime-rail.ts` that caused TS6133 errors.
- Dashboard build (`tsc --noEmit && vite build`) passes after the change.

Closes #2203

## Test plan
- [x] `npm run build` in `dashboard/` succeeds (tsc + vite)
- [x] Grep confirms no other file references the removed functions

Generated with [Claude Code](https://claude.com/claude-code)