### PR TITLE
refactor(dashboard): convert agent-monitor custom CSS to Tailwind

### DIFF
--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -125,13 +125,15 @@ export function AgentLiveTimeline({ name }: { name: string }) {
   }, [filtered.length])
 
   return html`
-    <div class="agent-live-timeline">
+    <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2 flex-wrap">
-        <div class="agent-live-filter-bar">
+        <div class="flex gap-1.5 flex-wrap">
           ${FILTER_CHIPS.map(chip => html`
             <button
               key=${chip.key}
-              class="agent-live-chip rounded-xl ${activeFilter.value === chip.key ? 'agent-live-chip--active' : ''}"
+              class="px-2.5 py-1 text-[length:var(--fs-xs)] rounded-xl border cursor-pointer transition-all duration-150 ${activeFilter.value === chip.key
+                ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
+                : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'}"
               onClick=${() => { activeFilter.value = chip.key }}
             >
               ${chip.label}
@@ -139,10 +141,12 @@ export function AgentLiveTimeline({ name }: { name: string }) {
           `)}
         </div>
         <div class="flex items-center gap-2 text-[length:var(--fs-xs)]">
-          <span class="agent-event-rate rounded-lg">${eventsPerMin}/min</span>
-          <span class="text-text-muted">${filtered.length} events</span>
+          <span class="px-2 py-0.5 rounded-lg bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)] text-[length:var(--fs-2xs)]">${eventsPerMin}/min</span>
+          <span class="text-[var(--text-muted)]">${filtered.length} events</span>
           <button
-            class="agent-live-autoscroll rounded-lg ${autoScroll.value ? 'agent-live-autoscroll--on' : ''}"
+            class="px-2 py-0.5 rounded-lg text-[length:var(--fs-2xs)] border cursor-pointer transition-all duration-150 ${autoScroll.value
+              ? 'border-[rgba(34,197,94,0.4)] text-[var(--ok)] bg-[var(--white-4)]'
+              : 'border-[var(--white-10)] text-[var(--text-dim)] bg-[var(--white-4)]'}"
             onClick=${() => { autoScroll.value = !autoScroll.value }}
             title=${autoScroll.value ? 'Auto-scroll ON' : 'Auto-scroll OFF'}
           >
@@ -159,9 +163,9 @@ export function AgentLiveTimeline({ name }: { name: string }) {
                 <span class="agent-event-badge ${eventKindBadgeClass(entry.eventType)}">
                   ${eventKindLabel(entry.eventType)}
                 </span>
-                <span class="agent-live-event-text">${compactText(entry.text)}</span>
+                <span class="flex-1 text-[#c8daf7] truncate">${compactText(entry.text)}</span>
                 ${entry.timestamp ? html`
-                  <span class="agent-live-event-time"><${TimeAgo} timestamp=${entry.timestamp} /></span>
+                  <span class="text-[var(--text-dim)] text-[length:var(--fs-xs)] whitespace-nowrap"><${TimeAgo} timestamp=${entry.timestamp} /></span>
                 ` : null}
               </div>
             `)}

--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -44,35 +44,35 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
 
       ${ctxPct != null ? html`
         <div class="flex items-center gap-1.5 text-[length:var(--fs-sm)]">
-          <span class="agent-runtime-label">CTX</span>
-          <div class="agent-runtime-ctx-bar rounded-full">
+          <span class="text-[length:var(--fs-2xs)] text-[var(--text-muted)] uppercase tracking-wider">CTX</span>
+          <div class="w-16 h-1.5 bg-[#1a1a2e] rounded-full overflow-hidden">
             <div
               class="agent-runtime-ctx-fill rounded-full ${ctxBarClass(ctxRatio)}"
               style=${{ width: `${ctxPct}%` }}
             ></div>
           </div>
-          <span class="agent-runtime-value">${ctxPct}%</span>
+          <span class="text-[length:var(--fs-sm)] text-[var(--text-body)] tabular-nums">${ctxPct}%</span>
         </div>
       ` : null}
 
       ${generation != null ? html`
         <div class="flex items-center gap-1.5 text-[length:var(--fs-sm)]">
-          <span class="agent-runtime-label">GEN</span>
-          <span class="agent-runtime-value">${generation}</span>
+          <span class="text-[length:var(--fs-2xs)] text-[var(--text-muted)] uppercase tracking-wider">GEN</span>
+          <span class="text-[length:var(--fs-sm)] text-[var(--text-body)] tabular-nums">${generation}</span>
         </div>
       ` : null}
 
       ${model ? html`
         <div class="flex items-center gap-1.5 text-[length:var(--fs-sm)]">
-          <span class="agent-runtime-label">MODEL</span>
-          <span class="agent-runtime-value agent-runtime-model">${model}</span>
+          <span class="text-[length:var(--fs-2xs)] text-[var(--text-muted)] uppercase tracking-wider">MODEL</span>
+          <span class="text-[length:var(--fs-sm)] text-[var(--text-body)] font-mono truncate max-w-[200px]">${model}</span>
         </div>
       ` : null}
 
       ${lastTurnAge != null ? html`
         <div class="flex items-center gap-1.5 text-[length:var(--fs-sm)]">
-          <span class="agent-runtime-label">TURN</span>
-          <span class="agent-runtime-value">${formatDuration(lastTurnAge)} ago</span>
+          <span class="text-[length:var(--fs-2xs)] text-[var(--text-muted)] uppercase tracking-wider">TURN</span>
+          <span class="text-[length:var(--fs-sm)] text-[var(--text-body)] tabular-nums">${formatDuration(lastTurnAge)} ago</span>
         </div>
       ` : null}
     </div>

--- a/dashboard/src/styles/agent-monitor.css
+++ b/dashboard/src/styles/agent-monitor.css
@@ -16,57 +16,7 @@
 .agent-runtime-ctx-fill.warn { background: var(--warn); }
 .agent-runtime-ctx-fill.bad { background: var(--bad-light); }
 
-/* ── Live Timeline ─────────────────────────────────────────── */
-.agent-live-filter-bar {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.agent-live-chip {
-  padding: 3px 10px;
-  font-size: var(--fs-xs);
-  border: 1px solid var(--white-10);
-  background: var(--white-4);
-  color: var(--text-dim);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.agent-live-chip:hover {
-  border-color: rgba(200, 168, 78, 0.6);
-  background: var(--white-8);
-  color: var(--text-body);
-}
-
-.agent-live-chip--active {
-  border-color: rgba(200, 168, 78, 0.5);
-  background: rgba(200, 168, 78, 0.12);
-  color: var(--ff-gold-bright, #e8d48b);
-}
-
-.agent-live-autoscroll {
-  padding: 2px 8px;
-  font-size: var(--fs-2xs);
-  border: 1px solid var(--white-10);
-  background: var(--white-4);
-  color: var(--text-dim);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.agent-live-autoscroll--on {
-  border-color: rgba(34, 197, 94, 0.4);
-  color: var(--ok);
-}
-
-.agent-event-rate {
-  padding: 2px 8px;
-  font-size: var(--fs-2xs);
-  background: var(--white-4);
-  border: 1px solid var(--white-8);
-  color: var(--text-muted);
-}
+/* ── Live Timeline — all styles inlined as Tailwind utilities ── */
 
 /* Event kind badge variants */
 .agent-event-badge--heartbeat { background: var(--ok-12); color: var(--ok); }


### PR DESCRIPTION
## Summary
agent-monitor 컴포넌트의 orphan 커스텀 CSS class를 전부 Tailwind utility로 교체.

**Tailwind-only 원칙**: 커스텀 CSS class를 만들면 스타일 규칙을 빠뜨리는 실수가 반복됨. Tailwind inline이면 구조적으로 불가능.

## Changes
| Component | Before (custom CSS) | After (Tailwind) |
|-----------|-------------------|------------------|
| live-timeline.ts | agent-live-timeline, filter-bar, chip, event-text/time | flex/gap/px/py/text inline |
| runtime-strip.ts | agent-runtime-label/value/model/ctx-bar | text utilities inline |
| agent-monitor.css | 52 lines removed | 1 comment line |
| global.css | stubs removed (#2373) | pointer to agent-monitor.css |

## Test plan
- [ ] Vite build 통과
- [ ] 에이전트 프로필 → 필터 칩 분리 렌더링
- [ ] Runtime strip 라벨(CTX/GEN/MODEL/TURN) 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)