### PR TITLE
fix(cascade): skip GLM fallback when ZAI_API_KEY unset

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -282,8 +282,15 @@ let default_config_path () : string option =
     All profiles are now in config/cascade.json (hot-reloadable). *)
 let default_model_strings ~cascade_name:_ =
   let llama_model = Env_config.Llama.default_model in
-  (if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else [])
-  @ [ "glm:auto" ]
+  let models =
+    if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else []
+  in
+  let models =
+    match Sys.getenv_opt "ZAI_API_KEY" with
+    | Some k when k <> "" -> models @ [ "glm:auto" ]
+    | _ -> models
+  in
+  if models = [] then [ "llama:auto" ] else models
 
 (* ================================================================ *)
 (* Named model execution                                            *)

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -168,17 +168,28 @@ let test_unknown_name_returns_fallback () =
   let models =
     Oas_worker.default_model_strings ~cascade_name:"nonexistent_xyz"
   in
-  check bool "catch-all returns non-empty" true (models <> []);
-  (* Always ends with glm:auto as safety net *)
-  let last = List.nth models (List.length models - 1) in
-  check string "last is glm:auto" "glm:auto" last
+  check bool "catch-all returns non-empty" true (models <> [])
 
-let test_briefing_always_has_glm_auto () =
+let test_glm_included_when_zai_key_set () =
+  with_env "ZAI_API_KEY" "test-key" (fun () ->
+    let models =
+      Oas_worker.default_model_strings ~cascade_name:"nonexistent_xyz"
+    in
+    check bool "has glm:auto" true (List.mem "glm:auto" models);
+    let last = List.nth models (List.length models - 1) in
+    check string "last is glm:auto" "glm:auto" last)
+
+let test_glm_excluded_when_zai_key_missing () =
+  with_env "ZAI_API_KEY" "" (fun () ->
+    let models =
+      Oas_worker.default_model_strings ~cascade_name:"nonexistent_xyz"
+    in
+    check bool "no glm:auto" true (not (List.mem "glm:auto" models));
+    check bool "still non-empty" true (models <> []))
+
+let test_briefing_non_empty () =
   let models = Oas_worker.default_model_strings ~cascade_name:"briefing" in
-  check bool "briefing is non-empty" true (List.length models >= 1);
-  (* glm:auto is always the final fallback *)
-  let last = List.nth models (List.length models - 1) in
-  check string "briefing ends with glm:auto" "glm:auto" last
+  check bool "briefing is non-empty" true (List.length models >= 1)
 
 let test_classification_uses_llama_first () =
   let models =
@@ -211,8 +222,12 @@ let () =
             test_all_known_names_return_nonempty;
           test_case "unknown name returns fallback" `Quick
             test_unknown_name_returns_fallback;
-          test_case "briefing always has glm:auto" `Quick
-            test_briefing_always_has_glm_auto;
+          test_case "glm included when ZAI_API_KEY set" `Quick
+            test_glm_included_when_zai_key_set;
+          test_case "glm excluded when ZAI_API_KEY missing" `Quick
+            test_glm_excluded_when_zai_key_missing;
+          test_case "briefing non-empty" `Quick
+            test_briefing_non_empty;
           test_case "classification uses llama first" `Quick
             test_classification_uses_llama_first;
         ] );


### PR DESCRIPTION
## Summary
- `default_model_strings`가 무조건 `glm:auto`를 cascade에 포함하던 문제 수정
- `ZAI_API_KEY` 환경변수가 없거나 빈 문자열이면 GLM을 cascade에서 제외
- llama 실패 시 중국어 auth 에러(`Header中未收到Authorization参数`) 방지

## Changes
- `oas_worker.ml`: GLM fallback에 env var 체크 추가
- `test/test_cascade.ml`: ZAI_API_KEY 유무에 따른 테스트 업데이트

## Test plan
- [ ] ZAI_API_KEY 미설정 시 cascade에 glm:auto 없는 것 확인
- [ ] ZAI_API_KEY 설정 시 cascade에 glm:auto 포함 확인
- [ ] llama + glm 둘 다 불가 시 llama:auto 절대 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)