### PR TITLE
fix(test): stabilize E2E tests against PG env leak and server_state race

### DIFF
--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -198,6 +198,11 @@ let with_server f =
         ("MASC_LODGE_DAEMON_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+        ("MASC_POSTGRES_URL", "");
+        ("DATABASE_URL", "");
+        ("SUPABASE_DB_URL", "");
+        ("SB_PG_URL", "");
+        ("MASC_BOARD_BACKEND", "jsonl");
       ]
   in
   let argv =

--- a/test/test_openapi_api_e2e.ml
+++ b/test/test_openapi_api_e2e.ml
@@ -190,6 +190,11 @@ let with_server f =
         ("MASC_LODGE_DAEMON_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+        ("MASC_POSTGRES_URL", "");
+        ("DATABASE_URL", "");
+        ("SUPABASE_DB_URL", "");
+        ("SB_PG_URL", "");
+        ("MASC_BOARD_BACKEND", "jsonl");
       ]
   in
   let argv =
@@ -212,14 +217,28 @@ let with_server f =
 
 let test_openapi_route_serves_document () =
   with_server @@ fun ~port ->
-  let res = run_curl ~port ~path:"/api/v1/openapi.json" () in
-  (match res.status with
-  | Some code -> check int "openapi route returns 200" 200 code
-  | None ->
-      fail
-        (Printf.sprintf "missing HTTP status (curl_exit=%d, stderr=%s)"
-           res.curl_exit res.stderr));
-  let json = Yojson.Safe.from_string res.body in
+  (* Retry up to 5 times: /health returns 200 before server_state is set,
+     so the openapi route may initially return {"error":"not initialized"} *)
+  let rec fetch_openapi retries =
+    let res = run_curl ~port ~path:"/api/v1/openapi.json" () in
+    (match res.status with
+    | Some code -> check int "openapi route returns 200" 200 code
+    | None ->
+        fail
+          (Printf.sprintf "missing HTTP status (curl_exit=%d, stderr=%s)"
+             res.curl_exit res.stderr));
+    let json = Yojson.Safe.from_string res.body in
+    let open Yojson.Safe.Util in
+    match json |> member "openapi" |> to_string_option with
+    | Some _ -> json
+    | None when retries > 0 ->
+        Unix.sleepf 0.5;
+        fetch_openapi (retries - 1)
+    | None ->
+        fail
+          (Printf.sprintf "openapi field missing after retries\nbody=%s" res.body)
+  in
+  let json = fetch_openapi 5 in
   let open Yojson.Safe.Util in
   check string "openapi version" "3.1.0" (json |> member "openapi" |> to_string);
   check bool "/mcp path present" true


### PR DESCRIPTION
## Summary

- The openapi E2E test failed because the test server inherited PostgreSQL connection env vars from the host environment, causing slow or failed initialization. The `/health` endpoint returns 200 before `server_state` is set, so routes guarded by `with_public_read` returned `{"error":"not initialized"}` instead of the expected response.
- Added `MASC_POSTGRES_URL`/`DATABASE_URL`/`SUPABASE_DB_URL`/`SB_PG_URL=""` and `MASC_BOARD_BACKEND=jsonl` env overrides to the openapi and board E2E tests, matching the existing operator test pattern.
- Added retry loop (up to 5 attempts, 0.5s backoff) in the openapi test to handle the `server_state` initialization race after health check passes.
- Board and operator tests were already passing on latest `main` but the board test received the same env isolation fix for robustness.

## Test plan

- [x] `dune exec test/test_openapi_api_e2e.exe` passes
- [x] `dune exec test/test_board_api_e2e.exe` passes
- [x] `dune exec test/test_operator_mcp_e2e.exe` passes
- [x] `dune build --root . -j 4` succeeds

Generated with [Claude Code](https://claude.com/claude-code)