### PR TITLE
fix: require read auth for sensitive HTTP reads

### DIFF
--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -52,7 +52,7 @@ let add_routes ~sw router =
                         ])))
        ) request reqd)
   |> Http.Router.prefix_get "/api/v1/agent-runs/" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_read_auth (fun _state req reqd ->
          let req_path = Http.Request.path req in
          match extract_path_param ~prefix:"/api/v1/agent-runs/" req_path with
          | None ->

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -11,10 +11,10 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 
-let add_routes router =
+  let add_routes router =
   router
   |> Http.Router.get "/api/v1/status" (fun request reqd ->
-       with_public_read (fun state _req reqd ->
+       with_read_auth (fun state _req reqd ->
          let config = state.Mcp_server.room_config in
          let room_state = Room.read_state config in
          let tempo = Tempo.get_tempo config in
@@ -27,7 +27,7 @@ let add_routes router =
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/tasks" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_read_auth (fun state req reqd ->
          let config = state.Mcp_server.room_config in
          let status_filter = query_param req "status" in
          let include_done = bool_query_param req "include_done" ~default:false in
@@ -85,7 +85,7 @@ let add_routes router =
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/agents" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_read_auth (fun state req reqd ->
          let config = state.Mcp_server.room_config in
          let status_filter = query_param req "status" in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
@@ -129,7 +129,7 @@ let add_routes router =
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/messages" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_read_auth (fun state req reqd ->
          let config = state.Mcp_server.room_config in
          let since_seq = int_query_param req "since_seq" ~default:0 in
          let limit = int_query_param req "limit" ~default:20 in

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -93,7 +93,7 @@ let test_http_write_auth_contracts () =
   check bool "keeper config update requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        {|with_token_permission_auth ~permission:Types.CanAdmin|});
-  check bool "board vote route uses tool auth guard" true
+  check bool "board vote route requires board vote tool auth" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
        {|with_tool_auth ~tool_name:"masc_board_vote"|});
   check bool "board vote route overwrites voter from auth identity" true
@@ -105,6 +105,28 @@ let test_http_write_auth_contracts () =
   check bool "provider runs post requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        {|with_token_permission_auth ~permission:Types.CanAdmin|})
+
+let test_http_read_surface_contracts () =
+  check bool "room status route now requires read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       {|"/api/v1/status" (fun request reqd ->
+       with_read_auth|});
+  check bool "room tasks route now requires read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       {|"/api/v1/tasks" (fun request reqd ->
+       with_read_auth|});
+  check bool "room agents route now requires read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       {|"/api/v1/agents" (fun request reqd ->
+       with_read_auth|});
+  check bool "room messages route now requires read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_room.ml"
+       {|"/api/v1/messages" (fun request reqd ->
+       with_read_auth|});
+  check bool "provider run status route now requires read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
+       {|"/api/v1/agent-runs/" (fun request reqd ->
+       with_read_auth|})
 
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)
@@ -295,6 +317,7 @@ let () =
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
+           test_case "http read surface contracts" `Quick test_http_read_surface_contracts;
            test_case "input validation contracts" `Quick test_input_validation_contracts;
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;


### PR DESCRIPTION
## Summary
- move room state/task/agent/message HTTP reads behind read auth
- require read auth for provider run status lookup
- keep loopback local UX intact while reducing remote metadata exposure

## Testing
- git diff --check
- dune build --root . test/test_ci_hardening_source.exe bin/main_eio.exe
- dune exec --root . test/test_ci_hardening_source.exe