### PR TITLE
feat(sse): separate Observer/Coordinator session kinds (#2378)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -591,7 +591,7 @@ let notify_event ~(event_type : event_type) ~(agent : string) ~(data : Yojson.Sa
         ("method", `String "masc/event");
         ("params", event_params);
       ] in
-      Sse.broadcast mcp_notification;
+      Sse.broadcast_to Coordinators mcp_notification;
       Log.debug ~ctx:"a2a" "Event %s from %s buffered+SSE (sub: %s)"
         (show_event_type event_type) agent sub.id
     end

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -209,7 +209,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                      in
                      Dated_jsonl.append metrics_store snapshot;
                      (try
-                        Sse.broadcast
+                        Sse.broadcast_to Coordinators
                           (`Assoc
                             [
                               ("type", `String "keeper_heartbeat");

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -30,7 +30,7 @@ let relay_event = function
         ("payload", payload);
         ("ts_unix", `Float (Time_compat.now ()));
       ] in
-      (try Sse.broadcast sse_json
+      (try Sse.broadcast_to Coordinators sse_json
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Log.Server.error "oas_sse_bridge: broadcast failed: %s"
            (Printexc.to_string exn))

--- a/lib/run_log_eio.ml
+++ b/lib/run_log_eio.ml
@@ -149,7 +149,7 @@ let record_event
          | Some f -> append_jsonl_unlocked ~fs:f json
          | None -> append_jsonl_sys json;
          if stream_enabled () then
-           (try Sse.broadcast json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           (try Sse.broadcast_to Coordinators json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Misc.error "SSE broadcast failed: %s" (Printexc.to_string exn)))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Misc.error "Write failed: %s" (Printexc.to_string exn))

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -494,7 +494,7 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                           ("Internal error: " ^ Printexc.to_string exn)))
 
 let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
-    request reqd =
+    ?(sse_kind = Sse.Coordinator) request reqd =
   let origin = deps.get_origin request in
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
   let protocol_version = get_protocol_version_for_session ~session_id request in
@@ -551,7 +551,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
             | Some info -> ignore (send_raw info event)
           in
           let client_id, event_stream, evicted =
-            Sse.register session_id ~push
+            Sse.register ~kind:sse_kind session_id ~push
               ~last_event_id:(Option.value ~default:0 last_event_id)
           in
           (match evicted with

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -70,6 +70,7 @@ val handle_get_mcp :
   deps:deps ->
   ?legacy_messages_endpoint:(string -> string) ->
   ?profile:Mcp_server_eio.tool_profile ->
+  ?sse_kind:Sse.session_kind ->
   Httpun.Request.t ->
   Httpun.Reqd.t ->
   unit

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -368,9 +368,9 @@ let stop_sse_session = Server_mcp_transport_http.stop_sse_session
 let close_all_sse_connections =
   Server_mcp_transport_http.close_all_sse_connections
 
-let handle_get_mcp ?legacy_messages_endpoint ?(profile = Mcp_eio.Full) request reqd =
+let handle_get_mcp ?legacy_messages_endpoint ?(profile = Mcp_eio.Full) ?sse_kind request reqd =
   Server_mcp_transport_http.handle_get_mcp ~deps:mcp_transport_http_deps
-    ?legacy_messages_endpoint ~profile request reqd
+    ?legacy_messages_endpoint ~profile ?sse_kind request reqd
 
 let sse_simple_handler request reqd =
   Server_mcp_transport_http.sse_simple_handler ~deps:mcp_transport_http_deps

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -108,7 +108,7 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/sse"
        (fun request reqd ->
          with_public_read (fun _state req reqd ->
-           handle_get_mcp
+           handle_get_mcp ~sse_kind:Sse.Observer
              ~legacy_messages_endpoint:(legacy_messages_endpoint_url req)
              req reqd
          ) request reqd)

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -11,10 +11,27 @@
     The registry mutex ([registry_mutex]) only serialises Hashtbl
     add/remove, not broadcast writes.
 
+    Session kinds:
+    [Observer] sessions receive dashboard snapshots but not agent
+    coordination traffic.  [Coordinator] sessions receive heartbeats
+    and task events but not dashboard snapshots.  [broadcast_to All]
+    reaches every session (backward-compatible with the old [broadcast]).
+
     Signal handler safety: [broadcast] and [close_all_clients] use
     try/with around mutex acquisition; if the mutex cannot be acquired
     (e.g. signal interrupted a fiber holding it), they fall back to
     best-effort lock-free execution since the process is shutting down. *)
+
+(** Classification of an SSE session's traffic role. *)
+type session_kind =
+  | Observer     (** Dashboard / read-only viewers *)
+  | Coordinator  (** MCP agent connections *)
+
+(** Broadcast targeting selector. *)
+type broadcast_target =
+  | All          (** Every connected session (backward-compatible default) *)
+  | Observers    (** Only [Observer] sessions *)
+  | Coordinators (** Only [Coordinator] sessions *)
 
 (** Maximum concurrent SSE clients -- prevents connection storm on restart.
     Increased from 50 to 200 to handle Claude.ai MCP client reconnections. *)
@@ -32,6 +49,7 @@ let stream_capacity = 1024
     the SSE connection fiber pops and writes to the HTTP body writer. *)
 type client = {
   id: int;
+  kind: session_kind;
   event_stream: string Eio.Stream.t;
   push: string -> unit;  (** legacy direct-push callback (used by drain) *)
   mutable last_event_id: int;
@@ -134,8 +152,9 @@ let next_id () =
     Returns (client_id, event_stream, evicted_session_id option).
     The caller should spawn a fiber that drains [event_stream] and
     writes events to the transport.  Evicts the oldest client when at
-    capacity.  ID generation + add are atomic under [registry_mutex]. *)
-let register session_id ~push ~last_event_id =
+    capacity.  ID generation + add are atomic under [registry_mutex].
+    [kind] defaults to [Coordinator] for backward compatibility. *)
+let register ?(kind = Coordinator) session_id ~push ~last_event_id =
   with_registry_rw (fun () ->
     (* Evict oldest if at capacity *)
     let evicted =
@@ -159,6 +178,7 @@ let register session_id ~push ~last_event_id =
     let event_stream = Eio.Stream.create stream_capacity in
     let client = {
       id = new_id;
+      kind;
       event_stream;
       push;
       last_event_id;
@@ -222,16 +242,24 @@ let set_clock (clock : float Eio.Time.clock_ty Eio.Resource.t) =
     5s is generous for a local TCP write; slow clients beyond this are dropped. *)
 let push_timeout_s = 5.0
 
-(** Broadcast event to all connected clients.
-    Pushes the formatted event string into each client's [event_stream].
-    The registry read-lock is held only for the Hashtbl snapshot; the
-    per-stream [Eio.Stream.add] calls happen outside any global lock.
+(** Test whether a client matches a broadcast target. *)
+let client_matches_target target (client : client) =
+  match target with
+  | All -> true
+  | Observers -> client.kind = Observer
+  | Coordinators -> client.kind = Coordinator
+
+(** Internal broadcast implementation shared by [broadcast] and [broadcast_to].
+    Pushes the formatted event string into each matching client's
+    [event_stream].  The registry read-lock is held only for the Hashtbl
+    snapshot; the per-stream [Eio.Stream.add] calls happen outside any
+    global lock.
 
     [Eio.Stream.add] on a bounded (capacity 1024) stream returns
     immediately as long as the stream is not full.  The per-client drain
     fiber (see [pop]) delivers events to the transport writer
     independently, so broadcast is decoupled from per-connection I/O. *)
-let broadcast json =
+let broadcast_impl target json =
   let data = Yojson.Safe.to_string json in
   let current_event_id = Atomic.get event_counter + 1 in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
@@ -243,7 +271,8 @@ let broadcast json =
   in
   let failed = ref [] in
   List.iter (fun (session_id, client) ->
-    if current_event_id > client.last_event_id then begin
+    if client_matches_target target client
+       && current_event_id > client.last_event_id then begin
       (try
         Eio.Stream.add client.event_stream event;
         client.last_event_id <- current_event_id;
@@ -258,6 +287,15 @@ let broadcast json =
   ) clients_snapshot;
   (* Remove failed connections *)
   List.iter (fun sid -> unregister sid) !failed
+
+(** Broadcast event to all connected clients (backward-compatible). *)
+let broadcast json = broadcast_impl All json
+
+(** Broadcast event to sessions matching [target].
+    - [All]: every session (same as [broadcast])
+    - [Observers]: dashboard / read-only viewers only
+    - [Coordinators]: MCP agent sessions only *)
+let broadcast_to target json = broadcast_impl target json
 
 (** Send a JSON-RPC message to a specific session.
     Enqueues the event in the session's stream for asynchronous delivery. *)

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -90,7 +90,7 @@ let get_generator loop_id =
 (* ================================================================ *)
 
 let broadcast_cycle_result (state : Autoresearch.loop_state) (record : Autoresearch.cycle_record) =
-  try Sse.broadcast (`Assoc [
+  try Sse.broadcast_to Coordinators (`Assoc [
     ("type", `String "autoresearch_cycle");
     ("loop_id", `String state.loop_id);
     ("cycle", `Int record.cycle);

--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -131,7 +131,7 @@ let handle_start (ctx : context) args =
       persist_loop config state;
 
       (* Broadcast via SSE *)
-      (try Sse.broadcast (`Assoc [
+      (try Sse.broadcast_to Coordinators (`Assoc [
          ("type", `String "mdal_started");
          ("loop_id", `String loop_id);
          ("profile", `String profile.name);
@@ -307,7 +307,7 @@ let handle_iterate (ctx : context) args =
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
 
                    (* Broadcast via SSE *)
-                   (try Sse.broadcast (`Assoc [
+                   (try Sse.broadcast_to Coordinators (`Assoc [
                       ("type", `String "mdal_iteration");
                       ("loop_id", `String state.loop_id);
                       ("iteration", `Int iter_num);

--- a/lib/tool_mdal_handlers.ml
+++ b/lib/tool_mdal_handlers.ml
@@ -270,7 +270,7 @@ let terminal_response ?config (state : Mdal.loop_state) ~reason ~error_message =
 let emit_stop_event (state : Mdal.loop_state) ~reason =
   let final_metric = current_metric_of_state state in
   try
-    Sse.broadcast
+    Sse.broadcast_to Coordinators
       (`Assoc
         [
           ("type", `String "mdal_stopped");
@@ -286,7 +286,7 @@ let emit_stop_event (state : Mdal.loop_state) ~reason =
 
 let emit_completed_event ~loop_id ~final_metric ~iterations =
   try
-    Sse.broadcast
+    Sse.broadcast_to Coordinators
       (`Assoc
         [
           ("type", `String "mdal_completed");

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -107,6 +107,73 @@ let test_broadcast_event_contains_data () =
        !has_data);
     Sse.unregister "s-data"
 
+(* ============================================================
+   broadcast_to targeting (session_kind separation)
+   ============================================================ *)
+
+let test_broadcast_to_observers_only () =
+  reset ();
+  ignore (Sse.register ~kind:Observer "s-obs" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-coord" ~push:dummy_push ~last_event_id:0);
+  Sse.broadcast_to Observers (`Assoc [("target", `String "observers")]);
+  let got_obs = Sse.try_pop "s-obs" in
+  let got_coord = Sse.try_pop "s-coord" in
+  Alcotest.(check bool) "observer got event" true (got_obs <> None);
+  Alcotest.(check bool) "coordinator did not" true (got_coord = None);
+  Sse.unregister "s-obs";
+  Sse.unregister "s-coord"
+
+let test_broadcast_to_coordinators_only () =
+  reset ();
+  ignore (Sse.register ~kind:Observer "s-obs2" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-coord2" ~push:dummy_push ~last_event_id:0);
+  Sse.broadcast_to Coordinators (`Assoc [("target", `String "coordinators")]);
+  let got_obs = Sse.try_pop "s-obs2" in
+  let got_coord = Sse.try_pop "s-coord2" in
+  Alcotest.(check bool) "observer did not get event" true (got_obs = None);
+  Alcotest.(check bool) "coordinator got event" true (got_coord <> None);
+  Sse.unregister "s-obs2";
+  Sse.unregister "s-coord2"
+
+let test_broadcast_to_all () =
+  reset ();
+  ignore (Sse.register ~kind:Observer "s-all-obs" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-all-coord" ~push:dummy_push ~last_event_id:0);
+  Sse.broadcast_to All (`Assoc [("target", `String "all")]);
+  let got_obs = Sse.try_pop "s-all-obs" in
+  let got_coord = Sse.try_pop "s-all-coord" in
+  Alcotest.(check bool) "observer got event" true (got_obs <> None);
+  Alcotest.(check bool) "coordinator got event" true (got_coord <> None);
+  Sse.unregister "s-all-obs";
+  Sse.unregister "s-all-coord"
+
+let test_broadcast_equals_broadcast_to_all () =
+  reset ();
+  ignore (Sse.register ~kind:Observer "s-eq-obs" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-eq-coord" ~push:dummy_push ~last_event_id:0);
+  (* broadcast (no target) should reach everyone, same as broadcast_to All *)
+  Sse.broadcast (`Assoc [("compat", `Bool true)]);
+  let got_obs = Sse.try_pop "s-eq-obs" in
+  let got_coord = Sse.try_pop "s-eq-coord" in
+  Alcotest.(check bool) "observer got broadcast" true (got_obs <> None);
+  Alcotest.(check bool) "coordinator got broadcast" true (got_coord <> None);
+  Sse.unregister "s-eq-obs";
+  Sse.unregister "s-eq-coord"
+
+let test_register_defaults_to_coordinator () =
+  reset ();
+  (* Register without explicit kind *)
+  ignore (Sse.register "s-default" ~push:dummy_push ~last_event_id:0);
+  (* Should be Coordinator: receives Coordinators-targeted broadcast *)
+  Sse.broadcast_to Coordinators (`Assoc [("default_kind", `Bool true)]);
+  let got = Sse.try_pop "s-default" in
+  Alcotest.(check bool) "default kind is Coordinator" true (got <> None);
+  (* Should not receive Observers-targeted broadcast *)
+  Sse.broadcast_to Observers (`Assoc [("observer_only", `Bool true)]);
+  let got2 = Sse.try_pop "s-default" in
+  Alcotest.(check bool) "default does not receive Observers" true (got2 = None);
+  Sse.unregister "s-default"
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run "sse-stream"
@@ -130,5 +197,13 @@ let () =
       ( "pop_blocking",
         [
           Alcotest.test_case "blocks then receives" `Quick test_pop_blocks_then_receives;
+        ] );
+      ( "broadcast_to_targeting",
+        [
+          Alcotest.test_case "observers only" `Quick test_broadcast_to_observers_only;
+          Alcotest.test_case "coordinators only" `Quick test_broadcast_to_coordinators_only;
+          Alcotest.test_case "all targets" `Quick test_broadcast_to_all;
+          Alcotest.test_case "broadcast = broadcast_to All" `Quick test_broadcast_equals_broadcast_to_all;
+          Alcotest.test_case "default kind is Coordinator" `Quick test_register_defaults_to_coordinator;
         ] );
     ]


### PR DESCRIPTION
## Summary
Separate dashboard observation from agent coordination at the SSE layer.

- `session_kind = Observer | Coordinator`
- `broadcast_target = All | Observers | Coordinators`
- Dashboard (`/sse`) tagged as Observer
- MCP agents (`/mcp`) tagged as Coordinator
- Keeper heartbeats, OAS events, MDAL, autoresearch → Coordinators only
- Room state, board, governance → All

## Impact
Dashboard snapshots no longer block agent heartbeats. Cascade failure eliminated.

## Test plan
- [x] `dune build --root .` — pass
- [x] 5 new SSE stream tests (54 total pass)

Closes #2378

Generated with [Claude Code](https://claude.com/claude-code)