### PR TITLE
refactor(keeper): migrate 12 inference params to OAS cascade (#2408 Phase 3)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -51,10 +51,8 @@ let normalize_response_text ~(text : string) ~(tool_names : string list) :
     @param user_message The user's message to the keeper
     @param cascade_name Cascade profile name for model selection
     @param generation Current generation counter
-    @param max_turns Maximum agent turns (default 3)
-    @param guardrails Optional OAS guardrails for tool safety gates
-    @param temperature MODEL temperature (default 0.3)
-    @param max_tokens Maximum output tokens (default 4096) *)
+    @param max_turns Maximum agent turns (default 100)
+    @param guardrails Optional OAS guardrails for tool safety gates *)
 let run_turn
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -69,8 +67,6 @@ let run_turn
     ~(generation : int)
     ?(max_turns : int = 100)
     ?guardrails
-    ?(temperature : float = 0.3)
-    ?(max_tokens : int = 4096)
     ?max_cost_usd
     ?on_event
     ?(autonomy_filter : string option)
@@ -170,8 +166,6 @@ let run_turn
       ~context_reducer:reducer
       ~memory
       ~max_turns
-      ~temperature
-      ~max_tokens
       ?guardrails
       ?on_event
       ~agent_ref

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -331,26 +331,8 @@ let normalize_drift_min_turn_gap (v : int) : int =
 (* Proactive turn parameters                                        *)
 (* ================================================================ *)
 
-let keeper_proactive_temperature_low () : float =
-  float_of_env_default
-    "MASC_KEEPER_PROACTIVE_TEMP_LOW"
-    ~default:0.55
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_proactive_temperature_mid () : float =
-  float_of_env_default
-    "MASC_KEEPER_PROACTIVE_TEMP_MID"
-    ~default:0.75
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_proactive_temperature_high () : float =
-  float_of_env_default
-    "MASC_KEEPER_PROACTIVE_TEMP_HIGH"
-    ~default:0.9
-    ~min_v:0.0
-    ~max_v:2.0
+(* Inference params (temperature) delegated to OAS cascade config.
+   Only non-inference operational thresholds remain here. *)
 
 let keeper_proactive_similarity_threshold () : float =
   float_of_env_default
@@ -360,36 +342,10 @@ let keeper_proactive_similarity_threshold () : float =
     ~max_v:1.0
 
 (* ================================================================ *)
-(* Keeper execution parameters (previously hardcoded)               *)
+(* Keeper execution parameters (operational, non-inference)          *)
 (* ================================================================ *)
 
-let keeper_proactive_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_PROACTIVE_MAX_TOKENS"
-    ~default:1024
-    ~min_v:128
-    ~max_v:4096
-
-let keeper_deterministic_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_DETERMINISTIC_TEMP"
-    ~default:0.3
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_reflection_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_REFLECTION_TEMP"
-    ~default:0.6
-    ~min_v:0.0
-    ~max_v:2.0
-
-let keeper_planning_temp () : float =
-  float_of_env_default
-    "MASC_KEEPER_PLANNING_TEMP"
-    ~default:0.35
-    ~min_v:0.0
-    ~max_v:2.0
+(* Inference params (temperature, max_tokens) delegated to OAS cascade. *)
 
 let keeper_batch_limit () : int =
   int_of_env_default
@@ -486,72 +442,14 @@ let keeper_max_tool_rounds () : int =
     ~min_v:1
     ~max_v:20
 
-(** Max tokens for autonomous execution MODEL calls.
-    Env: [MASC_KEEPER_AUTONOMOUS_MAX_TOKENS]. Default: 4000. *)
-let keeper_autonomous_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_MAX_TOKENS"
-    ~default:4000
-    ~min_v:512
-    ~max_v:16000
-
-(** Max tokens for keeper deliberation calls.
-    Env: [MASC_KEEPER_DELIBERATION_MAX_TOKENS]. Default: 1024. *)
-let keeper_deliberation_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_DELIBERATION_MAX_TOKENS"
-    ~default:1024
-    ~min_v:256
-    ~max_v:8000
-
-(** Max tokens for explicit reply generation.
-    Env: [MASC_KEEPER_EXPLICIT_REPLY_MAX_TOKENS]. Default: 256. *)
-let keeper_explicit_reply_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_EXPLICIT_REPLY_MAX_TOKENS"
-    ~default:256
-    ~min_v:64
-    ~max_v:2048
-
-(** Max tokens for social board initial turn.
-    Env: [MASC_KEEPER_SOCIAL_INITIAL_MAX_TOKENS]. Default: 768. *)
-let keeper_social_initial_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_SOCIAL_INITIAL_MAX_TOKENS"
-    ~default:768
-    ~min_v:256
-    ~max_v:4096
-
-(** Max tokens for social board followup turns.
-    Env: [MASC_KEEPER_SOCIAL_FOLLOWUP_MAX_TOKENS]. Default: 512. *)
-let keeper_social_followup_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_SOCIAL_FOLLOWUP_MAX_TOKENS"
-    ~default:512
-    ~min_v:128
-    ~max_v:4096
+(* Inference-related max_tokens params (autonomous, deliberation,
+   explicit_reply, social_initial, social_followup, unified_temperature,
+   unified_max_tokens) have been removed. OAS cascade config now owns
+   these values. See issue #2408 Phase 3. *)
 
 (* ================================================================ *)
-(* Unified Keeper Turn parameters                                   *)
+(* Unified Keeper Turn parameters (operational only)                *)
 (* ================================================================ *)
-
-(** Temperature for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_TEMP]. Default: 0.4. *)
-let keeper_unified_temperature () : float =
-  float_of_env_default
-    "MASC_KEEPER_UNIFIED_TEMP"
-    ~default:0.4
-    ~min_v:0.0
-    ~max_v:2.0
-
-(** Max output tokens for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TOKENS]. Default: 2048. *)
-let keeper_unified_max_tokens () : int =
-  int_of_env_default
-    "MASC_KEEPER_UNIFIED_MAX_TOKENS"
-    ~default:2048
-    ~min_v:256
-    ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
     Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 1000. *)

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -261,11 +261,6 @@ let proactive_retry_instruction attempt ~(reason : string) =
       "Retry policy: previous attempts failed (%s). You MUST output one decisive check-in now, materially different from the last preview."
       reason
 
-let proactive_temperature attempt =
-  if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
-  else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
-  else Keeper_config.keeper_proactive_temperature_high ()
-
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
   let end_marker = "[/STATE]" in
@@ -499,13 +494,11 @@ let run_proactive_generation
         if String.trim retry_hint = "" then base_prompt
         else Printf.sprintf "%s\n\n%s" base_prompt retry_hint
       in
-      let temperature = proactive_temperature attempt in
-      let max_tokens = 1024 in
       let (agent_result, attempt_latency) = timed (fun () ->
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
             ~tools ~initial_messages:ctx_work.messages
-            ~max_turns:10 ~temperature ~max_tokens ()) in
+            ~max_turns:10 ()) in
       match agent_result with
       | Error _ -> None
       | Ok result ->

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -126,6 +126,3 @@ val proactive_prompt_for_keeper :
 
 (** Generate retry instruction for proactive attempt. *)
 val proactive_retry_instruction : int -> reason:string -> string
-
-(** Get temperature for proactive attempt. *)
-val proactive_temperature : int -> float

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -348,11 +348,6 @@ let proactive_retry_instruction attempt ~(reason : string) =
       "Retry policy: previous attempts failed (%s). You MUST output one decisive check-in now, materially different from the last preview."
       reason
 
-let proactive_temperature attempt =
-  if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
-  else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
-  else Keeper_config.keeper_proactive_temperature_high ()
-
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
   let end_marker = "[/STATE]" in

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -48,8 +48,6 @@ type proactive_generation_result = {
 
 val proactive_retry_instruction : int -> reason:string -> string
 
-val proactive_temperature : int -> float
-
 val strip_state_blocks_text : string -> string
 
 val trim_to_option : string -> string option

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -94,9 +94,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         Keeper_unified_prompt.build_prompt ~meta ~observation
       in
       let base_dir = session_base_dir config in
-      (* 3. Derive parameters from keeper config (single values, no per-path split) *)
-      let temperature = Keeper_config.keeper_unified_temperature () in
-      let max_tokens = Keeper_config.keeper_unified_max_tokens () in
+      (* 3. Derive operational parameters from keeper config.
+         Inference params (temperature, max_tokens) are delegated to OAS cascade. *)
       let max_turns = Keeper_config.keeper_unified_max_turns () in
       let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
       (* 4. Build turn prompt callback: use our unified system prompt *)
@@ -110,7 +109,6 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~max_context:primary_max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
-              ~temperature ~max_tokens
               ~max_cost_usd
               ~autonomy_filter:observation.autonomy_level
               ())

--- a/lib/keeper/keeper_verifier.ml
+++ b/lib/keeper/keeper_verifier.ml
@@ -179,7 +179,7 @@ Keep it concise — max 3 sentences per step.|}
   match
     Oas_worker.run_named ~cascade_name:"keeper_autonomy"
       ~goal:prompt
-      ~max_turns:1 ~temperature:0.3 ~max_tokens:500 ()
+      ~max_turns:1 ()
   with
   | Ok result ->
     Ok (Agent_sdk.Types.text_of_content result.Oas_worker.response.content)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -261,15 +261,11 @@ let with_env name value f =
     f
 
 let test_unified_turn_runtime_defaults () =
-  with_env "MASC_KEEPER_UNIFIED_TEMP" "" (fun () ->
-  with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
+  (* Inference params (temperature, max_tokens) now delegated to OAS cascade.
+     Only operational params like max_turns remain in keeper_config. *)
   with_env "MASC_KEEPER_UNIFIED_MAX_TURNS" "" (fun () ->
-    check (float 0.01) "unified temp default" 0.4
-      (KC.keeper_unified_temperature ());
-    check int "unified max_tokens default" 2048
-      (KC.keeper_unified_max_tokens ());
     check int "unified max_turns default" 1000
-      (KC.keeper_unified_max_turns ()))))
+      (KC.keeper_unified_max_turns ()))
 
 (* ---------- Metrics observation tests ---------- *)
 


### PR DESCRIPTION
Remove 12 hardcoded inference functions from keeper_config. Temperature, max_tokens now come from OAS cascade defaults. -131 net lines. All keeper tests pass.