### PR TITLE
refactor(dashboard): @keyframes consolidate + tone utilities (2,406 lines)

### DIFF
--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -19,12 +19,12 @@ import { operatorSnapshot } from '../../operator-store'
 import { route } from '../../router'
 import type { DashboardWorkflowContext } from '../../workflow-context'
 import { relativeTime, formatElapsed } from '../../lib/format-time'
-import { toneClass, chainStatusTone, sessionStatusTone, expiryTone } from '../../lib/tone'
+import { toneClass, toneBorder, toneBg, chainStatusTone, sessionStatusTone, expiryTone } from '../../lib/tone'
 import { prettyJson, displayStatus } from '../../lib/status-label'
 
 // ── Pure helpers ──────────────────────────────
 
-export { relativeTime, formatElapsed, toneClass, chainStatusTone, sessionStatusTone, expiryTone, prettyJson, displayStatus }
+export { relativeTime, formatElapsed, toneClass, toneBorder, toneBg, chainStatusTone, sessionStatusTone, expiryTone, prettyJson, displayStatus }
 
 export function alertBorderTone(tone: string): string {
   if (tone === 'warn') return 'border-[rgba(251,191,36,0.26)]'

--- a/dashboard/src/components/command/war-room-panels.ts
+++ b/dashboard/src/components/command/war-room-panels.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { displayStatus, relativeTime, sessionStatusTone, toneClass } from './helpers'
+import { displayStatus, relativeTime, sessionStatusTone, toneClass, toneBorder } from './helpers'
 import { truncate } from '../../lib/truncate'
 
 type WarRoomWorkerView = {
@@ -104,7 +104,7 @@ export function WarRoomWorkerCard({ worker }: { worker: WarRoomWorkerView }) {
 
 export function WarRoomPresenceCard({ item }: { item: WarRoomPresenceView }) {
   return html`
-    <article class="cmd-card rounded-xl p-3 cmd-presence-card ${item.tone}">
+    <article class="cmd-card rounded-xl p-3 cmd-presence-card ${toneBorder(item.tone)}">
       <div class="cmd-card rounded-xl-head">
         <div>
           <strong>${item.name}</strong>
@@ -127,7 +127,7 @@ export function WarRoomPresenceCard({ item }: { item: WarRoomPresenceView }) {
 
 export function WarRoomFeedCard({ item }: { item: WarRoomFeedItem }) {
   return html`
-    <article class="grid grid-cols-[minmax(0,1fr)_minmax(220px,0.9fr)] gap-3.5 cmd-feed-card rounded-xl ${item.tone}">
+    <article class="grid grid-cols-[minmax(0,1fr)_minmax(220px,0.9fr)] gap-3.5 cmd-feed-card rounded-xl ${toneBorder(item.tone)}">
       <div class="min-w-0 [overflow-wrap:anywhere] break-words">
         <div class="flex justify-between items-start">
           <strong>${item.title}</strong>

--- a/dashboard/src/lib/tone.ts
+++ b/dashboard/src/lib/tone.ts
@@ -79,6 +79,19 @@ export function expiryTone(iso?: string | null): string {
   return ts <= Date.now() ? 'bad' : 'ok'
 }
 
+const TONE_BORDER: Record<string, string> = { ok: 'tone-border-ok', warn: 'tone-border-warn', bad: 'tone-border-bad' }
+const TONE_BG: Record<string, string> = { ok: 'tone-bg-ok', warn: 'tone-bg-warn', bad: 'tone-bg-bad' }
+
+/** Returns the tone-border-* utility class for a given tone value. */
+export function toneBorder(tone?: string | null): string {
+  return TONE_BORDER[toneClass(tone)] ?? 'tone-border-ok'
+}
+
+/** Returns the tone-bg-* utility class for a given tone value. */
+export function toneBg(tone?: string | null): string {
+  return TONE_BG[toneClass(tone)] ?? 'tone-bg-ok'
+}
+
 /** Governance tone — maps governance decision values to 'positive' | 'negative' | 'neutral'. */
 export function governanceToneClass(raw: string | null | undefined): string {
   const value = (raw || '').toLowerCase()

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -91,8 +91,3 @@
   color: var(--warn);
   animation: chatWarnPulse 2s ease-in-out infinite;
 }
-
-@keyframes chatWarnPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}

--- a/dashboard/src/styles/command-swarm.css
+++ b/dashboard/src/styles/command-swarm.css
@@ -96,15 +96,6 @@
 }
 .orchestra-signal-glyph { fill: var(--text-near-white); font-size: var(--fs-xs); font-weight: 700; }
 
-@keyframes orchestraFlow {
-  to { stroke-dashoffset: -40; }
-}
-
-@keyframes orchestraPulse {
-  0%, 100% { transform: scale(1); opacity: 0.92; }
-  50% { transform: scale(1.06); opacity: 1; }
-}
-
 /* ── SwarmHealthBar ────────────────────────────── */
 .swarm-health-seg { transition: flex 0.3s ease; }
 .swarm-health-seg.moving { background: var(--ok); }

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -151,12 +151,6 @@
   stroke: var(--bad); color: var(--bad);
   animation: pulse-ring 2s infinite;
 }
-@keyframes pulse-ring {
-  0% { opacity: 1; }
-  50% { opacity: 0.6; }
-  100% { opacity: 1; }
-}
-
 /* ── Agent card hover ── */
 .agent-card:hover {
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -352,9 +352,6 @@ a:hover {
 }
 
 @utility cmd-readiness-row {
-  &.warn { border-color: var(--warn-soft); }
-  &.ok { border-color: var(--ok-22); }
-  &.bad { border-color: var(--bad-soft); }
   & p { margin: 8px 0 0; color: var(--white-82); line-height: 1.5; }
 }
 
@@ -400,9 +397,8 @@ a:hover {
 @utility cmd-presence-card {
   background: linear-gradient(180deg, var(--white-5), var(--white-3h));
   border-color: rgba(148,163,184,0.18);
-  &.ok { border-color: var(--ok-24); display: grid; gap: 10px; }
-  &.warn { border-color: rgba(251,191,36,0.22); display: grid; gap: 10px; }
-  &.bad { border-color: rgba(248,113,113,0.26); display: grid; gap: 10px; }
+  display: grid;
+  gap: 10px;
 }
 
 @utility cmd-feed-card {
@@ -410,9 +406,6 @@ a:hover {
   border-color: rgba(148,163,184,0.18);
   display: grid;
   gap: 10px;
-  &.ok { border-color: var(--ok-24); }
-  &.warn { border-color: rgba(251,191,36,0.22); }
-  &.bad { border-color: rgba(248,113,113,0.26); }
 }
 
 @utility cmd-warroom-guidance {
@@ -570,78 +563,31 @@ a:hover {
 }
 
 @keyframes fadeSlide {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
-
 @keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.55;
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
 }
 
 @media (max-width: 1200px) {
-
-  .dashboard-layout {
-    grid-template-columns: 1fr;
-    gap: 14px;
-  }
-
+  .dashboard-layout { grid-template-columns: 1fr; gap: 14px; }
   .dashboard-rail {
-    position: static;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 10px;
-    max-height: none;
-    overflow-y: visible;
-    padding-right: 0;
+    position: static; display: grid; grid-template-columns: 1fr;
+    gap: 10px; max-height: none; overflow-y: visible; padding-right: 0;
   }
-
-  .rail-tab-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  .rail-tab-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
-
 @media (max-width: 880px) {
-
-  :root {
-    --header-h: 86px;
-  }
-
-  .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
-  }
-  .rail-tab-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
+  :root { --header-h: 86px; }
+  .stats-grid { grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); }
+  .rail-tab-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
-
 @media (max-width: 768px) {
-
-  .dashboard-rail {
-    grid-template-columns: 1fr;
-  }
-  .rail-inline-actions {
-    grid-template-columns: 1fr;
-  }
-
-  .rail-tab-list {
-    grid-template-columns: 1fr;
-  }
-
+  .dashboard-rail { grid-template-columns: 1fr; }
+  .rail-inline-actions { grid-template-columns: 1fr; }
+  .rail-tab-list { grid-template-columns: 1fr; }
 }
 
 /* prefers-reduced-motion handled by Tailwind motion-reduce: */
@@ -650,36 +596,12 @@ a:hover {
 /* connection-status/status-dot/event-count/pill/ctx-fill → Tailwind inline */
 
 /* status-dot-inline (dynamic status classes used by StatusBadge) */
-.status-dot-inline.in_progress,
-.status-dot-inline.running {
-  background: var(--warn);
-}
-
-.status-dot-inline.interrupted,
-.status-dot-inline.listening {
-  background: #38bdf8;
-}
-
-.status-dot-inline.inactive {
-  background: #5f7199;
-}
-
-.status-dot-inline.active {
-  background: var(--ok);
-}
-
-.status-dot-inline.busy,
-.status-dot-inline.stopped {
-  background: var(--text-slate);
-}
-
-.status-dot-inline.error {
-  background: #fb7185;
-}
-
-.status-dot-inline.offline {
-  background: #5f7199;
-}
+.status-dot-inline.in_progress, .status-dot-inline.running { background: var(--warn); }
+.status-dot-inline.interrupted, .status-dot-inline.listening { background: #38bdf8; }
+.status-dot-inline.inactive, .status-dot-inline.offline { background: #5f7199; }
+.status-dot-inline.active { background: var(--ok); }
+.status-dot-inline.busy, .status-dot-inline.stopped { background: var(--text-slate); }
+.status-dot-inline.error { background: #fb7185; }
 
 /* ── Animations (merged from animations.css) ── */
 /* ── Pixel avatar animations ──────────────────────────── */
@@ -722,5 +644,56 @@ a:hover {
   0%, 100% { border-color: var(--warn-28); }
   50% { border-color: rgba(251, 191, 36, 0.50); }
 }
+
+/* ── Component keyframes (consolidated) ──────────────────── */
+@keyframes blocker-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.4); }
+  50% { box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.7); }
+}
+@keyframes orchestraFlow { to { stroke-dashoffset: -40; } }
+@keyframes orchestraPulse {
+  0%, 100% { transform: scale(1); opacity: 0.92; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+@keyframes chatWarnPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+@keyframes livePulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--ok-25); }
+  50% { box-shadow: 0 0 8px 2px var(--ok-12); }
+}
+@keyframes activityFadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes keeper-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+@keyframes pulse-ring {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+@keyframes pipeline-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(96, 165, 250, 0); }
+  50% { box-shadow: 0 0 6px 2px rgba(96, 165, 250, 0.35); }
+}
+@keyframes pipeline-badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+@keyframes keeperPulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 var(--ok-40); }
+  50% { opacity: 0.6; box-shadow: 0 0 0 4px rgba(74,222,128,0); }
+}
+
+/* State tone utilities */
+.tone-border-ok { border-color: var(--ok-24); }
+.tone-border-warn { border-color: rgba(251,191,36,0.22); }
+.tone-border-bad { border-color: rgba(248,113,113,0.26); }
+.tone-bg-ok { background: var(--ok-soft); color: var(--ok); }
+.tone-bg-warn { background: rgba(251,191,36,0.16); color: var(--warn); }
+.tone-bg-bad { background: rgba(248,113,113,0.16); color: var(--bad-light); }
 
 /* monitor-row/pill state-offline, agents-workbench → Tailwind inline */

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -119,10 +119,6 @@ button.council-row.selected {
 }
 
 /* ── Keeper Rich Card (Overview) ──────────────────────────── */
-@keyframes keeperPulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 var(--ok-40); }
-  50% { opacity: 0.6; box-shadow: 0 0 0 4px rgba(74,222,128,0); }
-}
 
 /* ── Metric explain tooltip ──────────────────────────────── */
 .metric-tip-pop {

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -56,11 +56,6 @@
   color: var(--ff-gold, var(--ff-gold));
 }
 
-@keyframes keeper-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
-}
-
 /* Scrollbar */
 .keeper-chat__messages::-webkit-scrollbar {
   width: 4px;

--- a/dashboard/src/styles/live.css
+++ b/dashboard/src/styles/live.css
@@ -20,11 +20,6 @@
   box-shadow: 0 0 8px var(--blue-400-15);
 }
 
-@keyframes livePulse {
-  0%, 100% { box-shadow: 0 0 0 0 var(--ok-25); }
-  50% { box-shadow: 0 0 8px 2px var(--ok-12); }
-}
-
 /* ── Activity Stream ── */
 .activity-filter-btn {
   transition: background 0.15s, color 0.15s, border-color 0.15s;
@@ -56,11 +51,6 @@
 
 .activity-item-new {
   animation: activityFadeIn 0.3s ease-out;
-}
-
-@keyframes activityFadeIn {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
 }
 
 .activity-kind-chip.live-event-broadcast { background: var(--blue-400-15); color: var(--accent); }

--- a/dashboard/src/styles/oas-pipeline.css
+++ b/dashboard/src/styles/oas-pipeline.css
@@ -88,11 +88,6 @@
   background: rgba(100, 100, 120, 0.4);
 }
 
-@keyframes pipeline-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(96, 165, 250, 0); }
-  50% { box-shadow: 0 0 6px 2px rgba(96, 165, 250, 0.35); }
-}
-
 /* ── Pipeline stage badge variants ── */
 .pipeline-stage-badge.stage-idle {
   color: rgba(148, 163, 184, 0.85);
@@ -137,7 +132,3 @@
   border-color: rgba(100, 100, 110, 0.2);
 }
 
-@keyframes pipeline-badge-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}

--- a/dashboard/src/styles/ops.css
+++ b/dashboard/src/styles/ops.css
@@ -59,20 +59,9 @@
   transform: rotate(90deg);
 }
 
-.ops-guidance-card.ok {
-  border-color: var(--ok-35);
-  background: rgba(74, 222, 128, 0.06);
-}
-
-.ops-guidance-card.warn {
-  border-color: var(--warn-30);
-  background: rgba(251, 191, 36, 0.06);
-}
-
-.ops-guidance-card.bad {
-  border-color: var(--bad-30);
-  background: rgba(248, 113, 113, 0.06);
-}
+.ops-guidance-card.ok { border-color: var(--ok-35); background: rgba(74, 222, 128, 0.06); }
+.ops-guidance-card.warn { border-color: var(--warn-30); background: rgba(251, 191, 36, 0.06); }
+.ops-guidance-card.bad { border-color: var(--bad-30); background: rgba(248, 113, 113, 0.06); }
 
 .ops-entity-card:hover,
 .ops-entity-card.active {

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -52,11 +52,6 @@
   animation: blocker-pulse 1.5s ease-in-out infinite;
 }
 
-@keyframes blocker-pulse {
-  0%, 100% { box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.4); }
-  50% { box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.7); }
-}
-
 /* Activity dot — positioned absolute */
 .pixel-avatar__activity-dot {
   position: absolute;

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -92,17 +92,9 @@ button.monitor-row {
     background: var(--white-6);
   }
 
-  &.ok {
-    border-color: var(--ok-18);
-  }
-
-  &.warn {
-    border-color: var(--warn-28);
-  }
-
-  &.bad {
-    border-color: rgba(248, 113, 113, 0.34);
-  }
+  &.ok { border-color: var(--ok-18); }
+  &.warn { border-color: var(--warn-28); }
+  &.bad { border-color: rgba(248, 113, 113, 0.34); }
 }
 
 /* ── Status Badge ──────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- 11 @keyframes를 8개 파일에서 global.css로 통합
- tone-border/bg 공유 유틸리티 + toneBorder()/toneBg() 헬퍼
- state variant CSS 압축

CSS: 2,505 → **2,406** (-99)

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)