### PR TITLE
feat(governance): link audit trail to pending_confirm via trace_id

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -32,6 +32,7 @@ type action =
   | CircuitOpen
   | CircuitClose
   | SearchRefinement
+  | GovernanceDecision of string
   | Custom of string
 
 type audit_entry = {
@@ -43,6 +44,7 @@ type audit_entry = {
   outcome: outcome;
   cost_estimate: float option;
   token_count: int option;
+  trace_id: string option;
 }
 
 (** {1 Serialization} *)
@@ -61,6 +63,7 @@ let action_to_string = function
   | CircuitOpen -> "circuit_open"
   | CircuitClose -> "circuit_close"
   | SearchRefinement -> "search_refinement"
+  | GovernanceDecision decision -> "governance_decision:" ^ decision
   | Custom name -> "custom:" ^ name
 
 let string_to_action = function
@@ -78,6 +81,8 @@ let string_to_action = function
   | "search_refinement" -> SearchRefinement
   | s when String.length s > 10 && String.sub s 0 10 = "tool_call:" ->
       ToolCall (String.sub s 10 (String.length s - 10))
+  | s when String.length s > 20 && String.sub s 0 20 = "governance_decision:" ->
+      GovernanceDecision (String.sub s 20 (String.length s - 20))
   | s when String.length s > 7 && String.sub s 0 7 = "custom:" ->
       Custom (String.sub s 7 (String.length s - 7))
   | s -> Custom s
@@ -106,7 +111,11 @@ let entry_to_json (e : audit_entry) : Yojson.Safe.t =
     | Some t -> with_cost @ [("token_count", `Int t)]
     | None -> with_cost
   in
-  `Assoc with_tokens
+  let with_trace = match e.trace_id with
+    | Some tid -> with_tokens @ [("trace_id", `String tid)]
+    | None -> with_tokens
+  in
+  `Assoc with_trace
 
 (** Parse a JSON object back into an audit_entry *)
 let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
@@ -143,7 +152,11 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
         | _ -> None
       with Yojson.Safe.Util.Type_error _ -> None
     in
-    Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count }
+    let trace_id =
+      try json |> U.member "trace_id" |> U.to_string_option
+      with Yojson.Safe.Util.Type_error _ -> None
+    in
+    Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "audit_log: entry parse failed: %s" (Printexc.to_string exn);
     None
@@ -202,6 +215,7 @@ let log_action
     ?(details : Yojson.Safe.t = `Null)
     ?(cost_estimate : float option)
     ?(token_count : int option)
+    ?(trace_id : string option)
     ~outcome
     () =
   let entry = {
@@ -213,6 +227,7 @@ let log_action
     outcome;
     cost_estimate;
     token_count;
+    trace_id;
   } in
   append_entry config entry
 
@@ -278,6 +293,16 @@ let log_circuit_breaker config ~agent_id ~opened ~reason ?cost_estimate ?token_c
   log_action config ~agent_id ~action
     ~details:(`Assoc [("reason", `String reason)])
     ?cost_estimate ?token_count ~outcome:Success ()
+
+let log_governance_decision config ~agent_id ~trace_id ~decision ~action_type ~confirmation_state () =
+  log_action config ~agent_id
+    ~action:(GovernanceDecision decision)
+    ~trace_id
+    ~details:(`Assoc [
+      ("action_type", `String action_type);
+      ("confirmation_state", `String confirmation_state);
+    ])
+    ~outcome:Success ()
 
 (** {1 Pruning (replaces rotation)} *)
 

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -626,6 +626,10 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               latency_ms = 0;
               created_at = Types.now_iso ();
             };
+          Audit_log.log_governance_decision ctx.config
+            ~agent_id:actor ~trace_id:entry.trace_id
+            ~decision:"expired" ~action_type:entry.action_type
+            ~confirmation_state:"expired" ();
           Error "pending confirmation expired"
       | Some entry when not (String.equal actor entry.actor) ->
           append_action_log ctx.config
@@ -643,6 +647,10 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               latency_ms = 0;
               created_at = Types.now_iso ();
             };
+          Audit_log.log_governance_decision ctx.config
+            ~agent_id:actor ~trace_id:entry.trace_id
+            ~decision:"unauthorized" ~action_type:entry.action_type
+            ~confirmation_state:"denied" ();
           Error "actor is not allowed to confirm this action"
       | Some entry ->
           if String.equal decision "deny" then (
@@ -662,6 +670,10 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 latency_ms = 0;
                 created_at = Types.now_iso ();
               };
+            Audit_log.log_governance_decision ctx.config
+              ~agent_id:actor ~trace_id:entry.trace_id
+              ~decision:"deny" ~action_type:entry.action_type
+              ~confirmation_state:"denied" ();
             Ok
               (json_ok
                  [
@@ -698,6 +710,10 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 latency_ms;
                 created_at = Types.now_iso ();
               };
+            Audit_log.log_governance_decision ctx.config
+              ~agent_id:entry.actor ~trace_id:entry.trace_id
+              ~decision:"confirm" ~action_type:entry.action_type
+              ~confirmation_state:"confirmed" ();
             Ok
               (json_ok
                  [

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -308,12 +308,55 @@ let handle_governance_report ctx args =
   let json = report_to_json report in
   (true, Yojson.Safe.pretty_to_string json)
 
+(* Handle masc_audit_trail — query audit entries linked by trace_id *)
+let handle_audit_trail ctx args =
+  let trace_id = get_string_opt args "trace_id" in
+  let agent_filter = get_string_opt args "agent_id" in
+  let action_type_filter = get_string_opt args "action_type" in
+  let since_hours = get_float args "since_hours" 168.0 in
+  let limit = get_int args "limit" 100 in
+  let since_ts = Time_compat.now () -. (since_hours *. 3600.0) in
+  let entries = Audit_log.read_entries ctx.config in
+  let filtered =
+    entries
+    |> List.filter (fun (e : Audit_log.audit_entry) -> e.timestamp >= since_ts)
+    |> List.filter (fun (e : Audit_log.audit_entry) ->
+        match trace_id with
+        | Some tid -> e.trace_id = Some tid
+        | None -> true)
+    |> List.filter (fun (e : Audit_log.audit_entry) ->
+        match agent_filter with
+        | Some a -> String.equal e.agent_id a
+        | None -> true)
+    |> List.filter (fun (e : Audit_log.audit_entry) ->
+        match action_type_filter with
+        | Some at -> String.equal (Audit_log.action_to_string e.action) at
+        | None -> true)
+    |> List.sort (fun (a : Audit_log.audit_entry) (b : Audit_log.audit_entry) ->
+        Float.compare b.timestamp a.timestamp)
+  in
+  let limited =
+    let rec take n xs = match xs with
+      | [] -> []
+      | _ when n <= 0 -> []
+      | x :: rest -> x :: take (n - 1) rest
+    in
+    take limit filtered
+  in
+  let json = `Assoc [
+    ("count", `Int (List.length limited));
+    ("trace_id_filter", match trace_id with Some t -> `String t | None -> `Null);
+    ("entries", `List (List.map Audit_log.entry_to_json limited));
+  ] in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (* Dispatch handler *)
 let dispatch ctx ~name ~args =
   match name with
   | "masc_audit_query" -> Some (handle_audit_query ctx args)
   | "masc_audit_stats" -> Some (handle_audit_stats ctx args)
   | "masc_governance_report" -> Some (handle_governance_report ctx args)
+  | "masc_audit_trail" -> Some (handle_audit_trail ctx args)
   | _ -> None
 
 let schemas : Types.tool_schema list = [
@@ -395,6 +438,41 @@ Pair with masc_governance_set to configure audit policies, or masc_governance_st
         ("until", `Assoc [
           ("type", `String "string");
           ("description", `String "End of period as Unix timestamp string (optional, defaults to now)");
+        ]);
+      ]);
+    ];
+  };
+
+  (* masc_audit_trail *)
+  {
+    name = "masc_audit_trail";
+    description = "Query the audit trail by trace_id to follow a governance decision chain from pending_confirm through approval or rejection. \
+Use when investigating why a specific action was approved, denied, or expired. \
+Pair with masc_operator_confirm to see the original pending_confirm, or masc_governance_report for aggregate views.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("trace_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Trace ID linking a governance decision chain. Returns all audit entries sharing this trace_id.");
+        ]);
+        ("agent_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Filter by agent who performed the action (optional).");
+        ]);
+        ("action_type", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Filter by action type string, e.g. governance_decision:confirm (optional).");
+        ]);
+        ("since_hours", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Only show entries from last N hours (default: 168, i.e. 7 days).");
+          ("default", `Float 168.0);
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum entries to return (default: 100).");
+          ("default", `Int 100);
         ]);
       ]);
     ];

--- a/lib/tool_audit.mli
+++ b/lib/tool_audit.mli
@@ -49,6 +49,9 @@ val handle_audit_query : context -> Yojson.Safe.t -> bool * string
 (** Handle masc_audit_stats *)
 val handle_audit_stats : context -> Yojson.Safe.t -> bool * string
 
+(** Handle masc_audit_trail — query linked audit entries by trace_id *)
+val handle_audit_trail : context -> Yojson.Safe.t -> bool * string
+
 (** Generate governance summary from audit trail entries *)
 val governance_summary : ?since:string -> ?until_time:string -> Audit_log.audit_entry list -> governance_report
 

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -137,6 +137,7 @@ let register_all () =
   (* ── Mod_audit: Tool_audit ────────────────────────────────────── *)
   reg Mod_audit [
     "masc_audit_query"; "masc_audit_stats"; "masc_governance_report";
+    "masc_audit_trail";
   ];
 
   (* Mod_cost and Mod_rate_limit: fully covered by schemas — no entries needed *)

--- a/test/test_tool_audit_coverage.ml
+++ b/test/test_tool_audit_coverage.ml
@@ -196,6 +196,112 @@ let test_get_float_missing () =
     (Tool_args.get_float args "key" 1.5)
 
 (* ============================================================
+   Audit trail (trace_id linking) tests
+   ============================================================ *)
+
+module Audit_log = Masc_mcp.Audit_log
+
+let test_audit_entry_trace_id_in_json () =
+  let entry : Audit_log.audit_entry = {
+    timestamp = 1000000.0;
+    agent_id = "operator";
+    action = Audit_log.GovernanceDecision "confirm";
+    room_id = None;
+    details = `Assoc [("action_type", `String "room_pause")];
+    outcome = Audit_log.Success;
+    cost_estimate = None;
+    token_count = None;
+    trace_id = Some "ops_abc123";
+  } in
+  let json = Audit_log.entry_to_json entry in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "trace_id present" "ops_abc123"
+    (json |> member "trace_id" |> to_string);
+  Alcotest.(check string) "action contains decision"
+    "governance_decision:confirm"
+    (json |> member "action" |> to_string)
+
+let test_audit_entry_no_trace_id () =
+  let entry : Audit_log.audit_entry = {
+    timestamp = 1000000.0;
+    agent_id = "test";
+    action = Audit_log.Join;
+    room_id = None;
+    details = `Null;
+    outcome = Audit_log.Success;
+    cost_estimate = None;
+    token_count = None;
+    trace_id = None;
+  } in
+  let json = Audit_log.entry_to_json entry in
+  let keys = match json with `Assoc pairs -> List.map fst pairs | _ -> [] in
+  Alcotest.(check bool) "trace_id absent from JSON" false
+    (List.mem "trace_id" keys)
+
+let test_entry_of_json_with_trace_id () =
+  let json = `Assoc [
+    ("timestamp", `Float 1000000.0);
+    ("agent_id", `String "operator");
+    ("action", `String "governance_decision:deny");
+    ("room_id", `Null);
+    ("details", `Null);
+    ("outcome", `Assoc [("status", `String "success")]);
+    ("trace_id", `String "ops_xyz789");
+  ] in
+  match Audit_log.entry_of_json json with
+  | Some entry ->
+    Alcotest.(check (option string)) "trace_id parsed" (Some "ops_xyz789") entry.trace_id;
+    (match entry.action with
+     | Audit_log.GovernanceDecision "deny" -> ()
+     | _ -> Alcotest.fail "expected GovernanceDecision deny")
+  | None -> Alcotest.fail "entry_of_json returned None"
+
+let test_entry_of_json_without_trace_id () =
+  let json = `Assoc [
+    ("timestamp", `Float 1000000.0);
+    ("agent_id", `String "test");
+    ("action", `String "join");
+    ("room_id", `Null);
+    ("details", `Null);
+    ("outcome", `Assoc [("status", `String "success")]);
+  ] in
+  match Audit_log.entry_of_json json with
+  | Some entry ->
+    Alcotest.(check (option string)) "trace_id is None" None entry.trace_id
+  | None -> Alcotest.fail "entry_of_json returned None"
+
+let test_governance_decision_roundtrip () =
+  let action = Audit_log.GovernanceDecision "expired" in
+  let s = Audit_log.action_to_string action in
+  Alcotest.(check string) "serialized" "governance_decision:expired" s;
+  let parsed = Audit_log.string_to_action s in
+  match parsed with
+  | Audit_log.GovernanceDecision "expired" -> ()
+  | _ -> Alcotest.fail "roundtrip mismatch"
+
+let test_dispatch_audit_trail () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_audit.dispatch ctx ~name:"masc_audit_trail" ~args:(`Assoc []) in
+  Alcotest.(check bool) "audit_trail dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+let test_handle_audit_trail_with_trace_id () =
+  let ctx, base_dir = make_ctx () in
+  let args = `Assoc [
+    ("trace_id", `String "ops_test_12345678");
+    ("since_hours", `Float 720.0);
+  ] in
+  let (ok, msg) = Tool_audit.handle_audit_trail ctx args in
+  Alcotest.(check bool) "succeeds" true ok;
+  let json = Yojson.Safe.from_string msg in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "trace_id_filter echoed" "ops_test_12345678"
+    (json |> member "trace_id_filter" |> to_string);
+  Alcotest.(check int) "count is 0 for empty log" 0
+    (json |> member "count" |> to_int);
+  cleanup_dir base_dir
+
+(* ============================================================
    Test runner
    ============================================================ *)
 
@@ -231,5 +337,14 @@ let () =
       Alcotest.test_case "get_float present" `Quick test_get_float_present;
       Alcotest.test_case "get_float from int" `Quick test_get_float_from_int;
       Alcotest.test_case "get_float missing" `Quick test_get_float_missing;
+    ]);
+    ("audit_trail_trace_id", [
+      Alcotest.test_case "entry includes trace_id in JSON" `Quick test_audit_entry_trace_id_in_json;
+      Alcotest.test_case "entry omits trace_id when None" `Quick test_audit_entry_no_trace_id;
+      Alcotest.test_case "entry_of_json parses trace_id" `Quick test_entry_of_json_with_trace_id;
+      Alcotest.test_case "entry_of_json handles missing trace_id" `Quick test_entry_of_json_without_trace_id;
+      Alcotest.test_case "governance_decision action roundtrip" `Quick test_governance_decision_roundtrip;
+      Alcotest.test_case "audit_trail dispatches" `Quick test_dispatch_audit_trail;
+      Alcotest.test_case "audit_trail with trace_id filter" `Quick test_handle_audit_trail_with_trace_id;
     ]);
   ]


### PR DESCRIPTION
## Summary
- Add `trace_id` field to `audit_entry` type and `GovernanceDecision` action variant in `Audit_log`
- Emit linked audit entries when `pending_confirm` is resolved (confirmed, denied, expired, unauthorized)
- Add `masc_audit_trail` query tool for following governance decision chains by trace_id
- 7 new tests covering serialization roundtrip, JSON field presence, and query filtering

## Motivation
Governance decisions (pending_confirm) and the audit log were two separate systems with no linking. When investigating why an action was approved or denied, operators had to manually correlate entries by timestamp. This change links them via `trace_id` for traceable chains.

## Files changed (6)
- `lib/audit_log.ml` — trace_id field, GovernanceDecision variant, log_governance_decision
- `lib/operator/operator_control.ml` — emit audit entries on confirm_json outcomes
- `lib/tool_audit.ml` + `.mli` — masc_audit_trail handler and schema
- `lib/tool_tag_init.ml` — register masc_audit_trail tag
- `test/test_tool_audit_coverage.ml` — 7 new tests

## Test plan
- [x] `dune build --root .` passes
- [x] `test_tool_audit_coverage.exe` — 26/26 pass (7 new)
- [x] `test_dispatch_chain_evidence.exe` — passes
- [x] Pre-existing operator_control test failures confirmed identical on main (not introduced by this PR)

:robot: Generated with [Claude Code](https://claude.com/claude-code)