### PR TITLE
fix(eio): replace blocking Unix.sleepf with Eio_unix.sleep in lock spin

### DIFF
--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -233,7 +233,7 @@ let with_file_lock config path f =
           match backend_acquire_lock config ~key ~ttl_seconds ~owner with
           | Ok true -> true
           | _ ->
-              Unix.sleepf delay;
+              Eio_unix.sleep delay;
               acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
       in
       if acquire 20 0.005 then
@@ -256,7 +256,7 @@ let with_file_lock_r config path f : ('a, masc_error) result =
         else
           match backend_acquire_lock config ~key ~ttl_seconds ~owner with
           | Ok true -> true
-          | _ -> Unix.sleepf delay; acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
+          | _ -> Eio_unix.sleep delay; acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
       in
       if acquire 20 0.005 then
         Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"


### PR DESCRIPTION
## Summary

`with_file_lock`/`with_file_lock_r`의 lock spin에서 `Unix.sleepf` → `Eio_unix.sleep`.
Eio 서버에서 blocking sleep은 전체 domain을 차단하여 다른 fiber의 진행을 막음.

Fixes #2215

## Test plan
- [ ] `dune build` 성공 (CI에서 확인)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)