### PR TITLE
refactor: decouple display/cost from Model_spec fields (Phase 1)

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -5,9 +5,9 @@ open Keeper_types
 include Keeper_memory_bank
 
 let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Model_spec.model_spec) : float =
-  let input_cost = float_of_int usage.input_tokens *. model.cost_per_1k_input /. 1000.0 in
-  let output_cost = float_of_int usage.output_tokens *. model.cost_per_1k_output /. 1000.0 in
-  input_cost +. output_cost
+  let pricing = Llm_provider.Pricing.pricing_for_model model.model_id in
+  Llm_provider.Pricing.estimate_cost ~pricing
+    ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ()
 
 let model_spec_for_used (specs : Model_spec.model_spec list) (model_used : string) :
   Model_spec.model_spec option =

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -97,11 +97,14 @@ let handle_keeper_status ctx args : tool_result =
          in
 
          let models_resolved = `List (List.map (fun (s : Model_spec.model_spec) ->
+           let pricing = Llm_provider.Pricing.pricing_for_model s.model_id in
            `Assoc [
-             ("provider", `String (Model_spec.string_of_provider s.provider));
+             ("provider", `String s.model_id);
              ("model_id", `String s.model_id);
              ("max_context", `Int s.max_context);
              ("api_key_env", match s.api_key_env with None -> `Null | Some k -> `String k);
+             ("cost_per_million_input", `Float pricing.input_per_million);
+             ("cost_per_million_output", `Float pricing.output_per_million);
            ]
          ) specs) in
 

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -579,13 +579,9 @@ let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) 
 
 let estimate_cost_usd (model : Model_spec.model_spec)
     (usage : Agent_sdk.Types.api_usage) : float option =
-  let input_cost =
-    (float_of_int usage.input_tokens /. 1000.0) *. model.cost_per_1k_input
-  in
-  let output_cost =
-    (float_of_int usage.output_tokens /. 1000.0) *. model.cost_per_1k_output
-  in
-  Some (input_cost +. output_cost)
+  let pricing = Llm_provider.Pricing.pricing_for_model model.model_id in
+  Some (Llm_provider.Pricing.estimate_cost ~pricing
+    ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ())
 
 let local_worker_max_tokens () =
   match Sys.getenv_opt "MASC_LOCAL_WORKER_MAX_TOKENS" with

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -401,9 +401,12 @@ let run_named
   (* Use first available model as primary for Builder *)
   let primary_spec = match resolve_cascade_specs ~cascade_name with
     | spec :: _ -> spec
-    | [] -> { Model_spec.provider = Model_spec.Glm_cloud; model_id = "auto";
-              max_context = 8192; api_url = ""; api_key_env = None;
-              cost_per_1k_input = 0.0; cost_per_1k_output = 0.0 }
+    | [] ->
+      let pricing = Llm_provider.Pricing.pricing_for_model "auto" in
+      { Model_spec.provider = Model_spec.Glm_cloud; model_id = "auto";
+        max_context = 8192; api_url = ""; api_key_env = None;
+        cost_per_1k_input = pricing.input_per_million /. 1000.0;
+        cost_per_1k_output = pricing.output_per_million /. 1000.0 }
   in
   let config =
     config_for_model ~name ~model_spec:primary_spec ~system_prompt ~tools


### PR DESCRIPTION
## Summary

- **Phase 1/5** of Model_spec retirement: decouple display and cost calculation from Model_spec record fields, delegating to OAS `Llm_provider.Pricing` as single source of truth.
- **Display** (`keeper_status_detail.ml`): replaced `Model_spec.string_of_provider` variant match with direct `model_id` usage. Added `cost_per_million_input/output` from OAS Pricing to JSON output.
- **Cost** (`keeper_memory_recall.ml`, `worker_container_types.ml`): replaced `model.cost_per_1k_input/output` field reads with `Llm_provider.Pricing.pricing_for_model` + `estimate_cost`.
- **Fallback** (`oas_worker.ml`): fallback record now sources pricing from OAS Pricing for consistency.
- No type signature changes -- `Model_spec.model_spec` record fields are preserved for backward compatibility.

## Phase Plan

| Phase | Scope | Status |
|-------|-------|--------|
| **1** | Display + Cost decoupling (this PR) | In progress |
| 2 | Remove `cost_per_1k_*` fields from `model_spec` type | Planned |
| 3 | Replace `provider` variant with `string` | Planned |
| 4 | Inline `model_spec` into OAS `Provider_registry.entry` | Planned |
| 5 | Remove `Model_spec` module | Planned |

## Test plan

- [x] `dune build --root .` passes with no errors
- [ ] `make test` full test suite
- [ ] Manual verification: keeper status detail JSON output includes pricing info

Generated with [Claude Code](https://claude.com/claude-code)