### PR TITLE
fix(eio): resolve 3 silent failure and blocking bugs

### DIFF
--- a/lib/autoresearch_git.ml
+++ b/lib/autoresearch_git.ml
@@ -3,70 +3,89 @@
     Provides commit, reset, tag, branch, and worktree management
     used during the experiment cycle.
 
+    Uses Process_eio for non-blocking subprocess execution to avoid
+    freezing the Eio event loop during git operations.
+
     @since 2.80.0 *)
 
-(** Run a shell command and capture stdout lines. *)
+(** Run a shell command via Process_eio and capture stdout lines.
+    Non-blocking: delegates to Eio.Process instead of Unix.open_process_in. *)
 let run_capture_lines cmd =
-  let ic = Unix.open_process_in cmd in
-  let lines = ref [] in
-  (try
-     while true do
-       lines := input_line ic :: !lines
-     done
-   with End_of_file -> ());
-  let status = Unix.close_process_in ic in
-  (status, List.rev !lines)
+  let status, raw_output =
+    Process_eio.run_argv_with_status ~timeout_sec:30.0
+      ["sh"; "-c"; cmd]
+  in
+  let lines =
+    if String.length raw_output = 0 then []
+    else String.split_on_char '\n' raw_output
+         |> List.filter (fun s -> s <> "")
+  in
+  (status, lines)
 
 (** Get current HEAD commit hash (short). *)
 let git_head_short ~workdir =
   let cmd = Printf.sprintf "cd %s && git rev-parse --short HEAD 2>/dev/null"
     (Filename.quote workdir) in
-  let ic = Unix.open_process_in cmd in
-  Fun.protect ~finally:(fun () ->
-    ignore (Unix.close_process_in ic)
-  ) (fun () ->
-    try Some (String.trim (input_line ic)) with End_of_file -> None
-  )
+  let status, raw_output =
+    Process_eio.run_argv_with_status ~timeout_sec:10.0
+      ["sh"; "-c"; cmd]
+  in
+  match status with
+  | Unix.WEXITED 0 ->
+    let trimmed = String.trim raw_output in
+    if trimmed = "" then None else Some trimmed
+  | _ -> None
 
 (** Git commit result: Ok (Some hash) on success, Ok None when no diff,
     Error msg when git commit itself fails (e.g. missing identity, hooks). *)
 let git_commit ~workdir ~message
   : (string option, string) Stdlib.result =
-  let cmd = Printf.sprintf
+  let check_cmd = Printf.sprintf
     "cd %s && git add -A && git diff --cached --quiet"
     (Filename.quote workdir) in
-  if Sys.command cmd = 0 then
+  let check_status, _check_output =
+    Process_eio.run_argv_with_status ~timeout_sec:30.0
+      ["sh"; "-c"; check_cmd]
+  in
+  match check_status with
+  | Unix.WEXITED 0 ->
     (* No staged changes -- nothing to commit *)
     Result.ok None
-  else
+  | _ ->
     let commit_cmd = Printf.sprintf
       "cd %s && git commit -m %s 2>&1 && git rev-parse --short HEAD"
       (Filename.quote workdir) (Filename.quote message) in
-    let ic = Unix.open_process_in commit_cmd in
-    let lines = ref [] in
-    (try while true do lines := input_line ic :: !lines done
-     with End_of_file -> ());
-    let status = Unix.close_process_in ic in
-    match status with
+    let status, raw_output =
+      Process_eio.run_argv_with_status ~timeout_sec:30.0
+        ["sh"; "-c"; commit_cmd]
+    in
+    let lines =
+      String.split_on_char '\n' raw_output
+      |> List.filter (fun s -> s <> "")
+      |> List.rev
+    in
+    (match status with
     | Unix.WEXITED 0 ->
-      (match !lines with
+      (match lines with
        | hash :: _ -> Result.ok (Some (String.trim hash))
        | [] -> Result.error "git commit succeeded but no hash returned")
     | _ ->
-      let output = String.concat "\n" (List.rev !lines) in
-      Result.error (Printf.sprintf "git commit failed: %s" output)
+      let output = String.concat "\n" (List.rev lines) in
+      Result.error (Printf.sprintf "git commit failed: %s" output))
 
 (** Restore worktree files to current HEAD without moving the branch. *)
 let git_restore_head ~workdir =
   let cmd = Printf.sprintf "cd %s && git reset --hard HEAD 2>/dev/null"
     (Filename.quote workdir) in
-  ignore (Sys.command cmd)
+  ignore (Process_eio.run_argv_with_status ~timeout_sec:30.0
+    ["sh"; "-c"; cmd])
 
 (** Reset to HEAD~1, discarding the last commit. *)
 let git_reset_last ~workdir =
   let cmd = Printf.sprintf "cd %s && git reset --hard HEAD~1 2>/dev/null"
     (Filename.quote workdir) in
-  ignore (Sys.command cmd)
+  ignore (Process_eio.run_argv_with_status ~timeout_sec:30.0
+    ["sh"; "-c"; cmd])
 
 (** Commit with autoresearch-formatted message. *)
 let git_commit_cycle ~workdir ~cycle ~hypothesis ~baseline =
@@ -85,7 +104,8 @@ let git_tag_best ~workdir ~cycle ~score =
   let tag = Printf.sprintf "ar-best-c%d-%.4f" cycle score in
   let cmd = Printf.sprintf "cd %s && git tag -f %s 2>/dev/null"
     (Filename.quote workdir) (Filename.quote tag) in
-  ignore (Sys.command cmd)
+  ignore (Process_eio.run_argv_with_status ~timeout_sec:10.0
+    ["sh"; "-c"; cmd])
 
 (** Get the git top-level directory for a workdir. *)
 let git_top_level ~workdir =

--- a/lib/autoresearch_metric.ml
+++ b/lib/autoresearch_metric.ml
@@ -36,7 +36,8 @@ let validate_metric_fn fn =
     Ok fn
 
 (** Run metric_fn shell command and parse the last float from stdout.
-    Returns Error if command fails, metric_fn is unsafe, or output is not a valid float. *)
+    Returns Error if command fails, metric_fn is unsafe, or output is not a valid float.
+    Uses Process_eio.run_argv_with_status to avoid blocking the Eio event loop. *)
 let measure_metric ~workdir ~timeout_s metric_fn =
   match validate_metric_fn metric_fn with
   | Error e -> Error e
@@ -45,14 +46,13 @@ let measure_metric ~workdir ~timeout_s metric_fn =
   let cmd = Printf.sprintf "cd %s && %s %s 2>/dev/null | tail -1"
     (Filename.quote workdir) timeout_flag metric_fn in
   let start = Time_compat.now () in
-  let ic = Unix.open_process_in cmd in
-  let output = Fun.protect ~finally:(fun () ->
-    ignore (Unix.close_process_in ic)
-  ) (fun () ->
-    try input_line ic with End_of_file -> ""
-  ) in
+  let _status, raw_output =
+    Process_eio.run_argv_with_status ~timeout_sec:(timeout_s +. 5.0)
+      ["sh"; "-c"; cmd]
+  in
   let elapsed_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
-  match float_of_string_opt (String.trim output) with
+  let output = String.trim raw_output in
+  match float_of_string_opt output with
   | Some v -> Result.ok (v, elapsed_ms)
   | None -> Result.error (Printf.sprintf "metric_fn output not a float: %S" output)
 

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -50,6 +50,16 @@ let latest_loop_id = Autoresearch.latest_loop_id
 let pending_hypotheses : (string, string) Hashtbl.t =
   Hashtbl.create 4
 
+(** Eio.Mutex protecting [pending_hypotheses] and [custom_generators]
+    against concurrent fiber access from parallel tool handlers. *)
+let hypotheses_mu = Eio.Mutex.create ()
+
+(** Execute [f] under exclusive lock on the hypotheses/generators registry. *)
+let with_hypotheses_rw f = Eio.Mutex.use_rw ~protect:true hypotheses_mu (fun () -> f ())
+
+(** Execute [f] under shared read lock on the hypotheses/generators registry. *)
+let with_hypotheses_ro f = Eio.Mutex.use_ro hypotheses_mu (fun () -> f ())
+
 (** Code generator type for test injection.
     Returns Ok (hypothesis, new_code) or Error reason. *)
 type code_generator =
@@ -65,13 +75,15 @@ let custom_generators : (string, code_generator) Hashtbl.t =
 
 (** Set a custom code generator for a loop (used in tests). *)
 let set_generator loop_id gen =
-  Hashtbl.replace custom_generators loop_id gen
+  with_hypotheses_rw (fun () ->
+    Hashtbl.replace custom_generators loop_id gen)
 
 (** Get the code generator for a loop. Falls back to Autoresearch.generate_code_change. *)
 let get_generator loop_id =
-  match Hashtbl.find_opt custom_generators loop_id with
-  | Some gen -> gen
-  | None -> Autoresearch.generate_code_change
+  with_hypotheses_ro (fun () ->
+    match Hashtbl.find_opt custom_generators loop_id with
+    | Some gen -> gen
+    | None -> Autoresearch.generate_code_change)
 
 (* ================================================================ *)
 (* SSE Broadcast                                                    *)
@@ -240,7 +252,8 @@ let status_json ctx ~loop_id json_fields =
   let link =
     Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path loop_id
   in
-  let queued_hypothesis = Hashtbl.find_opt pending_hypotheses loop_id in
+  let queued_hypothesis = with_hypotheses_ro (fun () ->
+    Hashtbl.find_opt pending_hypotheses loop_id) in
   let link_fields =
     match link with
     | Some link ->
@@ -482,7 +495,8 @@ let handle_inject _ctx args =
           else begin
             state.queued_hypothesis <- Some hypothesis;
             Autoresearch.save_state ~base_path:_ctx.base_path state;
-            Hashtbl.replace pending_hypotheses id hypothesis;
+            with_hypotheses_rw (fun () ->
+              Hashtbl.replace pending_hypotheses id hypothesis);
             `Assoc [
               ("loop_id", `String id);
               ("status", `String "hypothesis_queued");
@@ -549,13 +563,14 @@ let handle_cycle ctx args =
       let code_result =
         let forced_hypothesis =
           Autoresearch.with_loops_rw (fun () ->
-            match Hashtbl.find_opt pending_hypotheses id with
-            | Some h ->
-                Hashtbl.remove pending_hypotheses id;
-                state.queued_hypothesis <- None;
-                Autoresearch.save_state ~base_path:ctx.base_path state;
-                Some h
-            | None -> get_string_opt args "hypothesis")
+            with_hypotheses_rw (fun () ->
+              match Hashtbl.find_opt pending_hypotheses id with
+              | Some h ->
+                  Hashtbl.remove pending_hypotheses id;
+                  state.queued_hypothesis <- None;
+                  Autoresearch.save_state ~base_path:ctx.base_path state;
+                  Some h
+              | None -> get_string_opt args "hypothesis"))
         in
           let generate = get_generator id in
           (match forced_hypothesis with

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -617,7 +617,21 @@ let execute_delegate_pipeline
                     ~worker_run_id ~worker_name
                     ~delegate_prompt;
                   Eio.Fiber.fork ~sw:sw_bg (fun () ->
-                      ignore (run_delegate ()));
+                      try ignore (run_delegate ())
+                      with
+                      | Eio.Cancel.Cancelled _ as exn -> raise exn
+                      | exn ->
+                        let err = Printexc.to_string exn in
+                        Log.Spawn.error
+                          "background delegate failed (worker_run_id=%s, agent=%s): %s"
+                          worker_run_id worker_name err;
+                        append_delegate_event ~worker_run_id
+                          ~worker_name ~delegate_prompt
+                          ?execution_scope
+                          ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                          ~trace_capability:"summary_only"
+                          ~resolved_runtime:"local"
+                          ~success:false ~error:err ());
                   Some
                     (`Assoc
                       [


### PR DESCRIPTION
## Summary

- **#2226**: Background delegate fiber (`tool_team_session_step.ml:620`) swallowed exceptions via `ignore(run_delegate())`. Now catches exceptions, logs via `Log.Spawn.error`, and records a `team_step_delegate` failure event — matching the existing pattern for background spawns at line 334.
- **#2213**: `pending_hypotheses` and `custom_generators` Hashtbl in `tool_autoresearch.ml` had no Eio.Mutex protection. Added `hypotheses_mu` with `with_hypotheses_rw`/`with_hypotheses_ro` wrappers around all access sites. Lock ordering: `loops_mu` → `hypotheses_mu` (consistent across all call sites).
- **#2216**: All `Unix.open_process_in` calls in `autoresearch_metric.ml` and `autoresearch_git.ml` replaced with `Process_eio.run_argv_with_status`, preventing Eio event loop freeze during metric measurement and git operations.

Closes #2226, closes #2213, closes #2216

## Test plan

- [ ] `dune build --root .` passes (verified locally)
- [ ] Verify autoresearch cycle runs without Eio freeze (metric + git operations)
- [ ] Verify background delegate failures are logged in stderr
- [ ] Verify concurrent hypothesis injection does not corrupt Hashtbl

🤖 Generated with [Claude Code](https://claude.com/claude-code)