### PR TITLE
fix: harden sensitive HTTP auth routes

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -141,7 +141,7 @@ let bearer_token_from_header value =
 let auth_token_from_request request =
   match Httpun.Headers.get request.Httpun.Request.headers "authorization" with
   | Some v -> bearer_token_from_header v
-  | None -> query_param request "token"
+  | None -> None
 
 (** TTS proxy — forwards text to ElevenLabs and returns audio/mpeg bytes.
     Reads ELEVENLABS_API_KEY from environment. *)
@@ -327,6 +327,37 @@ let authorize_tool_request ~base_path ~tool_name request :
           else
             Auth.authorize_tool base_path ~agent_name ~token ~tool_name)
 
+let authorize_token_bound_permission_request ~base_path ~permission request :
+    (string, Types.masc_error) result =
+  let auth_cfg = Auth.load_auth_config base_path in
+  if not auth_cfg.enabled then
+    Error
+      (Types.Unauthorized
+         "HTTP mutation requires room auth enabled with require_token=true.")
+  else if not auth_cfg.require_token then
+    Error
+      (Types.Unauthorized
+         "HTTP mutation requires bearer token auth (require_token=true).")
+  else
+    match auth_token_from_request request with
+    | None ->
+        Error
+          (Types.Unauthorized
+             "Authentication required. Use 'Authorization: Bearer <token>' header.")
+    | Some token -> (
+        match Auth.find_credential_by_token base_path ~token with
+        | Error err -> Error err
+        | Ok cred ->
+            if Types.has_permission cred.role permission then
+              Ok cred.agent_name
+            else
+              Error
+                (Types.Forbidden
+                   {
+                     agent = cred.agent_name;
+                     action = Types.show_permission permission;
+                   }))
+
 let rec with_public_read handler request reqd =
   let strict = http_auth_strict_enabled () in
   let path = Http_server_eio.Request.path request in
@@ -362,6 +393,15 @@ and with_tool_auth ~tool_name handler request reqd =
       let base_path = state.Mcp_server.room_config.base_path in
       match authorize_tool_request ~base_path ~tool_name request with
       | Ok () -> handler state request reqd
+      | Error err -> respond_auth_error request reqd err
+
+and with_token_permission_auth ~permission handler request reqd =
+  match !server_state with
+  | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
+  | Some state ->
+      let base_path = state.Mcp_server.room_config.base_path in
+      match authorize_token_bound_permission_request ~base_path ~permission request with
+      | Ok agent_name -> handler state agent_name request reqd
       | Error err -> respond_auth_error request reqd err
 
 let serve_agent_card ~host ~port request reqd =

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -29,6 +29,11 @@ let activity_events_http_json ~state request =
 let activity_graph_http_json ~state request =
   Server_activity_http.graph_http_json ~deps:activity_http_deps ~state request
 
+let json_upsert_string_field name value = function
+  | `Assoc fields ->
+      `Assoc ((name, `String value) :: List.remove_assoc name fields)
+  | json -> json
+
 let add_routes router =
   router
   |> Http.Router.get "/api/v1/activity/events" (fun request reqd ->
@@ -157,10 +162,14 @@ let add_routes router =
 
   (* Board write APIs — used by Bevy Viewer *)
   |> Http.Router.post "/api/v1/tools/masc_board_vote" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanBroadcast
+         (fun _state agent_name _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
-             let args = Yojson.Safe.from_string body_str in
+             let args =
+               Yojson.Safe.from_string body_str
+               |> json_upsert_string_field "voter" agent_name
+             in
              let (ok, msg) = Tool_board.handle_tool "masc_board_vote" args in
              let status = if ok then `OK else `Bad_request in
              respond_json_with_cors ~status request reqd
@@ -177,10 +186,14 @@ let add_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/tools/masc_board_comment" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanBroadcast
+         (fun _state agent_name _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
-             let args = Yojson.Safe.from_string body_str in
+             let args =
+               Yojson.Safe.from_string body_str
+               |> json_upsert_string_field "author" agent_name
+             in
              let (ok, msg) = Tool_board.handle_tool "masc_board_comment" args in
              let status = if ok then `Created else `Bad_request in
              respond_json_with_cors ~status request reqd

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -31,8 +31,10 @@ let activity_graph_http_json ~state request =
 
 let json_upsert_string_field name value = function
   | `Assoc fields ->
-      `Assoc ((name, `String value) :: List.remove_assoc name fields)
-  | json -> json
+      let fields = List.filter (fun (k, _) -> k <> name) fields in
+      `Assoc ((name, `String value) :: fields)
+  | _non_object ->
+      failwith (Printf.sprintf "json_upsert_string_field: expected JSON object, got non-object for field %S" name)
 
 let add_routes router =
   router

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -15,11 +15,11 @@ let add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
        (* POST /api/v1/broadcast - HTTP API for external tools like autocov *)
-       with_read_auth (fun state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanBroadcast
+         (fun state agent_name _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let agent_name = json |> Yojson.Safe.Util.member "agent_name" |> Yojson.Safe.Util.to_string in
              let message = json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string in
              let config = state.Mcp_server.room_config in
              let _ = Room.broadcast config ~from_agent:agent_name ~content:message in
@@ -34,11 +34,11 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.post "/broadcast" (fun request reqd ->
        (* POST /broadcast - Alias for autocov compatibility *)
-       with_read_auth (fun state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanBroadcast
+         (fun state agent_name _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let agent_name = json |> Yojson.Safe.Util.member "agent_name" |> Yojson.Safe.Util.to_string in
              let message = json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string in
              let config = state.Mcp_server.room_config in
              let _ = Room.broadcast config ~from_agent:agent_name ~content:message in
@@ -201,7 +201,8 @@ let add_routes ~sw ~clock router =
 
   (* Keeper config update — POST (PATCH semantic) to update prompt/drift fields *)
   |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
-       with_read_auth (fun state req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            let req_path = Http.Request.path req in
            let prefix = "/api/v1/keepers/" in

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -13,7 +13,8 @@ let add_routes ~sw router =
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/agent-runs" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun _state _agent_name _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
              try
                let json = Yojson.Safe.from_string body_str in

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -260,6 +260,30 @@ let test_permission_for_tool_interrupt () =
   | Some Types.CanInterrupt -> ()
   | _ -> fail "expected CanInterrupt"
 
+(* ============================================================
+   HTTP auth extraction regressions
+   ============================================================ *)
+
+let test_http_auth_token_from_header_only () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list [ ("authorization", "Bearer header-token") ]
+  in
+  let request =
+    Httpun.Request.create ~headers `GET
+      "/api/v1/tools/masc_board_vote?token=query-token"
+  in
+  check (option string) "header bearer token extracted" (Some "header-token")
+    (Server_auth.auth_token_from_request request)
+
+let test_http_auth_rejects_query_token_fallback () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let request =
+    Httpun.Request.create `GET "/api/v1/tools/masc_board_vote?token=query-token"
+  in
+  check (option string) "query token ignored" None
+    (Server_auth.auth_token_from_request request)
+
 let test_permission_for_tool_approve () =
   match Auth.permission_for_tool "masc_approve" with
   | Some Types.CanApprove -> ()
@@ -530,5 +554,10 @@ let () =
       (* gardener permission tests removed — Gardener deleted (#1834) *)
       test_case "unknown" `Quick test_permission_for_tool_unknown;
       test_case "empty" `Quick test_permission_for_tool_empty;
+    ];
+    "http_auth", [
+      test_case "header token only" `Quick test_http_auth_token_from_header_only;
+      test_case "reject query token fallback" `Quick
+        test_http_auth_rejects_query_token_fallback;
     ];
   ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -70,6 +70,36 @@ let test_route_auth_contracts () =
     (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
        {|h2_authorize_tool state ~tool_name:"masc_operator_confirm"|})
 
+let test_http_write_auth_contracts () =
+  check bool "server auth no longer accepts query token fallback" true
+    (not
+       (file_contains_pattern "lib/server/server_auth.ml"
+          {|query_param request "token"|}));
+  check bool "server auth defines token-bound permission helper" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "let authorize_token_bound_permission_request");
+  check bool "server auth exposes token-bound route helper" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "and with_token_permission_auth");
+  check bool "broadcast route requires token-bound broadcast permission" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       {|with_token_permission_auth ~permission:Types.CanBroadcast|});
+  check bool "keeper config update requires admin permission" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       {|with_token_permission_auth ~permission:Types.CanAdmin|});
+  check bool "board vote route requires token-bound broadcast permission" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
+       {|with_token_permission_auth ~permission:Types.CanBroadcast|});
+  check bool "board vote route overwrites voter from auth identity" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
+       {|json_upsert_string_field "voter" agent_name|});
+  check bool "board comment route overwrites author from auth identity" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
+       {|json_upsert_string_field "author" agent_name|});
+  check bool "provider runs post requires admin permission" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
+       {|with_token_permission_auth ~permission:Types.CanAdmin|})
+
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)
   check bool "broadcast validates empty message" true
@@ -173,6 +203,12 @@ let test_activity_surface_contracts () =
   check bool "room top-level module emits activity events" true
     (file_contains_pattern "lib/room.ml"
        "Activity_graph.emit config");
+  check bool "room task lifecycle emits activity events via hook" true
+    (file_contains_pattern "lib/room/room_task.ml"
+       "!Room_hooks.activity_emit_fn config");
+  check bool "room broadcast emits activity events via hook" true
+    (file_contains_pattern "lib/room/room_state.ml"
+       "!Room_hooks.activity_emit_fn config");
   check bool "board success paths emit activity events" true
     (file_contains_pattern "lib/tool_inline_dispatch_extra.ml"
        "Activity_graph.emit config");
@@ -243,6 +279,7 @@ let () =
            test_case "sync and asset contracts" `Quick test_ci_sync_and_asset_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
+           test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
            test_case "input validation contracts" `Quick test_input_validation_contracts;
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;


### PR DESCRIPTION
## Summary
- require token-bound auth for sensitive HTTP write routes
- stop trusting body-supplied broadcast/board identities
- remove query-string token fallback and add regression coverage

## Testing
- git diff --check
- dune build --root . test/test_auth_coverage.exe test/test_ci_hardening_source.exe bin/main_eio.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_ci_hardening_source.exe