### PR TITLE
fix(test): align keeper bootstrap source guard with code

### DIFF
--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -180,7 +180,7 @@ let test_source_main_keeper_bootstrap () =
   check bool "bootstrap sources have keeper bootstrap logging"
     true (any_file_contains_pattern
       [ "bin/main_eio.ml"; "lib/server/server_runtime_bootstrap.ml" ]
-      {|[main] keeper bootstrap failed:|})
+      {|keeper bootstrap failed|})
 
 (* MA-H2a/H2b removed: metrics_store_eio.ml migrated to Eio-native I/O (PR #2260),
    eliminating Unix fd close/unlock paths and their logging. *)


### PR DESCRIPTION
## Summary
- Follow-up to PR #2356 (which fixed the board vote test)
- The `test_silent_failures_p2a.ml` source guard test expected `[main] keeper bootstrap failed:` as a substring but `main_eio.ml` was changed to `[main] keeper bootstrap failed (continuing without keepers):`, breaking the match
- Updated pattern to `keeper bootstrap failed` which is present in both `bin/main_eio.ml` and `lib/server/server_runtime_bootstrap.ml`

## Test plan
- [x] `dune exec test/test_silent_failures_p2a.exe` passes (10/10 tests)
- [x] `dune build --root .` compiles

Generated with [Claude Code](https://claude.com/claude-code)