### PR TITLE
refactor: delegate default/preset resolution to OAS Cascade_config (Phase 3/5)

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -300,7 +300,32 @@ let rec model_spec_of_string s =
         parse_provider_model ~original:s ~provider_str ~model_id
 
 (* ================================================================ *)
+(* Cascade config path resolution                                    *)
+(* Shared between Model_spec and Oas_worker.                         *)
+(* ================================================================ *)
+
+(** Locate config/cascade.json via CWD or ME_ROOT.
+    Returns [Some path] when the file exists on disk. *)
+let cascade_config_path () : string option =
+  let base dir name = Filename.concat (Filename.concat dir "config") name in
+  let cwd = Sys.getcwd () in
+  let me_root =
+    Sys.getenv_opt "ME_ROOT"
+    |> Option.value
+         ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
+  in
+  let masc_root = Filename.concat me_root "workspace/yousleepwhen/masc-mcp" in
+  let candidates =
+    [ base cwd "cascade.json";
+      base masc_root "cascade.json" ]
+  in
+  List.find_opt Sys.file_exists candidates
+
+(* ================================================================ *)
 (* Default model label helpers                                       *)
+(* Delegates to OAS Cascade_config.resolve_model_strings when a      *)
+(* cascade config file is available, falling back to                  *)
+(* Provider_adapter env-driven label lists.                          *)
 (* ================================================================ *)
 
 let configured_default_model_label () =
@@ -308,11 +333,30 @@ let configured_default_model_label () =
   | Ok label -> Some label
   | Error _ -> None
 
+(** Resolve model labels via OAS Cascade_config when Eio runtime is active
+    and cascade config file exists.  Falls back to [defaults] when called
+    outside Eio (e.g. top-level module initialization in tests). *)
+let resolve_cascade_labels ~name ~defaults =
+  match cascade_config_path () with
+  | None -> defaults
+  | Some config_path -> (
+      try
+        Llm_provider.Cascade_config.resolve_model_strings
+          ~config_path ~name ~defaults ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ ->
+          (* Eio.Mutex requires Eio context; gracefully fall back when
+             called during module init (before Eio.main). *)
+          defaults)
+
 let default_execution_model_labels () =
-  Provider_adapter.preferred_execution_model_labels ()
+  resolve_cascade_labels ~name:"default"
+    ~defaults:(Provider_adapter.preferred_execution_model_labels ())
 
 let default_verifier_model_labels () =
-  Provider_adapter.preferred_verifier_model_labels ()
+  resolve_cascade_labels ~name:"verifier"
+    ~defaults:(Provider_adapter.preferred_verifier_model_labels ())
 
 (* ================================================================ *)
 (* Available spec filtering                                          *)
@@ -357,6 +401,11 @@ let default_verifier_model_spec () =
   first_available_model_spec (default_verifier_model_labels ())
 
 let default_local_model_spec () =
+  (* Resolution order (cascade-aware):
+     1. Explicit user config (MASC_DEFAULT_CASCADE / MASC_DEFAULT_PROVIDER+MODEL)
+     2. Cascade "default" profile from config/cascade.json (hot-reloadable)
+     3. Env-driven execution chain (Provider_adapter)
+     4. Hardcoded glm_cloud fallback *)
   match configured_default_model_label () with
   | Some label -> (
       match model_spec_of_string label with

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -1,8 +1,16 @@
-(** Model_spec — MODEL provider types, preset specs, and model spec parsing.
+(** Model_spec — OAS-backed model identity and resolution.
 
-    Extracted from {!Cascade} to decouple model identity from cascade orchestration.
+    Types and parsing remain for MASC-specific alias resolution
+    (Provider_adapter) and "default"/"default:override" forms.
+    Metadata (URLs, API keys, context sizes, costs) is sourced
+    from OAS Provider_registry and Pricing — single source of truth.
 
-    @since 2.117.0 *)
+    Default/preset resolution delegates to OAS Cascade_config
+    when [config/cascade.json] is present (hot-reloadable).
+
+    @since 2.117.0 — original extraction from Cascade
+    @since 2.123.0 — rewritten as OAS facade
+    @since 2.129.0 — default resolution via Cascade_config *)
 
 (** MODEL provider discriminator. *)
 type provider =
@@ -44,15 +52,25 @@ val gemini_pro : model_spec
     Returns [Error msg] on unrecognised input. *)
 val model_spec_of_string : string -> (model_spec, string) result
 
+(** {2 Cascade config} *)
+
+(** Locate [config/cascade.json] via CWD or ME_ROOT.
+    Returns [Some path] when the file exists on disk. *)
+val cascade_config_path : unit -> string option
+
 (** {2 Default model labels} *)
 
 (** Configured default model label from env, if any. *)
 val configured_default_model_label : unit -> string option
 
-(** Preferred execution model labels (env-driven). *)
+(** Preferred execution model labels.
+    Consults OAS [Cascade_config.resolve_model_strings] with
+    [config/cascade.json] when available, falling back to env-driven labels. *)
 val default_execution_model_labels : unit -> string list
 
-(** Preferred verifier model labels (env-driven). *)
+(** Preferred verifier model labels.
+    Consults OAS [Cascade_config.resolve_model_strings] with
+    [config/cascade.json] when available, falling back to env-driven labels. *)
 val default_verifier_model_labels : unit -> string list
 
 (** {2 Filtering and resolution} *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -268,22 +268,8 @@ let run_with_masc_tools
 (* Cascade profile defaults (moved from Cascade module)              *)
 (* ================================================================ *)
 
-(** Locate config/cascade.json via CWD or ME_ROOT.
-    Returns [Some path] when the file exists on disk. *)
-let default_config_path () : string option =
-  let base dir name = Filename.concat (Filename.concat dir "config") name in
-  let cwd = Sys.getcwd () in
-  let me_root =
-    Sys.getenv_opt "ME_ROOT"
-    |> Option.value
-         ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
-  in
-  let masc_root = Filename.concat me_root "workspace/yousleepwhen/masc-mcp" in
-  let candidates =
-    [ base cwd "cascade.json";
-      base masc_root "cascade.json" ]
-  in
-  List.find_opt Sys.file_exists candidates
+(** Delegate to {!Model_spec.cascade_config_path}. *)
+let default_config_path = Model_spec.cascade_config_path
 
 (** Hardcoded fallback defaults — used only when cascade.json is missing
     and the cascade name has no "{name}_models" entry.

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -26,7 +26,8 @@ type run_result = {
   trace_ref : Oas.Raw_trace.run_ref option;
 }
 
-(** Locate config/cascade.json via CWD or ME_ROOT. *)
+(** Locate config/cascade.json via CWD or ME_ROOT.
+    Delegates to {!Model_spec.cascade_config_path}. *)
 val default_config_path : unit -> string option
 
 (** Return the default model string list for a given cascade name. *)


### PR DESCRIPTION
## Summary

- Move `cascade_config_path()` from `oas_worker.ml` to `model_spec.ml` so default resolution can use cascade config
- Wire `default_execution_model_labels()` and `default_verifier_model_labels()` through `Cascade_config.resolve_model_strings` with `config/cascade.json` when available
- Add Eio-safe try/catch guard for callers at module-init time (e.g. `mitosis_helpers.ml`'s top-level `let default_verifier_models`)
- External call sites unchanged (0 signature changes)

### Resolution order (cascade-aware)
1. Explicit user config (`MASC_DEFAULT_CASCADE` / `MASC_DEFAULT_PROVIDER`+`MODEL`)
2. Named cascade profile from `config/cascade.json` (hot-reloadable via OAS)
3. Env-driven `Provider_adapter` label chain (existing behavior)
4. Hardcoded `glm_cloud` fallback (last resort)

### Files changed
| File | Change |
|------|--------|
| `lib/model_spec.ml` | Add `cascade_config_path()`, `resolve_cascade_labels()` with Eio guard |
| `lib/model_spec.mli` | Expose `cascade_config_path`, updated docstrings |
| `lib/oas_worker.ml` | Replace inline config path logic with `Model_spec.cascade_config_path` delegation |
| `lib/oas_worker.mli` | Docstring update |

### Context
Phase 3 of Model_spec retirement arc:
- Phase 1: Display+Cost (PR #2322)
- Phase 2: Parsing boundary (PR #2325)
- **Phase 3**: Default/preset resolution via OAS Cascade_config (this PR)

## Test plan
- [x] `dune build --root .` passes
- [x] `test_oas_worker` cascade_config tests pass (5/5)
- [x] Pre-existing `tool_mitosis_oas 8` failure confirmed unrelated (PG connectivity)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)