### PR TITLE
fix(build): remove duplicate Glm match case

### DIFF
--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -133,7 +133,6 @@ let provider_of_oas ~(registry_name : string)
   | Gemini -> Gemini
   | Glm -> Glm_cloud
   | Claude_code -> Claude
-  | Glm -> Glm_cloud
   | OpenAI_compat -> (
       match registry_name with
       | "llama" -> Llama


### PR DESCRIPTION
Removes redundant `| Glm -> Glm_cloud` case (line 136) introduced in #2341. Fixes warning 11 build failure.