### PR TITLE
fix(dashboard): SSE prefix mismatch, anchor hijack, TRPG archive, duplicate classes

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -261,7 +261,7 @@ export function ActivityGraphSurface() {
         </div>
         <${StatsRow} data=${data} />
         <${GraphView} data=${data} />
-        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" class="mt-2">
+        <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
           <span>생성 시각: ${data.generated_at}</span>
           <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
           ${data.window.room_id ? html`<span>room: ${data.window.room_id}</span>` : null}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -108,12 +108,12 @@ export function AgentDetailOverlay() {
                 <h2 class="m-0 flex items-baseline gap-2 text-[var(--text-strong)] text-xl">
                   ${displayName}
                   ${koreanName ? html`<span class="text-xs text-[var(--text-dim)]">(${koreanName})</span>` : ''}
-                  ${secondaryLabel ? html`<span class="font-mono" class="text-xs text-[var(--text-dim)]">${secondaryLabel}</span>` : ''}
+                  ${secondaryLabel ? html`<span class="font-mono text-xs text-[var(--text-dim)]">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div class="flex items-center gap-2 mt-1 flex-wrap">
                   <${StatusBadge} status=${headerStatus} />
                   ${isArchivedParticipant ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">archived session participant</span>` : null}
-                  ${agent?.model ? html`<span class="font-mono" class="text-xs bg-[#2a2a4a] px-1.5 py-0.5 rounded">${agent.model}</span>` : ''}
+                  ${agent?.model ? html`<span class="font-mono text-xs bg-[#2a2a4a] px-1.5 py-0.5 rounded">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span class="text-xs text-[var(--text-dim)]">${missionBrief.archived_reason}</span>`
                     : null}

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -57,7 +57,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${todo.length}</span>
           </div>
           ${sortedTodo.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">대기 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">대기 중인 태스크가 없습니다</div>`
             : sortedTodo.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -66,7 +66,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${inProgress.length}</span>
           </div>
           ${sortedInProgress.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">진행 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">진행 중인 태스크가 없습니다</div>`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -75,10 +75,10 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${done.length}</span>
           </div>
           ${sortedDone.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">완료된 태스크가 없습니다</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">완료된 태스크가 없습니다</div>`
             : sortedDone.slice(0, 20).map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
           ${sortedDone.length > 20
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="opacity-50">...외 ${sortedDone.length - 20}개 더 있음</div>`
+            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">...외 ${sortedDone.length - 20}개 더 있음</div>`
             : null}
         </div>
       </div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -187,7 +187,7 @@ function EditCheckbox({ field, label }: { field: keyof EditDraft; label: string 
   if (!d) return null
   const val = d[field] as boolean
   return html`
-    <div class="keeper-signal-row rounded-lg" class="mt-1">
+    <div class="keeper-signal-row rounded-lg mt-1">
       <span>${label}</span>
       <input
         type="checkbox"
@@ -203,7 +203,7 @@ function EditNumber({ field, label, min, max }: { field: keyof EditDraft; label:
   if (!d) return null
   const val = d[field] as number
   return html`
-    <div class="keeper-signal-row rounded-lg" class="mt-1">
+    <div class="keeper-signal-row rounded-lg mt-1">
       <span>${label}</span>
       <input
         type="number"

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -167,7 +167,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   const lineColor = lastRatio > 85 ? '#ef4444' : lastRatio > 70 ? '#f59e0b' : '#22c55e'
 
   return html`
-    <div class="context-chart" class="flex items-center gap-2">
+    <div class="context-chart flex items-center gap-2">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" style="background:#1a1a2e;border-radius:4px">
         <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
@@ -229,9 +229,9 @@ export function FieldDictionary({ keeper }: { keeper: Keeper }) {
       `)}
       ${keeper.trace_id ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Trace ID</span><span class="keeper-field-key font-mono">${keeper.trace_id}</span></div>` : ''}
       ${keeper.agent_name ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Agent</span><span class="flex-1 text-right text-[#ccc]">${keeper.agent_name}</span></div>` : ''}
-      ${keeper.primary_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Primary Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.primary_model}</span></div>` : ''}
-      ${keeper.active_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Active Model</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.active_model}</span></div>` : ''}
-      ${keeper.next_model_hint ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Next Model Hint</span><span class="font-mono" class="flex-1 text-right text-[#ccc]">${keeper.next_model_hint}</span></div>` : ''}
+      ${keeper.primary_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Primary Model</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.primary_model}</span></div>` : ''}
+      ${keeper.active_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Active Model</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.active_model}</span></div>` : ''}
+      ${keeper.next_model_hint ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Next Model Hint</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.next_model_hint}</span></div>` : ''}
       ${keeper.skill_primary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Primary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_primary}</span></div>` : ''}
       ${keeper.skill_secondary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Secondary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_secondary}</span></div>` : ''}
       ${keeper.skill_reason ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill Reason</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_reason}</span></div>` : ''}
@@ -295,7 +295,7 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 }
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">장비 없음</div>`
+  if (items.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">장비 없음</div>`
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -311,7 +311,7 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">관계 없음</div>`
+  if (entries.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">관계 없음</div>`
 
   return html`
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -249,7 +249,7 @@ export function KeeperDetailOverlay() {
                     ${keeper.memory_recent_note}
                   </div>
                 `
-                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-xs">No recent memory note</div>`}
+                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-xs">No recent memory note</div>`}
             </div>
           <//>
         </div>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -274,7 +274,7 @@ function PostCard({ post }: { post: BoardPost }) {
               </div>
             </div>
           <div class="flex gap-2.5 items-center flex-wrap text-[length:var(--fs-xs)] text-[#90a4cc]">
-            <span>작성자 <a class="author-link" class="cursor-pointer underline" onClick=${(e: Event) => { e.stopPropagation(); navigate('status', { section: 'agents', agent: post.author }) }}>${post.author}</a></span>
+            <span>작성자 <a class="author-link cursor-pointer underline" onClick=${(e: Event) => { e.stopPropagation(); navigate('status', { section: 'agents', agent: post.author }) }}>${post.author}</a></span>
             <span><${TimeAgo} timestamp=${post.created_at} /></span>
             ${isUpdated(post) ? html`<span>수정 <${TimeAgo} timestamp=${post.updated_at} /></span>` : null}
             <span>댓글 ${post.comment_count}</span>
@@ -302,7 +302,7 @@ function CommentItem({ comment }: { comment: BoardComment }) {
 
   return html`
     <div class="board-comment rounded-lg">
-      <span class="comment-author"><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a></span>
+      <span class="comment-author"><a class="author-link cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a></span>
       <span class="comment-time"><${TimeAgo} timestamp=${comment.created_at} /></span>
       <div class="comment-text">${comment.content}</div>
       ${needsTruncation ? html`
@@ -317,7 +317,7 @@ function CommentItem({ comment }: { comment: BoardComment }) {
 }
 
 function CommentThread({ comments }: { comments: BoardComment[] }) {
-  if (comments.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]" class="text-[13px]">아직 댓글이 없습니다</div>`
+  if (comments.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">아직 댓글이 없습니다</div>`
 
   return html`
     <div class="comment-thread flex flex-col gap-2">
@@ -328,7 +328,7 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
 
 function CommentForm({ postId }: { postId: string }) {
   return html`
-    <div class="comment-form" class="mt-3 flex gap-2">
+    <div class="comment-form mt-3 flex gap-2">
       <input
         type="text"
         class="font-[inherit]"
@@ -374,13 +374,13 @@ function PostDetail({ post }: { post: BoardPost }) {
             <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
           <div class="flex gap-2.5 items-center flex-wrap mt-3 text-[length:var(--fs-xs)] text-[#90a4cc]">
-            <span><a class="author-link" class="cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a></span>
+            <span><a class="author-link cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a></span>
             <${TimeAgo} timestamp=${post.created_at} />
             <span>${post.votes ?? 0} votes</span>
           </div>
           ${(post.hearth || post.visibility || post.expires_at)
             ? html`
-                <div class="post-chip-row" class="mt-2">
+                <div class="post-chip-row mt-2">
                   ${post.hearth ? html`<span class="board-meta-chip rounded-full">${post.hearth}</span>` : null}
                   ${post.visibility ? html`<span class="board-meta-chip rounded-full">${post.visibility}</span>` : null}
                   ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip rounded-full">${boardPostKind(post)}</span>` : null}
@@ -392,7 +392,7 @@ function PostDetail({ post }: { post: BoardPost }) {
             ? html`
                 <details class="mt-3">
                   <summary>운영 메타</summary>
-                  <div class="post-body" class="mt-2">
+                  <div class="post-body mt-2">
                     ${post.meta.source ? html`<div><strong>출처</strong>: ${post.meta.source}</div>` : null}
                     ${post.meta.state_block
                       ? html`<pre class="whitespace-pre-wrap mt-2">${post.meta.state_block}</pre>`

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -179,10 +179,10 @@ export function Mission() {
       </div>
 
       <nav class="mission-jump-strip flex gap-2 flex-wrap">
-        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-sessions">세션 ${sessionRows.length}</a>
-        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-keepers">키퍼 ${keeperRows.length}</a>
-        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-output">활동</a>
-        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full" href="#mission-attention">우선순위 ${attentionQueue.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full cursor-pointer" onClick=${(e: Event) => { e.preventDefault(); document.getElementById('mission-sessions')?.scrollIntoView({ behavior: 'smooth' }) }}>세션 ${sessionRows.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full cursor-pointer" onClick=${(e: Event) => { e.preventDefault(); document.getElementById('mission-keepers')?.scrollIntoView({ behavior: 'smooth' }) }}>키퍼 ${keeperRows.length}</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full cursor-pointer" onClick=${(e: Event) => { e.preventDefault(); document.getElementById('mission-output')?.scrollIntoView({ behavior: 'smooth' }) }}>활동</a>
+        <a class="px-2.5 py-1 border border-[var(--border-slate-22)] bg-[var(--white-3)] text-[#9fb8e1] text-[length:var(--fs-sm)] no-underline transition-colors duration-150 hover:bg-[var(--white-8)] rounded-full cursor-pointer" onClick=${(e: Event) => { e.preventDefault(); document.getElementById('mission-attention')?.scrollIntoView({ behavior: 'smooth' }) }}>우선순위 ${attentionQueue.length}</a>
       </nav>
 
       ${activeSessionId

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -146,7 +146,7 @@ export function Proof() {
       </div>
       <details class="mb-3">
         <summary style="cursor: pointer; color: rgba(255,255,255,0.5); font-size: 13px; padding: 6px 0;">상세 지표 (${8}개)</summary>
-        <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3" class="mt-2">
+        <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3 mt-2">
           <div class="summary-stat-card rounded-xl ${verdictTone(liveVerdict)}">
             <span>Live 판정</span>
             <strong>${liveVerdict}</strong>

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -67,7 +67,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" class="mt-2">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -1,16 +1,44 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { refreshTrpg, trpgLoading, trpgRoom, trpgState } from '../store'
+
+/** When true the TRPG backend returned 410 Gone (module archived). */
+const trpgArchived = signal(false)
+
+async function safeFetchTrpg(): Promise<void> {
+  try {
+    await refreshTrpg()
+  } catch (err: unknown) {
+    // Detect 410 Gone — the TRPG module has been archived server-side.
+    if (
+      err instanceof Error
+      && /\b410\b/.test(err.message)
+    ) {
+      trpgArchived.value = true
+    }
+  }
+}
 
 export function Trpg() {
   const state = trpgState.value
   const loading = trpgLoading.value
+  const archived = trpgArchived.value
 
   useEffect(() => {
-    if (!state && !loading) {
-      void refreshTrpg()
+    if (!state && !loading && !archived) {
+      void safeFetchTrpg()
     }
-  }, [state, loading])
+  }, [state, loading, archived])
+
+  if (archived) {
+    return html`
+      <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+        <div style="margin-bottom: 8px; font-size: 1.1em;">TRPG 모듈은 아카이브되었습니다</div>
+        <div style="font-size: 0.9em; opacity: 0.7;">이 모듈은 더 이상 활성 상태가 아닙니다. 과거 세션 기록은 서버 로그에 남아 있습니다.</div>
+      </div>
+    `
+  }
 
   if (loading && !state) {
     return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">TRPG 상태를 불러오는 중...</div>`
@@ -20,7 +48,7 @@ export function Trpg() {
     return html`
       <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
         <div style="margin-bottom: 12px;">활성 TRPG 세션이 없습니다.</div>
-        <button class="control-btn rounded-lg ghost" onClick=${() => void refreshTrpg()}>새로고침</button>
+        <button class="control-btn rounded-lg ghost" onClick=${() => void safeFetchTrpg()}>새로고침</button>
       </div>
     `
   }

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -66,15 +66,18 @@ interface SimpleRoute {
 }
 
 const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
-  // Agent lifecycle
-  agent_joined:   { target: 'execution' },
-  agent_left:     { target: 'execution' },
+  // Agent lifecycle (server may emit with or without "masc/" prefix)
+  agent_joined:          { target: 'execution' },
+  'masc/agent_joined':   { target: 'execution' },
+  agent_left:            { target: 'execution' },
+  'masc/agent_left':     { target: 'execution' },
   // Broadcasts
-  broadcast:      { target: 'execution' },
+  broadcast:             { target: 'execution' },
+  'masc/broadcast':      { target: 'execution' },
   // Keeper lifecycle (also triggers operator refresh via handler)
-  keeper_handoff:       { target: 'execution' },
-  keeper_compaction:    { target: 'execution' },
-  keeper_guardrail:     { target: 'execution' },
+  keeper_handoff:        { target: 'execution' },
+  keeper_compaction:     { target: 'execution' },
+  keeper_guardrail:      { target: 'execution' },
   // Client input
   client_input_approved:  { target: 'operator', debounceMs: 300 },
   client_input_rejected:  { target: 'operator', debounceMs: 300 },
@@ -108,6 +111,7 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
 
 const KEEPER_LIFECYCLE_EVENTS = new Set([
   'keeper_handoff', 'keeper_compaction', 'keeper_guardrail', 'keeper_turn_complete',
+  'masc/keeper_handoff', 'masc/keeper_compaction', 'masc/keeper_guardrail', 'masc/keeper_turn_complete',
 ])
 
 function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -184,7 +184,17 @@ export function connectSSE(): void {
 }
 
 function handleEvent(event: SSEEvent): void {
-  const type = event.type
+  // Normalize: server may emit "masc/agent_joined" or "agent_joined".
+  // Strip the "masc/" prefix for the core event types so both forms match
+  // the same switch cases.  Keep the original type for OAS/namespaced events
+  // that genuinely use colons or other prefixes.
+  const rawType = event.type
+  const MASC_PREFIX = 'masc/'
+  const type =
+    rawType.startsWith(MASC_PREFIX)
+    && !rawType.startsWith('masc/board_')   // board_post/board_comment already have explicit cases
+      ? rawType.slice(MASC_PREFIX.length)
+      : rawType
   const agent = event.agent ?? event.author ?? event.from ?? event.from_agent ?? ''
 
   switch (type) {


### PR DESCRIPTION
## Summary
- **B2 (SSE prefix)**: Server emits `masc/agent_joined`, `masc/agent_left`, `masc/broadcast` but dashboard only matched unprefixed forms. Added prefixed keys to `SIMPLE_ROUTES` and `KEEPER_LIFECYCLE_EVENTS`, plus early normalization in `handleEvent()` for the switch cases.
- **B3 (Mission anchors)**: Four `<a href="#mission-...">` links were changing `location.hash`, breaking the hash router. Replaced with `onClick` + `scrollIntoView({ behavior: 'smooth' })`.
- **B1 (TRPG archived)**: TRPG APIs return 410 Gone since the module was archived. Now detects 410 and shows a clear "archived" notice instead of error state.
- **D1 (Duplicate class attrs)**: Merged 25 duplicate `class="..."` attributes into single `class` attrs across 10 component files.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] SSE events with `masc/` prefix trigger correct refresh targets
- [ ] Mission jump links scroll without changing hash route
- [ ] TRPG tab shows archived notice instead of error
- [ ] No duplicate `class=""` attributes remain (verified via regex search)

Generated with [Claude Code](https://claude.com/claude-code)