### PR TITLE
fix(dashboard): improve spacing in agent roster, sidebar, and stats

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -146,7 +146,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         </div>
       </div>
 
-      <div class="flex flex-col gap-2.5">
+      <div class="flex flex-col gap-4">
         ${filtered.map((agent: Agent) => {
           const brief = briefMap.get(agent.name)
           const keeper = findKeeper(agent.name, keeperList, keeperBriefs)
@@ -157,7 +157,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <div
-              class="roster-card rounded-md transition-all duration-200 ${isKeeper ? 'roster-card--keeper' : ''}"
+              class="roster-card rounded-md p-4 transition-all duration-200 ${isKeeper ? 'roster-card--keeper' : ''}"
               key=${agent.name}
               onClick=${() => openAgentDetail(agent.name)}
               role="button"
@@ -173,7 +173,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   activityAge=${lastActivity}
                 />
               </div>
-              <div class="flex-1 min-w-0 flex flex-col gap-[5px] justify-center">
+              <div class="flex-1 min-w-0 flex flex-col gap-2 justify-center">
                 <div class="flex items-center gap-[var(--space-sm,8px)]">
                   <strong class="text-[length:var(--fs-lg)] text-[color:var(--ff-gold-bright)] font-semibold tracking-[0.3px]">${agent.name}</strong>
                   ${isKeeper ? html`

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -133,7 +133,7 @@ export function SideRail() {
       <div class="flex-1 overflow-y-auto py-4 px-3">
         <div class="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-[0.1em] px-2 mb-2">탐색</div>
 
-        <div class="flex flex-col gap-0.5">
+        <div class="flex flex-col gap-1">
           ${DASHBOARD_SURFACES.map(surface => {
             const isActive = surface.id === currentSurface
             return html`
@@ -155,7 +155,7 @@ export function SideRail() {
           return html`
             <div class="mt-5 pt-4 mx-4 border-t border-[var(--border-slate-12)]">
               <div class="text-[10px] font-medium text-[var(--text-muted)] uppercase tracking-[0.1em] px-2 mb-2">${currentView?.label ?? currentSurface}</div>
-              <div class="flex flex-col gap-0.5">
+              <div class="flex flex-col gap-1">
                 ${sectionItems.map(item => html`
                   <button
                     class="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-left cursor-pointer border-l-2 border-t-0 border-r-0 border-b-0 border-solid text-[13px] transition-all duration-150 ${currentSection?.id === item.id ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] font-medium' : 'border-l-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'}"

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -36,7 +36,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
       </div>
 
       <!-- Compact stat rows -->
-      <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px]">
+      <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-[11px]">
         <div class="flex items-center justify-between">
           <span class="text-[var(--text-muted)]">에이전트</span>
           <strong class="text-[var(--accent)] tabular-nums">${agents.value.length}</strong>


### PR DESCRIPTION
## Summary
Dashboard UI was too cramped ("빡빡"). Increased spacing in 3 areas:

### Agent Roster (agents page)
- Card list gap: 10px → 16px (gap-2.5 → gap-4)
- Card padding: 0 → 16px (added p-4)
- Card content gap: 5px → 8px (gap-[5px] → gap-2)

### Sidebar Navigation
- Nav item gap: 2px → 4px (gap-0.5 → gap-1)

### Status Footer
- Stats grid vertical gap: 4px → 6px (gap-y-1 → gap-y-1.5)

## Verification
Playwright screenshots before/after confirmed visual improvement.

## Test plan
- [ ] `npx vite build` passes
- [ ] Visual: agent roster has comfortable spacing between cards
- [ ] Visual: sidebar items are not cramped

Generated with [Claude Code](https://claude.com/claude-code)