### PR TITLE
refactor(dashboard): adopt StatGrid in agent profile

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -10,6 +10,7 @@ import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import { keeperIdentityHint } from './common/keeper-identity'
 import { EmptyState } from './common/empty-state'
+import { StatGrid } from './common/stat-tile'
 import { AgentAvatar } from './overview/agent-avatar'
 import {
   agents,
@@ -276,45 +277,23 @@ function CharacterPlate({ name }: { name: string }) {
         ` : null}
       </div>
 
-      ${isKeeper ? html`
-        <div class="grid grid-cols-4 gap-2 w-full mt-2">
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${ctxPct != null ? `${ctxPct}%` : 'N/A'}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">CTX</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${generation ?? 0}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">세대</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.turn_count ?? 0}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">턴</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${keeper.autonomous_action_count ?? 0}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">행동</span>
-          </div>
-        </div>
-      ` : html`
-        <div class="grid grid-cols-4 gap-2 w-full mt-2">
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_completed : 'N/A'}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">완료</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.tasks_claimed : 'N/A'}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">수임</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary ? summary.messages_sent : 'N/A'}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">메시지</span>
-          </div>
-          <div class="flex flex-col items-center px-2 py-1.5 bg-[rgba(200,168,78,0.05)] border border-[var(--ff-gold-10)] rounded-md flex-1">
-            <span class="text-[16px] font-bold tabular-nums text-[color:var(--text-strong)]">${summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A'}</span>
-            <span class="text-[length:var(--fs-2xs)] text-[color:var(--ff-gold)] tracking-[0.5px]">활동</span>
-          </div>
-        </div>
-      `}
+      <div class="w-full mt-2">
+        ${isKeeper ? html`
+          <${StatGrid} cols=${4} items=${[
+            { label: 'CTX', value: ctxPct != null ? `${ctxPct}%` : 'N/A', variant: 'gold' },
+            { label: '세대', value: generation ?? 0, variant: 'gold' },
+            { label: '턴', value: keeper.turn_count ?? 0, variant: 'gold' },
+            { label: '행동', value: keeper.autonomous_action_count ?? 0, variant: 'gold' },
+          ]} />
+        ` : html`
+          <${StatGrid} cols=${4} items=${[
+            { label: '완료', value: summary ? summary.tasks_completed : 'N/A', variant: 'gold' },
+            { label: '수임', value: summary ? summary.tasks_claimed : 'N/A', variant: 'gold' },
+            { label: '메시지', value: summary ? summary.messages_sent : 'N/A', variant: 'gold' },
+            { label: '활동', value: summary && summary.active_duration_minutes > 0 ? `${Math.round(summary.active_duration_minutes)}m` : summary ? '0m' : 'N/A', variant: 'gold' },
+          ]} />
+        `}
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
agent-profile CharacterPlate의 8개 인라인 stat 타일을 StatGrid 공통 컴포넌트로 교체.

- Keeper stats (CTX/세대/턴/행동): 16줄 → 4줄 config
- Agent stats (완료/수임/메시지/활동): 16줄 → 4줄 config
- gold variant로 기존 스타일과 동일한 시각적 결과

## Test plan
- [ ] Vite build 통과
- [ ] keeper 프로필에서 CTX/세대/턴/행동 표시 확인
- [ ] 일반 에이전트 프로필에서 완료/수임/메시지/활동 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)