### PR TITLE
refactor: route cascade resolution through OAS Provider_config

### DIFF
--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -39,6 +39,44 @@ let to_oas_provider (spec : Model_spec.model_spec) : Agent_sdk.Provider.config o
            model_id = pc.model_id;
            api_key_env = pc.api_key }
 
+(** Convert OAS Provider_config.t to OAS Provider.config for Agent Builder.
+    Provider_config.t already contains resolved API key and endpoint;
+    Provider.config is the Builder-level discriminated union. *)
+let provider_config_to_oas (cfg : Llm_provider.Provider_config.t)
+    : Agent_sdk.Provider.config =
+  match cfg.kind with
+  | Anthropic ->
+    { Agent_sdk.Provider.provider = Anthropic;
+      model_id = cfg.model_id;
+      api_key_env = if cfg.api_key <> "" then cfg.api_key else "ANTHROPIC_API_KEY" }
+  | Gemini ->
+    { provider = OpenAICompat { base_url = cfg.base_url; auth_header = None;
+        path = cfg.request_path; static_token = None };
+      model_id = cfg.model_id;
+      api_key_env = if cfg.api_key <> "" then cfg.api_key else "GEMINI_API_KEY" }
+  | Glm ->
+    { provider = OpenAICompat { base_url = cfg.base_url; auth_header = None;
+        path = cfg.request_path; static_token = None };
+      model_id = cfg.model_id;
+      api_key_env = if cfg.api_key <> "" then cfg.api_key else "ZAI_API_KEY" }
+  | OpenAI_compat ->
+    { provider =
+        (if String.length cfg.base_url > 0
+            && (String.sub cfg.base_url 0 (min 16 (String.length cfg.base_url))
+                = "http://127.0.0.1"
+                || String.sub cfg.base_url 0 (min 16 (String.length cfg.base_url))
+                   = "http://localhost")
+         then Local { base_url = cfg.base_url }
+         else OpenAICompat { base_url = cfg.base_url; auth_header = None;
+                path = cfg.request_path; static_token = None });
+      model_id = cfg.model_id;
+      api_key_env = cfg.api_key }
+  | Claude_code ->
+    { provider = OpenAICompat { base_url = cfg.base_url; auth_header = None;
+        path = cfg.request_path; static_token = None };
+      model_id = cfg.model_id;
+      api_key_env = cfg.api_key }
+
 let to_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message option =
   match m.role with System -> None | _ -> Some m
 

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -303,26 +303,23 @@ let require_eio () =
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
 
-(** Resolve cascade model specs from config + defaults. *)
-let resolve_cascade_specs ~cascade_name : Model_spec.model_spec list =
+(** Resolve cascade provider configs via OAS Cascade_config.
+    Returns OAS Provider_config.t list directly, bypassing Model_spec. *)
+let resolve_cascade_providers ~cascade_name : Llm_provider.Provider_config.t list =
   let defaults = default_model_strings ~cascade_name in
+  let config_path = default_config_path () in
   let configured =
-    match default_config_path () with
-    | Some path ->
-      let from_file =
-        Model_spec.load_cascade_profile ~config_path:path ~name:cascade_name
-      in
-      if from_file <> [] then from_file else defaults
-    | None -> defaults
+    Llm_provider.Cascade_config.resolve_model_strings
+      ?config_path ~name:cascade_name ~defaults ()
   in
-  let specs = Model_spec.available_model_specs_of_strings configured in
+  let specs = Llm_provider.Cascade_config.parse_model_strings configured in
   if specs <> [] then specs
   else if configured = defaults then (
       Log.Misc.warn "cascade %s: no callable models from built-in defaults" cascade_name;
       [])
     else (
       Log.Misc.warn "cascade %s: configured models unavailable — retrying built-in defaults" cascade_name;
-      Model_spec.available_model_specs_of_strings defaults)
+      Llm_provider.Cascade_config.parse_model_strings defaults)
 
 let config_for_model
     ~(name : string)
@@ -392,18 +389,30 @@ let run_named
   let named_cascade = Oas.Api.named_cascade ?config_path
     ~name:cascade_name ~defaults () in
   let name = Printf.sprintf "oas-%s" cascade_name in
-  (* Use first available model as primary for Builder.
-     Fallback to glm_cloud preset when no cascade models resolve. *)
-  let primary_spec = match resolve_cascade_specs ~cascade_name with
-    | spec :: _ -> spec
-    | [] -> Model_spec.glm_cloud
+  (* Use first available provider config as primary for Builder.
+     OAS named_cascade handles actual fallback — this is just the
+     initial provider for Agent construction. *)
+  let primary_provider = match resolve_cascade_providers ~cascade_name with
+    | cfg :: _ -> cfg
+    | [] ->
+      Llm_provider.Provider_config.make
+        ~kind:Llm_provider.Provider_config.Glm
+        ~model_id:"auto"
+        ~base_url:"https://open.bigmodel.cn/api/paas/v4"
+        ~request_path:"/chat/completions"
+        ()
+  in
+  let provider : Oas.Provider.config =
+    Oas_type_adapters.provider_config_to_oas primary_provider
   in
   let config =
-    config_for_model ~name ~model_spec:primary_spec ~system_prompt ~tools
-      ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
-      ?context_reducer ?memory
-      ~description:(Some (Printf.sprintf "cascade:%s" cascade_name))
-      ()
+    { (default_config ~name ~provider ~model_id:primary_provider.model_id
+         ~system_prompt ~tools)
+      with
+      max_turns; max_tokens; temperature;
+      guardrails; hooks; context_reducer; memory;
+      description = Some (Printf.sprintf "cascade:%s" cascade_name);
+    }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in
   match run ~sw ~net ~config ?on_event ?agent_ref goal with


### PR DESCRIPTION
## Summary
- Replace `resolve_cascade_specs` (Model_spec) with `resolve_cascade_providers` (OAS Cascade_config direct)
- Add `provider_config_to_oas` adapter in oas_type_adapters.ml
- run_named builds Agent from OAS Provider_config.t directly
- Fix duplicate Glm pattern match after rebase

Removes 5 Model_spec references from the cascade path.
Part of #2207 (Model_spec→OAS migration Phase B).

## Test plan
- [ ] `dune build` passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)