### PR TITLE
[Governance] Phase 1: remove dashboard clutter (RuntimeParams, ActivityRail, FreshnessStrip)

### DIFF
--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -18,6 +18,7 @@ import {
   orderStatusLabel,
   stanceLabel,
 } from './governance-utils'
+import { ActivityRail } from './governance-strips'
 
 export function PetitionEntry({ petition }: { petition: GovernanceCaseBundle['petitions'][number] }) {
   return html`
@@ -96,6 +97,7 @@ export function DecisionDetail() {
                   ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">심의 의견이 아직 없습니다.</div>`
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}
               </div>
+              <${ActivityRail} />
             `}
     <//>
   `

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -21,7 +21,10 @@ import {
 } from './governance-utils'
 
 // Re-export from split files for backward compatibility.
-export { ActivityRail, GovernanceFreshnessStrip, RuntimeParamsPanel } from './governance-strips'
+// ActivityRail is now rendered inside DecisionDetail only (not in main view).
+// GovernanceFreshnessStrip was inlined into GovernanceSummaryStrip.
+// RuntimeParamsPanel was removed (use masc_set_param CLI instead).
+export { ActivityRail } from './governance-strips'
 export { DecisionDetail } from './governance-detail'
 
 export function GuardrailPane({

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -3,16 +3,11 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { governanceToneClass } from '../lib/tone'
 import type { GovernanceTimelineEvent } from '../types'
-import type { RuntimeParamsSurface } from '../api'
 import {
   governanceData,
-  runtimeLoading,
-  runtimeParams,
-  runtimeSurfaces,
 } from './governance-store'
 import {
   activityKindLabel,
-  formatParamValue,
 } from './governance-utils'
 
 export function ActivityRail() {
@@ -82,61 +77,3 @@ function LifecycleProgress({ events }: { events: GovernanceTimelineEvent[] }) {
   `
 }
 
-export function GovernanceFreshnessStrip() {
-  const data = governanceData.value
-  if (!data) return null
-  const itemCount = data.items?.length ?? 0
-  const activityCount = data.activity?.length ?? 0
-  return html`
-    <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" style="margin-top:4px;margin-bottom:8px">
-      <span>데이터 범위: 진행 중 ${itemCount}건</span>
-      <span>최근 활동: ${activityCount}건</span>
-      ${data.generated_at ? html`<span>생성 시각: ${data.generated_at}</span>` : null}
-    </div>
-  `
-}
-
-export function RuntimeParamsPanel() {
-  const params = runtimeParams.value
-  const surfaces = runtimeSurfaces.value
-  if (params.length === 0 && !runtimeLoading.value) return null
-
-  return html`
-    <${Card} title="Runtime Parameters" class="section mb-3.5">
-      ${runtimeLoading.value
-        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">파라미터 로딩 중...</div>`
-        : html`
-            <div class="governance-params-surfaces">
-              ${surfaces.map((surface: RuntimeParamsSurface) => {
-                const surfaceParams = params.filter(p => surface.param_keys.includes(p.key))
-                return html`
-                  <div class="governance-surface-group">
-                    <div class="governance-surface-head">
-                      <strong>${surface.id}</strong>
-                      <span class="governance-chip rounded-full ${surface.risk === 'high' ? 'warn' : ''}">${surface.risk}</span>
-                      <span class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">${surface.description}</span>
-                    </div>
-                    <div class="governance-params-table">
-                      ${surfaceParams.map(param => html`
-                        <div class="governance-param-row ${param.has_override ? 'overridden' : ''}">
-                          <span class="governance-param-key">${param.key}</span>
-                          <span class="governance-param-value">
-                            ${formatParamValue(param.current)}
-                            ${param.has_override
-                              ? html`<span class="governance-chip rounded-full warn" style="margin-left:4px">override</span>`
-                              : null}
-                          </span>
-                          <span class="governance-param-default mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
-                            기본: ${formatParamValue(param.default)}
-                          </span>
-                        </div>
-                      `)}
-                    </div>
-                  </div>
-                `
-              })}
-            </div>
-          `}
-    <//>
-  `
-}

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -11,7 +11,6 @@ import {
   governanceLoading,
   governanceStarting,
   governanceTopicInput,
-  loadRuntimeParams,
   refreshGovernance,
   respondToExecutionOrder,
   selectDecision,
@@ -27,21 +26,21 @@ import {
   kindLabel,
 } from './governance-utils'
 import {
-  ActivityRail,
   DecisionDetail,
-  GovernanceFreshnessStrip,
   GuardrailPane,
-  RuntimeParamsPanel,
 } from './governance-panels'
 
 // Re-export for consumers that import from './governance'
 export { refreshGovernance, loadRuntimeParams } from './governance-store'
 
 function GovernanceSummaryStrip() {
-  const summary = governanceData.value?.summary
+  const data = governanceData.value
+  const summary = data?.summary
   const oldestAge = summary?.oldest_open_case_age_s
   const lastActivityAge = summary?.last_activity_age_s
   const isStale = (oldestAge != null && oldestAge > 86400) || (lastActivityAge != null && lastActivityAge > 86400)
+  const itemCount = data?.items?.length ?? 0
+  const activityCount = data?.activity?.length ?? 0
 
   return html`
     ${isStale ? html`
@@ -51,10 +50,14 @@ function GovernanceSummaryStrip() {
         테스트 잔재일 가능성이 높습니다.
       </div>
     ` : null}
+    <div class="flex flex-wrap gap-x-3 gap-y-1 mb-1 text-[var(--text-muted)] text-[length:var(--fs-xs)]">
+      <span>진행 중 ${itemCount}건 / 활동 ${activityCount}건</span>
+      ${data?.generated_at ? html`<span>${data.generated_at}</span>` : null}
+    </div>
     <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2.5 mb-3">
       <div class="board-summary-item flex flex-col gap-1">
         <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">열린 케이스</span>
-        <strong>${summary?.cases_open ?? governanceData.value?.items?.length ?? 0}</strong>
+        <strong>${summary?.cases_open ?? itemCount}</strong>
       </div>
       <div class="board-summary-item flex flex-col gap-1">
         <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">판정 대기</span>
@@ -184,12 +187,10 @@ function DecisionInbox() {
 export function Governance() {
   useEffect(() => {
     void refreshGovernance()
-    void loadRuntimeParams()
   }, [])
 
   return html`
     <div class="section-grid">
-      <${GovernanceFreshnessStrip} />
       <${GovernanceSummaryStrip} />
       <${GovernanceToolbar} />
       <div class="governance-layout">
@@ -200,8 +201,6 @@ export function Governance() {
           respondToExecutionOrder=${respondToExecutionOrder}
         />
       </div>
-      <${ActivityRail} />
-      <${RuntimeParamsPanel} />
     </div>
   `
 }


### PR DESCRIPTION
## Summary

거버넌스 대시보드 메인 뷰의 수직 공간을 확보하기 위해 불필요한 컴포넌트 3개를 정리합니다.

- **RuntimeParamsPanel 삭제**: 50개 이상의 런타임 파라미터를 대시보드에 나열할 필요 없음. CLI `masc_set_param`으로 충분.
- **ActivityRail 이동**: 메인 뷰에서 제거하고 `DecisionDetail` 내부(사건 상세 영역)에서만 렌더링되도록 변경. 사건을 선택했을 때만 관련 타임라인이 표시됨.
- **GovernanceFreshnessStrip 축소**: 독립 컴포넌트(9줄)를 `GovernanceSummaryStrip`의 subtitle 한 줄로 통합.

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `governance-strips.ts` | `GovernanceFreshnessStrip`, `RuntimeParamsPanel` 삭제 (-63줄) |
| `governance.ts` | 메인 뷰에서 3개 컴포넌트 제거, FreshnessStrip 정보를 SummaryStrip에 통합 |
| `governance-detail.ts` | `DecisionDetail` 내부에 `ActivityRail` 추가 |
| `governance-panels.ts` | re-export 정리, 변경 사유 주석 추가 |

## Verification

- `dune build` 통과 (OCaml 백엔드 영향 없음)
- `npm run build` 통과 (Vite 번들 생성 성공)
- 기존 타입 에러는 pre-existing (module resolution)이며 이번 변경과 무관

## Test plan

- [ ] `npm run dev`로 거버넌스 탭 진입 시 RuntimeParamsPanel이 보이지 않는지 확인
- [ ] 사건 선택 시 DecisionDetail 하단에 ActivityRail이 표시되는지 확인
- [ ] SummaryStrip 상단에 "진행 중 N건 / 활동 N건" 라인이 표시되는지 확인

Generated with [Claude Code](https://claude.com/claude-code)