### PR TITLE
fix(dashboard): restore base .dashboard-layout grid

### DIFF
--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -484,6 +484,20 @@ a:hover {
   }
 }
 
+/* Main 2-column layout — sidebar + content */
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 20px;
+  padding: 16px 20px 32px;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+.dashboard-main {
+  min-width: 0;
+}
+
 @media (max-width: 1200px) {
 
   .dashboard-layout {


### PR DESCRIPTION
## Summary

- Tailwind v4 migration PRs (#2266-#2288) deleted the base `.dashboard-layout` CSS rule, leaving only the `@media (max-width: 1200px)` override
- The 2-column grid (280px sidebar + 1fr content) was gone -- everything stacked vertically
- Added back the base `.dashboard-layout` grid definition and the missing `.dashboard-main` rule before the media query block

## Changes

`dashboard/src/styles/global.css`: 14 lines added (2 CSS rules)

## Verification

- `npm run build` passes (tsc + vite)
- Built CSS contains `.dashboard-layout{...display:grid}` with `grid-template-columns:280px 1fr`
- Built CSS contains `.dashboard-main{min-width:0}`