### PR TITLE
refactor: reduce Model_spec type coupling in keeper files (Phase 4B)

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -444,14 +444,14 @@ let looks_fragmentary_history_text (raw : string) : bool =
     hard_fragment || short_unterminated || trailing_connector
 
 let run_proactive_generation
-    ~(specs : Model_spec.model_spec list)
-    ~(primary : Model_spec.model_spec)
+    ~(model_labels : string list)
     ~(config : Room.config)
     ~(ctx_work : working_context)
     ~(meta : keeper_meta)
     ~(continuity_snapshot : keeper_state_snapshot option)
     ~(continuity_summary : string)
     ~(idle_seconds : int) : proactive_generation_result option =
+  let primary_model_id = Model_spec.resolve_primary_model_id model_labels in
   let base_prompt =
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
   in
@@ -487,7 +487,7 @@ let run_proactive_generation
       Some {
         reply = proactive_fallback_reply ~meta ~idle_seconds;
         usage = usage_acc;
-        model_used = primary.model_id;
+        model_used = primary_model_id;
         latency_ms = latency_acc;
         attempts = max_attempts;
         total_cost_usd = cost_acc;
@@ -510,12 +510,14 @@ let run_proactive_generation
       | Error _ -> None
       | Ok result ->
           let resp = result.Oas_worker.response in
-          let used_model =
-            model_spec_for_used specs resp.model
-            |> Option.value ~default:primary
+          let used_model_id =
+            Model_spec.find_model_id_for_used ~labels:model_labels
+              ~model_used:resp.model
           in
           let attempt_usage = usage_of_response resp in
-          let attempt_cost_usd = cost_usd_of_usage attempt_usage used_model in
+          let attempt_cost_usd =
+            cost_usd_of_usage attempt_usage ~model_id:used_model_id
+          in
           let attempt_content =
             let c = String.trim (Agent_sdk.Types.text_of_content resp.content) in
             let tool_names = List.filter_map (function

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -91,16 +91,14 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  let metrics_store =
                    keeper_metrics_store ctx.config meta_current.name
                  in
-                 let primary_model =
-                   match Model_spec.available_model_specs_of_strings meta_current.models with
-                   | primary :: _ -> primary
-                   | [] -> Model_spec.default_local_model_spec ()
+                 let primary_max_context =
+                   Model_spec.resolve_primary_max_context meta_current.models
                  in
                  let base_dir = session_base_dir ctx.config in
                  let _session, ctx_opt =
                    load_context_from_checkpoint
                      ~trace_id:meta_current.trace_id
-                     ~primary_model_max_tokens:primary_model.max_context
+                     ~primary_model_max_tokens:primary_max_context
                      ~base_dir
                  in
                  (match ctx_opt with

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -4,22 +4,9 @@ open Keeper_types
 
 include Keeper_memory_bank
 
-let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Model_spec.model_spec) : float =
-  let pricing = Llm_provider.Pricing.pricing_for_model model.model_id in
-  Llm_provider.Pricing.estimate_cost ~pricing
-    ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ()
-
-let model_spec_for_used (specs : Model_spec.model_spec list) (model_used : string) :
-  Model_spec.model_spec option =
-  let used =
-    if String.ends_with ~suffix:":latest" model_used then
-      String.sub model_used 0 (String.length model_used - String.length ":latest")
-    else
-      model_used
-  in
-  List.find_opt (fun (m : Model_spec.model_spec) ->
-    m.model_id = model_used || m.model_id = used
-  ) specs
+let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) ~(model_id : string) : float =
+  Model_spec.cost_usd_of_model_id ~model_id
+    ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens
 
 let read_file_tail_lines path ~max_bytes:_ ~max_lines : string list =
   if max_lines <= 0 then []

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -40,14 +40,14 @@ let handle_keeper_status ctx args : tool_result =
       in
       let models = m.models in
       let specs = Model_spec.available_model_specs_of_strings models in
-      let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
+      let primary_max_context = Model_spec.resolve_primary_max_context models in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
              let (_session, ctx_opt) =
                load_context_from_checkpoint
                  ~trace_id:m.trace_id
-                 ~primary_model_max_tokens:primary.max_context
+                 ~primary_model_max_tokens:primary_max_context
                  ~base_dir
              in
              ctx_opt
@@ -96,10 +96,11 @@ let handle_keeper_status ctx args : tool_result =
            compaction_policy_of_keeper m
          in
 
-         let models_resolved = `List (List.map (fun (s : Model_spec.model_spec) ->
+         let open Model_spec in
+         let models_resolved = `List (List.map (fun s ->
            let pricing = Llm_provider.Pricing.pricing_for_model s.model_id in
            `Assoc [
-             ("provider", `String s.model_id);
+             ("provider", `String (string_of_provider s.provider));
              ("model_id", `String s.model_id);
              ("max_context", `Int s.max_context);
              ("api_key_env", match s.api_key_env with None -> `Null | Some k -> `String k);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -119,8 +119,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       (match ensure_api_keys_for_labels effective_models with
        | Error e -> (false, "❌ " ^ e)
        | Ok () ->
-         let specs = Model_spec.available_model_specs_of_strings effective_models in
-         let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
+         let primary_max_context =
+           Model_spec.resolve_primary_max_context effective_models
+         in
             let base_dir = session_base_dir ctx.config in
             let policy_mode_learned = keeper_policy_mode_is_learned meta in
             let effective_no_skill_route = no_skill_route || policy_mode_learned in
@@ -196,7 +197,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             match
               Keeper_agent_run.run_turn
                 ~config:ctx.config ~meta ~base_dir
-                ~max_context:primary.max_context
+                ~max_context:primary_max_context
                 ~build_turn_prompt
                 ~user_message:message
                 ~cascade_name:"keeper_turn"

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -296,8 +296,7 @@ let ensure_keeper_exists
     (match ensure_api_keys_for_labels meta.models with
      | Error e -> Error e
      | Ok () ->
-       let specs = Model_spec.available_model_specs_of_strings meta.models in
-       let primary = match specs with m0 :: _ -> m0 | [] -> Model_spec.default_local_model_spec () in
+       let primary_max_context = Model_spec.resolve_primary_max_context meta.models in
        let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
        let persona_extended =
          Keeper_types_profile.load_persona_extended name
@@ -317,7 +316,7 @@ let ensure_keeper_exists
            ~persona_extended
            ()
        in
-       let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary.max_context in
+       let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in
        (try ignore (save_checkpoint session ctx0 ~generation:0)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
        match write_meta ctx.config meta with

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -273,12 +273,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     (match ensure_api_keys_for_labels requested_models with
      | Error e -> (false, e)
      | Ok () ->
-       let specs = Model_spec.available_model_specs_of_strings requested_models in
+       let primary_max_context = Model_spec.resolve_primary_max_context requested_models in
        let trace_id = generate_trace_id () in
-       let primary = match specs with
-         | m :: _ -> m
-         | [] -> Model_spec.default_local_model_spec ()
-       in
          let base_dir = session_base_dir ctx.config in
          mkdir_p base_dir;
          let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
@@ -300,7 +296,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                ~persona_extended
                ()
          in
-         let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary.max_context in
+         let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in
          (try ignore (save_checkpoint session ctx0 ~generation:0)
           with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (init) failed" exn);
          let meta = {

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -15,15 +15,15 @@ open Keeper_exec_context [@@warning "-33"]
 let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
-  let specs = Model_spec.available_model_specs_of_strings meta.models in
-  let primary =
-    match specs with p :: _ -> p | [] -> Model_spec.default_local_model_spec ()
+  let used_model_id =
+    Model_spec.find_model_id_for_used ~labels:meta.models
+      ~model_used:result.model_used
   in
-  let used_model =
-    model_spec_for_used specs result.model_used
-    |> Option.value ~default:primary
+  let turn_cost =
+    Model_spec.cost_usd_of_model_id ~model_id:used_model_id
+      ~input_tokens:result.usage.input_tokens
+      ~output_tokens:result.usage.output_tokens
   in
-  let turn_cost = cost_usd_of_usage result.usage used_model in
   let has_tool_calls = result.tools_used <> [] in
   let has_text =
     String.trim result.response_text <> ""
@@ -76,11 +76,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
   | Ok () ->
-      let specs = Model_spec.available_model_specs_of_strings model_labels in
-      let primary =
-        match specs with
-        | p :: _ -> p
-        | [] -> Model_spec.default_local_model_spec ()
+      let primary_max_context =
+        Model_spec.resolve_primary_max_context model_labels
       in
       (* 2. Build unified prompt *)
       let system_prompt, user_message =
@@ -100,7 +97,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let run_result, latency_ms =
         Keeper_exec_context.timed (fun () ->
             Keeper_agent_run.run_turn ~config ~meta ~base_dir
-              ~max_context:primary.max_context ~build_turn_prompt
+              ~max_context:primary_max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
               ~temperature ~max_tokens

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -98,17 +98,13 @@ let compute_idle_seconds ~(meta : keeper_meta) : int =
 (** Read context ratio from checkpoint if available. *)
 let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
   try
-    let primary_model =
-      match
-        Model_spec.available_model_specs_of_strings meta.models
-      with
-      | p :: _ -> p
-      | [] -> Model_spec.default_local_model_spec ()
+    let primary_max_context =
+      Model_spec.resolve_primary_max_context meta.models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
       load_context_from_checkpoint ~trace_id:meta.trace_id
-        ~primary_model_max_tokens:primary_model.max_context ~base_dir
+        ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
     | Some c -> Keeper_exec_context.context_ratio c
@@ -121,17 +117,13 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
 let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
     : string =
   try
-    let primary_model =
-      match
-        Model_spec.available_model_specs_of_strings meta.models
-      with
-      | p :: _ -> p
-      | [] -> Model_spec.default_local_model_spec ()
+    let primary_max_context =
+      Model_spec.resolve_primary_max_context meta.models
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
       load_context_from_checkpoint ~trace_id:meta.trace_id
-        ~primary_model_max_tokens:primary_model.max_context ~base_dir
+        ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
     | Some c ->

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -429,3 +429,35 @@ let default_local_model_spec () =
     Returns model label strings (e.g. ["llama:qwen3.5"; "glm:glm-4.7"]). *)
 let load_cascade_profile ~config_path ~name : string list =
   Llm_provider.Cascade_config.load_profile ~config_path ~name
+
+(* ================================================================ *)
+(* Convenience accessors — callers need scalar values, not model_spec *)
+(* ================================================================ *)
+
+let resolve_primary_spec labels =
+  match available_model_specs_of_strings labels with
+  | p :: _ -> p
+  | [] -> default_local_model_spec ()
+
+let resolve_primary_max_context labels =
+  (resolve_primary_spec labels).max_context
+
+let resolve_primary_model_id labels =
+  (resolve_primary_spec labels).model_id
+
+let find_model_id_for_used ~labels ~model_used =
+  let specs = available_model_specs_of_strings labels in
+  let used =
+    if String.ends_with ~suffix:":latest" model_used then
+      String.sub model_used 0 (String.length model_used - String.length ":latest")
+    else model_used
+  in
+  match List.find_opt (fun (m : model_spec) ->
+    m.model_id = model_used || m.model_id = used
+  ) specs with
+  | Some m -> m.model_id
+  | None -> (resolve_primary_spec labels).model_id
+
+let cost_usd_of_model_id ~model_id ~input_tokens ~output_tokens =
+  let pricing = Llm_provider.Pricing.pricing_for_model model_id in
+  Llm_provider.Pricing.estimate_cost ~pricing ~input_tokens ~output_tokens ()

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -93,3 +93,22 @@ val default_local_model_spec : unit -> model_spec
 (** Load cascade profile from OAS config file.
     Returns model label strings (e.g. ["llama:qwen3.5"; "glm:glm-4.7"]). *)
 val load_cascade_profile : config_path:string -> name:string -> string list
+
+(** {2 Convenience accessors (no model_spec in caller)} *)
+
+(** Resolve model labels to the primary model's [max_context].
+    Returns the default local model's max_context when no label resolves. *)
+val resolve_primary_max_context : string list -> int
+
+(** Resolve model labels to the primary model's [model_id].
+    Returns the default local model's model_id when no label resolves. *)
+val resolve_primary_model_id : string list -> string
+
+(** Find the model_id that matches [model_used] from a label list.
+    Strips [:latest] suffix before comparison.
+    Returns the default local model's model_id when no match is found. *)
+val find_model_id_for_used : labels:string list -> model_used:string -> string
+
+(** Estimate cost in USD from token usage and a model_id string.
+    Delegates to OAS [Llm_provider.Pricing]. *)
+val cost_usd_of_model_id : model_id:string -> input_tokens:int -> output_tokens:int -> float


### PR DESCRIPTION
## Summary
- Phase 4B of Model_spec retirement: reduce type coupling between keeper files and `Model_spec.model_spec` record
- Add 4 convenience functions to `Model_spec` that encapsulate the common "resolve labels -> pick primary -> extract scalar" pattern
- Refactor 9 keeper files to use these helpers instead of directly constructing/destructing `Model_spec.model_spec` values

## Changes

### New Model_spec convenience functions
- `resolve_primary_max_context : string list -> int` -- resolves labels to primary model's max_context
- `resolve_primary_model_id : string list -> string` -- resolves labels to primary model's model_id
- `find_model_id_for_used : labels -> model_used -> string` -- finds matching model_id from labels (replaces `model_spec_for_used`)
- `cost_usd_of_model_id : model_id -> input_tokens -> output_tokens -> float` -- cost estimation by model_id string

### Keeper file changes
| File | Before | After | Change |
|------|--------|-------|--------|
| keeper_unified_turn.ml | 4 refs | 3 (functions only) | Removed type dependency via find_model_id_for_used |
| keeper_world_observation.ml | 4 refs | 2 (functions only) | resolve_primary_max_context |
| keeper_status_detail.ml | 4 refs | 3 (1 `let open`) | resolve_primary_max_context, local open for JSON |
| keeper_memory_recall.ml | 4 refs | 1 (function only) | Removed model_spec_for_used, simplified cost_usd_of_usage |
| keeper_turn.ml | 2 refs | 1 | resolve_primary_max_context |
| keeper_turn_setup.ml | 2 refs | 1 | resolve_primary_max_context |
| keeper_turn_up_create.ml | 2 refs | 1 | resolve_primary_max_context |
| keeper_keepalive.ml | 2 refs | 1 | resolve_primary_max_context |
| keeper_exec_context.ml | 2 refs | 2 (functions only) | run_proactive_generation signature: specs/primary -> model_labels |

### Metrics
- Total `Model_spec.` references in keeper/: **28 -> 17** (-39%)
- `Model_spec.model_spec` type references: **8 -> 1** (-87.5%)
- Net lines: +95/-71

## Test plan
- [x] `dune build --root .` passes
- [x] `make test` -- no new failures (pre-existing failures unchanged)

Generated with [Claude Code](https://claude.com/claude-code)