### PR TITLE
refactor(dashboard): migrate governance-agent + tools + dashboard CSS to Tailwind v4

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -35,9 +35,9 @@ export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-de
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
-    <div class="agent-detail-task rounded-lg">
+    <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg">
       <span class="pill rounded-full">${task.id}</span>
-      <span class="agent-detail-task rounded-lg-title">${task.title}</span>
+      <span class="flex-1 text-[#d7e7ff]">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
   `
@@ -45,11 +45,11 @@ function TaskSummary({ task }: { task: Task }) {
 
 function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
-    <div class="agent-history-row">
+    <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5">
       <div class="mb-2">
         <span class="pill rounded-full">${row.taskId}</span>
       </div>
-      <pre class="agent-history-pre">${row.text || 'No task history yet'}</pre>
+      <pre class="m-0 whitespace-pre-wrap text-[length:var(--fs-sm)] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || 'No task history yet'}</pre>
     </div>
   `
 }
@@ -93,13 +93,13 @@ export function AgentDetailOverlay() {
 
   return html`
     <div
-      class="agent-detail-overlay"
+      class="agent-detail-overlay fixed inset-0 z-[var(--z-overlay-agent,3030)] bg-black/64 backdrop-blur-[4px] isolate flex items-center justify-center p-5"
       data-testid="agent-detail-overlay"
       onClick=${(e: Event) => {
         if ((e.target as HTMLElement).classList.contains('agent-detail-overlay')) closeAgentDetail()
       }}
     >
-      <div class="agent-detail-modal">
+      <div class="w-[min(1020px,100%)] max-h-[90vh] overflow-y-auto rounded-[14px] border border-[var(--border-slate-30)] bg-[rgba(16,25,45,0.95)] p-[18px]">
         <div class="flex justify-between gap-3 mb-3.5">
           <div class="flex flex-col gap-2 flex-1">
             <div class="flex items-center gap-3">
@@ -160,7 +160,7 @@ export function AgentDetailOverlay() {
           <${Card} title="최근 활동">
             ${lines.length === 0
               ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 활동 기록이 없습니다</div>`
-              : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) => html`<div key=${idx} class="agent-activity-line rounded-lg">${line}</div>`)}</div>`}
+              : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
           <//>
         </div>
 

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -225,37 +225,37 @@ function CharacterPlate({ name }: { name: string }) {
 
       <div class="flex flex-col gap-1.5 min-w-0">
         <div class="flex items-baseline gap-2 flex-wrap">
-          <h2 class="ff-plate__name">
+          <h2 class="m-0 text-[20px] text-[color:var(--ff-gold)] flex items-center gap-1.5">
             ${agentEmoji ? html`<span class="text-[1.4em]">${agentEmoji}</span>` : ''}
             ${displayName}
           </h2>
           ${koreanName ? html`<span class="text-[length:var(--fs-base)] text-[color:var(--text-muted)]">(${koreanName})</span>` : ''}
-          ${generation != null ? html`<span class="ff-plate__level rounded">Lv.${generation}</span>` : null}
+          ${generation != null ? html`<span class="text-[length:var(--fs-md)] font-bold text-[color:var(--accent)] bg-[var(--accent-10)] border border-[rgba(71,184,255,0.25)] px-1.5 py-px tabular-nums rounded">Lv.${generation}</span>` : null}
         </div>
 
         <div class="flex items-center gap-1.5 flex-wrap">
           <${StatusBadge} status=${headerStatus} />
-          ${model ? html`<span class="ff-plate__model rounded">${model}</span>` : null}
-          ${autonomy ? html`<span class="ff-plate__autonomy rounded">${autonomy}</span>` : null}
+          ${model ? html`<span class="font-[family-name:'IBM_Plex_Mono',monospace] text-[length:var(--fs-xs)] text-[color:var(--text-muted)] bg-[var(--accent-8)] border border-[rgba(71,184,255,0.15)] px-[5px] py-px rounded">${model}</span>` : null}
+          ${autonomy ? html`<span class="text-[length:var(--fs-xs)] text-[color:var(--ff-gold)] bg-[var(--ff-gold-10)] border border-[var(--ff-gold-20)] px-[5px] py-px rounded">${autonomy}</span>` : null}
           ${signalTruth ? html`<span class="ff-plate__signal rounded ff-plate__signal--${signalTruth}">${signalTruth}</span>` : null}
         </div>
 
         ${ctxPct != null ? html`
           <div class="flex items-center gap-2 mt-0.5">
-            <span class="ff-plate__bar-label">CTX</span>
+            <span class="text-[length:var(--fs-xs)] font-bold text-[color:var(--ff-gold)] tracking-[1px] w-7">CTX</span>
             <div class="h-1.5 mt-1.5 rounded-full overflow-hidden bg-[var(--white-10)]" style="flex:1">
               <div class="ctx-fill rounded-full ${ctxBarClass(ctxRatio)}" style=${{ width: `${ctxPct}%` }}></div>
             </div>
-            <span class="ff-plate__bar-value">${ctxPct}%</span>
+            <span class="text-[length:var(--fs-sm)] tabular-nums text-[color:var(--text-strong)] min-w-9 text-right">${ctxPct}%</span>
           </div>
         ` : null}
 
         <div class="flex gap-2 items-center flex-wrap">
           ${currentWork
             ? html`<span class="text-[length:var(--fs-base)] text-[#c8daf7]">${currentWork}</span>`
-            : html`<span class="text-[length:var(--fs-base)] text-[#c8daf7] ff-plate__work--idle">대기 중</span>`
+            : html`<span class="text-[length:var(--fs-base)] text-[#6b7fa0] italic">대기 중</span>`
           }
-          ${workerState ? html`<span class="ff-plate__worker-state">${workerState}</span>` : null}
+          ${workerState ? html`<span class="text-[length:var(--fs-xs)] text-[color:var(--accent)] bg-[var(--accent-8)] px-[5px] py-px rounded-[3px]">${workerState}</span>` : null}
           ${workerFocus ? html`<span class="text-[length:var(--fs-xs)] text-[#9ab3de]">${workerFocus}</span>` : null}
         </div>
 
@@ -276,40 +276,40 @@ function CharacterPlate({ name }: { name: string }) {
       </div>
 
       ${isKeeper ? html`
-        <div class="ff-plate__stats ff-plate__stats--keeper">
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${ctxPct != null ? `${ctxPct}%` : 'N/A'}</span>
+        <div class="grid grid-cols-2 gap-1.5 self-center min-w-[100px]">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${ctxPct != null ? `${ctxPct}%` : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">CTX</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${generation ?? 0}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${generation ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">세대</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${keeper.turn_count ?? 0}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.turn_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">턴</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${keeper.autonomous_action_count ?? 0}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.autonomous_action_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">행동</span>
           </div>
         </div>
       ` : html`
-        <div class="ff-plate__stats">
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary ? summary.tasks_completed : 'N/A'}</span>
+        <div class="grid grid-cols-2 gap-1.5 self-center min-w-[100px]">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_completed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">완료</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary ? summary.tasks_claimed : 'N/A'}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_claimed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">수임</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary ? summary.messages_sent : 'N/A'}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.messages_sent : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">메시지</span>
           </div>
-          <div class="ff-stat rounded-md">
-            <span class="ff-stat__value">${summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A'}</span>
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">활동</span>
           </div>
         </div>
@@ -332,7 +332,7 @@ export function AgentProfile({ name }: { name: string }) {
   const isKeeper = keeper != null
 
   return html`
-    <div class="ff-profile ${isKeeper ? 'ff-profile--keeper' : ''}">
+    <div class="px-1 ${isKeeper ? 'ff-profile--keeper' : ''}">
       <div class="flex gap-2 mb-3">
         <button class="control-btn rounded-lg ghost" onClick=${() => navigate('status', { section: 'agents' })}>← 목록</button>
         <button class="control-btn rounded-lg ghost" onClick=${() => { void loadProfile(name) }} disabled=${loading.value}>
@@ -358,9 +358,9 @@ export function AgentProfile({ name }: { name: string }) {
           ${owned.length === 0
             ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">할당된 태스크 없음</div>`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
-                <div class="agent-detail-task rounded-lg" key=${t.id}>
+                <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg" key=${t.id}>
                   <span class="pill rounded-full">${t.id}</span>
-                  <span class="agent-detail-task rounded-lg-title">${t.title}</span>
+                  <span class="flex-1 text-[#d7e7ff]">${t.title}</span>
                   <${StatusBadge} status=${t.status} />
                 </div>
               `)}</div>`}
@@ -379,23 +379,23 @@ export function AgentProfile({ name }: { name: string }) {
               ${collabs.length > 0 ? html`
                 <div class="flex flex-col gap-1">
                   ${collabs.map(c => html`
-                    <div class="ff-relation-row rounded" key=${c.name}
+                    <div class="flex items-center gap-2 px-2 py-1.5 transition-colors duration-150 hover:bg-[rgba(255,215,0,0.08)] rounded" key=${c.name}
                       onClick=${() => navigate('status', { section: 'agents', agent: c.name })}
                       style="cursor:pointer;"
                     >
-                      <span class="ff-relation-name">${c.name}</span>
-                      <span class="ff-relation-count">${c.collaborations}회</span>
+                      <span class="text-[color:var(--ff-gold)] font-semibold text-[length:var(--fs-base)] flex-1">${c.name}</span>
+                      <span class="text-[color:var(--white-50)] text-[length:var(--fs-sm)] tabular-nums">${c.collaborations}회</span>
                       ${c.last_collab ? html`<span class="ff-relation-time"><${TimeAgo} timestamp=${c.last_collab} /></span>` : null}
                     </div>
                   `)}
                 </div>
               ` : null}
               ${interests.length > 0 ? html`
-                <div class="ff-interests" class="mt-2">
+                <div class="border-t border-[var(--white-6)] pt-2 mt-2">
                   <span class="ff-interests-label">관심사</span>
                   <div class="flex flex-wrap gap-1 mt-1.5">
-                    ${interests.slice(0, 12).map(t => html`<span class="ff-interest-tag" key=${t}>${t}</span>`)}
-                    ${interests.length > 12 ? html`<span class="ff-interest-tag">+${interests.length - 12}</span>` : null}
+                    ${interests.slice(0, 12).map(t => html`<span class="bg-[rgba(255,215,0,0.1)] text-[color:var(--white-70)] px-2 py-0.5 rounded-[3px] text-[length:var(--fs-xs)] border border-[rgba(255,215,0,0.15)]" key=${t}>${t}</span>`)}
+                    ${interests.length > 12 ? html`<span class="bg-[rgba(255,215,0,0.1)] text-[color:var(--white-70)] px-2 py-0.5 rounded-[3px] text-[length:var(--fs-xs)] border border-[rgba(255,215,0,0.15)]">+${interests.length - 12}</span>` : null}
                   </div>
                 </div>
               ` : null}
@@ -411,8 +411,8 @@ export function AgentProfile({ name }: { name: string }) {
                 const title = detail.title ?? detail.content ?? ''
                 return html`
                   <div class="agent-timeline-event rounded" key=${idx}>
-                    <span class="ff-event-type">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="ff-event-detail">${compactCopy(title, 80)}</span>` : null}
+                    <span class="text-[length:var(--fs-xs)] font-semibold text-[color:var(--ff-gold)] min-w-8">${timelineEventLabel(evt.type)}</span>
+                    ${title ? html`<span class="flex-1 text-[length:var(--fs-sm)] text-[#c8daf7]">${compactCopy(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
                   </div>
                 `
@@ -426,16 +426,16 @@ export function AgentProfile({ name }: { name: string }) {
         <${Card} title="Room 활동" class="ff-card rounded-xl">
           ${lines.length === 0
             ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관련 활동 없음</div>`
-            : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) =>
-                html`<div key=${idx} class="agent-activity-line rounded-lg">${line}</div>`)}</div>`}
+            : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>
+                html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
         <//>
 
         ${taskHistories.value.length > 0 ? html`
           <${Card} title="태스크 이력" class="ff-card rounded-xl col-span-full">
             <div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`
-              <div class="agent-history-row" key=${row.taskId}>
+              <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
                 <div class="mb-2"><span class="pill rounded-full">${row.taskId}</span></div>
-                <pre class="agent-history-pre">${row.text || 'No history yet'}</pre>
+                <pre class="m-0 whitespace-pre-wrap text-[length:var(--fs-sm)] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || 'No history yet'}</pre>
               </div>
             `)}</div>
           <//>
@@ -445,8 +445,8 @@ export function AgentProfile({ name }: { name: string }) {
       ${isKeeper ? html`
         <${KeeperChatPanel} name=${name} />
       ` : html`
-        <div class="ff-profile__mention rounded-lg">
-          <span class="ff-profile__mention rounded-lg-label">@${name}</span>
+        <div class="flex gap-2 items-center px-3.5 py-2.5 bg-[rgba(10,22,40,0.8)] border border-[var(--ff-gold-15)] rounded-lg">
+          <span class="text-[length:var(--fs-sm)] font-semibold text-[color:var(--ff-gold)] whitespace-nowrap">@${name}</span>
           <input
             class="control-input rounded-lg"
             type="text"

--- a/dashboard/src/components/common/mitosis-ring.ts
+++ b/dashboard/src/components/common/mitosis-ring.ts
@@ -13,7 +13,7 @@ export function MitosisRing({ ratio, size = 40, stroke = 4 }: { ratio?: number; 
   else if (ratio >= 0.5) colorClass = 'mitosis-warn'
 
   return html`
-    <div class="mitosis-ring-container" title="Mitosis Context Load: ${Math.round(ratio * 100)}%">
+    <div class="relative inline-flex items-center justify-center ml-auto mr-2.5" title="Mitosis Context Load: ${Math.round(ratio * 100)}%">
       <svg class="mitosis-ring" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
         <circle class="mitosis-ring-bg" cx="${c}" cy="${c}" r="${r}" stroke-width="${stroke}" />
         <circle 
@@ -24,7 +24,7 @@ export function MitosisRing({ ratio, size = 40, stroke = 4 }: { ratio?: number; 
           stroke-dashoffset="${dashoffset}" 
         />
       </svg>
-      <span class="mitosis-text ${colorClass}">${Math.round(ratio * 100)}%</span>
+      <span class="absolute text-[0.65rem] font-bold ${colorClass}">${Math.round(ratio * 100)}%</span>
     </div>
   `
 }

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -36,7 +36,7 @@ export function KanbanCard({ task }: { task: Task }) {
       ` : null}
       <div class="kanban-card rounded-xl-meta">
         ${task.created_at ? html`<${TimeAgo} timestamp=${task.created_at} />` : html`<span>-</span>`}
-        ${task.assignee ? html`<span class="kanban-assignee rounded-lg">${task.assignee}</span>` : null}
+        ${task.assignee ? html`<span class="inline-flex items-center bg-[rgba(0,240,255,0.1)] text-[color:var(--accent)] px-2 py-1 gap-1 font-semibold before:content-['@'] rounded-lg">${task.assignee}</span>` : null}
       </div>
     </div>
   `
@@ -50,7 +50,7 @@ export function TaskBacklog() {
 
   return html`
     <${Card} title="태스크 백로그" class="section mb-3.5">
-      <div class="kanban-board">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6 items-start">
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
           <div class="kanban-header todo">
             <span>할 일</span>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -367,7 +367,7 @@ function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button class="back-btn rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+      <button class="mb-3 border border-[var(--border-slate-30)] px-3 py-[7px] text-[length:var(--fs-sm)] text-[#bdd8ff] bg-[var(--white-3)] cursor-pointer hover:bg-[var(--white-10)] rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
       <${Card} title=${post.title}>
         <div class="board-detail p-5">
           <div class="post-body">
@@ -439,7 +439,7 @@ export function Memory() {
       : html`
           <div>
             <${MemorySummary} />
-            <button class="back-btn rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+            <button class="mb-3 border border-[var(--border-slate-30)] px-3 py-[7px] text-[length:var(--fs-sm)] text-[#bdd8ff] bg-[var(--white-3)] cursor-pointer hover:bg-[var(--white-10)] rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
             ${detailLoading.value
               ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">글 불러오는 중...</div>`
               : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">글을 찾지 못했습니다</div>`}

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -179,10 +179,10 @@ export function Mission() {
       </div>
 
       <nav class="mission-jump-strip flex gap-2 flex-wrap">
-        <a class="mission-jump-link rounded-full" href="#mission-sessions">세션 ${sessionRows.length}</a>
-        <a class="mission-jump-link rounded-full" href="#mission-keepers">키퍼 ${keeperRows.length}</a>
-        <a class="mission-jump-link rounded-full" href="#mission-output">활동</a>
-        <a class="mission-jump-link rounded-full" href="#mission-attention">우선순위 ${attentionQueue.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-sessions">세션 ${sessionRows.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-keepers">키퍼 ${keeperRows.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-output">활동</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-attention">우선순위 ${attentionQueue.length}</a>
       </nav>
 
       ${activeSessionId
@@ -213,7 +213,7 @@ export function Mission() {
         error=${missionSessionDetailError.value}
       />
 
-      <details open id="mission-keepers" class="mission-collapsible-section">
+      <details open id="mission-keepers" class="border border-[var(--border-slate-12)] rounded-[var(--radius-md,10px)] overflow-hidden">
         <summary class="mission-collapsible-summary">키퍼 연속성 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${keeperRows.length}</span>${keeperStatusWarnings > 0 ? html` <span class="monitor-pill warn inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${keeperStatusWarnings} 주의</span>` : null}</summary>
         <${Card} title="키퍼 연속성" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
@@ -233,7 +233,7 @@ export function Mission() {
         <//>
       </details>
 
-      <details open id="mission-output" class="mission-collapsible-section">
+      <details open id="mission-output" class="border border-[var(--border-slate-12)] rounded-[var(--radius-md,10px)] overflow-hidden">
         <summary class="mission-collapsible-summary">최근 사회 활동 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${focusSessionOutputs.length + keeperOutputRows.length}</span></summary>
         <${Card} title="최근 사회 활동" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">
@@ -264,7 +264,7 @@ export function Mission() {
         <//>
       </details>
 
-      <details open id="mission-attention" class="mission-collapsible-section">
+      <details open id="mission-attention" class="border border-[var(--border-slate-12)] rounded-[var(--radius-md,10px)] overflow-hidden">
         <summary class="mission-collapsible-summary">세션 우선순위 <span class="monitor-pill inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]${attentionQueue.length > 0 ? ' warn' : ''}">${attentionQueue.length}</span></summary>
         <${Card} title="세션 우선순위" class="mission-list-card rounded-xl">
           <div class="grid gap-1 mb-3">

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -42,17 +42,17 @@ function tierBadgeClass(tier: string): string {
 function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount: number }) {
   if (items.length === 0) return html`<p class="muted">아직 도구 호출 기록이 없습니다.</p>`
   return html`
-    <div class="tool-bar-chart">
+    <div class="flex flex-col gap-1.5">
       ${items.map(item => {
         const pct = maxCount > 0 ? (item.call_count / maxCount) * 100 : 0
         return html`
           <div class="tool-bar-row" key=${item.name}>
-            <span class="tool-bar-name">${item.name}</span>
-            <span class="tool-bar-tier ${tierBadgeClass(item.tier)}">${tierLabel(item.tier)}</span>
-            <div class="tool-bar-track">
-              <div class="tool-bar-fill" style=${{ width: `${pct}%` }} />
+            <span class="text-[color:var(--text-body)] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[length:var(--fs-xs)]">${item.name}</span>
+            <span class="px-1.5 py-px rounded-[3px] text-[length:var(--fs-2xs)] font-semibold text-center ${tierBadgeClass(item.tier)}">${tierLabel(item.tier)}</span>
+            <div class="h-3.5 rounded-[3px] bg-[var(--white-6)] overflow-hidden">
+              <div class="h-full rounded-[3px] bg-[var(--accent)] min-w-0.5 transition-[width] duration-300 ease-in-out" style=${{ width: `${pct}%` }} />
             </div>
-            <span class="tool-bar-count">${item.call_count}</span>
+            <span class="text-[color:var(--text-muted)] text-[length:var(--fs-xs)] text-right font-mono">${item.call_count}</span>
           </div>
         `
       })}
@@ -71,19 +71,19 @@ function TierDistribution({ dist }: { dist: Record<string, number> }) {
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center gap-2.5">
-        <span class="tier-dist-label rounded badge-essential">필수</span>
-        <span class="tier-dist-count">${essential}</span>
-        <span class="tier-dist-pct">${essentialPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-essential">필수</span>
+        <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${essential}</span>
+        <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${essentialPct}%</span>
       </div>
       <div class="flex items-center gap-2.5">
-        <span class="tier-dist-label rounded badge-standard">표준</span>
-        <span class="tier-dist-count">${standardOnly}</span>
-        <span class="tier-dist-pct">${standardPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-standard">표준</span>
+        <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${standardOnly}</span>
+        <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${standardPct}%</span>
       </div>
       <div class="flex items-center gap-2.5">
-        <span class="tier-dist-label rounded badge-full">전체 전용</span>
-        <span class="tier-dist-count">${fullOnly}</span>
-        <span class="tier-dist-pct">${fullOnlyPct}%</span>
+        <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-full">전체 전용</span>
+        <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${fullOnly}</span>
+        <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${fullOnlyPct}%</span>
       </div>
     </div>
   `
@@ -103,7 +103,7 @@ export function ToolMetrics() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex justify-between items-center">
-        <h3 class="tool-metrics-title">도구 사용 현황</h3>
+        <h3 class="text-[color:var(--text-strong)] text-[length:var(--fs-lg)] font-semibold m-0">도구 사용 현황</h3>
         <button
           class="control-btn rounded-lg ghost"
           onClick=${() => void loadMetrics()}
@@ -113,7 +113,7 @@ export function ToolMetrics() {
         </button>
       </div>
 
-      ${error ? html`<div class="tool-metrics-error rounded-lg">${error}</div>` : null}
+      ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-[length:var(--fs-base)] rounded-lg">${error}</div>` : null}
 
       ${data ? html`
         <div class="tool-metrics-summary">
@@ -140,12 +140,12 @@ export function ToolMetrics() {
         </div>
 
         <div class="tool-metrics-sections">
-          <div class="tool-metrics-section">
-            <h4>계층 분포</h4>
+          <div>
+            <h4 class="text-[color:var(--text-muted)] text-[length:var(--fs-xs)] uppercase tracking-[0.05em] mb-2.5 mt-0">계층 분포</h4>
             <${TierDistribution} dist=${data.tier_distribution} />
           </div>
-          <div class="tool-metrics-section">
-            <h4>상위 20 도구</h4>
+          <div>
+            <h4 class="text-[color:var(--text-muted)] text-[length:var(--fs-xs)] uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
             <${BarChart}
               items=${data.top_20}
               maxCount=${data.top_20.length > 0 ? data.top_20[0]!.call_count : 0}

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -80,47 +80,47 @@ export function FullInventoryView({
   const directCallCount = inventory.filter(item => item.direct_call_allowed).length
 
   return html`
-    <div class="tool-inventory-sticky-header">
+    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--slate-gray-12)]">
       <div class="tool-inventory-summary">
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="stat-label">전체 도구</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
           <span class="stat-label">활성화됨</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${hiddenCount}</span>
           <span class="stat-label">숨김</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="stat-label">지원 중단</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${directCallCount}</span>
           <span class="stat-label">직접 호출</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${filtered.length}</span>
           <span class="stat-label">필터 결과</span>
         </div>
       </div>
 
-      <div class="tool-surface-tabs">
+      <div class="flex flex-wrap gap-2 mb-3.5">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
           <button
             class=${`control-btn${surfaceFilter.value === key ? ' is-active' : ''}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="tool-surface-count rounded-full">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="tool-surface-count inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[length:var(--fs-2xs)] font-semibold bg-[rgba(148,163,184,0.18)] text-[color:var(--text-slate)] rounded-full">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
 
-      <div class="tool-inventory-filters">
+      <div class="flex flex-wrap gap-2.5 items-center">
         <input
           class="control-input rounded-lg"
           type="text"
@@ -140,7 +140,7 @@ export function FullInventoryView({
           <option value="all">전체 카테고리</option>
           ${categories.map(category => html`<option value=${category}>${category}</option>`)}
         </select>
-        <label class="tool-inventory-toggle">
+        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
           <input
             type="checkbox"
             checked=${enabledOnly.value}
@@ -150,7 +150,7 @@ export function FullInventoryView({
           />
           <span>활성화만</span>
         </label>
-        <label class="tool-inventory-toggle">
+        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
           <input
             type="checkbox"
             checked=${directOnly.value}
@@ -160,7 +160,7 @@ export function FullInventoryView({
           />
           <span>직접 호출만</span>
         </label>
-        <label class="tool-inventory-toggle">
+        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
           <input
             type="checkbox"
             checked=${showHidden.value}
@@ -170,7 +170,7 @@ export function FullInventoryView({
           />
           <span>숨김 표시</span>
         </label>
-        <label class="tool-inventory-toggle">
+        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
           <input
             type="checkbox"
             checked=${showDeprecated.value}
@@ -186,16 +186,16 @@ export function FullInventoryView({
       </div>
     </div>
 
-    ${error ? html`<div class="tool-metrics-error rounded-lg">${error}</div>` : null}
+    ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-[length:var(--fs-base)] rounded-lg">${error}</div>` : null}
 
-    <div ref=${listContainerRef} class="tool-inventory-virtual-container">
+    <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-[300px]">
       ${filtered.length > 0
         ? html`<${VirtualList}
             items=${filtered}
             itemHeight=${130}
             renderItem=${(item: DashboardToolInventoryItem) => html`<${InventoryRow} item=${item} />`}
             getKey=${(item: DashboardToolInventoryItem) => item.name}
-            className="tool-inventory-list"
+            className="flex flex-col gap-3"
           />`
         : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">조건에 맞는 도구가 없습니다.</div>`}
     </div>

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -6,13 +6,13 @@ import { toolBadge } from './tool-state'
 
 export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
   return html`
-    <article class="tool-inventory-row">
-      <div class="tool-inventory-head">
+    <article class="flex flex-col gap-2.5 p-4 rounded-2xl bg-[rgba(15,23,42,0.72)] border border-[rgba(148,163,184,0.16)]">
+      <div class="flex justify-between gap-3 items-start">
         <div>
-          <div class="tool-inventory-name">${item.name}</div>
+          <div class="text-[length:var(--fs-lg)] font-bold text-[color:var(--text-near-white)]">${item.name}</div>
           <div class="tool-inventory-desc">${item.description}</div>
         </div>
-        <div class="tool-inventory-badges">
+        <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
           ${toolBadge(item.tier, item.tier === 'essential' ? 'ok' : item.tier === 'standard' ? 'warn' : 'default')}
           ${toolBadge(item.visibility)}
@@ -20,19 +20,19 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
-      <div class="tool-inventory-meta">
-        <span>카테고리: <strong>${item.category}</strong></span>
-        <span>모드: <strong>${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
-        <span>직접 호출: <strong>${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
-        <span>권한: <strong>${item.required_permission ?? '없음'}</strong></span>
+      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
+        <span>카테고리: <strong class="text-[color:var(--text-slate-light)]">${item.category}</strong></span>
+        <span>모드: <strong class="text-[color:var(--text-slate-light)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
+        <span>직접 호출: <strong class="text-[color:var(--text-slate-light)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
+        <span>권한: <strong class="text-[color:var(--text-slate-light)]">${item.required_permission ?? '없음'}</strong></span>
       </div>
       ${item.reason
         ? html`<div class="tool-inventory-reason">${item.reason}</div>`
         : null}
-      <div class="tool-inventory-links">
-        ${item.canonicalName ? html`<span>정식 이름: <strong>${item.canonicalName}</strong></span>` : null}
-        ${item.replacement ? html`<span>대체 도구: <strong>${item.replacement}</strong></span>` : null}
-        ${item.doc_refs.length > 0 ? html`<span>문서: <strong>${item.doc_refs.join(', ')}</strong></span>` : null}
+      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
+        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[color:var(--text-slate-light)]">${item.canonicalName}</strong></span>` : null}
+        ${item.replacement ? html`<span>대체 도구: <strong class="text-[color:var(--text-slate-light)]">${item.replacement}</strong></span>` : null}
+        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[color:var(--text-slate-light)]">${item.doc_refs.join(', ')}</strong></span>` : null}
       </div>
     </article>
   `

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -21,15 +21,15 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
   return html`
     <div class="py-2">
       <div class="tool-inventory-summary">
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
           <span class="stat-label">전체 도구</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
           <span class="stat-label">활성화됨</span>
         </div>
-        <div class="tool-inventory-stat">
+        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
           <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
           <span class="stat-label">폐기 예정</span>
         </div>
@@ -37,12 +37,12 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
       ${essential.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="tool-summary-heading">필수 도구 (상위 ${essential.length}개)</h4>
+          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">필수 도구 (상위 ${essential.length}개)</h4>
           <div class="flex flex-col gap-1.5">
             ${essential.map(item => html`
-              <div class="tool-summary-row rounded-lg" key=${item.name}>
-                <span class="tool-summary-name">${item.name}</span>
-                <span class="tool-summary-desc">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
+                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
               </div>
             `)}
@@ -52,12 +52,12 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
       ${neverUsed.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="tool-summary-heading">미사용 도구 (${neverUsed.length}개)</h4>
+          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">미사용 도구 (${neverUsed.length}개)</h4>
           <div class="flex flex-col gap-1.5">
             ${neverUsed.map(item => html`
-              <div class="tool-summary-row rounded-lg" key=${item.name}>
-                <span class="tool-summary-name">${item.name}</span>
-                <span class="tool-summary-desc">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
+                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${toolBadge(item.category)}
               </div>
             `)}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -1,4 +1,7 @@
-/* ── Runtime Collapsible ──────────────────────────────────── */
+/* ── Dashboard — kept: pseudo-elements, stateful selectors, hover/focus,
+   transitions, keyframes, webkit details, complex grids, table styles ── */
+
+/* ── Runtime Collapsible ── */
 .runtime-summary {
   cursor: pointer;
   color: var(--text-muted);
@@ -15,15 +18,15 @@
 }
 
 .runtime-summary::before {
-  content: '▸ ';
+  content: '\25B8 ';
   display: inline;
 }
 
 .runtime-collapsible[open] > .runtime-summary::before {
-  content: '▾ ';
+  content: '\25BE ';
 }
-/* ── Collapsible Sections ── */
 
+/* ── Collapsible Sections ── */
 .overview-section-collapsible {
   border: 1px solid var(--border-slate-12);
   border-radius: 10px;
@@ -53,7 +56,7 @@
 }
 
 .overview-section-collapsible > summary::before {
-  content: '▸';
+  content: '\25B8';
   font-size: var(--fs-xs);
   transition: transform 0.15s;
   display: inline-block;
@@ -69,6 +72,15 @@
   padding: 0 16px 12px;
 }
 
+.mission-collapsible-summary::before {
+  content: '\25B8';
+  font-size: var(--fs-xs);
+  color: var(--text-slate);
+  transition: transform 0.15s;
+  display: inline-block;
+}
+
+/* ── Monitor pills ── */
 .monitor-pill.ok {
   background: var(--ok-12);
   color: var(--ok);
@@ -90,27 +102,14 @@
   }
 }
 
+/* ── Board post (content-visibility) ── */
 .board-post {
   border-color: var(--card-border);
   content-visibility: auto;
   contain-intrinsic-size: auto 120px;
 }
 
-.back-btn {
-  margin-bottom: 12px;
-  border: 1px solid var(--border-slate-30);
-  padding: 7px 12px;
-  font-size: var(--fs-sm);
-  color: #bdd8ff;
-  background: var(--white-3);
-  cursor: pointer;
-}
-
-.back-btn:hover {
-  background: var(--white-10);
-}
-
-/* ── Control Dock ─────────────────────────────────────────── */
+/* ── Control Dock ── */
 .control-row {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -154,7 +153,7 @@
 }
 
 .control-btn:disabled {
-  opacity: 0.55;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
@@ -189,43 +188,7 @@
   color: #9fb8e1;
 }
 
-.control-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* ── Mission Jump Strip ────────────────────────────────── */
-
-.mission-jump-link {
-  padding: 4px 10px;
-  border: 1px solid var(--border-slate-22);
-  background: var(--white-3);
-  color: #9fb8e1;
-  font-size: var(--fs-sm);
-  text-decoration: none;
-  transition: background 0.15s;
-}
-
-.mission-jump-link:hover {
-  background: var(--white-8);
-}
-
-/* ── Mission Collapsible Sections ──────────────────────── */
-.mission-collapsible-section {
-  border: 1px solid var(--border-slate-12);
-  border-radius: var(--radius-md, 10px);
-  overflow: hidden;
-}
-
-.mission-collapsible-summary::before {
-  content: '\25B8';
-  font-size: var(--fs-xs);
-  color: var(--text-slate);
-  transition: transform 0.15s;
-  display: inline-block;
-}
-
-/* ── Mission Status Dot (alive / idle / offline) ───────── */
+/* ── Mission Status Dot ── */
 .mission-status-dot {
   width: 8px;
   height: 8px;
@@ -239,7 +202,7 @@
   box-shadow: 0 0 4px rgba(74, 222, 128, 0.5);
 }
 
-/* ── Card-level dimming for offline / idle ──────────────── */
+/* ── Card-level dimming ── */
 .mission-crew-card.mission-state-offline,
 .mission-activity-card.mission-state-offline {
   opacity: 0.4;
@@ -257,8 +220,7 @@
   opacity: 0.85;
 }
 
-/* ── Shared: pill bar, collapsible ── */
-
+/* ── Tab pill (hover/active transitions) ── */
 .tab-pill {
   padding: 4px 14px;
   border-radius: 16px;
@@ -294,22 +256,17 @@
   color: var(--text-strong);
 }
 
-/* ── Layout (merged from layout.css) ── */
-/* ── Responsive (components) ───────────────────────────────── */
+/* ── Responsive (layout) ── */
 @media (max-width: 960px) {
-
   .keeper-kpis { grid-template-columns: repeat(2, 1fr); }
   .agent-detail-grid { grid-template-columns: 1fr; }
-
 }
 @media (max-width: 880px) {
   .council-create { grid-template-columns: 1fr; }
   .control-row { grid-template-columns: 1fr; }
   .agent-mention-row { grid-template-columns: 1fr; }
-
 }
 @media (max-width: 600px) {
-
   .keeper-kpis { grid-template-columns: 1fr; }
   .metric-tip-pop {
     left: 0;
@@ -317,18 +274,9 @@
     min-width: 220px;
     max-width: min(320px, calc(100vw - 56px));
   }
-
 }
 
-/* Mitosis Ring Chart */
-.mitosis-ring-container {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: auto;
-  margin-right: 10px;
-}
+/* ── Mitosis Ring ── */
 .mitosis-ring {
   transform: rotate(-90deg);
 }
@@ -347,31 +295,20 @@
   stroke: var(--bad); color: var(--bad);
   animation: pulse-ring 2s infinite;
 }
-.mitosis-text {
-  position: absolute;
-  font-size: 0.65rem;
-  font-weight: 700;
-}
 @keyframes pulse-ring {
   0% { opacity: 1; }
   50% { opacity: 0.6; }
   100% { opacity: 1; }
 }
 
-/* Enhancements for Agent Cards */
+/* ── Agent card hover ── */
 .agent-card:hover {
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
   transform: translateY(-2px);
   border-color: var(--accent);
 }
 
-/* Cyberpunk Kanban Board */
-.kanban-board {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 24px;
-  align-items: start;
-}
+/* ── Kanban (pseudo-elements, priority variants, hover transform) ── */
 .kanban-header {
   font-size: 1.1rem;
   font-weight: 700;
@@ -416,22 +353,8 @@
   border-color: var(--accent);
   box-shadow: 0 4px 12px rgba(0, 240, 255, 0.1);
 }
-.kanban-assignee {
-  display: inline-flex;
-  align-items: center;
-  background: rgba(0, 240, 255, 0.1);
-  color: var(--accent);
-  padding: 4px 8px;
-  gap: 4px;
-  font-weight: 600;
-}
-.kanban-assignee::before {
-  content: "@";
-}
 
-/* ── Logs (merged from logs.css) ── */
-/* System Log Viewer */
-
+/* ── Logs (table styling, sticky, monospace) ── */
 .logs-select {
   background: var(--card);
   color: var(--text-body);
@@ -509,4 +432,3 @@
 .logs-row:hover {
   background: var(--white-3);
 }
-

--- a/dashboard/src/styles/governance-agent.css
+++ b/dashboard/src/styles/governance-agent.css
@@ -1,83 +1,4 @@
-/* ── Agent Detail Overlay ─────────────────────────────────── */
-.agent-detail-overlay {
-  /* Uses --z-overlay-agent */
-  position: fixed;
-  inset: 0;
-  z-index: var(--z-overlay-agent, 3030);
-  background: rgba(0, 0, 0, 0.64);
-  backdrop-filter: blur(4px);
-  isolation: isolate;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-}
-
-.agent-detail-modal {
-  width: min(1020px, 100%);
-  max-height: 90vh;
-  overflow-y: auto;
-  border-radius: 14px;
-  border: 1px solid var(--border-slate-30);
-  background: rgba(16, 25, 45, 0.95);
-  padding: 18px;
-}
-
-.agent-detail-task {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid var(--card-border);
-  background: var(--white-3);
-  padding: 8px 10px;
-}
-
-.agent-detail-task-title {
-  flex: 1;
-  color: #d7e7ff;
-}
-
-.agent-activity-list {
-  max-height: 210px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.agent-activity-line {
-  border: 1px solid var(--card-border);
-  background: var(--white-3);
-  padding: 8px 10px;
-  font-family: "IBM Plex Mono", "Fira Code", monospace;
-  font-size: var(--fs-sm);
-  color: #c8daf7;
-  line-height: 1.4;
-}
-
-.agent-history-row {
-  border: 1px solid var(--card-border);
-  border-radius: 10px;
-  background: var(--white-2);
-  padding: 10px;
-}
-
-.agent-history-pre {
-  margin: 0;
-  white-space: pre-wrap;
-  font-size: var(--fs-sm);
-  line-height: 1.5;
-  color: #cfe0ff;
-  font-family: "IBM Plex Mono", "Fira Code", monospace;
-}
-
-/* ── FF Character Sheet — Agent Profile ──────────────────── */
-
-.ff-profile {
-  padding: 0 4px;
-}
-
-/* --- Character Plate (top section) --- */
+/* ── FF Character Sheet — kept: gradient plate, signal variants, responsive ── */
 
 .ff-plate {
   display: grid;
@@ -98,49 +19,7 @@
     inset 0 1px 0 var(--ff-gold-8);
 }
 
-.ff-plate__name {
-  margin: 0;
-  font-size: 20px;
-  color: var(--ff-gold);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.ff-plate__level {
-  font-size: var(--fs-md);
-  font-weight: 700;
-  color: var(--accent);
-  background: var(--accent-10);
-  border: 1px solid rgba(71, 184, 255, 0.25);
-  padding: 1px 6px;
-  font-variant-numeric: tabular-nums;
-}
-
-.ff-plate__model {
-  font-family: "IBM Plex Mono", monospace;
-  font-size: var(--fs-xs);
-  color: var(--text-muted);
-  background: var(--accent-8);
-  border: 1px solid rgba(71, 184, 255, 0.15);
-  padding: 1px 5px;
-}
-
-.ff-plate__autonomy {
-  font-size: var(--fs-xs);
-  color: var(--ff-gold);
-  background: var(--ff-gold-10);
-  border: 1px solid var(--ff-gold-20);
-  padding: 1px 5px;
-}
-
-.ff-plate__signal {
-  font-size: var(--fs-2xs);
-  font-weight: 600;
-  letter-spacing: 0.5px;
-  padding: 1px 5px;
-}
-
+/* Signal badges — stateful variants */
 .ff-plate__signal--live {
   color: var(--ok);
   background: var(--ok-10);
@@ -159,95 +38,9 @@
   border: 1px solid rgba(128, 128, 128, 0.15);
 }
 
-.ff-plate__bar-label {
-  font-size: var(--fs-xs);
-  font-weight: 700;
-  color: var(--ff-gold);
-  letter-spacing: 1px;
-  width: 28px;
-}
-
-.ff-plate__bar-value {
-  font-size: var(--fs-sm);
-  font-variant-numeric: tabular-nums;
-  color: var(--text-strong);
-  min-width: 36px;
-  text-align: right;
-}
-
-.ff-plate__work--idle {
-  color: #6b7fa0;
-  font-style: italic;
-}
-
-.ff-plate__worker-state {
-  font-size: var(--fs-xs);
-  color: var(--accent);
-  background: var(--accent-8);
-  padding: 1px 5px;
-  border-radius: 3px;
-}
-
-/* Stats panel (right side) */
-.ff-plate__stats {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-  align-self: center;
-  min-width: 100px;
-}
-
-.ff-stat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 6px 8px;
-  background: rgba(200, 168, 78, 0.05);
-  border: 1px solid var(--ff-gold-10);
-}
-
-.ff-stat__value {
-  font-size: 16px;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  color: var(--text-strong);
-}
-
-/* --- Grid and Cards --- */
-
-/* Timeline events - compact FF style */
-.ff-event-type {
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  color: var(--ff-gold);
-  min-width: 32px;
-}
-
-.ff-event-detail {
+/* Mention bar — nested .control-input override */
+.ff-profile__mention .control-input {
   flex: 1;
-  font-size: var(--fs-sm);
-  color: #c8daf7;
-}
-
-/* Mention bar */
-.ff-profile__mention {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  padding: 10px 14px;
-  background: rgba(10, 22, 40, 0.8);
-  border: 1px solid var(--ff-gold-15);
-
-  & .control-input {
-    flex: 1;
-  }
-}
-
-.ff-profile__mention-label {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  color: var(--ff-gold);
-  white-space: nowrap;
 }
 
 @media (max-width: 768px) {
@@ -260,45 +53,4 @@
   .ff-plate__name-row { justify-content: center; }
   .ff-plate__badges { justify-content: center; }
   .ff-profile__grid { grid-template-columns: 1fr; }
-}
-
-/* --- Agent Relations Card --- */
-
-.ff-relation-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  transition: background 0.15s;
-
-  &:hover {
-    background: rgba(255, 215, 0, 0.08);
-  }
-}
-
-.ff-relation-name {
-  color: var(--ff-gold);
-  font-weight: 600;
-  font-size: var(--fs-base);
-  flex: 1;
-}
-
-.ff-relation-count {
-  color: var(--white-50);
-  font-size: var(--fs-sm);
-  font-variant-numeric: tabular-nums;
-}
-
-.ff-interests {
-  border-top: 1px solid var(--white-6);
-  padding-top: 8px;
-}
-
-.ff-interest-tag {
-  background: rgba(255, 215, 0, 0.1);
-  color: var(--white-70);
-  padding: 2px 8px;
-  border-radius: 3px;
-  font-size: var(--fs-xs);
-  border: 1px solid rgba(255, 215, 0, 0.15);
 }

--- a/dashboard/src/styles/tools.css
+++ b/dashboard/src/styles/tools.css
@@ -1,15 +1,6 @@
-/* --- Sticky header --- */
-.tool-inventory-sticky-header {
-  position: sticky;
-  top: var(--header-h);
-  z-index: var(--z-tab-sticky);
-  background: rgba(11, 18, 32, 0.95);
-  backdrop-filter: blur(8px);
-  padding: 12px 0;
-  border-bottom: 1px solid var(--slate-gray-12);
-}
+/* ── Tools — kept: auto-fit grid, webkit-line-clamp, back-to-top,
+   bar-row grid, tier badges, responsive, surface-count active ── */
 
-/* --- Summary stats --- */
 .tool-inventory-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
@@ -17,114 +8,7 @@
   margin: 18px 0;
 }
 
-.tool-inventory-stat {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 14px 16px;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-}
-
-.tool-inventory-stat .stat-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--text-near-white);
-}
-
-.tool-inventory-stat .stat-label {
-  font-size: var(--fs-sm);
-  color: var(--text-slate);
-}
-
-/* --- Surface tabs --- */
-.tool-surface-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 14px;
-}
-
-.tool-surface-tabs .control-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--fs-sm);
-}
-
-.tool-surface-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  height: 18px;
-  padding: 0 5px;
-  font-size: var(--fs-2xs);
-  font-weight: 600;
-  background: rgba(148, 163, 184, 0.18);
-  color: var(--text-slate);
-}
-
-.control-btn.is-active .tool-surface-count {
-  background: rgba(14, 165, 233, 0.25);
-  color: #7dd3fc;
-}
-
-/* --- Filters --- */
-.tool-inventory-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 0;
-}
-
-.tool-inventory-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: var(--fs-sm);
-  color: var(--text-slate-light);
-}
-
-/* --- Virtual scroll container --- */
-.tool-inventory-virtual-container {
-  overflow-y: auto;
-  max-height: calc(100vh - 420px);
-  min-height: 300px;
-}
-
-/* --- List & rows --- */
-.tool-inventory-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.tool-inventory-row {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(148, 163, 184, 0.16);
-}
-
-.tool-inventory-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: flex-start;
-}
-
-.tool-inventory-name {
-  font-size: var(--fs-lg);
-  font-weight: 700;
-  color: var(--text-near-white);
-}
-
+/* webkit-line-clamp — not expressible in Tailwind v4 */
 .tool-inventory-desc {
   margin-top: 4px;
   font-size: var(--fs-base);
@@ -140,27 +24,6 @@
   -webkit-line-clamp: unset;
 }
 
-.tool-inventory-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: flex-end;
-}
-
-.tool-inventory-meta,
-.tool-inventory-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  font-size: var(--fs-sm);
-  color: var(--text-slate);
-}
-
-.tool-inventory-meta strong,
-.tool-inventory-links strong {
-  color: var(--text-slate-light);
-}
-
 .tool-inventory-reason {
   font-size: var(--fs-sm);
   color: var(--warn);
@@ -170,13 +33,7 @@
   overflow: hidden;
 }
 
-.tool-inventory-usage-hint {
-  margin-bottom: 12px;
-  font-size: var(--fs-sm);
-  color: var(--text-slate);
-}
-
-/* --- Back to top --- */
+/* Back to top — visibility/hover transitions */
 .tool-back-to-top {
   position: fixed;
   bottom: 24px;
@@ -208,81 +65,13 @@
   color: var(--text-near-white);
 }
 
-/* --- Responsive --- */
-@media (max-width: 880px) {
-  .tool-inventory-head {
-    flex-direction: column;
-  }
-
-  .tool-inventory-badges {
-    justify-content: flex-start;
-  }
-
-  .tool-inventory-virtual-container {
-    max-height: calc(100vh - 480px);
-  }
+/* Surface count active state */
+.control-btn.is-active .tool-surface-count {
+  background: rgba(14, 165, 233, 0.25);
+  color: #7dd3fc;
 }
 
-/* --- Tool Summary View --- */
-
-
-.tool-summary-heading {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--white-60);
-  margin: 0 0 10px 0;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.tool-bar-chart {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.tool-summary-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  background: var(--panel-dark-60);
-  border: 1px solid var(--slate-gray-8);
-}
-
-.tool-summary-name {
-  font-size: var(--fs-base);
-  font-weight: 500;
-  color: var(--text-slate-light);
-  min-width: 180px;
-  flex-shrink: 0;
-}
-
-.tool-summary-desc {
-  font-size: var(--fs-sm);
-  color: var(--white-40);
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-/* ── Tool Metrics (P4 Phase 4.5) ──────────────────────────── */
-.tool-metrics-title {
-  color: var(--text-strong);
-  font-size: var(--fs-lg);
-  font-weight: 600;
-  margin: 0;
-}
-
-.tool-metrics-error {
-  padding: 10px 12px;
-  background: var(--bad-12);
-  border: 1px solid rgba(239, 68, 68, 0.34);
-  color: #fecaca;
-  font-size: var(--fs-base);
-}
-
-/* ── Summary stats row ──────────────────────────────────── */
+/* ── Tool Metrics ── */
 .tool-metrics-summary {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -301,61 +90,13 @@
   text-align: center;
 }
 
-.tool-metrics-stat .stat-value {
-  color: var(--text-strong);
-  font-size: 22px;
-  font-weight: 600;
-  line-height: 1.1;
-}
-
-.tool-metrics-stat .stat-label {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-/* ── Two-column sections ────────────────────────────────── */
 .tool-metrics-sections {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   gap: 16px;
 }
 
-.tool-metrics-section h4 {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin: 0 0 10px;
-}
-
-/* ── Tier distribution ──────────────────────────────────── */
-.tier-dist-label {
-  display: inline-block;
-  min-width: 72px;
-  padding: 2px 8px;
-  font-size: var(--fs-xs);
-  font-weight: 600;
-  text-align: center;
-}
-
-.tier-dist-count {
-  color: var(--text-strong);
-  font-size: var(--fs-md);
-  font-weight: 600;
-  min-width: 36px;
-  text-align: right;
-}
-
-.tier-dist-pct {
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-  min-width: 48px;
-  text-align: right;
-}
-
-/* ── Tier badges ────────────────────────────────────────── */
+/* Tier badges */
 .badge-essential {
   background: var(--ok-18);
   color: var(--ok);
@@ -371,7 +112,7 @@
   color: var(--text-muted);
 }
 
-/* ── Bar chart ──────────────────────────────────────────── */
+/* Bar chart row — complex grid template */
 .tool-bar-row {
   display: grid;
   grid-template-columns: minmax(140px, 0.8fr) 68px minmax(0, 1fr) 48px;
@@ -380,47 +121,12 @@
   font-size: var(--fs-sm);
 }
 
-.tool-bar-name {
-  color: var(--text-body);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: var(--fs-xs);
-}
-
-.tool-bar-tier {
-  padding: 1px 6px;
-  border-radius: 3px;
-  font-size: var(--fs-2xs);
-  font-weight: 600;
-  text-align: center;
-}
-
-.tool-bar-track {
-  height: 14px;
-  border-radius: 3px;
-  background: var(--white-6);
-  overflow: hidden;
-}
-
-.tool-bar-fill {
-  height: 100%;
-  border-radius: 3px;
-  background: var(--accent);
-  min-width: 2px;
-  transition: width 0.3s ease;
-}
-
-.tool-bar-count {
-  color: var(--text-muted);
-  font-size: var(--fs-xs);
-  text-align: right;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-/* ── Responsive ─────────────────────────────────────────── */
+/* ── Responsive ── */
 @media (max-width: 880px) {
+  .tool-inventory-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .tool-metrics-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary
Three CSS files migrated to Tailwind v4 utilities:

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| governance-agent.css | 304 | 56 | -82% |
| tools.css | 435 | 141 | -68% |
| dashboard.css | 512 | 434 | -15% |
| **Subtotal** | **1,251** | **631** | **-50%** |

## Cumulative session total (8 files)
| File | Before | After | Reduction |
|------|--------|-------|-----------|
| command.css | 972 | 258 | -73% |
| ops.css | 619 | 247 | -60% |
| mission.css | 461 | 24 | -95% |
| command-swarm.css | 416 | 192 | -54% |
| overview.css | 310 | 142 | -54% |
| governance-agent.css | 304 | 56 | -82% |
| tools.css | 435 | 141 | -68% |
| dashboard.css | 512 | 434 | -15% |
| **Total** | **4,029** | **1,494** | **-63%** |

## Test plan
- [x] `npx vite build` — pass (all 3 commits)

Generated with [Claude Code](https://claude.com/claude-code)