### PR TITLE
refactor: remove Model_spec from worker/chain/dashboard callers (Phase 5/5)

### DIFF
--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -203,14 +203,15 @@ let model_tool_defs_of_json = function
 
 type model_runner =
   | Stub
-  | Direct of Model_spec.model_spec
+  | Direct of string  (** model label, e.g. "llama:qwen3.5" *)
 
 let model_runner_of_string raw =
   let model = trim raw in
   let lower = String.lowercase_ascii model in
-  let direct spec =
-    match Model_spec.model_spec_of_string spec with
-    | Ok parsed -> Ok (Direct parsed)
+  let direct label =
+    (* Validate the label parses, but carry the string *)
+    match Model_spec.model_spec_of_string label with
+    | Ok _ -> Ok (Direct label)
     | Error msg -> Error msg
   in
   match lower with
@@ -241,7 +242,7 @@ let model_runner_of_string raw =
       direct (Printf.sprintf "codex-api:%s" effective)
   | value -> (
       match Model_spec.model_spec_of_string model with
-      | Ok parsed -> Ok (Direct parsed)
+      | Ok _ -> Ok (Direct model)
       | Error _ when starts_with ~prefix:"llama:" value -> direct model
       | Error _ when starts_with ~prefix:"gemini:" value -> direct model
       | Error _ when starts_with ~prefix:"claude:" value -> direct model
@@ -268,7 +269,7 @@ let call_model_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~promp
   match model_runner_of_string model with
   | Error msg -> Error msg
   | Ok Stub -> Ok (sprintf "[stub]%s" prompt)
-  | Ok (Direct spec) ->
+  | Ok (Direct model_label) ->
       let system_prompt =
         match system with
         | Some sys when trim sys <> "" -> sys
@@ -277,31 +278,35 @@ let call_model_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~promp
       let tool_defs = model_tool_defs_of_json tools in
       let result =
         if tool_defs = [] then
-          Oas_worker.run_model ~model_spec:spec ~goal:prompt ~system_prompt
+          Oas_worker.run_model_by_label ~model_label ~goal:prompt ~system_prompt
             ~max_turns:1 ~temperature:0.2 ~max_tokens:4096 ()
         else
-          Oas_worker.run_model_with_masc_tools ~model_spec:spec ~goal:prompt
-            ~system_prompt ~masc_tools:tool_defs
-            ~dispatch:(fun ~name ~args ->
-              match !tool_executor_ref with
-              | None -> (false, "native MASC tool executor unavailable")
-              | Some execute_tool ->
-                  let final_args =
-                    if starts_with ~prefix:"masc_" name then
-                      match args with
-                      | `Assoc fields when List.mem_assoc "agent_name" fields -> args
-                      | `Assoc fields ->
-                          `Assoc
-                            (("agent_name", `String runtime.agent_name) :: fields)
-                      | _ -> `Assoc [ ("agent_name", `String runtime.agent_name) ]
-                    else
-                      args
-                  in
-                  execute_tool ~sw:runtime.sw ~clock:runtime.clock
-                    ?mcp_session_id:runtime.mcp_session_id
-                    ?auth_token:runtime.auth_token runtime.mcp_state ~name
-                    ~arguments:final_args)
-            ~max_turns:1 ~temperature:0.2 ~max_tokens:4096 ()
+          (* Tool dispatch still needs model_spec for run_model_with_masc_tools *)
+          (match Model_spec.model_spec_of_string model_label with
+          | Error msg -> Error msg
+          | Ok spec ->
+            Oas_worker.run_model_with_masc_tools ~model_spec:spec ~goal:prompt
+              ~system_prompt ~masc_tools:tool_defs
+              ~dispatch:(fun ~name ~args ->
+                match !tool_executor_ref with
+                | None -> (false, "native MASC tool executor unavailable")
+                | Some execute_tool ->
+                    let final_args =
+                      if starts_with ~prefix:"masc_" name then
+                        match args with
+                        | `Assoc fields when List.mem_assoc "agent_name" fields -> args
+                        | `Assoc fields ->
+                            `Assoc
+                              (("agent_name", `String runtime.agent_name) :: fields)
+                        | _ -> `Assoc [ ("agent_name", `String runtime.agent_name) ]
+                      else
+                        args
+                    in
+                    execute_tool ~sw:runtime.sw ~clock:runtime.clock
+                      ?mcp_session_id:runtime.mcp_session_id
+                      ?auth_token:runtime.auth_token runtime.mcp_state ~name
+                      ~arguments:final_args)
+              ~max_turns:1 ~temperature:0.2 ~max_tokens:4096 ())
       in
       (match result with
       | Ok run_result ->
@@ -313,7 +318,7 @@ let call_model_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~promp
       | Error msg ->
           Error
             (Printf.sprintf "OAS model run failed (%s, timeout=%ds): %s"
-               spec.model_id timeout_sec msg))
+               model_label timeout_sec msg))
 
 let assoc_get_string_opt (json : Yojson.Safe.t) key =
   match U.member key json with

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -235,14 +235,14 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                  | [] when m.models <> [] ->
                      `Assoc [("has_checkpoint", `Bool false)]
                  | _ ->
-                     let primary =
-                       match specs with m0 :: _ -> m0 | [] -> Model_spec.llama_default
+                     let primary_max_context =
+                       Model_spec.resolve_primary_max_context m.models
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
                          ~trace_id:m.trace_id
-                         ~primary_model_max_tokens:(Model_spec.max_context primary)
+                         ~primary_model_max_tokens:primary_max_context
                          ~base_dir
                      in
                      match ctx_opt with

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -471,10 +471,6 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
               Ok (snapshot, model))
 
 let oas_provider_config_of_spec (spec : Model_spec.model_spec) =
-  (* Use registry_name_of_provider to identify Gemini instead of
-     matching the Model_spec.provider constructor directly.
-     Migration: callers will eventually receive Provider_config.t
-     and check kind = Gemini. *)
   match Model_spec.registry_name_of_provider spec.provider with
   | "gemini" -> (
       match Provider_adapter.resolve_gemini_direct_auth () with
@@ -493,6 +489,7 @@ let execute_single_agent_run ~sw:_ ~provider ~model ~prompt =
   match label_result with
   | Error _ as error -> error
   | Ok label -> (
+      (* Validate provider is runnable before attempting the run *)
       match Model_spec.model_spec_of_string label with
       | Error message -> Error message
       | Ok spec -> (
@@ -504,7 +501,7 @@ let execute_single_agent_run ~sw:_ ~provider ~model ~prompt =
                    provider)
           | Some _provider_cfg -> (
               match
-                Oas_worker.run_model ~model_spec:spec ~goal:prompt
+                Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
                   ~system_prompt:(run_system_prompt provider)
                   ~max_turns:4 ~max_tokens:2048 ~temperature:0.2 ()
               with

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -465,6 +465,7 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
                ~on_exec ()))
   | Error e, _ | _, Error e -> Error e
 
+(** Convert a model_spec to an OAS Provider.config with fallback for Custom providers. *)
 let oas_provider_of_model (model : Model_spec.model_spec) : Oas.Provider.config =
   match Oas_type_adapters.to_oas_provider model with
   | Some config -> config
@@ -482,6 +483,15 @@ let oas_provider_of_model (model : Model_spec.model_spec) : Oas.Provider.config 
         model_id = model.model_id;
         api_key_env = Option.value ~default:"DUMMY_KEY" model.api_key_env;
       }
+
+(** Resolve provider from a model label string.
+    Parses the label into a model_spec, then converts to Provider.config.
+    Returns the provider config and model_id on success. *)
+let resolve_oas_provider_of_label (label : string) :
+    (Oas.Provider.config * string, string) result =
+  match Model_spec.model_spec_of_string label with
+  | Error msg -> Error msg
+  | Ok spec -> Ok (oas_provider_of_model spec, spec.model_id)
 
 let oas_tool_names (tools : Oas.Tool.t list) =
   List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
@@ -532,15 +542,16 @@ let append_worker_completion_log ~base_path ~team_session_id ~worker_name
       ])
 
 (** Build (config, options) for Agent.resume — the continue_worker path.
-    New workers use Worker_oas.build_agent (Builder pattern) instead. *)
-let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
-    ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
+    New workers use Worker_oas.build_agent (Builder pattern) instead.
+    Accepts [~provider] + [~model_id] instead of Model_spec.model_spec. *)
+let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
+    ~max_turns ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
     ?(guardrails : Oas.Guardrails.t option) () =
   let config =
     {
       Oas.Types.default_config with
       name = worker_name;
-      model = model.Model_spec.model_id;
+      model = model_id;
       system_prompt = Some system_prompt;
       max_tokens = local_worker_max_tokens ();
       max_turns;
@@ -564,7 +575,7 @@ let build_resume_config ~worker_name ~model ~system_prompt ~tools ~max_turns
   let options =
     {
       Oas.Agent.default_options with
-      provider = Some (oas_provider_of_model model);
+      provider = Some provider;
       hooks;
       guardrails = effective_guardrails;
       raw_trace = Some raw_trace;

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -5,7 +5,8 @@ open Printf
 include Worker_container
 
 let run_worker_oas ~sw ~base_path ~worker_name
-    ~(model : Model_spec.model_spec) ~team_session_id
+    ~(provider : Agent_sdk.Provider.config) ~(model_id : string)
+    ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id
     ~role
@@ -27,7 +28,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
     let meta =
       make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
         ~mcp_session_id ~role ~selection_note ~execution_scope ~worker_class
-        ~worker_size ~effective_model:model.model_id
+        ~worker_size ~effective_model:model_id
         ~thinking_enabled ~max_turns_override:max_turns
         ~timeout_seconds:(Some timeout_sec)
     in
@@ -38,7 +39,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
           evidence_session_id_of_worker_run worker_run_id
         in
         let system_prompt =
-          default_system_prompt ~worker_name ~model_id:model.model_id
+          default_system_prompt ~worker_name ~model_id
             ?session_id:team_session_id ?role ?selection_note ()
         in
         let prompt =
@@ -70,7 +71,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
                         (match role with
                         | Some r -> r
                         | None -> "autonomous");
-                      model = model.model_id;
+                      model = model_id;
                     };
                   TeamContext team_ctx;
                   AvailableTools tool_names;
@@ -158,7 +159,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
         let gate_config =
           Worker_oas.gate_config_of_execution_scope meta.execution_scope
         in
-        Worker_oas.run_worker_via_oas ~sw ~base_path ~meta ~model
+        Worker_oas.run_worker_via_oas ~sw ~base_path ~meta ~provider
           ~system_prompt ~prompt ~tools ~raw_trace ~gate_config
           ?worker_run_id ()
 
@@ -307,7 +308,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                         | _ -> Oas.Hooks.Continue);
                 }
               in
-              let model =
+              let resume_model =
                 let base_model = Model_spec.default_local_model_spec () in
                 let model_id =
                   if checkpoint.model <> "" then checkpoint.model
@@ -315,6 +316,8 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 in
                 { base_model with model_id }
               in
+              let resume_provider = oas_provider_of_model resume_model in
+              let resume_model_id = resume_model.Model_spec.model_id in
               let prompt =
                 let tool_contract =
                   "Tool contract reminder: if you call masc_team_session_step \
@@ -359,9 +362,10 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 Verifier_oas.eval_gate_to_oas_guardrails gate
               in
               let config, options =
-                build_resume_config ~worker_name ~model
+                build_resume_config ~worker_name ~provider:resume_provider
+                  ~model_id:resume_model_id
                   ~system_prompt:
-                    (default_system_prompt ~worker_name ~model_id:model.model_id
+                    (default_system_prompt ~worker_name ~model_id:resume_model_id
                        ?session_id:meta.team_session_id ?role:meta.role
                        ?selection_note:meta.selection_note ())
                   ~tools ~max_turns ~thinking_enabled ~hooks ~raw_trace
@@ -380,7 +384,10 @@ let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
-  run_worker_oas ~sw ~base_path ~worker_name ~model ~team_session_id
+  let provider = oas_provider_of_model model in
+  let model_id = model.Model_spec.model_id in
+  run_worker_oas ~sw ~base_path ~worker_name ~provider ~model_id
+    ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
     ?thinking_enabled ?max_turns ?worker_run_id ~role
     ~selection_note ~prompt ~allowed_tools ~timeout_sec

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -577,9 +577,9 @@ let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) 
     cache_read_input_tokens =
       a.cache_read_input_tokens + b.cache_read_input_tokens }
 
-let estimate_cost_usd (model : Model_spec.model_spec)
+let estimate_cost_usd ~(model_id : string)
     (usage : Agent_sdk.Types.api_usage) : float option =
-  let pricing = Llm_provider.Pricing.pricing_for_model model.model_id in
+  let pricing = Llm_provider.Pricing.pricing_for_model model_id in
   Some (Llm_provider.Pricing.estimate_cost ~pricing
     ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ())
 

--- a/lib/mdal/mdal_worker.ml
+++ b/lib/mdal/mdal_worker.ml
@@ -52,32 +52,21 @@ let worker_name_for_state (state : Mdal.loop_state) =
   let safe_loop = Room_utils.safe_filename state.loop_id |> trunc in
   sprintf "mdal-%s-%02d" safe_loop (state.current_iteration + 1)
 
-let model_provider_label = function
-  | Model_spec.Llama -> "llama"
-  | Model_spec.Claude -> "claude"
-  | Model_spec.OpenAI -> "openai"
-  | Model_spec.Gemini -> "gemini"
-  | Model_spec.Glm_cloud -> "glm"
-  | Model_spec.OpenRouter -> "openrouter"
-  | Model_spec.Custom name -> "custom:" ^ name
-
 let model_label (spec : Model_spec.model_spec) =
-  sprintf "%s:%s" (model_provider_label spec.provider) spec.model_id
+  Model_spec.label_of_model_spec spec
 
+(** Validate that the model spec uses a supported provider.
+    Rejects OpenRouter and Custom providers. *)
 let validate_model_spec (spec : Model_spec.model_spec) :
     (Model_spec.model_spec, string) result =
-  match spec.provider with
-  | Model_spec.Claude
-  | Model_spec.OpenAI
-  | Model_spec.Gemini
-  | Model_spec.Llama
-  | Model_spec.Glm_cloud -> Ok spec
-  | Model_spec.OpenRouter
-  | Model_spec.Custom _ ->
+  let provider_str = Model_spec.string_of_provider spec.provider in
+  match provider_str with
+  | "llama" | "claude" | "openai" | "gemini" | "glm_cloud" -> Ok spec
+  | _ ->
       Error
         (sprintf
            "MDAL strict worker does not support provider `%s`. Use claude, openai, gemini, llama:<model>, or glm."
-           (model_provider_label spec.provider))
+           provider_str)
 
 let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
     (Model_spec.model_spec * string, string) result =

--- a/lib/model_spec.ml
+++ b/lib/model_spec.ml
@@ -46,6 +46,23 @@ let string_of_provider = function
   | OpenRouter -> "openrouter"
   | Custom s -> sprintf "custom(%s)" s
 
+(** Provider name suitable for use in parseable "provider:model" labels.
+    Unlike {!string_of_provider} (display-oriented), this returns names
+    that {!model_spec_of_string} can round-trip. *)
+let label_provider = function
+  | Llama -> "llama"
+  | Claude -> "claude"
+  | OpenAI -> "openai"
+  | Gemini -> "gemini"
+  | Glm_cloud -> "glm"
+  | OpenRouter -> "openrouter"
+  | Custom _ -> "custom"
+
+(** Build a parseable "provider:model_id" label from a model_spec.
+    The result can be passed to {!model_spec_of_string} for round-trip. *)
+let label_of_model_spec (spec : model_spec) : string =
+  sprintf "%s:%s" (label_provider spec.provider) spec.model_id
+
 (* ================================================================ *)
 (* OAS Provider facade                                               *)
 (* All OAS Llm_provider references are confined to this section.     *)

--- a/lib/model_spec.mli
+++ b/lib/model_spec.mli
@@ -29,8 +29,15 @@ type model_spec = {
   cost_per_1k_output : float;
 }
 
-(** Human-readable provider name. *)
+(** Human-readable provider name (display-oriented, not necessarily round-trip safe). *)
 val string_of_provider : provider -> string
+
+(** Provider name for parseable labels (round-trips with {!model_spec_of_string}). *)
+val label_provider : provider -> string
+
+(** Build a parseable ["provider:model_id"] label from a model_spec.
+    The result can be passed to {!model_spec_of_string} for round-trip. *)
+val label_of_model_spec : model_spec -> string
 
 (** {2 Preset specs} *)
 

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -420,6 +420,45 @@ let run_named
   | Ok _ -> Error (Printf.sprintf "cascade %s: response rejected by accept" cascade_name)
   | Error e -> Error e
 
+(** Run a single Agent.run() using a model label string (e.g. "llama:qwen3.5").
+    Parses the label into a model_spec internally. Callers do not need to hold
+    a Model_spec.model_spec value. *)
+let run_model_by_label
+    ~(model_label : string)
+    ~goal
+    ?(system_prompt = "")
+    ?(tools = [])
+    ?(max_turns = 20)
+    ?(temperature = 0.7)
+    ?(max_tokens = 4096)
+    ?(accept = fun (_ : Oas_response.api_response) -> true)
+    ?guardrails
+    ?hooks
+    ?context_reducer
+    ?memory
+    ?on_event
+    ()
+  : (run_result, string) result =
+  match Model_spec.model_spec_of_string model_label with
+  | Error msg -> Error msg
+  | Ok model_spec ->
+    match require_eio () with
+    | Error e -> Error e
+    | Ok (sw, net) ->
+        let config =
+          config_for_model ~name:"oas-label-model" ~model_spec ~system_prompt
+            ~tools ~max_turns ~max_tokens ~temperature ?guardrails ?hooks
+            ?context_reducer ?memory
+            ~description:(Some (Printf.sprintf "model_label:%s" model_label))
+            ()
+        in
+        (match run ~sw ~net ~config ?on_event goal with
+        | Ok result when accept result.response -> Ok result
+        | Ok _ ->
+            Error
+              (Printf.sprintf "response rejected by accept from %s" model_label)
+        | Error e -> Error e)
+
 let run_model
     ~model_spec
     ~goal

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -1,19 +1,17 @@
 (** Oas_worker — Unified entry point for OAS-based MASC tool modules.
 
     Callers either pass a [cascade_name] string for configured fallback
-    selection, or an explicit {!Model_spec.model_spec} when the runtime
-    must honor a concrete provider/model choice. Internal [config] / [build]
-    / [run] are implementation details and not exported.
+    selection, a [model_label] string for {!run_model_by_label}, or an
+    explicit {!Model_spec.model_spec} when the runtime must honor a
+    concrete provider/model choice. Internal [config] / [build] / [run]
+    are implementation details and not exported.
 
-    Single-turn calls use {!run_named} or {!run_model} with [max_turns = 1].
-    Tool-enabled flows use {!run_named_with_masc_tools} or
-    {!run_model_with_masc_tools}.
-
-    Cascade profile defaults and config path resolution are now hosted
-    directly in this module (moved from the deleted [Cascade] module).
+    Prefer {!run_named} (cascade) or {!run_model_by_label} (explicit model
+    as string) over {!run_model} (requires Model_spec.model_spec).
 
     @since Phase 1 — MASC→OAS migration
     @since Phase 4 — public API restricted to named cascade functions
+    @since Phase 5 — run_model_by_label added (string-based API)
     @since Phase 8 — Cascade module deleted, defaults moved here *)
 
 module Oas = Agent_sdk
@@ -53,6 +51,27 @@ val run_named :
   unit ->
   (run_result, string) result
 
+(** Run a single Agent.run() using a model label string (e.g. "llama:qwen3.5").
+    Parses the label internally. Callers do not need Model_spec.model_spec. *)
+val run_model_by_label :
+  model_label:string ->
+  goal:string ->
+  ?system_prompt:string ->
+  ?tools:Oas.Tool.t list ->
+  ?max_turns:int ->
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?accept:(Oas_response.api_response -> bool) ->
+  ?guardrails:Oas.Guardrails.t ->
+  ?hooks:Oas.Hooks.hooks ->
+  ?context_reducer:Oas.Context_reducer.t ->
+  ?memory:Oas.Memory.t ->
+  ?on_event:(Oas.Types.sse_event -> unit) ->
+  unit ->
+  (run_result, string) result
+
+(** Run a single Agent.run() with an explicit Model_spec.model_spec.
+    Prefer {!run_model_by_label} for new code. *)
 val run_model :
   model_spec:Model_spec.model_spec ->
   goal:string ->

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -261,16 +261,17 @@ let dispatch (ctx : context) ~(name : string) : result option =
             if trimmed = "" then None else Some trimmed
         | _ -> None
       in
-      let runtime_model =
+      let runtime_model_valid =
         match (spawn_agent_name, model_name) with
         | "llama", None -> Error "model is required when agent_name=llama"
         | "llama", Some raw ->
             let spec_name =
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
-            Model_spec.model_spec_of_string spec_name
-        | _, Some _ -> Model_spec.default_execution_model_spec ()
-        | _, None -> Model_spec.default_execution_model_spec ()
+            (* Validate the label parses without retaining model_spec *)
+            Model_spec.model_spec_of_string spec_name |> Result.map (fun _ -> ())
+        | _ ->
+            Model_spec.default_execution_model_spec () |> Result.map (fun _ -> ())
       in
       let module U = Yojson.Safe.Util in
       let working_dir = match arguments |> U.member "working_dir" with
@@ -283,9 +284,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
             Some (Team_session_types.execution_scope_of_string s)
         | _ -> None
       in
-       (match runtime_model with
+       (match runtime_model_valid with
        | Error e -> Some (false, e)
-       | Ok _runtime_model ->
+       | Ok () ->
            ignore (sw, state, execution_scope);
            let result =
              Spawn.spawn ~agent_name:spawn_agent_name

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -88,8 +88,8 @@ let execute_spawn_pipeline
                        | Some n -> n | None -> 10
                      in
                      let oas_result =
-                       Oas_worker.run_model
-                         ~model_spec:prepared.runtime_model
+                       Oas_worker.run_model_by_label
+                         ~model_label:(Model_spec.label_of_model_spec prepared.runtime_model)
                          ~goal:prepared.spec.spawn_prompt
                          ~system_prompt:(Printf.sprintf
                            "You are agent '%s'. Execute the task and return a clear result."

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -172,7 +172,7 @@ let gate_config_of_execution_scope
 let build_agent
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(meta : Worker_container_types.worker_container_meta)
-    ~(model : Model_spec.model_spec)
+    ~(provider : Oas.Provider.config)
     ~(system_prompt : string)
     ~(tools : Oas.Tool.t list)
     ~(hooks : Oas.Hooks.hooks)
@@ -181,7 +181,6 @@ let build_agent
     ?(gate_config : Eval_gate.gate_config option)
     () : (Oas.Agent.t, string) result =
   let config = agent_config_of_worker_meta meta ~system_prompt in
-  let provider = oas_provider_of_model model in
   let tool_names =
     List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
   in
@@ -265,7 +264,7 @@ let rec run_worker_via_oas
     ~(sw : Eio.Switch.t)
     ~(base_path : string)
     ~(meta : Worker_container_types.worker_container_meta)
-    ~(model : Model_spec.model_spec)
+    ~(provider : Oas.Provider.config)
     ~(system_prompt : string)
     ~(prompt : string)
     ~(tools : Oas.Tool.t list)
@@ -302,7 +301,7 @@ let rec run_worker_via_oas
     }
   in
   let* agent =
-    build_agent ~net ~meta ~model ~system_prompt ~tools ~hooks
+    build_agent ~net ~meta ~provider ~system_prompt ~tools ~hooks
       ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ?gate_config ()
   in
   let* () =
@@ -424,7 +423,7 @@ let orchestrate_workers
     ~(sw : Eio.Switch.t)
     ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(workers : (Worker_container_types.worker_container_meta
-                 * Model_spec.model_spec
+                 * Oas.Provider.config
                  * string (* system_prompt *)
                  * Oas.Tool.t list
                  * Oas.Raw_trace.t
@@ -436,7 +435,7 @@ let orchestrate_workers
   let ( let* ) = Result.bind in
   let rec build_agents acc = function
     | [] -> Ok (List.rev acc)
-    | (meta, model, system_prompt, tools, raw_trace, heartbeat_cbs) :: rest ->
+    | (meta, provider, system_prompt, tools, raw_trace, heartbeat_cbs) :: rest ->
       let tool_names_ref = ref [] in
       let hooks =
         {
@@ -451,7 +450,7 @@ let orchestrate_workers
         }
       in
       let* agent =
-        build_agent ~net ~meta ~model ~system_prompt ~tools ~hooks
+        build_agent ~net ~meta ~provider ~system_prompt ~tools ~hooks
           ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ()
       in
       ignore tool_names_ref;


### PR DESCRIPTION
## Summary

Phase 5 (final) of Model_spec retirement. Decouples the worker subsystem, chain, and dashboard callers from direct `Model_spec.model_spec` type usage.

- **model_spec.ml**: Added `label_provider` + `label_of_model_spec` for round-trip safe label generation (`"provider:model_id"` strings that `model_spec_of_string` can parse back)
- **oas_worker.ml**: Added `run_model_by_label` (string-based API). Callers no longer need to hold a `Model_spec.model_spec` value. Existing `run_model` retained for backward compat.
- **worker_oas.ml**: `build_agent`, `run_worker_via_oas`, `orchestrate_workers` now accept `Oas.Provider.config` instead of `Model_spec.model_spec`
- **worker_container.ml**: `build_resume_config` takes `~provider` + `~model_id`. Added `resolve_oas_provider_of_label` helper.
- **worker_container_runners.ml**: Internal `run_worker_oas` takes `~provider` + `~model_id`. Public `run_worker` converts at the boundary.
- **chain_native_eio.ml**: `Direct` variant carries a string label; tool-free path uses `run_model_by_label`
- **mdal_worker.ml**: Replaced 7-arm `Model_spec.provider` constructor matching with `Model_spec.string_of_provider` + string comparison
- **dashboard**: `execute_single_agent_run` uses `run_model_by_label`; keeper dashboard uses `resolve_primary_max_context` instead of `Model_spec.llama_default.max_context`
- **tool_inline_dispatch.ml**: Discards model_spec after validation
- **worker_container_types.ml**: `estimate_cost_usd` takes `~model_id:string`

Type-bearing `Model_spec.model_spec` refs outside model_spec.ml: **39 -> 24**. Remaining refs are structural (prepared_spawn record, oas_type_adapters conversion layer, local_runtime_pool bridge) and deferred.

## Test plan

- [x] `dune build --root .` passes (clean build)
- [x] Model_spec OAS bridge tests (20/20 pass)
- [x] Worker container tests (2/2 pass)
- [x] Chain native eio bootstrap tests (1/1 pass)
- [x] MDAL tests (43/43 pass)
- [ ] Full `make test` (known flaky tests: SSE storm e2e, board, ag_ui -- pre-existing on main)

Generated with [Claude Code](https://claude.com/claude-code)