### PR TITLE
feat(keeper): materialize learned procedures as runtime MCP tools

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -35,5 +35,6 @@
   "auto_responder_claude_models": ["claude:auto", "glm:auto"],
   "auto_responder_gemini_models": ["gemini:auto", "glm:auto"],
   "auto_responder_glm_models": ["glm:auto"],
-  "spawn_glm_models": ["glm:auto"]
+  "spawn_glm_models": ["glm:auto"],
+  "materialized_procedure_models": ["llama:auto", "glm:auto"]
 }

--- a/lib/dune
+++ b/lib/dune
@@ -507,6 +507,7 @@
    context_compact_oas
    verifier_oas
    procedural_memory
+   procedure_tool_materializer
    oas_events
    oas_worker
    tool_council_oas

--- a/lib/procedure_tool_materializer.ml
+++ b/lib/procedure_tool_materializer.ml
@@ -1,0 +1,261 @@
+(** Procedure-to-Tool Materializer — promotes high-confidence learned procedures
+    into callable MCP tools at runtime.
+
+    When a keeper's procedural memory reaches maturity (confidence >= 0.9,
+    evidence >= 5), the procedure is registered as an MCP tool via
+    Tool_dispatch.register.  The tool handler executes the procedure's pattern
+    as a structured prompt via Oas_worker.run_named, so there is no arbitrary
+    code execution — only LLM-mediated interpretation.
+
+    Materialized tool names use the "proc_" prefix to distinguish them from
+    built-in tools.
+
+    @since 2.128.0 *)
+
+open Printf
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+type materialized_tool = {
+  procedure_id : string;
+  tool_name : string;
+  description : string;
+  confidence : float;
+  evidence_count : int;
+  registered_at : float;
+}
+
+(* ================================================================ *)
+(* Internal state                                                   *)
+(* ================================================================ *)
+
+(** Materialized tool registry — keyed by procedure_id to prevent duplicates. *)
+let materialized : (string, materialized_tool) Hashtbl.t = Hashtbl.create 16
+
+(* ================================================================ *)
+(* Thresholds                                                       *)
+(* ================================================================ *)
+
+(** Minimum confidence for materialization.
+    Higher than crystallization (0.7) — only well-proven procedures
+    become callable tools. *)
+let materialize_min_confidence = 0.9
+
+(** Minimum evidence count for materialization. *)
+let materialize_min_evidence = 5
+
+(* ================================================================ *)
+(* Name sanitization                                                *)
+(* ================================================================ *)
+
+(** Convert a procedure pattern into a valid tool name.
+    - Lowercase
+    - Replace non-alphanumeric with underscore
+    - Collapse consecutive underscores
+    - Truncate to 48 chars
+    - Prefix with "proc_" *)
+let sanitize_tool_name (pattern : string) : string =
+  let buf = Buffer.create 64 in
+  let lower = String.lowercase_ascii pattern in
+  let prev_underscore = ref false in
+  String.iter (fun c ->
+    match c with
+    | 'a'..'z' | '0'..'9' ->
+      Buffer.add_char buf c;
+      prev_underscore := false
+    | _ ->
+      if not !prev_underscore && Buffer.length buf > 0 then begin
+        Buffer.add_char buf '_';
+        prev_underscore := true
+      end
+  ) lower;
+  let raw = Buffer.contents buf in
+  (* Trim trailing underscore *)
+  let trimmed =
+    if String.length raw > 0 && raw.[String.length raw - 1] = '_'
+    then String.sub raw 0 (String.length raw - 1)
+    else raw
+  in
+  (* Truncate *)
+  let truncated =
+    if String.length trimmed > 48
+    then String.sub trimmed 0 48
+    else trimmed
+  in
+  sprintf "proc_%s" truncated
+
+(* ================================================================ *)
+(* Handler factory                                                  *)
+(* ================================================================ *)
+
+(** Create a Tool_dispatch.handler that executes the procedure's pattern
+    as a structured prompt via OAS Agent.run.
+    Single-turn, no tools, low temperature for deterministic output. *)
+let make_handler (procedure : Procedural_memory.procedure) : Tool_dispatch.handler =
+  fun ~name:_ ~args ->
+    let query =
+      match args with
+      | `Assoc fields ->
+        (match List.assoc_opt "query" fields with
+         | Some (`String s) -> s
+         | _ -> Yojson.Safe.to_string args)
+      | _ -> Yojson.Safe.to_string args
+    in
+    let system_prompt = sprintf
+      "You are executing a learned procedure. Follow this pattern precisely:\n\n%s\n\n\
+       Apply this procedure to the user's request. Be concise and actionable."
+      procedure.pattern
+    in
+    match
+      Oas_worker.run_named
+        ~cascade_name:"materialized_procedure"
+        ~goal:query
+        ~system_prompt
+        ~max_turns:1
+        ~temperature:0.3
+        ~max_tokens:2048
+        ()
+    with
+    | Ok result ->
+      let text = Oas_response.text_of_response result.response in
+      Some (true, text)
+    | Error e ->
+      Some (false, sprintf "Procedure execution failed: %s" e)
+
+(* ================================================================ *)
+(* Tool schema factory                                              *)
+(* ================================================================ *)
+
+(** Generate a tool_schema for a materialized procedure. *)
+let make_schema ~tool_name ~description : Types.tool_schema =
+  {
+    name = tool_name;
+    description = sprintf
+      "[Learned procedure] %s" description;
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [
+          ("type", `String "string");
+          ("description", `String
+            "The request or context to apply this learned procedure to.");
+        ]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  }
+
+(* ================================================================ *)
+(* Scan and discover agent names                                    *)
+(* ================================================================ *)
+
+(** List agent names that have procedure directories. *)
+let discover_agent_names () : string list =
+  let me_root = Env_config.me_root () in
+  let dir = sprintf "%s/.masc/procedures" me_root in
+  if Sys.file_exists dir then
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun name ->
+      Sys.is_directory (Filename.concat dir name))
+  else []
+
+(* ================================================================ *)
+(* Core: materialize                                                *)
+(* ================================================================ *)
+
+let materialize_mature_procedures () : materialized_tool list =
+  let agent_names = discover_agent_names () in
+  let newly_materialized = ref [] in
+  List.iter (fun agent_name ->
+    let procedures = Procedural_memory.load_procedures ~agent_name in
+    List.iter (fun (proc : Procedural_memory.procedure) ->
+      let evidence_count = List.length proc.evidence in
+      (* Check maturity thresholds *)
+      if proc.confidence >= materialize_min_confidence
+         && evidence_count >= materialize_min_evidence
+         && not (Hashtbl.mem materialized proc.id)
+      then begin
+        let tool_name = sanitize_tool_name proc.pattern in
+        (* Avoid name collisions with existing tools *)
+        if not (Tool_dispatch.is_registered tool_name) then begin
+          let handler = make_handler proc in
+          (* Register in dispatch for tool call routing *)
+          Tool_dispatch.register ~tool_name ~handler;
+          let now = Time_compat.now () in
+          let mt = {
+            procedure_id = proc.id;
+            tool_name;
+            description = proc.pattern;
+            confidence = proc.confidence;
+            evidence_count;
+            registered_at = now;
+          } in
+          Hashtbl.replace materialized proc.id mt;
+          newly_materialized := mt :: !newly_materialized;
+          Log.Keeper.info
+            "materialized procedure %s as tool %s (confidence=%.2f, evidence=%d)"
+            proc.id tool_name proc.confidence evidence_count
+        end else
+          Log.Keeper.warn
+            "skipping procedure %s: tool name %s already registered"
+            proc.id tool_name
+      end
+    ) procedures
+  ) agent_names;
+  List.rev !newly_materialized
+
+(* ================================================================ *)
+(* Query                                                            *)
+(* ================================================================ *)
+
+let materialized_tools () : materialized_tool list =
+  Hashtbl.fold (fun _id mt acc -> mt :: acc) materialized []
+  |> List.sort (fun a b -> Float.compare b.registered_at a.registered_at)
+
+let materialized_count () : int =
+  Hashtbl.length materialized
+
+(* ================================================================ *)
+(* Dematerialize                                                    *)
+(* ================================================================ *)
+
+let dematerialize ~tool_name =
+  let to_remove = ref None in
+  Hashtbl.iter (fun id mt ->
+    if mt.tool_name = tool_name then
+      to_remove := Some id
+  ) materialized;
+  match !to_remove with
+  | Some id ->
+    Hashtbl.remove materialized id;
+    (* Note: Tool_dispatch does not expose an unregister function.
+       The handler remains in the dispatch registry but the tool
+       will not appear in materialized_tools() listings.
+       A full unregister would require extending Tool_dispatch. *)
+    Log.Keeper.info "dematerialized tool %s (procedure %s)" tool_name id
+  | None ->
+    Log.Keeper.warn "dematerialize: tool %s not found in materialized registry" tool_name
+
+(* ================================================================ *)
+(* JSON serialization (for dashboard/status)                        *)
+(* ================================================================ *)
+
+let materialized_tool_to_json (mt : materialized_tool) : Yojson.Safe.t =
+  `Assoc [
+    ("procedure_id", `String mt.procedure_id);
+    ("tool_name", `String mt.tool_name);
+    ("description", `String mt.description);
+    ("confidence", `Float mt.confidence);
+    ("evidence_count", `Int mt.evidence_count);
+    ("registered_at", `Float mt.registered_at);
+  ]
+
+let status_json () : Yojson.Safe.t =
+  let tools = materialized_tools () in
+  `Assoc [
+    ("materialized_count", `Int (List.length tools));
+    ("tools", `List (List.map materialized_tool_to_json tools));
+  ]

--- a/lib/procedure_tool_materializer.mli
+++ b/lib/procedure_tool_materializer.mli
@@ -1,0 +1,52 @@
+(** Procedure-to-Tool Materializer — promotes high-confidence learned procedures
+    into callable MCP tools at runtime.
+
+    Materialized tools use the "proc_" prefix and execute via Oas_worker.run_named
+    (structured prompt, not arbitrary code).
+
+    @since 2.128.0 *)
+
+(** A procedure that has been registered as a runtime MCP tool. *)
+type materialized_tool = {
+  procedure_id : string;
+  tool_name : string;
+  description : string;
+  confidence : float;
+  evidence_count : int;
+  registered_at : float;
+}
+
+val materialize_mature_procedures : unit -> materialized_tool list
+(** Scan procedural memory for mature entries (confidence >= 0.9,
+    evidence >= 5), register each as an MCP tool via Tool_dispatch.
+    Returns newly materialized tools (already-materialized are skipped). *)
+
+val materialized_tools : unit -> materialized_tool list
+(** List all currently materialized tools, sorted by registration time (newest first). *)
+
+val materialized_count : unit -> int
+(** Number of currently materialized tools. *)
+
+val dematerialize : tool_name:string -> unit
+(** Remove a materialized tool from the registry by tool name.
+    The tool's dispatch handler persists (Tool_dispatch has no unregister)
+    but the tool is removed from the materialized listing. *)
+
+val sanitize_tool_name : string -> string
+(** Convert a procedure pattern into a valid tool name with "proc_" prefix.
+    Exposed for testing. *)
+
+val status_json : unit -> Yojson.Safe.t
+(** JSON status of all materialized tools (for dashboard/status endpoints). *)
+
+val materialized_tool_to_json : materialized_tool -> Yojson.Safe.t
+(** Serialize a single materialized tool to JSON. *)
+
+val make_schema : tool_name:string -> description:string -> Types.tool_schema
+(** Generate a tool_schema for a materialized procedure.
+    Useful for callers that need to register materialized tool schemas
+    in Config.raw_all_tool_schemas or MCP schema listings. *)
+
+val discover_agent_names : unit -> string list
+(** List agent names that have procedure directories.
+    Exposed for testing. *)

--- a/test/dune
+++ b/test/dune
@@ -998,3 +998,15 @@
  (name test_chain_utils_coverage)
  (modules test_chain_utils_coverage)
  (libraries masc_mcp alcotest str yojson))
+
+; Procedure-to-Tool materializer tests (unit)
+(test
+ (name test_procedure_materializer)
+ (modules test_procedure_materializer)
+ (libraries masc_mcp alcotest yojson))
+
+; Procedure-to-Tool materializer tests (integration with filesystem)
+(test
+ (name test_procedure_materializer_integration)
+ (modules test_procedure_materializer_integration)
+ (libraries masc_mcp alcotest yojson unix))

--- a/test/test_procedure_materializer.ml
+++ b/test/test_procedure_materializer.ml
@@ -1,0 +1,191 @@
+(** Tests for Procedure_tool_materializer — materialization of learned procedures
+    as runtime MCP tools.
+
+    These tests exercise:
+    - Name sanitization
+    - Maturity threshold filtering (confidence, evidence)
+    - Duplicate prevention
+    - Dematerialization
+    - discover_agent_names with mock filesystem *)
+
+module Materializer = Masc_mcp.Procedure_tool_materializer
+
+(* ================================================================ *)
+(* Name sanitization tests                                          *)
+(* ================================================================ *)
+
+let test_sanitize_basic () =
+  let result = Materializer.sanitize_tool_name "simple pattern" in
+  Alcotest.(check string) "basic sanitization"
+    "proc_simple_pattern" result
+
+let test_sanitize_special_chars () =
+  let result = Materializer.sanitize_tool_name "When X, do Y! (always)" in
+  Alcotest.(check string) "special chars removed"
+    "proc_when_x_do_y_always" result
+
+let test_sanitize_consecutive_specials () =
+  let result = Materializer.sanitize_tool_name "a---b___c...d" in
+  Alcotest.(check string) "consecutive specials collapsed"
+    "proc_a_b_c_d" result
+
+let test_sanitize_leading_special () =
+  let result = Materializer.sanitize_tool_name "---start here" in
+  Alcotest.(check string) "leading specials skipped"
+    "proc_start_here" result
+
+let test_sanitize_truncation () =
+  let long_pattern = String.make 100 'a' in
+  let result = Materializer.sanitize_tool_name long_pattern in
+  (* "proc_" = 5 chars, truncated body = 48 chars, total = 53 *)
+  Alcotest.(check bool) "truncated to reasonable length"
+    true (String.length result <= 53);
+  Alcotest.(check bool) "starts with proc_"
+    true (String.sub result 0 5 = "proc_")
+
+let test_sanitize_empty () =
+  let result = Materializer.sanitize_tool_name "" in
+  Alcotest.(check string) "empty input" "proc_" result
+
+let test_sanitize_mixed_case () =
+  let result = Materializer.sanitize_tool_name "Run FAST Checks" in
+  Alcotest.(check string) "lowercased"
+    "proc_run_fast_checks" result
+
+let test_sanitize_numbers () =
+  let result = Materializer.sanitize_tool_name "step 1: do thing 2" in
+  Alcotest.(check string) "numbers preserved"
+    "proc_step_1_do_thing_2" result
+
+(* ================================================================ *)
+(* Materialized tools listing (empty state)                         *)
+(* ================================================================ *)
+
+let test_no_materialized_initially () =
+  let tools = Materializer.materialized_tools () in
+  (* After previous test runs there might be leftovers, so just
+     check the function returns without error *)
+  Alcotest.(check bool) "returns a list"
+    true (List.length tools >= 0)
+
+let test_materialized_count () =
+  let count = Materializer.materialized_count () in
+  Alcotest.(check bool) "count is non-negative"
+    true (count >= 0)
+
+(* ================================================================ *)
+(* Maturity threshold checks (unit logic)                           *)
+(* ================================================================ *)
+
+(** Verify that the threshold constants match the specification. *)
+let test_threshold_values () =
+  (* The materializer requires confidence >= 0.9 and evidence >= 5.
+     We test this by checking that a procedure with exactly these
+     values would pass, and one below would not.
+     Since the actual filtering happens inside materialize_mature_procedures
+     which reads from disk, we test the sanitize + json output path here. *)
+  let mt : Materializer.materialized_tool = {
+    procedure_id = "proc-test-001";
+    tool_name = "proc_test";
+    description = "test pattern";
+    confidence = 0.9;
+    evidence_count = 5;
+    registered_at = 1000.0;
+  } in
+  let json = Materializer.materialized_tool_to_json mt in
+  let open Yojson.Safe.Util in
+  Alcotest.(check (float 0.001)) "confidence in json" 0.9
+    (json |> member "confidence" |> to_float);
+  Alcotest.(check int) "evidence in json" 5
+    (json |> member "evidence_count" |> to_int);
+  Alcotest.(check string) "tool_name in json" "proc_test"
+    (json |> member "tool_name" |> to_string)
+
+(* ================================================================ *)
+(* Status JSON output                                               *)
+(* ================================================================ *)
+
+let test_status_json_structure () =
+  let json = Materializer.status_json () in
+  let open Yojson.Safe.Util in
+  let count = json |> member "materialized_count" |> to_int in
+  Alcotest.(check bool) "count is non-negative" true (count >= 0);
+  let tools = json |> member "tools" |> to_list in
+  Alcotest.(check int) "tools list matches count" count (List.length tools)
+
+(* ================================================================ *)
+(* Dematerialize (no-op on unknown tool)                            *)
+(* ================================================================ *)
+
+let test_dematerialize_unknown () =
+  (* Should not raise, just log a warning *)
+  Materializer.dematerialize ~tool_name:"proc_nonexistent_tool_xyz";
+  Alcotest.(check bool) "no exception" true true
+
+(* ================================================================ *)
+(* Tool name collision detection                                    *)
+(* ================================================================ *)
+
+let test_sanitize_deterministic () =
+  let name1 = Materializer.sanitize_tool_name "Do the thing carefully" in
+  let name2 = Materializer.sanitize_tool_name "Do the thing carefully" in
+  Alcotest.(check string) "same input produces same name" name1 name2
+
+let test_sanitize_different_inputs () =
+  let name1 = Materializer.sanitize_tool_name "pattern alpha" in
+  let name2 = Materializer.sanitize_tool_name "pattern beta" in
+  Alcotest.(check bool) "different inputs produce different names"
+    true (name1 <> name2)
+
+(* ================================================================ *)
+(* Discover agent names (filesystem dependent — test with temp dir) *)
+(* ================================================================ *)
+
+let test_discover_empty () =
+  (* With ME_ROOT pointing to the test env, procedures dir may not exist *)
+  let names = Materializer.discover_agent_names () in
+  Alcotest.(check bool) "returns a list" true (List.length names >= 0)
+
+(* ================================================================ *)
+(* Test runner                                                      *)
+(* ================================================================ *)
+
+let () =
+  let open Alcotest in
+  run "Procedure_tool_materializer"
+    [
+      ( "sanitize_tool_name",
+        [
+          test_case "basic pattern" `Quick test_sanitize_basic;
+          test_case "special characters" `Quick test_sanitize_special_chars;
+          test_case "consecutive specials" `Quick test_sanitize_consecutive_specials;
+          test_case "leading specials" `Quick test_sanitize_leading_special;
+          test_case "truncation" `Quick test_sanitize_truncation;
+          test_case "empty input" `Quick test_sanitize_empty;
+          test_case "mixed case" `Quick test_sanitize_mixed_case;
+          test_case "numbers preserved" `Quick test_sanitize_numbers;
+          test_case "deterministic" `Quick test_sanitize_deterministic;
+          test_case "different inputs" `Quick test_sanitize_different_inputs;
+        ] );
+      ( "materialized_tools",
+        [
+          test_case "no tools initially" `Quick test_no_materialized_initially;
+          test_case "count non-negative" `Quick test_materialized_count;
+        ] );
+      ( "threshold_values",
+        [
+          test_case "json serialization matches" `Quick test_threshold_values;
+        ] );
+      ( "status_json",
+        [
+          test_case "valid structure" `Quick test_status_json_structure;
+        ] );
+      ( "dematerialize",
+        [
+          test_case "unknown tool no-op" `Quick test_dematerialize_unknown;
+        ] );
+      ( "discover_agent_names",
+        [
+          test_case "returns list" `Quick test_discover_empty;
+        ] );
+    ]

--- a/test/test_procedure_materializer_integration.ml
+++ b/test/test_procedure_materializer_integration.ml
@@ -1,0 +1,299 @@
+(** Integration tests for Procedure_tool_materializer.
+
+    These tests create a temporary directory structure with real procedure
+    JSONL files, set ME_ROOT to point at it, and exercise the full
+    materialize_mature_procedures pipeline (filesystem discovery, threshold
+    filtering, dispatch registration, duplicate prevention).
+
+    Note: The handler calls Oas_worker.run_named which requires Eio context
+    (net, switch). We do NOT invoke the handler here — only verify that
+    the dispatch registration and threshold filtering work correctly. *)
+
+module Materializer = Masc_mcp.Procedure_tool_materializer
+module Proc_mem = Masc_mcp.Procedural_memory
+module Tool_dispatch = Masc_mcp.Tool_dispatch
+
+(* ================================================================ *)
+(* Temp dir helpers                                                 *)
+(* ================================================================ *)
+
+let tmp_base = Filename.get_temp_dir_name ()
+
+let make_temp_root () =
+  let name = Printf.sprintf "masc-test-%d-%06x"
+    (int_of_float (Unix.gettimeofday ()))
+    (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF) in
+  let root = Filename.concat tmp_base name in
+  Unix.mkdir root 0o755;
+  root
+
+let ensure_dir path =
+  let parts = String.split_on_char '/' path in
+  let _built = List.fold_left (fun acc part ->
+    if part = "" then acc  (* skip empty parts from leading slash *)
+    else begin
+      let next = if acc = "" then "/" ^ part else Filename.concat acc part in
+      (try Unix.mkdir next 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      next
+    end
+  ) "" parts in
+  ()
+
+let write_procedure_jsonl ~root ~agent_name (procs : Proc_mem.procedure list) =
+  let dir = Printf.sprintf "%s/.masc/procedures/%s" root agent_name in
+  ensure_dir dir;
+  let path = Filename.concat dir "procedures.jsonl" in
+  let lines = List.map (fun p ->
+    Yojson.Safe.to_string (Proc_mem.to_json p)
+  ) procs in
+  let content = String.concat "\n" lines ^ "\n" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let rec rm_rf path =
+  if Sys.is_directory path then begin
+    Array.iter (fun name ->
+      rm_rf (Filename.concat path name)
+    ) (Sys.readdir path);
+    Unix.rmdir path
+  end else
+    Sys.remove path
+
+(* ================================================================ *)
+(* Procedure factories                                              *)
+(* ================================================================ *)
+
+let mature_procedure ?(id = "proc-mature-001") () : Proc_mem.procedure =
+  { id;
+    agent_name = "keeper-alpha";
+    pattern = "When build fails, check dune-project version first";
+    evidence = ["ev1"; "ev2"; "ev3"; "ev4"; "ev5"; "ev6"];
+    success_count = 6;
+    failure_count = 0;
+    confidence = 1.0;
+    created_at = 1000.0;
+    last_applied = 2000.0;
+  }
+
+let immature_low_confidence () : Proc_mem.procedure =
+  { id = "proc-immature-low-conf";
+    agent_name = "keeper-alpha";
+    pattern = "Try restarting the server";
+    evidence = ["ev1"; "ev2"; "ev3"; "ev4"; "ev5"];
+    success_count = 3;
+    failure_count = 2;
+    confidence = 0.6;
+    created_at = 1000.0;
+    last_applied = 2000.0;
+  }
+
+let immature_low_evidence () : Proc_mem.procedure =
+  { id = "proc-immature-low-ev";
+    agent_name = "keeper-alpha";
+    pattern = "Use strict mode for type checking";
+    evidence = ["ev1"; "ev2"];
+    success_count = 2;
+    failure_count = 0;
+    confidence = 1.0;
+    created_at = 1000.0;
+    last_applied = 2000.0;
+  }
+
+(* ================================================================ *)
+(* Test: mature procedure gets materialized                         *)
+(* ================================================================ *)
+
+let test_materialize_mature () =
+  let root = make_temp_root () in
+  let old_me_root = Sys.getenv_opt "ME_ROOT" in
+  Unix.putenv "ME_ROOT" root;
+  Fun.protect ~finally:(fun () ->
+    (match old_me_root with
+     | Some v -> Unix.putenv "ME_ROOT" v
+     | None -> (* Cannot truly unsetenv in OCaml, set to empty *)
+       Unix.putenv "ME_ROOT" "");
+    (try rm_rf root with _ -> ())
+  ) (fun () ->
+    let proc = mature_procedure () in
+    write_procedure_jsonl ~root ~agent_name:"keeper-alpha" [proc];
+
+    let newly = Materializer.materialize_mature_procedures () in
+    Alcotest.(check bool) "at least one materialized"
+      true (List.length newly >= 1);
+
+    let found = List.find_opt (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-mature-001"
+    ) newly in
+    Alcotest.(check bool) "mature procedure found" true (Option.is_some found);
+
+    let mt = Option.get found in
+    Alcotest.(check bool) "tool name has proc_ prefix"
+      true (String.length mt.tool_name >= 5
+            && String.sub mt.tool_name 0 5 = "proc_");
+    Alcotest.(check bool) "registered in dispatch"
+      true (Tool_dispatch.is_registered mt.tool_name)
+  )
+
+(* ================================================================ *)
+(* Test: immature procedures are NOT materialized                   *)
+(* ================================================================ *)
+
+let test_skip_immature () =
+  let root = make_temp_root () in
+  let old_me_root = Sys.getenv_opt "ME_ROOT" in
+  Unix.putenv "ME_ROOT" root;
+  Fun.protect ~finally:(fun () ->
+    (match old_me_root with
+     | Some v -> Unix.putenv "ME_ROOT" v
+     | None -> Unix.putenv "ME_ROOT" "");
+    (try rm_rf root with _ -> ())
+  ) (fun () ->
+    let low_conf = immature_low_confidence () in
+    let low_ev = immature_low_evidence () in
+    write_procedure_jsonl ~root ~agent_name:"keeper-alpha" [low_conf; low_ev];
+
+    let newly = Materializer.materialize_mature_procedures () in
+    let found_low_conf = List.exists (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-immature-low-conf"
+    ) newly in
+    let found_low_ev = List.exists (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-immature-low-ev"
+    ) newly in
+    Alcotest.(check bool) "low confidence not materialized" false found_low_conf;
+    Alcotest.(check bool) "low evidence not materialized" false found_low_ev
+  )
+
+(* ================================================================ *)
+(* Test: duplicate prevention                                       *)
+(* ================================================================ *)
+
+let test_no_duplicate () =
+  let root = make_temp_root () in
+  let old_me_root = Sys.getenv_opt "ME_ROOT" in
+  Unix.putenv "ME_ROOT" root;
+  Fun.protect ~finally:(fun () ->
+    (match old_me_root with
+     | Some v -> Unix.putenv "ME_ROOT" v
+     | None -> Unix.putenv "ME_ROOT" "");
+    (try rm_rf root with _ -> ())
+  ) (fun () ->
+    let proc = { (mature_procedure ~id:"proc-dedup-test" ()) with
+      pattern = "Dedup test unique procedure for preventing duplicates"
+    } in
+    write_procedure_jsonl ~root ~agent_name:"keeper-alpha" [proc];
+
+    let first = Materializer.materialize_mature_procedures () in
+    let count_first = List.length (List.filter (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-dedup-test"
+    ) first) in
+
+    (* Call again — should not duplicate *)
+    let second = Materializer.materialize_mature_procedures () in
+    let count_second = List.length (List.filter (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-dedup-test"
+    ) second) in
+
+    Alcotest.(check int) "first call materializes once" 1 count_first;
+    Alcotest.(check int) "second call skips duplicate" 0 count_second
+  )
+
+(* ================================================================ *)
+(* Test: multi-agent discovery                                      *)
+(* ================================================================ *)
+
+let test_multi_agent () =
+  let root = make_temp_root () in
+  let old_me_root = Sys.getenv_opt "ME_ROOT" in
+  Unix.putenv "ME_ROOT" root;
+  Fun.protect ~finally:(fun () ->
+    (match old_me_root with
+     | Some v -> Unix.putenv "ME_ROOT" v
+     | None -> Unix.putenv "ME_ROOT" "");
+    (try rm_rf root with _ -> ())
+  ) (fun () ->
+    let proc_a = { (mature_procedure ~id:"proc-agent-a" ()) with
+      agent_name = "agent-a";
+      pattern = "Agent A unique procedure for review"
+    } in
+    let proc_b = { (mature_procedure ~id:"proc-agent-b" ()) with
+      agent_name = "agent-b";
+      pattern = "Agent B unique procedure for deploy"
+    } in
+    write_procedure_jsonl ~root ~agent_name:"agent-a" [proc_a];
+    write_procedure_jsonl ~root ~agent_name:"agent-b" [proc_b];
+
+    let agents = Materializer.discover_agent_names () in
+    Alcotest.(check bool) "discovers multiple agents"
+      true (List.length agents >= 2);
+    Alcotest.(check bool) "agent-a found"
+      true (List.mem "agent-a" agents);
+    Alcotest.(check bool) "agent-b found"
+      true (List.mem "agent-b" agents);
+
+    let newly = Materializer.materialize_mature_procedures () in
+    let has_a = List.exists (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-agent-a") newly in
+    let has_b = List.exists (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-agent-b") newly in
+    Alcotest.(check bool) "agent-a procedure materialized" true has_a;
+    Alcotest.(check bool) "agent-b procedure materialized" true has_b
+  )
+
+(* ================================================================ *)
+(* Test: dematerialize removes from listing                         *)
+(* ================================================================ *)
+
+let test_dematerialize_removes () =
+  let root = make_temp_root () in
+  let old_me_root = Sys.getenv_opt "ME_ROOT" in
+  Unix.putenv "ME_ROOT" root;
+  Fun.protect ~finally:(fun () ->
+    (match old_me_root with
+     | Some v -> Unix.putenv "ME_ROOT" v
+     | None -> Unix.putenv "ME_ROOT" "");
+    (try rm_rf root with _ -> ())
+  ) (fun () ->
+    let proc = { (mature_procedure ~id:"proc-dematerialize-test" ()) with
+      pattern = "Dematerialization target procedure unique"
+    } in
+    write_procedure_jsonl ~root ~agent_name:"keeper-alpha" [proc];
+
+    let newly = Materializer.materialize_mature_procedures () in
+    let mt = List.find (fun (mt : Materializer.materialized_tool) ->
+      mt.procedure_id = "proc-dematerialize-test"
+    ) newly in
+
+    let count_before = Materializer.materialized_count () in
+    Materializer.dematerialize ~tool_name:mt.tool_name;
+    let count_after = Materializer.materialized_count () in
+
+    Alcotest.(check bool) "count decreased by 1"
+      true (count_after = count_before - 1);
+
+    let still_listed = List.exists (fun (mt2 : Materializer.materialized_tool) ->
+      mt2.procedure_id = "proc-dematerialize-test"
+    ) (Materializer.materialized_tools ()) in
+    Alcotest.(check bool) "no longer in listing" false still_listed
+  )
+
+(* ================================================================ *)
+(* Test runner                                                      *)
+(* ================================================================ *)
+
+let () =
+  let open Alcotest in
+  run "Procedure_materializer_integration"
+    [
+      ( "materialize",
+        [
+          test_case "mature procedure gets materialized" `Quick test_materialize_mature;
+          test_case "immature procedures skipped" `Quick test_skip_immature;
+          test_case "no duplicate materialization" `Quick test_no_duplicate;
+          test_case "multi-agent discovery" `Quick test_multi_agent;
+        ] );
+      ( "dematerialize",
+        [
+          test_case "removes from listing" `Quick test_dematerialize_removes;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Implement Procedure-to-Tool Materializer (Plan item 2.3 — MASC differentiation feature)
- High-confidence learned procedures (confidence >= 0.9, evidence >= 5) are automatically promoted to callable MCP tools at runtime
- Tool handlers execute procedures as structured prompts via `Oas_worker.run_named` (LLM-mediated, not arbitrary code execution)

## Architecture

```
Procedural Memory → Materializer scan → Tool_dispatch.register → MCP tool callable
     (JSONL)        (threshold filter)    ("proc_" prefix)     (via OAS Agent.run)
```

**Pipeline**: `learning → crystallization → materialization → tool creation`

- Maturity threshold (0.9 confidence / 5 evidence) is intentionally higher than crystallization (0.7 / 3)
- `"materialized_procedure"` cascade entry in `config/cascade.json` (llama:auto, glm:auto)
- Name collision detection via `Tool_dispatch.is_registered`
- Dematerialization support for runtime tool removal

## Files

| File | Purpose |
|------|---------|
| `lib/procedure_tool_materializer.ml` | Core implementation (~200 LOC) |
| `lib/procedure_tool_materializer.mli` | Public interface |
| `test/test_procedure_materializer.ml` | 16 unit tests (sanitization, JSON, thresholds) |
| `test/test_procedure_materializer_integration.ml` | 5 integration tests (filesystem, materialization, dedup) |
| `config/cascade.json` | New `materialized_procedure_models` entry |
| `lib/dune` | Module registration |
| `test/dune` | Test registration |

## Test plan

- [x] Name sanitization: special chars, truncation, determinism (10 tests)
- [x] Threshold filtering: mature vs immature procedures (integration)
- [x] Duplicate prevention: same procedure not materialized twice
- [x] Multi-agent discovery: procedures from multiple keeper agents
- [x] Dematerialization: removal from registry
- [x] JSON serialization: status_json, materialized_tool_to_json
- [x] `dune build` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)