### PR TITLE
fix(board): wrap PG vote in transaction for atomicity

### DIFF
--- a/lib/board/board_pg.ml
+++ b/lib/board/board_pg.ml
@@ -422,34 +422,38 @@ let vote_post t ~voter ~post_id ~direction =
   | Ok pid ->
   let pid_str = Post_id.to_string pid in
   let dir_str = vote_direction_to_string direction in
-  (* All vote operations in single connection for consistency *)
+  (* All vote operations in a single transaction for atomicity.
+     Without this, concurrent votes can both read "no existing vote"
+     then both INSERT + increment, inflating the counter. *)
   let result = Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
-    (* Verify post exists *)
-    let* post_opt = C.find_opt get_post_q pid_str in
-    match post_opt with
-    | None -> Ok (Error (Post_not_found post_id))
-    | Some post_row ->
-    (* Check existing vote *)
-    let* existing = C.find_opt get_vote_q ("post", pid_str, voter) in
-    match existing with
-    | Some d when d = dir_str ->
-        Ok (Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
-          voter dir_str post_id)))
-    | Some _ ->
-        (* Flip vote: upsert + counter update atomically *)
-        let now = Time_compat.now () in
-        let* () = C.exec upsert_vote_q ("post", pid_str, voter, (dir_str, now)) in
-        let* () = C.exec (if dir_str = "up" then flip_to_up_post_q else flip_to_down_post_q) pid_str in
-        let* score = C.find get_post_score_q pid_str in
-        Ok (Ok (score, Some post_row))
-    | None ->
-        (* New vote: insert + counter update *)
-        let now = Time_compat.now () in
-        let* () = C.exec upsert_vote_q ("post", pid_str, voter, (dir_str, now)) in
-        let* () = C.exec (if dir_str = "up" then inc_up_post_q else inc_down_post_q) pid_str in
-        let* score = C.find get_post_score_q pid_str in
-        Ok (Ok (score, Some post_row))
+    C.with_transaction (fun () ->
+      (* Verify post exists *)
+      let* post_opt = C.find_opt get_post_q pid_str in
+      match post_opt with
+      | None -> Ok (Error (Post_not_found post_id))
+      | Some post_row ->
+      (* Check existing vote *)
+      let* existing = C.find_opt get_vote_q ("post", pid_str, voter) in
+      match existing with
+      | Some d when d = dir_str ->
+          Ok (Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
+            voter dir_str post_id)))
+      | Some _ ->
+          (* Flip vote: upsert + counter update atomically *)
+          let now = Time_compat.now () in
+          let* () = C.exec upsert_vote_q ("post", pid_str, voter, (dir_str, now)) in
+          let* () = C.exec (if dir_str = "up" then flip_to_up_post_q else flip_to_down_post_q) pid_str in
+          let* score = C.find get_post_score_q pid_str in
+          Ok (Ok (score, Some post_row))
+      | None ->
+          (* New vote: insert + counter update *)
+          let now = Time_compat.now () in
+          let* () = C.exec upsert_vote_q ("post", pid_str, voter, (dir_str, now)) in
+          let* () = C.exec (if dir_str = "up" then inc_up_post_q else inc_down_post_q) pid_str in
+          let* score = C.find get_post_score_q pid_str in
+          Ok (Ok (score, Some post_row))
+    )
   ) t.pool in
   match result with
   | Error err -> Error (caqti_err err)
@@ -485,32 +489,34 @@ let vote_comment t ~voter ~comment_id ~direction =
   let dir_str = vote_direction_to_string direction in
   let result = Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
-    (* Get comment author (also verifies existence) *)
-    let* author_opt = C.find_opt comment_author_q cid_str in
-    match author_opt with
-    | None ->
-        Ok (Error (Comment_not_found comment_id))
-    | Some author_name ->
-    (* Check existing vote *)
-    let* existing = C.find_opt get_vote_q ("comment", cid_str, voter) in
-    match existing with
-    | Some d when d = dir_str ->
-        Ok (Error (Already_voted (Printf.sprintf "%s already voted %s on comment %s"
-          voter dir_str comment_id)))
-    | Some _ ->
-        (* Flip vote *)
-        let now = Time_compat.now () in
-        let* () = C.exec upsert_vote_q ("comment", cid_str, voter, (dir_str, now)) in
-        let* () = C.exec (if dir_str = "up" then flip_to_up_comment_q else flip_to_down_comment_q) cid_str in
-        let* score = C.find get_comment_score_q cid_str in
-        Ok (Ok (score, author_name))
-    | None ->
-        (* New vote *)
-        let now = Time_compat.now () in
-        let* () = C.exec upsert_vote_q ("comment", cid_str, voter, (dir_str, now)) in
-        let* () = C.exec (if dir_str = "up" then inc_up_comment_q else inc_down_comment_q) cid_str in
-        let* score = C.find get_comment_score_q cid_str in
-        Ok (Ok (score, author_name))
+    C.with_transaction (fun () ->
+      (* Get comment author (also verifies existence) *)
+      let* author_opt = C.find_opt comment_author_q cid_str in
+      match author_opt with
+      | None ->
+          Ok (Error (Comment_not_found comment_id))
+      | Some author_name ->
+      (* Check existing vote *)
+      let* existing = C.find_opt get_vote_q ("comment", cid_str, voter) in
+      match existing with
+      | Some d when d = dir_str ->
+          Ok (Error (Already_voted (Printf.sprintf "%s already voted %s on comment %s"
+            voter dir_str comment_id)))
+      | Some _ ->
+          (* Flip vote *)
+          let now = Time_compat.now () in
+          let* () = C.exec upsert_vote_q ("comment", cid_str, voter, (dir_str, now)) in
+          let* () = C.exec (if dir_str = "up" then flip_to_up_comment_q else flip_to_down_comment_q) cid_str in
+          let* score = C.find get_comment_score_q cid_str in
+          Ok (Ok (score, author_name))
+      | None ->
+          (* New vote *)
+          let now = Time_compat.now () in
+          let* () = C.exec upsert_vote_q ("comment", cid_str, voter, (dir_str, now)) in
+          let* () = C.exec (if dir_str = "up" then inc_up_comment_q else inc_down_comment_q) cid_str in
+          let* score = C.find get_comment_score_q cid_str in
+          Ok (Ok (score, author_name))
+    )
   ) t.pool in
   match result with
   | Error err -> Error (caqti_err err)

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -122,6 +122,51 @@ let test_vote_flip = with_pg_backend (fun t ->
           Alcotest.(check int) "score after flip" (-1) score
 )
 
+(** Verify multiple distinct voters produce correct final score.
+    Before the transaction fix, concurrent SELECT+INSERT+UPDATE could
+    inflate counters when two votes raced on the same post. *)
+let test_vote_multiple_voters = with_pg_backend (fun t ->
+  match Board_pg.create_post t ~author:"pg-test-multi-voter" ~content:"pg multi vote" () with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      (* 3 upvotes from distinct voters *)
+      (match Board_pg.vote_post t ~voter:"pg-voter-a" ~post_id:pid ~direction:Board.Up with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok s -> Alcotest.(check int) "score after voter-a" 1 s);
+      (match Board_pg.vote_post t ~voter:"pg-voter-b" ~post_id:pid ~direction:Board.Up with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok s -> Alcotest.(check int) "score after voter-b" 2 s);
+      (match Board_pg.vote_post t ~voter:"pg-voter-c" ~post_id:pid ~direction:Board.Down with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok s -> Alcotest.(check int) "score after voter-c (down)" 1 s);
+      (* Verify final post state *)
+      (match Board_pg.get_post t ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok p ->
+           Alcotest.(check int) "final votes_up" 2 p.votes_up;
+           Alcotest.(check int) "final votes_down" 1 p.votes_down)
+)
+
+let test_vote_comment_atomic = with_pg_backend (fun t ->
+  match Board_pg.create_post t ~author:"pg-test-cv" ~content:"pg comment vote" () with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      (match Board_pg.add_comment t ~post_id:pid ~author:"pg-test-cv-a" ~content:"test" () with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok cmt ->
+           let cid = Board.Comment_id.to_string cmt.id in
+           (match Board_pg.vote_comment t ~voter:"pg-cv-1" ~comment_id:cid ~direction:Board.Up with
+            | Error e -> Alcotest.fail (Board.show_board_error e)
+            | Ok s -> Alcotest.(check int) "comment score" 1 s);
+           (* Duplicate vote returns Already_voted *)
+           (match Board_pg.vote_comment t ~voter:"pg-cv-1" ~comment_id:cid ~direction:Board.Up with
+            | Ok _ -> Alcotest.fail "Expected Already_voted"
+            | Error (Board.Already_voted _) -> ()
+            | Error e -> Alcotest.fail (Board.show_board_error e)))
+)
+
 (** {1 Stats / Search / Hearth} *)
 
 let test_stats = with_pg_backend (fun t ->
@@ -204,6 +249,8 @@ let () =
       Alcotest.test_case "upvote" `Quick test_vote_post;
       Alcotest.test_case "dedup" `Quick test_vote_dedup;
       Alcotest.test_case "flip" `Quick test_vote_flip;
+      Alcotest.test_case "multiple voters" `Quick test_vote_multiple_voters;
+      Alcotest.test_case "comment vote atomic" `Quick test_vote_comment_atomic;
     ];
     "misc", [
       Alcotest.test_case "stats" `Quick test_stats;


### PR DESCRIPTION
## Summary
- Wrap `vote_post` and `vote_comment` in `C.with_transaction` to prevent concurrent votes from inflating counters
- Without the transaction, two concurrent voters could both SELECT "no existing vote", then both INSERT + increment the counter
- Add tests for multiple-voter scoring correctness and comment vote dedup

## Test plan
- [ ] `dune build --root .` passes (verified locally)
- [ ] Existing vote tests (upvote, dedup, flip) still pass
- [ ] New `multiple voters` test verifies correct final score after sequential votes
- [ ] New `comment vote atomic` test verifies comment vote + dedup

Closes #2221

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>