### PR TITLE
fix(dashboard): normalize keeper chat error payload

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { KeeperChatStreamEvent } from '../api/keeper'
+import {
+  isKeeperTextContentEvent,
+  normalizeKeeperChatErrorValue,
+} from './keeper-chat-panel'
+
+describe('isKeeperTextContentEvent', () => {
+  it('accepts current AG-UI text content events', () => {
+    const event: KeeperChatStreamEvent = { type: 'TEXT_MESSAGE_CONTENT', delta: 'hi' }
+    expect(isKeeperTextContentEvent(event)).toBe(true)
+  })
+
+  it('keeps legacy text delta compatibility', () => {
+    const event: KeeperChatStreamEvent = { type: 'TEXT_DELTA', delta: 'hi' }
+    expect(isKeeperTextContentEvent(event)).toBe(true)
+  })
+
+  it('rejects non-text stream events', () => {
+    const event: KeeperChatStreamEvent = { type: 'RUN_ERROR', value: { message: 'boom' } }
+    expect(isKeeperTextContentEvent(event)).toBe(false)
+  })
+})
+
+describe('normalizeKeeperChatErrorValue', () => {
+  it('returns direct string errors unchanged', () => {
+    expect(normalizeKeeperChatErrorValue('boom')).toBe('boom')
+  })
+
+  it('extracts nested error messages from object payloads', () => {
+    expect(normalizeKeeperChatErrorValue({ message: 'stream failed' })).toBe('stream failed')
+    expect(normalizeKeeperChatErrorValue({ error: { message: 'backend exploded' } })).toBe('backend exploded')
+  })
+
+  it('falls back to a stable generic message', () => {
+    expect(normalizeKeeperChatErrorValue({ code: 500 })).toBe('Stream error')
+  })
+})

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { streamKeeperMessage, type KeeperChatStreamEvent } from '../api/keeper'
+import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
 
 interface ChatMessage {
@@ -20,6 +21,25 @@ const streamBuffer = signal('')
 const chatError = signal('')
 
 let activeAbort: AbortController | null = null
+
+export function isKeeperTextContentEvent(event: KeeperChatStreamEvent): boolean {
+  return event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA'
+}
+
+export function normalizeKeeperChatErrorValue(value: unknown): string {
+  const direct = asString(value)
+  if (direct) return direct
+  if (isRecord(value)) {
+    const nestedError = isRecord(value.error) ? value.error : null
+    const message =
+      asString(value.message)
+      ?? asString(value.error)
+      ?? asString(nestedError?.message)
+      ?? asString(nestedError?.error)
+    if (message) return message
+  }
+  return 'Stream error'
+}
 
 function cancelStream(): void {
   if (activeAbort) {
@@ -49,7 +69,7 @@ async function sendChat(keeperName: string): Promise<void> {
     await streamKeeperMessage(keeperName, text, undefined, {
       signal: activeAbort.signal,
       onEvent: (event: KeeperChatStreamEvent) => {
-        if (event.type === 'TEXT_DELTA' && event.delta) {
+        if (isKeeperTextContentEvent(event) && event.delta) {
           streamBuffer.value += event.delta
         } else if (event.type === 'RUN_FINISHED') {
           const finalText = streamBuffer.value.trim() || '(no response)'
@@ -59,7 +79,7 @@ async function sendChat(keeperName: string): Promise<void> {
           ]
           streamBuffer.value = ''
         } else if (event.type === 'RUN_ERROR') {
-          chatError.value = String(event.value ?? 'Stream error')
+          chatError.value = normalizeKeeperChatErrorValue(event.value)
         }
       },
     })


### PR DESCRIPTION
## Summary
- normalize structured keeper chat error payloads instead of rendering [object Object]
- accept both TEXT_MESSAGE_CONTENT and legacy TEXT_DELTA stream events in the legacy keeper chat panel
- add regression tests for event compatibility and error message extraction

## Verification
- npm run typecheck
- npm test -- src/components/keeper-chat-panel.test.ts
- npm run build