### PR TITLE
fix: catch Eio.Mutex.Poisoned in cascade resolution (fixes #2333)

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -344,7 +344,9 @@ let resolve_cascade_labels ~name ~defaults =
         Llm_provider.Cascade_config.resolve_model_strings
           ~config_path ~name ~defaults ()
       with
+      | Eio.Cancel.Cancelled (Eio.Mutex.Poisoned _) -> defaults
       | Eio.Cancel.Cancelled _ as e -> raise e
+      | Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> defaults
       | _ ->
           (* Eio.Mutex requires Eio context; gracefully fall back when
              called during module init (before Eio.main). *)


### PR DESCRIPTION
## Summary
서버 시작 시 `Eio__Eio_mutex.Poisoned` crash 수정.

`resolve_cascade_labels`에서 `Eio.Cancel.Cancelled(Poisoned _)`가 re-raise 되던 문제.
Poisoned를 명시적으로 catch하여 env-driven defaults로 fallback.

## Root cause
PR #2329 (cascade Phase 3)가 `Llm_provider.Cascade_config.resolve_model_strings`를 호출.
이 함수가 내부에서 Eio.Mutex를 사용하는데, keeper bootstrap 시점에 mutex가 poisoned 상태.

Fixes #2333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)