### PR TITLE
fix(test): align 3 stale source guards with current codebase

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -170,11 +170,8 @@ let test_activity_surface_contracts () =
   check bool "dashboard semantics use activity graph surface id" true
     (file_contains_pattern "lib/dashboard/dashboard_semantics.ml"
        {|surface ~id:"activity_graph"|});
-  check bool "room task lifecycle emits activity events" true
-    (file_contains_pattern "lib/room/room_task.ml"
-       "Activity_graph.emit config");
-  check bool "room broadcast emits activity events" true
-    (file_contains_pattern "lib/room/room_state.ml"
+  check bool "room emits activity events" true
+    (file_contains_pattern "lib/room.ml"
        "Activity_graph.emit config");
   check bool "board success paths emit activity events" true
     (file_contains_pattern "lib/tool_inline_dispatch_extra.ml"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -256,7 +256,7 @@ let test_unified_turn_runtime_defaults () =
     (KC.keeper_unified_temperature ());
   check int "unified max_tokens default" 2048
     (KC.keeper_unified_max_tokens ());
-  check int "unified max_turns default" 10
+  check int "unified max_turns default" 1000
     (KC.keeper_unified_max_turns ())
 
 (* ---------- Metrics observation tests ---------- *)

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -313,9 +313,8 @@ let test_eio_error_cutoff () =
     (status |> member "last_stop_reason" |> to_string)
 
 let test_eio_default_dispatch_uses_shared_cascade () =
-  check bool "uses Oas_worker.run_named" true
-    (file_contains_pattern "lib/room/room_walph_eio.ml"
-       {|Oas_worker.run_named ~cascade_name:"walph"|});
+  (* walph_eio is now a pure task-loop manager; LLM dispatch is delegated
+     externally via team_session or tool dispatch. Verify no legacy patterns. *)
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room/room_walph_eio.ml" "Llm_direct.dispatch");
   check bool "no direct run_prompt_cascade" false


### PR DESCRIPTION
## Summary
Fix 3 pre-existing test failures on main that block all PR CI:

- **config: unified max_turns** — default changed 10→1000 in PR #2204, test not updated
- **source_guard: activity surface** — `Activity_graph.emit` moved from `room_task.ml`/`room_state.ml` to `room.ml`
- **Eio Native: shared cascade** — walph is now a pure task-loop manager, no longer calls `Oas_worker.run_named` directly

## Changes
- `test/test_keeper_unified.ml` — expected value 10 → 1000
- `test/test_ci_hardening_source.ml` — update file path for activity emit check
- `test/test_walph_eio.ml` — remove stale Oas_worker.run_named assertion, keep legacy-removal guards

## Test plan
- [x] All 3 tests pass locally
- [ ] CI Build and Test green

Generated with Claude Code