### PR TITLE
fix(test): wrap metrics tests in Eio_main.run — fixes CI crash

### DIFF
--- a/test/test_metrics_store_eio.ml
+++ b/test/test_metrics_store_eio.ml
@@ -185,7 +185,8 @@ let test_generate_id () =
   print_endline "✓ test_generate_id passed"
 
 let () =
-  print_endline "\n=== Metrics_store_eio Tests (Pure Sync) ===\n";
+  Eio_main.run @@ fun _env ->
+  print_endline "\n=== Metrics_store_eio Tests ===\n";
   test_create_metric ();
   test_complete_metric ();
   test_record_and_get ();


### PR DESCRIPTION
## Summary

- PR #2260 (Eio-native metrics) 이후 `test_metrics_store_eio`가 Eio 컨텍스트 없이 `Room.init` 호출
- `Effect.Unhandled(Get_context)` 크래시로 CI Build and Test 실패
- `Eio_main.run` wrapper 추가로 8/8 테스트 통과

Fixes #2271

## Test plan
- [x] `dune build` 성공
- [x] `test_metrics_store_eio` 8/8 통과
- [ ] CI Build and Test green

Generated with [Claude Code](https://claude.com/claude-code)