### PR TITLE
feat(dashboard): board post creation from dashboard

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -467,6 +467,15 @@ export function voteBoardTool(postId: string, vote: 'up' | 'down', voter: string
   })
 }
 
+export function createPost(title: string, content: string, author: string, kind = 'internal'): Promise<unknown> {
+  return post(`/api/v1/tools/masc_board_post`, {
+    title,
+    content,
+    author,
+    kind,
+  })
+}
+
 export function commentPost(postId: string, author: string, content: string): Promise<unknown> {
   return post(`/api/v1/tools/masc_board_comment`, {
     post_id: postId,

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -17,6 +17,7 @@ import {
   votePost,
   fetchBoardPost,
   commentPost,
+  createPost,
 } from '../api'
 import { navigate, navigateToPost, route } from '../router'
 import type { BoardComment, BoardPost, BoardSortMode } from '../types'
@@ -36,6 +37,10 @@ const detailPostId = signal<string | null>(null)
 const commentText = signal('')
 const commentSubmitting = signal(false)
 const hideAutomationPosts = signal(true)
+const showNewPostForm = signal(false)
+const newPostTitle = signal('')
+const newPostContent = signal('')
+const newPostSubmitting = signal(false)
 const PAGE_SIZE = 20
 const visibleLimit = signal(PAGE_SIZE)
 
@@ -187,6 +192,65 @@ async function submitComment(postId: string) {
   } finally {
     commentSubmitting.value = false
   }
+}
+
+async function submitNewPost() {
+  const title = newPostTitle.value.trim()
+  const content = newPostContent.value.trim()
+  if (!title || !content) return
+  newPostSubmitting.value = true
+  try {
+    await createPost(title, content, commentAuthor.value)
+    newPostTitle.value = ''
+    newPostContent.value = ''
+    showNewPostForm.value = false
+    showToast('글을 등록했습니다', 'success')
+    refreshBoard()
+  } catch {
+    showToast('글 등록에 실패했습니다', 'error')
+  } finally {
+    newPostSubmitting.value = false
+  }
+}
+
+function NewPostForm() {
+  if (!showNewPostForm.value) {
+    return html`
+      <button
+        class="w-full py-2.5 rounded-lg border border-dashed border-[var(--card-border)] text-[13px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--text-body)] transition-colors bg-transparent"
+        onClick=${() => { showNewPostForm.value = true }}
+      >+ 새 글 작성</button>
+    `
+  }
+
+  return html`
+    <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-3">
+      <input
+        class="w-full px-3 py-2 rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] text-[14px] font-medium focus:border-[rgba(71,184,255,0.5)] outline-none placeholder:text-[var(--text-muted)]"
+        type="text"
+        placeholder="제목"
+        value=${newPostTitle.value}
+        onInput=${(e: Event) => { newPostTitle.value = (e.target as HTMLInputElement).value }}
+      />
+      <textarea
+        class="w-full px-3 py-2 rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] min-h-[80px] resize-y focus:border-[rgba(71,184,255,0.5)] outline-none placeholder:text-[var(--text-muted)]"
+        placeholder="내용을 입력하세요..."
+        value=${newPostContent.value}
+        onInput=${(e: Event) => { newPostContent.value = (e.target as HTMLTextAreaElement).value }}
+      ></textarea>
+      <div class="flex gap-2 justify-end">
+        <button
+          class="px-3 py-1.5 rounded-lg text-[13px] border border-[var(--card-border)] bg-transparent text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]"
+          onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
+        >취소</button>
+        <button
+          class="px-4 py-1.5 rounded-lg text-[13px] font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[rgba(71,184,255,0.2)] disabled:opacity-50"
+          disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
+          onClick=${() => { void submitNewPost() }}
+        >${newPostSubmitting.value ? '등록 중...' : '등록'}</button>
+      </div>
+    </div>
+  `
 }
 
 function SortBar() {
@@ -541,6 +605,9 @@ export function Memory() {
     <div>
       <${MemorySummary} />
       <${SortBar} />
+      <div class="mb-4">
+        <${NewPostForm} />
+      </div>
       ${boardLoading.value
         ? html`<div class="loading-state loading-pulse">메모리 피드 불러오는 중...</div>`
         : posts.length === 0

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -189,6 +189,31 @@ let add_routes router =
          )
        ) request reqd)
 
+  |> Http.Router.post "/api/v1/tools/masc_board_post" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_board_post"
+         (fun _state _req reqd ->
+         let agent_name = Option.bind (Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent") (fun s -> if s = "" then None else Some s) |> Option.value ~default:"dashboard" in
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args =
+               Yojson.Safe.from_string body_str
+               |> json_upsert_string_field "author" agent_name
+             in
+             let (ok, msg) = Tool_board.handle_tool "masc_board_post" args in
+             let status = if ok then `Created else `Bad_request in
+             respond_json_with_cors ~status request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool ok); ("message", `String msg)
+               ]))
+           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool false);
+                 ("message", `String (Printexc.to_string exn))
+               ]))
+         )
+       ) request reqd)
+
   |> Http.Router.post "/api/v1/tools/masc_board_comment" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_board_comment"
          (fun _state _req reqd ->


### PR DESCRIPTION
## Summary
- OCaml 서버에 /api/v1/tools/masc_board_post HTTP route 추가
- 프론트엔드 createPost() API 함수 추가
- 게시판 페이지에 "+ 새 글 작성" 버튼 + 폼 UI

## Test plan
- [x] `npm run build` 성공
- [x] `dune build` 성공

Generated with [Claude Code](https://claude.com/claude-code)