### PR TITLE
fix(dashboard): resolve 6 UI display issues

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -278,7 +278,7 @@ function CharacterPlate({ name }: { name: string }) {
       ${isKeeper ? html`
         <div class="ff-plate__stats ff-plate__stats--keeper">
           <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${ctxPct != null ? `${ctxPct}%` : '—'}</span>
+            <span class="ff-stat__value">${ctxPct != null ? `${ctxPct}%` : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">CTX</span>
           </div>
           <div class="ff-stat rounded-md">
@@ -294,26 +294,26 @@ function CharacterPlate({ name }: { name: string }) {
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">행동</span>
           </div>
         </div>
-      ` : summary ? html`
+      ` : html`
         <div class="ff-plate__stats">
           <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary.tasks_completed}</span>
+            <span class="ff-stat__value">${summary ? summary.tasks_completed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">완료</span>
           </div>
           <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary.tasks_claimed}</span>
+            <span class="ff-stat__value">${summary ? summary.tasks_claimed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">수임</span>
           </div>
           <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary.messages_sent}</span>
+            <span class="ff-stat__value">${summary ? summary.messages_sent : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">메시지</span>
           </div>
           <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : '0m'}</span>
+            <span class="ff-stat__value">${summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">활동</span>
           </div>
         </div>
-      ` : null}
+      `}
     </div>
   `
 }

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -44,7 +44,7 @@ type KeeperCardProps = {
 }
 
 function formatContext(value?: number | null): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) return '—'
+  if (typeof value !== 'number' || Number.isNaN(value)) return 'N/A'
   return `${Math.round(value * 100)}%`
 }
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -65,7 +65,7 @@ export function ConnectionStatus() {
 
 function shortCommit(commit: string | null | undefined): string {
   const value = commit?.trim()
-  if (!value) return '커밋 정보 없음'
+  if (!value) return 'dev'
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
@@ -75,7 +75,7 @@ export function BuildIdentityBadge() {
   const label = build
     ? `v${build.release_version} · ${shortCommit(build.commit)}`
     : status?.version
-      ? `v${status.version} · 커밋 정보 없음`
+      ? `v${status.version} · dev`
       : '버전 정보 없음'
 
   return html`
@@ -99,7 +99,7 @@ export function BuildIdentityBadge() {
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>커밋</span>
-                <strong class="text-[color:var(--text-strong)] text-right">${build?.commit ?? '커밋 정보 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.commit ?? 'git 미감지 (dev)'}</strong>
               </div>
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>서버 시작</span>

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -27,6 +27,10 @@ export function WorkerSupportRow({
   row: DashboardExecutionWorkerSupportBrief
   testId: string
 }) {
+  // When observation state is "offline", override status badge to match
+  // so we don't show "가동 중" badge alongside "오프라인" label.
+  const effectiveStatus = row.state === 'offline' ? 'offline' : (row.status ?? 'unknown')
+
   return html`
     <button class="monitor-row rounded-xl p-3.5 ${row.tone} state-${row.state}" data-testid=${testId} onClick=${() => openAgentDetail(row.name)}>
       <div class="monitor-row rounded-xl-header">
@@ -38,8 +42,10 @@ export function WorkerSupportRow({
           </div>
           <div class="monitor-note">${row.note}</div>
         </div>
-        <${StatusBadge} status=${row.status ?? 'unknown'} />
-        <span class="monitor-pill ${row.tone} state-${row.state} inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${agentStateLabel(row.state)}</span>
+        <${StatusBadge} status=${effectiveStatus} />
+        ${row.state !== 'offline' || effectiveStatus !== 'offline'
+          ? html`<span class="monitor-pill ${row.tone} state-${row.state} inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${agentStateLabel(row.state)}</span>`
+          : null}
       </div>
 
       <div class="monitor-meta">

--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -34,7 +34,7 @@ function OasSummaryLines() {
   return html`
     <div class="oas-summary-lines">
       <span>활성 에이전트 ${activeAgents.size}명</span>
-      <span>${health.totalEvents}건${snapshots.size > 0 ? `, 키퍼 ${snapshots.size}명` : ''}</span>
+      <span>${health.totalEvents}건${snapshots.size > 0 ? ` · 키퍼 ${snapshots.size}명` : ''}</span>
       <span>${agoMin != null ? `${agoMin}분 전` : '이벤트 대기 중'}</span>
     </div>
   `

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -14,7 +14,7 @@ import { selectPendingConfirmState } from '../pending-confirm'
 
 function shortCommit(commit: string | null | undefined): string {
   const value = commit?.trim()
-  if (!value) return '커밋 정보 없음'
+  if (!value) return 'dev'
   return value.length > 10 ? value.slice(0, 10) : value
 }
 

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -29,6 +29,14 @@
   margin-bottom: 6px;
 }
 
+.oas-summary-lines {
+  display: flex;
+  gap: 12px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted, #888);
+  margin-bottom: 10px;
+}
+
 .oas-empty {
   font-size: var(--fs-xs);
   color: var(--text-muted, #666);


### PR DESCRIPTION
## Summary
- Fix worker status badge showing "가동 중" alongside "offline" label by overriding StatusBadge when observation state is offline
- Replace em-dash "—" with "N/A" for missing CTX and context ratio values across keeper-card and agent-profile
- Always render agent stats grid in CharacterPlate (show "N/A" when timeline summary unavailable instead of hiding stats)
- Add CSS flex layout with gap for `.oas-summary-lines` to prevent "0명0건이벤트 대기 중" text concatenation
- Shorten build commit fallback text from "커밋 정보 없음" to "dev" in header badge and sidebar
- Use middle dot separator between event count and keeper count in OAS pipeline summary

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Vite production build succeeds
- [x] All 16 existing tests pass (`vitest run`)
- [ ] Visual verify: home view OAS summary has spacing between stats
- [ ] Visual verify: agent profile shows "N/A" for stats when no timeline data
- [ ] Visual verify: worker row shows single "offline" badge (not both "가동 중" + "오프라인")
- [ ] Visual verify: header build badge shows "dev" instead of "커밋 정보 없음"

Generated with [Claude Code](https://claude.com/claude-code)