### PR TITLE
refactor(model_spec): add OAS migration bridge (Phase 1)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -242,7 +242,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
                          ~trace_id:m.trace_id
-                         ~primary_model_max_tokens:primary.max_context
+                         ~primary_model_max_tokens:(Model_spec.max_context primary)
                          ~base_dir
                      in
                      match ctx_opt with

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -471,8 +471,12 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
               Ok (snapshot, model))
 
 let oas_provider_config_of_spec (spec : Model_spec.model_spec) =
-  match spec.provider with
-  | Model_spec.Gemini -> (
+  (* Use registry_name_of_provider to identify Gemini instead of
+     matching the Model_spec.provider constructor directly.
+     Migration: callers will eventually receive Provider_config.t
+     and check kind = Gemini. *)
+  match Model_spec.registry_name_of_provider spec.provider with
+  | "gemini" -> (
       match Provider_adapter.resolve_gemini_direct_auth () with
       | Provider_adapter.Gemini_api_key -> Oas_type_adapters.to_oas_provider spec
       | Provider_adapter.Gemini_vertex_adc _ -> None

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -96,13 +96,12 @@ let handle_keeper_status ctx args : tool_result =
            compaction_policy_of_keeper m
          in
 
-         let open Model_spec in
-         let models_resolved = `List (List.map (fun s ->
-           let pricing = Llm_provider.Pricing.pricing_for_model s.model_id in
+         let models_resolved = `List (List.map (fun (s : Model_spec.model_spec) ->
+           let pricing = Model_spec.pricing_of_spec s in
            `Assoc [
-             ("provider", `String (string_of_provider s.provider));
+             ("provider", `String (Model_spec.string_of_provider s.provider));
              ("model_id", `String s.model_id);
-             ("max_context", `Int s.max_context);
+             ("max_context", `Int (Model_spec.max_context s));
              ("api_key_env", match s.api_key_env with None -> `Null | Some k -> `String k);
              ("cost_per_million_input", `Float pricing.input_per_million);
              ("cost_per_million_output", `Float pricing.output_per_million);

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -463,3 +463,92 @@ let find_model_id_for_used ~labels ~model_used =
 let cost_usd_of_model_id ~model_id ~input_tokens ~output_tokens =
   let pricing = Llm_provider.Pricing.pricing_for_model model_id in
   Llm_provider.Pricing.estimate_cost ~pricing ~input_tokens ~output_tokens ()
+
+(* ================================================================ *)
+(* OAS Migration Bridge (Phase 1)                                    *)
+(* Bidirectional conversion: Model_spec.model_spec <-> OAS types.    *)
+(* Callers should migrate from Model_spec.model_spec to              *)
+(* Llm_provider.Provider_config.t or Agent_sdk.Provider.config.      *)
+(* ================================================================ *)
+
+(** Map MASC provider enum to OAS provider_kind.
+    Inverse of {!provider_of_oas}. Note that multiple MASC providers
+    map to OpenAI_compat (Llama, OpenAI, OpenRouter, Custom).
+    Glm_cloud maps to Glm (dedicated kind since OAS v0.83.0). *)
+let provider_kind_of_masc : provider -> Llm_provider.Provider_config.provider_kind =
+  function
+  | Claude -> Anthropic
+  | Gemini -> Gemini
+  | Glm_cloud -> Glm
+  | Llama | OpenAI | OpenRouter | Custom _ -> OpenAI_compat
+
+(** Map MASC provider enum to OAS registry name.
+    Used for Provider_registry lookups during conversion. *)
+let registry_name_of_provider : provider -> string = function
+  | Llama -> "llama"
+  | Claude -> "claude"
+  | Gemini -> "gemini"
+  | Glm_cloud -> "glm"
+  | OpenAI -> "openrouter"
+  | OpenRouter -> "openrouter"
+  | Custom _ -> "custom"
+
+(** Convert a MASC model_spec to an OAS Provider_config.t.
+
+    This is the forward migration path: callers holding a model_spec
+    can obtain the OAS wire-level config for passing to
+    Llm_provider.Complete.complete or Cascade_config functions.
+
+    Fields not present in model_spec (temperature, top_p, etc.)
+    use Provider_config.make defaults. *)
+let to_provider_config (spec : model_spec) : Llm_provider.Provider_config.t =
+  let kind = provider_kind_of_masc spec.provider in
+  let api_key =
+    match spec.api_key_env with
+    | Some env_name ->
+      Sys.getenv_opt env_name |> Option.value ~default:""
+    | None -> ""
+  in
+  Llm_provider.Provider_config.make
+    ~kind
+    ~model_id:spec.model_id
+    ~base_url:spec.api_url
+    ~api_key
+    ~request_path:(match kind with
+      | Anthropic -> "/v1/messages"
+      | Gemini -> "/v1beta/chat/completions"
+      | Glm -> "/chat/completions"
+      | OpenAI_compat -> "/v1/chat/completions"
+      | Claude_code -> "")
+    ()
+
+(** Convert an OAS Provider_config.t back to a MASC model_spec.
+
+    This is the backward-compat path: modules that still expect
+    model_spec can receive one from OAS-native callers. The
+    registry_name is required to disambiguate OpenAI_compat sub-families.
+
+    Pricing and max_context are looked up from OAS registries. *)
+let of_provider_config ?(registry_name : string option)
+    (pc : Llm_provider.Provider_config.t) : model_spec =
+  let rn = match registry_name with
+    | Some n -> n
+    | None -> (
+        match pc.kind with
+        | Anthropic -> "claude"
+        | Gemini -> "gemini"
+        | Glm -> "glm"
+        | Claude_code -> "claude"
+        | OpenAI_compat -> "openrouter")
+  in
+  model_spec_of_provider_config ~registry_name:rn pc
+
+(** Extract pricing info from a model_spec as an OAS Pricing.pricing record.
+    Avoids callers reaching into model_spec.cost_per_1k_* fields directly. *)
+let pricing_of_spec (spec : model_spec) : Llm_provider.Pricing.pricing =
+  Llm_provider.Pricing.pricing_for_model spec.model_id
+
+(** Extract max_context from a model_spec.
+    Callers should migrate to Provider_registry.entry.max_context
+    or Capabilities.capabilities.max_context_tokens. *)
+let max_context (spec : model_spec) : int = spec.max_context

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -133,7 +133,6 @@ let provider_of_oas ~(registry_name : string)
   | Gemini -> Gemini
   | Glm -> Glm_cloud
   | Claude_code -> Claude
-  | Glm -> Glm_cloud
   | OpenAI_compat -> (
       match registry_name with
       | "llama" -> Llama

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -112,3 +112,41 @@ val find_model_id_for_used : labels:string list -> model_used:string -> string
 (** Estimate cost in USD from token usage and a model_id string.
     Delegates to OAS [Llm_provider.Pricing]. *)
 val cost_usd_of_model_id : model_id:string -> input_tokens:int -> output_tokens:int -> float
+
+(** {2 OAS Migration Bridge (Phase 1)}
+
+    Bidirectional conversions between MASC [model_spec] and OAS types.
+    New callers should use OAS types directly
+    ({!Llm_provider.Provider_config.t}, {!Llm_provider.Cascade_config}).
+    Existing callers can migrate incrementally using these adapters. *)
+
+(** Map MASC provider to OAS provider_kind.
+    Glm_cloud maps to Glm. Llama, OpenAI, OpenRouter, Custom
+    all map to OpenAI_compat. *)
+val provider_kind_of_masc : provider -> Llm_provider.Provider_config.provider_kind
+
+(** Map MASC provider to OAS registry name (e.g. Llama -> "llama"). *)
+val registry_name_of_provider : provider -> string
+
+(** Convert model_spec to OAS Provider_config.t.
+    Forward migration path: callers holding a model_spec can obtain
+    the OAS wire-level config. Fields not present in model_spec
+    (temperature, top_p, etc.) use Provider_config.make defaults. *)
+val to_provider_config : model_spec -> Llm_provider.Provider_config.t
+
+(** Convert OAS Provider_config.t back to model_spec.
+    Backward-compat path. [registry_name] disambiguates
+    OpenAI_compat sub-families; omit to use kind-based default. *)
+val of_provider_config :
+  ?registry_name:string ->
+  Llm_provider.Provider_config.t ->
+  model_spec
+
+(** Extract pricing for a model_spec as OAS Pricing.pricing.
+    Prefer this over accessing cost_per_1k_* fields directly. *)
+val pricing_of_spec : model_spec -> Llm_provider.Pricing.pricing
+
+(** Extract max_context from a model_spec.
+    Migration target: Provider_registry.entry.max_context
+    or Capabilities.capabilities.max_context_tokens. *)
+val max_context : model_spec -> int

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -4,32 +4,40 @@
     to their OAS counterparts.  Most conversions are structural identity
     (shared type aliases); [to_oas_provider] performs actual mapping.
 
-    @since 2.130.0 *)
+    Phase 1 migration: uses {!Model_spec.to_provider_config} bridge
+    where possible, with provider-specific overrides for Llama (Local)
+    and Claude (Anthropic) which need Agent_sdk.Provider-specific constructors.
+
+    @since 2.130.0
+    @since 2.133.0 — Phase 1: migrated to Model_spec bridge *)
 
 let to_oas_provider (spec : Model_spec.model_spec) : Agent_sdk.Provider.config option =
-  match spec.provider with
-  | Claude ->
+  (* Use the Provider_config bridge for base_url, model_id, api_key *)
+  let pc = Model_spec.to_provider_config spec in
+  let rn = Model_spec.registry_name_of_provider spec.provider in
+  match rn with
+  | "claude" ->
     Some { Agent_sdk.Provider.provider = Anthropic;
-           model_id = spec.model_id;
-           api_key_env = Option.value ~default:"ANTHROPIC_API_KEY" spec.api_key_env }
-  | Llama ->
-    Some { provider = Local { base_url = spec.api_url };
-           model_id = spec.model_id; api_key_env = "" }
-  | Glm_cloud | OpenAI | OpenRouter ->
-    Some { provider = OpenAICompat { base_url = spec.api_url; auth_header = None;
-             path = "/v1/chat/completions"; static_token = None };
-           model_id = spec.model_id;
-           api_key_env = Option.value ~default:"" spec.api_key_env }
-  | Gemini ->
-    Some { provider = OpenAICompat { base_url = spec.api_url; auth_header = None;
-             path = "/v1beta/chat/completions"; static_token = None };
-           model_id = spec.model_id;
-           api_key_env = Option.value ~default:"GEMINI_API_KEY" spec.api_key_env }
-  | Custom _ ->
-    Some { provider = OpenAICompat { base_url = spec.api_url; auth_header = None;
-             path = "/v1/chat/completions"; static_token = None };
-           model_id = spec.model_id;
-           api_key_env = Option.value ~default:"" spec.api_key_env }
+           model_id = pc.model_id;
+           api_key_env =
+             if pc.api_key <> "" then pc.api_key
+             else "ANTHROPIC_API_KEY" }
+  | "llama" ->
+    Some { provider = Local { base_url = pc.base_url };
+           model_id = pc.model_id; api_key_env = "" }
+  | "gemini" ->
+    Some { provider = OpenAICompat { base_url = pc.base_url; auth_header = None;
+             path = pc.request_path; static_token = None };
+           model_id = pc.model_id;
+           api_key_env =
+             if pc.api_key <> "" then pc.api_key
+             else "GEMINI_API_KEY" }
+  | _ ->
+    (* glm, openrouter, custom: all OpenAI_compat wire format *)
+    Some { provider = OpenAICompat { base_url = pc.base_url; auth_header = None;
+             path = pc.request_path; static_token = None };
+           model_id = pc.model_id;
+           api_key_env = pc.api_key }
 
 let to_oas_message (m : Agent_sdk.Types.message) : Agent_sdk.Types.message option =
   match m.role with System -> None | _ -> Some m

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -73,19 +73,26 @@ type run_result = {
 (* Internal: resolve provider                                        *)
 (* ================================================================ *)
 
+(** Resolve a Model_spec.model_spec to an OAS Provider.config.
+    Uses Oas_type_adapters as primary path. Falls back to constructing
+    from Model_spec.to_provider_config bridge when the adapter returns None. *)
 let resolve_provider (spec : Model_spec.model_spec) : Oas.Provider.config =
   match Oas_type_adapters.to_oas_provider spec with
   | Some cfg -> cfg
   | None ->
+    (* Fallback: use the migration bridge to get Provider_config.t,
+       then map to the Agent_sdk.Provider.config expected by Builder.
+       This avoids reaching into model_spec fields directly. *)
+    let pc = Model_spec.to_provider_config spec in
     { Oas.Provider.provider =
         Oas.Provider.OpenAICompat {
-          base_url = spec.api_url;
+          base_url = pc.base_url;
           auth_header = None;
-          path = "/v1/chat/completions";
+          path = pc.request_path;
           static_token = None;
         };
-      model_id = spec.model_id;
-      api_key_env = Option.value ~default:"" spec.api_key_env;
+      model_id = pc.model_id;
+      api_key_env = pc.api_key;
     }
 
 (* ================================================================ *)
@@ -385,15 +392,11 @@ let run_named
   let named_cascade = Oas.Api.named_cascade ?config_path
     ~name:cascade_name ~defaults () in
   let name = Printf.sprintf "oas-%s" cascade_name in
-  (* Use first available model as primary for Builder *)
+  (* Use first available model as primary for Builder.
+     Fallback to glm_cloud preset when no cascade models resolve. *)
   let primary_spec = match resolve_cascade_specs ~cascade_name with
     | spec :: _ -> spec
-    | [] ->
-      let pricing = Llm_provider.Pricing.pricing_for_model "auto" in
-      { Model_spec.provider = Model_spec.Glm_cloud; model_id = "auto";
-        max_context = 8192; api_url = ""; api_key_env = None;
-        cost_per_1k_input = pricing.input_per_million /. 1000.0;
-        cost_per_1k_output = pricing.output_per_million /. 1000.0 }
+    | [] -> Model_spec.glm_cloud
   in
   let config =
     config_for_model ~name ~model_spec:primary_spec ~system_prompt ~tools


### PR DESCRIPTION
## Summary

Phase 1 of Model_spec -> OAS Provider_registry migration (#2207, #1878).

- Add bidirectional conversion functions to `model_spec.ml/.mli` as a compatibility bridge between `Model_spec.model_spec` and OAS `Llm_provider.Provider_config.t`
- Convert 5 representative callers (7 files) to use the bridge instead of direct `Model_spec` field access or constructor pattern matching
- No caller signature changes -- all existing interfaces preserved

### Bridge functions added

| Function | Direction | Purpose |
|----------|-----------|---------|
| `provider_kind_of_masc` | MASC -> OAS | Map provider enum to OAS provider_kind |
| `registry_name_of_provider` | MASC -> OAS | Map provider enum to registry name string |
| `to_provider_config` | MASC -> OAS | Full model_spec -> Provider_config.t conversion |
| `of_provider_config` | OAS -> MASC | Provider_config.t -> model_spec (backward compat) |
| `pricing_of_spec` | accessor | Extract OAS Pricing.pricing from model_spec |
| `max_context` | accessor | Extract max_context (migration stepping stone) |

### Callers converted (proof of concept)

- `oas_type_adapters.ml` -- uses `to_provider_config` bridge instead of direct field access
- `oas_worker.ml` -- resolve_provider fallback uses bridge; run_named uses glm_cloud preset
- `dashboard_provider_runs.ml` -- `registry_name_of_provider` instead of `Model_spec.Gemini` constructor match
- `dashboard_http_keeper.ml` -- `Model_spec.max_context` accessor
- `keeper_status_detail.ml` -- `pricing_of_spec` + `string_of_provider` via bridge

### Remaining (Phase 2+)

96 total references across 32 files. This PR converts ~10 references in 7 files. Per #2207:
- Phase B: migrate remaining callers 10 files per PR
- Phase C: remove model_spec.ml after all callers migrated

Ref: #2207, #1878

## Test plan

- [x] `dune build --root .` passes (clean)
- [x] `dune runtest --root .` -- no new test failures (pre-existing failures match main)
- [ ] Verify dashboard keeper detail still renders model info correctly
- [ ] Verify dashboard provider runs single-agent mode still works

Generated with [Claude Code](https://claude.com/claude-code)