### PR TITLE
perf(server): proactive cache for cp-snapshot endpoint

### DIFF
--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -95,7 +95,18 @@ let command_plane_summary_http_json ~state:_ =
      The background refresh loop populates the ref within one interval (120s). *)
   !_cp_summary_ref
 
-let command_plane_snapshot_http_json ~state =
+(* --- Command-plane snapshot proactive cache ---
+   Same pattern as the summary cache above, but with a shorter interval (5s)
+   because SSE clients poll this endpoint.  Without caching, N concurrent SSE
+   connections each trigger a full build_snapshot_state + JSON serialization,
+   turning a single ~200ms computation into N * 200ms of redundant I/O. *)
+
+let _cp_snapshot_ref : Yojson.Safe.t ref =
+  ref (`Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")])
+
+let _cp_snapshot_refresh_interval_s = 5.0
+
+let compute_cp_snapshot ~state =
   let config = state.Mcp_server.room_config in
   let snapshot = Command_plane_v2.snapshot_json config in
   let swarm_status =
@@ -104,6 +115,18 @@ let command_plane_snapshot_http_json ~state =
     else Swarm_status.empty_json
   in
   assoc_add "swarm_status" swarm_status snapshot
+
+let start_cp_snapshot_refresh_loop ~state ~sw ~clock =
+  Proactive_refresh.start ~sw ~clock
+    ~config:{ (Proactive_refresh.default_config
+                 ~label:"cp-snapshot"
+                 ~interval_s:_cp_snapshot_refresh_interval_s)
+              with timeout_s = 10.0 }
+    ~compute:(fun () -> compute_cp_snapshot ~state)
+    ~on_result:(fun snapshot -> _cp_snapshot_ref := snapshot)
+
+let command_plane_snapshot_http_json ~state:_ =
+  !_cp_snapshot_ref
 
 let command_plane_topology_http_json ~state =
   Command_plane_v2.topology_json state.Mcp_server.room_config

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -577,6 +577,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_refresh_loop ~state ~sw ~clock;
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
+      Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
       start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state;
       (* gRPC coordination transport (opt-in via MASC_GRPC_ENABLED=1) *)
       let tool_dispatcher _tool_name _args_json =


### PR DESCRIPTION
## Summary
- Add a `Proactive_refresh` loop (5s interval) for the `/api/v1/command-plane` snapshot endpoint
- Previously, each SSE client triggered a synchronous `build_snapshot_state` + JSON serialization (~200ms). With 13 concurrent SSE connections, this became redundant I/O
- Now all clients read from a cached ref, collapsing N concurrent computations into 1 background refresh
- Mirrors the existing `cp-summary` proactive cache pattern (120s) but with a shorter TTL suitable for the SSE hot path

## Changes
- `lib/server/server_command_plane_http_support.ml`: Add `_cp_snapshot_ref`, `compute_cp_snapshot`, `start_cp_snapshot_refresh_loop`; change `command_plane_snapshot_http_json` to return cached ref
- `lib/server/server_runtime_bootstrap.ml`: Wire the new refresh loop at server startup

## Test plan
- [x] `dune build` passes
- [ ] Verify SSE dashboard loads snapshot from cache (observe `cp-snapshot refreshed` log line)
- [ ] Confirm reduced filesystem I/O under concurrent SSE connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)