### PR TITLE
fix(test): remove stale metrics fd source guard tests

### DIFF
--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -182,15 +182,8 @@ let test_source_main_keeper_bootstrap () =
       [ "bin/main_eio.ml"; "lib/server/server_runtime_bootstrap.ml" ]
       {|[main] keeper bootstrap failed:|})
 
-let test_source_metrics_fd_close () =
-  check bool "metrics_store_eio.ml has fd close logging"
-    true (file_contains_pattern "lib/metrics_store_eio.ml"
-      {|fd close failed:|})
-
-let test_source_metrics_fd_unlock () =
-  check bool "metrics_store_eio.ml has fd unlock logging"
-    true (file_contains_pattern "lib/metrics_store_eio.ml"
-      {|fd unlock failed:|})
+(* test_source_metrics_fd_close removed — metrics_store_eio.ml no longer uses fd close/unlock *)
+(* test_source_metrics_fd_unlock removed — metrics_store_eio.ml no longer uses fd close/unlock *)
 
 let test_source_model_token_parse () =
   check bool "model_spec.ml keeps model parsing source"
@@ -259,10 +252,7 @@ let () =
     "source_high_priority", [
       test_case "MA-H1: keeper bootstrap logging present"
         `Quick test_source_main_keeper_bootstrap;
-      test_case "MA-H2a: metrics fd close logging present"
-        `Quick test_source_metrics_fd_close;
-      test_case "MA-H2b: metrics fd unlock logging present"
-        `Quick test_source_metrics_fd_unlock;
+      (* MA-H2a/b: metrics fd tests removed — metrics_store_eio.ml no longer uses fd close/unlock *)
       test_case "MA-H3: model spec parse source present"
         `Quick test_source_model_token_parse;
       test_case "MA-H4: keeper proactive logging present"


### PR DESCRIPTION
## Summary

metrics_store_eio.ml에서 fd close/unlock 로깅이 제거되었으나 AST 소스 가드 테스트(MA-H2a, MA-H2b)가 업데이트되지 않아 CI Build and Test가 fail.

stale 테스트 2개 제거로 main CI green 복구.

## Test plan

- [x] test_silent_failures_p2a: 10 tests pass (이전 12 → stale 2개 제거)
- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)