### PR TITLE
fix(dashboard): resolve agent roster flickering via fine-grained signals

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -7,7 +7,7 @@ import { useState } from 'preact/hooks'
 import type { Agent, Keeper } from '../types'
 import type { DashboardMissionKeeperBrief } from '../types/dashboard-mission'
 import { agents, keepers } from '../store'
-import { missionSnapshot } from '../mission-store'
+import { missionKeeperBriefs, missionAgentBriefs } from '../mission-signals'
 import { AgentAvatar } from './overview/agent-avatar'
 import { openAgentDetail } from './agent-detail'
 import { formatDuration } from './mission-utils'
@@ -82,9 +82,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   const agentList = agents.value
   const keeperList = keepers.value
-  const snap = missionSnapshot.value
-  const briefs = snap?.agent_briefs ?? []
-  const keeperBriefs = snap?.keeper_briefs ?? []
+  const briefs = missionAgentBriefs.value
+  const keeperBriefs = missionKeeperBriefs.value
 
   const briefMap = new Map(briefs.map(b => [b.agent_name, b]))
 

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -6,7 +6,7 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { navigate, route } from '../router'
 import { agents, keepers } from '../store'
-import { missionSnapshot } from '../mission-store'
+import { missionKeeperBriefs } from '../mission-signals'
 import { AgentRoster } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { Execution } from './agents'
@@ -23,9 +23,7 @@ function keeperNameSet(): Set<string> {
       ?? (k as { agent_name?: string }).agent_name
     if (name) names.add(name)
   }
-  const snap = missionSnapshot.value
-  const briefs = snap?.keeper_briefs ?? []
-  for (const kb of briefs) {
+  for (const kb of missionKeeperBriefs.value) {
     const name = (kb as { name?: string; agent_name?: string }).name
       ?? (kb as { agent_name?: string }).agent_name
     if (name) names.add(name)

--- a/dashboard/src/mission-signals.ts
+++ b/dashboard/src/mission-signals.ts
@@ -1,11 +1,22 @@
-import { signal } from '@preact/signals'
+import { signal, computed, type ReadonlySignal } from '@preact/signals'
 import type {
   DashboardMissionBriefingResponse,
   DashboardMissionResponse,
   DashboardMissionSessionDetailResponse,
+  DashboardMissionAgentBrief,
+  DashboardMissionKeeperBrief,
 } from './types'
 
 export const missionSnapshot = signal<DashboardMissionResponse | null>(null)
+
+// Fine-grained computed signals to avoid full re-render on every snapshot update.
+// Components that only need briefs subscribe to these instead of missionSnapshot.
+export const missionAgentBriefs: ReadonlySignal<DashboardMissionAgentBrief[]> = computed(
+  () => missionSnapshot.value?.agent_briefs ?? []
+)
+export const missionKeeperBriefs: ReadonlySignal<DashboardMissionKeeperBrief[]> = computed(
+  () => missionSnapshot.value?.keeper_briefs ?? []
+)
 export const missionLoading = signal(false)
 export const missionError = signal<string | null>(null)
 export const missionBriefing = signal<DashboardMissionBriefingResponse | null>(null)


### PR DESCRIPTION
## Summary
- Agent roster component re-rendered on every `missionSnapshot` signal update, causing visible flickering even when the agent/keeper briefs data was unchanged.
- Added `missionAgentBriefs` and `missionKeeperBriefs` as `computed` signals in `mission-signals.ts`, derived from `missionSnapshot`. These only trigger re-renders when their specific array values change.
- Updated `agent-roster.ts` to subscribe to the fine-grained signals instead of the monolithic snapshot.

## Changes
- `dashboard/src/mission-signals.ts` — added 2 computed signals (`missionAgentBriefs`, `missionKeeperBriefs`)
- `dashboard/src/components/agent-roster.ts` — switched from `missionSnapshot.value` to the new computed signals

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run dev` — agent roster no longer flickers on SSE mission updates
- [ ] Verify agent list, keeper badges, and context gauges still render correctly

Generated with [Claude Code](https://claude.com/claude-code)