### PR TITLE
fix(chain): cancel non-winning fibers in race node

### DIFF
--- a/lib/chain/chain_executor_resilience.ml
+++ b/lib/chain/chain_executor_resilience.ml
@@ -365,76 +365,85 @@ let execute_fallback ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : execut
   in
   try_nodes (primary :: fallbacks) []
 
-(** Execute race node - run all in parallel, first result wins (with timeout) *)
+(** Exception used to signal race completion and cancel non-winning fibers. *)
+exception Race_done
 
-let execute_race ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : execute_node_fn) ~tool_exec (parent : node)
+(** Execute race node - run all in parallel, first result wins (with timeout).
+    Uses a sub-switch to cancel non-winning fibers on resolution. *)
+
+let execute_race ctx ~sw:_ ~clock ~(exec_fn : exec_fn) ~(execute_node : execute_node_fn) ~tool_exec (parent : node)
     ~nodes ~timeout : (string, string) result =
   record_start ctx parent.id;
   let start = Time_compat.now () in
   let winner = ref None in
   let winner_mutex = Eio.Mutex.create () in
-  let winner_cond = Eio.Condition.create () in
   let all_errors = ref [] in
   let finished_count = ref 0 in
   let total_nodes = List.length nodes in
+  let timeout_sec = match timeout with Some t -> t | None -> 300.0 in
+  let timed_out = ref false in
+  let resolved = ref false in
 
-  (* Fork all race nodes in parallel *)
-  List.iter (fun (node : node) ->
-    Eio.Fiber.fork ~sw (fun () ->
-      let already_won = Eio.Mutex.use_rw winner_mutex ~protect:true (fun () -> Option.is_some !winner) in
-      if not already_won then begin
-        match execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node with
-        | Ok output ->
-            Eio.Mutex.use_rw winner_mutex ~protect:true (fun () ->
-              if Option.is_none !winner then begin
-                winner := Some (node.id, output);
-                Eio.Condition.broadcast winner_cond
-              end;
-              incr finished_count)
-        | Error msg ->
-            Eio.Mutex.use_rw winner_mutex ~protect:true (fun () ->
-              all_errors := (node.id ^ ": " ^ msg) :: !all_errors;
-              incr finished_count;
-              (* Wake up waiter if all have failed *)
-              if !finished_count = total_nodes then
-                Eio.Condition.broadcast winner_cond)
-      end)
-  ) nodes;
+  (* Run all racers inside a sub-switch so non-winning fibers get cancelled.
+     A single Race_done exception is used to terminate the switch.
+     The [resolved] flag prevents multiple Switch.fail calls. *)
+  (try
+    Eio.Switch.run (fun race_sw ->
+      let signal_done () =
+        if not !resolved then begin
+          resolved := true;
+          Eio.Switch.fail race_sw Race_done
+        end
+      in
+      (* Timeout fiber: sleep then signal if no resolution yet *)
+      Eio.Fiber.fork ~sw:race_sw (fun () ->
+        (try Eio.Time.sleep clock timeout_sec
+         with Eio.Cancel.Cancelled _ -> ());
+        if not !resolved then begin
+          timed_out := true;
+          signal_done ()
+        end);
+      (* Racer fibers *)
+      List.iter (fun (node : node) ->
+        Eio.Fiber.fork ~sw:race_sw (fun () ->
+          let already_won = Eio.Mutex.use_rw winner_mutex ~protect:true
+            (fun () -> Option.is_some !winner) in
+          if not already_won then
+            match execute_node ctx ~sw:race_sw ~clock ~exec_fn ~tool_exec node with
+            | Ok output ->
+                Eio.Mutex.use_rw winner_mutex ~protect:true (fun () ->
+                  if Option.is_none !winner then
+                    winner := Some (node.id, output);
+                  incr finished_count);
+                signal_done ()
+            | Error msg ->
+                Eio.Mutex.use_rw winner_mutex ~protect:true (fun () ->
+                  all_errors := (node.id ^ ": " ^ msg) :: !all_errors;
+                  incr finished_count);
+                if !finished_count = total_nodes then
+                  signal_done ()
+            | exception Eio.Cancel.Cancelled _ -> ()
+        )
+      ) nodes)
+  with Race_done -> ());
 
-  (* Wait for winner with optional timeout *)
-  let timeout_sec = match timeout with Some t -> t | None -> 300.0 in (* Default 5 min *)
-  let wait_for_winner () =
-    Eio.Mutex.use_rw winner_mutex ~protect:true (fun () ->
-      while Option.is_none !winner && !finished_count < total_nodes do
-        Eio.Condition.await winner_cond winner_mutex
-      done;
-      !winner)
-  in
-
-  let duration_ms = ref 0 in
-  let result =
-    try
-      Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-        let r = wait_for_winner () in
-        duration_ms := int_of_float ((Time_compat.now () -. start) *. 1000.0);
-        match r with
-        | Some (winner_id, output) ->
-            record_complete ctx parent.id ~duration_ms:!duration_ms ~success:true;
-            store_node_output ctx parent (Printf.sprintf "[winner: %s] %s" winner_id output);
-            Ok output
-        | None ->
-            let msg = Printf.sprintf "All racers failed: %s" (String.concat "; " !all_errors) in
-            record_complete ctx parent.id ~duration_ms:!duration_ms ~success:false;
-            record_error ctx parent.id msg;
-            Error msg)
-    with Eio.Time.Timeout ->
-      duration_ms := int_of_float ((Time_compat.now () -. start) *. 1000.0);
-      let msg = Printf.sprintf "Race timeout after %.1fs" timeout_sec in
-      record_complete ctx parent.id ~duration_ms:!duration_ms ~success:false;
-      record_error ctx parent.id msg;
-      Error msg
-  in
-  result
+  let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
+  if !timed_out then begin
+    let msg = Printf.sprintf "Race timeout after %.1fs" timeout_sec in
+    record_complete ctx parent.id ~duration_ms ~success:false;
+    record_error ctx parent.id msg;
+    Error msg
+  end else
+    match !winner with
+    | Some (winner_id, output) ->
+        record_complete ctx parent.id ~duration_ms ~success:true;
+        store_node_output ctx parent (Printf.sprintf "[winner: %s] %s" winner_id output);
+        Ok output
+    | None ->
+        let msg = Printf.sprintf "All racers failed: %s" (String.concat "; " !all_errors) in
+        record_complete ctx parent.id ~duration_ms ~success:false;
+        record_error ctx parent.id msg;
+        Error msg
 
 (** Execute StreamMerge node - process results progressively as they arrive *)
 

--- a/test/dune
+++ b/test/dune
@@ -281,6 +281,11 @@
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
+ (name test_race_cancel)
+ (modules test_race_cancel)
+ (libraries masc_mcp alcotest eio eio_main str unix))
+
+(test
  (name test_metrics_store_eio)
  (modules test_metrics_store_eio)
  (libraries masc_mcp alcotest str yojson))

--- a/test/test_race_cancel.ml
+++ b/test/test_race_cancel.ml
@@ -1,0 +1,120 @@
+(** Tests for race node fiber cancellation (issue #2219).
+    Verifies that non-winning fibers are cancelled after a winner is found. *)
+
+open Alcotest
+open Masc_mcp
+
+let make_ctx () =
+  Chain_executor_helpers.make_context
+    ~start_time:(Unix.gettimeofday ())
+    ~trace_enabled:false ~timeout:60 ~chain_id:"test-race" ()
+
+let make_node id =
+  Chain_types.{
+    id;
+    node_type = Model { model = "test"; system = None; prompt = "test";
+                        timeout = None; tools = None; prompt_ref = None;
+                        prompt_vars = []; thinking = false };
+    input_mapping = [];
+    output_key = None;
+    depends_on = None;
+  }
+
+let dummy_exec_fn ~model:_ ?system:_ ~prompt:_ ?tools:_ ?thinking:_ () =
+  Ok "unused"
+
+let dummy_tool_exec ~name:_ ~args:_ = Ok "unused"
+
+(** Verify that non-winning fibers are cancelled after first success.
+    We track how many execute_node calls actually complete (not cancelled). *)
+let test_race_cancels_losers () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let completed_count = Atomic.make 0 in
+  let ctx = make_ctx () in
+  let nodes = List.init 3 (fun i -> make_node (Printf.sprintf "racer_%d" i)) in
+
+  (* Slow execute_node: racer_0 finishes instantly, others sleep *)
+  let execute_node _ctx ~sw:_ ~clock:_ ~exec_fn:_ ~tool_exec:_ (node : Chain_types.node) =
+    if node.id = "racer_0" then begin
+      Atomic.incr completed_count;
+      Ok "winner-output"
+    end else begin
+      (* Sleep long enough that they'd run if not cancelled *)
+      (try Eio.Time.sleep clock 10.0
+       with Eio.Cancel.Cancelled _ -> ());
+      Atomic.incr completed_count;
+      Ok "loser-output"
+    end
+  in
+
+  let parent = make_node "race_parent" in
+  Eio.Switch.run (fun sw ->
+    let result =
+      Chain_executor_resilience.execute_race ctx ~sw ~clock
+        ~exec_fn:dummy_exec_fn ~execute_node ~tool_exec:dummy_tool_exec
+        parent ~nodes ~timeout:(Some 30.0)
+    in
+    match result with
+    | Ok output ->
+        check string "winner output" "winner-output" output;
+        (* Only racer_0 should have completed; losers should be cancelled *)
+        check int "only winner completed" 1 (Atomic.get completed_count)
+    | Error msg ->
+        failf "race should succeed, got error: %s" msg)
+
+(** Verify race returns error when all racers fail. *)
+let test_race_all_fail () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let ctx = make_ctx () in
+  let nodes = List.init 2 (fun i -> make_node (Printf.sprintf "fail_%d" i)) in
+
+  let execute_node _ctx ~sw:_ ~clock:_ ~exec_fn:_ ~tool_exec:_ (node : Chain_types.node) =
+    Error (Printf.sprintf "%s failed" node.id)
+  in
+
+  let parent = make_node "race_parent" in
+  Eio.Switch.run (fun sw ->
+    match Chain_executor_resilience.execute_race ctx ~sw ~clock
+            ~exec_fn:dummy_exec_fn ~execute_node ~tool_exec:dummy_tool_exec
+            parent ~nodes ~timeout:(Some 5.0) with
+    | Ok _ -> fail "expected all-fail race to return Error"
+    | Error msg ->
+        check bool "contains fail_0" true (String.length msg > 0);
+        check bool "error message present" true
+          (try ignore (Str.search_forward (Str.regexp_string "failed") msg 0); true
+           with Not_found -> false))
+
+(** Verify race handles timeout when no racer finishes in time. *)
+let test_race_timeout () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let ctx = make_ctx () in
+  let nodes = [make_node "slow_0"] in
+
+  let execute_node _ctx ~sw:_ ~clock ~exec_fn:_ ~tool_exec:_ (_node : Chain_types.node) =
+    (try Eio.Time.sleep clock 60.0
+     with Eio.Cancel.Cancelled _ -> ());
+    Ok "too-late"
+  in
+
+  let parent = make_node "race_parent" in
+  Eio.Switch.run (fun sw ->
+    match Chain_executor_resilience.execute_race ctx ~sw ~clock
+            ~exec_fn:dummy_exec_fn ~execute_node ~tool_exec:dummy_tool_exec
+            parent ~nodes ~timeout:(Some 0.5) with
+    | Ok _ -> fail "expected timeout"
+    | Error msg ->
+        check bool "timeout message" true
+          (try ignore (Str.search_forward (Str.regexp_string "timeout") msg 0); true
+           with Not_found -> false))
+
+let () =
+  run "race-cancel" [
+    "cancellation", [
+      test_case "non-winning fibers cancelled" `Quick test_race_cancels_losers;
+      test_case "all-fail returns error" `Quick test_race_all_fail;
+      test_case "timeout returns error" `Quick test_race_timeout;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- Race node (`execute_race`) forked fibers on the parent switch, so non-winning fibers ran to completion after a winner was found, leaking API calls and compute.
- Replaced parent-switch fork + `Condition.await` with a sub-switch (`Eio.Switch.run`) that scopes all racer fibers. `Switch.fail Race_done` cancels remaining fibers via Eio structured concurrency.
- A `resolved` flag prevents multiple `Switch.fail` calls (timeout vs racer completion).

Closes #2219

## Test plan
- [x] `test_race_cancels_losers`: Only the winning fiber completes; losers are cancelled (verified via `Atomic` counter).
- [x] `test_race_all_fail`: Returns error when all racers fail.
- [x] `test_race_timeout`: Returns timeout error when no racer finishes in time.
- [x] `dune build --root .` passes.

Generated with [Claude Code](https://claude.com/claude-code)