### PR TITLE
fix(dispatch): register Mod_shard tag for masc_tool_grant/revoke/list

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -542,6 +542,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           agent_name = Some agent_name; start_operation = None;
           start_team_session = None } in
         Tool_autoresearch.dispatch ctx ~name ~args:arguments
+    | Mod_shard ->
+        let (ok, json) = Tool_shard.execute name arguments in
+        Some (ok, Yojson.Safe.to_string json)
     | Mod_notifications ->
         Tool_notifications.dispatch state.Mcp_server.session_registry
           ~agent_name ~name arguments

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -159,6 +159,7 @@ type module_tag =
   | Mod_notifications | Mod_inline
   | Mod_autoresearch
   | Mod_model_catalog
+  | Mod_shard
 
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
 let tag_registry_initialized = ref false

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -87,6 +87,7 @@ type module_tag =
   | Mod_notifications | Mod_inline
   | Mod_autoresearch
   | Mod_model_catalog
+  | Mod_shard
 
 val register_module_tag : schemas:Types.tool_schema list -> tag:module_tag -> unit
 (** Register tool names from a schema list with a module tag. *)

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -164,6 +164,11 @@ let register_all () =
     "masc_keeper_tool_catalog";
   ];
 
+  (* ── Mod_shard: Tool_shard ────────────────────────────────────── *)
+  reg Mod_shard [
+    "masc_tool_grant"; "masc_tool_revoke"; "masc_tool_list";
+  ];
+
   (* ── Schema-gap fills for modules with partial schema exports ── *)
   reg Mod_room [
     "masc_workflow_guide"; "masc_check";


### PR DESCRIPTION
## Summary
- `masc_tool_grant`, `masc_tool_revoke`, `masc_tool_list` were advertised in `Tool_shard.schemas` (included in `all_schemas_with_perpetual`) but had no `Mod_shard` tag in the dispatch registry, making them permanently unreachable ("Unknown tool" on every call).
- Added `Mod_shard` variant to `module_tag`, registered the 3 tool names in `tool_tag_init.ml`, and routed to `Tool_shard.execute` in `dispatch_by_tag`.

## Test plan
- [x] `dune build --root .` passes
- [x] `test_tool_shard_coverage.exe` — 42/42 tests pass
- [x] Full `dune build @runtest` passes

Closes #2222

Generated with [Claude Code](https://claude.com/claude-code)