### PR TITLE
fix: don't crash server on keeper bootstrap failure

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -190,9 +190,10 @@ let run_server ~sw ~env ~host ~port ~base_path =
       ~make_request_handler:make_extended_handler
       ~make_h2_request_handler:Server_h2_gateway.make_request_handler
       ~make_h2_error_handler:Server_h2_gateway.make_error_handler
-  with exn ->
-    Log.Server.error "[main] keeper bootstrap failed: %s" (Printexc.to_string exn);
-    raise exn
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Server.error "[main] keeper bootstrap failed (continuing without keepers): %s" (Printexc.to_string exn)
 
 (** CLI options *)
 let port =


### PR DESCRIPTION
Eio.Mutex.Poisoned from kill -9 was crashing the entire server. Now logs error and continues.