### PR TITLE
fix(security): shell injection hardening and destructive gate bypass

### DIFF
--- a/lib/autoresearch_metric.ml
+++ b/lib/autoresearch_metric.ml
@@ -22,7 +22,9 @@ let contains_substring haystack needle =
     metric_fn is intentionally interpolated as a bare command (e.g. "python eval.py --metric accuracy"),
     so we cannot quote it. Instead we reject strings containing shell metacharacters
     that could chain or redirect commands. *)
-let dangerous_shell_chars = [';'; '|'; '&'; '`'; '$'; '('; ')'; '{'; '}'; '<'; '>'; '\n']
+let dangerous_shell_chars =
+  [';'; '|'; '&'; '`'; '$'; '('; ')'; '{'; '}'; '<'; '>'; '\n';
+   '#'; '!'; '~'; '['; ']'; '*'; '?'; '\\']
 
 (** Validate that metric_fn does not contain dangerous shell metacharacters.
     Returns Ok fn on success, Error message on failure. *)
@@ -39,7 +41,7 @@ let measure_metric ~workdir ~timeout_s metric_fn =
   match validate_metric_fn metric_fn with
   | Error e -> Error e
   | Ok metric_fn ->
-  let timeout_flag = Printf.sprintf "timeout %.0f" timeout_s in
+  let timeout_flag = Printf.sprintf "timeout %s" (Filename.quote (Printf.sprintf "%.0f" timeout_s)) in
   let cmd = Printf.sprintf "cd %s && %s %s 2>/dev/null | tail -1"
     (Filename.quote workdir) timeout_flag metric_fn in
   let start = Time_compat.now () in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -16,7 +16,7 @@
 
 (** Bash-like tools that need destructive pattern screening. *)
 let destructive_check_tools =
-  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit" ]
+  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit"; "keeper_github" ]
 
 (** Extract command or content string from tool input JSON for screening. *)
 let extract_command_from_input (input : Yojson.Safe.t) : string =
@@ -25,9 +25,12 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
     match input |> member "command" with
     | `String s -> s
     | `Null | _ ->
-      (match input |> member "content" with
+      (match input |> member "cmd" with
        | `String s -> s
-       | _ -> "")
+       | `Null | _ ->
+         (match input |> member "content" with
+          | `String s -> s
+          | _ -> ""))
   with Yojson.Safe.Util.Type_error _ -> ""
 
 (** Tools allowed at each autonomy level for the unified turn path.


### PR DESCRIPTION
## Summary
- Harden `autoresearch_metric.ml` shell metachar filter with 8 additional dangerous characters (`#!~[]*?\`) and quote timeout argument with `Filename.quote` (Closes #2212)
- Add `keeper_github` to `destructive_check_tools` in `keeper_hooks_oas.ml` and extend `extract_command_from_input` to read the `cmd` JSON key so the destructive gate screens gh commands (Closes #2214)

## Test plan
- [ ] `dune build --root .` compiles (verified locally)
- [ ] Verify `validate_metric_fn` rejects strings containing `#`, `!`, `~`, `[`, `]`, `*`, `?`, `\`
- [ ] Verify `keeper_github` with destructive commands (e.g. `gh repo delete`) is blocked by the pre_tool_use hook
- [ ] Verify `extract_command_from_input` reads `cmd` key from keeper_github input JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)