### PR TITLE
fix(autoresearch): shell injection defense + Eio.Mutex on shared state

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -32,6 +32,16 @@ include Autoresearch_types
 let active_loops : (string, loop_state) Hashtbl.t = Hashtbl.create 4
 let latest_loop_id : string option ref = ref None
 
+(** Eio.Mutex protecting [active_loops] and [latest_loop_id] against
+    concurrent reads/writes from parallel tool handlers. *)
+let loops_mu = Eio.Mutex.create ()
+
+(** Execute [f] under exclusive write lock on the loops registry. *)
+let with_loops_rw f = Eio.Mutex.use_rw ~protect:true loops_mu (fun () -> f ())
+
+(** Execute [f] under shared read lock on the loops registry. *)
+let with_loops_ro f = Eio.Mutex.use_ro loops_mu (fun () -> f ())
+
 let generate_loop_id () =
   let rnd = Mirage_crypto_rng.generate 4 in
   let hex = String.concat "" (
@@ -83,6 +93,7 @@ let latest_cycle_record = Autoresearch_storage.latest_cycle_record
 (* ================================================================ *)
 
 let contains_substring = Autoresearch_metric.contains_substring
+let validate_metric_fn = Autoresearch_metric.validate_metric_fn
 let measure_metric = Autoresearch_metric.measure_metric
 let measure_metric_with_retry = Autoresearch_metric.measure_metric_with_retry
 
@@ -202,7 +213,8 @@ let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
 let should_continue (state : loop_state) =
   state.status = Running && state.current_cycle < state.max_cycles
 
-(** Stop a running or persisted loop. *)
+(** Stop a running or persisted loop.
+    Acquires [loops_mu] write lock internally. *)
 let stop_loop ~base_path ?reason loop_id =
   let stop_state (state : loop_state) =
     state.status <- Stopped;
@@ -211,80 +223,83 @@ let stop_loop ~base_path ?reason loop_id =
     save_state ~base_path state;
     state
   in
-  match Hashtbl.find_opt active_loops loop_id with
-  | Some state -> Some (stop_state state)
-  | None -> (
-      match load_state ~base_path loop_id with
-      | None -> None
-      | Some persisted ->
-          let now = Time_compat.now () in
-          let state =
-            {
-              loop_id = persisted.loop_id;
-              goal = persisted.goal;
-              metric_fn = persisted.metric_fn;
-              model_model = persisted.model_model;
-              target_file = persisted.target_file;
-              status = persisted.status;
-              error_message = persisted.error_message;
-              current_cycle = persisted.current_cycle;
-              baseline = persisted.baseline;
-              best_score = persisted.best_score;
-              best_cycle = persisted.best_cycle;
-              queued_hypothesis = persisted.queued_hypothesis;
-              history = [];
-              total_keeps = persisted.total_keeps;
-              total_discards = persisted.total_discards;
-              insights = [];
-              start_time = now -. max 0.0 persisted.elapsed_s;
-              updated_at = now;
-              cycle_timeout_s = persisted.cycle_timeout_s;
-              max_cycles = persisted.max_cycles;
-              workdir = persisted.workdir;
-              source_workdir = persisted.source_workdir;
-              program_note = persisted.program_note;
-              warnings = persisted.warnings;
-            }
-          in
-          Some (stop_state state))
+  with_loops_rw (fun () ->
+    match Hashtbl.find_opt active_loops loop_id with
+    | Some state -> Some (stop_state state)
+    | None -> (
+        match load_state ~base_path loop_id with
+        | None -> None
+        | Some persisted ->
+            let now = Time_compat.now () in
+            let state =
+              {
+                loop_id = persisted.loop_id;
+                goal = persisted.goal;
+                metric_fn = persisted.metric_fn;
+                model_model = persisted.model_model;
+                target_file = persisted.target_file;
+                status = persisted.status;
+                error_message = persisted.error_message;
+                current_cycle = persisted.current_cycle;
+                baseline = persisted.baseline;
+                best_score = persisted.best_score;
+                best_cycle = persisted.best_cycle;
+                queued_hypothesis = persisted.queued_hypothesis;
+                history = [];
+                total_keeps = persisted.total_keeps;
+                total_discards = persisted.total_discards;
+                insights = [];
+                start_time = now -. max 0.0 persisted.elapsed_s;
+                updated_at = now;
+                cycle_timeout_s = persisted.cycle_timeout_s;
+                max_cycles = persisted.max_cycles;
+                workdir = persisted.workdir;
+                source_workdir = persisted.source_workdir;
+                program_note = persisted.program_note;
+                warnings = persisted.warnings;
+              }
+            in
+            Some (stop_state state)))
 
-(** Linked loop status JSON for swarm integration. *)
+(** Linked loop status JSON for swarm integration.
+    Acquires [loops_mu] read lock internally. *)
 let linked_status_json ~base_path (link : swarm_link) =
   let current_cycle, status, best_score, error_message, workdir, source_workdir,
       program_note, warnings, queued_hypothesis =
-    match Hashtbl.find_opt active_loops link.loop_id with
-    | Some state ->
-        ( state.current_cycle,
-          status_to_string state.status,
-          state.best_score,
-          state.error_message,
-          state.workdir,
-          state.source_workdir,
-          state.program_note,
-          state.warnings,
-          state.queued_hypothesis )
-    | None -> (
-        match load_state ~base_path link.loop_id with
-        | Some persisted ->
-            ( persisted.current_cycle,
-              status_to_string persisted.status,
-              persisted.best_score,
-              persisted.error_message,
-              persisted.workdir,
-              persisted.source_workdir,
-              persisted.program_note,
-              persisted.warnings,
-              persisted.queued_hypothesis )
-        | None ->
-            ( 0,
-              "missing",
-              0.0,
-              Some "state file missing",
-              managed_worktree_dir ~base_path link.loop_id,
-              "",
-              link.program_note,
-              [],
-              None ))
+    with_loops_ro (fun () ->
+      match Hashtbl.find_opt active_loops link.loop_id with
+      | Some state ->
+          ( state.current_cycle,
+            status_to_string state.status,
+            state.best_score,
+            state.error_message,
+            state.workdir,
+            state.source_workdir,
+            state.program_note,
+            state.warnings,
+            state.queued_hypothesis )
+      | None -> (
+          match load_state ~base_path link.loop_id with
+          | Some persisted ->
+              ( persisted.current_cycle,
+                status_to_string persisted.status,
+                persisted.best_score,
+                persisted.error_message,
+                persisted.workdir,
+                persisted.source_workdir,
+                persisted.program_note,
+                persisted.warnings,
+                persisted.queued_hypothesis )
+          | None ->
+              ( 0,
+                "missing",
+                0.0,
+                Some "state file missing",
+                managed_worktree_dir ~base_path link.loop_id,
+                "",
+                link.program_note,
+                [],
+                None )))
   in
   let last_decision =
     match latest_cycle_record ~base_path link.loop_id with

--- a/lib/autoresearch_metric.ml
+++ b/lib/autoresearch_metric.ml
@@ -18,9 +18,27 @@ let contains_substring haystack needle =
     done;
     !found
 
+(** Shell metacharacters that indicate injection risk in metric_fn.
+    metric_fn is intentionally interpolated as a bare command (e.g. "python eval.py --metric accuracy"),
+    so we cannot quote it. Instead we reject strings containing shell metacharacters
+    that could chain or redirect commands. *)
+let dangerous_shell_chars = [';'; '|'; '&'; '`'; '$'; '('; ')'; '{'; '}'; '<'; '>'; '\n']
+
+(** Validate that metric_fn does not contain dangerous shell metacharacters.
+    Returns Ok fn on success, Error message on failure. *)
+let validate_metric_fn fn =
+  let has_danger = String.to_seq fn |> Seq.exists (fun c -> List.mem c dangerous_shell_chars) in
+  if has_danger then
+    Error (Printf.sprintf "metric_fn contains dangerous shell metacharacters: %s" fn)
+  else
+    Ok fn
+
 (** Run metric_fn shell command and parse the last float from stdout.
-    Returns Error if command fails or output is not a valid float. *)
+    Returns Error if command fails, metric_fn is unsafe, or output is not a valid float. *)
 let measure_metric ~workdir ~timeout_s metric_fn =
+  match validate_metric_fn metric_fn with
+  | Error e -> Error e
+  | Ok metric_fn ->
   let timeout_flag = Printf.sprintf "timeout %.0f" timeout_s in
   let cmd = Printf.sprintf "cd %s && %s %s 2>/dev/null | tail -1"
     (Filename.quote workdir) timeout_flag metric_fn in

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -145,7 +145,7 @@ let persisted_summary_json (summary : Autoresearch.persisted_summary) =
 let resolve_loop_id args =
   match get_string_opt args "loop_id" with
   | Some id -> Some id
-  | None -> !latest_loop_id
+  | None -> Autoresearch.with_loops_ro (fun () -> !latest_loop_id)
 
 let prepare_start_params ctx args =
   let goal = get_string args "goal" "" in
@@ -162,6 +162,10 @@ let prepare_start_params ctx args =
   else if target_file = "" then
     Error "target_file is required"
   else
+    (* Validate metric_fn early to reject shell injection before any state is created *)
+    match Autoresearch_metric.validate_metric_fn metric_fn with
+    | Error e -> Error e
+    | Ok metric_fn ->
     Ok
       {
         goal;
@@ -176,8 +180,9 @@ let prepare_start_params ctx args =
 
 let register_loop ctx state =
   Autoresearch.save_state ~base_path:ctx.base_path state;
-  Hashtbl.replace active_loops state.loop_id state;
-  latest_loop_id := Some state.loop_id;
+  Autoresearch.with_loops_rw (fun () ->
+    Hashtbl.replace active_loops state.loop_id state;
+    latest_loop_id := Some state.loop_id);
   state
 
 let setup_running_loop ctx (params : start_params) =
@@ -412,8 +417,13 @@ let handle_status ctx args =
   match resolve_loop_id args with
   | None -> `Assoc [("error", `String "No autoresearch loop running")]
   | Some id ->
-    match Hashtbl.find_opt active_loops id with
-    | Some state -> status_json ctx ~loop_id:id (Autoresearch.summary state)
+    let in_memory = Autoresearch.with_loops_ro (fun () ->
+      match Hashtbl.find_opt active_loops id with
+      | Some state -> Some (Autoresearch.summary state)
+      | None -> None)
+    in
+    match in_memory with
+    | Some json -> status_json ctx ~loop_id:id json
     | None -> (
         match Autoresearch.load_state ~base_path:ctx.base_path id with
         | Some summary -> status_json ctx ~loop_id:id (persisted_summary_json summary)
@@ -463,69 +473,90 @@ let handle_inject _ctx args =
     match resolve_loop_id args with
     | None -> `Assoc [("error", `String "No autoresearch loop running")]
     | Some id ->
-      match Hashtbl.find_opt active_loops id with
-      | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
-      | Some state ->
-        if state.status <> Autoresearch.Running then
-          `Assoc [("error", `String "Loop is not running")]
-        else begin
-          state.queued_hypothesis <- Some hypothesis;
-          Autoresearch.save_state ~base_path:_ctx.base_path state;
-          Hashtbl.replace pending_hypotheses id hypothesis;
-          `Assoc [
-            ("loop_id", `String id);
-            ("status", `String "hypothesis_queued");
-            ("hypothesis", `String hypothesis);
-            ("will_test_at_cycle", `Int (state.current_cycle + 1));
-          ]
-        end
+      Autoresearch.with_loops_rw (fun () ->
+        match Hashtbl.find_opt active_loops id with
+        | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
+        | Some state ->
+          if state.status <> Autoresearch.Running then
+            `Assoc [("error", `String "Loop is not running")]
+          else begin
+            state.queued_hypothesis <- Some hypothesis;
+            Autoresearch.save_state ~base_path:_ctx.base_path state;
+            Hashtbl.replace pending_hypotheses id hypothesis;
+            `Assoc [
+              ("loop_id", `String id);
+              ("status", `String "hypothesis_queued");
+              ("hypothesis", `String hypothesis);
+              ("will_test_at_cycle", `Int (state.current_cycle + 1));
+            ]
+          end)
 
 (** Run one experiment cycle: the real Karpathy loop turn.
     Steps: read file -> generate code change -> fresh metric before ->
-    apply change -> git commit -> metric after -> keep/discard -> persist. *)
+    apply change -> git commit -> metric after -> keep/discard -> persist.
+
+    Acquires [loops_mu] for short critical sections around Hashtbl access.
+    Long-running operations (metric measurement, code generation, git) run
+    outside the lock. *)
 let handle_cycle ctx args =
   match resolve_loop_id args with
   | None -> `Assoc [("error", `String "No autoresearch loop running")]
   | Some id ->
-    match Hashtbl.find_opt active_loops id with
-    | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
-    | Some state ->
-      if state.status <> Autoresearch.Running then
-        `Assoc [("error", `String "Loop is not running")]
-      else if not (Autoresearch.should_continue state) then begin
-        state.status <- Autoresearch.Completed;
-        Autoresearch.save_state ~base_path:ctx.base_path state;
+    (* Short critical section: look up state and check preconditions *)
+    let state_or_error = Autoresearch.with_loops_rw (fun () ->
+      match Hashtbl.find_opt active_loops id with
+      | None -> Error (Printf.sprintf "Loop %s not found" id)
+      | Some state ->
+        if state.status <> Autoresearch.Running then
+          Error "Loop is not running"
+        else if not (Autoresearch.should_continue state) then begin
+          state.status <- Autoresearch.Completed;
+          Autoresearch.save_state ~base_path:ctx.base_path state;
+          Error "completed"
+        end else
+          Ok state)
+    in
+    (match state_or_error with
+    | Error "completed" ->
+        (* Reconstruct completion JSON: re-read state under lock *)
+        let best_score, best_cycle = Autoresearch.with_loops_ro (fun () ->
+          match Hashtbl.find_opt active_loops id with
+          | Some s -> (s.best_score, s.best_cycle)
+          | None -> (0.0, 0))
+        in
         `Assoc [
           ("loop_id", `String id);
           ("status", `String "completed");
           ("reason", `String "max_cycles reached");
-          ("best_score", `Float state.best_score);
-          ("best_cycle", `Int state.best_cycle);
+          ("best_score", `Float best_score);
+          ("best_cycle", `Int best_cycle);
         ]
-      end else begin
-        let workdir = state.workdir in
-        let timeout_s = state.cycle_timeout_s in
-        let target_file = state.target_file in
-        (* 1. Read target file *)
-        match Autoresearch.validate_target_file ~workdir target_file with
-        | Error e ->
-          `Assoc [
-            ("error", `String (Printf.sprintf "target_file invalid: %s" e));
-            ("loop_id", `String id);
-          ]
-        | Ok abs_path ->
-        let file_content = Autoresearch.read_file abs_path in
-        (* 2. Generate code change: injected hypothesis > arg > MODEL *)
-        let code_result =
-          let forced_hypothesis =
+    | Error msg -> `Assoc [("error", `String msg)]
+    | Ok state ->
+      let workdir = state.workdir in
+      let timeout_s = state.cycle_timeout_s in
+      let target_file = state.target_file in
+      (* 1. Read target file *)
+      match Autoresearch.validate_target_file ~workdir target_file with
+      | Error e ->
+        `Assoc [
+          ("error", `String (Printf.sprintf "target_file invalid: %s" e));
+          ("loop_id", `String id);
+        ]
+      | Ok abs_path ->
+      let file_content = Autoresearch.read_file abs_path in
+      (* 2. Generate code change: injected hypothesis > arg > MODEL *)
+      let code_result =
+        let forced_hypothesis =
+          Autoresearch.with_loops_rw (fun () ->
             match Hashtbl.find_opt pending_hypotheses id with
             | Some h ->
                 Hashtbl.remove pending_hypotheses id;
                 state.queued_hypothesis <- None;
                 Autoresearch.save_state ~base_path:ctx.base_path state;
                 Some h
-            | None -> get_string_opt args "hypothesis"
-          in
+            | None -> get_string_opt args "hypothesis")
+        in
           let generate = get_generator id in
           (match forced_hypothesis with
            | Some h ->
@@ -681,8 +712,8 @@ let handle_cycle ctx args =
                       ("baseline", `Float state.baseline);
                       ("best_score", `Float state.best_score);
                       ("cycles_remaining", `Int (state.max_cycles - state.current_cycle));
-                    ]))
-      end
+                    ])))
+
 
 (* ================================================================ *)
 (* Dispatch                                                         *)


### PR DESCRIPTION
## Summary

20-agent 코드 감사에서 발견된 Critical 2건 수정.

### 1. Shell injection defense (autoresearch_metric.ml)
- `validate_metric_fn`: shell metachar (`;|&\`$(){}<>\n`) 포함 시 거부
- `prepare_start_params`에서 조기 검증 (loop state 생성 전)
- `measure_metric`에서 defense-in-depth 재검증

### 2. Eio.Mutex on shared state (autoresearch.ml + tool_autoresearch.ml)
- `loops_mu = Eio.Mutex.create()` + `with_loops_rw`/`with_loops_ro` helpers
- 보호 대상: active_loops, latest_loop_id, pending_hypotheses
- Long-running operations (metric, codegen, git)은 lock 밖에서 실행

## Files Changed
- lib/autoresearch.ml (+40 -10)
- lib/autoresearch_metric.ml (+25 -2)
- lib/tool_autoresearch.ml (+124 -113)

## Test plan
- [x] dune build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)