### PR TITLE
fix(dashboard): perf bottleneck - metrics cap, cache backoff, CP mtime cache

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -121,10 +121,24 @@ let get_or_compute_eio key ~ttl compute =
               key elapsed;
             Hashtbl.remove table key;
             Eio.Condition.broadcast cond;
-            let new_cond = Eio.Condition.create () in
+            (* Fix D: cooldown after timeout eviction.
+               Instead of immediately starting a new Compute (which causes thrashing),
+               insert a short-lived Ready entry with error JSON.  Next request after
+               the cooldown_ttl will trigger a fresh compute. *)
+            let cooldown_ttl = 15.0 in
+            let ts = now () in
+            let error_value = `Assoc [
+              ("error", `String "computation_cooldown");
+              ("message", `String (Printf.sprintf
+                "Dashboard %s timed out (%.0fs). Cooling down for %.0fs."
+                key elapsed cooldown_ttl));
+              ("generated_at", `String (Types.now_iso ()));
+            ] in
             Hashtbl.replace table key
-              (Computing { cond = new_cond; started_at = now (); stale = None });
-            `Compute new_cond
+              (Ready { value = error_value;
+                       expires_at = ts +. cooldown_ttl;
+                       stale_until = ts +. cooldown_ttl });
+            `Hit error_value
           end else
             `Wait cond
         | _ ->

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -70,15 +70,19 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           in
 
           let metrics_store = Keeper_types.keeper_metrics_store config m.name in
-          let metrics_window_max_bytes = 200000 in
+          (* Cap metrics lines to avoid O(n) slowdown as keepers accumulate turns.
+             series_points (120) suffices for the chart; 500 covers 24h summary.
+             Previous value of 12000 caused 60K+ lines across 5 keepers. *)
+          let metrics_cap = if compact then series_points else 500 in
+          let metrics_window_max_bytes = if compact then 50000 else 200000 in
           let all_metrics_lines =
-            let n = max series_points 12000 in
+            let n = metrics_cap in
             let dated = Dated_jsonl.read_recent_lines metrics_store n in
             if dated <> [] then dated
             else
               let metrics_path = Keeper_types.keeper_metrics_path config m.name in
               Keeper_memory.read_file_tail_lines metrics_path
-                ~max_bytes:(max metrics_window_max_bytes 3000000) ~max_lines:n
+                ~max_bytes:metrics_window_max_bytes ~max_lines:n
           in
           let (metrics_24h, metrics_24h_summary) =
             if compact then (`Null, `Null)
@@ -140,21 +144,25 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             ) m.models)
           in
 
-          let memory_bank_summary =
-            Keeper_memory.read_keeper_memory_summary
-              config
-              ~name:m.name
-              ~max_bytes:120000
-              ~max_lines:200
-              ~recent_limit:4
-          in
-          let memory_bank_json =
-            Keeper_memory.memory_summary_to_json memory_bank_summary
-          in
-          let memory_recent_note =
-            match memory_bank_summary.Keeper_memory.recent_notes with
-            | row :: _ -> Some row.Keeper_memory.text
-            | [] -> None
+          (* In compact mode (used by execution surface), skip heavy memory bank I/O.
+             Full memory bank is only needed for individual keeper detail view. *)
+          let (memory_bank_json, memory_recent_note) =
+            if compact then
+              (`Assoc [("total_files", `Int 0); ("skipped", `Bool true)], None)
+            else
+              let summary =
+                Keeper_memory.read_keeper_memory_summary
+                  config
+                  ~name:m.name
+                  ~max_bytes:120000
+                  ~max_lines:200
+                  ~recent_limit:4
+              in
+              let note = match summary.Keeper_memory.recent_notes with
+                | row :: _ -> Some row.Keeper_memory.text
+                | [] -> None
+              in
+              (Keeper_memory.memory_summary_to_json summary, note)
           in
           let history_path =
             Filename.concat
@@ -417,11 +425,22 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
 	                | None -> `Null);
               ("metrics_window", metrics_window_summary);
               ("metrics_24h_summary", metrics_24h_summary);
-              ("memory_note_count", `Int memory_bank_summary.Keeper_memory.total_notes);
+              ("memory_note_count",
+                (match memory_bank_json with
+                 | `Assoc fields ->
+                     (match List.assoc_opt "total_notes" fields with
+                      | Some n -> n
+                      | None -> (match List.assoc_opt "total_files" fields with
+                                 | Some n -> n
+                                 | None -> `Int 0))
+                 | _ -> `Int 0));
               ("memory_top_kind",
-                match memory_bank_summary.Keeper_memory.top_kind with
-                | Some kind -> `String kind
-                | None -> `Null);
+                (match memory_bank_json with
+                 | `Assoc fields ->
+                     (match List.assoc_opt "top_kind" fields with
+                      | Some (`String _ as s) -> s
+                      | _ -> `Null)
+                 | _ -> `Null));
               ("memory_recent_note",
                 match memory_recent_note with
                 | Some text -> `String text

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -131,6 +131,7 @@ let provider_of_oas ~(registry_name : string)
   match kind with
   | Anthropic -> Claude
   | Gemini -> Gemini
+  | Glm -> Glm_cloud
   | Claude_code -> Claude
   | OpenAI_compat -> (
       match registry_name with

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -478,7 +478,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
   let command_plane_summary =
     if initialized then
       timed "command_plane_summary" (fun () ->
-        Some (Command_plane_v2.summary_json ~sessions:tracked_sessions config))
+        Some (Command_plane_v2.summary_json config))
     else None
   in
   let summary_fields = timed "summary_fields" (fun () ->
@@ -507,7 +507,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     else [])
   in
   let command_plane_json = timed "command_plane_json" (fun () ->
-    if initialized then Command_plane_v2.snapshot_json ~sessions:tracked_sessions config else `Assoc [])
+    if initialized then Command_plane_v2.snapshot_json config else `Assoc [])
   in
   let swarm_status_json =
     if initialized then

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -404,8 +404,8 @@ let _snapshot_cache : (string * Yojson.Safe.t * float) option ref = ref None
 
 let _snapshot_ttl_s =
   match Sys.getenv_opt "MASC_OPERATOR_CACHE_TTL" with
-  | Some s -> (try Float.of_string s with _ -> 5.0)
-  | None -> 5.0
+  | Some s -> (try Float.of_string s with _ -> 30.0)
+  | None -> 30.0
 
 let invalidate_snapshot_cache () = _snapshot_cache := None
 


### PR DESCRIPTION
## Summary
Dashboard progressive degradation (0min: OK → 45min: crash) 3가지 근본 원인 수정:

1. **Keeper metrics cap**: 12000줄→500줄 JSONL (5 keeper × 12K = 60K lines/render 해소)
2. **Cache timeout backoff**: eviction 후 15초 cooldown (thrashing loop 차단)
3. **CP mtime cache activation**: sessions 파라미터 제거로 mtime 캐시 활성화 (21초→~0초)
4. **Snapshot TTL**: 5초→30초 (compute > TTL 문제 해소)
5. **OAS Glm kind**: provider_of_oas에 Glm 매핑 추가

## Test plan
- [x] `dune build` passes
- [ ] 서버 30분+ keeper 5개 활성 상태 안정성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)