### PR TITLE
fix: add missing Glm case to provider_of_oas

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -132,6 +132,7 @@ let provider_of_oas ~(registry_name : string)
   | Anthropic -> Claude
   | Gemini -> Gemini
   | Claude_code -> Claude
+  | Glm -> Glm_cloud
   | OpenAI_compat -> (
       match registry_name with
       | "llama" -> Llama


### PR DESCRIPTION
## Summary
- OAS `provider_kind`에 `Glm` variant가 추가되었으나 MASC `model_spec.ml`의 pattern match에서 누락
- warning 8 (partial-match) → `-warn-error`로 CI 실패

## Changes
- `lib/model_spec.ml`: `| Glm -> Glm_cloud` 케이스 추가 (1줄)

## Test plan
- [x] `dune build` 통과
- [ ] CI Health check (warning-as-error) 통과 확인

Generated with [Claude Code](https://claude.com/claude-code)