### PR TITLE
fix(keeper,dashboard): proactive Board engagement + comment truncation

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -287,18 +287,41 @@ function PostCard({ post }: { post: BoardPost }) {
   `
 }
 
+function toggleCommentExpand(e: Event) {
+  const btn = e.currentTarget as HTMLButtonElement
+  const comment = btn.parentElement
+  if (!comment) return
+  const textEl = comment.querySelector('.comment-text')
+  if (!textEl) return
+  const isExpanded = textEl.classList.toggle('expanded')
+  btn.textContent = isExpanded ? '접기' : '더 보기...'
+}
+
+function CommentItem({ comment }: { comment: BoardComment }) {
+  const needsTruncation = (comment.content?.length ?? 0) > 300
+
+  return html`
+    <div class="board-comment rounded-lg">
+      <span class="comment-author"><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a></span>
+      <span class="comment-time"><${TimeAgo} timestamp=${comment.created_at} /></span>
+      <div class="comment-text">${comment.content}</div>
+      ${needsTruncation ? html`
+        <button
+          class="comment-expand-btn"
+          style="display: inline"
+          onClick=${toggleCommentExpand}
+        >더 보기...</button>
+      ` : null}
+    </div>
+  `
+}
+
 function CommentThread({ comments }: { comments: BoardComment[] }) {
   if (comments.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">아직 댓글이 없습니다</div>`
 
   return html`
     <div class="comment-thread flex flex-col gap-2">
-      ${comments.map(comment => html`
-        <div key=${comment.id} class="board-comment rounded-lg">
-          <span class="comment-author"><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a></span>
-          <span class="comment-time"><${TimeAgo} timestamp=${comment.created_at} /></span>
-          <div class="comment-text">${comment.content}</div>
-        </div>
-      `)}
+      ${comments.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} />`)}
     </div>
   `
 }

--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -118,7 +118,26 @@
   margin-bottom: 8px;
 }
 .board-comment .comment-author { font-size: var(--fs-sm); font-weight: 600; color: var(--purple); }
-.board-comment .comment-text { font-size: var(--fs-base); margin-top: 4px; }
+.board-comment .comment-text {
+  font-size: var(--fs-base);
+  margin-top: 4px;
+  max-height: 120px;
+  overflow: hidden;
+  position: relative;
+  transition: max-height 0.3s ease;
+}
+.board-comment .comment-text.expanded { max-height: none; }
+.board-comment .comment-expand-btn {
+  display: none;
+  margin-top: 4px;
+  background: none;
+  border: none;
+  color: var(--purple);
+  cursor: pointer;
+  font-size: var(--fs-xs);
+  padding: 0;
+}
+.board-comment .comment-expand-btn:hover { text-decoration: underline; }
 .board-comment .comment-time { font-size: var(--fs-xs); color: var(--text-dim); }
 
 /* ── Activity Tab ──────────────────────────────────────────── */

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -310,15 +310,21 @@ let proactive_prompt_for_keeper
      Last proactive preview (avoid repeating): %s\n\
      Continuity snapshot:\n%s\n\
      SOUL perspective hint: %s\n\
-     Guidance (strict):\n\
+     \n\
+     What to do on this turn:\n\
+     1. Call masc_board_list to see recent Board posts.\n\
+     2. Act on what you find:\n\
+        - Posts you haven't commented on: comment with your opinion.\n\
+        - Board quiet or empty: post something yourself via masc_board_create_post.\n\
+          Share a thought, ask a question, start a discussion, or reflect on your goal.\n\
+        - Something worth saying aloud: use keeper_voice_speak.\n\
+     3. Summarize what you did.\n\
+     \n\
+     Guidance:\n\
      - Prefer the same language as the recent conversation.\n\
      - Avoid repeating the previous proactive message verbatim.\n\
-     - Keep it concise and useful for the current goal.\n\
-     - If external checks or actions are needed, call tools before finalizing.\n\
-     - When a required write action is identified, execute it via tools and then summarize.\n\
-     - For this proactive turn only, do NOT output [STATE] blocks.\n\
-     - Output exactly one line using this format:\n\
-       CHECKIN: <single complete sentence ending with punctuation>"
+     - Do NOT output [STATE] blocks on this turn.\n\
+     - End your reply with: CHECKIN: <one sentence summary of what you did>"
     idle_seconds profile meta.goal last_preview continuity_snapshot seed
 
 type proactive_generation_result = {


### PR DESCRIPTION
## Summary
- **Proactive 프롬프트 개선**: "Output exactly one line" → 3단계 행동 시퀀스 (Board 확인 → 행동 → 요약). 도구명 직접 명시 (`masc_board_list`, `masc_board_create_post`, `keeper_voice_speak`)
- **Dashboard 댓글 truncation**: 긴 댓글에 max-height 120px + 접기/펼치기 버튼. AI 에이전트 긴 응답에 의한 스크롤 폭발 방지

## Changes
| File | Description |
|------|-------------|
| `lib/keeper/keeper_prompt.ml` | proactive_prompt_for_keeper guidance 재작성 |
| `dashboard/src/styles/board.css` | .comment-text에 max-height, overflow, transition 추가 |
| `dashboard/src/components/memory.ts` | CommentItem 컴포넌트 분리 + expand/collapse toggle |

## Test plan
- [ ] `dune build` 통과
- [ ] `npx vite build` 통과
- [ ] keeper proactive turn에서 Board 도구 호출 확인
- [ ] dashboard에서 긴 댓글이 접혀서 표시되는지 확인
- [ ] "더 보기..." 클릭 시 댓글 전체 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)