### PR TITLE
refactor(keeper): delegate inference params to cascade config

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -36,5 +36,12 @@
   "auto_responder_gemini_models": ["gemini:auto", "glm:auto"],
   "auto_responder_glm_models": ["glm:auto"],
   "spawn_glm_models": ["glm:auto"],
-  "materialized_procedure_models": ["llama:auto", "glm:auto"]
+  "materialized_procedure_models": ["llama:auto", "glm:auto"],
+
+  "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
+  "keeper_unified_temperature": 0.4,
+  "keeper_unified_max_tokens": 2048,
+  "keeper_autonomy_temperature": 0.3,
+  "keeper_autonomy_max_tokens": 500,
+  "keeper_turn_max_tokens": 1024
 }

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -1,0 +1,111 @@
+(** Per-cascade inference parameters from cascade.json.
+
+    Reads optional {name}_temperature and {name}_max_tokens fields from the
+    same cascade.json used by OAS Cascade_config.  This allows keeper and
+    other MASC modules to delegate inference parameter decisions to the
+    cascade configuration instead of maintaining parallel env-var knobs.
+
+    Resolution order:
+    1. cascade.json "{name}_temperature" / "{name}_max_tokens"
+    2. cascade.json "default_temperature" / "default_max_tokens"
+    3. Caller-provided fallback
+
+    @since v2.128.0 — #2408 Phase 3 keeper inference delegation *)
+
+(** Inference parameters resolved from cascade config. *)
+type t = {
+  temperature : float option;
+  max_tokens : int option;
+}
+
+let empty = { temperature = None; max_tokens = None }
+
+(* ── JSON cache (shares mtime-reload semantics with OAS) ────── *)
+
+let json_cache : (string, float * Yojson.Safe.t) Hashtbl.t =
+  Hashtbl.create 2
+
+let load_json (path : string) : Yojson.Safe.t option =
+  try
+    let st = Unix.stat path in
+    let mtime = st.Unix.st_mtime in
+    match Hashtbl.find_opt json_cache path with
+    | Some (cached_mtime, json) when Float.equal cached_mtime mtime ->
+      Some json
+    | _ ->
+      let ic = open_in path in
+      let content = Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () ->
+             let len = in_channel_length ic in
+             let buf = Bytes.create len in
+             really_input ic buf 0 len;
+             Bytes.to_string buf)
+      in
+      let json = Yojson.Safe.from_string content in
+      Hashtbl.replace json_cache path (mtime, json);
+      Some json
+  with _ -> None
+
+(* ── Field extraction helpers ──────────────────────────── *)
+
+let read_float_field (json : Yojson.Safe.t) (key : string) : float option =
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+
+let read_int_field (json : Yojson.Safe.t) (key : string) : int option =
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> Some i
+  | `Float f -> Some (int_of_float f)
+  | _ -> None
+
+(* ── Core extraction from a JSON value ─────────────────── *)
+
+(** Extract inference parameters from a parsed JSON value for a named cascade.
+    Exposed for testing without filesystem dependency. *)
+let for_json ~(name : string) (json : Yojson.Safe.t) : t =
+  let named_temp_key = name ^ "_temperature" in
+  let named_tokens_key = name ^ "_max_tokens" in
+  let default_temp_key = "default_temperature" in
+  let default_tokens_key = "default_max_tokens" in
+  let temperature =
+    match read_float_field json named_temp_key with
+    | Some _ as v -> v
+    | None -> read_float_field json default_temp_key
+  in
+  let max_tokens =
+    match read_int_field json named_tokens_key with
+    | Some _ as v -> v
+    | None -> read_int_field json default_tokens_key
+  in
+  { temperature; max_tokens }
+
+(* ── Public API ────────────────────────────────────────── *)
+
+(** Load inference parameters for a named cascade profile.
+
+    Reads from cascade.json located via {!Model_spec.cascade_config_path}.
+    Keys follow the pattern: "{name}_temperature", "{name}_max_tokens".
+    Falls back to "default_temperature" / "default_max_tokens" when the
+    named key is absent. *)
+let for_cascade ~(name : string) : t =
+  match Model_spec.cascade_config_path () with
+  | None -> empty
+  | Some path ->
+    match load_json path with
+    | None -> empty
+    | Some json -> for_json ~name json
+
+(** Resolve a temperature value: cascade config -> env-var fallback -> hardcoded default. *)
+let resolve_temperature ~(cascade_name : string) ~(fallback : unit -> float) : float =
+  match (for_cascade ~name:cascade_name).temperature with
+  | Some t -> t
+  | None -> fallback ()
+
+(** Resolve a max_tokens value: cascade config -> env-var fallback -> hardcoded default. *)
+let resolve_max_tokens ~(cascade_name : string) ~(fallback : unit -> int) : int =
+  match (for_cascade ~name:cascade_name).max_tokens with
+  | Some t -> t
+  | None -> fallback ()

--- a/lib/cascade_inference.mli
+++ b/lib/cascade_inference.mli
@@ -1,0 +1,51 @@
+(** Per-cascade inference parameters from cascade.json.
+
+    Reads optional temperature and max_tokens fields from the same
+    cascade.json used by OAS Cascade_config for model selection.
+    This allows keeper and other MASC modules to delegate inference
+    parameter decisions to the cascade configuration.
+
+    Resolution order:
+    1. cascade.json "{name}_temperature" / "{name}_max_tokens"
+    2. cascade.json "default_temperature" / "default_max_tokens"
+    3. Caller-provided fallback
+
+    @since v2.128.0 — #2408 Phase 3 keeper inference delegation *)
+
+(** Inference parameters resolved from cascade config. *)
+type t = {
+  temperature : float option;
+  max_tokens : int option;
+}
+
+(** No inference parameters specified. *)
+val empty : t
+
+(** Load inference parameters for a named cascade profile.
+
+    Reads from cascade.json located via {!Model_spec.cascade_config_path}.
+    Keys follow the pattern: "{name}_temperature", "{name}_max_tokens".
+    Falls back to "default_temperature" / "default_max_tokens" when the
+    named key is absent. Returns {!empty} when no config file is found. *)
+val for_cascade : name:string -> t
+
+(** Extract inference parameters from a parsed JSON value.
+    Same resolution logic as {!for_cascade} but operates on an in-memory
+    JSON value instead of reading from disk. Useful for testing. *)
+val for_json : name:string -> Yojson.Safe.t -> t
+
+(** Resolve a temperature value with cascade config priority.
+    Returns cascade config value if present, otherwise calls [fallback]. *)
+val resolve_temperature : cascade_name:string -> fallback:(unit -> float) -> float
+
+(** Resolve a max_tokens value with cascade config priority.
+    Returns cascade config value if present, otherwise calls [fallback]. *)
+val resolve_max_tokens : cascade_name:string -> fallback:(unit -> int) -> int
+
+(** {1 Low-level helpers (exposed for testing)} *)
+
+(** Read a float field from a JSON object. Returns [None] if absent or wrong type. *)
+val read_float_field : Yojson.Safe.t -> string -> float option
+
+(** Read an int field from a JSON object. Returns [None] if absent or wrong type. *)
+val read_int_field : Yojson.Safe.t -> string -> int option

--- a/lib/dune
+++ b/lib/dune
@@ -29,6 +29,7 @@
    capability_registry
    bounded
    cache_eio
+   cascade_inference
    env_config
    capability_match
    cancellation

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -500,7 +500,11 @@ let run_proactive_generation
         else Printf.sprintf "%s\n\n%s" base_prompt retry_hint
       in
       let temperature = proactive_temperature attempt in
-      let max_tokens = 1024 in
+      let max_tokens =
+        Cascade_inference.resolve_max_tokens
+          ~cascade_name:"keeper_turn"
+          ~fallback:(fun () -> 1024)
+      in
       let (agent_result, attempt_latency) = timed (fun () ->
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -94,9 +94,17 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         Keeper_unified_prompt.build_prompt ~meta ~observation
       in
       let base_dir = session_base_dir config in
-      (* 3. Derive parameters from keeper config (single values, no per-path split) *)
-      let temperature = Keeper_config.keeper_unified_temperature () in
-      let max_tokens = Keeper_config.keeper_unified_max_tokens () in
+      (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
+      let temperature =
+        Cascade_inference.resolve_temperature
+          ~cascade_name:"keeper_unified"
+          ~fallback:Keeper_config.keeper_unified_temperature
+      in
+      let max_tokens =
+        Cascade_inference.resolve_max_tokens
+          ~cascade_name:"keeper_unified"
+          ~fallback:Keeper_config.keeper_unified_max_tokens
+      in
       let max_turns = Keeper_config.keeper_unified_max_turns () in
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)

--- a/lib/keeper/keeper_verifier.ml
+++ b/lib/keeper/keeper_verifier.ml
@@ -176,10 +176,20 @@ Keep it concise — max 3 sentences per step.|}
      then String.sub keeper_context 0 500 ^ "..."
      else keeper_context)
   in
+  let temperature =
+    Cascade_inference.resolve_temperature
+      ~cascade_name:"keeper_autonomy"
+      ~fallback:(fun () -> 0.3)
+  in
+  let max_tokens =
+    Cascade_inference.resolve_max_tokens
+      ~cascade_name:"keeper_autonomy"
+      ~fallback:(fun () -> 500)
+  in
   match
     Oas_worker.run_named ~cascade_name:"keeper_autonomy"
       ~goal:prompt
-      ~max_turns:1 ~temperature:0.3 ~max_tokens:500 ()
+      ~max_turns:1 ~temperature ~max_tokens ()
   with
   | Ok result ->
     Ok (Agent_sdk.Types.text_of_content result.Oas_worker.response.content)

--- a/test/test_cascade.ml
+++ b/test/test_cascade.ml
@@ -199,6 +199,106 @@ let test_classification_uses_llama_first () =
   check bool "classification starts with llama:" true
     (String.length first > 6 && String.sub first 0 6 = "llama:")
 
+module Cascade_inference = Masc_mcp.Cascade_inference
+
+(* ── Cascade inference parameter tests ──────────────── *)
+
+let test_inference_empty () =
+  let e = Cascade_inference.empty in
+  check (option (float 0.01)) "no temperature" None e.temperature;
+  check (option int) "no max_tokens" None e.max_tokens
+
+let test_inference_read_float () =
+  let json = `Assoc [("t", `Float 0.5)] in
+  let v = Cascade_inference.read_float_field json "t" in
+  check (option (float 0.01)) "reads 0.5" (Some 0.5) v
+
+let test_inference_read_float_from_int () =
+  let json = `Assoc [("t", `Int 1)] in
+  let v = Cascade_inference.read_float_field json "t" in
+  check (option (float 0.01)) "reads 1.0" (Some 1.0) v
+
+let test_inference_read_float_missing () =
+  let json = `Assoc [] in
+  let v = Cascade_inference.read_float_field json "missing" in
+  check (option (float 0.01)) "None" None v
+
+let test_inference_read_int () =
+  let json = `Assoc [("n", `Int 4096)] in
+  let v = Cascade_inference.read_int_field json "n" in
+  check (option int) "reads 4096" (Some 4096) v
+
+let test_inference_read_int_missing () =
+  let json = `Assoc [] in
+  let v = Cascade_inference.read_int_field json "missing" in
+  check (option int) "None" None v
+
+(* ── Cascade inference parameter tests ───────────────────
+   Use for_json for deterministic filesystem-independent tests. *)
+
+let sample_cascade_json = Yojson.Safe.from_string {|{
+  "default_models": ["llama:auto"],
+  "keeper_unified_temperature": 0.4,
+  "keeper_unified_max_tokens": 2048,
+  "keeper_autonomy_temperature": 0.3,
+  "keeper_autonomy_max_tokens": 500,
+  "keeper_turn_max_tokens": 1024,
+  "default_temperature": 0.77,
+  "default_max_tokens": 999
+}|}
+
+let test_inference_for_json_named () =
+  let params = Cascade_inference.for_json ~name:"keeper_unified" sample_cascade_json in
+  check (option (float 0.01)) "temperature" (Some 0.4) params.temperature;
+  check (option int) "max_tokens" (Some 2048) params.max_tokens
+
+let test_inference_for_json_named_autonomy () =
+  let params = Cascade_inference.for_json ~name:"keeper_autonomy" sample_cascade_json in
+  check (option (float 0.01)) "temperature" (Some 0.3) params.temperature;
+  check (option int) "max_tokens" (Some 500) params.max_tokens
+
+let test_inference_for_json_partial () =
+  (* keeper_turn has max_tokens but no temperature — falls back to default_temperature *)
+  let params = Cascade_inference.for_json ~name:"keeper_turn" sample_cascade_json in
+  check (option (float 0.01)) "temperature falls to default" (Some 0.77) params.temperature;
+  check (option int) "max_tokens" (Some 1024) params.max_tokens
+
+let test_inference_for_json_unknown_falls_to_default () =
+  let params = Cascade_inference.for_json ~name:"nonexistent_xyz" sample_cascade_json in
+  check (option (float 0.01)) "default temperature" (Some 0.77) params.temperature;
+  check (option int) "default max_tokens" (Some 999) params.max_tokens
+
+let test_inference_for_json_no_defaults () =
+  let json = Yojson.Safe.from_string {|{"default_models": ["llama:auto"]}|} in
+  let params = Cascade_inference.for_json ~name:"unknown" json in
+  check (option (float 0.01)) "no temperature" None params.temperature;
+  check (option int) "no max_tokens" None params.max_tokens
+
+let test_inference_for_json_named_overrides_default () =
+  let json = Yojson.Safe.from_string {|{
+    "default_temperature": 0.77,
+    "named_temperature": 0.11,
+    "default_max_tokens": 999,
+    "named_max_tokens": 555
+  }|} in
+  let params = Cascade_inference.for_json ~name:"named" json in
+  check (option (float 0.01)) "named temperature wins" (Some 0.11) params.temperature;
+  check (option int) "named max_tokens wins" (Some 555) params.max_tokens
+
+let test_inference_resolve_temperature_fallback () =
+  (* resolve_temperature with a cascade_name that doesn't exist in config
+     — exercises the fallback path regardless of cascade.json location *)
+  let v = Cascade_inference.resolve_temperature
+      ~cascade_name:"nonexistent_test_xyz_12345"
+      ~fallback:(fun () -> 0.33) in
+  check (float 0.01) "fallback temperature" 0.33 v
+
+let test_inference_resolve_max_tokens_fallback () =
+  let v = Cascade_inference.resolve_max_tokens
+      ~cascade_name:"nonexistent_test_xyz_12345"
+      ~fallback:(fun () -> 42) in
+  check int "fallback max_tokens" 42 v
+
 let () =
   run "cascade"
     [
@@ -230,5 +330,36 @@ let () =
             test_briefing_non_empty;
           test_case "classification uses llama first" `Quick
             test_classification_uses_llama_first;
+        ] );
+      ( "inference_params",
+        [
+          test_case "empty has no values" `Quick
+            test_inference_empty;
+          test_case "read_float_field parses float" `Quick
+            test_inference_read_float;
+          test_case "read_float_field parses int as float" `Quick
+            test_inference_read_float_from_int;
+          test_case "read_float_field returns None for missing" `Quick
+            test_inference_read_float_missing;
+          test_case "read_int_field parses int" `Quick
+            test_inference_read_int;
+          test_case "read_int_field returns None for missing" `Quick
+            test_inference_read_int_missing;
+          test_case "for_json named cascade" `Quick
+            test_inference_for_json_named;
+          test_case "for_json keeper_autonomy" `Quick
+            test_inference_for_json_named_autonomy;
+          test_case "for_json partial falls to default" `Quick
+            test_inference_for_json_partial;
+          test_case "for_json unknown falls to default" `Quick
+            test_inference_for_json_unknown_falls_to_default;
+          test_case "for_json no defaults returns empty" `Quick
+            test_inference_for_json_no_defaults;
+          test_case "for_json named overrides default" `Quick
+            test_inference_for_json_named_overrides_default;
+          test_case "resolve_temperature fallback" `Quick
+            test_inference_resolve_temperature_fallback;
+          test_case "resolve_max_tokens fallback" `Quick
+            test_inference_resolve_max_tokens_fallback;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Keeper inference parameters (temperature, max_tokens) now resolve from `cascade.json` first, falling back to existing env-var defaults
- New `Cascade_inference` module reads `{name}_temperature` / `{name}_max_tokens` from cascade.json with mtime-based hot-reload cache
- Converts `keeper_unified_turn`, `keeper_verifier`, and `keeper_exec_context` (proactive max_tokens) to use cascade config resolution
- Proactive temperature escalation (attempt-based low/mid/high) intentionally preserved as keeper-specific logic

## Motivation
Part of #2408 Phase 3. Moves keeper closer to OAS-managed configuration by delegating inference parameter decisions to the cascade config layer. Reduces MASC-specific env-var proliferation (`MASC_KEEPER_UNIFIED_TEMP`, `MASC_KEEPER_UNIFIED_MAX_TOKENS`, etc.) while keeping them as backwards-compatible fallbacks.

## Resolution Order
```
cascade.json "{name}_temperature" -> cascade.json "default_temperature" -> caller fallback (env-var or hardcoded)
```

## Changed Files
| File | Change |
|------|--------|
| `lib/cascade_inference.ml` + `.mli` | New module: per-cascade inference param reader |
| `lib/keeper/keeper_unified_turn.ml` | temperature/max_tokens from cascade config |
| `lib/keeper/keeper_verifier.ml` | temperature/max_tokens from cascade config |
| `lib/keeper/keeper_exec_context.ml` | proactive max_tokens from cascade config |
| `config/cascade.json` | Added keeper_unified, keeper_autonomy, keeper_turn params |
| `test/test_cascade.ml` | 14 new tests (for_json, resolve_temperature, resolve_max_tokens) |

## Test plan
- [x] `dune build --root .` passes
- [x] `test/test_cascade.exe` — 24/24 pass (10 existing + 14 new)
- [x] `test/test_keeper_unified.exe` — 29/29 pass
- [ ] Verify keeper_unified turn uses cascade.json temperature (0.4) in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)