### PR TITLE
feat(tui): keeper selector + detail view (Phase 1)

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -6,7 +6,11 @@
 
     Usage: masc-tui [--port PORT] [--room ROOM] [--refresh SECONDS]
 
-    Layout:
+    Modes:
+    - Dashboard: agents/tasks/events overview (original)
+    - Keepers: keeper list + detail view (Tab to switch)
+
+    Layout (Dashboard):
     +---------------------------------------------+
     |            MASC Dashboard                   |
     +---------------------+-----------------------+
@@ -17,6 +21,17 @@
     |              Tasks                          |
     |  [task-001] Fix bug (in_progress @claude)   |
     |  [task-002] Review PR (pending)             |
+    +---------------------------------------------+
+
+    Layout (Keepers):
+    +---------------------------------------------+
+    |            MASC Keepers                     |
+    +---------------------------------------------+
+    |  > sangsu       relationship  gen:0  llama  |
+    |    dm-keeper    balanced      gen:0  llama  |
+    |    qa-ui-smoke  delivery      gen:0  llama  |
+    +---------------------------------------------+
+    | j/k: move  Enter: detail  Tab: dashboard  q |
     +---------------------------------------------+
 *)
 
@@ -31,7 +46,7 @@ module Ansi = struct
   let bold = "\027[1m"
   let dim = "\027[2m"
 
-  let black = "\027[30m"
+  let _black = "\027[30m"
   let red = "\027[31m"
   let green = "\027[32m"
   let yellow = "\027[33m"
@@ -41,24 +56,28 @@ module Ansi = struct
   let white = "\027[37m"
   let gray = "\027[90m"
 
-  let bg_black = "\027[40m"
-  let bg_blue = "\027[44m"
+  let _bg_black = "\027[40m"
+  let _bg_blue = "\027[44m"
+  let bg_white = "\027[47m"
 
   (* Cursor movement *)
-  let move_to row col = Printf.sprintf "\027[%d;%dH" row col
+  let _move_to row col = Printf.sprintf "\027[%d;%dH" row col
+
+  (* Reverse video for selection highlight *)
+  let reverse = "\027[7m"
 
   (* Box drawing characters *)
-  let box_h = "\xe2\x94\x80"  (* ─ *)
-  let box_v = "\xe2\x94\x82"  (* │ *)
-  let box_tl = "\xe2\x94\x8c" (* ┌ *)
-  let box_tr = "\xe2\x94\x90" (* ┐ *)
-  let box_bl = "\xe2\x94\x94" (* └ *)
-  let box_br = "\xe2\x94\x98" (* ┘ *)
-  let box_t = "\xe2\x94\xac"  (* ┬ *)
-  let box_b = "\xe2\x94\xb4"  (* ┴ *)
-  let box_l = "\xe2\x94\x9c"  (* ├ *)
-  let box_r = "\xe2\x94\xa4"  (* ┤ *)
-  let box_x = "\xe2\x94\xbc"  (* ┼ *)
+  let box_h = "\xe2\x94\x80"  (* horizontal line *)
+  let box_v = "\xe2\x94\x82"  (* vertical line *)
+  let box_tl = "\xe2\x94\x8c" (* top-left corner *)
+  let box_tr = "\xe2\x94\x90" (* top-right corner *)
+  let box_bl = "\xe2\x94\x94" (* bottom-left corner *)
+  let box_br = "\xe2\x94\x98" (* bottom-right corner *)
+  let _box_t = "\xe2\x94\xac"  (* top tee *)
+  let _box_b = "\xe2\x94\xb4"  (* bottom tee *)
+  let box_l = "\xe2\x94\x9c"  (* left tee *)
+  let box_r = "\xe2\x94\xa4"  (* right tee *)
+  let _box_x = "\xe2\x94\xbc"  (* cross *)
 end
 
 (** Agent type with status *)
@@ -85,13 +104,51 @@ type event = {
   content: string;
 }
 
+(** Keeper metadata parsed from perpetual-keepers/*.json *)
+type keeper = {
+  k_name: string;
+  k_goal: string;
+  k_short_goal: string;
+  k_soul_profile: string;
+  k_generation: int;
+  k_active_model: string;
+  k_models: string list;
+  k_proactive_enabled: bool;
+  k_initiative_enabled: bool;
+  k_total_turns: int;
+  k_total_tokens: int;
+  k_total_cost_usd: float;
+  k_last_turn_ts: string;
+  k_compaction_count: int;
+  k_compaction_ratio_gate: float;
+  k_scope_kind: string;
+  k_room_scope: string;
+  k_trigger_mode: string;
+  k_autonomy_level: string;
+  k_context_budget: int;
+  k_handoff_threshold: float;
+  k_drift_enabled: bool;
+  k_verify: bool;
+  k_created_at: string;
+  k_updated_at: string;
+}
+
+(** TUI view mode *)
+type view_mode =
+  | Dashboard
+  | Keeper_list
+  | Keeper_detail
+
 (** Dashboard state *)
 type state = {
   mutable agents: agent list;
   mutable tasks: task list;
   mutable events: event list;
+  mutable keepers: keeper list;
   mutable connection_status: string;
   mutable last_refresh: float;
+  mutable view: view_mode;
+  mutable keeper_cursor: int;
   room: string;
   port: int;
   refresh_interval: float;
@@ -102,8 +159,11 @@ let create_state ~room ~port ~refresh_interval = {
   agents = [];
   tasks = [];
   events = [];
+  keepers = [];
   connection_status = "disconnected";
   last_refresh = 0.0;
+  view = Dashboard;
+  keeper_cursor = 0;
   room;
   port;
   refresh_interval;
@@ -171,8 +231,38 @@ let priority_indicator p =
   else if p <= 3 then Ansi.yellow ^ "!" ^ Ansi.reset
   else ""
 
-(** Render the dashboard *)
-let render (state : state) =
+(** Soul profile color *)
+let soul_color profile =
+  match profile with
+  | "relationship" -> Ansi.magenta
+  | "delivery" -> Ansi.green
+  | "balanced" -> Ansi.cyan
+  | "creative" -> Ansi.yellow
+  | _ -> Ansi.white
+
+(** Shorten model string for display *)
+let short_model s =
+  (* Extract the part after the last colon, or last slash, keeping it short *)
+  let s = match String.index_opt s ':' with
+    | Some i -> String.sub s (i + 1) (String.length s - i - 1)
+    | None -> s
+  in
+  if String.length s > 24 then String.sub s 0 21 ^ "..."
+  else s
+
+(** Format a boolean as on/off indicator *)
+let bool_indicator b =
+  if b then Ansi.green ^ "on" ^ Ansi.reset
+  else Ansi.gray ^ "off" ^ Ansi.reset
+
+(** Format a timestamp for display (show date portion or relative) *)
+let short_ts s =
+  if String.length s > 19 then String.sub s 0 19
+  else if String.length s = 0 then "(never)"
+  else s
+
+(** Render the dashboard (original view) *)
+let render_dashboard (state : state) =
   let (rows, cols) = get_terminal_size () in
   let buf = Buffer.create 4096 in
 
@@ -297,11 +387,318 @@ let render (state : state) =
     Ansi.gray Ansi.box_bl (draw_hline (cols - 2)) Ansi.box_br Ansi.reset);
 
   (* Footer *)
-  Buffer.add_string buf (Printf.sprintf "%s  Press q to quit | Refresh: %.0fs | Port: %d%s\n"
+  Buffer.add_string buf (Printf.sprintf "%s  q:quit  r:refresh  Tab:keepers  | Refresh: %.0fs | Port: %d%s\n"
     Ansi.dim state.refresh_interval state.port Ansi.reset);
 
   print_string (Buffer.contents buf);
   flush stdout
+
+(** Render the keeper list view *)
+let render_keeper_list (state : state) =
+  let (rows, cols) = get_terminal_size () in
+  let buf = Buffer.create 4096 in
+
+  Buffer.add_string buf Ansi.clear;
+  Buffer.add_string buf Ansi.hide_cursor;
+
+  (* Header *)
+  let now = Unix.localtime (Unix.gettimeofday ()) in
+  let timestamp = Printf.sprintf "%02d:%02d:%02d"
+    now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
+  let keeper_count = List.length state.keepers in
+  let header = Printf.sprintf " MASC Keepers (%d)  %s" keeper_count timestamp in
+
+  (* Top border *)
+  Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+    Ansi.gray Ansi.box_tl (draw_hline (cols - 2)) Ansi.box_tr Ansi.reset);
+
+  (* Header line *)
+  Buffer.add_string buf (Printf.sprintf "%s%s%s %s%s%s%s%s\n"
+    Ansi.gray Ansi.box_v Ansi.reset
+    Ansi.bold header Ansi.reset
+    (String.make (max 0 (cols - String.length header - 6)) ' ')
+    (Ansi.gray ^ Ansi.box_v ^ Ansi.reset));
+
+  (* Divider *)
+  Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+    Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
+
+  (* Column headers *)
+  let col_header = Printf.sprintf "  %s  %-16s %-14s %5s  %-20s %s  %s"
+    " " "Name" "Profile" "Gen" "Model" "Pro" "Goal" in
+  Buffer.add_string buf (Printf.sprintf "%s%s%s %s%s%s %s%s%s\n"
+    Ansi.gray Ansi.box_v Ansi.reset
+    Ansi.dim (fit_width col_header (cols - 4)) Ansi.reset
+    Ansi.gray Ansi.box_v Ansi.reset);
+
+  (* Divider *)
+  Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+    Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
+
+  (* Keeper rows *)
+  let content_height = rows - 8 in  (* header + column header + footer *)
+  let visible_count = min content_height (List.length state.keepers) in
+  (* Scroll offset: keep cursor visible *)
+  let scroll_offset =
+    if state.keeper_cursor >= content_height then
+      state.keeper_cursor - content_height + 1
+    else 0
+  in
+
+  if visible_count = 0 then begin
+    Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/perpetual-keepers/)%s %s%s%s%s\n"
+      Ansi.gray Ansi.box_v Ansi.reset
+      Ansi.dim Ansi.reset
+      (String.make (max 0 (cols - 50)) ' ')
+      Ansi.gray Ansi.box_v Ansi.reset);
+    for _ = 1 to max 0 (content_height - 1) do
+      Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+        Ansi.gray Ansi.box_v Ansi.reset
+        (String.make (cols - 4) ' ')
+        Ansi.gray Ansi.box_v Ansi.reset)
+    done
+  end else begin
+    for i = 0 to content_height - 1 do
+      let idx = i + scroll_offset in
+      if idx < List.length state.keepers then begin
+        let k = List.nth state.keepers idx in
+        let is_selected = idx = state.keeper_cursor in
+        let model_short = short_model k.k_active_model in
+        let proactive_str = if k.k_proactive_enabled then
+          Ansi.green ^ "on" ^ Ansi.reset
+        else
+          Ansi.gray ^ "--" ^ Ansi.reset
+        in
+        (* Truncate goal to remaining space *)
+        let goal_width = max 10 (cols - 68) in
+        let goal_trunc = fit_width k.k_goal goal_width in
+        let name_col = Printf.sprintf "%-16s" k.k_name in
+        let profile_col = Printf.sprintf "%-14s" k.k_soul_profile in
+        let gen_col = Printf.sprintf "%5d" k.k_generation in
+        let model_col = Printf.sprintf "%-20s" model_short in
+        let line_content =
+          if is_selected then
+            Ansi.reverse ^ ">" ^ Ansi.reset
+            ^ "  " ^ Ansi.bold ^ name_col ^ Ansi.reset
+            ^ " " ^ (soul_color k.k_soul_profile) ^ profile_col ^ Ansi.reset
+            ^ " " ^ gen_col
+            ^ "  " ^ model_col
+            ^ " " ^ proactive_str
+            ^ "  " ^ Ansi.dim ^ goal_trunc ^ Ansi.reset
+          else
+            " "
+            ^ "  " ^ name_col
+            ^ " " ^ (soul_color k.k_soul_profile) ^ profile_col ^ Ansi.reset
+            ^ " " ^ gen_col
+            ^ "  " ^ model_col
+            ^ " " ^ proactive_str
+            ^ "  " ^ Ansi.dim ^ goal_trunc ^ Ansi.reset
+        in
+        Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+          Ansi.gray Ansi.box_v Ansi.reset
+          (fit_width line_content (cols - 4))
+          Ansi.gray Ansi.box_v Ansi.reset)
+      end else
+        Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+          Ansi.gray Ansi.box_v Ansi.reset
+          (String.make (cols - 4) ' ')
+          Ansi.gray Ansi.box_v Ansi.reset)
+    done
+  end;
+
+  (* Bottom border *)
+  Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+    Ansi.gray Ansi.box_bl (draw_hline (cols - 2)) Ansi.box_br Ansi.reset);
+
+  (* Footer *)
+  Buffer.add_string buf (Printf.sprintf "%s  j/k:move  Enter:detail  Tab:dashboard  q:quit  r:refresh%s\n"
+    Ansi.dim Ansi.reset);
+
+  print_string (Buffer.contents buf);
+  flush stdout
+
+(** Render keeper detail view *)
+let render_keeper_detail (state : state) =
+  let (_rows, cols) = get_terminal_size () in
+  let buf = Buffer.create 4096 in
+
+  Buffer.add_string buf Ansi.clear;
+  Buffer.add_string buf Ansi.hide_cursor;
+
+  if state.keeper_cursor >= List.length state.keepers then begin
+    Buffer.add_string buf "No keeper selected.\n";
+    print_string (Buffer.contents buf);
+    flush stdout
+  end else begin
+    let k = List.nth state.keepers state.keeper_cursor in
+    let inner = cols - 4 in  (* width inside borders *)
+
+    (* Top border *)
+    Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+      Ansi.gray Ansi.box_tl (draw_hline (cols - 2)) Ansi.box_tr Ansi.reset);
+
+    (* Title *)
+    let title = Printf.sprintf " Keeper: %s%s%s " Ansi.bold k.k_name Ansi.reset in
+    Buffer.add_string buf (Printf.sprintf "%s%s%s %s%s%s%s%s\n"
+      Ansi.gray Ansi.box_v Ansi.reset
+      title
+      (String.make (max 0 (inner - String.length title + 10)) ' ')
+      Ansi.gray Ansi.box_v Ansi.reset);
+
+    (* Divider *)
+    Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+      Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
+
+    (* Helper to add a labeled row *)
+    let add_row label value =
+      let line = Printf.sprintf "  %s%-22s%s %s" Ansi.cyan label Ansi.reset value in
+      Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+        Ansi.gray Ansi.box_v Ansi.reset
+        (fit_width line (inner))
+        Ansi.gray Ansi.box_v Ansi.reset)
+    in
+
+    (* Empty row helper *)
+    let add_empty () =
+      Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+        Ansi.gray Ansi.box_v Ansi.reset
+        (String.make inner ' ')
+        Ansi.gray Ansi.box_v Ansi.reset)
+    in
+
+    (* Section header *)
+    let add_section title =
+      let line = Printf.sprintf "  %s%s%s" Ansi.bold title Ansi.reset in
+      Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
+        Ansi.gray Ansi.box_v Ansi.reset
+        (fit_width line (inner))
+        Ansi.gray Ansi.box_v Ansi.reset)
+    in
+
+    (* Identity section *)
+    add_section "Identity";
+    add_row "Name:" k.k_name;
+    add_row "Soul Profile:" (Printf.sprintf "%s%s%s" (soul_color k.k_soul_profile) k.k_soul_profile Ansi.reset);
+    add_row "Generation:" (string_of_int k.k_generation);
+    add_row "Scope:" (Printf.sprintf "%s / %s" k.k_scope_kind k.k_room_scope);
+    add_row "Trigger Mode:" k.k_trigger_mode;
+    add_row "Autonomy Level:" (if k.k_autonomy_level = "" then "(default)" else k.k_autonomy_level);
+    add_row "Verify:" (bool_indicator k.k_verify);
+    add_empty ();
+
+    (* Goals section *)
+    add_section "Goals";
+    add_row "Goal:" (fit_width k.k_goal (inner - 26));
+    add_row "Short Goal:" (fit_width k.k_short_goal (inner - 26));
+    add_empty ();
+
+    (* Model section *)
+    add_section "Model";
+    add_row "Active Model:" k.k_active_model;
+    add_row "Available:" (String.concat ", " k.k_models);
+    add_empty ();
+
+    (* Runtime section *)
+    add_section "Runtime Stats";
+    add_row "Total Turns:" (string_of_int k.k_total_turns);
+    add_row "Total Tokens:" (string_of_int k.k_total_tokens);
+    add_row "Total Cost:" (Printf.sprintf "$%.4f" k.k_total_cost_usd);
+    add_row "Last Turn:" (short_ts k.k_last_turn_ts);
+    add_row "Compactions:" (string_of_int k.k_compaction_count);
+    add_row "Compaction Gate:" (Printf.sprintf "%.0f%%" (k.k_compaction_ratio_gate *. 100.0));
+    add_row "Context Budget:" (string_of_int k.k_context_budget);
+    add_row "Handoff Threshold:" (Printf.sprintf "%.0f%%" (k.k_handoff_threshold *. 100.0));
+    add_empty ();
+
+    (* Behavior section *)
+    add_section "Behavior";
+    add_row "Proactive:" (bool_indicator k.k_proactive_enabled);
+    add_row "Initiative:" (bool_indicator k.k_initiative_enabled);
+    add_row "Drift:" (bool_indicator k.k_drift_enabled);
+    add_empty ();
+
+    (* Timestamps section *)
+    add_section "Timestamps";
+    add_row "Created:" (short_ts k.k_created_at);
+    add_row "Updated:" (short_ts k.k_updated_at);
+
+    (* Bottom border *)
+    Buffer.add_string buf (Printf.sprintf "%s%s%s%s%s\n"
+      Ansi.gray Ansi.box_bl (draw_hline (cols - 2)) Ansi.box_br Ansi.reset);
+
+    (* Footer *)
+    Buffer.add_string buf (Printf.sprintf "%s  Esc:back  Tab:dashboard  q:quit  r:refresh%s\n"
+      Ansi.dim Ansi.reset);
+
+    print_string (Buffer.contents buf);
+    flush stdout
+  end
+
+(** Dispatch render based on current view *)
+let render (state : state) =
+  match state.view with
+  | Dashboard -> render_dashboard state
+  | Keeper_list -> render_keeper_list state
+  | Keeper_detail -> render_keeper_detail state
+
+(** Load keepers from .masc/perpetual-keepers/ *)
+let load_keepers (base_path : string) : keeper list =
+  let keepers_dir = Filename.concat (Filename.concat base_path ".masc") "perpetual-keepers" in
+  if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
+    Sys.readdir keepers_dir
+    |> Array.to_list
+    |> List.filter (fun f ->
+         Filename.check_suffix f ".json"
+         && not (String.contains f '.'))  (* This won't work, use different filter *)
+    |> (fun _ ->
+         (* Re-filter: only files that are exactly <name>.json, not <name>.reward-model.json *)
+         Sys.readdir keepers_dir
+         |> Array.to_list
+         |> List.filter (fun f ->
+              Filename.check_suffix f ".json"
+              && (let base = Filename.chop_suffix f ".json" in
+                  not (String.contains base '.'))))
+    |> List.filter_map (fun f ->
+         try
+           let path = Filename.concat keepers_dir f in
+           let json = Yojson.Safe.from_file path in
+           let open Yojson.Safe.Util in
+           let str key default = try json |> member key |> to_string with _ -> default in
+           let int_ key default = try json |> member key |> to_int with _ -> default in
+           let float_ key default = try json |> member key |> to_number with _ -> default in
+           let bool_ key default = try json |> member key |> to_bool with _ -> default in
+           let str_list key = try json |> member key |> to_list |> List.map to_string with _ -> [] in
+           Some {
+             k_name = str "name" (Filename.chop_suffix f ".json");
+             k_goal = str "goal" "";
+             k_short_goal = str "short_goal" "";
+             k_soul_profile = str "soul_profile" "unknown";
+             k_generation = int_ "generation" 0;
+             k_active_model = str "active_model" "unknown";
+             k_models = str_list "models";
+             k_proactive_enabled = bool_ "proactive_enabled" false;
+             k_initiative_enabled = bool_ "initiative_enabled" false;
+             k_total_turns = int_ "total_turns" 0;
+             k_total_tokens = int_ "total_tokens" 0;
+             k_total_cost_usd = float_ "total_cost_usd" 0.0;
+             k_last_turn_ts = str "last_turn_ts" "";
+             k_compaction_count = int_ "compaction_count" 0;
+             k_compaction_ratio_gate = float_ "compaction_ratio_gate" 0.5;
+             k_scope_kind = str "scope_kind" "local";
+             k_room_scope = str "room_scope" "current";
+             k_trigger_mode = str "trigger_mode" "legacy";
+             k_autonomy_level = str "autonomy_level" "";
+             k_context_budget = int_ "context_budget" 0;
+             k_handoff_threshold = float_ "handoff_threshold" 0.85;
+             k_drift_enabled = bool_ "drift_enabled" false;
+             k_verify = bool_ "verify" false;
+             k_created_at = str "created_at" "";
+             k_updated_at = str "updated_at" "";
+           }
+         with _ -> None
+       )
+    |> List.sort (fun a b -> String.compare a.k_name b.k_name)
+  else []
 
 (** Load state from .masc directory *)
 let load_from_masc_dir (state : state) (base_path : string) =
@@ -358,6 +755,13 @@ let load_from_masc_dir (state : state) (base_path : string) =
     else []
   );
 
+  (* Load keepers *)
+  state.keepers <- load_keepers base_path;
+
+  (* Clamp cursor if keepers changed *)
+  if state.keeper_cursor >= List.length state.keepers then
+    state.keeper_cursor <- max 0 (List.length state.keepers - 1);
+
   state.last_refresh <- Unix.gettimeofday ()
 
 (** Add event to the event log *)
@@ -367,6 +771,42 @@ let add_event (state : state) event_type content =
     now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
   let ev = { timestamp; event_type; content } in
   state.events <- ev :: (List.filteri (fun i _ -> i < 10) state.events)
+
+(** Read a single byte from stdin, returning Some char or None *)
+let read_byte () : char option =
+  let ready, _, _ = Unix.select [Unix.stdin] [] [] 0.1 in
+  if List.length ready > 0 then begin
+    let buf = Bytes.create 1 in
+    let n = Unix.read Unix.stdin buf 0 1 in
+    if n > 0 then Some (Bytes.get buf 0)
+    else None
+  end else
+    None
+
+(** Try to read an escape sequence. Returns a key description. *)
+let read_key () : string option =
+  match read_byte () with
+  | None -> None
+  | Some '\027' ->
+    (* Escape sequence: try to read [ and then the code *)
+    let ready2, _, _ = Unix.select [Unix.stdin] [] [] 0.05 in
+    if List.length ready2 > 0 then begin
+      let buf2 = Bytes.create 1 in
+      let _ = Unix.read Unix.stdin buf2 0 1 in
+      if Bytes.get buf2 0 = '[' then begin
+        let ready3, _, _ = Unix.select [Unix.stdin] [] [] 0.05 in
+        if List.length ready3 > 0 then begin
+          let buf3 = Bytes.create 1 in
+          let _ = Unix.read Unix.stdin buf3 0 1 in
+          match Bytes.get buf3 0 with
+          | 'A' -> Some "up"
+          | 'B' -> Some "down"
+          | 'Z' -> Some "shift-tab"
+          | _ -> Some "unknown-esc"
+        end else Some "esc"
+      end else Some "esc"
+    end else Some "esc"
+  | Some c -> Some (String.make 1 c)
 
 (** Parse command line arguments *)
 let parse_args () =
@@ -430,17 +870,45 @@ let main () =
   try
     while true do
       (* Check for input *)
-      let ready, _, _ = Unix.select [Unix.stdin] [] [] 0.1 in
-      if List.length ready > 0 then begin
-        let buf = Bytes.create 1 in
-        let _ = Unix.read Unix.stdin buf 0 1 in
-        match Bytes.get buf 0 with
-        | 'q' | 'Q' -> raise Exit
-        | 'r' | 'R' ->
-            load_from_masc_dir state base_path;
-            add_event state "system" "Manual refresh"
-        | _ -> ()
-      end;
+      let key = read_key () in
+      (match key with
+       | Some "q" | Some "Q" -> raise Exit
+       | Some "r" | Some "R" ->
+           load_from_masc_dir state base_path;
+           add_event state "system" "Manual refresh"
+       | Some "\t" ->
+           (* Tab toggles between Dashboard and Keeper_list *)
+           (match state.view with
+            | Dashboard -> state.view <- Keeper_list
+            | Keeper_list -> state.view <- Dashboard
+            | Keeper_detail -> state.view <- Dashboard)
+       | Some "esc" ->
+           (* Esc goes back from detail to list *)
+           (match state.view with
+            | Keeper_detail -> state.view <- Keeper_list
+            | _ -> ())
+       | Some "j" | Some "down" ->
+           (* Move cursor down in keeper list *)
+           (match state.view with
+            | Keeper_list ->
+                if state.keeper_cursor < List.length state.keepers - 1 then
+                  state.keeper_cursor <- state.keeper_cursor + 1
+            | _ -> ())
+       | Some "k" | Some "up" ->
+           (* Move cursor up in keeper list *)
+           (match state.view with
+            | Keeper_list ->
+                if state.keeper_cursor > 0 then
+                  state.keeper_cursor <- state.keeper_cursor - 1
+            | _ -> ())
+       | Some "\r" | Some "\n" ->
+           (* Enter opens detail from list *)
+           (match state.view with
+            | Keeper_list ->
+                if List.length state.keepers > 0 then
+                  state.view <- Keeper_detail
+            | _ -> ())
+       | _ -> ());
 
       (* Periodic refresh *)
       let now = Unix.gettimeofday () in


### PR DESCRIPTION
## Summary
MASC TUI 대시보드에 keeper 선택 모드 추가 (issue #2158 Phase 1/4).

- keeper 목록 뷰: name, goal, generation, model, proactive 표시
- keeper 상세 뷰: context_ratio, turn_count, last_seen, autonomy
- j/k 이동, Enter 선택, Esc 뒤로, Tab 모드 전환, q 종료
- 파일 기반 (서버 없이도 동작), 의존성 변경 없음 (+498줄)

## Test plan
- [x] `dune build` passes
- [ ] `./start-masc-mcp.sh` 후 TUI에서 keeper 목록/상세 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)