### PR TITLE
fix: handle Agent_sdk.Memory.store result type change

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -102,7 +102,7 @@ let institution_as_json (config : Room_utils.config) : Yojson.Safe.t option =
 let seed_institution ~(memory : Agent_sdk.Memory.t) ~(config : Room_utils.config) : bool =
   match institution_as_json config with
   | Some json ->
-    Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "institution" json;
+    ignore (Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "institution" json);
     true
   | None -> false
 
@@ -119,7 +119,7 @@ let seed_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limi
       ("procedures", `List (List.map Procedural_memory.to_json procs));
       ("count", `Int (List.length procs));
     ] in
-    Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "procedures" json;
+    ignore (Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "procedures" json);
     List.length procs
   end
 
@@ -281,7 +281,7 @@ let seed_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string)
   let episodes = Institution_eio.load_recent_episodes_jsonl ~limit in
   List.iter
     (fun episode ->
-      Agent_sdk.Memory.store_episode memory (oas_episode_of_institution episode))
+      ignore (Agent_sdk.Memory.store_episode memory (oas_episode_of_institution episode)))
     episodes;
   List.length episodes
 
@@ -341,7 +341,7 @@ let seed_procedures_as_oas ~(memory : Agent_sdk.Memory.t)
     ~(agent_name : string) ~(limit : int) : int =
   let procs = Procedural_memory.top_procedures ~agent_name ~limit in
   List.iter (fun p ->
-    Agent_sdk.Memory.store_procedure memory (oas_procedure_of_masc p)
+    ignore (Agent_sdk.Memory.store_procedure memory (oas_procedure_of_masc p))
   ) procs;
   List.length procs
 


### PR DESCRIPTION
## Summary

`Agent_sdk.Memory.store`/`store_episode`/`store_procedure`의 반환 타입이 `unit` → `(unit, string) result`로 변경됨.
4개 호출 지점에 `ignore()` 추가하여 빌드 수정.

main CI가 이 빌드 에러로 전체 fail 상태 — 이 PR로 복구.

## Test plan

- [x] `dune build --root .` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)