### PR TITLE
fix(board): allow dashboard vote/comment without bearer token

### DIFF
--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -162,10 +162,12 @@ let add_routes router =
               respond_json_with_cors ~status request reqd body)
        ) request reqd)
 
-  (* Board write APIs — used by Bevy Viewer *)
+  (* Board write APIs — used by dashboard + Bevy Viewer.
+     Uses with_tool_auth to allow localhost browser requests without token. *)
   |> Http.Router.post "/api/v1/tools/masc_board_vote" (fun request reqd ->
-       with_token_permission_auth ~permission:Types.CanBroadcast
-         (fun _state agent_name _req reqd ->
+       with_tool_auth ~tool_name:"masc_board_vote"
+         (fun _state _req reqd ->
+         let agent_name = Option.bind (Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent") (fun s -> if s = "" then None else Some s) |> Option.value ~default:"dashboard" in
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args =
@@ -188,8 +190,9 @@ let add_routes router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/tools/masc_board_comment" (fun request reqd ->
-       with_token_permission_auth ~permission:Types.CanBroadcast
-         (fun _state agent_name _req reqd ->
+       with_tool_auth ~tool_name:"masc_board_comment"
+         (fun _state _req reqd ->
+         let agent_name = Option.bind (Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent") (fun s -> if s = "" then None else Some s) |> Option.value ~default:"dashboard" in
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args =


### PR DESCRIPTION
## Summary
- Board vote/comment API가 `with_token_permission_auth`를 사용하여 대시보드에서 토큰 없이 댓글/투표 불가능한 문제 수정
- `with_tool_auth`로 전환: localhost same-origin 요청은 토큰 없이 허용
- agent_name은 `X-MASC-Agent` 헤더에서 읽고, 없으면 "dashboard" 기본값

## Test plan
- [x] `dune build` 성공
- [ ] 대시보드에서 토큰 없이 댓글 등록 확인
- [ ] curl localhost에서 토큰 없이 댓글 등록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)