### PR TITLE
fix(research): add API surface to context, prevent LLM hallucination

### DIFF
--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -41,6 +41,9 @@ let default ?(repo = default_repo_config ()) () : t =
        Propose ONE focused, small change per experiment. Prioritize: \
        bug fixes > simplification > performance > readability. \
        Keep changes to 1-3 files, under 50 lines. All tests must pass. \
+       CRITICAL: Only use functions that appear in the 'Public API signatures' section. \
+       Do NOT invent module names or function names. If a function does not appear \
+       in the .mli signatures provided, it does not exist. \
        Respond ONLY with a JSON object: \
        {\"description\": \"...\", \"target_file\": \"...\", \"rationale\": \"...\", \"patch\": \"...\"}";
   }

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -52,6 +52,24 @@ let gather_context ~(config : Research_config.repo_config) : string =
       Buffer.add_string parts (Printf.sprintf "... and %d more\n" (count - 30));
     Buffer.add_string parts "```\n\n"
   with _ -> ());
+  (* API surface from .mli files — prevents LLM from hallucinating APIs *)
+  (try
+    let _, stdout =
+      Process_eio.run_argv_with_status ~timeout_sec:10.0
+        [ "grep"; "-rn"; "^val "; config.path ^ "/lib"; "--include=*.mli" ]
+    in
+    let sigs = String.split_on_char '\n' stdout
+      |> List.filter (fun s -> String.length s > 0) in
+    let count = List.length sigs in
+    if count > 0 then begin
+      let sample = if count > 40 then List.filteri (fun i _ -> i < 40) sigs else sigs in
+      Buffer.add_string parts (Printf.sprintf "## Public API signatures (%d total, from .mli files)\n```\n" count);
+      List.iter (fun s -> Buffer.add_string parts s; Buffer.add_char parts '\n') sample;
+      if count > 40 then
+        Buffer.add_string parts (Printf.sprintf "... and %d more\n" (count - 40));
+      Buffer.add_string parts "```\n\n"
+    end
+  with _ -> ());
   (* TODOs *)
   (try
     let _, stdout =


### PR DESCRIPTION
## Summary
- E2E 시뮬레이션에서 Qwen3.5-35B가 존재하지 않는 API 제안 (Room.broadcast 등)
- `gather_context`에 `.mli` 파일의 `val` 시그니처 추가 (상위 40개)
- 시스템 프롬프트에 "제공된 API만 사용" 지시 추가
- OCaml 강타입이 빌드 단계에서 잡긴 하지만, 사전 방지가 루프 효율을 높임

## Root cause
LLM context에 파일 목록과 TODO만 있고 실제 함수 시그니처가 없었음.
LLM이 모듈 이름에서 함수를 추측 → hallucination → build failure → wasted iteration.

## Test plan
- [x] `dune build` 통과
- [ ] 동일 TODO 프롬프트로 재테스트 → 존재하는 API만 제안하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)