### PR TITLE
perf(room): mtime-based cache for read_current_room

### DIFF
--- a/lib/room/room_multi.ml
+++ b/lib/room/room_multi.ml
@@ -38,7 +38,13 @@ let registry_path config = registry_root_path config
 (** Get current room file path *)
 let current_room_path config = current_room_root_path config
 
-(** Read current room ID *)
+(** Mtime-based cache for current_room: avoids re-reading the file when
+    the modification time has not changed.  The file is tiny (~10 bytes)
+    and updates are rare (only via masc_set_room), so a single stat()
+    to check mtime is a safe substitute for open+read+close. *)
+let current_room_cache : (string * float * string option) ref =
+  ref ("", 0.0, None)
+
 let read_current_room config =
   let read_from path =
     match Safe_ops.read_file_safe path with
@@ -47,12 +53,27 @@ let read_current_room config =
       if trimmed = "" then None else Some trimmed
     | Error _ -> None
   in
-  match read_from (current_room_path config) with
-  | Some room_id -> Some room_id
-  | None ->
-      (match read_from (legacy_current_room_path config) with
-       | Some legacy_room -> Some legacy_room
-       | None -> Some "default")
+  let path = current_room_path config in
+  let mtime =
+    try (Unix.stat path).Unix.st_mtime
+    with Unix.Unix_error _ -> 0.0
+  in
+  let (cached_path, cached_mtime, cached_value) = !current_room_cache in
+  if String.equal cached_path path && Float.equal mtime cached_mtime
+     && mtime > 0.0 then
+    cached_value
+  else begin
+    let result =
+      match read_from path with
+      | Some room_id -> Some room_id
+      | None ->
+          (match read_from (legacy_current_room_path config) with
+           | Some legacy_room -> Some legacy_room
+           | None -> Some "default")
+    in
+    current_room_cache := (path, mtime, result);
+    result
+  end
 
 (** Write current room ID *)
 let write_current_room config room_id =
@@ -63,7 +84,9 @@ let write_current_room config room_id =
   (* Canonical location inside .masc/ *)
   write_to (current_room_path config);
   (* Legacy compatibility: keep base_path/current_room in sync *)
-  write_to (legacy_current_room_path config)
+  write_to (legacy_current_room_path config);
+  (* Invalidate the mtime cache so next read picks up the new value *)
+  current_room_cache := ("", 0.0, None)
 
 (** Get path for a specific room *)
 let room_path config room_id = room_dir_for config room_id


### PR DESCRIPTION
## Summary
- `read_current_room` called 19 times across codebase, each doing 3 syscalls (open+read+close)
- File changes only via `masc_set_room` (rare)
- Added mtime-based cache: stat-only (1 syscall) on cache hit vs 3 syscalls before
- `write_current_room` invalidates the cache

Eliminates ~38 redundant syscalls per MCP tool call path.

Closes #2238

## Test plan
- [ ] `dune build` passes
- [ ] Manual: call masc_status, verify room is returned correctly
- [ ] Manual: call masc_set_room, verify new room is picked up immediately

Generated with [Claude Code](https://claude.com/claude-code)