### PR TITLE
fix(dashboard): preserve original bg color and font size in StatCell

### DIFF
--- a/dashboard/src/components/common/stat-cell.ts
+++ b/dashboard/src/components/common/stat-cell.ts
@@ -9,14 +9,26 @@ interface StatCellProps {
   value: ComponentChildren
   detail?: ComponentChildren
   tone?: string
+  size?: 'md' | 'lg'
+  bg?: 'white-3' | 'white-4'
   class?: string
 }
 
-export function StatCell({ label, value, detail, tone, class: className }: StatCellProps) {
+const BG = {
+  'white-3': 'bg-[var(--white-3)]',
+  'white-4': 'bg-[var(--white-4)]',
+} as const
+
+const VALUE_SIZE = {
+  md: 'text-lg',
+  lg: 'text-xl',
+} as const
+
+export function StatCell({ label, value, detail, tone, size = 'md', bg = 'white-4', class: className }: StatCellProps) {
   return html`
-    <div class="p-4 rounded-xl bg-[var(--white-4)] border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
+    <div class="p-4 rounded-xl ${BG[bg]} border border-[var(--white-6)] grid gap-1.5 ${tone ?? ''} ${className ?? ''}">
       <span class="text-[10px] text-[var(--text-muted)] tracking-wider uppercase font-medium">${label}</span>
-      <strong class="text-[var(--text-strong)] text-lg leading-tight tabular-nums">${value}</strong>
+      <strong class="text-[var(--text-strong)] ${VALUE_SIZE[size]} leading-tight tabular-nums">${value}</strong>
       ${detail != null ? html`<small class="text-[var(--text-muted)] text-[10px] leading-relaxed">${detail}</small>` : null}
     </div>
   `

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -70,8 +70,8 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
         <details class="pt-2 border-t border-[var(--white-6)] mt-3">
           <summary>입력 · 응답 · 도구</summary>
           <div class="grid grid-cols-2 gap-3 mt-3">
-            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} />
-            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} />
+            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} bg="white-3" />
+            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} bg="white-3" />
           </div>
           <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
             <span>최근 도구 · ${recentToolsLabel}</span>
@@ -141,8 +141,8 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
         <details class="pt-2 border-t border-[var(--white-6)] mt-3">
           <summary>입력 · 응답 · 도구</summary>
           <div class="grid grid-cols-2 gap-3 mt-3">
-            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} />
-            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} />
+            <${StatCell} label="최근 입력" value=${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'} bg="white-3" />
+            <${StatCell} label="최근 응답" value=${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} bg="white-3" />
           </div>
           <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-snug mt-3">
             <span>최근 도구 · ${recentToolsLabel}</span>

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -45,5 +45,5 @@ export function SummaryStat({
   detail: string
   tone?: string | null
 }) {
-  return html`<${StatCell} label=${label} value=${value} detail=${detail} tone=${toneClass(tone)} />`
+  return html`<${StatCell} label=${label} value=${value} detail=${detail} tone=${toneClass(tone)} size="lg" />`
 }


### PR DESCRIPTION
## Summary
- GLM-5 리뷰 수정: `StatCell`에 `bg` prop 추가 (`white-3`/`white-4`), agent card의 입력/응답 셀 배경색 보존
- `size` prop 추가 (`md`/`lg`), `SummaryStat`이 원본 `text-xl` 유지
- #2432 머지 후 발견된 시각적 회귀 수정

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] 상황판 에이전트 카드 입력/응답 배경색 확인
- [ ] 요약 통계 숫자 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)