### PR TITLE
fix(backend): remove last Stdlib.Mutex from Memory backend

### DIFF
--- a/lib/backend/backend_core.ml
+++ b/lib/backend/backend_core.ml
@@ -235,7 +235,7 @@ module MemoryBackend : BACKEND = struct
     mutex: Eio.Mutex.t;
   }
 
-  let stdlib_mutex = Stdlib.Mutex.create ()
+  let _mem_poisoned_warned = Atomic.make false
 
   let with_lock t f =
     match
@@ -243,8 +243,11 @@ module MemoryBackend : BACKEND = struct
     with
     | result -> result
     | exception Effect.Unhandled _ ->
-        Stdlib.Mutex.lock stdlib_mutex;
-        Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock stdlib_mutex) f
+        f ()
+    | exception Eio__Eio_mutex.Poisoned _ ->
+        if not (Atomic.exchange _mem_poisoned_warned true) then
+          Log.Backend.warn "Memory backend: Eio.Mutex poisoned, running unprotected (non-Eio context)";
+        f ()
 
   let create (_cfg : config) : (t, error) result =
     Ok {


### PR DESCRIPTION
## Summary

Memory backend (`backend_core.ml`)의 마지막 `Stdlib.Mutex` 사용 제거.
PR #2315에서 FileSystemBackend에 적용한 동일 패턴을 Memory backend에도 적용.

- `Stdlib.Mutex` fallback → unprotected 실행 (non-Eio 테스트 컨텍스트)
- `Eio.Mutex.Poisoned` handler + `Atomic` once-only warning 추가
- 코드베이스에서 `Stdlib.Mutex` 완전 제거 (0건)

## Test plan
- [x] dune build + dune test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)