### PR TITLE
fix(keeper): guard parse exceptions in load_latest

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -116,4 +116,5 @@ let load_latest ~(session_dir : string) : Keeper_working_context.checkpoint opti
   | [] -> None
   | latest :: _ ->
     let path = Filename.concat session_dir latest in
-    Some (parse_checkpoint_file path)
+    (try Some (parse_checkpoint_file path)
+     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)


### PR DESCRIPTION
## Summary

`Keeper_checkpoint_store.load_latest`가 `checkpoint option`을 반환하지만 내부에서
`Sys_error`/`Yojson.Json_error`가 발생 가능. 손상된 checkpoint 파일에서 `None` 대신
예외가 전파됨.

`try/with`로 감싸서 파싱 실패 시 `None` 반환. `Eio.Cancel.Cancelled`는 re-raise.

Fixes #2262

## Test plan
- [x] `dune build` 성공
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)