### PR TITLE
refactor: reduce Model_spec coupling in keeper_types_resident (Phase 4A/5)

### DIFF
--- a/archive/trpg/lib/server/server_trpg_rest_models.ml
+++ b/archive/trpg/lib/server/server_trpg_rest_models.ml
@@ -65,12 +65,14 @@ let trpg_keeper_models_for_round () : string list =
     | Some models -> models
     | None -> trpg_default_fast_keeper_models ()
   in
-  match Keeper_types.model_specs_of_strings chosen with
-  | Ok _ -> chosen
-  | Error e ->
-      if chosen <> [] then
-        Log.Trpg.info "invalid keeper model override ignored: %s" e;
-      []
+  let valid_specs = Model_spec.available_model_specs_of_strings chosen in
+  if valid_specs <> [] || chosen = [] then
+    chosen
+  else begin
+    Log.Trpg.info "invalid keeper model override ignored: no valid specs for %s"
+      (String.concat ", " chosen);
+    []
+  end
 
 let trim_trailing_slashes (raw : string) : string =
   let rec loop value =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -222,9 +222,11 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
                 ]
             | None ->
-                (match Keeper_types.model_specs_of_strings m.models with
-                 | Error _ -> `Assoc [("has_checkpoint", `Bool false)]
-                 | Ok specs ->
+                (let specs = Model_spec.available_model_specs_of_strings m.models in
+                 match specs with
+                 | [] when m.models <> [] ->
+                     `Assoc [("has_checkpoint", `Bool false)]
+                 | _ ->
                      let primary =
                        match specs with m0 :: _ -> m0 | [] -> Model_spec.llama_default
                      in

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -18,35 +18,14 @@ let keeper_dir_ (config : Room.config) =
 let session_base_dir_ (config : Room.config) =
   Filename.concat (Filename.concat config.base_path ".masc") "perpetual"
 
-let model_specs_of_strings (model_strs : string list) :
-    (Model_spec.model_spec list, string) result =
-  let rec go acc = function
-    | [] -> Ok (List.rev acc)
-    | s :: rest -> (
-        match Model_spec.model_spec_of_string s with
-        | Ok spec -> go (spec :: acc) rest
-        | Error e -> Error (Printf.sprintf "Bad model spec %s: %s" s e))
-  in
-  go [] model_strs
-
 let env_present name =
   match Sys.getenv_opt name with
   | Some value -> String.trim value <> ""
   | None -> false
 
-let model_spec_is_local_runtime (model : Model_spec.model_spec) =
-  match model.provider with
-  | Model_spec.Llama -> true
-  | _ -> false
-
 let label_is_local_runtime (label : string) =
   let l = String.lowercase_ascii (String.trim label) in
   String.length l >= 6 && String.sub l 0 6 = "llama:"
-
-let model_spec_is_available (model : Model_spec.model_spec) =
-  match model.provider with
-  | Model_spec.Llama -> true
-  | _ -> true
 
 (** Check whether a model label refers to an available provider.
     Currently always returns true (all providers are considered available). *)
@@ -86,21 +65,6 @@ let maybe_append_keeper_fallback_models (models : string list) =
     in
     if extra = [] then models else models @ extra
 
-let ensure_api_keys (models : Model_spec.model_spec list) : (unit, string) result =
-  let missing =
-    List.filter_map (fun (m : Model_spec.model_spec) ->
-      match m.api_key_env with
-      | None -> None
-      | Some env ->
-          let v = Sys.getenv_opt env |> Option.value ~default:"" in
-          if v = "" then Some env else None)
-      models
-  in
-  match missing with
-  | [] -> Ok ()
-  | xs ->
-      Error (Printf.sprintf "Missing API key env vars: %s" (String.concat ", " xs))
-
 (** Check API key availability using model label strings (no model_spec needed).
     Parses labels to extract api_key_env, filtering out unparseable labels. *)
 let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
@@ -109,7 +73,19 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
     Error (Printf.sprintf "No valid/available model specs for labels: %s"
       (String.concat ", " labels))
   else
-    ensure_api_keys specs
+    let missing =
+      List.filter_map (fun (m : Model_spec.model_spec) ->
+        match m.api_key_env with
+        | None -> None
+        | Some env ->
+            let v = Sys.getenv_opt env |> Option.value ~default:"" in
+            if v = "" then Some env else None)
+        specs
+    in
+    match missing with
+    | [] -> Ok ()
+    | xs ->
+        Error (Printf.sprintf "Missing API key env vars: %s" (String.concat ", " xs))
 
 (** Legacy single-file metrics path (for fallback reads). *)
 let keeper_metrics_path config name =

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -104,9 +104,7 @@ let test_maybe_append_keeper_fallback_models_adds_glm_when_local_only () =
           ["llama:qwen3.5-35b-a3b-ud-q8-xl"]
       in
       let llama_listening =
-        match Masc_mcp.Keeper_types.model_specs_of_strings ["llama:qwen3.5-35b-a3b-ud-q8-xl"] with
-        | Ok [spec] -> Masc_mcp.Keeper_types.model_spec_is_available spec
-        | _ -> false
+        Masc_mcp.Keeper_types.label_is_available "llama:qwen3.5-35b-a3b-ud-q8-xl"
       in
       let expected =
         if llama_listening then


### PR DESCRIPTION
## Summary
- Remove 3 functions (`model_specs_of_strings`, `model_spec_is_local_runtime`, `model_spec_is_available`) from `keeper_types_resident.ml` that accepted `Model_spec.model_spec` as input
- Redirect callers to string-based equivalents (`label_is_local_runtime`, `label_is_available`, `Model_spec.available_model_specs_of_strings`)
- Inline `ensure_api_keys` (which took `model_spec list`) into `ensure_api_keys_for_labels` (which takes `string list`)
- Net result: `Model_spec.model_spec` type references in this file reduced from 9 to 2 (both internal to `ensure_api_keys_for_labels`)

## Context
Part of the Model_spec retirement series (Phase 4A/5). This addresses the largest consumer file in the keeper subsystem. The remaining 2 references are implementation-internal (parsing labels to inspect `api_key_env` fields) and cannot be eliminated without moving the API key check logic into `Model_spec` itself.

## Test plan
- [x] `dune build --root .` passes
- [x] `test_tool_keeper.exe` -- 22/22 tests pass
- [x] `test_cascade.exe` -- 10/10 tests pass
- [x] `test_model_client_coverage.exe` -- 7/7 tests pass
- [x] Pre-existing failures (`handoff force`, SSE storm E2E) confirmed on main -- unrelated

Generated with [Claude Code](https://claude.com/claude-code)