### PR TITLE
fix(log): default Ring.recent to newest-first ordering

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -96,7 +96,7 @@ module Ring = struct
                    module_name; message }
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
-      () : entry list =
+      ?(order = `Newest_first) () : entry list =
     let t = Atomic.get total in
     if t = 0 then []
     else begin
@@ -116,8 +116,10 @@ module Ring = struct
         end;
         decr i
       done;
-      (* Return in chronological order *)
-      !entries
+      (* Prepend builds oldest-first; reverse for newest-first *)
+      match order with
+      | `Oldest_first -> !entries
+      | `Newest_first -> List.rev !entries
     end
 
   let entry_to_json e =

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -53,6 +53,7 @@ module Ring : sig
     ?limit:int ->
     ?min_level:int ->
     ?module_filter:string ->
+    ?order:[< `Newest_first | `Oldest_first > `Newest_first ] ->
     unit ->
     entry list
 


### PR DESCRIPTION
## Summary
- 에러 로그 뷰어가 오래된 순서(oldest-first)로 표시되던 문제 수정
- `Ring.recent`에 `~order` 파라미터 추가 (`Newest_first` | `Oldest_first`)
- 기본값을 `Newest_first`로 변경하여 최신 에러가 상단에 표시

## Changes
- `log.ml`: Ring.recent에 order 파라미터 추가
- `log.mli`: 시그니처 업데이트

## Test plan
- [ ] 대시보드에서 로그 뷰어 확인 — 최신 에러가 상단
- [ ] API `/api/v1/logs` 응답 순서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)