### PR TITLE
fix: harden operator snapshot test paths

### DIFF
--- a/lib/command_plane/cp_unit.ml
+++ b/lib/command_plane/cp_unit.ml
@@ -1,5 +1,12 @@
 include Cp_unit_projection
 
+let safe_live_agents config =
+  let room_id = Room.current_room_id config in
+  Room.get_agents_raw_in_room config room_id
+  |> List.filter (fun (agent : Types.agent) ->
+         try Room.is_agent_joined config ~agent_name:agent.name with
+         | Sys_error _ | Not_found -> false)
+
 let validate_parent_kind child_kind parent_kind =
   match child_kind, parent_kind with
   | Company, _ -> false
@@ -48,7 +55,7 @@ let effective_units_for_validation config managed_units =
     managed_units
   else
     let live_names =
-      Room.get_agents_raw config
+      safe_live_agents config
       |> List.map (fun (agent : Types.agent) -> agent.name)
       |> List.sort_uniq String.compare
     in
@@ -394,11 +401,7 @@ let rec build_tree_json ~child_map ~unit_lookup ~agent_statuses ~live_agents ~op
           ])
 
 let topology_units config =
-  let agents =
-    Room.get_agents_raw config
-    |> List.filter (fun (agent : Types.agent) ->
-         try Room.is_agent_joined config ~agent_name:agent.name with Sys_error _ | Not_found -> false)
-  in
+  let agents = safe_live_agents config in
   let managed_units = read_units config in
   let normalized_units = augment_managed_units managed_units agents in
   let source =


### PR DESCRIPTION
## Summary
- make command-plane unit topology degrade safely when room state is not initialized
- avoid operator snapshot crashes in Postgres-autodetect fallback test environments
- update the silent-failure source guard to match the current keeper bootstrap log wording

## Verification
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_silent_failures_p2a.exe
- dune exec --root . test/test_ci_hardening_source.exe
- git diff --check