### PR TITLE
feat(governance): add masc_governance_rule tool for explicit case rulings

### DIFF
--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -323,6 +323,63 @@ let handle_execute_dry_run _ctx args =
     in
     (true, Council.ExecutorApi.dry_run ~topic ~result)
 
+(** Submit an explicit ruling on a governance case.
+    Allows agents and operators to approve/deny/dismiss pending cases. *)
+let handle_governance_rule ctx args =
+  let case_id = get_string args "case_id" "" in
+  let decision = get_string args "decision" "" in
+  let summary = get_string args "summary" "" in
+  if String.trim case_id = "" || String.trim decision = "" || String.trim summary = "" then
+    (false, "case_id, decision (approve|deny|dismiss), and summary are required")
+  else
+    let decision_lower = String.lowercase_ascii decision in
+    match decision_lower with
+    | "approve" | "deny" | "dismiss" ->
+        let now = Time_compat.now () in
+        let status_str = match decision_lower with
+          | "approve" -> "approved"
+          | "deny" -> "denied"
+          | "dismiss" -> "dismissed"
+          | _ -> "denied"
+        in
+        let auto_exec = match decision_lower with
+          | "approve" -> "ready_auto_execute"
+          | _ -> "none"
+        in
+        let evidence_refs = get_string_list args "evidence_refs" in
+        let confidence = match Yojson.Safe.Util.member "confidence" args with
+          | `Float f -> f
+          | `Int n -> float_of_int n
+          | _ -> 0.9
+        in
+        let ruling : GV2.ruling = {
+          id = GV2.generate_id "ruling";
+          case_id;
+          status = status_str;
+          summary;
+          confidence;
+          provenance = "agent_explicit";
+          generated_at = now;
+          expires_at = None;
+          keeper_name = ctx.agent_name;
+          model_used = None;
+          risk_class = GV2.Low;
+          evidence_refs;
+          recommended_action = None;
+          auto_execution_state = auto_exec;
+        } in
+        (match GV2.save_ruling ctx.base_path ruling with
+         | Ok updated_case ->
+             let json = `Assoc [
+               ("ruling", ruling_json ruling);
+               ("case_status", `String (GV2.case_status_to_string updated_case.status));
+               ("case_id", `String case_id);
+             ] in
+             (true, Yojson.Safe.pretty_to_string json)
+         | Error msg -> (false, msg))
+    | other ->
+        (false, Printf.sprintf "invalid decision %S: must be approve, deny, or dismiss" other)
+
 (** Delegated handlers from {!Tool_council_feed}. *)
 let handle_governance_feed = Tool_council_feed.handle_governance_feed
 let handle_runtime_params = Tool_council_feed.handle_runtime_params
@@ -340,6 +397,7 @@ let dispatch ctx ~name ~args : result option =
   | "masc_cases" -> Some (handle_cases ctx args)
   | "masc_case_status" -> Some (handle_case_status ctx args)
   | "masc_ruling_status" -> Some (handle_ruling_status ctx args)
+  | "masc_governance_rule" -> Some (handle_governance_rule ctx args)
   | "masc_execution_orders" -> Some (handle_execution_orders ctx args)
   | "masc_governance_status" -> Some (handle_governance_status ctx args)
   | "masc_governance_feed" -> Some (handle_governance_feed ctx args)

--- a/lib/tool_council_schemas.ml
+++ b/lib/tool_council_schemas.ml
@@ -108,6 +108,29 @@ After masc_case_brief_submit may trigger a ruling; pair with masc_execution_orde
       ];
     `Assoc
       [
+        ("name", `String "masc_governance_rule");
+        ("description", `String "Submit an explicit ruling on a Governance V2 case. \
+Approve, deny, or dismiss a pending case with a summary and optional evidence. \
+Use when a case needs a decision: stale cases can be dismissed, valid petitions approved or denied. \
+After masc_case_status shows a pending case; pair with masc_ruling_status to verify.");
+        ( "inputSchema",
+          `Assoc
+            [
+              ("type", `String "object");
+              ( "properties",
+                `Assoc
+                  [
+                    ("case_id", `Assoc [ ("type", `String "string"); ("description", `String "Governance V2 case ID") ]);
+                    ("decision", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "approve"; `String "deny"; `String "dismiss" ]); ("description", `String "Ruling decision") ]);
+                    ("summary", `Assoc [ ("type", `String "string"); ("description", `String "Ruling rationale") ]);
+                    ("confidence", `Assoc [ ("type", `String "number"); ("description", `String "Confidence 0-1 (default 0.9)") ]);
+                    ("evidence_refs", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]); ("description", `String "Evidence references") ]);
+                  ] );
+              ("required", `List [ `String "case_id"; `String "decision"; `String "summary" ]);
+            ] );
+      ];
+    `Assoc
+      [
         ("name", `String "masc_execution_orders");
         ("description", `String "List execution orders, inspect a case order, or confirm/deny a human gate decision. \
 Use when reviewing or acting on enforcement actions from governance rulings. \


### PR DESCRIPTION
## Summary
거버넌스 V2에 판정(ruling) tool 추가. 기존에는 petition/brief만 가능하고 ruling을 내리는 경로가 없어서 케이스가 영원히 pending_ruling에 머물렀다.

## Changes
- `tool_council.ml`: `handle_governance_rule` handler (approve/deny/dismiss)
- `tool_council_schemas.ml`: MCP schema definition
- dispatch에 `masc_governance_rule` 라우팅 추가

## Usage
```
masc_governance_rule(case_id="case-xxx", decision="dismiss", summary="stale test case")
masc_governance_rule(case_id="case-xxx", decision="approve", summary="valid petition, proceed")
```

## Test plan
- [x] `dune build` passes
- [ ] stale 케이스에 dismiss ruling 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)