### PR TITLE
fix(oas): harden OAS bridge — error propagation, dedup, silent-pass

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -331,6 +331,20 @@ let seed_procedures_as_oas ~(memory : Agent_sdk.Memory.t)
   ) procs;
   List.length procs
 
+let dedupe_procedures_by_id (procs : Procedural_memory.procedure list) =
+  let latest_by_id = Hashtbl.create (max 16 (List.length procs)) in
+  List.iter (fun (p : Procedural_memory.procedure) ->
+    Hashtbl.replace latest_by_id p.id p
+  ) procs;
+  let seen = Hashtbl.create (Hashtbl.length latest_by_id) in
+  List.filter_map (fun (p : Procedural_memory.procedure) ->
+    if Hashtbl.mem seen p.id then None
+    else begin
+      Hashtbl.add seen p.id ();
+      Hashtbl.find_opt latest_by_id p.id
+    end
+  ) procs
+
 (** Flush OAS procedures back to [Procedural_memory].
 
     Extracts procedures from the Procedural tier that have been updated
@@ -341,13 +355,15 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
     Agent_sdk.Memory.matching_procedures memory
       ~pattern:"" ()
   in
+  let existing_raw = Procedural_memory.load_procedures ~agent_name in
+  let procedures = ref (dedupe_procedures_by_id existing_raw) in
+  let needs_rewrite = ref (List.length existing_raw <> List.length !procedures) in
   let flushed = ref 0 in
   List.iter (fun (op : Agent_sdk.Memory.procedure) ->
-    let existing = Procedural_memory.load_procedures ~agent_name in
     let updated =
       match List.find_opt (fun (p : Procedural_memory.procedure) ->
         p.id = op.id
-      ) existing with
+      ) !procedures with
       | Some old_p ->
         (* Only flush if counts changed *)
         if old_p.success_count <> op.success_count
@@ -358,7 +374,10 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
             confidence = op.confidence;
             last_applied = op.last_used;
           } in
-          Procedural_memory.save_procedure ~agent_name updated_p;
+          procedures := List.map (fun (p : Procedural_memory.procedure) ->
+            if p.id = old_p.id then updated_p else p
+          ) !procedures;
+          needs_rewrite := true;
           true
         end else false
       | None ->
@@ -374,11 +393,14 @@ let flush_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int
           created_at = Unix.gettimeofday ();
           last_applied = op.last_used;
         } in
-        Procedural_memory.save_procedure ~agent_name new_p;
+        procedures := !procedures @ [new_p];
+        needs_rewrite := true;
         true
     in
     if updated then incr flushed
   ) oas_procs;
+  if !needs_rewrite then
+    Procedural_memory.rewrite_procedures ~agent_name !procedures;
   !flushed
 
 (* ================================================================ *)

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -193,17 +193,20 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
        Running and accepts manual steps via masc_team_session_step. *)
     if session.planned_workers <> [] then
       Eio.Fiber.fork ~sw (fun () ->
-        let masc_tools = Team_session_oas_bridge.supported_local_worker_tools () in
         let result =
-          Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-            ~session_id ~masc_tools
-            ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
-              ~sw ~clock ~config)
+          match Team_session_oas_bridge.supported_local_worker_tools () with
+          | Ok masc_tools ->
+            Team_session_swarm_runner.run_swarm ~sw ~clock ~config
+              ~session_id ~masc_tools
+              ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
+                ~sw ~clock ~config)
+          | Error reason -> Error reason
         in
         match result with
         | Ok _session ->
           with_runtimes_lock (fun () -> Hashtbl.remove runtimes session_id)
         | Error reason ->
+          Log.Session.error "team-session swarm startup failed: %s" reason;
           ignore (finalize_session ~config ~session_id
             ~final_status:Team_session_types.Failed ~reason
             ~generate_report:true);
@@ -680,20 +683,21 @@ let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
                     @ checkpoint_detail @ event_context));
               (* Phase C-2c: reconnect also uses swarm runner *)
               Eio.Fiber.fork ~sw (fun () ->
-                let masc_tools =
-                  Team_session_oas_bridge.supported_local_worker_tools ()
-                in
                 let result =
-                  Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-                    ~session_id:session.session_id ~masc_tools
-                    ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
-                      ~sw ~clock ~config)
+                  match Team_session_oas_bridge.supported_local_worker_tools () with
+                  | Ok masc_tools ->
+                    Team_session_swarm_runner.run_swarm ~sw ~clock ~config
+                      ~session_id:session.session_id ~masc_tools
+                      ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
+                        ~sw ~clock ~config)
+                  | Error reason -> Error reason
                 in
                 match result with
                 | Ok _s ->
                   with_runtimes_lock (fun () ->
                     Hashtbl.remove runtimes session.session_id)
                 | Error reason ->
+                  Log.Session.error "team-session swarm restart failed: %s" reason;
                   ignore (finalize_session ~config ~session_id:session.session_id
                     ~final_status:Team_session_types.Failed ~reason
                     ~generate_report:true);

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -43,9 +43,9 @@ let supported_local_worker_tools () =
     Agent_tool_surfaces.local_worker_tool_schemas
       ~names:supported_local_worker_tool_names ()
   with
-  | Ok schemas -> schemas
+  | Ok schemas -> Ok schemas
   | Error msg ->
-      failwith
+      Error
         (Printf.sprintf
            "team_session_oas_bridge: failed to resolve worker tool schemas: %s"
            msg)

--- a/lib/team_session/team_session_oas_bridge.mli
+++ b/lib/team_session/team_session_oas_bridge.mli
@@ -4,7 +4,8 @@
 
 module Swarm = Agent_sdk_swarm
 
-val supported_local_worker_tools : unit -> Types.tool_schema list
+val supported_local_worker_tools :
+  unit -> (Types.tool_schema list, string) result
 
 val dispatch_supported_tool :
   sw:Eio.Switch.t ->

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -111,7 +111,7 @@ let parse_verdict (text : string) : verdict =
   else
     (* If model doesn't follow format, treat as warning *)
     if String.length trimmed > 0 then Warn trimmed
-    else Pass
+    else Warn "empty verifier output"
 
 (* ================================================================ *)
 (* Verification Prompt                                              *)

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -255,6 +255,53 @@ let test_procedural_record_success () =
    | None -> Alcotest.fail "expected procedure after success");
   cleanup_tmp_dir dir
 
+let test_flush_procedures_dedupes_legacy_records () =
+  let dir = setup_tmp_dir () in
+  let agent_name = "test-pr-flush" in
+  let existing_old : Procedural_memory.procedure = {
+    id = "proc-legacy";
+    agent_name;
+    pattern = "deploy failure";
+    evidence = ["old"];
+    success_count = 1;
+    failure_count = 0;
+    confidence = 1.0;
+    created_at = 100.0;
+    last_applied = 110.0;
+  } in
+  let existing_latest = {
+    existing_old with
+    evidence = ["latest"];
+    success_count = 2;
+    created_at = 200.0;
+    last_applied = 210.0;
+  } in
+  Procedural_memory.save_procedure ~agent_name existing_old;
+  Procedural_memory.save_procedure ~agent_name existing_latest;
+  let memory = Memory_oas_bridge.create_memory ~agent_name () in
+  let oas_proc : Oas.Memory.procedure = {
+    id = "proc-legacy";
+    pattern = "deploy failure";
+    action = "rollback";
+    success_count = 2;
+    failure_count = 0;
+    confidence = 1.0;
+    last_used = 210.0;
+    metadata = [];
+  } in
+  Oas.Memory.store_procedure memory oas_proc;
+  let flushed = Memory_oas_bridge.flush_procedures ~memory ~agent_name in
+  Alcotest.(check int) "no flush when latest record already matches" 0 flushed;
+  let persisted = Procedural_memory.load_procedures ~agent_name in
+  Alcotest.(check int) "legacy duplicates rewritten away" 1
+    (List.length persisted);
+  let final = List.hd persisted in
+  Alcotest.(check string) "id preserved" "proc-legacy" final.id;
+  Alcotest.(check int) "latest success count preserved" 2 final.success_count;
+  Alcotest.(check string) "latest evidence preserved" "latest"
+    (List.hd final.evidence);
+  cleanup_tmp_dir dir
+
 (* ================================================================ *)
 (* Stats                                                             *)
 (* ================================================================ *)
@@ -434,6 +481,8 @@ let () =
     ("procedural", [
       Alcotest.test_case "store and recall" `Quick test_procedural_store_recall;
       Alcotest.test_case "record success" `Quick test_procedural_record_success;
+      Alcotest.test_case "flush dedupes legacy records" `Quick
+        test_flush_procedures_dedupes_legacy_records;
     ]);
     ("stats", [
       Alcotest.test_case "all tiers" `Quick test_stats_all_tiers;

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -227,7 +227,11 @@ let test_session_to_swarm_config_health_contract () =
 (* ================================================================ *)
 
 let test_supported_local_worker_tools_present () =
-  let schemas = Team_session_oas_bridge.supported_local_worker_tools () in
+  let schemas =
+    match Team_session_oas_bridge.supported_local_worker_tools () with
+    | Ok schemas -> schemas
+    | Error message -> Alcotest.failf "expected schemas, got error: %s" message
+  in
   let names =
     List.map (fun (schema : Types.tool_schema) -> schema.name) schemas
   in

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -207,9 +207,12 @@ let test_parse_verdict_unknown_defaults_to_warn () =
   | Warn _ -> ()
   | _ -> Alcotest.fail "unknown text should default to Warn"
 
-let test_parse_verdict_empty_defaults_to_pass () =
-  Alcotest.(check bool) "empty -> Pass" true
-    (Verifier_oas.parse_verdict "" = Pass)
+let test_parse_verdict_empty_defaults_to_warn () =
+  match Verifier_oas.parse_verdict "" with
+  | Warn reason ->
+    Alcotest.(check string) "empty output reason"
+      "empty verifier output" reason
+  | _ -> Alcotest.fail "empty text should default to Warn"
 
 (* ================================================================ *)
 (* should_skip (verify fast path)                                    *)
@@ -323,8 +326,8 @@ let () =
         test_parse_verdict_case_insensitive;
       Alcotest.test_case "unknown -> Warn" `Quick
         test_parse_verdict_unknown_defaults_to_warn;
-      Alcotest.test_case "empty -> Pass" `Quick
-        test_parse_verdict_empty_defaults_to_pass;
+      Alcotest.test_case "empty -> Warn" `Quick
+        test_parse_verdict_empty_defaults_to_warn;
     ]);
     ("verify_skip", [
       Alcotest.test_case "read-only skips" `Quick test_verify_skips_readonly;


### PR DESCRIPTION
## Summary

- **memory_oas_bridge**: Add `dedupe_procedures_by_id` to batch-rewrite procedural memory instead of per-procedure I/O. Eliminates O(n^2) load/save in `flush_procedures` and prevents duplicate entries from legacy data.
- **team_session_oas_bridge**: `supported_local_worker_tools` now returns `(tool_schema list, string) result` instead of calling `failwith`. Callers in `team_session_engine_eio` handle the error gracefully with pattern matching instead of crashing the swarm runner.
- **verifier_oas**: Empty verifier output returns `Warn "empty verifier output"` instead of silent `Pass`, preventing unverified results from being accepted without notice.

## Changes (8 files, +109 -26)

| File | Change |
|------|--------|
| `lib/memory_oas_bridge.ml` | Batch dedupe + single rewrite for procedural memory flush |
| `lib/team_session/team_session_oas_bridge.ml` | `failwith` → `Error` (result type) |
| `lib/team_session/team_session_oas_bridge.mli` | Signature: `unit -> result` |
| `lib/team_session/team_session_engine_eio.ml` | Handle `Ok`/`Error` at both call sites |
| `lib/verifier_oas.ml` | Empty output → `Warn` instead of `Pass` |
| `test/test_memory_oas_5tier.ml` | New test: flush dedupes legacy records |
| `test/test_team_session_oas_bridge.ml` | Updated for result type |
| `test/test_verifier_oas_bridge.ml` | Updated: empty → Warn assertion |

## Test plan

- [x] `dune build --root .` passes
- [ ] `dune test --root .` passes (running)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)