### PR TITLE
refactor(dashboard): migrate roster + live + governance + oas-pipeline CSS to Tailwind v4

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -120,14 +120,14 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   }
 
   return html`
-    <div class="roster-page agent-page">
-      <div class="roster-header mb-6">
-        <h2 class="roster-title">${keeperFilter === 'keeper-only' ? '키퍼' : keeperFilter === 'agent-only' ? '에이전트' : '에이전트'} (${filtered.length})</h2>
-        <p class="agent-page__subtitle">${keeperFilter === 'keeper-only' ? '키퍼 런타임이 있는 에이전트' : keeperFilter === 'agent-only' ? '키퍼 런타임이 없는 에이전트' : '등록된 에이전트 — keeper 런타임이 있으면 컨텍스트 게이지 표시'}</p>
+    <div class="p-[var(--space-lg,24px)] max-w-[960px] agent-page">
+      <div class="mb-6">
+        <h2 class="text-[20px] font-semibold text-[color:var(--ff-gold-bright)] mb-[var(--space-md,16px)] tracking-[0.5px] [text-shadow:0_1px_4px_rgba(212,169,75,0.2)]">${keeperFilter === 'keeper-only' ? '키퍼' : keeperFilter === 'agent-only' ? '에이전트' : '에이전트'} (${filtered.length})</h2>
+        <p class="text-[length:var(--fs-sm)] text-[color:var(--white-30)] mt-1">${keeperFilter === 'keeper-only' ? '키퍼 런타임이 있는 에이전트' : keeperFilter === 'agent-only' ? '키퍼 런타임이 없는 에이전트' : '등록된 에이전트 — keeper 런타임이 있으면 컨텍스트 게이지 표시'}</p>
         <div class="flex gap-[var(--space-md,16px)] items-center flex-wrap">
           <input
             type="text"
-            class="roster-search rounded transition-colors duration-200"
+            class="py-1.5 px-3 border border-[var(--ff-border-subtle)] bg-[var(--ff-navy)] text-[color:var(--white-90)] text-[length:var(--fs-base)] w-[200px] rounded transition-colors duration-200 focus:outline-none focus:border-[var(--ff-gold)] focus:shadow-[0_0_0_2px_var(--ff-gold-dim)] placeholder:text-[color:var(--white-25)]"
             placeholder="이름 검색..."
             value=${search}
             onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
@@ -157,13 +157,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <div
-              class="roster-card rounded-xl rounded-md transition-all duration-200 ${isKeeper ? 'roster-card--keeper' : ''}"
+              class="roster-card rounded-md transition-all duration-200 ${isKeeper ? 'roster-card--keeper' : ''}"
               key=${agent.name}
               onClick=${() => openAgentDetail(agent.name)}
               role="button"
               tabindex="0"
             >
-              <div class="roster-card__avatar">
+              <div class="shrink-0 relative roster-card__avatar">
                 <${AgentAvatar}
                   name=${agent.name}
                   status=${agent.status}
@@ -173,9 +173,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   activityAge=${lastActivity}
                 />
               </div>
-              <div class="roster-card__info">
+              <div class="flex-1 min-w-0 flex flex-col gap-[5px] justify-center">
                 <div class="flex items-center gap-[var(--space-sm,8px)]">
-                  <strong class="roster-card__name">${agent.name}</strong>
+                  <strong class="text-[length:var(--fs-lg)] text-[color:var(--ff-gold-bright)] font-semibold tracking-[0.3px]">${agent.name}</strong>
                   ${isKeeper ? html`
                     <span class="roster-card__keeper-tag">keeper</span>
                   ` : null}
@@ -195,21 +195,21 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                         style=${{ width: `${ctxPct}%` }}
                       />
                     </div>
-                    <span class="roster-card__gauge-label">ctx ${ctxPct}%</span>
+                    <span class="text-[length:var(--fs-xs)] text-[color:var(--white-40)] whitespace-nowrap min-w-[50px] tabular-nums">ctx ${ctxPct}%</span>
                   </div>
                 ` : null}
 
                 ${currentWork ? html`
-                  <div class="roster-card__work">${currentWork}</div>
+                  <div class="text-[length:var(--fs-base)] text-[color:var(--white-55)] overflow-hidden text-ellipsis whitespace-nowrap">${currentWork}</div>
                 ` : html`
-                  <div class="roster-card__work roster-card__work--empty">작업 없음</div>
+                  <div class="text-[length:var(--fs-base)] text-[color:var(--white-20)] overflow-hidden text-ellipsis whitespace-nowrap italic">작업 없음</div>
                 `}
-                <div class="roster-card__meta">
+                <div class="flex gap-[var(--space-sm,8px)] text-[length:var(--fs-xs)] text-[color:var(--white-30)]">
                   ${lastActivity != null ? html`
                     <span>${formatDuration(lastActivity)} 전</span>
                   ` : null}
                   ${keeper?.model ? html`
-                    <span class="roster-card__model">${keeper.model}</span>
+                    <span class="py-px px-1.5 bg-[rgba(212,169,75,0.08)] border border-[var(--ff-border-subtle)] rounded-[3px] text-[rgba(212,169,75,0.6)]">${keeper.model}</span>
                   ` : null}
                 </div>
               </div>
@@ -217,7 +217,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           `
         })}
         ${filtered.length === 0 ? html`
-          <div class="roster-empty rounded-md">조건에 맞는 에이전트가 없습니다.</div>
+          <div class="py-[var(--space-xl,32px)] text-center text-[color:var(--white-20)] text-[length:var(--fs-md)] border border-dashed border-[var(--ff-border-subtle)] rounded-md">조건에 맞는 에이전트가 없습니다.</div>
         ` : null}
       </div>
     </div>

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -27,7 +27,7 @@ export function PetitionEntry({ petition }: { petition: GovernanceCaseBundle['pe
         <strong>${petition.created_by || petition.origin || 'system'}</strong>
         ${petition.created_at ? html`<span><${TimeAgo} timestamp=${petition.created_at} /></span>` : null}
       </div>
-      <div class="governance-ledger-body">${petition.title}</div>
+      <div class="mt-2 text-[#d7e7ff] leading-[1.5] break-words">${petition.title}</div>
       <div class="governance-chip rounded-full-row">
         ${petition.source_refs.map(ref => html`<span class="governance-chip rounded-full">${ref}</span>`)}
       </div>
@@ -43,7 +43,7 @@ export function BriefEntry({ brief }: { brief: GovernanceCaseBrief }) {
         <strong>${brief.author}</strong>
         ${brief.created_at ? html`<span><${TimeAgo} timestamp=${brief.created_at} /></span>` : null}
       </div>
-      <div class="governance-ledger-body">${brief.summary}</div>
+      <div class="mt-2 text-[#d7e7ff] leading-[1.5] break-words">${brief.summary}</div>
       <div class="governance-chip rounded-full-row">
         ${brief.evidence_refs.map(ref => html`<span class="governance-chip rounded-full">${ref}</span>`)}
       </div>
@@ -71,7 +71,7 @@ export function DecisionDetail() {
               <div class="flex justify-between items-start gap-4 mb-3.5">
                 <div>
                   <h3>${detail.case.title}</h3>
-                  <div class="council-sub">
+                  <div class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
                     <span>${detail.case.id}</span>
                     <span>${caseStatusLabel(detail.case.status)}</span>
                     ${detail.case.updated_at
@@ -79,11 +79,11 @@ export function DecisionDetail() {
                       : null}
                   </div>
                 </div>
-                <div class="governance-balance-grid">
-                  <span class="governance-balance"><strong>${petitions.length}</strong>건 청원</span>
-                  <span class="governance-balance"><strong>${briefs.length}</strong>건 의견</span>
-                  <span class="governance-balance"><strong>${item.confidence != null ? Math.round(item.confidence * 100) : 0}</strong>% 확신도</span>
-                  <span class="governance-balance"><strong>${orderStatusLabel(detail.execution_order?.status)}</strong></span>
+                <div class="grid grid-cols-[repeat(2,minmax(90px,1fr))] gap-2">
+                  <span class="border border-[var(--card-border)] rounded-[10px] py-2 px-2.5 bg-[var(--white-4)] text-[#c8daf7] text-[length:var(--fs-sm)]"><strong>${petitions.length}</strong>건 청원</span>
+                  <span class="border border-[var(--card-border)] rounded-[10px] py-2 px-2.5 bg-[var(--white-4)] text-[#c8daf7] text-[length:var(--fs-sm)]"><strong>${briefs.length}</strong>건 의견</span>
+                  <span class="border border-[var(--card-border)] rounded-[10px] py-2 px-2.5 bg-[var(--white-4)] text-[#c8daf7] text-[length:var(--fs-sm)]"><strong>${item.confidence != null ? Math.round(item.confidence * 100) : 0}</strong>% 확신도</span>
+                  <span class="border border-[var(--card-border)] rounded-[10px] py-2 px-2.5 bg-[var(--white-4)] text-[#c8daf7] text-[length:var(--fs-sm)]"><strong>${orderStatusLabel(detail.execution_order?.status)}</strong></span>
                 </div>
               </div>
               <div class="flex flex-col gap-2.5">

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -44,13 +44,13 @@ export function GuardrailPane({
           : html`
               <div class="flex flex-col gap-2">
                 <h4>판정</h4>
-                <div class="council-sub">
+                <div class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
                   <span>${caseStatusLabel(ruling?.status || 'pending')}</span>
                   <span>${confidenceText(ruling?.confidence)}</span>
                   ${ruling?.generated_at ? html`<span><${TimeAgo} timestamp=${ruling.generated_at} /></span>` : null}
                 </div>
                 ${ruling?.summary
-                  ? html`<div class="governance-summary-callout">${ruling.summary}</div>`
+                  ? html`<div class="mb-3 border border-[rgba(71,184,255,0.22)] rounded-[10px] bg-[rgba(71,184,255,0.09)] text-[#dcecff] py-[11px] px-3 leading-[1.5]">${ruling.summary}</div>`
                   : html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">아직 판정이 생성되지 않았습니다.</div>`}
                 <div class="governance-chip rounded-full-row">
                   ${item.provenance ? html`<span class="governance-chip rounded-full">${item.provenance}</span>` : null}
@@ -125,13 +125,13 @@ export function ActionRequestCard({ order }: { order: GovernanceExecutionOrder |
   return html`
     <div class="flex flex-col gap-2">
       <h4>집행 명령</h4>
-      <div class="council-sub">
+      <div class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
         <span>${request.resolved_tool || request.action_kind || request.target_type || 'action'}</span>
         <span>${orderStatusLabel(order.status)}</span>
       </div>
       ${request.target_type ? html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">대상 ${request.target_type}${request.target_id ? `:${request.target_id}` : ''}</div>` : null}
       ${request.reason ? html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">${request.reason}</div>` : null}
-      ${request.payload_preview ? html`<pre class="council-detail governance-preview">${serializePreview(request.payload_preview)}</pre>` : null}
+      ${request.payload_preview ? html`<pre class="whitespace-pre-wrap border border-[var(--card-border)] rounded-[9px] bg-[rgba(0,0,0,0.28)] text-[#d3e3ff] p-3 text-[length:var(--fs-sm)] leading-[1.5] font-mono mt-0 text-[length:var(--fs-xs)] max-h-[180px] overflow-auto">${serializePreview(request.payload_preview)}</pre>` : null}
       ${order.execution_ref ? html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">결과 참조 ${order.execution_ref}</div>` : null}
       ${order.result_summary ? html`<div class="text-[#c8daf7] text-[length:var(--fs-sm)] leading-[1.45]">${order.result_summary}</div>` : null}
     </div>

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -114,7 +114,7 @@ export function RuntimeParamsPanel() {
                     <div class="governance-surface-head">
                       <strong>${surface.id}</strong>
                       <span class="governance-chip rounded-full ${surface.risk === 'high' ? 'warn' : ''}">${surface.risk}</span>
-                      <span class="council-sub">${surface.description}</span>
+                      <span class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">${surface.description}</span>
                     </div>
                     <div class="governance-params-table">
                       ${surfaceParams.map(param => html`
@@ -126,7 +126,7 @@ export function RuntimeParamsPanel() {
                               ? html`<span class="governance-chip rounded-full warn" style="margin-left:4px">override</span>`
                               : null}
                           </span>
-                          <span class="governance-param-default council-sub">
+                          <span class="governance-param-default mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
                             기본: ${formatParamValue(param.default)}
                           </span>
                         </div>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -80,7 +80,7 @@ function GovernanceToolbar() {
   return html`
     <${Card} title="청원 콘솔" class="section mb-3.5">
       <div class="flex flex-col gap-3">
-        <div class="council-create">
+        <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-2 items-center">
           <input
             class="control-input rounded-lg"
             type="text"
@@ -126,7 +126,7 @@ function GovernanceToolbar() {
             </button>
           `)}
         </div>
-        ${governanceError.value ? html`<div class="council-error rounded-lg">${governanceError.value}</div>` : null}
+        ${governanceError.value ? html`<div class="mt-2.5 border border-[rgba(239,68,68,0.35)] py-2 px-2.5 text-[#f7b6b6] text-[length:var(--fs-sm)] rounded-lg">${governanceError.value}</div>` : null}
       </div>
     <//>
   `
@@ -136,7 +136,7 @@ function DecisionInbox() {
   const items = filteredItemsByFilter(governanceFilter.value, governanceData.value?.items ?? [])
   return html`
     <${Card} title="사건 수신함" class="section mb-3.5">
-      <div class="council-list governance-inbox">
+      <div class="flex flex-col gap-2 governance-inbox">
         ${items.length === 0
           ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
           : items.map(item => {
@@ -147,11 +147,11 @@ function DecisionInbox() {
                   onClick=${() => selectDecision(item)}
                 >
                   <div class="min-w-0">
-                    <div class="governance-row-head">
+                    <div class="flex items-center gap-2 min-w-0">
                       <span class="governance-kind rounded-full">${kindLabel(item.kind)}</span>
-                      <span class="council-topic">${item.topic}</span>
+                      <span class="text-[#e8f0ff] text-[length:var(--fs-md)] font-semibold break-words">${item.topic}</span>
                     </div>
-                    <div class="council-sub">
+                    <div class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
                       <span>${item.truth_summary || '사실 요약이 아직 없습니다'}</span>
                       ${item.last_activity_at
                         ? html`<span><${TimeAgo} timestamp=${item.last_activity_at} /></span>`
@@ -169,7 +169,7 @@ function DecisionInbox() {
                         : null}
                     </div>
                   </div>
-                  <div class="governance-row-side">
+                  <div class="flex flex-col items-end gap-2">
                     <span class="council-state rounded-full ${governanceToneClass(item.status)}">${caseStatusLabel(item.status)}</span>
                     <span class="governance-vote-meter">${item.brief_count ?? 0}건</span>
                   </div>

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -14,8 +14,8 @@ export function Live() {
   return html`
     <div class="grid gap-4">
       <div class="live-header">
-        <h2>라이브 모니터</h2>
-        <div class="live-header-stats">
+        <h2 class="m-0 text-[1.25rem] font-semibold">라이브 모니터</h2>
+        <div class="flex gap-3 items-center text-[0.8rem] text-[color:var(--white-50)]">
           <span class="live-stat">
             <span class="live-stat-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
             ${isConnected ? '연결됨' : '오프라인'}

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -42,24 +42,24 @@ export function ActivityStream() {
   return html`
     <div class="grid gap-2.5 grid-rows-[auto_auto_1fr] min-h-0">
       <div class="activity-stream-head">
-        <h3>Activity Stream</h3>
+        <h3 class="m-0 text-[0.95rem] font-semibold">Activity Stream</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${entries.length} events</span>
       </div>
       <${FilterBar} />
       <div class="activity-stream-list">
         ${entries.length === 0
-          ? html`<div class="activity-empty">필터에 맞는 이벤트 없음</div>`
+          ? html`<div class="py-6 text-center text-[color:var(--white-25)] text-[0.8rem]">필터에 맞는 이벤트 없음</div>`
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}
               class="activity-item rounded-lg ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
-              <div class="activity-item rounded-lg-head">
+              <div class="activity-item-head">
                 <span class="activity-kind-chip rounded ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
-                <span class="activity-agent">${entry.agent}</span>
-                <span class="activity-time">${formatTimeAgo(entry.timestamp)}</span>
+                <span class="text-[0.75rem] text-[color:var(--white-60)] font-medium">${entry.agent}</span>
+                <span class="text-[0.7rem] text-[color:var(--white-30)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="activity-item rounded-lg-text">${entry.text}</div>
+              <div class="text-[0.8rem] text-[color:var(--white-70)] leading-[1.4] break-words">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -28,35 +28,35 @@ export function FocusSidebar() {
   return html`
     <div class="grid gap-2.5 grid-rows-[auto_1fr] min-h-0">
       <div class="focus-sidebar-head">
-        <h3>Agents</h3>
+        <h3 class="m-0 text-[0.95rem] font-semibold">Agents</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length} active</span>
       </div>
-      <div class="focus-sidebar-list">
+      <div class="grid gap-1.5 content-start overflow-y-auto max-h-[560px] pr-1">
         ${list.length === 0
-          ? html`<div class="focus-empty">No active agents</div>`
+          ? html`<div class="py-6 text-center text-[color:var(--white-25)] text-[0.8rem]">No active agents</div>`
           : list.map(agent => html`
             <div
               key=${agent.name}
-              class="focus-agent-card rounded-xl transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
-                <span class="focus-agent-name">
+                <span class="text-[0.85rem] font-medium flex items-center gap-1">
                   ${agent.emoji ? html`<span class="text-[0.95rem]">${agent.emoji}</span>` : null}
                   ${agent.koreanName ?? agent.name}
                 </span>
                 <span class="focus-pressure-badge rounded-md ${pressureClass(agent.pressure)}">
                   ${pressureLabel(agent.pressure)}
-                  ${agent.assignedCount > 0 ? html` <span class="focus-task-count rounded">${agent.assignedCount}</span>` : null}
+                  ${agent.assignedCount > 0 ? html` <span class="bg-[var(--white-10)] px-1 text-[0.6rem] rounded">${agent.assignedCount}</span>` : null}
                 </span>
               </div>
               ${agent.currentTask
-                ? html`<div class="focus-current-task rounded-md">${agent.currentTask}</div>`
+                ? html`<div class="text-[0.75rem] text-[color:var(--white-55)] py-[3px] px-2 bg-[var(--white-3)] border border-[var(--white-5)] whitespace-nowrap overflow-hidden text-ellipsis rounded-md">${agent.currentTask}</div>`
                 : null}
               <div class="focus-agent-footer">
                 ${agent.lastActivityText
-                  ? html`<span class="focus-activity-text">${agent.lastActivityText}</span>`
-                  : html`<span class="focus-activity-text italic text-[rgba(255,255,255,0.25)]">No recent activity</span>`}
+                  ? html`<span class="text-[0.72rem] text-[color:var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
+                  : html`<span class="text-[0.72rem] text-[color:var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic text-[rgba(255,255,255,0.25)]">No recent activity</span>`}
                 ${agent.lastActivityAt
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -34,7 +34,7 @@ export function PulseStrip() {
           title="${p.koreanName ? `${p.name} (${p.koreanName})` : p.name}${p.currentTask ? ` — ${p.currentTask}` : ''}"
         >
           <span class="text-[1.15rem] leading-none">${p.emoji || p.name.charAt(0).toUpperCase()}</span>
-          <span class="pulse-name">${p.koreanName ?? p.name}</span>
+          <span class="text-[0.65rem] text-[color:var(--white-55)] whitespace-nowrap overflow-hidden text-ellipsis max-w-[64px]">${p.koreanName ?? p.name}</span>
         </button>
       `)}
     </div>

--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -66,7 +66,7 @@ function OasSummaryLines() {
   const agoMin = lastEventTs != null ? Math.round((Date.now() / 1000 - lastEventTs) / 60) : null
 
   return html`
-    <div class="oas-summary-lines">
+    <div class="flex gap-3 text-[length:var(--fs-xs)] text-[color:var(--text-muted,#888)] mb-2.5">
       <span>활성 에이전트 ${activeAgents.size}명</span>
       <span>${health.totalEvents}건${snapshots.size > 0 ? ` · 키퍼 ${snapshots.size}명` : ''}</span>
       <span>${agoMin != null ? `${agoMin}분 전` : '이벤트 대기 중'}</span>
@@ -87,13 +87,13 @@ function OasKeeperBars() {
         const barClass = pct > 70 ? 'bar--warn' : pct > 50 ? 'bar--mid' : 'bar--ok'
         return html`
           <div class="oas-keeper-row rounded" key=${snap.keeper_name}>
-            <span class="oas-keeper-name">${snap.keeper_name}</span>
-            <span class="oas-keeper-gen">gen ${snap.generation}</span>
+            <span class="text-[color:var(--text-strong,var(--text-near-white))] font-medium min-w-[80px] max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap">${snap.keeper_name}</span>
+            <span class="text-[color:var(--text-muted,#666)] text-[length:var(--fs-2xs)] min-w-[40px]">gen ${snap.generation}</span>
             <div class="oas-keeper-bar-wrap">
               <div class="oas-keeper-bar ${barClass}" style=${{ width: `${pct}%` }}></div>
             </div>
-            <span class="oas-keeper-pct">${pct}%</span>
-            <span class="oas-keeper-msgs">${snap.message_count} msgs</span>
+            <span class="text-[color:var(--text-muted,#888)] tabular-nums min-w-[32px] text-right">${pct}%</span>
+            <span class="text-[color:var(--text-muted,#666)] text-[length:var(--fs-2xs)] min-w-[48px]">${snap.message_count} msgs</span>
           </div>
         `
       })}
@@ -104,16 +104,16 @@ function OasKeeperBars() {
 function OasRawEventList() {
   const events = oasAgentEvents.value
   if (events.length === 0) {
-    return html`<div class="oas-empty">OAS 에이전트 이벤트 대기 중...</div>`
+    return html`<div class="text-[length:var(--fs-xs)] text-[color:var(--text-muted,#666)] py-2">OAS 에이전트 이벤트 대기 중...</div>`
   }
 
   return html`
     <div class="flex flex-col gap-0.5">
       ${events.slice(0, 15).map((ev, i) => html`
         <div class="oas-event-row rounded" key=${i}>
-          <span class="oas-event-ts">${formatTs(ev.timestamp)}</span>
-          <span class="oas-event-agent">${ev.agent_name}</span>
-          <span class="oas-event-type">${eventTypeLabel(ev.type)}</span>
+          <span class="text-[color:var(--text-muted,#666)] tabular-nums min-w-[56px]">${formatTs(ev.timestamp)}</span>
+          <span class="text-[color:var(--text-strong,var(--text-near-white))] font-medium min-w-[80px] max-w-[120px] overflow-hidden text-ellipsis whitespace-nowrap">${ev.agent_name}</span>
+          <span class="text-[color:var(--text-muted,#888)] min-w-[60px]">${eventTypeLabel(ev.type)}</span>
           ${ev.action ? html`<span class="oas-event-badge ${actionBadge(ev.action)}">${ev.action}</span>` : null}
           ${ev.trigger ? html`<span class="oas-event-trigger">${ev.trigger}</span>` : null}
           ${ev.success != null ? html`<span class="oas-event-ok ${ev.success ? 'ok' : 'fail'}">${ev.success ? 'ok' : 'fail'}</span>` : null}
@@ -129,18 +129,18 @@ export function OasPipeline() {
   const eventLabel = `${health.totalEvents}건`
 
   return html`
-    <div class="oas-pipeline rounded-lg">
+    <div class="bg-[var(--card,#1a1f2e)] border border-[var(--card-border,#2a2f3e)] py-3 px-4 mt-3 rounded-lg">
       <div class="flex justify-between items-center mb-3">
-        <span class="oas-pipeline__title">실행 흐름</span>
+        <span class="text-[length:var(--fs-base)] font-semibold text-[color:var(--text-strong,var(--text-near-white))] tracking-[0.5px]">실행 흐름</span>
         <div class="home-section-actions">
-          <span class="oas-pipeline__count">${eventLabel}</span>
+          <span class="text-[length:var(--fs-xs)] text-[color:var(--text-muted,#888)] tabular-nums">${eventLabel}</span>
         </div>
       </div>
 
       <${OasSummaryLines} />
 
       <div class="mb-2.5">
-        <div class="oas-section-label">키퍼 컨텍스트</div>
+        <div class="text-[length:var(--fs-xs)] font-medium text-[color:var(--text-muted,#888)] uppercase tracking-[0.5px] mb-1.5">키퍼 컨텍스트</div>
         <${OasKeeperBars} />
       </div>
 

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -122,15 +122,15 @@ export function SituationBanner({ snap, roomHealth }: SituationBannerProps) {
       </span>
     </div>
     ${showReasons ? html`
-      <details class="situation-reasons-collapse mb-2" open=${reasons.length <= 5}>
-        <summary class="situation-reasons-collapse__summary">
+      <details class="mb-2" open=${reasons.length <= 5}>
+        <summary class="cursor-pointer text-[length:var(--fs-xs)] text-[color:var(--text-muted,var(--text-slate))] py-1 px-[var(--space-md,16px)] tracking-[0.04em] hover:text-[color:var(--text-strong)]">
           상세 ${reasons.length}건
         </summary>
-        <div class="situation-reasons">
+        <div class="flex flex-col gap-1 py-1.5 px-[var(--space-md,16px)] border-l-2 border-l-[var(--color-ff-border)]">
           ${reasons.map((r, i) => html`
-            <div class="situation-reason situation-reason--${r.severity}" key=${i}>
-              <span class="situation-reason__tag">${CATEGORY_LABELS[r.category] ?? r.category}</span>
-              <span class="situation-reason__text">${r.text}</span>
+            <div class="flex items-center gap-[var(--space-sm,8px)] text-[length:var(--fs-sm)] ${r.severity === 'bad' ? 'text-[rgba(239,68,68,0.9)]' : r.severity === 'warn' ? 'text-[color:var(--ff-gold)]' : 'text-[color:var(--white-55)]'}" key=${i}>
+              <span class="text-[9px] py-px px-1.5 rounded-sm bg-[rgba(212,169,75,0.08)] border border-[var(--ff-border-subtle)] whitespace-nowrap uppercase tracking-[0.5px] font-semibold">${CATEGORY_LABELS[r.category] ?? r.category}</span>
+              <span class="overflow-hidden text-ellipsis whitespace-nowrap">${r.text}</span>
             </div>
           `)}
         </div>

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -1,23 +1,6 @@
-/* ── Council ──────────────────────────────────────────────── */
-.council-create {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 8px;
-  align-items: center;
-}
+/* MASC Dashboard -- Governance (retained: stateful variants, compound selectors, responsive) */
 
-.council-error {
-  margin-top: 10px;
-  border: 1px solid rgba(239, 68, 68, 0.35);
-  padding: 8px 10px;
-  color: #f7b6b6;
-  font-size: var(--fs-sm);
-}
-.council-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+/* ── Council Row (stateful: hover, selected, content-visibility) ── */
 
 .council-row {
   width: 100%;
@@ -44,21 +27,7 @@ button.council-row.selected {
   background: var(--accent-14);
 }
 
-.council-topic {
-  color: #e8f0ff;
-  font-size: var(--fs-md);
-  font-weight: 600;
-  word-break: break-word;
-}
-
-.council-sub {
-  margin-top: 4px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  color: #8ea9d6;
-  font-size: var(--fs-xs);
-}
+/* ── Council State badges (multi-variant) ── */
 
 .council-state {
   padding: 3px 9px;
@@ -83,17 +52,19 @@ button.council-row.selected {
   color: #ffe09b;
 }
 
-.council-detail {
-  white-space: pre-wrap;
-  border: 1px solid var(--card-border);
-  border-radius: 9px;
-  background: rgba(0, 0, 0, 0.28);
-  color: #d3e3ff;
-  padding: 12px;
-  font-size: var(--fs-sm);
-  line-height: 1.5;
-  font-family: "IBM Plex Mono", "Fira Code", monospace;
+.council-state.negative {
+  border-color: rgba(239, 68, 68, 0.46);
+  background: rgba(239, 68, 68, 0.14);
+  color: #fecaca;
 }
+
+.council-state.neutral {
+  border-color: rgba(138, 163, 211, 0.25);
+  background: var(--white-6);
+  color: #b7cbee;
+}
+
+/* ── Governance Layout (3-column grid + responsive) ── */
 
 .governance-layout {
   display: grid;
@@ -107,12 +78,7 @@ button.council-row.selected {
   overflow-y: auto;
 }
 
-.governance-row-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
+/* ── Governance Kind chip ── */
 
 .governance-kind {
   flex: 0 0 auto;
@@ -125,19 +91,7 @@ button.council-row.selected {
   letter-spacing: 0.08em;
 }
 
-.governance-row-side {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 8px;
-}
-
-.governance-chip-row {
-  margin-top: 8px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
+/* ── Governance Chips (multi-variant: ok, warn) ── */
 
 .governance-chip {
   padding: 3px 8px;
@@ -160,68 +114,7 @@ button.council-row.selected {
   color: #ffe09b;
 }
 
-.council-state.negative {
-  border-color: rgba(239, 68, 68, 0.46);
-  background: rgba(239, 68, 68, 0.14);
-  color: #fecaca;
-}
-
-.council-state.neutral {
-  border-color: rgba(138, 163, 211, 0.25);
-  background: var(--white-6);
-  color: #b7cbee;
-}
-
-.governance-detail-head h3 {
-  margin: 0;
-  color: #e8f0ff;
-  font-size: 18px;
-}
-
-.governance-balance-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(90px, 1fr));
-  gap: 8px;
-}
-
-.governance-balance {
-  border: 1px solid var(--card-border);
-  border-radius: 10px;
-  padding: 8px 10px;
-  background: var(--white-4);
-  color: #c8daf7;
-  font-size: var(--fs-sm);
-}
-
-.governance-summary-callout {
-  margin-bottom: 12px;
-  border: 1px solid rgba(71, 184, 255, 0.22);
-  border-radius: 10px;
-  background: rgba(71, 184, 255, 0.09);
-  color: #dcecff;
-  padding: 11px 12px;
-  line-height: 1.5;
-}
-
-.governance-ledger-row,
-.governance-activity-row {
-  border: 1px solid var(--card-border);
-  border-radius: 10px;
-  background: var(--white-3h);
-  padding: 10px 11px;
-}
-
-.governance-ledger-head strong {
-  color: #e8f0ff;
-  font-size: var(--fs-sm);
-}
-
-.governance-ledger-body {
-  margin-top: 8px;
-  color: #d7e7ff;
-  line-height: 1.5;
-  word-break: break-word;
-}
+/* ── Governance Badge (multi-variant: positive, negative) ── */
 
 .governance-badge {
   padding: 2px 8px;
@@ -238,21 +131,24 @@ button.council-row.selected {
   color: #fecaca;
 }
 
-.governance-side-block h4 {
-  margin: 0;
-  color: #e8f0ff;
-  font-size: var(--fs-base);
+/* ── Ledger/Activity Rows ── */
+
+.governance-ledger-row,
+.governance-activity-row {
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  background: var(--white-3h);
+  padding: 10px 11px;
 }
 
-.governance-preview {
-  margin-top: 0;
-  font-size: var(--fs-xs);
-  max-height: 180px;
-  overflow: auto;
+.governance-ledger-head strong {
+  color: #e8f0ff;
+  font-size: var(--fs-sm);
 }
+
+/* ── Responsive ── */
 
 @media (max-width: 1200px) {
-
   .governance-layout {
     grid-template-columns: 1fr;
   }
@@ -260,5 +156,4 @@ button.council-row.selected {
   .governance-inbox {
     max-height: none;
   }
-
 }

--- a/dashboard/src/styles/live.css
+++ b/dashboard/src/styles/live.css
@@ -1,4 +1,6 @@
-/* ── Pulse Strip ────────────────────────────────────── */
+/* MASC Dashboard -- Live Monitor (retained: animations, stateful variants, compound selectors) */
+
+/* ── Pulse Strip ── */
 
 .pulse-strip {
   display: flex;
@@ -10,7 +12,6 @@
   align-items: center;
   min-height: 56px;
 }
-
 
 .pulse-bubble {
   display: flex;
@@ -42,21 +43,12 @@
   box-shadow: 0 0 8px var(--blue-400-15);
 }
 
-.pulse-name {
-  font-size: 0.65rem;
-  color: var(--white-55);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 64px;
-}
-
 @keyframes livePulse {
   0%, 100% { box-shadow: 0 0 0 0 var(--ok-25); }
   50% { box-shadow: 0 0 8px 2px var(--ok-12); }
 }
 
-/* ── Live Panels (Activity + Focus) ──────────────────── */
+/* ── Live Panels ── */
 
 .live-panels {
   display: grid;
@@ -65,14 +57,7 @@
   min-height: 480px;
 }
 
-/* ── Activity Stream ─────────────────────────────────── */
-
-.activity-stream-head h3,
-.focus-sidebar-head h3 {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
+/* ── Activity Stream ── */
 
 .activity-filter-btn {
   padding: 3px 10px;
@@ -102,14 +87,6 @@
   overflow-y: auto;
   max-height: 520px;
   padding-right: 4px;
-}
-
-.activity-empty,
-.focus-empty {
-  padding: 24px;
-  text-align: center;
-  color: var(--white-25);
-  font-size: 0.8rem;
 }
 
 .activity-item {
@@ -150,35 +127,7 @@
 .activity-kind-chip.live-event-keeper { background: rgba(168,85,247,0.15); color: #a855f7; }
 .activity-kind-chip.live-event-system { background: var(--white-6); color: var(--white-50); }
 
-.activity-agent {
-  font-size: 0.75rem;
-  color: var(--white-60);
-  font-weight: 500;
-}
-
-.activity-time {
-  font-size: 0.7rem;
-  color: var(--white-30);
-  margin-left: auto;
-}
-
-.activity-item-text {
-  font-size: 0.8rem;
-  color: var(--white-70);
-  line-height: 1.4;
-  word-break: break-word;
-}
-
-/* ── Focus Sidebar ───────────────────────────────────── */
-
-.focus-sidebar-list {
-  display: grid;
-  gap: 6px;
-  align-content: start;
-  overflow-y: auto;
-  max-height: 560px;
-  padding-right: 4px;
-}
+/* ── Focus Sidebar ── */
 
 .focus-agent-card {
   padding: 10px 12px;
@@ -199,14 +148,6 @@
 .focus-agent-selected {
   border-color: rgba(96,165,250,0.4);
   background: rgba(96,165,250,0.05);
-}
-
-.focus-agent-name {
-  font-size: 0.85rem;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .focus-pressure-badge {
@@ -233,63 +174,13 @@
   color: var(--warn);
 }
 
-.focus-task-count {
-  background: var(--white-10);
-  padding: 0 4px;
-  font-size: 0.6rem;
-}
-
-.focus-current-task {
-  font-size: 0.75rem;
-  color: var(--white-55);
-  padding: 3px 8px;
-  background: var(--white-3);
-  border: 1px solid var(--white-5);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.focus-activity-text {
-  font-size: 0.72rem;
-  color: var(--white-40);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 1;
-  min-width: 0;
-}
-
 .focus-agent-footer .time-ago {
   font-size: 0.68rem;
   color: var(--white-30);
   flex-shrink: 0;
 }
 
-/* ── Live Responsive ─────────────────────────────────── */
-
-@media (max-width: 1100px) {
-  .live-panels {
-    grid-template-columns: 1fr;
-  }
-}
-/* ══════════════════════════════════════════════════════════
-   Live Monitor Tab
-   ══════════════════════════════════════════════════════════ */
-
-.live-header h2 {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-.live-header-stats {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  font-size: 0.8rem;
-  color: var(--white-50);
-}
+/* ── Live Stat Dot ── */
 
 .live-stat-dot {
   width: 6px;
@@ -304,4 +195,12 @@
 
 .live-stat-dot.disconnected {
   background: var(--bad);
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 1100px) {
+  .live-panels {
+    grid-template-columns: 1fr;
+  }
 }

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -1,49 +1,6 @@
-/* OAS Pipeline component styles */
+/* MASC Dashboard -- OAS Pipeline (retained: stateful variants, animations, compound selectors) */
 
-.oas-pipeline {
-  background: var(--card, #1a1f2e);
-  border: 1px solid var(--card-border, #2a2f3e);
-  padding: 12px 16px;
-  margin-top: 12px;
-}
-
-.oas-pipeline__title {
-  font-size: var(--fs-base);
-  font-weight: 600;
-  color: var(--text-strong, var(--text-near-white));
-  letter-spacing: 0.5px;
-}
-
-.oas-pipeline__count {
-  font-size: var(--fs-xs);
-  color: var(--text-muted, #888);
-  font-variant-numeric: tabular-nums;
-}
-
-.oas-section-label {
-  font-size: var(--fs-xs);
-  font-weight: 500;
-  color: var(--text-muted, #888);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 6px;
-}
-
-.oas-summary-lines {
-  display: flex;
-  gap: 12px;
-  font-size: var(--fs-xs);
-  color: var(--text-muted, #888);
-  margin-bottom: 10px;
-}
-
-.oas-empty {
-  font-size: var(--fs-xs);
-  color: var(--text-muted, #666);
-  padding: 8px 0;
-}
-
-/* Agent event list */
+/* ── Event/Keeper Row hover ── */
 
 .oas-event-row {
   display: flex;
@@ -58,27 +15,7 @@
   background: var(--white-6, var(--white-3));
 }
 
-.oas-event-ts {
-  color: var(--text-muted, #666);
-  font-variant-numeric: tabular-nums;
-  min-width: 56px;
-}
-
-.oas-event-agent,
-.oas-keeper-name {
-  color: var(--text-strong, var(--text-near-white));
-  font-weight: 500;
-  min-width: 80px;
-  max-width: 120px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.oas-event-type {
-  color: var(--text-muted, #888);
-  min-width: 60px;
-}
+/* ── Event Badge variants ── */
 
 .oas-event-badge {
   padding: 1px 6px;
@@ -95,7 +32,7 @@
 .oas-event-ok.ok { color: var(--ok); }
 .oas-event-ok.fail { color: var(--bad-light); }
 
-/* Keeper snapshot list */
+/* ── Keeper context bars ── */
 
 .oas-keeper-row {
   display: flex;
@@ -103,12 +40,6 @@
   gap: 8px;
   padding: 4px 6px;
   font-size: var(--fs-xs);
-}
-
-.oas-keeper-gen {
-  color: var(--text-muted, #666);
-  font-size: var(--fs-2xs);
-  min-width: 40px;
 }
 
 .oas-keeper-bar-wrap {
@@ -130,19 +61,7 @@
 .bar--mid { background: #facc15; }
 .bar--warn { background: var(--bad-light); }
 
-.oas-keeper-pct {
-  color: var(--text-muted, #888);
-  font-variant-numeric: tabular-nums;
-  min-width: 32px;
-  text-align: right;
-}
-
-.oas-keeper-msgs {
-  color: var(--text-muted, #666);
-  font-size: var(--fs-2xs);
-  min-width: 48px;
-}
-/* ── Pipeline Stage Indicator ─────────────────────────── */
+/* ── Pipeline Stage Indicator ── */
 
 .pipeline-stage-node {
   display: flex;
@@ -224,7 +143,7 @@
   border-color: rgba(75, 75, 85, 0.8);
 }
 
-/* Passed stages get a subtle highlight */
+/* Passed stages */
 .pipeline-stage-node.passed .pipeline-stage-dot {
   background: rgba(100, 100, 120, 0.5);
   border-color: rgba(100, 100, 120, 0.7);
@@ -243,7 +162,7 @@
   }
 }
 
-/* ── Compact badge variant (for roster cards) ──────────── */
+/* ── Compact badge variant (for roster cards) ── */
 
 .pipeline-stage-badge {
   display: inline-flex;

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -1,77 +1,6 @@
-/* MASC Dashboard — Roster Pages (FF Character Sheet Theme) */
+/* MASC Dashboard -- Roster (retained: pseudo-elements, stateful variants, gradients) */
 
-/* ============================================
-   Roster Page — Full-page entity list
-   FF-inspired: navy panels, gold borders,
-   ornamental corners, RPG stat blocks
-   ============================================ */
-
-.roster-page {
-  padding: var(--space-lg, 24px);
-  max-width: 960px;
-}
-
-.roster-title {
-  font-size: 20px;
-  font-weight: 600;
-  color: var(--ff-gold-bright);
-  margin: 0 0 var(--space-md, 16px) 0;
-  letter-spacing: 0.5px;
-  text-shadow: 0 1px 4px rgba(212, 169, 75, 0.2);
-}
-
-.agent-page__subtitle {
-  font-size: var(--fs-sm);
-  color: var(--white-30);
-  margin-top: 4px;
-}
-
-.roster-search {
-  padding: 6px 12px;
-  border: 1px solid var(--ff-border-subtle);
-  background: var(--ff-navy);
-  color: var(--white-90);
-  font-size: var(--fs-base);
-  width: 200px;
-}
-
-.roster-search:focus {
-  outline: none;
-  border-color: var(--ff-gold);
-  box-shadow: 0 0 0 2px var(--ff-gold-dim);
-}
-
-.roster-search::placeholder {
-  color: var(--white-25);
-}
-
-.roster-filter-btn {
-  padding: 4px 10px;
-  border-radius: 3px;
-  border: 1px solid var(--ff-border-subtle);
-  background: transparent;
-  color: var(--white-45);
-  font-size: var(--fs-sm);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.roster-filter-btn:hover {
-  background: var(--ff-gold-dim);
-  color: var(--ff-gold-bright);
-  border-color: var(--color-ff-border);
-}
-
-.roster-filter-btn.active {
-  background: var(--ff-gold-dim);
-  color: var(--ff-gold-bright);
-  border-color: var(--ff-gold);
-}
-
-/* ============================================
-   Roster Cards — FF Character Sheet style
-   ============================================ */
-
+/* ── Roster Card — FF corner ornaments (pseudo-elements) ── */
 
 .roster-card {
   display: flex;
@@ -83,7 +12,6 @@
   position: relative;
 }
 
-/* FF corner ornaments */
 .roster-card::before,
 .roster-card::after {
   content: '';
@@ -121,11 +49,6 @@
 }
 
 /* Avatar frame — pixel art portrait */
-.roster-card__avatar {
-  flex-shrink: 0;
-  position: relative;
-}
-
 .roster-card__avatar::after {
   content: '';
   position: absolute;
@@ -135,53 +58,32 @@
   pointer-events: none;
 }
 
-.roster-card__info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  justify-content: center;
-}
+/* ── Filter buttons (hover/active state) ── */
 
-.roster-card__name {
-  font-size: var(--fs-lg);
-  color: var(--ff-gold-bright);
-  font-weight: 600;
-  letter-spacing: 0.3px;
-}
-
-.roster-card__work {
-  font-size: var(--fs-base);
-  color: var(--white-55);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.roster-card__work--empty {
-  color: var(--white-20);
-  font-style: italic;
-}
-
-.roster-card__meta {
-  display: flex;
-  gap: var(--space-sm, 8px);
-  font-size: var(--fs-xs);
-  color: var(--white-30);
-}
-
-.roster-card__model {
-  padding: 1px 6px;
-  background: rgba(212, 169, 75, 0.08);
-  border: 1px solid var(--ff-border-subtle);
+.roster-filter-btn {
+  padding: 4px 10px;
   border-radius: 3px;
-  color: rgba(212, 169, 75, 0.6);
+  border: 1px solid var(--ff-border-subtle);
+  background: transparent;
+  color: var(--white-45);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: all 0.15s;
 }
 
-/* ============================================
-   Status Badges — RPG class labels
-   ============================================ */
+.roster-filter-btn:hover {
+  background: var(--ff-gold-dim);
+  color: var(--ff-gold-bright);
+  border-color: var(--color-ff-border);
+}
+
+.roster-filter-btn.active {
+  background: var(--ff-gold-dim);
+  color: var(--ff-gold-bright);
+  border-color: var(--ff-gold);
+}
+
+/* ── Status Badges — RPG class labels ── */
 
 .roster-badge {
   font-size: var(--fs-2xs);
@@ -210,18 +112,7 @@
   border: 1px solid rgba(100, 100, 120, 0.15);
 }
 
-.roster-empty {
-  padding: var(--space-xl, 32px);
-  text-align: center;
-  color: var(--white-20);
-  font-size: var(--fs-md);
-  border: 1px dashed var(--ff-border-subtle);
-}
-
-/* ============================================
-   Keeper inline variant — blue accent on agent card
-   Agent with keeper runtime gets visual distinction
-   ============================================ */
+/* ── Keeper inline variant — blue accent ── */
 
 .roster-card--keeper {
   border-left: 3px solid #4a9ef5;
@@ -277,87 +168,8 @@
   transition: width 0.3s ease;
 }
 
-.roster-card__gauge-label {
-  font-size: var(--fs-xs);
-  color: var(--white-40);
-  white-space: nowrap;
-  min-width: 50px;
-  font-variant-numeric: tabular-nums;
-}
+/* ── Pressure bar gradients ── */
 
-/* ============================================
-   Situation Reasons (WHY panel)
-   ============================================ */
-
-.situation-reasons-collapse__summary {
-  cursor: pointer;
-  font-size: var(--fs-xs);
-  color: var(--text-muted, var(--text-slate));
-  padding: 4px var(--space-md, 16px);
-  letter-spacing: 0.04em;
-}
-.situation-reasons-collapse__summary:hover {
-  color: var(--text-strong);
-}
-
-.situation-reasons {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 6px var(--space-md, 16px);
-  border-left: 2px solid var(--color-ff-border);
-}
-
-.situation-reason {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm, 8px);
-  font-size: var(--fs-sm);
-  color: var(--white-55);
-}
-
-.situation-reason--bad {
-  color: rgba(239, 68, 68, 0.9);
-}
-
-.situation-reason--warn {
-  color: var(--ff-gold);
-}
-
-.situation-reason__tag {
-  font-size: 9px;
-  padding: 1px 6px;
-  border-radius: 2px;
-  background: rgba(212, 169, 75, 0.08);
-  border: 1px solid var(--ff-border-subtle);
-  white-space: nowrap;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-}
-
-.situation-reason__text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* ============================================
-   Overview Enhancements
-   ============================================ */
-/* Attention badge — gold warning */
-.attention-badge {
-  background: rgba(212, 169, 75, 0.15);
-  color: var(--ff-gold);
-  border: 1px solid rgba(212, 169, 75, 0.3);
-  border-radius: 3px;
-  padding: 2px 8px;
-  font-weight: 600;
-  font-size: var(--fs-xs);
-}
-
-/* Session triage additions */
-/* Pressure bar colors — FF HP gradient */
 .pressure--ok {
   background: linear-gradient(90deg, #1a9c3a, #3dcc5e);
 }
@@ -372,4 +184,16 @@
 
 .pressure--red {
   background: linear-gradient(90deg, #b91c1c, var(--bad));
+}
+
+/* ── Attention badge ── */
+
+.attention-badge {
+  background: rgba(212, 169, 75, 0.15);
+  color: var(--ff-gold);
+  border: 1px solid rgba(212, 169, 75, 0.3);
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-weight: 600;
+  font-size: var(--fs-xs);
 }


### PR DESCRIPTION
## Summary
4 CSS files migrated:

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| roster.css | 376 | 199 | -47% |
| live.css | 308 | 206 | -33% |
| governance.css | 264 | 159 | -40% |
| oas-pipeline.css | 307 | 225 | -27% |
| **Subtotal** | **1,255** | **789** | **-37%** |

## Cumulative (12 files this session)
**5,284 → 2,283 lines (-57%)**

Generated with [Claude Code](https://claude.com/claude-code)