### PR TITLE
fix(room): prevent stale task restoration in claim_next_r

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -761,20 +761,25 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
            | None -> false)
         | _ -> false
       ) sorted in
-      if stale <> [] then begin
-        let stale_ids = List.map (fun (t : Types.task) -> t.id) stale in
-        let remaining = List.filter (fun (t : Types.task) ->
-          not (List.mem t.id stale_ids)
-        ) backlog.tasks in
-        write_backlog config { backlog with tasks = remaining };
-        log_event config (Printf.sprintf
-          "{\"type\":\"stale_task_auto_archive\",\"count\":%d,\"threshold_days\":%d,\"ts\":\"%s\"}"
-          (List.length stale) stale_threshold_days (now_iso ()));
-        let _ = broadcast config ~from_agent:"system"
-          ~content:(Printf.sprintf "📦 Auto-archived %d stale Todo task(s) (>%dd old)"
-            (List.length stale) stale_threshold_days) in
-        ()
-      end;
+      let stale_ids = List.map (fun (t : Types.task) -> t.id) stale in
+      (* Re-derive working_tasks after stale removal to prevent
+         second write_backlog from restoring archived tasks (#2237) *)
+      let working_tasks =
+        if stale <> [] then begin
+          let remaining = List.filter (fun (t : Types.task) ->
+            not (List.mem t.id stale_ids)
+          ) backlog.tasks in
+          write_backlog config { backlog with tasks = remaining };
+          log_event config (Printf.sprintf
+            "{\"type\":\"stale_task_auto_archive\",\"count\":%d,\"threshold_days\":%d,\"ts\":\"%s\"}"
+            (List.length stale) stale_threshold_days (now_iso ()));
+          let _ = broadcast config ~from_agent:"system"
+            ~content:(Printf.sprintf "📦 Auto-archived %d stale Todo task(s) (>%dd old)"
+              (List.length stale) stale_threshold_days) in
+          List.filter (fun (t : Types.task) ->
+            not (List.mem t.id stale_ids)) working_tasks
+        end else working_tasks
+      in
       let unclaimed = List.filter (fun t ->
         match t.task_status with
         | Todo -> true


### PR DESCRIPTION
## Summary

`claim_next_r`에서 `working_tasks`가 stale 제거 전 `backlog.tasks`로 초기화됨.
stale 제거 후 `write_backlog(remaining)` 성공하지만, 이후 `write_backlog(working_tasks)`에서
stale tasks가 복원됨.

stale 제거 블록 후 `working_tasks`를 `stale_ids` 기준으로 re-filter.

Fixes #2237

## Test plan
- [x] `dune build` 성공
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)