### PR TITLE
feat(research): expose research loop as MCP tools

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -546,6 +546,7 @@
    research_config
    research_metric
    research_loop
+   tool_research
    ;; Anti-Fake Test Quality Scoring (harness P2)
    anti_fake
    ;; godsplit-phase1: type/schema sub-modules

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -137,6 +137,7 @@ let () =
   register_module_tag ~schemas:Tool_compact.schemas ~tag:Mod_compact;
   register_module_tag ~schemas:Tool_mdal.schemas ~tag:Mod_mdal;
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
+  register_module_tag ~schemas:Tool_research.schemas ~tag:Mod_research;
   register_module_tag ~schemas:Tool_model_catalog.schemas ~tag:Mod_model_catalog;
   (* Tool_trpg archived (#1668) *)
   register_module_tag ~schemas:Tool_notifications.schemas ~tag:Mod_notifications;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -544,6 +544,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           agent_name = Some agent_name; start_operation = None;
           start_team_session = None } in
         Tool_autoresearch.dispatch ctx ~name ~args:arguments
+    | Mod_research ->
+        let ctx : Tool_research.context = { base_path = config.base_path;
+          agent_name = Some agent_name } in
+        Tool_research.dispatch ctx ~name ~args:arguments
     | Mod_shard ->
         let (ok, json) = Tool_shard.execute name arguments in
         Some (ok, Yojson.Safe.to_string json)

--- a/lib/research/tool_research.ml
+++ b/lib/research/tool_research.ml
@@ -1,0 +1,92 @@
+(** Tool_research — MCP tool for the code research loop.
+
+    Exposes Research_loop as a MASC tool:
+    - masc_research_start: kick off an automated code improvement loop
+    - masc_research_status: check running experiment results *)
+
+let schemas : Types.tool_schema list = [
+  {
+    name = "masc_research_start";
+    description = "Start an automated code improvement research loop. \
+Uses local LLM (Qwen3.5-35B via llama-server) to propose small code improvements, \
+tests them in isolated git worktrees, and keeps changes that pass all tests. \
+Results logged to research_results.tsv.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo_path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Target repository path (default: MASC base path)");
+        ]);
+        ("max_iterations", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum number of experiments (default: 20)");
+        ]);
+        ("cascade_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "LLM cascade name (default: llama)");
+        ]);
+      ]);
+      ("required", `List []);
+    ];
+  };
+  {
+    name = "masc_research_status";
+    description = "Show results from the most recent research loop run. \
+Returns the contents of research_results.tsv with experiment outcomes.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+]
+
+type context = {
+  base_path : string;
+  agent_name : string option;
+}
+
+let dispatch (ctx : context) ~name ~args : (bool * string) option =
+  match name with
+  | "masc_research_start" ->
+    let repo_path =
+      Yojson.Safe.Util.(member "repo_path" args |> to_string_option)
+      |> Option.value ~default:ctx.base_path
+    in
+    let max_iterations =
+      Yojson.Safe.Util.(member "max_iterations" args |> to_int_option)
+      |> Option.value ~default:20
+    in
+    let cascade_name =
+      Yojson.Safe.Util.(member "cascade_name" args |> to_string_option)
+      |> Option.value ~default:"llama"
+    in
+    let config = Research_config.default
+      ~repo:(Research_config.default_repo_config ~path:repo_path ())
+      ()
+    in
+    let config = { config with
+      max_iterations;
+      cascade_name;
+      results_file = Printf.sprintf "%s/research_results.tsv" repo_path;
+    } in
+    let results = Research_loop.run ~config in
+    let kept = List.filter (fun (e : Research_loop.experiment_entry) ->
+      e.metric.status = Research_metric.Keep) results in
+    let summary = Printf.sprintf
+      "Research complete. %d experiments run, %d kept.\nResults: %s"
+      (List.length results) (List.length kept) config.results_file
+    in
+    Some (true, summary)
+
+  | "masc_research_status" ->
+    let results_file = Printf.sprintf "%s/research_results.tsv" ctx.base_path in
+    if Sys.file_exists results_file then begin
+      let ic = open_in results_file in
+      let content = In_channel.input_all ic in
+      close_in ic;
+      Some (true, content)
+    end else
+      Some (true, "No research results found. Run masc_research_start first.")
+
+  | _ -> None

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -158,6 +158,7 @@ type module_tag =
   | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
   | Mod_notifications | Mod_inline
   | Mod_autoresearch
+  | Mod_research
   | Mod_model_catalog
   | Mod_shard
   | Mod_fire_task

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -86,6 +86,7 @@ type module_tag =
   | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
   | Mod_notifications | Mod_inline
   | Mod_autoresearch
+  | Mod_research
   | Mod_model_catalog
   | Mod_shard
   | Mod_fire_task


### PR DESCRIPTION
## Summary
- `masc_research_start`: 자동화된 코드 개선 연구 루프 시작
- `masc_research_status`: 최근 연구 결과 조회
- Tool dispatch 연결 (Mod_research variant)

## Follows
- PR #2409 (research loop core, merged)

## Test plan
- [x] `dune build` 통과
- [ ] `masc_research_status` 호출 → "No research results found" 반환
- [ ] llama-server 구동 시 `masc_research_start` → 1회 실험 완주

🤖 Generated with [Claude Code](https://claude.com/claude-code)