### PR TITLE
fix(dashboard): add missing live timeline filter chip styles

### DIFF
--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -17,17 +17,55 @@
 .agent-runtime-ctx-fill.bad { background: var(--bad-light); }
 
 /* ── Live Timeline ─────────────────────────────────────────── */
+.agent-live-filter-bar {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .agent-live-chip {
+  padding: 3px 10px;
+  font-size: var(--fs-xs);
+  border: 1px solid var(--white-10);
+  background: var(--white-4);
+  color: var(--text-dim);
+  cursor: pointer;
   transition: all 0.15s;
 }
 
 .agent-live-chip:hover {
   border-color: rgba(200, 168, 78, 0.6);
-  color: var(--text-body, var(--text-body));
+  background: var(--white-8);
+  color: var(--text-body);
+}
+
+.agent-live-chip--active {
+  border-color: rgba(200, 168, 78, 0.5);
+  background: rgba(200, 168, 78, 0.12);
+  color: var(--ff-gold-bright, #e8d48b);
 }
 
 .agent-live-autoscroll {
+  padding: 2px 8px;
+  font-size: var(--fs-2xs);
+  border: 1px solid var(--white-10);
+  background: var(--white-4);
+  color: var(--text-dim);
+  cursor: pointer;
   transition: all 0.15s;
+}
+
+.agent-live-autoscroll--on {
+  border-color: rgba(34, 197, 94, 0.4);
+  color: var(--ok);
+}
+
+.agent-event-rate {
+  padding: 2px 8px;
+  font-size: var(--fs-2xs);
+  background: var(--white-4);
+  border: 1px solid var(--white-8);
+  color: var(--text-muted);
 }
 
 /* Event kind badge variants */

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -2203,19 +2203,7 @@ button.monitor-row {
 .agent-runtime-ctx-fill.warn { background: var(--warn); }
 .agent-runtime-ctx-fill.bad { background: var(--bad-light); }
 
-/* ── Live Timeline ─────────────────────────────────────────── */
-.agent-live-chip {
-  transition: all 0.15s;
-}
-
-.agent-live-chip:hover {
-  border-color: rgba(200, 168, 78, 0.6);
-  color: var(--text-body, var(--text-body));
-}
-
-.agent-live-autoscroll {
-  transition: all 0.15s;
-}
+/* ── Live Timeline — see agent-monitor.css ─────────────────── */
 
 /* Event kind badge variants */
 .agent-event-badge--heartbeat { background: var(--ok-12); color: var(--ok); }


### PR DESCRIPTION
## Summary
- 에이전트 프로필 실시간 탭의 필터 버튼(All/Heartbeat/Turn/Tool/Error/Lifecycle)에 CSS 정의가 없어서 스타일 없이 텍스트가 붙어 렌더링되던 문제 수정
- `agent-live-filter-bar`: flex + gap 6px
- `agent-live-chip`: padding, border, background, hover/active 상태
- `agent-event-rate`, `agent-live-autoscroll`: 기본 스타일
- global.css의 중복 stub 제거 → agent-monitor.css로 통합

## Before
`AllHeartbeatTurnToolErrorLifecycle` (스타일 없이 연속 텍스트)

## After
`[All] [Heartbeat] [Turn] [Tool] [Error] [Lifecycle]` (구분된 칩 버튼)

## Test plan
- [ ] Vite build 통과
- [ ] 에이전트 프로필 → 실시간 탭 → 필터 칩 개별 렌더링 확인
- [ ] 칩 hover/active 상태 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)