### PR TITLE
sec(keeper): keeper_github destructive gate bypass fix

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -16,18 +16,22 @@
 
 (** Bash-like tools that need destructive pattern screening. *)
 let destructive_check_tools =
-  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit" ]
+  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit"; "keeper_github" ]
 
-(** Extract command or content string from tool input JSON for screening. *)
+(** Extract command or content string from tool input JSON for screening.
+    Reads "command", "cmd" (keeper_github), or "content" keys. *)
 let extract_command_from_input (input : Yojson.Safe.t) : string =
   let open Yojson.Safe.Util in
   try
     match input |> member "command" with
     | `String s -> s
     | `Null | _ ->
-      (match input |> member "content" with
+      (match input |> member "cmd" with
        | `String s -> s
-       | _ -> "")
+       | `Null | _ ->
+         (match input |> member "content" with
+          | `String s -> s
+          | _ -> ""))
   with Yojson.Safe.Util.Type_error _ -> ""
 
 (** Tools allowed at each autonomy level for the unified turn path.


### PR DESCRIPTION
Closes #2214. keeper_github added to destructive_check_tools. extract_command_from_input reads cmd key.