### PR TITLE
fix(test): align board vote source guard with tool_auth pattern

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -93,9 +93,9 @@ let test_http_write_auth_contracts () =
   check bool "keeper config update requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        {|with_token_permission_auth ~permission:Types.CanAdmin|});
-  check bool "board vote route requires token-bound broadcast permission" true
+  check bool "board vote route uses tool auth guard" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
-       {|with_token_permission_auth ~permission:Types.CanBroadcast|});
+       {|with_tool_auth ~tool_name:"masc_board_vote"|});
   check bool "board vote route overwrites voter from auth identity" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
        {|json_upsert_string_field "voter" agent_name|});


### PR DESCRIPTION
## Summary
- Two source guard test assertions were out of sync with code changes on main:
  1. **board vote auth**: PR #2332 changed vote/comment routes from `with_token_permission_auth` to `with_tool_auth` for dashboard compatibility, but `test_ci_hardening_source.ml` was not updated
  2. **keeper bootstrap log**: The log message in `main_eio.ml` was changed to include "(continuing without keepers)" before the colon, breaking the substring match in `test_silent_failures_p2a.ml`

## Test plan
- [x] `dune exec test/test_ci_hardening_source.exe` passes (11/11 tests)
- [x] `dune exec test/test_silent_failures_p2a.exe` passes (10/10 tests)
- [x] `dune build --root .` compiles

Generated with [Claude Code](https://claude.com/claude-code)