### PR TITLE
fix(dashboard): improve home page layout, spacing, and visual hierarchy

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -178,15 +178,17 @@ export function SideRail() {
           `
         })()}
 
-        <div class="mt-3.5 pt-2.5 border-t border-[var(--card-border)] grid gap-1">
-          <div class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">현재 화면</div>
-          <strong class="text-[color:var(--text-strong)] text-sm">${currentSection ? `${currentView?.label ?? current} · ${currentSection.label}` : currentView?.label ?? current}</strong>
-          <p class="text-[color:var(--text-muted)] text-xs leading-[1.45]">${currentSection?.description ?? currentView?.description ?? '운영 화면'}</p>
-        </div>
+        ${current !== 'home' ? html`
+          <div class="mt-3.5 pt-2.5 border-t border-[var(--card-border)] grid gap-1">
+            <div class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">현재 화면</div>
+            <strong class="text-[color:var(--text-strong)] text-sm">${currentSection ? `${currentView?.label ?? current} · ${currentSection.label}` : currentView?.label ?? current}</strong>
+            <p class="text-[color:var(--text-muted)] text-xs leading-[1.45]">${currentSection?.description ?? currentView?.description ?? '운영 화면'}</p>
+          </div>
+        ` : null}
       </section>
 
       <${SnapshotCard} currentTab=${current} />
-      <${InterveneRailCard} />
+      ${current !== 'home' ? html`<${InterveneRailCard} />` : null}
     </aside>
   `
 }

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -82,7 +82,11 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
   if (raw.length === 0) {
     return html`
       <div class="narrative-timeline">
-        <div class="text-text-muted text-center p-3 text-sm">이벤트 대기 중...</div>
+        <div class="flex flex-col items-center justify-center gap-3 py-10 px-4 border border-dashed border-[var(--border-slate-16)] rounded-lg bg-[var(--white-2)]">
+          <span class="text-2xl opacity-40">📡</span>
+          <div class="text-text-muted text-sm text-center">이벤트 대기 중</div>
+          <div class="text-text-muted text-xs text-center opacity-60 max-w-[32ch] leading-[1.5]">에이전트 활동, 세션 변경, 시스템 이벤트가 여기에 실시간으로 나타납니다.</div>
+        </div>
       </div>
     `
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -83,11 +83,11 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
 
   return html`
     <div
-      class="hot-session-card rounded-xl rounded-lg ${s.blocker_summary ? 'border-[var(--bad)] bg-[rgba(239,68,68,0.06)]' : ''}"
+      class="hot-session-card rounded-lg p-3 border border-[var(--border-slate-16)] bg-[var(--white-3)] cursor-pointer ${s.blocker_summary ? 'border-[var(--bad)] bg-[rgba(239,68,68,0.06)]' : ''}"
       key=${s.session_id}
       onClick=${() => navigate('status', { section: 'sessions', session_id: s.session_id })}
     >
-      <div class="text-base font-semibold text-text-strong whitespace-nowrap overflow-hidden text-ellipsis">${primary}</div>
+      <div class="text-sm font-semibold text-text-strong leading-[1.35] line-clamp-2">${primary}</div>
       ${secondary ? html`<div class="hot-session-card__context">${secondary}</div>` : null}
       <div class="flex flex-wrap gap-1.5 mt-2">
         ${creator
@@ -120,7 +120,7 @@ type SessionLaneProps = {
 
 function SessionLane({ title, description, tone, sessions, emptyCopy }: SessionLaneProps) {
   return html`
-    <section class="hot-session-lane hot-session-lane--${tone}">
+    <section class="hot-session-lane hot-session-lane--${tone} rounded-lg border border-[var(--border-slate-12)] p-3.5 grid gap-3">
       <div class="flex items-start justify-between gap-3">
         <div>
           <div class="flex items-center gap-2">
@@ -131,7 +131,7 @@ function SessionLane({ title, description, tone, sessions, emptyCopy }: SessionL
         </div>
       </div>
       ${sessions.length > 0
-        ? html`<div class="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">${sessions.map(renderSessionCard)}</div>`
+        ? html`<div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-2">${sessions.map(renderSessionCard)}</div>`
         : html`<div class="grid place-items-center min-h-[116px] p-3 border border-dashed border-[var(--border-slate-18)] text-[color:var(--text-muted)] text-[length:var(--fs-sm)] text-center bg-[var(--white-2)] rounded-lg">${emptyCopy}</div>`}
     </section>
   `
@@ -205,17 +205,17 @@ function AgentPulse() {
         linkLabel="전체 보기"
         onLink=${() => navigate('status', { section: 'agents' })}
       />
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-1">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2">
         ${agents.map((a: ObservatoryAgent) => html`
           <div
-            class="flex items-center gap-2 py-1.5 px-2.5 cursor-pointer transition-[background] duration-150 hover:bg-[var(--white-4)] rounded-xl rounded-md agent-pulse-card--${a.state}"
+            class="flex items-center gap-3 py-2.5 px-3 cursor-pointer transition-[background] duration-150 hover:bg-[var(--white-4)] rounded-lg border border-[var(--border-slate-12)] bg-[var(--white-2)] agent-pulse-card--${a.state}"
             key=${a.name}
             onClick=${() => navigate('status', { section: 'agents', agent: a.name })}
           >
-            <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${28} />
-            <div class="flex flex-col min-w-0">
-              <span class="text-sm font-semibold text-text-strong whitespace-nowrap overflow-hidden text-ellipsis">${a.koreanName ?? a.name}</span>
-              <span class="text-xs text-text-muted whitespace-nowrap overflow-hidden text-ellipsis">
+            <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${32} />
+            <div class="flex flex-col min-w-0 gap-0.5">
+              <span class="text-sm font-semibold text-text-strong">${a.koreanName ?? a.name}</span>
+              <span class="text-xs text-text-muted leading-[1.4] line-clamp-2">
                 ${stateIcon(a.state)} ${a.focus ?? a.currentTask ?? a.status}
               </span>
             </div>
@@ -233,22 +233,27 @@ export function Overview() {
   const roomHealth = snap?.summary?.room_health ?? null
 
   return html`
-    <div class="grid gap-4">
+    <div class="grid gap-5">
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
       <${AttentionSpotlight} snap=${snap} />
 
-      <div class="grid gap-4">
+      <section class="grid gap-5 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
         <${HotSessions} />
+      </section>
+
+      <section class="grid gap-3 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
         <${AgentPulse} />
+      </section>
 
-        <${OasPipeline} />
+      <${OasPipeline} />
 
+      <section class="grid gap-3 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
         <${HomeSectionHeader}
           label="최근 활동"
-         
+
         />
         <${NarrativeTimeline} entries=${journal} maxItems=${8} />
-      </div>
+      </section>
     </div>
   `
 }

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -29,21 +29,21 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
         <span class="inline-flex items-center py-1 px-[9px] text-[10px] uppercase tracking-[0.08em] rounded-full border border-solid ${liveConnected ? 'text-[#86efac] border-[var(--ok-30)] bg-[var(--ok-12)]' : 'text-[#fda4af] border-[rgba(239,68,68,0.28)] bg-[var(--bad-12)]'}">${liveConnected ? '연결됨' : '오프라인'}</span>
       </div>
       <div class="grid grid-cols-2 gap-2">
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">에이전트</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${agents.value.length}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
+          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">에이전트</span>
+          <strong class="text-[color:var(--accent)] text-lg leading-[1.1] tabular-nums">${agents.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">키퍼</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${keepers.value.length}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
+          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">키퍼</span>
+          <strong class="text-[color:var(--ok)] text-lg leading-[1.1] tabular-nums">${keepers.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">태스크</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${tasks.value.length}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
+          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">태스크</span>
+          <strong class="text-[color:var(--warn)] text-lg leading-[1.1] tabular-nums">${tasks.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">이벤트</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${eventCount.value}</strong>
+        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
+          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">이벤트</span>
+          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1] tabular-nums">${eventCount.value}</strong>
         </div>
       </div>
       <div class="rail-inline-actions mt-3 grid grid-cols-2 gap-2">

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -86,6 +86,10 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  margin-top: 2px;
 }
 
 /* Agent Pulse */


### PR DESCRIPTION
## Summary
6 design fixes for the home page based on visual inspection:

1. **Agent cards**: wider grid (260px min), text wraps instead of truncating, borders + background
2. **Empty timeline**: structured empty state with icon + description instead of bare text
3. **Stat cards**: label hierarchy fixed — labels more readable, color-coded per metric
4. **Sidebar**: removed duplicate "홈" label
5. **InterveneRailCard**: hidden on home tab (not relevant for overview)
6. **Section spacing**: added borders, subtle backgrounds, consistent padding to all sections

## Test plan
- [x] `npx vite build` — pass

Generated with [Claude Code](https://claude.com/claude-code)