### PR TITLE
refactor: swap parsing boundary to OAS Cascade_config (Phase 2/5)

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -118,8 +118,141 @@ let gemini_pro =
     ~model_id:Env_config.Gemini.default_model ~provider:Gemini
 
 (* ================================================================ *)
-(* Model spec parsing                                                *)
+(* OAS Cascade_config bridge                                         *)
+(* Converts OAS Provider_config.t → MASC model_spec.                 *)
 (* ================================================================ *)
+
+(** Map OAS provider_kind to MASC provider enum.
+    OAS provider_kind is coarser (Anthropic, OpenAI_compat, Gemini)
+    so we use the registry name to disambiguate OpenAI_compat
+    sub-families (Llama, OpenAI, Glm_cloud, OpenRouter). *)
+let provider_of_oas ~(registry_name : string)
+    ~(kind : Llm_provider.Provider_config.provider_kind) : provider =
+  match kind with
+  | Anthropic -> Claude
+  | Gemini -> Gemini
+  | Claude_code -> Claude
+  | OpenAI_compat -> (
+      match registry_name with
+      | "llama" -> Llama
+      | "glm" -> Glm_cloud
+      | "openrouter" -> OpenRouter
+      | _ -> OpenAI)
+
+(** Convert an OAS Provider_config.t + registry entry into a MASC model_spec.
+    Uses the registry for max_context and api_key_env, and Pricing for costs. *)
+let model_spec_of_provider_config ~(registry_name : string)
+    (pc : Llm_provider.Provider_config.t) : model_spec =
+  let provider = provider_of_oas ~registry_name ~kind:pc.kind in
+  let entry = Llm_provider.Provider_registry.find default_registry registry_name in
+  let max_context =
+    match entry with Some e -> e.max_context | None -> 128_000
+  in
+  let api_key_env =
+    match entry with
+    | Some e when e.defaults.api_key_env <> "" -> Some e.defaults.api_key_env
+    | _ -> None
+  in
+  let pricing = Llm_provider.Pricing.pricing_for_model pc.model_id in
+  { provider;
+    model_id = pc.model_id;
+    max_context;
+    api_url = pc.base_url;
+    api_key_env;
+    cost_per_1k_input = pricing.input_per_million /. 1000.0;
+    cost_per_1k_output = pricing.output_per_million /. 1000.0 }
+
+(** Map MASC Provider_adapter canonical names to OAS registry names.
+    Returns None when no mapping exists (caller handles the error). *)
+let oas_registry_name_of_canonical = function
+  | "llama"      -> Some "llama"
+  | "claude-api" -> Some "claude"
+  | "gemini-api" -> Some "gemini"
+  | "glm"        -> Some "glm"
+  | "openrouter" -> Some "openrouter"
+  | "codex-api"  -> Some "openrouter"
+  | _            -> None
+
+(* ================================================================ *)
+(* Model spec parsing                                                *)
+(* Delegates core provider:model parsing to OAS                      *)
+(* Cascade_config.parse_model_string_exn, keeping MASC-specific      *)
+(* alias resolution and model shortcut handling.                     *)
+(* ================================================================ *)
+
+(** Parse a provider:model string via OAS, with MASC alias and shortcut
+    handling layered on top.  The flow is:
+    1. Resolve MASC provider aliases (Provider_adapter) to canonical name
+    2. Apply MASC model shortcuts (gemini:pro, claude:opus, glm:auto)
+    3. Normalize canonical name → OAS registry name
+    4. Delegate to OAS Cascade_config.parse_model_string_exn
+    5. Convert Provider_config.t → model_spec *)
+let parse_provider_model ~(original : string) ~(provider_str : string)
+    ~(model_id : string) : (model_spec, string) result =
+  (* Step 1: resolve MASC alias to canonical adapter name *)
+  match Provider_adapter.resolve_direct_adapter provider_str with
+  | Some adapter -> (
+      (* Step 2: apply MASC model shortcuts *)
+      match adapter.canonical_name with
+      | "gemini-api" when model_id = "pro" -> Ok gemini_pro
+      | "gemini-api" when model_id = "flash" ->
+          let flash = Env_config_governance.Gemini.flash_model in
+          Ok { gemini_pro with
+               model_id = (if flash = "" then "flash" else flash) }
+      | "claude-api" when model_id = "opus" -> Ok claude_opus
+      | "claude-api" when model_id = "sonnet" -> Ok claude_sonnet
+      | "glm" when model_id = "auto" ->
+          Ok { glm_cloud with model_id = "" }
+      | canonical -> (
+          (* Step 3: map to OAS registry name *)
+          match oas_registry_name_of_canonical canonical with
+          | None ->
+              Error (sprintf
+                "Cannot parse model spec: %s (unsupported adapter '%s')"
+                original provider_str)
+          | Some registry_name ->
+              (* Step 4: delegate to OAS *)
+              let oas_label = sprintf "%s:%s" registry_name model_id in
+              match
+                Llm_provider.Cascade_config.parse_model_string_exn oas_label
+              with
+              | Error msg ->
+                  Error (sprintf "Cannot parse model spec: %s (%s)"
+                           original msg)
+              | Ok pc ->
+                  (* Step 5: convert back with MASC provider enum *)
+                  Ok (model_spec_of_provider_config ~registry_name pc)))
+  | None -> (
+      (* No MASC adapter found — try custom or direct OAS parse *)
+      match provider_str with
+      | "custom" ->
+          let oas_label = sprintf "custom:%s" model_id in
+          (match
+             Llm_provider.Cascade_config.parse_model_string_exn oas_label
+           with
+          | Error msg ->
+              Error (sprintf "Cannot parse model spec: %s (%s)" original msg)
+          | Ok pc ->
+              let actual_model = pc.model_id in
+              let api_url =
+                if pc.base_url <> "" then pc.base_url
+                else Env_config_runtime.Custom_model.default_server_url
+              in
+              let pricing =
+                Llm_provider.Pricing.pricing_for_model actual_model
+              in
+              Ok { provider = Custom actual_model;
+                   model_id = actual_model;
+                   max_context = 128_000;
+                   api_url;
+                   api_key_env = None;
+                   cost_per_1k_input = pricing.input_per_million /. 1000.0;
+                   cost_per_1k_output = pricing.output_per_million /. 1000.0 })
+      | _ ->
+          Error (sprintf
+            "Cannot parse model spec: %s (unsupported provider '%s'; \
+             supported: llama, claude, gemini, glm, openrouter, custom)"
+            original provider_str))
 
 let rec model_spec_of_string s =
   let s = String.trim s in
@@ -143,77 +276,28 @@ let rec model_spec_of_string s =
   match String.index_opt s ':' with
   | None ->
     Error
-      (Printf.sprintf
+      (sprintf
          "Cannot parse model spec: %s (expected provider:model or default[:model])"
          s)
   | Some idx ->
     if idx = 0 || idx >= String.length s - 1 then
       Error
-        (Printf.sprintf
+        (sprintf
            "Cannot parse model spec: %s (expected provider:model or default[:model])"
            s)
     else
-      let provider = String.sub s 0 idx |> String.lowercase_ascii in
+      let provider_str = String.sub s 0 idx |> String.lowercase_ascii in
       let model_id =
         String.sub s (idx + 1) (String.length s - idx - 1)
         |> String.trim
       in
       if model_id = "" then
         Error
-          (Printf.sprintf
+          (sprintf
              "Cannot parse model spec: %s (expected provider:model or default[:model])"
              s)
       else
-        match Provider_adapter.resolve_direct_adapter provider with
-        | Some adapter when adapter.canonical_name = "llama" ->
-          Ok { llama_default with model_id }
-        | Some adapter when adapter.canonical_name = "gemini-api" ->
-          if model_id = "pro" then Ok gemini_pro
-          else if model_id = "flash" then
-            let flash = Env_config_governance.Gemini.flash_model in
-            Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
-          else
-            Ok { gemini_pro with model_id }
-        | Some adapter when adapter.canonical_name = "claude-api" ->
-          if model_id = "opus" then Ok claude_opus
-          else if model_id = "sonnet" then Ok claude_sonnet
-          else Ok { claude_opus with model_id }
-        | Some adapter when adapter.canonical_name = "codex-api" ->
-          Ok { openai_default with model_id }
-        | Some adapter when adapter.canonical_name = "glm" ->
-          let effective_id = if model_id = "auto" then "" else model_id in
-          Ok { glm_cloud with model_id = effective_id }
-        | Some adapter when adapter.canonical_name = "openrouter" ->
-          Ok (make_of_registry ~registry_name:"openrouter"
-                ~model_id ~provider:OpenRouter)
-        | Some _ ->
-          Error (Printf.sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
-        | None ->
-          match provider with
-        | "custom" ->
-          let actual_model, url =
-            match String.index_opt model_id '@' with
-            | Some at_idx ->
-              ( String.sub model_id 0 at_idx,
-                String.sub model_id (at_idx + 1)
-                  (String.length model_id - at_idx - 1) )
-            | None -> (model_id, Env_config_runtime.Custom_model.default_server_url)
-          in
-          let pricing = Llm_provider.Pricing.pricing_for_model actual_model in
-          Ok {
-            provider = Custom actual_model;
-            model_id = actual_model;
-            max_context = 128_000;
-            api_url = url;
-            api_key_env = None;
-            cost_per_1k_input = pricing.input_per_million /. 1000.0;
-            cost_per_1k_output = pricing.output_per_million /. 1000.0;
-          }
-        | _ ->
-          Error
-            (Printf.sprintf
-               "Cannot parse model spec: %s (unsupported provider '%s'; supported: llama, claude, gemini, glm, openrouter, custom)"
-               s provider)
+        parse_provider_model ~original:s ~provider_str ~model_id
 
 (* ================================================================ *)
 (* Default model label helpers                                       *)

--- a/test/dune
+++ b/test/dune
@@ -276,6 +276,11 @@
  (libraries masc_mcp alcotest unix eio eio_main))
 
 (test
+ (name test_model_spec_oas_bridge)
+ (modules test_model_spec_oas_bridge)
+ (libraries masc_mcp alcotest unix))
+
+(test
  (name test_chain_native_eio_bootstrap)
  (modules test_chain_native_eio_bootstrap)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_model_spec_oas_bridge.ml
+++ b/test/test_model_spec_oas_bridge.ml
@@ -1,0 +1,248 @@
+(** Tests for the OAS parsing boundary swap in Model_spec.
+
+    Verifies that model_spec_of_string delegates to OAS
+    Cascade_config.parse_model_string_exn for core provider:model parsing
+    while maintaining MASC-specific alias and shortcut behavior. *)
+
+open Alcotest
+
+module Model_spec = Masc_mcp.Model_spec
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+(* ── Core provider:model parsing via OAS ────────────── *)
+
+let test_llama_basic () =
+  match Model_spec.model_spec_of_string "llama:qwen3.5-35b" with
+  | Ok spec ->
+      check bool "provider is Llama" true (spec.provider = Model_spec.Llama);
+      check string "model_id" "qwen3.5-35b" spec.model_id;
+      check bool "max_context > 0" true (spec.max_context > 0);
+      check bool "api_url non-empty" true (String.length spec.api_url > 0)
+  | Error msg -> fail (Printf.sprintf "llama parse failed: %s" msg)
+
+let test_gemini_basic () =
+  with_env "GEMINI_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "gemini:gemini-2.5-pro" with
+    | Ok spec ->
+        check bool "provider is Gemini" true
+          (spec.provider = Model_spec.Gemini);
+        check string "model_id" "gemini-2.5-pro" spec.model_id
+    | Error msg -> fail (Printf.sprintf "gemini parse failed: %s" msg))
+
+let test_claude_basic () =
+  with_env "ANTHROPIC_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "claude:claude-opus-4-6" with
+    | Ok spec ->
+        check bool "provider is Claude" true
+          (spec.provider = Model_spec.Claude);
+        check string "model_id" "claude-opus-4-6" spec.model_id
+    | Error msg -> fail (Printf.sprintf "claude parse failed: %s" msg))
+
+let test_glm_basic () =
+  with_env "ZAI_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "glm:glm-4.5" with
+    | Ok spec ->
+        check bool "provider is Glm_cloud" true
+          (spec.provider = Model_spec.Glm_cloud);
+        check string "model_id" "glm-4.5" spec.model_id
+    | Error msg -> fail (Printf.sprintf "glm parse failed: %s" msg))
+
+let test_openrouter_basic () =
+  with_env "OPENROUTER_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "openrouter:meta-llama/llama-3" with
+    | Ok spec ->
+        check bool "provider is OpenRouter" true
+          (spec.provider = Model_spec.OpenRouter);
+        check string "model_id" "meta-llama/llama-3" spec.model_id
+    | Error msg -> fail (Printf.sprintf "openrouter parse failed: %s" msg))
+
+(* ── MASC model shortcuts preserved ────────────────── *)
+
+let test_gemini_pro_shortcut () =
+  with_env "GEMINI_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "gemini:pro" with
+    | Ok spec ->
+        check bool "provider is Gemini" true
+          (spec.provider = Model_spec.Gemini);
+        check bool "model_id non-empty" true
+          (String.length spec.model_id > 0)
+    | Error msg -> fail (Printf.sprintf "gemini:pro failed: %s" msg))
+
+let test_gemini_flash_shortcut () =
+  with_env "GEMINI_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "gemini:flash" with
+    | Ok spec ->
+        check bool "provider is Gemini" true
+          (spec.provider = Model_spec.Gemini);
+        check bool "model_id non-empty" true
+          (String.length spec.model_id > 0)
+    | Error msg -> fail (Printf.sprintf "gemini:flash failed: %s" msg))
+
+let test_claude_opus_shortcut () =
+  with_env "ANTHROPIC_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "claude:opus" with
+    | Ok spec ->
+        check bool "provider is Claude" true
+          (spec.provider = Model_spec.Claude)
+    | Error msg -> fail (Printf.sprintf "claude:opus failed: %s" msg))
+
+let test_claude_sonnet_shortcut () =
+  with_env "ANTHROPIC_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "claude:sonnet" with
+    | Ok spec ->
+        check bool "provider is Claude" true
+          (spec.provider = Model_spec.Claude)
+    | Error msg -> fail (Printf.sprintf "claude:sonnet failed: %s" msg))
+
+let test_glm_auto_shortcut () =
+  with_env "ZAI_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "glm:auto" with
+    | Ok spec ->
+        check bool "provider is Glm_cloud" true
+          (spec.provider = Model_spec.Glm_cloud);
+        check string "model_id is empty (auto)" "" spec.model_id
+    | Error msg -> fail (Printf.sprintf "glm:auto failed: %s" msg))
+
+(* ── MASC alias resolution preserved ───────────────── *)
+
+let test_anthropic_alias () =
+  with_env "ANTHROPIC_API_KEY" "test-key" (fun () ->
+    match Model_spec.model_spec_of_string "anthropic:test-model" with
+    | Ok spec ->
+        check bool "provider is Claude" true
+          (spec.provider = Model_spec.Claude);
+        check string "model_id" "test-model" spec.model_id
+    | Error msg -> fail (Printf.sprintf "anthropic alias failed: %s" msg))
+
+let test_llamacpp_alias () =
+  match Model_spec.model_spec_of_string "llamacpp:test-model" with
+  | Ok spec ->
+      check bool "provider is Llama" true
+        (spec.provider = Model_spec.Llama);
+      check string "model_id" "test-model" spec.model_id
+  | Error msg -> fail (Printf.sprintf "llamacpp alias failed: %s" msg)
+
+(* ── Custom provider (delegated to OAS) ────────────── *)
+
+let test_custom_with_url () =
+  match
+    Model_spec.model_spec_of_string "custom:my-model@http://10.0.0.1:9090"
+  with
+  | Ok spec ->
+      (match spec.provider with
+       | Model_spec.Custom name ->
+           check string "custom name" "my-model" name
+       | _ -> fail "expected Custom provider");
+      check string "api_url" "http://10.0.0.1:9090" spec.api_url
+  | Error msg -> fail (Printf.sprintf "custom parse failed: %s" msg)
+
+let test_custom_without_url () =
+  match Model_spec.model_spec_of_string "custom:my-model" with
+  | Ok spec ->
+      (match spec.provider with
+       | Model_spec.Custom name ->
+           check string "custom name" "my-model" name
+       | _ -> fail "expected Custom provider")
+  | Error msg -> fail (Printf.sprintf "custom bare failed: %s" msg)
+
+(* ── Error cases ───────────────────────────────────── *)
+
+let test_invalid_no_colon () =
+  match Model_spec.model_spec_of_string "nocolon" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error for no-colon input"
+
+let test_invalid_empty_model () =
+  match Model_spec.model_spec_of_string "llama:" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error for empty model"
+
+let test_invalid_empty_provider () =
+  match Model_spec.model_spec_of_string ":model" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error for empty provider"
+
+let test_invalid_unknown_provider () =
+  match Model_spec.model_spec_of_string "unknown_xyz:model" with
+  | Error _ -> ()
+  | Ok _ -> fail "expected error for unknown provider"
+
+(* ── OAS bridge: model_spec_of_provider_config ─────── *)
+
+let test_provider_config_conversion () =
+  (* Verify that the OAS Provider_config → model_spec conversion
+     produces consistent results with direct model_spec_of_string *)
+  match Model_spec.model_spec_of_string "llama:qwen3.5-35b" with
+  | Ok spec ->
+      check bool "has pricing" true
+        (spec.cost_per_1k_input >= 0.0);
+      check bool "has max_context" true
+        (spec.max_context > 0)
+  | Error msg -> fail (Printf.sprintf "conversion test failed: %s" msg)
+
+(* ── Availability gating (OAS checks env vars) ─────── *)
+
+let test_unavailable_provider_error () =
+  with_env "GEMINI_API_KEY" "" (fun () ->
+    match Model_spec.model_spec_of_string "gemini:gemini-2.5-pro" with
+    | Error msg ->
+        check bool "error mentions unavailable" true
+          (String.length msg > 0)
+    | Ok _ ->
+        (* Vertex ADC fallback may make gemini available even without
+           GEMINI_API_KEY, so this is also acceptable *)
+        ())
+
+let () =
+  run "Model_spec OAS bridge"
+    [
+      ( "core_parsing",
+        [
+          test_case "llama basic" `Quick test_llama_basic;
+          test_case "gemini basic" `Quick test_gemini_basic;
+          test_case "claude basic" `Quick test_claude_basic;
+          test_case "glm basic" `Quick test_glm_basic;
+          test_case "openrouter basic" `Quick test_openrouter_basic;
+        ] );
+      ( "masc_shortcuts",
+        [
+          test_case "gemini:pro shortcut" `Quick test_gemini_pro_shortcut;
+          test_case "gemini:flash shortcut" `Quick test_gemini_flash_shortcut;
+          test_case "claude:opus shortcut" `Quick test_claude_opus_shortcut;
+          test_case "claude:sonnet shortcut" `Quick test_claude_sonnet_shortcut;
+          test_case "glm:auto shortcut" `Quick test_glm_auto_shortcut;
+        ] );
+      ( "masc_aliases",
+        [
+          test_case "anthropic alias" `Quick test_anthropic_alias;
+          test_case "llamacpp alias" `Quick test_llamacpp_alias;
+        ] );
+      ( "custom",
+        [
+          test_case "custom with url" `Quick test_custom_with_url;
+          test_case "custom without url" `Quick test_custom_without_url;
+        ] );
+      ( "errors",
+        [
+          test_case "no colon" `Quick test_invalid_no_colon;
+          test_case "empty model" `Quick test_invalid_empty_model;
+          test_case "empty provider" `Quick test_invalid_empty_provider;
+          test_case "unknown provider" `Quick test_invalid_unknown_provider;
+        ] );
+      ( "oas_bridge",
+        [
+          test_case "provider_config conversion" `Quick
+            test_provider_config_conversion;
+          test_case "unavailable provider error" `Quick
+            test_unavailable_provider_error;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Replace hand-rolled `provider:model` parsing in `model_spec_of_string` with delegation to OAS `Cascade_config.parse_model_string_exn`
- Add OAS bridge layer: `provider_of_oas`, `model_spec_of_provider_config`, `oas_registry_name_of_canonical` for type conversion
- Keep MASC-specific logic (default/default:override, alias resolution, model shortcuts) as wrapper on top of OAS parsing
- All 7 external call sites continue working unchanged (boundary swap is internal to `model_spec.ml`)
- 20 new tests covering core parsing, MASC shortcuts, aliases, custom provider, and error cases

## Context

Phase 2 of 5 in the Model_spec retirement plan:
- Phase 1 (merged): Display + Cost decoupling (#2322)
- **Phase 2 (this PR): Parsing boundary swap**
- Phase 3: Call site migration to Provider_config.t
- Phase 4: model_spec type removal
- Phase 5: Provider_adapter consolidation

## Test plan

- [x] `dune build --root .` compiles cleanly
- [x] `make test` passes (full suite including 20 new OAS bridge tests)
- [x] Existing cascade, model_client, provider_adapter tests unaffected
- [ ] CI checks green

Generated with [Claude Code](https://claude.com/claude-code)