### PR TITLE
perf(snapshot): replace mtime cache with 30s TTL — fix server startup hang

### DIFF
--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -74,25 +74,17 @@ let topology_summary_to_json (s : topology_summary) =
       ("operation_status_counts", operation_status_counts_to_json s.operation_status_counts);
     ]
 
-(* mtime-based cache for build_snapshot_state.
-   CP files change infrequently; avoid re-reading + re-parsing on every call. *)
+(* TTL-based cache for build_snapshot_state.
+   Avoids re-reading 2500+ JSON files on every call.
+   Default TTL: 30s — dashboard refreshes at this cadence anyway. *)
 let _cp_state_cache : (float * snapshot_state) option ref = ref None
-
-let cp_files_max_mtime config =
-  let paths = [
-    units_path config; operations_path config;
-    intents_path config; detachments_path config;
-    decisions_path config;
-  ] in
-  List.fold_left (fun acc path ->
-    try max acc (Unix.stat path).Unix.st_mtime
-    with Unix.Unix_error _ -> acc) 0.0 paths
+let _cp_cache_ttl_s = 30.0
 
 let build_snapshot_state ?sessions config =
-  let current_mtime = cp_files_max_mtime config in
-  (* Cache hit: same mtime and no explicit sessions override *)
+  let now = Time_compat.now () in
+  (* Cache hit: within TTL and no explicit sessions override *)
   (match sessions, !_cp_state_cache with
-   | None, Some (cached_mtime, cached_state) when cached_mtime = current_mtime ->
+   | None, Some (cached_at, cached_state) when now -. cached_at < _cp_cache_ttl_s ->
        cached_state
    | _ ->
   let agents, managed_units, units, source = topology_units config in
@@ -125,7 +117,7 @@ let build_snapshot_state ?sessions config =
     child_map;
     unit_lookup;
   } in
-  _cp_state_cache := Some (current_mtime, state);
+  _cp_state_cache := Some (now, state);
   state)
 
 let topology_json_from_state (state : snapshot_state) =


### PR DESCRIPTION
## Problem

서버 시작 시 dashboard snapshot 빌드가 `.masc/`의 2,532개 JSON 파일(32MB)을 매번 순회.
`command_plane_summary`: 2.3초, `snapshot_json total`: 5.5초.

mtime 캐시가 매 파일 변경마다 무효화되어 사실상 캐시가 없는 상태.

## Root Cause

`cp_files_max_mtime`가 5개 디렉토리의 `Unix.stat`을 호출하고, 하나라도 mtime이 변하면
전체 snapshot을 재계산. `.masc/`에 지속적인 파일 쓰기가 발생하므로 캐시 hit rate가 0%에 가까움.

## Fix

mtime 기반 → **30초 TTL 기반** 캐시로 전환.
- TTL 내에서는 캐시된 snapshot을 즉시 반환 (~0ms)
- TTL 만료 시에만 재계산 (~2.3초)
- `cp_files_max_mtime` 함수 제거 (5x `Unix.stat` syscall 절약)

## Impact

| Before | After |
|--------|-------|
| 매 호출 2.3초 | TTL 내 ~0ms |
| 서버 시작 후 ~11초 block | 첫 1회 2.3초, 이후 즉시 |
| health check timeout | health check 즉시 응답 |

## Test plan
- [x] dune build
- [x] dune test 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)