### PR TITLE
feat(dashboard): professional keeper detail page redesign

### DIFF
--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -34,35 +34,35 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
   const denyKey = `deny:${decision.decision_id}`
   const isLegacy = decision.source === 'projected_operator'
   return html`
-    <article class="cmd-card rounded-xl ${toneClass(decision.status)}">
-      <div class="cmd-card rounded-xl-head">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] ${toneClass(decision.status)}">
+      <div class="flex justify-between items-start gap-3 mb-2">
         <div>
-          <strong>${decision.requested_action}</strong>
-          <div class="cmd-card rounded-xl-sub">${decision.scope_type}:${decision.scope_id}</div>
+          <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${decision.requested_action}</strong>
+          <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${decision.scope_type}:${decision.scope_id}</div>
         </div>
         <span class="cmd-chip rounded-full ${toneClass(decision.status)}">${controlStatusLabel(decision.status ?? 'pending')}</span>
       </div>
-      <div class="cmd-card rounded-xl-grid">
-        <span>결정 ID</span><span>${decision.decision_id}</span>
-        <span>요청자</span><span>${decision.requested_by ?? '알 수 없음'}</span>
-        <span>출처</span><span>${decision.source ?? 'managed'}</span>
-        <span>트레이스</span><span class="font-mono">${decision.trace_id}</span>
-        <span>생성 시각</span><span>${relativeTime(decision.created_at)}</span>
-        <span>이유</span><span>${decision.reason ?? '정보 없음'}</span>
+      <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
+        <span class="text-[var(--text-muted)]">결정 ID</span><span class="text-[var(--text-body)]">${decision.decision_id}</span>
+        <span class="text-[var(--text-muted)]">요청자</span><span class="text-[var(--text-body)]">${decision.requested_by ?? '알 수 없음'}</span>
+        <span class="text-[var(--text-muted)]">출처</span><span class="text-[var(--text-body)]">${decision.source ?? 'managed'}</span>
+        <span class="text-[var(--text-muted)]">트레이스</span><span class="font-mono text-[var(--text-body)]">${decision.trace_id}</span>
+        <span class="text-[var(--text-muted)]">생성 시각</span><span class="text-[var(--text-body)]">${relativeTime(decision.created_at)}</span>
+        <span class="text-[var(--text-muted)]">이유</span><span class="text-[var(--text-body)]">${decision.reason ?? '정보 없음'}</span>
       </div>
       ${decision.status === 'pending' && !isLegacy
         ? html`
             <div class="flex gap-2.5 flex-wrap mt-3">
-              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
+              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
-              <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
+              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(denyKey) ? '거부 중…' : '거부'}
               </button>
             </div>
           `
         : null}
-      ${isLegacy ? html`<div class="cmd-card rounded-xl-foot">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
+      ${isLegacy ? html`<div class="mt-2 text-[12px] text-[var(--text-muted)] border-t border-[var(--white-4)] pt-2">레거시 operator 승인입니다. 실제 실행은 operator control에서 처리합니다.</div>` : null}
     </article>
   `
 }
@@ -75,27 +75,27 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
   const killSwitch = !!unit.policy?.kill_switch
   const utilization = Math.round((row.utilization ?? 0) * 100)
   return html`
-    <article class="cmd-card rounded-xl p-3">
-      <div class="cmd-card rounded-xl-head">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="flex justify-between items-start gap-3 mb-2">
         <div>
-          <strong>${unit.label}</strong>
-          <div class="cmd-card rounded-xl-sub">${unit.unit_id}</div>
+          <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${unit.label}</strong>
+          <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${unit.unit_id}</div>
         </div>
         <span class="cmd-chip rounded-full ${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')}">${utilization}%</span>
       </div>
-      <div class="cmd-card rounded-xl-grid">
-        <span>편성</span><span>${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>
-        <span>정원</span><span>${row.headcount_cap ?? 0}</span>
-        <span>작전</span><span>${row.active_operations ?? 0}/${row.active_operation_cap ?? 0}</span>
-        <span>자율성</span><span>${unit.policy?.autonomy_level ?? '정보 없음'}</span>
-        <span>동결</span><span>${frozen ? '예' : '아니오'}</span>
-        <span>킬 스위치</span><span>${killSwitch ? '켜짐' : '꺼짐'}</span>
+      <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
+        <span class="text-[var(--text-muted)]">편성</span><span class="text-[var(--text-body)]">${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>
+        <span class="text-[var(--text-muted)]">정원</span><span class="text-[var(--text-body)]">${row.headcount_cap ?? 0}</span>
+        <span class="text-[var(--text-muted)]">작전</span><span class="text-[var(--text-body)]">${row.active_operations ?? 0}/${row.active_operation_cap ?? 0}</span>
+        <span class="text-[var(--text-muted)]">자율성</span><span class="text-[var(--text-body)]">${unit.policy?.autonomy_level ?? '정보 없음'}</span>
+        <span class="text-[var(--text-muted)]">동결</span><span class="text-[var(--text-body)]">${frozen ? '예' : '아니오'}</span>
+        <span class="text-[var(--text-muted)]">킬 스위치</span><span class="text-[var(--text-body)]">${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
       <div class="flex gap-2.5 flex-wrap mt-3">
-        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
+        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>
-        <button class="control-btn rounded-lg ghost" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
+        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
           ${actionDisabled(killKey) ? '적용 중…' : killSwitch ? '킬 스위치 해제' : '킬 스위치 켜기'}
         </button>
       </div>
@@ -107,23 +107,19 @@ export function ControlSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">승인 대기</div>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)] mb-3">승인 대기</h3>
         ${snapshot && snapshot.decisions.decisions.length > 0
-          ? html`<div class="cmd-card rounded-xl-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${snapshot.decisions.decisions.map(decision => html`<${DecisionCard} decision=${decision} />`)}
             </div>`
           : html`<div class="empty-state">지금 승인 대기 항목은 없습니다.</div>`}
       </section>
 
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">유닛 제어</div>
-        </div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)] mb-3">유닛 제어</h3>
         ${snapshot && snapshot.capacity.capacity.length > 0
-          ? html`<div class="cmd-card rounded-xl-stack">
+          ? html`<div class="flex flex-col gap-3">
               ${snapshot.capacity.capacity.map(row => html`<${CapacityRowCard} row=${row} />`)}
             </div>`
           : html`<div class="empty-state">제어할 용량 행이 아직 없습니다.</div>`}

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -222,14 +222,14 @@ export function Command() {
   return html`
     <section class="flex flex-col gap-[18px] ${wallboardMode ? 'p-4 rounded-[18px] cmd-plane-view wallboard' : ''}">
       ${wallboardMode ? null : html`
-        <div class="flex justify-between gap-4 items-start">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] flex justify-between gap-4 items-start max-[880px]:flex-col">
           <div>
-            <h2>지휘면</h2>
-            <p>기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
+            <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">지휘면</h2>
+            <p class="text-[13px] text-[var(--text-muted)] leading-relaxed max-w-[62ch]">기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
           </div>
           <div class="flex gap-2.5 flex-wrap">
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 void fire(() => runCommandPlaneDispatchTick())
               }}
@@ -238,7 +238,7 @@ export function Command() {
               ${actionDisabled('dispatch:tick') ? '정리 중...' : 'Tick 실행'}
             </button>
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 void refreshRoomTruth()
                 void refreshCommandPlaneCurrentSurface()
@@ -253,7 +253,7 @@ export function Command() {
               ${commandPlaneLoading.value ? '새로고침 중...' : '새로고침'}
             </button>
             <button
-              class="control-btn rounded-lg ghost"
+              class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {
                 setCommandPlaneSurface('warroom')
                 navigate('operations', { ...surfaceRouteParams('warroom'), presentation: 'wallboard' })

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -284,9 +284,9 @@ export function OperationsSurface() {
   const snapshot = commandPlaneSnapshot.value
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">작전</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">작전</h3>
         </div>
         ${snapshot && snapshot.operations.operations.length > 0
           ? html`<div class="cmd-card rounded-xl-stack">
@@ -294,9 +294,9 @@ export function OperationsSurface() {
             </div>`
           : html`<div class="empty-state">관리형 또는 투영된 작전이 없습니다.</div>`}
       </section>
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">분견대</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">분견대</h3>
         </div>
         ${snapshot && snapshot.detachments.detachments.length > 0
           ? html`<div class="cmd-card rounded-xl-stack">
@@ -330,9 +330,9 @@ export function ChainsSurface() {
 
   return html`
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">Chains</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Chains</h3>
         </div>
         <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${chainStatusTone(summary?.connection.status)}">
           <div class="flex justify-between gap-2.5 items-start">
@@ -384,9 +384,9 @@ export function ChainsSurface() {
         </div>
       </section>
 
-      <section class="card rounded-xl min-h-[240px]">
-        <div class="card rounded-xl-title-row">
-          <div class="card rounded-xl-title">체인 상세</div>
+      <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
+        <div class="pb-2 border-b border-[var(--card-border)] mb-3">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">체인 상세</h3>
         </div>
         ${selectedOverlay
           ? html`

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1,7 +1,6 @@
-// Keeper config panel — structured config viewer with inline editing.
+// Keeper config panel -- structured config viewer with inline editing.
 // Fetches /api/v1/keepers/:name/config and renders grouped sections.
-// Edit mode enables PATCH for prompt-related fields (goal, soul, will, needs,
-// desires, instructions, drift).
+// Redesigned: clean section headers, consistent row styling, proper form controls.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -98,46 +97,45 @@ export function resetKeeperConfig(): void {
 
 function ConfigRow({ label, value }: { label: string; value: string }) {
   return html`
-    <div class="keeper-signal-row rounded-lg">
-      <span>${label}</span>
-      <strong>${value}</strong>
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+      <span class="text-xs text-[var(--text-muted)]">${label}</span>
+      <span class="text-xs font-medium text-[var(--text-strong)]">${value}</span>
     </div>
   `
 }
 
 function SectionHeader({ title }: { title: string }) {
   return html`
-    <div style="font-size:12px; font-weight:700; color:#a78bfa; text-transform:uppercase; letter-spacing:1px; margin-top:16px; margin-bottom:8px; padding-bottom:4px; border-bottom:1px solid rgba(167,139,250,0.2);">
+    <div class="text-[10px] font-bold uppercase tracking-wider text-[var(--purple)] mt-4 mb-2 pb-1 border-b border-[rgba(167,139,250,0.15)]">
       ${title}
     </div>
   `
 }
 
 function BoolBadge({ value }: { value: boolean }) {
-  const color = value ? '#4ade80' : '#6b7280'
-  const text = value ? 'on' : 'off'
-  return html`<span style="color:${color}; font-weight:600;">${text}</span>`
+  return value
+    ? html`<span class="text-xs font-semibold text-[#4ade80]">on</span>`
+    : html`<span class="text-xs font-semibold text-[#6b7280]">off</span>`
 }
 
 function ModelList({ models }: { models: string[] }) {
-  if (models.length === 0) return html`<span class="text-[#666]">none</span>`
+  if (models.length === 0) return html`<span class="text-[11px] text-[var(--text-muted)] italic">none</span>`
   return html`
     <div class="flex flex-wrap gap-1">
-      ${models.map(m => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full" style="font-size:11px;">${m}</span>`)}
+      ${models.map(m => html`<span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${m}</span>`)}
     </div>
   `
 }
 
 function LongText({ text }: { text: string }) {
-  if (!text || text.trim() === '') return html`<span class="text-[#666]">--</span>`
+  if (!text || text.trim() === '') return html`<span class="text-[11px] text-[var(--text-muted)] italic">--</span>`
   const truncated = text.length > 200 ? text.slice(0, 200) + '...' : text
-  return html`<div style="font-size:12px; color:#ccc; white-space:pre-wrap; max-height:120px; overflow-y:auto; background:rgba(255,255,255,0.02); padding:6px 8px; border-radius:4px; margin-top:4px;">${truncated}</div>`
+  return html`<div class="text-xs text-[var(--text-body)] whitespace-pre-wrap max-h-[120px] overflow-y-auto bg-[var(--white-3)] py-2 px-3 rounded-lg mt-1 leading-relaxed">${truncated}</div>`
 }
 
 const SOUL_PROFILES = ['balanced', 'safety', 'delivery', 'research', 'relationship', 'minimal'] as const
 
-const fieldStyle = 'width:100%; background:#1a1a2e; color:#ccc; border:1px solid #333; border-radius:4px; padding:6px 8px; font-size:12px; font-family:inherit; resize:vertical;'
-const btnBase = 'border:none; border-radius:4px; padding:4px 12px; font-size:12px; cursor:pointer; font-weight:600;'
+const fieldStyle = 'width:100%; background:rgba(11,18,32,0.8); color:var(--text-body); border:1px solid var(--card-border); border-radius:8px; padding:8px 10px; font-size:12px; font-family:inherit; resize:vertical;'
 
 // ── Edit field components ────────────────────────────────
 
@@ -153,7 +151,7 @@ function EditTextarea({ field, label, rows = 3 }: { field: keyof EditDraft; labe
   const val = d[field] as string
   return html`
     <div class="mt-2">
-      <div class="text-[11px] text-[var(--text-dim)] mb-0.5">${label}</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">${label}</div>
       <textarea
         style=${fieldStyle}
         rows=${rows}
@@ -170,7 +168,7 @@ function EditSelect({ field, label, options }: { field: keyof EditDraft; label: 
   const val = d[field] as string
   return html`
     <div class="mt-2">
-      <div class="text-[11px] text-[var(--text-dim)] mb-0.5">${label}</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">${label}</div>
       <select
         style=${fieldStyle}
         value=${val}
@@ -187,11 +185,12 @@ function EditCheckbox({ field, label }: { field: keyof EditDraft; label: string 
   if (!d) return null
   const val = d[field] as boolean
   return html`
-    <div class="keeper-signal-row rounded-lg mt-1">
-      <span>${label}</span>
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)] mt-1">
+      <span class="text-xs text-[var(--text-muted)]">${label}</span>
       <input
         type="checkbox"
         checked=${val}
+        class="cursor-pointer"
         onChange=${(e: Event) => updateDraft(field, (e.target as HTMLInputElement).checked)}
       />
     </div>
@@ -203,11 +202,11 @@ function EditNumber({ field, label, min, max }: { field: keyof EditDraft; label:
   if (!d) return null
   const val = d[field] as number
   return html`
-    <div class="keeper-signal-row rounded-lg mt-1">
-      <span>${label}</span>
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)] mt-1">
+      <span class="text-xs text-[var(--text-muted)]">${label}</span>
       <input
         type="number"
-        style="width:60px; background:#1a1a2e; color:#ccc; border:1px solid #333; border-radius:4px; padding:4px 6px; font-size:12px;"
+        class="w-16 bg-[rgba(11,18,32,0.8)] text-[var(--text-body)] border border-[var(--card-border)] rounded-md py-1 px-2 text-xs"
         value=${val}
         min=${min}
         max=${max}
@@ -231,11 +230,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   }
 
   if (state.status === 'loading') {
-    return html`<div class="flex flex-col gap-1.5"><div style="color:#888; font-size:13px; padding:12px 0;">Loading config...</div></div>`
+    return html`<div class="py-3 text-xs text-[var(--text-muted)]">Loading config...</div>`
   }
 
   if (state.status === 'error') {
-    return html`<div class="flex flex-col gap-1.5"><div style="color:#ef4444; font-size:13px; padding:12px 0;">${state.message}</div></div>`
+    return html`<div class="py-3 text-xs text-[#ef4444]">${state.message}</div>`
   }
 
   if (state.status !== 'loaded') return null
@@ -278,27 +277,29 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     }
   }
 
+  const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-semibold cursor-pointer border-none'
+
   // --- Toolbar ---
   const toolbar = html`
-    <div class="flex gap-1.5 items-center mb-2">
+    <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
         <button
-          style="${btnBase} background:#4ade80; color:#000;"
+          class="${btnBase} bg-[#4ade80] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? 'Saving...' : 'Save'}</button>
         <button
-          style="${btnBase} background:#444; color:#ccc;"
+          class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
         >Cancel</button>
       ` : html`
         <button
-          style="${btnBase} background:#a78bfa; color:#000;"
+          class="${btnBase} bg-[var(--purple)] text-[#000]"
           onClick=${enterEditMode}
         >Edit</button>
       `}
-      ${saveError.value ? html`<span style="color:#ef4444; font-size:12px;">${saveError.value}</span>` : null}
+      ${saveError.value ? html`<span class="text-xs text-[#ef4444]">${saveError.value}</span>` : null}
     </div>
   `
 
@@ -316,26 +317,26 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <${EditTextarea} field="instructions" label="Instructions" rows=${4} />
   ` : html`
     <${SectionHeader} title="Prompt" />
-    <div class="text-[11px] text-[var(--text-dim)] mb-0.5">Goal</div>
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">Goal</div>
     <${LongText} text=${c.prompt.goal} />
     ${c.prompt.short_goal ? html`
-      <div class="text-[11px] text-[var(--text-dim)] mt-2 mb-0.5">Short-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Short-term goal</div>
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
-      <div class="text-[11px] text-[var(--text-dim)] mt-2 mb-0.5">Mid-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Mid-term goal</div>
       <${LongText} text=${c.prompt.mid_goal} />
     ` : null}
     ${c.prompt.long_goal ? html`
-      <div class="text-[11px] text-[var(--text-dim)] mt-2 mb-0.5">Long-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Long-term goal</div>
       <${LongText} text=${c.prompt.long_goal} />
     ` : null}
     ${c.prompt.soul_profile ? html`
-      <div class="text-[11px] text-[var(--text-dim)] mt-2 mb-0.5">Soul profile</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Soul profile</div>
       <${LongText} text=${c.prompt.soul_profile} />
     ` : null}
     ${c.prompt.instructions ? html`
-      <div class="text-[11px] text-[var(--text-dim)] mt-2 mb-0.5">Instructions</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Instructions</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
   `
@@ -349,9 +350,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
   ` : html`
     <${SectionHeader} title="Drift" />
-    <div class="keeper-signal-row rounded-lg">
-      <span>Enabled</span>
-      <strong><${BoolBadge} value=${c.drift.enabled} /></strong>
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+      <span class="text-xs text-[var(--text-muted)]">Enabled</span>
+      <${BoolBadge} value=${c.drift.enabled} />
     </div>
     <${ConfigRow} label="Min turn gap" value=${String(c.drift.min_turn_gap)} />
     <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
@@ -368,17 +369,17 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="Policy mode" value=${c.execution.policy_mode || '--'} />
       <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
-      <div class="keeper-signal-row rounded-lg">
-        <span>Verify</span>
-        <strong><${BoolBadge} value=${c.execution.verify} /></strong>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Verify</span>
+        <${BoolBadge} value=${c.execution.verify} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[11px] text-[var(--text-dim)] mb-1">Models</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Models</div>
         <${ModelList} models=${c.execution.models} />
       </div>
       ${c.execution.allowed_models.length > 0 ? html`
         <div class="mt-1.5">
-          <div class="text-[11px] text-[var(--text-dim)] mb-1">Allowed models</div>
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Allowed models</div>
           <${ModelList} models=${c.execution.allowed_models} />
         </div>
       ` : null}
@@ -393,9 +394,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Proactive (read-only) --- */}
       <${SectionHeader} title="Proactive" />
-      <div class="keeper-signal-row rounded-lg">
-        <span>Enabled</span>
-        <strong><${BoolBadge} value=${c.proactive.enabled} /></strong>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Enabled</span>
+        <${BoolBadge} value=${c.proactive.enabled} />
       </div>
       <${ConfigRow} label="Idle trigger" value=${c.proactive.idle_sec + 's'} />
       <${ConfigRow} label="Cooldown" value=${c.proactive.cooldown_sec + 's'} />
@@ -405,9 +406,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="Initiative" />
-      <div class="keeper-signal-row rounded-lg">
-        <span>Enabled</span>
-        <strong><${BoolBadge} value=${c.initiative.enabled} /></strong>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Enabled</span>
+        <${BoolBadge} value=${c.initiative.enabled} />
       </div>
       <${ConfigRow} label="Scope" value=${c.initiative.scope || '--'} />
       <${ConfigRow} label="Idle trigger" value=${c.initiative.idle_sec + 's'} />
@@ -416,9 +417,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Handoff (read-only) --- */}
       <${SectionHeader} title="Handoff" />
-      <div class="keeper-signal-row rounded-lg">
-        <span>Auto</span>
-        <strong><${BoolBadge} value=${c.handoff.auto} /></strong>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Auto</span>
+        <${BoolBadge} value=${c.handoff.auto} />
       </div>
       <${ConfigRow} label="Threshold" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
       <${ConfigRow} label="Cooldown" value=${c.handoff.cooldown_sec + 's'} />

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -1,6 +1,6 @@
 // Keeper detail sub-components — KPIs, charts, field dictionary,
 // TRPG stats, equipment, relationships, autonomy, traits
-// Extracted from keeper-detail.ts for maintainability.
+// Redesigned: individual KPI cards, clean table, proper spacing.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -30,35 +30,35 @@ export function AutonomyMeter({ keeper }: { keeper: Keeper }) {
   const pct = ((idx + 1) / AUTONOMY_LEVELS.length) * 100
 
   return html`
-    <div class="flex flex-col gap-1.5">
-      <div class="mb-2">
-        <div class="flex justify-between items-center mb-1">
-          <span style="font-size:13px; font-weight:600; color:${info.color};">${info.label}</span>
-          <span class="text-[11px] text-[var(--text-dim)]">${idx + 1} / ${AUTONOMY_LEVELS.length}</span>
+    <div class="flex flex-col gap-2">
+      <div>
+        <div class="flex justify-between items-center mb-1.5">
+          <span class="text-[13px] font-semibold" style="color:${info.color};">${info.label}</span>
+          <span class="text-[11px] text-[var(--text-muted)]">${idx + 1} / ${AUTONOMY_LEVELS.length}</span>
         </div>
-        <div style="width:100%; height:6px; background:#1a1a2e; border-radius:3px; overflow:hidden;">
-          <div style="width:${pct}%; height:100%; background:${info.color}; border-radius:3px; transition:width 0.3s;"></div>
+        <div class="w-full h-1.5 bg-[var(--white-6)] rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-300" style="width:${pct}%; background:${info.color};"></div>
         </div>
-        <div class="flex justify-between mt-0.5">
+        <div class="flex justify-between mt-1.5">
           ${AUTONOMY_LEVELS.map((a, i) => html`
-            <span style="width:8px; height:8px; border-radius:50%; background:${i <= idx ? a.color : '#333'}; display:inline-block;"></span>
+            <span class="size-2 rounded-full inline-block transition-colors" style="background:${i <= idx ? a.color : 'var(--white-10)'};"></span>
           `)}
         </div>
       </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Autonomous actions</span>
-        <strong>${keeper.autonomous_action_count ?? 0}</strong>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Autonomous actions</span>
+        <span class="text-xs font-medium text-[var(--text-strong)]">${keeper.autonomous_action_count ?? 0}</span>
       </div>
       ${keeper.last_autonomous_action_at
-        ? html`<div class="keeper-signal-row rounded-lg">
-            <span>Last autonomous action</span>
-            <strong><${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></strong>
+        ? html`<div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+            <span class="text-xs text-[var(--text-muted)]">Last autonomous action</span>
+            <span class="text-xs font-medium text-[var(--text-strong)]"><${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>
           </div>`
         : null}
       ${keeper.active_goal_ids && keeper.active_goal_ids.length > 0
-        ? html`<div class="keeper-signal-row rounded-lg">
-            <span>Active goals</span>
-            <strong>${keeper.active_goal_ids.length}</strong>
+        ? html`<div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+            <span class="text-xs text-[var(--text-muted)]">Active goals</span>
+            <span class="text-xs font-medium text-[var(--text-strong)]">${keeper.active_goal_ids.length}</span>
           </div>`
         : null}
     </div>
@@ -68,14 +68,26 @@ export function AutonomyMeter({ keeper }: { keeper: Keeper }) {
 // ── Utility functions ────────────────────────────────────
 
 export function formatTokens(n: number | undefined): string {
-  if (!n) return '—'
+  if (!n) return '-'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
   return String(n)
 }
 
 
-// ── KPI & Chart components ───────────────────────────────
+// ── KPI Card ─────────────────────────────────────────────
+
+function KpiCard({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return html`
+    <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1">
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${label}</div>
+      <div class="text-2xl font-bold text-[var(--text-strong)] tabular-nums leading-tight">${value}</div>
+      ${hint ? html`<div class="text-[11px] text-[var(--text-muted)] leading-snug">${hint}</div>` : null}
+    </div>
+  `
+}
+
+// ── KPI Grid ─────────────────────────────────────────────
 
 export function KpiGrid({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
@@ -85,61 +97,50 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
       ? `$${lastPt.cost_usd.toFixed(4)}`
       : null
 
-  const items: { label: string; value: string | number; hint?: string }[] = [
-    {
-      label: '세대',
-      value: keeper.generation ?? '-',
-      hint: '승계 횟수',
-    },
-    {
-      label: '턴',
-      value: keeper.turn_count ?? '-',
-      hint: '총 루프 턴',
-    },
-    {
-      label: '컨텍스트',
-      value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-',
-      hint: keeper.context_ratio != null && keeper.context_ratio > 0.8 ? '한계 근접' : undefined,
-    },
-    {
-      label: '활동도',
-      value: keeper.activityLevel ?? '-',
-      hint: '0–5 단계',
-    },
-  ]
+  const contextHint = keeper.context_ratio != null && keeper.context_ratio > 0.8 ? 'Approaching limit' : undefined
 
   return html`
-    <div class="grid grid-cols-4 gap-2.5 mb-4">
-      ${items.map(i => html`
-        <div class="keeper-kpi rounded-lg">
-          <div class="keeper-kpi rounded-lg-label">${i.label}</div>
-          <div class="keeper-kpi rounded-lg-value">${i.value}</div>
-          ${i.hint ? html`<div class="keeper-kpi rounded-lg-hint">${i.hint}</div>` : null}
-        </div>
-      `)}
-      <div class="kpi-tile">
-        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${formatTokens(keeper.context_tokens)}</div>
-        <div class="kpi-label">Tokens</div>
-      </div>
-      <div class="kpi-tile">
-        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${keeper.handoff_count_total ?? '—'}</div>
-        <div class="kpi-label">Handoffs</div>
-      </div>
-      <div class="kpi-tile">
-        <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${keeper.compaction_count ?? '—'}</div>
-        <div class="kpi-label">Compactions</div>
-      </div>
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-5">
+      <${KpiCard}
+        label="Generation"
+        value=${keeper.generation ?? '-'}
+        hint="Succession count"
+      />
+      <${KpiCard}
+        label="Turns"
+        value=${keeper.turn_count ?? '-'}
+        hint="Total loop turns"
+      />
+      <${KpiCard}
+        label="Context"
+        value=${keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-'}
+        hint=${contextHint}
+      />
+      <${KpiCard}
+        label="Activity"
+        value=${keeper.activityLevel ?? '-'}
+        hint="Level 0-5"
+      />
+      <${KpiCard}
+        label="Tokens"
+        value=${formatTokens(keeper.context_tokens)}
+      />
+      <${KpiCard}
+        label="Handoffs"
+        value=${keeper.handoff_count_total ?? '-'}
+      />
+      <${KpiCard}
+        label="Compactions"
+        value=${keeper.compaction_count ?? '-'}
+      />
       ${latestCost
-        ? html`
-            <div class="kpi-tile">
-              <div class="text-[color:var(--text-strong)] text-[17px] leading-[1.1] font-semibold tabular-nums">${latestCost}</div>
-              <div class="kpi-label">Cost (USD)</div>
-            </div>
-          `
+        ? html`<${KpiCard} label="Cost (USD)" value=${latestCost} />`
         : null}
     </div>
   `
 }
+
+// ── Context Chart ────────────────────────────────────────
 
 export function ContextChart({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
@@ -147,11 +148,11 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
     const pct = ((keeper.context?.context_ratio ?? 0) * 100)
     const color = pct > 85 ? '#ef4444' : pct > 70 ? '#f59e0b' : '#22c55e'
     return html`
-      <div class="context-chart">
-        <div class="chart-bar-bg">
-          <div class="chart-bar" style="width:${pct.toFixed(1)}%;background:${color}"></div>
+      <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+        <div class="flex-1 h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-300" style="width:${pct.toFixed(1)}%;background:${color}"></div>
         </div>
-        <span class="chart-pct">${pct.toFixed(1)}%</span>
+        <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${pct.toFixed(1)}%</span>
       </div>`
   }
 
@@ -167,10 +168,10 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
   const lineColor = lastRatio > 85 ? '#ef4444' : lastRatio > 70 ? '#f59e0b' : '#22c55e'
 
   return html`
-    <div class="context-chart flex items-center gap-2">
-      <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" style="background:#1a1a2e;border-radius:4px">
-        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
-        <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
+    <div class="flex items-center gap-3 mb-5 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded" style="background:#0b1220;">
+        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
+        <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#444" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" stroke="#f59e0b" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
           <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
@@ -180,7 +181,7 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
           <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" fill="#a855f7"/>
         `)}
       </svg>
-      <span class="chart-pct">${lastRatio.toFixed(1)}%</span>
+      <span class="text-sm font-semibold tabular-nums text-[var(--text-strong)]">${lastRatio.toFixed(1)}%</span>
     </div>`
 }
 
@@ -207,6 +208,28 @@ export function FieldDictionary({ keeper }: { keeper: Keeper }) {
     { title: 'Interests', key: 'interests', value: keeper.interests?.join(', ') || '-' },
   ]
 
+  // Extra fields from keeper object
+  const extras: { title: string; value: string; mono?: boolean }[] = []
+  if (keeper.trace_id) extras.push({ title: 'Trace ID', value: keeper.trace_id, mono: true })
+  if (keeper.agent_name) extras.push({ title: 'Agent', value: keeper.agent_name })
+  if (keeper.primary_model) extras.push({ title: 'Primary Model', value: keeper.primary_model, mono: true })
+  if (keeper.active_model) extras.push({ title: 'Active Model', value: keeper.active_model, mono: true })
+  if (keeper.next_model_hint) extras.push({ title: 'Next Model Hint', value: keeper.next_model_hint, mono: true })
+  if (keeper.skill_primary) extras.push({ title: 'Skill (Primary)', value: keeper.skill_primary })
+  if (keeper.skill_secondary) extras.push({ title: 'Skill (Secondary)', value: keeper.skill_secondary })
+  if (keeper.skill_reason) extras.push({ title: 'Skill Reason', value: keeper.skill_reason })
+  if (keeper.context_source) extras.push({ title: 'Context Source', value: keeper.context_source })
+  if (keeper.context_tokens != null) extras.push({ title: 'Context Tokens', value: formatTokens(keeper.context_tokens) })
+  if (keeper.context_max != null) extras.push({ title: 'Context Max', value: formatTokens(keeper.context_max) })
+  if (keeper.memory_recent_note) extras.push({ title: 'Memory Note', value: keeper.memory_recent_note })
+  if (keeper.k2k_count != null) extras.push({ title: 'K2K Count', value: String(keeper.k2k_count) })
+  if (keeper.conversation_tail_count != null) extras.push({ title: 'Conv Tail', value: String(keeper.conversation_tail_count) })
+  if (keeper.handoff_count_total != null) extras.push({ title: 'Total Handoffs', value: String(keeper.handoff_count_total) })
+  if (keeper.compaction_count != null) extras.push({ title: 'Compactions', value: String(keeper.compaction_count) })
+  if (keeper.last_compaction_saved_tokens != null) extras.push({ title: 'Last Compact Saved', value: formatTokens(keeper.last_compaction_saved_tokens) })
+  if (keeper.context?.message_count != null) extras.push({ title: 'Message Count', value: String(keeper.context.message_count) })
+  if (keeper.context?.has_checkpoint != null) extras.push({ title: 'Has Checkpoint', value: keeper.context.has_checkpoint ? 'Yes' : 'No' })
+
   const filtered = filter
     ? fields.filter(f => f.title.toLowerCase().includes(filter) || f.key.includes(filter) || f.value.toLowerCase().includes(filter))
     : fields
@@ -214,38 +237,27 @@ export function FieldDictionary({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="max-h-[460px] overflow-y-auto">
       <input
-        class="keeper-field-search rounded-lg"
+        class="w-full py-2 px-3 mb-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--ok-40)]"
         type="text"
-        placeholder="필드 검색..."
+        placeholder="Search fields..."
         value=${fieldSearch.value}
         onInput=${(e: Event) => { fieldSearch.value = (e.target as HTMLInputElement).value }}
       />
-      ${filtered.map(f => html`
-        <div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]">
-          <span class="font-semibold min-w-[90px]">${f.title}</span>
-          <span class="font-mono text-cyan text-[var(--fs-sm)]">${f.key}</span>
-          <span class="flex-1 text-right text-[#ccc]">${f.value}</span>
-        </div>
-      `)}
-      ${keeper.trace_id ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Trace ID</span><span class="keeper-field-key font-mono">${keeper.trace_id}</span></div>` : ''}
-      ${keeper.agent_name ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Agent</span><span class="flex-1 text-right text-[#ccc]">${keeper.agent_name}</span></div>` : ''}
-      ${keeper.primary_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Primary Model</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.primary_model}</span></div>` : ''}
-      ${keeper.active_model ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Active Model</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.active_model}</span></div>` : ''}
-      ${keeper.next_model_hint ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Next Model Hint</span><span class="font-mono flex-1 text-right text-[#ccc]">${keeper.next_model_hint}</span></div>` : ''}
-      ${keeper.skill_primary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Primary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_primary}</span></div>` : ''}
-      ${keeper.skill_secondary ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill (Secondary)</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_secondary}</span></div>` : ''}
-      ${keeper.skill_reason ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Skill Reason</span><span class="flex-1 text-right text-[#ccc]">${keeper.skill_reason}</span></div>` : ''}
-      ${keeper.context_source ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Source</span><span class="flex-1 text-right text-[#ccc]">${keeper.context_source}</span></div>` : ''}
-      ${keeper.context_tokens != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Tokens</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_tokens)}</span></div>` : ''}
-      ${keeper.context_max != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Context Max</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.context_max)}</span></div>` : ''}
-      ${keeper.memory_recent_note ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Memory Note</span><span class="flex-1 text-right text-[#ccc]">${keeper.memory_recent_note}</span></div>` : ''}
-      ${keeper.k2k_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">K2K Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.k2k_count}</span></div>` : ''}
-      ${keeper.conversation_tail_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Conv Tail</span><span class="flex-1 text-right text-[#ccc]">${keeper.conversation_tail_count}</span></div>` : ''}
-      ${keeper.handoff_count_total != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Total Handoffs</span><span class="flex-1 text-right text-[#ccc]">${keeper.handoff_count_total}</span></div>` : ''}
-      ${keeper.compaction_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Compactions</span><span class="flex-1 text-right text-[#ccc]">${keeper.compaction_count}</span></div>` : ''}
-      ${keeper.last_compaction_saved_tokens != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Last Compact Saved</span><span class="flex-1 text-right text-[#ccc]">${formatTokens(keeper.last_compaction_saved_tokens)}</span></div>` : ''}
-      ${keeper.context?.message_count != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Message Count</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.message_count}</span></div>` : ''}
-      ${keeper.context?.has_checkpoint != null ? html`<div class="flex gap-2.5 py-1.5 border-b border-[var(--white-4)] text-[var(--fs-base)]"><span class="font-semibold min-w-[90px]">Has Checkpoint</span><span class="flex-1 text-right text-[#ccc]">${keeper.context.has_checkpoint ? 'Yes' : 'No'}</span></div>` : ''}
+      <div class="flex flex-col">
+        ${filtered.map((f, i) => html`
+          <div class="grid grid-cols-[100px_80px_1fr] gap-2 py-2 px-2 text-xs rounded-md ${i % 2 === 0 ? 'bg-[var(--white-2)]' : ''}">
+            <span class="font-semibold text-[var(--text-body)] truncate">${f.title}</span>
+            <span class="font-mono text-[var(--cyan)] text-[11px] truncate">${f.key}</span>
+            <span class="text-right text-[var(--text-body)] truncate">${f.value}</span>
+          </div>
+        `)}
+        ${extras.map((f, i) => html`
+          <div class="grid grid-cols-[100px_1fr] gap-2 py-2 px-2 text-xs rounded-md ${(filtered.length + i) % 2 === 0 ? 'bg-[var(--white-2)]' : ''}">
+            <span class="font-semibold text-[var(--text-body)] truncate">${f.title}</span>
+            <span class="text-right text-[var(--text-body)] truncate ${f.mono ? 'font-mono' : ''}">${f.value}</span>
+          </div>
+        `)}
+      </div>
     </div>
   `
 }
@@ -258,21 +270,27 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 
   return html`
     <div>
-      <div class="flex gap-3 mb-2.5">
+      <div class="flex gap-3 mb-3">
         <div class="flex-1">
-          <div class="text-[11px] text-[var(--text-dim)]">HP ${stats.hp}/${stats.max_hp}</div>
-          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:3px; overflow:hidden;">
-            <div style="width:${hpPct}%; height:100%; background:${hpPct > 50 ? '#4ade80' : hpPct > 25 ? '#fbbf24' : '#ef4444'}; border-radius:3px;" />
+          <div class="flex justify-between text-[11px] text-[var(--text-muted)] mb-1">
+            <span>HP</span>
+            <span>${stats.hp}/${stats.max_hp}</span>
+          </div>
+          <div class="h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
+            <div class="h-full rounded-full transition-all" style="width:${hpPct}%; background:${hpPct > 50 ? '#4ade80' : hpPct > 25 ? '#fbbf24' : '#ef4444'};" />
           </div>
         </div>
         <div class="flex-1">
-          <div class="text-[11px] text-[var(--text-dim)]">MP ${stats.mp}/${stats.max_mp}</div>
-          <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:3px; overflow:hidden;">
-            <div style="width:${mpPct}%; height:100%; background:#818cf8; border-radius:3px;" />
+          <div class="flex justify-between text-[11px] text-[var(--text-muted)] mb-1">
+            <span>MP</span>
+            <span>${stats.mp}/${stats.max_mp}</span>
+          </div>
+          <div class="h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
+            <div class="h-full rounded-full" style="width:${mpPct}%; background:#818cf8;" />
           </div>
         </div>
       </div>
-      <div class="grid grid-cols-3 gap-1.5">
+      <div class="grid grid-cols-3 gap-2">
         ${[
           { label: 'STR', value: stats.strength },
           { label: 'DEX', value: stats.dexterity },
@@ -281,28 +299,28 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
           { label: 'WIS', value: stats.wisdom },
           { label: 'CHA', value: stats.charisma },
         ].map(s => html`
-          <div class="text-center p-1.5 bg-[var(--white-3)] rounded-md">
-            <div class="text-[10px] text-[var(--text-dim)] uppercase">${s.label}</div>
-            <div class="text-base font-bold text-[#e0e0e0]">${s.value}</div>
+          <div class="text-center py-2 px-1.5 bg-[var(--white-3)] rounded-lg border border-[var(--card-border)]">
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">${s.label}</div>
+            <div class="text-lg font-bold text-[var(--text-strong)] mt-0.5">${s.value}</div>
           </div>
         `)}
       </div>
-      <div class="mt-2 text-xs text-[var(--text-dim)]">
-        Level ${stats.level} — XP ${stats.xp}
+      <div class="mt-3 text-xs text-[var(--text-muted)]">
+        Level ${stats.level} -- XP ${stats.xp}
       </div>
     </div>
   `
 }
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state">장비 없음</div>`
+  if (items.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No equipment</div>`
 
   return html`
     <div class="flex flex-col gap-1.5">
       ${items.map((item, i) => html`
-        <div class="keeper-equipment-row rounded-md">
-          <span>${item}</span>
-          <span class="text-cyan text-[var(--fs-xs)]">#${i + 1}</span>
+        <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+          <span class="text-xs text-[var(--text-body)]">${item}</span>
+          <span class="text-[10px] text-[var(--cyan)] font-mono">#${i + 1}</span>
         </div>
       `)}
     </div>
@@ -311,14 +329,14 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state">관계 없음</div>`
+  if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No relationships</div>`
 
   return html`
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">
       ${entries.map(([name, relation]) => html`
-        <div class="flex items-center gap-2 py-1.5 px-2.5 bg-[var(--white-3)] rounded-md">
-          <span class="keeper-mention-chip rounded-full">${name}</span>
-          <span class="font-mono text-[var(--fs-xs)] text-[var(--text-dim)]">${relation}</span>
+        <div class="flex items-center gap-2 py-2 px-3 bg-[var(--white-3)] rounded-lg">
+          <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${name}</span>
+          <span class="text-[11px] text-[var(--text-muted)] font-mono">${relation}</span>
         </div>
       `)}
     </div>
@@ -330,11 +348,10 @@ export function TraitsList({ traits, label }: { traits: string[]; label: string 
 
   return html`
     <div class="mb-3">
-      <div class="text-[11px] text-[var(--text-dim)] uppercase tracking-wider mb-1.5">${label}</div>
+      <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold mb-2">${label}</div>
       <div class="flex flex-wrap gap-1.5">
-        ${traits.map(t => html`<span class="keeper-mention-chip rounded-full">${t}</span>`)}
+        ${traits.map(t => html`<span class="inline-flex items-center py-0.5 px-2.5 rounded-full text-[11px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${t}</span>`)}
       </div>
     </div>
   `
 }
-

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1,5 +1,6 @@
 // Keeper runtime signals, neighborhood, and tool audit panels.
-// Extracted from keeper-detail-panels.ts for maintainability.
+// Redesigned: consistent signal row styling with inline Tailwind,
+// clean tool chip badges, proper section spacing.
 
 import { html } from 'htm/preact'
 import { TimeAgo } from './common/time-ago'
@@ -69,6 +70,41 @@ function formatPct(value: number | undefined): string {
   return `${Math.round(value * 100)}%`
 }
 
+// ── Shared row component ─────────────────────────────────
+
+function SignalRow({ label, value }: { label: string; value: string | number }) {
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+      <span class="text-xs text-[var(--text-muted)]">${label}</span>
+      <span class="text-xs font-medium text-[var(--text-strong)]">${value}</span>
+    </div>
+  `
+}
+
+// ── Tool chip badge ──────────────────────────────────────
+
+function ToolChip({ name }: { name: string }) {
+  return html`
+    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${name}</span>
+  `
+}
+
+// ── Tool list section ────────────────────────────────────
+
+function ToolSection({ title, description, tools, fallback }: { title: string; description?: string; tools: string[]; fallback: string }) {
+  return html`
+    <div class="flex flex-col gap-1.5 mt-3">
+      <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</span>
+      ${description ? html`<span class="text-[11px] text-[var(--text-muted)] leading-snug">${description}</span>` : null}
+      <div class="flex flex-wrap gap-1.5">
+        ${tools.length > 0
+          ? tools.map(tool => html`<${ToolChip} name=${tool} />`)
+          : html`<span class="text-[11px] text-[var(--text-muted)] italic">${fallback}</span>`}
+      </div>
+    </div>
+  `
+}
+
 // ── Runtime Signals ──────────────────────────────────────
 
 export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
@@ -76,23 +112,23 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
 
   const rows: Array<{ label: string; value: string | number }> = [
     { label: 'Model fallback', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
-    { label: '선제적 폴백', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
-    { label: '메모리 통과율', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
-    { label: '핸드오프', value: typeof mw?.handoff_count === 'number' ? mw.handoff_count : keeper.handoff_count_total ?? '-' },
-    { label: '컴팩션', value: typeof mw?.compaction_events === 'number' ? mw.compaction_events : keeper.compaction_count ?? '-' },
-    { label: '절약 토큰', value: typeof mw?.compaction_saved_tokens === 'number' ? mw.compaction_saved_tokens : keeper.last_compaction_saved_tokens ?? '-' },
-    { label: 'K2K 이벤트', value: keeper.k2k_count ?? '-' },
-    { label: '대화 꼬리', value: keeper.conversation_tail_count ?? '-' },
-    { label: '도구 호출', value: typeof mw?.tool_call_count === 'number' ? mw.tool_call_count : '-' },
-    { label: '미리보기 유사도', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
-    { label: '메모리 평균 점수', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
-    { label: '폴백 비율', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
+    { label: 'Proactive fallback', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
+    { label: 'Memory pass rate', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
+    { label: 'Handoffs', value: typeof mw?.handoff_count === 'number' ? mw.handoff_count : keeper.handoff_count_total ?? '-' },
+    { label: 'Compactions', value: typeof mw?.compaction_events === 'number' ? mw.compaction_events : keeper.compaction_count ?? '-' },
+    { label: 'Saved tokens', value: typeof mw?.compaction_saved_tokens === 'number' ? mw.compaction_saved_tokens : keeper.last_compaction_saved_tokens ?? '-' },
+    { label: 'K2K events', value: keeper.k2k_count ?? '-' },
+    { label: 'Conv tail', value: keeper.conversation_tail_count ?? '-' },
+    { label: 'Tool calls', value: typeof mw?.tool_call_count === 'number' ? mw.tool_call_count : '-' },
+    { label: 'Preview similarity', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
+    { label: 'Memory avg score', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
+    { label: 'Fallback rate', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
   ]
 
   const visibleRows = rows.filter(row =>
     !(
       row.value === '-'
-      || row.value === '—'
+      || row.value === '\u2014'
       || row.value === ''
     ))
 
@@ -100,12 +136,7 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-col gap-1.5">
-      ${visibleRows.map(r => html`
-        <div class="keeper-signal-row rounded-lg">
-          <span>${r.label}</span>
-          <strong>${r.value}</strong>
-        </div>
-      `)}
+      ${visibleRows.map(r => html`<${SignalRow} label=${r.label} value=${r.value} />`)}
     </div>
   `
 }
@@ -133,8 +164,8 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const auditAt = missionBrief?.tool_audit_at ?? keeper.tool_audit_at
   const capabilities = keeper.agent?.capabilities ?? []
   const roomName = room.current_room ?? room.room_id ?? serverStatus.value?.room ?? 'default'
-  const project = room.project ?? serverStatus.value?.project ?? '확인 없음'
-  const cluster = room.cluster ?? serverStatus.value?.cluster ?? '확인 없음'
+  const project = room.project ?? serverStatus.value?.project ?? 'N/A'
+  const cluster = room.cluster ?? serverStatus.value?.cluster ?? 'N/A'
   const allowlistFallback = toolAuditStateLabel(allowlistEmptyState(keeper))
   const observedFallback = toolAuditStateLabel(observedToolsEmptyState(keeper, auditSource))
   const metadataFallback = toolAuditStateLabel(auditMetadataState(keeper, auditSource))
@@ -150,95 +181,63 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-col gap-1.5">
-      <div class="keeper-signal-row rounded-lg">
-        <span>Room</span>
-        <strong>${roomName}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Project</span>
-        <strong>${project}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Cluster</span>
-        <strong>${cluster}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Current task</span>
-        <strong>${currentTaskLabel}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Skill route</span>
-        <strong>${skillRouteLabel}</strong>
-      </div>
+      <${SignalRow} label="Room" value=${roomName} />
+      <${SignalRow} label="Project" value=${project} />
+      <${SignalRow} label="Cluster" value=${cluster} />
+      <${SignalRow} label="Current task" value=${currentTaskLabel} />
+      <${SignalRow} label="Skill route" value=${skillRouteLabel} />
+
       <div class="flex justify-end mt-1">
-        <button class="control-btn rounded-lg ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
+        <button
+          class="py-1.5 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
+          onClick=${() => { openToolsInventory(openToolsQuery) }}
+        >
           Open tools panel
         </button>
       </div>
-      <div class="flex flex-col gap-2 mt-2">
-        <span class="text-xs text-[var(--text-dim)]">Allowed tools</span>
-        <span class="text-[11px] text-[var(--text-slate)]">Currently permitted tools for this keeper runtime.</span>
-        <div class="flex flex-wrap gap-1.5">
-          ${allowedTools.length > 0
-            ? allowedTools.map(tool => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${tool}</span>`)
-            : html`<span class="text-xs text-[var(--text-dim)]">${allowlistFallback}</span>`}
-        </div>
+
+      <${ToolSection}
+        title="Allowed tools"
+        description="Currently permitted tools for this keeper runtime."
+        tools=${allowedTools}
+        fallback=${allowlistFallback}
+      />
+
+      <${ToolSection}
+        title="Observed tools"
+        description="Recent execution evidence from heartbeat or runtime telemetry."
+        tools=${observedTools}
+        fallback=${observedFallback}
+      />
+
+      <${SignalRow} label="Tool calls" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
+      <${SignalRow} label="Evidence source" value=${auditSource ?? metadataFallback} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Observed at</span>
+        <span class="text-xs font-medium text-[var(--text-strong)]">${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</span>
       </div>
-      <div class="flex flex-col gap-2 mt-2">
-        <span class="text-xs text-[var(--text-dim)]">Observed tools</span>
-        <span class="text-[11px] text-[var(--text-slate)]">Recent execution evidence from heartbeat or runtime telemetry.</span>
-        <div class="flex flex-wrap gap-1.5">
-          ${observedTools.length > 0
-            ? observedTools.map(tool => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${tool}</span>`)
-            : html`<span class="text-xs text-[var(--text-dim)]">${observedFallback}</span>`}
-        </div>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Tool calls</span>
-        <strong>${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Evidence source</span>
-        <strong>${auditSource ?? metadataFallback}</strong>
-      </div>
-      <div class="keeper-signal-row rounded-lg">
-        <span>Observed at</span>
-        <strong>${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</strong>
-      </div>
-      <div class="flex flex-col gap-2 mt-2">
-        <span class="text-xs text-[var(--text-dim)]">Keeper recent tools</span>
-        <div class="flex flex-wrap gap-1.5">
-          ${recentTools.length > 0
-            ? recentTools.map(tool => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${tool}</span>`)
-            : html`<span class="text-xs text-[var(--text-dim)]">${linkedRecentFallback}</span>`}
-        </div>
-      </div>
+
+      <${ToolSection}
+        title="Keeper recent tools"
+        tools=${recentTools}
+        fallback=${linkedRecentFallback}
+      />
+
       ${topTools.length > 0
-        ? html`
-            <div class="flex flex-col gap-2 mt-2">
-              <span class="text-xs text-[var(--text-dim)]">Window top tools</span>
-              <div class="flex flex-wrap gap-1.5">
-                ${topTools.map(tool => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${tool}</span>`)}
-              </div>
-            </div>
-          `
+        ? html`<${ToolSection} title="Window top tools" tools=${topTools} fallback="" />`
         : null}
-      <div class="flex flex-col gap-2 mt-2">
-        <span class="text-xs text-[var(--text-dim)]">Capabilities</span>
-        <div class="flex flex-wrap gap-1.5">
-          ${capabilities.length > 0
-            ? capabilities.map(capability => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${capability}</span>`)
-            : html`<span class="text-xs text-[var(--text-dim)]">등록된 capability 없음</span>`}
-        </div>
-      </div>
-      <div class="flex flex-col gap-2 mt-2">
-        <span class="text-xs text-[var(--text-dim)]">Available actions nearby</span>
-        <div class="flex flex-wrap gap-1.5">
-          ${actions.length > 0
-            ? actions.map(action => html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${actionDescriptorLabel(action.action_type)}</span>`)
-            : html`<span class="text-xs text-[var(--text-dim)]">operator action 광고 없음</span>`}
-        </div>
-      </div>
+
+      <${ToolSection}
+        title="Capabilities"
+        tools=${capabilities}
+        fallback="No registered capabilities"
+      />
+
+      <${ToolSection}
+        title="Available actions nearby"
+        tools=${actions.map(action => actionDescriptorLabel(action.action_type))}
+        fallback="No operator action advertisements"
+      />
     </div>
   `
 }

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1,12 +1,10 @@
 // Keeper detail overlay — full keeper info with KPIs, field dictionary,
 // memory, conversations, equipment, relationships, handoff timeline
-// CSS classes: .keeper-kpis, .keeper-field-dict, .keeper-memory-list, etc. (components.css)
+// Redesigned: professional dashboard-grade layout with Tailwind inline styles.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { runOperatorAction } from '../api'
-import { Card } from './common/card'
-import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
@@ -48,7 +46,7 @@ export function closeKeeperDetail() {
   resetKeeperConfig()
 }
 
-// ── Main Detail Overlay ───────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────
 
 function currentOperatorActor(): string {
   const q = new URLSearchParams(window.location.search)
@@ -75,24 +73,57 @@ async function runSocialSweep(): Promise<void> {
   }
 }
 
+// ── Status Badge (colored pill) ──────────────────────────
+
+function statusColor(status: string): { bg: string; text: string; dot: string } {
+  switch (status.trim().toLowerCase()) {
+    case 'active':
+    case 'running':
+      return { bg: 'bg-[rgba(74,222,128,0.12)]', text: 'text-[#4ade80]', dot: 'bg-[#4ade80]' }
+    case 'working':
+      return { bg: 'bg-[rgba(74,222,128,0.12)]', text: 'text-[#7ae09a]', dot: 'bg-[#7ae09a]' }
+    case 'idle':
+    case 'quiet':
+      return { bg: 'bg-[rgba(251,191,36,0.12)]', text: 'text-[#fbbf24]', dot: 'bg-[#fbbf24]' }
+    case 'offline':
+    case 'inactive':
+      return { bg: 'bg-[rgba(148,163,184,0.12)]', text: 'text-[#94a3b8]', dot: 'bg-[#64748b]' }
+    case 'error':
+    case 'critical':
+      return { bg: 'bg-[rgba(239,68,68,0.12)]', text: 'text-[#ef4444]', dot: 'bg-[#ef4444]' }
+    default:
+      return { bg: 'bg-[rgba(138,163,211,0.1)]', text: 'text-[#86a0cf]', dot: 'bg-[#86a0cf]' }
+  }
+}
+
+function KeeperStatusPill({ status }: { status: string }) {
+  const c = statusColor(status)
+  return html`
+    <span class="inline-flex items-center gap-1.5 py-1 px-3 rounded-full text-xs font-medium ${c.bg} ${c.text}">
+      <span class="size-2 rounded-full ${c.dot}"></span>
+      ${status}
+    </span>
+  `
+}
+
+// ── Comms Panel ──────────────────────────────────────────
+
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
-    <div class="mt-5 border-t border-[var(--white-10)] pt-5">
-      <h3 class="m-0 mb-3.5 text-cyan text-[var(--fs-lg)]">Direct Comms</h3>
+    <div class="mt-6 border-t border-[var(--border-slate-12)] pt-6">
+      <h3 class="m-0 mb-4 text-[15px] font-semibold text-[var(--text-strong)]">Direct Comms</h3>
 
-      <div class="flex flex-col gap-3.5">
-        ${'' /* Chat takes full width — the primary interaction surface */}
+      <div class="flex flex-col gap-4">
         <div class="w-full">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
-            placeholder="이 키퍼에게 직접 프롬프트"
+            placeholder="Send a direct prompt to this keeper"
           />
         </div>
 
-        ${'' /* Diagnostics and actions in a collapsible panel below */}
-        <details class="keeper-comms-diagnostics">
-          <summary class="keeper-comms-diagnostics-toggle cursor-pointer py-2.5 px-3.5 text-[var(--fs-sm)] text-text-muted tracking-[0.03em] list-none select-none">런타임 진단 및 액션</summary>
-          <div class="flex flex-col gap-3 px-3.5 pb-3.5">
+        <details class="keeper-comms-diagnostics group">
+          <summary class="keeper-comms-diagnostics-toggle cursor-pointer py-2.5 px-4 text-xs text-[var(--text-muted)] tracking-wider uppercase list-none select-none rounded-lg hover:bg-[var(--white-3)]">Runtime diagnostics</summary>
+          <div class="flex flex-col gap-3 px-4 pb-4 pt-2">
             <${KeeperDiagnosticSummary} keeper=${keeper} />
             <${KeeperRuntimeActions}
               actor=${currentOperatorActor()}
@@ -106,6 +137,19 @@ function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   `
 }
 
+// ── Section Card (detail page variant) ───────────────────
+
+function SectionCard({ title, children }: { title: string; children: preact.ComponentChildren }) {
+  return html`
+    <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-3">${title}</div>
+      ${children}
+    </div>
+  `
+}
+
+// ── Main Detail Overlay ─────────────────────────────────
+
 export function KeeperDetailOverlay() {
   const keeper = selectedKeeper.value
   if (!keeper) return null
@@ -114,142 +158,148 @@ export function KeeperDetailOverlay() {
     <div
       class="keeper-detail-overlay"
       data-testid="keeper-detail-overlay"
-      class="flex items-center justify-center p-5"
       onClick=${(e: Event) => {
         if ((e.target as HTMLElement).classList.contains('keeper-detail-overlay')) {
           closeKeeperDetail()
         }
       }}
     >
-      <div style="max-width:1100px; width:100%; max-height:90vh; overflow-y:auto; background:#1a1a2e; border-radius:16px; border:1px solid rgba(255,255,255,0.08); padding:24px;">
-        ${'' /* Header */}
-        <div class="flex items-center justify-between mb-5">
-          <div class="flex items-center gap-3">
-            <span class="text-[32px]">${keeper.emoji}</span>
-            <div>
-              <h2 class="m-0 text-xl text-[#e0e0e0]">${keeper.name}</h2>
-              ${keeper.koreanName ? html`<div class="text-[13px] text-[var(--text-dim)]">${keeper.koreanName}</div>` : null}
+      <div class="w-full max-w-[1100px] max-h-[90vh] overflow-y-auto bg-[#111a2e] rounded-2xl border border-[var(--card-border)] p-6 shadow-2xl">
+
+        ${'' /* ── Header ── */}
+        <div class="flex items-start justify-between mb-6">
+          <div class="flex items-center gap-3.5">
+            <span class="text-[32px] leading-none">${keeper.emoji}</span>
+            <div class="flex flex-col">
+              <div class="flex items-center gap-2.5">
+                <h2 class="m-0 text-xl font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
+                <${KeeperStatusPill} status=${keeper.status} />
+                ${keeper.model ? html`
+                  <span class="inline-flex items-center py-0.5 px-2.5 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${keeper.model}</span>
+                ` : null}
+              </div>
+              ${keeper.koreanName ? html`<div class="text-[13px] text-[var(--text-muted)] mt-0.5">${keeper.koreanName}</div>` : null}
             </div>
-            <${StatusBadge} status=${keeper.status} />
-            ${keeper.model ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${keeper.model}</span>` : null}
           </div>
           <button
             onClick=${() => closeKeeperDetail()}
-            style="background:none; border:none; color:#888; cursor:pointer; font-size:20px; padding:4px 8px;"
-          >✕</button>
+            class="flex items-center justify-center size-8 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm"
+            aria-label="Close"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="2" y1="2" x2="12" y2="12"/><line x1="12" y1="2" x2="2" y2="12"/></svg>
+          </button>
         </div>
 
-        ${'' /* Pipeline stage indicator */}
+        ${'' /* ── Pipeline stage indicator ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
 
-        ${'' /* KPIs */}
+        ${'' /* ── KPIs ── */}
         <${KpiGrid} keeper=${keeper} />
 
-        ${'' /* Context chart */}
+        ${'' /* ── Context chart ── */}
         <${ContextChart} keeper=${keeper} />
 
-        ${'' /* Direct conversation — placed prominently before detail cards */}
+        ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />
 
-        ${'' /* Two-column grid for sections */}
-        <div class="grid grid-cols-2 gap-4 mt-4">
+        ${'' /* ── Detail sections grid ── */}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
 
-          ${'' /* Left: Field Dictionary */}
-          <${Card} title="필드 사전">
+          <${SectionCard} title="Field Dictionary">
             <${FieldDictionary} keeper=${keeper} />
           <//>
 
-          ${'' /* Right: Traits + Interests */}
-          <${Card} title="프로필">
-            <${TraitsList} traits=${keeper.traits ?? []} label="특성" />
-            <${TraitsList} traits=${keeper.interests ?? []} label="관심사" />
+          <${SectionCard} title="Profile">
+            <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
+            <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
             ${keeper.primaryValue
-              ? html`<div class="text-xs text-[var(--text-dim)]">핵심 가치: <span class="text-[var(--ok)]">${keeper.primaryValue}</span></div>`
+              ? html`<div class="flex items-center gap-2 mt-3 text-xs text-[var(--text-muted)]">
+                  <span class="text-[var(--text-muted)]">Core value:</span>
+                  <span class="font-medium text-[var(--ok)]">${keeper.primaryValue}</span>
+                </div>`
               : null}
             ${keeper.skill_primary
-              ? html`<div class="text-xs text-[var(--text-dim)] mt-1.5">
-                  스킬 경로: <span class="text-[var(--cyan)]">${keeper.skill_primary}</span>
+              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
+                  <span>Skill path:</span>
+                  <span class="font-medium text-[var(--cyan)]">${keeper.skill_primary}</span>
                 </div>`
               : null}
             ${keeper.skill_reason
-              ? html`<div class="text-xs text-[var(--text-dim)] mt-1">${keeper.skill_reason}</div>`
+              ? html`<div class="text-[11px] text-[var(--text-muted)] mt-1 leading-relaxed">${keeper.skill_reason}</div>`
               : null}
             ${keeper.last_heartbeat
-              ? html`<div class="text-xs text-[var(--text-dim)] mt-1.5">
-                  마지막 하트비트: <${TimeAgo} timestamp=${keeper.last_heartbeat} />
+              ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
+                  <span>Last heartbeat:</span>
+                  <${TimeAgo} timestamp=${keeper.last_heartbeat} />
                 </div>`
               : null}
           <//>
 
-          ${'' /* Autonomy Level (if available) */}
           ${keeper.autonomy_level
             ? html`
-              <${Card} title="자율성">
+              <${SectionCard} title="Autonomy">
                 <${AutonomyMeter} keeper=${keeper} />
               <//>
             `
             : null}
 
-          ${'' /* TRPG Stats (if available) */}
           ${keeper.trpg_stats
             ? html`
-              <${Card} title="TRPG Stats">
+              <${SectionCard} title="TRPG Stats">
                 <${TrpgStats} stats=${keeper.trpg_stats} />
               <//>
             `
             : null}
 
-          ${'' /* Equipment */}
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`
-              <${Card} title="Equipment (${keeper.inventory.length})">
+              <${SectionCard} title="Equipment (${keeper.inventory.length})">
                 <${EquipmentList} items=${keeper.inventory} />
               <//>
             `
             : null}
 
-          ${'' /* Relationships */}
           ${keeper.relationships && Object.keys(keeper.relationships).length > 0
             ? html`
-              <${Card} title="Relationships (${Object.keys(keeper.relationships).length})">
+              <${SectionCard} title="Relationships (${Object.keys(keeper.relationships).length})">
                 <${RelationshipList} rels=${keeper.relationships} />
               <//>
             `
             : null}
 
-          <${Card} title="런타임 신호">
+          <${SectionCard} title="Runtime Signals">
             <${RuntimeSignals} keeper=${keeper} />
           <//>
 
-          <${Card} title="이웃 관계 및 도구 감사">
+          <${SectionCard} title="Neighborhood & Tool Audit">
             <${KeeperNeighborhood} keeper=${keeper} />
           <//>
 
-          <${Card} title="Config">
+          <${SectionCard} title="Config">
             <${KeeperConfigPanel} keeperName=${keeper.name} />
           <//>
 
-          <${Card} title="메모리 및 컨텍스트">
-            <div class="flex flex-col gap-1.5">
-              <div class="keeper-signal-row rounded-lg">
-                <span>Context source</span>
-                <strong>${keeper.context_source ?? keeper.context?.source ?? '-'}</strong>
+          <${SectionCard} title="Memory & Context">
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+                <span class="text-xs text-[var(--text-muted)]">Context source</span>
+                <span class="text-xs font-medium text-[var(--text-strong)]">${keeper.context_source ?? keeper.context?.source ?? '-'}</span>
               </div>
-              <div class="keeper-signal-row rounded-lg">
-                <span>Context tokens</span>
-                <strong>
+              <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+                <span class="text-xs text-[var(--text-muted)]">Context tokens</span>
+                <span class="text-xs font-medium text-[var(--text-strong)]">
                   ${keeper.context_tokens ?? keeper.context?.context_tokens ?? '-'}
                   /
                   ${keeper.context_max ?? keeper.context?.context_max ?? '-'}
-                </strong>
+                </span>
               </div>
               ${keeper.memory_recent_note
                 ? html`
-                  <div class="keeper-memory-note rounded-lg">
+                  <div class="py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
                     ${keeper.memory_recent_note}
                   </div>
                 `
-                : html`<div class="empty-state">No recent memory note</div>`}
+                : html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No recent memory note</div>`}
             </div>
           <//>
         </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -63,26 +63,26 @@ function quietReasonLabel(reason?: string | null): string {
 function nextActionLabel(path: string): string {
   switch (path) {
     case 'manual_social_sweep':
-      return '소셜 스윕 실행'
+      return 'social sweep'
     case 'probe':
-      return '프로브'
+      return 'probe'
     case 'recover':
-      return '복구'
+      return 'recover'
     default:
-      return '메시지'
+      return 'message'
   }
 }
 
 function continuityStateLabel(state?: KeeperDiagnostic['continuity_state']): string | null {
   switch (state) {
     case 'healthy':
-      return '정상'
+      return 'healthy'
     case 'recovering':
-      return '복구 중'
+      return 'recovering'
     case 'desired_offline':
-      return '의도적 오프라인'
+      return 'desired offline'
     case 'offline':
-      return '오프라인'
+      return 'offline'
     default:
       return null
   }
@@ -107,6 +107,16 @@ function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnosti
   return detail?.diagnostic ?? keeper.diagnostic ?? null
 }
 
+// ── Diagnostic chip ──────────────────────────────────────
+
+function DiagChip({ label }: { label: string }) {
+  return html`
+    <span class="inline-flex items-center py-0.5 px-2 rounded-full text-[10px] font-medium bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.25)]">${label}</span>
+  `
+}
+
+// ── Diagnostic Summary ───────────────────────────────────
+
 export function KeeperDiagnosticSummary({
   keeper,
   showRawStatus = false,
@@ -121,7 +131,7 @@ export function KeeperDiagnosticSummary({
   }, [keeper?.name])
 
   if (!keeper) {
-    return html`<div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">Select a keeper to inspect direct reply state.</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] leading-relaxed py-2">Select a keeper to inspect direct reply state.</div>`
   }
 
   const detail = keeperStatusDetails.value[keeper.name]
@@ -129,35 +139,37 @@ export function KeeperDiagnosticSummary({
   const busy = keeperHydrating.value[keeper.name]
 
   return html`
-    <div class="py-[10px] px-3 rounded-[10px] border border-solid border-[rgba(138,163,211,0.24)] bg-[rgba(5,14,31,0.55)]">
-      <div class="control-inline-meta flex flex-wrap gap-1.5">
+    <div class="py-3 px-4 rounded-xl border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
+      <div class="flex flex-wrap gap-1.5 mb-2">
         ${continuityStateLabel(diagnostic?.continuity_state)
-          ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${continuityStateLabel(diagnostic?.continuity_state)}</span>`
+          ? html`<${DiagChip} label=${continuityStateLabel(diagnostic?.continuity_state)} />`
           : null}
-        <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${diagnostic?.health_state ?? 'unknown'}</span>
-        <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${quietReasonLabel(diagnostic?.quiet_reason)}</span>
-        <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">next ${nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')}</span>
-        ${busy ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">refreshing</span>` : null}
+        <${DiagChip} label=${diagnostic?.health_state ?? 'unknown'} />
+        <${DiagChip} label=${quietReasonLabel(diagnostic?.quiet_reason)} />
+        <${DiagChip} label=${'next: ' + nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')} />
+        ${busy ? html`<${DiagChip} label="refreshing" />` : null}
       </div>
-      <div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">
+      <div class="text-xs text-[var(--text-body)] leading-relaxed">
         ${diagnostic?.continuity_summary
           ?? diagnostic?.summary
           ?? 'Keeper diagnostic summary is not available yet. Probe or open the detail overlay to inspect current runtime state.'}
       </div>
-      <div class="control-status-copy text-[#d5e5fb] text-[length:var(--fs-sm)] leading-[1.5]">
+      <div class="text-xs text-[var(--text-body)] leading-relaxed mt-1">
         Reply: ${diagnostic?.last_reply_status ?? 'unknown'}
-        ${diagnostic?.last_reply_at ? html` · ${formatTime(diagnostic.last_reply_at)}` : null}
-        ${diagnostic?.next_eligible_at_s ? html` · next eligible ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
+        ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}
+        ${diagnostic?.next_eligible_at_s ? html` -- next eligible ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
       ${diagnostic?.last_error
-        ? html`<div class="control-status-copy text-[#ffb4b4] text-[length:var(--fs-sm)] leading-[1.5]">${diagnostic.last_error}</div>`
+        ? html`<div class="text-xs text-[#ffb4b4] leading-relaxed mt-1">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<pre class="mt-2 py-[10px] px-3 rounded-[10px] border border-solid border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[length:var(--fs-sm)] leading-[1.55] whitespace-pre-wrap break-words font-[family:'Fira_Code',monospace] max-h-[240px] overflow-auto">${detail?.rawText ?? 'No keeper status loaded yet.'}</pre>`
+        ? html`<pre class="mt-3 py-3 px-4 rounded-lg border border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[11px] leading-relaxed whitespace-pre-wrap break-words font-mono max-h-[240px] overflow-auto">${detail?.rawText ?? 'No keeper status loaded yet.'}</pre>`
         : null}
     </div>
   `
 }
+
+// ── Conversation Panel ───────────────────────────────────
 
 export function KeeperConversationPanel({
   keeperName,
@@ -180,7 +192,7 @@ export function KeeperConversationPanel({
   }, [showMetadata])
 
   const rawThread = keeperThreads.value[keeperName] ?? []
-  // Filter out system/tool messages — only show user and assistant conversation
+  // Filter out system/tool messages -- only show user and assistant conversation
   const thread = rawThread.filter(
     entry => entry.role === 'user' || entry.role === 'assistant',
   )
@@ -201,19 +213,19 @@ export function KeeperConversationPanel({
   }
 
   return html`
-    <div class="keeper-conversation-shell flex flex-col gap-2.5">
+    <div class="flex flex-col gap-3">
       <div class="flex justify-end">
         <button
           type="button"
-          class="control-btn rounded-lg ghost"
+          class="py-1 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
           onClick=${() => { setShowMetadata(!showMetadata) }}
         >
-          ${showMetadata ? '메타 숨기기' : '메타 표시'}
+          ${showMetadata ? 'Hide metadata' : 'Show metadata'}
         </button>
       </div>
       <${ChatTranscript}
         entries=${thread}
-        emptyText="아직 직접 대화 기록이 없습니다."
+        emptyText="No direct conversation history yet."
         showMetadata=${showMetadata}
       />
       <${ChatComposer}
@@ -226,10 +238,12 @@ export function KeeperConversationPanel({
         onSend=${() => { void submit() }}
         onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
       />
-      ${error ? html`<div class="control-status-copy text-[#ffb4b4] text-[length:var(--fs-sm)] leading-[1.5]">${error}</div>` : null}
+      ${error ? html`<div class="text-xs text-[#ffb4b4] leading-relaxed">${error}</div>` : null}
     </div>
   `
 }
+
+// ── Runtime Actions ──────────────────────────────────────
 
 export function KeeperRuntimeActions({
   actor,
@@ -247,10 +261,16 @@ export function KeeperRuntimeActions({
   const recommended = diagnostic?.next_action_path ?? 'direct_message'
   const canRecover = diagnostic?.recoverable ?? recommended === 'recover'
 
+  const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-medium cursor-pointer transition-colors border'
+  const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`
+  const activeGhostBtn = `${btnBase} border-[rgba(71,184,255,0.4)] bg-[var(--accent-12)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.2)]`
+  const secondaryBtn = `${btnBase} border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)] text-[#fbbf24] hover:bg-[rgba(251,191,36,0.15)]`
+  const activeSecondaryBtn = `${btnBase} border-[rgba(251,191,36,0.5)] bg-[rgba(251,191,36,0.15)] text-[#fbbf24] hover:bg-[rgba(251,191,36,0.2)]`
+
   return html`
-    <div class="control-actions flex flex-wrap gap-1.5">
+    <div class="flex flex-wrap gap-2">
       <button
-        class=${`control-btn ghost ${recommended === 'probe' ? 'is-active' : ''}`}
+        class=${recommended === 'probe' ? activeGhostBtn : ghostBtn}
         onClick=${() => {
           void probeKeeperRuntime(keeper.name, actor).catch(err => {
             const message = err instanceof Error ? err.message : `Failed to probe ${keeper.name}`
@@ -259,10 +279,10 @@ export function KeeperRuntimeActions({
         }}
         disabled=${probing || !actor.trim()}
       >
-        ${probing ? '프로브 중...' : '프로브'}
+        ${probing ? 'Probing...' : 'Probe'}
       </button>
       <button
-        class=${`control-btn secondary ${recommended === 'recover' ? 'is-active' : ''}`}
+        class=${recommended === 'recover' ? activeSecondaryBtn : secondaryBtn}
         onClick=${() => {
           void recoverKeeperRuntime(keeper.name, actor).catch(err => {
             const message = err instanceof Error ? err.message : `Failed to recover ${keeper.name}`
@@ -271,13 +291,13 @@ export function KeeperRuntimeActions({
         }}
         disabled=${recovering || !canRecover || !actor.trim()}
       >
-        ${recovering ? '복구 중...' : '복구'}
+        ${recovering ? 'Recovering...' : 'Recover'}
       </button>
       <button
-        class=${`control-btn ghost ${recommended === 'manual_social_sweep' ? 'is-active' : ''}`}
+        class=${recommended === 'manual_social_sweep' ? activeGhostBtn : ghostBtn}
         onClick=${onSocialSweep}
       >
-        소셜 스윕 실행
+        Social sweep
       </button>
     </div>
   `

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -153,7 +153,7 @@ export function OpsSessionColumn() {
           </div>
           <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${liveSessions.length === 0
-              ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">지금 바로 개입할 live team session이 없습니다.</div>`
+              ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 바로 개입할 live team session이 없습니다.</div>`
               : liveSessions.map(session => renderSessionCard(session))}
           </div>
         </div>
@@ -211,7 +211,7 @@ export function OpsSessionColumn() {
                 </div>
                 <div class="mt-1.5 whitespace-pre-wrap break-words">${item.summary}</div>
               </article>
-            `) : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션의 attention item은 없습니다.</div>`}
+            `) : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션의 attention item은 없습니다.</div>`}
             ${sessionDigest.worker_cards.length > 0 ? sessionDigest.worker_cards.map(card => html`
               <article key=${`${card.actor ?? card.spawn_role ?? 'worker'}:${card.spawn_agent ?? card.runtime_pool ?? 'runtime'}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
@@ -226,7 +226,7 @@ export function OpsSessionColumn() {
             `) : null}
           </div>
         ` : html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">세션을 고르면 세부 요약을 불러옵니다.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">세션을 고르면 세부 요약을 불러옵니다.</div>
         `}
       </section>
 
@@ -287,17 +287,17 @@ export function OpsSessionColumn() {
                 ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.error
-                ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${selectedSession.linked_autoresearch.error}</div>`
+                ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${selectedSession.linked_autoresearch.error}</div>`
                 : null}
             ` : null}
             ${selectedSession.recent_events && selectedSession.recent_events.length > 0 ? html`
               <pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[length:var(--fs-xs)] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(selectedSession.recent_events.slice(-3))}</pre>
             ` : null}
           </div>
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">먼저 세션을 하나 고르세요.</div>`}
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 세션을 하나 고르세요.</div>`}
 
         ${selectedSession && !selectedSessionActionable ? html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
         ` : null}
 
         ${linkedAutoresearch?.loop_id ? html`
@@ -328,7 +328,7 @@ export function OpsSessionColumn() {
             </button>
             <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
           </div>
-          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--white-12)] text-[var(--text-muted)] text-[var(--fs-base)]">${autoresearchError.value}</div>` : null}
+          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${autoresearchError.value}</div>` : null}
         ` : null}
 
         <label class="control-label" for="ops-turn-kind">세션 액션</label>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -80,49 +80,49 @@ export function FullInventoryView({
   const directCallCount = inventory.filter(item => item.direct_call_allowed).length
 
   return html`
-    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--slate-gray-12)]">
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-[18px]">
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="stat-label">전체 도구</span>
+    <div class="sticky top-[var(--header-h)] z-[var(--z-tab-sticky)] bg-[rgba(11,18,32,0.95)] backdrop-blur-[8px] py-3 border-b border-[var(--card-border)]">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="stat-label">활성화됨</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${hiddenCount}</span>
-          <span class="stat-label">숨김</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">숨김</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="stat-label">지원 중단</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">지원 중단</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${directCallCount}</span>
-          <span class="stat-label">직접 호출</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${filtered.length}</span>
-          <span class="stat-label">필터 결과</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
       </div>
 
       <div class="flex flex-wrap gap-2 mb-3.5">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
           <button
-            class=${`control-btn${surfaceFilter.value === key ? ' is-active' : ''}`}
+            class=${`px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
             ${SURFACE_LABELS[key]}
-            <span class="tool-surface-count inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[length:var(--fs-2xs)] font-semibold bg-[rgba(148,163,184,0.18)] text-[color:var(--text-slate)] rounded-full">${surfaceCountForFilter(inventory, key)}</span>
+            <span class="inline-flex items-center justify-center min-w-5 h-[18px] px-[5px] text-[10px] font-semibold bg-[var(--white-8)] text-[var(--text-muted)] rounded-full ml-1">${surfaceCountForFilter(inventory, key)}</span>
           </button>
         `)}
       </div>
 
       <div class="flex flex-wrap gap-2.5 items-center">
         <input
-          class="control-input rounded-lg"
+          class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none max-w-[320px]"
           type="text"
           placeholder="도구, 문서, 권한, 대체 도구 검색..."
           value=${searchQuery.value}
@@ -131,7 +131,7 @@ export function FullInventoryView({
           }}
         />
         <select
-          class="control-select"
+          class="px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none"
           value=${categoryFilter.value}
           onChange=${(e: Event) => {
             categoryFilter.value = (e.target as HTMLSelectElement).value
@@ -140,7 +140,7 @@ export function FullInventoryView({
           <option value="all">전체 카테고리</option>
           ${categories.map(category => html`<option value=${category}>${category}</option>`)}
         </select>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${enabledOnly.value}
@@ -150,7 +150,7 @@ export function FullInventoryView({
           />
           <span>활성화만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${directOnly.value}
@@ -160,7 +160,7 @@ export function FullInventoryView({
           />
           <span>직접 호출만</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showHidden.value}
@@ -170,7 +170,7 @@ export function FullInventoryView({
           />
           <span>숨김 표시</span>
         </label>
-        <label class="inline-flex items-center gap-2 text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)]">
+        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"
             checked=${showDeprecated.value}
@@ -180,13 +180,17 @@ export function FullInventoryView({
           />
           <span>지원 중단 표시</span>
         </label>
-        <button class="control-btn rounded-lg ghost" onClick=${() => { void loadTools() }} disabled=${loading}>
+        <button
+          class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
+          onClick=${() => { void loadTools() }}
+          disabled=${loading}
+        >
           ${loading ? '새로고침 중...' : '새로고침'}
         </button>
       </div>
     </div>
 
-    ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-[length:var(--fs-base)] rounded-lg">${error}</div>` : null}
+    ${error ? html`<div class="px-3 py-2.5 bg-[var(--bad-12)] border border-[var(--bad-30)] text-[#fecaca] text-[13px] rounded-lg mt-2">${error}</div>` : null}
 
     <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-[300px]">
       ${filtered.length > 0

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -6,11 +6,11 @@ import { toolBadge } from './tool-state'
 
 export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
   return html`
-    <article class="flex flex-col gap-2.5 p-4 rounded-2xl bg-[rgba(15,23,42,0.72)] border border-[rgba(148,163,184,0.16)]">
+    <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
         <div>
-          <div class="text-[length:var(--fs-lg)] font-bold text-[color:var(--text-near-white)]">${item.name}</div>
-          <div class="tool-inventory-desc">${item.description}</div>
+          <div class="text-[15px] font-bold text-[var(--text-strong)]">${item.name}</div>
+          <div class="tool-inventory-desc text-[12px] text-[var(--text-muted)] mt-0.5">${item.description}</div>
         </div>
         <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -20,19 +20,19 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
-      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
-        <span>카테고리: <strong class="text-[color:var(--text-slate-light)]">${item.category}</strong></span>
-        <span>모드: <strong class="text-[color:var(--text-slate-light)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
-        <span>직접 호출: <strong class="text-[color:var(--text-slate-light)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
-        <span>권한: <strong class="text-[color:var(--text-slate-light)]">${item.required_permission ?? '없음'}</strong></span>
+      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-2">
+        <span>카테고리: <strong class="text-[var(--text-body)]">${item.category}</strong></span>
+        <span>모드: <strong class="text-[var(--text-body)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
+        <span>직접 호출: <strong class="text-[var(--text-body)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
+        <span>권한: <strong class="text-[var(--text-body)]">${item.required_permission ?? '없음'}</strong></span>
       </div>
       ${item.reason
-        ? html`<div class="tool-inventory-reason">${item.reason}</div>`
+        ? html`<div class="tool-inventory-reason text-[12px] text-[var(--text-muted)] mt-1.5">${item.reason}</div>`
         : null}
-      <div class="flex flex-wrap gap-3 text-[length:var(--fs-sm)] text-[color:var(--text-slate)]">
-        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[color:var(--text-slate-light)]">${item.canonicalName}</strong></span>` : null}
-        ${item.replacement ? html`<span>대체 도구: <strong class="text-[color:var(--text-slate-light)]">${item.replacement}</strong></span>` : null}
-        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[color:var(--text-slate-light)]">${item.doc_refs.join(', ')}</strong></span>` : null}
+      <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-1.5">
+        ${item.canonicalName ? html`<span>정식 이름: <strong class="text-[var(--text-body)]">${item.canonicalName}</strong></span>` : null}
+        ${item.replacement ? html`<span>대체 도구: <strong class="text-[var(--text-body)]">${item.replacement}</strong></span>` : null}
+        ${item.doc_refs.length > 0 ? html`<span>문서: <strong class="text-[var(--text-body)]">${item.doc_refs.join(', ')}</strong></span>` : null}
       </div>
     </article>
   `

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -70,26 +70,13 @@ export function toolMatchesQuery(item: DashboardToolInventoryItem, rawQuery: str
 }
 
 export function toolBadge(label: string, tone: 'default' | 'ok' | 'warn' | 'surface' = 'default') {
-  const color =
-    tone === 'ok' ? '#7dd3fc'
-      : tone === 'warn' ? '#fbbf24'
-      : tone === 'surface' ? '#c4b5fd'
-      : '#cbd5e1'
-  const background =
-    tone === 'ok' ? 'rgba(14, 165, 233, 0.18)'
-      : tone === 'warn' ? 'rgba(245, 158, 11, 0.18)'
-      : tone === 'surface' ? 'rgba(139, 92, 246, 0.18)'
-      : 'rgba(148, 163, 184, 0.16)'
+  const toneClass =
+    tone === 'ok' ? 'text-[#7dd3fc] bg-[rgba(14,165,233,0.18)]'
+      : tone === 'warn' ? 'text-[var(--warn)] bg-[var(--warn-12)]'
+      : tone === 'surface' ? 'text-[#c4b5fd] bg-[rgba(139,92,246,0.18)]'
+      : 'text-[var(--text-muted)] bg-[var(--white-8)]'
   return html`
-    <span
-      style=${{
-        fontSize: '11px',
-        color,
-        background,
-        borderRadius: '999px',
-        padding: '2px 8px',
-      }}
-    >
+    <span class="text-[11px] rounded-full px-2 py-0.5 ${toneClass}">
       ${label}
     </span>
   `

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -20,29 +20,29 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
   return html`
     <div class="py-2">
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-[18px]">
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${totalCount}</span>
-          <span class="stat-label">전체 도구</span>
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3 my-4">
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${totalCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="stat-label">활성화됨</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
         </div>
-        <div class="flex flex-col gap-1.5 px-4 py-3.5 rounded-[14px] bg-[rgba(15,23,42,0.8)] border border-[rgba(148,163,184,0.16)]">
-          <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
-          <span class="stat-label">폐기 예정</span>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">폐기 예정</span>
         </div>
       </div>
 
       ${essential.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">필수 도구 (상위 ${essential.length}개)</h4>
-          <div class="flex flex-col gap-1.5">
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">필수 도구 (상위 ${essential.length}개)</h4>
+          <div class="flex flex-col">
             ${essential.map(item => html`
-              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
-                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
-                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+                <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
               </div>
             `)}
@@ -52,12 +52,12 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
 
       ${neverUsed.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-[length:var(--fs-base)] font-semibold text-[color:var(--white-60)] mb-2.5 mt-0 uppercase tracking-[0.3px]">미사용 도구 (${neverUsed.length}개)</h4>
-          <div class="flex flex-col gap-1.5">
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">미사용 도구 (${neverUsed.length}개)</h4>
+          <div class="flex flex-col">
             ${neverUsed.map(item => html`
-              <div class="flex items-center gap-2.5 px-3 py-2 bg-[var(--panel-dark-60)] border border-[var(--slate-gray-8)] rounded-lg" key=${item.name}>
-                <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-slate-light)] min-w-[180px] shrink-0">${item.name}</span>
-                <span class="text-[length:var(--fs-sm)] text-[color:var(--white-40)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
+              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+                <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
+                <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${toolBadge(item.category)}
               </div>
             `)}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -31,15 +31,14 @@ export function Tools() {
     <div>
       <${Card} title="시스템 도구 목록" class="section mb-3.5">
         <div class="mb-3.5">
-          <h2 class="monitor-headline">시스템 도구 목록</h2>
-          <p class="monitor-subheadline">
+          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">시스템 도구 목록</h2>
+          <p class="text-[12px] text-[var(--text-muted)] leading-relaxed">
             ${showFullInventory.value
               ? 'hidden/deprecated 포함 전체 도구 surface를 봅니다.'
               : '필수 도구와 사용 현황 요약입니다.'}
           </p>
           <button
-            class="control-btn rounded-lg ghost"
-            class="mt-2"
+            class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)] mt-2"
             onClick=${() => { showFullInventory.value = !showFullInventory.value }}
           >
             ${showFullInventory.value ? '요약 보기' : '전체 인벤토리 보기'}
@@ -59,7 +58,7 @@ export function Tools() {
       <${Card} title="도구 사용 현황" class="section mb-3.5">
         ${usage
           ? html`
-              <div class="tool-inventory-usage-hint">
+              <div class="text-[12px] text-[var(--text-muted)] mb-2">
                 등록됨 ${usage.registered_count} · 사용된 ${usage.distinct_tools_called} · 미사용 ${usage.never_called_count}
               </div>
             `
@@ -67,7 +66,7 @@ export function Tools() {
         <${ToolMetrics} />
       <//>
       ${data?.generated_at
-        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[length:var(--fs-sm)]">
+        ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-2.5 text-[var(--text-muted)] text-[12px]">
             <span>생성 시각: ${data.generated_at}</span>
             <span>metrics 기준: 최근 1시간</span>
           </div>`


### PR DESCRIPTION
## Summary

키퍼 상세 페이지 완전 재설계:
- 상태 pill (green=active, gray=offline)
- 4열 KPI 그리드
- 채팅 버블 (user/keeper 구분)
- 필드 사전 (교차 행 배경 + 검색)
- 런타임 진단 SignalRow 컴포넌트
- 모든 orphan CSS class → Tailwind

## Test plan
- [x] `npm run build` 성공

Generated with [Claude Code](https://claude.com/claude-code)