### PR TITLE
refactor(dashboard): CSS → Tailwind (11,230 → 7,479 lines, -33.4%)

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -173,12 +173,12 @@ export function GraphView({ data }: GraphViewProps) {
     : null
 
   return html`
-    <div ref=${containerRef} class="activity-graph-container">
+    <div ref=${containerRef} class="activity-graph-container rounded-xl">
       <canvas ref=${canvasRef} class="block w-full cursor-crosshair" />
       ${hoveredNode ? html`
         <div class="activity-graph-tooltip">
           <strong>${hoveredNode.label}</strong>
-          <span class="activity-graph-tooltip-kind">${hoveredNode.kind}</span>
+          <span class="activity-graph-tooltip-kind rounded-md">${hoveredNode.kind}</span>
           <span>weight ${hoveredNode.weight}</span>
           <span>status ${hoveredNode.status}</span>
         </div>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -85,30 +85,30 @@ function eventSummary(event: ActivityGraphTimelineEvent): string {
 function StatsRow({ data }: { data: ActivityGraphResponse }) {
   const s = data.stats
   return html`
-    <div class="stats-grid">
-      <div class="stat-card">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-4">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">노드</div>
-        <div class="stat-value">${s.node_count}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.node_count}</div>
       </div>
-      <div class="stat-card">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">엣지</div>
-        <div class="stat-value">${s.edge_count}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.edge_count}</div>
       </div>
-      <div class="stat-card">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">에이전트</div>
-        <div class="stat-value">${s.agent_count}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.agent_count}</div>
       </div>
-      <div class="stat-card">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">활성</div>
-        <div class="stat-value" class="text-[var(--ok)]">${s.active_agents}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums text-[var(--ok)]">${s.active_agents}</div>
       </div>
-      <div class="stat-card">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">작업</div>
-        <div class="stat-value">${s.task_count}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.task_count}</div>
       </div>
-      <div class="stat-card">
+      <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
         <div class="stat-label">이벤트</div>
-        <div class="stat-value">${s.event_count}</div>
+        <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.event_count}</div>
       </div>
     </div>
   `
@@ -116,15 +116,15 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
 function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
   if (events.length === 0) {
-    return html`<div class="empty-state">최근 실행 이벤트가 없습니다.</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 실행 이벤트가 없습니다.</div>`
   }
   return html`
     <div class="monitor-list">
       ${events.map(event => {
         const actor = eventActor(event)
         return html`
-          <div class="monitor-row p-3.5 ok" key=${event.seq}>
-            <div class="monitor-row-header">
+          <div class="monitor-row rounded-xl p-3.5 ok" key=${event.seq}>
+            <div class="monitor-row rounded-xl-header">
               <div class="min-w-0">
                 <div class="monitor-name-line">
                   <span class="monitor-title">${actor || '(unknown)'}</span>
@@ -132,7 +132,7 @@ function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
                 </div>
                 <div class="monitor-note">${eventSummary(event)}</div>
               </div>
-              <span class="monitor-pill ok">${eventKindLabel(event.kind)}</span>
+              <span class="monitor-pill ok inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${eventKindLabel(event.kind)}</span>
             </div>
             <div class="monitor-meta">
               <span>${event.room_id}</span>
@@ -153,7 +153,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
     .slice(0, 15)
 
   if (agentNodes.length === 0) {
-    return html`<div class="empty-state">활동 집계에 포함된 에이전트가 없습니다.</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 집계에 포함된 에이전트가 없습니다.</div>`
   }
 
   const maxWeight = agentNodes[0]?.weight ?? 1
@@ -163,16 +163,16 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
       ${agentNodes.map((node, i) => {
         const pct = maxWeight > 0 ? (node.weight / maxWeight) * 100 : 0
         return html`
-          <div class="activity-graph-leaderboard-row" key=${node.id}>
-            <span class="activity-graph-leaderboard-rank">${i + 1}</span>
+          <div class="flex items-center gap-[10px] py-2 px-3 rounded-[10px] bg-[rgba(15,23,42,0.5)] border border-solid border-[var(--slate-gray-8)]" key=${node.id}>
+            <span class="w-[22px] text-center text-sm font-bold text-text-slate">${i + 1}</span>
             <div class="flex-1 flex flex-col gap-1 min-w-0">
               <span class="text-base font-semibold text-[var(--text-near-white)] whitespace-nowrap overflow-hidden text-ellipsis">${node.label}</span>
               <div class="activity-graph-leaderboard-bar-wrap">
                 <div class="activity-graph-leaderboard-bar" style="width:${pct}%"></div>
               </div>
             </div>
-            <span class="activity-graph-leaderboard-weight">${node.weight}</span>
-            <span class="activity-graph-leaderboard-status ${node.status === 'offline' || node.status === 'retired' ? 'inactive' : 'active'}">${node.status}</span>
+            <span class="text-sm font-semibold text-text-slate-light min-w-[32px] text-right">${node.weight}</span>
+            <span class="activity-graph-leaderboard-status rounded-md ${node.status === 'offline' || node.status === 'retired' ? 'inactive' : 'active'}">${node.status}</span>
           </div>
         `
       })}
@@ -188,13 +188,13 @@ function KindBreakdown({ nodes }: { nodes: ActivityGraphNode[] }) {
   const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1])
 
   if (sorted.length === 0) {
-    return html`<div class="empty-state">분석할 노드 종류가 없습니다.</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">분석할 노드 종류가 없습니다.</div>`
   }
 
   return html`
     <div class="flex flex-wrap gap-2">
       ${sorted.map(([kind, count]) => html`
-        <div class="activity-graph-kind-chip" key=${kind}>
+        <div class="activity-graph-kind-chip rounded-lg" key=${kind}>
           <span class="text-sm text-text-slate-light">${kindLabel(kind)}</span>
           <span class="text-base font-bold text-[var(--text-near-white)]">${count}</span>
         </div>
@@ -211,7 +211,7 @@ function EmptyActivityGraph() {
           <h2 class="monitor-headline">활동 그래프가 비어 있습니다</h2>
           <p class="monitor-subheadline">이 뷰는 런타임 실행 이벤트를 읽어 그래프를 그립니다. 지금은 기록된 이벤트가 없어 화면이 비어 있습니다.</p>
         </div>
-        <div class="empty-state">
+        <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
           아직 claim, broadcast, team-session, board 같은 실행 이벤트가 activity feed에 기록되지 않았습니다.
         </div>
       <//>
@@ -229,22 +229,22 @@ export function ActivityGraphSurface() {
   const loading = graphLoading.value
 
   if (loading && !data) {
-    return html`<div class="loading-indicator">활동 그래프 불러오는 중...</div>`
+    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">활동 그래프 불러오는 중...</div>`
   }
 
   if (error && !data) {
     return html`
       <div class="agents-monitor">
         <${Card} title="오류" class="section mb-3.5" testId="activity_graph.error">
-          <div class="empty-state">활동 그래프를 불러올 수 없습니다: ${error}</div>
-          <button class="control-btn ghost" onClick=${loadGraph}>다시 시도</button>
+          <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 그래프를 불러올 수 없습니다: ${error}</div>
+          <button class="control-btn rounded-lg ghost" onClick=${loadGraph}>다시 시도</button>
         <//>
       </div>
     `
   }
 
   if (!data) {
-    return html`<div class="empty-state">활동 데이터가 없습니다.</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 데이터가 없습니다.</div>`
   }
 
   if ((data.stats.event_count ?? 0) === 0) {
@@ -268,7 +268,7 @@ export function ActivityGraphSurface() {
         </div>
       <//>
 
-      <div class="agents-workbench">
+      <div class="grid grid-cols-[minmax(0,1.08fr)_minmax(0,0.96fr)_minmax(0,0.88fr)] gap-4">
         <${Card} title="활동 주체 순위" class="section mb-3.5" testId="activity_graph.leaderboard">
           <div class="mb-3.5">
             <h2 class="monitor-headline">활동 주체 순위</h2>

--- a/dashboard/src/components/activity.ts
+++ b/dashboard/src/components/activity.ts
@@ -10,10 +10,10 @@ const activityGraphExpanded = signal(false)
 
 export function Activity() {
   return html`
-    <div class="tab-unified">
+    <div class="tab-unified grid gap-[var(--space-md,16px)]">
       <${Live} />
       <details
-        class="tab-collapsible"
+        class="tab-collapsible rounded-lg"
         open=${activityGraphExpanded.value}
         onToggle=${(e: Event) => { activityGraphExpanded.value = (e.target as HTMLDetailsElement).open }}
       >

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -12,11 +12,11 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="실시간 활동 스트림">
       ${entries.length === 0
-        ? html`<div class="empty-state">관련 이벤트 없음</div>`
+        ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관련 이벤트 없음</div>`
         : html`
-            <div class="agent-journal-stream">
+            <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`
-                <div class="agent-journal-entry" key=${idx}>
+                <div class="agent-journal-entry rounded" key=${idx}>
                   <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
                   <span class="agent-journal-type">${entry.eventType}</span>
                   <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -35,22 +35,22 @@ export function AgentTimelineSection() {
   return html`
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0} events)">
       ${summary ? html`
-        <div class="agent-timeline-summary">
-          ${summary.tasks_completed > 0 ? html`<span class="pill">완료 ${summary.tasks_completed}</span>` : null}
-          ${summary.tasks_claimed > 0 ? html`<span class="pill">수임 ${summary.tasks_claimed}</span>` : null}
-          ${summary.messages_sent > 0 ? html`<span class="pill">메시지 ${summary.messages_sent}</span>` : null}
-          ${summary.active_duration_minutes > 0 ? html`<span class="pill">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+        <div class="flex gap-1.5 flex-wrap mb-2">
+          ${summary.tasks_completed > 0 ? html`<span class="pill rounded-full">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="pill rounded-full">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="pill rounded-full">메시지 ${summary.messages_sent}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="pill rounded-full">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
         </div>
       ` : null}
       ${events.length === 0
-        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
+        ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">타임라인 이벤트 없음</div>`
         : html`
-            <div class="agent-timeline-list">
+            <div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">
               ${events.map((evt: AgentTimelineEvent, idx: number) => {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
                 return html`
-                  <div class="agent-timeline-event" key=${idx}>
+                  <div class="agent-timeline-event rounded" key=${idx}>
                     <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
                     <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
                     ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -12,34 +12,34 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
 
   return html`
     <${Card} title="Worker Status">
-      <div class="agent-worker-brief">
-        <div class="agent-worker-brief__row">
-          <span class="agent-worker-brief__label">State</span>
+      <div class="flex flex-col gap-1.5">
+        <div class="flex items-baseline gap-2 text-[length:var(--fs-sm)]">
+          <span class="text-[length:var(--fs-xs)] text-[var(--text-muted)] min-w-[60px] shrink-0">State</span>
           <${StatusBadge} status=${worker.state} />
         </div>
         ${worker.focus ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Focus</span>
+          <div class="flex items-baseline gap-2 text-[length:var(--fs-sm)]">
+            <span class="text-[length:var(--fs-xs)] text-[var(--text-muted)] min-w-[60px] shrink-0">Focus</span>
             <span>${worker.focus}</span>
           </div>
         ` : null}
         ${worker.recent_output_preview ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Output</span>
+          <div class="flex items-baseline gap-2 text-[length:var(--fs-sm)]">
+            <span class="text-[length:var(--fs-xs)] text-[var(--text-muted)] min-w-[60px] shrink-0">Output</span>
             <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Session</span>
+          <div class="flex items-baseline gap-2 text-[length:var(--fs-sm)]">
+            <span class="text-[length:var(--fs-xs)] text-[var(--text-muted)] min-w-[60px] shrink-0">Session</span>
             <span class="font-mono" style="font-size: 11px">${worker.related_session_id}</span>
           </div>
         ` : null}
         ${worker.last_signal_at ? html`
-          <div class="agent-worker-brief__row">
-            <span class="agent-worker-brief__label">Signal</span>
+          <div class="flex items-baseline gap-2 text-[length:var(--fs-sm)]">
+            <span class="text-[length:var(--fs-xs)] text-[var(--text-muted)] min-w-[60px] shrink-0">Signal</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
-            ${worker.signal_truth ? html`<span class="pill">${worker.signal_truth}</span>` : null}
+            ${worker.signal_truth ? html`<span class="pill rounded-full">${worker.signal_truth}</span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -35,9 +35,9 @@ export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-de
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
-    <div class="agent-detail-task">
-      <span class="pill">${task.id}</span>
-      <span class="agent-detail-task-title">${task.title}</span>
+    <div class="agent-detail-task rounded-lg">
+      <span class="pill rounded-full">${task.id}</span>
+      <span class="agent-detail-task rounded-lg-title">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
   `
@@ -47,7 +47,7 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
     <div class="agent-history-row">
       <div class="mb-2">
-        <span class="pill">${row.taskId}</span>
+        <span class="pill rounded-full">${row.taskId}</span>
       </div>
       <pre class="agent-history-pre">${row.text || 'No task history yet'}</pre>
     </div>
@@ -100,29 +100,29 @@ export function AgentDetailOverlay() {
       }}
     >
       <div class="agent-detail-modal">
-        <div class="agent-detail-header">
+        <div class="flex justify-between gap-3 mb-3.5">
           <div class="flex flex-col gap-2 flex-1">
             <div class="flex items-center gap-3">
               ${agentEmoji ? html`<span class="text-[2rem]">${agentEmoji}</span>` : ''}
               <div>
-                <h2 class="m-0 flex items-baseline gap-2">
+                <h2 class="m-0 flex items-baseline gap-2 text-[var(--text-strong)] text-xl">
                   ${displayName}
                   ${koreanName ? html`<span class="text-xs text-[var(--text-dim)]">(${koreanName})</span>` : ''}
                   ${secondaryLabel ? html`<span class="font-mono" class="text-xs text-[var(--text-dim)]">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-1 flex-wrap">
                   <${StatusBadge} status=${headerStatus} />
-                  ${isArchivedParticipant ? html`<span class="pill">archived session participant</span>` : null}
+                  ${isArchivedParticipant ? html`<span class="pill rounded-full">archived session participant</span>` : null}
                   ${agent?.model ? html`<span class="font-mono" class="text-xs bg-[#2a2a4a] px-1.5 py-0.5 rounded">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-[var(--text-dim)]">${missionBrief.archived_reason}</span>`
                     : null}
-                  ${signalTruth ? html`<span class="pill">signal · ${signalTruth}</span>` : null}
-                  ${evidenceSource ? html`<span class="pill">source · ${evidenceSource}</span>` : null}
+                  ${signalTruth ? html`<span class="pill rounded-full">signal · ${signalTruth}</span>` : null}
+                  ${evidenceSource ? html`<span class="pill rounded-full">source · ${evidenceSource}</span>` : null}
                 </div>
               </div>
             </div>
-            <div class="agent-detail-sub">
+            <div class="mt-1.5 flex gap-2 flex-wrap text-[#9ab3de] text-[length:var(--fs-sm)]">
               ${agent?.current_task || missionBrief?.current_work
                 ? html`<span>Task: ${agent?.current_task ?? missionBrief?.current_work}</span>`
                 : null}
@@ -130,7 +130,7 @@ export function AgentDetailOverlay() {
             </div>
             ${keeper || continuitySummary || missionBrief?.related_session_id
               ? html`
-                  <div class="agent-detail-sub">
+                  <div class="mt-1.5 flex gap-2 flex-wrap text-[#9ab3de] text-[length:var(--fs-sm)]">
                     ${keeper
                       ? html`<span>Linked keeper: ${keeper.name}${keeperIdentity ? ` · ${keeperIdentity}` : ''}</span>`
                       : null}
@@ -141,26 +141,26 @@ export function AgentDetailOverlay() {
               : null}
           </div>
           <div class="flex gap-2">
-            <button class="control-btn ghost" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
+            <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
               ${loading.value ? '새로고침 중...' : '새로고침'}
             </button>
-            <button class="control-btn ghost" onClick=${closeAgentDetail}>닫기</button>
+            <button class="control-btn rounded-lg ghost" onClick=${closeAgentDetail}>닫기</button>
           </div>
         </div>
 
-        ${detailError.value ? html`<div class="council-error">${detailError.value}</div>` : null}
+        ${detailError.value ? html`<div class="council-error rounded-lg">${detailError.value}</div>` : null}
 
-        <div class="agent-detail-grid">
+        <div class="grid grid-cols-2 gap-3 mb-3">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
-              ? html`<div class="empty-state">할당된 작업이 없습니다</div>`
-              : html`<div class="agent-detail-task-list">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">할당된 작업이 없습니다</div>`
+              : html`<div class="flex flex-col gap-2">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
           <//>
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="empty-state">최근 활동 기록이 없습니다</div>`
-              : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) => html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 활동 기록이 없습니다</div>`
+              : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) => html`<div key=${idx} class="agent-activity-line rounded-lg">${line}</div>`)}</div>`}
           <//>
         </div>
 
@@ -169,14 +169,14 @@ export function AgentDetailOverlay() {
         <${AgentWorkerBrief} agentName=${agentName} />
         <${Card} title="작업 이력">
           ${taskHistories.value.length === 0
-            ? html`<div class="empty-state">작업 이력이 없습니다</div>`
-            : html`<div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">작업 이력이 없습니다</div>`
+            : html`<div class="flex flex-col gap-2.5">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
         <//>
 
         <${Card} title="직접 멘션">
-          <div class="agent-mention-row">
+          <div class="grid grid-cols-[1fr_auto] gap-2">
             <input
-              class="control-input"
+              class="control-input rounded-lg"
               type="text"
               placeholder="@멘션 메시지"
               value=${mentionText.value}
@@ -185,7 +185,7 @@ export function AgentDetailOverlay() {
               disabled=${sendingMention.value}
             />
             <button
-              class="control-btn"
+              class="control-btn rounded-lg"
               onClick=${() => { void submitMention() }}
               disabled=${sendingMention.value || mentionText.value.trim() === ''}
             >

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -131,7 +131,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
           ${FILTER_CHIPS.map(chip => html`
             <button
               key=${chip.key}
-              class="agent-live-chip ${activeFilter.value === chip.key ? 'agent-live-chip--active' : ''}"
+              class="agent-live-chip rounded-xl ${activeFilter.value === chip.key ? 'agent-live-chip--active' : ''}"
               onClick=${() => { activeFilter.value = chip.key }}
             >
               ${chip.label}
@@ -139,10 +139,10 @@ export function AgentLiveTimeline({ name }: { name: string }) {
           `)}
         </div>
         <div class="agent-live-meta">
-          <span class="agent-event-rate">${eventsPerMin}/min</span>
+          <span class="agent-event-rate rounded-lg">${eventsPerMin}/min</span>
           <span class="text-text-muted">${filtered.length} events</span>
           <button
-            class="agent-live-autoscroll ${autoScroll.value ? 'agent-live-autoscroll--on' : ''}"
+            class="agent-live-autoscroll rounded-lg ${autoScroll.value ? 'agent-live-autoscroll--on' : ''}"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
             title=${autoScroll.value ? 'Auto-scroll ON' : 'Auto-scroll OFF'}
           >
@@ -153,15 +153,15 @@ export function AgentLiveTimeline({ name }: { name: string }) {
 
       <div class="agent-live-stream" ref=${scrollRef}>
         ${filtered.length === 0
-          ? html`<div class="empty-state">필터에 맞는 이벤트 없음</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">필터에 맞는 이벤트 없음</div>`
           : filtered.map((entry: JournalEntry, idx: number) => html`
-              <div class="agent-live-event" key=${idx}>
+              <div class="agent-live-event rounded" key=${idx}>
                 <span class="agent-event-badge ${eventKindBadgeClass(entry.eventType)}">
                   ${eventKindLabel(entry.eventType)}
                 </span>
-                <span class="agent-live-event-text">${compactText(entry.text)}</span>
+                <span class="agent-live-event rounded-text">${compactText(entry.text)}</span>
                 ${entry.timestamp ? html`
-                  <span class="agent-live-event-time"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                  <span class="agent-live-event rounded-time"><${TimeAgo} timestamp=${entry.timestamp} /></span>
                 ` : null}
               </div>
             `)}

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -45,9 +45,9 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
       ${ctxPct != null ? html`
         <div class="agent-runtime-metric">
           <span class="agent-runtime-label">CTX</span>
-          <div class="agent-runtime-ctx-bar">
+          <div class="agent-runtime-ctx-bar rounded-full">
             <div
-              class="agent-runtime-ctx-fill ${ctxBarClass(ctxRatio)}"
+              class="agent-runtime-ctx-fill rounded-full ${ctxBarClass(ctxRatio)}"
               style=${{ width: `${ctxPct}%` }}
             ></div>
           </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -210,7 +210,7 @@ function CharacterPlate({ name }: { name: string }) {
 
   return html`
     <div class="ff-plate">
-      <div class="ff-plate__portrait">
+      <div class="flex flex-col items-center gap-1.5">
         <${AgentAvatar}
           name=${name}
           status=${headerStatus}
@@ -223,34 +223,34 @@ function CharacterPlate({ name }: { name: string }) {
         ${isKeeper ? html`<div class="text-[9px] font-bold tracking-[1.5px] text-[color:var(--ff-gold)] uppercase text-center">KEEPER</div>` : null}
       </div>
 
-      <div class="ff-plate__info">
-        <div class="ff-plate__name-row">
+      <div class="flex flex-col gap-1.5 min-w-0">
+        <div class="flex items-baseline gap-2 flex-wrap">
           <h2 class="ff-plate__name">
             ${agentEmoji ? html`<span class="text-[1.4em]">${agentEmoji}</span>` : ''}
             ${displayName}
           </h2>
           ${koreanName ? html`<span class="text-[length:var(--fs-base)] text-[color:var(--text-muted)]">(${koreanName})</span>` : ''}
-          ${generation != null ? html`<span class="ff-plate__level">Lv.${generation}</span>` : null}
+          ${generation != null ? html`<span class="ff-plate__level rounded">Lv.${generation}</span>` : null}
         </div>
 
-        <div class="ff-plate__badges">
+        <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
-          ${model ? html`<span class="ff-plate__model">${model}</span>` : null}
-          ${autonomy ? html`<span class="ff-plate__autonomy">${autonomy}</span>` : null}
-          ${signalTruth ? html`<span class="ff-plate__signal ff-plate__signal--${signalTruth}">${signalTruth}</span>` : null}
+          ${model ? html`<span class="ff-plate__model rounded">${model}</span>` : null}
+          ${autonomy ? html`<span class="ff-plate__autonomy rounded">${autonomy}</span>` : null}
+          ${signalTruth ? html`<span class="ff-plate__signal rounded ff-plate__signal--${signalTruth}">${signalTruth}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
-          <div class="ff-plate__bar-row">
+          <div class="flex items-center gap-2 mt-0.5">
             <span class="ff-plate__bar-label">CTX</span>
-            <div class="ctx-bar" style="flex:1">
-              <div class="ctx-fill ${ctxBarClass(ctxRatio)}" style=${{ width: `${ctxPct}%` }}></div>
+            <div class="h-1.5 mt-1.5 rounded-full overflow-hidden bg-[var(--white-10)]" style="flex:1">
+              <div class="ctx-fill rounded-full ${ctxBarClass(ctxRatio)}" style=${{ width: `${ctxPct}%` }}></div>
             </div>
             <span class="ff-plate__bar-value">${ctxPct}%</span>
           </div>
         ` : null}
 
-        <div class="ff-plate__status-line">
+        <div class="flex gap-2 items-center flex-wrap">
           ${currentWork
             ? html`<span class="text-[length:var(--fs-base)] text-[#c8daf7]">${currentWork}</span>`
             : html`<span class="text-[length:var(--fs-base)] text-[#c8daf7] ff-plate__work--idle">대기 중</span>`
@@ -260,14 +260,14 @@ function CharacterPlate({ name }: { name: string }) {
         </div>
 
         ${lastSeenAt || lastActivity != null ? html`
-          <div class="ff-plate__meta-line">
+          <div class="flex gap-2.5 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
             ${lastSeenAt ? html`<span>마지막 확인: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
             ${lastActivity != null ? html`<span>${formatDuration(lastActivity)} 전 활동</span>` : null}
           </div>
         ` : null}
 
         ${keeperIdent || continuitySummary || brief?.related_session_id ? html`
-          <div class="ff-plate__meta-line">
+          <div class="flex gap-2.5 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
             ${keeperIdent ? html`<span>${keeperIdent}</span>` : null}
             ${brief?.related_session_id ? html`<span>세션 ${brief.related_session_id}</span>` : null}
             ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}
@@ -277,38 +277,38 @@ function CharacterPlate({ name }: { name: string }) {
 
       ${isKeeper ? html`
         <div class="ff-plate__stats ff-plate__stats--keeper">
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${ctxPct != null ? `${ctxPct}%` : '—'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">CTX</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${generation ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">세대</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${keeper.turn_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">턴</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${keeper.autonomous_action_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">행동</span>
           </div>
         </div>
       ` : summary ? html`
         <div class="ff-plate__stats">
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${summary.tasks_completed}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">완료</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${summary.tasks_claimed}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">수임</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${summary.messages_sent}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">메시지</span>
           </div>
-          <div class="ff-stat">
+          <div class="ff-stat rounded-md">
             <span class="ff-stat__value">${summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : '0m'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">활동</span>
           </div>
@@ -333,14 +333,14 @@ export function AgentProfile({ name }: { name: string }) {
 
   return html`
     <div class="ff-profile ${isKeeper ? 'ff-profile--keeper' : ''}">
-      <div class="ff-profile__toolbar">
-        <button class="control-btn ghost" onClick=${() => navigate('status', { section: 'agents' })}>← 목록</button>
-        <button class="control-btn ghost" onClick=${() => { void loadProfile(name) }} disabled=${loading.value}>
+      <div class="flex gap-2 mb-3">
+        <button class="control-btn rounded-lg ghost" onClick=${() => navigate('status', { section: 'agents' })}>← 목록</button>
+        <button class="control-btn rounded-lg ghost" onClick=${() => { void loadProfile(name) }} disabled=${loading.value}>
           ${loading.value ? '...' : '새로고침'}
         </button>
       </div>
 
-      ${profileError.value ? html`<div class="council-error">${profileError.value}</div>` : null}
+      ${profileError.value ? html`<div class="council-error rounded-lg">${profileError.value}</div>` : null}
 
       <${CharacterPlate} name=${name} />
 
@@ -352,15 +352,15 @@ export function AgentProfile({ name }: { name: string }) {
         </div>
       ` : null}
 
-      <div class="ff-profile__grid">
+      <div class="grid grid-cols-2 gap-3.5 mb-3.5">
         ${!isKeeper ? html`
-        <${Card} title="태스크 (${owned.length})" class="ff-card">
+        <${Card} title="태스크 (${owned.length})" class="ff-card rounded-xl">
           ${owned.length === 0
-            ? html`<div class="empty-state">할당된 태스크 없음</div>`
-            : html`<div class="agent-detail-task-list">${owned.map(t => html`
-                <div class="agent-detail-task" key=${t.id}>
-                  <span class="pill">${t.id}</span>
-                  <span class="agent-detail-task-title">${t.title}</span>
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">할당된 태스크 없음</div>`
+            : html`<div class="flex flex-col gap-2">${owned.map(t => html`
+                <div class="agent-detail-task rounded-lg" key=${t.id}>
+                  <span class="pill rounded-full">${t.id}</span>
+                  <span class="agent-detail-task rounded-lg-title">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
               `)}</div>`}
@@ -375,11 +375,11 @@ export function AgentProfile({ name }: { name: string }) {
           const hasData = collabs.length > 0 || interests.length > 0
           if (!hasData) return null
           return html`
-            <${Card} title="관계 (${collabs.length})" class="ff-card">
+            <${Card} title="관계 (${collabs.length})" class="ff-card rounded-xl">
               ${collabs.length > 0 ? html`
-                <div class="ff-relations-list">
+                <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
-                    <div class="ff-relation-row" key=${c.name}
+                    <div class="ff-relation-row rounded" key=${c.name}
                       onClick=${() => navigate('status', { section: 'agents', agent: c.name })}
                       style="cursor:pointer;"
                     >
@@ -393,7 +393,7 @@ export function AgentProfile({ name }: { name: string }) {
               ${interests.length > 0 ? html`
                 <div class="ff-interests" class="mt-2">
                   <span class="ff-interests-label">관심사</span>
-                  <div class="ff-interests-tags">
+                  <div class="flex flex-wrap gap-1 mt-1.5">
                     ${interests.slice(0, 12).map(t => html`<span class="ff-interest-tag" key=${t}>${t}</span>`)}
                     ${interests.length > 12 ? html`<span class="ff-interest-tag">+${interests.length - 12}</span>` : null}
                   </div>
@@ -403,14 +403,14 @@ export function AgentProfile({ name }: { name: string }) {
           `
         })()}
 
-        <${Card} title="타임라인" class="ff-card">
+        <${Card} title="타임라인" class="ff-card rounded-xl">
           ${!timeline || (timeline.events ?? []).length === 0
-            ? html`<div class="empty-state">이벤트 없음</div>`
-            : html`<div class="agent-timeline-list">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이벤트 없음</div>`
+            : html`<div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
                 return html`
-                  <div class="agent-timeline-event" key=${idx}>
+                  <div class="agent-timeline-event rounded" key=${idx}>
                     <span class="ff-event-type">${timelineEventLabel(evt.type)}</span>
                     ${title ? html`<span class="ff-event-detail">${compactCopy(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
@@ -419,22 +419,22 @@ export function AgentProfile({ name }: { name: string }) {
               })}</div>`}
         <//>
 
-        <${Card} title="실시간" class="ff-card">
+        <${Card} title="실시간" class="ff-card rounded-xl">
           <${AgentLiveTimeline} name=${name} />
         <//>
 
-        <${Card} title="Room 활동" class="ff-card">
+        <${Card} title="Room 활동" class="ff-card rounded-xl">
           ${lines.length === 0
-            ? html`<div class="empty-state">관련 활동 없음</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관련 활동 없음</div>`
             : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) =>
-                html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
+                html`<div key=${idx} class="agent-activity-line rounded-lg">${line}</div>`)}</div>`}
         <//>
 
         ${taskHistories.value.length > 0 ? html`
-          <${Card} title="태스크 이력" class="ff-card col-span-full">
+          <${Card} title="태스크 이력" class="ff-card rounded-xl col-span-full">
             <div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`
               <div class="agent-history-row" key=${row.taskId}>
-                <div class="mb-2"><span class="pill">${row.taskId}</span></div>
+                <div class="mb-2"><span class="pill rounded-full">${row.taskId}</span></div>
                 <pre class="agent-history-pre">${row.text || 'No history yet'}</pre>
               </div>
             `)}</div>
@@ -445,10 +445,10 @@ export function AgentProfile({ name }: { name: string }) {
       ${isKeeper ? html`
         <${KeeperChatPanel} name=${name} />
       ` : html`
-        <div class="ff-profile__mention">
-          <span class="ff-profile__mention-label">@${name}</span>
+        <div class="ff-profile__mention rounded-lg">
+          <span class="ff-profile__mention rounded-lg-label">@${name}</span>
           <input
-            class="control-input"
+            class="control-input rounded-lg"
             type="text"
             placeholder="메시지 입력..."
             value=${mentionText.value}
@@ -457,7 +457,7 @@ export function AgentProfile({ name }: { name: string }) {
             disabled=${sendingMention.value}
           />
           <button
-            class="control-btn"
+            class="control-btn rounded-lg"
             onClick=${() => { void submitMention(name) }}
             disabled=${sendingMention.value || mentionText.value.trim() === ''}
           >

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -125,10 +125,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       <div class="roster-header mb-6">
         <h2 class="roster-title">${keeperFilter === 'keeper-only' ? '키퍼' : keeperFilter === 'agent-only' ? '에이전트' : '에이전트'} (${filtered.length})</h2>
         <p class="agent-page__subtitle">${keeperFilter === 'keeper-only' ? '키퍼 런타임이 있는 에이전트' : keeperFilter === 'agent-only' ? '키퍼 런타임이 없는 에이전트' : '등록된 에이전트 — keeper 런타임이 있으면 컨텍스트 게이지 표시'}</p>
-        <div class="roster-controls">
+        <div class="flex gap-[var(--space-md,16px)] items-center flex-wrap">
           <input
             type="text"
-            class="roster-search"
+            class="roster-search rounded transition-colors duration-200"
             placeholder="이름 검색..."
             value=${search}
             onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
@@ -147,7 +147,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         </div>
       </div>
 
-      <div class="roster-list">
+      <div class="flex flex-col gap-2.5">
         ${filtered.map((agent: Agent) => {
           const brief = briefMap.get(agent.name)
           const keeper = findKeeper(agent.name, keeperList, keeperBriefs)
@@ -158,7 +158,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <div
-              class="roster-card ${isKeeper ? 'roster-card--keeper' : ''}"
+              class="roster-card rounded-xl rounded-md transition-all duration-200 ${isKeeper ? 'roster-card--keeper' : ''}"
               key=${agent.name}
               onClick=${() => openAgentDetail(agent.name)}
               role="button"
@@ -175,7 +175,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 />
               </div>
               <div class="roster-card__info">
-                <div class="roster-card__header">
+                <div class="flex items-center gap-[var(--space-sm,8px)]">
                   <strong class="roster-card__name">${agent.name}</strong>
                   ${isKeeper ? html`
                     <span class="roster-card__keeper-tag">keeper</span>
@@ -189,7 +189,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
 
                 ${isKeeper && ctxPct != null ? html`
-                  <div class="roster-card__gauge">
+                  <div class="flex items-center gap-2">
                     <div class="roster-card__gauge-track">
                       <div
                         class="roster-card__gauge-bar ${pressureClass(keeper.context_ratio)}"
@@ -218,7 +218,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           `
         })}
         ${filtered.length === 0 ? html`
-          <div class="roster-empty">조건에 맞는 에이전트가 없습니다.</div>
+          <div class="roster-empty rounded-md">조건에 맞는 에이전트가 없습니다.</div>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -68,7 +68,7 @@ export function AgentsUnified() {
   const agentOnlyCount = totalCount - keeperCount
 
   return html`
-    <div class="agents-unified">
+    <div class="grid gap-[var(--space-md,16px)]">
       <div class="flex gap-1.5">
         ${CHIPS.map(c => html`
           <button
@@ -80,9 +80,9 @@ export function AgentsUnified() {
             }}
           >
             ${c.label}
-            ${c.id === 'all' ? html`<span class="agents-chip-count">${totalCount}</span>` : null}
-            ${c.id === 'agents' ? html`<span class="agents-chip-count">${agentOnlyCount}</span>` : null}
-            ${c.id === 'keepers' ? html`<span class="agents-chip-count">${keeperCount}</span>` : null}
+            ${c.id === 'all' ? html`<span class="agents-chip-count rounded-lg">${totalCount}</span>` : null}
+            ${c.id === 'agents' ? html`<span class="agents-chip-count rounded-lg">${agentOnlyCount}</span>` : null}
+            ${c.id === 'keepers' ? html`<span class="agents-chip-count rounded-lg">${keeperCount}</span>` : null}
           </button>
         `)}
       </div>

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -128,14 +128,14 @@ export function Execution() {
       >
         ${allClear
           ? html`
-              <div class="empty-state ok" data-testid="execution.all-clear">
+              <div class="empty-state ok text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" data-testid="execution.all-clear">
                 정상 운영 중. 주의가 필요한 항목이 없습니다.
               </div>
             `
           : html`<${ExecutionQueueBody} queueRows=${queueRows} />`}
       <//>
 
-      <div class="agents-workbench">
+      <div class="grid grid-cols-[minmax(0,1.08fr)_minmax(0,0.96fr)_minmax(0,0.88fr)] gap-4">
         <${Card}
           title="관련 세션"
           class="section mb-3.5"
@@ -162,7 +162,7 @@ export function Execution() {
         >
           <div class="monitor-list">
             ${workerSupportRows.length === 0
-              ? html`<div class="empty-state">참여 에이전트가 없습니다.</div>`
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">참여 에이전트가 없습니다.</div>`
               : workerSupportRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.worker-card" />`)}
           </div>
         <//>
@@ -175,7 +175,7 @@ export function Execution() {
         >
           <div class="monitor-list">
             ${continuityRows.length === 0
-              ? html`<div class="empty-state">연속성 경고 없음</div>`
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">연속성 경고 없음</div>`
               : continuityRows.map(row => html`<${ContinuityRow} key=${row.name} row=${row} />`)}
           </div>
         <//>
@@ -188,7 +188,7 @@ export function Execution() {
         >
           <div class="monitor-list">
             ${offlineRows.length === 0
-              ? html`<div class="empty-state">오프라인 에이전트 없음</div>`
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오프라인 에이전트 없음</div>`
               : offlineRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.offline-worker-card" />`)}
           </div>
         <//>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -123,8 +123,8 @@ export function ChatMessageBubble({
           <div class="chat-bubble-identity-copy">
             <div class="chat-bubble-labels">
               <span class=${`chat-role-chip ${bubbleTone(entry)}`}>${entry.label}</span>
-              <span class="chat-delivery-chip">${deliveryLabel(entry)}</span>
-              ${entry.timestamp ? html`<span class="chat-time-chip">${timeLabel(entry.timestamp)}</span>` : null}
+              <span class="chat-delivery-chip rounded-full">${deliveryLabel(entry)}</span>
+              ${entry.timestamp ? html`<span class="chat-time-chip rounded-full">${timeLabel(entry.timestamp)}</span>` : null}
             </div>
             <div class="chat-identity-title">${avatarLabel(entry)}</div>
           </div>
@@ -133,7 +133,7 @@ export function ChatMessageBubble({
           ? html`
               <button
                 type="button"
-                class="chat-disclosure-btn"
+                class="chat-disclosure-btn rounded-full"
                 onClick=${() => { setExpanded(!expanded) }}
               >
                 ${expanded ? '상세 숨기기' : '상세 보기'}
@@ -143,8 +143,8 @@ export function ChatMessageBubble({
       </div>
 
       ${showMetadata && detailItems.length > 0
-        ? html`<div class="chat-detail-chip-row">
-            ${detailItems.map(item => html`<span class="chat-detail-chip">${item}</span>`)}
+        ? html`<div class="chat-detail-chip rounded-full-row">
+            ${detailItems.map(item => html`<span class="chat-detail-chip rounded-full">${item}</span>`)}
           </div>`
         : null}
 
@@ -153,12 +153,12 @@ export function ChatMessageBubble({
 
       ${expanded && entry.details
         ? html`
-            <div class="chat-detail-panel">
+            <div class="chat-detail-panel rounded-xl">
               ${overview.length > 0
                 ? html`
                     <div class="chat-overview-grid">
                       ${overview.map(item => html`
-                        <div class="chat-overview-card">
+                        <div class="chat-overview-card rounded-xl">
                           <div class="chat-overview-label">${item.label}</div>
                           <div class="chat-overview-value">${item.value}</div>
                         </div>
@@ -183,7 +183,7 @@ export function ChatMessageBubble({
                       <div class="chat-detail-section-title">상태 스냅샷</div>
                       <div class="chat-state-grid">
                         ${state.map(item => html`
-                          <div class="chat-state-card">
+                          <div class="chat-state-card rounded-xl">
                             <div class="chat-state-label">${item.label}</div>
                             <div class="chat-state-value">${item.value}</div>
                           </div>
@@ -197,7 +197,7 @@ export function ChatMessageBubble({
                     <div class="chat-detail-section">
                       <button
                         type="button"
-                        class="chat-raw-toggle"
+                        class="chat-raw-toggle rounded-full"
                         onClick=${() => { setRawExpanded(!rawExpanded) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
@@ -282,16 +282,16 @@ export function ChatComposer({
   return html`
     <div class="chat-composer">
       <textarea
-        class="control-textarea min-h-[72px]"
+        class="control-textarea rounded-lg min-h-[72px]"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}
         disabled=${disabled}
       ></textarea>
-      <div class="chat-composer-actions">
+      <div class="flex gap-2 items-center">
         <button
           type="button"
-          class="control-btn${warnClass}"
+          class="control-btn rounded-lg${warnClass}"
           onClick=${onSend}
           disabled=${disabled || streaming || draft.trim() === ''}
         >
@@ -301,7 +301,7 @@ export function ChatComposer({
           ? html`
               <button
                 type="button"
-                class="control-btn ghost"
+                class="control-btn rounded-lg ghost"
                 onClick=${onAbort}
               >
                 중지

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -34,15 +34,15 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
   const denyKey = `deny:${decision.decision_id}`
   const isLegacy = decision.source === 'projected_operator'
   return html`
-    <article class="command-card ${toneClass(decision.status)}">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl ${toneClass(decision.status)}">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${decision.requested_action}</strong>
-          <div class="command-card-sub">${decision.scope_type}:${decision.scope_id}</div>
+          <div class="command-card rounded-xl-sub">${decision.scope_type}:${decision.scope_id}</div>
         </div>
-        <span class="command-chip ${toneClass(decision.status)}">${controlStatusLabel(decision.status ?? 'pending')}</span>
+        <span class="command-chip rounded-full ${toneClass(decision.status)}">${controlStatusLabel(decision.status ?? 'pending')}</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>결정 ID</span><span>${decision.decision_id}</span>
         <span>요청자</span><span>${decision.requested_by ?? '알 수 없음'}</span>
         <span>출처</span><span>${decision.source ?? 'managed'}</span>
@@ -53,16 +53,16 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
       ${decision.status === 'pending' && !isLegacy
         ? html`
             <div class="command-action-row">
-              <button class="control-btn ghost" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
+              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
-              <button class="control-btn ghost" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
+              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(denyKey) ? '거부 중…' : '거부'}
               </button>
             </div>
           `
         : null}
-      ${isLegacy ? html`<div class="command-card-foot">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
+      ${isLegacy ? html`<div class="command-card rounded-xl-foot">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
     </article>
   `
 }
@@ -75,15 +75,15 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
   const killSwitch = !!unit.policy?.kill_switch
   const utilization = Math.round((row.utilization ?? 0) * 100)
   return html`
-    <article class="command-card p-3">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl p-3">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${unit.label}</strong>
-          <div class="command-card-sub">${unit.unit_id}</div>
+          <div class="command-card rounded-xl-sub">${unit.unit_id}</div>
         </div>
-        <span class="command-chip ${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')}">${utilization}%</span>
+        <span class="command-chip rounded-full ${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')}">${utilization}%</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>편성</span><span>${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>
         <span>정원</span><span>${row.headcount_cap ?? 0}</span>
         <span>작전</span><span>${row.active_operations ?? 0}/${row.active_operation_cap ?? 0}</span>
@@ -92,10 +92,10 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
         <span>킬 스위치</span><span>${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
       <div class="command-action-row">
-        <button class="control-btn ghost" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
+        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>
-        <button class="control-btn ghost" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
+        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
           ${actionDisabled(killKey) ? '적용 중…' : killSwitch ? '킬 스위치 해제' : '킬 스위치 켜기'}
         </button>
       </div>
@@ -107,26 +107,26 @@ export function ControlSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="command-surface-grid">
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">승인 대기</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">승인 대기</div>
         </div>
         ${snapshot && snapshot.decisions.decisions.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${snapshot.decisions.decisions.map(decision => html`<${DecisionCard} decision=${decision} />`)}
             </div>`
-          : html`<div class="empty-state">지금 승인 대기 항목은 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 승인 대기 항목은 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">유닛 제어</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">유닛 제어</div>
         </div>
         ${snapshot && snapshot.capacity.capacity.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${snapshot.capacity.capacity.map(row => html`<${CapacityRowCard} row=${row} />`)}
             </div>`
-          : html`<div class="empty-state">제어할 용량 행이 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">제어할 용량 행이 아직 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -192,51 +192,51 @@ function GuidedPanel() {
 
   return html`
     <div class="command-guided-layout">
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">즉시 조치</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">즉시 조치</div>
         </div>
-        <div class="command-guide-card highlight mb-3">
+        <div class="command-guide-card rounded-xl highlight mb-3">
           <div class="command-guide-head">
             <strong>${nextStep?.title ?? nextTool}</strong>
-            <span class="command-chip ok">${nextTool}</span>
+            <span class="command-chip rounded-full ok">${nextTool}</span>
           </div>
           <p>${nextStep?.summary ?? '지금 막고 있는 병목을 풀기 위해 canonical flow의 다음 tool부터 실행합니다.'}</p>
           ${nextStep?.success_signals?.length
-            ? html`<div class="command-tag-row">
-                ${nextStep.success_signals.map(signal => html`<span class="command-tag ok">${signal}</span>`)}
+            ? html`<div class="command-tag rounded-full-row">
+                ${nextStep.success_signals.map(signal => html`<span class="command-tag rounded-full ok">${signal}</span>`)}
               </div>`
             : null}
         </div>
 
         <div class="command-readiness-list">
           ${readiness.map(item => html`
-            <article class="command-readiness-row ${toneClass(item.tone)}">
+            <article class="command-readiness-row rounded-xl ${toneClass(item.tone)}">
               <div>
                 <div class="command-readiness-title-row">
                   <strong>${item.title}</strong>
-                  <span class="command-chip ${toneClass(item.tone)}">${item.tone}</span>
+                  <span class="command-chip rounded-full ${toneClass(item.tone)}">${item.tone}</span>
                 </div>
                 <p>${item.detail}</p>
               </div>
-              <div class="command-card-foot">Next tool: ${item.tool}</div>
+              <div class="command-card rounded-xl-foot">Next tool: ${item.tool}</div>
             </article>
           `)}
         </div>
 
         ${pitfalls.length > 0
           ? html`
-              <div class="command-guide-card warn">
+              <div class="command-guide-card rounded-xl warn">
                 <div class="command-guide-head">
                   <strong>자주 막히는 지점</strong>
-                  <span class="command-chip warn">${pitfalls.length}</span>
+                  <span class="command-chip rounded-full warn">${pitfalls.length}</span>
                 </div>
                 <div class="command-guide-list">
                   ${pitfalls.map(pitfall => html`
                     <article class="command-guide-inline">
                       <strong>${pitfall.title}</strong>
                       <div>${pitfall.symptom}</div>
-                      <div class="command-card-sub">${pitfall.fix_tool} 로 해결: ${pitfall.fix_summary}</div>
+                      <div class="command-card rounded-xl-sub">${pitfall.fix_tool} 로 해결: ${pitfall.fix_summary}</div>
                     </article>
                   `)}
                 </div>
@@ -245,24 +245,24 @@ function GuidedPanel() {
           : null}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">운영 경로</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">운영 경로</div>
         </div>
         ${commandPlaneHelpLoading.value
-          ? html`<div class="empty-state">CPv2 runbook 불러오는 중…</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">CPv2 runbook 불러오는 중…</div>`
           : commandPlaneHelpError.value
-            ? html`<div class="empty-state error">${commandPlaneHelpError.value}</div>`
+            ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneHelpError.value}</div>`
             : html`
                 <div class="grid gap-3">
                   ${renderedPaths.map(path => html`
-                    <article class="command-guide-card">
+                    <article class="command-guide-card rounded-xl">
                       <div class="command-guide-head">
                         <strong>${path.title}</strong>
-                        <span class="command-chip">${path.id}</span>
+                        <span class="command-chip rounded-full">${path.id}</span>
                       </div>
                       <p>${path.summary}</p>
-                      <div class="command-card-sub">${path.when_to_use}</div>
+                      <div class="command-card rounded-xl-sub">${path.when_to_use}</div>
                       <div class="command-step-list compact">
                         ${path.steps.slice(0, 4).map(step => html`
                           <div class="command-step-row">
@@ -276,7 +276,7 @@ function GuidedPanel() {
                 </div>
                 ${docs.length > 0
                   ? html`<div class="command-doc-links">
-                      ${docs.map(doc => html`<span class="command-tag">${doc.title}: ${doc.path}</span>`)}
+                      ${docs.map(doc => html`<span class="command-tag rounded-full">${doc.title}: ${doc.path}</span>`)}
                     </div>`
                   : null}
               `}
@@ -295,10 +295,10 @@ export function SummarySurface() {
 
 export function DetailLoadingState() {
   if (commandPlaneDetailLoading.value) {
-    return html`<div class="empty-state">command-plane detail 불러오는 중…</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">command-plane detail 불러오는 중…</div>`
   }
   if (commandPlaneDetailError.value) {
-    return html`<div class="empty-state error">${commandPlaneDetailError.value}</div>`
+    return html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneDetailError.value}</div>`
   }
-  return html`<div class="empty-state">surface를 선택하면 command-plane detail을 로드합니다.</div>`
+  return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">surface를 선택하면 command-plane detail을 로드합니다.</div>`
 }

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -53,7 +53,7 @@ function SurfaceTabs() {
               .filter(surface => surface.group === group.id)
               .map(surface => html`
                 <button
-                  class="command-surface-tab ${commandPlaneSurface.value === surface.id ? 'active' : ''}"
+                  class="command-surface-tab rounded-full ${commandPlaneSurface.value === surface.id ? 'active' : ''}"
                   onClick=${() => {
                     setCommandPlaneSurface(surface.id)
                     navigate('operations', surfaceRouteParams(surface.id))
@@ -229,7 +229,7 @@ export function Command() {
           </div>
           <div class="panel-actions">
             <button
-              class="control-btn ghost"
+              class="control-btn rounded-lg ghost"
               onClick=${() => {
                 void fire(() => runCommandPlaneDispatchTick())
               }}
@@ -238,7 +238,7 @@ export function Command() {
               ${actionDisabled('dispatch:tick') ? '정리 중...' : 'Tick 실행'}
             </button>
             <button
-              class="control-btn ghost"
+              class="control-btn rounded-lg ghost"
               onClick=${() => {
                 void refreshRoomTruth()
                 void refreshCommandPlaneCurrentSurface()
@@ -253,7 +253,7 @@ export function Command() {
               ${commandPlaneLoading.value ? '새로고침 중...' : '새로고침'}
             </button>
             <button
-              class="control-btn ghost"
+              class="control-btn rounded-lg ghost"
               onClick=${() => {
                 setCommandPlaneSurface('warroom')
                 navigate('operations', { ...surfaceRouteParams('warroom'), presentation: 'wallboard' })
@@ -266,10 +266,10 @@ export function Command() {
       `}
 
       ${commandPlaneError.value
-        ? html`<div class="empty-state error">${commandPlaneError.value}</div>`
+        ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneError.value}</div>`
         : null}
       ${commandPlaneActionError.value
-        ? html`<div class="empty-state error">${commandPlaneActionError.value}</div>`
+        ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneActionError.value}</div>`
         : null}
       ${wallboardMode ? null : html`<${RoomTruthStrip} />`}
       ${wallboardMode ? null : html`<${CommandWorkflowBanner} />`}

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -95,7 +95,7 @@ function MermaidGraph({ source }: { source: string }) {
 
   return html`
     <div class="mt-3 min-h-[160px]">
-      ${error ? html`<div class="empty-state error">${error}</div>` : null}
+      ${error ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${error}</div>` : null}
       <div class="command-chain-graph" ref=${hostRef}></div>
     </div>
   `
@@ -107,20 +107,20 @@ function ChainOperationListItem(
   const chain = overlay.operation.chain
   const runtime = overlay.runtime
   return html`
-    <button class="command-chain-item ${selected ? 'selected' : ''}" onClick=${onSelect}>
-      <div class="command-card-head">
+    <button class="command-chain-item rounded-xl ${selected ? 'selected' : ''}" onClick=${onSelect}>
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${overlay.operation.objective}</strong>
-          <div class="command-card-sub">${overlay.operation.operation_id}</div>
+          <div class="command-card rounded-xl-sub">${overlay.operation.operation_id}</div>
         </div>
-        <span class="command-chip ${chainStatusTone(chain?.status)}">${chain?.status ?? overlay.operation.status}</span>
+        <span class="command-chip rounded-full ${chainStatusTone(chain?.status)}">${chain?.status ?? overlay.operation.status}</span>
       </div>
-      <div class="command-tag-row">
-        <span class="command-tag">${chain?.kind ?? 'chain_dsl'}</span>
-        ${chain?.chain_id ? html`<span class="command-tag">${chain.chain_id}</span>` : null}
-        ${runtime ? html`<span class="command-tag ${chainStatusTone(chain?.status)}">${formatPercent(runtime.progress)} progress</span>` : null}
+      <div class="command-tag rounded-full-row">
+        <span class="command-tag rounded-full">${chain?.kind ?? 'chain_dsl'}</span>
+        ${chain?.chain_id ? html`<span class="command-tag rounded-full">${chain.chain_id}</span>` : null}
+        ${runtime ? html`<span class="command-tag rounded-full ${chainStatusTone(chain?.status)}">${formatPercent(runtime.progress)} progress</span>` : null}
       </div>
-      <div class="command-card-sub">${historySummary(overlay.history)}</div>
+      <div class="command-card rounded-xl-sub">${historySummary(overlay.history)}</div>
     </button>
   `
 }
@@ -130,10 +130,10 @@ function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
     <article class="command-chain-history-row text-red-300">
       <div class="command-guide-head">
         <strong>${item.chain_id ?? '알 수 없는 체인'}</strong>
-        <span class="command-chip ${chainStatusTone(item.event)}">${item.event}</span>
+        <span class="command-chip rounded-full ${chainStatusTone(item.event)}">${item.event}</span>
       </div>
-      <div class="command-card-sub">${relativeTime(item.timestamp)}</div>
-      <div class="command-card-sub">${historySummary(item)}</div>
+      <div class="command-card rounded-xl-sub">${relativeTime(item.timestamp)}</div>
+      <div class="command-card rounded-xl-sub">${historySummary(item)}</div>
     </article>
   `
 }
@@ -143,13 +143,13 @@ function ChainRunNodeRow({ node }: { node: CommandPlaneChainRunNode }) {
     <article class="command-chain-node-row">
       <div class="command-guide-head">
         <strong>${node.id}</strong>
-        <span class="command-chip ${chainStatusTone(node.status)}">${node.status ?? '확인 필요'}</span>
+        <span class="command-chip rounded-full ${chainStatusTone(node.status)}">${node.status ?? '확인 필요'}</span>
       </div>
-      <div class="command-card-sub">
+      <div class="command-card rounded-xl-sub">
         ${node.type ?? '노드'}
         ${typeof node.duration_ms === 'number' ? ` · ${node.duration_ms}ms` : ''}
       </div>
-      ${node.error ? html`<div class="command-card-sub text-red-300">${node.error}</div>` : null}
+      ${node.error ? html`<div class="command-card rounded-xl-sub text-red-300">${node.error}</div>` : null}
     </article>
   `
 }
@@ -162,15 +162,15 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
   const chain = op.chain
   const runId = chain?.run_id ?? null
   return html`
-    <article class="command-card">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${op.objective}</strong>
-          <div class="command-card-sub">${op.operation_id}</div>
+          <div class="command-card rounded-xl-sub">${op.operation_id}</div>
         </div>
-        <span class="command-chip ${toneClass(op.status === 'active' ? 'ok' : op.status === 'paused' ? 'warn' : op.status === 'failed' ? 'bad' : 'ok')}">${operationStatusLabel(op.status)}</span>
+        <span class="command-chip rounded-full ${toneClass(op.status === 'active' ? 'ok' : op.status === 'paused' ? 'warn' : op.status === 'failed' ? 'bad' : 'ok')}">${operationStatusLabel(op.status)}</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>유닛</span><span>${card.assigned_unit_label ?? op.assigned_unit_id}</span>
         <span>트레이스</span><span class="font-mono">${op.trace_id}</span>
         <span>자율성</span><span>${op.autonomy_level ?? '정보 없음'}</span>
@@ -180,20 +180,20 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
       </div>
       ${chain
         ? html`
-            <div class="command-tag-row">
-              <span class="command-tag">${chain.kind}</span>
-              <span class="command-tag ${chainStatusTone(chain.status)}">${operationStatusLabel(chain.status)}</span>
-              ${chain.chain_id ? html`<span class="command-tag">${chain.chain_id}</span>` : null}
-              ${chain.run_id ? html`<span class="command-tag">실행 ${chain.run_id}</span>` : null}
+            <div class="command-tag rounded-full-row">
+              <span class="command-tag rounded-full">${chain.kind}</span>
+              <span class="command-tag rounded-full ${chainStatusTone(chain.status)}">${operationStatusLabel(chain.status)}</span>
+              ${chain.chain_id ? html`<span class="command-tag rounded-full">${chain.chain_id}</span>` : null}
+              ${chain.run_id ? html`<span class="command-tag rounded-full">실행 ${chain.run_id}</span>` : null}
             </div>
           `
         : null}
       ${op.checkpoint_ref
-        ? html`<div class="command-card-foot">체크포인트 ${op.checkpoint_ref}</div>`
+        ? html`<div class="command-card rounded-xl-foot">체크포인트 ${op.checkpoint_ref}</div>`
         : null}
       <div class="command-action-row">
         <button
-          class="control-btn ghost"
+          class="control-btn rounded-lg ghost"
           onClick=${() => {
             setCommandPlaneSurface('swarm')
             navigate('operations', {
@@ -208,7 +208,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
         ${chain
           ? html`
               <button
-                class="control-btn ghost"
+                class="control-btn rounded-lg ghost"
                 onClick=${() => {
                   focusCommandPlaneChainOperation(op.operation_id)
                   setCommandPlaneSurface('chains')
@@ -221,17 +221,17 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
           : null}
         ${op.source === 'managed' && op.status === 'active'
           ? html`
-              <button class="control-btn ghost" disabled=${actionDisabled(pauseKey)} onClick=${() => fire(() => pauseCommandPlaneOperation(op.operation_id))}>
+              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(pauseKey)} onClick=${() => fire(() => pauseCommandPlaneOperation(op.operation_id))}>
                 ${actionDisabled(pauseKey) ? '일시정지 중…' : '일시정지'}
               </button>
-              <button class="control-btn ghost" disabled=${actionDisabled(recallKey)} onClick=${() => fire(() => recallCommandPlaneOperation(op.operation_id))}>
+              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(recallKey)} onClick=${() => fire(() => recallCommandPlaneOperation(op.operation_id))}>
                 ${actionDisabled(recallKey) ? '회수 중…' : '회수'}
               </button>
             `
           : null}
         ${op.source === 'managed' && op.status === 'paused'
           ? html`
-              <button class="control-btn ghost" disabled=${actionDisabled(resumeKey)} onClick=${() => fire(() => resumeCommandPlaneOperation(op.operation_id))}>
+              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(resumeKey)} onClick=${() => fire(() => resumeCommandPlaneOperation(op.operation_id))}>
                 ${actionDisabled(resumeKey) ? '재개 중…' : '재개'}
               </button>
             `
@@ -244,15 +244,15 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
 function DetachmentCard({ card }: { card: CommandPlaneDetachmentCard }) {
   const detachment = card.detachment
   return html`
-    <article class="command-card p-3">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl p-3">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${detachment.detachment_id}</strong>
-          <div class="command-card-sub">${card.operation?.objective ?? detachment.operation_id}</div>
+          <div class="command-card rounded-xl-sub">${card.operation?.objective ?? detachment.operation_id}</div>
         </div>
-        <span class="command-chip ${toneClass(detachment.status)}">${detachment.status ?? 'active'}</span>
+        <span class="command-chip rounded-full ${toneClass(detachment.status)}">${detachment.status ?? 'active'}</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>유닛</span><span>${card.assigned_unit_label ?? detachment.assigned_unit_id}</span>
         <span>리더</span><span>${detachment.leader_id ?? '미지정'}</span>
         <span>편성</span><span>${detachment.roster.length}</span>
@@ -263,9 +263,9 @@ function DetachmentCard({ card }: { card: CommandPlaneDetachmentCard }) {
         <span>하트비트</span><span>${deadlineLabel(detachment.heartbeat_deadline)}</span>
         <span>최근 갱신</span><span>${relativeTime(detachment.updated_at)}</span>
       </div>
-      <div class="command-tag-row">
+      <div class="command-tag rounded-full-row">
         ${detachment.heartbeat_deadline
-          ? html`<span class="command-tag ${expiryTone(detachment.heartbeat_deadline)}">
+          ? html`<span class="command-tag rounded-full ${expiryTone(detachment.heartbeat_deadline)}">
               기한 ${detachment.heartbeat_deadline}
             </span>`
           : null}
@@ -278,25 +278,25 @@ export function OperationsSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="command-surface-grid">
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">작전</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">작전</div>
         </div>
         ${snapshot && snapshot.operations.operations.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${snapshot.operations.operations.map(card => html`<${OperationCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state">관리형 또는 투영된 작전이 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관리형 또는 투영된 작전이 없습니다.</div>`}
       </section>
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">분견대</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">분견대</div>
         </div>
         ${snapshot && snapshot.detachments.detachments.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${snapshot.detachments.detachments.map(card => html`<${DetachmentCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state">투영된 분견대가 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">투영된 분견대가 없습니다.</div>`}
       </section>
     </div>
   `
@@ -324,17 +324,17 @@ export function ChainsSurface() {
 
   return html`
     <div class="command-grid">
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">Chains</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">Chains</div>
         </div>
-        <article class="command-guide-card ${chainStatusTone(summary?.connection.status)}">
+        <article class="command-guide-card rounded-xl ${chainStatusTone(summary?.connection.status)}">
           <div class="command-guide-head">
             <strong>native chain 연결</strong>
-            <span class="command-chip ${chainStatusTone(summary?.connection.status)}">${summary?.connection.status ?? 'disconnected'}</span>
+            <span class="command-chip rounded-full ${chainStatusTone(summary?.connection.status)}">${summary?.connection.status ?? 'disconnected'}</span>
           </div>
           <p>${summary?.connection.message ?? '체인 요약은 MASC 프록시를 통해 집계됩니다.'}</p>
-          <div class="command-card-grid">
+          <div class="command-card rounded-xl-grid">
             <span>기준 URL</span><span>${summary?.connection.base_url ?? '정보 없음'}</span>
             <span>연결된 작전</span><span>${summary?.summary?.linked_operations ?? 0}</span>
             <span>활성 체인</span><span>${summary?.summary?.active_chains ?? 0}</span>
@@ -344,11 +344,11 @@ export function ChainsSurface() {
         </article>
 
         ${commandPlaneChainError.value
-          ? html`<div class="empty-state error">${commandPlaneChainError.value}</div>`
+          ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneChainError.value}</div>`
           : null}
 
         ${commandPlaneChainLoading.value && !summary
-          ? html`<div class="empty-state">체인 오버레이 불러오는 중…</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 오버레이 불러오는 중…</div>`
           : overlays.length > 0
             ? html`
                 <div class="command-chain-list">
@@ -361,40 +361,40 @@ export function ChainsSurface() {
                   `)}
                 </div>
               `
-            : html`<div class="empty-state">체인 기반 작전이 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 기반 작전이 아직 없습니다.</div>`}
 
         <div class="command-chain-history">
           <div class="command-guide-head">
             <strong>최근 이력</strong>
-            <span class="command-chip">${summary?.recent_history.length ?? 0}</span>
+            <span class="command-chip rounded-full">${summary?.recent_history.length ?? 0}</span>
           </div>
           ${summary && summary.recent_history.length > 0
             ? html`
-                <div class="command-card-stack">
+                <div class="command-card rounded-xl-stack">
                   ${summary.recent_history.slice(0, 6).map(item => html`<${ChainHistoryRow} item=${item} />`)}
                 </div>
               `
-            : html`<div class="empty-state">최근 체인 이력이 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 체인 이력이 없습니다.</div>`}
         </div>
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">체인 상세</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">체인 상세</div>
         </div>
         ${selectedOverlay
           ? html`
-              <article class="command-card">
-                <div class="command-card-head">
+              <article class="command-card rounded-xl">
+                <div class="command-card rounded-xl-head">
                   <div>
                     <strong>${selectedOverlay.operation.objective}</strong>
-                    <div class="command-card-sub">${selectedOverlay.operation.operation_id}</div>
+                    <div class="command-card rounded-xl-sub">${selectedOverlay.operation.operation_id}</div>
                   </div>
-                  <span class="command-chip ${chainStatusTone(selectedOverlay.operation.chain?.status)}">
+                  <span class="command-chip rounded-full ${chainStatusTone(selectedOverlay.operation.chain?.status)}">
                     ${selectedOverlay.operation.chain?.status ?? selectedOverlay.operation.status}
                   </span>
                 </div>
-                <div class="command-card-grid">
+                <div class="command-card rounded-xl-grid">
                   <span>종류</span><span>${selectedOverlay.operation.chain?.kind ?? 'chain_dsl'}</span>
                   <span>체인 ID</span><span>${selectedOverlay.operation.chain?.chain_id ?? 'goal-driven'}</span>
                   <span>실행 ID</span><span>${selectedRunId ?? '아직 구체화되지 않음'}</span>
@@ -403,54 +403,54 @@ export function ChainsSurface() {
                   <span>최근 갱신</span><span>${relativeTime(selectedOverlay.operation.chain?.last_sync_at ?? selectedOverlay.operation.updated_at)}</span>
                 </div>
                 ${selectedOverlay.operation.chain?.goal
-                  ? html`<div class="command-card-foot">${selectedOverlay.operation.chain.goal}</div>`
+                  ? html`<div class="command-card rounded-xl-foot">${selectedOverlay.operation.chain.goal}</div>`
                   : null}
               </article>
 
               ${selectedOverlay.mermaid
                 ? html`
-                    <div class="command-chain-panel">
+                    <div class="command-chain-panel rounded-xl">
                       <div class="command-guide-head">
                         <strong>Mermaid 그래프</strong>
-                        <span class="command-chip">${selectedOverlay.operation.chain?.chain_id ?? 'graph'}</span>
+                        <span class="command-chip rounded-full">${selectedOverlay.operation.chain?.chain_id ?? 'graph'}</span>
                       </div>
                       <${MermaidGraph} source=${selectedOverlay.mermaid} />
                     </div>
                   `
-                : html`<div class="empty-state">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
+                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
 
-              <div class="command-chain-panel">
+              <div class="command-chain-panel rounded-xl">
                 <div class="command-guide-head">
                   <strong>실행 상세</strong>
-                  <span class="command-chip ${run?.success === false ? 'bad' : 'ok'}">
+                  <span class="command-chip rounded-full ${run?.success === false ? 'bad' : 'ok'}">
                     ${run
                       ? (run.success === false ? '실패' : isPreviewRun ? '미리보기' : '기록됨')
                       : '대기 중'}
                   </span>
                 </div>
                 ${commandPlaneChainRunLoading.value
-                  ? html`<div class="empty-state">실행 상세 불러오는 중…</div>`
+                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실행 상세 불러오는 중…</div>`
                   : commandPlaneChainRunError.value
-                    ? html`<div class="empty-state error">${commandPlaneChainRunError.value}</div>`
+                    ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneChainRunError.value}</div>`
                     : run && run.nodes.length > 0
                       ? html`
-                          <div class="command-card-grid">
+                          <div class="command-card rounded-xl-grid">
                             <span>체인</span><span>${run.chain_id}</span>
                             <span>실행</span><span>${run.run_id ?? '미리보기만 있음'}</span>
                             <span>지속시간</span><span>${run.duration_ms != null ? `${run.duration_ms}ms` : '정보 없음'}</span>
                             <span>노드</span><span>${run.nodes.length}</span>
                           </div>
                           ${isPreviewRun
-                            ? html`<div class="command-card-foot">run-store에 기록되기 전, 설계된 체인으로 만든 미리보기입니다.</div>`
+                            ? html`<div class="command-card rounded-xl-foot">run-store에 기록되기 전, 설계된 체인으로 만든 미리보기입니다.</div>`
                             : null}
-                          <div class="command-card-stack">
+                          <div class="command-card rounded-xl-stack">
                             ${run.nodes.map(node => html`<${ChainRunNodeRow} node=${node} />`)}
                           </div>
                         `
-                      : html`<div class="empty-state">이 작전의 run-store 상세는 아직 없습니다.</div>`}
+                      : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이 작전의 run-store 상세는 아직 없습니다.</div>`}
               </div>
             `
-          : html`<div class="empty-state">그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -363,21 +363,21 @@ export function OrchestraNodeLayer({
 
 export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOrchestraResponse }) {
   const selected = selectedTarget(orchestra)
-  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card"><div class="empty-state">선택 가능한 대상이 아직 없습니다.</div></aside>`
+  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">선택 가능한 대상이 아직 없습니다.</div></aside>`
   if (selected.type === 'signal') {
     const signalNode = selected.value
     return html`
-      <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card ${toneClass(signalNode.tone)}">
-        <div class="card-title-row">
-          <div class="card-title">${signalNode.label}</div>
-          <span class="command-chip ${toneClass(signalNode.tone)}">${orchestraNodeKindLabel(signalNode.kind)}</span>
+      <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl ${toneClass(signalNode.tone)}">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">${signalNode.label}</div>
+          <span class="command-chip rounded-full ${toneClass(signalNode.tone)}">${orchestraNodeKindLabel(signalNode.kind)}</span>
         </div>
         <p>${signalNode.detail ?? '세부 설명이 없습니다.'}</p>
         ${signalNode.suggested_surface
           ? html`
               <div class="command-action-row">
                 <button
-                  class="control-btn"
+                  class="control-btn rounded-lg"
                   onClick=${() => jumpTo('command', signalNode.suggested_surface, signalNode.suggested_params ?? {})}
                 >
                   추천 화면 열기
@@ -393,12 +393,12 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
   const relatedSignals = orchestra.signals.filter(signalNode => signalNode.source_id === node.id || signalNode.target_id === node.id)
   const relatedEdges = orchestra.edges.filter(edge => edge.source === node.id || edge.target === node.id)
   return html`
-    <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card ${toneClass(node.tone)}">
-      <div class="card-title-row">
-        <div class="card-title">${node.label}</div>
-        <span class="command-chip ${toneClass(node.tone)}">${orchestraNodeKindLabel(node.kind)}</span>
+    <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl ${toneClass(node.tone)}">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">${node.label}</div>
+        <span class="command-chip rounded-full ${toneClass(node.tone)}">${orchestraNodeKindLabel(node.kind)}</span>
       </div>
-      ${node.subtitle ? html`<p class="command-card-sub">${node.subtitle}</p>` : null}
+      ${node.subtitle ? html`<p class="command-card rounded-xl-sub">${node.subtitle}</p>` : null}
       <div class="orchestra-fact-list flex flex-col gap-2">
         ${node.facts.map(factRow => html`
           <div class="orchestra-fact-row flex justify-between gap-3 py-2 px-2.5 rounded-[10px]">
@@ -408,16 +408,16 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
         `)}
       </div>
       ${relatedSignals.length > 0 ? html`
-        <div class="command-tag-row">
-          ${relatedSignals.map(signalNode => html`<span class="command-chip ${toneClass(signalNode.tone)}">${signalNode.label}</span>`)}
+        <div class="command-tag rounded-full-row">
+          ${relatedSignals.map(signalNode => html`<span class="command-chip rounded-full ${toneClass(signalNode.tone)}">${signalNode.label}</span>`)}
         </div>
       ` : null}
-      <div class="command-card-sub">연결 ${relatedEdges.length}개 · 근거 ${node.provenance}</div>
+      <div class="command-card rounded-xl-sub">연결 ${relatedEdges.length}개 · 근거 ${node.provenance}</div>
       ${(node.link_tab && (node.link_surface || Object.keys(node.link_params ?? {}).length > 0))
         ? html`
             <div class="command-action-row">
               <button
-                class="control-btn"
+                class="control-btn rounded-lg"
                 onClick=${() => jumpTo(node.link_tab ?? 'command', node.link_surface, node.link_params ?? {})}
               >
                 이 화면 열기

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -215,13 +215,13 @@ export function OrchestraSurface() {
   }, [])
 
   if (commandPlaneOrchestraLoading.value && !orchestra) {
-    return html`<section class="card min-h-[240px]"><div class="empty-state">오케스트라 맵 불러오는 중…</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오케스트라 맵 불러오는 중…</div></section>`
   }
   if (commandPlaneOrchestraError.value) {
-    return html`<section class="card min-h-[240px]"><div class="empty-state error">${commandPlaneOrchestraError.value}</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneOrchestraError.value}</div></section>`
   }
   if (!orchestra) {
-    return html`<section class="card min-h-[240px]"><div class="empty-state">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
   }
 
   const density = orchestraDensity.value
@@ -328,33 +328,33 @@ export function OrchestraSurface() {
   }
 
   return html`
-    <section class="card min-h-[240px] overflow-hidden">
-      <div class="card-title-row">
-        <div class="card-title">오케스트라 맵</div>
+    <section class="card rounded-xl min-h-[240px] overflow-hidden">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">오케스트라 맵</div>
       </div>
-      <p class="command-card-sub">
+      <p class="command-card rounded-xl-sub">
         룸 전체를 한 장의 작전판으로 읽는 시각화입니다. 확대/이동으로 밀집 구간을 읽고, 노드를 눌러 상세 신호와 연결 대상을 확인합니다.
       </p>
 
       <div class="orchestra-toolbar">
         <div class="orchestra-toolbar-group">
-          <button class="control-btn ghost" onClick=${applyFit}>맞춤 보기</button>
-          <button class="control-btn ghost" onClick=${resetView}>초기화</button>
+          <button class="control-btn rounded-lg ghost" onClick=${applyFit}>맞춤 보기</button>
+          <button class="control-btn rounded-lg ghost" onClick=${resetView}>초기화</button>
         </div>
         <div class="orchestra-toolbar-group">
           <button
-            class="control-btn ghost"
+            class="control-btn rounded-lg ghost"
             onClick=${() => zoomAround(viewport.width / 2, viewport.height / 2, 1.12)}
           >
             확대
           </button>
           <button
-            class="control-btn ghost"
+            class="control-btn rounded-lg ghost"
             onClick=${() => zoomAround(viewport.width / 2, viewport.height / 2, 0.9)}
           >
             축소
           </button>
-          <span class="command-chip">${Math.round(camera.zoom * 100)}%</span>
+          <span class="command-chip rounded-full">${Math.round(camera.zoom * 100)}%</span>
         </div>
         <div class="orchestra-toolbar-group">
           <button
@@ -375,7 +375,7 @@ export function OrchestraSurface() {
           >
             집약
           </button>
-          <span class="command-chip">${densityLabel(density)}</span>
+          <span class="command-chip rounded-full">${densityLabel(density)}</span>
         </div>
       </div>
 
@@ -420,13 +420,13 @@ export function OrchestraSurface() {
             </g>
           </svg>
           <div class="orchestra-summary-strip">
-            <span class="command-chip">세션 ${orchestra.summary?.session_count ?? 0}</span>
-            <span class="command-chip">워커 ${orchestra.summary?.worker_count ?? 0}</span>
-            <span class="command-chip">키퍼 ${orchestra.summary?.keeper_count ?? 0}</span>
-            <span class="command-chip ${toneClass(orchestra.signals.some(signalNode => signalNode.tone === 'bad') ? 'bad' : orchestra.signals.length > 0 ? 'warn' : 'ok')}">
+            <span class="command-chip rounded-full">세션 ${orchestra.summary?.session_count ?? 0}</span>
+            <span class="command-chip rounded-full">워커 ${orchestra.summary?.worker_count ?? 0}</span>
+            <span class="command-chip rounded-full">키퍼 ${orchestra.summary?.keeper_count ?? 0}</span>
+            <span class="command-chip rounded-full ${toneClass(orchestra.signals.some(signalNode => signalNode.tone === 'bad') ? 'bad' : orchestra.signals.length > 0 ? 'warn' : 'ok')}">
               신호 ${orchestra.summary?.signal_count ?? orchestra.signals.length}
             </span>
-            <span class="command-chip">갱신 ${relativeTime(orchestra.generated_at)}</span>
+            <span class="command-chip rounded-full">갱신 ${relativeTime(orchestra.generated_at)}</span>
           </div>
         </div>
 

--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -30,13 +30,13 @@ export function CommandWorkflowBanner() {
     <section class="command-focus-banner">
       <div class="command-focus-head">
         <strong>${context.source_label}</strong>
-        <span class="command-chip">${workflowActionLabel(context.action_type)}</span>
-        <span class="command-chip">${workflowTargetLabel(context)}</span>
-        <span class="command-chip">${workflowCommandSurfaceLabel(route.value.params.surface ?? 'warroom')}</span>
+        <span class="command-chip rounded-full">${workflowActionLabel(context.action_type)}</span>
+        <span class="command-chip rounded-full">${workflowTargetLabel(context)}</span>
+        <span class="command-chip rounded-full">${workflowCommandSurfaceLabel(route.value.params.surface ?? 'warroom')}</span>
       </div>
       <div class="text-[rgba(255,255,255,0.84)] leading-normal">${context.summary}</div>
       ${context.payload_preview
-        ? html`<div class="command-focus-preview">${context.payload_preview}</div>`
+        ? html`<div class="command-focus-preview rounded-xl">${context.payload_preview}</div>`
         : null}
     </section>
   `
@@ -49,13 +49,13 @@ export function CommandEntryStrip() {
 
   return html`
     <section class="command-entry-strip">
-      <article class="command-entry-card">
-        <span class="command-entry-label">현재 표면</span>
+      <article class="command-entry-card rounded-xl">
+        <span class="text-[rgba(148,163,184,0.92)] text-[length:var(--fs-xs)] uppercase tracking-[0.08em]">현재 표면</span>
         <strong>${guide.title}</strong>
         <p>${guide.description}</p>
       </article>
-      <article class="command-entry-card">
-        <span class="command-entry-label">다음 추천</span>
+      <article class="command-entry-card rounded-xl">
+        <span class="text-[rgba(148,163,184,0.92)] text-[length:var(--fs-xs)] uppercase tracking-[0.08em]">다음 추천</span>
         <strong>${recommendation.tool}</strong>
         <p>${recommendation.reason}</p>
       </article>
@@ -77,9 +77,9 @@ function GraphicGauge({
   color: string
 }) {
   return html`
-    <article class="command-gauge-card">
+    <article class="grid grid-cols-[88px_minmax(0,1fr)] gap-3 items-center p-3 rounded-2xl bg-[rgba(255,255,255,0.045)] border border-solid border-[var(--white-8)] min-w-0">
       <div class="command-gauge-ring" style=${gaugeStyle(percent, color)}>
-        <div class="command-gauge-core">
+        <div class="w-full h-full rounded-full bg-[rgba(8,14,28,0.92)] border border-solid border-[var(--white-6)] grid place-items-center content-center text-center">
           <strong>${value}</strong>
           <span>${Math.round(clampPercent(percent))}%</span>
         </div>
@@ -111,7 +111,7 @@ function SignalRail({
         <span>${label}</span>
         <strong>${value}</strong>
       </div>
-      <div class="command-signal-bar">
+      <div class="command-signal-bar rounded-full">
         <span class="${toneClass(tone)}" style=${`width: ${Math.max(8, Math.round(clampPercent(percent)))}%`}></span>
       </div>
       <small>${detail}</small>
@@ -155,14 +155,14 @@ export function SummaryHero() {
   return html`
     <section class="command-hero command-hero-summary">
       <div class="command-hero-copy">
-        <span class="command-hero-kicker">현재 지휘 상태</span>
+        <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">현재 지휘 상태</span>
         <h3>${headline}</h3>
         <p>${subcopy}</p>
         <div class="command-hero-badges">
-        <span class="command-chip ${toneClass(activeOps > 0 ? 'ok' : 'warn')}">활성 작전 ${activeOps}</span>
-          <span class="command-chip ${toneClass(movingLanes > 0 ? 'ok' : activeLanes > 0 ? 'warn' : 'warn')}">이동 레인 ${movingLanes}/${Math.max(activeLanes, movingLanes)}</span>
-          <span class="command-chip ${toneClass(badAlerts > 0 ? 'bad' : warnAlerts > 0 ? 'warn' : 'ok')}">치명 알림 ${badAlerts}</span>
-          <span class="command-chip ${toneClass(pendingApprovals > 0 ? 'warn' : 'ok')}">승인 대기 ${pendingApprovals}</span>
+        <span class="command-chip rounded-full ${toneClass(activeOps > 0 ? 'ok' : 'warn')}">활성 작전 ${activeOps}</span>
+          <span class="command-chip rounded-full ${toneClass(movingLanes > 0 ? 'ok' : activeLanes > 0 ? 'warn' : 'warn')}">이동 레인 ${movingLanes}/${Math.max(activeLanes, movingLanes)}</span>
+          <span class="command-chip rounded-full ${toneClass(badAlerts > 0 ? 'bad' : warnAlerts > 0 ? 'warn' : 'ok')}">치명 알림 ${badAlerts}</span>
+          <span class="command-chip rounded-full ${toneClass(pendingApprovals > 0 ? 'warn' : 'ok')}">승인 대기 ${pendingApprovals}</span>
         </div>
       </div>
 
@@ -245,13 +245,13 @@ export function SummaryCards() {
   const cache = microarch?.cache
   return html`
     <div class="command-summary-grid">
-      <div class="monitor-stat-card"><span>유닛</span><strong>${topology?.total_units ?? 0}</strong><small>${topology?.managed_unit_count ?? 0}개 관리 중</small></div>
-      <div class="monitor-stat-card"><span>작전</span><strong>${ops?.active ?? 0}</strong><small>${summary?.detachments.summary?.active ?? 0}개 실행체</small></div>
-      <div class="monitor-stat-card"><span>승인</span><strong>${decisions?.pending ?? 0}</strong><small>${decisions?.total ?? 0}개 추적 중</small></div>
-      <div class="monitor-stat-card ${highlightKey === 'alerts' ? 'highlight' : ''}"><span>알림</span><strong>${alerts?.bad ?? 0}</strong><small>${alerts?.warn ?? 0}건 주의</small></div>
-      <div class="monitor-stat-card"><span>체인</span><strong>${chainSummary?.summary?.active_chains ?? 0}</strong><small>${chainSummary?.summary?.linked_operations ?? 0}개 연결</small></div>
-      <div class="monitor-stat-card ${highlightKey === 'swarm' ? 'highlight' : ''}"><span>스웜</span><strong>${swarm?.active_lanes ?? 0}</strong><small>${swarm ? `${swarm.stalled_lanes ?? 0}개 정체 · ${relativeTime(swarm.last_movement_at)}` : 'lane snapshot 없음'}</small></div>
-      <div class="monitor-stat-card ${highlightKey === 'microarch' ? 'highlight' : ''}"><span>마이크로아크</span><strong>${issuePressure?.pending_ops ?? 0}</strong><small>${cache?.l1_hit_rate != null ? `${formatPercent(cache.l1_hit_rate)} L1 적중` : '캐시 데이터 없음'} · ${issuePressure?.tone ?? '정보 없음'}</small></div>
+      <div class="monitor-stat-card rounded-xl"><span>유닛</span><strong>${topology?.total_units ?? 0}</strong><small>${topology?.managed_unit_count ?? 0}개 관리 중</small></div>
+      <div class="monitor-stat-card rounded-xl"><span>작전</span><strong>${ops?.active ?? 0}</strong><small>${summary?.detachments.summary?.active ?? 0}개 실행체</small></div>
+      <div class="monitor-stat-card rounded-xl"><span>승인</span><strong>${decisions?.pending ?? 0}</strong><small>${decisions?.total ?? 0}개 추적 중</small></div>
+      <div class="monitor-stat-card rounded-xl ${highlightKey === 'alerts' ? 'highlight' : ''}"><span>알림</span><strong>${alerts?.bad ?? 0}</strong><small>${alerts?.warn ?? 0}건 주의</small></div>
+      <div class="monitor-stat-card rounded-xl"><span>체인</span><strong>${chainSummary?.summary?.active_chains ?? 0}</strong><small>${chainSummary?.summary?.linked_operations ?? 0}개 연결</small></div>
+      <div class="monitor-stat-card rounded-xl ${highlightKey === 'swarm' ? 'highlight' : ''}"><span>스웜</span><strong>${swarm?.active_lanes ?? 0}</strong><small>${swarm ? `${swarm.stalled_lanes ?? 0}개 정체 · ${relativeTime(swarm.last_movement_at)}` : 'lane snapshot 없음'}</small></div>
+      <div class="monitor-stat-card rounded-xl ${highlightKey === 'microarch' ? 'highlight' : ''}"><span>마이크로아크</span><strong>${issuePressure?.pending_ops ?? 0}</strong><small>${cache?.l1_hit_rate != null ? `${formatPercent(cache.l1_hit_rate)} L1 적중` : '캐시 데이터 없음'} · ${issuePressure?.tone ?? '정보 없음'}</small></div>
     </div>
   `
 }

--- a/dashboard/src/components/command/swarm-cards.ts
+++ b/dashboard/src/components/command/swarm-cards.ts
@@ -11,13 +11,13 @@ import { alertBorderTone, relativeTime, toneClass } from './helpers'
 
 export function SwarmChecklistCard({ item }: { item: CommandPlaneSwarmChecklistItem }) {
   return html`
-    <article class="command-guide-card ${toneClass(item.status)}">
+    <article class="command-guide-card rounded-xl ${toneClass(item.status)}">
       <div class="command-guide-head">
         <strong>${item.title}</strong>
-        <span class="command-chip ${toneClass(item.status)}">${item.status}</span>
+        <span class="command-chip rounded-full ${toneClass(item.status)}">${item.status}</span>
       </div>
       <p>${item.detail}</p>
-      <div class="command-card-foot">Next tool: ${item.next_tool}</div>
+      <div class="command-card rounded-xl-foot">Next tool: ${item.next_tool}</div>
     </article>
   `
 }
@@ -25,9 +25,9 @@ export function SwarmChecklistCard({ item }: { item: CommandPlaneSwarmChecklistI
 export function SwarmBlockerCard({ blocker }: { blocker: CommandPlaneSwarmBlocker }) {
   return html`
     <article class="command-alert ${toneClass(blocker.severity)} ${alertBorderTone(toneClass(blocker.severity))}">
-      <div class="command-card-head">
+      <div class="command-card rounded-xl-head">
         <strong>${blocker.title}</strong>
-        <span class="command-chip ${toneClass(blocker.severity)}">${blocker.severity}</span>
+        <span class="command-chip rounded-full ${toneClass(blocker.severity)}">${blocker.severity}</span>
       </div>
       <div class="command-alert-meta">
         <span>${blocker.code}</span>
@@ -40,17 +40,17 @@ export function SwarmBlockerCard({ blocker }: { blocker: CommandPlaneSwarmBlocke
 
 export function SwarmWorkerCard({ worker }: { worker: CommandPlaneSwarmWorker }) {
   return html`
-    <article class="command-card p-3">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl p-3">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${worker.name}</strong>
-          <div class="command-card-sub">${worker.role} · ${worker.lane}</div>
+          <div class="command-card rounded-xl-sub">${worker.role} · ${worker.lane}</div>
         </div>
-        <span class="command-chip ${toneClass(worker.joined ? (worker.heartbeat_fresh ? 'ok' : 'warn') : 'bad')}">
+        <span class="command-chip rounded-full ${toneClass(worker.joined ? (worker.heartbeat_fresh ? 'ok' : 'warn') : 'bad')}">
           ${worker.status}
         </span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>Joined</span><span>${worker.joined ? 'yes' : 'no'}</span>
         <span>Live</span><span>${worker.live_presence ? 'yes' : 'no'}</span>
         <span>Completed</span><span>${worker.completed ? 'yes' : 'no'}</span>
@@ -61,15 +61,15 @@ export function SwarmWorkerCard({ worker }: { worker: CommandPlaneSwarmWorker })
         <span>Squad</span><span>${worker.squad_member ? 'yes' : 'no'}</span>
         <span>Detachment</span><span>${worker.detachment_member ? 'yes' : 'no'}</span>
       </div>
-      <div class="command-tag-row">
-        <span class="command-tag">${worker.lane}</span>
-        <span class="command-tag ${worker.current_task_matches_run ? 'ok' : 'warn'}">current_task</span>
-        <span class="command-tag ${worker.claim_marker_seen ? 'ok' : 'warn'}">claim</span>
-        <span class="command-tag ${worker.done_marker_seen ? 'ok' : 'warn'}">done</span>
-        <span class="command-tag ${worker.final_marker_seen ? 'ok' : 'warn'}">final</span>
+      <div class="command-tag rounded-full-row">
+        <span class="command-tag rounded-full">${worker.lane}</span>
+        <span class="command-tag rounded-full ${worker.current_task_matches_run ? 'ok' : 'warn'}">current_task</span>
+        <span class="command-tag rounded-full ${worker.claim_marker_seen ? 'ok' : 'warn'}">claim</span>
+        <span class="command-tag rounded-full ${worker.done_marker_seen ? 'ok' : 'warn'}">done</span>
+        <span class="command-tag rounded-full ${worker.final_marker_seen ? 'ok' : 'warn'}">final</span>
       </div>
       ${worker.last_message
-        ? html`<div class="command-card-foot">${relativeTime(worker.last_message.timestamp)} · ${worker.last_message.content}</div>`
+        ? html`<div class="command-card rounded-xl-foot">${relativeTime(worker.last_message.timestamp)} · ${worker.last_message.content}</div>`
         : null}
     </article>
   `
@@ -101,7 +101,7 @@ export function SwarmEventNode({ event }: { event: CommandPlaneSwarmTimelineEven
       <div class="swarm-event-body min-w-0 flex-1">
         <strong>${event.title}</strong>
         <span class="swarm-event-kind">${event.kind}</span>
-        ${event.detail ? html`<div class="command-card-sub">${event.detail}</div>` : null}
+        ${event.detail ? html`<div class="command-card rounded-xl-sub">${event.detail}</div>` : null}
       </div>
     </div>
   `
@@ -111,8 +111,8 @@ export function SwarmGapDot({ gap }: { gap: CommandPlaneSwarmGap }) {
   return html`
     <div class="swarm-gap-inline flex items-center gap-1.5">
       <span class="swarm-gap-dot"></span>
-      <span class="command-chip ${toneClass(gap.severity)}">${gap.code} (${gap.count})</span>
-      <span class="command-card-sub">${gap.summary}</span>
+      <span class="command-chip rounded-full ${toneClass(gap.severity)}">${gap.code} (${gap.count})</span>
+      <span class="command-card rounded-xl-sub">${gap.summary}</span>
     </div>
   `
 }
@@ -127,14 +127,14 @@ export function SwarmProofPanel({ proof }: { proof?: CommandPlaneSwarmProof }) {
           ? 'ok'
           : 'warn'
   return html`
-    <div class="command-guide-card ${toneClass(tone)}">
+    <div class="command-guide-card rounded-xl ${toneClass(tone)}">
         <div class="command-guide-head">
           <strong>Hot Proof / 가동 증거</strong>
-          <span class="command-chip ${toneClass(tone)}">${proof?.status ?? 'missing'}</span>
+          <span class="command-chip rounded-full ${toneClass(tone)}">${proof?.status ?? 'missing'}</span>
         </div>
       ${proof
         ? html`
-            <div class="command-card-grid">
+            <div class="command-card rounded-xl-grid">
               <span>소스</span><span>${proof.source}</span>
               <span>런</span><span>${proof.run_id ?? 'n/a'}</span>
               <span>수집 시각</span><span>${relativeTime(proof.captured_at)}</span>
@@ -144,7 +144,7 @@ export function SwarmProofPanel({ proof }: { proof?: CommandPlaneSwarmProof }) {
               <span>워커 증거</span><span>${proof.workers.expected ?? 'n/a'} 예상 · ${proof.workers.done ?? 'n/a'} 완료 · ${proof.workers.final ?? 'n/a'} 최종</span>
             </div>
             ${proof.artifact_ref
-              ? html`<div class="command-card-foot">${proof.artifact_ref}</div>`
+              ? html`<div class="command-card rounded-xl-foot">${proof.artifact_ref}</div>`
               : null}
             ${proof.missing_reason
               ? html`<p>${proof.missing_reason}</p>`

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -35,34 +35,34 @@ export function SwarmLivePanels() {
 
   return html`
     <div class="command-surface-grid">
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">스웜 라이브 런</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">스웜 라이브 런</div>
         </div>
         ${commandPlaneSwarmLoading.value
-          ? html`<div class="empty-state">Loading swarm live state…</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">Loading swarm live state…</div>`
           : commandPlaneSwarmError.value
-            ? html`<div class="empty-state error">${commandPlaneSwarmError.value}</div>`
+            ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneSwarmError.value}</div>`
             : swarm
               ? html`
-                  <div class="command-tag-row">
-                    <span class="command-tag">experimental</span>
+                  <div class="command-tag rounded-full-row">
+                    <span class="command-tag rounded-full">experimental</span>
                     <${ProvenanceChip} item=${{ kind: 'derived', label: 'derived read-model' }} />
-                    <span class="command-tag ${swarm.run_resolution || swarm.resolution_recommendation ? 'warn' : 'ok'}">
+                    <span class="command-tag rounded-full ${swarm.run_resolution || swarm.resolution_recommendation ? 'warn' : 'ok'}">
                       ${swarm.run_resolution || swarm.resolution_recommendation ? 'operator resolution aware' : 'no resolution advice'}
                     </span>
                   </div>
-                  <div class="command-card-sub">
+                  <div class="command-card rounded-xl-sub">
                     이 화면은 swarm-live의 사회 truth 자체가 아니라, 실험적 오케스트레이션을 읽기 위한 파생 관찰면입니다.
                   </div>
                   <div class="command-summary-grid">
-                    <div class="monitor-stat-card"><span>실행 런</span><strong>${swarm.run_id ?? runId ?? 'swarm-live'}</strong><small>${swarm.room_id ?? 'room 정보 없음'}</small></div>
-                    <div class="monitor-stat-card"><span>워커</span><strong>${swarm.summary?.joined_workers ?? 0}/${swarm.summary?.expected_workers ?? 0}</strong><small>${swarm.summary?.live_workers ?? 0}개 가동 · ${swarm.summary?.completed_workers ?? 0}개 완료</small></div>
-                    <div class="monitor-stat-card"><span>런타임</span><strong>${runtimeState}</strong><small>slots ${actualSlots}/${expectedSlots} · ctx ${actualCtx}/${expectedCtx}</small></div>
-                    <div class="monitor-stat-card"><span>고동시성</span><strong>${swarm.summary?.pass_hot_concurrency ? '통과' : '확인 필요'}</strong><small>${swarm.provider?.slot_url ?? 'slot 정보 없음'}</small></div>
-                    <div class="monitor-stat-card"><span>종단 점검</span><strong>${swarm.summary?.pass_end_to_end ? '통과' : '확인 필요'}</strong><small>${swarm.recommended_next_tool ?? 'masc_observe_traces'}</small></div>
+                    <div class="monitor-stat-card rounded-xl"><span>실행 런</span><strong>${swarm.run_id ?? runId ?? 'swarm-live'}</strong><small>${swarm.room_id ?? 'room 정보 없음'}</small></div>
+                    <div class="monitor-stat-card rounded-xl"><span>워커</span><strong>${swarm.summary?.joined_workers ?? 0}/${swarm.summary?.expected_workers ?? 0}</strong><small>${swarm.summary?.live_workers ?? 0}개 가동 · ${swarm.summary?.completed_workers ?? 0}개 완료</small></div>
+                    <div class="monitor-stat-card rounded-xl"><span>런타임</span><strong>${runtimeState}</strong><small>slots ${actualSlots}/${expectedSlots} · ctx ${actualCtx}/${expectedCtx}</small></div>
+                    <div class="monitor-stat-card rounded-xl"><span>고동시성</span><strong>${swarm.summary?.pass_hot_concurrency ? '통과' : '확인 필요'}</strong><small>${swarm.provider?.slot_url ?? 'slot 정보 없음'}</small></div>
+                    <div class="monitor-stat-card rounded-xl"><span>종단 점검</span><strong>${swarm.summary?.pass_end_to_end ? '통과' : '확인 필요'}</strong><small>${swarm.recommended_next_tool ?? 'masc_observe_traces'}</small></div>
                   </div>
-                  <div class="command-card-grid">
+                  <div class="command-card rounded-xl-grid">
                     <span>작전</span><span>${swarm.operation?.operation_id ?? operationId ?? '없음'}</span>
                     <span>분대</span><span>${swarm.squad?.label ?? '없음'}</span>
                     <span>실행체</span><span>${swarm.detachment?.detachment_id ?? '없음'}</span>
@@ -72,44 +72,44 @@ export function SwarmLivePanels() {
                     <span>추천 도구</span><span>${swarm.recommended_next_tool ?? 'masc_observe_traces'}</span>
                   </div>
                   ${swarm.truth_notes.length > 0
-                    ? html`<div class="command-tag-row">
-                        ${swarm.truth_notes.map(note => html`<span class="command-tag">${note}</span>`)}
+                    ? html`<div class="command-tag rounded-full-row">
+                        ${swarm.truth_notes.map(note => html`<span class="command-tag rounded-full">${note}</span>`)}
                       </div>`
                     : null}
                   <${SwarmRunResolutionCard} swarm=${swarm} />
                 `
-              : html`<div class="empty-state">스웜 read-model이 아직 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">스웜 read-model이 아직 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">체크리스트</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">체크리스트</div>
         </div>
         ${swarm && swarm.checklist.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${swarm.checklist.map(item => html`<${SwarmChecklistCard} item=${item} />`)}
             </div>`
-          : html`<div class="empty-state">체크리스트가 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체크리스트가 아직 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">워커</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">워커</div>
         </div>
         ${swarm && swarm.workers.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${swarm.workers.map(worker => html`<${SwarmWorkerCard} worker=${worker} />`)}
             </div>`
-          : html`<div class="empty-state">워커 행이 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">워커 행이 아직 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">런타임</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">런타임</div>
         </div>
         ${swarm?.provider
           ? html`
-              <div class="command-card-grid">
+              <div class="command-card rounded-xl-grid">
                 <span>Provider</span><span>${swarm.provider.provider_base_url ?? 'n/a'}</span>
                 <span>Provider Reachable</span><span>${swarm.provider.provider_reachable == null ? 'n/a' : swarm.provider.provider_reachable ? 'yes' : 'no'}</span>
                 <span>Requested Model</span><span>${swarm.provider.provider_model_id ?? 'n/a'}</span>
@@ -127,7 +127,7 @@ export function SwarmLivePanels() {
                 <span>Doctor Checked</span><span>${swarm.provider.checked_at ? relativeTime(swarm.provider.checked_at) : 'n/a'}</span>
               </div>
               ${swarm.provider.detail
-                ? html`<div class="command-card-sub">${swarm.provider.detail}</div>`
+                ? html`<div class="command-card rounded-xl-sub">${swarm.provider.detail}</div>`
                 : null}
               ${swarm.provider.timeline.length > 0
                 ? html`<div class="command-trace-stack">
@@ -136,32 +136,32 @@ export function SwarmLivePanels() {
                         <div class="command-trace-main">
                           <div class="command-trace-head">
                             <strong>${sample.active_slots} active</strong>
-                            <span class="command-chip">${relativeTime(sample.timestamp)}</span>
+                            <span class="command-chip rounded-full">${relativeTime(sample.timestamp)}</span>
                           </div>
-                          <div class="command-card-sub">slots ${sample.active_slot_ids.join(', ') || 'none'}</div>
+                          <div class="command-card rounded-xl-sub">slots ${sample.active_slot_ids.join(', ') || 'none'}</div>
                         </div>
                       </article>
                     `)}
                   </div>`
-                : html`<div class="empty-state">slot telemetry가 아직 없습니다.</div>`}
+                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">slot telemetry가 아직 없습니다.</div>`}
             `
-          : html`<div class="empty-state">런타임 telemetry가 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">런타임 telemetry가 아직 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">막힘 요인</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">막힘 요인</div>
         </div>
         ${swarm && swarm.blockers.length > 0
-          ? html`<div class="command-card-stack">
+          ? html`<div class="command-card rounded-xl-stack">
               ${swarm.blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)}
             </div>`
-          : html`<div class="empty-state">막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">최근 메시지</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">최근 메시지</div>
         </div>
         ${swarm && swarm.recent_messages.length > 0
           ? html`<div class="command-trace-stack">
@@ -170,26 +170,26 @@ export function SwarmLivePanels() {
                   <div class="command-trace-main">
                     <div class="command-trace-head">
                       <strong>${message.from}</strong>
-                      <span class="command-chip">${relativeTime(message.timestamp)}</span>
+                      <span class="command-chip rounded-full">${relativeTime(message.timestamp)}</span>
                     </div>
-                    <div class="command-card-sub">seq ${message.seq}</div>
+                    <div class="command-card rounded-xl-sub">seq ${message.seq}</div>
                   </div>
                   <pre class="command-trace-detail">${formatMessageContent(message.content)}</pre>
                 </article>
               `)}
             </div>`
-          : html`<div class="empty-state">run 범위 메시지가 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">run 범위 메시지가 아직 없습니다.</div>`}
       </section>
 
-      <section class="card min-h-[240px]">
-        <div class="card-title-row">
-          <div class="card-title">최근 트레이스 이벤트</div>
+      <section class="card rounded-xl min-h-[240px]">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">최근 트레이스 이벤트</div>
         </div>
         ${swarm && swarm.recent_trace_events.length > 0
           ? html`<div class="command-trace-stack">
               ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
             </div>`
-          : html`<div class="empty-state">run 범위 trace event가 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">run 범위 trace event가 아직 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -32,55 +32,55 @@ export function SwarmOverviewPanel() {
   const compactLayout = lanes.length <= 1
 
   return html`
-    <section class="card min-h-[240px]">
-      <div class="card-title-row">
-        <div class="card-title">스웜</div>
+    <section class="card rounded-xl min-h-[240px]">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">스웜</div>
       </div>
       ${swarm
         ? html`
             <${SwarmStoryboard} lanes=${lanes} />
             <div class="command-summary-grid mt-3">
-              <div class="monitor-stat-card"><span>활성 레인</span><strong>${overview?.active_lanes ?? 0}</strong><small>${overview?.moving_lanes ?? 0}개 이동 중</small></div>
-              <div class="monitor-stat-card"><span>정체</span><strong>${overview?.stalled_lanes ?? 0}</strong><small>${overview?.projected_lanes ?? 0}개 예상 레인</small></div>
-              <div class="monitor-stat-card"><span>마지막 이동</span><strong>${relativeTime(overview?.last_movement_at)}</strong><small>${swarm.generated_at ? `스냅샷 ${relativeTime(swarm.generated_at)}` : '방금 스냅샷'}</small></div>
-              <div class="monitor-stat-card"><span>다음 액션</span><strong>${recommendation?.label ?? '운영자 상태 확인'}</strong><small>${recommendation?.tool ?? 'masc_operator_snapshot'}</small></div>
+              <div class="monitor-stat-card rounded-xl"><span>활성 레인</span><strong>${overview?.active_lanes ?? 0}</strong><small>${overview?.moving_lanes ?? 0}개 이동 중</small></div>
+              <div class="monitor-stat-card rounded-xl"><span>정체</span><strong>${overview?.stalled_lanes ?? 0}</strong><small>${overview?.projected_lanes ?? 0}개 예상 레인</small></div>
+              <div class="monitor-stat-card rounded-xl"><span>마지막 이동</span><strong>${relativeTime(overview?.last_movement_at)}</strong><small>${swarm.generated_at ? `스냅샷 ${relativeTime(swarm.generated_at)}` : '방금 스냅샷'}</small></div>
+              <div class="monitor-stat-card rounded-xl"><span>다음 액션</span><strong>${recommendation?.label ?? '운영자 상태 확인'}</strong><small>${recommendation?.tool ?? 'masc_operator_snapshot'}</small></div>
             </div>
 
             ${lanes.length > 0 ? html`<${SwarmHealthBar} lanes=${lanes} />` : null}
 
             <div class="command-swarm-layout ${compactLayout ? 'compact' : ''}">
-              <div class="command-card-stack">
+              <div class="command-card rounded-xl-stack">
                 ${lanes.length > 0
                   ? lanes.map(lane => html`<${SwarmLaneStrip} lane=${lane} />`)
-                  : html`<div class="empty-state">활성 스웜 레인이 없습니다.</div>`}
+                  : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활성 스웜 레인이 없습니다.</div>`}
               </div>
 
-              <div class="command-card-stack">
-                <div class="command-guide-card highlight ${focusKey === 'recommendation' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
+              <div class="command-card rounded-xl-stack">
+                <div class="command-guide-card rounded-xl highlight ${focusKey === 'recommendation' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
                   <div class="command-guide-head">
                     <strong>${recommendation?.label ?? '운영자 상태 확인'}</strong>
-                    <span class="command-chip">${recommendation?.lane_id ?? '전체'}</span>
+                    <span class="command-chip rounded-full">${recommendation?.lane_id ?? '전체'}</span>
                   </div>
                   <p>${recommendation?.reason ?? '보이는 활성 스웜 레인이 아직 없습니다.'}</p>
-                  <div class="command-card-foot">${recommendation?.tool ?? 'masc_operator_snapshot'}</div>
+                  <div class="command-card rounded-xl-foot">${recommendation?.tool ?? 'masc_operator_snapshot'}</div>
                 </div>
 
                 <${SwarmProofPanel} proof=${proof} />
 
-                <div class="command-guide-card ${gaps.length > 0 ? 'warn' : 'ok'} ${focusKey === 'gaps' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
+                <div class="command-guide-card rounded-xl ${gaps.length > 0 ? 'warn' : 'ok'} ${focusKey === 'gaps' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
                   <div class="command-guide-head">
                     <strong>핵심 공백</strong>
-                    <span class="command-chip ${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')}">${gaps.length}</span>
+                    <span class="command-chip rounded-full ${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')}">${gaps.length}</span>
                   </div>
                   ${gaps.length > 0
                     ? html`<div class="swarm-event-rail">${gaps.slice(0, 4).map(gap => html`<${SwarmGapDot} gap=${gap} />`)}</div>`
                     : html`<p>지금 보이는 핵심 공백은 없습니다.</p>`}
                 </div>
 
-                <div class="command-guide-card">
+                <div class="command-guide-card rounded-xl">
                   <div class="command-guide-head">
                     <strong>이동 타임라인</strong>
-                    <span class="command-chip">${timeline.length}</span>
+                    <span class="command-chip rounded-full">${timeline.length}</span>
                   </div>
                   ${timeline.length > 0
                     ? html`<div class="swarm-event-rail">${timeline.map(event => html`<${SwarmEventNode} event=${event} />`)}</div>`
@@ -89,7 +89,7 @@ export function SwarmOverviewPanel() {
               </div>
             </div>
           `
-        : html`<div class="empty-state">스웜 상태를 아직 불러오지 못했습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">스웜 상태를 아직 불러오지 못했습니다.</div>`}
     </section>
   `
 }

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -41,7 +41,7 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
           : 26
 
   return html`
-    <article class="swarm-lane-strip ${toneClass(tone)}">
+    <article class="swarm-lane-strip transition-colors duration-200 ${toneClass(tone)}">
       <div class="swarm-lane-head flex items-center justify-between gap-2">
         <div class="swarm-lane-head-left flex items-center gap-2 min-w-0">
           <span class="swarm-motion-dot inline-block rounded-full shrink-0 w-2.5 h-2.5 ${lane.motion_state}"></span>
@@ -50,14 +50,14 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
             <strong>${lane.label}</strong>
           </div>
         </div>
-        <div class="command-tag-row">
-          <span class="command-chip ${toneClass(tone)}">${lane.phase}</span>
-          <span class="command-chip ${toneClass(tone)}">${lane.motion_state}</span>
-          <span class="command-chip">${relativeTime(lane.last_movement_at)}</span>
+        <div class="command-tag rounded-full-row">
+          <span class="command-chip rounded-full ${toneClass(tone)}">${lane.phase}</span>
+          <span class="command-chip rounded-full ${toneClass(tone)}">${lane.motion_state}</span>
+          <span class="command-chip rounded-full">${relativeTime(lane.last_movement_at)}</span>
         </div>
       </div>
       <p class="swarm-lane-reason">${lane.movement_reason}</p>
-      <div class="swarm-lane-track">
+      <div class="swarm-lane-track rounded-full">
         <span class="${toneClass(tone)}" style=${`width:${progressPercent}%`}></span>
       </div>
       <div class="swarm-lane-details flex flex-col gap-1.5 mt-2">
@@ -86,12 +86,12 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
           : null}
       </div>
       ${lane.blockers.length > 0
-        ? html`<div class="swarm-lane-blockers">막힘: ${lane.blockers.join(' · ')}</div>`
+        ? html`<div class="swarm-lane-blockers rounded-md">막힘: ${lane.blockers.join(' · ')}</div>`
         : null}
       ${lane.hard_flags.length > 0
         ? html`
             <div class="swarm-lane-flags flex flex-wrap gap-1 mt-1">
-              ${lane.hard_flags.map((flag: CommandPlaneSwarmFlag) => html`<span class="command-chip ${toneClass(flag.severity)}">${flag.code}</span>`)}
+              ${lane.hard_flags.map((flag: CommandPlaneSwarmFlag) => html`<span class="command-chip rounded-full ${toneClass(flag.severity)}">${flag.code}</span>`)}
             </div>
           `
         : null}
@@ -110,10 +110,10 @@ export function SwarmStoryboard({ lanes }: { lanes: CommandPlaneSwarmLane[] }) {
         const operations = lane.counts.operations ?? 0
         const detachments = lane.counts.detachments ?? 0
         return html`
-          <article class="swarm-story-card ${toneClass(tone)}">
+          <article class="swarm-story-card rounded-xl ${toneClass(tone)}">
             <div class="swarm-story-topline flex justify-between gap-1.5 flex-wrap">
-              <span class="command-chip ${toneClass(tone)}">${lane.motion_state}</span>
-              <span class="command-chip">${lane.phase}</span>
+              <span class="command-chip rounded-full ${toneClass(tone)}">${lane.motion_state}</span>
+              <span class="command-chip rounded-full">${lane.phase}</span>
             </div>
             <strong>${lane.label}</strong>
             <p>${lane.current_step}</p>
@@ -229,10 +229,10 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
   }
 
   return html`
-    <article class="command-guide-card ${toneClass(tone)}">
+    <article class="command-guide-card rounded-xl ${toneClass(tone)}">
       <div class="command-guide-head">
         <strong>Run Resolution</strong>
-        <span class="command-chip ${toneClass(tone)}">
+        <span class="command-chip rounded-full ${toneClass(tone)}">
           ${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)}
         </span>
       </div>
@@ -241,7 +241,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
           ? `이 run은 ${resolution.decided_by}가 ${relativeTime(resolution.decided_at)}에 soft abandon 처리했습니다. ${resolution.reason}`
           : recommendation?.reason ?? '이 run에 대한 별도 resolution recommendation은 아직 없습니다.'}
       </p>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>Run</span><span>${runId}</span>
         <span>Provenance</span><span><${ProvenanceChip} item=${{ kind: recommendation?.provenance ?? 'recorded' }} /></span>
         <span>Engine</span><span>${recommendation?.decision_engine ?? 'operator_record'}</span>
@@ -249,27 +249,27 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
       </div>
       ${recommendation?.evidence
         ? html`
-            <div class="command-tag-row">
-              <span class="command-tag">joined ${recommendation.evidence.joined_workers ?? 0}</span>
-              <span class="command-tag">trace ${recommendation.evidence.trace_events ?? 0}</span>
-              <span class="command-tag">message ${recommendation.evidence.message_events ?? 0}</span>
+            <div class="command-tag rounded-full-row">
+              <span class="command-tag rounded-full">joined ${recommendation.evidence.joined_workers ?? 0}</span>
+              <span class="command-tag rounded-full">trace ${recommendation.evidence.trace_events ?? 0}</span>
+              <span class="command-tag rounded-full">message ${recommendation.evidence.message_events ?? 0}</span>
               ${recommendation.evidence.runtime_blocker
-                ? html`<span class="command-tag ${toneClass('bad')}">${recommendation.evidence.runtime_blocker}</span>`
+                ? html`<span class="command-tag rounded-full ${toneClass('bad')}">${recommendation.evidence.runtime_blocker}</span>`
                 : null}
             </div>
           `
         : null}
       ${pendingConfirm
         ? html`
-            <div class="command-guide-card warn">
+            <div class="command-guide-card rounded-xl warn">
               <div class="command-guide-head">
                 <strong>확인 대기</strong>
-                <span class="command-chip warn">${pendingConfirm.confirm_token}</span>
+                <span class="command-chip rounded-full warn">${pendingConfirm.confirm_token}</span>
               </div>
               ${pendingConfirm.preview ? html`<pre class="command-trace-detail">${previewText(pendingConfirm.preview)}</pre>` : null}
               <div class="command-action-row">
-                <button class="control-btn" onClick=${() => { void confirmPending('confirm') }} disabled=${operatorActionBusy.value}>확인 실행</button>
-                <button class="control-btn ghost" onClick=${() => { void confirmPending('deny') }} disabled=${operatorActionBusy.value}>취소</button>
+                <button class="control-btn rounded-lg" onClick=${() => { void confirmPending('confirm') }} disabled=${operatorActionBusy.value}>확인 실행</button>
+                <button class="control-btn rounded-lg ghost" onClick=${() => { void confirmPending('deny') }} disabled=${operatorActionBusy.value}>취소</button>
               </div>
             </div>
           `

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -71,17 +71,17 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
   const source = node.unit.source ?? 'unknown'
   const connectionLabel = activeOps > 0 ? `${activeOps}개 작전 연결` : '실행 연결 없음'
   return html`
-    <div class="command-tree-node depth-${Math.min(depth, 3)} ${depth <= 2 ? 'border-[rgba(248,113,113,0.3)]' : ''}">
+    <div class="command-tree-node rounded-xl depth-${Math.min(depth, 3)} ${depth <= 2 ? 'border-[rgba(248,113,113,0.3)]' : ''}">
       <div class="command-tree-head">
         <div>
           <div class="command-tree-title-row">
             <strong>${node.unit.label}</strong>
-            <span class="command-chip">${unitKindLabel(node.unit.kind)}</span>
-            <span class="command-chip ${toneClass(node.health)}">${node.health ?? 'ok'}</span>
-            <span class="command-chip ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
-            <span class="command-chip ${activeOps > 0 ? 'ok' : 'warn'}">${connectionLabel}</span>
-            ${policy?.frozen ? html`<span class="command-chip warn">동결됨</span>` : null}
-            ${policy?.kill_switch ? html`<span class="command-chip bad">킬 스위치</span>` : null}
+            <span class="command-chip rounded-full">${unitKindLabel(node.unit.kind)}</span>
+            <span class="command-chip rounded-full ${toneClass(node.health)}">${node.health ?? 'ok'}</span>
+            <span class="command-chip rounded-full ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
+            <span class="command-chip rounded-full ${activeOps > 0 ? 'ok' : 'warn'}">${connectionLabel}</span>
+            ${policy?.frozen ? html`<span class="command-chip rounded-full warn">동결됨</span>` : null}
+            ${policy?.kill_switch ? html`<span class="command-chip rounded-full bad">킬 스위치</span>` : null}
           </div>
           <div class="command-tree-meta">
             <span>ID ${node.unit.unit_id}</span>
@@ -90,10 +90,10 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
             <span>작전 ${activeOps}</span>
             <span>자율성 ${policy?.autonomy_level ?? '정보 없음'}</span>
           </div>
-          <div class="command-card-sub">${nodeRealitySummary(node)}</div>
+          <div class="command-card rounded-xl-sub">${nodeRealitySummary(node)}</div>
           ${node.reasons && node.reasons.length > 0
-            ? html`<div class="command-tag-row">
-                ${node.reasons.map(reason => html`<span class="command-tag warn">${reason}</span>`)}
+            ? html`<div class="command-tag rounded-full-row">
+                ${node.reasons.map(reason => html`<span class="command-tag rounded-full warn">${reason}</span>`)}
               </div>`
             : null}
         </div>
@@ -110,9 +110,9 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
 function AlertCard({ alert }: { alert: CommandPlaneAlert }) {
   return html`
     <article class="command-alert ${toneClass(alert.severity)} ${alertBorderTone(toneClass(alert.severity))}">
-      <div class="command-card-head">
+      <div class="command-card rounded-xl-head">
         <strong>${alert.title ?? alert.kind ?? alert.alert_id}</strong>
-        <span class="command-chip ${toneClass(alert.severity)}">${alert.severity ?? 'warn'}</span>
+        <span class="command-chip rounded-full ${toneClass(alert.severity)}">${alert.severity ?? 'warn'}</span>
       </div>
       <div class="command-alert-meta">
         <span>${alert.scope_type ?? '범위'}:${alert.scope_id ?? '정보 없음'}</span>
@@ -129,10 +129,10 @@ export function TraceRow({ event }: { event: CommandPlaneTraceEvent }) {
       <div class="command-trace-main">
         <div class="command-trace-head">
           <strong>${event.event_type}</strong>
-          <span class="command-chip">${event.source ?? 'control_plane'}</span>
-          <span class="command-chip">${relativeTime(event.timestamp)}</span>
+          <span class="command-chip rounded-full">${event.source ?? 'control_plane'}</span>
+          <span class="command-chip rounded-full">${relativeTime(event.timestamp)}</span>
         </div>
-        <div class="command-card-sub">
+        <div class="command-card rounded-xl-sub">
           ${event.operation_id ?? event.trace_id}
           ${event.unit_id ? ` · ${event.unit_id}` : ''}
           ${event.actor ? ` · ${event.actor}` : ''}
@@ -151,17 +151,17 @@ export function TopologySurface() {
   const managedUnits = summary?.managed_unit_count ?? 0
   const activeOps = summary?.active_operation_count ?? 0
   return html`
-    <section class="card min-h-[240px]">
-      <div class="card-title-row">
-        <div class="card-title">지휘 계층</div>
+    <section class="card rounded-xl min-h-[240px]">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">지휘 계층</div>
       </div>
       ${snapshot
         ? html`
-            <div class="command-topology-explainer">
+            <div class="command-topology-explainer rounded-xl">
               <div class="command-tree-title-row">
-                <span class="command-chip ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
-                <span class="command-chip">관리 유닛 ${managedUnits}</span>
-                <span class="command-chip ${activeOps > 0 ? 'ok' : 'warn'}">활성 작전 ${activeOps}</span>
+                <span class="command-chip rounded-full ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
+                <span class="command-chip rounded-full">관리 유닛 ${managedUnits}</span>
+                <span class="command-chip rounded-full ${activeOps > 0 ? 'ok' : 'warn'}">활성 작전 ${activeOps}</span>
               </div>
               <p>${topologySourceExplanation(source)}</p>
             </div>
@@ -169,7 +169,7 @@ export function TopologySurface() {
         : null}
       ${snapshot && snapshot.topology.units.length > 0
         ? html`${snapshot.topology.units.map(node => html`<${TopologyNode} node=${node} />`)}`
-        : html`<div class="empty-state">지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다.</div>`}
     </section>
   `
 }
@@ -177,15 +177,15 @@ export function TopologySurface() {
 export function AlertsSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
-    <section class="card min-h-[240px]">
-      <div class="card-title-row">
-        <div class="card-title">경보</div>
+    <section class="card rounded-xl min-h-[240px]">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">경보</div>
       </div>
       ${snapshot && snapshot.alerts.alerts.length > 0
-        ? html`<div class="command-card-stack">
+        ? html`<div class="command-card rounded-xl-stack">
             ${snapshot.alerts.alerts.map(alert => html`<${AlertCard} alert=${alert} />`)}
           </div>`
-        : html`<div class="empty-state">지금 올라온 지휘면 경보는 없습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 올라온 지휘면 경보는 없습니다.</div>`}
     </section>
   `
 }
@@ -193,15 +193,15 @@ export function AlertsSurface() {
 export function TraceSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
-    <section class="card min-h-[240px]">
-      <div class="card-title-row">
-        <div class="card-title">최근 트레이스</div>
+    <section class="card rounded-xl min-h-[240px]">
+      <div class="card rounded-xl-title-row">
+        <div class="card rounded-xl-title">최근 트레이스</div>
       </div>
       ${snapshot && snapshot.traces.events.length > 0
         ? html`<div class="command-trace-stack">
             ${snapshot.traces.events.map(event => html`<${TraceRow} event=${event} />`)}
           </div>`
-        : html`<div class="empty-state">최근 트레이스 이벤트가 없습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 트레이스 이벤트가 없습니다.</div>`}
     </section>
   `
 }

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -79,9 +79,9 @@ export function WarRoomBodyGrid({
   return html`
     <div class="command-warroom-grid ${wallboard ? 'wallboard' : ''}">
       <div class="command-warroom-column">
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">실행 흐름</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">실행 흐름</div>
           </div>
           ${liveLanes.length > 0
             ? html`
@@ -90,103 +90,103 @@ export function WarRoomBodyGrid({
               `
             : selectedSession
               ? html`
-                  <article class="command-guide-card">
+                  <article class="command-guide-card rounded-xl">
                     <div class="command-guide-head">
                       <strong>${selectedSession.session_id}</strong>
-                      <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                      <span class="command-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
                     </div>
                     <p>스웜 실시간 증거는 아직 약합니다. 이 카드는 세션 요약과 워커 기록을 기준으로 유지합니다.</p>
-                    <div class="command-card-grid">
+                    <div class="command-card rounded-xl-grid">
                       <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
                       <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
                       <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>
                     </div>
                   </article>
                 `
-              : html`<div class="empty-state">보이는 레인이 아직 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">보이는 레인이 아직 없습니다.</div>`}
         </section>
 
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">오케스트레이션</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">오케스트레이션</div>
           </div>
           <${WarRoomOrchestrationRail} chainOverlay=${chainOverlay} linkedAutoresearch=${linkedAutoresearch} />
         </section>
 
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">워커 현황</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">워커 현황</div>
           </div>
           ${workers.length > 0
-            ? html`<div class="command-card-stack">
+            ? html`<div class="command-card rounded-xl-stack">
                 ${workers.map(worker => html`<${WarRoomWorkerCard} worker=${worker} />`)}
               </div>`
-            : html`<div class="empty-state">활성 워커 카드가 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활성 워커 카드가 아직 없습니다.</div>`}
         </section>
       </div>
 
       <div class="command-warroom-column">
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">상황 피드</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">상황 피드</div>
           </div>
           ${feedItems.length > 0
             ? html`<div class="command-trace-stack">
                 ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
         </section>
 
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">트레이스 흐름</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">트레이스 흐름</div>
           </div>
           ${swarm && swarm.recent_trace_events.length > 0
             ? html`<div class="command-trace-stack">
                 ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
               </div>`
-            : html`<div class="empty-state">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
         </section>
       </div>
 
       <div class="command-warroom-column">
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">Agents</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">Agents</div>
           </div>
           ${agentViews.length > 0
             ? html`<div class="warroom-presence-grid">
                 ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">가시적인 active agent가 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 active agent가 아직 없습니다.</div>`}
         </section>
 
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">Keepers</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">Keepers</div>
           </div>
           ${keeperViews.length > 0
             ? html`<div class="warroom-presence-grid">
                 ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
         </section>
 
-        <section class="card min-h-[240px]">
-          <div class="card-title-row">
-            <div class="card-title">압력</div>
+        <section class="card rounded-xl min-h-[240px]">
+          <div class="card rounded-xl-title-row">
+            <div class="card rounded-xl-title">압력</div>
           </div>
-          <div class="command-card-stack">
+          <div class="command-card rounded-xl-stack">
             ${swarmHasEvidence && swarm ? html`<${SwarmRunResolutionCard} swarm=${swarm} />` : null}
             ${blockers.length > 0
               ? blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)
-              : html`<div class="command-guide-card ok"><p>지금 보이는 blocker는 없습니다.</p></div>`}
+              : html`<div class="command-guide-card rounded-xl ok"><p>지금 보이는 blocker는 없습니다.</p></div>`}
             ${pendingApprovals > 0
               ? html`
-                  <article class="command-guide-card warn">
+                  <article class="command-guide-card rounded-xl warn">
                     <div class="command-guide-head">
                       <strong>승인 대기</strong>
-                      <span class="command-chip warn">${pendingApprovals}</span>
+                      <span class="command-chip rounded-full warn">${pendingApprovals}</span>
                     </div>
                     <p>엄격 액션이 묶여 있습니다. 실제 승인 처리는 제어 표면에서 합니다.</p>
                   </article>
@@ -194,32 +194,32 @@ export function WarRoomBodyGrid({
               : null}
             ${pendingConfirmTotal > 0
               ? html`
-                  <article class="command-guide-card warn">
+                  <article class="command-guide-card rounded-xl warn">
                     <div class="command-guide-head">
                       <strong>확인 대기</strong>
-                      <span class="command-chip warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
+                      <span class="command-chip rounded-full warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
                     </div>
                     <p>
                       운영자 미리보기가 사람 확인을 기다리고 있습니다.
                       ${pendingConfirmHidden > 0 ? ` 현재 actor 기준으로는 ${pendingConfirmVisible}건만 보입니다.` : ''}
                     </p>
-                    <div class="command-tag-row">
-                      ${pendingConfirms.slice(0, 3).map(item => html`<span class="command-tag">${item.confirm_token}</span>`)}
+                    <div class="command-tag rounded-full-row">
+                      ${pendingConfirms.slice(0, 3).map(item => html`<span class="command-tag rounded-full">${item.confirm_token}</span>`)}
                     </div>
                   </article>
                 `
               : null}
             ${activeLane
               ? html`
-                  <article class="command-card p-3">
-                    <div class="command-card-head">
+                  <article class="command-card rounded-xl p-3">
+                    <div class="command-card rounded-xl-head">
                       <div>
                         <strong>${activeLane.label}</strong>
-                        <div class="command-card-sub">${activeLane.kind} · ${activeLane.phase}</div>
+                        <div class="command-card rounded-xl-sub">${activeLane.kind} · ${activeLane.phase}</div>
                       </div>
-                      <span class="command-chip ${toneClass(sessionStatusTone(activeLane.motion_state))}">${displayStatus(activeLane.motion_state)}</span>
+                      <span class="command-chip rounded-full ${toneClass(sessionStatusTone(activeLane.motion_state))}">${displayStatus(activeLane.motion_state)}</span>
                     </div>
-                    <div class="command-card-grid">
+                    <div class="command-card rounded-xl-grid">
                       <span>현재 단계</span><span>${activeLane.current_step}</span>
                       <span>이동 사유</span><span>${activeLane.movement_reason}</span>
                       <span>막힘 수</span><span>${activeLane.blockers.length}</span>
@@ -230,15 +230,15 @@ export function WarRoomBodyGrid({
               : null}
             ${swarmHasEvidence && swarm?.detachment
               ? html`
-                  <article class="command-card p-3">
-                    <div class="command-card-head">
+                  <article class="command-card rounded-xl p-3">
+                    <div class="command-card rounded-xl-head">
                       <div>
                         <strong>${swarm.detachment.detachment_id}</strong>
-                        <div class="command-card-sub">${swarm.detachment.assigned_unit_id}</div>
+                        <div class="command-card rounded-xl-sub">${swarm.detachment.assigned_unit_id}</div>
                       </div>
-                      <span class="command-chip ${toneClass(sessionStatusTone(swarm.detachment.status))}">${displayStatus(swarm.detachment.status ?? 'active')}</span>
+                      <span class="command-chip rounded-full ${toneClass(sessionStatusTone(swarm.detachment.status))}">${displayStatus(swarm.detachment.status ?? 'active')}</span>
                     </div>
-                    <div class="command-card-grid">
+                    <div class="command-card rounded-xl-grid">
                       <span>리더</span><span>${swarm.detachment.leader_id ?? '미지정'}</span>
                       <span>편성</span><span>${swarm.detachment.roster.length}</span>
                       <span>세션</span><span>${swarm.detachment.session_id ?? '연결 없음'}</span>
@@ -248,15 +248,15 @@ export function WarRoomBodyGrid({
                 `
               : selectedSession
                 ? html`
-                    <article class="command-card p-3">
-                      <div class="command-card-head">
+                    <article class="command-card rounded-xl p-3">
+                      <div class="command-card rounded-xl-head">
                         <div>
                           <strong>${selectedSession.session_id}</strong>
-                          <div class="command-card-sub">현재 세션 기준</div>
+                          <div class="command-card rounded-xl-sub">현재 세션 기준</div>
                         </div>
-                        <span class="command-chip ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                        <span class="command-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
                       </div>
-                      <div class="command-card-grid">
+                      <div class="command-card rounded-xl-grid">
                         <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>
                         <span>경과</span><span>${formatElapsed(selectedSession.elapsed_sec)}</span>
                         <span>남은 시간</span><span>${formatElapsed(selectedSession.remaining_sec)}</span>

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -92,15 +92,15 @@ export function WarRoomHeroStrip({
     <section class="command-warroom-strip ${toneClass(stickyTone)} ${wallboard ? 'wallboard' : ''}">
       <div class="command-warroom-strip-head">
         <div>
-          <span class="command-hero-kicker">${wallboard ? 'War Room Wallboard' : '실시간 워룸'}</span>
+          <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">${wallboard ? 'War Room Wallboard' : '실시간 워룸'}</span>
           <strong>${heroTitle}</strong>
-          <div class="command-card-sub">
+          <div class="command-card rounded-xl-sub">
             ${swarmHasEvidence ? (swarm?.operation?.operation_id ?? '작전 정보 없음') : '세션 기준값'}
             ${selectedSession?.session_id ? ` · 세션 ${selectedSession.session_id}` : ''}
             ${swarmHasEvidence && swarm?.detachment?.detachment_id ? ` · 분견대 ${swarm.detachment.detachment_id}` : ''}
             ${activeLane ? ` · 대표 레인 ${activeLane.label}` : ''}
           </div>
-          <div class="command-warroom-summary">${heroSummary}</div>
+          <div class="mt-3 text-[rgba(226,232,240,0.86)] leading-[1.55] max-w-[82ch]">${heroSummary}</div>
           ${activeSummary?.summary
             ? html`<div class="command-warroom-guidance ${guidanceLayerTone(guidanceLayer)}">
                 <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
@@ -109,13 +109,13 @@ export function WarRoomHeroStrip({
             : null}
         </div>
         <div class="command-warroom-hero-actions">
-          <button class="control-btn ghost" onClick=${onRefresh}>새로고침</button>
+          <button class="control-btn rounded-lg ghost" onClick=${onRefresh}>새로고침</button>
           ${wallboard
             ? html`
-                <button class="control-btn ghost" onClick=${onToggleFullscreen}>
+                <button class="control-btn rounded-lg ghost" onClick=${onToggleFullscreen}>
                   ${fullscreenActive ? '전체 화면 해제' : '전체 화면'}
                 </button>
-                <button class="control-btn ghost" onClick=${standardView}>
+                <button class="control-btn rounded-lg ghost" onClick=${standardView}>
                   표준 보기
                 </button>
               `
@@ -139,27 +139,27 @@ export function WarRoomHeroStrip({
         </div>
       </div>
       <div class="command-warroom-strip-stats">
-        <div class="monitor-stat-card">
+        <div class="monitor-stat-card rounded-xl">
           <span>워커</span>
           <strong>${workerJoined ?? 0}/${workerExpected ?? 0}</strong>
           <small>${swarmHasEvidence ? (swarm?.summary?.completed_workers ?? 0) : 0} 완료 · ${workerCardCount} 카드</small>
         </div>
-        <div class="monitor-stat-card">
+        <div class="monitor-stat-card rounded-xl">
           <span>런타임</span>
           <strong>${swarmHasEvidence ? (swarm?.provider?.runtime_blocker ? '막힘' : swarm?.provider?.provider_reachable ? '준비됨' : selectedSession ? displayStatus(selectedSession.status) : '확인 필요') : (selectedSession ? displayStatus(selectedSession.status) : '확인 필요')}</strong>
           <small>${swarmHasEvidence ? `설정 ${swarm?.provider?.configured_capacity ?? 'n/a'} · 실제 ${swarm?.provider?.actual_slots ?? swarm?.provider?.total_slots ?? 0} · hot ${swarm?.summary?.peak_hot_slots ?? swarm?.provider?.peak_active_slots ?? 0}` : `세션 워커 ${workerCardCount}`}</small>
         </div>
-        <div class="monitor-stat-card ${toneClass(blockersCount > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')}">
+        <div class="monitor-stat-card rounded-xl ${toneClass(blockersCount > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')}">
           <span>압력</span>
           <strong>${blockersCount + pendingApprovals + pendingConfirmTotal}</strong>
           <small>막힘 ${blockersCount} · 승인 ${pendingApprovals} · 확인 ${pendingConfirmVisible}${pendingConfirmHidden > 0 ? `/${pendingConfirmTotal}` : ''}</small>
         </div>
-        <div class="monitor-stat-card ${toneClass(guidanceLayerTone(guidanceLayer))}">
+        <div class="monitor-stat-card rounded-xl ${toneClass(guidanceLayerTone(guidanceLayer))}">
           <span>상주 판정기</span>
           <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
           <small>${guidanceFreshnessLabel(activeSummary)}${residentRuntime?.model_used ? ` · ${residentRuntime.model_used}` : ''}</small>
         </div>
-        <div class="monitor-stat-card">
+        <div class="monitor-stat-card rounded-xl">
           <span>마지막 신호</span>
           <strong>${relativeTime(latestSignal)}</strong>
           <small>${latestMessage ? '메시지' : latestTrace ? '트레이스' : '대기 중'}</small>

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -355,7 +355,7 @@ export function WarRoomJumpButton({
 }) {
   return html`
     <button
-      class="control-btn ghost"
+      class="control-btn rounded-lg ghost"
       onClick=${() => {
         if (surface) {
           setCommandPlaneSurface(surface)
@@ -378,22 +378,22 @@ export function WarRoomOrchestrationRail({
   linkedAutoresearch?: OperatorLinkedAutoresearch | null
 }) {
   if (!chainOverlay && !linkedAutoresearch) {
-    return html`<div class="command-guide-card"><p>이 세션에 붙은 chain/autoresearch 오버레이가 아직 없습니다.</p></div>`
+    return html`<div class="command-guide-card rounded-xl"><p>이 세션에 붙은 chain/autoresearch 오버레이가 아직 없습니다.</p></div>`
   }
 
   return html`
     <div class="warroom-orchestration-grid">
       ${chainOverlay
         ? html`
-            <article class="command-card warroom-orchestration-card min-h-[220px]">
-              <div class="command-card-head">
+            <article class="command-card rounded-xl warroom-orchestration-card min-h-[220px]">
+              <div class="command-card rounded-xl-head">
                 <div>
                   <strong>Chain Orchestration</strong>
-                  <div class="command-card-sub">${chainOverlay.operation.operation_id}</div>
+                  <div class="command-card rounded-xl-sub">${chainOverlay.operation.operation_id}</div>
                 </div>
-                <span class="command-chip ${toneClass(sessionStatusTone(chainOverlay.operation.status))}">${displayStatus(chainOverlay.operation.status)}</span>
+                <span class="command-chip rounded-full ${toneClass(sessionStatusTone(chainOverlay.operation.status))}">${displayStatus(chainOverlay.operation.status)}</span>
               </div>
-              <div class="command-card-grid">
+              <div class="command-card rounded-xl-grid">
                 <span>Chain</span><span>${chainOverlay.runtime?.chain_id ?? chainOverlay.preview_run?.chain_id ?? 'n/a'}</span>
                 <span>Progress</span><span>${formatPercent(chainOverlay.runtime?.progress)}</span>
                 <span>Elapsed</span><span>${formatElapsed(chainOverlay.runtime?.elapsed_sec)}</span>
@@ -411,15 +411,15 @@ export function WarRoomOrchestrationRail({
         : null}
       ${linkedAutoresearch
         ? html`
-            <article class="command-card warroom-orchestration-card min-h-[220px]">
-              <div class="command-card-head">
+            <article class="command-card rounded-xl warroom-orchestration-card min-h-[220px]">
+              <div class="command-card rounded-xl-head">
                 <div>
                   <strong>Autoresearch Loop</strong>
-                  <div class="command-card-sub">${linkedAutoresearch.loop_id ?? linkedAutoresearch.session_id ?? 'linked session'}</div>
+                  <div class="command-card rounded-xl-sub">${linkedAutoresearch.loop_id ?? linkedAutoresearch.session_id ?? 'linked session'}</div>
                 </div>
-                <span class="command-chip ${linkedAutoresearch.error ? 'bad' : linkedAutoresearch.status === 'running' ? 'warn' : 'ok'}">${linkedAutoresearch.status ?? 'unknown'}</span>
+                <span class="command-chip rounded-full ${linkedAutoresearch.error ? 'bad' : linkedAutoresearch.status === 'running' ? 'warn' : 'ok'}">${linkedAutoresearch.status ?? 'unknown'}</span>
               </div>
-              <div class="command-card-grid">
+              <div class="command-card rounded-xl-grid">
                 <span>Cycle</span><span>${linkedAutoresearch.current_cycle ?? 0}</span>
                 <span>Best score</span><span>${linkedAutoresearch.best_score ?? 'n/a'}</span>
                 <span>Target</span><span>${linkedAutoresearch.target_file ?? 'n/a'}</span>

--- a/dashboard/src/components/command/war-room-panels.ts
+++ b/dashboard/src/components/command/war-room-panels.ts
@@ -78,25 +78,25 @@ function warRoomMarkerLabel(marker: string): string {
 
 export function WarRoomWorkerCard({ worker }: { worker: WarRoomWorkerView }) {
   return html`
-    <article class="command-card p-3 warroom-worker-card ${toneClass(sessionStatusTone(worker.status))}">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl p-3 warroom-worker-card ${toneClass(sessionStatusTone(worker.status))}">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${worker.name}</strong>
-          <div class="command-card-sub">${worker.role} · ${worker.lane}</div>
+          <div class="command-card rounded-xl-sub">${worker.role} · ${worker.lane}</div>
         </div>
-        <span class="command-chip ${toneClass(sessionStatusTone(worker.status))}">${displayStatus(worker.status)}</span>
+        <span class="command-chip rounded-full ${toneClass(sessionStatusTone(worker.status))}">${displayStatus(worker.status)}</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>출처</span><span>${warRoomSourceLabel(worker.source)}</span>
         <span>과업</span><span>${worker.task}</span>
         <span>최근 신호</span><span>${worker.heartbeat}</span>
         <span>근거</span><span>${worker.detail}</span>
       </div>
-      <div class="command-tag-row mt-2.5">
-        ${worker.markers.map(marker => html`<span class="command-tag">${warRoomMarkerLabel(marker)}</span>`)}
+      <div class="command-tag rounded-full-row mt-2.5">
+        ${worker.markers.map(marker => html`<span class="command-tag rounded-full">${warRoomMarkerLabel(marker)}</span>`)}
       </div>
       ${worker.note
-        ? html`<div class="command-card-foot">${truncate(worker.note, 220)}</div>`
+        ? html`<div class="command-card rounded-xl-foot">${truncate(worker.note, 220)}</div>`
         : null}
     </article>
   `
@@ -104,38 +104,38 @@ export function WarRoomWorkerCard({ worker }: { worker: WarRoomWorkerView }) {
 
 export function WarRoomPresenceCard({ item }: { item: WarRoomPresenceView }) {
   return html`
-    <article class="command-card p-3 warroom-presence-card ${item.tone}">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl p-3 warroom-presence-card ${item.tone}">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${item.name}</strong>
-          <div class="command-card-sub">${item.role} · ${item.source}</div>
+          <div class="command-card rounded-xl-sub">${item.role} · ${item.source}</div>
         </div>
-        <span class="command-chip ${item.tone}">${item.status}</span>
+        <span class="command-chip rounded-full ${item.tone}">${item.status}</span>
       </div>
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>현재 과업</span><span>${item.task}</span>
         <span>최근 신호</span><span>${item.signal}</span>
         <span>근거</span><span>${item.detail}</span>
       </div>
-      <div class="command-tag-row">
-        ${item.chips.map(chip => html`<span class="command-tag">${chip}</span>`)}
+      <div class="command-tag rounded-full-row">
+        ${item.chips.map(chip => html`<span class="command-tag rounded-full">${chip}</span>`)}
       </div>
-      ${item.note ? html`<div class="command-card-foot">${truncate(item.note, 200)}</div>` : null}
+      ${item.note ? html`<div class="command-card rounded-xl-foot">${truncate(item.note, 200)}</div>` : null}
     </article>
   `
 }
 
 export function WarRoomFeedCard({ item }: { item: WarRoomFeedItem }) {
   return html`
-    <article class="command-trace-row warroom-feed-card ${item.tone}">
+    <article class="command-trace-row warroom-feed-card rounded-xl ${item.tone}">
       <div class="command-trace-main">
         <div class="command-trace-head">
           <strong>${item.title}</strong>
-          <span class="command-chip ${item.tone}">${item.timestamp ? relativeTime(item.timestamp) : item.source}</span>
+          <span class="command-chip rounded-full ${item.tone}">${item.timestamp ? relativeTime(item.timestamp) : item.source}</span>
         </div>
-        <div class="command-card-sub">${item.meta}</div>
+        <div class="command-card rounded-xl-sub">${item.meta}</div>
       </div>
-      <div class="warroom-feed-detail">${item.detail}</div>
+      <div class="text-[rgba(226,232,240,0.86)] leading-[1.55] whitespace-pre-wrap break-words [overflow-wrap:anywhere]">${item.detail}</div>
     </article>
   `
 }

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -189,15 +189,15 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
 
   if (!hasLiveRun && !selectedSession) {
     if (commandPlaneSwarmLoading.value || operatorLoading.value) {
-      return html`<div class="empty-state">실시간 워룸 불러오는 중…</div>`
+      return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실시간 워룸 불러오는 중…</div>`
     }
     return html`
-      <section class="card min-h-[240px] command-warroom-empty ${wallboard ? 'wallboard' : ''}">
-        <div class="card-title-row">
-          <div class="card-title">실시간 워룸</div>
+      <section class="card rounded-xl min-h-[240px] command-warroom-empty ${wallboard ? 'wallboard' : ''}">
+        <div class="card rounded-xl-title-row">
+          <div class="card rounded-xl-title">실시간 워룸</div>
         </div>
         <div class="command-warroom-empty-copy">
-          <span class="command-hero-kicker">Narrative Playback</span>
+          <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">Narrative Playback</span>
           <strong>지금 붙잡을 live swarm 또는 team session이 없습니다</strong>
           <p>chain, autoresearch, worker wallboard는 활성 작전 또는 세션이 생기면 자동으로 붙습니다. 지금은 drill-down surface로 이동하는 편이 맞습니다.</p>
         </div>

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -12,11 +12,11 @@ interface CardProps {
 
 export function Card({ title, class: className, testId, children }: CardProps) {
   return html`
-    <div class="card ${className ?? ''}" data-testid=${testId}>
+    <div class="card rounded-xl ${className ?? ''}" data-testid=${testId}>
       ${title
         ? html`
-            <div class="card-title-row">
-              <div class="card-title">${title}</div>
+            <div class="card rounded-xl-title-row">
+              <div class="card rounded-xl-title">${title}</div>
             </div>
           `
         : null}

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -24,11 +24,11 @@ export class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.error) {
       return html`
-        <div class="error-card my-3 rounded-lg border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-4">
+        <div class="error-card rounded-xl my-3 rounded-lg border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-4">
           <strong class="text-[var(--bad)]">${this.props.label ?? 'Component'} 렌더링 오류</strong>
           <pre class="text-xs whitespace-pre-wrap mt-2 opacity-70">${this.state.error.message}</pre>
           <button
-            class="mt-2 px-3 py-1 cursor-pointer rounded border border-[var(--card-border)] bg-[var(--white-6)] text-[var(--text-body)] text-sm hover:bg-[var(--white-10)]"
+            class="mt-2 px-3 py-1 cursor-pointer rounded border border-[var(--card rounded-xl-border)] bg-[var(--white-6)] text-[var(--text-body)] text-sm hover:bg-[var(--white-10)]"
             onClick=${() => this.setState({ error: null })}
           >다시 시도</button>
         </div>

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -94,9 +94,9 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
                 <${MitosisRing} ratio=${model.contextRatio ?? 0} size=${34} stroke=${4} />
                 <${StatusBadge} status=${model.statusRaw ?? 'unknown'} />
                 ${model.pipelineStage ? html`<${PipelineStageBadge} stage=${model.pipelineStage} />` : null}
-                ${model.stateLabel ? html`<span class="monitor-pill ${toneClass}">${model.stateLabel}</span>` : null}
+                ${model.stateLabel ? html`<span class="monitor-pill ${toneClass} inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${model.stateLabel}</span>` : null}
               `
-            : html`<span class="command-chip ${toneClass}">${model.statusLabel}</span>`}
+            : html`<span class="command-chip rounded-full ${toneClass}">${model.statusLabel}</span>`}
         </div>
 
         <div class=${variant === 'mission' ? 'flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]' : 'monitor-meta'}>

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -57,7 +57,7 @@ function parseBlocks(src: string) {
       }
       const inner = thinkLines.join('\n').trim()
       nodes.push(html`
-        <details class="think-block">
+        <details class="think-block rounded-lg">
           <summary>Thinking...</summary>
           <div>${inlineToVdom(inner)}</div>
         </details>

--- a/dashboard/src/components/common/metric-tooltip.ts
+++ b/dashboard/src/components/common/metric-tooltip.ts
@@ -16,7 +16,7 @@ export function MetricTooltip({ metric }: MetricTooltipProps) {
       title="${def.description} (source: ${def.sourcePath})"
     >
       i
-      <span class="metric-tip-pop" role="tooltip">
+      <span class="metric-tip-pop rounded-lg" role="tooltip">
         <strong>${def.label}</strong>
         <span>${def.description}</span>
         ${def.formula ? html`<span><code class="text-[#9ad9ff]">formula:</code> ${def.formula}</span>` : null}

--- a/dashboard/src/components/common/provenance-strip.ts
+++ b/dashboard/src/components/common/provenance-strip.ts
@@ -54,7 +54,7 @@ export function ProvenanceChip({ item }: { item: ProvenanceItem }) {
   const label = provenanceLabel(item)
   const tone = provenanceTone(item.kind)
   return html`
-    <span class="command-chip ${tone}" title=${provenanceDetail(item.kind)}>
+    <span class="command-chip rounded-full ${tone}" title=${provenanceDetail(item.kind)}>
       ${label}
     </span>
   `

--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -21,17 +21,17 @@ export function RoomTruthStrip() {
 
   return html`
     <section class="room-truth-strip">
-      <article class="room-truth-card">
+      <article class="room-truth-card rounded-xl">
         <span class="room-truth-label">현황</span>
         <strong>에이전트 ${counts?.agents ?? 0} · 태스크 ${counts?.tasks ?? 0} · 키퍼 ${counts?.keepers ?? 0}</strong>
         <p>${status?.project ?? 'project'} · ${status?.paused ? '일시정지' : '활성'}</p>
       </article>
 
-      <article class="room-truth-card">
+      <article class="room-truth-card rounded-xl">
         <span class="room-truth-label">세션</span>
         <strong>활성 ${execution?.active_sessions ?? 0} · 막힘 ${blocked}</strong>
         <div class="room-truth-chip-row">
-          <span class="command-chip ${toneClass(blocked > 0 ? 'warn' : 'ok')}">
+          <span class="command-chip rounded-full ${toneClass(blocked > 0 ? 'warn' : 'ok')}">
             우선 ${execution?.priority_items ?? 0}
           </span>
         </div>

--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -60,7 +60,7 @@ function statusLabel(status: string): string {
 export function StatusBadge({ status, label }: StatusBadgeProps) {
   return html`
     <span class="border border-solid border-[var(--card-border)] ${status} ${status === 'offline' ? 'text-[#8da4cc]' : ''}">
-      <span class="status-dot-inline ${status}"></span>
+      <span class="size-1.5 rounded-full inline-block status-dot-inline ${status}"></span>
       ${label ?? statusLabel(status)}
     </span>
   `

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -19,22 +19,22 @@ export function Operations() {
   const section = currentSection()
 
   return html`
-    <div class="tab-unified">
-      <div class="tab-pill-bar">
+    <div class="tab-unified grid gap-[var(--space-md,16px)]">
+      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
         <button
-          class="tab-pill ${section === 'intervene' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'intervene' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >
           개입
         </button>
         <button
-          class="tab-pill ${section === 'command' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'command' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('operations', { section: 'command' })}
         >
           지휘
         </button>
         <button
-          class="tab-pill ${section === 'tools' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'tools' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('operations', { section: 'tools' })}
         >
           도구

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -27,7 +27,7 @@ const LazyLabSurface = lazy(async () => ({ default: (await import('./lab-unified
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
 function lazyTabFallback(label: string) {
-  return html`<div class="loading-indicator">${label} 불러오는 중...</div>`
+  return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">${label} 불러오는 중...</div>`
 }
 
 function formatDisconnectDuration(): string {
@@ -50,12 +50,12 @@ export function ConnectionStatus() {
     : `재연결 중...${formatDisconnectDuration()}`
 
   return html`
-    <div class="connection-status ${isConnected ? 'connected' : 'disconnected'}">
-      <span class="status-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
+    <div class="flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-muted)] whitespace-nowrap connection-status ${isConnected ? 'connected' : 'disconnected'}">
+      <span class="size-[9px] rounded-full inline-block status-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
       <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`
         <span
-          class="event-count attention-badge cursor-pointer"
+          class="event-count rounded-full attention-badge cursor-pointer"
           onClick=${() => navigate('home')}
         >주의 ${attentionCount}건</span>
       ` : null}
@@ -81,7 +81,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button
-        class="version-badge build-badge-trigger"
+        class="text-[11px] py-[2px] px-[9px] rounded-full border border-solid border-[rgba(71,184,255,0.35)] bg-[var(--accent-soft)] text-[#9ad9ff] build-badge-trigger"
         type="button"
         aria-expanded=${buildIdentityOpen.value}
         onClick=${() => {
@@ -93,25 +93,25 @@ export function BuildIdentityBadge() {
       ${buildIdentityOpen.value
         ? html`
             <div class="build-badge-panel">
-              <div class="build-badge-row">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
-                <strong>${build?.release_version ?? status?.version ?? 'unknown'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
               </div>
-              <div class="build-badge-row">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>커밋</span>
-                <strong>${build?.commit ?? '커밋 정보 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.commit ?? '커밋 정보 없음'}</strong>
               </div>
-              <div class="build-badge-row">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>서버 시작</span>
-                <strong>${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
               </div>
-              <div class="build-badge-row">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>업타임</span>
-                <strong>${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s` : '알 수 없음'}</strong>
               </div>
-              <div class="build-badge-row">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>쉘 스냅샷</span>
-                <strong>${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
               </div>
             </div>
           `
@@ -129,13 +129,13 @@ export function SideRail() {
 
   return html`
     <aside class="dashboard-rail">
-      <section class="rail-card rail-card-compact">
-        <div class="rail-card-head">
-          <h3>탐색</h3>
+      <section class="rail-card rounded-xl py-2.5 px-3">
+        <div class="flex items-center justify-between gap-3">
+          <h3 class="mb-0">탐색</h3>
         </div>
 
         <!-- Primary surfaces (5 items) -->
-        <div class="rail-tab-list">
+        <div class="rail-tab-list grid grid-cols-1 gap-1.5">
           ${DASHBOARD_SURFACES.map(surface => {
             const isActive = surface.id === currentSurface
             return html`
@@ -145,9 +145,9 @@ export function SideRail() {
                 onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
               >
                 <span class="text-base leading-[1.2]">${surface.icon}</span>
-                <span class="rail-tab-copy">
-                  <strong>${surface.label}</strong>
-                  <span>${surface.description}</span>
+                <span class="min-w-0 grid gap-0.5">
+                  <strong class="text-[color:var(--text-strong)] text-[13px] leading-[1.3]">${surface.label}</strong>
+                  <span class="text-[color:var(--text-muted)] text-[11px] leading-[1.4]">${surface.description}</span>
                 </span>
               </button>
             `
@@ -160,16 +160,16 @@ export function SideRail() {
           return html`
             <div class="rail-nav-group mt-3">
               <div class="rail-group-label">${currentView?.label ?? currentSurface} 하위</div>
-              <div class="rail-tab-list mt-1.5">
+              <div class="rail-tab-list grid grid-cols-1 gap-1.5 mt-1.5">
                 ${sectionItems.map(item => html`
                   <button
                     class="rail-tab-btn py-2 px-2.5 ${currentSection?.id === item.id ? 'active' : ''}"
                     key=${item.id}
                     onClick=${() => navigate(currentSurface, item.params)}
                   >
-                    <span class="rail-tab-copy">
-                      <strong class="text-xs">${item.label}</strong>
-                      <span>${item.description}</span>
+                    <span class="min-w-0 grid gap-0.5">
+                      <strong class="text-[color:var(--text-strong)] text-xs leading-[1.3]">${item.label}</strong>
+                      <span class="text-[color:var(--text-muted)] text-[11px] leading-[1.4]">${item.description}</span>
                     </span>
                   </button>
                 `)}
@@ -178,10 +178,10 @@ export function SideRail() {
           `
         })()}
 
-        <div class="rail-view-note">
-          <div class="rail-view-note-label">현재 화면</div>
-          <strong>${currentSection ? `${currentView?.label ?? current} · ${currentSection.label}` : currentView?.label ?? current}</strong>
-          <p>${currentSection?.description ?? currentView?.description ?? '운영 화면'}</p>
+        <div class="mt-3.5 pt-2.5 border-t border-[var(--card-border)] grid gap-1">
+          <div class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">현재 화면</div>
+          <strong class="text-[color:var(--text-strong)] text-sm">${currentSection ? `${currentView?.label ?? current} · ${currentSection.label}` : currentView?.label ?? current}</strong>
+          <p class="text-[color:var(--text-muted)] text-xs leading-[1.45]">${currentSection?.description ?? currentView?.description ?? '운영 화면'}</p>
         </div>
       </section>
 
@@ -234,7 +234,7 @@ export function TabContent() {
 
 export function DashboardMain() {
   if (dashboardLoading.value && !connected.value && !roomTruthInitializing.value) {
-    return html`<div class="loading-indicator">대시보드 불러오는 중...</div>`
+    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">대시보드 불러오는 중...</div>`
   }
 
   const routeLabel = [
@@ -249,7 +249,7 @@ export function DashboardMain() {
 
   return html`
     ${roomTruthInitializing.value ? html`
-      <div class="loading-banner">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
+      <div class="text-center py-[6px] px-4 bg-[rgba(230,167,0,0.12)] border-b border-solid border-b-[rgba(230,167,0,0.3)] text-[#e6a700] text-[0.8rem] shrink-0">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <${TabContent} />

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -27,16 +27,16 @@ export function OperationCard({ brief, selected }: { brief: DashboardExecutionOp
       <div class="flex justify-between gap-2 items-start flex-wrap">
         <div>
           <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${brief.operation_id}${brief.assigned_unit_label ? ` · ${brief.assigned_unit_label}` : ''}</div>
-          <div class="mission-card-title">${brief.objective}</div>
+          <div class="mission-card rounded-xl-title">${brief.objective}</div>
         </div>
-        <span class="command-chip ${terminal ? 'muted' : toneClass(brief.blocker_summary ? 'warn' : brief.status)}">${statusLabel(brief.status)}</span>
+        <span class="command-chip rounded-full ${terminal ? 'muted' : toneClass(brief.blocker_summary ? 'warn' : brief.status)}">${statusLabel(brief.status)}</span>
       </div>
-      <div class="mission-card-meta">
+      <div class="mission-card rounded-xl-meta">
         ${brief.stage ? html`<span>단계 · ${brief.stage}</span>` : null}
         ${brief.linked_session_id ? html`<span>세션 · ${brief.linked_session_id}</span>` : null}
         ${brief.updated_at ? html`<span><${TimeAgo} timestamp=${brief.updated_at} /></span>` : null}
       </div>
-      ${brief.blocker_summary ? html`<div class="mission-card-detail">${brief.blocker_summary}</div>` : null}
+      ${brief.blocker_summary ? html`<div class="mission-card rounded-xl-detail">${brief.blocker_summary}</div>` : null}
       ${brief.next_tool ? html`<div class="monitor-footnote">다음 도구 · ${brief.next_tool}</div>` : null}
       <${HandoffButtons} command=${brief.command_handoff} />
     </button>
@@ -56,7 +56,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
     <div class="monitor-list">
       ${hasActive
         ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
-        : html`<div class="empty-state">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -30,11 +30,11 @@ export function QueueCard({ item, selected }: { item: DashboardExecutionQueueIte
       <div class="flex justify-between gap-2 items-start flex-wrap">
         <div>
           <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${item.kind === 'session' ? item.target_id : item.linked_session_id ?? item.target_id}</div>
-          <div class="mission-card-title">${item.summary}</div>
+          <div class="mission-card rounded-xl-title">${item.summary}</div>
         </div>
-        <span class="command-chip ${terminal ? 'muted' : toneClass(item.severity)}">${statusLabel(item.status ?? item.severity)}</span>
+        <span class="command-chip rounded-full ${terminal ? 'muted' : toneClass(item.severity)}">${statusLabel(item.status ?? item.severity)}</span>
       </div>
-      <div class="mission-card-meta">
+      <div class="mission-card rounded-xl-meta">
         <span>${queueKindLabel(item.kind)}</span>
         ${item.linked_operation_id ? html`<span>연결 작전 · ${item.linked_operation_id}</span>` : null}
         ${item.last_seen_at ? html`<span><${TimeAgo} timestamp=${item.last_seen_at} /></span>` : null}
@@ -60,7 +60,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
     <div class="monitor-alert-list">
       ${hasActive
         ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
-        : html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금은 개입이 필요한 실행이 없습니다.</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -30,20 +30,20 @@ export function SessionCard({ brief, selected }: { brief: DashboardExecutionSess
       <div class="flex justify-between gap-2 items-start flex-wrap">
         <div>
           <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
-          <div class="mission-card-title">${brief.goal}</div>
+          <div class="mission-card rounded-xl-title">${brief.goal}</div>
         </div>
-        <span class="command-chip ${terminal ? 'muted' : toneClass(brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
+        <span class="command-chip rounded-full ${terminal ? 'muted' : toneClass(brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
       </div>
-      <div class="mission-card-meta">
+      <div class="mission-card rounded-xl-meta">
         <span>건강도 · ${statusLabel(brief.health ?? 'ok')}</span>
         <span>live ${liveCount} · seen ${seenCount} · planned ${plannedCount}</span>
         ${brief.linked_operation_id ? html`<span>연결 작전 · ${brief.linked_operation_id}</span>` : null}
         ${brief.last_activity_at ? html`<span><${TimeAgo} timestamp=${brief.last_activity_at} /></span>` : null}
       </div>
       ${brief.runtime_blocker
-        ? html`<div class="mission-card-detail">${brief.runtime_blocker}</div>`
+        ? html`<div class="mission-card rounded-xl-detail">${brief.runtime_blocker}</div>`
         : brief.last_activity_summary
-          ? html`<div class="mission-card-detail">${brief.last_activity_summary}</div>`
+          ? html`<div class="mission-card rounded-xl-detail">${brief.last_activity_summary}</div>`
           : null}
       <div class="monitor-footnote">
         ${brief.worker_gap_summary ?? `관측 기준 · ${brief.counts_basis ?? 'recent_turns'}`}
@@ -69,7 +69,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
     <div class="monitor-list">
       ${hasActive
         ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
-        : html`<div class="empty-state">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/shared.ts
+++ b/dashboard/src/components/execution/shared.ts
@@ -135,9 +135,9 @@ export function MonitorStat({
   caption?: string
 }) {
   return html`
-    <div class="stat-card">
+    <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
       <div class="stat-label">${label}</div>
-      <div class="stat-value" style=${color ? `color:${color}` : ''}>${value}</div>
+      <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums" style=${color ? `color:${color}` : ''}>${value}</div>
       ${caption ? html`<div class="monitor-stat-caption">${caption}</div>` : null}
     </div>
   `
@@ -155,7 +155,7 @@ export function HandoffButtons({
       ${intervene
         ? html`
             <button
-              class="control-btn ghost"
+              class="control-btn rounded-lg ghost"
               data-testid="execution.handoff-intervene"
               onClick=${(event: Event) => {
                 event.stopPropagation()
@@ -169,7 +169,7 @@ export function HandoffButtons({
       ${command
         ? html`
             <button
-              class="control-btn ghost"
+              class="control-btn rounded-lg ghost"
               data-testid="execution.handoff-command"
               onClick=${(event: Event) => {
                 event.stopPropagation()

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -28,8 +28,8 @@ export function WorkerSupportRow({
   testId: string
 }) {
   return html`
-    <button class="monitor-row p-3.5 ${row.tone} state-${row.state}" data-testid=${testId} onClick=${() => openAgentDetail(row.name)}>
-      <div class="monitor-row-header">
+    <button class="monitor-row rounded-xl p-3.5 ${row.tone} state-${row.state}" data-testid=${testId} onClick=${() => openAgentDetail(row.name)}>
+      <div class="monitor-row rounded-xl-header">
         <span class="agent-emoji">${row.emoji ?? ''}</span>
         <div class="min-w-0">
           <div class="monitor-name-line">
@@ -39,7 +39,7 @@ export function WorkerSupportRow({
           <div class="monitor-note">${row.note}</div>
         </div>
         <${StatusBadge} status=${row.status ?? 'unknown'} />
-        <span class="monitor-pill ${row.tone} state-${row.state}">${agentStateLabel(row.state)}</span>
+        <span class="monitor-pill ${row.tone} state-${row.state} inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${agentStateLabel(row.state)}</span>
       </div>
 
       <div class="monitor-meta">

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -19,7 +19,7 @@ import {
 
 export function GoalRow({ goal }: { goal: Goal }) {
   return html`
-    <div class="goal-row">
+    <div class="goal-row rounded-lg">
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-2">
           <span class="goal-horizon-badge" style="color:${horizonColor(goal.horizon)}">
@@ -27,7 +27,7 @@ export function GoalRow({ goal }: { goal: Goal }) {
           </span>
           <span class="goal-title">${goal.title}</span>
         </div>
-        <div class="goal-meta">
+        <div class="flex gap-2.5 flex-wrap mt-1 text-[length:var(--fs-xs)] text-[var(--text-dim)]">
           <span class="text-amber-500 tracking-[1px]" title="Priority ${goal.priority}">${priorityStars(goal.priority)}</span>
           ${goal.metric ? html`<span class="text-cyan">${goal.metric}${goal.target_value ? ` \u2192 ${goal.target_value}` : ''}</span>` : null}
           ${goal.due_date ? html`<span class="text-[var(--bad-light)]">Due: <${TimeAgo} timestamp=${goal.due_date} /></span>` : null}
@@ -36,7 +36,7 @@ export function GoalRow({ goal }: { goal: Goal }) {
           <div class="goal-review-note">${goal.last_review_note}</div>
         ` : null}
       </div>
-      <div class="goal-row-right">
+      <div class="goal-row rounded-lg-right">
         <${StatusBadge} status=${goal.status} />
         <div class="goal-updated">
           <${TimeAgo} timestamp=${goal.updated_at} />
@@ -51,7 +51,7 @@ export function HorizonGroup({ horizon, items }: { horizon: string; items: Goal[
   const sorted = [...items].sort((a, b) => b.priority - a.priority)
   return html`
     <${Card} title="${horizonLabel(horizon)} 목표 (${items.length})" class="section mb-3.5">
-      <div class="goal-list">
+      <div class="flex flex-col gap-0.5">
         ${sorted.map(g => html`<${GoalRow} key=${g.id} goal=${g} />`)}
       </div>
     <//>
@@ -60,23 +60,23 @@ export function HorizonGroup({ horizon, items }: { horizon: string; items: Goal[
 
 export function FilterBar() {
   return html`
-    <div class="goal-filters">
-      <div class="goal-filter-group">
+    <div class="flex gap-4 flex-wrap mt-3">
+      <div class="flex items-center gap-1">
         <label class="goal-filter-label">범위</label>
         ${(['all', 'short', 'mid', 'long'] as HorizonFilter[]).map(h => html`
           <button
-            class="goal-filter-btn ${horizonFilter.value === h ? 'active' : ''}"
+            class="goal-filter-btn rounded-xl ${horizonFilter.value === h ? 'active' : ''}"
             onClick=${() => { horizonFilter.value = h }}
           >
             ${h === 'all' ? '전체' : horizonLabel(h)}
           </button>
         `)}
       </div>
-      <div class="goal-filter-group">
+      <div class="flex items-center gap-1">
         <label class="goal-filter-label">상태</label>
         ${(['all', 'active', 'completed', 'paused'] as StatusFilter[]).map(s => html`
           <button
-            class="goal-filter-btn ${statusFilter.value === s ? 'active' : ''}"
+            class="goal-filter-btn rounded-xl ${statusFilter.value === s ? 'active' : ''}"
             onClick=${() => { statusFilter.value = s }}
           >
             ${statusFilterLabel(s)}
@@ -97,27 +97,27 @@ export function GoalsSummary() {
   }
   return html`
     <div class="goal-summary">
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value">${all.length}</div>
         <div class="goal-summary-label">전체</div>
       </div>
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value" class="text-[var(--ok)]">${active}</div>
         <div class="goal-summary-label">진행 중</div>
       </div>
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value" class="text-[var(--text-dim)]">${completed}</div>
         <div class="goal-summary-label">완료</div>
       </div>
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value" style="color:${horizonColor('short')}">${byHorizon.short}</div>
         <div class="goal-summary-label">단기</div>
       </div>
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value" style="color:${horizonColor('mid')}">${byHorizon.mid}</div>
         <div class="goal-summary-label">중기</div>
       </div>
-      <div class="goal-summary-item">
+      <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value" style="color:${horizonColor('long')}">${byHorizon.long}</div>
         <div class="goal-summary-label">장기</div>
       </div>

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -21,22 +21,22 @@ export function KanbanCard({ task }: { task: Task }) {
   const hasDescription = Boolean(task.description)
 
   return html`
-    <div class="kanban-card ${pClass}">
-      <div class="kanban-card-header">
-        <span class="priority-badge priority-badge--${pClass}">${priorityLabel(p)}</span>
-        <div class="kanban-card-title">${task.title}</div>
+    <div class="kanban-card rounded-xl ${pClass}">
+      <div class="kanban-card rounded-xl-header">
+        <span class="priority-badge rounded priority-badge--${pClass}">${priorityLabel(p)}</span>
+        <div class="kanban-card rounded-xl-title">${task.title}</div>
       </div>
       ${hasDescription ? html`
         <div
-          class="task-description-preview ${isExpanded ? 'task-description-preview--expanded' : ''}"
+          class="task-description-preview transition-colors duration-150 ${isExpanded ? 'task-description-preview--expanded' : ''}"
           onClick=${() => toggleTaskExpand(task.id)}
         >
           ${isExpanded ? task.description : truncate(task.description ?? '', 80)}
         </div>
       ` : null}
-      <div class="kanban-card-meta">
+      <div class="kanban-card rounded-xl-meta">
         ${task.created_at ? html`<${TimeAgo} timestamp=${task.created_at} />` : html`<span>-</span>`}
-        ${task.assignee ? html`<span class="kanban-assignee">${task.assignee}</span>` : null}
+        ${task.assignee ? html`<span class="kanban-assignee rounded-lg">${task.assignee}</span>` : null}
       </div>
     </div>
   `
@@ -51,34 +51,34 @@ export function TaskBacklog() {
   return html`
     <${Card} title="태스크 백로그" class="section mb-3.5">
       <div class="kanban-board">
-        <div class="kanban-column">
+        <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
           <div class="kanban-header todo">
             <span>할 일</span>
-            <span class="kanban-badge">${todo.length}</span>
+            <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${todo.length}</span>
           </div>
           ${sortedTodo.length === 0
-            ? html`<div class="empty-state" class="opacity-50">대기 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">대기 중인 태스크가 없습니다</div>`
             : sortedTodo.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
-        <div class="kanban-column">
+        <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
           <div class="kanban-header inprogress">
             <span>진행 중</span>
-            <span class="kanban-badge">${inProgress.length}</span>
+            <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${inProgress.length}</span>
           </div>
           ${sortedInProgress.length === 0
-            ? html`<div class="empty-state" class="opacity-50">진행 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">진행 중인 태스크가 없습니다</div>`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
-        <div class="kanban-column">
+        <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
           <div class="kanban-header done">
             <span>완료</span>
-            <span class="kanban-badge">${done.length}</span>
+            <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${done.length}</span>
           </div>
           ${sortedDone.length === 0
-            ? html`<div class="empty-state" class="opacity-50">완료된 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">완료된 태스크가 없습니다</div>`
             : sortedDone.slice(0, 20).map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
           ${sortedDone.length > 20
-            ? html`<div class="empty-state" class="opacity-50">...외 ${sortedDone.length - 20}개 더 있음</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">...외 ${sortedDone.length - 20}개 더 있음</div>`
             : null}
         </div>
       </div>

--- a/dashboard/src/components/goals/mdal-components.ts
+++ b/dashboard/src/components/goals/mdal-components.ts
@@ -14,20 +14,20 @@ export function LoopRow({ loop }: { loop: MdalLoop }) {
       : '아직 근거 없음'
 
   return html`
-    <div class="planning-loop-row">
+    <div class="planning-loop-row rounded-xl">
       <div class="grid gap-2.5">
         <div class="planning-loop-head">
           <div>
             <div class="planning-loop-id">${loop.profile}</div>
             <div class="planning-loop-sub">${loop.loop_id}</div>
           </div>
-          <div class="planning-loop-badges">
+          <div class="flex gap-1.5 flex-wrap">
             <${StatusBadge} status=${loop.status} />
-            <span class="pill">${loop.current_iteration}${loop.max_iterations > 0 ? `/${loop.max_iterations}` : ''}</span>
+            <span class="pill rounded-full">${loop.current_iteration}${loop.max_iterations > 0 ? `/${loop.max_iterations}` : ''}</span>
           </div>
         </div>
 
-        <div class="planning-loop-metrics">
+        <div class="flex gap-2.5 flex-wrap text-[#b9c9ea] text-[length:var(--fs-sm)]">
           <span>Baseline ${formatMetric(loop.baseline_metric)}</span>
           <span>현재 ${formatMetric(loop.current_metric)}</span>
           <span class=${formatMetricDelta(loop).startsWith('+') ? 'text-[#9af3ba]' : 'text-[#fda4af]'}>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -35,33 +35,33 @@ export function Planning() {
     <div>
 
       <!-- Step 1: Task-based stats grid -->
-      <div class="stats-grid">
-        <div class="stat-card">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-4">
+        <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
           <div class="stat-label">전체 태스크</div>
-          <div class="stat-value">${totalTasks}</div>
+          <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalTasks}</div>
         </div>
-        <div class="stat-card">
+        <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
           <div class="stat-label">할 일</div>
-          <div class="stat-value" class="text-[#e0e0e0]">${todo.length}</div>
+          <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums text-[#e0e0e0]">${todo.length}</div>
         </div>
-        <div class="stat-card">
+        <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
           <div class="stat-label">진행 중</div>
-          <div class="stat-value" class="text-[var(--warn)]">${inProgress.length}</div>
+          <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums text-[var(--warn)]">${inProgress.length}</div>
         </div>
-        <div class="stat-card">
+        <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
           <div class="stat-label">완료</div>
-          <div class="stat-value" class="text-[var(--ok)]">${done.length}</div>
+          <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums text-[var(--ok)]">${done.length}</div>
         </div>
-        <div class="stat-card">
+        <div class="border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5">
           <div class="stat-label">높은 우선순위</div>
-          <div class="stat-value" style="color:${highPriority > 0 ? '#f87171' : '#888'}">${highPriority}</div>
+          <div class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums" style="color:${highPriority > 0 ? '#f87171' : '#888'}">${highPriority}</div>
         </div>
       </div>
 
       <!-- Compact refresh toolbar -->
       <div class="planning-toolbar">
         <button
-          class="control-btn secondary"
+          class="control-btn rounded-lg secondary"
           onClick=${() => {
             refreshGoals()
             refreshMdal()
@@ -79,23 +79,23 @@ export function Planning() {
       <details class="overview-section-collapsible" open=${hasGoals}>
         <summary>
           목표 파이프라인
-          <span class="monitor-pill ml-auto">${goals.value.length}</span>
+          <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em] ml-auto">${goals.value.length}</span>
         </summary>
         <div>
           ${hasGoals ? html`
             <${GoalsSummary} />
             <${FilterBar} />
             ${goalsLoading.value && goals.value.length === 0
-              ? html`<div class="loading-indicator">목표 불러오는 중...</div>`
+              ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">목표 불러오는 중...</div>`
               : filteredGoals.value.length === 0
-                ? html`<div class="empty-state">현재 필터에 맞는 목표가 없습니다</div>`
+                ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">현재 필터에 맞는 목표가 없습니다</div>`
                 : html`
                     <${HorizonGroup} horizon="short" items=${grouped.short ?? []} />
                     <${HorizonGroup} horizon="mid" items=${grouped.mid ?? []} />
                     <${HorizonGroup} horizon="long" items=${grouped.long ?? []} />
                   `}
           ` : html`
-            <div class="empty-state">
+            <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
               장기 목표가 아직 없습니다. <code>masc_goal_upsert</code>로 단기/중기/장기 목표를 등록하면 메트릭 기반 추적이 시작됩니다.
             </div>
           `}
@@ -106,15 +106,15 @@ export function Planning() {
       <details class="overview-section-collapsible" open=${hasLoops}>
         <summary>
           MDAL 루프
-          <span class="monitor-pill ml-auto">${loops.length}</span>
+          <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em] ml-auto">${loops.length}</span>
         </summary>
         <div>
           ${mdalLoading.value && loops.length === 0
-            ? html`<div class="loading-indicator">MDAL 루프 불러오는 중...</div>`
+            ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">MDAL 루프 불러오는 중...</div>`
             : loops.length === 0 && (mdalState === 'error' || lastMdalError.value)
-              ? html`<div class="empty-state">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
+              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
               : loops.length === 0
-                ? html`<div class="empty-state">가동 중인 루프가 없습니다. <code>masc_mdal_start</code>로 시작할 수 있습니다.</div>`
+                ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가동 중인 루프가 없습니다. <code>masc_mdal_start</code>로 시작할 수 있습니다.</div>`
                 : html`
                   <div class="grid gap-3">
                     ${loops.map(loop => html`<${LoopRow} key=${loop.loop_id} loop=${loop} />`)}

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -22,14 +22,14 @@ import {
 export function PetitionEntry({ petition }: { petition: GovernanceCaseBundle['petitions'][number] }) {
   return html`
     <div class="governance-ledger-row">
-      <div class="governance-ledger-head">
-        <span class="governance-badge text-[#b7cbee]">청원</span>
+      <div class="flex flex-wrap items-center gap-2 text-[#9ab3de] text-[length:var(--fs-xs)]">
+        <span class="governance-badge rounded-full text-[#b7cbee]">청원</span>
         <strong>${petition.created_by || petition.origin || 'system'}</strong>
         ${petition.created_at ? html`<span><${TimeAgo} timestamp=${petition.created_at} /></span>` : null}
       </div>
       <div class="governance-ledger-body">${petition.title}</div>
-      <div class="governance-chip-row">
-        ${petition.source_refs.map(ref => html`<span class="governance-chip">${ref}</span>`)}
+      <div class="governance-chip rounded-full-row">
+        ${petition.source_refs.map(ref => html`<span class="governance-chip rounded-full">${ref}</span>`)}
       </div>
     </div>
   `
@@ -38,14 +38,14 @@ export function PetitionEntry({ petition }: { petition: GovernanceCaseBundle['pe
 export function BriefEntry({ brief }: { brief: GovernanceCaseBrief }) {
   return html`
     <div class="governance-ledger-row">
-      <div class="governance-ledger-head">
-        <span class="governance-badge ${governanceToneClass(brief.stance)}">${stanceLabel(brief.stance)}</span>
+      <div class="flex flex-wrap items-center gap-2 text-[#9ab3de] text-[length:var(--fs-xs)]">
+        <span class="governance-badge rounded-full ${governanceToneClass(brief.stance)}">${stanceLabel(brief.stance)}</span>
         <strong>${brief.author}</strong>
         ${brief.created_at ? html`<span><${TimeAgo} timestamp=${brief.created_at} /></span>` : null}
       </div>
       <div class="governance-ledger-body">${brief.summary}</div>
-      <div class="governance-chip-row">
-        ${brief.evidence_refs.map(ref => html`<span class="governance-chip">${ref}</span>`)}
+      <div class="governance-chip rounded-full-row">
+        ${brief.evidence_refs.map(ref => html`<span class="governance-chip rounded-full">${ref}</span>`)}
       </div>
     </div>
   `
@@ -64,11 +64,11 @@ export function DecisionDetail() {
      
     >
       ${detailLoading.value
-        ? html`<div class="loading-indicator">거버넌스 상세 불러오는 중...</div>`
+        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">거버넌스 상세 불러오는 중...</div>`
         : !item || !detail
-          ? html`<div class="empty-state">왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다.</div>`
           : html`
-              <div class="governance-detail-head">
+              <div class="flex justify-between items-start gap-4 mb-3.5">
                 <div>
                   <h3>${detail.case.title}</h3>
                   <div class="council-sub">
@@ -86,14 +86,14 @@ export function DecisionDetail() {
                   <span class="governance-balance"><strong>${orderStatusLabel(detail.execution_order?.status)}</strong></span>
                 </div>
               </div>
-              <div class="governance-ledger">
+              <div class="flex flex-col gap-2.5">
                 ${petitions.length === 0
-                  ? html`<div class="empty-state">기록된 청원이 없습니다.</div>`
+                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">기록된 청원이 없습니다.</div>`
                   : petitions.map(petition => html`<${PetitionEntry} key=${petition.id} petition=${petition} />`)}
               </div>
-              <div class="governance-ledger">
+              <div class="flex flex-col gap-2.5">
                 ${briefs.length === 0
-                  ? html`<div class="empty-state">심의 의견이 아직 없습니다.</div>`
+                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">심의 의견이 아직 없습니다.</div>`
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}
               </div>
             `}

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -37,12 +37,12 @@ export function GuardrailPane({
   const ruling = detail?.ruling
   const order = detail?.execution_order
   return html`
-    <div class="governance-side-column">
+    <div class="flex flex-col gap-3.5">
       <${Card} title="판정 / 집행" class="section mb-3.5">
         ${!item || !detail
-          ? html`<div class="empty-state">사건을 고르면 판정과 집행 경로가 보입니다.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">사건을 고르면 판정과 집행 경로가 보입니다.</div>`
           : html`
-              <div class="governance-side-block">
+              <div class="flex flex-col gap-2">
                 <h4>판정</h4>
                 <div class="council-sub">
                   <span>${caseStatusLabel(ruling?.status || 'pending')}</span>
@@ -52,23 +52,23 @@ export function GuardrailPane({
                 ${ruling?.summary
                   ? html`<div class="governance-summary-callout">${ruling.summary}</div>`
                   : html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">아직 판정이 생성되지 않았습니다.</div>`}
-                <div class="governance-chip-row">
-                  ${item.provenance ? html`<span class="governance-chip">${item.provenance}</span>` : null}
-                  ${item.risk_class ? html`<span class="governance-chip">${item.risk_class}</span>` : null}
-                  ${item.subject_type ? html`<span class="governance-chip text-[#95a9cd]">${item.subject_type}</span>` : null}
+                <div class="governance-chip rounded-full-row">
+                  ${item.provenance ? html`<span class="governance-chip rounded-full">${item.provenance}</span>` : null}
+                  ${item.risk_class ? html`<span class="governance-chip rounded-full">${item.risk_class}</span>` : null}
+                  ${item.subject_type ? html`<span class="governance-chip rounded-full text-[#95a9cd]">${item.subject_type}</span>` : null}
                 </div>
               </div>
               <${ActionRequestCard} order=${order} />
               ${order?.status === 'needs_human_gate'
                 ? html`
-                    <div class="governance-side-block">
+                    <div class="flex flex-col gap-2">
                       <h4>관리자 승인</h4>
                       <div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">이 집행은 고위험으로 분류되어 수동 결재가 필요합니다.</div>
                       <div class="flex gap-2">
-                        <button class="control-btn secondary" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
+                        <button class="control-btn rounded-lg secondary" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '승인'}
                         </button>
-                        <button class="control-btn ghost" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
+                        <button class="control-btn rounded-lg ghost" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '거부'}
                         </button>
                       </div>
@@ -79,13 +79,13 @@ export function GuardrailPane({
     <//>
       <${Card} title="심의 입력" class="section mb-3.5">
         ${!item
-          ? html`<div class="empty-state">사건을 선택한 뒤 의견을 추가하세요.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">사건을 선택한 뒤 의견을 추가하세요.</div>`
           : html`
-              <div class="governance-side-block">
-                <div class="governance-filter-row">
+              <div class="flex flex-col gap-2">
+                <div class="flex flex-wrap gap-2">
                   ${(['support', 'oppose', 'neutral'] as const).map(stance => html`
                     <button
-                      class="control-btn ${governanceBriefStance.value === stance ? 'is-active' : 'ghost'}"
+                      class="control-btn rounded-lg ${governanceBriefStance.value === stance ? 'is-active' : 'ghost'}"
                       onClick=${() => {
                         governanceBriefStance.value = stance
                       }}
@@ -95,7 +95,7 @@ export function GuardrailPane({
                   `)}
                 </div>
                 <textarea
-                  class="control-input"
+                  class="control-input rounded-lg"
                   rows=${5}
                   placeholder="이 사건에 대한 심의 의견을 입력하세요..."
                   value=${governanceBriefInput.value}
@@ -105,7 +105,7 @@ export function GuardrailPane({
                 ></textarea>
                 <div class="flex gap-2">
                   <button
-                    class="control-btn secondary"
+                    class="control-btn rounded-lg secondary"
                     onClick=${submitBrief}
                     disabled=${governanceBriefSubmitting.value || governanceBriefInput.value.trim() === ''}
                   >
@@ -123,7 +123,7 @@ export function ActionRequestCard({ order }: { order: GovernanceExecutionOrder |
   if (!order?.action_request) return null
   const request = order.action_request
   return html`
-    <div class="governance-side-block">
+    <div class="flex flex-col gap-2">
       <h4>집행 명령</h4>
       <div class="council-sub">
         <span>${request.resolved_tool || request.action_kind || request.target_type || 'action'}</span>

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -30,11 +30,11 @@ export function ActivityRail() {
   }
   return html`
     <${Card} title="활동 타임라인" class="section mb-3.5">
-      <div class="governance-activity-list">
+      <div class="flex flex-col gap-2">
         ${grouped.size === 0
-          ? html`<div class="empty-state">거버넌스 활동이 아직 없습니다.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">거버넌스 활동이 아직 없습니다.</div>`
           : Array.from(grouped.entries()).map(([, group]) => html`
-              <div class="governance-case-group">
+              <div class="governance-case-group rounded-lg">
                 <div class="governance-case-header">
                   <span class="governance-case-topic">${group.topic}</span>
                   <${LifecycleProgress} events=${group.events} />
@@ -42,7 +42,7 @@ export function ActivityRail() {
                 <div class="governance-case-events">
                   ${group.events.map((event: GovernanceTimelineEvent) => html`
                     <div class="governance-activity-row">
-                      <span class="governance-badge ${governanceToneClass(event.kind)}">${activityKindLabel(event.kind)}</span>
+                      <span class="governance-badge rounded-full ${governanceToneClass(event.kind)}">${activityKindLabel(event.kind)}</span>
                       <span class="governance-event-summary">${event.summary || ''}</span>
                       ${event.created_at ? html`<span class="governance-event-time"><${TimeAgo} timestamp=${event.created_at} /></span>` : null}
                     </div>
@@ -104,7 +104,7 @@ export function RuntimeParamsPanel() {
   return html`
     <${Card} title="Runtime Parameters" class="section mb-3.5">
       ${runtimeLoading.value
-        ? html`<div class="loading-indicator">파라미터 로딩 중...</div>`
+        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">파라미터 로딩 중...</div>`
         : html`
             <div class="governance-params-surfaces">
               ${surfaces.map((surface: RuntimeParamsSurface) => {
@@ -113,7 +113,7 @@ export function RuntimeParamsPanel() {
                   <div class="governance-surface-group">
                     <div class="governance-surface-head">
                       <strong>${surface.id}</strong>
-                      <span class="governance-chip ${surface.risk === 'high' ? 'warn' : ''}">${surface.risk}</span>
+                      <span class="governance-chip rounded-full ${surface.risk === 'high' ? 'warn' : ''}">${surface.risk}</span>
                       <span class="council-sub">${surface.description}</span>
                     </div>
                     <div class="governance-params-table">
@@ -123,7 +123,7 @@ export function RuntimeParamsPanel() {
                           <span class="governance-param-value">
                             ${formatParamValue(param.current)}
                             ${param.has_override
-                              ? html`<span class="governance-chip warn" style="margin-left:4px">override</span>`
+                              ? html`<span class="governance-chip rounded-full warn" style="margin-left:4px">override</span>`
                               : null}
                           </span>
                           <span class="governance-param-default council-sub">

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -45,7 +45,7 @@ function GovernanceSummaryStrip() {
 
   return html`
     ${isStale ? html`
-      <div class="governance-stale-warning">
+      <div class="governance-stale-warning rounded-md">
         모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
         ${lastActivityAge != null ? html` 마지막 활동: ${formatAgeSummary(lastActivityAge)} 전.` : null}
         테스트 잔재일 가능성이 높습니다.
@@ -79,10 +79,10 @@ function GovernanceSummaryStrip() {
 function GovernanceToolbar() {
   return html`
     <${Card} title="청원 콘솔" class="section mb-3.5">
-      <div class="governance-toolbar">
+      <div class="flex flex-col gap-3">
         <div class="council-create">
           <input
-            class="control-input"
+            class="control-input rounded-lg"
             type="text"
             placeholder="청원 제목을 입력하세요..."
             value=${governanceTopicInput.value}
@@ -95,17 +95,17 @@ function GovernanceToolbar() {
             disabled=${governanceStarting.value}
           />
           <button
-            class="control-btn secondary"
+            class="control-btn rounded-lg secondary"
             onClick=${submitPetition}
             disabled=${governanceStarting.value || governanceTopicInput.value.trim() === ''}
           >
             ${governanceStarting.value ? '접수 중...' : '청원 접수'}
           </button>
-          <button class="control-btn ghost" onClick=${refreshGovernance} disabled=${governanceLoading.value}>
+          <button class="control-btn rounded-lg ghost" onClick=${refreshGovernance} disabled=${governanceLoading.value}>
             ${governanceLoading.value ? '새로고침 중...' : '새로고침'}
           </button>
         </div>
-        <div class="governance-filter-row">
+        <div class="flex flex-wrap gap-2">
           ${(
             [
               ['open', '진행 중'],
@@ -116,7 +116,7 @@ function GovernanceToolbar() {
             ] as Array<[GovernanceFilter, string]>
           ).map(([key, label]) => html`
             <button
-              class="control-btn ${governanceFilter.value === key ? 'is-active' : 'ghost'}"
+              class="control-btn rounded-lg ${governanceFilter.value === key ? 'is-active' : 'ghost'}"
               onClick=${async () => {
                 governanceFilter.value = key
                 await refreshGovernance()
@@ -126,7 +126,7 @@ function GovernanceToolbar() {
             </button>
           `)}
         </div>
-        ${governanceError.value ? html`<div class="council-error">${governanceError.value}</div>` : null}
+        ${governanceError.value ? html`<div class="council-error rounded-lg">${governanceError.value}</div>` : null}
       </div>
     <//>
   `
@@ -138,7 +138,7 @@ function DecisionInbox() {
     <${Card} title="사건 수신함" class="section mb-3.5">
       <div class="council-list governance-inbox">
         ${items.length === 0
-          ? html`<div class="empty-state">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`
@@ -148,7 +148,7 @@ function DecisionInbox() {
                 >
                   <div class="min-w-0">
                     <div class="governance-row-head">
-                      <span class="governance-kind">${kindLabel(item.kind)}</span>
+                      <span class="governance-kind rounded-full">${kindLabel(item.kind)}</span>
                       <span class="council-topic">${item.topic}</span>
                     </div>
                     <div class="council-sub">
@@ -157,20 +157,20 @@ function DecisionInbox() {
                         ? html`<span><${TimeAgo} timestamp=${item.last_activity_at} /></span>`
                         : null}
                     </div>
-                    <div class="governance-chip-row">
-                      ${item.origin ? html`<span class="governance-chip text-[#95a9cd]">${item.origin}</span>` : null}
-                      ${item.risk_class ? html`<span class="governance-chip">${item.risk_class}</span>` : null}
-                      ${item.provenance ? html`<span class="governance-chip">${item.provenance}</span>` : null}
+                    <div class="governance-chip rounded-full-row">
+                      ${item.origin ? html`<span class="governance-chip rounded-full text-[#95a9cd]">${item.origin}</span>` : null}
+                      ${item.risk_class ? html`<span class="governance-chip rounded-full">${item.risk_class}</span>` : null}
+                      ${item.provenance ? html`<span class="governance-chip rounded-full">${item.provenance}</span>` : null}
                       ${item.status === 'needs_human_gate'
-                        ? html`<span class="governance-chip warn">관리자 승인 필요</span>`
+                        ? html`<span class="governance-chip rounded-full warn">관리자 승인 필요</span>`
                         : null}
                       ${item.status === 'executed'
-                        ? html`<span class="governance-chip ok">집행 완료</span>`
+                        ? html`<span class="governance-chip rounded-full ok">집행 완료</span>`
                         : null}
                     </div>
                   </div>
                   <div class="governance-row-side">
-                    <span class="council-state ${governanceToneClass(item.status)}">${caseStatusLabel(item.status)}</span>
+                    <span class="council-state rounded-full ${governanceToneClass(item.status)}">${caseStatusLabel(item.status)}</span>
                     <span class="governance-vote-meter">${item.brief_count ?? 0}건</span>
                   </div>
                 </button>

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -91,31 +91,31 @@ export function KeeperChatPanel({ name }: { name: string }) {
       <div class="keeper-chat__header">
         <span class="keeper-chat__title">@${name} 대화</span>
         ${isStreaming ? html`
-          <button class="control-btn ghost keeper-chat__cancel" onClick=${cancelStream}>중단</button>
+          <button class="control-btn rounded-lg ghost keeper-chat__cancel" onClick=${cancelStream}>중단</button>
         ` : null}
       </div>
 
       <div class="keeper-chat__messages" ref=${scrollRef}>
         ${messages.length === 0 && !isStreaming ? html`
-          <div class="keeper-chat__empty">keeper에게 메시지를 보내세요</div>
+          <div class="text-[var(--white-20)] text-[var(--fs-base)] text-center py-10">keeper에게 메시지를 보내세요</div>
         ` : null}
 
         ${messages.map((msg, idx) => html`
-          <div key=${idx} class="keeper-chat__msg keeper-chat__msg--${msg.role} ${msg.role === 'user' ? 'self-end' : 'self-start'}">
-            <span class="keeper-chat__role">${msg.role === 'user' ? 'You' : name}</span>
-            <div class="keeper-chat__text">${msg.content}</div>
+          <div key=${idx} class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--${msg.role} ${msg.role === 'user' ? 'self-end' : 'self-start'}">
+            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${msg.role === 'user' ? 'You' : name}</span>
+            <div class="keeper-chat__text rounded-lg">${msg.content}</div>
           </div>
         `)}
 
         ${isStreaming && buffer ? html`
-          <div class="keeper-chat__msg keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
-            <span class="keeper-chat__role">${name}</span>
-            <div class="keeper-chat__text">${buffer}<span class="keeper-chat__cursor">|</span></div>
+          <div class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
+            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${name}</span>
+            <div class="keeper-chat__text rounded-lg">${buffer}<span class="keeper-chat__cursor">|</span></div>
           </div>
         ` : isStreaming ? html`
-          <div class="keeper-chat__msg keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
-            <span class="keeper-chat__role">${name}</span>
-            <div class="keeper-chat__text keeper-chat__text--thinking">thinking...</div>
+          <div class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
+            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${name}</span>
+            <div class="keeper-chat__text rounded-lg keeper-chat__text--thinking">thinking...</div>
           </div>
         ` : null}
       </div>
@@ -124,7 +124,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
 
       <div class="keeper-chat__input-row">
         <input
-          class="control-input flex-1"
+          class="control-input rounded-lg flex-1"
           type="text"
           placeholder="메시지 입력..."
           value=${chatInput.value}
@@ -133,7 +133,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
           disabled=${isStreaming}
         />
         <button
-          class="control-btn shrink-0"
+          class="control-btn rounded-lg shrink-0"
           onClick=${() => { void sendChat(name) }}
           disabled=${isStreaming || chatInput.value.trim() === ''}
         >

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -98,7 +98,7 @@ export function resetKeeperConfig(): void {
 
 function ConfigRow({ label, value }: { label: string; value: string }) {
   return html`
-    <div class="keeper-signal-row">
+    <div class="keeper-signal-row rounded-lg">
       <span>${label}</span>
       <strong>${value}</strong>
     </div>
@@ -123,7 +123,7 @@ function ModelList({ models }: { models: string[] }) {
   if (models.length === 0) return html`<span class="text-[#666]">none</span>`
   return html`
     <div class="flex flex-wrap gap-1">
-      ${models.map(m => html`<span class="pill" style="font-size:11px;">${m}</span>`)}
+      ${models.map(m => html`<span class="pill rounded-full" style="font-size:11px;">${m}</span>`)}
     </div>
   `
 }
@@ -187,7 +187,7 @@ function EditCheckbox({ field, label }: { field: keyof EditDraft; label: string 
   if (!d) return null
   const val = d[field] as boolean
   return html`
-    <div class="keeper-signal-row" class="mt-1">
+    <div class="keeper-signal-row rounded-lg" class="mt-1">
       <span>${label}</span>
       <input
         type="checkbox"
@@ -203,7 +203,7 @@ function EditNumber({ field, label, min, max }: { field: keyof EditDraft; label:
   if (!d) return null
   const val = d[field] as number
   return html`
-    <div class="keeper-signal-row" class="mt-1">
+    <div class="keeper-signal-row rounded-lg" class="mt-1">
       <span>${label}</span>
       <input
         type="number"
@@ -231,11 +231,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   }
 
   if (state.status === 'loading') {
-    return html`<div class="keeper-signal-list"><div style="color:#888; font-size:13px; padding:12px 0;">Loading config...</div></div>`
+    return html`<div class="flex flex-col gap-1.5"><div style="color:#888; font-size:13px; padding:12px 0;">Loading config...</div></div>`
   }
 
   if (state.status === 'error') {
-    return html`<div class="keeper-signal-list"><div style="color:#ef4444; font-size:13px; padding:12px 0;">${state.message}</div></div>`
+    return html`<div class="flex flex-col gap-1.5"><div style="color:#ef4444; font-size:13px; padding:12px 0;">${state.message}</div></div>`
   }
 
   if (state.status !== 'loaded') return null
@@ -349,7 +349,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
   ` : html`
     <${SectionHeader} title="Drift" />
-    <div class="keeper-signal-row">
+    <div class="keeper-signal-row rounded-lg">
       <span>Enabled</span>
       <strong><${BoolBadge} value=${c.drift.enabled} /></strong>
     </div>
@@ -359,7 +359,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   `
 
   return html`
-    <div class="keeper-signal-list">
+    <div class="flex flex-col gap-1.5">
 
       ${toolbar}
 
@@ -368,7 +368,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="Policy mode" value=${c.execution.policy_mode || '--'} />
       <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Verify</span>
         <strong><${BoolBadge} value=${c.execution.verify} /></strong>
       </div>
@@ -393,7 +393,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Proactive (read-only) --- */}
       <${SectionHeader} title="Proactive" />
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Enabled</span>
         <strong><${BoolBadge} value=${c.proactive.enabled} /></strong>
       </div>
@@ -405,7 +405,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="Initiative" />
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Enabled</span>
         <strong><${BoolBadge} value=${c.initiative.enabled} /></strong>
       </div>
@@ -416,7 +416,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Handoff (read-only) --- */}
       <${SectionHeader} title="Handoff" />
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Auto</span>
         <strong><${BoolBadge} value=${c.handoff.auto} /></strong>
       </div>

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -30,7 +30,7 @@ export function AutonomyMeter({ keeper }: { keeper: Keeper }) {
   const pct = ((idx + 1) / AUTONOMY_LEVELS.length) * 100
 
   return html`
-    <div class="keeper-signal-list">
+    <div class="flex flex-col gap-1.5">
       <div class="mb-2">
         <div class="flex justify-between items-center mb-1">
           <span style="font-size:13px; font-weight:600; color:${info.color};">${info.label}</span>
@@ -45,18 +45,18 @@ export function AutonomyMeter({ keeper }: { keeper: Keeper }) {
           `)}
         </div>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Autonomous actions</span>
         <strong>${keeper.autonomous_action_count ?? 0}</strong>
       </div>
       ${keeper.last_autonomous_action_at
-        ? html`<div class="keeper-signal-row">
+        ? html`<div class="keeper-signal-row rounded-lg">
             <span>Last autonomous action</span>
             <strong><${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></strong>
           </div>`
         : null}
       ${keeper.active_goal_ids && keeper.active_goal_ids.length > 0
-        ? html`<div class="keeper-signal-row">
+        ? html`<div class="keeper-signal-row rounded-lg">
             <span>Active goals</span>
             <strong>${keeper.active_goal_ids.length}</strong>
           </div>`
@@ -109,30 +109,30 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
   ]
 
   return html`
-    <div class="keeper-kpis">
+    <div class="grid grid-cols-4 gap-2.5 mb-4">
       ${items.map(i => html`
-        <div class="keeper-kpi">
-          <div class="keeper-kpi-label">${i.label}</div>
-          <div class="keeper-kpi-value">${i.value}</div>
-          ${i.hint ? html`<div class="keeper-kpi-hint">${i.hint}</div>` : null}
+        <div class="keeper-kpi rounded-lg">
+          <div class="keeper-kpi rounded-lg-label">${i.label}</div>
+          <div class="keeper-kpi rounded-lg-value">${i.value}</div>
+          ${i.hint ? html`<div class="keeper-kpi rounded-lg-hint">${i.hint}</div>` : null}
         </div>
       `)}
       <div class="kpi-tile">
-        <div class="kpi-value">${formatTokens(keeper.context_tokens)}</div>
+        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${formatTokens(keeper.context_tokens)}</div>
         <div class="kpi-label">Tokens</div>
       </div>
       <div class="kpi-tile">
-        <div class="kpi-value">${keeper.handoff_count_total ?? '—'}</div>
+        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${keeper.handoff_count_total ?? '—'}</div>
         <div class="kpi-label">Handoffs</div>
       </div>
       <div class="kpi-tile">
-        <div class="kpi-value">${keeper.compaction_count ?? '—'}</div>
+        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${keeper.compaction_count ?? '—'}</div>
         <div class="kpi-label">Compactions</div>
       </div>
       ${latestCost
         ? html`
             <div class="kpi-tile">
-              <div class="kpi-value">${latestCost}</div>
+              <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${latestCost}</div>
               <div class="kpi-label">Cost (USD)</div>
             </div>
           `
@@ -212,40 +212,40 @@ export function FieldDictionary({ keeper }: { keeper: Keeper }) {
     : fields
 
   return html`
-    <div class="keeper-field-dict">
+    <div class="max-h-[460px] overflow-y-auto">
       <input
-        class="keeper-field-search"
+        class="keeper-field-search rounded-lg"
         type="text"
         placeholder="필드 검색..."
         value=${fieldSearch.value}
         onInput=${(e: Event) => { fieldSearch.value = (e.target as HTMLInputElement).value }}
       />
       ${filtered.map(f => html`
-        <div class="keeper-field-row">
+        <div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]">
           <span class="font-semibold min-w-[90px]">${f.title}</span>
-          <span class="keeper-field-key">${f.key}</span>
+          <span class="font-mono text-cyan text-[var(--fs-sm)]">${f.key}</span>
           <span class="flex-1 text-right text-[#ccc]">${f.value}</span>
         </div>
       `)}
-      ${keeper.trace_id ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Trace ID</span><span class="keeper-field-key font-mono">${keeper.trace_id}</span></div>` : ''}
-      ${keeper.agent_name ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Agent</span><span class="flex-1 text-right text-[#ccc]">${keeper.agent_name}</span></div>` : ''}
-      ${keeper.primary_model ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Primary Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.primary_model}</span></div>` : ''}
-      ${keeper.active_model ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Active Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.active_model}</span></div>` : ''}
-      ${keeper.next_model_hint ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Next Model Hint</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.next_model_hint}</span></div>` : ''}
-      ${keeper.skill_primary ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Skill (Primary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_primary}</span></div>` : ''}
-      ${keeper.skill_secondary ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Skill (Secondary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_secondary}</span></div>` : ''}
-      ${keeper.skill_reason ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Skill Reason</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_reason}</span></div>` : ''}
-      ${keeper.context_source ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Context Source</span><span class="flex-1 text-right text-[#ccc]">${keeper.context_source}</span></div>` : ''}
-      ${keeper.context_tokens != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Context Tokens</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_tokens)}</span></div>` : ''}
-      ${keeper.context_max != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Context Max</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_max)}</span></div>` : ''}
-      ${keeper.memory_recent_note ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Memory Note</span><span class="flex-1 text-right text-[#ccc]">${keeper.memory_recent_note}</span></div>` : ''}
-      ${keeper.k2k_count != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">K2K Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.k2k_count}</span></div>` : ''}
-      ${keeper.conversation_tail_count != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Conv Tail</span><span class="flex-1 text-right text-[#ccc]">${keeper.conversation_tail_count}</span></div>` : ''}
-      ${keeper.handoff_count_total != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Total Handoffs</span><span class="flex-1 text-right text-[#ccc]">${keeper.handoff_count_total}</span></div>` : ''}
-      ${keeper.compaction_count != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Compactions</span><span class="flex-1 text-right text-[#ccc]">${keeper.compaction_count}</span></div>` : ''}
-      ${keeper.last_compaction_saved_tokens != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Last Compact Saved</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.last_compaction_saved_tokens)}</span></div>` : ''}
-      ${keeper.context?.message_count != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Message Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.message_count}</span></div>` : ''}
-      ${keeper.context?.has_checkpoint != null ? html`<div class="keeper-field-row"><span class="font-semibold min-w-[90px]">Has Checkpoint</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.has_checkpoint ? 'Yes' : 'No'}</span></div>` : ''}
+      ${keeper.trace_id ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Trace ID</span><span class="keeper-field-key font-mono">${keeper.trace_id}</span></div>` : ''}
+      ${keeper.agent_name ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Agent</span><span class="flex-1 text-right text-[#ccc]">${keeper.agent_name}</span></div>` : ''}
+      ${keeper.primary_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Primary Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.primary_model}</span></div>` : ''}
+      ${keeper.active_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Active Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.active_model}</span></div>` : ''}
+      ${keeper.next_model_hint ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Next Model Hint</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.next_model_hint}</span></div>` : ''}
+      ${keeper.skill_primary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Primary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_primary}</span></div>` : ''}
+      ${keeper.skill_secondary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Secondary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_secondary}</span></div>` : ''}
+      ${keeper.skill_reason ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill Reason</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_reason}</span></div>` : ''}
+      ${keeper.context_source ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Source</span><span class="flex-1 text-right text-[#ccc]">${keeper.context_source}</span></div>` : ''}
+      ${keeper.context_tokens != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Tokens</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_tokens)}</span></div>` : ''}
+      ${keeper.context_max != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Max</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_max)}</span></div>` : ''}
+      ${keeper.memory_recent_note ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Memory Note</span><span class="flex-1 text-right text-[#ccc]">${keeper.memory_recent_note}</span></div>` : ''}
+      ${keeper.k2k_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">K2K Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.k2k_count}</span></div>` : ''}
+      ${keeper.conversation_tail_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Conv Tail</span><span class="flex-1 text-right text-[#ccc]">${keeper.conversation_tail_count}</span></div>` : ''}
+      ${keeper.handoff_count_total != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Total Handoffs</span><span class="flex-1 text-right text-[#ccc]">${keeper.handoff_count_total}</span></div>` : ''}
+      ${keeper.compaction_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Compactions</span><span class="flex-1 text-right text-[#ccc]">${keeper.compaction_count}</span></div>` : ''}
+      ${keeper.last_compaction_saved_tokens != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Last Compact Saved</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.last_compaction_saved_tokens)}</span></div>` : ''}
+      ${keeper.context?.message_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Message Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.message_count}</span></div>` : ''}
+      ${keeper.context?.has_checkpoint != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Has Checkpoint</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.has_checkpoint ? 'Yes' : 'No'}</span></div>` : ''}
     </div>
   `
 }
@@ -295,14 +295,14 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 }
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state" class="text-[13px]">장비 없음</div>`
+  if (items.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">장비 없음</div>`
 
   return html`
-    <div class="keeper-equipment-list">
+    <div class="flex flex-col gap-1.5">
       ${items.map((item, i) => html`
-        <div class="keeper-equipment-row">
+        <div class="keeper-equipment-row rounded-md">
           <span>${item}</span>
-          <span class="keeper-gen-label">#${i + 1}</span>
+          <span class="text-cyan text-[var(--fs-xs)]">#${i + 1}</span>
         </div>
       `)}
     </div>
@@ -311,14 +311,14 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state" class="text-[13px]">관계 없음</div>`
+  if (entries.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">관계 없음</div>`
 
   return html`
-    <div class="keeper-k2k-list">
+    <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
         <div class="flex items-center gap-2 py-1.5 px-2.5 bg-[var(--white-3)] rounded-md">
-          <span class="keeper-mention-chip">${name}</span>
-          <span class="keeper-k2k-route">${relation}</span>
+          <span class="keeper-mention-chip rounded-full">${name}</span>
+          <span class="font-mono text-[var(--fs-xs)] text-[var(--text-dim)]">${relation}</span>
         </div>
       `)}
     </div>
@@ -332,7 +332,7 @@ export function TraitsList({ traits, label }: { traits: string[]; label: string 
     <div class="mb-3">
       <div class="text-[11px] text-[var(--text-dim)] uppercase tracking-wider mb-1.5">${label}</div>
       <div class="flex flex-wrap gap-1.5">
-        ${traits.map(t => html`<span class="keeper-mention-chip">${t}</span>`)}
+        ${traits.map(t => html`<span class="keeper-mention-chip rounded-full">${t}</span>`)}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -99,9 +99,9 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
   if (visibleRows.length === 0) return null
 
   return html`
-    <div class="keeper-signal-list">
+    <div class="flex flex-col gap-1.5">
       ${visibleRows.map(r => html`
-        <div class="keeper-signal-row">
+        <div class="keeper-signal-row rounded-lg">
           <span>${r.label}</span>
           <strong>${r.value}</strong>
         </div>
@@ -149,29 +149,29 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
 
   return html`
-    <div class="keeper-signal-list">
-      <div class="keeper-signal-row">
+    <div class="flex flex-col gap-1.5">
+      <div class="keeper-signal-row rounded-lg">
         <span>Room</span>
         <strong>${roomName}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Project</span>
         <strong>${project}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Cluster</span>
         <strong>${cluster}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Current task</span>
         <strong>${currentTaskLabel}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Skill route</span>
         <strong>${skillRouteLabel}</strong>
       </div>
       <div class="flex justify-end mt-1">
-        <button class="control-btn ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
+        <button class="control-btn rounded-lg ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
           Open tools panel
         </button>
       </div>
@@ -180,7 +180,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-[11px] text-[var(--text-slate)]">Currently permitted tools for this keeper runtime.</span>
         <div class="flex flex-wrap gap-1.5">
           ${allowedTools.length > 0
-            ? allowedTools.map(tool => html`<span class="pill">${tool}</span>`)
+            ? allowedTools.map(tool => html`<span class="pill rounded-full">${tool}</span>`)
             : html`<span class="text-xs text-[var(--text-dim)]">${allowlistFallback}</span>`}
         </div>
       </div>
@@ -189,19 +189,19 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-[11px] text-[var(--text-slate)]">Recent execution evidence from heartbeat or runtime telemetry.</span>
         <div class="flex flex-wrap gap-1.5">
           ${observedTools.length > 0
-            ? observedTools.map(tool => html`<span class="pill">${tool}</span>`)
+            ? observedTools.map(tool => html`<span class="pill rounded-full">${tool}</span>`)
             : html`<span class="text-xs text-[var(--text-dim)]">${observedFallback}</span>`}
         </div>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Tool calls</span>
         <strong>${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Evidence source</span>
         <strong>${auditSource ?? metadataFallback}</strong>
       </div>
-      <div class="keeper-signal-row">
+      <div class="keeper-signal-row rounded-lg">
         <span>Observed at</span>
         <strong>${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</strong>
       </div>
@@ -209,7 +209,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-xs text-[var(--text-dim)]">Keeper recent tools</span>
         <div class="flex flex-wrap gap-1.5">
           ${recentTools.length > 0
-            ? recentTools.map(tool => html`<span class="pill">${tool}</span>`)
+            ? recentTools.map(tool => html`<span class="pill rounded-full">${tool}</span>`)
             : html`<span class="text-xs text-[var(--text-dim)]">${linkedRecentFallback}</span>`}
         </div>
       </div>
@@ -218,7 +218,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
             <div class="flex flex-col gap-2 mt-2">
               <span class="text-xs text-[var(--text-dim)]">Window top tools</span>
               <div class="flex flex-wrap gap-1.5">
-                ${topTools.map(tool => html`<span class="pill">${tool}</span>`)}
+                ${topTools.map(tool => html`<span class="pill rounded-full">${tool}</span>`)}
               </div>
             </div>
           `
@@ -227,7 +227,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-xs text-[var(--text-dim)]">Capabilities</span>
         <div class="flex flex-wrap gap-1.5">
           ${capabilities.length > 0
-            ? capabilities.map(capability => html`<span class="pill">${capability}</span>`)
+            ? capabilities.map(capability => html`<span class="pill rounded-full">${capability}</span>`)
             : html`<span class="text-xs text-[var(--text-dim)]">등록된 capability 없음</span>`}
         </div>
       </div>
@@ -235,7 +235,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
         <span class="text-xs text-[var(--text-dim)]">Available actions nearby</span>
         <div class="flex flex-wrap gap-1.5">
           ${actions.length > 0
-            ? actions.map(action => html`<span class="pill">${actionDescriptorLabel(action.action_type)}</span>`)
+            ? actions.map(action => html`<span class="pill rounded-full">${actionDescriptorLabel(action.action_type)}</span>`)
             : html`<span class="text-xs text-[var(--text-dim)]">operator action 광고 없음</span>`}
         </div>
       </div>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -77,10 +77,10 @@ async function runSocialSweep(): Promise<void> {
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
-    <div class="keeper-comms-section">
-      <h3 class="keeper-comms-heading">Direct Comms</h3>
+    <div class="mt-5 border-t border-[var(--white-10)] pt-5">
+      <h3 class="m-0 mb-3.5 text-cyan text-[var(--fs-lg)]">Direct Comms</h3>
 
-      <div class="keeper-comms-layout">
+      <div class="flex flex-col gap-3.5">
         ${'' /* Chat takes full width — the primary interaction surface */}
         <div class="w-full">
           <${KeeperConversationPanel}
@@ -91,8 +91,8 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
 
         ${'' /* Diagnostics and actions in a collapsible panel below */}
         <details class="keeper-comms-diagnostics">
-          <summary class="keeper-comms-diagnostics-toggle">런타임 진단 및 액션</summary>
-          <div class="keeper-comms-diagnostics-body">
+          <summary class="keeper-comms-diagnostics-toggle cursor-pointer py-2.5 px-3.5 text-[var(--fs-sm)] text-text-muted tracking-[0.03em] list-none select-none">런타임 진단 및 액션</summary>
+          <div class="flex flex-col gap-3 px-3.5 pb-3.5">
             <${KeeperDiagnosticSummary} keeper=${keeper} />
             <${KeeperRuntimeActions}
               actor=${currentOperatorActor()}
@@ -131,7 +131,7 @@ export function KeeperDetailOverlay() {
               ${keeper.koreanName ? html`<div class="text-[13px] text-[var(--text-dim)]">${keeper.koreanName}</div>` : null}
             </div>
             <${StatusBadge} status=${keeper.status} />
-            ${keeper.model ? html`<span class="pill">${keeper.model}</span>` : null}
+            ${keeper.model ? html`<span class="pill rounded-full">${keeper.model}</span>` : null}
           </div>
           <button
             onClick=${() => closeKeeperDetail()}
@@ -230,12 +230,12 @@ export function KeeperDetailOverlay() {
           <//>
 
           <${Card} title="메모리 및 컨텍스트">
-            <div class="keeper-signal-list">
-              <div class="keeper-signal-row">
+            <div class="flex flex-col gap-1.5">
+              <div class="keeper-signal-row rounded-lg">
                 <span>Context source</span>
                 <strong>${keeper.context_source ?? keeper.context?.source ?? '-'}</strong>
               </div>
-              <div class="keeper-signal-row">
+              <div class="keeper-signal-row rounded-lg">
                 <span>Context tokens</span>
                 <strong>
                   ${keeper.context_tokens ?? keeper.context?.context_tokens ?? '-'}
@@ -245,11 +245,11 @@ export function KeeperDetailOverlay() {
               </div>
               ${keeper.memory_recent_note
                 ? html`
-                  <div class="keeper-memory-note">
+                  <div class="keeper-memory-note rounded-lg">
                     ${keeper.memory_recent_note}
                   </div>
                 `
-                : html`<div class="empty-state" class="text-xs">No recent memory note</div>`}
+                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-xs">No recent memory note</div>`}
             </div>
           <//>
         </div>

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -30,7 +30,7 @@ export function PipelineStageBar({ stage }: { stage?: PipelineStage | null }) {
     return html`
       <div class="pipeline-stage-bar">
         <div class="pipeline-stage-node active stage-offline">
-          <span class="pipeline-stage-dot"></span>
+          <span class="pipeline-stage-dot transition-all duration-300"></span>
           <span class="pipeline-stage-label">offline</span>
         </div>
       </div>
@@ -54,7 +54,7 @@ export function PipelineStageBar({ stage }: { stage?: PipelineStage | null }) {
         return html`
           ${i > 0 ? html`<span class="pipeline-stage-connector"></span>` : null}
           <div class=${nodeClass}>
-            <span class="pipeline-stage-dot"></span>
+            <span class="pipeline-stage-dot transition-all duration-300"></span>
             ${isActive
               ? html`<span class="pipeline-stage-label">${s.label}</span>`
               : null}
@@ -79,7 +79,7 @@ export function PipelineStageBadge({
     STAGES.find((s) => s.key === current)?.label ?? current
 
   return html`
-    <span class="pipeline-stage-badge stage-${current}">
+    <span class="pipeline-stage-badge rounded-full stage-${current}">
       ${label}
     </span>
   `

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -121,7 +121,7 @@ export function KeeperDiagnosticSummary({
   }, [keeper?.name])
 
   if (!keeper) {
-    return html`<div class="control-status-copy">Select a keeper to inspect direct reply state.</div>`
+    return html`<div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">Select a keeper to inspect direct reply state.</div>`
   }
 
   const detail = keeperStatusDetails.value[keeper.name]
@@ -129,31 +129,31 @@ export function KeeperDiagnosticSummary({
   const busy = keeperHydrating.value[keeper.name]
 
   return html`
-    <div class="control-result-box">
-      <div class="control-inline-meta">
+    <div class="py-[10px] px-3 rounded-[10px] border border-solid border-[rgba(138,163,211,0.24)] bg-[rgba(5,14,31,0.55)]">
+      <div class="control-inline-meta flex flex-wrap gap-1.5">
         ${continuityStateLabel(diagnostic?.continuity_state)
-          ? html`<span class="pill">${continuityStateLabel(diagnostic?.continuity_state)}</span>`
+          ? html`<span class="pill rounded-full">${continuityStateLabel(diagnostic?.continuity_state)}</span>`
           : null}
-        <span class="pill">${diagnostic?.health_state ?? 'unknown'}</span>
-        <span class="pill">${quietReasonLabel(diagnostic?.quiet_reason)}</span>
-        <span class="pill">next ${nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')}</span>
-        ${busy ? html`<span class="pill">refreshing</span>` : null}
+        <span class="pill rounded-full">${diagnostic?.health_state ?? 'unknown'}</span>
+        <span class="pill rounded-full">${quietReasonLabel(diagnostic?.quiet_reason)}</span>
+        <span class="pill rounded-full">next ${nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')}</span>
+        ${busy ? html`<span class="pill rounded-full">refreshing</span>` : null}
       </div>
-      <div class="control-status-copy">
+      <div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">
         ${diagnostic?.continuity_summary
           ?? diagnostic?.summary
           ?? 'Keeper diagnostic summary is not available yet. Probe or open the detail overlay to inspect current runtime state.'}
       </div>
-      <div class="control-status-copy">
+      <div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">
         Reply: ${diagnostic?.last_reply_status ?? 'unknown'}
         ${diagnostic?.last_reply_at ? html` · ${formatTime(diagnostic.last_reply_at)}` : null}
         ${diagnostic?.next_eligible_at_s ? html` · next eligible ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
       ${diagnostic?.last_error
-        ? html`<div class="control-status-copy text-[#ffb4b4]">${diagnostic.last_error}</div>`
+        ? html`<div class="control-status-copy text-[#ffb4b4] text-[length:var(--fs-sm)] leading-[1.5]">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<pre class="keeper-status-console">${detail?.rawText ?? 'No keeper status loaded yet.'}</pre>`
+        ? html`<pre class="mt-2 py-[10px] px-3 rounded-[10px] border border-solid border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[length:var(--fs-sm)] leading-[1.55] whitespace-pre-wrap break-words font-[family:'Fira_Code',monospace] max-h-[240px] overflow-auto">${detail?.rawText ?? 'No keeper status loaded yet.'}</pre>`
         : null}
     </div>
   `
@@ -201,11 +201,11 @@ export function KeeperConversationPanel({
   }
 
   return html`
-    <div class="keeper-conversation-shell">
+    <div class="keeper-conversation-shell flex flex-col gap-2.5">
       <div class="flex justify-end">
         <button
           type="button"
-          class="control-btn ghost"
+          class="control-btn rounded-lg ghost"
           onClick=${() => { setShowMetadata(!showMetadata) }}
         >
           ${showMetadata ? '메타 숨기기' : '메타 표시'}
@@ -226,7 +226,7 @@ export function KeeperConversationPanel({
         onSend=${() => { void submit() }}
         onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
       />
-      ${error ? html`<div class="control-status-copy text-[#ffb4b4]">${error}</div>` : null}
+      ${error ? html`<div class="control-status-copy text-[#ffb4b4] text-[length:var(--fs-sm)] leading-[1.5]">${error}</div>` : null}
     </div>
   `
 }
@@ -248,7 +248,7 @@ export function KeeperRuntimeActions({
   const canRecover = diagnostic?.recoverable ?? recommended === 'recover'
 
   return html`
-    <div class="control-actions">
+    <div class="control-actions flex flex-wrap gap-1.5">
       <button
         class=${`control-btn ghost ${recommended === 'probe' ? 'is-active' : ''}`}
         onClick=${() => {

--- a/dashboard/src/components/lab-unified.ts
+++ b/dashboard/src/components/lab-unified.ts
@@ -17,22 +17,22 @@ export function LabSurface() {
   const section = currentSection()
 
   return html`
-    <div class="tab-unified">
-      <div class="tab-pill-bar">
+    <div class="tab-unified grid gap-[var(--space-md,16px)]">
+      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
         <button
-          class="tab-pill ${section === 'overview' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'overview' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('lab', { section: 'overview' })}
         >
           개요
         </button>
         <button
-          class="tab-pill ${section === 'trpg' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'trpg' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('lab', { section: 'trpg' })}
         >
           TRPG
         </button>
         <button
-          class="tab-pill ${section === 'avatars' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'avatars' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('lab', { section: 'avatars' })}
         >
           아바타

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -11,7 +11,7 @@ function AvatarGallery() {
   const displayAgents = agentList.slice(0, 12)
 
   if (displayAgents.length === 0) {
-    return html`<div class="empty-state">에이전트 데이터를 불러오는 중...</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">에이전트 데이터를 불러오는 중...</div>`
   }
 
   return html`

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -26,7 +26,7 @@ function FilterBar() {
       ${FILTER_OPTIONS.map(opt => html`
         <button
           key=${opt.kind}
-          class="activity-filter-btn ${opt.cssClass} ${active.has(opt.kind) ? 'active' : ''}"
+          class="activity-filter-btn rounded-md ${opt.cssClass} ${active.has(opt.kind) ? 'active' : ''}"
           onClick=${() => toggleLiveFilter(opt.kind)}
         >
           ${opt.label}
@@ -40,7 +40,7 @@ export function ActivityStream() {
   const entries = filteredJournal.value
 
   return html`
-    <div class="activity-stream">
+    <div class="grid gap-2.5 grid-rows-[auto_auto_1fr] min-h-0">
       <div class="activity-stream-head">
         <h3>Activity Stream</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${entries.length} events</span>
@@ -52,14 +52,14 @@ export function ActivityStream() {
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}
-              class="activity-item ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
+              class="activity-item rounded-lg ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
-              <div class="activity-item-head">
-                <span class="activity-kind-chip ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
+              <div class="activity-item rounded-lg-head">
+                <span class="activity-kind-chip rounded ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
                 <span class="activity-agent">${entry.agent}</span>
                 <span class="activity-time">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="activity-item-text">${entry.text}</div>
+              <div class="activity-item rounded-lg-text">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -26,7 +26,7 @@ export function FocusSidebar() {
   const selected = selectedAgentName.value
 
   return html`
-    <div class="focus-sidebar">
+    <div class="grid gap-2.5 grid-rows-[auto_1fr] min-h-0">
       <div class="focus-sidebar-head">
         <h3>Agents</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length} active</span>
@@ -37,7 +37,7 @@ export function FocusSidebar() {
           : list.map(agent => html`
             <div
               key=${agent.name}
-              class="focus-agent-card ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card rounded-xl transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
@@ -45,13 +45,13 @@ export function FocusSidebar() {
                   ${agent.emoji ? html`<span class="text-[0.95rem]">${agent.emoji}</span>` : null}
                   ${agent.koreanName ?? agent.name}
                 </span>
-                <span class="focus-pressure-badge ${pressureClass(agent.pressure)}">
+                <span class="focus-pressure-badge rounded-md ${pressureClass(agent.pressure)}">
                   ${pressureLabel(agent.pressure)}
-                  ${agent.assignedCount > 0 ? html` <span class="focus-task-count">${agent.assignedCount}</span>` : null}
+                  ${agent.assignedCount > 0 ? html` <span class="focus-task-count rounded">${agent.assignedCount}</span>` : null}
                 </span>
               </div>
               ${agent.currentTask
-                ? html`<div class="focus-current-task">${agent.currentTask}</div>`
+                ? html`<div class="focus-current-task rounded-md">${agent.currentTask}</div>`
                 : null}
               <div class="focus-agent-footer">
                 ${agent.lastActivityText

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -18,14 +18,14 @@ export function PulseStrip() {
 
   if (pulses.length === 0) {
     return html`
-      <div class="pulse-strip">
+      <div class="pulse-strip rounded-xl">
         <span class="text-[rgba(255,255,255,0.3)] text-[0.8rem]">연결된 에이전트 없음</span>
       </div>
     `
   }
 
   return html`
-    <div class="pulse-strip">
+    <div class="pulse-strip rounded-xl">
       ${pulses.map(p => html`
         <button
           key=${p.name}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -46,11 +46,11 @@ export function LogViewer() {
   })
 
   return html`
-    <div class="logs-viewer">
-      <div class="logs-toolbar">
-        <div class="logs-filters">
+    <div class="logs-viewer flex flex-col gap-2 h-full min-h-0">
+      <div class="logs-toolbar flex justify-between items-center gap-4 py-2 shrink-0">
+        <div class="logs-filters flex gap-2 items-center">
           <select
-            class="logs-select"
+            class="logs-select rounded"
             value=${levelFilter.value}
             onChange=${(e: Event) => {
               levelFilter.value = (e.target as HTMLSelectElement).value
@@ -64,7 +64,7 @@ export function LogViewer() {
           </select>
 
           <input
-            class="logs-module-input"
+            class="logs-module-input rounded"
             type="text"
             placeholder="module filter"
             value=${moduleFilter.value}
@@ -77,7 +77,7 @@ export function LogViewer() {
           />
 
           <select
-            class="logs-select"
+            class="logs-select rounded"
             value=${String(logLimit.value)}
             onChange=${(e: Event) => {
               logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -91,9 +91,9 @@ export function LogViewer() {
           </select>
         </div>
 
-        <div class="logs-actions">
+        <div class="logs-actions flex gap-3 items-center text-[0.75rem] text-[color:var(--text-muted)]">
           <span class="tabular-nums">${(logTotal.value ?? 0).toLocaleString()}건</span>
-          <label class="logs-auto-label">
+          <label class="logs-auto-label flex items-center gap-1 cursor-pointer">
             <input
               type="checkbox"
               checked=${autoRefresh.value}
@@ -101,7 +101,7 @@ export function LogViewer() {
             />
             자동
           </label>
-          <button class="logs-refresh-btn" onClick=${() => { void loadLogs() }}
+          <button class="logs-refresh-btn rounded" onClick=${() => { void loadLogs() }}
             disabled=${logLoading.value}>
             ${logLoading.value ? '...' : '새로고침'}
           </button>
@@ -109,27 +109,27 @@ export function LogViewer() {
       </div>
 
       ${logError.value ? html`
-        <div class="logs-error">${logError.value}</div>
+        <div class="p-2 bg-[rgba(224,80,80,0.15)] border border-solid border-[#e05050] text-[#e05050] text-[0.8rem] rounded">${logError.value}</div>
       ` : null}
 
-      <div class="logs-table-wrap">
+      <div class="logs-table-wrap rounded">
         <table class="logs-table">
           <thead>
             <tr>
-              <th class="logs-col-ts">timestamp</th>
-              <th class="logs-col-level">level</th>
-              <th class="logs-col-module">module</th>
+              <th class="logs-col-ts w-44 whitespace-nowrap text-[color:var(--text-muted)]">timestamp</th>
+              <th class="logs-col-level w-14 whitespace-nowrap font-semibold">level</th>
+              <th class="logs-col-module w-32 whitespace-nowrap text-[color:var(--accent)]">module</th>
               <th class="break-words">message</th>
             </tr>
           </thead>
           <tbody>
             ${logEntries.value.map(entry => html`
               <tr key=${entry.seq} class="logs-row logs-level-${entry.level.toLowerCase()}">
-                <td class="logs-col-ts">${entry.ts.replace('T', ' ').replace('Z', '')}</td>
-                <td class="logs-col-level" style="color: ${LEVEL_COLORS[entry.level] ?? 'inherit'}">
+                <td class="logs-col-ts w-44 whitespace-nowrap text-[color:var(--text-muted)]">${entry.ts.replace('T', ' ').replace('Z', '')}</td>
+                <td class="logs-col-level w-14 whitespace-nowrap font-semibold" style="color: ${LEVEL_COLORS[entry.level] ?? 'inherit'}">
                   ${entry.level}
                 </td>
-                <td class="logs-col-module">${entry.module}</td>
+                <td class="logs-col-module w-32 whitespace-nowrap text-[color:var(--accent)]">${entry.module}</td>
                 <td class="break-words">${entry.message}</td>
               </tr>
             `)}

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -107,8 +107,8 @@ function expiryChip(post: BoardPost) {
   if (!post.expires_at) return null
   const expiresAtMs = Date.parse(post.expires_at)
   if (!Number.isFinite(expiresAtMs)) return null
-  if (expiresAtMs <= Date.now()) return html`<span class="board-meta-chip">만료됨</span>`
-  return html`<span class="board-meta-chip">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
+  if (expiresAtMs <= Date.now()) return html`<span class="board-meta-chip rounded-full">만료됨</span>`
+  return html`<span class="board-meta-chip rounded-full">만료까지 <${TimeAgo} timestamp=${post.expires_at} /></span>`
 }
 
 async function loadPostDetail(postId: string) {
@@ -177,7 +177,7 @@ function SortBar() {
       <div class="board-controls">
         ${SORT_MODES.map(mode => html`
           <button
-            class="board-sort-btn ${current === mode.id ? 'active' : ''}"
+            class="board-sort-btn rounded-lg transition-all duration-200 ${current === mode.id ? 'active' : ''}"
             onClick=${() => {
               boardSortMode.value = mode.id
               visibleLimit.value = PAGE_SIZE
@@ -190,7 +190,7 @@ function SortBar() {
       </div>
       <div class="board-toolbar-actions">
         <button
-          class="control-btn ghost ${hideAutomationPosts.value ? 'is-active' : ''}"
+          class="control-btn rounded-lg ghost ${hideAutomationPosts.value ? 'is-active' : ''}"
           onClick=${() => {
             hideAutomationPosts.value = !hideAutomationPosts.value
           }}
@@ -198,7 +198,7 @@ function SortBar() {
           ${hideLabel}
         </button>
         <button
-          class="control-btn ghost ${boardExcludeSystem.value ? 'is-active' : ''}"
+          class="control-btn rounded-lg ghost ${boardExcludeSystem.value ? 'is-active' : ''}"
           onClick=${() => {
             boardExcludeSystem.value = !boardExcludeSystem.value
             refreshBoard()
@@ -206,7 +206,7 @@ function SortBar() {
         >
           ${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 글 표시 중'}
         </button>
-        <button class="control-btn ghost" onClick=${refreshBoard} disabled=${boardLoading.value}>
+        <button class="control-btn rounded-lg ghost" onClick=${refreshBoard} disabled=${boardLoading.value}>
           ${boardLoading.value ? '새로고침 중...' : '새로고침'}
         </button>
       </div>
@@ -256,7 +256,7 @@ function PostCard({ post }: { post: BoardPost }) {
   }
 
   return html`
-    <div class="board-post" onClick=${() => navigateToPost(post.id)}>
+    <div class="board-post rounded-xl" onClick=${() => navigateToPost(post.id)}>
       <div class="vote-column">
         <button class="vote-btn upvote" onClick=${(event: Event) => handleVote('up', event)}>▲</button>
         <span class="vote-count">${post.votes ?? 0}</span>
@@ -267,13 +267,13 @@ function PostCard({ post }: { post: BoardPost }) {
             <div class="post-title-row">
               <div class="text-[#e8f0ff]">${post.title}</div>
               <div class="post-chip-row">
-                ${isUpdated(post) ? html`<span class="board-meta-chip">수정됨</span>` : null}
-                ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip">${boardPostKind(post)}</span>` : null}
-                ${post.hearth ? html`<span class="board-meta-chip">${post.hearth}</span>` : null}
-                ${post.visibility ? html`<span class="board-meta-chip">${post.visibility}</span>` : null}
+                ${isUpdated(post) ? html`<span class="board-meta-chip rounded-full">수정됨</span>` : null}
+                ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip rounded-full">${boardPostKind(post)}</span>` : null}
+                ${post.hearth ? html`<span class="board-meta-chip rounded-full">${post.hearth}</span>` : null}
+                ${post.visibility ? html`<span class="board-meta-chip rounded-full">${post.visibility}</span>` : null}
               </div>
             </div>
-          <div class="post-meta">
+          <div class="post-meta flex gap-2.5 items-center flex-wrap">
             <span>작성자 <a class="author-link" class="cursor-pointer underline" onClick=${(e: Event) => { e.stopPropagation(); navigate('status', { section: 'agents', agent: post.author }) }}>${post.author}</a></span>
             <span><${TimeAgo} timestamp=${post.created_at} /></span>
             ${isUpdated(post) ? html`<span>수정 <${TimeAgo} timestamp=${post.updated_at} /></span>` : null}
@@ -288,12 +288,12 @@ function PostCard({ post }: { post: BoardPost }) {
 }
 
 function CommentThread({ comments }: { comments: BoardComment[] }) {
-  if (comments.length === 0) return html`<div class="empty-state" class="text-[13px]">아직 댓글이 없습니다</div>`
+  if (comments.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">아직 댓글이 없습니다</div>`
 
   return html`
-    <div class="comment-thread">
+    <div class="comment-thread flex flex-col gap-2">
       ${comments.map(comment => html`
-        <div key=${comment.id} class="board-comment">
+        <div key=${comment.id} class="board-comment rounded-lg">
           <span class="comment-author"><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a></span>
           <span class="comment-time"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <div class="comment-text">${comment.content}</div>
@@ -344,13 +344,13 @@ function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button class="back-btn" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+      <button class="back-btn rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
       <${Card} title=${post.title}>
         <div class="board-detail p-5">
           <div class="post-body">
             <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
-          <div class="post-meta" class="mt-3">
+          <div class="post-meta flex gap-2.5 items-center flex-wrap mt-3">
             <span><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a></span>
             <${TimeAgo} timestamp=${post.created_at} />
             <span>${post.votes ?? 0} votes</span>
@@ -358,9 +358,9 @@ function PostDetail({ post }: { post: BoardPost }) {
           ${(post.hearth || post.visibility || post.expires_at)
             ? html`
                 <div class="post-chip-row" class="mt-2">
-                  ${post.hearth ? html`<span class="board-meta-chip">${post.hearth}</span>` : null}
-                  ${post.visibility ? html`<span class="board-meta-chip">${post.visibility}</span>` : null}
-                  ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip">${boardPostKind(post)}</span>` : null}
+                  ${post.hearth ? html`<span class="board-meta-chip rounded-full">${post.hearth}</span>` : null}
+                  ${post.visibility ? html`<span class="board-meta-chip rounded-full">${post.visibility}</span>` : null}
+                  ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip rounded-full">${boardPostKind(post)}</span>` : null}
                   ${expiryChip(post)}
                 </div>
               `
@@ -387,7 +387,7 @@ function PostDetail({ post }: { post: BoardPost }) {
 
       <${Card} title="댓글">
         ${detailLoading.value
-          ? html`<div class="loading-indicator">댓글 불러오는 중...</div>`
+          ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">댓글 불러오는 중...</div>`
           : html`<${CommentThread} comments=${detailComments.value} />`}
         <${CommentForm} postId=${post.id} />
       <//>
@@ -416,10 +416,10 @@ export function Memory() {
       : html`
           <div>
             <${MemorySummary} />
-            <button class="back-btn" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+            <button class="back-btn rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
             ${detailLoading.value
-              ? html`<div class="loading-indicator">글 불러오는 중...</div>`
-              : html`<div class="empty-state">글을 찾지 못했습니다</div>`}
+              ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">글 불러오는 중...</div>`
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">글을 찾지 못했습니다</div>`}
           </div>
         `
   }
@@ -429,18 +429,18 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${boardLoading.value
-        ? html`<div class="loading-indicator">메모리 피드 불러오는 중...</div>`
+        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">메모리 피드 불러오는 중...</div>`
         : posts.length === 0
-          ? html`<div class="empty-state">아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다.</div>`
+          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다.</div>`
           : html`
               <${Card} title="사람이 쓴 글" class="section mb-3.5">
-                <div class="board-post-list">
+                <div class="board-post rounded-xl-list flex flex-col gap-2">
                   ${grouped.human.slice(0, visibleLimit.value).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
                 </div>
                 ${grouped.human.length > visibleLimit.value ? html`
                   <div class="text-center py-3">
                     <button
-                      class="control-btn ghost"
+                      class="control-btn rounded-lg ghost"
                       onClick=${() => { visibleLimit.value = visibleLimit.value + PAGE_SIZE }}
                     >
                       더 보기 (${grouped.human.length - visibleLimit.value}개 남음)
@@ -451,7 +451,7 @@ export function Memory() {
               ${grouped.operations.length > 0
                 ? html`
                     <${Card} title="자동화 · 시스템" class="section mb-3.5">
-                      <div class="board-post-list">
+                      <div class="board-post rounded-xl-list flex flex-col gap-2">
                         ${grouped.operations.map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
                       </div>
                     <//>

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -32,7 +32,7 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
       ? row.recentTools.join(', ')
       : toolAuditStateLabel(observedToolsEmptyState(row.keeper, row.brief.tool_audit_source))
   return html`
-    <article class="mission-activity-card ${toneClass(row.brief.status ?? row.agent?.status)}">
+    <article class="mission-activity-card rounded-xl ${toneClass(row.brief.status ?? row.agent?.status)}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => openAgentDetail(row.brief.agent_name)}>
         <div class="flex justify-between gap-2.5 items-start">
           <div class="flex gap-2.5 items-start">
@@ -42,7 +42,7 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
               <span>${info.model !== info.nickname ? `${info.model} · ` : ''}${info.nickname}</span>
             </div>
           </div>
-          <span class="command-chip ${toneClass(row.brief.status ?? row.agent?.status)}">${statusLabel(row.brief.status ?? row.agent?.status)}</span>
+          <span class="command-chip rounded-full ${toneClass(row.brief.status ?? row.agent?.status)}">${statusLabel(row.brief.status ?? row.agent?.status)}</span>
         </div>
 
         <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
@@ -102,7 +102,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
       : toolAuditStateLabel(linkedRecentToolsEmptyState(row.keeper))
 
   return html`
-    <article class="mission-activity-card ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
+    <article class="mission-activity-card rounded-xl ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => {
         const keeper: Keeper = row.keeper ?? {
           name: row.brief.name,
@@ -121,7 +121,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
               ${row.keeper?.koreanName ? html`<span>${row.keeper.koreanName}</span>` : null}
             </div>
           </div>
-          <span class="command-chip ${toneClass(row.brief.status ?? row.keeper?.status)}">${statusLabel(row.brief.status ?? row.keeper?.status)}</span>
+          <span class="command-chip rounded-full ${toneClass(row.brief.status ?? row.keeper?.status)}">${statusLabel(row.brief.status ?? row.keeper?.status)}</span>
         </div>
 
         <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
@@ -167,9 +167,9 @@ export function InternalSignalCard({ item }: { item: DashboardMissionInternalSig
   const action = item.action ?? null
   const attention = item.attention ?? null
   return html`
-    <article class="mission-action-card ${toneClass(item.severity)}">
+    <article class="mission-action-card rounded-xl ${toneClass(item.severity)}">
       <div class="flex justify-between gap-2 items-start flex-wrap">
-        <span class="command-chip ${toneClass(item.severity)}">
+        <span class="command-chip rounded-full ${toneClass(item.severity)}">
           ${item.signal_type === 'action' && action ? workflowActionLabel(action.action_type) : attention?.kind ?? '내부 신호'}
         </span>
         <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
@@ -179,13 +179,13 @@ export function InternalSignalCard({ item }: { item: DashboardMissionInternalSig
       <div class="flex gap-2 flex-wrap mt-2.5">
         ${action
           ? html`
-              <button class="control-btn ghost" onClick=${() => openActionIntervene(action, attention, '상황판 내부 신호')}>이 액션으로 개입 열기</button>
-              <button class="control-btn ghost" onClick=${() => openActionCommand(action, attention, '상황판 내부 신호')}>이 이슈의 원인 보기</button>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, attention, '상황판 내부 신호')}>이 액션으로 개입 열기</button>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openActionCommand(action, attention, '상황판 내부 신호')}>이 이슈의 원인 보기</button>
             `
           : attention
             ? html`
-                <button class="control-btn ghost" onClick=${() => openIncidentIntervene(attention)}>이 이슈로 개입 열기</button>
-                <button class="control-btn ghost" onClick=${() => openIncidentCommand(attention)}>이 이슈의 원인 보기</button>
+                <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentIntervene(attention)}>이 이슈로 개입 열기</button>
+                <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentCommand(attention)}>이 이슈의 원인 보기</button>
               `
             : null}
       </div>

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -37,14 +37,14 @@ export function AttentionCard({
   const action = item.top_action ?? null
 
   return html`
-    <article class="mission-attention-card ${toneClass(action?.severity ?? item.severity)} ${selected ? 'is-selected' : ''}">
+    <article class="mission-attention-card rounded-xl ${toneClass(action?.severity ?? item.severity)} ${selected ? 'is-selected' : ''}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleAttention(item.id)}>
         <div class="flex justify-between gap-2 items-start flex-wrap">
           <div>
             <strong>${item.summary}</strong>
             <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</div>
           </div>
-          <span class="command-chip ${toneClass(action?.severity ?? item.severity)}">${action ? actionModeLabel(action) : item.severity}</span>
+          <span class="command-chip rounded-full ${toneClass(action?.severity ?? item.severity)}">${action ? actionModeLabel(action) : item.severity}</span>
         </div>
 
         <div class="grid grid-cols-2 gap-2.5">
@@ -86,7 +86,7 @@ export function AttentionCard({
                 `)}
               </div>
             `
-          : html`<div class="empty-state">직접 연결된 세션이 아직 없습니다.</div>`}
+          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">직접 연결된 세션이 아직 없습니다.</div>`}
 
         ${item.related_agent_names.length > 0
           ? html`
@@ -113,16 +113,16 @@ export function AttentionCard({
       <div class="flex gap-2 flex-wrap mt-2.5">
         ${action
           ? html`
-              <button class="control-btn ghost" onClick=${() => openActionIntervene(action, incident, '상황판 주의 신호')}>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, incident, '상황판 주의 신호')}>
                 이 액션으로 개입 열기
               </button>
-              <button class="control-btn ghost" onClick=${() => openActionCommand(action, incident, '상황판 주의 신호')}>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openActionCommand(action, incident, '상황판 주의 신호')}>
                 원인 보기
               </button>
             `
           : html`
-              <button class="control-btn ghost" onClick=${() => openIncidentIntervene(incident)}>이 이슈로 개입 열기</button>
-              <button class="control-btn ghost" onClick=${() => openIncidentCommand(incident)}>이 이슈의 원인 보기</button>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentIntervene(incident)}>이 이슈로 개입 열기</button>
+              <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentCommand(incident)}>이 이슈의 원인 보기</button>
             `}
       </div>
     </article>

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -18,7 +18,7 @@ export function MissionBriefingCard() {
     || (briefing?.status === 'unavailable' && !briefing?.cached)
 
   return html`
-    <${Card} title="판단 레이어" class="mission-briefing-card">
+    <${Card} title="판단 레이어" class="mission-briefing-card rounded-xl">
       <div class="grid gap-1 mb-3">
         <h3>왜 그렇게 보이나</h3>
         <p>사회 truth를 읽은 뒤에만 별도 판단 결과를 참고하고, 근거는 접어서 둡니다.</p>
@@ -31,18 +31,18 @@ export function MissionBriefingCard() {
       </div>
 
       <div class="flex gap-2 flex-wrap mb-3">
-        <span class="command-chip ${briefingTone}">
+        <span class="command-chip rounded-full ${briefingTone}">
           ${statusLabel(briefing?.status ?? (missionBriefingError.value ? 'error' : 'loading'))}
         </span>
-        ${briefing?.model ? html`<span class="command-chip">${briefing.model}</span>` : null}
-        ${briefing?.generated_at ? html`<span class="command-chip">${relativeTime(briefing.generated_at)}</span>` : null}
-        ${briefing?.cached ? html`<span class="command-chip">캐시</span>` : null}
-        ${briefing?.stale ? html`<span class="command-chip warn">오래됨</span>` : null}
-        ${briefing?.refreshing ? html`<span class="command-chip warn">갱신 중</span>` : null}
+        ${briefing?.model ? html`<span class="command-chip rounded-full">${briefing.model}</span>` : null}
+        ${briefing?.generated_at ? html`<span class="command-chip rounded-full">${relativeTime(briefing.generated_at)}</span>` : null}
+        ${briefing?.cached ? html`<span class="command-chip rounded-full">캐시</span>` : null}
+        ${briefing?.stale ? html`<span class="command-chip rounded-full warn">오래됨</span>` : null}
+        ${briefing?.refreshing ? html`<span class="command-chip rounded-full warn">갱신 중</span>` : null}
       </div>
 
-      ${missionBriefingError.value ? html`<div class="empty-state error">${missionBriefingError.value}</div>` : null}
-      ${briefing?.error ? html`<div class="empty-state error">${briefing.error}</div>` : null}
+      ${missionBriefingError.value ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${missionBriefingError.value}</div>` : null}
+      ${briefing?.error ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${briefing.error}</div>` : null}
       ${briefing?.summary ? html`<div class="grid gap-1">${briefing.summary}</div>` : null}
       ${briefing?.last_error && !briefing.error
         ? html`<div class="grid gap-1">최근 갱신 실패: ${briefing.last_error}</div>`
@@ -52,15 +52,15 @@ export function MissionBriefingCard() {
         ? html`
             <div class="grid grid-cols-3 gap-3">
               ${briefing.sections.slice(0, 3).map(section => html`
-                <article class="mission-briefing-section ${toneClass(section.status)}">
+                <article class="mission-briefing-section rounded-xl ${toneClass(section.status)}">
                   <div class="flex justify-between gap-2 items-start flex-wrap">
                     <strong>${section.label}</strong>
                     <div class="flex gap-2 flex-wrap justify-end">
-                      <span class="command-chip ${toneClass(section.status)}">${statusLabel(section.status)}</span>
+                      <span class="command-chip rounded-full ${toneClass(section.status)}">${statusLabel(section.status)}</span>
                       ${signalClassLabel(section.signal_class)
-                        ? html`<span class="command-chip ${section.signal_class === 'mixed' ? 'warn' : ''}">${signalClassLabel(section.signal_class)}</span>`
+                        ? html`<span class="command-chip rounded-full ${section.signal_class === 'mixed' ? 'warn' : ''}">${signalClassLabel(section.signal_class)}</span>`
                         : null}
-                      ${section.evidence_quality ? html`<span class="command-chip">${section.evidence_quality}</span>` : null}
+                      ${section.evidence_quality ? html`<span class="command-chip rounded-full">${section.evidence_quality}</span>` : null}
                     </div>
                   </div>
                   <p>${section.summary}</p>
@@ -80,7 +80,7 @@ export function MissionBriefingCard() {
           `
         : (!missionBriefingLoading.value && !missionBriefingError.value && showEmpty
             ? html`
-                <div class="empty-state">
+                <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
                   ${briefing?.status === 'pending'
                     ? '최신 스냅샷으로 브리핑을 생성 중입니다. 마지막 성공 결과가 생기면 자동으로 다시 읽습니다.'
                     : '판단 결과가 아직 없습니다.'}
@@ -94,10 +94,10 @@ export function MissionBriefingCard() {
               <summary>관측 공백 (${briefing.metadata_gap_count ?? briefing.metadata_gaps.length})</summary>
               <div class="flex flex-col gap-3">
                 ${briefing.metadata_gaps.map(item => html`
-                  <article class="mission-briefing-gap ${item.severity === 'watch' ? 'warn' : ''}">
+                  <article class="mission-briefing-gap rounded-xl ${item.severity === 'watch' ? 'warn' : ''}">
                     <div class="flex justify-between gap-2 items-start flex-wrap">
                       <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
-                      <span class="command-chip ${item.severity === 'watch' ? 'warn' : ''}">${statusLabel(item.severity)}</span>
+                      <span class="command-chip rounded-full ${item.severity === 'watch' ? 'warn' : ''}">${statusLabel(item.severity)}</span>
                     </div>
                     <p>${item.summary}</p>
                   </article>
@@ -108,10 +108,10 @@ export function MissionBriefingCard() {
         : null}
 
       <div class="flex gap-2 flex-wrap mt-2.5">
-        <button class="control-btn ghost" onClick=${() => { void refreshMissionBriefing(retryNeedsForce) }} disabled=${missionBriefingLoading.value}>
+        <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshMissionBriefing(retryNeedsForce) }} disabled=${missionBriefingLoading.value}>
           ${missionBriefingLoading.value ? '응답 기다리는 중…' : '판단 다시 읽기'}
         </button>
-        <button class="control-btn ghost" onClick=${() => { void refreshMissionBriefing(true) }} disabled=${missionBriefingLoading.value}>
+        <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshMissionBriefing(true) }} disabled=${missionBriefingLoading.value}>
           강제 갱신
         </button>
       </div>

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -59,7 +59,7 @@ export function SummaryStat({
   tone?: string | null
 }) {
   return html`
-    <article class="mission-stat-card p-3.5 rounded-[14px] border border-[var(--white-8)] bg-[var(--white-4)] grid gap-1.5 ${toneClass(tone)}">
+    <article class="mission-stat-card rounded-xl p-3.5 rounded-[14px] border border-[var(--white-8)] bg-[var(--white-4)] grid gap-1.5 ${toneClass(tone)}">
       <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">${label}</span>
       <strong class="text-[var(--text-strong)] text-[26px] leading-none">${value}</strong>
       <small class="text-[rgba(255,255,255,0.68)] leading-[1.45]">${detail}</small>

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -32,7 +32,7 @@ export function SessionBriefCard({
   const plannedCount = brief.planned_count ?? brief.member_names.length
 
   return html`
-    <article class="mission-crew-card ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${liveStateClass(brief.status, brief.health)} ${selected ? 'is-selected' : ''}">
+    <article class="mission-crew-card rounded-xl ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${liveStateClass(brief.status, brief.health)} ${selected ? 'is-selected' : ''}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleSession(brief.session_id)}>
         <div class="flex justify-between gap-2 items-start flex-wrap">
           <div>
@@ -42,7 +42,7 @@ export function SessionBriefCard({
             </div>
             <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
           </div>
-          <span class="command-chip ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
+          <span class="command-chip rounded-full ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
         </div>
 
         <div class="grid grid-cols-2 gap-2.5">
@@ -108,10 +108,10 @@ export function SessionBriefCard({
         : null}
 
       <div class="flex gap-2 flex-wrap mt-2.5">
-        <button class="control-btn ghost" onClick=${() => openSession('intervene', brief.session_id)}>세션 개입 열기</button>
-        <button class="control-btn ghost" onClick=${() => openSession('command', brief.session_id)}>세션 원인 보기</button>
+        <button class="control-btn rounded-lg ghost" onClick=${() => openSession('intervene', brief.session_id)}>세션 개입 열기</button>
+        <button class="control-btn rounded-lg ghost" onClick=${() => openSession('command', brief.session_id)}>세션 원인 보기</button>
         ${action
-          ? html`<button class="control-btn ghost" onClick=${() => openActionIntervene(action, incident, '상황판 세션 요약')}>추천 액션 열기</button>`
+          ? html`<button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, incident, '상황판 세션 요약')}>추천 액션 열기</button>`
           : null}
       </div>
     </article>
@@ -129,16 +129,16 @@ export function SessionDetailCard({
 }) {
   if (loading && !detail) {
     return html`
-      <${Card} title="세션 상세" class="mission-list-card">
-        <div class="loading-indicator">세션 상세 불러오는 중...</div>
+      <${Card} title="세션 상세" class="mission-list-card rounded-xl">
+        <div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">세션 상세 불러오는 중...</div>
       <//>
     `
   }
 
   if (error && !detail) {
     return html`
-      <${Card} title="세션 상세" class="mission-list-card">
-        <div class="empty-state error">${error}</div>
+      <${Card} title="세션 상세" class="mission-list-card rounded-xl">
+        <div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${error}</div>
       <//>
     `
   }
@@ -149,7 +149,7 @@ export function SessionDetailCard({
 
   const session = detail.session
   return html`
-    <${Card} title="세션 상세" class="mission-list-card">
+    <${Card} title="세션 상세" class="mission-list-card rounded-xl">
       <div class="grid gap-1 mb-3">
         <h3 class="m-0 text-[var(--text-strong)] text-lg">${session.goal}</h3>
         <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">${session.session_id}${session.room ? ` · ${session.room}` : ''}</p>
@@ -161,7 +161,7 @@ export function SessionDetailCard({
         <div class="grid gap-2.5">
           <div class="flex justify-between gap-2 items-start flex-wrap">
             <strong>타임라인</strong>
-            <span class="command-chip">${detail.timeline.length}</span>
+            <span class="command-chip rounded-full">${detail.timeline.length}</span>
           </div>
           <div class="flex flex-col gap-2.5">
             ${detail.timeline.length > 0
@@ -174,14 +174,14 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.68)] leading-[1.45]">${item.actor ? `${item.actor} · ` : ''}${item.event_type ?? '이벤트'}</small>
                   </article>
                 `)
-              : html`<div class="empty-state">표시할 세션 이벤트가 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">표시할 세션 이벤트가 없습니다.</div>`}
           </div>
         </div>
 
         <div class="grid gap-2.5">
           <div class="flex justify-between gap-2 items-start flex-wrap">
             <strong>참여자</strong>
-            <span class="command-chip">${detail.participants.length}</span>
+            <span class="command-chip rounded-full">${detail.participants.length}</span>
           </div>
           <div class="flex flex-col gap-3 compact">
             ${detail.participants.length > 0
@@ -195,7 +195,7 @@ export function SessionDetailCard({
                     </small>
                   </button>
                 `)
-              : html`<div class="empty-state">세션 참여자 미리보기가 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">세션 참여자 미리보기가 없습니다.</div>`}
           </div>
         </div>
       </div>
@@ -204,7 +204,7 @@ export function SessionDetailCard({
         <div class="grid gap-2.5">
           <div class="flex justify-between gap-2 items-start flex-wrap">
             <strong>연결된 작전</strong>
-            <span class="command-chip">${detail.operations.length}</span>
+            <span class="command-chip rounded-full">${detail.operations.length}</span>
           </div>
           <div class="flex flex-col gap-2 mt-2.5">
             ${detail.operations.length > 0
@@ -215,14 +215,14 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}</small>
                   </button>
                 `)
-              : html`<div class="empty-state">연결된 작전이 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">연결된 작전이 없습니다.</div>`}
           </div>
         </div>
 
         <div class="grid gap-2.5">
           <div class="flex justify-between gap-2 items-start flex-wrap">
             <strong>연속성 관찰</strong>
-            <span class="command-chip">${detail.keepers.length}</span>
+            <span class="command-chip rounded-full">${detail.keepers.length}</span>
           </div>
           <div class="flex flex-col gap-2 mt-2.5">
             ${detail.keepers.length > 0
@@ -233,7 +233,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${keeper.current_work ?? '현재 작업 정보 없음'}</small>
                   </div>
                 `)
-              : html`<div class="empty-state">직접 연결된 키퍼는 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">직접 연결된 키퍼는 없습니다.</div>`}
           </div>
         </div>
       </div>

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -35,13 +35,13 @@ import { ProvenanceStrip } from './common/provenance-strip'
 export function Mission() {
   const mission = missionSnapshot.value
   if (missionLoading.value && !mission) {
-    return html`<div class="loading-indicator">상황판 스냅샷 불러오는 중...</div>`
+    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">상황판 스냅샷 불러오는 중...</div>`
   }
   if (missionError.value && !mission) {
-    return html`<div class="empty-state error">${missionError.value}</div>`
+    return html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${missionError.value}</div>`
   }
   if (!mission) {
-    return html`<div class="empty-state">상황판 스냅샷이 아직 없습니다.</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">상황판 스냅샷이 아직 없습니다.</div>`
   }
 
   const sessionRows = mission.sessions
@@ -120,9 +120,9 @@ export function Mission() {
           <p>지금 어떤 세션이 돌고 있고, 누가 참여하며, 어디가 막혔는지를 한 시점에서 읽는 기본 관찰면입니다.</p>
         </div>
         <div class="flex gap-2 flex-wrap items-center">
-          <span class="command-chip ${toneClass(mission.summary.room_health)}">${statusLabel(mission.summary.room_health)}</span>
-          <span class="command-chip">${mission.summary.project ?? '프로젝트 미지정'}${mission.summary.current_room ? ` · ${mission.summary.current_room}` : ''}</span>
-          <span class="command-chip">${mission.generated_at ? relativeTime(mission.generated_at) : '기록 없음'}</span>
+          <span class="command-chip rounded-full ${toneClass(mission.summary.room_health)}">${statusLabel(mission.summary.room_health)}</span>
+          <span class="command-chip rounded-full">${mission.summary.project ?? '프로젝트 미지정'}${mission.summary.current_room ? ` · ${mission.summary.current_room}` : ''}</span>
+          <span class="command-chip rounded-full">${mission.generated_at ? relativeTime(mission.generated_at) : '기록 없음'}</span>
         </div>
       </div>
 
@@ -178,23 +178,23 @@ export function Mission() {
         />
       </div>
 
-      <nav class="mission-jump-strip">
-        <a class="mission-jump-link" href="#mission-sessions">세션 ${sessionRows.length}</a>
-        <a class="mission-jump-link" href="#mission-keepers">키퍼 ${keeperRows.length}</a>
-        <a class="mission-jump-link" href="#mission-output">활동</a>
-        <a class="mission-jump-link" href="#mission-attention">우선순위 ${attentionQueue.length}</a>
+      <nav class="mission-jump-strip flex gap-2 flex-wrap">
+        <a class="mission-jump-link rounded-full" href="#mission-sessions">세션 ${sessionRows.length}</a>
+        <a class="mission-jump-link rounded-full" href="#mission-keepers">키퍼 ${keeperRows.length}</a>
+        <a class="mission-jump-link rounded-full" href="#mission-output">활동</a>
+        <a class="mission-jump-link rounded-full" href="#mission-attention">우선순위 ${attentionQueue.length}</a>
       </nav>
 
       ${activeSessionId
         ? html`
             <div class="mt-3.5 py-2.5 px-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] flex items-center justify-between gap-3 text-[rgba(255,255,255,0.78)]">
               <span>현재 관찰 세션 · ${focusSession?.goal ?? activeSessionId}${activeAttention ? ` · ${activeAttention.summary}` : ''}</span>
-              <button class="control-btn ghost" onClick=${clearMissionSelection}>선택 해제</button>
+              <button class="control-btn rounded-lg ghost" onClick=${clearMissionSelection}>선택 해제</button>
             </div>
           `
         : null}
 
-      <${Card} title="진행중인 세션" class="mission-list-card" id="mission-sessions">
+      <${Card} title="진행중인 세션" class="mission-list-card rounded-xl" id="mission-sessions">
         <div class="grid gap-1 mb-3">
           <h3 class="m-0 text-[var(--text-strong)] text-lg">지금 진행중인 일</h3>
           <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">세션을 기준으로 목표, 최근 흐름, 막힘, 연결된 작전을 먼저 읽고 사회의 현재 상태를 파악합니다.</p>
@@ -203,7 +203,7 @@ export function Mission() {
         <div class="flex flex-col gap-3">
           ${sessionRows.length > 0
             ? sessionRows.map(row => html`<${SessionBriefCard} key=${row.session_id} brief=${row} selected=${activeSessionId === row.session_id} />`)
-            : html`<div class="empty-state">지금 보이는 팀 세션이 없습니다.</div>`}
+            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 보이는 팀 세션이 없습니다.</div>`}
         </div>
       <//>
 
@@ -214,8 +214,8 @@ export function Mission() {
       />
 
       <details open id="mission-keepers" class="mission-collapsible-section">
-        <summary class="mission-collapsible-summary">키퍼 연속성 <span class="monitor-pill">${keeperRows.length}</span>${keeperStatusWarnings > 0 ? html` <span class="monitor-pill warn">${keeperStatusWarnings} 주의</span>` : null}</summary>
-        <${Card} title="키퍼 연속성" class="mission-list-card">
+        <summary class="mission-collapsible-summary">키퍼 연속성 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${keeperRows.length}</span>${keeperStatusWarnings > 0 ? html` <span class="monitor-pill warn inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${keeperStatusWarnings} 주의</span>` : null}</summary>
+        <${Card} title="키퍼 연속성" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3 class="m-0 text-[var(--text-strong)] text-lg">세션 밖에서 움직이는 행위자</h3>
             <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">키퍼는 세션과 별개로 보고, 사회의 연속성과 장기 행위자 상태를 먼저 읽습니다.</p>
@@ -224,18 +224,18 @@ export function Mission() {
           <div class="flex flex-col gap-3">
             ${keeperRows.length > 0
               ? keeperRows.map(row => html`<${KeeperBriefCard} key=${row.brief.name} row=${row} />`)
-              : html`<div class="empty-state">지금 보이는 키퍼가 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 보이는 키퍼가 없습니다.</div>`}
           </div>
           <div class="flex gap-2 flex-wrap mt-2.5">
-            <button class="control-btn ghost" onClick=${() => navigate('status', { section: 'sessions' })}>세션 보기</button>
-            <button class="control-btn ghost" onClick=${() => navigate('operations', { section: 'command' })}>지휘 진단면 보기</button>
+            <button class="control-btn rounded-lg ghost" onClick=${() => navigate('status', { section: 'sessions' })}>세션 보기</button>
+            <button class="control-btn rounded-lg ghost" onClick=${() => navigate('operations', { section: 'command' })}>지휘 진단면 보기</button>
           </div>
         <//>
       </details>
 
       <details open id="mission-output" class="mission-collapsible-section">
-        <summary class="mission-collapsible-summary">최근 사회 활동 <span class="monitor-pill">${focusSessionOutputs.length + keeperOutputRows.length}</span></summary>
-        <${Card} title="최근 사회 활동" class="mission-list-card">
+        <summary class="mission-collapsible-summary">최근 사회 활동 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${focusSessionOutputs.length + keeperOutputRows.length}</span></summary>
+        <${Card} title="최근 사회 활동" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3 class="m-0 text-[var(--text-strong)] text-lg">누가 방금 무엇을 했나</h3>
             <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">선택된 세션과 연결된 행위자의 최근 출력만 모아 읽고, 해석은 뒤로 미룹니다.</p>
@@ -251,7 +251,7 @@ export function Mission() {
                     <div>${row.recent_output_preview}</div>
                   </div>
                 `)
-              : html`<div class="empty-state">선택된 세션에서 바로 읽을 최근 출력이 없습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">선택된 세션에서 바로 읽을 최근 출력이 없습니다.</div>`}
             ${keeperOutputRows.length > 0
               ? keeperOutputRows.map(row => html`
                   <div class="grid gap-1">
@@ -265,8 +265,8 @@ export function Mission() {
       </details>
 
       <details open id="mission-attention" class="mission-collapsible-section">
-        <summary class="mission-collapsible-summary">세션 우선순위 <span class="monitor-pill${attentionQueue.length > 0 ? ' warn' : ''}">${attentionQueue.length}</span></summary>
-        <${Card} title="세션 우선순위" class="mission-list-card">
+        <summary class="mission-collapsible-summary">세션 우선순위 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]${attentionQueue.length > 0 ? ' warn' : ''}">${attentionQueue.length}</span></summary>
+        <${Card} title="세션 우선순위" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3 class="m-0 text-[var(--text-strong)] text-lg">어느 세션을 먼저 봐야 하나</h3>
             <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">주의 신호는 truth를 훑은 다음에만 읽고, 세션 집중 순서를 정하는 용도로만 씁니다.</p>
@@ -275,7 +275,7 @@ export function Mission() {
           <div class="mission-lane-stack">
             ${attentionQueue.length > 0
               ? attentionQueue.map(item => html`<${AttentionCard} key=${item.id} item=${item} selected=${activeSelectedAttentionId === item.id} sessionLookup=${sessionLookup} />`)
-              : html`<div class="empty-state">지금 세션 단위 주의 대기열은 비어 있습니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 세션 단위 주의 대기열은 비어 있습니다.</div>`}
           </div>
         <//>
       </details>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -168,10 +168,10 @@ export function Ops() {
           </p>
         </div>
         <div class="flex items-end gap-2.5 flex-wrap max-[880px]:w-full">
-          <label class="control-label" for="ops-actor">개입 ID</label>
+          <label class="control-label text-[length:var(--fs-xs)] text-[color:var(--text-muted)] tracking-[0.06em] uppercase" for="ops-actor">개입 ID</label>
           <input
             id="ops-actor"
-            class="control-input ops-actor-input min-w-[180px]"
+            class="control-input rounded-lg ops-actor-input min-w-[180px]"
             type="text"
             value=${actorName.value}
             onInput=${(event: Event) => persistActorName((event.target as HTMLInputElement).value)}
@@ -191,18 +191,18 @@ export function Ops() {
         </div>
       </div>
 
-      ${operatorError.value ? html`<section class="ops-banner error">${operatorError.value}</section>` : null}
-      ${operatorDigestError.value ? html`<section class="ops-banner error">${operatorDigestError.value}</section>` : null}
+      ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl error">${operatorError.value}</section>` : null}
+      ${operatorDigestError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl error">${operatorDigestError.value}</section>` : null}
       <${RoomTruthStrip} />
       ${workflowContext ? html`
-        <section class="ops-banner ${workflowReady ? 'info' : 'warn'} grid gap-2">
+        <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl ${workflowReady ? 'info' : 'warn'} grid gap-2">
           <div class="flex gap-2 flex-wrap items-center text-[rgba(255,255,255,0.72)]">
             <strong>${workflowContext.source_label}</strong>
             <span>${workflowActionLabel(workflowContext.action_type)}</span>
             <span>${workflowTargetLabel(workflowContext)}</span>
           </div>
           <div class="text-[rgba(255,255,255,0.84)] leading-[1.5]">${workflowContext.summary}</div>
-          ${workflowContext.payload_preview ? html`<div class="ops-handoff-preview">${workflowContext.payload_preview}</div>` : null}
+          ${workflowContext.payload_preview ? html`<div class="ops-handoff-preview rounded-xl">${workflowContext.payload_preview}</div>` : null}
           <div class="text-[rgba(255,255,255,0.58)] text-[var(--fs-sm)]">
             ${workflowReady
               ? '추천 액션 기준으로 대상 선택과 입력값을 미리 맞춰 두었습니다.'
@@ -252,11 +252,11 @@ export function Ops() {
         }
         if (actions.length === 0) return null
         return html`
-          <section class="ops-action-guide">
+          <section class="rounded-[10px] py-4 px-5 mb-4 bg-[rgba(138,163,211,0.06)] border border-solid border-[rgba(138,163,211,0.15)]">
             <h3 class="text-[var(--fs-base)] font-semibold text-[rgba(255,255,255,0.6)] mb-2.5">지금 할 수 있는 것</h3>
             <div class="flex flex-col gap-2">
               ${actions.slice(0, 3).map(action => html`
-                <button class="ops-action-guide-item ${action.tone}" onClick=${action.onClick}>
+                <button class="ops-action-guide-item rounded-lg ${action.tone}" onClick=${action.onClick}>
                   <strong class="font-semibold">${action.label}</strong>
                   <span>${action.desc}</span>
                 </button>
@@ -271,9 +271,9 @@ export function Ops() {
           <h2 class="monitor-headline">개입 우선순위</h2>
           <p class="monitor-subheadline">지금 가장 먼저 손댈 대상이 방인지, 세션인지, 키퍼인지 먼저 좁힙니다.</p>
         </div>
-        <div class="ops-priority-grid">
+        <div class="ops-priority-grid grid grid-cols-4 gap-2.5 max-[1200px]:grid-cols-2 max-[880px]:grid-cols-1">
           ${priorityCards.map(card => html`
-            <div key=${card.key} class="ops-priority-card ${card.tone}">
+            <div key=${card.key} class="ops-priority-card p-3.5 rounded-xl border border-[var(--border-slate-16)] bg-[var(--white-3)] grid gap-1.5 rounded-xl ${card.tone}">
               <span class="text-text-muted text-[var(--fs-xs)] uppercase tracking-[0.06em]">${card.label}</span>
               <strong>${card.value}</strong>
               <div class="text-[#9ab1d7] text-[var(--fs-sm)] leading-[1.45]">${card.detail}</div>
@@ -282,7 +282,7 @@ export function Ops() {
         </div>
       </section>
 
-      <div class="ops-workbench">
+      <div class="ops-workbench grid gap-4 max-[1200px]:grid-cols-1">
         <${OpsRoomColumn} />
         <${OpsSessionColumn} />
         <${OpsKeeperColumn} />

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -52,14 +52,14 @@ export function OpsKeeperColumn() {
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">장기 실행 중인 keeper를 고르고 바로 probe나 방향 수정 메시지를 보냅니다.</p>
 
         <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
-          ${keepers.length === 0 ? html`<div class="ops-empty">지금 보이는 keeper가 없습니다.</div>` : keepers.map(keeper => html`
+          ${keepers.length === 0 ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 보이는 keeper가 없습니다.</div>` : keepers.map(keeper => html`
             ${(() => {
               const tone = keeperPriorityTone(keeper)
               const prioritySummary = keeperPrioritySummary(keeper)
               return html`
             <button
               key=${keeper.name}
-              class="ops-entity-card ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
+              class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
               onClick=${() => { selectedKeeperName.value = keeper.name }}
             >
               <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
@@ -72,13 +72,13 @@ export function OpsKeeperColumn() {
                   onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
                 >상세</span>
               </div>
-              <div class="ops-entity-meta">
+              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>${keeper.last_model_used ?? keeper.model ?? 'model 확인 필요'}</span>
                 <span>${typeof keeper.context_ratio === 'number' ? `${Math.round(keeper.context_ratio * 100)}% ctx` : typeof keeper.context_tokens === 'number' ? `${Math.round(keeper.context_tokens / 1000)}k tok` : 'ctx 확인 필요'}</span>
                 <span>${relativeAge(keeper.last_turn_ago_s)}</span>
               </div>
               ${keeper.short_goal || keeper.goal ? html`
-                <div class="ops-entity-goal" title=${keeper.goal ?? ''}>${truncateGoal(keeper.short_goal ?? keeper.goal ?? '')}</div>
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1.5 p-1 px-1.5 bg-[var(--card)] rounded-[4px]" title=${keeper.goal ?? ''}>${truncateGoal(keeper.short_goal ?? keeper.goal ?? '')}</div>
               ` : null}
               ${tone !== 'ok'
                 ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-1.5">점검 이유: ${prioritySummary}</div>`
@@ -96,14 +96,14 @@ export function OpsKeeperColumn() {
         <div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-3">Persistent agent는 resident keeper와 분리해서 참고용으로만 보여줍니다.</div>
         <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
           ${persistentAgents.length === 0
-            ? html`<div class="ops-empty">분리된 persistent agent는 없습니다.</div>`
+            ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">분리된 persistent agent는 없습니다.</div>`
             : persistentAgents.map(agent => html`
-                <article key=${agent.name} class="ops-entity-card">
+                <article key=${agent.name} class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer">
                   <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
                     <strong>${agent.name}</strong>
                     <span class="border border-solid border-[var(--card-border)] ${agent.status ?? 'idle'} ${agent.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(agent.status)}</span>
                   </div>
-                  <div class="ops-entity-meta">
+                  <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                     <span>persistent</span>
                     <span>${agent.model ?? 'model 확인 필요'}</span>
                     <span>${relativeAge(agent.last_turn_ago_s)}</span>
@@ -121,8 +121,8 @@ export function OpsKeeperColumn() {
 
         ${selectedKeeper ? html`
           <div class="flex flex-col gap-2">
-            <div class="ops-detail-title">${selectedKeeper.name}</div>
-            <div class="ops-detail-meta">
+            <div class="mt-1.5 whitespace-pre-wrap break-words">${selectedKeeper.name}</div>
+            <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
               <span>자율성: ${selectedKeeper.autonomy_level ?? '확인 없음'}</span>
               <span>세대: ${selectedKeeper.generation ?? 0}</span>
               <span>활성 목표: ${selectedKeeper.active_goal_ids?.length ?? 0}</span>
@@ -132,13 +132,13 @@ export function OpsKeeperColumn() {
             ${keeperPriorityTone(selectedKeeper) !== 'ok'
               ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-2">현재 점검 이유: ${keeperPrioritySummary(selectedKeeper)}</div>`
               : null}
-            ${selectedKeeper.goal ? html`<div class="ops-detail-goal">${selectedKeeper.goal}</div>` : null}
+            ${selectedKeeper.goal ? html`<div class="whitespace-normal mt-1.5 py-1 px-1.5 bg-[var(--card)] rounded-[4px] text-[var(--fs-xs)] text-text-muted">${selectedKeeper.goal}</div>` : null}
           </div>
           <${KeeperConversationPanel}
             keeperName=${selectedKeeper.name}
             placeholder="구조화된 probe, 방향 수정, 재지시 내용을 적으세요"
           />
-        ` : html`<div class="ops-empty">먼저 keeper를 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">먼저 keeper를 하나 고르세요.</div>`}
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
@@ -167,7 +167,7 @@ export function OpsKeeperColumn() {
                 `
               })}
             </div>`
-          : html`<div class="ops-empty">액션 없음</div>`}
+          : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">액션 없음</div>`}
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
@@ -176,15 +176,15 @@ export function OpsKeeperColumn() {
         </div>
         <div class="flex flex-col gap-2">
           ${operatorActionLog.value.length === 0 ? html`
-            <div class="ops-empty">이 세션에서 실행한 개입이 아직 없습니다.</div>
+            <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션에서 실행한 개입이 아직 없습니다.</div>
           ` : operatorActionLog.value.map(entry => html`
-            <article key=${entry.id} class="ops-log-entry ${entry.outcome}">
-              <div class="ops-log-head">
+            <article key=${entry.id} class="ops-log-entry p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${entry.outcome}">
+              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <strong>${actionTypeLabel(entry.action_type)}</strong>
                 <span>${entry.target_label}</span>
                 <span>${entry.at}</span>
               </div>
-              <div class="ops-log-body">${entry.message}</div>
+              <div class="mt-1.5 whitespace-pre-wrap break-words">${entry.message}</div>
             </article>
           `)}
         </div>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -69,7 +69,7 @@ export function OpsRoomColumn() {
           <div class="card-title">추천 개입</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">백엔드 digest가 지금 가장 작은 다음 행동을 추천합니다.</p>
-        <article class="ops-guidance-card ${guidanceLayerTone(guidanceLayer)}">
+        <article class="ops-guidance-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
           <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
             <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
             <span>${residentRuntime?.keeper_name ?? roomDigest?.judgment_owner ?? 'judge 없음'}</span>
@@ -84,17 +84,17 @@ export function OpsRoomColumn() {
           </div>
         </article>
         ${operatorDigestLoading.value && !roomDigest ? html`
-          <div class="ops-empty">개입 추천을 불러오는 중입니다...</div>
+          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">개입 추천을 불러오는 중입니다...</div>
         ` : activeRecommendedActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${activeRecommendedActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'room'}`} class="ops-log-entry ${item.severity}">
-                <div class="ops-log-head">
+              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'room'}`} class="ops-log-entry p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${item.severity}">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
                 </div>
-                <div class="ops-log-body">${item.reason}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words">${item.reason}</div>
                 ${item.suggested_payload ? html`
                   <div class="flex justify-between items-center gap-3 mt-2.5 max-[880px]:flex-col max-[880px]:items-start">
                     <button class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
@@ -106,7 +106,7 @@ export function OpsRoomColumn() {
             `)}
           </div>
         ` : html`
-          <div class="ops-empty">지금 떠 있는 추천 개입은 없습니다.</div>
+          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 떠 있는 추천 개입은 없습니다.</div>
         `}
       </section>
 
@@ -122,13 +122,13 @@ export function OpsRoomColumn() {
         ${confirmRequiredActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${confirmRequiredActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}`} class="ops-log-entry">
-                <div class="ops-log-head">
+              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
                 </div>
-                <div class="ops-log-body">${item.description ?? '설명 확인 필요'}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words">${item.description ?? '설명 확인 필요'}</div>
               </article>
             `)}
           </div>
@@ -136,13 +136,13 @@ export function OpsRoomColumn() {
         ${pendingConfirms.length > 0 ? html`
           <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
             ${pendingConfirms.map(item => html`
-              <article key=${item.confirm_token} class="ops-confirmation-card">
+              <article key=${item.confirm_token} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
                 <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${item.delegated_tool ?? '위임 도구 확인 필요'}</span>
                 </div>
-                ${item.preview ? html`<pre class="ops-code-block compact">${prettyJson(item.preview)}</pre>` : null}
+                ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-[10px] bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
                 <div class="flex justify-between items-center gap-3 mt-2.5 max-[880px]:flex-col max-[880px]:items-start">
                   <button class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
                     실행
@@ -156,7 +156,7 @@ export function OpsRoomColumn() {
             `)}
           </div>
         ` : html`
-          <div class="ops-empty">
+          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">
             ${hiddenCount > 0 && actorFilter
               ? `현재 선택한 actor(${actorFilter}) 기준 승인 대기는 0건입니다. 다른 actor 대기 ${hiddenCount}건${hiddenActors.length > 0 ? ` · ${hiddenActors.join(', ')}` : ''}`
               : '지금 승인 대기는 없습니다. 위 목록의 preview-confirm 액션을 먼저 만들어야 여기에 쌓입니다.'}
@@ -170,24 +170,24 @@ export function OpsRoomColumn() {
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. room 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
 
-        <div class="ops-stat-grid">
-          <div class="ops-stat">
+        <div class="grid grid-cols-2 gap-2.5 max-[880px]:grid-cols-1">
+          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>Room</span>
             <strong>${room.current_room ?? room.room_id ?? 'default'}</strong>
           </div>
-          <div class="ops-stat">
+          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>프로젝트</span>
             <strong>${room.project ?? '확인 없음'}</strong>
           </div>
-          <div class="ops-stat">
+          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>클러스터</span>
             <strong>${room.cluster ?? '확인 없음'}</strong>
           </div>
-          <div class="ops-stat ${room.paused ? 'warn' : 'ok'}">
+          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${room.paused ? 'warn' : 'ok'}">
             <span>상태</span>
             <strong>${room.paused ? '일시정지' : '진행 중'}</strong>
           </div>
-          <div class="ops-stat ${runtimeJudgeTone(residentRuntime)}">
+          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${runtimeJudgeTone(residentRuntime)}">
             <span>Resident Judge</span>
             <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
           </div>
@@ -195,16 +195,16 @@ export function OpsRoomColumn() {
 
         <details
           ref=${roomControlDisclosureRef}
-          class="ops-control-disclosure"
+          class="ops-control-disclosure mt-0.5 border border-[var(--white-8)] rounded-xl bg-[var(--white-2)]"
           open=${room.paused ? true : undefined}
         >
-          <summary class="ops-control-summary">
+          <summary class="ops-control-summary list-none cursor-pointer grid gap-1 p-3 px-3.5">
             <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 room 제어</span>
             <strong>${room.paused ? '지금은 room이 멈춰 있어 재개 동선이 열려 있습니다.' : '방송 · 일시정지/재개 · 작업 주입'}</strong>
             <span>${room.paused ? '운영 점검 후 재개하거나 공지를 보내세요.' : 'room 전체에 영향 주는 액션만 이 안에 넣었습니다.'}</span>
           </summary>
 
-          <div class="ops-control-body">
+          <div class="grid gap-3 px-3.5 pb-3.5 border-t border-[var(--white-8)]">
             <label class="control-label" for="ops-broadcast">Room 방송</label>
             <div class="control-row">
               <input
@@ -286,16 +286,16 @@ export function OpsRoomColumn() {
         ${roomFeed.length > 0 ? html`
           <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
             ${roomFeed.map(message => html`
-              <article key=${message.seq ?? message.id ?? message.timestamp} class="ops-feed-item">
-                <div class="ops-feed-meta">
+              <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${message.from}</strong>
                   <span>${message.timestamp}</span>
                 </div>
-                <div class="ops-feed-content">${formatMessageContent(message.content)}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words">${formatMessageContent(message.content)}</div>
               </article>
             `)}
           </div>
-        ` : html`<div class="ops-empty">최근 room 메시지가 없습니다.</div>`}
+        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">최근 room 메시지가 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -122,14 +122,14 @@ export function OpsSessionColumn() {
   ) => html`
     <button
       key=${session.session_id}
-      class="ops-entity-card ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
+      class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
       onClick=${() => { selectedSessionId.value = session.session_id }}
     >
       <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
         <strong>${session.session_id}</strong>
         <span class="border border-solid border-[var(--card-border)] ${session.status ?? 'idle'} ${session.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(session.status)}</span>
       </div>
-      <div class="ops-entity-meta">
+      <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
         <span>${Math.round(session.progress_pct ?? 0)}%</span>
         <span>${sessionOutcomeLabel(session)}</span>
         <span>${archived ? '종료 세션' : `팀 상태 ${sessionHealthLabel(session)}`}</span>
@@ -152,7 +152,7 @@ export function OpsSessionColumn() {
           </div>
           <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
             ${liveSessions.length === 0
-              ? html`<div class="ops-empty">지금 바로 개입할 live team session이 없습니다.</div>`
+              ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 바로 개입할 live team session이 없습니다.</div>`
               : liveSessions.map(session => renderSessionCard(session))}
           </div>
         </div>
@@ -174,7 +174,7 @@ export function OpsSessionColumn() {
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">snapshot이 아니라 digest 기준 attention과 worker 카드를 보여줍니다.</p>
         ${selectedSession && sessionDigest ? html`
-          <article class="ops-guidance-card ${guidanceLayerTone(guidanceLayer)}">
+          <article class="ops-guidance-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
             <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
               <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
               <span>${runtimeJudgeLabel(residentRuntime)}</span>
@@ -191,41 +191,41 @@ export function OpsSessionColumn() {
           ${activeRecommendedActions.length > 0 ? html`
             <div class="flex flex-col gap-2">
               ${activeRecommendedActions.map(item => html`
-                <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'session'}`} class="ops-log-entry ${item.severity}">
-                  <div class="ops-log-head">
+                <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'session'}`} class="ops-log-entry p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${item.severity}">
+                  <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                     <strong>${actionTypeLabel(item.action_type)}</strong>
                     <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   </div>
-                  <div class="ops-log-body">${item.reason}</div>
+                  <div class="mt-1.5 whitespace-pre-wrap break-words">${item.reason}</div>
                 </article>
               `)}
             </div>
           ` : null}
           <div class="flex flex-col gap-2">
             ${sessionDigest.attention_items.length > 0 ? sessionDigest.attention_items.map(item => html`
-              <article key=${`${item.kind}:${item.target_id ?? 'session'}`} class="ops-log-entry ${item.severity}">
-                <div class="ops-log-head">
+              <article key=${`${item.kind}:${item.target_id ?? 'session'}`} class="ops-log-entry p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${item.severity}">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${item.kind}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                 </div>
-                <div class="ops-log-body">${item.summary}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words">${item.summary}</div>
               </article>
-            `) : html`<div class="ops-empty">이 세션의 attention item은 없습니다.</div>`}
+            `) : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션의 attention item은 없습니다.</div>`}
             ${sessionDigest.worker_cards.length > 0 ? sessionDigest.worker_cards.map(card => html`
-              <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="ops-log-entry">
-                <div class="ops-log-head">
+              <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${card.actor ?? card.spawn_role ?? 'worker'}</strong>
                   <span>${displayStatus(card.status)}</span>
                   <span>${card.spawn_agent ?? card.runtime_pool ?? 'runtime 확인 필요'}</span>
                 </div>
-                <div class="ops-log-body">
+                <div class="mt-1.5 whitespace-pre-wrap break-words">
                   ${(card.worker_class ?? 'worker')}${card.lane_id ? ` · ${card.lane_id}` : ''}${card.routing_reason ? ` · ${card.routing_reason}` : ''}
                 </div>
               </article>
             `) : null}
           </div>
         ` : html`
-          <div class="ops-empty">세션을 고르면 세부 요약을 불러옵니다.</div>
+          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">세션을 고르면 세부 요약을 불러옵니다.</div>
         `}
       </section>
 
@@ -241,12 +241,12 @@ export function OpsSessionColumn() {
         ${availableSessionActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${availableSessionActions.map(action => html`
-              <article key=${action.action_type} class="ops-log-entry">
-                <div class="ops-log-head">
+              <article key=${action.action_type} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(action.action_type)}</strong>
                   <span>${deliveryModeLabel(action.confirm_required)}</span>
                 </div>
-                <div class="ops-log-body">${action.description ?? '설명 확인 필요'}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words">${action.description ?? '설명 확인 필요'}</div>
               </article>
             `)}
           </div>
@@ -254,21 +254,21 @@ export function OpsSessionColumn() {
 
         ${selectedSession ? html`
           <div class="flex flex-col gap-2">
-            <div class="ops-detail-title">${selectedSession.session_id}</div>
-            <div class="ops-detail-meta">
+            <div class="mt-1.5 whitespace-pre-wrap break-words">${selectedSession.session_id}</div>
+            <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
               <span>상태: ${displayStatus(selectedSession.status)}</span>
               <span>경과: ${selectedSession.elapsed_sec ?? 0}초</span>
               <span>남은 시간: ${selectedSession.remaining_sec ?? 0}초</span>
               <span>${selectedSessionActionable ? `팀 상태: ${sessionHealthLabel(selectedSession)}` : '종료 세션'}</span>
             </div>
             ${selectedSession.linked_autoresearch ? html`
-              <div class="ops-detail-meta">
+              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>Autoresearch: ${String(selectedSession.linked_autoresearch.status ?? 'unknown')}</span>
                 <span>Loop: ${String(selectedSession.linked_autoresearch.loop_id ?? 'n/a')}</span>
                 <span>Cycle: ${String(selectedSession.linked_autoresearch.current_cycle ?? 0)}</span>
                 <span>Best: ${String(selectedSession.linked_autoresearch.best_score ?? 'n/a')}</span>
               </div>
-              <div class="ops-detail-meta">
+              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>파일: ${selectedSession.linked_autoresearch.target_file ?? 'n/a'}</span>
                 <span>최근 결정: ${selectedSession.linked_autoresearch.last_decision ?? 'n/a'}</span>
                 <span>세션 연결: ${selectedSession.linked_autoresearch.session_id ?? selectedSession.session_id}</span>
@@ -286,17 +286,17 @@ export function OpsSessionColumn() {
                 ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.error
-                ? html`<div class="ops-empty">${selectedSession.linked_autoresearch.error}</div>`
+                ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">${selectedSession.linked_autoresearch.error}</div>`
                 : null}
             ` : null}
             ${selectedSession.recent_events && selectedSession.recent_events.length > 0 ? html`
-              <pre class="ops-code-block compact">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
+              <pre class="mt-2 py-[10px] px-3 rounded-[10px] bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
             ` : null}
           </div>
-        ` : html`<div class="ops-empty">먼저 세션을 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">먼저 세션을 하나 고르세요.</div>`}
 
         ${selectedSession && !selectedSessionActionable ? html`
-          <div class="ops-empty">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
+          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
         ` : null}
 
         ${linkedAutoresearch?.loop_id ? html`
@@ -327,7 +327,7 @@ export function OpsSessionColumn() {
             </button>
             <span class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
           </div>
-          ${autoresearchError.value ? html`<div class="ops-empty">${autoresearchError.value}</div>` : null}
+          ${autoresearchError.value ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">${autoresearchError.value}</div>` : null}
         ` : null}
 
         <label class="control-label" for="ops-turn-kind">세션 액션</label>

--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -114,7 +114,7 @@ export function AgentAvatar({
 
   const avatar = html`
     <div
-      class="pixel-avatar ${sizeClass} ${blockerClass} ${ringClass}"
+      class="pixel-avatar rounded-md ${sizeClass} ${blockerClass} ${ringClass}"
       data-status=${statusAttr}
       title=${name}
       onClick=${onClick}
@@ -128,7 +128,7 @@ export function AgentAvatar({
         aria-label=${activityDotLabel(activityAge ?? null)}
       />
       ${bubbleText ? html`
-        <span class="pixel-avatar__speech-bubble ${alwaysShowBubble ? 'always-visible' : ''}">
+        <span class="pixel-avatar__speech-bubble rounded-md ${alwaysShowBubble ? 'always-visible' : ''}">
           ${bubbleText}
         </span>
       ` : null}
@@ -142,7 +142,7 @@ export function AgentAvatar({
     : 'pixel-avatar-name'
 
   return html`
-    <div class="pixel-avatar-wrap">
+    <div class="pixel-avatar rounded-md-wrap">
       ${avatar}
       <span class=${nameClass}>${name}</span>
     </div>

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -91,7 +91,7 @@ export function AttentionSpotlight({ snap }: AttentionSpotlightProps) {
             </span>
             <div class="flex gap-1.5 flex-wrap items-center">
               ${item.relatedNames.map(name => html`
-                <span class="attention-spotlight__chip" key=${name}>${name}</span>
+                <span class="attention-spotlight__chip rounded-full" key=${name}>${name}</span>
               `)}
               ${item.lastSeen ? html`
                 <span class="text-text-muted text-xs">${relativeTime(item.lastSeen)}</span>

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -111,7 +111,7 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
       `)}
       ${hasMore ? html`
         <button
-          class="narrative-timeline__load-more"
+          class="narrative-timeline__load-more rounded-md"
           onClick=${() => { expandedItems.value += baseLimit }}
         >
           더 보기 (${totalAvailable - limit}건 남음)

--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -47,12 +47,12 @@ function OasKeeperBars() {
   const entries = [...snapshots.values()].sort((a, b) => b.timestamp - a.timestamp)
 
   return html`
-    <div class="oas-keeper-list">
+    <div class="flex flex-col gap-1">
       ${entries.map(snap => {
         const pct = Math.round(snap.context_ratio * 100)
         const barClass = pct > 70 ? 'bar--warn' : pct > 50 ? 'bar--mid' : 'bar--ok'
         return html`
-          <div class="oas-keeper-row" key=${snap.keeper_name}>
+          <div class="oas-keeper-row rounded" key=${snap.keeper_name}>
             <span class="oas-keeper-name">${snap.keeper_name}</span>
             <span class="oas-keeper-gen">gen ${snap.generation}</span>
             <div class="oas-keeper-bar-wrap">
@@ -74,9 +74,9 @@ function OasRawEventList() {
   }
 
   return html`
-    <div class="oas-event-list">
+    <div class="flex flex-col gap-0.5">
       ${events.slice(0, 15).map((ev, i) => html`
-        <div class="oas-event-row" key=${i}>
+        <div class="oas-event-row rounded" key=${i}>
           <span class="oas-event-ts">${formatTs(ev.timestamp)}</span>
           <span class="oas-event-agent">${ev.agent_name}</span>
           <span class="oas-event-type">${ev.type}</span>
@@ -94,8 +94,8 @@ export function OasPipeline() {
   const eventLabel = `${health.totalEvents}건`
 
   return html`
-    <div class="oas-pipeline">
-      <div class="oas-pipeline__header">
+    <div class="oas-pipeline rounded-lg">
+      <div class="flex justify-between items-center mb-3">
         <span class="oas-pipeline__title">실행 흐름</span>
         <div class="home-section-actions">
           <span class="oas-pipeline__count">${eventLabel}</span>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -83,7 +83,7 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
 
   return html`
     <div
-      class="hot-session-card ${s.blocker_summary ? 'hot-session-card--critical' : ''}"
+      class="hot-session-card rounded-xl rounded-lg ${s.blocker_summary ? 'border-[var(--bad)] bg-[rgba(239,68,68,0.06)]' : ''}"
       key=${s.session_id}
       onClick=${() => navigate('status', { section: 'sessions', session_id: s.session_id })}
     >
@@ -91,11 +91,11 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
       ${secondary ? html`<div class="hot-session-card__context">${secondary}</div>` : null}
       <div class="flex flex-wrap gap-1.5 mt-2">
         ${creator
-          ? html`<span class="hot-session-card__chip ${systemSession ? 'hot-session-card__chip--system' : ''}">
+          ? html`<span class="hot-session-card__chip rounded-full ${systemSession ? 'border-[rgba(34,197,94,0.22)] bg-[rgba(34,197,94,0.12)] text-[#b7f3c9]' : ''}">
               ${systemSession ? '시스템' : '주체'} · ${creator}
             </span>`
           : null}
-        ${s.status ? html`<span class="hot-session-card__chip">${statusLabel(s.status)}</span>` : null}
+        ${s.status ? html`<span class="hot-session-card__chip rounded-full">${statusLabel(s.status)}</span>` : null}
       </div>
       <div class="flex gap-2 flex-wrap text-xs text-text-muted mt-2">
         ${s.member_names?.length ? html`
@@ -125,14 +125,14 @@ function SessionLane({ title, description, tone, sessions, emptyCopy }: SessionL
         <div>
           <div class="flex items-center gap-2">
             <h3 class="m-0 text-base font-semibold text-text-strong">${title}</h3>
-            <span class="hot-session-lane__count">${sessions.length}</span>
+            <span class="inline-flex items-center justify-center min-w-[24px] h-6 px-2 bg-[var(--white-8)] text-[color:var(--text-muted)] text-[length:var(--fs-xs)] font-semibold rounded-full">${sessions.length}</span>
           </div>
           <p class="mt-1 mb-0 text-text-muted text-sm leading-[1.45]">${description}</p>
         </div>
       </div>
       ${sessions.length > 0
-        ? html`<div class="hot-sessions__grid">${sessions.map(renderSessionCard)}</div>`
-        : html`<div class="hot-session-lane__empty">${emptyCopy}</div>`}
+        ? html`<div class="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">${sessions.map(renderSessionCard)}</div>`
+        : html`<div class="grid place-items-center min-h-[116px] p-3 border border-dashed border-[var(--border-slate-18)] text-[color:var(--text-muted)] text-[length:var(--fs-sm)] text-center bg-[var(--white-2)] rounded-lg">${emptyCopy}</div>`}
     </section>
   `
 }
@@ -164,7 +164,7 @@ function HotSessions() {
         linkLabel="전체 보기"
         onLink=${() => navigate('status', { section: 'sessions' })}
       />
-      <div class="hot-sessions__lanes">
+      <div class="grid grid-cols-2 max-[960px]:grid-cols-1 gap-3">
         <${SessionLane}
           title="사용자 작업"
           description="사람이 직접 연 협업 세션과 지금 손대고 있는 일입니다."
@@ -208,7 +208,7 @@ function AgentPulse() {
       <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1">
         ${agents.map((a: ObservatoryAgent) => html`
           <div
-            class="agent-pulse-card agent-pulse-card--${a.state}"
+            class="agent-pulse-card rounded-xl rounded-md agent-pulse-card--${a.state}"
             key=${a.name}
             onClick=${() => navigate('status', { section: 'agents', agent: a.name })}
           >

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -115,7 +115,7 @@ export function SituationBanner({ snap, roomHealth }: SituationBannerProps) {
   const showReasons = tone !== 'ok' && reasons.length > 0
 
   return html`
-    <div class="situation-banner situation-banner--${tone}">
+    <div class="situation-banner rounded-md situation-banner--${tone}">
       <${HealthBeacon} health=${roomHealth ?? tone} />
       <span class="flex-1 min-w-0">${text}</span>
       <span class="inline-flex items-center shrink-0">

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -35,16 +35,16 @@ export function SelectionCard({
     && summary?.historical_verdict === 'proven'
     && summary?.live_verdict !== 'proven'
   return html`
-    <div class="command-guide-card ${selectionTone(selection)}">
+    <div class="command-guide-card rounded-xl ${selectionTone(selection)}">
       <div class="command-guide-head">
         <strong>${selectionLabel(selection)}</strong>
-        <span class="command-chip ${selectionTone(selection)}">${selection.mode ?? 'none'}</span>
+        <span class="command-chip rounded-full ${selectionTone(selection)}">${selection.mode ?? 'none'}</span>
       </div>
       <p>${selection.reason ?? '근거 컨텍스트 선택 정보가 없습니다.'}</p>
       ${historicalStronger
         ? html`<p>선택된 최신 세션은 과거 proof가 더 강하고 현재 live evidence는 더 약합니다.</p>`
         : null}
-      <div class="command-card-grid">
+      <div class="command-card rounded-xl-grid">
         <span>선택된 세션</span><span>${selection.selected_session_id ?? '없음'}</span>
         <span>작성자</span><span>${selection.selected_created_by ?? '없음'}</span>
         <span>선택된 목표</span><span>${selection.selected_goal ?? '없음'}</span>
@@ -56,8 +56,8 @@ export function SelectionCard({
 
 export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) {
   return html`
-    <article class="command-card proof-artifact-row">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl proof-artifact-row">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${item.summary ?? item.event_type ?? '도구 근거'}</strong>
           <div class="command-meta-line">
@@ -65,7 +65,7 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
             <span>${item.event_type ?? 'event'}</span>
           </div>
         </div>
-        <span class="command-chip">${relativeTime(item.timestamp ?? null)}</span>
+        <span class="command-chip rounded-full">${relativeTime(item.timestamp ?? null)}</span>
       </div>
       ${(() => {
         const tags = toolEvidenceTags(item)
@@ -81,8 +81,8 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
 
 export function TimelineRow({ item }: { item: DedupedTimelineItem }) {
   return html`
-    <article class="command-card proof-timeline-row">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl proof-timeline-row">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${item.summary ?? item.event_type ?? '이벤트'}</strong>
           <div class="command-meta-line">
@@ -91,7 +91,7 @@ export function TimelineRow({ item }: { item: DedupedTimelineItem }) {
             <span>${item.actor ?? '시스템'}</span>
           </div>
         </div>
-        <span class="command-chip">${relativeTime(item.timestamp)}</span>
+        <span class="command-chip rounded-full">${relativeTime(item.timestamp)}</span>
       </div>
       ${item.sources.length > 1
         ? html`<div class="semantic-tag-row">
@@ -119,7 +119,7 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
             <span>${lastSeen ? relativeTime(lastSeen) : '기록 없음'}</span>
           </div>
         </div>
-        <span class="command-chip ${actorActivityTone(item)}">
+        <span class="command-chip rounded-full ${actorActivityTone(item)}">
           ${actorActivityLabel(item)}
         </span>
       </div>
@@ -127,19 +127,19 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
         <span>${actorActivityMeta(item)}</span>
       </div>
       ${item.activity_detail
-        ? html`<div class="proof-summary-block">
+        ? html`<div class="proof-summary-block rounded-xl">
             <strong>현재 해석</strong>
             <span>${item.activity_detail}</span>
           </div>`
         : null}
       ${eventSummary
-        ? html`<div class="proof-summary-block">
+        ? html`<div class="proof-summary-block rounded-xl">
             <strong>최근 흔적</strong>
             <span>${eventSummary}</span>
           </div>`
         : null}
       ${requestPreview && item.activity_state !== 'acted'
-        ? html`<div class="proof-summary-block">
+        ? html`<div class="proof-summary-block rounded-xl">
             <strong>최근 요청</strong>
             <span>${requestPreview}</span>
           </div>`
@@ -167,15 +167,15 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
 
 export function ArtifactRow({ item }: { item: DashboardProofArtifactRef }) {
   return html`
-    <article class="command-card proof-artifact-row">
-      <div class="command-card-head">
+    <article class="command-card rounded-xl proof-artifact-row">
+      <div class="command-card rounded-xl-head">
         <div>
           <strong>${item.kind}</strong>
           <div class="command-meta-line">
             <span>${compactPath(item.path)}</span>
           </div>
         </div>
-        <span class="command-chip ${item.exists ? 'ok' : 'warn'}">${item.exists ? '존재함' : '없음'}</span>
+        <span class="command-chip rounded-full ${item.exists ? 'ok' : 'warn'}">${item.exists ? '존재함' : '없음'}</span>
       </div>
     </article>
   `

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -47,11 +47,11 @@ export function Proof() {
   const snapshot = proofSnapshot.value
 
   if (proofLoading.value && !snapshot) {
-    return html`<section class="dashboard-panel"><div class="loading-indicator">근거 화면 불러오는 중…</div></section>`
+    return html`<section class="dashboard-panel"><div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">근거 화면 불러오는 중…</div></section>`
   }
 
   if (proofError.value && !snapshot) {
-    return html`<section class="dashboard-panel"><div class="error-card">${proofError.value}</div></section>`
+    return html`<section class="dashboard-panel"><div class="error-card rounded-xl">${proofError.value}</div></section>`
   }
 
   const summary = snapshot?.summary
@@ -106,30 +106,30 @@ export function Proof() {
           <p>이 세션이 실제로 여러 참여자의 흔적, 상호작용, 산출물, 실행 backing을 남겼는지 읽는 표면입니다.</p>
         </div>
         <div class="flex gap-2 flex-wrap items-center">
-          <span class="command-chip ${verdictTone(verdict)}">${verdictChipLabel(verdict)}</span>
-          ${snapshot?.session_id ? html`<span class="command-chip">${snapshot.session_id}</span>` : null}
-          ${snapshot?.generated_at ? html`<span class="command-chip">${relativeTime(snapshot.generated_at)}</span>` : null}
+          <span class="command-chip rounded-full ${verdictTone(verdict)}">${verdictChipLabel(verdict)}</span>
+          ${snapshot?.session_id ? html`<span class="command-chip rounded-full">${snapshot.session_id}</span>` : null}
+          ${snapshot?.generated_at ? html`<span class="command-chip rounded-full">${relativeTime(snapshot.generated_at)}</span>` : null}
         </div>
       </div>
 
       ${proofError.value
-        ? html`<div class="error-card">${proofError.value}</div>`
+        ? html`<div class="error-card rounded-xl">${proofError.value}</div>`
         : null}
 
       <${SelectionCard} selection=${selection} summary=${summary ?? null} />
 
       <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3">
-        <div class="summary-stat-card ${verdictTone(verdict)}">
+        <div class="summary-stat-card rounded-xl ${verdictTone(verdict)}">
           <span>판정</span>
           <strong>${verdictLabel(verdict)}</strong>
           <small>${summary?.detail ?? '협업 증거를 verdict로 요약합니다.'}</small>
         </div>
-        <div class="summary-stat-card">
+        <div class="summary-stat-card rounded-xl">
           <span>실제 흔적</span>
           <strong>${actorCount}</strong>
           <small>이벤트를 남긴 actor 수${plannedActorCount > 0 ? ` (계획 ${plannedActorCount})` : ''}</small>
         </div>
-        <div class="summary-stat-card ${evidenceCount > 0 ? 'ok' : 'warn'}">
+        <div class="summary-stat-card rounded-xl ${evidenceCount > 0 ? 'ok' : 'warn'}">
           <span>근거</span>
           <strong>${evidenceCount}</strong>
           <small>도구 ${(toolEvidence?.length ?? 0)} / 산출물 ${presentArtifacts}/${artifacts.length} / CP ${traceCount}</small>
@@ -138,37 +138,37 @@ export function Proof() {
       <details class="mb-3">
         <summary style="cursor: pointer; color: rgba(255,255,255,0.5); font-size: 13px; padding: 6px 0;">상세 지표 (${7}개)</summary>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3" class="mt-2">
-          <div class="summary-stat-card ${verdictTone(liveVerdict)}">
+          <div class="summary-stat-card rounded-xl ${verdictTone(liveVerdict)}">
             <span>Live 판정</span>
             <strong>${liveVerdict}</strong>
             <small>${verdictBasisLabel(verdictBasis)} 기준</small>
           </div>
-          <div class="summary-stat-card ${verdictTone(historicalVerdict ?? 'insufficient')}">
+          <div class="summary-stat-card rounded-xl ${verdictTone(historicalVerdict ?? 'insufficient')}">
             <span>Historical</span>
             <strong>${historicalVerdict ?? 'none'}</strong>
             <small>persisted proof 문서 기준</small>
           </div>
-          <div class="summary-stat-card ${unansweredActorCount > 0 ? 'warn' : 'ok'}">
+          <div class="summary-stat-card rounded-xl ${unansweredActorCount > 0 ? 'warn' : 'ok'}">
             <span>무응답</span>
             <strong>${unansweredActorCount}</strong>
             <small>${unansweredActorCount > 0 ? '호출됐지만 응답 없음' : '없음'}</small>
           </div>
-          <div class="summary-stat-card ${interactionCount > 0 ? 'ok' : 'warn'}">
+          <div class="summary-stat-card rounded-xl ${interactionCount > 0 ? 'ok' : 'warn'}">
             <span>직접 상호작용</span>
             <strong>${interactionCount}</strong>
             <small>참여자 간 직접 연결</small>
           </div>
-          <div class="summary-stat-card ${traceCount > 0 ? 'ok' : 'warn'}">
+          <div class="summary-stat-card rounded-xl ${traceCount > 0 ? 'ok' : 'warn'}">
             <span>CP 트레이스</span>
             <strong>${traceCount}</strong>
             <small>관리형 backing</small>
           </div>
-          <div class="summary-stat-card ${(missingArtifacts === 0 && artifacts.length > 0) ? 'ok' : 'warn'}">
+          <div class="summary-stat-card rounded-xl ${(missingArtifacts === 0 && artifacts.length > 0) ? 'ok' : 'warn'}">
             <span>산출물</span>
             <strong>${presentArtifacts}/${artifacts.length}</strong>
             <small>${missingArtifacts > 0 ? `${missingArtifacts}개 누락` : '전부 존재함'}</small>
           </div>
-          <div class="summary-stat-card ${plannedActorCount > actorCount ? 'warn' : 'ok'}">
+          <div class="summary-stat-card rounded-xl ${plannedActorCount > actorCount ? 'warn' : 'ok'}">
             <span>계획된 참여자</span>
             <strong>${plannedActorCount}</strong>
             <small>${mentionedActorCount > 0 ? `${mentionedActorCount}명 호출됨` : '호출 기록 없음'}</small>
@@ -177,14 +177,14 @@ export function Proof() {
       </details>
 
       <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-        <${Card} title="3줄 근거 요약" class="mission-list-card">
+        <${Card} title="3줄 근거 요약" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>핵심 증명</h3>
             <p>결론, 왜 아직 부족한지, 다음에 무엇을 남겨야 하는지만 먼저 봅니다.</p>
           </div>
           <div class="grid gap-2.5">
             ${reasonLines.map((line, idx) => html`
-              <article class="proof-summary-block ${idx === 1 && verdict !== 'proven' ? verdictTone(verdict) : ''}">
+              <article class="proof-summary-block rounded-xl ${idx === 1 && verdict !== 'proven' ? verdictTone(verdict) : ''}">
                 <strong>${idx === 0 ? '지금 결론' : idx === 1 ? '왜 이렇게 판정됐나' : '다음 보강 포인트'}</strong>
                 <span>${line}</span>
               </article>
@@ -192,7 +192,7 @@ export function Proof() {
           </div>
         <//>
 
-        <${Card} title="증명 대상" class="mission-list-card">
+        <${Card} title="증명 대상" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>무엇을 증명하려는가</h3>
             <p>이 화면이 어떤 세션과 목표를 기준으로 그려졌는지 먼저 고정합니다.</p>
@@ -206,7 +206,7 @@ export function Proof() {
       </div>
 
       <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-        <${Card} title="협업 타임라인" class="mission-list-card">
+        <${Card} title="협업 타임라인" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>협업 타임라인</h3>
             <p>team-session과 command-plane에서 같은 사건이 보이면 한 줄로 묶어 읽습니다.</p>
@@ -214,11 +214,11 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${dedupedTimeline.length > 0
               ? dedupedTimeline.slice(0, 18).map(item => html`<${TimelineRow} key=${item.id} item=${item} />`)
-              : html`<div class="empty-state">타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다.</div>`}
           </div>
         <//>
 
-        <${Card} title="참여 흔적" class="mission-list-card">
+        <${Card} title="참여 흔적" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>누가 무엇을 남겼는가</h3>
             <p>실제 흔적, 호출만 된 참여자, 계획만 된 참여자를 구분해서 봅니다.</p>
@@ -226,13 +226,13 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${contributions.length > 0
               ? contributions.map(item => html`<${ActorContributionRow} key=${item.actor} item=${item} />`)
-              : html`<div class="empty-state">참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다.</div>`}
           </div>
         <//>
       </div>
 
       <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-        <${Card} title="도구 근거" class="mission-list-card">
+        <${Card} title="도구 근거" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>어떤 도구를 언제 썼는가</h3>
             <p>숫자만 보여주지 말고, 최근 도구 호출 근거를 직접 확인합니다.</p>
@@ -240,11 +240,11 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${toolEvidence.length > 0
               ? toolEvidence.map((item, idx) => html`<${ToolEvidenceRow} key=${`${item.actor ?? 'system'}-${idx}`} item=${item} />`)
-              : html`<div class="empty-state">도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다.</div>`}
           </div>
         <//>
 
-        <${Card} title="실행 근거" class="mission-list-card">
+        <${Card} title="실행 근거" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>실행 backing은 얼마나 남아 있나</h3>
             <p>작전, 분견대, 트레이스 수만 먼저 보고, 원본 CPv2 dump는 접어서 봅니다.</p>
@@ -258,7 +258,7 @@ export function Proof() {
       </div>
 
       <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-        <${Card} title="산출물" class="mission-list-card">
+        <${Card} title="산출물" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
             <h3>어떤 파일 산출물이 남았나</h3>
             <p>proof/report/session 기록 파일의 존재 여부를 빠르게 확인합니다.</p>
@@ -266,7 +266,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${artifacts.length > 0
               ? artifacts.map(item => html`<${ArtifactRow} key=${item.path} item=${item} />`)
-              : html`<div class="empty-state">산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다.</div>`}
+              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다.</div>`}
           </div>
         <//>
       </div>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -19,36 +19,74 @@ function shortCommit(commit: string | null | undefined): string {
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
+function residentStatusLabel(
+  status: 'live' | 'quiet' | 'starting' | 'idle' | 'disabled',
+) {
+  if (status === 'live') return '가동 중'
+  if (status === 'quiet') return '조용함'
+  if (status === 'starting') return '기동 중'
+  if (status === 'idle') return '대기 중'
+  return '비활성'
+}
+
+function renderRuntimeStat(label: string, value: ComponentChildren) {
+  return html`
+    <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
+      <span>${label}</span>
+      <strong class="text-[color:var(--text-strong)] text-right">${value}</strong>
+    </div>
+  `
+}
+
+function renderResidentRuntimeCard(
+  title: string,
+  statusLabel: string,
+  tone: 'ok' | 'warn' | 'bad',
+  rows: ComponentChildren[],
+  hint?: ComponentChildren,
+) {
+  return html`
+    <div style="padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
+      <div class="flex items-center justify-between gap-3 m-0">
+        <h3 class="text-xs">${title}</h3>
+        <span class="rail-section-chip rounded-full ${tone}">${statusLabel}</span>
+      </div>
+      ${rows}
+      ${hint ? html`<div class="mt-2.5 text-xs text-[color:var(--text-muted)]">${hint}</div>` : null}
+    </div>
+  `
+}
+
 export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build
   const residentCards: ComponentChildren[] = []
 
   return html`
-    <section class="rail-card">
-      <div class="rail-card-head">
-        <h3>현황</h3>
-        <span class="rail-section-chip ${liveConnected ? 'ok' : 'bad'}">${liveConnected ? '연결됨' : '오프라인'}</span>
+    <section class="rail-card rounded-xl">
+      <div class="flex items-center justify-between gap-3">
+        <h3 class="mb-0">현황</h3>
+        <span class="rail-section-chip rounded-full ${liveConnected ? 'ok' : 'bad'}">${liveConnected ? '연결됨' : '오프라인'}</span>
       </div>
-      <div class="rail-stat-grid">
-        <div class="rail-stat-card">
-          <span>에이전트</span>
-          <strong>${agents.value.length}</strong>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">에이전트</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${agents.value.length}</strong>
         </div>
-        <div class="rail-stat-card">
-          <span>키퍼</span>
-          <strong>${keepers.value.length}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">키퍼</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${keepers.value.length}</strong>
         </div>
-        <div class="rail-stat-card">
-          <span>태스크</span>
-          <strong>${tasks.value.length}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">태스크</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${tasks.value.length}</strong>
         </div>
-        <div class="rail-stat-card">
-          <span>이벤트</span>
-          <strong>${eventCount.value}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">이벤트</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${eventCount.value}</strong>
         </div>
       </div>
-      <div class="rail-inline-actions">
+      <div class="mt-3 grid grid-cols-2 gap-2">
         <button
           class="rail-refresh-btn"
           onClick=${() => {
@@ -58,12 +96,12 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
         >
           새로고침
         </button>
-        <button class="rail-secondary-btn" onClick=${() => navigate('operations', { section: 'intervene' })}>
+        <button class="rail-secondary-btn w-full border border-[var(--card-border)] rounded-[10px] py-[9px] px-[11px] bg-[var(--white-4)] text-[color:var(--text-body)] text-xs cursor-pointer" onClick=${() => navigate('operations', { section: 'intervene' })}>
           운영 패널 열기
         </button>
       </div>
       ${build
-        ? html`<div class="rail-build-hint">서버 빌드 · v${build.release_version} · ${shortCommit(build.commit)}</div>`
+        ? html`<div class="mt-2.5 text-xs text-[color:var(--text-muted)]">서버 빌드 · v${build.release_version} · ${shortCommit(build.commit)}</div>`
         : null}
       ${residentCards.length > 0
         ? html`
@@ -83,26 +121,26 @@ export function InterveneRailCard() {
   const keeperCount = snapshot?.keepers.length ?? 0
 
   return html`
-    <section class="rail-card">
-      <div class="rail-card-head">
-        <h3>개입 바로가기</h3>
-        <span class="rail-section-chip ${pendingConfirms > 0 ? 'warn' : 'ok'}">${pendingConfirms > 0 ? '확인 필요' : '정상'}</span>
+    <section class="rail-card rounded-xl">
+      <div class="flex items-center justify-between gap-3">
+        <h3 class="mb-0">개입 바로가기</h3>
+        <span class="rail-section-chip rounded-full ${pendingConfirms > 0 ? 'warn' : 'ok'}">${pendingConfirms > 0 ? '확인 필요' : '정상'}</span>
       </div>
-      <div class="rail-stat-grid">
-        <div class="rail-stat-card">
-          <span>확인 대기</span>
-          <strong>${pendingConfirms}</strong>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">확인 대기</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${pendingConfirms}</strong>
         </div>
-        <div class="rail-stat-card">
-          <span>Session</span>
-          <strong>${sessionCount}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">Session</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${sessionCount}</strong>
         </div>
-        <div class="rail-stat-card">
-          <span>키퍼</span>
-          <strong>${keeperCount}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
+          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">키퍼</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${keeperCount}</strong>
         </div>
       </div>
-      <div class="rail-inline-actions">
+      <div class="mt-3 grid grid-cols-2 gap-2">
         <button
           class="rail-refresh-btn"
           onClick=${() => {
@@ -112,7 +150,7 @@ export function InterveneRailCard() {
         >
           개입 데이터 갱신
         </button>
-        <button class="rail-secondary-btn" onClick=${() => navigate('operations', { section: 'intervene' })}>
+        <button class="rail-secondary-btn w-full border border-[var(--card-border)] rounded-[10px] py-[9px] px-[11px] bg-[var(--white-4)] text-[color:var(--text-body)] text-xs cursor-pointer" onClick=${() => navigate('operations', { section: 'intervene' })}>
           운영 패널 열기
         </button>
       </div>

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -19,22 +19,22 @@ export function Status() {
   const section = currentSection()
 
   return html`
-    <div class="tab-unified">
-      <div class="tab-pill-bar">
+    <div class="tab-unified grid gap-[var(--space-md,16px)]">
+      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
         <button
-          class="tab-pill ${section === 'sessions' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'sessions' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('status', { section: 'sessions' })}
         >
           세션
         </button>
         <button
-          class="tab-pill ${section === 'agents' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'agents' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('status', { section: 'agents' })}
         >
           에이전트
         </button>
         <button
-          class="tab-pill ${section === 'activity' ? 'tab-pill--active' : ''}"
+          class="tab-pill rounded-full ${section === 'activity' ? 'tab-pill--active' : ''}"
           onClick=${() => navigate('status', { section: 'activity' })}
         >
           활동

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -69,19 +69,19 @@ function TierDistribution({ dist }: { dist: Record<string, number> }) {
   const standardPct = total > 0 ? ((standardOnly / total) * 100).toFixed(1) : '0'
   const fullOnlyPct = total > 0 ? ((fullOnly / total) * 100).toFixed(1) : '0'
   return html`
-    <div class="tier-dist">
-      <div class="tier-dist-row">
-        <span class="tier-dist-label badge-essential">필수</span>
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2.5">
+        <span class="tier-dist-label rounded badge-essential">필수</span>
         <span class="tier-dist-count">${essential}</span>
         <span class="tier-dist-pct">${essentialPct}%</span>
       </div>
-      <div class="tier-dist-row">
-        <span class="tier-dist-label badge-standard">표준</span>
+      <div class="flex items-center gap-2.5">
+        <span class="tier-dist-label rounded badge-standard">표준</span>
         <span class="tier-dist-count">${standardOnly}</span>
         <span class="tier-dist-pct">${standardPct}%</span>
       </div>
-      <div class="tier-dist-row">
-        <span class="tier-dist-label badge-full">전체 전용</span>
+      <div class="flex items-center gap-2.5">
+        <span class="tier-dist-label rounded badge-full">전체 전용</span>
         <span class="tier-dist-count">${fullOnly}</span>
         <span class="tier-dist-pct">${fullOnlyPct}%</span>
       </div>
@@ -101,11 +101,11 @@ export function ToolMetrics() {
   }, [])
 
   return html`
-    <div class="tool-metrics">
-      <div class="tool-metrics-header">
+    <div class="flex flex-col gap-4">
+      <div class="flex justify-between items-center">
         <h3 class="tool-metrics-title">도구 사용 현황</h3>
         <button
-          class="control-btn ghost"
+          class="control-btn rounded-lg ghost"
           onClick=${() => void loadMetrics()}
           disabled=${loading}
         >
@@ -113,28 +113,28 @@ export function ToolMetrics() {
         </button>
       </div>
 
-      ${error ? html`<div class="tool-metrics-error">${error}</div>` : null}
+      ${error ? html`<div class="tool-metrics-error rounded-lg">${error}</div>` : null}
 
       ${data ? html`
         <div class="tool-metrics-summary">
           <div class="tool-metrics-stat">
-            <span class="stat-value">${data.total_calls}</span>
+            <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>
             <span class="stat-label">총 호출 수</span>
           </div>
           <div class="tool-metrics-stat">
-            <span class="stat-value">${data.distinct_tools_called}</span>
+            <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
             <span class="stat-label">사용된 도구</span>
           </div>
           <div class="tool-metrics-stat">
-            <span class="stat-value">${data.never_called_count}</span>
+            <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.never_called_count}</span>
             <span class="stat-label">미사용 도구</span>
           </div>
           <div class="tool-metrics-stat">
-            <span class="stat-value">${data.registered_count}</span>
+            <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.registered_count}</span>
             <span class="stat-label">등록됨 (v2)</span>
           </div>
           <div class="tool-metrics-stat">
-            <span class="stat-value">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
+            <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
             <span class="stat-label">Dispatch v2</span>
           </div>
         </div>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -83,27 +83,27 @@ export function FullInventoryView({
     <div class="tool-inventory-sticky-header">
       <div class="tool-inventory-summary">
         <div class="tool-inventory-stat">
-          <span class="stat-value">${totalCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="stat-label">전체 도구</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${enabledCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
           <span class="stat-label">활성화됨</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${hiddenCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${hiddenCount}</span>
           <span class="stat-label">숨김</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${deprecatedCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="stat-label">지원 중단</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${directCallCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${directCallCount}</span>
           <span class="stat-label">직접 호출</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${filtered.length}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${filtered.length}</span>
           <span class="stat-label">필터 결과</span>
         </div>
       </div>
@@ -115,14 +115,14 @@ export function FullInventoryView({
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="tool-surface-count">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="tool-surface-count rounded-full">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
 
       <div class="tool-inventory-filters">
         <input
-          class="control-input"
+          class="control-input rounded-lg"
           type="text"
           placeholder="도구, 문서, 권한, 대체 도구 검색..."
           value=${searchQuery.value}
@@ -180,13 +180,13 @@ export function FullInventoryView({
           />
           <span>지원 중단 표시</span>
         </label>
-        <button class="control-btn ghost" onClick=${() => { void loadTools() }} disabled=${loading}>
+        <button class="control-btn rounded-lg ghost" onClick=${() => { void loadTools() }} disabled=${loading}>
           ${loading ? '새로고침 중...' : '새로고침'}
         </button>
       </div>
     </div>
 
-    ${error ? html`<div class="tool-metrics-error">${error}</div>` : null}
+    ${error ? html`<div class="tool-metrics-error rounded-lg">${error}</div>` : null}
 
     <div ref=${listContainerRef} class="tool-inventory-virtual-container">
       ${filtered.length > 0
@@ -197,7 +197,7 @@ export function FullInventoryView({
             getKey=${(item: DashboardToolInventoryItem) => item.name}
             className="tool-inventory-list"
           />`
-        : html`<div class="empty-state">조건에 맞는 도구가 없습니다.</div>`}
+        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">조건에 맞는 도구가 없습니다.</div>`}
     </div>
 
     <button

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -22,15 +22,15 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
     <div class="py-2">
       <div class="tool-inventory-summary">
         <div class="tool-inventory-stat">
-          <span class="stat-value">${totalCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="stat-label">전체 도구</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${enabledCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
           <span class="stat-label">활성화됨</span>
         </div>
         <div class="tool-inventory-stat">
-          <span class="stat-value">${deprecatedCount}</span>
+          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="stat-label">폐기 예정</span>
         </div>
       </div>
@@ -38,9 +38,9 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
       ${essential.length > 0 ? html`
         <div class="mt-5">
           <h4 class="tool-summary-heading">필수 도구 (상위 ${essential.length}개)</h4>
-          <div class="tool-summary-list">
+          <div class="flex flex-col gap-1.5">
             ${essential.map(item => html`
-              <div class="tool-summary-row" key=${item.name}>
+              <div class="tool-summary-row rounded-lg" key=${item.name}>
                 <span class="tool-summary-name">${item.name}</span>
                 <span class="tool-summary-desc">${item.description?.slice(0, 60) ?? ''}</span>
                 ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -53,9 +53,9 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
       ${neverUsed.length > 0 ? html`
         <div class="mt-5">
           <h4 class="tool-summary-heading">미사용 도구 (${neverUsed.length}개)</h4>
-          <div class="tool-summary-list">
+          <div class="flex flex-col gap-1.5">
             ${neverUsed.map(item => html`
-              <div class="tool-summary-row" key=${item.name}>
+              <div class="tool-summary-row rounded-lg" key=${item.name}>
                 <span class="tool-summary-name">${item.name}</span>
                 <span class="tool-summary-desc">${item.description?.slice(0, 60) ?? ''}</span>
                 ${toolBadge(item.category)}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -38,7 +38,7 @@ export function Tools() {
               : '필수 도구와 사용 현황 요약입니다.'}
           </p>
           <button
-            class="control-btn ghost"
+            class="control-btn rounded-lg ghost"
             class="mt-2"
             onClick=${() => { showFullInventory.value = !showFullInventory.value }}
           >

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -13,33 +13,33 @@ export function Trpg() {
   }, [state, loading])
 
   if (loading && !state) {
-    return html`<div class="empty-state">TRPG 상태를 불러오는 중...</div>`
+    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">TRPG 상태를 불러오는 중...</div>`
   }
 
   if (!state) {
     return html`
-      <div class="empty-state">
+      <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
         <div style="margin-bottom: 12px;">활성 TRPG 세션이 없습니다.</div>
-        <button class="control-btn ghost" onClick=${() => void refreshTrpg()}>새로고침</button>
+        <button class="control-btn rounded-lg ghost" onClick=${() => void refreshTrpg()}>새로고침</button>
       </div>
     `
   }
 
   return html`
     <div class="monitor-summary-grid">
-      <div class="monitor-summary-card">
+      <div class="monitor-summary-card rounded-xl">
         <div class="monitor-summary-label">ROOM</div>
         <div class="monitor-summary-value">${trpgRoom.value || state.session?.room || '-'}</div>
       </div>
-      <div class="monitor-summary-card">
+      <div class="monitor-summary-card rounded-xl">
         <div class="monitor-summary-label">SESSION</div>
         <div class="monitor-summary-value">${state.session?.status ?? 'active'}</div>
       </div>
-      <div class="monitor-summary-card">
+      <div class="monitor-summary-card rounded-xl">
         <div class="monitor-summary-label">PARTY</div>
         <div class="monitor-summary-value">${state.party.length}</div>
       </div>
-      <div class="monitor-summary-card">
+      <div class="monitor-summary-card rounded-xl">
         <div class="monitor-summary-label">EVENTS</div>
         <div class="monitor-summary-value">${state.story_log.length}</div>
       </div>

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -28,12 +28,12 @@ export function Work() {
     : 'board'
 
   return html`
-    <div class="tab-unified">
-      <div class="tab-pill-bar">
+    <div class="tab-unified grid gap-[var(--space-md,16px)]">
+      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
         ${SECTIONS.map(s => html`
           <button
             key=${s.id}
-            class="tab-pill ${current === s.id ? 'tab-pill--active' : ''}"
+            class="tab-pill rounded-full ${current === s.id ? 'tab-pill--active' : ''}"
             title=${s.tooltip}
             onClick=${() => navigate('work', { section: s.id })}
           >

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -85,7 +85,6 @@
 
 .agent-live-chip {
   padding: 3px 10px;
-  border-radius: 12px;
   border: 1px solid var(--ff-border-subtle);
   background: none;
   color: var(--text-muted, var(--text-muted));
@@ -120,12 +119,10 @@
   padding: 2px 8px;
   background: var(--accent-10);
   border: 1px solid var(--accent-20);
-  border-radius: 8px;
 }
 
 .agent-live-autoscroll {
   padding: 2px 8px;
-  border-radius: 8px;
   border: 1px solid var(--ff-border-subtle);
   background: none;
   color: var(--text-muted);
@@ -157,7 +154,6 @@
   gap: 6px;
   padding: 4px 8px;
   font-size: var(--fs-sm);
-  border-radius: 4px;
   transition: background 0.1s;
 }
 

--- a/dashboard/src/styles/agent.css
+++ b/dashboard/src/styles/agent.css
@@ -6,7 +6,6 @@
   background: var(--white-4);
   border-radius: 10px;
   border: 1px solid var(--white-8);
-  transition: border-color 0.2s;
   color: inherit;
   font: inherit;
   text-align: left;
@@ -22,14 +21,6 @@
 .agent-card .agent-emoji { font-size: 24px; }
 .agent-card .agent-name { font-size: var(--fs-lg); font-weight: 600; }
 /* ── Agent Journal Stream (Phase 2) ───────────────────────── */
-.agent-journal-stream {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 280px;
-  overflow-y: auto;
-}
-
 .agent-journal-entry,
 .agent-timeline-event {
   display: flex;
@@ -37,7 +28,6 @@
   gap: 6px;
   padding: 4px 8px;
   font-size: var(--fs-sm);
-  border-radius: 4px;
   transition: background 0.1s;
 }
 
@@ -79,26 +69,6 @@
 }
 
 /* ── Agent Worker Brief ───────────────────────────────────── */
-.agent-worker-brief {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.agent-worker-brief__row {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  font-size: var(--fs-sm);
-}
-
-.agent-worker-brief__label {
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  min-width: 60px;
-  flex-shrink: 0;
-}
-
 .agent-worker-brief__preview {
   color: var(--text-body);
   font-style: italic;
@@ -109,21 +79,6 @@
 }
 
 /* ── Agent Timeline Section (Phase 3) ─────────────────────── */
-.agent-timeline-summary {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  margin-bottom: 8px;
-}
-
-.agent-timeline-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
 .agent-timeline-type {
   font-size: var(--fs-xs);
   font-weight: 500;
@@ -133,11 +88,6 @@
 }
 
 /* ── Agents Unified Tab (chip toggle) ────────── */
-.agents-unified {
-  display: grid;
-  gap: var(--space-md, 16px);
-}
-
 .agents-chip {
   padding: 4px 14px;
   border-radius: 16px;
@@ -164,7 +114,6 @@
   text-align: center;
   padding: 1px 5px;
   margin-left: 4px;
-  border-radius: 8px;
   background: var(--white-12);
   color: inherit;
 }

--- a/dashboard/src/styles/board.css
+++ b/dashboard/src/styles/board.css
@@ -31,12 +31,10 @@
 .board-sort-btn {
   padding: 6px 14px;
   border: 1px solid var(--white-10);
-  border-radius: 8px;
   background: var(--white-4);
   color: var(--text-dim);
   cursor: pointer;
   font-size: var(--fs-sm);
-  transition: all 0.2s;
 }
 .board-sort-btn:hover { background: var(--white-8); color: #ccc; }
 .board-sort-btn.active {
@@ -50,7 +48,6 @@
   gap: 10px;
   padding: 14px 14px 13px;
   background: var(--white-4);
-  border-radius: 12px;
   cursor: pointer;
   border: 1px solid var(--white-6);
   margin-bottom: 10px;
@@ -90,7 +87,6 @@
 .board-meta-chip {
   font-size: var(--fs-2xs);
   padding: 2px 8px;
-  border-radius: 999px;
   border: 1px solid rgba(71, 184, 255, 0.3);
   color: #9ad9ff;
   background: var(--accent-12);
@@ -118,7 +114,6 @@
   margin-left: 40px;
   padding: 10px 12px;
   background: var(--white-3);
-  border-radius: 8px;
   border-left: 2px solid rgba(167,139,250,0.3);
   margin-bottom: 8px;
 }

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -59,7 +59,6 @@
   justify-content: center;
   width: 30px;
   height: 30px;
-  border-radius: 999px;
   font-size: var(--fs-xs);
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -100,7 +99,6 @@
 .chat-detail-chip {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
   padding: 2px 8px;
   font-size: var(--fs-xs);
   letter-spacing: 0.03em;
@@ -138,7 +136,6 @@
   border: 1px solid rgba(138, 163, 211, 0.24);
   background: var(--white-4);
   color: #a8c3eb;
-  border-radius: 999px;
   padding: 4px 10px;
   font-size: var(--fs-xs);
   cursor: pointer;
@@ -163,7 +160,6 @@
   flex-direction: column;
   gap: 12px;
   padding: 12px;
-  border-radius: 12px;
   border: 1px solid var(--border-slate-16);
   background:
     linear-gradient(180deg, rgba(7, 17, 37, 0.9), rgba(4, 12, 28, 0.82));
@@ -239,7 +235,6 @@
   border: 1px solid var(--border-slate-18);
   background: var(--white-3);
   color: #9db7e2;
-  border-radius: 999px;
   padding: 4px 10px;
   font-size: var(--fs-xs);
   cursor: pointer;
@@ -253,12 +248,6 @@
   font-size: var(--fs-xs);
   line-height: 1.55;
   color: #95f3bc;
-}
-
-.chat-composer-actions {
-  display: flex;
-  gap: 8px;
-  align-items: center;
 }
 
 /* ── Stream Warning (60s+ elapsed) ─────────────────────── */

--- a/dashboard/src/styles/command-swarm.css
+++ b/dashboard/src/styles/command-swarm.css
@@ -39,7 +39,6 @@
 .swarm-story-strip span {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
   padding: 4px 8px;
   background: var(--white-6);
   color: rgba(191,219,254,0.9);
@@ -275,7 +274,6 @@
   border-left: 3px solid var(--card-border, var(--white-10));
   background: var(--white-3);
   border-radius: 0 8px 8px 0;
-  transition: border-color 0.2s;
 }
 .swarm-lane-strip.ok { border-left-color: var(--ok); }
 .swarm-lane-strip.warn { border-left-color: var(--warn); }
@@ -308,7 +306,6 @@
 .swarm-lane-track {
   margin-top: 10px;
   height: 8px;
-  border-radius: 999px;
   background: var(--white-6);
   overflow: hidden;
 }
@@ -316,7 +313,6 @@
 .swarm-lane-track span {
   display: block;
   height: 100%;
-  border-radius: 999px;
   background: linear-gradient(90deg, rgba(103,232,249,0.92), rgba(74,222,128,0.92));
 }
 
@@ -360,7 +356,6 @@
 .swarm-lane-blockers {
   background: rgba(239,68,68,0.1);
   border: 1px solid rgba(239,68,68,0.25);
-  border-radius: 6px;
   padding: 6px 10px;
   font-size: 0.78rem;
   color: var(--bad);

--- a/dashboard/src/styles/command.css
+++ b/dashboard/src/styles/command.css
@@ -110,7 +110,6 @@
 
 .command-focus-preview {
   padding: 10px 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-5);
   color: var(--text-strong);
@@ -145,12 +144,6 @@
   }
 }
 
-.command-entry-label {
-  color: rgba(148, 163, 184, 0.92);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
 
 .command-summary-grid {
   display: grid;
@@ -212,20 +205,6 @@
   }
 }
 
-.command-hero-kicker {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  gap: 8px;
-  padding: 5px 10px;
-  border-radius: 999px;
-  color: #7dd3fc;
-  background: rgba(14, 116, 144, 0.22);
-  border: 1px solid rgba(125, 211, 252, 0.18);
-  font-size: var(--fs-xs);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
 
 .command-hero-badges,
 .command-tab-group-items {
@@ -251,7 +230,6 @@
 .command-tree-node {
   background: var(--white-4);
   border: 1px solid var(--white-8);
-  border-radius: 12px;
   padding: 14px;
 
   &.depth-3 {
@@ -287,7 +265,6 @@
   flex-direction: column;
   gap: 10px;
   padding: 14px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-3);
 
@@ -393,7 +370,6 @@
   border: 1px solid var(--white-12);
   background: var(--white-4);
   color: var(--white-72);
-  border-radius: 999px;
   padding: 8px 14px;
   text-transform: capitalize;
 
@@ -498,12 +474,6 @@
   }
 }
 
-.command-warroom-summary {
-  margin-top: 12px;
-  color: rgba(226,232,240,0.86);
-  line-height: 1.55;
-  max-width: 82ch;
-}
 
 .command-warroom-hero-actions {
   display: flex;
@@ -548,13 +518,6 @@
   gap: 10px;
 }
 
-.warroom-feed-detail {
-  color: rgba(226,232,240,0.86);
-  line-height: 1.55;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
 
 @media (max-width: 1450px) {
 
@@ -622,7 +585,6 @@
 .command-topology-explainer {
   margin-bottom: 14px;
   padding: 14px;
-  border-radius: 12px;
   background: var(--white-4);
   border: 1px solid var(--white-8);
 }
@@ -670,7 +632,6 @@
   cursor: pointer;
   background: var(--white-4);
   border: 1px solid var(--white-8);
-  border-radius: 12px;
   padding: 14px;
 
   &.selected {
@@ -683,7 +644,6 @@
 .command-chain-panel {
   margin-top: 14px;
   padding: 14px;
-  border-radius: 12px;
   background: var(--white-4);
   border: 1px solid var(--white-8);
 }
@@ -707,7 +667,6 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 8px;
-  border-radius: 999px;
   font-size: var(--fs-xs);
   letter-spacing: 0.02em;
   background: var(--white-8);
@@ -838,17 +797,6 @@
   gap: 12px;
 }
 
-.command-gauge-card {
-  display: grid;
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: 12px;
-  align-items: center;
-  padding: 12px;
-  border-radius: 16px;
-  background: rgba(255,255,255,0.045);
-  border: 1px solid var(--white-8);
-  min-width: 0;
-}
 
 .command-gauge-ring {
   width: 88px;
@@ -859,17 +807,6 @@
   box-shadow: inset 0 0 0 1px var(--white-4);
 }
 
-.command-gauge-core {
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background: rgba(8, 14, 28, 0.92);
-  border: 1px solid var(--white-6);
-  display: grid;
-  place-items: center;
-  align-content: center;
-  text-align: center;
-}
 
 .command-gauge-core strong,
 .command-signal-copy strong {
@@ -939,7 +876,6 @@
 .command-signal-bar {
   position: relative;
   height: 8px;
-  border-radius: 999px;
   overflow: hidden;
   background: var(--white-6);
 }
@@ -947,7 +883,6 @@
 .command-signal-bar span {
   display: block;
   height: 100%;
-  border-radius: 999px;
   background: linear-gradient(90deg, rgba(103,232,249,0.86), rgba(74,222,128,0.9));
 }
 

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -69,16 +69,6 @@
   padding: 0 16px 12px;
 }
 
-.monitor-pill {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 3px 8px;
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
 .monitor-pill.ok {
   background: var(--ok-12);
   color: var(--ok);
@@ -100,30 +90,15 @@
   }
 }
 
-.board-post-list,
-.comment-thread {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .board-post {
   border-color: var(--card-border);
   content-visibility: auto;
   contain-intrinsic-size: auto 120px;
 }
 
-.post-meta {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
 .back-btn {
   margin-bottom: 12px;
   border: 1px solid var(--border-slate-30);
-  border-radius: 8px;
   padding: 7px 12px;
   font-size: var(--fs-sm);
   color: #bdd8ff;
@@ -136,36 +111,15 @@
 }
 
 /* ── Control Dock ─────────────────────────────────────────── */
-.control-label {
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
 .control-row {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 6px;
 }
 
-.control-actions,
-.control-inline-meta,
-.tab-pill-bar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.control-status-copy {
-  color: #d5e5fb;
-  font-size: var(--fs-sm);
-  line-height: 1.5;
-}
-
 .control-input,
 .control-textarea {
   width: 100%;
-  border-radius: 8px;
   border: 1px solid rgba(138, 163, 211, 0.28);
   background: var(--white-4);
   color: #d3e3ff;
@@ -187,7 +141,6 @@
 
 .control-btn {
   border: 1px solid rgba(71, 184, 255, 0.45);
-  border-radius: 8px;
   background: var(--accent-18);
   color: #c9ebff;
   padding: 8px 12px;
@@ -229,27 +182,7 @@
   background: rgba(59, 18, 24, 0.45);
   color: #ffd6d6;
 }
-.keeper-status-console {
-  margin: 8px 0 0;
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--card-border);
-  background: rgba(2, 10, 24, 0.82);
-  color: #9ad8b6;
-  font-size: var(--fs-sm);
-  line-height: 1.55;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: "Fira Code", monospace;
-  max-height: 240px;
-  overflow: auto;
-}
 
-.keeper-conversation-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
 .control-btn.ghost {
   border-color: var(--border-slate-35);
   background: var(--white-5);
@@ -262,15 +195,9 @@
 }
 
 /* ── Mission Jump Strip ────────────────────────────────── */
-.mission-jump-strip {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
 
 .mission-jump-link {
   padding: 4px 10px;
-  border-radius: 999px;
   border: 1px solid var(--border-slate-22);
   background: var(--white-3);
   color: #9fb8e1;
@@ -330,11 +257,7 @@
   opacity: 0.85;
 }
 
-/* ── Shared: tab-unified, pill bar, collapsible ── */
-.tab-unified {
-  display: grid;
-  gap: var(--space-md, 16px);
-}
+/* ── Shared: pill bar, collapsible ── */
 
 .tab-pill {
   padding: 4px 14px;
@@ -358,7 +281,6 @@
 
 .tab-collapsible {
   border: 1px solid var(--card-border, var(--white-6));
-  border-radius: 8px;
 }
 .tab-collapsible__summary {
   padding: 8px 12px;
@@ -440,7 +362,6 @@
 .agent-card:hover {
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
   transform: translateY(-2px);
-  transition: all 0.2s ease;
   border-color: var(--accent);
 }
 
@@ -450,15 +371,6 @@
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px;
   align-items: start;
-}
-.kanban-column {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  background: rgba(10, 15, 29, 0.5);
-  border-radius: var(--radius-lg);
-  padding: 20px;
-  border: 1px solid var(--accent-10);
 }
 .kanban-header {
   font-size: 1.1rem;
@@ -474,12 +386,6 @@
 .kanban-header.inprogress .kanban-badge { background: var(--accent-soft); color: var(--accent); }
 .kanban-header.done .kanban-badge { background: rgba(0, 255, 157, 0.15); color: var(--ok); }
 
-.kanban-badge {
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-size: 0.8rem;
-  font-weight: bold;
-}
 .kanban-card {
   background: var(--card);
   backdrop-filter: blur(8px);
@@ -510,72 +416,26 @@
   border-color: var(--accent);
   box-shadow: 0 4px 12px rgba(0, 240, 255, 0.1);
 }
-.kanban-card-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--text-strong);
-  line-height: 1.4;
-  margin-left: 8px;
-}
-.kanban-card-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-left: 8px;
-}
 .kanban-assignee {
   display: inline-flex;
   align-items: center;
   background: rgba(0, 240, 255, 0.1);
   color: var(--accent);
   padding: 4px 8px;
-  border-radius: 8px;
   gap: 4px;
   font-weight: 600;
 }
 .kanban-assignee::before {
   content: "@";
-  opacity: 0.7;
-}
-
-.memory-note {
-  font-style: italic;
-  color: var(--accent);
 }
 
 /* ── Logs (merged from logs.css) ── */
 /* System Log Viewer */
 
-.logs-viewer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  height: 100%;
-  min-height: 0;
-}
-
-.logs-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.5rem 0;
-  flex-shrink: 0;
-}
-
-.logs-filters {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
 .logs-select {
   background: var(--card);
   color: var(--text-body);
   border: 1px solid var(--card-border);
-  border-radius: 4px;
   padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
@@ -585,7 +445,6 @@
   background: var(--card);
   color: var(--text-body);
   border: 1px solid var(--card-border);
-  border-radius: 4px;
   padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
@@ -596,26 +455,10 @@
   color: var(--text-muted);
 }
 
-.logs-actions {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.logs-auto-label {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  cursor: pointer;
-}
-
 .logs-refresh-btn {
   background: var(--card);
   color: var(--text-body);
   border: 1px solid var(--card-border);
-  border-radius: 4px;
   padding: 0.2rem 0.6rem;
   font-size: 0.75rem;
   font-family: "JetBrains Mono", "Fira Code", "SF Mono", monospace;
@@ -626,20 +469,10 @@
   border-color: var(--accent);
 }
 
-.logs-error {
-  padding: 0.5rem;
-  background: rgba(224, 80, 80, 0.15);
-  border: 1px solid #e05050;
-  border-radius: 4px;
-  color: #e05050;
-  font-size: 0.8rem;
-}
-
 .logs-table-wrap {
   flex: 1;
   overflow: auto;
   border: 1px solid var(--card-border);
-  border-radius: 4px;
   background: var(--card);
 }
 
@@ -671,24 +504,6 @@
   padding: 0.2rem 0.5rem;
   border-bottom: 1px solid var(--white-4);
   vertical-align: top;
-}
-
-.logs-col-ts {
-  width: 11rem;
-  white-space: nowrap;
-  color: var(--text-muted);
-}
-
-.logs-col-level {
-  width: 3.5rem;
-  white-space: nowrap;
-  font-weight: 600;
-}
-
-.logs-col-module {
-  width: 8rem;
-  white-space: nowrap;
-  color: var(--accent);
 }
 
 .logs-row:hover {

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -295,14 +295,6 @@ a:hover {
 
 /* Header */
 
-.version-badge {
-  font-size: 11px;
-  padding: 2px 9px;
-  border-radius: 999px;
-  border: 1px solid rgba(71, 184, 255, 0.35);
-  background: var(--accent-soft);
-  color: #9ad9ff;
-}
 
 .build-badge-trigger {
   cursor: pointer;
@@ -323,32 +315,10 @@ a:hover {
   gap: 8px;
 }
 
-.build-badge-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.build-badge-row strong {
-  color: var(--text-strong);
-  text-align: right;
-}
-
-.rail-build-hint {
-  margin-top: 10px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-.kpi-value {
-  color: var(--text-strong);
-  font-size: 17px;
-  line-height: 1.1;
-  font-weight: 650;
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
-}
+/* build-badge-row → Tailwind (flex justify-between gap-3 text-xs text-[color:var(--text-muted)]) */
+/* build-badge-row strong → Tailwind (text-[color:var(--text-strong)] text-right) */
+/* rail-build-hint → Tailwind (mt-2.5 text-xs text-[color:var(--text-muted)]) */
+/* kpi-value → Tailwind (text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums) */
 
 /* Main layout */
 .dashboard-rail {
@@ -376,12 +346,8 @@ a:hover {
   padding: 14px;
 }
 
-.rail-card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
+/* rail-card-head → Tailwind (flex items-center justify-between gap-3) */
+/* rail-card-head h3 → Tailwind (mb-0) */
 
 .rail-card h3 {
   color: var(--text-strong);
@@ -391,14 +357,9 @@ a:hover {
   margin-bottom: 10px;
 }
 
-.rail-card-head h3 {
-  margin-bottom: 0;
-}
-
 .rail-section-chip {
   display: inline-flex;
   align-items: center;
-  border-radius: 999px;
   padding: 4px 9px;
   font-size: 10px;
   text-transform: uppercase;
@@ -419,11 +380,7 @@ a:hover {
   border-color: rgba(239, 68, 68, 0.28);
   background: var(--bad-12);
 }
-.rail-tab-list {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 6px;
-}
+/* rail-tab-list → Tailwind (grid grid-cols-1 gap-1.5) */
 
 .rail-tab-btn {
   border: 1px solid var(--card-border);
@@ -450,23 +407,9 @@ a:hover {
   background: var(--white-10);
 }
 
-.rail-tab-copy {
-  min-width: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.rail-tab-copy strong {
-  color: var(--text-strong);
-  font-size: 13px;
-  line-height: 1.3;
-}
-
-.rail-tab-copy span {
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.4;
-}
+/* rail-tab-copy → Tailwind (min-w-0 grid gap-0.5) */
+/* rail-tab-copy strong → Tailwind (text-[color:var(--text-strong)] text-[13px] leading-[1.3]) */
+/* rail-tab-copy span → Tailwind (text-[color:var(--text-muted)] text-[11px] leading-[1.4]) */
 
 .rail-tab-btn.active .rail-tab-copy span {
   color: #c7dcf7;
@@ -476,73 +419,11 @@ a:hover {
   margin-top: 14px;
 }
 
-.rail-view-note {
-  margin-top: 14px;
-  padding-top: 10px;
-  border-top: 1px solid var(--card-border);
-  display: grid;
-  gap: 4px;
-}
-
-.rail-view-note-label,
-.rail-stat-card span {
-  color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.rail-view-note strong {
-  color: var(--text-strong);
-  font-size: 14px;
-}
-
-.rail-view-note p {
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-/* ── Compact Rail (Phase 2) ── */
-
-.rail-card-compact {
-  padding: 10px 12px;
-}
-
-.rail-card-compact .rail-tab-btn {
-  padding: 6px 8px;
-  gap: 6px;
-}
-
-.rail-card-compact .rail-tab-btn strong {
-  font-size: 13px;
-}
-.rail-stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.rail-stat-card {
-  border: 1px solid var(--border-slate-16);
-  border-radius: 10px;
-  padding: 10px 11px;
-  background: var(--white-3);
-  display: grid;
-  gap: 4px;
-}
-
-.rail-stat-card strong {
-  color: var(--text-strong);
-  font-size: 18px;
-  line-height: 1.1;
-}
-.rail-inline-actions {
-  margin-top: 12px;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
+/* rail-view-note, rail-view-note-label, rail-stat-card span/strong → Tailwind */
+/* rail-card-compact → Tailwind (py-2.5 px-3) */
+/* rail-stat-grid → Tailwind (grid grid-cols-2 gap-2) */
+/* rail-stat-card → Tailwind inline */
+/* rail-inline-actions → Tailwind (mt-3 grid grid-cols-2 gap-2) */
 .rail-refresh-btn {
   width: 100%;
   border: 1px solid rgba(71, 184, 255, 0.4);
@@ -558,57 +439,14 @@ a:hover {
   background: var(--accent-20);
 }
 
-.rail-secondary-btn {
-  width: 100%;
-  border: 1px solid var(--card-border);
-  border-radius: 10px;
-  padding: 9px 11px;
-  background: var(--white-4);
-  color: var(--text-body);
-  font-size: 12px;
-  cursor: pointer;
-}
+/* rail-secondary-btn → Tailwind (w-full border border-[var(--card-border)] rounded-[10px] py-[9px] px-[11px] bg-[var(--white-4)] text-[color:var(--text-body)] text-xs cursor-pointer) */
 
 /* Core cards and sections */
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-  margin-bottom: 16px;
-}
+/* stats-grid → Tailwind (grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-4) */
 
-.stat-card {
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-md);
-  background: var(--card);
-  padding: 15px 14px;
-}
-
-.stat-value {
-  margin-top: 6px;
-  color: var(--text-strong);
-  font-size: 30px;
-  font-weight: 700;
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
-}
-
-.section h2 {
-  color: var(--text-strong);
-  font-size: 14px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  margin-bottom: 10px;
-}
-
-.empty-state {
-  text-align: center;
-  border: 1px dashed var(--card-border);
-  border-radius: 10px;
-  padding: 22px 16px;
-  color: var(--text-muted);
-}
+/* stat-card → Tailwind (border border-[var(--card-border)] rounded-[var(--radius-md)] bg-[var(--card)] py-[15px] px-3.5) */
+/* stat-value → Tailwind (mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums) */
+/* empty-state base → Tailwind (text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]) */
 
 .empty-state.ok {
   border-color: var(--ok-30);
@@ -618,20 +456,10 @@ a:hover {
 .loading-indicator {
   text-align: center;
   border: 1px dashed var(--card-border);
-  border-radius: 12px;
   padding: 48px 16px;
   color: var(--text-muted);
 }
 
-.loading-banner {
-  text-align: center;
-  padding: 6px 16px;
-  background: rgba(230, 167, 0, 0.12);
-  border-bottom: 1px solid rgba(230, 167, 0, 0.3);
-  color: #e6a700;
-  font-size: 0.8rem;
-  flex-shrink: 0;
-}
 
 @keyframes fadeSlide {
   from {
@@ -802,7 +630,6 @@ a:hover {
   padding: 2px 8px;
   min-width: 80px;
   border: 1px solid var(--card-border);
-  border-radius: 999px;
   background: var(--white-4);
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";
@@ -811,7 +638,6 @@ a:hover {
 .pill {
   font-size: var(--fs-2xs);
   padding: 2px 8px;
-  border-radius: 999px;
   border: 1px solid rgba(71, 184, 255, 0.36);
   background: var(--accent-12);
   color: #9ad9ff;
@@ -820,7 +646,6 @@ a:hover {
 .ctx-bar {
   height: 6px;
   margin-top: 6px;
-  border-radius: 999px;
   overflow: hidden;
   background: var(--white-10);
 }
@@ -828,7 +653,6 @@ a:hover {
 .ctx-fill {
   height: 100%;
   background: linear-gradient(90deg, var(--accent), var(--ok));
-  border-radius: 999px;
   transition: width 0.25s ease;
 }
 

--- a/dashboard/src/styles/goals.css
+++ b/dashboard/src/styles/goals.css
@@ -12,7 +12,6 @@
   text-align: center;
   padding: 8px 4px;
   background: var(--white-3);
-  border-radius: 8px;
 }
 
 .goal-summary-value {
@@ -27,19 +26,6 @@
   margin-top: 2px;
 }
 
-.goal-filters {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  margin-top: 12px;
-}
-
-.goal-filter-group {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 .goal-filter-label {
   font-size: var(--fs-xs);
   color: var(--text-dim);
@@ -51,7 +37,6 @@
   border: 1px solid var(--white-8);
   color: #aaa;
   padding: 3px 10px;
-  border-radius: 12px;
   font-size: var(--fs-sm);
   cursor: pointer;
   transition: all 0.15s;
@@ -68,19 +53,12 @@
   color: #818cf8;
 }
 
-.goal-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
 .goal-row {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
   padding: 10px 12px;
-  border-radius: 8px;
   background: var(--white-2);
   transition: background 0.15s;
 }
@@ -90,7 +68,6 @@
 }
 .planning-loop-row {
   border: 1px solid var(--card-border);
-  border-radius: 12px;
   background: rgba(13, 22, 40, 0.58);
   padding: 14px;
 }
@@ -117,20 +94,6 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-.planning-loop-badges {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.planning-loop-metrics {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  color: #b9c9ea;
-  font-size: var(--fs-sm);
-}
-
 .planning-loop-target {
   color: var(--text-body);
   font-size: var(--fs-base);
@@ -154,15 +117,6 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-}
-
-.goal-meta {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 4px;
-  font-size: var(--fs-xs);
-  color: var(--text-dim);
 }
 
 .goal-review-note {
@@ -205,7 +159,6 @@
   font-size: var(--fs-2xs);
   font-weight: 700;
   padding: 2px 6px;
-  border-radius: 4px;
   letter-spacing: 0.5px;
   flex-shrink: 0;
   line-height: 1;
@@ -254,7 +207,6 @@
   padding: 4px 8px;
   border-left: 2px solid var(--white-6);
   cursor: pointer;
-  transition: color 0.15s;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -23,47 +23,11 @@
   padding: 18px;
 }
 
-.agent-detail-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-
-  & h2 {
-    color: var(--text-strong);
-    font-size: 20px;
-    margin: 0;
-  }
-}
-
-.agent-detail-sub {
-  margin-top: 6px;
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  color: #9ab3de;
-  font-size: var(--fs-sm);
-}
-
-.agent-detail-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.agent-detail-task-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .agent-detail-task {
   display: flex;
   align-items: center;
   gap: 8px;
   border: 1px solid var(--card-border);
-  border-radius: 8px;
   background: var(--white-3);
   padding: 8px 10px;
 }
@@ -83,19 +47,12 @@
 
 .agent-activity-line {
   border: 1px solid var(--card-border);
-  border-radius: 8px;
   background: var(--white-3);
   padding: 8px 10px;
   font-family: "IBM Plex Mono", "Fira Code", monospace;
   font-size: var(--fs-sm);
   color: #c8daf7;
   line-height: 1.4;
-}
-
-.agent-history-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
 }
 
 .agent-history-row {
@@ -114,22 +71,10 @@
   font-family: "IBM Plex Mono", "Fira Code", monospace;
 }
 
-.agent-mention-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 8px;
-}
-
 /* ── FF Character Sheet — Agent Profile ──────────────────── */
 
 .ff-profile {
   padding: 0 4px;
-}
-
-.ff-profile__toolbar {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 12px;
 }
 
 /* --- Character Plate (top section) --- */
@@ -153,27 +98,6 @@
     inset 0 1px 0 var(--ff-gold-8);
 }
 
-.ff-plate__portrait {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-.ff-plate__info {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.ff-plate__name-row {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
 .ff-plate__name {
   margin: 0;
   font-size: 20px;
@@ -189,16 +113,8 @@
   color: var(--accent);
   background: var(--accent-10);
   border: 1px solid rgba(71, 184, 255, 0.25);
-  border-radius: 4px;
   padding: 1px 6px;
   font-variant-numeric: tabular-nums;
-}
-
-.ff-plate__badges {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
 }
 
 .ff-plate__model {
@@ -207,7 +123,6 @@
   color: var(--text-muted);
   background: var(--accent-8);
   border: 1px solid rgba(71, 184, 255, 0.15);
-  border-radius: 4px;
   padding: 1px 5px;
 }
 
@@ -216,7 +131,6 @@
   color: var(--ff-gold);
   background: var(--ff-gold-10);
   border: 1px solid var(--ff-gold-20);
-  border-radius: 4px;
   padding: 1px 5px;
 }
 
@@ -224,7 +138,6 @@
   font-size: var(--fs-2xs);
   font-weight: 600;
   letter-spacing: 0.5px;
-  border-radius: 4px;
   padding: 1px 5px;
 }
 
@@ -246,14 +159,6 @@
   border: 1px solid rgba(128, 128, 128, 0.15);
 }
 
-/* CTX bar row */
-.ff-plate__bar-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 2px;
-}
-
 .ff-plate__bar-label {
   font-size: var(--fs-xs);
   font-weight: 700;
@@ -270,14 +175,6 @@
   text-align: right;
 }
 
-/* Status line */
-.ff-plate__status-line {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
 .ff-plate__work--idle {
   color: #6b7fa0;
   font-style: italic;
@@ -289,14 +186,6 @@
   background: var(--accent-8);
   padding: 1px 5px;
   border-radius: 3px;
-}
-
-.ff-plate__meta-line {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
 }
 
 /* Stats panel (right side) */
@@ -313,7 +202,6 @@
   flex-direction: column;
   align-items: center;
   padding: 6px 8px;
-  border-radius: 6px;
   background: rgba(200, 168, 78, 0.05);
   border: 1px solid var(--ff-gold-10);
 }
@@ -326,13 +214,6 @@
 }
 
 /* --- Grid and Cards --- */
-
-.ff-profile__grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-bottom: 14px;
-}
 
 /* Timeline events - compact FF style */
 .ff-event-type {
@@ -354,7 +235,6 @@
   gap: 8px;
   align-items: center;
   padding: 10px 14px;
-  border-radius: 8px;
   background: rgba(10, 22, 40, 0.8);
   border: 1px solid var(--ff-gold-15);
 
@@ -384,18 +264,11 @@
 
 /* --- Agent Relations Card --- */
 
-.ff-relations-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
 .ff-relation-row {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  border-radius: 4px;
   transition: background 0.15s;
 
   &:hover {
@@ -419,13 +292,6 @@
 .ff-interests {
   border-top: 1px solid var(--white-6);
   padding-top: 8px;
-}
-
-.ff-interests-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 6px;
 }
 
 .ff-interest-tag {

--- a/dashboard/src/styles/governance-keeper.css
+++ b/dashboard/src/styles/governance-keeper.css
@@ -30,7 +30,6 @@
   min-width: 250px;
   max-width: 320px;
   padding: 9px 10px;
-  border-radius: 8px;
   border: 1px solid var(--border-slate-35);
   background: rgba(10, 18, 34, 0.96);
   color: #d3e3ff;
@@ -64,7 +63,6 @@
 .governance-stale-warning {
   padding: 10px 14px;
   margin-bottom: 8px;
-  border-radius: 6px;
   border: 1px solid rgba(251, 191, 36, 0.25);
   background: rgba(251, 191, 36, 0.06);
   color: rgba(251, 191, 36, 0.85);
@@ -76,7 +74,6 @@
 
 .governance-case-group {
   border: 1px solid var(--white-6);
-  border-radius: 8px;
   padding: 10px 12px;
   margin-bottom: 8px;
   background: var(--white-2);

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -9,14 +9,11 @@
 .council-error {
   margin-top: 10px;
   border: 1px solid rgba(239, 68, 68, 0.35);
-  border-radius: 8px;
   padding: 8px 10px;
   color: #f7b6b6;
   font-size: var(--fs-sm);
 }
-.council-list,
-.governance-side-block,
-.governance-activity-list {
+.council-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -64,7 +61,6 @@ button.council-row.selected {
 }
 
 .council-state {
-  border-radius: 999px;
   padding: 3px 9px;
   font-size: var(--fs-xs);
   text-transform: lowercase;
@@ -99,18 +95,6 @@ button.council-row.selected {
   font-family: "IBM Plex Mono", "Fira Code", monospace;
 }
 
-.governance-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.governance-filter-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
 .governance-layout {
   display: grid;
   grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.45fr) minmax(280px, 1fr);
@@ -132,7 +116,6 @@ button.council-row.selected {
 
 .governance-kind {
   flex: 0 0 auto;
-  border-radius: 999px;
   padding: 2px 8px;
   border: 1px solid var(--border-slate-22);
   background: var(--white-6);
@@ -157,7 +140,6 @@ button.council-row.selected {
 }
 
 .governance-chip {
-  border-radius: 999px;
   padding: 3px 8px;
   border: 1px solid var(--card-border);
   background: var(--white-5);
@@ -188,14 +170,6 @@ button.council-row.selected {
   border-color: rgba(138, 163, 211, 0.25);
   background: var(--white-6);
   color: #b7cbee;
-}
-
-.governance-detail-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-  margin-bottom: 14px;
 }
 
 .governance-detail-head h3 {
@@ -229,27 +203,12 @@ button.council-row.selected {
   line-height: 1.5;
 }
 
-.governance-ledger {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
 .governance-ledger-row,
 .governance-activity-row {
   border: 1px solid var(--card-border);
   border-radius: 10px;
   background: var(--white-3h);
   padding: 10px 11px;
-}
-
-.governance-ledger-head {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  color: #9ab3de;
-  font-size: var(--fs-xs);
 }
 
 .governance-ledger-head strong {
@@ -265,7 +224,6 @@ button.council-row.selected {
 }
 
 .governance-badge {
-  border-radius: 999px;
   padding: 2px 8px;
   font-size: var(--fs-2xs);
   text-transform: lowercase;
@@ -278,12 +236,6 @@ button.council-row.selected {
   border-color: rgba(239, 68, 68, 0.44);
   background: var(--bad-12);
   color: #fecaca;
-}
-
-.governance-side-column {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
 }
 
 .governance-side-block h4 {

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -24,144 +24,19 @@
   position: relative;
 }
 
-/* Keeper KPIs */
-.keeper-kpis {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
-  margin-bottom: 16px;
-}
-.keeper-kpi {
-  background: var(--white-4);
-  border-radius: 8px;
-  padding: 12px;
-  text-align: center;
-  border: 1px solid var(--white-6);
-}
-.keeper-kpi-label { font-size: var(--fs-2xs); text-transform: uppercase; color: var(--text-dim); letter-spacing: 1px; }
-.keeper-kpi-value { font-size: 22px; font-weight: bold; color: var(--ok); margin-top: 4px; }
-.keeper-kpi-hint { font-size: var(--fs-2xs); color: var(--text-dim); margin-top: 2px; }
-
-/* Keeper Field Dictionary */
-.keeper-field-dict {
-  max-height: 460px;
-  overflow-y: auto;
-}
-.keeper-field-search {
-  width: 100%;
-  padding: 8px 12px;
-  background: var(--white-6);
-  border: 1px solid var(--white-10);
-  border-radius: 8px;
-  color: var(--text-near-white);
-  font-size: var(--fs-base);
-  margin-bottom: 10px;
-}
-.keeper-field-search:focus { outline: none; border-color: var(--ok-40); }
-.keeper-field-row {
-  display: flex;
-  gap: 10px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--white-4);
-  font-size: var(--fs-base);
-}
-.keeper-field-key { font-family: monospace; color: var(--cyan); font-size: var(--fs-sm); }
-
-.keeper-signal-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.keeper-signal-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 7px 9px;
-  border: 1px solid var(--border-slate-18);
-  border-radius: 8px;
-  background: var(--white-3);
-  font-size: var(--fs-sm);
-}
-
 .keeper-signal-row strong {
   color: #d9ebff;
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";
 }
 
-.keeper-memory-note {
-  margin-top: 10px;
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  background: var(--white-2);
-  padding: 10px;
-  font-size: var(--fs-sm);
-  color: #cfe0ff;
-  line-height: 1.5;
-}
+.keeper-field-search:focus { outline: none; border-color: var(--ok-40); }
 
-/* Keeper Equipment */
-.keeper-equipment-list { display: flex; flex-direction: column; gap: 6px; }
-.keeper-equipment-row {
-  display: flex; justify-content: space-between;
-  padding: 6px 10px;
-  background: var(--white-3);
-  border-radius: 6px;
-  font-size: var(--fs-base);
-}
-.keeper-gen-label { color: var(--cyan); font-size: var(--fs-xs); }
-
-/* Keeper Memory */
-.keeper-memory-list { display: flex; flex-direction: column; gap: 6px; max-height: 220px; overflow-y: auto; }
-
-/* Keeper K2K */
-.keeper-k2k-list { max-height: 220px; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
-.keeper-k2k-route { font-family: monospace; font-size: var(--fs-xs); color: var(--text-dim); }
-
-/* Keeper Mentions */
-.keeper-mention-chip {
-  font-size: var(--fs-xs);
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--ok-12);
-  color: var(--ok);
-}
-
-/* ── Keeper Comms Section (chat + diagnostics) ────────── */
-.keeper-comms-section {
-  margin-top: 20px;
-  border-top: 1px solid var(--white-10);
-  padding-top: 20px;
-}
-
-.keeper-comms-heading {
-  margin: 0 0 14px;
-  color: var(--cyan);
-  font-family: var(--font-display, inherit);
-  font-size: var(--fs-lg);
-}
-
-.keeper-comms-layout {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
+/* Keeper Comms */
 .keeper-comms-diagnostics {
   border: 1px solid rgba(138, 163, 211, 0.14);
   border-radius: 10px;
   background: rgba(5, 14, 31, 0.5);
-}
-
-.keeper-comms-diagnostics-toggle {
-  cursor: pointer;
-  padding: 10px 14px;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-  letter-spacing: 0.03em;
-  list-style: none;
-  user-select: none;
 }
 
 .keeper-comms-diagnostics-toggle::-webkit-details-marker {
@@ -180,21 +55,7 @@
   transform: rotate(90deg);
 }
 
-.keeper-comms-diagnostics-body {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 0 14px 14px;
-}
-
-/* Shell wrapper for conversation panel inside comms section */
-.keeper-conversation-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-/* ── Keeper Chat Panel (merged from keeper-chat.css) ────── */
+/* ── Keeper Chat Panel ────────── */
 
 .keeper-chat {
   border: 1px solid var(--ff-border, var(--color-ff-border));
@@ -237,177 +98,8 @@
   gap: 10px;
 }
 
-.keeper-chat__empty {
-  color: var(--white-20);
-  font-size: var(--fs-base);
-  text-align: center;
-  padding: 40px 0;
-}
-
-.keeper-chat__msg {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  max-width: 85%;
-}
-
-.keeper-chat__role {
-  font-size: var(--fs-2xs);
-  color: var(--white-35);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
 .keeper-chat__msg--user .keeper-chat__role {
   text-align: right;
-}
-
-.keeper-chat__text {
-  font-size: var(--fs-base);
-  line-height: 1.5;
-  padding: 8px 12px;
-  border-radius: 8px;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.keeper-chat__msg--user .keeper-chat__text {
-  background: var(--accent-12);
-  border: 1px solid var(--accent-20);
-  color: var(--text-body, var(--text-body));
-}
-
-.keeper-chat__msg--assistant .keeper-chat__text {
-  background: var(--ff-gold-8);
-  border: 1px solid var(--ff-border-subtle, var(--ff-border-subtle));
-  color: var(--text-body, var(--text-body));
-}
-
-.keeper-chat__msg--streaming .keeper-chat__text {
-  border-color: var(--ff-gold-dim);
-}
-
-.keeper-chat__text--thinking {
-  color: var(--white-30);
-  font-style: italic;
-}
-
-.keeper-chat__cursor {
-  animation: keeper-blink 0.8s step-end infinite;
-  color: var(--ff-gold, var(--ff-gold));
-}
-
-@keyframes keeper-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
-}
-
-.keeper-chat__error {
-  padding: 6px 14px;
-  font-size: var(--fs-sm);
-  color: var(--ff-hp-low, var(--bad-light));
-  background: var(--bad-8);
-  border-top: 1px solid var(--bad-15);
-}
-
-.keeper-chat__input-row {
-  display: flex;
-  gap: 8px;
-  padding: 10px 14px;
-  border-top: 1px solid var(--ff-border-subtle, var(--ff-border-subtle));
-  background: var(--ff-navy-60);
-}
-
-/* Scrollbar */
-.keeper-chat__messages::-webkit-scrollbar {
-  width: 4px;
-}
-
-.keeper-chat__messages::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.keeper-chat__messages::-webkit-scrollbar-thumb {
-  background: var(--ff-gold-20);
-  border-radius: 2px;
-}
-
-/* ── Keeper Chat (merged from keeper-chat.css) ── */
-/* Keeper Chat Panel — FF-themed conversation UI */
-
-.keeper-chat {
-  border: 1px solid var(--ff-border, var(--color-ff-border));
-  border-radius: var(--radius-md, 12px);
-  background: var(--ff-panel, var(--color-ff-panel));
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.keeper-chat__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--ff-border-subtle, var(--ff-border-subtle));
-  background: var(--ff-navy-60);
-}
-
-.keeper-chat__title {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--ff-gold-bright, var(--ff-gold-bright));
-  letter-spacing: 0.3px;
-}
-
-.keeper-chat__cancel {
-  font-size: var(--fs-xs);
-  color: var(--ff-hp-low, var(--bad-light));
-}
-
-.keeper-chat__messages {
-  flex: 1;
-  min-height: 200px;
-  max-height: 400px;
-  overflow-y: auto;
-  padding: 12px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.keeper-chat__empty {
-  color: var(--white-20);
-  font-size: var(--fs-base);
-  text-align: center;
-  padding: 40px 0;
-}
-
-.keeper-chat__msg {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  max-width: 85%;
-}
-
-.keeper-chat__role {
-  font-size: var(--fs-2xs);
-  color: var(--white-35);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.keeper-chat__msg--user .keeper-chat__role {
-  text-align: right;
-}
-
-.keeper-chat__text {
-  font-size: var(--fs-base);
-  line-height: 1.5;
-  padding: 8px 12px;
-  border-radius: 8px;
-  white-space: pre-wrap;
-  word-break: break-word;
 }
 
 .keeper-chat__msg--user .keeper-chat__text {

--- a/dashboard/src/styles/live.css
+++ b/dashboard/src/styles/live.css
@@ -6,7 +6,6 @@
   padding: 12px 16px;
   background: var(--white-2);
   border: 1px solid var(--white-6);
-  border-radius: 12px;
   overflow-x: auto;
   align-items: center;
   min-height: 56px;
@@ -68,13 +67,6 @@
 
 /* ── Activity Stream ─────────────────────────────────── */
 
-.activity-stream {
-  display: grid;
-  gap: 10px;
-  grid-template-rows: auto auto 1fr;
-  min-height: 0;
-}
-
 .activity-stream-head h3,
 .focus-sidebar-head h3 {
   margin: 0;
@@ -84,7 +76,6 @@
 
 .activity-filter-btn {
   padding: 3px 10px;
-  border-radius: 6px;
   border: 1px solid var(--white-10);
   background: transparent;
   color: var(--white-40);
@@ -123,7 +114,6 @@
 
 .activity-item {
   padding: 8px 12px;
-  border-radius: 8px;
   background: var(--white-2);
   border-left: 3px solid transparent;
   transition: background 0.15s;
@@ -150,7 +140,6 @@
 .activity-kind-chip {
   font-size: 0.65rem;
   padding: 1px 6px;
-  border-radius: 4px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -181,13 +170,6 @@
 }
 
 /* ── Focus Sidebar ───────────────────────────────────── */
-
-.focus-sidebar {
-  display: grid;
-  gap: 10px;
-  grid-template-rows: auto 1fr;
-  min-height: 0;
-}
 
 .focus-sidebar-list {
   display: grid;
@@ -230,7 +212,6 @@
 .focus-pressure-badge {
   font-size: 0.65rem;
   padding: 2px 8px;
-  border-radius: 6px;
   font-weight: 500;
   display: flex;
   align-items: center;
@@ -254,7 +235,6 @@
 
 .focus-task-count {
   background: var(--white-10);
-  border-radius: 4px;
   padding: 0 4px;
   font-size: 0.6rem;
 }
@@ -264,7 +244,6 @@
   color: var(--white-55);
   padding: 3px 8px;
   background: var(--white-3);
-  border-radius: 6px;
   border: 1px solid var(--white-5);
   white-space: nowrap;
   overflow: hidden;

--- a/dashboard/src/styles/mission.css
+++ b/dashboard/src/styles/mission.css
@@ -89,7 +89,6 @@
 }
 .mission-action-preview {
   padding: 10px 12px;
-  border-radius: 12px;
   background: var(--white-5);
   border: 1px solid var(--white-8);
   color: var(--text-strong);
@@ -100,7 +99,6 @@
   display: grid;
   gap: 6px;
   padding: 12px 14px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-4);
 }
@@ -172,7 +170,6 @@
 
 .mission-briefing-section {
   padding: 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-4);
   display: grid;
@@ -201,7 +198,6 @@
 
 .mission-briefing-gap {
   padding: 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-3);
   display: grid;
@@ -217,7 +213,6 @@
 .mission-selection-bar {
   margin-top: 14px;
   padding: 10px 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-8);
   background: var(--white-4);
   display: flex;
@@ -287,7 +282,6 @@
 .mission-link-row {
   width: 100%;
   padding: 10px 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-6);
   background: var(--white-3);
   display: grid;
@@ -310,7 +304,6 @@
 
 .mission-pill {
   padding: 6px 10px;
-  border-radius: 999px;
   border: 1px solid var(--white-8);
   background: var(--white-4);
   color: rgba(255,255,255,0.76);
@@ -324,7 +317,6 @@
 
 .mission-evidence-list span {
   padding: 10px 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-6);
   background: var(--white-3);
   color: var(--white-72);
@@ -355,7 +347,6 @@
 
 .mission-fact-tile {
   padding: 12px;
-  border-radius: 12px;
   background: var(--white-4);
   border: 1px solid var(--white-6);
   display: grid;
@@ -373,7 +364,6 @@
 .mission-member-preview {
   width: 100%;
   padding: 12px;
-  border-radius: 12px;
   border: 1px solid var(--white-6);
   background: var(--white-3);
   display: grid;
@@ -428,7 +418,6 @@
 .mission-io-item,
 .mission-timeline-row {
   padding: 12px;
-  border-radius: 12px;
   background: var(--white-3);
   border: 1px solid var(--white-6);
   display: grid;

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -3,7 +3,6 @@
 .oas-pipeline {
   background: var(--card, #1a1f2e);
   border: 1px solid var(--card-border, #2a2f3e);
-  border-radius: 8px;
   padding: 12px 16px;
   margin-top: 12px;
 }
@@ -57,7 +56,6 @@
   gap: 8px;
   padding: 3px 6px;
   font-size: var(--fs-xs);
-  border-radius: 4px;
 }
 
 .oas-event-row:hover,
@@ -116,7 +114,6 @@
   gap: 8px;
   padding: 4px 6px;
   font-size: var(--fs-xs);
-  border-radius: 4px;
 }
 
 .oas-keeper-gen {
@@ -177,7 +174,6 @@
   border-radius: 50%;
   background: rgba(100, 100, 120, 0.35);
   border: 1.5px solid rgba(100, 100, 120, 0.5);
-  transition: all 0.3s ease;
   flex-shrink: 0;
 }
 
@@ -272,7 +268,6 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 999px;
   font-size: var(--fs-2xs);
   font-weight: 500;
   letter-spacing: 0.04em;

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -1,42 +1,4 @@
 /* ── Ops Tab ───────────────────────────────────────────────── */
-.ops-view {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.ops-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-}
-
-.ops-heading {
-  color: var(--text-strong);
-  font-size: 24px;
-  line-height: 1.2;
-}
-
-.ops-subheading {
-  margin-top: 6px;
-  color: var(--text-muted);
-  font-size: var(--fs-base);
-  max-width: 62ch;
-}
-
-.ops-toolbar {
-  display: flex;
-  align-items: flex-end;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.ops-banner {
-  border-radius: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--white-8);
-}
 
 .ops-banner.error {
   background: var(--bad-12);
@@ -56,72 +18,13 @@
   color: #cffafe;
 }
 
-
-
-.ops-handoff-head {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
-  color: var(--white-72);
-}
-
-.ops-handoff-head strong,
-.ops-entity-section-head strong,
-.ops-guidance-head strong,
-.ops-entity-title-row strong {
-  color: var(--text-strong);
-}
-
-.ops-handoff-preview {
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: var(--white-5);
-  border: 1px solid var(--white-8);
-  color: var(--text-strong);
-  line-height: 1.45;
-}
-
-.ops-handoff-meta {
-  color: rgba(255,255,255,0.58);
-  font-size: var(--fs-sm);
-}
-
 .ops-workbench {
-  display: grid;
   grid-template-columns: minmax(0, 0.92fr) minmax(0, 0.9fr) minmax(0, 1.18fr);
-  gap: 16px;
-}
-
-.ops-column {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-width: 0;
 }
 
 .ops-action-guide {
-  border-radius: 10px;
-  padding: 16px 20px;
-  margin-bottom: 16px;
   background: rgba(138, 163, 211, 0.06);
   border: 1px solid rgba(138, 163, 211, 0.15);
-}
-
-.ops-action-guide-title {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--white-60);
-  margin-bottom: 10px;
-}
-
-.ops-action-guide-list,
-.ops-log-list,
-.ops-entity-section,
-.ops-detail-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .ops-action-guide-item {
@@ -129,7 +32,6 @@
   flex-direction: column;
   gap: 2px;
   padding: 10px 14px;
-  border-radius: 8px;
   border: none;
   cursor: pointer;
   text-align: left;
@@ -143,7 +45,6 @@
 
 .ops-action-guide-item span {
   font-size: var(--fs-sm);
-  opacity: 0.7;
 }
 
 .ops-action-guide-item.bad {
@@ -161,21 +62,6 @@
   color: var(--ok);
 }
 
-.ops-priority-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.ops-priority-card {
-  padding: 14px;
-  border-radius: 12px;
-  border: 1px solid var(--border-slate-16);
-  background: var(--white-3);
-  display: grid;
-  gap: 6px;
-}
-
 .ops-priority-card.ok {
   border-color: var(--ok-24);
 }
@@ -188,30 +74,10 @@
   border-color: rgba(248, 113, 113, 0.34);
 }
 
-.ops-priority-label {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
 .ops-priority-card strong {
   color: var(--text-strong);
   font-size: 24px;
   line-height: 1.1;
-}
-
-.ops-priority-detail {
-  color: #9ab1d7;
-  font-size: var(--fs-sm);
-  line-height: 1.45;
-}
-
-.ops-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-height: 0;
 }
 
 .ops-lane-panel {
@@ -219,21 +85,6 @@
   background:
     linear-gradient(180deg, rgba(13, 22, 40, 0.76), rgba(13, 22, 40, 0.62)),
     radial-gradient(circle at top right, var(--accent-10), transparent 42%);
-}
-.ops-stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.ops-stat {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--white-8);
-  background: var(--white-3);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
 }
 
 .ops-stat span {
@@ -256,46 +107,9 @@
   border-color: rgba(251, 191, 36, 0.35);
 }
 
-.ops-section-head {
-  margin-top: 2px;
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.ops-context-note {
-  margin-top: -2px;
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  line-height: 1.45;
-}
-
-.ops-control-disclosure {
-  margin-top: 2px;
-  border: 1px solid var(--white-8);
-  border-radius: 12px;
-  background: var(--white-2);
-}
-
-.ops-control-summary {
-  list-style: none;
-  cursor: pointer;
-  display: grid;
-  gap: 4px;
-  padding: 12px 14px;
-}
-
 .ops-control-summary::-webkit-details-marker,
 .ops-archive-summary::-webkit-details-marker {
   display: none;
-}
-
-.ops-control-kicker {
-  color: #9fe6b5;
-  font-size: var(--fs-2xs);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .ops-control-summary strong {
@@ -308,25 +122,6 @@
   color: var(--text-muted);
   font-size: var(--fs-sm);
   line-height: 1.45;
-}
-
-.ops-control-body {
-  display: grid;
-  gap: 12px;
-  padding: 0 14px 14px 14px;
-  border-top: 1px solid var(--white-8);
-}
-
-.ops-feed-list,
-.ops-entity-list,
-.ops-confirmation-list,
-.ops-entity-section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
 }
 
 .ops-archive-panel {
@@ -345,7 +140,7 @@
 }
 
 .ops-archive-summary::before {
-  content: '▸';
+  content: '\25B8';
   display: inline-block;
   margin-right: 6px;
   transition: transform 120ms ease;
@@ -353,16 +148,6 @@
 
 .ops-archive-panel[open] .ops-archive-summary::before {
   transform: rotate(90deg);
-}
-
-.ops-guidance-card {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--white-8);
-  background: var(--white-3);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
 }
 
 .ops-guidance-card.ok {
@@ -380,86 +165,6 @@
   background: rgba(248, 113, 113, 0.06);
 }
 
-.ops-guidance-head,
-.ops-guidance-meta,
-.ops-confirmation-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-}
-
-.ops-guidance-body {
-  color: var(--text-strong);
-  line-height: 1.5;
-}
-
-.ops-feed-item,
-.ops-confirmation-card,
-.ops-detail-card,
-.ops-log-entry {
-  padding: 12px;
-  border-radius: 10px;
-  background: var(--white-3);
-  border: 1px solid var(--white-8);
-}
-
-.ops-feed-meta,
-.ops-log-head,
-.ops-detail-meta,
-.ops-entity-meta,
-.ops-entity-goal,
-.ops-detail-goal {
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  margin-top: 4px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.ops-detail-goal {
-  white-space: normal;
-  margin-top: 6px;
-  padding: 4px 6px;
-  background: var(--card);
-  border-radius: 4px;
-}
-
-.ops-entity-stats {
-  display: flex;
-  gap: 8px;
-  font-size: var(--fs-2xs);
-  color: var(--text-muted);
-  margin-top: 2px;
-}
-
-.ops-entity-stats .keepalive-active {
-  color: var(--accent);
-  font-weight: 600;
-}
-
-.ops-feed-meta strong,
-.ops-log-head strong,
-.ops-detail-title,
-.ops-feed-content,
-.ops-log-body {
-  margin-top: 6px;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.ops-entity-card {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--white-8);
-  background: var(--white-3);
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
 
 .ops-entity-card:hover,
 .ops-entity-card.active {
@@ -467,45 +172,11 @@
   background: var(--accent-8);
 }
 
-.ops-entity-title-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
+.ops-entity-stats .keepalive-active {
+  color: var(--accent);
+  font-weight: 600;
 }
 
-.ops-confirmation-actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  margin-top: 10px;
-}
-
-.ops-token {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  word-break: break-all;
-}
-
-.ops-code-block {
-  margin-top: 8px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: rgba(8, 15, 29, 0.82);
-  border: 1px solid var(--white-8);
-  color: #b9d6ff;
-  font-size: var(--fs-xs);
-  line-height: 1.45;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.ops-code-block.compact {
-  max-height: 180px;
-}
 
 .ops-log-entry.preview {
   border-color: rgba(251, 191, 36, 0.26);
@@ -520,18 +191,9 @@
   border-color: rgba(239, 68, 68, 0.26);
 }
 
-.ops-empty {
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px dashed var(--white-12);
-  color: var(--text-muted);
-  font-size: var(--fs-base);
-}
-
 @media (max-width: 1200px) {
 
-  .command-entry-strip,
-  .ops-priority-grid {
+  .command-entry-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -543,35 +205,13 @@
 
 @media (max-width: 880px) {
 
-  .ops-header {
-    flex-direction: column;
-  }
-
   .command-entry-strip {
     grid-template-columns: 1fr;
-  }
-
-  .ops-toolbar {
-    width: 100%;
   }
 
   .ops-actor-input {
     min-width: 0;
     flex: 1;
-  }
-
-  .ops-stat-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .ops-priority-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .ops-confirmation-actions,
-  .ops-entity-title-row {
-    flex-direction: column;
-    align-items: flex-start;
   }
 
   .planning-header,

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -10,7 +10,6 @@
   align-items: center;
   gap: 12px;
   padding: 14px 18px;
-  border-radius: 6px;
   background: var(--color-ff-panel);
   border: 1px solid var(--border-subtle, var(--ff-gold-15));
   border-left: 3px solid var(--ok);
@@ -48,42 +47,17 @@
 .attention-spotlight__card.warn { border-color: var(--warn-30); }
 .attention-spotlight__card.bad { border-color: var(--bad-30); }
 
-.attention-spotlight__bar {
-  width: 4px;
-  flex-shrink: 0;
-}
-
 .attention-spotlight__card.ok .attention-spotlight__bar { background: var(--agent-working, var(--agent-working)); }
 .attention-spotlight__card.warn .attention-spotlight__bar { background: var(--agent-busy, var(--agent-busy)); }
 .attention-spotlight__card.bad .attention-spotlight__bar { background: var(--bad, var(--bad)); }
 
-.attention-spotlight__body {
-  display: grid;
-  gap: 6px;
-  padding: 10px 14px;
-  min-width: 0;
-}
-
-.attention-spotlight__summary {
-  color: var(--text-strong);
-  font-size: var(--fs-base);
-  font-weight: 500;
-  line-height: 1.4;
-}
-
 .attention-spotlight__chip {
   padding: 2px 8px;
-  border-radius: 999px;
   background: var(--white-6);
   border: 1px solid var(--white-8);
   font-size: var(--fs-xs);
   color: var(--warm-amber, #f5c542);
   font-weight: 500;
-}
-
-.attention-spotlight__time {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
 }
 
 /* ── Narrative Timeline ──────────────────────── */
@@ -101,13 +75,6 @@
   scrollbar-color: rgba(138, 163, 211, 0.15) transparent;
 }
 
-.narrative-timeline__empty {
-  color: var(--text-muted);
-  text-align: center;
-  padding: 12px;
-  font-size: var(--fs-sm);
-}
-
 .narrative-group__label {
   color: var(--text-muted);
   font-size: var(--fs-xs);
@@ -115,12 +82,6 @@
   letter-spacing: 0.04em;
   padding-bottom: 2px;
   border-bottom: 1px solid var(--border-slate-8);
-}
-
-.narrative-event__text {
-  color: var(--text-body);
-  font-size: var(--fs-sm);
-  line-height: 1.45;
 }
 
 .narrative-event__raw summary {
@@ -135,7 +96,6 @@
   font-size: var(--fs-xs);
   padding: 4px 8px;
   background: var(--white-2);
-  border-radius: 4px;
   margin-top: 2px;
   line-height: 1.4;
 }
@@ -147,7 +107,6 @@
   margin-top: 4px;
   background: none;
   border: 1px dashed var(--card-border, var(--white-10));
-  border-radius: 6px;
   color: var(--text-muted);
   font-size: var(--fs-xs);
   cursor: pointer;
@@ -158,31 +117,7 @@
   color: var(--accent);
 }
 
-/* ── Layout ──────────────────────────────────── */
-.overview-surface,
-.overview-surface--home,
-.home-body {
-  display: grid;
-  gap: var(--space-md, 16px);
-}
-
 /* ── Health beacon ─────────────────────────────── */
-.health-beacon {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: var(--fs-sm);
-  font-weight: 500;
-}
-
-.health-beacon__dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
 
 .health-beacon.ok .health-beacon__dot {
   background: var(--agent-working, var(--agent-working));
@@ -206,31 +141,7 @@
 .health-beacon.warn { color: var(--agent-busy, var(--agent-busy)); }
 .health-beacon.bad { color: var(--bad, var(--bad)); }
 
-/* ── Slim header variant for Home ──────────────── */
-.dashboard-header--slim {
-  min-height: auto;
-  padding: 10px 18px;
-}
-
-.dashboard-header--slim .header-title-wrap h1 { font-size: 20px; }
-.dashboard-header--slim .header-subtitle { display: none; }
-.dashboard-layout--home { grid-template-columns: 1fr; }
-
 /* ── Home Command Center ─────────────────────── */
-
-.home-section-label {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.home-section-copy {
-  margin-top: 3px;
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  line-height: 1.45;
-}
 
 .home-section-link {
   font-size: var(--fs-xs);
@@ -241,11 +152,6 @@
 .home-section-link:hover { text-decoration: underline; }
 
 /* Hot Sessions */
-.hot-sessions__lanes {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
 
 .hot-session-lane {
   display: grid;
@@ -266,75 +172,16 @@
   background: linear-gradient(180deg, rgba(34, 197, 94, 0.08), var(--ff-navy-44));
 }
 
-.hot-session-lane__title {
-  margin: 0;
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--text-strong);
-}
-
-.hot-session-lane__count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 8px;
-  border-radius: 999px;
-  background: var(--white-8);
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  font-weight: 600;
-}
-
-.hot-session-lane__description {
-  margin: 4px 0 0;
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  line-height: 1.45;
-}
-
-.hot-session-lane__empty {
-  display: grid;
-  place-items: center;
-  min-height: 116px;
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px dashed var(--border-slate-18);
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  text-align: center;
-  background: var(--white-2);
-}
-
-.hot-sessions__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: var(--space-sm, 8px);
-}
 
 .hot-session-card {
   background: var(--white-3);
   border: 1px solid var(--card-border, var(--white-8));
-  border-radius: 8px;
   padding: 10px 12px;
   cursor: pointer;
   transition: border-color 0.15s;
 }
 .hot-session-card:hover {
   border-color: var(--accent);
-}
-.hot-session-card--critical {
-  border-color: var(--bad);
-  background: rgba(239, 68, 68, 0.06);
-}
-.hot-session-card__goal {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--text-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .hot-session-card__context {
   margin-top: 4px;
@@ -351,54 +198,20 @@
   align-items: center;
   min-height: 20px;
   padding: 0 8px;
-  border-radius: 999px;
   border: 1px solid var(--border-slate-18);
   background: var(--border-slate-8);
   color: var(--text-muted);
   font-size: var(--fs-2xs);
   letter-spacing: 0.02em;
 }
-.hot-session-card__chip--system {
-  border-color: rgba(34, 197, 94, 0.22);
-  background: rgba(34, 197, 94, 0.12);
-  color: #b7f3c9;
-}
-.hot-session-card__meta {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  margin-top: 8px;
-}
-.hot-session-card__blocker {
-  font-size: var(--fs-xs);
-  color: var(--bad);
-  margin-top: 4px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-@media (max-width: 960px) {
-  .hot-sessions__lanes {
-    grid-template-columns: 1fr;
-  }
-}
 
 /* Agent Pulse */
-.agent-pulse__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: var(--space-xs, 4px);
-}
 
 .agent-pulse-card {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  border-radius: 6px;
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -413,43 +226,20 @@
 }
 .agent-pulse-card--quiet {
   border-left: 2px solid var(--text-muted, var(--text-slate));
-  opacity: 0.7;
 }
 .agent-pulse-card--offline {
   border-left: 2px solid var(--text-muted, var(--text-slate));
   opacity: 0.4;
 }
-.agent-pulse-card__name {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  color: var(--text-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.agent-pulse-card__status {
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
-/* ── Activity graph (merged from activity-graph.css) ────── */
+/* ── Activity graph ────────────────────────────── */
 
 .activity-graph-container {
   position: relative;
   width: 100%;
-  border-radius: 12px;
   overflow: hidden;
   background: #0f1117;
   margin: 12px 0;
-}
-
-.activity-graph-canvas {
-  display: block;
-  width: 100%;
-  cursor: crosshair;
 }
 
 .activity-graph-tooltip {
@@ -475,45 +265,9 @@
 
 .activity-graph-tooltip-kind {
   padding: 2px 7px;
-  border-radius: 6px;
   background: var(--slate-gray-15);
   font-size: var(--fs-xs);
   color: var(--text-slate);
-}
-
-.activity-graph-leaderboard-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: 10px;
-  background: rgba(15, 23, 42, 0.5);
-  border: 1px solid var(--slate-gray-8);
-}
-
-.activity-graph-leaderboard-rank {
-  width: 22px;
-  text-align: center;
-  font-size: var(--fs-sm);
-  font-weight: 700;
-  color: var(--text-slate);
-}
-
-.activity-graph-leaderboard-info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.activity-graph-leaderboard-name {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--text-near-white);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .activity-graph-leaderboard-bar-wrap {
@@ -530,18 +284,9 @@
   transition: width 0.3s ease;
 }
 
-.activity-graph-leaderboard-weight {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  color: var(--text-slate-light);
-  min-width: 32px;
-  text-align: right;
-}
-
 .activity-graph-leaderboard-status {
   font-size: var(--fs-xs);
   padding: 2px 7px;
-  border-radius: 6px;
 }
 
 .activity-graph-leaderboard-status.active {
@@ -559,175 +304,6 @@
   align-items: center;
   gap: 6px;
   padding: 6px 12px;
-  border-radius: 8px;
   background: var(--panel-dark-60);
   border: 1px solid var(--slate-gray-12);
-}
-
-.activity-graph-kind-label {
-  font-size: var(--fs-sm);
-  color: var(--text-slate-light);
-}
-
-.activity-graph-kind-count {
-  font-size: var(--fs-base);
-  font-weight: 700;
-  color: var(--text-near-white);
-}
-
-/* ── Activity Graph (merged from activity-graph.css) ── */
-/* Activity graph surface — graph visualization and activity feed */
-
-.activity-graph-container {
-  position: relative;
-  width: 100%;
-  border-radius: 12px;
-  overflow: hidden;
-  background: #0f1117;
-  margin: 12px 0;
-}
-
-.activity-graph-canvas {
-  display: block;
-  width: 100%;
-  cursor: crosshair;
-}
-
-.activity-graph-tooltip {
-  position: absolute;
-  bottom: 12px;
-  left: 12px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
-  border-radius: 10px;
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid var(--slate-gray-20);
-  font-size: var(--fs-sm);
-  color: var(--text-slate-light);
-  pointer-events: none;
-}
-
-.activity-graph-tooltip strong {
-  font-size: var(--fs-base);
-  color: var(--text-near-white);
-}
-
-.activity-graph-tooltip-kind {
-  padding: 2px 7px;
-  border-radius: 6px;
-  background: var(--slate-gray-15);
-  font-size: var(--fs-xs);
-  color: var(--text-slate);
-}
-
-/* Leaderboard */
-
-.activity-graph-leaderboard {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.activity-graph-leaderboard-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: 10px;
-  background: rgba(15, 23, 42, 0.5);
-  border: 1px solid var(--slate-gray-8);
-}
-
-.activity-graph-leaderboard-rank {
-  width: 22px;
-  text-align: center;
-  font-size: var(--fs-sm);
-  font-weight: 700;
-  color: var(--text-slate);
-}
-
-.activity-graph-leaderboard-info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-}
-
-.activity-graph-leaderboard-name {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--text-near-white);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.activity-graph-leaderboard-bar-wrap {
-  height: 4px;
-  border-radius: 2px;
-  background: var(--slate-gray-10);
-  overflow: hidden;
-}
-
-.activity-graph-leaderboard-bar {
-  height: 100%;
-  border-radius: 2px;
-  background: var(--cyan);
-  transition: width 0.3s ease;
-}
-
-.activity-graph-leaderboard-weight {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  color: var(--text-slate-light);
-  min-width: 32px;
-  text-align: right;
-}
-
-.activity-graph-leaderboard-status {
-  font-size: var(--fs-xs);
-  padding: 2px 7px;
-  border-radius: 6px;
-}
-
-.activity-graph-leaderboard-status.active {
-  color: var(--ok);
-  background: var(--ok-10);
-}
-
-.activity-graph-leaderboard-status.inactive {
-  color: var(--text-slate);
-  background: var(--slate-gray-10);
-}
-
-/* Kind breakdown chips */
-
-.activity-graph-kind-breakdown {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.activity-graph-kind-chip {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 8px;
-  background: var(--panel-dark-60);
-  border: 1px solid var(--slate-gray-12);
-}
-
-.activity-graph-kind-label {
-  font-size: var(--fs-sm);
-  color: var(--text-slate-light);
-}
-
-.activity-graph-kind-count {
-  font-size: var(--fs-base);
-  font-weight: 700;
-  color: var(--text-near-white);
 }

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -9,7 +9,6 @@
   grid-template: repeat(8, 1fr) / repeat(8, 1fr);
   width: 48px;
   height: 48px;
-  border-radius: 6px;
   overflow: visible;
   flex-shrink: 0;
   image-rendering: pixelated;
@@ -19,19 +18,16 @@
 .pixel-avatar--sm {
   width: 32px;
   height: 32px;
-  border-radius: 4px;
 }
 
 .pixel-avatar--lg {
   width: 64px;
   height: 64px;
-  border-radius: 8px;
 }
 
 .pixel-avatar--xl {
   width: 96px;
   height: 96px;
-  border-radius: 8px;
   box-shadow:
     0 0 0 2px var(--ff-navy),
     0 0 0 3px var(--ff-gold),
@@ -131,7 +127,6 @@
   transform: translateX(-50%);
   white-space: nowrap;
   padding: 3px 8px;
-  border-radius: 6px;
   background: rgba(30, 30, 40, 0.92);
   border: 1px solid var(--white-12);
   color: var(--text-strong);

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -26,22 +26,13 @@
   margin-top: 4px;
 }
 
-.roster-controls {
-  display: flex;
-  gap: var(--space-md, 16px);
-  align-items: center;
-  flex-wrap: wrap;
-}
-
 .roster-search {
   padding: 6px 12px;
-  border-radius: 4px;
   border: 1px solid var(--ff-border-subtle);
   background: var(--ff-navy);
   color: var(--white-90);
   font-size: var(--fs-base);
   width: 200px;
-  transition: border-color 0.2s;
 }
 
 .roster-search:focus {
@@ -81,11 +72,6 @@
    Roster Cards — FF Character Sheet style
    ============================================ */
 
-.roster-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
 
 .roster-card {
   display: flex;
@@ -93,9 +79,7 @@
   padding: 16px 20px;
   background: var(--color-ff-panel);
   border: 1px solid var(--color-ff-border);
-  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.2s;
   position: relative;
 }
 
@@ -158,12 +142,6 @@
   flex-direction: column;
   gap: 5px;
   justify-content: center;
-}
-
-.roster-card__header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm, 8px);
 }
 
 .roster-card__name {
@@ -238,7 +216,6 @@
   color: var(--white-20);
   font-size: var(--fs-md);
   border: 1px dashed var(--ff-border-subtle);
-  border-radius: 6px;
 }
 
 /* ============================================
@@ -285,12 +262,6 @@
 }
 
 /* Inline context gauge */
-.roster-card__gauge {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .roster-card__gauge-track {
   flex: 1;
   height: 8px;

--- a/dashboard/src/styles/tools.css
+++ b/dashboard/src/styles/tools.css
@@ -60,7 +60,6 @@
   min-width: 20px;
   height: 18px;
   padding: 0 5px;
-  border-radius: 999px;
   font-size: var(--fs-2xs);
   font-weight: 600;
   background: rgba(148, 163, 184, 0.18);
@@ -236,7 +235,6 @@
   letter-spacing: 0.3px;
 }
 
-.tool-summary-list,
 .tool-bar-chart {
   display: flex;
   flex-direction: column;
@@ -248,7 +246,6 @@
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
-  border-radius: 8px;
   background: var(--panel-dark-60);
   border: 1px solid var(--slate-gray-8);
 }
@@ -270,18 +267,6 @@
   white-space: nowrap;
 }
 /* ── Tool Metrics (P4 Phase 4.5) ──────────────────────────── */
-.tool-metrics {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.tool-metrics-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .tool-metrics-title {
   color: var(--text-strong);
   font-size: var(--fs-lg);
@@ -291,7 +276,6 @@
 
 .tool-metrics-error {
   padding: 10px 12px;
-  border-radius: 8px;
   background: var(--bad-12);
   border: 1px solid rgba(239, 68, 68, 0.34);
   color: #fecaca;
@@ -347,23 +331,10 @@
 }
 
 /* ── Tier distribution ──────────────────────────────────── */
-.tier-dist {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.tier-dist-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
 .tier-dist-label {
   display: inline-block;
   min-width: 72px;
   padding: 2px 8px;
-  border-radius: 4px;
   font-size: var(--fs-xs);
   font-weight: 600;
   text-align: center;

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -27,13 +27,11 @@
 .markdown-content code {
   background: var(--white-8);
   padding: 1px 5px;
-  border-radius: 4px;
   font-size: var(--fs-sm);
 }
 .markdown-content pre {
   background: rgba(0,0,0,0.3);
   padding: 12px;
-  border-radius: 8px;
   overflow-x: auto;
   font-size: var(--fs-sm);
 }
@@ -47,7 +45,6 @@
 .think-block {
   background: rgba(167,139,250,0.06);
   border: 1px solid rgba(167,139,250,0.15);
-  border-radius: 8px;
   padding: 10px 14px;
   margin: 8px 0;
 
@@ -61,7 +58,6 @@
 .main-tab-bar {
   margin: 0;
   padding: 8px;
-  border-radius: 12px;
   border: 1px solid var(--border-slate-22);
   background: rgba(17, 26, 46, 0.8);
   backdrop-filter: blur(8px);
@@ -231,7 +227,6 @@ button.monitor-row {
   color: inherit;
   font: inherit;
   text-align: left;
-  border-radius: 12px;
   cursor: pointer;
   transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
 
@@ -326,7 +321,6 @@ button.monitor-alert.bad,
   gap: 4px;
   font-size: var(--fs-xs);
   padding: 2px 8px;
-  border-radius: 999px;
 }
 .status-badge.active { background: var(--ok-soft); color: var(--ok); }
 .status-badge.busy { background: var(--warn-15); color: var(--warn); }
@@ -348,7 +342,6 @@ button.monitor-alert.bad,
 /* ── Card (generic wrapper) ────────────────────────────────── */
 .card {
   background: var(--white-3);
-  border-radius: 12px;
   padding: 20px;
   border: 1px solid var(--white-8);
 }


### PR DESCRIPTION
## Summary

대시보드 CSS를 Tailwind utility로 대규모 전환. 21개 병렬 에이전트 투입.

| 항목 | Before | After | 변화 |
|------|--------|-------|------|
| CSS 줄 | 11,230 | **7,479** | **-33.4%** |
| CSS 파일 | 34 | **22** | **-35%** |

116 files changed, 1363 ins, 3259 del.

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)