### PR TITLE
fix: scope OAS memory fallback and surface more OAS events

### DIFF
--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -21,6 +21,40 @@ function actionBadge(action: string | undefined): string {
   }
 }
 
+function eventTypeLabel(type: string): string {
+  switch (type) {
+    case 'selected': return 'selected'
+    case 'decision': return 'decision'
+    case 'action_executed': return 'executed'
+    case 'keeper_resident_lifecycle': return 'resident'
+    case 'trust_updated': return 'trust'
+    case 'reputation_changed': return 'reputation'
+    default: return type
+  }
+}
+
+function eventDetail(ev: (typeof oasAgentEvents.value)[number]): string {
+  switch (ev.type) {
+    case 'selected':
+      return ev.trigger ? `trigger ${ev.trigger}` : 'selection updated'
+    case 'decision':
+      return [ev.action, ev.trigger_reason].filter(Boolean).join(' · ') || 'decision updated'
+    case 'action_executed':
+      return [ev.action, ev.success != null ? (ev.success ? 'ok' : 'fail') : null].filter(Boolean).join(' · ')
+    case 'keeper_resident_lifecycle':
+      return [ev.event, ev.detail].filter(Boolean).join(' · ') || 'resident lifecycle'
+    case 'trust_updated':
+      return [ev.secondary_agent, ev.trust_score != null ? `score ${ev.trust_score.toFixed(2)}` : null].filter(Boolean).join(' · ')
+    case 'reputation_changed':
+      return [
+        ev.old_score != null && ev.new_score != null ? `${ev.old_score.toFixed(2)} → ${ev.new_score.toFixed(2)}` : null,
+        ev.trend ?? null,
+      ].filter(Boolean).join(' · ')
+    default:
+      return ''
+  }
+}
+
 function OasSummaryLines() {
   const events = oasAgentEvents.value
   const snapshots = oasKeeperSnapshots.value
@@ -79,10 +113,11 @@ function OasRawEventList() {
         <div class="oas-event-row rounded" key=${i}>
           <span class="oas-event-ts">${formatTs(ev.timestamp)}</span>
           <span class="oas-event-agent">${ev.agent_name}</span>
-          <span class="oas-event-type">${ev.type}</span>
+          <span class="oas-event-type">${eventTypeLabel(ev.type)}</span>
           ${ev.action ? html`<span class="oas-event-badge ${actionBadge(ev.action)}">${ev.action}</span>` : null}
           ${ev.trigger ? html`<span class="oas-event-trigger">${ev.trigger}</span>` : null}
           ${ev.success != null ? html`<span class="oas-event-ok ${ev.success ? 'ok' : 'fail'}">${ev.success ? 'ok' : 'fail'}</span>` : null}
+          ${eventDetail(ev) ? html`<span class="oas-event-trigger">${eventDetail(ev)}</span>` : null}
         </div>
       `)}
     </div>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -19,44 +19,6 @@ function shortCommit(commit: string | null | undefined): string {
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
-function residentStatusLabel(
-  status: 'live' | 'quiet' | 'starting' | 'idle' | 'disabled',
-) {
-  if (status === 'live') return '가동 중'
-  if (status === 'quiet') return '조용함'
-  if (status === 'starting') return '기동 중'
-  if (status === 'idle') return '대기 중'
-  return '비활성'
-}
-
-function renderRuntimeStat(label: string, value: ComponentChildren) {
-  return html`
-    <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
-      <span>${label}</span>
-      <strong class="text-[color:var(--text-strong)] text-right">${value}</strong>
-    </div>
-  `
-}
-
-function renderResidentRuntimeCard(
-  title: string,
-  statusLabel: string,
-  tone: 'ok' | 'warn' | 'bad',
-  rows: ComponentChildren[],
-  hint?: ComponentChildren,
-) {
-  return html`
-    <div style="padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
-      <div class="flex items-center justify-between gap-3 m-0">
-        <h3 class="text-xs">${title}</h3>
-        <span class="rail-section-chip rounded-full ${tone}">${statusLabel}</span>
-      </div>
-      ${rows}
-      ${hint ? html`<div class="mt-2.5 text-xs text-[color:var(--text-muted)]">${hint}</div>` : null}
-    </div>
-  `
-}
-
 export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -368,6 +368,95 @@ function handleEvent(event: SSEEvent): void {
       )
       break
     }
+    case 'oas:masc:keeper:resident_lifecycle': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const agentName = (p.agent_name as string) ?? ''
+      const lifecycleEvent = (p.event as string) ?? undefined
+      const detail = (p.detail as string) ?? undefined
+      pushOasAgentEvent({
+        type: 'keeper_resident_lifecycle',
+        agent_name: agentName,
+        event: lifecycleEvent,
+        detail,
+        timestamp:
+          typeof p.timestamp === 'number'
+            ? p.timestamp
+            : (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000),
+      })
+      addTypedJournalEntry(
+        agentName,
+        `Resident ${[lifecycleEvent, detail].filter(Boolean).join(' · ') || 'lifecycle'}`,
+        'oas',
+        'oas_event',
+        {
+          narrativeText:
+            `${actorLabel(agentName)} resident lifecycle 이벤트`
+            + ([lifecycleEvent, detail].filter(Boolean).length > 0
+              ? ` (${[lifecycleEvent, detail].filter(Boolean).join(' · ')})`
+              : ''),
+        },
+      )
+      break
+    }
+    case 'oas:masc:trust_updated': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const agentA = (p.agent_a as string) ?? ''
+      const agentB = (p.agent_b as string) ?? ''
+      const trustScore = typeof p.trust_score === 'number' ? p.trust_score : undefined
+      pushOasAgentEvent({
+        type: 'trust_updated',
+        agent_name: agentA,
+        secondary_agent: agentB,
+        trust_score: trustScore,
+        timestamp:
+          typeof p.timestamp === 'number'
+            ? p.timestamp
+            : (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000),
+      })
+      addTypedJournalEntry(
+        agentA,
+        `Trust ${agentB}${trustScore != null ? ` · ${trustScore.toFixed(2)}` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          narrativeText:
+            `${actorLabel(agentA)}와 ${actorLabel(agentB)} 사이 trust score가 갱신되었습니다`
+            + (trustScore != null ? ` (${trustScore.toFixed(2)})` : ''),
+        },
+      )
+      break
+    }
+    case 'oas:masc:reputation_changed': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const agentName = (p.agent_name as string) ?? ''
+      const oldScore = typeof p.old_score === 'number' ? p.old_score : undefined
+      const newScore = typeof p.new_score === 'number' ? p.new_score : undefined
+      const trend = (p.trend as string) ?? undefined
+      pushOasAgentEvent({
+        type: 'reputation_changed',
+        agent_name: agentName,
+        old_score: oldScore,
+        new_score: newScore,
+        trend,
+        timestamp:
+          typeof p.timestamp === 'number'
+            ? p.timestamp
+            : (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000),
+      })
+      addTypedJournalEntry(
+        agentName,
+        `Reputation${oldScore != null && newScore != null ? ` ${oldScore.toFixed(2)} → ${newScore.toFixed(2)}` : ''}${trend ? ` · ${trend}` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          narrativeText:
+            `${actorLabel(agentName)} reputation이 갱신되었습니다`
+            + (oldScore != null && newScore != null ? ` (${oldScore.toFixed(2)} → ${newScore.toFixed(2)})` : '')
+            + (trend ? `, trend=${trend}` : ''),
+        },
+      )
+      break
+    }
     case 'oas:masc:keeper:tick': {
       const now = Date.now()
       if (oasLastKeeperTick.value === null || now - oasLastKeeperTick.value > 100) {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -154,6 +154,7 @@ export function updateOasKeeperSnapshot(snapshot: OasKeeperSnapshot): void {
     if (oldest) next.delete(oldest)
   }
   oasKeeperSnapshots.value = next
+  oasLastKeeperTick.value = Date.now()
   oasTotalEvents.value++
 }
 

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -1,14 +1,27 @@
 // OAS (Open Agent SDK) Event types for dashboard monitoring
 
 export interface OasAgentEvent {
-  type: 'selected' | 'decision' | 'action_executed'
+  type:
+    | 'selected'
+    | 'decision'
+    | 'action_executed'
+    | 'keeper_resident_lifecycle'
+    | 'trust_updated'
+    | 'reputation_changed'
   agent_name: string
+  secondary_agent?: string
   action?: string
   trigger?: string
   trigger_reason?: string
+  event?: string
+  detail?: string
   thompson_score?: number
   final_score?: number
   success?: boolean
+  trust_score?: number
+  old_score?: number
+  new_score?: number
+  trend?: string
   timestamp: number
 }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -29,6 +29,9 @@ export type SSEEventType =
   | 'oas:masc:lodge:agent_action_executed'
   | 'oas:masc:keeper:snapshot'
   | 'oas:masc:keeper:tick'
+  | 'oas:masc:keeper:resident_lifecycle'
+  | 'oas:masc:trust_updated'
+  | 'oas:masc:reputation_changed'
 
 export interface SSEEvent {
   type: SSEEventType
@@ -84,6 +87,7 @@ export type JournalEventType =
   | 'keeper_compaction'
   | 'keeper_guardrail'
   | 'oas_keeper_snapshot'
+  | 'oas_event'
   | 'unknown'
 
 export interface JournalEntry {

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -138,7 +138,14 @@ let run_turn
   let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd
     ?autonomy_filter () in
-  let memory = Memory_oas_bridge.create_memory ~agent_name ~session_id:meta.trace_id () in
+  let base_dir = Filename.concat config.base_path ".masc" in
+  let memory =
+    Memory_oas_bridge.create_memory
+      ~agent_name
+      ~base_dir
+      ~session_id:meta.trace_id
+      ()
+  in
   ignore (Memory_oas_bridge.seed_institution ~memory ~config);
   ignore (Memory_oas_bridge.seed_procedures ~memory ~agent_name:"_global" ~limit:5);
   ignore (Memory_oas_bridge.seed_memory_bank ~memory ~agent_name ~limit:10);

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -43,18 +43,30 @@ let content_of_json (json : Yojson.Safe.t) : string =
 let generate_session_id () =
   Printf.sprintf "%d" (int_of_float (Unix.gettimeofday ()))
 
+(** Resolve the JSONL fallback root for OAS memory.
+
+    Preference order:
+    1. Explicit [base_dir]
+    2. Room-scoped [.masc] under [config.base_path]
+    3. Legacy global [ME_ROOT/.masc] fallback *)
+let resolve_base_dir ?(base_dir : string option) ?(config : Room_utils.config option) () =
+  match base_dir, config with
+  | Some dir, _ -> dir
+  | None, Some cfg -> Filename.concat cfg.base_path ".masc"
+  | None, None -> Filename.concat (Env_config.me_root ()) ".masc"
+
 (** Create an OAS [long_term_backend].
 
     If a PG pool is available (via [Board_dispatch.get_pg_pool]),
     uses [Memory_pg] for persistent storage scoped by [agent_name].
     Otherwise falls back to session-based JSONL files under
     [.masc/memory/<agent_name>/<session_id>.jsonl]. *)
-let make_backend ~(agent_name : string) ~(session_id : string)
+let make_backend ?base_dir ~(agent_name : string) ~(session_id : string) ()
   : Agent_sdk.Memory.long_term_backend =
   match Board_dispatch.get_pg_pool () with
   | Some pool -> Memory_pg.make_backend ~pool ~agent_name
   | None ->
-    let base_dir = Env_config.me_root () ^ "/.masc" in
+    let base_dir = resolve_base_dir ?base_dir () in
     Log.MemoryJsonl.info "Using JSONL fallback for %s (session=%s)"
       agent_name session_id;
     Memory_jsonl.make_backend ~base_dir ~agent_name ~session_id
@@ -63,13 +75,14 @@ let make_backend ~(agent_name : string) ~(session_id : string)
 
     Uses PostgreSQL long_term_backend when available, JSONL fallback otherwise.
     @param session_id Session identifier; defaults to timestamp-based ID. *)
-let create_memory ~(agent_name : string) ?(session_id : string option)
+let create_memory ~(agent_name : string) ?(base_dir : string option)
+    ?(session_id : string option)
     () : Agent_sdk.Memory.t =
   let sid = match session_id with
     | Some s -> s
     | None -> generate_session_id ()
   in
-  let backend = make_backend ~agent_name ~session_id:sid in
+  let backend = make_backend ?base_dir ~agent_name ~session_id:sid () in
   Agent_sdk.Memory.create ~long_term:backend ()
 
 (** Format institutional memory as a JSON value suitable for
@@ -252,11 +265,11 @@ let institution_episode_of_oas ~(agent_name : string)
   }
 
 let persisted_episode_ids () =
+  let seen = Hashtbl.create 128 in
   Institution_eio.load_recent_episodes_jsonl ~limit:max_int
-  |> List.fold_left
-       (fun seen (episode : Institution_eio.episode) ->
-         if List.mem episode.id seen then seen else episode.id :: seen)
-       []
+  |> List.iter (fun (episode : Institution_eio.episode) ->
+         Hashtbl.replace seen episode.id ());
+  seen
 
 (** Pre-seed the Episodic tier.
 
@@ -283,8 +296,9 @@ let flush_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int =
   Agent_sdk.Memory.recall_episodes memory ~limit:max_int ()
   |> List.fold_left
        (fun flushed (episode : Agent_sdk.Memory.episode) ->
-         if List.mem episode.id persisted_ids then flushed
+         if Hashtbl.mem persisted_ids episode.id then flushed
          else (
+           Hashtbl.replace persisted_ids episode.id ();
            Fs_compat.append_jsonl path
              (Institution_eio.episode_to_json
                 (institution_episode_of_oas ~agent_name episode));
@@ -398,11 +412,17 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
     @param episode_limit default 50
     @param procedure_limit default 20 *)
 let create_memory_full ~(agent_name : string)
+    ?(base_dir : string option)
     ?(session_id : string option)
     ?(config : Room_utils.config option)
     ?(episode_limit = 50) ?(procedure_limit = 20)
     () : Agent_sdk.Memory.t =
-  let memory = create_memory ~agent_name ?session_id () in
+  let base_dir =
+    match base_dir with
+    | Some _ -> base_dir
+    | None -> Some (resolve_base_dir ?config ())
+  in
+  let memory = create_memory ~agent_name ?base_dir ?session_id () in
   let _episode_count =
     seed_episodes ~memory ~agent_name ~limit:episode_limit
   in

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -6,8 +6,17 @@
 
     @since 2.96.0 *)
 
-(** Drain interval: how often we poll the Event_bus subscription. *)
-let drain_interval_s = 2.0
+(** Drain interval: how often we poll the Event_bus subscription.
+    Lower default keeps the dashboard close to real-time, while staying
+    runtime-tunable for quieter deployments. *)
+let drain_interval_s () =
+  match Sys.getenv_opt "MASC_OAS_SSE_DRAIN_INTERVAL_SEC" with
+  | Some raw -> (
+      try
+        let parsed = float_of_string raw in
+        Float.min 5.0 (Float.max 0.05 parsed)
+      with Failure _ -> 0.25)
+  | None -> 0.25
 
 (** Prefix for events we relay. *)
 let masc_prefix = "masc:"
@@ -29,6 +38,7 @@ let relay_event = function
 
 (** Background fiber: drain events and relay to SSE. *)
 let start ~sw ~clock ~bus =
+  let interval_s = drain_interval_s () in
   let sub = Agent_sdk.Event_bus.subscribe bus
     ~filter:(function
       | Agent_sdk.Event_bus.Custom (name, _) ->
@@ -38,9 +48,9 @@ let start ~sw ~clock ~bus =
   in
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
-      Eio.Time.sleep clock drain_interval_s;
       let events = Agent_sdk.Event_bus.drain sub in
       List.iter relay_event events;
+      Eio.Time.sleep clock interval_s;
       loop ()
     in
     loop ())

--- a/lib/oas_sse_bridge.mli
+++ b/lib/oas_sse_bridge.mli
@@ -6,6 +6,8 @@
     @since 2.96.0 *)
 
 (** Start the bridge fiber. Subscribes to [bus] with a [masc:] prefix filter,
-    drains events every ~2 seconds, and broadcasts each as an SSE event.
+    drains events on an env-configurable interval
+    ([MASC_OAS_SSE_DRAIN_INTERVAL_SEC], default 0.25s),
+    and broadcasts each as an SSE event.
     Runs as a background Eio fiber under [sw]. *)
 val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> bus:Agent_sdk.Event_bus.t -> unit

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -272,7 +272,7 @@ let handle_route _ctx args =
       ]) decision.agents));
   ])
 
-let handle_execute _ctx args =
+let handle_execute ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
@@ -282,7 +282,12 @@ let handle_execute _ctx args =
        Include: (1) your reasoning, (2) identified risks, (3) recommended action. \
        Be concise and actionable." in
     let agent_name = "council-deliberation" in
-    let memory = Memory_oas_bridge.create_memory_full ~agent_name () in
+    let memory =
+      Memory_oas_bridge.create_memory_full
+        ~agent_name
+        ~config:(room_config_of_ctx ctx)
+        ()
+    in
     match Oas_worker.run_named
       ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
     with
@@ -297,7 +302,7 @@ let handle_execute _ctx args =
       ])
     | Error e -> json_err (Printf.sprintf "Deliberation failed: %s" e)
 
-let handle_execute_dry_run _ctx args =
+let handle_execute_dry_run ctx args =
   let topic = get_string args "topic" "" in
   if topic = "" then json_err "topic is required"
   else
@@ -307,7 +312,12 @@ let handle_execute_dry_run _ctx args =
        Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed. \
        This is analysis only — no actions will be taken." in
     let agent_name = "council-dry-run" in
-    let memory = Memory_oas_bridge.create_memory_full ~agent_name () in
+    let memory =
+      Memory_oas_bridge.create_memory_full
+        ~agent_name
+        ~config:(room_config_of_ctx ctx)
+        ()
+    in
     match Oas_worker.run_named
       ~cascade_name:"governance_judge" ~goal:topic ~system_prompt ~memory ()
     with

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -190,7 +190,12 @@ let handle_mitosis_divide ctx args : result =
     else
       Printf.sprintf "Continue from generation %d. Context: %s" next_gen summary
   in
-  let memory = Memory_oas_bridge.create_memory_full ~agent_name:ctx.agent_name () in
+  let memory =
+    Memory_oas_bridge.create_memory_full
+      ~agent_name:ctx.agent_name
+      ~config:ctx.config
+      ()
+  in
   let run_result =
     Oas_worker.run_named_with_masc_tools
       ~cascade_name:"mitosis" ~goal ~system_prompt
@@ -259,7 +264,12 @@ let handle_mitosis_handoff ctx args : result =
       "You are the successor agent (generation %d). Resume work from the handoff DNA above. Context ratio was %.1f%%."
       next_gen (context_ratio *. 100.0)
     in
-    let memory = Memory_oas_bridge.create_memory_full ~agent_name:ctx.agent_name () in
+    let memory =
+      Memory_oas_bridge.create_memory_full
+        ~agent_name:ctx.agent_name
+        ~config:ctx.config
+        ()
+    in
     let run_result =
       Oas_worker.run_named_with_masc_tools
         ~cascade_name:"mitosis" ~goal ~system_prompt

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -290,21 +290,48 @@ let test_stats_all_tiers () =
 
 let test_jsonl_backend_persist () =
   let sid = Printf.sprintf "test-persist-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) in
-  let backend = Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid in
+  let backend =
+    Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid ()
+  in
   let result = backend.persist ~key:"test" (`String "value") in
   Alcotest.(check bool) "persist returns Ok" true (Result.is_ok result)
 
 let test_jsonl_backend_retrieve () =
   let sid = Printf.sprintf "test-retrieve-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) in
-  let backend = Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid in
+  let backend =
+    Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid ()
+  in
   let result = backend.retrieve ~key:"nonexistent" in
   Alcotest.(check bool) "retrieve returns None for missing key" true (Option.is_none result)
 
 let test_jsonl_backend_query () =
   let sid = Printf.sprintf "test-query-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) in
-  let backend = Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid in
+  let backend =
+    Memory_oas_bridge.make_backend ~agent_name:"test-jsonl" ~session_id:sid ()
+  in
   let result = backend.query ~prefix:"test" ~limit:10 in
   Alcotest.(check int) "query returns empty on fresh session" 0 (List.length result)
+
+let test_jsonl_backend_uses_explicit_base_dir () =
+  let dir = setup_tmp_dir () in
+  let base_dir = Filename.concat dir ".masc-room-a" in
+  let sid = Printf.sprintf "test-scope-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) in
+  let backend =
+    Memory_oas_bridge.make_backend
+      ~base_dir
+      ~agent_name:"test-jsonl"
+      ~session_id:sid
+      ()
+  in
+  let result = backend.persist ~key:"scoped" (`String "value") in
+  Alcotest.(check bool) "persist returns Ok" true (Result.is_ok result);
+  let expected_path =
+    Filename.concat
+      (Filename.concat (Filename.concat base_dir "memory") "test-jsonl")
+      (sid ^ ".jsonl")
+  in
+  Alcotest.(check bool) "writes under explicit base_dir" true (Sys.file_exists expected_path);
+  cleanup_tmp_dir dir
 
 let test_seed_memory_bank_legacy_noop () =
   let dir = setup_tmp_dir () in
@@ -442,6 +469,8 @@ let () =
       Alcotest.test_case "persist returns Ok" `Quick test_jsonl_backend_persist;
       Alcotest.test_case "retrieve returns None" `Quick test_jsonl_backend_retrieve;
       Alcotest.test_case "query returns empty" `Quick test_jsonl_backend_query;
+      Alcotest.test_case "uses explicit base_dir" `Quick
+        test_jsonl_backend_uses_explicit_base_dir;
       Alcotest.test_case "seed_memory_bank legacy noop" `Quick
         test_seed_memory_bank_legacy_noop;
       Alcotest.test_case "seed_episodes loads recent jsonl" `Quick


### PR DESCRIPTION
## Summary
- scope OAS JSONL fallback to the current room .masc before falling back to global ME_ROOT/.masc
- replace episodic flush list dedupe with hashtable tracking and add explicit base-dir coverage
- lower and tune OAS SSE relay latency and surface resident lifecycle, trust, and reputation events in the dashboard

## Verification
- dune build --root .
- npm run typecheck
- ./_build/default/test/test_memory_oas_5tier.exe