### PR TITLE
fix(keeper): remove blocking Unix I/O and unbounded full_history

### DIFF
--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -34,17 +34,6 @@ let env_present name =
   | Some value -> String.trim value <> ""
   | None -> false
 
-let ollama_port_listening () =
-  try
-    let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-    Fun.protect
-      ~finally:(fun () -> try Unix.close sock with Unix.Unix_error _ -> ())
-      (fun () ->
-        Unix.connect sock (Unix.ADDR_INET (Unix.inet_addr_loopback, 11434));
-        true)
-  with Unix.Unix_error _ ->
-    false
-
 let model_spec_is_local_runtime (model : Model_spec.model_spec) =
   match model.provider with
   | Model_spec.Llama -> true
@@ -189,9 +178,4 @@ let maybe_rotate_file path =
 let append_jsonl_line path (json : Yojson.Safe.t) =
   maybe_rotate_file path;
   let line = utf8_repair_string (Yojson.Safe.to_string json) ^ "\n" in
-  let fd =
-    Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND] 0o644
-  in
-  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
-      let _ = Unix.write_substring fd line 0 (String.length line) in
-      ())
+  Fs_compat.append_file path line

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -43,7 +43,6 @@ type checkpoint = {
 type session_context = {
   session_id : string;
   session_dir : string;
-  mutable full_history : Agent_sdk.Types.message list;
   mutable checkpoints : checkpoint list;
 }
 
@@ -298,11 +297,10 @@ let restore_checkpoint ckpt ~max_tokens =
 let create_session ~session_id ~base_dir =
   let session_dir = Filename.concat base_dir session_id in
   ensure_dir session_dir;
-  { session_id; session_dir; full_history = []; checkpoints = [] }
+  { session_id; session_dir; checkpoints = [] }
 
 let persist_message session msg =
   let msg = Inference_utils.sanitize_message_utf8 msg in
-  session.full_history <- session.full_history @ [msg];
   let path = Filename.concat session.session_dir "history.jsonl" in
   let now_ts = Time_compat.now () in
   let payload =


### PR DESCRIPTION
## Summary
- Remove dead `ollama_port_listening` function (blocking `Unix.socket`/`Unix.connect`, zero callers since Ollama removal in 2026-03-18)
- Replace blocking `Unix.openfile`/`Unix.write_substring`/`Unix.close` in `append_jsonl_line` with `Fs_compat.append_file` (Eio-native when `global_fs` is set)
- Remove `full_history` field from `session_context` in `keeper_working_context.ml` (O(n) list append on every message, never read anywhere)

## Test plan
- [x] `dune build --root .` passes
- [ ] Existing `test_metrics_rotation` tests pass (they call `append_jsonl_line` via `Keeper_types`)
- [ ] `test_tool_keeper` tests pass (they call `append_jsonl_line`)

Closes #2229

Generated with [Claude Code](https://claude.com/claude-code)