### PR TITLE
feat(keeper): unlock L3 tools — shell_readonly, code nav, github

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -47,10 +47,18 @@ let allowed_tools_for_autonomy_level
     "extend_turns";
     "keeper_voice_speak"; "keeper_voice_agent";
   ] in
+  (* L3 adds read-only shell + code navigation — keepers can inspect
+     the codebase, run tests, and search without modifying files. *)
+  let l3_tools = [
+    "keeper_shell_readonly";
+    "keeper_code_read"; "keeper_code_search"; "keeper_code_symbols";
+    "keeper_github";
+  ] in
   match String.lowercase_ascii (String.trim level) with
-  | "l4_autonomous" -> Some ("keeper_bash" :: base_safe)
+  | "l3_guided" -> Some (l3_tools @ base_safe)
+  | "l4_autonomous" -> Some ("keeper_bash" :: "keeper_fs_edit" :: "keeper_edit" :: l3_tools @ base_safe)
   | "l5_independent" -> None  (* AllowAll *)
-  | _ -> Some base_safe  (* L1/L2/L3 and unknown: safe tools only *)
+  | _ -> Some base_safe  (* L1/L2 and unknown: safe tools only *)
 
 (** Build OAS hooks for a keeper agent.
 

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -427,7 +427,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
         parsed_ts
     in
     let autonomy_level =
-      Safe_ops.json_string ~default:"l1_reactive" "autonomy_level" json
+      Safe_ops.json_string ~default:"l3_guided" "autonomy_level" json
     in
     let active_goal_ids = Safe_ops.json_string_list "active_goal_ids" json in
     let auto_team_session_enabled =


### PR DESCRIPTION
## Summary
keeper들이 실제로 일할 수 있게 도구를 열어줌.

### 변경
- 기본 autonomy: `l1_reactive` → `l3_guided`
- L3 도구: `keeper_shell_readonly`, `keeper_code_read`, `keeper_code_search`, `keeper_code_symbols`, `keeper_github`
- L4 도구: L3 + `keeper_bash`, `keeper_fs_edit`, `keeper_edit`

### 이전 문제
keeper들이 turn마다 4-8K 토큰을 소비하면서 board에 "상태 보고"만 쓰고, autonomy gate가 실제 도구를 전부 차단. sangsu 왈: "상태 보고는 불필요해. 할 일 있으면 말해."

### 이후
keeper가 코드를 읽고, 테스트를 실행하고, GitHub 이슈를 확인할 수 있음. 파일 수정은 L4 이상에서만 허용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)