### PR TITLE
fix(oas): plumb swarm trace refs and refine completion outcomes

### DIFF
--- a/docs/OAS-MIGRATION-NEXT-STEPS.md
+++ b/docs/OAS-MIGRATION-NEXT-STEPS.md
@@ -24,7 +24,7 @@ They do. The gap is that the bridge is still lossy.
 ### What remains
 
 - preserve more `planned_worker` metadata in swarm entries
-- extend telemetry beyond usage/turn_count so swarm outputs carry trace refs too
+- preserve richer telemetry semantics beyond the current `trace_ref`/usage/turn_count baseline when the swarm runner needs more operator-facing detail
 - decide whether the current single-pass success-ratio convergence policy should become a richer multi-iteration strategy
 - replace the current room-init `resource_check` with a broader runtime-health probe if needed
 - decide whether session-level budget needs token/cost enforcement beyond the current `duration_seconds` wall-clock budget

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -47,7 +47,7 @@ The main remaining problems are no longer “missing migration” at large. They
 The bridge still throws away part of MASC session semantics:
 
 - `planned_worker` metadata is only partially projected into swarm entries
-- per-agent telemetry now exists, but only usage/turn_count are surfaced; `trace_ref` is still absent
+- per-agent telemetry now includes `trace_ref`, usage, and turn_count, so downstream proof views can link back to raw OAS runs
 - convergence now uses a single-pass success-ratio callback, but not a richer multi-iteration swarm policy
 - `resource_check` now guards on room initialization only; it is not yet a broader runtime-health probe
 - budget now derives wall-clock time from `duration_seconds`, but there is still no richer token/cost policy

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -36,6 +36,7 @@ type config = {
   memory : Oas.Memory.t option;
   named_cascade : Oas.Api.named_cascade option;
   initial_messages : Oas.Types.message list;
+  raw_trace : Oas.Raw_trace.t option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -53,6 +54,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     memory = None;
     named_cascade = None;
     initial_messages = [];
+    raw_trace = None;
   }
 
 (* ================================================================ *)
@@ -64,6 +66,7 @@ type run_result = {
   checkpoint : Oas.Checkpoint.t option;
   session_id : string;
   turns : int;
+  trace_ref : Oas.Raw_trace.run_ref option;
 }
 
 (* ================================================================ *)
@@ -153,6 +156,10 @@ let build
     | Some m -> Oas.Builder.with_memory m builder
     | None -> builder
   in
+  let builder = match config.raw_trace with
+    | Some raw_trace -> Oas.Builder.with_raw_trace raw_trace builder
+    | None -> builder
+  in
   let builder = match config.named_cascade with
     | Some nc -> Oas.Builder.with_named_cascade nc builder
     | None -> builder
@@ -221,9 +228,10 @@ let run
         ~detail:(Printf.sprintf "session=%s" session_id)
     ) config.event_bus;
     let turns = (Oas.Agent.state agent).turn_count in
+    let trace_ref = Oas.Agent.last_raw_trace_run agent in
     Oas.Agent.close agent;
     (match result with
-    | Ok response -> Ok { response; checkpoint; session_id; turns }
+    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref }
     | Error err ->
       Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
   with
@@ -456,6 +464,7 @@ let run_named_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
+    ?raw_trace
     ?on_event
     ()
   : (run_result, string) result =
@@ -479,6 +488,7 @@ let run_named_with_masc_tools
           ~description:(Some (Printf.sprintf "cascade:%s" cascade_name))
           ()
       in
+      let config = { config with raw_trace } in
       match run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch ?on_event goal with
       | Ok result -> Ok result
       | Error e when rest <> [] ->
@@ -501,6 +511,7 @@ let run_model_with_masc_tools
     ?guardrails
     ?hooks
     ?memory
+    ?raw_trace
     ?on_event
     ()
   : (run_result, string) result =
@@ -514,5 +525,6 @@ let run_model_with_masc_tools
           ~description:(Some "model_spec:explicit")
           ()
       in
+      let config = { config with raw_trace } in
       run_with_masc_tools ~sw ~net ~config ~masc_tools ~dispatch ?on_event
         goal

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -23,6 +23,7 @@ type run_result = {
   checkpoint : Oas.Checkpoint.t option;
   session_id : string;
   turns : int;
+  trace_ref : Oas.Raw_trace.run_ref option;
 }
 
 (** Locate config/cascade.json via CWD or ME_ROOT. *)
@@ -79,6 +80,7 @@ val run_named_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
+  ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->
   (run_result, string) result
@@ -95,6 +97,7 @@ val run_model_with_masc_tools :
   ?guardrails:Oas.Guardrails.t ->
   ?hooks:Oas.Hooks.hooks ->
   ?memory:Oas.Memory.t ->
+  ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   unit ->
   (run_result, string) result

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -215,10 +215,23 @@ let cascade_of_worker
 let telemetry_of_run_result (result : Oas_worker.run_result) :
     Swarm.Swarm_types.agent_telemetry =
   {
-    Swarm.Swarm_types.trace_ref = None;
+    Swarm.Swarm_types.trace_ref = result.trace_ref;
     usage = Option.map (Oas.Types.add_usage Oas.Types.empty_usage) result.response.usage;
     turn_count = max 1 result.turns;
   }
+
+let create_team_session_raw_trace ~(config : Room.config) ~(session_id : string)
+    ~(agent_name : string) : Oas.Raw_trace.t option =
+  match
+    Oas.Raw_trace.create_for_session
+      ~session_root:(Worker_container.oas_trace_session_root ~base_path:config.base_path)
+      ~session_id ~agent_name ()
+  with
+  | Ok raw_trace -> Some raw_trace
+  | Error err ->
+      Log.Session.warn "team_session_oas_bridge: raw trace disabled for %s: %s"
+        agent_name (Oas.Error.to_string err);
+      None
 
 let make_convergence_metric ~(entry_count : int)
     (success_by_agent : (string, bool) Hashtbl.t) :
@@ -255,6 +268,7 @@ let budget_of_session_timeout timeout_sec =
 
 let planned_worker_to_entry_with_state
     ~(config : Room.config)
+    ~(session_id : string)
     ~(session_cascade : string list)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -272,6 +286,9 @@ let planned_worker_to_entry_with_state
       (match pw.spawn_role with Some r -> r | None -> "execute")
   in
   let run ~sw:_ prompt =
+    let raw_trace =
+      create_team_session_raw_trace ~config ~session_id ~agent_name:name
+    in
     let dispatch_with_defaults ~name:(tool_name : string) ~(args : Yojson.Safe.t)
       =
       dispatch ~name:tool_name
@@ -281,7 +298,7 @@ let planned_worker_to_entry_with_state
       Oas_worker.run_named_with_masc_tools
         ~cascade_name ~goal:prompt ~system_prompt
         ~masc_tools ~dispatch:dispatch_with_defaults ~max_turns
-        ~temperature:0.3 ~max_tokens:4096 ()
+        ~temperature:0.3 ~max_tokens:4096 ?raw_trace ()
     with
     | Ok result ->
         Hashtbl.replace success_by_agent name true;
@@ -299,13 +316,14 @@ let planned_worker_to_entry_with_state
 
 let planned_worker_to_entry
     ~(config : Room.config)
+    ~(session_id : string)
     ~(session_cascade : string list)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     (pw : Team_session_types.planned_worker)
   : Swarm.Swarm_types.agent_entry =
   let success_by_agent = Hashtbl.create 1 in
-  planned_worker_to_entry_with_state ~config ~session_cascade ~masc_tools
+  planned_worker_to_entry_with_state ~config ~session_id ~session_cascade ~masc_tools
     ~dispatch ~success_by_agent pw
 
 (* ── session -> swarm_config ───────────────────────────────────── *)
@@ -319,7 +337,7 @@ let session_to_swarm_config
   let success_by_agent = Hashtbl.create 8 in
   let entries =
     List.map
-      (planned_worker_to_entry_with_state ~config
+      (planned_worker_to_entry_with_state ~config ~session_id:session.session_id
          ~session_cascade:session.model_cascade ~masc_tools ~dispatch
          ~success_by_agent)
       session.planned_workers
@@ -350,14 +368,39 @@ let session_to_swarm_config
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)
 
+let final_outcome_of_swarm_result
+    (result : Swarm.Swarm_types.swarm_result)
+  : Team_session_types.session_status * string =
+  if result.converged then
+    (Team_session_types.Completed, "swarm_converged")
+  else
+    let last_agent_results =
+      match List.rev result.iterations with
+      | [] -> []
+      | last :: _ -> last.agent_results
+    in
+    let success_count, error_count =
+      List.fold_left
+        (fun (successes, errors) (_, status) ->
+          match status with
+          | Swarm.Swarm_types.Done_ok _ -> (successes + 1, errors)
+          | Swarm.Swarm_types.Done_error _ -> (successes, errors + 1)
+          | Swarm.Swarm_types.Idle | Swarm.Swarm_types.Working ->
+              (successes, errors))
+        (0, 0) last_agent_results
+    in
+    if success_count > 0 then
+      (Team_session_types.Interrupted, "swarm_partial_completion")
+    else if error_count > 0 then
+      (Team_session_types.Failed, "swarm_all_agents_failed")
+    else
+      (Team_session_types.Failed, "swarm_exhausted")
+
 let apply_swarm_result
     (session : Team_session_types.session)
     (result : Swarm.Swarm_types.swarm_result)
   : Team_session_types.session =
-  let final_status =
-    if result.converged then Team_session_types.Completed
-    else Team_session_types.Failed
-  in
+  let final_status, stop_reason = final_outcome_of_swarm_result result in
   let now = Time_compat.now () in
   { session with
     status = final_status;
@@ -367,6 +410,4 @@ let apply_swarm_result
     stopped_at = Some now;
     last_event_at = Some now;
     updated_at_iso = Types.now_iso ();
-    stop_reason =
-      Some (if result.converged then "swarm_converged"
-            else "swarm_exhausted") }
+    stop_reason = Some stop_reason }

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -28,8 +28,12 @@ val cascade_of_worker :
   session_cascade:string list ->
   Team_session_types.planned_worker -> string
 
+val telemetry_of_run_result :
+  Oas_worker.run_result -> Swarm.Swarm_types.agent_telemetry
+
 val planned_worker_to_entry :
   config:Room.config ->
+  session_id:string ->
   session_cascade:string list ->
   masc_tools:Types.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> bool * string) ->

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -8,6 +8,7 @@
 open Masc_mcp
 
 module Swarm = Agent_sdk_swarm
+module Oas = Agent_sdk
 
 (* ================================================================ *)
 (* Role mapping tests                                               *)
@@ -222,6 +223,43 @@ let test_session_to_swarm_config_health_contract () =
   Alcotest.(check bool) "resource check passes for initialized room" true
     resource_ok
 
+let test_telemetry_of_run_result_carries_trace_ref () =
+  let trace_ref =
+    {
+      Oas.Raw_trace.worker_run_id = "run-123";
+      path = "/tmp/oas-trace.jsonl";
+      start_seq = 1;
+      end_seq = 7;
+      agent_name = "test-agent";
+      session_id = Some "team-session-1";
+    }
+  in
+  let result : Oas_worker.run_result =
+    {
+      response =
+        {
+          Oas.Types.id = "resp-1";
+          model = "glm:auto";
+          stop_reason = Oas.Types.EndTurn;
+          content = [];
+          usage = None;
+        };
+      checkpoint = None;
+      session_id = "session-1";
+      turns = 3;
+      trace_ref = Some trace_ref;
+    }
+  in
+  let telemetry = Team_session_oas_bridge.telemetry_of_run_result result in
+  Alcotest.(check int) "turn_count preserved" 3 telemetry.turn_count;
+  match telemetry.trace_ref with
+  | Some actual ->
+      Alcotest.(check string) "worker_run_id" trace_ref.worker_run_id
+        actual.worker_run_id;
+      Alcotest.(check string) "agent_name" trace_ref.agent_name
+        actual.agent_name
+  | None -> Alcotest.fail "expected trace_ref in telemetry"
+
 (* ================================================================ *)
 (* Supported tool runtime tests                                     *)
 (* ================================================================ *)
@@ -309,6 +347,8 @@ let () =
         test_cascade_empty_model_string;
       Alcotest.test_case "session swarm health contract" `Quick
         test_session_to_swarm_config_health_contract;
+      Alcotest.test_case "telemetry carries trace_ref" `Quick
+        test_telemetry_of_run_result_carries_trace_ref;
     ];
     "supported_tools", [
       Alcotest.test_case "schemas present" `Quick

--- a/test/test_team_session_swarm_runner.ml
+++ b/test/test_team_session_swarm_runner.ml
@@ -132,6 +132,90 @@ let test_apply_exhausted_result () =
   Alcotest.(check string) "stop_reason exhausted"
     "swarm_exhausted" (Option.get updated.stop_reason)
 
+let test_apply_partial_result () =
+  let session = make_test_session "s-partial" in
+  let result : Swarm.Swarm_types.swarm_result = {
+    iterations = [
+      {
+        Swarm.Swarm_types.iteration = 1;
+        metric_value = Some 0.5;
+        agent_results = [
+          ( "agent-ok",
+            Swarm.Swarm_types.Done_ok
+              {
+                elapsed = 1.0;
+                text = "done";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+          ( "agent-err",
+            Swarm.Swarm_types.Done_error
+              {
+                elapsed = 1.5;
+                error = "boom";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+        ];
+        elapsed = 2.0;
+        timestamp = Time_compat.now ();
+        trace_refs = [];
+      };
+    ];
+    final_metric = Some 0.5;
+    converged = false;
+    total_elapsed = 2.0;
+    total_usage = { Agent_sdk.Types.total_input_tokens = 0;
+      total_output_tokens = 0; total_cache_creation_input_tokens = 0;
+      total_cache_read_input_tokens = 0; api_calls = 0;
+      estimated_cost_usd = 0.0 };
+  } in
+  let updated = Team_session_oas_bridge.apply_swarm_result session result in
+  Alcotest.(check string) "status interrupted"
+    "interrupted" (Team_session_types.status_to_string updated.status);
+  Alcotest.(check string) "stop_reason partial"
+    "swarm_partial_completion" (Option.get updated.stop_reason)
+
+let test_apply_all_agents_failed_result () =
+  let session = make_test_session "s-all-failed" in
+  let result : Swarm.Swarm_types.swarm_result = {
+    iterations = [
+      {
+        Swarm.Swarm_types.iteration = 1;
+        metric_value = Some 0.0;
+        agent_results = [
+          ( "agent-1",
+            Swarm.Swarm_types.Done_error
+              {
+                elapsed = 1.0;
+                error = "first";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+          ( "agent-2",
+            Swarm.Swarm_types.Done_error
+              {
+                elapsed = 1.1;
+                error = "second";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+        ];
+        elapsed = 2.1;
+        timestamp = Time_compat.now ();
+        trace_refs = [];
+      };
+    ];
+    final_metric = Some 0.0;
+    converged = false;
+    total_elapsed = 2.1;
+    total_usage = { Agent_sdk.Types.total_input_tokens = 0;
+      total_output_tokens = 0; total_cache_creation_input_tokens = 0;
+      total_cache_read_input_tokens = 0; api_calls = 0;
+      estimated_cost_usd = 0.0 };
+  } in
+  let updated = Team_session_oas_bridge.apply_swarm_result session result in
+  Alcotest.(check string) "status failed"
+    "failed" (Team_session_types.status_to_string updated.status);
+  Alcotest.(check string) "stop_reason all agents failed"
+    "swarm_all_agents_failed" (Option.get updated.stop_reason)
+
 let test_apply_updates_stopped_at () =
   let session = make_test_session "s-ts" in
   Alcotest.(check bool) "initially no stopped_at"
@@ -243,6 +327,10 @@ let () =
         test_apply_converged_result;
       Alcotest.test_case "exhausted result" `Quick
         test_apply_exhausted_result;
+      Alcotest.test_case "partial result" `Quick
+        test_apply_partial_result;
+      Alcotest.test_case "all agents failed result" `Quick
+        test_apply_all_agents_failed_result;
       Alcotest.test_case "updates stopped_at" `Quick
         test_apply_updates_stopped_at;
     ];


### PR DESCRIPTION
## Summary
- plumb OAS raw trace refs through the OAS worker result
- expose team-session swarm telemetry with trace_ref, usage, and turn count
- distinguish non-converged swarm outcomes as partial completion, all-agents-failed, or exhausted

## Validation
- git diff --check
- dune build --root . @check
- targeted runtest aliases for team_session_oas_bridge and team_session_swarm_runner still hang in this checkout, so compile + regression coverage was used as the local gate
