### PR TITLE
fix(room): eliminate per-call filesystem read in masc_dir Default scope

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -391,7 +391,7 @@ let resolve_execution_scope ~base_path ~(team_session_id : string option)
   | None -> (
       match team_session_id with
       | Some session_id -> (
-          match Team_session_store.load_session (Room.default_config base_path) session_id with
+          match Team_session_store.load_session (Room.default_config base_path |> Room.config_with_resolved_scope) session_id with
           | Some session -> session.execution_scope
           | None -> Team_session_types.Limited_code_change)
       | None -> Team_session_types.Limited_code_change)

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -58,15 +58,15 @@ let resolve_initial_scope config =
   | Some room_id -> Named room_id
 
 (** Scope-based directory resolution.
-    Named scope: pure, deterministic (no filesystem reads).
-    Default scope: reads current_room file for backward compatibility. *)
+    Both branches are pure — no filesystem reads.
+    Default scope resolves to the root .masc/ directory.
+    Named scope resolves to .masc/rooms/{id}/ (with legacy fallback).
+    Callers that need the current_room file must call
+    [config_with_resolved_scope] at config creation time. *)
 let masc_dir config =
   match config.scope with
   | Named id -> room_dir_for config id
-  | Default ->
-    match read_current_room config with
-    | Some room_id -> room_dir_for config room_id
-    | None -> masc_root_dir config
+  | Default -> masc_root_dir config
 
 let agents_dir config = Filename.concat (masc_dir config) "agents"
 let tasks_dir config = Filename.concat (masc_dir config) "tasks"

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -75,7 +75,7 @@ let load_findings ~base_path ~team_session_id : string list =
     with Sys_error _ -> []
 
 let build ~base_path ~team_session_id =
-  let room_config = Room.default_config base_path in
+  let room_config = Room.default_config base_path |> Room.config_with_resolved_scope in
   let session_opt =
     Team_session_store.load_session room_config team_session_id
   in

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -438,7 +438,7 @@ let handle_stop ctx args =
     match Autoresearch.stop_loop ~base_path:ctx.base_path ~reason id with
     | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
     | Some state ->
-        let config = Room.default_config ctx.base_path in
+        let config = Room.default_config ctx.base_path |> Room.config_with_resolved_scope in
         (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
         | Some link ->
             (try
@@ -676,7 +676,7 @@ let handle_cycle ctx args =
                        state.baseline <- score_after);
                     state.current_cycle <- state.current_cycle + 1;
                     Autoresearch.save_state ~base_path:ctx.base_path state;
-                    let config = Room.default_config ctx.base_path in
+                    let config = Room.default_config ctx.base_path |> Room.config_with_resolved_scope in
                     (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
                     | Some link ->
                         (try

--- a/lib/tool_council_helpers.ml
+++ b/lib/tool_council_helpers.ml
@@ -21,7 +21,7 @@ let gen_id prefix =
 let room_config_of_ctx (ctx : context) =
   match ctx.room_config with
   | Some config -> config
-  | None -> Room.default_config ctx.base_path
+  | None -> Room.default_config ctx.base_path |> Room.config_with_resolved_scope
 
 let ensure_room_ready (ctx : context) =
   let config = room_config_of_ctx ctx in

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -42,7 +42,7 @@ let json_err msg = (false, Yojson.Safe.pretty_to_string
 let room_config_of_ctx (ctx : context) =
   match ctx.room_config with
   | Some config -> config
-  | None -> Room.default_config ctx.base_path
+  | None -> Room.default_config ctx.base_path |> Room.config_with_resolved_scope
 
 let ensure_room_ready (ctx : context) =
   let config = room_config_of_ctx ctx in

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -51,13 +51,14 @@ let handle_start (ctx : context) : result option =
         if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then begin
           (* Auto-create .masc/ and initialize room structure *)
           (try Unix.mkdir masc_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-          let tmp_config = Room.default_config expanded in
+          let tmp_config = Room.default_config expanded |> Room.config_with_resolved_scope in
           let _msg = Room.init tmp_config ~agent_name:(Some agent_name) in
           state.Mcp_server.room_config <- tmp_config;
           Ok tmp_config
         end else begin
-          state.Mcp_server.room_config <- Room.default_config expanded;
-          Ok state.Mcp_server.room_config
+          let cfg = Room.default_config expanded |> Room.config_with_resolved_scope in
+          state.Mcp_server.room_config <- cfg;
+          Ok cfg
         end
       end
     end
@@ -214,7 +215,7 @@ let handle_set_room (ctx : context) : result option =
     if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then
       Some (false, Printf.sprintf "No .masc/ directory found in: %s\nRun masc_init to initialize, or choose a MASC-enabled directory." resolved)
     else begin
-      state.Mcp_server.room_config <- Room.default_config expanded;
+      state.Mcp_server.room_config <- Room.default_config expanded |> Room.config_with_resolved_scope;
       let rc = state.Mcp_server.room_config in
       let status = if Room.is_initialized rc then "ok" else "(not initialized)" in
       let workspace_note =

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -248,14 +248,19 @@ let test_room_task_isolation () =
     ignore (Room.room_create config ~name:"Isolated Room" ~description:None);
     ignore (Room.room_enter config ~room_id:"isolated-room" ~agent_type:"codex" ());
 
-    (* Default room tasks should not leak into the new room. *)
-    check int "isolated room starts empty" 0 (task_count config);
+    (* Re-resolve scope after room_enter wrote current_room file.
+       masc_dir no longer re-reads the file on every call. *)
+    let isolated_config = Room.config_with_resolved_scope config in
 
-    ignore (Room.add_task config ~title:"isolated-task" ~priority:3 ~description:"isolated room task");
-    check int "isolated room task count" 1 (task_count config);
+    (* Default room tasks should not leak into the new room. *)
+    check int "isolated room starts empty" 0 (task_count isolated_config);
+
+    ignore (Room.add_task isolated_config ~title:"isolated-task" ~priority:3 ~description:"isolated room task");
+    check int "isolated room task count" 1 (task_count isolated_config);
 
     ignore (Room.room_enter config ~room_id:"default" ~agent_type:"codex" ());
-    check int "default room remains isolated" 1 (task_count config);
+    let default_config = Room.config_with_resolved_scope config in
+    check int "default room remains isolated" 1 (task_count default_config);
   )
 
 let test_rooms_list_task_count_active_only () =
@@ -271,7 +276,9 @@ let test_rooms_list_task_count_active_only () =
 
     ignore (Room.room_create config ~name:"Count Room" ~description:None);
     ignore (Room.room_enter config ~room_id:"count-room" ~agent_type:"codex" ());
-    ignore (Room.add_task config ~title:"count-room-task" ~priority:3 ~description:"");
+    (* Re-resolve scope after room_enter wrote current_room file *)
+    let count_config = Room.config_with_resolved_scope config in
+    ignore (Room.add_task count_config ~title:"count-room-task" ~priority:3 ~description:"");
 
     let result = Room.rooms_list config in
     check (option int) "default counts only active tasks" (Some 1)


### PR DESCRIPTION
## Summary
- `masc_dir` with `Default` scope was reading the `current_room` file from disk on every call. This is a hot path since `agents_dir`, `tasks_dir`, `messages_dir`, `state_path`, and other functions all call `masc_dir`.
- `Default` scope now returns `masc_root_dir` directly (pure, no filesystem I/O). All callers of `Room.default_config` that were missing scope resolution now pipe through `config_with_resolved_scope`.
- Updated `test_multi_room` to re-resolve scope after `room_enter` calls, matching the explicit resolution contract.

Closes #2238

## Test plan
- [x] `dune build --root .` passes
- [x] `dune test --root .` passes (all existing tests)
- [x] `test_room.exe` — 85 tests pass
- [x] `test_room_utils_coverage.exe` — 75 tests pass
- [x] `test_multi_room.exe` — 12 tests pass (2 updated for new contract)
- [x] `test_room_coverage.exe` — 51 tests pass

Generated with [Claude Code](https://claude.com/claude-code)