### PR TITLE
refactor(dashboard): extract shared primitives and normalize mission card spacing

### DIFF
--- a/dashboard/src/components/common/action-bar.ts
+++ b/dashboard/src/components/common/action-bar.ts
@@ -1,0 +1,32 @@
+// ActionBar — consistent action button row at the bottom of cards.
+// Replaces repeated flex gap-2 flex-wrap mt-2.5 + control-btn patterns.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+interface ActionBarProps {
+  children: ComponentChildren
+  class?: string
+}
+
+export function ActionBar({ children, class: className }: ActionBarProps) {
+  return html`
+    <div class="flex gap-3 flex-wrap mt-3 ${className ?? ''}">
+      ${children}
+    </div>
+  `
+}
+
+interface ActionBtnProps {
+  label: string
+  onClick: (e: Event) => void
+  disabled?: boolean
+}
+
+export function ActionBtn({ label, onClick, disabled }: ActionBtnProps) {
+  return html`
+    <button class="control-btn rounded-lg ghost" onClick=${onClick} disabled=${disabled}>
+      ${label}
+    </button>
+  `
+}

--- a/dashboard/src/components/common/list-item.ts
+++ b/dashboard/src/components/common/list-item.ts
@@ -1,0 +1,28 @@
+// ListItem — clickable or static list row with title/subtitle/detail.
+// Replaces 8+ inline w-full p-3 rounded-xl border grid gap-1 patterns.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+interface ListItemProps {
+  title: ComponentChildren
+  subtitle?: ComponentChildren
+  detail?: ComponentChildren
+  onClick?: (e: Event) => void
+  class?: string
+}
+
+export function ListItem({ title, subtitle, detail, onClick, class: className }: ListItemProps) {
+  const base = `w-full p-4 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1.5 text-left text-inherit ${onClick ? 'cursor-pointer' : 'cursor-default'} ${className ?? ''}`
+
+  const content = html`
+    <strong class="text-[var(--text-strong)]">${title}</strong>
+    ${subtitle != null ? html`<span class="text-[rgba(255,255,255,0.72)] leading-snug">${subtitle}</span>` : null}
+    ${detail != null ? html`<small class="text-[rgba(255,255,255,0.72)] leading-snug">${detail}</small>` : null}
+  `
+
+  if (onClick) {
+    return html`<button class="${base}" onClick=${onClick}>${content}</button>`
+  }
+  return html`<div class="${base}">${content}</div>`
+}

--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -1,0 +1,23 @@
+// StatCell — label/value/detail stat box for mission cards and grids.
+// Replaces 12+ inline p-3 rounded-xl bg-[var(--white-4)] grid gap-1 patterns.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+interface StatCellProps {
+  label: string
+  value: ComponentChildren
+  detail?: ComponentChildren
+  tone?: string
+  class?: string
+}
+
+export function StatCell({ label, value, detail, tone, class: className }: StatCellProps) {
+  return html`
+    <div class="p-4 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
+      <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
+      <strong class="text-[var(--text-strong)] text-lg leading-tight tabular-nums">${value}</strong>
+      ${detail != null ? html`<small class="text-[var(--text-muted)] text-[10px] leading-relaxed">${detail}</small>` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/common/tag-badge.ts
+++ b/dashboard/src/components/common/tag-badge.ts
@@ -1,0 +1,19 @@
+// TagBadge — rounded-full info chip for inline metadata display.
+// Replaces 5+ inline px-2.5 py-1.5 rounded-full border patterns.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+interface TagBadgeProps {
+  children: ComponentChildren
+  onClick?: (e: Event) => void
+  class?: string
+}
+
+export function TagBadge({ children, onClick, class: className }: TagBadgeProps) {
+  const base = 'px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-xs leading-tight'
+  if (onClick) {
+    return html`<button class="${base} cursor-pointer ${className ?? ''}" onClick=${onClick}>${children}</button>`
+  }
+  return html`<span class="${base} ${className ?? ''}">${children}</span>`
+}

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -1,6 +1,8 @@
 import { html } from 'htm/preact'
 import { extractAgentInfo } from './common/agent-info'
 import { linkedRecentToolsEmptyState, observedToolsEmptyState, toolAuditStateLabel } from './common/tool-audit'
+import { StatCell } from './common/stat-cell'
+import { ActionBar, ActionBtn } from './common/action-bar'
 import { openAgentDetail } from './agent-detail'
 import { openKeeperDetail } from './keeper-detail'
 import { workflowActionLabel } from '../workflow-context'
@@ -32,10 +34,10 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
       ? row.recentTools.join(', ')
       : toolAuditStateLabel(observedToolsEmptyState(row.keeper, row.brief.tool_audit_source))
   return html`
-    <article class="w-full p-3.5 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.agent?.status)}">
+    <article class="w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.agent?.status)}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => openAgentDetail(row.brief.agent_name)}>
-        <div class="flex justify-between gap-2.5 items-start">
-          <div class="flex gap-2.5 items-start">
+        <div class="flex justify-between gap-3 items-start">
+          <div class="flex gap-3 items-start">
             <span class="agent-emoji">${row.agent?.emoji ?? row.keeper?.emoji ?? ''}</span>
             <div>
               <strong>${row.brief.agent_name}</strong>
@@ -45,39 +47,33 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
           <span class="cmd-chip rounded-full ${toneClass(row.brief.status ?? row.agent?.status)}">${statusLabel(row.brief.status ?? row.agent?.status)}</span>
         </div>
 
-        <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+        <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug">
           <span>어디서 · ${row.where}</span>
           <span>누구와 · ${who}</span>
           <span>주의 신호 · ${row.brief.related_attention_count}</span>
         </div>
 
-        <div class="grid gap-1">
+        <div class="grid gap-1.5">
           <span>무엇을</span>
           <strong>${row.currentWork}</strong>
           ${row.how ? html`<small>어떻게 · ${row.how}</small>` : null}
         </div>
       </button>
 
-      <details class="pt-1 border-t border-[var(--white-6)]">
+      <details class="pt-2 border-t border-[var(--white-6)]">
         <summary>최근 흐름</summary>
-        <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+        <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
           ${row.recentEvent ? html`<span>최근 일 · ${row.recentEvent}</span>` : html`<span>최근 사건 요약 없음</span>`}
           <span>관련 세션 · ${row.brief.related_session_id ?? '없음'}</span>
         </div>
 
-        <details class="pt-1 border-t border-[var(--white-6)] mt-2">
+        <details class="pt-2 border-t border-[var(--white-6)] mt-3">
           <summary>입력 · 응답 · 도구</summary>
-          <div class="grid grid-cols-2 gap-2.5">
-            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-              <span>최근 입력</span>
-              <strong>${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'}</strong>
-            </div>
-            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-              <span>최근 응답</span>
-              <strong>${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'}</strong>
-            </div>
+          <div class="grid grid-cols-2 gap-3 mt-3">
+            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} />
+            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} />
           </div>
-          <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+          <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
             <span>최근 도구 · ${recentToolsLabel}</span>
           </div>
         </details>
@@ -102,7 +98,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
       : toolAuditStateLabel(linkedRecentToolsEmptyState(row.keeper))
 
   return html`
-    <article class="w-full p-3.5 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
+    <article class="w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => {
         const keeper: Keeper = row.keeper ?? {
           name: row.brief.name,
@@ -112,8 +108,8 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
         } as Keeper
         openKeeperDetail(keeper)
       }}>
-        <div class="flex justify-between gap-2.5 items-start">
-          <div class="flex gap-2.5 items-start">
+        <div class="flex justify-between gap-3 items-start">
+          <div class="flex gap-3 items-start">
             <div class="mission-status-dot ${liveStateClass(row.brief.status, row.keeper?.status)} ${dotStateBg(liveStateClass(row.brief.status, row.keeper?.status))}"></div>
             <span class="agent-emoji">${row.keeper?.emoji ?? ''}</span>
             <div>
@@ -124,37 +120,31 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
           <span class="cmd-chip rounded-full ${toneClass(row.brief.status ?? row.keeper?.status)}">${statusLabel(row.brief.status ?? row.keeper?.status)}</span>
         </div>
 
-        <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+        <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug">
           <span>최근 하트비트 · ${row.keeper?.last_heartbeat ? relativeTime(row.keeper.last_heartbeat) : '기록 없음'}</span>
           <span>${continuity || '연속성 정보 없음'}</span>
         </div>
 
-        <div class="grid gap-1">
+        <div class="grid gap-1.5">
           <span>무엇을</span>
           <strong>${row.currentWork}</strong>
           ${row.keeper?.skill_reason ? html`<small>판단 요약 · ${trimText(row.keeper.skill_reason, 120)}</small>` : null}
         </div>
       </button>
 
-      <details class="pt-1 border-t border-[var(--white-6)]">
+      <details class="pt-2 border-t border-[var(--white-6)]">
         <summary>연속성 상세</summary>
-        <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+        <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
           <span>에이전트 · ${row.brief.agent_name ?? row.keeper?.agent_name ?? '기록 없음'}</span>
           ${row.recentEvent ? html`<span>최근 일 · ${row.recentEvent}</span>` : null}
         </div>
-        <details class="pt-1 border-t border-[var(--white-6)] mt-2">
+        <details class="pt-2 border-t border-[var(--white-6)] mt-3">
           <summary>입력 · 응답 · 도구</summary>
-          <div class="grid grid-cols-2 gap-2.5">
-            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-              <span>최근 입력</span>
-              <strong>${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'}</strong>
-            </div>
-            <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-              <span>최근 응답</span>
-              <strong>${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'}</strong>
-            </div>
+          <div class="grid grid-cols-2 gap-3 mt-3">
+            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} />
+            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} />
           </div>
-          <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+          <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
             <span>최근 도구 · ${recentToolsLabel}</span>
           </div>
         </details>
@@ -167,28 +157,28 @@ export function InternalSignalCard({ item }: { item: DashboardMissionInternalSig
   const action = item.action ?? null
   const attention = item.attention ?? null
   return html`
-    <article class="p-3.5 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] ${toneClass(item.severity)}">
-      <div class="flex justify-between gap-2 items-start flex-wrap">
+    <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 ${toneClass(item.severity)}">
+      <div class="flex justify-between gap-3 items-start flex-wrap">
         <span class="cmd-chip rounded-full ${toneClass(item.severity)}">
           ${item.signal_type === 'action' && action ? workflowActionLabel(action.action_type) : attention?.kind ?? '내부 신호'}
         </span>
         <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
       </div>
       <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${item.summary}</p>
-      ${action ? html`<div class="py-2.5 px-3 rounded-xl bg-[var(--white-5)] border border-[var(--white-8)] text-[var(--text-strong)] leading-[1.45]">${action.reason}</div>` : null}
-      <div class="flex gap-2 flex-wrap mt-2.5">
+      ${action ? html`<div class="py-3 px-4 rounded-xl bg-[var(--white-5)] border border-[var(--white-8)] text-[var(--text-strong)] leading-snug">${action.reason}</div>` : null}
+      <${ActionBar}>
         ${action
           ? html`
-              <button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, attention, '상황판 내부 신호')}>이 액션으로 개입 열기</button>
-              <button class="control-btn rounded-lg ghost" onClick=${() => openActionCommand(action, attention, '상황판 내부 신호')}>이 이슈의 원인 보기</button>
+              <${ActionBtn} label="이 액션으로 개입 열기" onClick=${() => openActionIntervene(action, attention, '상황판 내부 신호')} />
+              <${ActionBtn} label="이 이슈의 원인 보기" onClick=${() => openActionCommand(action, attention, '상황판 내부 신호')} />
             `
           : attention
             ? html`
-                <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentIntervene(attention)}>이 이슈로 개입 열기</button>
-                <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentCommand(attention)}>이 이슈의 원인 보기</button>
+                <${ActionBtn} label="이 이슈로 개입 열기" onClick=${() => openIncidentIntervene(attention)} />
+                <${ActionBtn} label="이 이슈의 원인 보기" onClick=${() => openIncidentCommand(attention)} />
               `
             : null}
-      </div>
+      <//>
     </article>
   `
 }

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -1,5 +1,9 @@
 import { html } from 'htm/preact'
 import { EmptyState } from './common/empty-state'
+import { StatCell } from './common/stat-cell'
+import { TagBadge } from './common/tag-badge'
+import { ListItem } from './common/list-item'
+import { ActionBar, ActionBtn } from './common/action-bar'
 import { openAgentDetail } from './agent-detail'
 import { workflowActionLabel } from '../workflow-context'
 import type {
@@ -38,52 +42,37 @@ export function AttentionCard({
   const action = item.top_action ?? null
 
   return html`
-    <article class="mission-attention-card p-3.5 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-6),var(--white-3))] grid gap-3 ${toneClass(action?.severity ?? item.severity)} ${selected ? 'is-selected' : ''}">
+    <article class="mission-attention-card p-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-6),var(--white-3))] grid gap-3 ${toneClass(action?.severity ?? item.severity)} ${selected ? 'is-selected' : ''}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleAttention(item.id)}>
-        <div class="flex justify-between gap-2 items-start flex-wrap">
+        <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
             <strong>${item.summary}</strong>
-            <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</div>
+            <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)] mt-1">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</div>
           </div>
           <span class="cmd-chip rounded-full ${toneClass(action?.severity ?? item.severity)}">${action ? actionModeLabel(action) : item.severity}</span>
         </div>
 
-        <div class="grid grid-cols-2 gap-2.5">
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span>영향 세션</span>
-            <strong>${item.related_session_ids.length}</strong>
-            <small>${item.related_session_ids.slice(0, 2).join(', ') || '없음'}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span>영향 에이전트</span>
-            <strong>${item.related_agent_names.length}</strong>
-            <small>${item.related_agent_names.slice(0, 3).join(', ') || '없음'}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span>최근 신호</span>
-            <strong>${item.last_seen_at ? relativeTime(item.last_seen_at) : '기록 없음'}</strong>
-            <small>${missionTargetTypeLabel(item.target_type)}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span>다음 액션</span>
-            <strong>${action ? workflowActionLabel(action.action_type) : '판단 필요'}</strong>
-            <small>${action ? actionTargetLabel(action) : '추천 액션 없음'}</small>
-          </div>
+        <div class="grid grid-cols-2 gap-3">
+          <${StatCell} label="영향 세션" value=${item.related_session_ids.length} detail=${item.related_session_ids.slice(0, 2).join(', ') || '없음'} />
+          <${StatCell} label="영향 에이전트" value=${item.related_agent_names.length} detail=${item.related_agent_names.slice(0, 3).join(', ') || '없음'} />
+          <${StatCell} label="최근 신호" value=${item.last_seen_at ? relativeTime(item.last_seen_at) : '기록 없음'} detail=${missionTargetTypeLabel(item.target_type)} />
+          <${StatCell} label="다음 액션" value=${action ? workflowActionLabel(action.action_type) : '판단 필요'} detail=${action ? actionTargetLabel(action) : '추천 액션 없음'} />
         </div>
       </button>
 
-      ${action ? html`<div class="grid gap-1">${action.reason}</div>` : null}
+      ${action ? html`<div class="grid gap-1.5 px-1">${action.reason}</div>` : null}
 
-      <details class="pt-1 border-t border-[var(--white-6)]">
+      <details class="pt-2 border-t border-[var(--white-6)]">
         <summary>연결된 흐름 보기</summary>
         ${linkedSessions.length > 0
           ? html`
-              <div class="flex flex-col gap-2 mt-2.5">
+              <div class="flex flex-col gap-3 mt-3">
                 ${linkedSessions.slice(0, 4).map(session => html`
-                  <button class="w-full py-2.5 px-3 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1 text-left text-inherit cursor-pointer" onClick=${() => toggleSession(session.session_id)}>
-                    <strong>${session.goal}</strong>
-                    <span>${statusLabel(session.status)} · ${session.last_event_summary ?? '최근 사건 없음'}</span>
-                  </button>
+                  <${ListItem}
+                    title=${session.goal}
+                    subtitle=${html`${statusLabel(session.status)} · ${session.last_event_summary ?? '최근 사건 없음'}`}
+                    onClick=${() => toggleSession(session.session_id)}
+                  />
                 `)}
               </div>
             `
@@ -91,9 +80,9 @@ export function AttentionCard({
 
         ${item.related_agent_names.length > 0
           ? html`
-              <div class="flex gap-2 flex-wrap mt-2.5">
+              <div class="flex gap-3 flex-wrap mt-3">
                 ${item.related_agent_names.slice(0, 8).map(name => html`
-                  <button class="px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-[length:var(--fs-sm)] leading-[1.35] cursor-pointer" onClick=${() => openAgentDetail(name)}>${name}</button>
+                  <${TagBadge} onClick=${() => openAgentDetail(name)}>${name}<//>
                 `)}
               </div>
             `
@@ -101,9 +90,9 @@ export function AttentionCard({
 
         ${item.evidence_preview.length > 0
           ? html`
-              <details class="pt-1 border-t border-[var(--white-6)] mt-2">
+              <details class="pt-2 border-t border-[var(--white-6)] mt-3">
                 <summary>근거 미리보기</summary>
-                <div class="grid gap-2 mt-2.5">
+                <div class="grid gap-3 mt-3">
                   ${item.evidence_preview.map(text => html`<span>${text}</span>`)}
                 </div>
               </details>
@@ -111,21 +100,17 @@ export function AttentionCard({
           : null}
       </details>
 
-      <div class="flex gap-2 flex-wrap mt-2.5">
+      <${ActionBar}>
         ${action
           ? html`
-              <button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, incident, '상황판 주의 신호')}>
-                이 액션으로 개입 열기
-              </button>
-              <button class="control-btn rounded-lg ghost" onClick=${() => openActionCommand(action, incident, '상황판 주의 신호')}>
-                원인 보기
-              </button>
+              <${ActionBtn} label="이 액션으로 개입 열기" onClick=${() => openActionIntervene(action, incident, '상황판 주의 신호')} />
+              <${ActionBtn} label="원인 보기" onClick=${() => openActionCommand(action, incident, '상황판 주의 신호')} />
             `
           : html`
-              <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentIntervene(incident)}>이 이슈로 개입 열기</button>
-              <button class="control-btn rounded-lg ghost" onClick=${() => openIncidentCommand(incident)}>이 이슈의 원인 보기</button>
+              <${ActionBtn} label="이 이슈로 개입 열기" onClick=${() => openIncidentIntervene(incident)} />
+              <${ActionBtn} label="이 이슈의 원인 보기" onClick=${() => openIncidentCommand(incident)} />
             `}
-      </div>
+      <//>
     </article>
   `
 }

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -1,6 +1,8 @@
 import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
+import { TagBadge } from './common/tag-badge'
+import { ActionBar, ActionBtn } from './common/action-bar'
 import { ProvenanceStrip } from './common/provenance-strip'
 import {
   missionBriefing,
@@ -20,7 +22,7 @@ export function MissionBriefingCard() {
 
   return html`
     <${Card} title="판단 레이어" class="mission-briefing-card rounded-xl">
-      <div class="grid gap-1 mb-3">
+      <div class="grid gap-1.5 mb-4">
         <h3>왜 그렇게 보이나</h3>
         <p>사회 truth를 읽은 뒤에만 별도 판단 결과를 참고하고, 근거는 접어서 둡니다.</p>
         <${ProvenanceStrip}
@@ -31,7 +33,7 @@ export function MissionBriefingCard() {
         />
       </div>
 
-      <div class="flex gap-2 flex-wrap mb-3">
+      <div class="flex gap-3 flex-wrap mb-4">
         <span class="cmd-chip rounded-full ${briefingTone}">
           ${statusLabel(briefing?.status ?? (missionBriefingError.value ? 'error' : 'loading'))}
         </span>
@@ -44,17 +46,17 @@ export function MissionBriefingCard() {
 
       ${missionBriefingError.value ? html`<${EmptyState} message=${missionBriefingError.value} compact />` : null}
       ${briefing?.error ? html`<${EmptyState} message=${briefing.error} compact />` : null}
-      ${briefing?.summary ? html`<div class="grid gap-1">${briefing.summary}</div>` : null}
+      ${briefing?.summary ? html`<div class="grid gap-1.5">${briefing.summary}</div>` : null}
       ${briefing?.last_error && !briefing.error
-        ? html`<div class="grid gap-1">최근 갱신 실패: ${briefing.last_error}</div>`
+        ? html`<div class="grid gap-1.5">최근 갱신 실패: ${briefing.last_error}</div>`
         : null}
 
       ${briefing && briefing.sections.length > 0
         ? html`
-            <div class="grid grid-cols-3 gap-3">
+            <div class="grid grid-cols-3 gap-3 mt-3">
               ${briefing.sections.slice(0, 3).map(section => html`
-                <article class="p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-2 ${toneClass(section.status)}">
-                  <div class="flex justify-between gap-2 items-start flex-wrap">
+                <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 ${toneClass(section.status)}">
+                  <div class="flex justify-between gap-3 items-start flex-wrap">
                     <strong>${section.label}</strong>
                     <div class="flex gap-2 flex-wrap justify-end">
                       <span class="cmd-chip rounded-full ${toneClass(section.status)}">${statusLabel(section.status)}</span>
@@ -67,10 +69,10 @@ export function MissionBriefingCard() {
                   <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${section.summary}</p>
                   ${section.evidence.length > 0
                     ? html`
-                        <details class="pt-1 border-t border-[var(--white-6)] mt-2">
+                        <details class="pt-2 border-t border-[var(--white-6)] mt-3">
                           <summary>근거 보기</summary>
-                          <div class="flex gap-2 flex-wrap mt-2.5">
-                            ${section.evidence.map(item => html`<span class="px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-[length:var(--fs-sm)] leading-[1.35]">${item}</span>`)}
+                          <div class="flex gap-3 flex-wrap mt-3">
+                            ${section.evidence.map(item => html`<${TagBadge}>${item}<//>`)}
                           </div>
                         </details>
                       `
@@ -89,16 +91,16 @@ export function MissionBriefingCard() {
 
       ${briefing && briefing.metadata_gaps.length > 0
         ? html`
-            <details class="pt-1 border-t border-[var(--white-6)] mt-2 mt-3">
+            <details class="pt-2 border-t border-[var(--white-6)] mt-4">
               <summary>관측 공백 (${briefing.metadata_gap_count ?? briefing.metadata_gaps.length})</summary>
-              <div class="flex flex-col gap-3">
+              <div class="flex flex-col gap-3 mt-3">
                 ${briefing.metadata_gaps.map(item => html`
-                  <article class="p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] grid gap-2 ${item.severity === 'watch' ? 'warn' : ''}">
-                    <div class="flex justify-between gap-2 items-start flex-wrap">
+                  <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] grid gap-3 ${item.severity === 'watch' ? 'warn' : ''}">
+                    <div class="flex justify-between gap-3 items-start flex-wrap">
                       <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
                       <span class="cmd-chip rounded-full ${item.severity === 'watch' ? 'warn' : ''}">${statusLabel(item.severity)}</span>
                     </div>
-                    <p class="m-0 text-[rgba(255,255,255,0.78)] leading-[1.45]">${item.summary}</p>
+                    <p class="m-0 text-[rgba(255,255,255,0.78)] leading-snug">${item.summary}</p>
                   </article>
                 `)}
               </div>
@@ -106,14 +108,18 @@ export function MissionBriefingCard() {
           `
         : null}
 
-      <div class="flex gap-2 flex-wrap mt-2.5">
-        <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshMissionBriefing(retryNeedsForce) }} disabled=${missionBriefingLoading.value}>
-          ${missionBriefingLoading.value ? '응답 기다리는 중…' : '판단 다시 읽기'}
-        </button>
-        <button class="control-btn rounded-lg ghost" onClick=${() => { void refreshMissionBriefing(true) }} disabled=${missionBriefingLoading.value}>
-          강제 갱신
-        </button>
-      </div>
+      <${ActionBar}>
+        <${ActionBtn}
+          label=${missionBriefingLoading.value ? '응답 기다리는 중…' : '판단 다시 읽기'}
+          onClick=${() => { void refreshMissionBriefing(retryNeedsForce) }}
+          disabled=${missionBriefingLoading.value}
+        />
+        <${ActionBtn}
+          label="강제 갱신"
+          onClick=${() => { void refreshMissionBriefing(true) }}
+          disabled=${missionBriefingLoading.value}
+        />
+      <//>
     <//>
   `
 }

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatCell } from './common/stat-cell'
 import {
   toneClass,
   relativeTime,
@@ -23,25 +24,11 @@ export function MissionContextBar({
 }) {
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-3">
-      <div class="p-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1">
-        <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">프로젝트</span>
-        <span class="text-sm font-medium text-[var(--text-strong)]">${project ?? '확인 없음'}</span>
-      </div>
-      <div class="p-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1">
-        <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">방</span>
-        <span class="text-sm font-medium text-[var(--text-strong)]">${room ?? '기본 방'}</span>
-      </div>
-      <div class="p-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1">
-        <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">갱신 시각</span>
-        <span class="text-sm font-medium text-[var(--text-strong)]">${generatedAt ? relativeTime(generatedAt) : '기록 없음'}</span>
-      </div>
+      <${StatCell} label="프로젝트" value=${project ?? '확인 없음'} />
+      <${StatCell} label="방" value=${room ?? '기본 방'} />
+      <${StatCell} label="갱신 시각" value=${generatedAt ? relativeTime(generatedAt) : '기록 없음'} />
       ${cluster && cluster !== 'unknown'
-        ? html`
-            <div class="p-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1">
-              <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">배포 메타</span>
-              <span class="text-sm font-medium text-[var(--text-strong)]">${cluster}</span>
-            </div>
-          `
+        ? html`<${StatCell} label="배포 메타" value=${cluster} />`
         : null}
     </div>
   `
@@ -58,11 +45,5 @@ export function SummaryStat({
   detail: string
   tone?: string | null
 }) {
-  return html`
-    <article class="rounded-lg p-3 border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1 ${toneClass(tone)}">
-      <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
-      <strong class="text-xl text-[var(--text-strong)] leading-none tabular-nums">${value}</strong>
-      <span class="text-[10px] text-[var(--text-muted)] leading-relaxed">${detail}</span>
-    </article>
-  `
+  return html`<${StatCell} label=${label} value=${value} detail=${detail} tone=${toneClass(tone)} />`
 }

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -1,6 +1,10 @@
 import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
+import { StatCell } from './common/stat-cell'
+import { TagBadge } from './common/tag-badge'
+import { ListItem } from './common/list-item'
+import { ActionBar, ActionBtn } from './common/action-bar'
 import { openAgentDetail } from './agent-detail'
 import type {
   DashboardMissionSessionCard,
@@ -33,47 +37,31 @@ export function SessionBriefCard({
   const plannedCount = brief.planned_count ?? brief.member_names.length
 
   return html`
-    <article class="mission-crew-card p-3.5 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-5),var(--white-3))] grid gap-3 ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${liveStateClass(brief.status, brief.health)} ${selected ? 'is-selected' : ''}">
+    <article class="mission-crew-card p-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-5),var(--white-3))] grid gap-3 ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${liveStateClass(brief.status, brief.health)} ${selected ? 'is-selected' : ''}">
       <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleSession(brief.session_id)}>
-        <div class="flex justify-between gap-2 items-start flex-wrap">
+        <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
-            <div style="display:flex;align-items:center;gap:8px">
+            <div class="flex items-center gap-2">
               <div class="mission-status-dot ${liveStateClass(brief.status, brief.health)} ${dotStateBg(liveStateClass(brief.status, brief.health))}"></div>
               <strong>${brief.goal}</strong>
             </div>
-            <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)]">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
+            <div class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-sm)] mt-1">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
           </div>
           <span class="cmd-chip rounded-full ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
         </div>
 
-        <div class="grid grid-cols-2 gap-2.5">
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">멤버</span>
-            <strong class="text-[var(--text-strong)] text-lg">${brief.member_names.length}</strong>
-            <small class="grid gap-1">${brief.member_names.slice(0, 3).join(', ') || '없음'}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">가동 시간</span>
-            <strong class="text-[var(--text-strong)] text-lg">${formatDuration(brief.elapsed_sec)}</strong>
-            <small class="grid gap-1">${brief.started_at ? `${relativeTime(brief.started_at)} 시작` : '시작 시각 없음'}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">최근 흐름</span>
-            <strong class="text-[var(--text-strong)] text-lg">${brief.last_event_at ? relativeTime(brief.last_event_at) : '기록 없음'}</strong>
-            <small class="grid gap-1">${brief.communication_summary ?? '요약 없음'}</small>
-          </div>
-          <div class="p-3 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1">
-            <span class="text-[rgba(255,255,255,0.52)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">충원 상태</span>
-            <strong class="text-[var(--text-strong)] text-lg">${liveCount}/${brief.required_count || 1}</strong>
-            <small class="grid gap-1">live · seen ${seenCount} · planned ${plannedCount}</small>
-          </div>
+        <div class="grid grid-cols-2 gap-3">
+          <${StatCell} label="멤버" value=${brief.member_names.length} detail=${brief.member_names.slice(0, 3).join(', ') || '없음'} />
+          <${StatCell} label="가동 시간" value=${formatDuration(brief.elapsed_sec)} detail=${brief.started_at ? `${relativeTime(brief.started_at)} 시작` : '시작 시각 없음'} />
+          <${StatCell} label="최근 흐름" value=${brief.last_event_at ? relativeTime(brief.last_event_at) : '기록 없음'} detail=${brief.communication_summary ?? '요약 없음'} />
+          <${StatCell} label="충원 상태" value=${`${liveCount}/${brief.required_count || 1}`} detail=${`live · seen ${seenCount} · planned ${plannedCount}`} />
         </div>
       </button>
 
-      ${brief.blocker_summary ? html`<div class="grid gap-1">막힘 · ${brief.blocker_summary}</div>` : null}
-      ${brief.counts_basis ? html`<div class="grid gap-1">관측 기준 · ${brief.counts_basis}</div>` : null}
+      ${brief.blocker_summary ? html`<div class="grid gap-1.5 px-1">막힘 · ${brief.blocker_summary}</div>` : null}
+      ${brief.counts_basis ? html`<div class="grid gap-1.5 px-1">관측 기준 · ${brief.counts_basis}</div>` : null}
 
-      <div class="grid gap-1">
+      <div class="grid gap-1.5 px-1">
         <span>최근 사건</span>
         <strong>${brief.last_event_summary ?? '최근 세션 이벤트가 없습니다.'}</strong>
         <small>${brief.last_event_at ? relativeTime(brief.last_event_at) : '시각 없음'}</small>
@@ -81,11 +69,9 @@ export function SessionBriefCard({
 
       ${brief.operation_badges.length > 0
         ? html`
-            <div class="flex gap-2 flex-wrap mt-2.5">
+            <div class="flex gap-3 flex-wrap">
               ${brief.operation_badges.slice(0, 3).map(operation => html`
-                <span class="px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-[length:var(--fs-sm)] leading-[1.35]">
-                  ${operation.operation_id} · ${statusLabel(operation.status)}${operation.stage ? ` · ${operation.stage}` : ''}
-                </span>
+                <${TagBadge}>${operation.operation_id} · ${statusLabel(operation.status)}${operation.stage ? ` · ${operation.stage}` : ''}<//>
               `)}
             </div>
           `
@@ -93,28 +79,26 @@ export function SessionBriefCard({
 
       ${members.length > 0
         ? html`
-            <div class="grid grid-cols-2 gap-2.5">
+            <div class="grid grid-cols-2 gap-3">
               ${members.map(member => html`
-                <button class="w-full p-3 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1 text-left text-inherit" onClick=${() => openAgentDetail(member.agent_name)}>
-                  <strong class="text-[var(--text-strong)]">${member.agent_name}</strong>
-                  <span class="text-[rgba(255,255,255,0.72)] leading-[1.45]">
-                    ${member.current_work ?? '현재 작업 없음'}
-                    ${member.is_live === false ? ' · archived' : member.is_live === true ? ' · live' : ''}
-                  </span>
-                  <small class="text-[rgba(255,255,255,0.72)] leading-[1.45]">${member.recent_output_preview ?? member.recent_input_preview ?? '최근 입출력 없음'}</small>
-                </button>
+                <${ListItem}
+                  title=${member.agent_name}
+                  subtitle=${html`${member.current_work ?? '현재 작업 없음'}${member.is_live === false ? ' · archived' : member.is_live === true ? ' · live' : ''}`}
+                  detail=${member.recent_output_preview ?? member.recent_input_preview ?? '최근 입출력 없음'}
+                  onClick=${() => openAgentDetail(member.agent_name)}
+                />
               `)}
             </div>
           `
         : null}
 
-      <div class="flex gap-2 flex-wrap mt-2.5">
-        <button class="control-btn rounded-lg ghost" onClick=${() => openSession('intervene', brief.session_id)}>세션 개입 열기</button>
-        <button class="control-btn rounded-lg ghost" onClick=${() => openSession('command', brief.session_id)}>세션 원인 보기</button>
+      <${ActionBar}>
+        <${ActionBtn} label="세션 개입 열기" onClick=${() => openSession('intervene', brief.session_id)} />
+        <${ActionBtn} label="세션 원인 보기" onClick=${() => openSession('command', brief.session_id)} />
         ${action
-          ? html`<button class="control-btn rounded-lg ghost" onClick=${() => openActionIntervene(action, incident, '상황판 세션 요약')}>추천 액션 열기</button>`
+          ? html`<${ActionBtn} label="추천 액션 열기" onClick=${() => openActionIntervene(action, incident, '상황판 세션 요약')} />`
           : null}
-      </div>
+      <//>
     </article>
   `
 }
@@ -151,88 +135,85 @@ export function SessionDetailCard({
   const session = detail.session
   return html`
     <${Card} title="세션 상세" class="mission-list-card rounded-xl">
-      <div class="grid gap-1 mb-3">
+      <div class="grid gap-1.5 mb-4">
         <h3 class="m-0 text-[var(--text-strong)] text-lg">${session.goal}</h3>
         <p class="m-0 text-[rgba(255,255,255,0.68)] leading-normal">${session.session_id}${session.room ? ` · ${session.room}` : ''}</p>
       </div>
 
-      ${error ? html`<div class="grid gap-1">${error}</div>` : null}
+      ${error ? html`<div class="grid gap-1.5">${error}</div>` : null}
 
-      <div class="grid grid-cols-2 gap-4 mt-3">
-        <div class="grid gap-2.5">
-          <div class="flex justify-between gap-2 items-start flex-wrap">
+      <div class="grid grid-cols-2 gap-5 mt-4">
+        <div class="grid gap-3">
+          <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>타임라인</strong>
             <span class="cmd-chip rounded-full">${detail.timeline.length}</span>
           </div>
-          <div class="flex flex-col gap-2.5">
+          <div class="flex flex-col gap-3">
             ${detail.timeline.length > 0
               ? detail.timeline.map(item => html`
-                  <article class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-                    <div class="flex justify-between gap-2 items-start flex-wrap">
-                      <strong>${item.summary}</strong>
-                      <span>${item.timestamp ? relativeTime(item.timestamp) : '시각 없음'}</span>
-                    </div>
-                    <small class="text-[rgba(255,255,255,0.68)] leading-[1.45]">${item.actor ? `${item.actor} · ` : ''}${item.event_type ?? '이벤트'}</small>
-                  </article>
+                  <${ListItem}
+                    title=${item.summary}
+                    subtitle=${item.timestamp ? relativeTime(item.timestamp) : '시각 없음'}
+                    detail=${html`${item.actor ? `${item.actor} · ` : ''}${item.event_type ?? '이벤트'}`}
+                  />
                 `)
               : html`<${EmptyState} message="표시할 세션 이벤트가 없습니다." compact />`}
           </div>
         </div>
 
-        <div class="grid gap-2.5">
-          <div class="flex justify-between gap-2 items-start flex-wrap">
+        <div class="grid gap-3">
+          <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>참여자</strong>
             <span class="cmd-chip rounded-full">${detail.participants.length}</span>
           </div>
-          <div class="flex flex-col gap-3 compact">
+          <div class="flex flex-col gap-3">
             ${detail.participants.length > 0
               ? detail.participants.map(participant => html`
-                  <button class="w-full p-3 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1 text-left text-inherit" onClick=${() => openAgentDetail(participant.agent_name)}>
-                    <strong class="text-[var(--text-strong)]">${participant.agent_name}</strong>
-                    <span class="text-[rgba(255,255,255,0.72)] leading-[1.45]">${participant.current_work ?? '현재 작업 없음'}</span>
-                    <small class="text-[rgba(255,255,255,0.72)] leading-[1.45]">
-                      ${participant.recent_output_preview ?? participant.recent_input_preview ?? '최근 입출력 없음'}
-                      ${participant.last_activity_at ? ` · ${relativeTime(participant.last_activity_at)}` : ''}
-                    </small>
-                  </button>
+                  <${ListItem}
+                    title=${participant.agent_name}
+                    subtitle=${participant.current_work ?? '현재 작업 없음'}
+                    detail=${html`${participant.recent_output_preview ?? participant.recent_input_preview ?? '최근 입출력 없음'}${participant.last_activity_at ? ` · ${relativeTime(participant.last_activity_at)}` : ''}`}
+                    onClick=${() => openAgentDetail(participant.agent_name)}
+                  />
                 `)
               : html`<${EmptyState} message="세션 참여자 미리보기가 없습니다." compact />`}
           </div>
         </div>
       </div>
 
-      <div class="grid grid-cols-2 gap-4 mt-3">
-        <div class="grid gap-2.5">
-          <div class="flex justify-between gap-2 items-start flex-wrap">
+      <div class="grid grid-cols-2 gap-5 mt-4">
+        <div class="grid gap-3">
+          <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>연결된 작전</strong>
             <span class="cmd-chip rounded-full">${detail.operations.length}</span>
           </div>
-          <div class="flex flex-col gap-2 mt-2.5">
+          <div class="flex flex-col gap-3">
             ${detail.operations.length > 0
               ? detail.operations.map(operation => html`
-                  <button class="w-full py-2.5 px-3 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1 text-left text-inherit cursor-pointer" onClick=${() => openSession('command', session.session_id)}>
-                    <strong class="text-[var(--text-strong)]">${operation.operation_id}</strong>
-                    <span class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${statusLabel(operation.status)}${operation.stage ? ` · ${operation.stage}` : ''}</span>
-                    <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}</small>
-                  </button>
+                  <${ListItem}
+                    title=${operation.operation_id}
+                    subtitle=${html`${statusLabel(operation.status)}${operation.stage ? ` · ${operation.stage}` : ''}`}
+                    detail=${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}
+                    onClick=${() => openSession('command', session.session_id)}
+                  />
                 `)
               : html`<${EmptyState} message="연결된 작전이 없습니다." compact />`}
           </div>
         </div>
 
-        <div class="grid gap-2.5">
-          <div class="flex justify-between gap-2 items-start flex-wrap">
+        <div class="grid gap-3">
+          <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>연속성 관찰</strong>
             <span class="cmd-chip rounded-full">${detail.keepers.length}</span>
           </div>
-          <div class="flex flex-col gap-2 mt-2.5">
+          <div class="flex flex-col gap-3">
             ${detail.keepers.length > 0
               ? detail.keepers.map(keeper => html`
-                  <div class="w-full py-2.5 px-3 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1 text-left text-inherit cursor-default">
-                    <strong class="text-[var(--text-strong)]">${keeper.name}</strong>
-                    <span class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${statusLabel(keeper.status)}${keeper.generation != null ? ` · 세대 ${keeper.generation}` : ''}</span>
-                    <small class="text-[rgba(255,255,255,0.7)] leading-[1.45]">${keeper.current_work ?? '현재 작업 정보 없음'}</small>
-                  </div>
+                  <${ListItem}
+                    title=${keeper.name}
+                    subtitle=${html`${statusLabel(keeper.status)}${keeper.generation != null ? ` · 세대 ${keeper.generation}` : ''}`}
+                    detail=${keeper.current_work ?? '현재 작업 정보 없음'}
+                  />
                 `)
               : html`<${EmptyState} message="직접 연결된 키퍼는 없습니다." compact />`}
           </div>


### PR DESCRIPTION
## Summary
- 4개 공유 프리미티브 추출 (`StatCell`, `TagBadge`, `ListItem`, `ActionBar`) → `common/`
- mission card 5개 파일에서 12+ 인라인 반복 패턴 제거
- 스페이싱 정규화: `p-3/3.5`→`p-4`, `gap-2.5`→`gap-3`, `mt-2.5`→`mt-3`, `gap-1`→`gap-1.5`
- 순 -57줄 감소, 가독성 및 여백 개선

## Test plan
- [x] `npx tsc --noEmit` 통과 (수정 파일 에러 0건)
- [x] `npx vite build` 성공
- [ ] 브라우저에서 상황판(mission) 탭 시각 확인
- [ ] 세션 카드, 주의 카드, 에이전트 카드, 브리핑 카드 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)