### PR TITLE
fix(dashboard): cap keeper metrics and add cache timeout backoff

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -121,10 +121,24 @@ let get_or_compute_eio key ~ttl compute =
               key elapsed;
             Hashtbl.remove table key;
             Eio.Condition.broadcast cond;
-            let new_cond = Eio.Condition.create () in
+            (* Fix D: cooldown after timeout eviction.
+               Instead of immediately starting a new Compute (which causes thrashing),
+               insert a short-lived Ready entry with error JSON.  Next request after
+               the cooldown_ttl will trigger a fresh compute. *)
+            let cooldown_ttl = 15.0 in
+            let ts = now () in
+            let error_value = `Assoc [
+              ("error", `String "computation_cooldown");
+              ("message", `String (Printf.sprintf
+                "Dashboard %s timed out (%.0fs). Cooling down for %.0fs."
+                key elapsed cooldown_ttl));
+              ("generated_at", `String (Types.now_iso ()));
+            ] in
             Hashtbl.replace table key
-              (Computing { cond = new_cond; started_at = now (); stale = None });
-            `Compute new_cond
+              (Ready { value = error_value;
+                       expires_at = ts +. cooldown_ttl;
+                       stale_until = ts +. cooldown_ttl });
+            `Hit error_value
           end else
             `Wait cond
         | _ ->

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -70,15 +70,19 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           in
 
           let metrics_store = Keeper_types.keeper_metrics_store config m.name in
-          let metrics_window_max_bytes = 200000 in
+          (* Cap metrics lines to avoid O(n) slowdown as keepers accumulate turns.
+             series_points (120) suffices for the chart; 500 covers 24h summary.
+             Previous value of 12000 caused 60K+ lines across 5 keepers. *)
+          let metrics_cap = if compact then series_points else 500 in
+          let metrics_window_max_bytes = if compact then 50000 else 200000 in
           let all_metrics_lines =
-            let n = max series_points 12000 in
+            let n = metrics_cap in
             let dated = Dated_jsonl.read_recent_lines metrics_store n in
             if dated <> [] then dated
             else
               let metrics_path = Keeper_types.keeper_metrics_path config m.name in
               Keeper_memory.read_file_tail_lines metrics_path
-                ~max_bytes:(max metrics_window_max_bytes 3000000) ~max_lines:n
+                ~max_bytes:metrics_window_max_bytes ~max_lines:n
           in
           let (metrics_24h, metrics_24h_summary) =
             if compact then (`Null, `Null)
@@ -140,21 +144,25 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             ) m.models)
           in
 
-          let memory_bank_summary =
-            Keeper_memory.read_keeper_memory_summary
-              config
-              ~name:m.name
-              ~max_bytes:120000
-              ~max_lines:200
-              ~recent_limit:4
-          in
-          let memory_bank_json =
-            Keeper_memory.memory_summary_to_json memory_bank_summary
-          in
-          let memory_recent_note =
-            match memory_bank_summary.Keeper_memory.recent_notes with
-            | row :: _ -> Some row.Keeper_memory.text
-            | [] -> None
+          (* In compact mode (used by execution surface), skip heavy memory bank I/O.
+             Full memory bank is only needed for individual keeper detail view. *)
+          let (memory_bank_json, memory_recent_note) =
+            if compact then
+              (`Assoc [("total_files", `Int 0); ("skipped", `Bool true)], None)
+            else
+              let summary =
+                Keeper_memory.read_keeper_memory_summary
+                  config
+                  ~name:m.name
+                  ~max_bytes:120000
+                  ~max_lines:200
+                  ~recent_limit:4
+              in
+              let note = match summary.Keeper_memory.recent_notes with
+                | row :: _ -> Some row.Keeper_memory.text
+                | [] -> None
+              in
+              (Keeper_memory.memory_summary_to_json summary, note)
           in
           let history_path =
             Filename.concat
@@ -417,11 +425,22 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
 	                | None -> `Null);
               ("metrics_window", metrics_window_summary);
               ("metrics_24h_summary", metrics_24h_summary);
-              ("memory_note_count", `Int memory_bank_summary.Keeper_memory.total_notes);
+              ("memory_note_count",
+                (match memory_bank_json with
+                 | `Assoc fields ->
+                     (match List.assoc_opt "total_notes" fields with
+                      | Some n -> n
+                      | None -> (match List.assoc_opt "total_files" fields with
+                                 | Some n -> n
+                                 | None -> `Int 0))
+                 | _ -> `Int 0));
               ("memory_top_kind",
-                match memory_bank_summary.Keeper_memory.top_kind with
-                | Some kind -> `String kind
-                | None -> `Null);
+                (match memory_bank_json with
+                 | `Assoc fields ->
+                     (match List.assoc_opt "top_kind" fields with
+                      | Some (`String _ as s) -> s
+                      | _ -> `Null)
+                 | _ -> `Null));
               ("memory_recent_note",
                 match memory_recent_note with
                 | Some text -> `String text


### PR DESCRIPTION
## Summary
- Keeper dashboard metrics 12000줄 → 500줄 (compact: 120줄) 로 상한 설정
- compact 모드에서 memory bank I/O 완전 스킵
- Cache timeout 후 15초 cooldown (thrashing 방지)

## Problem
5개 keeper 동시 활성 시 dashboard가 점진적으로 악화:
```
0분:  execution 0.1s
10분: snapshot 1~3s
20분: snapshot 5~9s, cp-summary 30s
30분: execution 30s timeout, mission 120s cache timeout
40분: evict → recompute → timeout 루프 (thrashing)
45분: Eio_mutex.Poisoned → crash
```

## Root Cause
1. keeper 당 12000줄 JSONL 읽기 + 파싱 (5 keeper × 12000 = 60K lines/render)
2. cache timeout eviction 후 즉시 재계산 → 같은 타임아웃 → 무한 루프
3. mutex를 잡은 fiber가 timeout으로 죽으면 Poisoned 전파

## Fix
| Fix | File | Change |
|-----|------|--------|
| A | `dashboard_http_keeper.ml` | metrics cap 12K→500, compact memory skip |
| D | `dashboard_cache.ml` | eviction 후 15s cooldown Ready entry |

## Test plan
- [x] `dune build` passes
- [ ] 서버 재시작 후 30분 이상 keeper 5개 활성 상태에서 dashboard 응답시간 관찰
- [ ] eviction 시 cooldown 메시지 확인 (thrashing 대신 15s 간격)

🤖 Generated with [Claude Code](https://claude.com/claude-code)