### PR TITLE
feat(tools): add token budget limiter for tool descriptions

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -385,6 +385,7 @@
    tool_mdal_schemas
    tool_mdal_handlers
    tool_library
+   tool_budget
    tool_catalog
    tool_result
    tool_dispatch

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -58,38 +58,63 @@ WORKFLOW: masc_status → masc_transition(claim) → masc_worktree_create (isola
 Use masc_heartbeat periodically; use @agent mentions in masc_broadcast. \
 Prefer worktrees for parallel work."
 
+let apply_budget_filter ?budget_tokens schemas =
+  match budget_tokens with
+  | None -> (
+      match Tool_budget.default_budget () with
+      | None -> schemas
+      | Some budget ->
+          let usage_counts name =
+            match Tool_metrics.stats_for name with
+            | Some s -> s.Tool_metrics.call_count
+            | None -> 0
+          in
+          Tool_budget.filter_by_budget ~budget_tokens:budget ~usage_counts
+            ~tool_schemas:schemas)
+  | Some budget ->
+      let usage_counts name =
+        match Tool_metrics.stats_for name with
+        | Some s -> s.Tool_metrics.call_count
+        | None -> 0
+      in
+      Tool_budget.filter_by_budget ~budget_tokens:budget ~usage_counts
+        ~tool_schemas:schemas
+
 let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = false)
-    ?mode_override state profile =
-  match profile with
-  | Full ->
-      let categories =
-        match mode_override with
-        | Some mode_str ->
-            (match Mode.mode_of_string (String.lowercase_ascii mode_str) with
-             | Some mode -> Mode.categories_for_mode mode
-             | None ->
-                 let room_path = Room.masc_dir state.Mcp_server.room_config in
-                 let config = Config.load room_path in
-                 config.Config.enabled_categories)
-        | None ->
-            let room_path = Room.masc_dir state.Mcp_server.room_config in
-            let config = Config.load room_path in
-            config.Config.enabled_categories
-      in
-      Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
-  | Managed_agent ->
-      let passthrough =
-        Config.visible_tool_schemas ~include_hidden:false ~include_deprecated:false ()
-        |> List.filter (fun (schema : Types.tool_schema) ->
-               List.mem schema.name managed_agent_passthrough_tool_names
-               && Tool_catalog.is_visible schema.name)
-      in
-      dedupe_tool_schemas_by_name
-        (Sdk_tool_contract.sdk_tool_schemas @ passthrough)
-  | Operator_remote -> Tool_operator.remote_schemas
-  | Role_filtered mode ->
-      let categories = Mode.categories_for_mode mode in
-      Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
+    ?mode_override ?budget_tokens state profile =
+  let schemas =
+    match profile with
+    | Full ->
+        let categories =
+          match mode_override with
+          | Some mode_str ->
+              (match Mode.mode_of_string (String.lowercase_ascii mode_str) with
+               | Some mode -> Mode.categories_for_mode mode
+               | None ->
+                   let room_path = Room.masc_dir state.Mcp_server.room_config in
+                   let config = Config.load room_path in
+                   config.Config.enabled_categories)
+          | None ->
+              let room_path = Room.masc_dir state.Mcp_server.room_config in
+              let config = Config.load room_path in
+              config.Config.enabled_categories
+        in
+        Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
+    | Managed_agent ->
+        let passthrough =
+          Config.visible_tool_schemas ~include_hidden:false ~include_deprecated:false ()
+          |> List.filter (fun (schema : Types.tool_schema) ->
+                 List.mem schema.name managed_agent_passthrough_tool_names
+                 && Tool_catalog.is_visible schema.name)
+        in
+        dedupe_tool_schemas_by_name
+          (Sdk_tool_contract.sdk_tool_schemas @ passthrough)
+    | Operator_remote -> Tool_operator.remote_schemas
+    | Role_filtered mode ->
+        let categories = Mode.categories_for_mode mode in
+        Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
+  in
+  apply_budget_filter ?budget_tokens schemas
 
 let tool_allowed_in_profile state profile tool_name =
   match profile with

--- a/lib/tool_budget.ml
+++ b/lib/tool_budget.ml
@@ -1,0 +1,52 @@
+(** Tool description budget limiter.
+
+    Ranks tools by tier and usage frequency, truncates when budget exceeded.
+    Token estimation: ~4 characters per token (conservative approximation). *)
+
+let estimate_tokens (s : string) : int =
+  max 1 ((String.length s + 3) / 4)
+
+let tier_rank (name : string) : int =
+  match Tool_catalog.tool_tier name with
+  | Tool_catalog.Essential -> 0
+  | Tool_catalog.Standard -> 1
+  | Tool_catalog.Full -> 2
+
+let filter_by_budget ~budget_tokens ~usage_counts
+    ~(tool_schemas : Types.tool_schema list) : Types.tool_schema list =
+  if budget_tokens <= 0 then []
+  else
+    (* Sort: tier ascending (Essential first), then usage descending *)
+    let sorted =
+      List.sort
+        (fun (a : Types.tool_schema) (b : Types.tool_schema) ->
+          let ta = tier_rank a.name in
+          let tb = tier_rank b.name in
+          if ta <> tb then Int.compare ta tb
+          else
+            (* Higher usage first *)
+            Int.compare (usage_counts b.name) (usage_counts a.name))
+        tool_schemas
+    in
+    (* Accumulate tools until budget is exhausted *)
+    let _remaining, accepted =
+      List.fold_left
+        (fun (remaining, acc) (schema : Types.tool_schema) ->
+          if remaining <= 0 then (remaining, acc)
+          else
+            let cost = estimate_tokens schema.description in
+            (* Always include if we have any budget left, even if it slightly
+               exceeds the limit. This avoids dropping a tool that barely
+               overflows. *)
+            (remaining - cost, schema :: acc))
+        (budget_tokens, []) sorted
+    in
+    List.rev accepted
+
+let default_budget () : int option =
+  match Sys.getenv_opt "MASC_TOOL_DESCRIPTION_BUDGET" with
+  | Some raw -> (
+      match int_of_string_opt (String.trim raw) with
+      | Some v when v > 0 -> Some v
+      | _ -> None)
+  | None -> None

--- a/lib/tool_budget.mli
+++ b/lib/tool_budget.mli
@@ -1,0 +1,23 @@
+(** Tool description budget limiter.
+
+    Ranks tools by tier (Essential > Standard > Full) and usage frequency,
+    then truncates the list when the estimated token cost of descriptions
+    exceeds the given budget.
+
+    Token estimation: 1 token per 4 characters of description text. *)
+
+val estimate_tokens : string -> int
+(** Estimate the token count for a description string (~4 chars/token). *)
+
+val filter_by_budget :
+  budget_tokens:int ->
+  usage_counts:(string -> int) ->
+  tool_schemas:Types.tool_schema list ->
+  Types.tool_schema list
+(** Keep highest-priority tools within [budget_tokens].
+    Priority order: Essential tier first, then Standard, then Full.
+    Within the same tier, tools with higher usage count rank first.
+    [usage_counts] returns call count for a tool name (0 if unknown). *)
+
+val default_budget : unit -> int option
+(** Read [MASC_TOOL_DESCRIPTION_BUDGET] env var. [None] means no limit. *)

--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,7 @@
         test_keeper_resident_supervisor
         test_metrics_rotation
         test_tool_tier
+        test_tool_budget
         test_tool_exposure
         test_code_swarm
         test_autonomy_liberation
@@ -55,6 +56,7 @@
           test_keeper_resident_supervisor
           test_metrics_rotation
           test_tool_tier
+          test_tool_budget
           test_tool_exposure
           test_code_swarm
           test_autonomy_liberation

--- a/test/test_tool_budget.ml
+++ b/test/test_tool_budget.ml
@@ -1,0 +1,116 @@
+(** Tests for Tool_budget — token budget limiter for tool descriptions *)
+
+module Tool_budget = Masc_mcp.Tool_budget
+module Tool_catalog = Masc_mcp.Tool_catalog
+
+let mk_schema name desc : Types.tool_schema =
+  { name; description = desc; input_schema = `Assoc [] }
+
+(* Helper: always returns 0 usage *)
+let no_usage _ = 0
+
+let essential_schema =
+  mk_schema "masc_join" "Join the coordination room."
+
+let standard_schema =
+  mk_schema "masc_board_post" "Post a message to the board."
+
+let full_schema =
+  mk_schema "masc_risc_pipeline_status" "Get RISC pipeline status for advanced debugging."
+
+let all_test_schemas = [ essential_schema; standard_schema; full_schema ]
+
+let () =
+  let open Alcotest in
+  run "Tool_budget"
+    [
+      ( "estimate_tokens",
+        [
+          test_case "empty string returns 1" `Quick (fun () ->
+              check int "min 1" 1 (Tool_budget.estimate_tokens ""));
+          test_case "4 chars = 1 token" `Quick (fun () ->
+              check int "4 chars" 1 (Tool_budget.estimate_tokens "abcd"));
+          test_case "5 chars = 2 tokens" `Quick (fun () ->
+              check int "5 chars" 2 (Tool_budget.estimate_tokens "abcde"));
+          test_case "100 chars = 25 tokens" `Quick (fun () ->
+              check int "100 chars" 25
+                (Tool_budget.estimate_tokens (String.make 100 'x')));
+        ] );
+      ( "budget_zero",
+        [
+          test_case "budget=0 returns empty list" `Quick (fun () ->
+              let result =
+                Tool_budget.filter_by_budget ~budget_tokens:0
+                  ~usage_counts:no_usage ~tool_schemas:all_test_schemas
+              in
+              check int "empty" 0 (List.length result));
+        ] );
+      ( "budget_unlimited",
+        [
+          test_case "budget=max_int returns all tools" `Quick (fun () ->
+              let result =
+                Tool_budget.filter_by_budget ~budget_tokens:max_int
+                  ~usage_counts:no_usage ~tool_schemas:all_test_schemas
+              in
+              check int "all tools" 3 (List.length result));
+        ] );
+      ( "tier_priority",
+        [
+          test_case "Essential tier tools are included first" `Quick (fun () ->
+              (* Budget enough for ~1 tool description only *)
+              let budget = Tool_budget.estimate_tokens essential_schema.description in
+              let result =
+                Tool_budget.filter_by_budget ~budget_tokens:budget
+                  ~usage_counts:no_usage ~tool_schemas:all_test_schemas
+              in
+              check int "one tool" 1 (List.length result);
+              check string "essential first"
+                "masc_join"
+                (List.hd result).name);
+          test_case "Essential before Standard before Full" `Quick (fun () ->
+              (* Give enough budget for exactly 2 tools *)
+              let budget =
+                Tool_budget.estimate_tokens essential_schema.description
+                + Tool_budget.estimate_tokens standard_schema.description
+              in
+              let result =
+                Tool_budget.filter_by_budget ~budget_tokens:budget
+                  ~usage_counts:no_usage ~tool_schemas:all_test_schemas
+              in
+              check int "two tools" 2 (List.length result);
+              check string "first is essential"
+                "masc_join"
+                (List.nth result 0).name;
+              check string "second is standard"
+                "masc_board_post"
+                (List.nth result 1).name);
+        ] );
+      ( "usage_frequency",
+        [
+          test_case "higher usage ranked first within same tier" `Quick (fun () ->
+              let s1 = mk_schema "masc_board_post" "Post a message." in
+              let s2 = mk_schema "masc_board_search" "Search the board." in
+              let usage_counts name =
+                if name = "masc_board_search" then 100
+                else if name = "masc_board_post" then 5
+                else 0
+              in
+              (* Budget for 1 tool only *)
+              let budget = Tool_budget.estimate_tokens s1.description in
+              let result =
+                Tool_budget.filter_by_budget ~budget_tokens:budget
+                  ~usage_counts ~tool_schemas:[ s1; s2 ]
+              in
+              check int "one tool" 1 (List.length result);
+              check string "higher usage wins"
+                "masc_board_search"
+                (List.hd result).name);
+        ] );
+      ( "default_budget",
+        [
+          test_case "returns None when env var not set" `Quick (fun () ->
+              (* In test env, the env var should not be set *)
+              check bool "no budget" true
+                (Tool_budget.default_budget () = None));
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add `Tool_budget` module that ranks tools by tier (Essential > Standard > Full) and runtime usage frequency, then truncates the list when estimated token cost exceeds a configurable budget.
- Token estimation uses ~4 chars/token. Env var `MASC_TOOL_DESCRIPTION_BUDGET` sets default budget (no limit if unset).
- Integrate via optional `?budget_tokens` parameter on `tool_schemas_for_profile` in `mcp_server_eio_tool_profile.ml`.
- 10 unit tests covering zero/unlimited budget, tier ordering, and usage-based ranking.

## Motivation
With 300+ tools, sending all descriptions to LLMs wastes context tokens. This allows capping description payload while preserving the most important tools (Essential tier, high-usage).

## Files changed
- `lib/tool_budget.ml` / `.mli` — new module (~50 LOC)
- `lib/mcp_server_eio_tool_profile.ml` — add `?budget_tokens` + `apply_budget_filter`
- `lib/dune` — register `tool_budget`
- `test/test_tool_budget.ml` — 10 tests
- `test/dune` — register test

## Test plan
- [x] `dune build --root .` succeeds
- [x] `test_tool_budget` — 10/10 pass
- [x] `test_tool_tier` — 21/21 pass (no regression)

Generated with [Claude Code](https://claude.com/claude-code)