### PR TITLE
feat(dashboard): overhaul status view and agent detail UI with glassmorphism

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -36,9 +36,9 @@ export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-de
 
 function TaskSummary({ task }: { task: Task }) {
   return html`
-    <div class="flex items-center gap-2 border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 rounded-lg">
-      <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${task.id}</span>
-      <span class="flex-1 text-[#d7e7ff]">${task.title}</span>
+    <div class="flex items-center gap-3 border border-card-border bg-card/40 hover:bg-card/60 transition-colors px-3 py-2.5 rounded-xl shadow-sm">
+      <span class="text-[10px] font-medium py-1 px-2.5 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">${task.id}</span>
+      <span class="flex-1 text-[13px] text-text-strong font-medium truncate">${task.title}</span>
       <${StatusBadge} status=${task.status} />
     </div>
   `
@@ -46,11 +46,11 @@ function TaskSummary({ task }: { task: Task }) {
 
 function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   return html`
-    <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5">
-      <div class="mb-2">
-        <span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${row.taskId}</span>
+    <div class="border border-card-border rounded-xl bg-card/40 p-4 shadow-sm hover:border-accent/30 transition-colors group">
+      <div class="mb-3">
+        <span class="text-[10px] font-medium py-1 px-2.5 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm group-hover:bg-accent/20 transition-colors">${row.taskId}</span>
       </div>
-      <pre class="m-0 whitespace-pre-wrap text-[length:var(--fs-sm)] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || 'No task history yet'}</pre>
+      <pre class="m-0 whitespace-pre-wrap text-[12px] leading-relaxed text-text-body font-mono opacity-90">${row.text || 'No task history yet'}</pre>
     </div>
   `
 }
@@ -94,106 +94,108 @@ export function AgentDetailOverlay() {
 
   return html`
     <div
-      class="agent-detail-overlay fixed inset-0 z-[var(--z-overlay-agent,3030)] bg-black/64 backdrop-blur-[4px] isolate flex items-center justify-center p-5"
+      class="agent-detail-overlay fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm isolate flex items-center justify-center p-6 animate-in fade-in duration-200"
       data-testid="agent-detail-overlay"
       onClick=${(e: Event) => {
         if ((e.target as HTMLElement).classList.contains('agent-detail-overlay')) closeAgentDetail()
       }}
     >
-      <div class="w-[min(1020px,100%)] max-h-[90vh] overflow-y-auto rounded-[14px] border border-[var(--border-slate-30)] bg-[rgba(16,25,45,0.95)] p-[18px]">
-        <div class="flex justify-between gap-3 mb-3.5">
-          <div class="flex flex-col gap-2 flex-1">
-            <div class="flex items-center gap-3">
-              ${agentEmoji ? html`<span class="text-[2rem]">${agentEmoji}</span>` : ''}
+      <div class="w-[min(1080px,100%)] max-h-[90vh] overflow-y-auto rounded-2xl border border-card-border bg-bg-1/95 backdrop-blur-2xl p-6 shadow-2xl shadow-black/50 ring-1 ring-white/5">
+        <div class="flex justify-between items-start gap-4 mb-6">
+          <div class="flex flex-col gap-3 flex-1">
+            <div class="flex items-center gap-4">
+              ${agentEmoji ? html`<div class="size-12 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
               <div>
-                <h2 class="m-0 flex items-baseline gap-2 text-[var(--text-strong)] text-xl">
+                <h2 class="m-0 flex items-baseline gap-2.5 text-text-strong text-2xl font-bold tracking-tight">
                   ${displayName}
-                  ${koreanName ? html`<span class="text-xs text-[var(--text-dim)]">(${koreanName})</span>` : ''}
-                  ${secondaryLabel ? html`<span class="font-mono text-xs text-[var(--text-dim)]">${secondaryLabel}</span>` : ''}
+                  ${koreanName ? html`<span class="text-sm text-text-dim font-medium tracking-normal">(${koreanName})</span>` : ''}
+                  ${secondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-white/5 px-2 py-0.5 rounded-md">${secondaryLabel}</span>` : ''}
                 </h2>
-                <div class="flex items-center gap-2 mt-1 flex-wrap">
+                <div class="flex items-center gap-2 mt-2 flex-wrap">
                   <${StatusBadge} status=${headerStatus} />
-                  ${isArchivedParticipant ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">archived session participant</span>` : null}
-                  ${agent?.model ? html`<span class="font-mono text-xs bg-[#2a2a4a] px-1.5 py-0.5 rounded">${agent.model}</span>` : ''}
+                  ${isArchivedParticipant ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">archived session participant</span>` : null}
+                  ${agent?.model ? html`<span class="font-mono text-[10px] font-medium bg-white/10 border border-white/5 px-2 py-1 rounded-md text-text-muted shadow-sm">${agent.model}</span>` : ''}
                   ${!agent && missionBrief?.archived_reason
-                    ? html`<span class="text-xs text-[var(--text-dim)]">${missionBrief.archived_reason}</span>`
+                    ? html`<span class="text-xs text-text-dim italic">${missionBrief.archived_reason}</span>`
                     : null}
-                  ${signalTruth ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">signal · ${signalTruth}</span>` : null}
-                  ${evidenceSource ? html`<span class="text-[length:var(--fs-2xs)] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">source · ${evidenceSource}</span>` : null}
+                  ${signalTruth ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">signal · ${signalTruth}</span>` : null}
+                  ${evidenceSource ? html`<span class="text-[10px] font-medium py-1 px-2 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm">source · ${evidenceSource}</span>` : null}
                 </div>
               </div>
             </div>
-            <div class="mt-1.5 flex gap-2 flex-wrap text-[#9ab3de] text-[length:var(--fs-sm)]">
+            <div class="mt-2 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
               ${agent?.current_task || missionBrief?.current_work
-                ? html`<span>Task: ${agent?.current_task ?? missionBrief?.current_work}</span>`
+                ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">Task: <span class="text-text-strong">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
                 : null}
-              ${lastSeenAt ? html`<span>Last seen: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
+              ${lastSeenAt ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">Last seen: <span class="text-text-strong"><${TimeAgo} timestamp=${lastSeenAt} /></span></span>` : null}
             </div>
             ${keeper || continuitySummary || missionBrief?.related_session_id
               ? html`
-                  <div class="mt-1.5 flex gap-2 flex-wrap text-[#9ab3de] text-[length:var(--fs-sm)]">
+                  <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
                     ${keeper
-                      ? html`<span>Linked keeper: ${keeper.name}${keeperIdentity ? ` · ${keeperIdentity}` : ''}</span>`
+                      ? html`<span class="flex items-center gap-1.5">Linked keeper: <strong class="text-text-strong">${keeper.name}</strong>${keeperIdentity ? html`<span class="text-text-dim text-xs">· ${keeperIdentity}</span>` : ''}</span>`
                       : null}
-                    ${missionBrief?.related_session_id ? html`<span>Session: ${missionBrief.related_session_id}</span>` : null}
-                    ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}
+                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">Session: <strong class="font-mono text-text-strong text-xs bg-white/5 px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
+                    ${continuitySummary ? html`<span class="text-accent/90 bg-accent/10 px-2 py-0.5 rounded-md border border-accent/10">${continuitySummary}</span>` : null}
                   </div>
                 `
               : null}
           </div>
-          <div class="flex gap-2">
-            <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
+          <div class="flex gap-2 shrink-0">
+            <button class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-card-border bg-card/60 text-text-body hover:bg-white/10 hover:text-text-strong transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
               ${loading.value ? '새로고침 중...' : '새로고침'}
             </button>
-            <button class="control-btn rounded-lg ghost" onClick=${closeAgentDetail}>닫기</button>
+            <button class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-all duration-200 shadow-sm" onClick=${closeAgentDetail}>닫기</button>
           </div>
         </div>
 
-        ${detailError.value ? html`<div class="council-error rounded-lg">${detailError.value}</div>` : null}
+        ${detailError.value ? html`<div class="p-4 mb-4 text-bad border border-bad/30 rounded-xl bg-bad/10 shadow-sm font-medium text-sm">${detailError.value}</div>` : null}
 
-        <div class="grid grid-cols-2 gap-3 mb-3">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-5">
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
-              ? html`<${EmptyState} message="할당된 작업이 없습니다" compact />`
-              : html`<div class="flex flex-col gap-2">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
+              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
+              : html`<div class="flex flex-col gap-2.5">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
           <//>
 
           <${Card} title="최근 활동">
             ${lines.length === 0
-              ? html`<${EmptyState} message="최근 활동 기록이 없습니다" compact />`
-              : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[length:var(--fs-sm)] text-[#c8daf7] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
+              ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="최근 활동 기록이 없습니다" compact /></div>`
+              : html`<div class="max-h-[240px] overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="border border-card-border bg-card/40 px-3 py-2.5 font-mono text-[12px] text-text-body leading-relaxed rounded-xl shadow-sm hover:bg-card/60 transition-colors">${line}</div>`)}</div>`}
           <//>
         </div>
 
-        <${AgentJournalStream} agentName=${agentName} />
-        <${AgentTimelineSection} />
-        <${AgentWorkerBrief} agentName=${agentName} />
-        <${Card} title="작업 이력">
-          ${taskHistories.value.length === 0
-            ? html`<${EmptyState} message="작업 이력이 없습니다" compact />`
-            : html`<div class="flex flex-col gap-2.5">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
-        <//>
+        <div class="flex flex-col gap-5">
+          <${AgentJournalStream} agentName=${agentName} />
+          <${AgentTimelineSection} />
+          <${AgentWorkerBrief} agentName=${agentName} />
+          <${Card} title="작업 이력">
+            ${taskHistories.value.length === 0
+              ? html`<${EmptyState} message="작업 이력이 없습니다" compact />`
+              : html`<div class="flex flex-col gap-3">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
+          <//>
 
-        <${Card} title="직접 멘션">
-          <div class="grid grid-cols-[1fr_auto] gap-2">
-            <input
-              class="control-input rounded-lg"
-              type="text"
-              placeholder="@멘션 메시지"
-              value=${mentionText.value}
-              onInput=${(e: Event) => { mentionText.value = (e.target as HTMLInputElement).value }}
-              onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void submitMention() }}
-              disabled=${sendingMention.value}
-            />
-            <button
-              class="control-btn rounded-lg"
-              onClick=${() => { void submitMention() }}
-              disabled=${sendingMention.value || mentionText.value.trim() === ''}
-            >
-              ${sendingMention.value ? '전송 중...' : '전송'}
-            </button>
-          </div>
-        <//>
+          <${Card} title="직접 멘션">
+            <div class="grid grid-cols-[1fr_auto] gap-3">
+              <input
+                class="w-full px-4 py-2.5 rounded-xl border border-card-border bg-card/60 text-text-strong text-[13px] placeholder:text-text-dim focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner"
+                type="text"
+                placeholder="@멘션 메시지 입력..."
+                value=${mentionText.value}
+                onInput=${(e: Event) => { mentionText.value = (e.target as HTMLInputElement).value }}
+                onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void submitMention() }}
+                disabled=${sendingMention.value}
+              />
+              <button
+                class="px-5 py-2.5 text-[13px] font-semibold rounded-xl border border-transparent bg-accent text-bg-0 hover:bg-accent/90 transition-all duration-200 shadow-md shadow-accent/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick=${() => { void submitMention() }}
+                disabled=${sendingMention.value || mentionText.value.trim() === ''}
+              >
+                ${sendingMention.value ? '전송 중...' : '전송하기'}
+              </button>
+            </div>
+          <//>
+        </div>
       </div>
     </div>
   `

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -19,33 +19,35 @@ export function Status() {
   const section = currentSection()
 
   return html`
-    <div class="flex flex-col gap-4">
-      <div class="flex gap-1 p-1 bg-[var(--white-3)] rounded-lg w-fit">
+    <div class="flex flex-col gap-6">
+      <div class="flex gap-1.5 p-1.5 bg-card/40 backdrop-blur-md border border-card-border rounded-xl w-fit shadow-sm shadow-black/10">
         <button
-          class="px-3.5 py-1.5 rounded-md text-xs font-medium transition-all cursor-pointer border-0 ${section === 'sessions' ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)]'}"
+          class="px-4 py-2 rounded-lg text-[13px] font-semibold transition-all duration-200 cursor-pointer border border-transparent ${section === 'sessions' ? 'bg-accent/10 text-accent border-accent/20 shadow-sm' : 'bg-transparent text-text-muted hover:bg-white/5 hover:text-text-body'}"
           onClick=${() => navigate('status', { section: 'sessions' })}
         >
-          세션
+          세션 현황
         </button>
         <button
-          class="px-3.5 py-1.5 rounded-md text-xs font-medium transition-all cursor-pointer border-0 ${section === 'agents' ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)]'}"
+          class="px-4 py-2 rounded-lg text-[13px] font-semibold transition-all duration-200 cursor-pointer border border-transparent ${section === 'agents' ? 'bg-accent/10 text-accent border-accent/20 shadow-sm' : 'bg-transparent text-text-muted hover:bg-white/5 hover:text-text-body'}"
           onClick=${() => navigate('status', { section: 'agents' })}
         >
-          에이전트
+          에이전트 목록
         </button>
         <button
-          class="px-3.5 py-1.5 rounded-md text-xs font-medium transition-all cursor-pointer border-0 ${section === 'activity' ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)]'}"
+          class="px-4 py-2 rounded-lg text-[13px] font-semibold transition-all duration-200 cursor-pointer border border-transparent ${section === 'activity' ? 'bg-accent/10 text-accent border-accent/20 shadow-sm' : 'bg-transparent text-text-muted hover:bg-white/5 hover:text-text-body'}"
           onClick=${() => navigate('status', { section: 'activity' })}
         >
-          활동
+          최근 활동
         </button>
       </div>
 
-      ${section === 'agents'
-        ? html`<${AgentsUnified} />`
-        : section === 'activity'
-          ? html`<${Activity} />`
-          : html`<${Mission} />`}
+      <div class="transition-opacity duration-300">
+        ${section === 'agents'
+          ? html`<${AgentsUnified} />`
+          : section === 'activity'
+            ? html`<${Activity} />`
+            : html`<${Mission} />`}
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Description
Continues the UI overhaul by upgrading the Status surface and the Agent Detail modal to match the modern Tailwind glassmorphism design language.

- Upgrades the Agent Detail overlay to use a blurred backdrop and soft card borders.
- Refines typography, pill badges, and input forms for direct mentions.
- Replaces harsh colored backgrounds with subtle `bg-accent/10` or `bg-card/40` utilities.
- Modernizes the top toggle buttons in the Status view to feel like floating pills.