### PR TITLE
fix(test): isolate keeper unified test from env var overrides

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -251,13 +251,27 @@ let test_hooks_allowed_tools_l5 () =
 
 (* ---------- Config tests ---------- *)
 
+let with_env name value f =
+  let original = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    (fun () ->
+      Unix.putenv name value;
+      f ())
+
 let test_unified_turn_runtime_defaults () =
+  with_env "MASC_KEEPER_UNIFIED_TEMP" "" (fun () ->
+  with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
+  with_env "MASC_KEEPER_UNIFIED_MAX_TURNS" "" (fun () ->
   check (float 0.01) "unified temp default" 0.4
     (KC.keeper_unified_temperature ());
   check int "unified max_tokens default" 2048
     (KC.keeper_unified_max_tokens ());
   check int "unified max_turns default" 1000
-    (KC.keeper_unified_max_turns ())
+    (KC.keeper_unified_max_turns ()))))
 
 (* ---------- Metrics observation tests ---------- *)
 


### PR DESCRIPTION
## Summary
- `unified runtime defaults` 테스트가 환경변수(`MASC_KEEPER_UNIFIED_*`)에 의해 깨지는 문제 수정
- `with_env`로 테스트 실행 중 관련 환경변수를 빈 문자열로 격리

## Changes
- `test/test_keeper_unified.ml`: 3개 env var 격리 래핑 추가

## Test plan
- [ ] 환경변수 설정된 상태에서도 테스트 통과 확인
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)