### PR TITLE
fix(room): bump version in release_stale_claims

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -953,7 +953,7 @@ let release_stale_claims config ~ttl_seconds =
       | Todo | Done _ | Cancelled _ -> task
     ) backlog.tasks in
     if !stale_tasks <> [] then begin
-      let updated_backlog = { backlog with tasks = updated_tasks } in
+      let updated_backlog = { tasks = updated_tasks; last_updated = now_str; version = backlog.version + 1 } in
       write_backlog config updated_backlog
     end;
     List.rev !stale_tasks


### PR DESCRIPTION
## Summary
- `release_stale_claims` wrote backlog without incrementing `version` or updating `last_updated`
- This allowed `transition_task_r` to bypass the optimistic lock (`expected_version` check), causing state corruption
- Added `version = backlog.version + 1` and `last_updated = now_str` consistent with all other `write_backlog` call sites

Closes #2235

## Test plan
- [x] `dune build --root .` passes
- [ ] Verify stale claim release now increments version (manual or integration test)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>