### PR TITLE
refactor(dashboard): migrate command + ui + chat + goals CSS to Tailwind v4 (-239 lines)

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -119,14 +119,14 @@ function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
     return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 실행 이벤트가 없습니다.</div>`
   }
   return html`
-    <div class="monitor-list">
+    <div class="flex flex-col gap-2.5">
       ${events.map(event => {
         const actor = eventActor(event)
         return html`
           <div class="monitor-row rounded-xl p-3.5 ok" key=${event.seq}>
             <div class="monitor-row rounded-xl-header">
               <div class="min-w-0">
-                <div class="monitor-name-line">
+                <div class="flex items-center gap-2 flex-wrap">
                   <span class="monitor-title">${actor || '(unknown)'}</span>
                   <span class="monitor-sub">${eventKindLabel(event.kind)}</span>
                 </div>
@@ -134,7 +134,7 @@ function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
               </div>
               <span class="monitor-pill ok inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${eventKindLabel(event.kind)}</span>
             </div>
-            <div class="monitor-meta">
+            <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
               <span>${event.room_id}</span>
               ${event.ts_iso ? html`<span><${TimeAgo} timestamp=${event.ts_iso} /></span>` : null}
               ${event.tags.length > 0 ? html`<span>${event.tags.join(', ')}</span>` : null}
@@ -205,7 +205,7 @@ function KindBreakdown({ nodes }: { nodes: ActivityGraphNode[] }) {
 
 function EmptyActivityGraph() {
   return html`
-    <div class="agents-monitor">
+    <div class="flex flex-col gap-5">
       <${Card} title="활동 그래프" class="section mb-3.5" testId="activity_graph.graph">
         <div class="mb-3.5">
           <h2 class="monitor-headline">활동 그래프가 비어 있습니다</h2>
@@ -234,7 +234,7 @@ export function ActivityGraphSurface() {
 
   if (error && !data) {
     return html`
-      <div class="agents-monitor">
+      <div class="flex flex-col gap-5">
         <${Card} title="오류" class="section mb-3.5" testId="activity_graph.error">
           <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 그래프를 불러올 수 없습니다: ${error}</div>
           <button class="control-btn rounded-lg ghost" onClick=${loadGraph}>다시 시도</button>
@@ -252,7 +252,7 @@ export function ActivityGraphSurface() {
   }
 
   return html`
-    <div class="agents-monitor">
+    <div class="flex flex-col gap-5">
 
       <${Card} title="활동 그래프" class="section mb-3.5" testId="activity_graph.graph">
         <div class="mb-3.5">
@@ -261,7 +261,7 @@ export function ActivityGraphSurface() {
         </div>
         <${StatsRow} data=${data} />
         <${GraphView} data=${data} />
-        <div class="monitor-meta" class="mt-2">
+        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" class="mt-2">
           <span>생성 시각: ${data.generated_at}</span>
           <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
           ${data.window.room_id ? html`<span>room: ${data.window.room_id}</span>` : null}

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -118,7 +118,7 @@ export function Execution() {
     && operationRowsAll.length === 0
 
   return html`
-    <div class="agents-monitor">
+    <div class="flex flex-col gap-5">
       <${RoomTruthStrip} />
       <${Card}
         title="주의 항목"
@@ -160,7 +160,7 @@ export function Execution() {
          
           testId="execution.worker-support"
         >
-          <div class="monitor-list">
+          <div class="flex flex-col gap-2.5">
             ${workerSupportRows.length === 0
               ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">참여 에이전트가 없습니다.</div>`
               : workerSupportRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.worker-card" />`)}
@@ -173,7 +173,7 @@ export function Execution() {
          
           testId="execution.continuity"
         >
-          <div class="monitor-list">
+          <div class="flex flex-col gap-2.5">
             ${continuityRows.length === 0
               ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">연속성 경고 없음</div>`
               : continuityRows.map(row => html`<${ContinuityRow} key=${row.name} row=${row} />`)}
@@ -186,7 +186,7 @@ export function Execution() {
          
           testId="execution.offline-workers"
         >
-          <div class="monitor-list">
+          <div class="flex flex-col gap-2.5">
             ${offlineRows.length === 0
               ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오프라인 에이전트 없음</div>`
               : offlineRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.offline-worker-card" />`)}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -156,7 +156,7 @@ export function ChatMessageBubble({
             <div class="chat-detail-panel rounded-xl">
               ${overview.length > 0
                 ? html`
-                    <div class="chat-overview-grid">
+                    <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
                         <div class="chat-overview-card rounded-xl">
                           <div class="chat-overview-label">${item.label}</div>
@@ -181,7 +181,7 @@ export function ChatMessageBubble({
                 ? html`
                     <div class="chat-detail-section">
                       <div class="chat-detail-section-title">상태 스냅샷</div>
-                      <div class="chat-state-grid">
+                      <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
                           <div class="chat-state-card rounded-xl">
                             <div class="chat-state-label">${item.label}</div>

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -52,7 +52,7 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
       </div>
       ${decision.status === 'pending' && !isLegacy
         ? html`
-            <div class="command-action-row">
+            <div class="flex gap-2.5 flex-wrap mt-3">
               <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
@@ -91,7 +91,7 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
         <span>동결</span><span>${frozen ? '예' : '아니오'}</span>
         <span>킬 스위치</span><span>${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
-      <div class="command-action-row">
+      <div class="flex gap-2.5 flex-wrap mt-3">
         <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -197,7 +197,7 @@ function GuidedPanel() {
           <div class="card rounded-xl-title">즉시 조치</div>
         </div>
         <div class="command-guide-card rounded-xl highlight mb-3">
-          <div class="command-guide-head">
+          <div class="flex justify-between gap-2.5 items-start">
             <strong>${nextStep?.title ?? nextTool}</strong>
             <span class="command-chip rounded-full ok">${nextTool}</span>
           </div>
@@ -209,11 +209,11 @@ function GuidedPanel() {
             : null}
         </div>
 
-        <div class="command-readiness-list">
+        <div class="flex flex-col gap-2.5">
           ${readiness.map(item => html`
             <article class="command-readiness-row rounded-xl ${toneClass(item.tone)}">
               <div>
-                <div class="command-readiness-title-row">
+                <div class="flex justify-between gap-2.5 items-start">
                   <strong>${item.title}</strong>
                   <span class="command-chip rounded-full ${toneClass(item.tone)}">${item.tone}</span>
                 </div>
@@ -227,11 +227,11 @@ function GuidedPanel() {
         ${pitfalls.length > 0
           ? html`
               <div class="command-guide-card rounded-xl warn">
-                <div class="command-guide-head">
+                <div class="flex justify-between gap-2.5 items-start">
                   <strong>자주 막히는 지점</strong>
                   <span class="command-chip rounded-full warn">${pitfalls.length}</span>
                 </div>
-                <div class="command-guide-list">
+                <div class="flex flex-col gap-3">
                   ${pitfalls.map(pitfall => html`
                     <article class="p-3 rounded-[10px] bg-[rgba(9,12,20,0.5)] border border-solid border-[var(--white-6)] break-words [overflow-wrap:anywhere]">
                       <strong>${pitfall.title}</strong>
@@ -257,15 +257,15 @@ function GuidedPanel() {
                 <div class="grid gap-3">
                   ${renderedPaths.map(path => html`
                     <article class="command-guide-card rounded-xl">
-                      <div class="command-guide-head">
+                      <div class="flex justify-between gap-2.5 items-start">
                         <strong>${path.title}</strong>
                         <span class="command-chip rounded-full">${path.id}</span>
                       </div>
                       <p>${path.summary}</p>
                       <div class="command-card rounded-xl-sub">${path.when_to_use}</div>
-                      <div class="command-step-list compact">
+                      <div class="flex flex-col gap-1.5 mt-3">
                         ${path.steps.slice(0, 4).map(step => html`
-                          <div class="command-step-row">
+                          <div class="flex gap-2.5 flex-wrap items-baseline">
                             <span class="font-mono text-[#67e8f9] text-[length:var(--fs-sm)]">${step.tool}</span>
                             <span>${step.title}</span>
                           </div>
@@ -275,7 +275,7 @@ function GuidedPanel() {
                   `)}
                 </div>
                 ${docs.length > 0
-                  ? html`<div class="command-doc-links">
+                  ? html`<div class="flex flex-wrap gap-2 mt-3">
                       ${docs.map(doc => html`<span class="command-tag rounded-full">${doc.title}: ${doc.path}</span>`)}
                     </div>`
                   : null}

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -44,11 +44,11 @@ import { ControlSurface } from './control'
 
 function SurfaceTabs() {
   return html`
-    <div class="command-surface-tabs grouped">
+    <div class="command-surface-tabs flex-col gap-3">
       ${COMMAND_SURFACE_GROUPS.map(group => html`
-        <div class="command-tab-group" key=${group.id}>
+        <div class="flex flex-col gap-1.5" key=${group.id}>
           <span class="command-tab-group-label">${group.label}</span>
-          <div class="command-tab-group-items">
+          <div class="flex flex-wrap gap-2">
             ${COMMAND_SURFACE_META
               .filter(surface => surface.group === group.id)
               .map(surface => html`
@@ -222,12 +222,12 @@ export function Command() {
   return html`
     <section class="dashboard-panel command-plane-view ${wallboardMode ? 'wallboard' : ''}">
       ${wallboardMode ? null : html`
-        <div class="panel-header">
+        <div class="flex justify-between gap-4 items-start">
           <div>
             <h2>지휘면</h2>
             <p>기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
           </div>
-          <div class="panel-actions">
+          <div class="flex gap-2.5 flex-wrap">
             <button
               class="control-btn rounded-lg ghost"
               onClick=${() => {

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -134,7 +134,7 @@ function ChainOperationListItem(
 function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
   return html`
     <article class="command-chain-history-row text-red-300">
-      <div class="command-guide-head">
+      <div class="flex justify-between gap-2.5 items-start">
         <strong>${item.chain_id ?? '알 수 없는 체인'}</strong>
         <span class="command-chip rounded-full ${chainStatusTone(item.event)}">${item.event}</span>
       </div>
@@ -147,7 +147,7 @@ function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
 function ChainRunNodeRow({ node }: { node: CommandPlaneChainRunNode }) {
   return html`
     <article class="p-3 rounded-[10px] bg-[rgba(9,12,20,0.5)] border border-solid border-[var(--white-6)]">
-      <div class="command-guide-head">
+      <div class="flex justify-between gap-2.5 items-start">
         <strong>${node.id}</strong>
         <span class="command-chip rounded-full ${chainStatusTone(node.status)}">${node.status ?? '확인 필요'}</span>
       </div>
@@ -197,7 +197,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
       ${op.checkpoint_ref
         ? html`<div class="command-card rounded-xl-foot">체크포인트 ${op.checkpoint_ref}</div>`
         : null}
-      <div class="command-action-row">
+      <div class="flex gap-2.5 flex-wrap mt-3">
         <button
           class="control-btn rounded-lg ghost"
           onClick=${() => {
@@ -335,7 +335,7 @@ export function ChainsSurface() {
           <div class="card rounded-xl-title">Chains</div>
         </div>
         <article class="command-guide-card rounded-xl ${chainStatusTone(summary?.connection.status)}">
-          <div class="command-guide-head">
+          <div class="flex justify-between gap-2.5 items-start">
             <strong>native chain 연결</strong>
             <span class="command-chip rounded-full ${chainStatusTone(summary?.connection.status)}">${summary?.connection.status ?? 'disconnected'}</span>
           </div>
@@ -357,7 +357,7 @@ export function ChainsSurface() {
           ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 오버레이 불러오는 중…</div>`
           : overlays.length > 0
             ? html`
-                <div class="command-chain-list">
+                <div class="flex flex-col gap-3 mt-3.5">
                   ${overlays.map(overlay => html`
                     <${ChainOperationListItem}
                       overlay=${overlay}
@@ -369,8 +369,8 @@ export function ChainsSurface() {
               `
             : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 기반 작전이 아직 없습니다.</div>`}
 
-        <div class="command-chain-history">
-          <div class="command-guide-head">
+        <div class="flex flex-col gap-3 mt-3.5">
+          <div class="flex justify-between gap-2.5 items-start">
             <strong>최근 이력</strong>
             <span class="command-chip rounded-full">${summary?.recent_history.length ?? 0}</span>
           </div>
@@ -416,7 +416,7 @@ export function ChainsSurface() {
               ${selectedOverlay.mermaid
                 ? html`
                     <div class="command-chain-panel rounded-xl">
-                      <div class="command-guide-head">
+                      <div class="flex justify-between gap-2.5 items-start">
                         <strong>Mermaid 그래프</strong>
                         <span class="command-chip rounded-full">${selectedOverlay.operation.chain?.chain_id ?? 'graph'}</span>
                       </div>
@@ -426,7 +426,7 @@ export function ChainsSurface() {
                 : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
 
               <div class="command-chain-panel rounded-xl">
-                <div class="command-guide-head">
+                <div class="flex justify-between gap-2.5 items-start">
                   <strong>실행 상세</strong>
                   <span class="command-chip rounded-full ${run?.success === false ? 'bad' : 'ok'}">
                     ${run

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -375,7 +375,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
         <p>${signalNode.detail ?? '세부 설명이 없습니다.'}</p>
         ${signalNode.suggested_surface
           ? html`
-              <div class="command-action-row">
+              <div class="flex gap-2.5 flex-wrap mt-3">
                 <button
                   class="control-btn rounded-lg"
                   onClick=${() => jumpTo('command', signalNode.suggested_surface, signalNode.suggested_params ?? {})}
@@ -415,7 +415,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
       <div class="command-card rounded-xl-sub">연결 ${relatedEdges.length}개 · 근거 ${node.provenance}</div>
       ${(node.link_tab && (node.link_surface || Object.keys(node.link_params ?? {}).length > 0))
         ? html`
-            <div class="command-action-row">
+            <div class="flex gap-2.5 flex-wrap mt-3">
               <button
                 class="control-btn rounded-lg"
                 onClick=${() => jumpTo(node.link_tab ?? 'command', node.link_surface, node.link_params ?? {})}

--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -28,7 +28,7 @@ export function CommandWorkflowBanner() {
   if (!context) return null
   return html`
     <section class="command-focus-banner">
-      <div class="command-focus-head">
+      <div class="flex gap-2 flex-wrap items-center">
         <strong>${context.source_label}</strong>
         <span class="command-chip rounded-full">${workflowActionLabel(context.action_type)}</span>
         <span class="command-chip rounded-full">${workflowTargetLabel(context)}</span>
@@ -48,7 +48,7 @@ export function CommandEntryStrip() {
   const recommendation = currentSurfaceRecommendation(surface)
 
   return html`
-    <section class="command-entry-strip">
+    <section class="grid grid-cols-2 gap-3">
       <article class="command-entry-card rounded-xl">
         <span class="text-[rgba(148,163,184,0.92)] text-[length:var(--fs-xs)] uppercase tracking-[0.08em]">현재 표면</span>
         <strong>${guide.title}</strong>
@@ -84,7 +84,7 @@ function GraphicGauge({
           <span>${Math.round(clampPercent(percent))}%</span>
         </div>
       </div>
-      <div class="command-gauge-copy">
+      <div class="grid gap-1 min-w-0">
         <span>${label}</span>
         <small>${subtext}</small>
       </div>
@@ -107,7 +107,7 @@ function SignalRail({
 }) {
   return html`
     <article class="command-signal-rail ${toneClass(tone)}">
-      <div class="command-signal-copy">
+      <div class="flex items-baseline justify-between gap-2.5">
         <span>${label}</span>
         <strong>${value}</strong>
       </div>
@@ -158,7 +158,7 @@ export function SummaryHero() {
         <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">현재 지휘 상태</span>
         <h3>${headline}</h3>
         <p>${subcopy}</p>
-        <div class="command-hero-badges">
+        <div class="flex flex-wrap gap-2">
         <span class="command-chip rounded-full ${toneClass(activeOps > 0 ? 'ok' : 'warn')}">활성 작전 ${activeOps}</span>
           <span class="command-chip rounded-full ${toneClass(movingLanes > 0 ? 'ok' : activeLanes > 0 ? 'warn' : 'warn')}">이동 레인 ${movingLanes}/${Math.max(activeLanes, movingLanes)}</span>
           <span class="command-chip rounded-full ${toneClass(badAlerts > 0 ? 'bad' : warnAlerts > 0 ? 'warn' : 'ok')}">치명 알림 ${badAlerts}</span>
@@ -244,7 +244,7 @@ export function SummaryCards() {
   const issuePressure = microarch?.signals?.issue_pressure
   const cache = microarch?.cache
   return html`
-    <div class="command-summary-grid">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-3">
       <div class="monitor-stat-card rounded-xl"><span>유닛</span><strong>${topology?.total_units ?? 0}</strong><small>${topology?.managed_unit_count ?? 0}개 관리 중</small></div>
       <div class="monitor-stat-card rounded-xl"><span>작전</span><strong>${ops?.active ?? 0}</strong><small>${summary?.detachments.summary?.active ?? 0}개 실행체</small></div>
       <div class="monitor-stat-card rounded-xl"><span>승인</span><strong>${decisions?.pending ?? 0}</strong><small>${decisions?.total ?? 0}개 추적 중</small></div>

--- a/dashboard/src/components/command/swarm-cards.ts
+++ b/dashboard/src/components/command/swarm-cards.ts
@@ -12,7 +12,7 @@ import { alertBorderTone, relativeTime, toneClass } from './helpers'
 export function SwarmChecklistCard({ item }: { item: CommandPlaneSwarmChecklistItem }) {
   return html`
     <article class="command-guide-card rounded-xl ${toneClass(item.status)}">
-      <div class="command-guide-head">
+      <div class="flex justify-between gap-2.5 items-start">
         <strong>${item.title}</strong>
         <span class="command-chip rounded-full ${toneClass(item.status)}">${item.status}</span>
       </div>
@@ -128,7 +128,7 @@ export function SwarmProofPanel({ proof }: { proof?: CommandPlaneSwarmProof }) {
           : 'warn'
   return html`
     <div class="command-guide-card rounded-xl ${toneClass(tone)}">
-        <div class="command-guide-head">
+        <div class="flex justify-between gap-2.5 items-start">
           <strong>Hot Proof / 가동 증거</strong>
           <span class="command-chip rounded-full ${toneClass(tone)}">${proof?.status ?? 'missing'}</span>
         </div>

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -130,7 +130,7 @@ export function SwarmLivePanels() {
                 ? html`<div class="command-card rounded-xl-sub">${swarm.provider.detail}</div>`
                 : null}
               ${swarm.provider.timeline.length > 0
-                ? html`<div class="command-trace-stack">
+                ? html`<div class="flex flex-col gap-3">
                     ${swarm.provider.timeline.slice(-12).map(sample => html`
                       <article class="command-trace-row">
                         <div class="command-trace-main">
@@ -164,7 +164,7 @@ export function SwarmLivePanels() {
           <div class="card rounded-xl-title">최근 메시지</div>
         </div>
         ${swarm && swarm.recent_messages.length > 0
-          ? html`<div class="command-trace-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${swarm.recent_messages.map(message => html`
                 <article class="command-trace-row">
                   <div class="command-trace-main">
@@ -186,7 +186,7 @@ export function SwarmLivePanels() {
           <div class="card rounded-xl-title">최근 트레이스 이벤트</div>
         </div>
         ${swarm && swarm.recent_trace_events.length > 0
-          ? html`<div class="command-trace-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
             </div>`
           : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">run 범위 trace event가 아직 없습니다.</div>`}

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -57,7 +57,7 @@ export function SwarmOverviewPanel() {
 
               <div class="command-card rounded-xl-stack">
                 <div class="command-guide-card rounded-xl highlight ${focusKey === 'recommendation' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
-                  <div class="command-guide-head">
+                  <div class="flex justify-between gap-2.5 items-start">
                     <strong>${recommendation?.label ?? '운영자 상태 확인'}</strong>
                     <span class="command-chip rounded-full">${recommendation?.lane_id ?? '전체'}</span>
                   </div>
@@ -68,7 +68,7 @@ export function SwarmOverviewPanel() {
                 <${SwarmProofPanel} proof=${proof} />
 
                 <div class="command-guide-card rounded-xl ${gaps.length > 0 ? 'warn' : 'ok'} ${focusKey === 'gaps' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
-                  <div class="command-guide-head">
+                  <div class="flex justify-between gap-2.5 items-start">
                     <strong>핵심 공백</strong>
                     <span class="command-chip rounded-full ${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')}">${gaps.length}</span>
                   </div>
@@ -78,7 +78,7 @@ export function SwarmOverviewPanel() {
                 </div>
 
                 <div class="command-guide-card rounded-xl">
-                  <div class="command-guide-head">
+                  <div class="flex justify-between gap-2.5 items-start">
                     <strong>이동 타임라인</strong>
                     <span class="command-chip rounded-full">${timeline.length}</span>
                   </div>

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -230,7 +230,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
 
   return html`
     <article class="command-guide-card rounded-xl ${toneClass(tone)}">
-      <div class="command-guide-head">
+      <div class="flex justify-between gap-2.5 items-start">
         <strong>Run Resolution</strong>
         <span class="command-chip rounded-full ${toneClass(tone)}">
           ${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)}
@@ -262,12 +262,12 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
       ${pendingConfirm
         ? html`
             <div class="command-guide-card rounded-xl warn">
-              <div class="command-guide-head">
+              <div class="flex justify-between gap-2.5 items-start">
                 <strong>확인 대기</strong>
                 <span class="command-chip rounded-full warn">${pendingConfirm.confirm_token}</span>
               </div>
               ${pendingConfirm.preview ? html`<pre class="m-0 p-3 rounded-[10px] bg-[rgba(9,12,20,0.75)] text-[rgba(224,242,254,0.92)] text-[length:var(--fs-sm)] leading-[1.45] max-h-[220px] overflow-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]">${previewText(pendingConfirm.preview)}</pre>` : null}
-              <div class="command-action-row">
+              <div class="flex gap-2.5 flex-wrap mt-3">
                 <button class="control-btn rounded-lg" onClick=${() => { void confirmPending('confirm') }} disabled=${operatorActionBusy.value}>확인 실행</button>
                 <button class="control-btn rounded-lg ghost" onClick=${() => { void confirmPending('deny') }} disabled=${operatorActionBusy.value}>취소</button>
               </div>

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -83,7 +83,7 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
             ${policy?.frozen ? html`<span class="command-chip rounded-full warn">동결됨</span>` : null}
             ${policy?.kill_switch ? html`<span class="command-chip rounded-full bad">킬 스위치</span>` : null}
           </div>
-          <div class="command-tree-meta">
+          <div class="flex gap-2 flex-wrap mt-2 text-[var(--white-56)] text-[length:var(--fs-sm)]">
             <span>ID ${node.unit.unit_id}</span>
             <span>리더 ${node.unit.leader_id ?? '미지정'} / ${node.leader_status ?? '확인 필요'}</span>
             <span>편성 ${rosterLive}/${rosterTotal}</span>
@@ -99,7 +99,7 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
         </div>
       </div>
       ${node.children.length > 0
-        ? html`<div class="command-tree-children">
+        ? html`<div class="flex flex-col gap-2.5 mt-3 pl-4 border-l border-[var(--white-8)]">
             ${node.children.map(child => html`<${TopologyNode} node=${child} depth=${depth + 1} />`)}
           </div>`
         : null}
@@ -198,7 +198,7 @@ export function TraceSurface() {
         <div class="card rounded-xl-title">최근 트레이스</div>
       </div>
       ${snapshot && snapshot.traces.events.length > 0
-        ? html`<div class="command-trace-stack">
+        ? html`<div class="flex flex-col gap-3">
             ${snapshot.traces.events.map(event => html`<${TraceRow} event=${event} />`)}
           </div>`
         : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 트레이스 이벤트가 없습니다.</div>`}

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -78,7 +78,7 @@ export function WarRoomBodyGrid({
 }: WarRoomBodyProps) {
   return html`
     <div class="command-warroom-grid ${wallboard ? 'wallboard' : ''}">
-      <div class="command-warroom-column">
+      <div class="flex flex-col gap-4 min-w-0">
         <section class="card rounded-xl min-h-[240px]">
           <div class="card rounded-xl-title-row">
             <div class="card rounded-xl-title">실행 흐름</div>
@@ -91,7 +91,7 @@ export function WarRoomBodyGrid({
             : selectedSession
               ? html`
                   <article class="command-guide-card rounded-xl">
-                    <div class="command-guide-head">
+                    <div class="flex justify-between gap-2.5 items-start">
                       <strong>${selectedSession.session_id}</strong>
                       <span class="command-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
                     </div>
@@ -125,13 +125,13 @@ export function WarRoomBodyGrid({
         </section>
       </div>
 
-      <div class="command-warroom-column">
+      <div class="flex flex-col gap-4 min-w-0">
         <section class="card rounded-xl min-h-[240px]">
           <div class="card rounded-xl-title-row">
             <div class="card rounded-xl-title">상황 피드</div>
           </div>
           ${feedItems.length > 0
-            ? html`<div class="command-trace-stack">
+            ? html`<div class="flex flex-col gap-3">
                 ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
               </div>`
             : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
@@ -142,20 +142,20 @@ export function WarRoomBodyGrid({
             <div class="card rounded-xl-title">트레이스 흐름</div>
           </div>
           ${swarm && swarm.recent_trace_events.length > 0
-            ? html`<div class="command-trace-stack">
+            ? html`<div class="flex flex-col gap-3">
                 ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
               </div>`
             : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
         </section>
       </div>
 
-      <div class="command-warroom-column">
+      <div class="flex flex-col gap-4 min-w-0">
         <section class="card rounded-xl min-h-[240px]">
           <div class="card rounded-xl-title-row">
             <div class="card rounded-xl-title">Agents</div>
           </div>
           ${agentViews.length > 0
-            ? html`<div class="warroom-presence-grid">
+            ? html`<div class="grid grid-cols-1 gap-3">
                 ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
             : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 active agent가 아직 없습니다.</div>`}
@@ -166,7 +166,7 @@ export function WarRoomBodyGrid({
             <div class="card rounded-xl-title">Keepers</div>
           </div>
           ${keeperViews.length > 0
-            ? html`<div class="warroom-presence-grid">
+            ? html`<div class="grid grid-cols-1 gap-3">
                 ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
             : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
@@ -184,7 +184,7 @@ export function WarRoomBodyGrid({
             ${pendingApprovals > 0
               ? html`
                   <article class="command-guide-card rounded-xl warn">
-                    <div class="command-guide-head">
+                    <div class="flex justify-between gap-2.5 items-start">
                       <strong>승인 대기</strong>
                       <span class="command-chip rounded-full warn">${pendingApprovals}</span>
                     </div>
@@ -195,7 +195,7 @@ export function WarRoomBodyGrid({
             ${pendingConfirmTotal > 0
               ? html`
                   <article class="command-guide-card rounded-xl warn">
-                    <div class="command-guide-head">
+                    <div class="flex justify-between gap-2.5 items-start">
                       <strong>확인 대기</strong>
                       <span class="command-chip rounded-full warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
                     </div>

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -108,7 +108,7 @@ export function WarRoomHeroStrip({
               </div>`
             : null}
         </div>
-        <div class="command-warroom-hero-actions">
+        <div class="flex gap-2.5 flex-wrap items-start justify-end">
           <button class="control-btn rounded-lg ghost" onClick=${onRefresh}>새로고침</button>
           ${wallboard
             ? html`

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -382,7 +382,7 @@ export function WarRoomOrchestrationRail({
   }
 
   return html`
-    <div class="warroom-orchestration-grid">
+    <div class="grid grid-cols-1 gap-3">
       ${chainOverlay
         ? html`
             <article class="command-card rounded-xl warroom-orchestration-card min-h-[220px]">
@@ -399,7 +399,7 @@ export function WarRoomOrchestrationRail({
                 <span>Elapsed</span><span>${formatElapsed(chainOverlay.runtime?.elapsed_sec)}</span>
                 <span>최근 이벤트</span><span>${historySummary(chainOverlay.history)}</span>
               </div>
-              <div class="command-action-row">
+              <div class="flex gap-2.5 flex-wrap mt-3">
                 <${WarRoomJumpButton}
                   label="체인 상세"
                   surface="chains"
@@ -425,7 +425,7 @@ export function WarRoomOrchestrationRail({
                 <span>Target</span><span>${linkedAutoresearch.target_file ?? 'n/a'}</span>
                 <span>Last decision</span><span>${linkedAutoresearch.last_decision ?? linkedAutoresearch.error ?? '기록 없음'}</span>
               </div>
-              <div class="command-action-row">
+              <div class="flex gap-2.5 flex-wrap mt-3">
                 <${WarRoomJumpButton} label="세션 개입" />
                 ${linkedAutoresearch.operation_id
                   ? html`<${WarRoomJumpButton}

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -196,12 +196,12 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
         <div class="card rounded-xl-title-row">
           <div class="card rounded-xl-title">실시간 워룸</div>
         </div>
-        <div class="command-warroom-empty-copy">
+        <div class="flex flex-col gap-2.5 max-w-[520px]">
           <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">Narrative Playback</span>
           <strong>지금 붙잡을 live swarm 또는 team session이 없습니다</strong>
           <p>chain, autoresearch, worker wallboard는 활성 작전 또는 세션이 생기면 자동으로 붙습니다. 지금은 drill-down surface로 이동하는 편이 맞습니다.</p>
         </div>
-        <div class="command-action-row">
+        <div class="flex gap-2.5 flex-wrap mt-3">
           <${WarRoomJumpButton} label="작전 보기" surface="operations" />
           <${WarRoomJumpButton} label="스웜 보기" surface="swarm" />
           <${WarRoomJumpButton} label="체인 보기" surface="chains" />

--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -20,7 +20,7 @@ export function RoomTruthStrip() {
   const blocked = execution?.blocked_sessions ?? 0
 
   return html`
-    <section class="room-truth-strip">
+    <section class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3 mb-4">
       <article class="room-truth-card rounded-xl">
         <span class="room-truth-label">현황</span>
         <strong>에이전트 ${counts?.agents ?? 0} · 태스크 ${counts?.tasks ?? 0} · 키퍼 ${counts?.keepers ?? 0}</strong>
@@ -30,7 +30,7 @@ export function RoomTruthStrip() {
       <article class="room-truth-card rounded-xl">
         <span class="room-truth-label">세션</span>
         <strong>활성 ${execution?.active_sessions ?? 0} · 막힘 ${blocked}</strong>
-        <div class="room-truth-chip-row">
+        <div class="flex flex-wrap gap-2">
           <span class="command-chip rounded-full ${toneClass(blocked > 0 ? 'warn' : 'ok')}">
             우선 ${execution?.priority_items ?? 0}
           </span>

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -34,7 +34,7 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="toast-container">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2">
       ${items.map(t => html`
         <div key=${t.id} class="toast ${t.type}" onClick=${() => dismissToast(t.id)}>
           ${t.message}

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -53,7 +53,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
       <h2 class="monitor-headline">영향받는 작전</h2>
       <p class="monitor-subheadline">지휘 평면 작전의 막힘과 다음 도구만 얇게 보여주고, 자세한 근거는 원인 화면으로 넘깁니다.</p>
     </div>
-    <div class="monitor-list">
+    <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
         : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
@@ -62,7 +62,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
       ? html`
           <details class="mt-1" data-testid="execution.operations-terminal">
             <summary class="runtime-summary">종료된 작전 ${terminalOps.length}건</summary>
-            <div class="monitor-list">
+            <div class="flex flex-col gap-2.5">
               ${terminalOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -57,7 +57,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
       <h2 class="monitor-headline">개입이 필요한 실행</h2>
       <p class="monitor-subheadline">진행 중인 세션과 작전 중 막힌 항목을 보여줍니다.${hasTerminal ? ' 종료된 항목은 하단에 접혀 있습니다.' : ''}</p>
     </div>
-    <div class="monitor-alert-list">
+    <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
         : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금은 개입이 필요한 실행이 없습니다.</div>`}
@@ -66,7 +66,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
       ? html`
           <details class="mt-1" data-testid="execution.queue-terminal">
             <summary class="runtime-summary">종료된 항목 ${terminalItems.length}건</summary>
-            <div class="monitor-alert-list">
+            <div class="flex flex-col gap-2.5">
               ${terminalItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -66,7 +66,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
       <h2 class="monitor-headline">영향받는 세션</h2>
       <p class="monitor-subheadline">대기열에서 고른 실행이 어떤 세션 목표와 실행 막힘을 갖는지 요약합니다.</p>
     </div>
-    <div class="monitor-list">
+    <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
         : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
@@ -75,7 +75,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
       ? html`
           <details class="mt-1" data-testid="execution.sessions-terminal">
             <summary class="runtime-summary">종료된 세션 ${terminalSessions.length}건</summary>
-            <div class="monitor-list">
+            <div class="flex flex-col gap-2.5">
               ${terminalSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -36,7 +36,7 @@ export function WorkerSupportRow({
       <div class="monitor-row rounded-xl-header">
         <span class="agent-emoji">${row.emoji ?? ''}</span>
         <div class="min-w-0">
-          <div class="monitor-name-line">
+          <div class="flex items-center gap-2 flex-wrap">
             <span class="monitor-title">${row.name}</span>
             ${row.korean_name ? html`<span class="monitor-sub">${row.korean_name}</span>` : null}
           </div>
@@ -48,7 +48,7 @@ export function WorkerSupportRow({
           : null}
       </div>
 
-      <div class="monitor-meta">
+      <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
         ${row.last_signal_at ? html`<span>신호 <${TimeAgo} timestamp=${row.last_signal_at} /></span>` : html`<span>최근 신호 없음</span>`}
         <span>${signalTruthLabel(row.signal_truth)} · ${evidenceSourceLabel(row.evidence_source)}</span>
         ${typeof row.last_signal_age_sec === 'number' ? html`<span>${row.last_signal_age_sec}s ago</span>` : null}

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -36,7 +36,7 @@ export function GoalRow({ goal }: { goal: Goal }) {
           <div class="goal-review-note">${goal.last_review_note}</div>
         ` : null}
       </div>
-      <div class="goal-row rounded-lg-right">
+      <div class="flex flex-col items-end gap-1 shrink-0">
         <${StatusBadge} status=${goal.status} />
         <div class="goal-updated">
           <${TimeAgo} timestamp=${goal.updated_at} />
@@ -96,7 +96,7 @@ export function GoalsSummary() {
     if (g.horizon in byHorizon) byHorizon[g.horizon as keyof typeof byHorizon]++
   }
   return html`
-    <div class="goal-summary">
+    <div class="flex gap-3 flex-wrap">
       <div class="goal-summary-item rounded-lg">
         <div class="goal-summary-value">${all.length}</div>
         <div class="goal-summary-label">전체</div>

--- a/dashboard/src/components/goals/mdal-components.ts
+++ b/dashboard/src/components/goals/mdal-components.ts
@@ -16,7 +16,7 @@ export function LoopRow({ loop }: { loop: MdalLoop }) {
   return html`
     <div class="planning-loop-row rounded-xl">
       <div class="grid gap-2.5">
-        <div class="planning-loop-head">
+        <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
             <div class="planning-loop-id">${loop.profile}</div>
             <div class="planning-loop-sub">${loop.loop_id}</div>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -59,7 +59,7 @@ export function Planning() {
       </div>
 
       <!-- Compact refresh toolbar -->
-      <div class="planning-toolbar">
+      <div class="flex justify-end py-2 mb-1">
         <button
           class="control-btn rounded-lg secondary"
           onClick=${() => {

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -88,7 +88,7 @@ export function GovernanceFreshnessStrip() {
   const itemCount = data.items?.length ?? 0
   const activityCount = data.activity?.length ?? 0
   return html`
-    <div class="monitor-meta" style="margin-top:4px;margin-bottom:8px">
+    <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" style="margin-top:4px;margin-bottom:8px">
       <span>데이터 범위: 진행 중 ${itemCount}건</span>
       <span>최근 활동: ${activityCount}건</span>
       ${data.generated_at ? html`<span>생성 시각: ${data.generated_at}</span>` : null}

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -159,7 +159,7 @@ export function Ops() {
     <section class="flex flex-col gap-4">
       <div class="flex justify-between items-start gap-4 max-[880px]:flex-col card">
         <div>
-          <div class="card-title-row">
+          <div class="flex items-start justify-between gap-3 mb-[15px]">
             <div class="card-title">개입</div>
           </div>
           <h2 class="text-text-strong text-2xl leading-[1.2]">방, 세션, 키퍼를 바로 조정하는 화면</h2>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -47,7 +47,7 @@ export function OpsKeeperColumn() {
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel ops-keeper-section">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">Keeper 개입</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">장기 실행 중인 keeper를 고르고 바로 probe나 방향 수정 메시지를 보냅니다.</p>
@@ -115,7 +115,7 @@ export function OpsKeeperColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">선택한 Keeper 액션</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">선택한 keeper에만 직접 메시지를 보내서 probe, 수정, 재지시를 합니다.</p>
@@ -143,7 +143,7 @@ export function OpsKeeperColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">액션</div>
           <span style="font-size:0.75rem;opacity:0.5">${availableActions.length}개</span>
         </div>
@@ -172,7 +172,7 @@ export function OpsKeeperColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">최근 개입 로그</div>
         </div>
         <div class="flex flex-col gap-2">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -66,7 +66,7 @@ export function OpsRoomColumn() {
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="card flex flex-col gap-3 min-h-0">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">추천 개입</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">백엔드 digest가 지금 가장 작은 다음 행동을 추천합니다.</p>
@@ -112,7 +112,7 @@ export function OpsRoomColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0 ops-pending-section">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">승인 대기</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">
@@ -166,7 +166,7 @@ export function OpsRoomColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">Room 상태</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. room 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
@@ -280,7 +280,7 @@ export function OpsRoomColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">최근 Room 메시지</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -141,7 +141,7 @@ export function OpsSessionColumn() {
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">Session 개입</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">지금 개입 가능한 세션만 위에 두고, 종료된 세션은 아래에 접어 둡니다.</p>
@@ -170,7 +170,7 @@ export function OpsSessionColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">선택한 Session 요약</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">snapshot이 아니라 digest 기준 attention과 worker 카드를 보여줍니다.</p>
@@ -231,7 +231,7 @@ export function OpsSessionColumn() {
       </section>
 
       <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="card-title-row">
+        <div class="flex items-start justify-between gap-3 mb-[15px]">
           <div class="card-title">선택한 Session 액션</div>
         </div>
         <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -75,7 +75,7 @@ export function ToolEvidenceRow({ item }: { item: DashboardProofToolEvidence }) 
       ${(() => {
         const tags = toolEvidenceTags(item)
         return tags.length > 0
-          ? html`<div class="semantic-tag-row">
+          ? html`<div class="flex flex-wrap gap-1.5 mb-3">
               ${tags.map(name => html`<span class="semantic-tag">${name}</span>`)}
             </div>`
           : null
@@ -118,7 +118,7 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
           </div>`
         : null}
       ${toolNames.length > 0
-        ? html`<div class="semantic-tag-row">
+        ? html`<div class="flex flex-wrap gap-1.5 mb-3">
             ${toolNames.map(name => html`<span class="semantic-tag">${name}</span>`)}
           </div>`
         : null}
@@ -141,7 +141,7 @@ export function TimelineRow({ item }: { item: DedupedTimelineItem }) {
         <span class="command-chip rounded-full">${relativeTime(item.timestamp)}</span>
       </div>
       ${item.sources.length > 1
-        ? html`<div class="semantic-tag-row">
+        ? html`<div class="flex flex-wrap gap-1.5 mb-3">
             ${item.sources.map(source => html`<span class="semantic-tag">${source}</span>`)}
           </div>`
         : null}
@@ -204,7 +204,7 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
           </div>`
         : null}
       ${Array.isArray(item.recent_tool_names) && item.recent_tool_names.length > 0
-        ? html`<div class="semantic-tag-row">
+        ? html`<div class="flex flex-wrap gap-1.5 mb-3">
             ${item.recent_tool_names.map(name => html`<span class="semantic-tag">${name}</span>`)}
           </div>`
         : null}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -67,7 +67,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="monitor-meta" class="mt-2">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" class="mt-2">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -175,12 +175,7 @@
   text-transform: uppercase;
 }
 
-.chat-overview-grid,
-.chat-state-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(116px, 1fr));
-  gap: 8px;
-}
+/* chat-overview-grid, chat-state-grid: migrated to inline Tailwind */
 
 .chat-overview-card,
 .chat-state-card {

--- a/dashboard/src/styles/command.css
+++ b/dashboard/src/styles/command.css
@@ -23,34 +23,8 @@
   }
 }
 
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  align-items: flex-start;
-
-  & h2 {
-    margin: 0 0 6px;
-    font-size: 24px;
-  }
-
-  & p {
-    margin: 0;
-    color: rgba(255,255,255,0.66);
-    line-height: 1.5;
-  }
-}
-
-.panel-actions,
-.command-surface-tabs {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-
-  & span:nth-child(odd) {
-    color: rgba(255,255,255,0.48);
-  }
-}
+/* panel-header: migrated to inline Tailwind (flex justify-between gap-4 items-start) */
+/* panel-actions: migrated to inline Tailwind (flex gap-2.5 flex-wrap) */
 
 .monitor-stat-card {
   background: var(--white-4);
@@ -96,16 +70,7 @@
   gap: 8px;
 }
 
-.command-focus-head {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
-
-  & strong {
-    color: var(--text-strong);
-  }
-}
+/* command-focus-head: migrated to inline Tailwind (flex gap-2 flex-wrap items-center) */
 
 .command-focus-preview {
   padding: 10px 12px;
@@ -115,11 +80,7 @@
   line-height: 1.45;
 }
 
-.command-entry-strip {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
+/* command-entry-strip: migrated to inline Tailwind (grid grid-cols-2 gap-3) */
 
 .command-entry-card {
   padding: 14px 16px;
@@ -143,12 +104,7 @@
   }
 }
 
-
-.command-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 12px;
-}
+/* command-summary-grid: migrated to inline Tailwind */
 
 .command-hero {
   position: relative;
@@ -204,13 +160,7 @@
   }
 }
 
-
-.command-hero-badges,
-.command-tab-group-items {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
+/* command-hero-badges, command-tab-group-items: migrated to inline Tailwind (flex flex-wrap gap-2) */
 
 .command-guided-layout {
   display: grid;
@@ -218,12 +168,7 @@
   gap: 16px;
 }
 
-.command-guide-list,
-.command-trace-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
+/* command-guide-list, command-trace-stack: migrated to inline Tailwind (flex flex-col gap-3) */
 
 .command-guide-card,
 .command-tree-node {
@@ -253,11 +198,7 @@
   line-height: 1.5;
 }
 
-.command-readiness-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
+/* command-readiness-list: migrated to inline Tailwind (flex flex-col gap-2.5) */
 
 .command-readiness-row {
   display: flex;
@@ -286,40 +227,9 @@
   }
 }
 
-.command-readiness-title-row,
-.command-guide-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  align-items: flex-start;
-}
-
-
-
-.command-step-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
-
-  &.compact {
-    gap: 6px;
-  }
-}
-
-.command-step-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: baseline;
-}
-
-.command-doc-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
-}
+/* command-readiness-title-row, command-guide-head: migrated to inline Tailwind */
+/* command-step-list, command-step-row: migrated to inline Tailwind */
+/* command-doc-links: migrated to inline Tailwind */
 
 .command-section-stack {
   display: flex;
@@ -331,16 +241,8 @@
   }
 }
 
-.command-surface-tabs.grouped {
-  flex-direction: column;
-  gap: 12px;
-}
-
-.command-tab-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
+/* command-surface-tabs.grouped: migrated to inline Tailwind */
+/* command-tab-group: migrated to inline Tailwind (flex flex-col gap-1.5) */
 
 .command-tab-group-label {
   font-size: var(--fs-xs);
@@ -428,12 +330,7 @@
   }
 }
 
-.command-warroom-column {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-width: 0;
-}
+/* command-warroom-column: migrated to inline Tailwind (flex flex-col gap-4 min-w-0) */
 
 .command-warroom-empty {
   min-height: 360px;
@@ -448,32 +345,9 @@
   }
 }
 
-.command-warroom-empty-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-width: 520px;
-
-  & strong {
-    font-size: 26px;
-  }
-}
-
-
-.command-warroom-hero-actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: flex-end;
-}
-
-.warroom-orchestration-grid,
-.warroom-presence-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 12px;
-}
+/* command-warroom-empty-copy: migrated to inline Tailwind (flex flex-col gap-2.5 max-w-[520px]) */
+/* command-warroom-hero-actions: migrated to inline Tailwind */
+/* warroom-orchestration-grid, warroom-presence-grid: migrated to inline Tailwind (grid grid-cols-1 gap-3) */
 
 .warroom-orchestration-card,
 .warroom-presence-card,
@@ -526,8 +400,7 @@
 .command-hero-summary,
 .command-guided-layout,
 .command-surface-grid,
-.command-grid,
-.command-summary-grid {
+.command-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -537,14 +410,14 @@
 
 }
 
-.command-card-stack,
-.command-chain-list,
-.command-chain-history {
+.command-card-stack {
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin-top: 14px;
 }
+
+/* command-chain-list, command-chain-history: migrated to inline Tailwind */
 
 .command-card,
 .command-alert,
@@ -581,12 +454,7 @@
   word-break: break-word;
 }
 
-.command-action-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-top: 12px;
-}
+/* command-action-row: migrated to inline Tailwind (flex gap-2.5 flex-wrap mt-3) */
 
 .command-chain-item {
   width: 100%;
@@ -661,7 +529,6 @@
 .command-chip.warn,
 .command-chip.bad,
 .command-chip.muted,
-.command-tree-meta,
 .command-tag-row {
   display: flex;
   gap: 8px;
@@ -670,6 +537,8 @@
   color: var(--white-56);
   font-size: var(--fs-sm);
 }
+
+/* command-tree-meta: migrated to inline Tailwind */
 
 .command-warroom-guidance {
   display: grid;
@@ -703,14 +572,7 @@
   }
 }
 
-.command-tree-children {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-top: 12px;
-  padding-left: 16px;
-  border-left: 1px solid var(--white-8);
-}
+/* command-tree-children: migrated to inline Tailwind */
 
 .command-trace-row {
   display: grid;
@@ -726,14 +588,12 @@
 
 .command-guide-card p,
 .command-readiness-row p,
-.command-doc-links .command-tag,
 .swarm-event-node,
 .swarm-event-body {
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-/* ── Command Gauge (merged from command-gauge.css) ── */
 /* ── Command Gauge + Signal ───────────────────────────────── */
 
 .command-gauge-grid {
@@ -768,11 +628,7 @@
   margin-top: 4px;
 }
 
-.command-gauge-copy {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
+/* command-gauge-copy: migrated to inline Tailwind (grid gap-1 min-w-0) */
 
 .command-gauge-copy span {
   color: rgba(191, 219, 254, 0.92);
@@ -806,12 +662,7 @@
 .command-signal-rail.warn { border-color: var(--warn-20); }
 .command-signal-rail.bad { border-color: rgba(248,113,113,0.22); }
 
-.command-signal-copy {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
-}
+/* command-signal-copy: migrated to inline Tailwind (flex items-baseline justify-between gap-2.5) */
 
 .command-signal-copy span {
   color: rgba(148, 163, 184, 0.9);

--- a/dashboard/src/styles/goals.css
+++ b/dashboard/src/styles/goals.css
@@ -1,10 +1,6 @@
 /* ── Goals ────────────────────────────────────── */
 
-.goal-summary {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
+/* goal-summary: migrated to inline Tailwind (flex gap-3 flex-wrap) */
 
 .goal-summary-item {
   flex: 1;
@@ -72,13 +68,7 @@
   padding: 14px;
 }
 
-.planning-loop-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
+/* planning-loop-head: migrated to inline Tailwind */
 
 .planning-loop-id {
   color: var(--text-strong);
@@ -128,27 +118,14 @@
   border-left: 2px solid var(--white-8);
 }
 
-.goal-row-right {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
-  flex-shrink: 0;
-}
+/* goal-row-right: migrated to inline Tailwind (flex flex-col items-end gap-1 shrink-0) */
 
 .goal-updated {
   font-size: var(--fs-xs);
   color: var(--text-dim);
 }
 
-/* -- Planning toolbar (compact refresh) -- */
-
-.planning-toolbar {
-  display: flex;
-  justify-content: flex-end;
-  padding: 8px 0;
-  margin-bottom: 4px;
-}
+/* planning-toolbar: migrated to inline Tailwind (flex justify-end py-2 mb-1) */
 
 /* -- Priority badge (inline P1-P4) -- */
 
@@ -220,4 +197,3 @@
   white-space: normal;
   text-overflow: unset;
 }
-

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -1,14 +1,5 @@
 /* ── Toast Notifications ───────────────────────────────────── */
-.toast-container {
-  /* Uses --z-overlay-toast */
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: var(--z-overlay-toast, 3070);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+/* toast-container: migrated to inline Tailwind */
 .toast {
   padding: 12px 20px;
   border-radius: 10px;
@@ -118,12 +109,7 @@ button.agent-card {
   }
 }
 
-.room-truth-strip {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin: 0 0 16px;
-}
+/* room-truth-strip: migrated to inline Tailwind */
 
 .room-truth-strip-loading,
 .room-truth-strip-error {
@@ -171,11 +157,7 @@ button.agent-card {
   color: #7fa5d8;
 }
 
-.room-truth-chip-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
+/* room-truth-chip-row: migrated to inline Tailwind (flex flex-wrap gap-2) */
 
 .agent-card .agent-task {
   margin-top: 10px;
@@ -187,11 +169,7 @@ button.agent-card {
   margin-top: 10px;
 }
 
-.agents-monitor {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
+/* agents-monitor: migrated to inline Tailwind (flex flex-col gap-5) */
 
 .monitor-stat-caption {
   margin-top: 6px;
@@ -212,12 +190,7 @@ button.agent-card {
   line-height: 1.45;
 }
 
-.monitor-alert-list,
-.monitor-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
+/* monitor-alert-list, monitor-list: migrated to inline Tailwind (flex flex-col gap-2.5) */
 
 button.monitor-alert,
 button.monitor-row {
@@ -261,19 +234,8 @@ button.monitor-alert.bad,
   padding: 12px 14px;
 }
 
-.monitor-row-header {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
-  align-items: center;
-  gap: 10px;
-}
-
-.monitor-name-line {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
+/* monitor-row-header: migrated to inline Tailwind */
+/* monitor-name-line: migrated to inline Tailwind (flex items-center gap-2 flex-wrap) */
 
 .monitor-title {
   color: #f5f7ff;
@@ -291,14 +253,7 @@ button.monitor-alert.bad,
   font-size: var(--fs-sm);
 }
 
-.monitor-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
-  margin-top: 10px;
-  color: var(--text-muted);
-  font-size: var(--fs-sm);
-}
+/* monitor-meta: migrated to inline Tailwind */
 
 .monitor-focus {
   margin-top: 10px;
@@ -352,21 +307,5 @@ button.monitor-alert.bad,
   color: var(--ok);
   margin-bottom: 15px;
 }
-.card-title-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 15px;
-
-  & .card-title {
-    margin-bottom: 0;
-  }
-}
-.semantic-tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-bottom: 12px;
-}
-.semantic-tag,
+/* card-title-row: migrated to inline Tailwind (flex items-start justify-between gap-3 mb-[15px]) */
+/* semantic-tag-row: migrated to inline Tailwind (flex flex-wrap gap-1.5 mb-3) */


### PR DESCRIPTION
## Summary
4 CSS files — remaining simple layout classes migrated to Tailwind.
Most remaining CSS is complex (gradients, pseudo-elements, stateful variants) and stays as CSS.

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| command.css | 853 | 704 | -17% |
| ui.css | 372 | 311 | -16% |
| chat.css | 263 | 258 | -2% |
| goals.css | 223 | 199 | -11% |

## Current CSS total: ~5,286 lines
Tailwind migration is reaching diminishing returns — remaining CSS is primarily:
- Gradient/pseudo-element styling
- Stateful variant classes (.ok/.warn/.bad/.active)
- Keyframe animations
- Responsive media queries
- Nested selectors with semantic overrides

Generated with [Claude Code](https://claude.com/claude-code)