### PR TITLE
feat(context): session-level budget manager with compression phases

### DIFF
--- a/lib/context_budget_manager.ml
+++ b/lib/context_budget_manager.ml
@@ -1,0 +1,84 @@
+(** Context Budget Manager — session-level context window budget tracking.
+
+    Tracks accumulated token usage across tool schemas and conversation turns,
+    and determines compression phase based on usage ratio.
+
+    Phase thresholds (usage_ratio):
+    - 0.0 .. 0.50: None_phase
+    - 0.50 .. 0.70: Compact_tools
+    - 0.70 .. 0.85: Drop_low
+    - 0.85+:        Summarize
+
+    @since 2.128.0 *)
+
+type compression_phase =
+  | None_phase
+  | Compact_tools
+  | Drop_low
+  | Summarize
+
+let show_compression_phase = function
+  | None_phase -> "none"
+  | Compact_tools -> "compact_tools"
+  | Drop_low -> "drop_low"
+  | Summarize -> "summarize"
+
+type t = {
+  mutable tool_schema_tokens : int;
+  mutable turn_tokens : int;
+  max_budget_value : int;
+}
+
+let default_max_budget = 100_000
+
+let max_budget_from_env () : int =
+  match Sys.getenv_opt "MASC_CONTEXT_BUDGET_MAX" with
+  | Some raw -> (
+      match int_of_string_opt (String.trim raw) with
+      | Some v when v > 0 -> v
+      | _ -> default_max_budget)
+  | None -> default_max_budget
+
+let create ?(max_budget = 0) () : t =
+  let max_budget_value =
+    if max_budget > 0 then max_budget else max_budget_from_env ()
+  in
+  { tool_schema_tokens = 0; turn_tokens = 0; max_budget_value }
+
+let record_tool_schemas (t : t) ~count:_ ~estimated_tokens =
+  t.tool_schema_tokens <- t.tool_schema_tokens + estimated_tokens
+
+let record_turn (t : t) ~estimated_tokens =
+  t.turn_tokens <- t.turn_tokens + estimated_tokens
+
+let total_tokens (t : t) : int =
+  t.tool_schema_tokens + t.turn_tokens
+
+let max_budget (t : t) : int = t.max_budget_value
+
+let usage_ratio (t : t) : float =
+  if t.max_budget_value <= 0 then 0.0
+  else float_of_int (total_tokens t) /. float_of_int t.max_budget_value
+
+let phase_of_ratio (ratio : float) : compression_phase =
+  if ratio < 0.50 then None_phase
+  else if ratio < 0.70 then Compact_tools
+  else if ratio < 0.85 then Drop_low
+  else Summarize
+
+let current_phase (t : t) : compression_phase =
+  phase_of_ratio (usage_ratio t)
+
+let tool_budget_for_phase (t : t) : int option =
+  match current_phase t with
+  | None_phase -> None
+  | Compact_tools -> Some (t.max_budget_value / 10)
+  | Drop_low -> Some (t.max_budget_value / 20)
+  | Summarize -> Some (t.max_budget_value / 40)
+
+let summary (t : t) : string =
+  let ratio = usage_ratio t in
+  let phase = current_phase t in
+  Printf.sprintf "context_budget: %d/%d tokens (%.0f%%), phase=%s"
+    (total_tokens t) t.max_budget_value (ratio *. 100.0)
+    (show_compression_phase phase)

--- a/lib/context_budget_manager.mli
+++ b/lib/context_budget_manager.mli
@@ -1,0 +1,55 @@
+(** Context Budget Manager — session-level context window budget tracking.
+
+    Tracks accumulated token usage across tool schemas and conversation turns,
+    and determines compression phase based on usage ratio against a maximum budget.
+
+    Phase thresholds:
+    - 0-50%:  None_phase      — full descriptions, no compression
+    - 50-70%: Compact_tools   — one-line tool descriptions
+    - 70-85%: Drop_low        — drop low-importance messages
+    - 85%+:   Summarize       — summarize old turns
+
+    Default max budget from [MASC_CONTEXT_BUDGET_MAX] env var (fallback: 100000).
+
+    @since 2.128.0 *)
+
+type compression_phase =
+  | None_phase
+  | Compact_tools
+  | Drop_low
+  | Summarize
+
+val show_compression_phase : compression_phase -> string
+(** Human-readable phase name. *)
+
+type t
+(** Abstract budget state. *)
+
+val create : ?max_budget:int -> unit -> t
+(** Create a budget tracker.
+    [max_budget] defaults to [MASC_CONTEXT_BUDGET_MAX] env var, or 100000. *)
+
+val record_tool_schemas : t -> count:int -> estimated_tokens:int -> unit
+(** Record token cost of tool schemas sent to the model. *)
+
+val record_turn : t -> estimated_tokens:int -> unit
+(** Record token cost of a conversation turn (user + assistant). *)
+
+val current_phase : t -> compression_phase
+(** Determine compression phase from current usage ratio. *)
+
+val tool_budget_for_phase : t -> int option
+(** Suggested tool description token budget for current phase.
+    [None] at [None_phase] (no limit). *)
+
+val usage_ratio : t -> float
+(** Current usage as a fraction of max budget (0.0 to 1.0+). *)
+
+val total_tokens : t -> int
+(** Total accumulated tokens (tool schemas + turns). *)
+
+val max_budget : t -> int
+(** Maximum budget configured for this tracker. *)
+
+val summary : t -> string
+(** Human-readable status line. *)

--- a/lib/dune
+++ b/lib/dune
@@ -50,6 +50,7 @@
    cp_lifecycle_intents
    cp_lifecycle_policy
    config
+   context_budget_manager
    context_router
    dashboard
    dashboard_labels

--- a/test/dune
+++ b/test/dune
@@ -1028,3 +1028,9 @@
  (name test_grpc_coordination)
  (modules test_grpc_coordination)
  (libraries masc_mcp alcotest yojson unix))
+
+; Context Budget Manager — session-level budget tracking with compression phases
+(test
+ (name test_context_budget)
+ (modules test_context_budget)
+ (libraries masc_mcp alcotest))

--- a/test/test_context_budget.ml
+++ b/test/test_context_budget.ml
@@ -1,0 +1,181 @@
+(** Tests for Context_budget_manager — session-level context budget tracking. *)
+
+module Cbm = Masc_mcp.Context_budget_manager
+
+let () =
+  let open Alcotest in
+  run "Context_budget_manager"
+    [
+      ( "create",
+        [
+          test_case "default max budget" `Quick (fun () ->
+              (* env var MASC_CONTEXT_BUDGET_MAX is unset in test env *)
+              let t = Cbm.create () in
+              check int "default 100000" 100_000 (Cbm.max_budget t);
+              check int "total starts at 0" 0 (Cbm.total_tokens t));
+          test_case "custom max budget" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:50_000 () in
+              check int "custom" 50_000 (Cbm.max_budget t));
+          test_case "zero max_budget falls back to env/default" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:0 () in
+              check int "fallback" 100_000 (Cbm.max_budget t));
+        ] );
+      ( "record_turn",
+        [
+          test_case "single turn accumulates" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:500;
+              check int "500" 500 (Cbm.total_tokens t));
+          test_case "multiple turns accumulate" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:300;
+              Cbm.record_turn t ~estimated_tokens:200;
+              Cbm.record_turn t ~estimated_tokens:100;
+              check int "600" 600 (Cbm.total_tokens t));
+        ] );
+      ( "record_tool_schemas",
+        [
+          test_case "tool schemas accumulate" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_tool_schemas t ~count:5 ~estimated_tokens:1000;
+              check int "1000" 1000 (Cbm.total_tokens t));
+          test_case "tool schemas + turns combine" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_tool_schemas t ~count:3 ~estimated_tokens:800;
+              Cbm.record_turn t ~estimated_tokens:200;
+              check int "1000 combined" 1000 (Cbm.total_tokens t));
+        ] );
+      ( "usage_ratio",
+        [
+          test_case "zero usage" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              let r = Cbm.usage_ratio t in
+              check bool "0.0" true (Float.equal r 0.0));
+          test_case "half usage" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:5_000;
+              let r = Cbm.usage_ratio t in
+              check bool "0.5" true (Float.equal r 0.5));
+          test_case "full usage" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:10_000;
+              let r = Cbm.usage_ratio t in
+              check bool "1.0" true (Float.equal r 1.0));
+          test_case "over budget" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:15_000;
+              let r = Cbm.usage_ratio t in
+              check bool ">1.0" true (r > 1.0));
+        ] );
+      ( "phase_transitions",
+        [
+          test_case "0% -> None_phase" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              check string "none" "none"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "49% -> None_phase" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:4_999;
+              check string "none at 49%" "none"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "50% exact -> Compact_tools" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:5_000;
+              check string "compact at 50%" "compact_tools"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "69% -> Compact_tools" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:6_999;
+              check string "compact at 69%" "compact_tools"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "70% exact -> Drop_low" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:7_000;
+              check string "drop_low at 70%" "drop_low"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "84% -> Drop_low" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:8_499;
+              check string "drop_low at 84%" "drop_low"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "85% exact -> Summarize" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:8_500;
+              check string "summarize at 85%" "summarize"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "100% -> Summarize" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:10_000;
+              check string "summarize at 100%" "summarize"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+          test_case "progressive accumulation crosses phases" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              check string "start: none" "none"
+                (Cbm.show_compression_phase (Cbm.current_phase t));
+              Cbm.record_turn t ~estimated_tokens:5_000;
+              check string "50%: compact" "compact_tools"
+                (Cbm.show_compression_phase (Cbm.current_phase t));
+              Cbm.record_turn t ~estimated_tokens:2_000;
+              check string "70%: drop_low" "drop_low"
+                (Cbm.show_compression_phase (Cbm.current_phase t));
+              Cbm.record_turn t ~estimated_tokens:1_500;
+              check string "85%: summarize" "summarize"
+                (Cbm.show_compression_phase (Cbm.current_phase t)));
+        ] );
+      ( "tool_budget_for_phase",
+        [
+          test_case "None_phase returns None" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:100_000 () in
+              check bool "no limit" true
+                (Cbm.tool_budget_for_phase t = None));
+          test_case "Compact_tools returns max/10" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:100_000 () in
+              Cbm.record_turn t ~estimated_tokens:50_000;
+              check (option int) "10000" (Some 10_000)
+                (Cbm.tool_budget_for_phase t));
+          test_case "Drop_low returns max/20" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:100_000 () in
+              Cbm.record_turn t ~estimated_tokens:70_000;
+              check (option int) "5000" (Some 5_000)
+                (Cbm.tool_budget_for_phase t));
+          test_case "Summarize returns max/40" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:100_000 () in
+              Cbm.record_turn t ~estimated_tokens:85_000;
+              check (option int) "2500" (Some 2_500)
+                (Cbm.tool_budget_for_phase t));
+        ] );
+      ( "summary",
+        [
+          test_case "format at zero" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              let s = Cbm.summary t in
+              check bool "contains tokens" true
+                (String.length s > 0);
+              check bool "contains 0/10000" true
+                (let needle = "0/10000" in
+                 let nl = String.length needle in
+                 let sl = String.length s in
+                 nl <= sl &&
+                 let rec check_at i =
+                   if i > sl - nl then false
+                   else if String.sub s i nl = needle then true
+                   else check_at (i + 1)
+                 in
+                 check_at 0));
+          test_case "format at 50%" `Quick (fun () ->
+              let t = Cbm.create ~max_budget:10_000 () in
+              Cbm.record_turn t ~estimated_tokens:5_000;
+              let s = Cbm.summary t in
+              check bool "contains phase" true
+                (let needle = "compact_tools" in
+                 let nl = String.length needle in
+                 let sl = String.length s in
+                 nl <= sl &&
+                 let rec check_at i =
+                   if i > sl - nl then false
+                   else if String.sub s i nl = needle then true
+                   else check_at (i + 1)
+                 in
+                 check_at 0));
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add `Context_budget_manager` module (`lib/context_budget_manager.ml` + `.mli`) for session-level context window budget tracking
- 4 progressive compression phases based on usage ratio: None (0-50%), Compact_tools (50-70%), Drop_low (70-85%), Summarize (85%+)
- Per-phase tool description budget: None (unlimited), max/10, max/20, max/40
- Configurable via `MASC_CONTEXT_BUDGET_MAX` env var (default 100000)
- 26 unit tests covering creation, accumulation, phase transitions, budget calculation, and summary formatting

## Context
Plan item 3.2 — builds on Tool Budget (1.1). Phase 1 is the standalone module; keeper integration is Phase 2.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune exec test/test_context_budget.exe` — 26/26 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)