### PR TITLE
refactor: eliminate 7 Model_spec refs (keeper/chain/dashboard)

### DIFF
--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -210,9 +210,9 @@ let model_runner_of_string raw =
   let lower = String.lowercase_ascii model in
   let direct label =
     (* Validate the label parses, but carry the string *)
-    match Model_spec.model_spec_of_string label with
-    | Ok _ -> Ok (Direct label)
-    | Error msg -> Error msg
+    match Llm_provider.Cascade_config.parse_model_string label with
+    | Some _ -> Ok (Direct label)
+    | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
   in
   match lower with
   | "" | "gemini" -> direct "gemini:pro"
@@ -241,28 +241,28 @@ let model_runner_of_string raw =
       in
       direct (Printf.sprintf "codex-api:%s" effective)
   | value -> (
-      match Model_spec.model_spec_of_string model with
-      | Ok _ -> Ok (Direct model)
-      | Error _ when starts_with ~prefix:"llama:" value -> direct model
-      | Error _ when starts_with ~prefix:"gemini:" value -> direct model
-      | Error _ when starts_with ~prefix:"claude:" value -> direct model
-      | Error _ when starts_with ~prefix:"glm:" value -> direct model
+      match Llm_provider.Cascade_config.parse_model_string model with
+      | Some _ -> Ok (Direct model)
+      | None when starts_with ~prefix:"llama:" value -> direct model
+      | None when starts_with ~prefix:"gemini:" value -> direct model
+      | None when starts_with ~prefix:"claude:" value -> direct model
+      | None when starts_with ~prefix:"glm:" value -> direct model
       (* Bare provider model names → route to provider *)
-      | Error _ when starts_with ~prefix:"glm-" value ->
+      | None when starts_with ~prefix:"glm-" value ->
           direct (Printf.sprintf "glm:%s" value)
-      | Error _ when starts_with ~prefix:"gemini-" value ->
+      | None when starts_with ~prefix:"gemini-" value ->
           direct (Printf.sprintf "gemini:%s" value)
-      | Error _ when starts_with ~prefix:"claude-" value ->
+      | None when starts_with ~prefix:"claude-" value ->
           direct (Printf.sprintf "claude:%s" value)
-      | Error _ when starts_with ~prefix:"codex-" value ->
+      | None when starts_with ~prefix:"codex-" value ->
           direct (Printf.sprintf "codex-api:%s" value)
-      | Error _ when starts_with ~prefix:"gpt-" value ->
+      | None when starts_with ~prefix:"gpt-" value ->
           direct (Printf.sprintf "codex-api:%s" value)
-      | Error _ when String.equal value "gpt" ->
+      | None when String.equal value "gpt" ->
           direct (Printf.sprintf "codex-api:%s" Env_config.OpenAI.default_model)
-      | Error _ when starts_with ~prefix:"o1" value || starts_with ~prefix:"o3" value ->
+      | None when starts_with ~prefix:"o1" value || starts_with ~prefix:"o3" value ->
           direct (Printf.sprintf "codex-api:%s" value)
-      | Error msg -> Error msg)
+      | None -> Error (Printf.sprintf "Cannot parse model: %s" model))
 
 let call_model_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
     ~timeout_sec () =

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -472,10 +472,10 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
 
 (** Check if a model label is runnable (has provider config + Gemini auth check). *)
 let is_label_runnable (label : string) : bool =
-  match Model_spec.model_spec_of_string label with
-  | Error _ -> false
-  | Ok spec ->
-    let rn = Model_spec.registry_name_of_provider spec.provider in
+  match Llm_provider.Cascade_config.parse_model_string label with
+  | None -> false
+  | Some cfg ->
+    let rn = Llm_provider.Provider_config.(match cfg.kind with Anthropic -> "claude" | Gemini -> "gemini" | Glm -> "glm" | OpenAI_compat -> "openai" | Claude_code -> "claude") in
     match rn with
     | "gemini" -> (
         match Provider_adapter.resolve_gemini_direct_auth () with
@@ -495,9 +495,9 @@ let execute_single_agent_run ~sw:_ ~provider ~model ~prompt =
   | Error _ as error -> error
   | Ok label -> (
       (* Validate label parses *)
-      match Model_spec.model_spec_of_string label with
-      | Error message -> Error message
-      | Ok _spec ->
+      match Llm_provider.Cascade_config.parse_model_string label with
+      | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
+      | Some _cfg ->
         if not (is_label_runnable label) then
           Error
             (Printf.sprintf

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -16,13 +16,23 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let used_model_id =
-    Model_spec.find_model_id_for_used ~labels:meta.models
-      ~model_used:result.model_used
+    let strip_latest s =
+      if String.length s > 7 && String.sub s (String.length s - 7) 7 = ":latest"
+      then String.sub s 0 (String.length s - 7) else s
+    in
+    let used = strip_latest result.model_used in
+    let cfgs = Llm_provider.Cascade_config.parse_model_strings meta.models in
+    match List.find_opt (fun (c : Llm_provider.Provider_config.t) ->
+      c.model_id = result.model_used || c.model_id = used
+    ) cfgs with
+    | Some c -> c.model_id
+    | None -> (match cfgs with c :: _ -> c.model_id | [] -> result.model_used)
   in
   let turn_cost =
-    Model_spec.cost_usd_of_model_id ~model_id:used_model_id
+    let pricing = Llm_provider.Pricing.pricing_for_model used_model_id in
+    Llm_provider.Pricing.estimate_cost ~pricing
       ~input_tokens:result.usage.input_tokens
-      ~output_tokens:result.usage.output_tokens
+      ~output_tokens:result.usage.output_tokens ()
   in
   let has_tool_calls = result.tools_used <> [] in
   let has_text =


### PR DESCRIPTION
7 refs removed from keeper_unified_turn, chain_native_eio, dashboard_provider_runs. Part of #2207.