### PR TITLE
refactor(dashboard): StatGrid adoption + agent-roster fix

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { GraphView } from './activity-graph-view'
 import { fetchActivityGraph } from '../api'
@@ -116,7 +117,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
 
 function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
   if (events.length === 0) {
-    return html`<div class="empty-state">최근 실행 이벤트가 없습니다.</div>`
+    return html`<${EmptyState} message="최근 실행 이벤트가 없습니다." compact />`
   }
   return html`
     <div class="flex flex-col gap-2.5">
@@ -153,7 +154,7 @@ function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
     .slice(0, 15)
 
   if (agentNodes.length === 0) {
-    return html`<div class="empty-state">활동 집계에 포함된 에이전트가 없습니다.</div>`
+    return html`<${EmptyState} message="활동 집계에 포함된 에이전트가 없습니다." compact />`
   }
 
   const maxWeight = agentNodes[0]?.weight ?? 1
@@ -188,7 +189,7 @@ function KindBreakdown({ nodes }: { nodes: ActivityGraphNode[] }) {
   const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1])
 
   if (sorted.length === 0) {
-    return html`<div class="empty-state">분석할 노드 종류가 없습니다.</div>`
+    return html`<${EmptyState} message="분석할 노드 종류가 없습니다." compact />`
   }
 
   return html`
@@ -211,9 +212,7 @@ function EmptyActivityGraph() {
           <h2 class="monitor-headline">활동 그래프가 비어 있습니다</h2>
           <p class="monitor-subheadline">이 뷰는 런타임 실행 이벤트를 읽어 그래프를 그립니다. 지금은 기록된 이벤트가 없어 화면이 비어 있습니다.</p>
         </div>
-        <div class="empty-state">
-          아직 claim, broadcast, team-session, board 같은 실행 이벤트가 activity feed에 기록되지 않았습니다.
-        </div>
+        <${EmptyState} message="아직 claim, broadcast, team-session, board 같은 실행 이벤트가 activity feed에 기록되지 않았습니다." compact />
       <//>
     </div>
   `
@@ -236,7 +235,7 @@ export function ActivityGraphSurface() {
     return html`
       <div class="flex flex-col gap-5">
         <${Card} title="오류" class="section mb-3.5" testId="activity_graph.error">
-          <div class="empty-state">활동 그래프를 불러올 수 없습니다: ${error}</div>
+          <${EmptyState} message=${'활동 그래프를 불러올 수 없습니다: ' + error} compact />
           <button class="control-btn rounded-lg ghost" onClick=${loadGraph}>다시 시도</button>
         <//>
       </div>
@@ -244,7 +243,7 @@ export function ActivityGraphSurface() {
   }
 
   if (!data) {
-    return html`<div class="empty-state">활동 데이터가 없습니다.</div>`
+    return html`<${EmptyState} message="활동 데이터가 없습니다." compact />`
   }
 
   if ((data.stats.event_count ?? 0) === 0) {

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { agentJournalEntries, compactCopy, journalKindIcon } from './agent-detail-state'
 import type { JournalEntry } from '../types'
@@ -12,7 +13,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
   return html`
     <${Card} title="실시간 활동 스트림">
       ${entries.length === 0
-        ? html`<div class="empty-state">관련 이벤트 없음</div>`
+        ? html`<${EmptyState} message="관련 이벤트 없음" compact />`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[280px] overflow-y-auto">
               ${entries.map((entry: JournalEntry, idx: number) => html`

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { agentTimeline, compactCopy } from './agent-detail-state'
 import type { AgentTimelineEvent } from '../api'
@@ -43,7 +44,7 @@ export function AgentTimelineSection() {
         </div>
       ` : null}
       ${events.length === 0
-        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
+        ? html`<${EmptyState} message="타임라인 이벤트 없음" compact />`
         : html`
             <div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">
               ${events.map((evt: AgentTimelineEvent, idx: number) => {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { keeperIdentityHint } from './common/keeper-identity'
@@ -153,13 +154,13 @@ export function AgentDetailOverlay() {
         <div class="grid grid-cols-2 gap-3 mb-3">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
-              ? html`<div class="empty-state">할당된 작업이 없습니다</div>`
+              ? html`<${EmptyState} message="할당된 작업이 없습니다" compact />`
               : html`<div class="flex flex-col gap-2">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
           <//>
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<div class="empty-state">최근 활동 기록이 없습니다</div>`
+              ? html`<${EmptyState} message="최근 활동 기록이 없습니다" compact />`
               : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
           <//>
         </div>
@@ -169,7 +170,7 @@ export function AgentDetailOverlay() {
         <${AgentWorkerBrief} agentName=${agentName} />
         <${Card} title="작업 이력">
           ${taskHistories.value.length === 0
-            ? html`<div class="empty-state">작업 이력이 없습니다</div>`
+            ? html`<${EmptyState} message="작업 이력이 없습니다" compact />`
             : html`<div class="flex flex-col gap-2.5">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
         <//>
 

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -9,6 +9,7 @@ import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import { keeperIdentityHint } from './common/keeper-identity'
+import { EmptyState } from './common/empty-state'
 import { AgentAvatar } from './overview/agent-avatar'
 import {
   agents,
@@ -356,7 +357,7 @@ export function AgentProfile({ name }: { name: string }) {
         ${!isKeeper ? html`
         <${Card} title="태스크 (${owned.length})" class="ff-card rounded-xl">
           ${owned.length === 0
-            ? html`<div class="empty-state">할당된 태스크 없음</div>`
+            ? html`<${EmptyState} message="할당된 태스크 없음" compact />`
             : html`<div class="flex flex-col gap-2">${owned.map(t => html`
                 <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg" key=${t.id}>
                   <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${t.id}</span>
@@ -405,7 +406,7 @@ export function AgentProfile({ name }: { name: string }) {
 
         <${Card} title="타임라인" class="ff-card rounded-xl">
           ${!timeline || (timeline.events ?? []).length === 0
-            ? html`<div class="empty-state">이벤트 없음</div>`
+            ? html`<${EmptyState} message="이벤트 없음" compact />`
             : html`<div class="flex flex-col gap-0.5 max-h-[300px] overflow-y-auto">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
                 const detail = evt.detail as Record<string, string | undefined>
                 const title = detail.title ?? detail.content ?? ''
@@ -425,7 +426,7 @@ export function AgentProfile({ name }: { name: string }) {
 
         <${Card} title="Room 활동" class="ff-card rounded-xl">
           ${lines.length === 0
-            ? html`<div class="empty-state">관련 활동 없음</div>`
+            ? html`<${EmptyState} message="관련 활동 없음" compact />`
             : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>
                 html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
         <//>

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { RoomTruthStrip } from './common/room-truth-strip'
 import {
   executionQueue,
@@ -162,7 +163,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${workerSupportRows.length === 0
-              ? html`<div class="empty-state">참여 에이전트가 없습니다.</div>`
+              ? html`<${EmptyState} message="참여 에이전트가 없습니다." compact />`
               : workerSupportRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.worker-card" />`)}
           </div>
         <//>
@@ -175,7 +176,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${continuityRows.length === 0
-              ? html`<div class="empty-state">연속성 경고 없음</div>`
+              ? html`<${EmptyState} message="연속성 경고 없음" compact />`
               : continuityRows.map(row => html`<${ContinuityRow} key=${row.name} row=${row} />`)}
           </div>
         <//>
@@ -188,7 +189,7 @@ export function Execution() {
         >
           <div class="flex flex-col gap-2.5">
             ${offlineRows.length === 0
-              ? html`<div class="empty-state">오프라인 에이전트 없음</div>`
+              ? html`<${EmptyState} message="오프라인 에이전트 없음" compact />`
               : offlineRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.offline-worker-card" />`)}
           </div>
         <//>

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import type {
   CommandPlaneCapacityRow,
   CommandPlaneDecisionRecord,
@@ -113,7 +114,7 @@ export function ControlSurface() {
           ? html`<div class="flex flex-col gap-3">
               ${snapshot.decisions.decisions.map(decision => html`<${DecisionCard} decision=${decision} />`)}
             </div>`
-          : html`<div class="empty-state">지금 승인 대기 항목은 없습니다.</div>`}
+          : html`<${EmptyState} message="지금 승인 대기 항목은 없습니다." compact />`}
       </section>
 
       <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
@@ -122,7 +123,7 @@ export function ControlSurface() {
           ? html`<div class="flex flex-col gap-3">
               ${snapshot.capacity.capacity.map(row => html`<${CapacityRowCard} row=${row} />`)}
             </div>`
-          : html`<div class="empty-state">제어할 용량 행이 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="제어할 용량 행이 아직 없습니다." compact />`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import type { CommandPlaneHelpPath } from '../../types'
 import {
   commandPlaneDetailError,
@@ -250,9 +251,9 @@ function GuidedPanel() {
           <div class="card rounded-xl-title">운영 경로</div>
         </div>
         ${commandPlaneHelpLoading.value
-          ? html`<div class="empty-state">CPv2 runbook 불러오는 중…</div>`
+          ? html`<${EmptyState} message="CPv2 runbook 불러오는 중…" compact />`
           : commandPlaneHelpError.value
-            ? html`<div class="empty-state error">${commandPlaneHelpError.value}</div>`
+            ? html`<${EmptyState} message=${commandPlaneHelpError.value} compact />`
             : html`
                 <div class="grid gap-3">
                   ${renderedPaths.map(path => html`
@@ -295,10 +296,10 @@ export function SummarySurface() {
 
 export function DetailLoadingState() {
   if (commandPlaneDetailLoading.value) {
-    return html`<div class="empty-state">command-plane detail 불러오는 중…</div>`
+    return html`<${EmptyState} message="command-plane detail 불러오는 중…" compact />`
   }
   if (commandPlaneDetailError.value) {
-    return html`<div class="empty-state error">${commandPlaneDetailError.value}</div>`
+    return html`<${EmptyState} message=${commandPlaneDetailError.value} compact />`
   }
-  return html`<div class="empty-state">surface를 선택하면 command-plane detail을 로드합니다.</div>`
+  return html`<${EmptyState} message="surface를 선택하면 command-plane detail을 로드합니다." compact />`
 }

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { useEffect } from 'preact/hooks'
 import {
   commandPlaneActionError,
@@ -266,10 +267,10 @@ export function Command() {
       `}
 
       ${commandPlaneError.value
-        ? html`<div class="empty-state error">${commandPlaneError.value}</div>`
+        ? html`<${EmptyState} message=${commandPlaneError.value} compact />`
         : null}
       ${commandPlaneActionError.value
-        ? html`<div class="empty-state error">${commandPlaneActionError.value}</div>`
+        ? html`<${EmptyState} message=${commandPlaneActionError.value} compact />`
         : null}
       ${wallboardMode ? null : html`<${RoomTruthStrip} />`}
       ${wallboardMode ? null : html`<${CommandWorkflowBanner} />`}

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type {
   ChainHistoryEventSummary,
@@ -101,7 +102,7 @@ function MermaidGraph({ source }: { source: string }) {
 
   return html`
     <div class="mt-3 min-h-[160px]">
-      ${error ? html`<div class="empty-state error">${error}</div>` : null}
+      ${error ? html`<${EmptyState} message=${error} compact />` : null}
       <div class="overflow-auto rounded-[10px] p-3 bg-[rgba(9,12,20,0.7)] cmd-chain-graph" ref=${hostRef}></div>
     </div>
   `
@@ -292,7 +293,7 @@ export function OperationsSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.operations.operations.map(card => html`<${OperationCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state">관리형 또는 투영된 작전이 없습니다.</div>`}
+          : html`<${EmptyState} message="관리형 또는 투영된 작전이 없습니다." compact />`}
       </section>
       <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)] min-h-[240px]">
         <div class="pb-2 border-b border-[var(--card-border)] mb-3">
@@ -302,7 +303,7 @@ export function OperationsSurface() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${snapshot.detachments.detachments.map(card => html`<${DetachmentCard} card=${card} />`)}
             </div>`
-          : html`<div class="empty-state">투영된 분견대가 없습니다.</div>`}
+          : html`<${EmptyState} message="투영된 분견대가 없습니다." compact />`}
       </section>
     </div>
   `
@@ -350,11 +351,11 @@ export function ChainsSurface() {
         </article>
 
         ${commandPlaneChainError.value
-          ? html`<div class="empty-state error">${commandPlaneChainError.value}</div>`
+          ? html`<${EmptyState} message=${commandPlaneChainError.value} compact />`
           : null}
 
         ${commandPlaneChainLoading.value && !summary
-          ? html`<div class="empty-state">체인 오버레이 불러오는 중…</div>`
+          ? html`<${EmptyState} message="체인 오버레이 불러오는 중…" compact />`
           : overlays.length > 0
             ? html`
                 <div class="flex flex-col gap-3 mt-3.5">
@@ -367,7 +368,7 @@ export function ChainsSurface() {
                   `)}
                 </div>
               `
-            : html`<div class="empty-state">체인 기반 작전이 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="체인 기반 작전이 아직 없습니다." compact />`}
 
         <div class="flex flex-col gap-3 mt-3.5">
           <div class="flex justify-between gap-2.5 items-start">
@@ -380,7 +381,7 @@ export function ChainsSurface() {
                   ${summary.recent_history.slice(0, 6).map(item => html`<${ChainHistoryRow} item=${item} />`)}
                 </div>
               `
-            : html`<div class="empty-state">최근 체인 이력이 없습니다.</div>`}
+            : html`<${EmptyState} message="최근 체인 이력이 없습니다." compact />`}
         </div>
       </section>
 
@@ -423,7 +424,7 @@ export function ChainsSurface() {
                       <${MermaidGraph} source=${selectedOverlay.mermaid} />
                     </div>
                   `
-                : html`<div class="empty-state">기록된 Mermaid 그래프가 아직 없습니다.</div>`}
+                : html`<${EmptyState} message="기록된 Mermaid 그래프가 아직 없습니다." compact />`}
 
               <div class="mt-3.5 p-3.5 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
                 <div class="flex justify-between gap-2.5 items-start">
@@ -435,9 +436,9 @@ export function ChainsSurface() {
                   </span>
                 </div>
                 ${commandPlaneChainRunLoading.value
-                  ? html`<div class="empty-state">실행 상세 불러오는 중…</div>`
+                  ? html`<${EmptyState} message="실행 상세 불러오는 중…" compact />`
                   : commandPlaneChainRunError.value
-                    ? html`<div class="empty-state error">${commandPlaneChainRunError.value}</div>`
+                    ? html`<${EmptyState} message=${commandPlaneChainRunError.value} compact />`
                     : run && run.nodes.length > 0
                       ? html`
                           <div class="cmd-card rounded-xl-grid">
@@ -453,10 +454,10 @@ export function ChainsSurface() {
                             ${run.nodes.map(node => html`<${ChainRunNodeRow} node=${node} />`)}
                           </div>
                         `
-                      : html`<div class="empty-state">이 작전의 run-store 상세는 아직 없습니다.</div>`}
+                      : html`<${EmptyState} message="이 작전의 run-store 상세는 아직 없습니다." compact />`}
               </div>
             `
-          : html`<div class="empty-state">그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요.</div>`}
+          : html`<${EmptyState} message="그래프와 실행 상세를 보려면 체인 기반 작전을 고르세요." compact />`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import type {
   CommandPlaneOrchestraEdge,
   CommandPlaneOrchestraNode,
@@ -363,7 +364,7 @@ export function OrchestraNodeLayer({
 
 export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOrchestraResponse }) {
   const selected = selectedTarget(orchestra)
-  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl"><div class="empty-state">선택 가능한 대상이 아직 없습니다.</div></aside>`
+  if (!selected) return html`<aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl"><${EmptyState} message="선택 가능한 대상이 아직 없습니다." compact /></aside>`
   if (selected.type === 'signal') {
     const signalNode = selected.value
     return html`

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { groupByKey } from '../common/collection'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type {
@@ -215,13 +216,13 @@ export function OrchestraSurface() {
   }, [])
 
   if (commandPlaneOrchestraLoading.value && !orchestra) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state">오케스트라 맵 불러오는 중…</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><${EmptyState} message="오케스트라 맵 불러오는 중…" compact /></section>`
   }
   if (commandPlaneOrchestraError.value) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state error">${commandPlaneOrchestraError.value}</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><${EmptyState} message=${commandPlaneOrchestraError.value} compact /></section>`
   }
   if (!orchestra) {
-    return html`<section class="card rounded-xl min-h-[240px]"><div class="empty-state">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
+    return html`<section class="card rounded-xl min-h-[240px]"><${EmptyState} message="오케스트라 맵 데이터가 아직 없습니다." compact /></section>`
   }
 
   const density = orchestraDensity.value

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import {
   commandPlaneSwarm,
   commandPlaneSwarmError,
@@ -40,9 +41,9 @@ export function SwarmLivePanels() {
           <div class="card rounded-xl-title">스웜 라이브 런</div>
         </div>
         ${commandPlaneSwarmLoading.value
-          ? html`<div class="empty-state">Loading swarm live state…</div>`
+          ? html`<${EmptyState} message="Loading swarm live state…" compact />`
           : commandPlaneSwarmError.value
-            ? html`<div class="empty-state error">${commandPlaneSwarmError.value}</div>`
+            ? html`<${EmptyState} message=${commandPlaneSwarmError.value} compact />`
             : swarm
               ? html`
                   <div class="cmd-tag rounded-full-row">
@@ -78,7 +79,7 @@ export function SwarmLivePanels() {
                     : null}
                   <${SwarmRunResolutionCard} swarm=${swarm} />
                 `
-              : html`<div class="empty-state">스웜 read-model이 아직 없습니다.</div>`}
+              : html`<${EmptyState} message="스웜 read-model이 아직 없습니다." compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -89,7 +90,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.checklist.map(item => html`<${SwarmChecklistCard} item=${item} />`)}
             </div>`
-          : html`<div class="empty-state">체크리스트가 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="체크리스트가 아직 없습니다." compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -100,7 +101,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.workers.map(worker => html`<${SwarmWorkerCard} worker=${worker} />`)}
             </div>`
-          : html`<div class="empty-state">워커 행이 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="워커 행이 아직 없습니다." compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -143,9 +144,9 @@ export function SwarmLivePanels() {
                       </article>
                     `)}
                   </div>`
-                : html`<div class="empty-state">slot telemetry가 아직 없습니다.</div>`}
+                : html`<${EmptyState} message="slot telemetry가 아직 없습니다." compact />`}
             `
-          : html`<div class="empty-state">런타임 telemetry가 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="런타임 telemetry가 아직 없습니다." compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -156,7 +157,7 @@ export function SwarmLivePanels() {
           ? html`<div class="cmd-card rounded-xl-stack">
               ${swarm.blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)}
             </div>`
-          : html`<div class="empty-state">막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.</div>`}
+          : html`<${EmptyState} message=${`막힘 요인은 없습니다. 다음 액션은 ${swarm?.recommended_next_tool ?? 'masc_observe_traces'} 입니다.`} compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -178,7 +179,7 @@ export function SwarmLivePanels() {
                 </article>
               `)}
             </div>`
-          : html`<div class="empty-state">run 범위 메시지가 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="run 범위 메시지가 아직 없습니다." compact />`}
       </section>
 
       <section class="card rounded-xl min-h-[240px]">
@@ -189,7 +190,7 @@ export function SwarmLivePanels() {
           ? html`<div class="flex flex-col gap-3">
               ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
             </div>`
-          : html`<div class="empty-state">run 범위 trace event가 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="run 범위 trace event가 아직 없습니다." compact />`}
       </section>
     </div>
   `

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { route } from '../../router'
 import { workflowContextForRoute } from '../../workflow-context'
 import {
@@ -52,7 +53,7 @@ export function SwarmOverviewPanel() {
               <div class="cmd-card rounded-xl-stack">
                 ${lanes.length > 0
                   ? lanes.map(lane => html`<${SwarmLaneStrip} lane=${lane} />`)
-                  : html`<div class="empty-state">활성 스웜 레인이 없습니다.</div>`}
+                  : html`<${EmptyState} message="활성 스웜 레인이 없습니다." compact />`}
               </div>
 
               <div class="cmd-card rounded-xl-stack">
@@ -89,7 +90,7 @@ export function SwarmOverviewPanel() {
               </div>
             </div>
           `
-        : html`<div class="empty-state">스웜 상태를 아직 불러오지 못했습니다.</div>`}
+        : html`<${EmptyState} message="스웜 상태를 아직 불러오지 못했습니다." compact />`}
     </section>
   `
 }

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import type {
   CommandPlaneAlert,
   CommandPlaneTraceEvent,
@@ -169,7 +170,7 @@ export function TopologySurface() {
         : null}
       ${snapshot && snapshot.topology.units.length > 0
         ? html`${snapshot.topology.units.map(node => html`<${TopologyNode} node=${node} />`)}`
-        : html`<div class="empty-state">지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다.</div>`}
+        : html`<${EmptyState} message="지금은 실시간 에이전트나 관리 유닛 기준으로 그릴 지휘 계층이 없습니다." compact />`}
     </section>
   `
 }
@@ -185,7 +186,7 @@ export function AlertsSurface() {
         ? html`<div class="cmd-card rounded-xl-stack">
             ${snapshot.alerts.alerts.map(alert => html`<${AlertCard} alert=${alert} />`)}
           </div>`
-        : html`<div class="empty-state">지금 올라온 지휘면 경보는 없습니다.</div>`}
+        : html`<${EmptyState} message="지금 올라온 지휘면 경보는 없습니다." compact />`}
     </section>
   `
 }
@@ -201,7 +202,7 @@ export function TraceSurface() {
         ? html`<div class="flex flex-col gap-3">
             ${snapshot.traces.events.map(event => html`<${TraceRow} event=${event} />`)}
           </div>`
-        : html`<div class="empty-state">최근 트레이스 이벤트가 없습니다.</div>`}
+        : html`<${EmptyState} message="최근 트레이스 이벤트가 없습니다." compact />`}
     </section>
   `
 }

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import type {
   CommandPlaneChainOverlay,
   CommandPlaneSwarmBlocker,
@@ -103,7 +104,7 @@ export function WarRoomBodyGrid({
                     </div>
                   </article>
                 `
-              : html`<div class="empty-state">보이는 레인이 아직 없습니다.</div>`}
+              : html`<${EmptyState} message="보이는 레인이 아직 없습니다." compact />`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -121,7 +122,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="cmd-card rounded-xl-stack">
                 ${workers.map(worker => html`<${WarRoomWorkerCard} worker=${worker} />`)}
               </div>`
-            : html`<div class="empty-state">활성 워커 카드가 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="활성 워커 카드가 아직 없습니다." compact />`}
         </section>
       </div>
 
@@ -134,7 +135,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="flex flex-col gap-3">
                 ${feedItems.map(item => html`<${WarRoomFeedCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">메시지, chain, autoresearch, attention feed가 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="메시지, chain, autoresearch, attention feed가 아직 없습니다." compact />`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -145,7 +146,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="flex flex-col gap-3">
                 ${swarm.recent_trace_events.map(event => html`<${TraceRow} event=${event} />`)}
               </div>`
-            : html`<div class="empty-state">실행 범위 트레이스 이벤트가 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="실행 범위 트레이스 이벤트가 아직 없습니다." compact />`}
         </section>
       </div>
 
@@ -158,7 +159,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="grid grid-cols-1 gap-3">
                 ${agentViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">가시적인 active agent가 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="가시적인 active agent가 아직 없습니다." compact />`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">
@@ -169,7 +170,7 @@ export function WarRoomBodyGrid({
             ? html`<div class="grid grid-cols-1 gap-3">
                 ${keeperViews.map(item => html`<${WarRoomPresenceCard} item=${item} />`)}
               </div>`
-            : html`<div class="empty-state">가시적인 keeper/runtime 카드가 아직 없습니다.</div>`}
+            : html`<${EmptyState} message="가시적인 keeper/runtime 카드가 아직 없습니다." compact />`}
         </section>
 
         <section class="card rounded-xl min-h-[240px]">

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { useEffect, useState } from 'preact/hooks'
 import type {
   CommandPlaneSwarmLane,
@@ -189,7 +190,7 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
 
   if (!hasLiveRun && !selectedSession) {
     if (commandPlaneSwarmLoading.value || operatorLoading.value) {
-      return html`<div class="empty-state">실시간 워룸 불러오는 중…</div>`
+      return html`<${EmptyState} message="실시간 워룸 불러오는 중…" compact />`
     }
     return html`
       <section class="card rounded-xl ${wallboard ? 'min-h-[calc(100vh-180px)]' : 'min-h-[360px]'} flex flex-col justify-center gap-[18px]">

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -12,9 +12,10 @@ interface FilterChip<T extends string> {
 interface FilterChipsProps<T extends string> {
   chips: FilterChip<T>[]
   active: Signal<T>
+  onChange?: (key: T) => void
 }
 
-export function FilterChips<T extends string>({ chips, active }: FilterChipsProps<T>) {
+export function FilterChips<T extends string>({ chips, active, onChange }: FilterChipsProps<T>) {
   return html`
     <div class="flex gap-1.5 flex-wrap">
       ${chips.map(chip => html`
@@ -23,7 +24,7 @@ export function FilterChips<T extends string>({ chips, active }: FilterChipsProp
           class="px-2.5 py-1 text-[length:var(--fs-xs)] rounded-xl border cursor-pointer transition-all duration-150 ${active.value === chip.key
             ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
             : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'}"
-          onClick=${() => { active.value = chip.key }}
+          onClick=${() => { active.value = chip.key; onChange?.(chip.key) }}
         >
           ${chip.label}
         </button>

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -1,6 +1,7 @@
 // 실행 표면 — 작전 카드 및 본문
 
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionOperationBrief } from '../../types'
 import {
@@ -56,7 +57,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
-        : html`<div class="empty-state">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
+        : html`<${EmptyState} message=${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'} compact />`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -1,6 +1,7 @@
 // 실행 표면 — 대기열 카드 및 본문
 
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionQueueItem } from '../../types'
 import {
@@ -60,7 +61,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
-        : html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`}
+        : html`<${EmptyState} message="지금은 개입이 필요한 실행이 없습니다." compact />`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -1,6 +1,7 @@
 // 실행 표면 — 세션 카드 및 본문
 
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionSessionBrief } from '../../types'
 import {
@@ -69,7 +70,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
     <div class="flex flex-col gap-2.5">
       ${hasActive
         ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
-        : html`<div class="empty-state">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
+        : html`<${EmptyState} message=${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'} compact />`}
     </div>
     ${hasTerminal
       ? html`

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { Card } from '../common/card'
 import { StatusBadge } from '../common/status-badge'
 import { TimeAgo } from '../common/time-ago'
+import { FilterChips } from '../common/filter-chips'
 import { goals } from '../../store'
 import type { Goal } from '../../types'
 import {
@@ -59,29 +60,22 @@ export function HorizonGroup({ horizon, items }: { horizon: string; items: Goal[
 }
 
 export function FilterBar() {
+  const horizonChips = (['all', 'short', 'mid', 'long'] as HorizonFilter[]).map(h => ({
+    key: h, label: h === 'all' ? '전체' : horizonLabel(h),
+  }))
+  const statusChips = (['all', 'active', 'completed', 'paused'] as StatusFilter[]).map(s => ({
+    key: s, label: statusFilterLabel(s),
+  }))
+
   return html`
     <div class="flex gap-4 flex-wrap mt-3">
-      <div class="flex items-center gap-1">
-        <label class="text-[length:var(--fs-xs)] text-[color:var(--text-dim)] mr-1">범위</label>
-        ${(['all', 'short', 'mid', 'long'] as HorizonFilter[]).map(h => html`
-          <button
-            class="goal-filter-btn rounded-xl ${horizonFilter.value === h ? 'active' : ''}"
-            onClick=${() => { horizonFilter.value = h }}
-          >
-            ${h === 'all' ? '전체' : horizonLabel(h)}
-          </button>
-        `)}
+      <div class="flex items-center gap-1.5">
+        <label class="text-[length:var(--fs-xs)] text-[color:var(--text-dim)]">범위</label>
+        <${FilterChips} chips=${horizonChips} active=${horizonFilter} />
       </div>
-      <div class="flex items-center gap-1">
-        <label class="text-[length:var(--fs-xs)] text-[color:var(--text-dim)] mr-1">상태</label>
-        ${(['all', 'active', 'completed', 'paused'] as StatusFilter[]).map(s => html`
-          <button
-            class="goal-filter-btn rounded-xl ${statusFilter.value === s ? 'active' : ''}"
-            onClick=${() => { statusFilter.value = s }}
-          >
-            ${statusFilterLabel(s)}
-          </button>
-        `)}
+      <div class="flex items-center gap-1.5">
+        <label class="text-[length:var(--fs-xs)] text-[color:var(--text-dim)]">상태</label>
+        <${FilterChips} chips=${statusChips} active=${statusFilter} />
       </div>
     </div>
   `

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -1,6 +1,7 @@
 // Kanban board components: KanbanCard, TaskBacklog
 
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { tasksByStatus } from '../../store'
@@ -57,7 +58,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${todo.length}</span>
           </div>
           ${sortedTodo.length === 0
-            ? html`<div class="empty-state">대기 중인 태스크가 없습니다</div>`
+            ? html`<${EmptyState} message="대기 중인 태스크가 없습니다" compact />`
             : sortedTodo.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -66,7 +67,7 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${inProgress.length}</span>
           </div>
           ${sortedInProgress.length === 0
-            ? html`<div class="empty-state">진행 중인 태스크가 없습니다</div>`
+            ? html`<${EmptyState} message="진행 중인 태스크가 없습니다" compact />`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         </div>
         <div class="flex flex-col gap-4 bg-[rgba(10,15,29,0.5)] rounded-[var(--radius-lg)] p-5 border border-solid border-[var(--accent-10)]">
@@ -75,10 +76,10 @@ export function TaskBacklog() {
             <span class="kanban-badge px-2.5 py-1 rounded-xl text-[0.8rem] font-bold">${done.length}</span>
           </div>
           ${sortedDone.length === 0
-            ? html`<div class="empty-state">완료된 태스크가 없습니다</div>`
+            ? html`<${EmptyState} message="완료된 태스크가 없습니다" compact />`
             : sortedDone.slice(0, 20).map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
           ${sortedDone.length > 20
-            ? html`<div class="empty-state">...외 ${sortedDone.length - 20}개 더 있음</div>`
+            ? html`<${EmptyState} message=${`...외 ${sortedDone.length - 20}개 더 있음`} compact />`
             : null}
         </div>
       </div>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -1,6 +1,7 @@
 // Planning main component — orchestrates goals, MDAL, and kanban views
 
 import { html } from 'htm/preact'
+import { EmptyState } from '../common/empty-state'
 import {
   goals,
   goalsLoading,
@@ -88,16 +89,14 @@ export function Planning() {
             ${goalsLoading.value && goals.value.length === 0
               ? html`<div class="loading-state loading-pulse">목표 불러오는 중...</div>`
               : filteredGoals.value.length === 0
-                ? html`<div class="empty-state">현재 필터에 맞는 목표가 없습니다</div>`
+                ? html`<${EmptyState} message="현재 필터에 맞는 목표가 없습니다" compact />`
                 : html`
                     <${HorizonGroup} horizon="short" items=${grouped.short ?? []} />
                     <${HorizonGroup} horizon="mid" items=${grouped.mid ?? []} />
                     <${HorizonGroup} horizon="long" items=${grouped.long ?? []} />
                   `}
           ` : html`
-            <div class="empty-state">
-              장기 목표가 아직 없습니다. <code class="px-1 py-0.5 rounded bg-[var(--white-8)] text-[var(--text-body)] text-[11px]">masc_goal_upsert</code>로 단기/중기/장기 목표를 등록하면 메트릭 기반 추적이 시작됩니다.
-            </div>
+            <${EmptyState} message="장기 목표가 아직 없습니다. masc_goal_upsert로 등록하면 메트릭 기반 추적이 시작됩니다." />
           `}
         </div>
       </details>
@@ -112,9 +111,9 @@ export function Planning() {
           ${mdalLoading.value && loops.length === 0
             ? html`<div class="loading-state loading-pulse">MDAL 루프 불러오는 중...</div>`
             : loops.length === 0 && (mdalState === 'error' || lastMdalError.value)
-              ? html`<div class="empty-state">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
+              ? html`<${EmptyState} message="MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요." />`
               : loops.length === 0
-                ? html`<div class="empty-state">가동 중인 루프가 없습니다. <code class="px-1 py-0.5 rounded bg-[var(--white-8)] text-[var(--text-body)] text-[11px]">masc_mdal_start</code>로 시작할 수 있습니다.</div>`
+                ? html`<${EmptyState} message="가동 중인 루프가 없습니다. masc_mdal_start로 시작할 수 있습니다." />`
                 : html`
                   <div class="grid gap-3">
                     ${loops.map(loop => html`<${LoopRow} key=${loop.loop_id} loop=${loop} />`)}

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from './common/empty-state'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { governanceToneClass } from '../lib/tone'
@@ -67,7 +68,7 @@ export function DecisionDetail() {
       ${detailLoading.value
         ? html`<div class="loading-state loading-pulse">거버넌스 상세 불러오는 중...</div>`
         : !item || !detail
-          ? html`<div class="empty-state">왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다.</div>`
+          ? html`<${EmptyState} message="왼쪽 수신함에서 사건을 선택하면 청원, 심의, 판정, 집행 기록이 여기에 표시됩니다." compact />`
           : html`
               <div class="flex justify-between items-start gap-4 mb-3.5">
                 <div>
@@ -89,12 +90,12 @@ export function DecisionDetail() {
               </div>
               <div class="flex flex-col gap-2.5">
                 ${petitions.length === 0
-                  ? html`<div class="empty-state">기록된 청원이 없습니다.</div>`
+                  ? html`<${EmptyState} message="기록된 청원이 없습니다." compact />`
                   : petitions.map(petition => html`<${PetitionEntry} key=${petition.id} petition=${petition} />`)}
               </div>
               <div class="flex flex-col gap-2.5">
                 ${briefs.length === 0
-                  ? html`<div class="empty-state">심의 의견이 아직 없습니다.</div>`
+                  ? html`<${EmptyState} message="심의 의견이 아직 없습니다." compact />`
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}
               </div>
               <${ActivityRail} />

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from './common/empty-state'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import type { GovernanceExecutionOrder } from '../types'
@@ -43,7 +44,7 @@ export function GuardrailPane({
     <div class="flex flex-col gap-3.5">
       <${Card} title="판정 / 집행" class="section mb-3.5">
         ${!item || !detail
-          ? html`<div class="empty-state">사건을 고르면 판정과 집행 경로가 보입니다.</div>`
+          ? html`<${EmptyState} message="사건을 고르면 판정과 집행 경로가 보입니다." compact />`
           : html`
               <div class="flex flex-col gap-2">
                 <h4>판정</h4>
@@ -82,7 +83,7 @@ export function GuardrailPane({
     <//>
       <${Card} title="심의 입력" class="section mb-3.5">
         ${!item
-          ? html`<div class="empty-state">사건을 선택한 뒤 의견을 추가하세요.</div>`
+          ? html`<${EmptyState} message="사건을 선택한 뒤 의견을 추가하세요." compact />`
           : html`
               <div class="flex flex-col gap-2">
                 <div class="flex flex-wrap gap-2">

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from './common/empty-state'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { governanceToneClass } from '../lib/tone'
@@ -32,7 +33,7 @@ export function ActivityRail() {
     <${Card} title="활동 타임라인" class="section mb-3.5">
       <div class="flex flex-col gap-2">
         ${grouped.size === 0
-          ? html`<div class="empty-state">거버넌스 활동이 아직 없습니다.</div>`
+          ? html`<${EmptyState} message="거버넌스 활동이 아직 없습니다." compact />`
           : Array.from(grouped.entries()).map(([, group]) => html`
               <div class="governance-case-group rounded-lg">
                 <div class="flex items-center justify-between mb-2 gap-2">

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { EmptyState } from './common/empty-state'
+import { FilterChips } from './common/filter-chips'
 import { governanceToneClass } from '../lib/tone'
 import type { GovernanceFilter } from './governance-utils'
 import {
@@ -117,31 +118,17 @@ function GovernanceToolbar() {
             ${governanceLoading.value ? '새로고침 중...' : '새로고침'}
           </button>
         </div>
-        <div class="flex flex-wrap gap-1.5">
-          ${(
-            [
-              ['open', '진행 중'],
-              ['pending_ruling', '판정 대기'],
-              ['needs_human_gate', '승인 대기'],
-              ['executed', '집행 완료'],
-              ['blocked', '보류/종결'],
-            ] as Array<[GovernanceFilter, string]>
-          ).map(([key, label]) => html`
-            <button
-              class="px-2.5 py-1 rounded-lg text-[11px] font-medium border transition-all cursor-pointer
-                ${governanceFilter.value === key
-                  ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
-                  : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
-                }"
-              onClick=${async () => {
-                governanceFilter.value = key
-                await refreshGovernance()
-              }}
-            >
-              ${label}
-            </button>
-          `)}
-        </div>
+        <${FilterChips}
+          chips=${[
+            { key: 'open', label: '진행 중' },
+            { key: 'pending_ruling', label: '판정 대기' },
+            { key: 'needs_human_gate', label: '승인 대기' },
+            { key: 'executed', label: '집행 완료' },
+            { key: 'blocked', label: '보류/종결' },
+          ]}
+          active=${governanceFilter}
+          onChange=${() => { void refreshGovernance() }}
+        />
         ${governanceError.value ? html`<div class="mt-2 p-2.5 rounded-lg border border-[rgba(239,68,68,0.35)] bg-[var(--bad-8)] text-[#f7b6b6] text-[12px]">${governanceError.value}</div>` : null}
       </div>
     <//>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
+import { EmptyState } from './common/empty-state'
 import { governanceToneClass } from '../lib/tone'
 import type { GovernanceFilter } from './governance-utils'
 import {
@@ -153,7 +154,7 @@ function DecisionInbox() {
     <${Card} title="사건 수신함" class="section mb-4">
       <div class="flex flex-col gap-2 governance-inbox">
         ${items.length === 0
-          ? html`<div class="empty-state">이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.</div>`
+          ? html`<${EmptyState} message="이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요." />`
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { route } from '../router'
 import { agents } from '../store'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { Trpg } from './trpg'
 import { AgentAvatar } from './overview/agent-avatar'
 
@@ -11,7 +12,7 @@ function AvatarGallery() {
   const displayAgents = agentList.slice(0, 12)
 
   if (displayAgents.length === 0) {
-    return html`<div class="empty-state">에이전트 데이터를 불러오는 중...</div>`
+    return html`<${EmptyState} message="에이전트 데이터를 불러오는 중..." compact />`
   }
 
   return html`

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -5,6 +5,7 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
+import { EmptyState } from './common/empty-state'
 import { stripStateBlocks } from '../keeper-message'
 import {
   boardPosts,
@@ -446,7 +447,7 @@ function CommentItem({ comment }: { comment: BoardComment }) {
 }
 
 function CommentThread({ comments }: { comments: BoardComment[] }) {
-  if (comments.length === 0) return html`<div class="empty-state text-[13px] text-[var(--text-muted)]">아직 댓글이 없습니다</div>`
+  if (comments.length === 0) return html`<${EmptyState} message="아직 댓글이 없습니다" compact />`
 
   const INITIAL_SHOW = 3
   const [expanded, setExpanded] = useState(false)
@@ -614,7 +615,7 @@ export function Memory() {
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
               ? html`<div class="loading-state loading-pulse">글 불러오는 중...</div>`
-              : html`<div class="empty-state">글을 찾지 못했습니다</div>`}
+              : html`<${EmptyState} message="글을 찾지 못했습니다" compact />`}
           </div>
         `
   }
@@ -629,7 +630,7 @@ export function Memory() {
       ${boardLoading.value
         ? html`<div class="loading-state loading-pulse">메모리 피드 불러오는 중...</div>`
         : posts.length === 0
-          ? html`<div class="empty-state">아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다.</div>`
+          ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`
               <${Card} title="사람이 쓴 글" class="mb-4">
                 <div class="flex flex-col gap-2">

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from './common/empty-state'
 import { openAgentDetail } from './agent-detail'
 import { workflowActionLabel } from '../workflow-context'
 import type {
@@ -86,7 +87,7 @@ export function AttentionCard({
                 `)}
               </div>
             `
-          : html`<div class="empty-state">직접 연결된 세션이 아직 없습니다.</div>`}
+          : html`<${EmptyState} message="직접 연결된 세션이 아직 없습니다." compact />`}
 
         ${item.related_agent_names.length > 0
           ? html`

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { ProvenanceStrip } from './common/provenance-strip'
 import {
   missionBriefing,
@@ -41,8 +42,8 @@ export function MissionBriefingCard() {
         ${briefing?.refreshing ? html`<span class="cmd-chip rounded-full warn">갱신 중</span>` : null}
       </div>
 
-      ${missionBriefingError.value ? html`<div class="empty-state error">${missionBriefingError.value}</div>` : null}
-      ${briefing?.error ? html`<div class="empty-state error">${briefing.error}</div>` : null}
+      ${missionBriefingError.value ? html`<${EmptyState} message=${missionBriefingError.value} compact />` : null}
+      ${briefing?.error ? html`<${EmptyState} message=${briefing.error} compact />` : null}
       ${briefing?.summary ? html`<div class="grid gap-1">${briefing.summary}</div>` : null}
       ${briefing?.last_error && !briefing.error
         ? html`<div class="grid gap-1">최근 갱신 실패: ${briefing.last_error}</div>`
@@ -80,11 +81,9 @@ export function MissionBriefingCard() {
           `
         : (!missionBriefingLoading.value && !missionBriefingError.value && showEmpty
             ? html`
-                <div class="empty-state">
-                  ${briefing?.status === 'pending'
+                <${EmptyState} message=${briefing?.status === 'pending'
                     ? '최신 스냅샷으로 브리핑을 생성 중입니다. 마지막 성공 결과가 생기면 자동으로 다시 읽습니다.'
-                    : '판단 결과가 아직 없습니다.'}
-                </div>
+                    : '판단 결과가 아직 없습니다.'} compact />
               `
             : null)}
 

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { openAgentDetail } from './agent-detail'
 import type {
   DashboardMissionSessionCard,
@@ -138,7 +139,7 @@ export function SessionDetailCard({
   if (error && !detail) {
     return html`
       <${Card} title="세션 상세" class="mission-list-card rounded-xl">
-        <div class="empty-state error">${error}</div>
+        <${EmptyState} message=${error} compact />
       <//>
     `
   }
@@ -174,7 +175,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.68)] leading-[1.45]">${item.actor ? `${item.actor} · ` : ''}${item.event_type ?? '이벤트'}</small>
                   </article>
                 `)
-              : html`<div class="empty-state">표시할 세션 이벤트가 없습니다.</div>`}
+              : html`<${EmptyState} message="표시할 세션 이벤트가 없습니다." compact />`}
           </div>
         </div>
 
@@ -195,7 +196,7 @@ export function SessionDetailCard({
                     </small>
                   </button>
                 `)
-              : html`<div class="empty-state">세션 참여자 미리보기가 없습니다.</div>`}
+              : html`<${EmptyState} message="세션 참여자 미리보기가 없습니다." compact />`}
           </div>
         </div>
       </div>
@@ -215,7 +216,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}</small>
                   </button>
                 `)
-              : html`<div class="empty-state">연결된 작전이 없습니다.</div>`}
+              : html`<${EmptyState} message="연결된 작전이 없습니다." compact />`}
           </div>
         </div>
 
@@ -233,7 +234,7 @@ export function SessionDetailCard({
                     <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${keeper.current_work ?? '현재 작업 정보 없음'}</small>
                   </div>
                 `)
-              : html`<div class="empty-state">직접 연결된 키퍼는 없습니다.</div>`}
+              : html`<${EmptyState} message="직접 연결된 키퍼는 없습니다." compact />`}
           </div>
         </div>
       </div>

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { navigate } from '../router'
 import {
   missionError,
@@ -38,10 +39,10 @@ export function Mission() {
     return html`<div class="loading-state loading-pulse">상황판 스냅샷 불러오는 중...</div>`
   }
   if (missionError.value && !mission) {
-    return html`<div class="empty-state error">${missionError.value}</div>`
+    return html`<${EmptyState} message=${missionError.value} compact />`
   }
   if (!mission) {
-    return html`<div class="empty-state">상황판 스냅샷이 아직 없습니다.</div>`
+    return html`<${EmptyState} message="상황판 스냅샷이 아직 없습니다." compact />`
   }
 
   const sessionRows = mission.sessions

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
 import { route } from '../router'
 import { proofError, proofLoading, proofSnapshot, refreshProofSnapshot } from '../proof-store'
 import type {
@@ -232,7 +233,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${dedupedTimeline.length > 0
               ? dedupedTimeline.slice(0, 18).map(item => html`<${TimelineRow} key=${item.id} item=${item} />`)
-              : html`<div class="empty-state">타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다.</div>`}
+              : html`<${EmptyState} message="타임라인 근거가 없습니다. 에이전트 협업이 진행되면 세션과 지휘 이벤트가 여기에 나타납니다." compact />`}
           </div>
         <//>
 
@@ -244,7 +245,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${contributions.length > 0
               ? contributions.map(item => html`<${ActorContributionRow} key=${item.actor} item=${item} />`)
-              : html`<div class="empty-state">참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다.</div>`}
+              : html`<${EmptyState} message="참여 흔적이 없습니다. 에이전트가 작업에 참여하면 턴, 도구 호출, 산출물이 기록됩니다." compact />`}
           </div>
         <//>
       </div>
@@ -258,7 +259,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${toolEvidence.length > 0
               ? toolEvidence.map((item, idx) => html`<${ToolEvidenceRow} key=${`${item.actor ?? 'system'}-${idx}`} item=${item} />`)
-              : html`<div class="empty-state">도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다.</div>`}
+              : html`<${EmptyState} message="도구 근거가 없습니다. 에이전트가 MCP 도구를 사용하면 호출 내역이 여기에 기록됩니다." compact />`}
           </div>
         <//>
 
@@ -270,7 +271,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${workerRunEvidence.length > 0
               ? workerRunEvidence.map(item => html`<${WorkerRunEvidenceRow} key=${item.worker_run_id} item=${item} />`)
-              : html`<div class="empty-state">표시할 OAS worker evidence가 없습니다. raw trace 또는 summary-only evidence가 생기면 여기에 나타납니다.</div>`}
+              : html`<${EmptyState} message="표시할 OAS worker evidence가 없습니다. raw trace 또는 summary-only evidence가 생기면 여기에 나타납니다." compact />`}
           </div>
         <//>
       </div>
@@ -298,7 +299,7 @@ export function Proof() {
           <div class="flex flex-col gap-3">
             ${artifacts.length > 0
               ? artifacts.map(item => html`<${ArtifactRow} key=${item.path} item=${item} />`)
-              : html`<div class="empty-state">산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다.</div>`}
+              : html`<${EmptyState} message="산출물이 없습니다. proof/report/session 파일이 생성되면 존재 여부가 표시됩니다." compact />`}
           </div>
         <//>
       </div>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback } from 'preact/hooks'
 import { VirtualList } from '../common/virtual-list'
+import { EmptyState } from '../common/empty-state'
 import { route } from '../../router'
 import type { DashboardToolInventoryItem } from '../../api'
 import { InventoryRow } from './tool-inventory-row'
@@ -201,7 +202,7 @@ export function FullInventoryView({
             getKey=${(item: DashboardToolInventoryItem) => item.name}
             className="flex flex-col gap-3"
           />`
-        : html`<div class="empty-state">조건에 맞는 도구가 없습니다.</div>`}
+        : html`<${EmptyState} message="조건에 맞는 도구가 없습니다." compact />`}
     </div>
 
     <button

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { refreshTrpg, trpgLoading, trpgRoom, trpgState } from '../store'
+import { EmptyState } from './common/empty-state'
 
 /** When true the TRPG backend returned 410 Gone (module archived). */
 const trpgArchived = signal(false)
@@ -32,25 +33,18 @@ export function Trpg() {
   }, [state, loading, archived])
 
   if (archived) {
-    return html`
-      <div class="empty-state">
-        <div style="margin-bottom: 8px; font-size: 1.1em;">TRPG 모듈은 아카이브되었습니다</div>
-        <div style="font-size: 0.9em; opacity: 0.7;">이 모듈은 더 이상 활성 상태가 아닙니다. 과거 세션 기록은 서버 로그에 남아 있습니다.</div>
-      </div>
-    `
+    return html`<${EmptyState} message="TRPG 모듈은 아카이브되었습니다. 과거 세션 기록은 서버 로그에 남아 있습니다." />`
   }
 
   if (loading && !state) {
-    return html`<div class="empty-state">TRPG 상태를 불러오는 중...</div>`
+    return html`<${EmptyState} message="TRPG 상태를 불러오는 중..." compact />`
   }
 
   if (!state) {
-    return html`
-      <div class="empty-state">
-        <div style="margin-bottom: 12px;">활성 TRPG 세션이 없습니다.</div>
-        <button class="control-btn rounded-lg ghost" onClick=${() => void safeFetchTrpg()}>새로고침</button>
-      </div>
-    `
+    return html`<${EmptyState}
+      message="활성 TRPG 세션이 없습니다."
+      action=${html`<button class="px-3 py-1.5 text-xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] rounded-lg cursor-pointer hover:bg-[var(--white-8)]" onClick=${() => void safeFetchTrpg()}>새로고침</button>`}
+    />`
   }
 
   return html`

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { refreshTrpg, trpgLoading, trpgRoom, trpgState } from '../store'
 import { EmptyState } from './common/empty-state'
+import { StatGrid } from './common/stat-tile'
 
 /** When true the TRPG backend returned 410 Gone (module archived). */
 const trpgArchived = signal(false)
@@ -48,23 +49,11 @@ export function Trpg() {
   }
 
   return html`
-    <div class="monitor-summary-grid">
-      <div class="monitor-summary-card rounded-xl">
-        <div class="monitor-summary-label">ROOM</div>
-        <div class="monitor-summary-value">${trpgRoom.value || state.session?.room || '-'}</div>
-      </div>
-      <div class="monitor-summary-card rounded-xl">
-        <div class="monitor-summary-label">SESSION</div>
-        <div class="monitor-summary-value">${state.session?.status ?? 'active'}</div>
-      </div>
-      <div class="monitor-summary-card rounded-xl">
-        <div class="monitor-summary-label">PARTY</div>
-        <div class="monitor-summary-value">${state.party.length}</div>
-      </div>
-      <div class="monitor-summary-card rounded-xl">
-        <div class="monitor-summary-label">EVENTS</div>
-        <div class="monitor-summary-value">${state.story_log.length}</div>
-      </div>
-    </div>
+    <${StatGrid} cols=${4} items=${[
+      { label: 'ROOM', value: trpgRoom.value || state.session?.room || '-' },
+      { label: 'SESSION', value: state.session?.status ?? 'active' },
+      { label: 'PARTY', value: state.party.length },
+      { label: 'EVENTS', value: state.story_log.length },
+    ]} />
   `
 }


### PR DESCRIPTION
## Summary
- **TRPG**: 4개 인라인 monitor-summary-card → `StatGrid` 컴포넌트 (-11줄)
- **agent-roster**: 이전 EmptyState 배치에서 발생한 backtick 이스케이프 구문 에러 수정

## Test plan
- [ ] Vite build 통과
- [ ] TRPG 페이지 stats 정상 렌더링
- [ ] 에이전트 목록 페이지 정상 로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)