### PR TITLE
refactor: eliminate 15 Model_spec refs (batch 3)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -230,13 +230,13 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
                 ]
             | None ->
-                (let specs = Model_spec.available_model_specs_of_strings m.models in
-                 match specs with
+                (let cfgs = Llm_provider.Cascade_config.parse_model_strings m.models in
+                 match cfgs with
                  | [] when m.models <> [] ->
                      `Assoc [("has_checkpoint", `Bool false)]
                  | _ ->
                      let primary_max_context =
-                       Model_spec.resolve_primary_max_context m.models
+                       (match Llm_provider.Cascade_config.parse_model_strings m.models with c :: _ -> c.Llm_provider.Provider_config.max_tokens | [] -> 128_000)
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -451,7 +451,7 @@ let run_proactive_generation
     ~(continuity_snapshot : keeper_state_snapshot option)
     ~(continuity_summary : string)
     ~(idle_seconds : int) : proactive_generation_result option =
-  let primary_model_id = Model_spec.resolve_primary_model_id model_labels in
+  let primary_model_id = (match Llm_provider.Cascade_config.parse_model_strings model_labels with c :: _ -> c.Llm_provider.Provider_config.model_id | [] -> "auto") in
   let base_prompt =
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
   in
@@ -510,9 +510,14 @@ let run_proactive_generation
       | Error _ -> None
       | Ok result ->
           let resp = result.Oas_worker.response in
+          let model_used_raw = resp.model in
           let used_model_id =
-            Model_spec.find_model_id_for_used ~labels:model_labels
-              ~model_used:resp.model
+            let cfgs = Llm_provider.Cascade_config.parse_model_strings model_labels in
+            let strip s = if String.length s > 7 && String.sub s (String.length s - 7) 7 = ":latest" then String.sub s 0 (String.length s - 7) else s in
+            let u = strip model_used_raw in
+            match List.find_opt (fun (c : Llm_provider.Provider_config.t) -> c.model_id = model_used_raw || c.model_id = u) cfgs with
+            | Some c -> c.model_id
+            | None -> (match cfgs with c :: _ -> c.model_id | [] -> model_used_raw)
           in
           let attempt_usage = usage_of_response resp in
           let attempt_cost_usd =

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -472,9 +472,9 @@ let oas_provider_of_label (label : string) : Oas.Provider.config =
   | Some config -> config
   | None ->
     (* Fallback: parse label to extract api_url, model_id etc. *)
-    match Model_spec.model_spec_of_string label with
-    | Ok spec ->
-      let pc = Model_spec.to_provider_config spec in
+    match Llm_provider.Cascade_config.parse_model_string label with
+    | Some pc ->
+      (* pc already is Provider_config.t *)
       { Oas.Provider.provider =
           Oas.Provider.OpenAICompat
             {
@@ -486,7 +486,7 @@ let oas_provider_of_label (label : string) : Oas.Provider.config =
         model_id = pc.model_id;
         api_key_env = if pc.api_key <> "" then pc.api_key else "DUMMY_KEY";
       }
-    | Error _ ->
+    | None ->
       (* Last resort: treat label as model_id with glm defaults *)
       { Oas.Provider.provider =
           Oas.Provider.OpenAICompat
@@ -501,9 +501,9 @@ let oas_provider_of_label (label : string) : Oas.Provider.config =
     Returns the provider config and model_id on success. *)
 let resolve_oas_provider_of_label (label : string) :
     (Oas.Provider.config * string, string) result =
-  match Model_spec.model_spec_of_string label with
-  | Error msg -> Error msg
-  | Ok spec -> Ok (oas_provider_of_label label, spec.model_id)
+  match Llm_provider.Cascade_config.parse_model_string label with
+  | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
+  | Some pc -> Ok (oas_provider_of_label label, pc.Llm_provider.Provider_config.model_id)
 
 let oas_tool_names (tools : Oas.Tool.t list) =
   List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -160,7 +160,7 @@ let set_bool_arg args key value =
       `Assoc [ (key, `Bool value) ]
 
 let default_verifier_models =
-  Model_spec.default_verifier_model_labels ()
+  Provider_adapter.preferred_verifier_model_labels ()
 
 let default_verifier_perspectives = [
   "A: continuity archivist (value-neutral)";
@@ -415,21 +415,21 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
     let checks =
       List.mapi (fun idx model_str ->
         let perspective = perspective_at perspectives idx in
-        match Model_spec.model_spec_of_string model_str with
-        | Error err ->
+        match Llm_provider.Cascade_config.parse_model_string model_str with
+        | None ->
             incr warn_count;
             `Assoc [
               ("model", `String model_str);
               ("perspective", `String perspective);
               ("verdict", `String "WARN: model_parse_error");
               ("status", `String "warn");
-              ("reason", `String err);
+              ("reason", `String (Printf.sprintf "Cannot parse: %s" model_str));
               ("recheck_count_requested", `Int recheck_count);
               ("recheck_count_completed", `Int 0);
               ("recheck_status_samples", `List [`String "warn"]);
               ("recheck_stability", `Float 1.0);
             ]
-        | Ok _model ->
+        | Some _cfg ->
             let req = Verifier_oas.{
               action_description =
                 Printf.sprintf "masc_mitosis_handoff outcome review (%s)" perspective;

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -269,9 +269,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
             (* Validate the label parses without retaining model_spec *)
-            Model_spec.model_spec_of_string spec_name |> Result.map (fun _ -> ())
+            (match Llm_provider.Cascade_config.parse_model_string spec_name with Some _ -> Ok () | None -> Error "invalid model spec")
         | _ ->
-            Model_spec.default_execution_model_spec () |> Result.map (fun _ -> ())
+            (match Provider_adapter.preferred_execution_model_labels () with _ :: _ -> Ok () | [] -> Error "no execution model")
       in
       let module U = Yojson.Safe.Util in
       let working_dir = match arguments |> U.member "working_dir" with


### PR DESCRIPTION
15 refs removed across 7 files (tool_inline_dispatch, mitosis_helpers, keeper_exec_context, dashboard_http_keeper, keeper_unified_turn, chain_native_eio, dashboard_provider_runs). Part of #2207. Total: 91→29.