### PR TITLE
feat(dashboard): pro sidebar + toast + ops surfaces

### DIFF
--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -17,6 +17,24 @@ interface Toast {
 let _nextId = 0
 const toasts = signal<Toast[]>([])
 
+const BORDER_COLOR: Record<ToastType, string> = {
+  success: 'border-l-[var(--ok)]',
+  warning: 'border-l-[var(--warn)]',
+  error: 'border-l-[var(--bad)]',
+}
+
+const ICON: Record<ToastType, string> = {
+  success: '✓',
+  warning: '⚠',
+  error: '✕',
+}
+
+const ICON_COLOR: Record<ToastType, string> = {
+  success: 'text-[var(--ok)]',
+  warning: 'text-[var(--warn)]',
+  error: 'text-[var(--bad)]',
+}
+
 export function showToast(message: string, type: ToastType = 'success', durationMs = 4000): void {
   const id = ++_nextId
   toasts.value = [...toasts.value, { id, message, type }]
@@ -34,10 +52,15 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2.5">
       ${items.map(t => html`
-        <div key=${t.id} class="toast ${t.type}" onClick=${() => dismissToast(t.id)}>
-          ${t.message}
+        <div
+          key=${t.id}
+          class="flex items-center gap-2.5 py-2.5 px-3.5 min-w-[240px] max-w-[380px] rounded-lg border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.95)] shadow-[0_8px_24px_rgba(0,0,0,0.35),0_2px_8px_rgba(0,0,0,0.2)] backdrop-blur-sm cursor-pointer transition-opacity duration-200 hover:opacity-90 animate-[slideInRight_0.25s_ease-out] ${BORDER_COLOR[t.type]}"
+          onClick=${() => dismissToast(t.id)}
+        >
+          <span class="text-sm shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
+          <span class="text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
         </div>
       `)}
     </div>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -138,7 +138,7 @@ export function SideRail() {
             const isActive = surface.id === currentSurface
             return html`
               <button
-                class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-0 transition-colors duration-150 ${isActive ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)]'}"
+                class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-l-2 border-t-0 border-r-0 border-b-0 border-solid transition-all duration-150 ${isActive ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]' : 'border-l-transparent bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)] hover:border-l-[var(--white-20)]'}"
                 key=${surface.id}
                 onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
               >
@@ -153,12 +153,12 @@ export function SideRail() {
         ${(() => {
           if (sectionItems.length === 0) return null
           return html`
-            <div class="mt-5 pt-4 border-t border-[var(--white-6)]">
+            <div class="mt-5 pt-4 mx-4 border-t border-[var(--border-slate-12)]">
               <div class="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-[0.1em] px-2 mb-2">${currentView?.label ?? currentSurface}</div>
               <div class="flex flex-col gap-0.5">
                 ${sectionItems.map(item => html`
                   <button
-                    class="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left cursor-pointer border-0 text-[13px] transition-colors duration-150 ${currentSection?.id === item.id ? 'bg-[var(--accent-soft)] text-[var(--accent)] font-medium' : 'bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'}"
+                    class="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left cursor-pointer border-l-2 border-t-0 border-r-0 border-b-0 border-solid text-[13px] transition-all duration-150 ${currentSection?.id === item.id ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] font-medium' : 'border-l-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'}"
                     key=${item.id}
                     onClick=${() => navigate(currentSurface, item.params)}
                   >
@@ -172,7 +172,7 @@ export function SideRail() {
       </div>
 
       <!-- Status Footer -->
-      <div class="shrink-0 border-t border-[var(--white-6)] p-3">
+      <div class="shrink-0 border-t border-[var(--border-slate-12)] p-3">
         <${SnapshotCard} currentTab=${current} />
       </div>
     </nav>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -157,32 +157,29 @@ export function Ops() {
 
   return html`
     <section class="flex flex-col gap-4">
-      <div class="flex justify-between items-start gap-4 max-[880px]:flex-col card">
+      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex justify-between items-start gap-4 max-[880px]:flex-col">
         <div>
-          <div class="flex items-start justify-between gap-3 mb-[15px]">
-            <div class="card-title">개입</div>
-          </div>
-          <h2 class="text-text-strong text-2xl leading-[1.2]">방, 세션, 키퍼를 바로 조정하는 화면</h2>
-          <p class="mt-1.5 text-text-muted text-[var(--fs-base)] max-w-[62ch]">
-            읽는 화면이 아니라 행동하는 화면입니다. 방, 세션, 키퍼를 나눠 보고 바로 개입합니다.
+          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">개입</h2>
+          <p class="text-[13px] text-[var(--text-muted)] max-w-[62ch] leading-relaxed">
+            방, 세션, 키퍼를 나눠 보고 바로 개입합니다.
           </p>
         </div>
         <div class="flex items-end gap-2.5 flex-wrap max-[880px]:w-full">
-          <label class="control-label text-[length:var(--fs-xs)] text-[color:var(--text-muted)] tracking-[0.06em] uppercase" for="ops-actor">개입 ID</label>
+          <label class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium" for="ops-actor">개입 ID</label>
           <input
             id="ops-actor"
-            class="control-input rounded-lg ops-actor-input min-w-[180px]"
+            class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none ops-actor-input min-w-[180px]"
             type="text"
             value=${actorName.value}
             onInput=${(event: Event) => persistActorName((event.target as HTMLInputElement).value)}
           />
-            <button
-              class="control-btn ghost"
-              onClick=${() => {
-                void refreshRoomTruth()
-                void refreshOperatorSnapshot()
-                void refreshOperatorRoomDigest()
-                void refreshOperatorSessionDigest(selectedSession?.session_id ?? null)
+          <button
+            class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
+            onClick=${() => {
+              void refreshRoomTruth()
+              void refreshOperatorSnapshot()
+              void refreshOperatorRoomDigest()
+              void refreshOperatorSessionDigest(selectedSession?.session_id ?? null)
             }}
             disabled=${operatorLoading.value || operatorActionBusy.value}
           >
@@ -191,19 +188,19 @@ export function Ops() {
         </div>
       </div>
 
-      ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl error">${operatorError.value}</section>` : null}
-      ${operatorDigestError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl error">${operatorDigestError.value}</section>` : null}
+      ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
+      ${operatorDigestError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorDigestError.value}</section>` : null}
       <${RoomTruthStrip} />
       ${workflowContext ? html`
-        <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--white-8)] rounded-xl ${workflowReady ? 'info' : 'warn'} grid gap-2">
-          <div class="flex gap-2 flex-wrap items-center text-[rgba(255,255,255,0.72)]">
-            <strong>${workflowContext.source_label}</strong>
+        <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] ${workflowReady ? 'info' : 'warn'} grid gap-2">
+          <div class="flex gap-2 flex-wrap items-center text-[var(--text-body)]">
+            <strong class="font-semibold">${workflowContext.source_label}</strong>
             <span>${workflowActionLabel(workflowContext.action_type)}</span>
             <span>${workflowTargetLabel(workflowContext)}</span>
           </div>
-          <div class="text-[rgba(255,255,255,0.84)] leading-[1.5]">${workflowContext.summary}</div>
-          ${workflowContext.payload_preview ? html`<div class="ops-handoff-preview rounded-xl">${workflowContext.payload_preview}</div>` : null}
-          <div class="text-[rgba(255,255,255,0.58)] text-[var(--fs-sm)]">
+          <div class="text-[var(--text-strong)] leading-relaxed">${workflowContext.summary}</div>
+          ${workflowContext.payload_preview ? html`<div class="mt-1 p-2 rounded-lg bg-[var(--white-3)] text-[12px] font-mono">${workflowContext.payload_preview}</div>` : null}
+          <div class="text-[var(--text-muted)] text-[12px]">
             ${workflowReady
               ? '추천 액션 기준으로 대상 선택과 입력값을 미리 맞춰 두었습니다.'
               : '대상이 현재 snapshot에 없습니다. 일반 개입 화면으로 열렸고, 실제 대상 선택은 수동으로 해야 합니다.'}
@@ -252,8 +249,8 @@ export function Ops() {
         }
         if (actions.length === 0) return null
         return html`
-          <section class="rounded-[10px] py-4 px-5 mb-4 bg-[rgba(138,163,211,0.06)] border border-solid border-[rgba(138,163,211,0.15)]">
-            <h3 class="text-[var(--fs-base)] font-semibold text-[rgba(255,255,255,0.6)] mb-2.5">지금 할 수 있는 것</h3>
+          <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+            <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">지금 할 수 있는 것</h3>
             <div class="flex flex-col gap-2">
               ${actions.slice(0, 3).map(action => html`
                 <button class="ops-action-guide-item rounded-lg ${action.tone}" onClick=${action.onClick}>
@@ -266,17 +263,15 @@ export function Ops() {
         `
       })()}
 
-      <section class="card">
-        <div class="mb-3.5">
-          <h2 class="monitor-headline">개입 우선순위</h2>
-          <p class="monitor-subheadline">지금 가장 먼저 손댈 대상이 방인지, 세션인지, 키퍼인지 먼저 좁힙니다.</p>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">개입 우선순위</h2>
+        <p class="text-[12px] text-[var(--text-muted)] mb-3.5">지금 가장 먼저 손댈 대상이 방인지, 세션인지, 키퍼인지 먼저 좁힙니다.</p>
         <div class="ops-priority-grid grid grid-cols-4 gap-2.5 max-[1200px]:grid-cols-2 max-[880px]:grid-cols-1">
           ${priorityCards.map(card => html`
-            <div key=${card.key} class="ops-priority-card p-3.5 rounded-xl border border-[var(--border-slate-16)] bg-[var(--white-3)] grid gap-1.5 rounded-xl ${card.tone}">
-              <span class="text-text-muted text-[var(--fs-xs)] uppercase tracking-[0.06em]">${card.label}</span>
+            <div key=${card.key} class="ops-priority-card p-3.5 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-1.5 ${card.tone}">
+              <span class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.06em] font-medium">${card.label}</span>
               <strong>${card.value}</strong>
-              <div class="text-[#9ab1d7] text-[var(--fs-sm)] leading-[1.45]">${card.detail}</div>
+              <div class="text-[var(--text-muted)] text-[12px] leading-[1.45]">${card.detail}</div>
             </div>
           `)}
         </div>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -96,17 +96,20 @@ export function OpsKeeperColumn() {
             })()}
           `)}
         </div>
-        <div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-3">Persistent agent는 resident keeper와 분리해서 참고용으로만 보여줍니다.</div>
-        <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-3">Persistent agent는 resident keeper와 분리해서 참고용으로만 보여줍니다.</p>
+        <div class="flex flex-col gap-2">
           ${persistentAgents.length === 0
-            ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">분리된 persistent agent는 없습니다.</div>`
+            ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">분리된 persistent agent는 없습니다.</div>`
             : persistentAgents.map(agent => html`
-                <article key=${agent.name} class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer">
+                <article key=${agent.name} class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
                   <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
-                    <strong>${agent.name}</strong>
-                    <span class="border border-solid border-[var(--card-border)] ${agent.status ?? 'idle'} ${agent.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(agent.status)}</span>
+                    <strong class="text-[13px] font-semibold">${agent.name}</strong>
+                    <span class="inline-flex items-center gap-1.5 text-[11px]">
+                      <span class="w-2 h-2 rounded-full ${agent.status === 'offline' ? 'bg-[var(--text-muted)]' : 'bg-[var(--warn)]'}"></span>
+                      ${displayStatus(agent.status)}
+                    </span>
                   </div>
-                  <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+                  <div class="text-[11px] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis flex gap-2">
                     <span>persistent</span>
                     <span>${agent.model ?? 'model 확인 필요'}</span>
                     <span>${relativeAge(agent.last_turn_ago_s)}</span>
@@ -116,16 +119,14 @@ export function OpsKeeperColumn() {
         </div>
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">선택한 Keeper 액션</div>
-        </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">선택한 keeper에만 직접 메시지를 보내서 probe, 수정, 재지시를 합니다.</p>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-lane-panel">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">선택한 Keeper 액션</h3>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">선택한 keeper에만 직접 메시지를 보내서 probe, 수정, 재지시를 합니다.</p>
 
         ${selectedKeeper ? html`
           <div class="flex flex-col gap-2">
-            <div class="mt-1.5 whitespace-pre-wrap break-words">${selectedKeeper.name}</div>
-            <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+            <div class="text-[13px] font-semibold text-[var(--text-strong)]">${selectedKeeper.name}</div>
+            <div class="text-[11px] text-[var(--text-muted)] flex flex-wrap gap-2">
               <span>자율성: ${selectedKeeper.autonomy_level ?? '확인 없음'}</span>
               <span>세대: ${selectedKeeper.generation ?? 0}</span>
               <span>활성 목표: ${selectedKeeper.active_goal_ids?.length ?? 0}</span>
@@ -133,35 +134,35 @@ export function OpsKeeperColumn() {
               ${selectedKeeper.last_model_used ? html`<span>모델: ${selectedKeeper.last_model_used}</span>` : null}
             </div>
             ${keeperPriorityTone(selectedKeeper) !== 'ok'
-              ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-2">현재 점검 이유: ${keeperPrioritySummary(selectedKeeper)}</div>`
+              ? html`<div class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-1">현재 점검 이유: ${keeperPrioritySummary(selectedKeeper)}</div>`
               : null}
-            ${selectedKeeper.goal ? html`<div class="whitespace-normal mt-1.5 py-1 px-1.5 bg-[var(--card)] rounded-[4px] text-[var(--fs-xs)] text-text-muted">${selectedKeeper.goal}</div>` : null}
+            ${selectedKeeper.goal ? html`<div class="whitespace-normal mt-1.5 py-1 px-1.5 bg-[var(--white-3)] rounded text-[11px] text-[var(--text-muted)]">${selectedKeeper.goal}</div>` : null}
           </div>
           <${KeeperConversationPanel}
             keeperName=${selectedKeeper.name}
             placeholder="구조화된 probe, 방향 수정, 재지시 내용을 적으세요"
           />
-        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">먼저 keeper를 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 keeper를 하나 고르세요.</div>`}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">액션</div>
-          <span style="font-size:0.75rem;opacity:0.5">${availableActions.length}개</span>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0">
+        <div class="flex items-center justify-between pb-2 border-b border-[var(--card-border)]">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">액션</h3>
+          <span class="text-[12px] text-[var(--text-muted)]">${availableActions.length}개</span>
         </div>
         ${availableActions.length
-          ? html`<div style="display:flex;flex-direction:column;gap:0.5rem">
+          ? html`<div class="flex flex-col gap-2">
               ${['room', 'keeper', 'team_session'].map(targetType => {
                 const group = availableActions.filter((a: any) => a.target_type === targetType)
                 if (group.length === 0) return null
                 return html`
                   <div key=${targetType}>
-                    <div style="font-size:0.7rem;opacity:0.4;margin-bottom:0.25rem">${targetTypeLabel(targetType)}</div>
-                    <div style="display:flex;flex-wrap:wrap;gap:0.25rem">
+                    <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">${targetTypeLabel(targetType)}</div>
+                    <div class="flex flex-wrap gap-1">
                       ${group.map((action: any) => html`
                         <span key=${action.action_type}
                           title=${action.description ?? ''}
-                          style="font-size:0.75rem;padding:0.15rem 0.5rem;border-radius:4px;background:${action.confirm_required ? 'rgba(255,180,50,0.15)' : 'rgba(100,200,255,0.1)'};border:1px solid ${action.confirm_required ? 'rgba(255,180,50,0.3)' : 'rgba(100,200,255,0.2)'};cursor:default">
+                          class="text-[12px] px-2 py-0.5 rounded cursor-default ${action.confirm_required ? 'bg-[var(--warn-12)] border border-[var(--warn-28)] text-[var(--warn)]' : 'bg-[var(--accent-8)] border border-[var(--accent-12)] text-[var(--accent)]'}">
                           ${actionTypeLabel(action.action_type)}
                         </span>
                       `)}
@@ -170,24 +171,22 @@ export function OpsKeeperColumn() {
                 `
               })}
             </div>`
-          : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">액션 없음</div>`}
+          : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">액션 없음</div>`}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">최근 개입 로그</div>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">최근 개입 로그</h3>
         <div class="flex flex-col gap-2">
           ${operatorActionLog.value.length === 0 ? html`
-            <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션에서 실행한 개입이 아직 없습니다.</div>
+            <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션에서 실행한 개입이 아직 없습니다.</div>
           ` : operatorActionLog.value.map(entry => html`
-            <article key=${entry.id} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(entry.outcome)}">
-              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
-                <strong>${actionTypeLabel(entry.action_type)}</strong>
+            <article key=${entry.id} class="py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded ${logEntryBorderClass(entry.outcome)}">
+              <div class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex gap-2">
+                <strong class="font-semibold">${actionTypeLabel(entry.action_type)}</strong>
                 <span>${entry.target_label}</span>
                 <span>${entry.at}</span>
               </div>
-              <div class="mt-1.5 whitespace-pre-wrap break-words">${entry.message}</div>
+              <div class="mt-1 text-[13px] whitespace-pre-wrap break-words text-[var(--text-body)]">${entry.message}</div>
             </article>
           `)}
         </div>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -46,48 +46,50 @@ export function OpsKeeperColumn() {
 
   return html`
     <div class="flex flex-col gap-4 min-w-0">
-      <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel ops-keeper-section">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">Keeper 개입</div>
-        </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">장기 실행 중인 keeper를 고르고 바로 probe나 방향 수정 메시지를 보냅니다.</p>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-lane-panel ops-keeper-section">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">Keeper 개입</h3>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">장기 실행 중인 keeper를 고르고 바로 probe나 방향 수정 메시지를 보냅니다.</p>
 
-        <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
-          ${keepers.length === 0 ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 보이는 keeper가 없습니다.</div>` : keepers.map(keeper => html`
+        <div class="flex flex-col gap-2">
+          ${keepers.length === 0 ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 보이는 keeper가 없습니다.</div>` : keepers.map(keeper => html`
             ${(() => {
               const tone = keeperPriorityTone(keeper)
               const prioritySummary = keeperPrioritySummary(keeper)
               return html`
             <button
               key=${keeper.name}
-              class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
+              class="ops-entity-card p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] text-inherit text-left cursor-pointer w-full ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
               onClick=${() => { selectedKeeperName.value = keeper.name }}
             >
               <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
-                <strong>${keeper.name}</strong>
-                <span class="border border-solid border-[var(--card-border)] ${keeper.status ?? 'idle'} ${keeper.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(keeper.status)}</span>
-                <span
-                  class="ops-detail-link"
-                  title="키퍼 상세 보기"
-                  style="cursor:pointer; font-size:12px; opacity:0.6; margin-left:auto;"
-                  onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
-                >상세</span>
+                <strong class="text-[13px] font-semibold">${keeper.name}</strong>
+                <div class="flex items-center gap-2 ml-auto">
+                  <span class="inline-flex items-center gap-1.5 text-[11px]">
+                    <span class="w-2 h-2 rounded-full ${keeper.status === 'offline' ? 'bg-[var(--text-muted)]' : keeper.status === 'active' || keeper.status === 'running' ? 'bg-[var(--ok)]' : 'bg-[var(--warn)]'}"></span>
+                    ${displayStatus(keeper.status)}
+                  </span>
+                  <span
+                    class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer transition-colors"
+                    title="키퍼 상세 보기"
+                    onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
+                  >상세</span>
+                </div>
               </div>
-              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <div class="text-[11px] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis flex gap-2">
                 <span>${keeper.last_model_used ?? keeper.model ?? 'model 확인 필요'}</span>
                 <span>${typeof keeper.context_ratio === 'number' ? `${Math.round(keeper.context_ratio * 100)}% ctx` : typeof keeper.context_tokens === 'number' ? `${Math.round(keeper.context_tokens / 1000)}k tok` : 'ctx 확인 필요'}</span>
                 <span>${relativeAge(keeper.last_turn_ago_s)}</span>
               </div>
               ${keeper.short_goal || keeper.goal ? html`
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1.5 p-1 px-1.5 bg-[var(--card)] rounded-[4px]" title=${keeper.goal ?? ''}>${truncateGoal(keeper.short_goal ?? keeper.goal ?? '')}</div>
+                <div class="text-[11px] text-[var(--text-muted)] mt-1.5 p-1 px-1.5 bg-[var(--white-3)] rounded" title=${keeper.goal ?? ''}>${truncateGoal(keeper.short_goal ?? keeper.goal ?? '')}</div>
               ` : null}
               ${tone !== 'ok'
-                ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45] mt-1.5">점검 이유: ${prioritySummary}</div>`
+                ? html`<div class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-1.5">점검 이유: ${prioritySummary}</div>`
                 : null}
-              <div class="flex gap-2 text-[var(--fs-2xs)] text-text-muted mt-0.5">
+              <div class="flex gap-2 text-[10px] text-[var(--text-muted)] mt-1">
                 ${typeof keeper.turn_count === 'number' ? html`<span>turns: ${keeper.turn_count}</span>` : null}
                 ${typeof keeper.autonomous_action_count === 'number' ? html`<span>actions: ${keeper.autonomous_action_count}</span>` : null}
-                ${keeper.keepalive_running ? html`<span class="keepalive-active">keepalive</span>` : null}
+                ${keeper.keepalive_running ? html`<span class="text-[var(--ok)]">keepalive</span>` : null}
               </div>
             </button>
               `

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -65,20 +65,20 @@ export function OpsRoomColumn() {
 
   return html`
     <div class="flex flex-col gap-4 min-w-0">
-      <section class="card flex flex-col gap-3 min-h-0">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">추천 개입</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">추천 개입</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">백엔드 digest가 지금 가장 작은 다음 행동을 추천합니다.</p>
-        <article class="ops-guidance-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
-          <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">백엔드 digest가 지금 가장 작은 다음 행동을 추천합니다.</p>
+        <article class="ops-guidance-card p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
+          <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
             <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
             <span>${residentRuntime?.keeper_name ?? roomDigest?.judgment_owner ?? 'judge 없음'}</span>
           </div>
-          <div class="text-text-strong leading-[1.5]">
+          <div class="text-[var(--text-strong)] leading-[1.5]">
             ${activeSummary?.summary ?? '현재 active guidance 요약이 없습니다. fallback queue만 표시합니다.'}
           </div>
-          <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
+          <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
             <span>authoritative ${roomDigest?.authoritative_judgment_available ? 'yes' : 'no'}</span>
             <span>${guidanceFreshnessLabel(activeSummary)}</span>
             ${residentRuntime?.model_used ? html`<span>${residentRuntime.model_used}</span>` : null}
@@ -89,8 +89,8 @@ export function OpsRoomColumn() {
         ` : activeRecommendedActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${activeRecommendedActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'room'}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'room'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
@@ -107,15 +107,15 @@ export function OpsRoomColumn() {
             `)}
           </div>
         ` : html`
-          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 떠 있는 추천 개입은 없습니다.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 떠 있는 추천 개입은 없습니다.</div>
         `}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0 ops-pending-section">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">승인 대기</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-pending-section">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">승인 대기</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
           ${actorFilter
             ? `현재 actor ${actorFilter} 기준 queue를 읽습니다. 승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.`
             : '승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.'}
@@ -123,8 +123,8 @@ export function OpsRoomColumn() {
         ${confirmRequiredActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${confirmRequiredActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
@@ -135,15 +135,15 @@ export function OpsRoomColumn() {
           </div>
         ` : null}
         ${pendingConfirms.length > 0 ? html`
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${pendingConfirms.map(item => html`
-              <article key=${item.confirm_token} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
+              <article key=${item.confirm_token} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${item.delegated_tool ?? '위임 도구 확인 필요'}</span>
                 </div>
-                ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-[10px] bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
+                ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
                 <div class="flex justify-between items-center gap-3 mt-2.5 max-[880px]:flex-col max-[880px]:items-start">
                   <button class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
                     실행
@@ -151,13 +151,13 @@ export function OpsRoomColumn() {
                   <button class="control-btn ghost" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
                     거부
                   </button>
-                  <span class="text-text-muted text-[var(--fs-xs)] font-mono break-all">${item.confirm_token}</span>
+                  <span class="text-[var(--text-muted)] text-[var(--fs-xs)] font-mono break-all">${item.confirm_token}</span>
                 </div>
               </article>
             `)}
           </div>
         ` : html`
-          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">
             ${hiddenCount > 0 && actorFilter
               ? `현재 선택한 actor(${actorFilter}) 기준 승인 대기는 0건입니다. 다른 actor 대기 ${hiddenCount}건${hiddenActors.length > 0 ? ` · ${hiddenActors.join(', ')}` : ''}`
               : '지금 승인 대기는 없습니다. 위 목록의 preview-confirm 액션을 먼저 만들어야 여기에 쌓입니다.'}
@@ -165,30 +165,30 @@ export function OpsRoomColumn() {
         `}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">Room 상태</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-lane-panel">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Room 상태</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. room 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. room 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
 
         <div class="grid grid-cols-2 gap-2.5 max-[880px]:grid-cols-1">
-          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
+          <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>Room</span>
             <strong>${room.current_room ?? room.room_id ?? 'default'}</strong>
           </div>
-          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
+          <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>프로젝트</span>
             <strong>${room.project ?? '확인 없음'}</strong>
           </div>
-          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
+          <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>클러스터</span>
             <strong>${room.cluster ?? '확인 없음'}</strong>
           </div>
-          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${room.paused ? 'warn' : 'ok'}">
+          <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${room.paused ? 'warn' : 'ok'}">
             <span>상태</span>
             <strong>${room.paused ? '일시정지' : '진행 중'}</strong>
           </div>
-          <div class="ops-stat p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${runtimeJudgeTone(residentRuntime)}">
+          <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${runtimeJudgeTone(residentRuntime)}">
             <span>Resident Judge</span>
             <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
           </div>
@@ -241,7 +241,7 @@ export function OpsRoomColumn() {
               </button>
             </div>
 
-            <div class="mt-0.5 text-text-muted text-[var(--fs-xs)] tracking-[0.05em] uppercase">작업 주입</div>
+            <div class="mt-0.5 text-[var(--text-muted)] text-[var(--fs-xs)] tracking-[0.05em] uppercase">작업 주입</div>
             <input
               class="control-input"
               type="text"
@@ -279,16 +279,16 @@ export function OpsRoomColumn() {
         </details>
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">최근 Room 메시지</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">최근 Room 메시지</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
         ${roomFeed.length > 0 ? html`
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${roomFeed.map(message => html`
-              <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${message.from}</strong>
                   <span>${message.timestamp}</span>
                 </div>
@@ -296,7 +296,7 @@ export function OpsRoomColumn() {
               </article>
             `)}
           </div>
-        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">최근 room 메시지가 없습니다.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">최근 room 메시지가 없습니다.</div>`}
       </section>
     </div>
   `

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -123,14 +123,14 @@ export function OpsSessionColumn() {
   ) => html`
     <button
       key=${session.session_id}
-      class="ops-entity-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
+      class="ops-entity-card p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
       onClick=${() => { selectedSessionId.value = session.session_id }}
     >
       <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
         <strong>${session.session_id}</strong>
         <span class="border border-solid border-[var(--card-border)] ${session.status ?? 'idle'} ${session.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(session.status)}</span>
       </div>
-      <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+      <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
         <span>${Math.round(session.progress_pct ?? 0)}%</span>
         <span>${sessionOutcomeLabel(session)}</span>
         <span>${archived ? '종료 세션' : `팀 상태 ${sessionHealthLabel(session)}`}</span>
@@ -140,50 +140,50 @@ export function OpsSessionColumn() {
 
   return html`
     <div class="flex flex-col gap-4 min-w-0">
-      <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">Session 개입</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-lane-panel">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Session 개입</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">지금 개입 가능한 세션만 위에 두고, 종료된 세션은 아래에 접어 둡니다.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">지금 개입 가능한 세션만 위에 두고, 종료된 세션은 아래에 접어 둡니다.</p>
 
         <div class="flex flex-col gap-2">
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             <strong>${'개입 가능한 세션'}</strong>
             <span>${liveSessions.length}</span>
           </div>
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${liveSessions.length === 0
-              ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">지금 바로 개입할 live team session이 없습니다.</div>`
+              ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">지금 바로 개입할 live team session이 없습니다.</div>`
               : liveSessions.map(session => renderSessionCard(session))}
           </div>
         </div>
 
         ${archivedSessions.length > 0 ? html`
           <details class="ops-archive-panel">
-            <summary class="cursor-pointer text-text-muted text-[var(--fs-sm)] list-none">최근 종료 세션 ${archivedSessions.length}</summary>
-            <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">완료/중단된 세션은 읽기 전용 참고용입니다. 새 노트, 작업, 중지는 위 live 세션에만 적용하세요.</p>
-            <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-text-muted">
+            <summary class="cursor-pointer text-[var(--text-muted)] text-[var(--fs-sm)] list-none">최근 종료 세션 ${archivedSessions.length}</summary>
+            <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">완료/중단된 세션은 읽기 전용 참고용입니다. 새 노트, 작업, 중지는 위 live 세션에만 적용하세요.</p>
+            <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
               ${archivedSessions.slice(0, 8).map(session => renderSessionCard(session, true))}
             </div>
           </details>
         ` : null}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">선택한 Session 요약</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">선택한 Session 요약</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">snapshot이 아니라 digest 기준 attention과 worker 카드를 보여줍니다.</p>
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">snapshot이 아니라 digest 기준 attention과 worker 카드를 보여줍니다.</p>
         ${selectedSession && sessionDigest ? html`
-          <article class="ops-guidance-card p-3 rounded-[10px] border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
-            <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
+          <article class="ops-guidance-card p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-2 ${guidanceLayerTone(guidanceLayer)}">
+            <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
               <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
               <span>${runtimeJudgeLabel(residentRuntime)}</span>
             </div>
-            <div class="text-text-strong leading-[1.5]">
+            <div class="text-[var(--text-strong)] leading-[1.5]">
               ${activeSummary?.summary ?? '현재 이 session에 대한 resident guidance가 없습니다. fallback digest를 표시합니다.'}
             </div>
-            <div class="flex flex-wrap gap-2 text-text-muted text-[var(--fs-xs)]">
+            <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
               <span>authoritative ${sessionDigest.authoritative_judgment_available ? 'yes' : 'no'}</span>
               <span>${guidanceFreshnessLabel(activeSummary)}</span>
               ${residentRuntime?.model_used ? html`<span>${residentRuntime.model_used}</span>` : null}
@@ -192,8 +192,8 @@ export function OpsSessionColumn() {
           ${activeRecommendedActions.length > 0 ? html`
             <div class="flex flex-col gap-2">
               ${activeRecommendedActions.map(item => html`
-                <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'session'}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
-                  <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+                <article key=${`${item.action_type}:${item.target_type}:${item.target_id ?? 'session'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
+                  <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                     <strong>${actionTypeLabel(item.action_type)}</strong>
                     <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   </div>
@@ -204,17 +204,17 @@ export function OpsSessionColumn() {
           ` : null}
           <div class="flex flex-col gap-2">
             ${sessionDigest.attention_items.length > 0 ? sessionDigest.attention_items.map(item => html`
-              <article key=${`${item.kind}:${item.target_id ?? 'session'}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${`${item.kind}:${item.target_id ?? 'session'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] ${logEntryBorderClass(item.severity)}">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${item.kind}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                 </div>
                 <div class="mt-1.5 whitespace-pre-wrap break-words">${item.summary}</div>
               </article>
-            `) : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션의 attention item은 없습니다.</div>`}
+            `) : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션의 attention item은 없습니다.</div>`}
             ${sessionDigest.worker_cards.length > 0 ? sessionDigest.worker_cards.map(card => html`
-              <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${card.actor ?? card.spawn_role ?? 'worker'}</strong>
                   <span>${displayStatus(card.status)}</span>
                   <span>${card.spawn_agent ?? card.runtime_pool ?? 'runtime 확인 필요'}</span>
@@ -226,15 +226,15 @@ export function OpsSessionColumn() {
             `) : null}
           </div>
         ` : html`
-          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">세션을 고르면 세부 요약을 불러옵니다.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">세션을 고르면 세부 요약을 불러옵니다.</div>
         `}
       </section>
 
-      <section class="card flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <div class="flex items-start justify-between gap-3 mb-[15px]">
-          <div class="card-title">선택한 Session 액션</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex flex-col gap-3 min-h-0 ops-lane-panel">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">선택한 Session 액션</h3>
         </div>
-        <p class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
           ${selectedSessionActionable
             ? '선택한 live 세션에만 메모, 작업, 체크포인트, 중지 요청을 보냅니다.'
             : '종료된 세션은 여기서 읽기만 하고, 실제 개입은 위 live 세션을 다시 골라서 진행합니다.'}
@@ -242,8 +242,8 @@ export function OpsSessionColumn() {
         ${availableSessionActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${availableSessionActions.map(action => html`
-              <article key=${action.action_type} class="p-3 rounded-[10px] bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <article key=${action.action_type} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(action.action_type)}</strong>
                   <span>${deliveryModeLabel(action.confirm_required)}</span>
                 </div>
@@ -256,20 +256,20 @@ export function OpsSessionColumn() {
         ${selectedSession ? html`
           <div class="flex flex-col gap-2">
             <div class="mt-1.5 whitespace-pre-wrap break-words">${selectedSession.session_id}</div>
-            <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+            <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
               <span>상태: ${displayStatus(selectedSession.status)}</span>
               <span>경과: ${selectedSession.elapsed_sec ?? 0}초</span>
               <span>남은 시간: ${selectedSession.remaining_sec ?? 0}초</span>
               <span>${selectedSessionActionable ? `팀 상태: ${sessionHealthLabel(selectedSession)}` : '종료 세션'}</span>
             </div>
             ${selectedSession.linked_autoresearch ? html`
-              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>Autoresearch: ${String(selectedSession.linked_autoresearch.status ?? 'unknown')}</span>
                 <span>Loop: ${String(selectedSession.linked_autoresearch.loop_id ?? 'n/a')}</span>
                 <span>Cycle: ${String(selectedSession.linked_autoresearch.current_cycle ?? 0)}</span>
                 <span>Best: ${String(selectedSession.linked_autoresearch.best_score ?? 'n/a')}</span>
               </div>
-              <div class="text-[var(--fs-xs)] text-text-muted mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
+              <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>파일: ${selectedSession.linked_autoresearch.target_file ?? 'n/a'}</span>
                 <span>최근 결정: ${selectedSession.linked_autoresearch.last_decision ?? 'n/a'}</span>
                 <span>세션 연결: ${selectedSession.linked_autoresearch.session_id ?? selectedSession.session_id}</span>
@@ -278,26 +278,26 @@ export function OpsSessionColumn() {
                   : null}
               </div>
               ${selectedSession.linked_autoresearch.program_note
-                ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">Program note: ${selectedSession.linked_autoresearch.program_note}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Program note: ${selectedSession.linked_autoresearch.program_note}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.queued_hypothesis
-                ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">Queued hypothesis: ${selectedSession.linked_autoresearch.queued_hypothesis}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Queued hypothesis: ${selectedSession.linked_autoresearch.queued_hypothesis}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.warnings && selectedSession.linked_autoresearch.warnings.length > 0
-                ? html`<div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.error
-                ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">${selectedSession.linked_autoresearch.error}</div>`
+                ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${selectedSession.linked_autoresearch.error}</div>`
                 : null}
             ` : null}
             ${selectedSession.recent_events && selectedSession.recent_events.length > 0 ? html`
-              <pre class="mt-2 py-[10px] px-3 rounded-[10px] bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
+              <pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
             ` : null}
           </div>
-        ` : html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">먼저 세션을 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">먼저 세션을 하나 고르세요.</div>`}
 
         ${selectedSession && !selectedSessionActionable ? html`
-          <div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
         ` : null}
 
         ${linkedAutoresearch?.loop_id ? html`
@@ -326,9 +326,9 @@ export function OpsSessionColumn() {
             <button class="control-btn" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
               hypothesis 주입
             </button>
-            <span class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
+            <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
           </div>
-          ${autoresearchError.value ? html`<div class="p-3 rounded-[10px] border border-dashed border-[var(--white-12)] text-text-muted text-[var(--fs-base)]">${autoresearchError.value}</div>` : null}
+          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${autoresearchError.value}</div>` : null}
         ` : null}
 
         <label class="control-label" for="ops-turn-kind">세션 액션</label>
@@ -349,7 +349,7 @@ export function OpsSessionColumn() {
             적용
           </button>
         </div>
-        <div class="-mt-0.5 text-text-muted text-[var(--fs-sm)] leading-[1.45]">현재 선택: ${sessionActionLabel(teamTurnKind.value)}</div>
+        <div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">현재 선택: ${sessionActionLabel(teamTurnKind.value)}</div>
 
         <textarea
           class="control-textarea"

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -23,32 +23,42 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const build = serverStatus.value?.build
 
   return html`
-    <section class="border border-solid border-[var(--card-border)] rounded-xl bg-[var(--card)] p-3.5">
-      <div class="flex items-center justify-between gap-3">
-        <h3 class="mb-0 text-[color:var(--text-strong)] text-xs uppercase tracking-[0.08em]">현황</h3>
-        <span class="inline-flex items-center py-1 px-[9px] text-[10px] uppercase tracking-[0.08em] rounded-full border border-solid ${liveConnected ? 'text-[#86efac] border-[var(--ok-30)] bg-[var(--ok-12)]' : 'text-[#fda4af] border-[rgba(239,68,68,0.28)] bg-[var(--bad-12)]'}">${liveConnected ? '연결됨' : '오프라인'}</span>
+    <section class="grid gap-2.5">
+      <!-- Connection + Version row -->
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex items-center gap-1.5">
+          <span class="size-[7px] rounded-full inline-block ${liveConnected ? 'bg-[var(--ok)] shadow-[0_0_6px_rgba(74,222,128,0.6)]' : 'bg-[var(--bad)]'}"></span>
+          <span class="text-[10px] ${liveConnected ? 'text-[#86efac]' : 'text-[#fda4af]'}">${liveConnected ? '연결됨' : '오프라인'}</span>
+        </div>
+        ${build
+          ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">v${build.release_version} · ${shortCommit(build.commit)}</span>`
+          : null}
       </div>
-      <div class="grid grid-cols-2 gap-2">
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
-          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">에이전트</span>
-          <strong class="text-[color:var(--accent)] text-lg leading-[1.1] tabular-nums">${agents.value.length}</strong>
+
+      <!-- Compact stat rows -->
+      <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px]">
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">에이전트</span>
+          <strong class="text-[var(--accent)] tabular-nums">${agents.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
-          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">키퍼</span>
-          <strong class="text-[color:var(--ok)] text-lg leading-[1.1] tabular-nums">${keepers.value.length}</strong>
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">키퍼</span>
+          <strong class="text-[var(--ok)] tabular-nums">${keepers.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
-          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">태스크</span>
-          <strong class="text-[color:var(--warn)] text-lg leading-[1.1] tabular-nums">${tasks.value.length}</strong>
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">태스크</span>
+          <strong class="text-[var(--warn)] tabular-nums">${tasks.value.length}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-0.5">
-          <span class="text-[color:var(--text-body)] text-xs tracking-[0.02em] font-medium">이벤트</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1] tabular-nums">${eventCount.value}</strong>
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">이벤트</span>
+          <strong class="text-[var(--text-strong)] tabular-nums">${eventCount.value}</strong>
         </div>
       </div>
-      <div class="rail-inline-actions mt-3 grid grid-cols-2 gap-2">
+
+      <!-- Actions -->
+      <div class="grid grid-cols-2 gap-1.5">
         <button
-          class="w-full border border-solid border-[rgba(71,184,255,0.4)] rounded-[10px] bg-[var(--accent-12)] text-[#d7efff] py-[9px] px-[11px] text-xs cursor-pointer hover:bg-[var(--accent-20)]"
+          class="w-full border border-solid border-[rgba(71,184,255,0.3)] rounded-lg bg-[var(--accent-12)] text-[#d7efff] py-1.5 px-2 text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--accent-20)]"
           onClick=${() => {
             refreshDashboard()
             refreshForTab(currentTab)
@@ -56,13 +66,13 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
         >
           새로고침
         </button>
-        <button class="rail-secondary-btn w-full border border-[var(--card-border)] rounded-[10px] py-[9px] px-[11px] bg-[var(--white-4)] text-[color:var(--text-body)] text-xs cursor-pointer" onClick=${() => navigate('operations', { section: 'intervene' })}>
-          운영 패널 열기
+        <button
+          class="w-full border border-solid border-[var(--card-border)] rounded-lg py-1.5 px-2 bg-[var(--white-4)] text-[var(--text-body)] text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--white-8)]"
+          onClick=${() => navigate('operations', { section: 'intervene' })}
+        >
+          운영 패널
         </button>
       </div>
-      ${build
-        ? html`<div class="mt-2.5 text-xs text-[color:var(--text-muted)]">서버 빌드 · v${build.release_version} · ${shortCommit(build.commit)}</div>`
-        : null}
     </section>
   `
 }
@@ -74,37 +84,40 @@ export function InterveneRailCard() {
   const keeperCount = snapshot?.keepers.length ?? 0
 
   return html`
-    <section class="border border-solid border-[var(--card-border)] rounded-xl bg-[var(--card)] p-3.5">
-      <div class="flex items-center justify-between gap-3">
-        <h3 class="mb-0 text-[color:var(--text-strong)] text-xs uppercase tracking-[0.08em]">개입 바로가기</h3>
-        <span class="inline-flex items-center py-1 px-[9px] text-[10px] uppercase tracking-[0.08em] rounded-full border border-solid ${pendingConfirms > 0 ? 'text-[color:var(--text-body)] border-[var(--warn-soft)] bg-[var(--white-6)]' : 'text-[#86efac] border-[var(--ok-30)] bg-[var(--ok-12)]'}">${pendingConfirms > 0 ? '확인 필요' : '정상'}</span>
+    <section class="border border-solid border-[var(--card-border)] rounded-xl bg-[var(--card)] p-3">
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <h3 class="text-[var(--text-strong)] text-[11px] uppercase tracking-[0.08em] font-medium">개입</h3>
+        <span class="text-[10px] ${pendingConfirms > 0 ? 'text-[var(--warn)]' : 'text-[#86efac]'}">${pendingConfirms > 0 ? `대기 ${pendingConfirms}건` : '정상'}</span>
       </div>
-      <div class="grid grid-cols-2 gap-2">
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">확인 대기</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${pendingConfirms}</strong>
+      <div class="grid grid-cols-3 gap-x-3 gap-y-1 text-[11px] mb-2.5">
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">대기</span>
+          <strong class="text-[var(--text-strong)] tabular-nums">${pendingConfirms}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">Session</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${sessionCount}</strong>
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">세션</span>
+          <strong class="text-[var(--text-strong)] tabular-nums">${sessionCount}</strong>
         </div>
-        <div class="border border-[var(--border-slate-16)] rounded-[10px] py-2.5 px-[11px] bg-[var(--white-3)] grid gap-1">
-          <span class="text-[color:var(--text-muted)] text-[11px] tracking-[0.06em] uppercase">키퍼</span>
-          <strong class="text-[color:var(--text-strong)] text-lg leading-[1.1]">${keeperCount}</strong>
+        <div class="flex items-center justify-between">
+          <span class="text-[var(--text-muted)]">키퍼</span>
+          <strong class="text-[var(--text-strong)] tabular-nums">${keeperCount}</strong>
         </div>
       </div>
-      <div class="rail-inline-actions mt-3 grid grid-cols-2 gap-2">
+      <div class="grid grid-cols-2 gap-1.5">
         <button
-          class="w-full border border-solid border-[rgba(71,184,255,0.4)] rounded-[10px] bg-[var(--accent-12)] text-[#d7efff] py-[9px] px-[11px] text-xs cursor-pointer hover:bg-[var(--accent-20)]"
+          class="w-full border border-solid border-[rgba(71,184,255,0.3)] rounded-lg bg-[var(--accent-12)] text-[#d7efff] py-1.5 px-2 text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--accent-20)]"
           onClick=${() => {
             refreshOperatorSnapshot()
             refreshOperatorRoomDigest()
           }}
         >
-          개입 데이터 갱신
+          갱신
         </button>
-        <button class="rail-secondary-btn w-full border border-[var(--card-border)] rounded-[10px] py-[9px] px-[11px] bg-[var(--white-4)] text-[color:var(--text-body)] text-xs cursor-pointer" onClick=${() => navigate('operations', { section: 'intervene' })}>
-          운영 패널 열기
+        <button
+          class="w-full border border-solid border-[var(--card-border)] rounded-lg py-1.5 px-2 bg-[var(--white-4)] text-[var(--text-body)] text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--white-8)]"
+          onClick=${() => navigate('operations', { section: 'intervene' })}
+        >
+          운영 패널
         </button>
       </div>
     </section>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -2058,13 +2058,11 @@ tbody tr:hover {
 
 /* ═══ UI ═══ */
 
-/* ── Toast Notifications ───────────────────────────────────── */
-.toast {
-  animation: slideIn 0.3s ease;
+/* ── Toast Notifications (styling moved to component Tailwind) ── */
+@keyframes slideInRight {
+  from { transform: translateX(100%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
 }
-.toast.success { border-left: 4px solid var(--ok); }
-.toast.warning { border-left: 4px solid var(--warn); }
-.toast.error { border-left: 4px solid var(--bad); }
 
 /* ── Markdown Rendered Content ─────────────────────────────── */
 .markdown-content code {


### PR DESCRIPTION
## Summary
- 사이드바: 2px accent border active, hover transitions
- Toast: backdrop-blur, colored left border
- Operations/Command 카드 시스템 개선
- SnapshotCard 컴팩트화

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)