### PR TITLE
fix(quality): deduplicate ISO8601 parsing, narrow catch-all exceptions

### DIFF
--- a/lib/activity_graph.ml
+++ b/lib/activity_graph.ml
@@ -336,9 +336,14 @@ let emit config ~room_id ?actor ?subject ?(tags = []) ~kind ~payload () =
   List.iter
     (fun (session_id, client) ->
       if value.seq > client.last_seq && client_matches client value then
-        match client.push encoded with
-        | () -> client.last_seq <- value.seq
-        | exception _ -> failed := session_id :: !failed)
+        (try
+          client.push encoded;
+          client.last_seq <- value.seq
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Log.Misc.warn "SSE push failed for %s: %s" session_id (Printexc.to_string exn);
+            failed := session_id :: !failed))
     snapshot;
   List.iter unregister !failed;
   value

--- a/lib/chain/chain_telemetry.ml
+++ b/lib/chain/chain_telemetry.ml
@@ -402,7 +402,7 @@ let event_to_json_string event =
 let event_of_json_string str =
   match Yojson.Safe.from_string str with
   | json -> chain_event_of_yojson json
-  | exception _ -> Result.Error "Invalid JSON"
+  | exception (Yojson.Json_error msg) -> Result.Error ("Invalid JSON: " ^ msg)
 
 (** {1 Pretty Printing} *)
 

--- a/lib/message_schema.ml
+++ b/lib/message_schema.ml
@@ -169,10 +169,10 @@ let validate ?(mode=Permissive) raw_message =
            | Strict -> Error (Printf.sprintf "Schema validation failed: %s" reason)
            | Warn -> Ok (Freeform raw_message)
            | Permissive -> Ok (Freeform raw_message))
-  | exception _ ->
-      match mode with
+  | exception (Yojson.Json_error _) ->
+      (match mode with
       | Strict -> Error "Message must be valid JSON in strict mode"
-      | Warn | Permissive -> Ok (Freeform raw_message)
+      | Warn | Permissive -> Ok (Freeform raw_message))
 
 let message_type_string = function
   | TaskUpdate _ -> "task_update"
@@ -311,13 +311,13 @@ let validate_envelope ?(mode=Permissive) raw_json =
                Ok { sender = "unknown"; timestamp = Time_compat.now ();
                     sequence = 0; channel = "freeform";
                     message = Freeform raw_json })
-  | exception _ ->
-      match mode with
+  | exception (Yojson.Json_error _) ->
+      (match mode with
       | Strict -> Error "Envelope must be valid JSON in strict mode"
       | _ ->
           Ok { sender = "unknown"; timestamp = Time_compat.now ();
                sequence = 0; channel = "freeform";
-               message = Freeform raw_json }
+               message = Freeform raw_json })
 
 let roundtrip msg =
   let json = to_json msg in

--- a/lib/post_verifier_model.ml
+++ b/lib/post_verifier_model.ml
@@ -76,7 +76,7 @@ let parse_geval_response (text : string) :
             else trimmed)
   in
   match Yojson.Safe.from_string json_str with
-  | exception _ -> Error (Printf.sprintf "invalid JSON: %s" json_str)
+  | exception (Yojson.Json_error msg) -> Error (Printf.sprintf "invalid JSON (%s): %s" msg json_str)
   | json ->
       let open Yojson.Safe.Util in
       (try

--- a/lib/room/resilience.ml
+++ b/lib/room/resilience.ml
@@ -12,31 +12,14 @@ module Time = struct
   (** Get current time as Unix float *)
   let now () = Time_compat.now ()
 
-  (** Parse ISO 8601 UTC timestamp ("YYYY-MM-DDTHH:MM:SSZ") to Unix epoch.
-
-      [Unix.mktime] interprets its argument as local time. To get the
-      correct UTC epoch we compute the local-UTC offset and add it.
-
-      [tz_offset = local_epoch - utc_as_local] yields a positive value
-      for east-of-UTC zones (e.g. +32400 for KST/UTC+9).
-      [local_epoch + tz_offset] then recovers the true UTC epoch. *)
+  (** Parse ISO 8601 UTC timestamp to Unix epoch.
+      Delegates to canonical implementation in Types_core. *)
   let parse_iso8601_opt s =
-    try
-      Scanf.sscanf s "%04d-%02d-%02dT%02d:%02d:%02dZ"
-        (fun year mon day hour min sec ->
-          let tm = {
-            Unix.tm_sec = sec; tm_min = min; tm_hour = hour;
-            tm_mday = day; tm_mon = mon - 1; tm_year = year - 1900;
-            tm_wday = 0; tm_yday = 0; tm_isdst = false;
-          } in
-          let local_epoch, _ = Unix.mktime tm in
-          let utc_of_local = Unix.gmtime local_epoch in
-          let utc_as_local, _ = Unix.mktime utc_of_local in
-          let tz_offset = local_epoch -. utc_as_local in
-          Some (local_epoch +. tz_offset))
-    with Scanf.Scan_failure _ | Failure _ | End_of_file ->
-      Log.Misc.error "parse_iso8601_opt failed for: %S" s;
-      None
+    match Types_core.parse_iso8601_opt s with
+    | Some _ as result -> result
+    | None ->
+        Log.Misc.error "parse_iso8601_opt failed for: %S" s;
+        None
 
   (** Check if a timestamp is older than threshold *)
   let is_stale ?(threshold=default_zombie_threshold) timestamp_str =

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -726,20 +726,8 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
       (* Starvation prevention: Calculate effective priority
          Tasks waiting >24h get priority boost (-1 per 24h, min 1) *)
       let now = Time_compat.now () in
-      let parse_time iso =
-        try
-          (* Parse ISO 8601: 2026-01-05T12:30:00Z *)
-          Scanf.sscanf iso "%d-%d-%dT%d:%d:%d"
-            (fun y mo d h mi _ ->
-              let tm = { Unix.tm_sec = 0; tm_min = mi; tm_hour = h;
-                         tm_mday = d; tm_mon = mo - 1; tm_year = y - 1900;
-                         tm_wday = 0; tm_yday = 0; tm_isdst = false } in
-              let local_epoch, _ = Unix.mktime tm in
-              let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
-              let tz_offset = local_epoch -. utc_as_local in
-              Some (local_epoch +. tz_offset))
-        with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
-      in
+      (* Reuse canonical UTC parser from Types_core *)
+      let parse_time = Types_core.parse_iso8601_opt in
       let effective_priority (task : Types.task) =
         let age_hours =
           match parse_time task.created_at with

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -110,7 +110,7 @@ let now_iso () =
     tm.tm_hour tm.tm_min tm.tm_sec
 
 (** Parse ISO8601 "YYYY-MM-DDTHH:MM:SSZ" to Unix float (UTC). *)
-let parse_iso8601_opt_internal s =
+let parse_iso8601_opt s =
   try
     Scanf.sscanf s "%04d-%02d-%02dT%02d:%02d:%02dZ"
       (fun year mon day hour min sec ->
@@ -128,7 +128,7 @@ let parse_iso8601_opt_internal s =
 
 (** Parse ISO8601 timestamp to Unix float. Returns default_time on parse failure. *)
 let parse_iso8601 ?(default_time = Time_compat.now () -. 60.0) timestamp =
-  match parse_iso8601_opt_internal timestamp with
+  match parse_iso8601_opt timestamp with
   | Some unix_ts -> unix_ts
   | None -> default_time
 


### PR DESCRIPTION
## Summary

코드 리뷰 sweep 2차. 7개 파일, 2개 카테고리.

### 1. ISO8601 파싱 통합 (-29 lines)
- `types_core.ml`의 `parse_iso8601_opt`를 canonical 구현으로 승격
- `room_task.ml`의 중복 `parse_time` 제거 → canonical 위임
- `resilience.ml`의 중복 `parse_iso8601_opt` 제거 → canonical 위임
- DST 경계 문제는 기존 패턴으로 올바르게 처리됨 (UTC 입력 전제)

### 2. catch-all 예외 패턴 좁히기 (5건)
- `| exception _` → `| exception (Yojson.Json_error _)` 4건
- `| exception _` → `try/with` + Eio.Cancel re-raise + 로깅 1건
- 에러 메시지에 Yojson 파싱 실패 사유 포함

## Test plan
- [x] dune build 성공
- [x] dune test 전체 통과 (EXIT: 0)
- [ ] 외부 모델 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)