### PR TITLE
fix(autoresearch): re-raise Eio.Cancel.Cancelled in knowledge fetch

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -77,7 +77,9 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
       timestamp = (try member "timestamp" json |> to_float
                    with _ -> Unix.gettimeofday ());
     }
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
 
 (** {1 Storage (JSONL)} *)
 


### PR DESCRIPTION
## Summary
- The broad `with exn ->` catch in `finding_of_yojson` (line 80) swallowed `Eio.Cancel.Cancelled`, preventing cooperative cancellation from propagating through Eio fibers.
- Added explicit re-raise of `Eio.Cancel.Cancelled _` before the catch-all fallback.

## Test plan
- [x] `dune build --root .` passes
- [x] `test_autoresearch_knowledge.exe` — 3/3 tests pass (roundtrip, no-match, serialization)

Generated with [Claude Code](https://claude.com/claude-code)