### PR TITLE
fix(dashboard): close XSS via Mermaid securityLevel:loose + innerHTML

### DIFF
--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -64,7 +64,7 @@ export async function getMermaid(): Promise<MermaidApi> {
   mermaid.initialize({
     startOnLoad: false,
     theme: 'dark',
-    securityLevel: 'loose',
+    securityLevel: 'strict',
   })
   mermaidConfigured = true
   return mermaid

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -71,7 +71,7 @@ function MermaidGraph({ source }: { source: string }) {
     let cancelled = false
     const host = hostRef.current
     if (!host) return undefined
-    host.innerHTML = ''
+    host.textContent = ''
     setError(null)
 
     const render = async () => {
@@ -79,7 +79,13 @@ function MermaidGraph({ source }: { source: string }) {
         const mermaid = await getMermaid()
         const { svg } = await mermaid.render(`command-chain-${incrementMermaidRenderCount()}`, source)
         if (cancelled || !hostRef.current) return
-        hostRef.current.innerHTML = svg
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(svg, 'image/svg+xml')
+        const svgEl = doc.documentElement
+        if (svgEl instanceof SVGElement) {
+          hostRef.current.textContent = ''
+          hostRef.current.appendChild(svgEl)
+        }
       } catch (err) {
         if (cancelled) return
         setError(err instanceof Error ? err.message : 'Mermaid 렌더링에 실패했습니다')
@@ -89,7 +95,7 @@ function MermaidGraph({ source }: { source: string }) {
     void render()
     return () => {
       cancelled = true
-      if (hostRef.current) hostRef.current.innerHTML = ''
+      if (hostRef.current) hostRef.current.textContent = ''
     }
   }, [source])
 


### PR DESCRIPTION
## Summary
- Mermaid `securityLevel`을 `'loose'`에서 `'strict'`로 변경하여 렌더된 다이어그램 내 스크립트 실행을 차단
- `MermaidGraph` 컴포넌트에서 `innerHTML = svg` 대신 `DOMParser` + `appendChild`로 SVG를 삽입하여 raw HTML injection 경로 제거
- 기존 `innerHTML = ''` 호출도 `textContent = ''`로 교체

## Test plan
- [x] `npm run build` 성공 확인
- [ ] Mermaid 그래프가 포함된 체인 표면에서 다이어그램이 정상 렌더링되는지 확인
- [ ] `<script>alert(1)</script>` 등 악의적 payload가 포함된 Mermaid source에서 스크립트가 실행되지 않는지 확인

Closes #2227

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>