### PR TITLE
fix(chain): apply per-node timeout in execute_model_node

### DIFF
--- a/lib/chain/chain_executor_eio.ml
+++ b/lib/chain/chain_executor_eio.ml
@@ -21,7 +21,7 @@ include Chain_executor_leaf
 (** Forward declaration for recursive execution *)
 let rec execute_node ctx ~sw ~clock ~exec_fn ~tool_exec (node : node) : (string, string) result =
   match node.node_type with
-  | Model _ -> execute_model_node ctx ~exec_fn ~node node.node_type
+  | Model _ -> execute_model_node ctx ~clock ~exec_fn ~node node.node_type
   | Tool _ -> execute_tool_node ctx ~tool_exec ~node node.node_type
   | Pipeline nodes -> execute_pipeline ctx ~sw ~clock ~exec_fn ~tool_exec node nodes
   | Fanout nodes -> execute_fanout ctx ~sw ~clock ~exec_fn ~tool_exec node nodes

--- a/lib/chain/chain_executor_leaf.ml
+++ b/lib/chain/chain_executor_leaf.ml
@@ -11,9 +11,9 @@
 include Chain_executor_helpers
 
 (** Execute a single MODEL node *)
-let execute_model_node ctx ~(exec_fn : exec_fn) ~(node : node) (model : node_type) : (string, string) result =
+let execute_model_node ctx ~clock ~(exec_fn : exec_fn) ~(node : node) (model : node_type) : (string, string) result =
   match model with
-  | Model { model; system; prompt; timeout = _; tools; prompt_ref; prompt_vars = _; thinking } ->
+  | Model { model; system; prompt; timeout; tools; prompt_ref; prompt_vars = _; thinking } ->
       let inputs = resolve_inputs ctx node.input_mapping in
       let resolved_prompt = substitute_prompt prompt inputs in
       (* Apply iteration variable substitution if in GoalDriven context *)
@@ -205,7 +205,21 @@ let execute_model_node ctx ~(exec_fn : exec_fn) ~(node : node) (model : node_typ
             (* Pass through MODEL errors as before *)
             Error msg
       in
-      let final_result = try_with_empty_guard ~attempt:1 ~prompt_to_use:prompt_with_context in
+      let final_result =
+        let run () = try_with_empty_guard ~attempt:1 ~prompt_to_use:prompt_with_context in
+        match timeout with
+        | Some secs when secs > 0 ->
+            let timeout_s = float_of_int secs in
+            (match Eio.Time.with_timeout clock timeout_s (fun () -> Ok (run ())) with
+             | Ok r -> r
+             | Error `Timeout ->
+                 let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
+                 record_complete ctx node.id ~duration_ms ~success:false ~node_type:"model";
+                 record_error ctx node.id ~node_type:"model"
+                   (Printf.sprintf "MODEL node timed out after %ds" secs);
+                 Error (Printf.sprintf "MODEL node timed out after %ds" secs))
+        | _ -> run ()
+      in
       (match final_result with
       | Ok output -> Ok output
       | Error msg ->


### PR DESCRIPTION
## Summary
- Fixes per-node timeout being ignored in `chain_executor_leaf.ml:16` where `timeout = _` discarded the value.
- Adds `~clock` parameter to `execute_model_node` and wraps the `exec_fn` call with `Eio.Time.with_timeout` when a positive timeout is specified.
- On timeout, records completion/error metrics and returns a descriptive error.

Closes #2218

## Test plan
- [x] `dune build --root .` passes
- [x] 142 chain tests pass (`test_chain_coverage`)
- [x] Chain orchestrator tests pass (`test_chain_orchestrator_eio`)
- [x] Chain native eio bootstrap test passes

Generated with [Claude Code](https://claude.com/claude-code)