### PR TITLE
fix: block cross-origin browser tool mutations

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -175,6 +175,58 @@ let agent_from_request request =
            | Some v -> Some (decode v)
            | None -> Option.map decode (query_param request "agent_name"))
 
+let effective_port_of_uri (uri : Uri.t) =
+  match Uri.port uri with
+  | Some port -> Some port
+  | None -> (
+      match Uri.scheme uri with
+      | Some "http" -> Some 80
+      | Some "https" -> Some 443
+      | _ -> None)
+
+let host_port_of_origin origin =
+  try
+    let uri = Uri.of_string origin in
+    match Uri.host uri with
+    | None -> None
+    | Some host ->
+        Some
+          ( String.trim host |> String.lowercase_ascii,
+            effective_port_of_uri uri )
+  with _ -> None
+
+let host_port_of_request request =
+  match Httpun.Headers.get request.Httpun.Request.headers "host" with
+  | None -> None
+  | Some host_header -> (
+      try
+        let uri = Uri.of_string ("http://" ^ host_header) in
+        match Uri.host uri with
+        | None -> None
+        | Some host ->
+            Some
+              ( String.trim host |> String.lowercase_ascii,
+                effective_port_of_uri uri )
+      with _ -> None)
+
+let ensure_same_origin_browser_request request :
+    (unit, Types.masc_error) result =
+  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
+  | None -> Ok ()
+  | Some origin -> (
+      match host_port_of_origin origin, host_port_of_request request with
+      | Some (origin_host, origin_port), Some (request_host, request_port)
+        when String.equal origin_host request_host
+             && origin_port = request_port ->
+          Ok ()
+      | _ ->
+          Error
+            (Types.Forbidden
+               {
+                 agent = "browser";
+                 action = "cross-origin HTTP mutation";
+               }))
+
 let http_status_of_auth_error = function
   | Types.Unauthorized _ | Types.InvalidToken _ | Types.TokenExpired _ -> `Unauthorized
   | Types.Forbidden _ -> `Forbidden
@@ -310,7 +362,15 @@ let authorize_tool_request ~base_path ~tool_name request :
     (unit, Types.masc_error) result =
   let auth_cfg = Auth.load_auth_config base_path in
   let token = auth_token_from_request request in
-  match ensure_strict_http_token_auth ~endpoint:("HTTP tool access for " ^ tool_name) auth_cfg with
+  match
+    if Option.is_some token then Ok ()
+    else ensure_same_origin_browser_request request
+  with
+  | Error err -> Error err
+  | Ok () ->
+      (match ensure_strict_http_token_auth
+               ~endpoint:("HTTP tool access for " ^ tool_name) auth_cfg
+       with
   | Error msg -> Error (Types.Unauthorized msg)
   | Ok auth_cfg -> (
       match resolve_agent_name_for_auth ~base_path request ~token with
@@ -325,7 +385,7 @@ let authorize_tool_request ~base_path ~tool_name request :
               (Types.Unauthorized
                  "Agent name required (X-MASC-Agent or token-bound credential)")
           else
-            Auth.authorize_tool base_path ~agent_name ~token ~tool_name)
+            Auth.authorize_tool base_path ~agent_name ~token ~tool_name))
 
 let authorize_token_bound_permission_request ~base_path ~permission request :
     (string, Types.masc_error) result =

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -261,6 +261,47 @@ let test_permission_for_tool_interrupt () =
   | _ -> fail "expected CanInterrupt"
 
 (* ============================================================
+   HTTP same-origin mutation guard regressions
+   ============================================================ *)
+
+let test_same_origin_browser_request_allows_missing_origin () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers = Httpun.Headers.of_list [ ("host", "127.0.0.1:8935") ] in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_same_origin_browser_request_allows_matching_origin () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "127.0.0.1:8935");
+        ("origin", "http://127.0.0.1:8935");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_same_origin_browser_request_rejects_cross_origin () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "127.0.0.1:8935");
+        ("origin", "https://evil.example");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> fail "expected cross-origin browser request to be rejected"
+  | Error (Types.Forbidden _) -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+(* ============================================================
    HTTP auth extraction regressions
    ============================================================ *)
 
@@ -559,5 +600,11 @@ let () =
       test_case "header token only" `Quick test_http_auth_token_from_header_only;
       test_case "reject query token fallback" `Quick
         test_http_auth_rejects_query_token_fallback;
+      test_case "same-origin allows missing origin" `Quick
+        test_same_origin_browser_request_allows_missing_origin;
+      test_case "same-origin allows matching origin" `Quick
+        test_same_origin_browser_request_allows_matching_origin;
+      test_case "same-origin rejects cross origin" `Quick
+        test_same_origin_browser_request_rejects_cross_origin;
     ];
   ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -81,6 +81,12 @@ let test_http_write_auth_contracts () =
   check bool "server auth exposes token-bound route helper" true
     (file_contains_pattern "lib/server/server_auth.ml"
        "and with_token_permission_auth");
+  check bool "server auth defines same-origin browser guard" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "let ensure_same_origin_browser_request");
+  check bool "tool auth enforces same-origin when no bearer token" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "else ensure_same_origin_browser_request request");
   check bool "broadcast route requires token-bound broadcast permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        {|with_token_permission_auth ~permission:Types.CanBroadcast|});


### PR DESCRIPTION
## Summary
- reject cross-origin browser-origin requests for tool-auth HTTP mutations when no bearer token is present
- keep same-origin dashboard/browser flows working while blocking localhost drive-by writes
- add regression coverage for same-origin auth guard and source contracts

## Testing
- git diff --check
- dune build --root . test/test_auth_coverage.exe test/test_ci_hardening_source.exe bin/main_eio.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_ci_hardening_source.exe