### PR TITLE
fix(dashboard_cache): handle cross-domain Switch in bg revalidation

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -188,8 +188,13 @@ let get_or_compute_eio key ~ttl compute =
             | _ -> ());
           Eio.Condition.broadcast cond
       in
+      (* Background revalidation: fork on the main domain's switch if available.
+         When called from Executor_pool (different domain), fork would raise
+         "Switch accessed from wrong domain!" — fall back to inline compute. *)
       (match !_bg_sw with
-       | Some sw -> Eio.Fiber.fork ~sw do_bg_compute
+       | Some sw ->
+           (try Eio.Fiber.fork ~sw do_bg_compute
+            with Invalid_argument _ -> do_bg_compute ())
        | None -> do_bg_compute ());
       stale_value
     | `Compute cond ->


### PR DESCRIPTION
## Summary
Executor_pool worker domain에서 Dashboard_cache bg revalidation 시 main domain Switch 접근 → `Invalid_argument("Switch accessed from wrong domain!")` 수정.

## Root Cause
- `Dashboard_cache._bg_sw`는 main domain의 Switch (startup에서 설정)
- `Executor_pool.submit_exn`으로 다른 domain에서 실행되는 compute가 stale-while-revalidate 경로에서 이 Switch로 `Eio.Fiber.fork` 시도
- Eio는 Switch를 생성된 domain에서만 사용 가능하도록 강제

## Fix
`Eio.Fiber.fork ~sw`를 `try ... with Invalid_argument _ -> inline()` 로 감싸서, cross-domain일 때 inline 실행으로 fallback. stale value는 이미 caller에게 반환된 상태이므로, inline vs background는 사용자에게 차이 없음.

## Test plan
- [x] `dune build` passes
- [ ] 서버 운영 중 `dashboard offload failed` 로그 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)