### PR TITLE
fix: handle Glm provider_kind + Poisoned mutex crash

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -344,7 +344,9 @@ let resolve_cascade_labels ~name ~defaults =
         Llm_provider.Cascade_config.resolve_model_strings
           ~config_path ~name ~defaults ()
       with
+      | Eio.Cancel.Cancelled (Eio.Mutex.Poisoned _) -> defaults
       | Eio.Cancel.Cancelled _ as e -> raise e
+      | Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> defaults
       | _ ->
           (* Eio.Mutex requires Eio context; gracefully fall back when
              called during module init (before Eio.main). *)

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -131,6 +131,7 @@ let provider_of_oas ~(registry_name : string)
   match kind with
   | Anthropic -> Claude
   | Gemini -> Gemini
+  | Glm -> Glm_cloud
   | Claude_code -> Claude
   | OpenAI_compat -> (
       match registry_name with


### PR DESCRIPTION
## Summary
1. OAS `provider_kind`에 `Glm` variant 추가 후 MASC `model_spec.ml` pattern match 누락 → 빌드 실패
2. `resolve_cascade_labels`에서 `Cancelled(Poisoned _)` re-raise → 서버 시작 crash

## Changes
- `model_spec.ml`: `| Glm -> Glm_cloud` 추가 + Poisoned catch

Fixes #2333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)