### PR TITLE
feat(dashboard): professional UI overhaul — cards, tabs, typography

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -116,7 +116,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
 function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
   if (events.length === 0) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 실행 이벤트가 없습니다.</div>`
+    return html`<div class="empty-state">최근 실행 이벤트가 없습니다.</div>`
   }
   return html`
     <div class="flex flex-col gap-2.5">
@@ -153,7 +153,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
     .slice(0, 15)
 
   if (agentNodes.length === 0) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 집계에 포함된 에이전트가 없습니다.</div>`
+    return html`<div class="empty-state">활동 집계에 포함된 에이전트가 없습니다.</div>`
   }
 
   const maxWeight = agentNodes[0]?.weight ?? 1
@@ -188,7 +188,7 @@ function KindBreakdown({ nodes }: { nodes: ActivityGraphNode[] }) {
   const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1])
 
   if (sorted.length === 0) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">분석할 노드 종류가 없습니다.</div>`
+    return html`<div class="empty-state">분석할 노드 종류가 없습니다.</div>`
   }
 
   return html`
@@ -211,7 +211,7 @@ function EmptyActivityGraph() {
           <h2 class="monitor-headline">활동 그래프가 비어 있습니다</h2>
           <p class="monitor-subheadline">이 뷰는 런타임 실행 이벤트를 읽어 그래프를 그립니다. 지금은 기록된 이벤트가 없어 화면이 비어 있습니다.</p>
         </div>
-        <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+        <div class="empty-state">
           아직 claim, broadcast, team-session, board 같은 실행 이벤트가 activity feed에 기록되지 않았습니다.
         </div>
       <//>
@@ -229,14 +229,14 @@ export function ActivityGraphSurface() {
   const loading = graphLoading.value
 
   if (loading && !data) {
-    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">활동 그래프 불러오는 중...</div>`
+    return html`<div class="loading-state loading-pulse">활동 그래프 불러오는 중...</div>`
   }
 
   if (error && !data) {
     return html`
       <div class="flex flex-col gap-5">
         <${Card} title="오류" class="section mb-3.5" testId="activity_graph.error">
-          <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 그래프를 불러올 수 없습니다: ${error}</div>
+          <div class="empty-state">활동 그래프를 불러올 수 없습니다: ${error}</div>
           <button class="control-btn rounded-lg ghost" onClick=${loadGraph}>다시 시도</button>
         <//>
       </div>
@@ -244,7 +244,7 @@ export function ActivityGraphSurface() {
   }
 
   if (!data) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활동 데이터가 없습니다.</div>`
+    return html`<div class="empty-state">활동 데이터가 없습니다.</div>`
   }
 
   if ((data.stats.event_count ?? 0) === 0) {

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -12,7 +12,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="실시간 활동 스트림">
       ${entries.length === 0
-        ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관련 이벤트 없음</div>`
+        ? html`<div class="empty-state">관련 이벤트 없음</div>`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -43,7 +43,7 @@ export function AgentTimelineSection() {
         </div>
       ` : null}
       ${events.length === 0
-        ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">타임라인 이벤트 없음</div>`
+        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">
               ${events.map((evt: AgentTimelineEvent, idx: number) => {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -153,13 +153,13 @@ export function AgentDetailOverlay() {
         <div class="grid grid-cols-2 gap-3 mb-3">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">할당된 작업이 없습니다</div>`
+              ? html`<div class="empty-state">할당된 작업이 없습니다</div>`
               : html`<div class="flex flex-col gap-2">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
           <//>
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 활동 기록이 없습니다</div>`
+              ? html`<div class="empty-state">최근 활동 기록이 없습니다</div>`
               : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
           <//>
         </div>
@@ -169,7 +169,7 @@ export function AgentDetailOverlay() {
         <${AgentWorkerBrief} agentName=${agentName} />
         <${Card} title="작업 이력">
           ${taskHistories.value.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">작업 이력이 없습니다</div>`
+            ? html`<div class="empty-state">작업 이력이 없습니다</div>`
             : html`<div class="flex flex-col gap-2.5">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
         <//>
 

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -153,7 +153,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
 
       <div class="flex flex-col gap-0.5 max-h-[320px] overflow-y-auto" ref=${scrollRef}>
         ${filtered.length === 0
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">필터에 맞는 이벤트 없음</div>`
+          ? html`<div class="empty-state">필터에 맞는 이벤트 없음</div>`
           : filtered.map((entry: JournalEntry, idx: number) => html`
               <div class="flex items-baseline gap-1.5 py-1 px-2 text-[length:var(--fs-sm)] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                 <span class="agent-event-badge ${eventKindBadgeClass(entry.eventType)}">

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -356,7 +356,7 @@ export function AgentProfile({ name }: { name: string }) {
         ${!isKeeper ? html`
         <${Card} title="태스크 (${owned.length})" class="ff-card rounded-xl">
           ${owned.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">할당된 태스크 없음</div>`
+            ? html`<div class="empty-state">할당된 태스크 없음</div>`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
                 <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg" key=${t.id}>
                   <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${t.id}</span>
@@ -405,7 +405,7 @@ export function AgentProfile({ name }: { name: string }) {
 
         <${Card} title="타임라인" class="ff-card rounded-xl">
           ${!timeline || (timeline.events ?? []).length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이벤트 없음</div>`
+            ? html`<div class="empty-state">이벤트 없음</div>`
             : html`<div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
@@ -425,7 +425,7 @@ export function AgentProfile({ name }: { name: string }) {
 
         <${Card} title="Room 활동" class="ff-card rounded-xl">
           ${lines.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관련 활동 없음</div>`
+            ? html`<div class="empty-state">관련 활동 없음</div>`
             : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>
                 html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
         <//>

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -162,7 +162,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${workerSupportRows.length === 0
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">참여 에이전트가 없습니다.</div>`
+              ? html`<div class="empty-state">참여 에이전트가 없습니다.</div>`
               : workerSupportRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.worker-card" />`)}
           </div>
         <//>
@@ -175,7 +175,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${continuityRows.length === 0
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">연속성 경고 없음</div>`
+              ? html`<div class="empty-state">연속성 경고 없음</div>`
               : continuityRows.map(row => html`<${ContinuityRow} key=${row.name} row=${row} />`)}
           </div>
         <//>
@@ -188,7 +188,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${offlineRows.length === 0
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오프라인 에이전트 없음</div>`
+              ? html`<div class="empty-state">오프라인 에이전트 없음</div>`
               : offlineRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.offline-worker-card" />`)}
           </div>
         <//>

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -115,7 +115,7 @@ export function ControlSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.decisions.decisions.map(decision => html`<${DecisionCard} decision=${decision} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 승인 대기 항목은 없습니다.</div>`}
+          : html`<div class="empty-state">지금 승인 대기 항목은 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -126,7 +126,7 @@ export function ControlSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.capacity.capacity.map(row => html`<${CapacityRowCard} row=${row} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">제어할 용량 행이 아직 없습니다.</div>`}
+          : html`<div class="empty-state">제어할 용량 행이 아직 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -250,9 +250,9 @@ function GuidedPanel() {
           <div class="card rounded-xl-title">운영 경로</div>
         </div>
         ${commandPlaneHelpLoading.value
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">CPv2 runbook 불러오는 중…</div>`
+          ? html`<div class="empty-state">CPv2 runbook 불러오는 중…</div>`
           : commandPlaneHelpError.value
-            ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneHelpError.value}</div>`
+            ? html`<div class="empty-state error">${commandPlaneHelpError.value}</div>`
             : html`
                 <div class="grid gap-3">
                   ${renderedPaths.map(path => html`
@@ -295,10 +295,10 @@ export function SummarySurface() {
 
 export function DetailLoadingState() {
   if (commandPlaneDetailLoading.value) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">command-plane detail 불러오는 중…</div>`
+    return html`<div class="empty-state">command-plane detail 불러오는 중…</div>`
   }
   if (commandPlaneDetailError.value) {
-    return html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneDetailError.value}</div>`
+    return html`<div class="empty-state error">${commandPlaneDetailError.value}</div>`
   }
-  return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">surface를 선택하면 command-plane detail을 로드합니다.</div>`
+  return html`<div class="empty-state">surface를 선택하면 command-plane detail을 로드합니다.</div>`
 }

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -266,10 +266,10 @@ export function Command() {
       `}
 
       ${commandPlaneError.value
-        ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneError.value}</div>`
+        ? html`<div class="empty-state error">${commandPlaneError.value}</div>`
         : null}
       ${commandPlaneActionError.value
-        ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneActionError.value}</div>`
+        ? html`<div class="empty-state error">${commandPlaneActionError.value}</div>`
         : null}
       ${wallboardMode ? null : html`<${RoomTruthStrip} />`}
       ${wallboardMode ? null : html`<${CommandWorkflowBanner} />`}

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -101,7 +101,7 @@ function MermaidGraph({ source }: { source: string }) {
 
   return html`
     <div class="mt-3 min-h-[160px]">
-      ${error ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${error}</div>` : null}
+      ${error ? html`<div class="empty-state error">${error}</div>` : null}
       <div class="overflow-auto rounded-[10px] p-3 bg-[rgba(9,12,20,0.7)] cmd-chain-graph" ref=${hostRef}></div>
     </div>
   `
@@ -292,7 +292,7 @@ export function OperationsSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.operations.operations.map(card => html`<${OperationCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">관리형 또는 투영된 작전이 없습니다.</div>`}
+          : html`<div class="empty-state">관리형 또는 투영된 작전이 없습니다.</div>`}
       </section>
       <section class="card rounded-xl min-h-[240px]">
         <div class="card rounded-xl-title-row">
@@ -302,7 +302,7 @@ export function OperationsSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.detachments.detachments.map(card => html`<${DetachmentCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">투영된 분견대가 없습니다.</div>`}
+          : html`<div class="empty-state">투영된 분견대가 없습니다.</div>`}
       </section>
     </div>
   `
@@ -350,11 +350,11 @@ export function ChainsSurface() {
         </article>
 
         ${commandPlaneChainError.value
-          ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneChainError.value}</div>`
+          ? html`<div class="empty-state error">${commandPlaneChainError.value}</div>`
           : null}
 
         ${commandPlaneChainLoading.value && !summary
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 오버레이 불러오는 중…</div>`
+          ? html`<div class="empty-state">체인 오버레이 불러오는 중…</div>`
           : overlays.length > 0
             ? html`
                 <div class="flex flex-col gap-3 mt-3.5">
@@ -367,7 +367,7 @@ export function ChainsSurface() {
                   `)}
                 </div>
               `
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체인 기반 작전이 아직 없습니다.</div>`}
+            : html`<div class="empty-state">체인 기반 작전이 아직 없습니다.</div>`}
 
         <div class="flex flex-col gap-3 mt-3.5">
           <div class="flex justify-between gap-2.5 items-start">
@@ -380,7 +380,7 @@ export function ChainsSurface() {
                   ${summary.recent_history.slice(0, 6).map(item => html`<${ChainHistoryRow} item=${item} />`)}
                 </div>
               `
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 체인 이력이 없습니다.</div>`}
+            : html`<div class="empty-state">최근 체인 이력이 없습니다.</div>`}
         </div>
       </section>
 
@@ -423,7 +423,7 @@ export function ChainsSurface() {
                       <${MermaidGraph} source=${selectedOverlay.mermaid} />
                     </div>
                   `
-                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
+                : html`<div class="empty-state">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
 
               <div class="mt-3.5 p-3.5 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
                 <div class="flex justify-between gap-2.5 items-start">
@@ -435,9 +435,9 @@ export function ChainsSurface() {
                   </span>
                 </div>
                 ${commandPlaneChainRunLoading.value
-                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실행 상세 불러오는 중…</div>`
+                  ? html`<div class="empty-state">실행 상세 불러오는 중…</div>`
                   : commandPlaneChainRunError.value
-                    ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneChainRunError.value}</div>`
+                    ? html`<div class="empty-state error">${commandPlaneChainRunError.value}</div>`
                     : run && run.nodes.length > 0
                       ? html`
                           <div class="cmd-card rounded-xl-grid">
@@ -453,10 +453,10 @@ export function ChainsSurface() {
                             ${run.nodes.map(node => html`<${ChainRunNodeRow} node=${node} />`)}
                           </div>
                         `
-                      : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이 작전의 run-store 상세는 아직 없습니다.</div>`}
+                      : html`<div class="empty-state">이 작전의 run-store 상세는 아직 없습니다.</div>`}
               </div>
             `
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요.</div>`}
+          : html`<div class="empty-state">그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -363,7 +363,7 @@ export function OrchestraNodeLayer({
 
 export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOrchestraResponse }) {
   const selected = selectedTarget(orchestra)
-  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">선택 가능한 대상이 아직 없습니다.</div></aside>`
+  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl"><div class="empty-state">선택 가능한 대상이 아직 없습니다.</div></aside>`
   if (selected.type === 'signal') {
     const signalNode = selected.value
     return html`

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -215,13 +215,13 @@ export function OrchestraSurface() {
   }, [])
 
   if (commandPlaneOrchestraLoading.value && !orchestra) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오케스트라 맵 불러오는 중…</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state">오케스트라 맵 불러오는 중…</div></section>`
   }
   if (commandPlaneOrchestraError.value) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneOrchestraError.value}</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state error">${commandPlaneOrchestraError.value}</div></section>`
   }
   if (!orchestra) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
   }
 
   const density = orchestraDensity.value

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -40,9 +40,9 @@ export function SwarmLivePanels() {
           <div class="card rounded-xl-title">스웜 라이브 런</div>
         </div>
         ${commandPlaneSwarmLoading.value
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">Loading swarm live state…</div>`
+          ? html`<div class="empty-state">Loading swarm live state…</div>`
           : commandPlaneSwarmError.value
-            ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${commandPlaneSwarmError.value}</div>`
+            ? html`<div class="empty-state error">${commandPlaneSwarmError.value}</div>`
             : swarm
               ? html`
                   <div class="cmd-tag rounded-full-row">
@@ -78,7 +78,7 @@ export function SwarmLivePanels() {
                     : null}
                   <${SwarmRunResolutionCard} swarm=${swarm} />
                 `
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">스웜 read-model이 아직 없습니다.</div>`}
+              : html`<div class="empty-state">스웜 read-model이 아직 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -89,7 +89,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.checklist.map(item => html`<${SwarmChecklistCard} item=${item} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">체크리스트가 아직 없습니다.</div>`}
+          : html`<div class="empty-state">체크리스트가 아직 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -100,7 +100,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.workers.map(worker => html`<${SwarmWorkerCard} worker=${worker} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">워커 행이 아직 없습니다.</div>`}
+          : html`<div class="empty-state">워커 행이 아직 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -143,9 +143,9 @@ export function SwarmLivePanels() {
                       </article>
                     `)}
                   </div>`
-                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">slot telemetry가 아직 없습니다.</div>`}
+                : html`<div class="empty-state">slot telemetry가 아직 없습니다.</div>`}
             `
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">런타임 telemetry가 아직 없습니다.</div>`}
+          : html`<div class="empty-state">런타임 telemetry가 아직 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -156,7 +156,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.</div>`}
+          : html`<div class="empty-state">막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -178,7 +178,7 @@ export function SwarmLivePanels() {
                 </article>
               `)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">run 범위 메시지가 아직 없습니다.</div>`}
+          : html`<div class="empty-state">run 범위 메시지가 아직 없습니다.</div>`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -189,7 +189,7 @@ export function SwarmLivePanels() {
           ? html`<div class="flex flex-col gap-3">
               ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
             </div>`
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">run 범위 trace event가 아직 없습니다.</div>`}
+          : html`<div class="empty-state">run 범위 trace event가 아직 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -52,7 +52,7 @@ export function SwarmOverviewPanel() {
               <div class="cmd-card rounded-xl-stack">
                 ${lanes.length > 0
                   ? lanes.map(lane => html`<${SwarmLaneStrip} lane=${lane} />`)
-                  : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활성 스웜 레인이 없습니다.</div>`}
+                  : html`<div class="empty-state">활성 스웜 레인이 없습니다.</div>`}
               </div>
 
               <div class="cmd-card rounded-xl-stack">
@@ -89,7 +89,7 @@ export function SwarmOverviewPanel() {
               </div>
             </div>
           `
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">스웜 상태를 아직 불러오지 못했습니다.</div>`}
+        : html`<div class="empty-state">스웜 상태를 아직 불러오지 못했습니다.</div>`}
     </section>
   `
 }

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -169,7 +169,7 @@ export function TopologySurface() {
         : null}
       ${snapshot && snapshot.topology.units.length > 0
         ? html`${snapshot.topology.units.map(node => html`<${TopologyNode} node=${node} />`)}`
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다.</div>`}
+        : html`<div class="empty-state">지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다.</div>`}
     </section>
   `
 }
@@ -185,7 +185,7 @@ export function AlertsSurface() {
         ? html`<div class="cmd-card rounded-xl-stack">
             ${snapshot.alerts.alerts.map(alert => html`<${AlertCard} alert=${alert} />`)}
           </div>`
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 올라온 지휘면 경보는 없습니다.</div>`}
+        : html`<div class="empty-state">지금 올라온 지휘면 경보는 없습니다.</div>`}
     </section>
   `
 }
@@ -201,7 +201,7 @@ export function TraceSurface() {
         ? html`<div class="flex flex-col gap-3">
             ${snapshot.traces.events.map(event => html`<${TraceRow} event=${event} />`)}
           </div>`
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">최근 트레이스 이벤트가 없습니다.</div>`}
+        : html`<div class="empty-state">최근 트레이스 이벤트가 없습니다.</div>`}
     </section>
   `
 }

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -103,7 +103,7 @@ export function WarRoomBodyGrid({
                     </div>
                   </article>
                 `
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">보이는 레인이 아직 없습니다.</div>`}
+              : html`<div class="empty-state">보이는 레인이 아직 없습니다.</div>`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -121,7 +121,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="cmd-card rounded-xl-stack">
                 ${workers.map(worker => html`<${WarRoomWorkerCard} worker=${worker} />`)}
               </div>`
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">활성 워커 카드가 아직 없습니다.</div>`}
+            : html`<div class="empty-state">활성 워커 카드가 아직 없습니다.</div>`}
         </section>
       </div>
 
@@ -134,7 +134,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="flex flex-col gap-3">
                 ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
+            : html`<div class="empty-state">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -145,7 +145,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="flex flex-col gap-3">
                 ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
               </div>`
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
+            : html`<div class="empty-state">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
         </section>
       </div>
 
@@ -158,7 +158,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="grid grid-cols-1 gap-3">
                 ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 active agent가 아직 없습니다.</div>`}
+            : html`<div class="empty-state">가시적인 active agent가 아직 없습니다.</div>`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -169,7 +169,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="grid grid-cols-1 gap-3">
                 ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
+            : html`<div class="empty-state">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -189,7 +189,7 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
 
   if (!hasLiveRun && !selectedSession) {
     if (commandPlaneSwarmLoading.value || operatorLoading.value) {
-      return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">실시간 워룸 불러오는 중…</div>`
+      return html`<div class="empty-state">실시간 워룸 불러오는 중…</div>`
     }
     return html`
       <section class="card rounded-xl ${wallboard ? 'min-h-[calc(100vh-180px)]' : 'min-h-[360px]'} flex flex-col justify-center gap-[18px]">

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -1,4 +1,5 @@
 // Generic card wrapper — consistent card styling
+// Card system: p-4, bg-[var(--card)], border border-[var(--card-border)], rounded-xl
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
@@ -12,11 +13,11 @@ interface CardProps {
 
 export function Card({ title, class: className, testId, children }: CardProps) {
   return html`
-    <div class="card rounded-xl ${className ?? ''}" data-testid=${testId}>
+    <div class="card ${className ?? ''}" data-testid=${testId}>
       ${title
         ? html`
-            <div class="card rounded-xl-title-row">
-              <div class="card rounded-xl-title">${title}</div>
+            <div class="card-title-row">
+              <div class="card-title">${title}</div>
             </div>
           `
         : null}

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -19,22 +19,22 @@ export function Operations() {
   const section = currentSection()
 
   return html`
-    <div class="tab-unified grid gap-[var(--space-md,16px)]">
-      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
+    <div class="tab-unified grid gap-4">
+      <div class="tab-pill-bar">
         <button
-          class="tab-pill rounded-full ${section === 'intervene' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'intervene' ? 'active' : ''}"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >
           개입
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'command' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'command' ? 'active' : ''}"
           onClick=${() => navigate('operations', { section: 'command' })}
         >
           지휘
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'tools' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'tools' ? 'active' : ''}"
           onClick=${() => navigate('operations', { section: 'tools' })}
         >
           도구

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -27,7 +27,7 @@ const LazyLabSurface = lazy(async () => ({ default: (await import('./lab-unified
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
 function lazyTabFallback(label: string) {
-  return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">${label} 불러오는 중...</div>`
+  return html`<div class="loading-state loading-pulse">${label} 불러오는 중...</div>`
 }
 
 function formatDisconnectDuration(): string {
@@ -222,7 +222,7 @@ export function TabContent() {
 
 export function DashboardMain() {
   if (dashboardLoading.value && !connected.value && !roomTruthInitializing.value) {
-    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">대시보드 불러오는 중...</div>`
+    return html`<div class="loading-state loading-pulse">대시보드 불러오는 중...</div>`
   }
 
   const routeLabel = [

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -56,7 +56,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
+        : html`<div class="empty-state">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -60,7 +60,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금은 개입이 필요한 실행이 없습니다.</div>`}
+        : html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -69,7 +69,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
+        : html`<div class="empty-state">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -57,7 +57,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${todo.length}</span>
           </div>
           ${sortedTodo.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">대기 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state">대기 중인 태스크가 없습니다</div>`
             : sortedTodo.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -66,7 +66,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${inProgress.length}</span>
           </div>
           ${sortedInProgress.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">진행 중인 태스크가 없습니다</div>`
+            ? html`<div class="empty-state">진행 중인 태스크가 없습니다</div>`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -75,10 +75,10 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${done.length}</span>
           </div>
           ${sortedDone.length === 0
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">완료된 태스크가 없습니다</div>`
+            ? html`<div class="empty-state">완료된 태스크가 없습니다</div>`
             : sortedDone.slice(0, 20).map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
           ${sortedDone.length > 20
-            ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] opacity-50">...외 ${sortedDone.length - 20}개 더 있음</div>`
+            ? html`<div class="empty-state">...외 ${sortedDone.length - 20}개 더 있음</div>`
             : null}
         </div>
       </div>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -86,16 +86,16 @@ export function Planning() {
             <${GoalsSummary} />
             <${FilterBar} />
             ${goalsLoading.value && goals.value.length === 0
-              ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">목표 불러오는 중...</div>`
+              ? html`<div class="loading-state loading-pulse">목표 불러오는 중...</div>`
               : filteredGoals.value.length === 0
-                ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">현재 필터에 맞는 목표가 없습니다</div>`
+                ? html`<div class="empty-state">현재 필터에 맞는 목표가 없습니다</div>`
                 : html`
                     <${HorizonGroup} horizon="short" items=${grouped.short ?? []} />
                     <${HorizonGroup} horizon="mid" items=${grouped.mid ?? []} />
                     <${HorizonGroup} horizon="long" items=${grouped.long ?? []} />
                   `}
           ` : html`
-            <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+            <div class="empty-state">
               장기 목표가 아직 없습니다. <code>masc_goal_upsert</code>로 단기/중기/장기 목표를 등록하면 메트릭 기반 추적이 시작됩니다.
             </div>
           `}
@@ -110,11 +110,11 @@ export function Planning() {
         </summary>
         <div>
           ${mdalLoading.value && loops.length === 0
-            ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">MDAL 루프 불러오는 중...</div>`
+            ? html`<div class="loading-state loading-pulse">MDAL 루프 불러오는 중...</div>`
             : loops.length === 0 && (mdalState === 'error' || lastMdalError.value)
-              ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
+              ? html`<div class="empty-state">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
               : loops.length === 0
-                ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">가동 중인 루프가 없습니다. <code>masc_mdal_start</code>로 시작할 수 있습니다.</div>`
+                ? html`<div class="empty-state">가동 중인 루프가 없습니다. <code>masc_mdal_start</code>로 시작할 수 있습니다.</div>`
                 : html`
                   <div class="grid gap-3">
                     ${loops.map(loop => html`<${LoopRow} key=${loop.loop_id} loop=${loop} />`)}

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -65,9 +65,9 @@ export function DecisionDetail() {
      
     >
       ${detailLoading.value
-        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">거버넌스 상세 불러오는 중...</div>`
+        ? html`<div class="loading-state loading-pulse">거버넌스 상세 불러오는 중...</div>`
         : !item || !detail
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다.</div>`
+          ? html`<div class="empty-state">왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다.</div>`
           : html`
               <div class="flex justify-between items-start gap-4 mb-3.5">
                 <div>
@@ -89,12 +89,12 @@ export function DecisionDetail() {
               </div>
               <div class="flex flex-col gap-2.5">
                 ${petitions.length === 0
-                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">기록된 청원이 없습니다.</div>`
+                  ? html`<div class="empty-state">기록된 청원이 없습니다.</div>`
                   : petitions.map(petition => html`<${PetitionEntry} key=${petition.id} petition=${petition} />`)}
               </div>
               <div class="flex flex-col gap-2.5">
                 ${briefs.length === 0
-                  ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">심의 의견이 아직 없습니다.</div>`
+                  ? html`<div class="empty-state">심의 의견이 아직 없습니다.</div>`
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}
               </div>
               <${ActivityRail} />

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -43,7 +43,7 @@ export function GuardrailPane({
     <div class="flex flex-col gap-3.5">
       <${Card} title="판정 / 집행" class="section mb-3.5">
         ${!item || !detail
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">사건을 고르면 판정과 집행 경로가 보입니다.</div>`
+          ? html`<div class="empty-state">사건을 고르면 판정과 집행 경로가 보입니다.</div>`
           : html`
               <div class="flex flex-col gap-2">
                 <h4>판정</h4>
@@ -82,7 +82,7 @@ export function GuardrailPane({
     <//>
       <${Card} title="심의 입력" class="section mb-3.5">
         ${!item
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">사건을 선택한 뒤 의견을 추가하세요.</div>`
+          ? html`<div class="empty-state">사건을 선택한 뒤 의견을 추가하세요.</div>`
           : html`
               <div class="flex flex-col gap-2">
                 <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -3,11 +3,16 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { governanceToneClass } from '../lib/tone'
 import type { GovernanceTimelineEvent } from '../types'
+import type { RuntimeParamsSurface } from '../api'
 import {
   governanceData,
+  runtimeLoading,
+  runtimeParams,
+  runtimeSurfaces,
 } from './governance-store'
 import {
   activityKindLabel,
+  formatParamValue,
 } from './governance-utils'
 
 export function ActivityRail() {
@@ -27,7 +32,7 @@ export function ActivityRail() {
     <${Card} title="활동 타임라인" class="section mb-3.5">
       <div class="flex flex-col gap-2">
         ${grouped.size === 0
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">거버넌스 활동이 아직 없습니다.</div>`
+          ? html`<div class="empty-state">거버넌스 활동이 아직 없습니다.</div>`
           : Array.from(grouped.entries()).map(([, group]) => html`
               <div class="governance-case-group rounded-lg">
                 <div class="flex items-center justify-between mb-2 gap-2">
@@ -77,3 +82,61 @@ function LifecycleProgress({ events }: { events: GovernanceTimelineEvent[] }) {
   `
 }
 
+export function GovernanceFreshnessStrip() {
+  const data = governanceData.value
+  if (!data) return null
+  const itemCount = data.items?.length ?? 0
+  const activityCount = data.activity?.length ?? 0
+  return html`
+    <div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]" style="margin-top:4px;margin-bottom:8px">
+      <span>데이터 범위: 진행 중 ${itemCount}건</span>
+      <span>최근 활동: ${activityCount}건</span>
+      ${data.generated_at ? html`<span>생성 시각: ${data.generated_at}</span>` : null}
+    </div>
+  `
+}
+
+export function RuntimeParamsPanel() {
+  const params = runtimeParams.value
+  const surfaces = runtimeSurfaces.value
+  if (params.length === 0 && !runtimeLoading.value) return null
+
+  return html`
+    <${Card} title="Runtime Parameters" class="section mb-3.5">
+      ${runtimeLoading.value
+        ? html`<div class="loading-state loading-pulse">파라미터 로딩 중...</div>`
+        : html`
+            <div class="governance-params-surfaces">
+              ${surfaces.map((surface: RuntimeParamsSurface) => {
+                const surfaceParams = params.filter(p => surface.param_keys.includes(p.key))
+                return html`
+                  <div class="governance-surface-group">
+                    <div class="governance-surface-head">
+                      <strong>${surface.id}</strong>
+                      <span class="governance-chip rounded-full ${surface.risk === 'high' ? 'warn' : ''}">${surface.risk}</span>
+                      <span class="mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">${surface.description}</span>
+                    </div>
+                    <div class="governance-params-table">
+                      ${surfaceParams.map(param => html`
+                        <div class="governance-param-row ${param.has_override ? 'overridden' : ''}">
+                          <span class="governance-param-key">${param.key}</span>
+                          <span class="governance-param-value">
+                            ${formatParamValue(param.current)}
+                            ${param.has_override
+                              ? html`<span class="governance-chip rounded-full warn" style="margin-left:4px">override</span>`
+                              : null}
+                          </span>
+                          <span class="governance-param-default mt-1 flex flex-wrap gap-2 text-[#8ea9d6] text-[length:var(--fs-xs)]">
+                            기본: ${formatParamValue(param.default)}
+                          </span>
+                        </div>
+                      `)}
+                    </div>
+                  </div>
+                `
+              })}
+            </div>
+          `}
+    <//>
+  `
+}

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -141,7 +141,7 @@ function DecisionInbox() {
     <${Card} title="사건 수신함" class="section mb-3.5">
       <div class="flex flex-col gap-2 governance-inbox">
         ${items.length === 0
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
+          ? html`<div class="empty-state">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -295,7 +295,7 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 }
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">장비 없음</div>`
+  if (items.length === 0) return html`<div class="empty-state">장비 없음</div>`
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -311,7 +311,7 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">관계 없음</div>`
+  if (entries.length === 0) return html`<div class="empty-state">관계 없음</div>`
 
   return html`
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -249,7 +249,7 @@ export function KeeperDetailOverlay() {
                     ${keeper.memory_recent_note}
                   </div>
                 `
-                : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-xs">No recent memory note</div>`}
+                : html`<div class="empty-state">No recent memory note</div>`}
             </div>
           <//>
         </div>

--- a/dashboard/src/components/lab-unified.ts
+++ b/dashboard/src/components/lab-unified.ts
@@ -18,21 +18,21 @@ export function LabSurface() {
 
   return html`
     <div class="tab-unified grid gap-[var(--space-md,16px)]">
-      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
+      <div class="tab-pill-bar">
         <button
-          class="tab-pill rounded-full ${section === 'overview' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'overview' ? 'active' : ''}"
           onClick=${() => navigate('lab', { section: 'overview' })}
         >
           개요
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'trpg' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'trpg' ? 'active' : ''}"
           onClick=${() => navigate('lab', { section: 'trpg' })}
         >
           TRPG
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'avatars' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'avatars' ? 'active' : ''}"
           onClick=${() => navigate('lab', { section: 'avatars' })}
         >
           아바타

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -11,7 +11,7 @@ function AvatarGallery() {
   const displayAgents = agentList.slice(0, 12)
 
   if (displayAgents.length === 0) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">에이전트 데이터를 불러오는 중...</div>`
+    return html`<div class="empty-state">에이전트 데이터를 불러오는 중...</div>`
   }
 
   return html`

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -221,26 +221,26 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.human.length + grouped.operations.length
   return html`
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2.5 mb-3">
-      <div class="board-summary-item flex flex-col gap-1">
-        <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">보이는 글</span>
-        <strong>${visibleCount}</strong>
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-4 mb-4">
+      <div class="flex flex-col gap-1 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-xs text-[var(--text-muted)] tracking-wider uppercase font-medium">보이는 글</span>
+        <strong class="text-lg font-semibold text-[var(--text-strong)]">${visibleCount}</strong>
       </div>
-      <div class="board-summary-item flex flex-col gap-1">
-        <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">정렬</span>
-        <strong>${sortLabel}</strong>
+      <div class="flex flex-col gap-1 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-xs text-[var(--text-muted)] tracking-wider uppercase font-medium">정렬</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${sortLabel}</strong>
       </div>
-      <div class="board-summary-item flex flex-col gap-1">
-        <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">잡음 필터</span>
-        <strong>${hideAutomationPosts.value ? `자동화 ${grouped.hiddenAutomation}건 숨김` : '분리된 레인 표시'}</strong>
+      <div class="flex flex-col gap-1 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-xs text-[var(--text-muted)] tracking-wider uppercase font-medium">잡음 필터</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${hideAutomationPosts.value ? `자동화 ${grouped.hiddenAutomation}건 숨김` : '분리된 레인 표시'}</strong>
       </div>
-      <div class="board-summary-item flex flex-col gap-1">
-        <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">시스템 글 정책</span>
-        <strong>${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 레인 표시'}</strong>
+      <div class="flex flex-col gap-1 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-xs text-[var(--text-muted)] tracking-wider uppercase font-medium">시스템 글 정책</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 레인 표시'}</strong>
       </div>
-      <div class="board-summary-item flex flex-col gap-1">
-        <span class="board-summary-label text-[color:var(--text-muted)] text-[length:var(--fs-xs)] tracking-[0.06em] uppercase">최근 갱신</span>
-        <strong>${lastBoardRefreshAt.value ? html`<${TimeAgo} timestamp=${lastBoardRefreshAt.value} />` : '아직 불러오지 않음'}</strong>
+      <div class="flex flex-col gap-1 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-xs text-[var(--text-muted)] tracking-wider uppercase font-medium">최근 갱신</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${lastBoardRefreshAt.value ? html`<${TimeAgo} timestamp=${lastBoardRefreshAt.value} />` : '아직 불러오지 않음'}</strong>
       </div>
     </div>
   `
@@ -258,7 +258,7 @@ function PostCard({ post }: { post: BoardPost }) {
   }
 
   return html`
-    <div class="board-post rounded-xl" onClick=${() => navigateToPost(post.id)}>
+    <div class="board-post rounded-xl p-4 border border-[var(--card-border)] bg-[var(--card)] hover:border-[var(--accent)]/30 transition-colors" onClick=${() => navigateToPost(post.id)}>
       <div class="vote-column">
         <button class="vote-btn upvote" onClick=${(event: Event) => handleVote('up', event)}>▲</button>
         <span class="vote-count">${post.votes ?? 0}</span>
@@ -267,15 +267,15 @@ function PostCard({ post }: { post: BoardPost }) {
       <div class="post-content">
         <div class="grid gap-2">
             <div class="post-title-row">
-              <div class="text-[#e8f0ff]">${post.title}</div>
-              <div class="post-chip-row">
-                ${isUpdated(post) ? html`<span class="board-meta-chip rounded-full">수정됨</span>` : null}
-                ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip rounded-full">${boardPostKind(post)}</span>` : null}
-                ${post.hearth ? html`<span class="board-meta-chip rounded-full">${post.hearth}</span>` : null}
-                ${post.visibility ? html`<span class="board-meta-chip rounded-full">${post.visibility}</span>` : null}
+              <div class="text-sm font-medium text-[var(--text-strong)]">${post.title}</div>
+              <div class="post-chip-row flex gap-1.5 flex-wrap">
+                ${isUpdated(post) ? html`<span class="status-badge">수정됨</span>` : null}
+                ${boardPostKind(post) !== 'human' ? html`<span class="status-badge">${boardPostKind(post)}</span>` : null}
+                ${post.hearth ? html`<span class="status-badge">${post.hearth}</span>` : null}
+                ${post.visibility ? html`<span class="status-badge">${post.visibility}</span>` : null}
               </div>
             </div>
-          <div class="flex gap-2.5 items-center flex-wrap text-[length:var(--fs-xs)] text-[#90a4cc]">
+          <div class="flex gap-2.5 items-center flex-wrap text-xs text-[var(--text-muted)]">
             <span>작성자 <a class="author-link cursor-pointer underline" onClick=${(e: Event) => { e.stopPropagation(); navigate('status', { section: 'agents', agent: post.author }) }}>${post.author}</a></span>
             <span><${TimeAgo} timestamp=${post.created_at} /></span>
             ${isUpdated(post) ? html`<span>수정 <${TimeAgo} timestamp=${post.updated_at} /></span>` : null}
@@ -283,7 +283,7 @@ function PostCard({ post }: { post: BoardPost }) {
             <span>투표 ${post.votes ?? 0}</span>
           </div>
         </div>
-        <div class="text-[color:var(--text-body)] text-[length:var(--fs-base)] leading-[1.6]">${previewText(stripStateBlocks(post.body))}</div>
+        <div class="text-[13px] text-[var(--text-body)] leading-[1.6] mt-2">${previewText(stripStateBlocks(post.body))}</div>
       </div>
     </div>
   `
@@ -319,7 +319,7 @@ function CommentItem({ comment }: { comment: BoardComment }) {
 }
 
 function CommentThread({ comments }: { comments: BoardComment[] }) {
-  if (comments.length === 0) return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)] text-[13px]">아직 댓글이 없습니다</div>`
+  if (comments.length === 0) return html`<div class="empty-state">아직 댓글이 없습니다</div>`
 
   return html`
     <div class="comment-thread flex flex-col gap-2">
@@ -369,23 +369,23 @@ function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button class="mb-3 border border-[var(--border-slate-30)] px-3 py-[7px] text-[length:var(--fs-sm)] text-[#bdd8ff] bg-[var(--white-3)] cursor-pointer hover:bg-[var(--white-10)] rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+      <button class="control-btn ghost mb-4" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
       <${Card} title=${post.title}>
-        <div class="board-detail p-5">
-          <div class="post-body">
+        <div class="board-detail">
+          <div class="post-body text-[13px] text-[var(--text-body)] leading-[1.6]">
             <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
-          <div class="flex gap-2.5 items-center flex-wrap mt-3 text-[length:var(--fs-xs)] text-[#90a4cc]">
+          <div class="flex gap-2.5 items-center flex-wrap mt-4 text-xs text-[var(--text-muted)]">
             <span><a class="author-link cursor-pointer underline" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a></span>
             <${TimeAgo} timestamp=${post.created_at} />
             <span>${post.votes ?? 0} votes</span>
           </div>
           ${(post.hearth || post.visibility || post.expires_at)
             ? html`
-                <div class="post-chip-row mt-2">
-                  ${post.hearth ? html`<span class="board-meta-chip rounded-full">${post.hearth}</span>` : null}
-                  ${post.visibility ? html`<span class="board-meta-chip rounded-full">${post.visibility}</span>` : null}
-                  ${boardPostKind(post) !== 'human' ? html`<span class="board-meta-chip rounded-full">${boardPostKind(post)}</span>` : null}
+                <div class="flex gap-1.5 flex-wrap mt-3">
+                  ${post.hearth ? html`<span class="status-badge">${post.hearth}</span>` : null}
+                  ${post.visibility ? html`<span class="status-badge">${post.visibility}</span>` : null}
+                  ${boardPostKind(post) !== 'human' ? html`<span class="status-badge">${boardPostKind(post)}</span>` : null}
                   ${expiryChip(post)}
                 </div>
               `
@@ -412,7 +412,7 @@ function PostDetail({ post }: { post: BoardPost }) {
 
       <${Card} title="댓글">
         ${detailLoading.value
-          ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">댓글 불러오는 중...</div>`
+          ? html`<div class="loading-state loading-pulse">댓글 불러오는 중...</div>`
           : html`<${CommentThread} comments=${detailComments.value} />`}
         <${CommentForm} postId=${post.id} />
       <//>
@@ -441,10 +441,10 @@ export function Memory() {
       : html`
           <div>
             <${MemorySummary} />
-            <button class="mb-3 border border-[var(--border-slate-30)] px-3 py-[7px] text-[length:var(--fs-sm)] text-[#bdd8ff] bg-[var(--white-3)] cursor-pointer hover:bg-[var(--white-10)] rounded-lg" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
+            <button class="control-btn ghost mb-4" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
             ${detailLoading.value
-              ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">글 불러오는 중...</div>`
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">글을 찾지 못했습니다</div>`}
+              ? html`<div class="loading-state loading-pulse">글 불러오는 중...</div>`
+              : html`<div class="empty-state">글을 찾지 못했습니다</div>`}
           </div>
         `
   }
@@ -454,18 +454,18 @@ export function Memory() {
       <${MemorySummary} />
       <${SortBar} />
       ${boardLoading.value
-        ? html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">메모리 피드 불러오는 중...</div>`
+        ? html`<div class="loading-state loading-pulse">메모리 피드 불러오는 중...</div>`
         : posts.length === 0
-          ? html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다.</div>`
+          ? html`<div class="empty-state">아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다.</div>`
           : html`
-              <${Card} title="사람이 쓴 글" class="section mb-3.5">
-                <div class="board-post rounded-xl-list flex flex-col gap-2">
+              <${Card} title="사람이 쓴 글" class="mb-4">
+                <div class="flex flex-col gap-4">
                   ${grouped.human.slice(0, visibleLimit.value).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
                 </div>
                 ${grouped.human.length > visibleLimit.value ? html`
-                  <div class="text-center py-3">
+                  <div class="text-center py-4">
                     <button
-                      class="control-btn rounded-lg ghost"
+                      class="control-btn ghost"
                       onClick=${() => { visibleLimit.value = visibleLimit.value + PAGE_SIZE }}
                     >
                       더 보기 (${grouped.human.length - visibleLimit.value}개 남음)
@@ -475,8 +475,8 @@ export function Memory() {
               <//>
               ${grouped.operations.length > 0
                 ? html`
-                    <${Card} title="자동화 · 시스템" class="section mb-3.5">
-                      <div class="board-post rounded-xl-list flex flex-col gap-2">
+                    <${Card} title="자동화 · 시스템" class="mb-4">
+                      <div class="flex flex-col gap-4">
                         ${grouped.operations.map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
                       </div>
                     <//>

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -86,7 +86,7 @@ export function AttentionCard({
                 `)}
               </div>
             `
-          : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">직접 연결된 세션이 아직 없습니다.</div>`}
+          : html`<div class="empty-state">직접 연결된 세션이 아직 없습니다.</div>`}
 
         ${item.related_agent_names.length > 0
           ? html`

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -41,8 +41,8 @@ export function MissionBriefingCard() {
         ${briefing?.refreshing ? html`<span class="cmd-chip rounded-full warn">갱신 중</span>` : null}
       </div>
 
-      ${missionBriefingError.value ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${missionBriefingError.value}</div>` : null}
-      ${briefing?.error ? html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${briefing.error}</div>` : null}
+      ${missionBriefingError.value ? html`<div class="empty-state error">${missionBriefingError.value}</div>` : null}
+      ${briefing?.error ? html`<div class="empty-state error">${briefing.error}</div>` : null}
       ${briefing?.summary ? html`<div class="grid gap-1">${briefing.summary}</div>` : null}
       ${briefing?.last_error && !briefing.error
         ? html`<div class="grid gap-1">최근 갱신 실패: ${briefing.last_error}</div>`
@@ -80,7 +80,7 @@ export function MissionBriefingCard() {
           `
         : (!missionBriefingLoading.value && !missionBriefingError.value && showEmpty
             ? html`
-                <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+                <div class="empty-state">
                   ${briefing?.status === 'pending'
                     ? '최신 스냅샷으로 브리핑을 생성 중입니다. 마지막 성공 결과가 생기면 자동으로 다시 읽습니다.'
                     : '판단 결과가 아직 없습니다.'}

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -130,7 +130,7 @@ export function SessionDetailCard({
   if (loading && !detail) {
     return html`
       <${Card} title="세션 상세" class="mission-list-card rounded-xl">
-        <div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">세션 상세 불러오는 중...</div>
+        <div class="loading-state loading-pulse">세션 상세 불러오는 중...</div>
       <//>
     `
   }
@@ -138,7 +138,7 @@ export function SessionDetailCard({
   if (error && !detail) {
     return html`
       <${Card} title="세션 상세" class="mission-list-card rounded-xl">
-        <div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${error}</div>
+        <div class="empty-state error">${error}</div>
       <//>
     `
   }
@@ -174,7 +174,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.68)] leading-[1.45]">${item.actor ? `${item.actor} · ` : ''}${item.event_type ?? '이벤트'}</small>
                   </article>
                 `)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">표시할 세션 이벤트가 없습니다.</div>`}
+              : html`<div class="empty-state">표시할 세션 이벤트가 없습니다.</div>`}
           </div>
         </div>
 
@@ -195,7 +195,7 @@ export function SessionDetailCard({
                     </small>
                   </button>
                 `)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">세션 참여자 미리보기가 없습니다.</div>`}
+              : html`<div class="empty-state">세션 참여자 미리보기가 없습니다.</div>`}
           </div>
         </div>
       </div>
@@ -215,7 +215,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}</small>
                   </button>
                 `)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">연결된 작전이 없습니다.</div>`}
+              : html`<div class="empty-state">연결된 작전이 없습니다.</div>`}
           </div>
         </div>
 
@@ -233,7 +233,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${keeper.current_work ?? '현재 작업 정보 없음'}</small>
                   </div>
                 `)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">직접 연결된 키퍼는 없습니다.</div>`}
+              : html`<div class="empty-state">직접 연결된 키퍼는 없습니다.</div>`}
           </div>
         </div>
       </div>

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -35,13 +35,13 @@ import { ProvenanceStrip } from './common/provenance-strip'
 export function Mission() {
   const mission = missionSnapshot.value
   if (missionLoading.value && !mission) {
-    return html`<div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">상황판 스냅샷 불러오는 중...</div>`
+    return html`<div class="loading-state loading-pulse">상황판 스냅샷 불러오는 중...</div>`
   }
   if (missionError.value && !mission) {
-    return html`<div class="empty-state error text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">${missionError.value}</div>`
+    return html`<div class="empty-state error">${missionError.value}</div>`
   }
   if (!mission) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">상황판 스냅샷이 아직 없습니다.</div>`
+    return html`<div class="empty-state">상황판 스냅샷이 아직 없습니다.</div>`
   }
 
   const sessionRows = mission.sessions
@@ -203,7 +203,7 @@ export function Mission() {
         <div class="flex flex-col gap-4">
           ${sessionRows.length > 0
             ? sessionRows.map(row => html`<${SessionBriefCard} key=${row.session_id} brief=${row} selected=${activeSessionId === row.session_id} />`)
-            : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 보이는 팀 세션이 없습니다.</div>`}
+            : html`<div class="empty-state">지금 보이는 팀 세션이 없습니다.</div>`}
         </div>
       <//>
 
@@ -224,7 +224,7 @@ export function Mission() {
           <div class="flex flex-col gap-4">
             ${keeperRows.length > 0
               ? keeperRows.map(row => html`<${KeeperBriefCard} key=${row.brief.name} row=${row} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 보이는 키퍼가 없습니다.</div>`}
+              : html`<div class="empty-state">지금 보이는 키퍼가 없습니다.</div>`}
           </div>
           <div class="flex gap-2 flex-wrap mt-2.5">
             <button class="control-btn rounded-lg ghost" onClick=${() => navigate('status', { section: 'sessions' })}>세션 보기</button>
@@ -251,7 +251,7 @@ export function Mission() {
                     <div>${row.recent_output_preview}</div>
                   </div>
                 `)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">선택된 세션에서 바로 읽을 최근 출력이 없습니다.</div>`}
+              : html`<div class="empty-state">선택된 세션에서 바로 읽을 최근 출력이 없습니다.</div>`}
             ${keeperOutputRows.length > 0
               ? keeperOutputRows.map(row => html`
                   <div class="grid gap-1">
@@ -275,7 +275,7 @@ export function Mission() {
           <div class="p-3.5 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-6),var(--white-3))] grid gap-3">
             ${attentionQueue.length > 0
               ? attentionQueue.map(item => html`<${AttentionCard} key=${item.id} item=${item} selected=${activeSelectedAttentionId === item.id} sessionLookup=${sessionLookup} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">지금 세션 단위 주의 대기열은 비어 있습니다.</div>`}
+              : html`<div class="empty-state">지금 세션 단위 주의 대기열은 비어 있습니다.</div>`}
           </div>
         <//>
       </details>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -85,7 +85,7 @@ export function OpsRoomColumn() {
           </div>
         </article>
         ${operatorDigestLoading.value && !roomDigest ? html`
-          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">개입 추천을 불러오는 중입니다...</div>
+          <div class="loading-state loading-pulse">개입 추천을 불러오는 중입니다...</div>
         ` : activeRecommendedActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${activeRecommendedActions.map(item => html`

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -73,28 +73,26 @@ export function AttentionSpotlight({ snap }: AttentionSpotlightProps) {
   if (items.length === 0) return null
 
   return html`
-    <div class="flex flex-col gap-1">
+    <div class="flex flex-col gap-2">
       <div class="flex items-start justify-between mb-1 gap-3">
         <div>
-          <span class="text-text-muted text-xs tracking-[0.06em] uppercase">주의 항목</span>
-          <div class="mt-[3px] text-text-muted text-sm leading-[1.45]">지금 바로 확인할 blocker와 attention 신호만 상단에 압축합니다.</div>
-        </div>
-        <div class="inline-flex items-center gap-2 flex-wrap justify-end">
+          <span class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">주의 항목</span>
+          <div class="mt-1 text-[13px] text-[var(--text-muted)] leading-[1.45]">지금 바로 확인할 blocker와 attention 신호만 상단에 압축합니다.</div>
         </div>
       </div>
       ${items.map(item => html`
-        <div class="attention-spotlight__card ${toneClass(item.severity)}" key=${item.id}>
+        <div class="attention-spotlight__card ${toneClass(item.severity)} rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex overflow-hidden" key=${item.id}>
           <div class="w-1 shrink-0 attention-spotlight__bar" />
-          <div class="grid gap-1.5 p-[10px_14px] min-w-0">
-            <span class="text-text-strong text-base font-medium leading-[1.4]">
+          <div class="grid gap-1.5 p-4 min-w-0">
+            <span class="text-sm font-medium text-[var(--text-strong)] leading-[1.4]">
               ${trimText(item.summary, 100)}
             </span>
             <div class="flex gap-1.5 flex-wrap items-center">
               ${item.relatedNames.map(name => html`
-                <span class="py-0.5 px-2 bg-[var(--white-6)] border border-[var(--white-8)] text-[length:var(--fs-xs)] text-[color:var(--warm-amber,#f5c542)] font-medium rounded-full" key=${name}>${name}</span>
+                <span class="status-badge" key=${name}>${name}</span>
               `)}
               ${item.lastSeen ? html`
-                <span class="text-text-muted text-xs">${relativeTime(item.lastSeen)}</span>
+                <span class="text-xs text-[var(--text-muted)]">${relativeTime(item.lastSeen)}</span>
               ` : null}
             </div>
           </div>

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -82,10 +82,10 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
   if (raw.length === 0) {
     return html`
       <div class="narrative-timeline">
-        <div class="flex flex-col items-center justify-center gap-3 py-10 px-4 border border-dashed border-[var(--border-slate-16)] rounded-lg bg-[var(--white-2)]">
-          <span class="text-2xl opacity-40">📡</span>
-          <div class="text-text-muted text-sm text-center">이벤트 대기 중</div>
-          <div class="text-text-muted text-xs text-center opacity-60 max-w-[32ch] leading-[1.5]">에이전트 활동, 세션 변경, 시스템 이벤트가 여기에 실시간으로 나타납니다.</div>
+        <div class="empty-state">
+          <span class="empty-state-icon">📡</span>
+          <div class="empty-state-title">이벤트 대기 중</div>
+          <div class="empty-state-desc">에이전트 활동, 세션 변경, 시스템 이벤트가 여기에 실시간으로 나타납니다.</div>
         </div>
       </div>
     `

--- a/dashboard/src/components/overview/oas-pipeline.ts
+++ b/dashboard/src/components/overview/oas-pipeline.ts
@@ -66,7 +66,7 @@ function OasSummaryLines() {
   const agoMin = lastEventTs != null ? Math.round((Date.now() / 1000 - lastEventTs) / 60) : null
 
   return html`
-    <div class="flex gap-3 text-[length:var(--fs-xs)] text-[color:var(--text-muted,#888)] mb-2.5">
+    <div class="flex gap-3 text-[13px] text-[var(--text-body)] mb-3">
       <span>활성 에이전트 ${activeAgents.size}명</span>
       <span>${health.totalEvents}건${snapshots.size > 0 ? ` · 키퍼 ${snapshots.size}명` : ''}</span>
       <span>${agoMin != null ? `${agoMin}분 전` : '이벤트 대기 중'}</span>
@@ -129,18 +129,16 @@ export function OasPipeline() {
   const eventLabel = `${health.totalEvents}건`
 
   return html`
-    <div class="bg-[var(--card,#1a1f2e)] border border-[var(--card-border,#2a2f3e)] py-3 px-4 mt-3 rounded-lg">
-      <div class="flex justify-between items-center mb-3">
-        <span class="text-[length:var(--fs-base)] font-semibold text-[color:var(--text-strong,var(--text-near-white))] tracking-[0.5px]">실행 흐름</span>
-        <div class="home-section-actions">
-          <span class="text-[length:var(--fs-xs)] text-[color:var(--text-muted,#888)] tabular-nums">${eventLabel}</span>
-        </div>
+    <div class="card">
+      <div class="flex justify-between items-center mb-4">
+        <span class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">실행 흐름</span>
+        <span class="text-xs text-[var(--text-muted)] tabular-nums">${eventLabel}</span>
       </div>
 
       <${OasSummaryLines} />
 
-      <div class="mb-2.5">
-        <div class="text-[length:var(--fs-xs)] font-medium text-[color:var(--text-muted,#888)] uppercase tracking-[0.5px] mb-1.5">키퍼 컨텍스트</div>
+      <div class="mb-3">
+        <div class="text-xs text-[var(--text-muted)] uppercase tracking-wider font-medium mb-1.5">키퍼 컨텍스트</div>
         <${OasKeeperBars} />
       </div>
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -62,14 +62,14 @@ function HomeSectionHeader({
   onLink?: () => void
 }) {
   return html`
-    <div class="flex items-start justify-between mb-1 gap-3">
+    <div class="flex items-start justify-between mb-2 gap-3">
       <div>
-        <span class="text-text-muted text-xs tracking-[0.06em] uppercase">${label}</span>
-        ${copy ? html`<div class="mt-[3px] text-text-muted text-sm leading-[1.45]">${copy}</div>` : null}
+        <span class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">${label}</span>
+        ${copy ? html`<div class="mt-1 text-[13px] text-[var(--text-muted)] leading-[1.45]">${copy}</div>` : null}
       </div>
       <div class="inline-flex items-center gap-2 flex-wrap justify-end">
         ${linkLabel && onLink
-          ? html`<a class="text-[length:var(--fs-xs)] text-accent cursor-pointer no-underline hover:underline" onClick=${onLink}>${linkLabel}</a>`
+          ? html`<a class="text-xs text-accent cursor-pointer no-underline hover:underline" onClick=${onLink}>${linkLabel}</a>`
           : null}
       </div>
     </div>
@@ -83,28 +83,26 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
 
   return html`
     <div
-      class="hot-session-card rounded-lg p-3 border border-[var(--border-slate-16)] bg-[var(--white-3)] cursor-pointer ${s.blocker_summary ? 'border-[var(--bad)] bg-[rgba(239,68,68,0.06)]' : ''}"
+      class="hot-session-card rounded-xl p-4 border border-[var(--card-border)] bg-[var(--card)] cursor-pointer hover:border-[var(--accent)]/30 transition-colors ${s.blocker_summary ? 'border-[var(--bad)] bg-[rgba(239,68,68,0.06)]' : ''}"
       key=${s.session_id}
       onClick=${() => navigate('status', { section: 'sessions', session_id: s.session_id })}
     >
-      <div class="text-sm font-semibold text-text-strong leading-[1.35] line-clamp-2">${primary}</div>
-      ${secondary ? html`<div class="hot-session-card__context">${secondary}</div>` : null}
-      <div class="flex flex-wrap gap-1.5 mt-2">
+      <div class="text-sm font-medium text-[var(--text-strong)] leading-[1.35] line-clamp-2">${primary}</div>
+      ${secondary ? html`<div class="hot-session-card__context mt-1 text-[13px] text-[var(--text-body)]">${secondary}</div>` : null}
+      <div class="flex flex-wrap gap-1.5 mt-2.5">
         ${creator
-          ? html`<span class="inline-flex items-center min-h-5 px-2 border border-[var(--border-slate-18)] bg-[var(--border-slate-8)] text-[color:var(--text-muted)] text-[length:var(--fs-2xs)] tracking-[0.02em] rounded-full ${systemSession ? 'border-[rgba(34,197,94,0.22)] bg-[rgba(34,197,94,0.12)] text-[#b7f3c9]' : ''}">
-              ${systemSession ? '시스템' : '주체'} · ${creator}
-            </span>`
+          ? html`<span class="status-badge ${systemSession ? 'active' : ''}">${systemSession ? '시스템' : '주체'} · ${creator}</span>`
           : null}
-        ${s.status ? html`<span class="inline-flex items-center min-h-5 px-2 border border-[var(--border-slate-18)] bg-[var(--border-slate-8)] text-[color:var(--text-muted)] text-[length:var(--fs-2xs)] tracking-[0.02em] rounded-full">${statusLabel(s.status)}</span>` : null}
+        ${s.status ? html`<span class="status-badge">${statusLabel(s.status)}</span>` : null}
       </div>
-      <div class="flex gap-2 flex-wrap text-xs text-text-muted mt-2">
+      <div class="flex gap-2 flex-wrap text-xs text-[var(--text-muted)] mt-2">
         ${s.member_names?.length ? html`
           <span>${s.member_names.slice(0, 3).join(', ')}${s.member_names.length > 3 ? ` +${s.member_names.length - 3}` : ''}</span>
         ` : null}
         ${s.elapsed_sec ? html`<span>${formatDuration(s.elapsed_sec)}</span>` : null}
       </div>
       ${s.blocker_summary ? html`
-        <div class="text-xs text-bad mt-1 overflow-hidden text-ellipsis whitespace-nowrap">${s.blocker_summary}</div>
+        <div class="text-xs text-bad mt-1.5 overflow-hidden text-ellipsis whitespace-nowrap">${s.blocker_summary}</div>
       ` : null}
     </div>
   `
@@ -120,19 +118,19 @@ type SessionLaneProps = {
 
 function SessionLane({ title, description, tone, sessions, emptyCopy }: SessionLaneProps) {
   return html`
-    <section class="hot-session-lane hot-session-lane--${tone} rounded-lg border border-[var(--border-slate-12)] p-3.5 grid gap-3">
+    <section class="hot-session-lane hot-session-lane--${tone} rounded-xl border border-[var(--card-border)] p-4 grid gap-4">
       <div class="flex items-start justify-between gap-3">
         <div>
           <div class="flex items-center gap-2">
-            <h3 class="m-0 text-base font-semibold text-text-strong">${title}</h3>
-            <span class="inline-flex items-center justify-center min-w-[24px] h-6 px-2 bg-[var(--white-8)] text-[color:var(--text-muted)] text-[length:var(--fs-xs)] font-semibold rounded-full">${sessions.length}</span>
+            <h3 class="m-0 text-sm font-medium text-[var(--text-strong)]">${title}</h3>
+            <span class="status-badge">${sessions.length}</span>
           </div>
-          <p class="mt-1 mb-0 text-text-muted text-sm leading-[1.45]">${description}</p>
+          <p class="mt-1 mb-0 text-[13px] text-[var(--text-muted)] leading-[1.45]">${description}</p>
         </div>
       </div>
       ${sessions.length > 0
-        ? html`<div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-2">${sessions.map(renderSessionCard)}</div>`
-        : html`<div class="grid place-items-center min-h-[116px] p-3 border border-dashed border-[var(--border-slate-18)] text-[color:var(--text-muted)] text-[length:var(--fs-sm)] text-center bg-[var(--white-2)] rounded-lg">${emptyCopy}</div>`}
+        ? html`<div class="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4">${sessions.map(renderSessionCard)}</div>`
+        : html`<div class="empty-state"><span class="empty-state-desc">${emptyCopy}</span></div>`}
     </section>
   `
 }
@@ -205,17 +203,17 @@ function AgentPulse() {
         linkLabel="전체 보기"
         onLink=${() => navigate('status', { section: 'agents' })}
       />
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
         ${agents.map((a: ObservatoryAgent) => html`
           <div
-            class="flex items-center gap-3 py-2.5 px-3 cursor-pointer transition-[background] duration-150 hover:bg-[var(--white-4)] rounded-lg border border-[var(--border-slate-12)] bg-[var(--white-2)] agent-pulse-card--${a.state}"
+            class="flex items-center gap-3 p-4 cursor-pointer transition-colors duration-150 hover:border-[var(--accent)]/30 rounded-xl border border-[var(--card-border)] bg-[var(--card)] agent-pulse-card--${a.state}"
             key=${a.name}
             onClick=${() => navigate('status', { section: 'agents', agent: a.name })}
           >
             <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${32} />
             <div class="flex flex-col min-w-0 gap-0.5">
-              <span class="text-sm font-semibold text-text-strong">${a.koreanName ?? a.name}</span>
-              <span class="text-xs text-text-muted leading-[1.4] line-clamp-2">
+              <span class="text-sm font-medium text-[var(--text-strong)]">${a.koreanName ?? a.name}</span>
+              <span class="text-xs text-[var(--text-muted)] leading-[1.4] line-clamp-2">
                 ${stateIcon(a.state)} ${a.focus ?? a.currentTask ?? a.status}
               </span>
             </div>
@@ -233,21 +231,21 @@ export function Overview() {
   const roomHealth = snap?.summary?.room_health ?? null
 
   return html`
-    <div class="grid gap-5">
+    <div class="grid gap-4">
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
       <${AttentionSpotlight} snap=${snap} />
 
-      <section class="grid gap-5 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
+      <section class="card grid gap-4">
         <${HotSessions} />
       </section>
 
-      <section class="grid gap-3 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
+      <section class="card grid gap-4">
         <${AgentPulse} />
       </section>
 
       <${OasPipeline} />
 
-      <section class="grid gap-3 border border-[var(--border-slate-12)] rounded-xl bg-[var(--white-2)] p-4">
+      <section class="card grid gap-4">
         <${HomeSectionHeader}
           label="최근 활동"
 

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -49,7 +49,7 @@ export function Proof() {
   const snapshot = proofSnapshot.value
 
   if (proofLoading.value && !snapshot) {
-    return html`<section class="flex flex-col gap-[18px]"><div class="text-center border border-dashed border-[var(--card-border)] rounded-xl py-12 px-4 text-[color:var(--text-muted)]">근거 화면 불러오는 중…</div></section>`
+    return html`<section class="flex flex-col gap-[18px]"><div class="loading-state loading-pulse">근거 화면 불러오는 중…</div></section>`
   }
 
   if (proofError.value && !snapshot) {
@@ -228,7 +228,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${dedupedTimeline.length > 0
               ? dedupedTimeline.slice(0, 18).map(item => html`<${TimelineRow} key=${item.id} item=${item} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다.</div>`}
+              : html`<div class="empty-state">타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다.</div>`}
           </div>
         <//>
 
@@ -240,7 +240,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${contributions.length > 0
               ? contributions.map(item => html`<${ActorContributionRow} key=${item.actor} item=${item} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다.</div>`}
+              : html`<div class="empty-state">참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다.</div>`}
           </div>
         <//>
       </div>
@@ -254,7 +254,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${toolEvidence.length > 0
               ? toolEvidence.map((item, idx) => html`<${ToolEvidenceRow} key=${`${item.actor ?? 'system'}-${idx}`} item=${item} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다.</div>`}
+              : html`<div class="empty-state">도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다.</div>`}
           </div>
         <//>
 
@@ -294,7 +294,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${artifacts.length > 0
               ? artifacts.map(item => html`<${ArtifactRow} key=${item.path} item=${item} />`)
-              : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다.</div>`}
+              : html`<div class="empty-state">산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다.</div>`}
           </div>
         <//>
       </div>

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -19,22 +19,22 @@ export function Status() {
   const section = currentSection()
 
   return html`
-    <div class="tab-unified grid gap-[var(--space-md,16px)]">
-      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
+    <div class="tab-unified grid gap-4">
+      <div class="tab-pill-bar">
         <button
-          class="tab-pill rounded-full ${section === 'sessions' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'sessions' ? 'active' : ''}"
           onClick=${() => navigate('status', { section: 'sessions' })}
         >
           세션
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'agents' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'agents' ? 'active' : ''}"
           onClick=${() => navigate('status', { section: 'agents' })}
         >
           에이전트
         </button>
         <button
-          class="tab-pill rounded-full ${section === 'activity' ? 'tab-pill--active' : ''}"
+          class="tab-pill-btn ${section === 'activity' ? 'active' : ''}"
           onClick=${() => navigate('status', { section: 'activity' })}
         >
           활동

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -197,7 +197,7 @@ export function FullInventoryView({
             getKey=${(item: DashboardToolInventoryItem) => item.name}
             className="flex flex-col gap-3"
           />`
-        : html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">조건에 맞는 도구가 없습니다.</div>`}
+        : html`<div class="empty-state">조건에 맞는 도구가 없습니다.</div>`}
     </div>
 
     <button

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -33,7 +33,7 @@ export function Trpg() {
 
   if (archived) {
     return html`
-      <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+      <div class="empty-state">
         <div style="margin-bottom: 8px; font-size: 1.1em;">TRPG 모듈은 아카이브되었습니다</div>
         <div style="font-size: 0.9em; opacity: 0.7;">이 모듈은 더 이상 활성 상태가 아닙니다. 과거 세션 기록은 서버 로그에 남아 있습니다.</div>
       </div>
@@ -41,12 +41,12 @@ export function Trpg() {
   }
 
   if (loading && !state) {
-    return html`<div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">TRPG 상태를 불러오는 중...</div>`
+    return html`<div class="empty-state">TRPG 상태를 불러오는 중...</div>`
   }
 
   if (!state) {
     return html`
-      <div class="empty-state text-center border border-dashed border-[var(--card-border)] rounded-[10px] py-[22px] px-4 text-[color:var(--text-muted)]">
+      <div class="empty-state">
         <div style="margin-bottom: 12px;">활성 TRPG 세션이 없습니다.</div>
         <button class="control-btn rounded-lg ghost" onClick=${() => void safeFetchTrpg()}>새로고침</button>
       </div>

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -28,12 +28,12 @@ export function Work() {
     : 'board'
 
   return html`
-    <div class="tab-unified grid gap-[var(--space-md,16px)]">
-      <div class="tab-pill rounded-full-bar flex flex-wrap gap-1.5">
+    <div class="tab-unified grid gap-4">
+      <div class="tab-pill-bar">
         ${SECTIONS.map(s => html`
           <button
             key=${s.id}
-            class="tab-pill rounded-full ${current === s.id ? 'tab-pill--active' : ''}"
+            class="tab-pill-btn ${current === s.id ? 'active' : ''}"
             title=${s.tooltip}
             onClick=${() => navigate('work', { section: s.id })}
           >

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -102,13 +102,76 @@
   opacity: 0.85;
 }
 
-/* ── Tab pill (hover/active transitions) ── */
-.tab-pill {
-  transition: all 0.15s;
+/* ── Tab pill bar (GCP-style segmented control) ── */
+.tab-pill-bar {
+  display: flex;
+  gap: 4px;
+  background: var(--white-3);
+  padding: 4px;
+  border-radius: 10px;
 }
-.tab-pill:hover {
-  border-color: var(--accent);
-  color: var(--text-strong);
+.tab-pill-btn {
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: none;
+  background: transparent;
+  white-space: nowrap;
+}
+.tab-pill-btn:hover {
+  color: var(--text-body);
+  background: var(--white-6);
+}
+.tab-pill-btn.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+  cursor: default;
+}
+
+/* ── Empty state (standardized) ── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  text-align: center;
+}
+.empty-state-icon {
+  font-size: 1.875rem;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+.empty-state-title {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text-body);
+  margin-bottom: 4px;
+}
+.empty-state-desc {
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+/* ── Loading state (standardized) ── */
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+@keyframes loadingPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.loading-pulse {
+  animation: loadingPulse 1.5s ease-in-out infinite;
 }
 
 .tab-collapsible__summary:hover {

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -258,11 +258,10 @@ a:hover {
    ──────────────────────────────────────────────────────────── */
 
 .card {
-  background:
-    linear-gradient(180deg, var(--white-4), var(--white-2));
-  border: 1px solid var(--border-slate-16);
-  border-radius: var(--radius-md);
-  padding: 20px;
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 16px;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.18),
     0 4px 12px rgba(0, 0, 0, 0.10);
@@ -273,15 +272,18 @@ a:hover {
   border-color: var(--border-slate-22);
 }
 
+.card-title-row {
+  margin-bottom: 12px;
+}
+
 .card-title {
-  font-size: var(--fs-md);
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
   color: var(--text-strong);
   letter-spacing: -0.01em;
   line-height: 1.3;
-  padding-bottom: 4px;
-  border-bottom: 2px solid var(--border-slate-12);
-  margin-bottom: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-slate-12);
 }
 
 .monitor-headline {
@@ -304,9 +306,11 @@ a:hover {
 /* ── Section header (reusable pattern) ─────────────────────── */
 
 .section-header {
-  font-size: var(--fs-md);
+  font-size: 14px;
   font-weight: 600;
   color: var(--text-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
   padding-bottom: 8px;
   border-bottom: 1px solid var(--border-slate-12);
   margin-bottom: 12px;
@@ -1787,13 +1791,76 @@ tbody tr:hover {
   opacity: 0.85;
 }
 
-/* ── Tab pill (hover/active transitions) ── */
-.tab-pill {
-  transition: all 0.15s;
+/* ── Tab pill bar (GCP-style segmented control) ── */
+.tab-pill-bar {
+  display: flex;
+  gap: 4px;
+  background: var(--white-3);
+  padding: 4px;
+  border-radius: 10px;
 }
-.tab-pill:hover {
-  border-color: var(--accent);
-  color: var(--text-strong);
+.tab-pill-btn {
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: none;
+  background: transparent;
+  white-space: nowrap;
+}
+.tab-pill-btn:hover {
+  color: var(--text-body);
+  background: var(--white-6);
+}
+.tab-pill-btn.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+  cursor: default;
+}
+
+/* ── Empty state (standardized) ── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  text-align: center;
+}
+.empty-state-icon {
+  font-size: 1.875rem;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+.empty-state-title {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text-body);
+  margin-bottom: 4px;
+}
+.empty-state-desc {
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+/* ── Loading state (standardized) ── */
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+@keyframes loadingPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.loading-pulse {
+  animation: loadingPulse 1.5s ease-in-out infinite;
 }
 
 .tab-collapsible__summary:hover {


### PR DESCRIPTION
## Summary

GCP/AWS급 대시보드 UI 전면 개선:

### 레이아웃 (이전 커밋)
- 48px 슬림 top bar
- 240px 고정 사이드바 (깔끔한 네비게이션)
- full-height flex 레이아웃

### 카드 시스템
- 일관된 padding (16px), border, rounded-xl
- hover 효과 + transition

### 타이포그래피
- 명확한 계층: title 18px → section 14px → body 13px → meta 12px

### 탭 필
- GCP 스타일: 배경 컨테이너 + rounded pill
- active/inactive 명확한 구분

### 빈 상태 + 로딩
- 중앙 정렬 empty state
- pulse 애니메이션 loading

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)