### PR TITLE
fix(quality): code review sweep — Stdlib.Mutex, eprintf, ignore patterns

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -191,7 +191,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
       ~make_h2_request_handler:Server_h2_gateway.make_request_handler
       ~make_h2_error_handler:Server_h2_gateway.make_error_handler
   with exn ->
-    Printf.eprintf "[main] keeper bootstrap failed: %s\n%!" (Printexc.to_string exn);
+    Log.Server.error "[main] keeper bootstrap failed: %s" (Printexc.to_string exn);
     raise exn
 
 (** CLI options *)
@@ -241,14 +241,14 @@ let run_cmd host port base_path =
   let initiate_shutdown signal_name =
     if not !shutdown_initiated then begin
       shutdown_initiated := true;
-      Printf.eprintf "\n[MASC] Received %s, shutting down gracefully...\n%!" signal_name;
+      Log.Server.info "[MASC] Received %s, shutting down gracefully..." signal_name;
 
       (* Start force-exit timer: if shutdown doesn't complete in 5s, force exit *)
       if not !force_exit_timer_started then begin
         force_exit_timer_started := true;
         ignore (Thread.create (fun () ->
           Unix.sleepf 5.0;
-          Printf.eprintf "[MASC] Graceful shutdown timed out after 5s, forcing exit.\n%!";
+          Log.Server.error "[MASC] Graceful shutdown timed out after 5s, forcing exit.";
           exit 1
         ) ())
       end;
@@ -259,7 +259,7 @@ let run_cmd host port base_path =
         signal_name
       in
       Sse.broadcast (Yojson.Safe.from_string shutdown_data);
-      Printf.eprintf "[MASC] Sent shutdown notification to %d SSE clients\n%!" (Sse.client_count ());
+      Log.Server.info "[MASC] Sent shutdown notification to %d SSE clients" (Sse.client_count ());
 
       (* Give clients 200ms to receive the notification *)
       Unix.sleepf 0.2;
@@ -269,7 +269,7 @@ let run_cmd host port base_path =
 
       (* Flush dirty board data to prevent data loss *)
       (try Board_dispatch.flush ()
-       with _ -> Printf.eprintf "[Shutdown] Board flush skipped (not initialized)\n%!");
+       with _ -> Log.Server.warn "[Shutdown] Board flush skipped (not initialized)");
 
       (* Also close local SSE connections tracked in main_eio *)
       close_all_sse_connections ();
@@ -294,22 +294,21 @@ let run_cmd host port base_path =
       run_server ~sw ~env ~host ~port ~base_path
     with
     | Shutdown ->
-        Printf.eprintf "🚀 MASC MCP: Shutdown complete.\n%!"
+        Log.Server.info "MASC MCP: Shutdown complete."
     | Eio.Cancel.Cancelled _ ->
-        Printf.eprintf "🚀 MASC MCP: Shutdown complete.\n%!"
+        Log.Server.info "MASC MCP: Shutdown complete."
     | Unix.Unix_error (Unix.EADDRINUSE, _, _) when attempt < max_bind_retries ->
         let delay = Float.min 30.0 (2.0 ** Float.of_int attempt) in
-        Printf.eprintf "⚠️  Port %d in use, retrying in %.0fs (attempt %d/%d)...\n%!"
+        Log.Server.warn "Port %d in use, retrying in %.0fs (attempt %d/%d)"
           port delay (attempt + 1) max_bind_retries;
         Time_compat.sleep delay;
         try_start (attempt + 1)
     | Unix.Unix_error (Unix.EADDRINUSE, _, _) ->
-        Printf.eprintf "❌ [MASC FATAL] Port %d is still in use after %d retries.\n%!"
-          port max_bind_retries;
-        Printf.eprintf "   Try: lsof -i :%d | grep LISTEN\n%!" port;
+        Log.Server.error "[FATAL] Port %d is still in use after %d retries. Try: lsof -i :%d | grep LISTEN"
+          port max_bind_retries port;
         exit 1
     | Unix.Unix_error (Unix.EACCES, _, _) ->
-        Printf.eprintf "❌ [MASC FATAL] Permission denied binding to port %d.\n%!" port;
+        Log.Server.error "[FATAL] Permission denied binding to port %d" port;
         exit 1)
   in
   try_start 0

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -9,27 +9,23 @@ module FileSystemBackend : BACKEND = struct
     mutex: Eio.Mutex.t;
   }
 
-  (** Stdlib.Mutex fallback for non-Eio contexts (tests).
-      Allocated once per FileSystemBackend instance. *)
-  let stdlib_mutex = Stdlib.Mutex.create ()
-
   let with_lock t f =
     (* Eio.Mutex requires an Eio runtime (Cancel context).
-       When called outside Eio_main.run (e.g. tests), fall back to
-       Stdlib.Mutex to preserve mutual exclusion. Production always
-       runs under Eio where Eio.Mutex is preferred.
-       Two-phase: if Eio.Mutex fails (Effect.Unhandled), use Stdlib.Mutex.
-       If f() fails inside the lock, re-raise. *)
+       When called outside Eio_main.run (e.g. unit tests without Eio),
+       Effect.Unhandled is raised. A prior failure may also leave the mutex
+       in a Poisoned state (Eio__Eio_mutex.Poisoned).
+       In both cases, run the function unprotected — safe because test
+       contexts are single-fiber with no contention. *)
     match
       Eio.Mutex.use_rw ~protect:true t.mutex (fun () -> f ())
     with
     | result -> result
-    | exception Effect.Unhandled _ | exception Eio__Eio_mutex.Poisoned _ ->
-        (* No Eio runtime (e.g. tests) — fall back to Stdlib.Mutex.
-           Effect.Unhandled: first attempt without Eio context.
-           Eio_mutex.Poisoned: mutex poisoned by a prior failed attempt. *)
-        Stdlib.Mutex.lock stdlib_mutex;
-        Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
+    | exception Effect.Unhandled _ ->
+        f ()
+    | exception Eio__Eio_mutex.Poisoned _ ->
+        (* Mutex poisoned by a prior Effect.Unhandled failure (no Eio context).
+           Safe to run unprotected in single-fiber test contexts. *)
+        f ()
 
   (* Security: validate key with strict allowlist (parse, don't sanitize) *)
   let validate_key key =

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -9,6 +9,10 @@ module FileSystemBackend : BACKEND = struct
     mutex: Eio.Mutex.t;
   }
 
+  (* Once-only flag to avoid log spam in test contexts where every call
+     after the first Effect.Unhandled triggers Poisoned. *)
+  let poisoned_warned = Atomic.make false
+
   let with_lock t f =
     (* Eio.Mutex requires an Eio runtime (Cancel context).
        When called outside Eio_main.run (e.g. unit tests without Eio),
@@ -25,6 +29,8 @@ module FileSystemBackend : BACKEND = struct
     | exception Eio__Eio_mutex.Poisoned _ ->
         (* Mutex poisoned by a prior Effect.Unhandled failure (no Eio context).
            Safe to run unprotected in single-fiber test contexts. *)
+        if not (Atomic.exchange poisoned_warned true) then
+          Log.Backend.warn "Eio.Mutex poisoned, running unprotected (non-Eio context)";
         f ()
 
   (* Security: validate key with strict allowlist (parse, don't sanitize) *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -385,7 +385,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
       { stop; started_at = Time_compat.now () };
     (try
        if not (Room_utils.is_initialized ctx.config) then
-         ignore (Room.init ctx.config ~agent_name:None)
+         let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ()
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -142,7 +142,7 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (* Room initialization *)
     (try
        if not (Room_utils.is_initialized ctx.config) then
-         ignore (Room.init ctx.config ~agent_name:None)
+         let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ()
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Keeper.error "supervisor room init failed: %s"
          (Printexc.to_string exn));

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -253,7 +253,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let init_error =
     if (not auth_enabled) && join_required && not !room_init_cached then
       (try
-         ignore (Room.init config ~agent_name:None);
+         let (_init_msg : string) = Room.init config ~agent_name:None in
          room_init_cached := true;  (* Fix 3: update cache after successful init *)
          None
        with Invalid_argument msg -> Some msg

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -253,21 +253,27 @@ let claim_task_r config ~agent_name ~task_id
               actual = Types_core.role_to_string agent_role;
             })
           else begin
-            let found = ref false in
-            let already_claimed = ref None in
-            let new_tasks = List.map (fun t ->
-              if t.id = task_id then begin
-                found := true;
-                match t.task_status with
-                | Todo -> { t with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } }
-                | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
-                    already_claimed := Some assignee; t
-              end else t
-            ) backlog.tasks in
-            if not !found then Error (Types.TaskNotFound task_id)
-            else match !already_claimed with
-              | Some other -> Error (Types.TaskAlreadyClaimed { task_id; by = other })
-              | None ->
+            (* fold_left to find+transform in a single pass without mutable refs.
+               Uses polymorphic variants for inline state tracking. *)
+            let claim_state, new_tasks =
+              List.fold_left (fun (state, acc) t ->
+                if t.id = task_id then
+                  match t.task_status with
+                  | Todo ->
+                      let t' = { t with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } } in
+                      (`Claimed_ok, t' :: acc)
+                  | Claimed { assignee; _ } | InProgress { assignee; _ }
+                  | Done { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
+                      (`Claimed_by assignee, t :: acc)
+                else
+                  (state, t :: acc)
+              ) (`Not_found, []) backlog.tasks
+            in
+            let new_tasks = List.rev new_tasks in
+            match claim_state with
+            | `Not_found -> Error (Types.TaskNotFound task_id)
+            | `Claimed_by other -> Error (Types.TaskAlreadyClaimed { task_id; by = other })
+            | `Claimed_ok ->
                   let new_backlog = {
                     tasks = new_tasks;
                     last_updated = now_iso ();

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -43,7 +43,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   state
 
 let bootstrap_server_state (state : Mcp_server.server_state) =
-  ignore (Room.init state.room_config ~agent_name:None);
+  let (_init_msg : string) = Room.init state.room_config ~agent_name:None in
   Chain_native_eio.ensure_bootstrap state.room_config;
   (try Tool_command_plane.backfill_chain_overlays state.room_config
    with

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -96,7 +96,8 @@ let tool_requires_presence = function
 
 let ensure_agent_joined ~(config : Room.config) ~(agent_name : string) =
   try
-    if not (Room.is_initialized config) then ignore (Room.init config ~agent_name:None);
+    if not (Room.is_initialized config) then (
+      let (_init_msg : string) = Room.init config ~agent_name:None in ());
     let joined =
       try Room.is_agent_joined config ~agent_name
       with Sys_error _ | Not_found | Yojson.Json_error _ -> false

--- a/lib/tool_council_helpers.ml
+++ b/lib/tool_council_helpers.ml
@@ -25,8 +25,9 @@ let room_config_of_ctx (ctx : context) =
 
 let ensure_room_ready (ctx : context) =
   let config = room_config_of_ctx ctx in
-  if not (Room.is_initialized config) then
-    ignore (Room.init config ~agent_name:(Some ctx.agent_name));
+  (if not (Room.is_initialized config) then
+    let (_init_msg : string) = Room.init config ~agent_name:(Some ctx.agent_name) in
+    ());
   config
 
 let contains_text haystack needle =

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -46,8 +46,9 @@ let room_config_of_ctx (ctx : context) =
 
 let ensure_room_ready (ctx : context) =
   let config = room_config_of_ctx ctx in
-  if not (Room.is_initialized config) then
-    ignore (Room.init config ~agent_name:(Some ctx.agent_name));
+  (if not (Room.is_initialized config) then
+    let (_init_msg : string) = Room.init config ~agent_name:(Some ctx.agent_name) in
+    ());
   config
 
 (** Deterministic ID generation using Collaboration.generate_id.


### PR DESCRIPTION
## Summary

코드 리뷰 기반 품질 개선. 10개 파일, 4개 카테고리.

### 1. Stdlib.Mutex fallback 제거 (backend.ml)
- Eio 컨텍스트에서 Stdlib.Mutex 사용은 deadlock 위험
- 테스트는 단일 fiber이므로 unprotected 실행으로 충분
- Poisoned 경로에 once-only 경고 로그 추가 (GLM-5 리뷰 반영)

### 2. Printf.eprintf → Log.Server (main_eio.ml)
- 11개 eprintf 호출을 구조화된 Log.Server 로깅으로 전환
- Log 모듈이 내부적으로 eprintf + %! 사용하므로 flush 보장

### 3. ignore(Room.init) → typed binding (7 files)
- ignore 대신 let (_init_msg : string) = ...로 타입 명시
- 반환 타입 변경 시 컴파일러가 즉시 감지

### 4. room_task.ml claim_task 리팩토링
- mutable ref + List.map → List.fold_left + polymorphic variant
- task_id 중복 시 undefined behavior 제거

## External Review
- GLM-5 리뷰 완료. HIGH 1건(Poisoned 경로) → once-only 로그로 대응

## Test plan
- [x] dune build 성공
- [x] dune test 전체 통과 (27 tests, EXIT: 0)
- [x] GLM-5 외부 리뷰 + 피드백 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)