### PR TITLE
feat(dashboard): improve agent profile UI and add worktrees view

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -276,39 +276,39 @@ function CharacterPlate({ name }: { name: string }) {
       </div>
 
       ${isKeeper ? html`
-        <div class="grid grid-cols-2 gap-1.5 self-center min-w-[100px]">
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+        <div class="grid grid-cols-4 gap-2 w-full mt-2">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${ctxPct != null ? `${ctxPct}%` : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">CTX</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${generation ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">세대</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.turn_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">턴</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.autonomous_action_count ?? 0}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">행동</span>
           </div>
         </div>
       ` : html`
-        <div class="grid grid-cols-2 gap-1.5 self-center min-w-[100px]">
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+        <div class="grid grid-cols-4 gap-2 w-full mt-2">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_completed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">완료</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_claimed : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">수임</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.messages_sent : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">메시지</span>
           </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md">
+          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
             <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A'}</span>
             <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">활동</span>
           </div>

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -7,19 +7,21 @@ import { Memory } from './memory'
 import { Governance } from './governance'
 import { Proof } from './proof'
 import { Planning } from './goals'
+import { Worktrees } from './worktrees'
 import { ErrorBoundary } from './common/error-boundary'
 
-type WorkSection = 'board' | 'governance' | 'evidence' | 'planning'
+type WorkSection = 'board' | 'governance' | 'evidence' | 'planning' | 'worktrees'
 
 const SECTIONS: { id: WorkSection; label: string; tooltip: string }[] = [
   { id: 'board', label: '게시판', tooltip: '에이전트 간 소통과 지식 공유' },
   { id: 'governance', label: '거버넌스', tooltip: '의사결정 기록과 판결' },
   { id: 'evidence', label: '근거', tooltip: '작업 증거와 검증 결과' },
   { id: 'planning', label: '계획', tooltip: '장기 목표와 메트릭 루프' },
+  { id: 'worktrees', label: '워크트리', tooltip: '활성화된 작업 공간 관리' },
 ]
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'governance' || v === 'evidence' || v === 'planning'
+  return v === 'board' || v === 'governance' || v === 'evidence' || v === 'planning' || v === 'worktrees'
 }
 
 export function Work() {
@@ -46,7 +48,8 @@ export function Work() {
         ${current === 'board' ? html`<${Memory} />`
           : current === 'governance' ? html`<${Governance} />`
           : current === 'evidence' ? html`<${Proof} />`
-          : html`<${Planning} />`
+          : current === 'planning' ? html`<${Planning} />`
+          : html`<${Worktrees} />`
         }
       </>
     </div>

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -1,0 +1,106 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import { callMcpTool } from '../api/mcp'
+
+interface Worktree {
+  id: string
+  branch: string
+  path: string
+  agent?: string
+  task_id?: string
+  created_at?: string
+}
+
+export function Worktrees() {
+  const [worktrees, setWorktrees] = useState<Worktree[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true)
+        const resText = await callMcpTool('masc_worktree_list', {})
+        // The MCP tool returns text (often markdown or JSON). 
+        // Let's parse it if it's JSON or display it.
+        try {
+          const parsed = JSON.parse(resText)
+          setWorktrees(Array.isArray(parsed) ? parsed : parsed.worktrees || [])
+        } catch {
+          // If it's just raw text, we might need a different display.
+          // For now, let's wrap it in an object to render.
+          setWorktrees([{ id: 'raw', branch: 'Unknown', path: resText }])
+        }
+      } catch (err: any) {
+        setError(err.message || 'Failed to load worktrees')
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (loading) {
+    return html`<div class="loading-state loading-pulse">워크트리 목록을 불러오는 중...</div>`
+  }
+
+  if (error) {
+    return html`<div class="text-[var(--bad)] p-4 border border-[var(--bad)] rounded bg-[rgba(255,0,0,0.1)]">${error}</div>`
+  }
+
+  if (worktrees.length === 0) {
+    return html`
+      <div class="empty-state text-center p-8 text-[var(--text-muted)] border border-dashed border-[var(--card-border)] rounded-xl bg-[var(--white-2)]">
+        활성화된 워크트리가 없습니다.
+      </div>
+    `
+  }
+
+  // Check if it's the raw text fallback
+  if (worktrees.length === 1 && worktrees[0].id === 'raw') {
+    return html`
+      <div class="bg-[var(--bg-1)] border border-[var(--card-border)] rounded-xl p-4">
+        <pre class="font-mono text-sm text-[var(--text-body)] whitespace-pre-wrap">${worktrees[0].path}</pre>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="grid gap-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-lg font-semibold tracking-tight text-[var(--text-strong)]">활성 워크트리</h2>
+        <span class="text-sm px-2 py-1 bg-[var(--white-6)] rounded-full text-[var(--text-muted)]">${worktrees.length}개</span>
+      </div>
+      
+      <div class="grid gap-3 grid-cols-1 lg:grid-cols-2">
+        ${worktrees.map(wt => html`
+          <div key=${wt.id || wt.branch} class="flex flex-col gap-2 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--bg-1)] hover:border-[var(--accent-soft)] transition-colors shadow-sm">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <span class="text-[16px]">🌿</span>
+                <span class="font-medium text-[var(--text-strong)] truncate" title=${wt.branch}>${wt.branch}</span>
+              </div>
+              ${wt.agent ? html`<span class="text-xs px-2 py-0.5 rounded-full bg-[rgba(71,184,255,0.15)] text-[#9ad9ff] border border-[rgba(71,184,255,0.3)]">${wt.agent}</span>` : null}
+            </div>
+            
+            <div class="text-xs text-[var(--text-muted)] flex items-center gap-2 font-mono mt-1">
+              <span>📁</span> <span class="truncate" title=${wt.path}>${wt.path}</span>
+            </div>
+            
+            ${wt.task_id ? html`
+              <div class="text-xs text-[var(--text-muted)] flex items-center gap-2 mt-1">
+                <span>📋</span> <span>${wt.task_id}</span>
+              </div>
+            ` : null}
+            
+            ${wt.created_at ? html`
+              <div class="text-[10px] text-[var(--text-dim)] mt-2 pt-2 border-t border-[var(--border-slate-12)]">
+                생성: ${new Date(wt.created_at).toLocaleString()}
+              </div>
+            ` : null}
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -9,6 +9,7 @@ export type SurfaceSectionId =
   | 'governance'
   | 'evidence'
   | 'planning'
+  | 'worktrees'
   | 'intervene'
   | 'command'
   | 'tools'
@@ -163,6 +164,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '계획',
       description: '장기 목표와 메트릭 루프를 봅니다.',
       params: { section: 'planning' },
+    },
+    {
+      id: 'worktrees',
+      label: '워크트리',
+      description: '현재 활성화된 작업 공간(Worktree)을 봅니다.',
+      params: { section: 'worktrees' },
     },
   ],
   operations: [


### PR DESCRIPTION
## Description
- Implemented a 4-column horizontal layout for agent statistics on the Agent Profile page to reduce UI clutter and improve visibility.
- Added a new `Worktrees` view to the `Work` tab to visualize active git worktrees and their associated agents/tasks.