### PR TITLE
refactor(dashboard): final orphan CSS cleanup

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -132,11 +132,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             value=${search}
             onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
           />
-          <div class="flex gap-1">
+          <div class="flex gap-1.5">
             ${(['all', 'active', 'idle', 'offline'] as StatusFilter[]).map(f => html`
               <button
                 key=${f}
-                class="roster-filter-btn ${filter === f ? 'active' : ''}"
+                class="px-2.5 py-1 text-[length:var(--fs-xs)] rounded-xl border cursor-pointer transition-all duration-150 ${filter === f
+                  ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
+                  : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'}"
                 onClick=${() => setFilter(f)}
               >
                 ${f === 'all' ? '전체' : f === 'active' ? '활성' : f === 'idle' ? '유휴' : '오프라인'} ${counts[f]}

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -26,7 +26,9 @@ function FilterBar() {
       ${FILTER_OPTIONS.map(opt => html`
         <button
           key=${opt.kind}
-          class="activity-filter-btn rounded-md ${opt.cssClass} ${active.has(opt.kind) ? 'active' : ''}"
+          class="px-2 py-0.5 text-[length:var(--fs-xs)] rounded-md border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
+            ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
+            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'}"
           onClick=${() => toggleLiveFilter(opt.kind)}
         >
           ${opt.label}

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { EmptyState } from './common/empty-state'
 import { useEffect, useState } from 'preact/hooks'
 import { callMcpTool } from '../api/mcp'
 
@@ -46,9 +47,7 @@ export function Worktrees() {
 
   if (!worktrees || worktrees.length === 0) {
     return html`
-      <div class="empty-state text-center p-10 text-text-muted border border-dashed border-card-border rounded-2xl bg-card/20 backdrop-blur-sm">
-        활성화된 워크트리가 없습니다.
-      </div>
+      <${EmptyState} message="활성화된 워크트리가 없습니다." />
     `
   }
 


### PR DESCRIPTION
## Summary
마지막 orphan CSS class 3개를 Tailwind inline으로 교체:
- `worktrees.ts`: 마지막 `class="empty-state"` → `EmptyState` 컴포넌트
- `agent-roster.ts`: `roster-filter-btn` (CSS 정의 없음) → Tailwind chip 스타일
- `live/activity-stream.ts`: `activity-filter-btn` (CSS 정의 없음) → Tailwind chip 스타일

## Result
- `class="empty-state"`: 0건 남음 (전체 dashboard)
- orphan filter button classes: 0건 남음

## Test plan
- [ ] Vite build 통과
- [ ] 에이전트 목록 필터 정상 동작
- [ ] 활동 스트림 필터 정상 동작
- [ ] 워크트리 빈 상태 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)