### PR TITLE
feat(dashboard): professional ops + command + tools + sidebar polish

### DIFF
--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -34,35 +34,35 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
   const denyKey = `deny:${decision.decision_id}`
   const isLegacy = decision.source === 'projected_operator'
   return html`
-    <article class="cmd-card rounded-xl ${toneClass(decision.status)}">
-      <div class="cmd-card rounded-xl-head">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] ${toneClass(decision.status)}">
+      <div class="flex justify-between items-start gap-3 mb-2">
         <div>
-          <strong>${decision.requested_action}</strong>
-          <div class="cmd-card rounded-xl-sub">${decision.scope_type}:${decision.scope_id}</div>
+          <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${decision.requested_action}</strong>
+          <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${decision.scope_type}:${decision.scope_id}</div>
         </div>
         <span class="cmd-chip rounded-full ${toneClass(decision.status)}">${controlStatusLabel(decision.status ?? 'pending')}</span>
       </div>
-      <div class="cmd-card rounded-xl-grid">
-        <span>결정 ID</span><span>${decision.decision_id}</span>
-        <span>요청자</span><span>${decision.requested_by ?? '알 수 없음'}</span>
-        <span>출처</span><span>${decision.source ?? 'managed'}</span>
-        <span>트레이스</span><span class="font-mono">${decision.trace_id}</span>
-        <span>생성 시각</span><span>${relativeTime(decision.created_at)}</span>
-        <span>이유</span><span>${decision.reason ?? '정보 없음'}</span>
+      <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
+        <span class="text-[var(--text-muted)]">결정 ID</span><span class="text-[var(--text-body)]">${decision.decision_id}</span>
+        <span class="text-[var(--text-muted)]">요청자</span><span class="text-[var(--text-body)]">${decision.requested_by ?? '알 수 없음'}</span>
+        <span class="text-[var(--text-muted)]">출처</span><span class="text-[var(--text-body)]">${decision.source ?? 'managed'}</span>
+        <span class="text-[var(--text-muted)]">트레이스</span><span class="font-mono text-[var(--text-body)]">${decision.trace_id}</span>
+        <span class="text-[var(--text-muted)]">생성 시각</span><span class="text-[var(--text-body)]">${relativeTime(decision.created_at)}</span>
+        <span class="text-[var(--text-muted)]">이유</span><span class="text-[var(--text-body)]">${decision.reason ?? '정보 없음'}</span>
       </div>
       ${decision.status === 'pending' && !isLegacy
         ? html`
             <div class="flex gap-2.5 flex-wrap mt-3">
-              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
+              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
-              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
+              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(denyKey) ? '거부 중…' : '거부'}
               </button>
             </div>
           `
         : null}
-      ${isLegacy ? html`<div class="cmd-card rounded-xl-foot">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
+      ${isLegacy ? html`<div class="mt-2 text-[12px] text-[var(--text-muted)] border-t border-[var(--white-4)] pt-2">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
     </article>
   `
 }
@@ -75,27 +75,27 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
   const killSwitch = !!unit.policy?.kill_switch
   const utilization = Math.round((row.utilization ?? 0) * 100)
   return html`
-    <article class="cmd-card rounded-xl p-3">
-      <div class="cmd-card rounded-xl-head">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="flex justify-between items-start gap-3 mb-2">
         <div>
-          <strong>${unit.label}</strong>
-          <div class="cmd-card rounded-xl-sub">${unit.unit_id}</div>
+          <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${unit.label}</strong>
+          <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${unit.unit_id}</div>
         </div>
         <span class="cmd-chip rounded-full ${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')}">${utilization}%</span>
       </div>
-      <div class="cmd-card rounded-xl-grid">
-        <span>편성</span><span>${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>
-        <span>정원</span><span>${row.headcount_cap ?? 0}</span>
-        <span>작전</span><span>${row.active_operations ?? 0}/${row.active_operation_cap ?? 0}</span>
-        <span>자율성</span><span>${unit.policy?.autonomy_level ?? '정보 없음'}</span>
-        <span>동결</span><span>${frozen ? '예' : '아니오'}</span>
-        <span>킬 스위치</span><span>${killSwitch ? '켜짐' : '꺼짐'}</span>
+      <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
+        <span class="text-[var(--text-muted)]">편성</span><span class="text-[var(--text-body)]">${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>
+        <span class="text-[var(--text-muted)]">정원</span><span class="text-[var(--text-body)]">${row.headcount_cap ?? 0}</span>
+        <span class="text-[var(--text-muted)]">작전</span><span class="text-[var(--text-body)]">${row.active_operations ?? 0}/${row.active_operation_cap ?? 0}</span>
+        <span class="text-[var(--text-muted)]">자율성</span><span class="text-[var(--text-body)]">${unit.policy?.autonomy_level ?? '정보 없음'}</span>
+        <span class="text-[var(--text-muted)]">동결</span><span class="text-[var(--text-body)]">${frozen ? '예' : '아니오'}</span>
+        <span class="text-[var(--text-muted)]">킬 스위치</span><span class="text-[var(--text-body)]">${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
       <div class="flex gap-2.5 flex-wrap mt-3">
-        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
+        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>
-        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
+        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
           ${actionDisabled(killKey) ? '적용 중…' : killSwitch ? '킬 스위치 해제' : '킬 스위치 켜기'}
         </button>
       </div>
@@ -107,23 +107,19 @@ export function ControlSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">승인 대기</div>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)] mb-3">승인 대기</h3>
         ${snapshot && snapshot.decisions.decisions.length > 0
-          ? html`<div class="cmd-card rounded-xl-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${snapshot.decisions.decisions.map(decision => html`<${DecisionCard} decision=${decision} />`)}
             </div>`
           : html`<div class="empty-state">지금 승인 대기 항목은 없습니다.</div>`}
       </section>
 
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">유닛 제어</div>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)] mb-3">유닛 제어</h3>
         ${snapshot && snapshot.capacity.capacity.length > 0
-          ? html`<div class="cmd-card rounded-xl-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${snapshot.capacity.capacity.map(row => html`<${CapacityRowCard} row=${row} />`)}
             </div>`
           : html`<div class="empty-state">제어할 용량 행이 아직 없습니다.</div>`}

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -222,14 +222,14 @@ export function Command() {
   return html`
     <section class="flex flex-col gap-[18px] ${wallboardMode ? 'p-4 rounded-[18px] cmd-plane-view wallboard' : ''}">
       ${wallboardMode ? null : html`
-        <div class="flex justify-between gap-4 items-start">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex justify-between gap-4 items-start max-[880px]:flex-col">
           <div>
-            <h2>지휘면</h2>
-            <p>기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
+            <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">지휘면</h2>
+            <p class="text-[13px] text-[var(--text-muted)] leading-relaxed max-w-[62ch]">기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
           </div>
           <div class="flex gap-2.5 flex-wrap">
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 void fire(() => runCommandPlaneDispatchTick())
               }}
@@ -238,7 +238,7 @@ export function Command() {
               ${actionDisabled('dispatch:tick') ? '정리 중...' : 'Tick 실행'}
             </button>
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 void refreshRoomTruth()
                 void refreshCommandPlaneCurrentSurface()
@@ -253,7 +253,7 @@ export function Command() {
               ${commandPlaneLoading.value ? '새로고침 중...' : '새로고침'}
             </button>
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 setCommandPlaneSurface('warroom')
                 navigate('operations', { ...surfaceRouteParams('warroom'), presentation: 'wallboard' })

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -284,9 +284,9 @@ export function OperationsSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">작전</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">작전</h3>
         </div>
         ${snapshot && snapshot.operations.operations.length > 0
           ? html`<div class="cmd-card rounded-xl-stack">
@@ -294,9 +294,9 @@ export function OperationsSurface() {
             </div>`
           : html`<div class="empty-state">관리형 또는 투영된 작전이 없습니다.</div>`}
       </section>
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">분견대</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">분견대</h3>
         </div>
         ${snapshot && snapshot.detachments.detachments.length > 0
           ? html`<div class="cmd-card rounded-xl-stack">
@@ -330,9 +330,9 @@ export function ChainsSurface() {
 
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">Chains</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Chains</h3>
         </div>
         <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${chainStatusTone(summary?.connection.status)}">
           <div class="flex justify-between gap-2.5 items-start">
@@ -384,9 +384,9 @@ export function ChainsSurface() {
         </div>
       </section>
 
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">체인 상세</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">체인 상세</h3>
         </div>
         ${selectedOverlay
           ? html`

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -153,7 +153,7 @@ export function OpsSessionColumn() {
           </div>
           <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${liveSessions.length === 0
-              ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">지금 바로 개입할 live team session이 없습니다.</div>`
+              ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 바로 개입할 live team session이 없습니다.</div>`
               : liveSessions.map(session => renderSessionCard(session))}
           </div>
         </div>
@@ -211,7 +211,7 @@ export function OpsSessionColumn() {
                 </div>
                 <div class="mt-1.5 whitespace-pre-wrap break-words">${item.summary}</div>
               </article>
-            `) : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션의 attention item은 없습니다.</div>`}
+            `) : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션의 attention item은 없습니다.</div>`}
             ${sessionDigest.worker_cards.length > 0 ? sessionDigest.worker_cards.map(card => html`
               <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
@@ -226,7 +226,7 @@ export function OpsSessionColumn() {
             `) : null}
           </div>
         ` : html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">세션을 고르면 세부 요약을 불러옵니다.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">세션을 고르면 세부 요약을 불러옵니다.</div>
         `}
       </section>
 
@@ -287,17 +287,17 @@ export function OpsSessionColumn() {
                 ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.error
-                ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${selectedSession.linked_autoresearch.error}</div>`
+                ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${selectedSession.linked_autoresearch.error}</div>`
                 : null}
             ` : null}
             ${selectedSession.recent_events && selectedSession.recent_events.length > 0 ? html`
               <pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
             ` : null}
           </div>
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">먼저 세션을 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 세션을 하나 고르세요.</div>`}
 
         ${selectedSession && !selectedSessionActionable ? html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
         ` : null}
 
         ${linkedAutoresearch?.loop_id ? html`
@@ -328,7 +328,7 @@ export function OpsSessionColumn() {
             </button>
             <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
           </div>
-          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${autoresearchError.value}</div>` : null}
+          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${autoresearchError.value}</div>` : null}
         ` : null}
 
         <label class="control-label" for="ops-turn-kind">세션 액션</label>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -80,49 +80,49 @@ export function FullInventoryView({
   const directCallCount = inventory.filter(item => item.direct_call_allowed).length
 
   return html`
-    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--slate-gray-12)]">
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-[18px]">
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="stat-label">전체 도구</span>
+    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--card-border)]">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="stat-label">활성화됨</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${hiddenCount}</span>
-          <span class="stat-label">숨김</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="stat-label">지원 중단</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${directCallCount}</span>
-          <span class="stat-label">직접 호출</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${filtered.length}</span>
-          <span class="stat-label">필터 결과</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
       </div>
 
       <div class="flex flex-wrap gap-2 mb-3.5">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
           <button
-            class=${`control-btn${surfaceFilter.value === key ? ' is-active' : ''}`}
+            class=${`px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="tool-surface-count inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[length:var(--fs-2xs)] font-semibold bg-[rgba(148,163,184,0.18)] text-[color:var(--text-slate)] rounded-full">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[10px] font-semibold bg-[var(--white-8)] text-[var(--text-muted)] rounded-full ml-1">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
 
       <div class="flex flex-wrap gap-2.5 items-center">
         <input
-          class="control-input rounded-lg"
+          class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none max-w-[320px]"
           type="text"
           placeholder="도구, 문서, 권한, 대체 도구 검색..."
           value=${searchQuery.value}
@@ -131,7 +131,7 @@ export function FullInventoryView({
           }}
         />
         <select
-          class="control-select"
+          class="px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none"
           value=${categoryFilter.value}
           onChange=${(e: Event) => {
             categoryFilter.value = (e.target as HTMLSelectElement).value
@@ -140,7 +140,7 @@ export function FullInventoryView({
           <option value="all">전체 카테고리</option>
           ${categories.map(category => html`<option value=${category}>${category}</option>`)}
         </select>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${enabledOnly.value}
@@ -150,7 +150,7 @@ export function FullInventoryView({
           />
           <span>활성화만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${directOnly.value}
@@ -160,7 +160,7 @@ export function FullInventoryView({
           />
           <span>직접 호출만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showHidden.value}
@@ -170,7 +170,7 @@ export function FullInventoryView({
           />
           <span>숨김 표시</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showDeprecated.value}
@@ -180,13 +180,17 @@ export function FullInventoryView({
           />
           <span>지원 중단 표시</span>
         </label>
-        <button class="control-btn rounded-lg ghost" onClick=${() => { void loadTools() }} disabled=${loading}>
+        <button
+          class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
+          onClick=${() => { void loadTools() }}
+          disabled=${loading}
+        >
           ${loading ? '새로고침 중...' : '새로고침'}
         </button>
       </div>
     </div>
 
-    ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-[length:var(--fs-base)] rounded-lg">${error}</div>` : null}
+    ${error ? html`<div class="px-3 py-2.5 bg-[var(--bad-12)] border border-[var(--bad-30)] text-[#fecaca] text-[13px] rounded-lg mt-2">${error}</div>` : null}
 
     <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-[300px]">
       ${filtered.length > 0

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -6,11 +6,11 @@ import { toolBadge } from './tool-state'
 
 export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
   return html`
-    <article class="flex flex-col gap-2.5 p-4 rounded-2xl bg-[rgba(15,23,42,0.72)] border border-[rgba(148,163,184,0.16)]">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
         <div>
-          <div class="text-[length:var(--fs-lg)] font-bold text-[color:var(--text-near-white)]">${item.name}</div>
-          <div class="tool-inventory-desc">${item.description}</div>
+          <div class="text-[15px] font-bold text-[var(--text-strong)]">${item.name}</div>
+          <div class="tool-inventory-desc text-[12px] text-[var(--text-muted)] mt-0.5">${item.description}</div>
         </div>
         <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -20,19 +20,19 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
-      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
-        <span>카테고리: <strong class="text-[color:var(--text-slate-light)]">${item.category}</strong></span>
-        <span>모드: <strong class="text-[color:var(--text-slate-light)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
-        <span>직접 호출: <strong class="text-[color:var(--text-slate-light)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
-        <span>권한: <strong class="text-[color:var(--text-slate-light)]">${item.required_permission ?? '없음'}</strong></span>
+      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-2">
+        <span>카테고리: <strong class="text-[var(--text-body)]">${item.category}</strong></span>
+        <span>모드: <strong class="text-[var(--text-body)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
+        <span>직접 호출: <strong class="text-[var(--text-body)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
+        <span>권한: <strong class="text-[var(--text-body)]">${item.required_permission ?? '없음'}</strong></span>
       </div>
       ${item.reason
-        ? html`<div class="tool-inventory-reason">${item.reason}</div>`
+        ? html`<div class="tool-inventory-reason text-[12px] text-[var(--text-muted)] mt-1.5">${item.reason}</div>`
         : null}
-      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
-        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[color:var(--text-slate-light)]">${item.canonicalName}</strong></span>` : null}
-        ${item.replacement ? html`<span>대체 도구: <strong class="text-[color:var(--text-slate-light)]">${item.replacement}</strong></span>` : null}
-        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[color:var(--text-slate-light)]">${item.doc_refs.join(', ')}</strong></span>` : null}
+      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-1.5">
+        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[var(--text-body)]">${item.canonicalName}</strong></span>` : null}
+        ${item.replacement ? html`<span>대체 도구: <strong class="text-[var(--text-body)]">${item.replacement}</strong></span>` : null}
+        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[var(--text-body)]">${item.doc_refs.join(', ')}</strong></span>` : null}
       </div>
     </article>
   `

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -70,26 +70,13 @@ export function toolMatchesQuery(item: DashboardToolInventoryItem, rawQuery: str
 }
 
 export function toolBadge(label: string, tone: 'default' | 'ok' | 'warn' | 'surface' = 'default') {
-  const color =
-    tone === 'ok' ? '#7dd3fc'
-      : tone === 'warn' ? '#fbbf24'
-      : tone === 'surface' ? '#c4b5fd'
-      : '#cbd5e1'
-  const background =
-    tone === 'ok' ? 'rgba(14, 165, 233, 0.18)'
-      : tone === 'warn' ? 'rgba(245, 158, 11, 0.18)'
-      : tone === 'surface' ? 'rgba(139, 92, 246, 0.18)'
-      : 'rgba(148, 163, 184, 0.16)'
+  const toneClass =
+    tone === 'ok' ? 'text-[#7dd3fc] bg-[rgba(14,165,233,0.18)]'
+      : tone === 'warn' ? 'text-[var(--warn)] bg-[var(--warn-12)]'
+      : tone === 'surface' ? 'text-[#c4b5fd] bg-[rgba(139,92,246,0.18)]'
+      : 'text-[var(--text-muted)] bg-[var(--white-8)]'
   return html`
-    <span
-      style=${{
-        fontSize: '11px',
-        color,
-        background,
-        borderRadius: '999px',
-        padding: '2px 8px',
-      }}
-    >
+    <span class="text-[11px] rounded-full px-2 py-0.5 ${toneClass}">
       ${label}
     </span>
   `

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -20,29 +20,29 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
   return html`
     <div class="py-2">
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-[18px]">
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="stat-label">전체 도구</span>
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="stat-label">활성화됨</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="stat-label">폐기 예정</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">폐기 예정</span>
         </div>
       </div>
 
       ${essential.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">필수 도구 (상위 ${essential.length}개)</h4>
-          <div class="flex flex-col gap-1.5">
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">필수 도구 (상위 ${essential.length}개)</h4>
+          <div class="flex flex-col">
             ${essential.map(item => html`
-              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
-                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
-                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+                <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
               </div>
             `)}
@@ -52,12 +52,12 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
       ${neverUsed.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">미사용 도구 (${neverUsed.length}개)</h4>
-          <div class="flex flex-col gap-1.5">
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">미사용 도구 (${neverUsed.length}개)</h4>
+          <div class="flex flex-col">
             ${neverUsed.map(item => html`
-              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
-                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
-                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+                <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${toolBadge(item.category)}
               </div>
             `)}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -31,15 +31,14 @@ export function Tools() {
     <div>
       <${Card} title="시스템 도구 목록" class="section mb-3.5">
         <div class="mb-3.5">
-          <h2 class="monitor-headline">시스템 도구 목록</h2>
-          <p class="monitor-subheadline">
+          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">시스템 도구 목록</h2>
+          <p class="text-[12px] text-[var(--text-muted)] leading-relaxed">
             ${showFullInventory.value
               ? 'hidden/deprecated 포함 전체 도구 surface를 봅니다.'
               : '필수 도구와 사용 현황 요약입니다.'}
           </p>
           <button
-            class="control-btn rounded-lg ghost"
-            class="mt-2"
+            class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)] mt-2"
             onClick=${() => { showFullInventory.value = !showFullInventory.value }}
           >
             ${showFullInventory.value ? '요약 보기' : '전체 인벤토리 보기'}
@@ -59,7 +58,7 @@ export function Tools() {
       <${Card} title="도구 사용 현황" class="section mb-3.5">
         ${usage
           ? html`
-              <div class="tool-inventory-usage-hint">
+              <div class="text-[12px] text-[var(--text-muted)] mb-2">
                 등록됨 ${usage.registered_count} · 사용된 ${usage.distinct_tools_called} · 미사용 ${usage.never_called_count}
               </div>
             `
@@ -67,7 +66,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[12px]">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`


### PR DESCRIPTION
## Summary
운영/지휘/도구 + 사이드바 + 토스트 프로페셔널 개선.
15 files, 278 ins, 261 del.

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)