### PR TITLE
refactor: eliminate last Model_spec function call (91→0 complete)

### DIFF
--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -86,12 +86,12 @@ let for_json ~(name : string) (json : Yojson.Safe.t) : t =
 
 (** Load inference parameters for a named cascade profile.
 
-    Reads from cascade.json located via {!Model_spec.cascade_config_path}.
+    Reads from cascade.json located via {!Oas_worker.default_config_path}.
     Keys follow the pattern: "{name}_temperature", "{name}_max_tokens".
     Falls back to "default_temperature" / "default_max_tokens" when the
     named key is absent. *)
 let for_cascade ~(name : string) : t =
-  match Model_spec.cascade_config_path () with
+  match Oas_worker.default_config_path () with
   | None -> empty
   | Some path ->
     match load_json path with

--- a/lib/oas_type_adapters.ml
+++ b/lib/oas_type_adapters.ml
@@ -6,7 +6,7 @@
 
     @since 2.130.0
     @since 2.133.0 — Phase 1: migrated to Model_spec bridge
-    @since 2.134.0 — Phase 6: eliminated Model_spec.model_spec exposure
+    @since 2.134.0 — Phase 6: eliminated Model_spec.model_spec exposure (legacy)
     @since 2.135.0 — Phase 7: eliminated Model_spec function calls *)
 
 (** Convert OAS Provider_config.t to OAS Provider.config for Agent Builder.

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -325,7 +325,7 @@ let require_eio () =
   | _, None -> Error "Eio net not available (running outside server context)"
 
 (** Resolve cascade provider configs via OAS Cascade_config.
-    Returns OAS Provider_config.t list directly, bypassing Model_spec. *)
+    Returns OAS Provider_config.t list directly, bypassing the old Model_spec facade. *)
 let resolve_cascade_providers ~cascade_name : Llm_provider.Provider_config.t list =
   let defaults = default_model_strings ~cascade_name in
   let config_path = default_config_path () in


### PR DESCRIPTION
Last functional Model_spec call removed. cascade_inference.ml: cascade_config_path → Oas_worker.default_config_path. Migration complete.