### PR TITLE
refactor(dashboard): extract CmdStatCard for command plane stat boxes

### DIFF
--- a/dashboard/src/components/command/cmd-stat-card.ts
+++ b/dashboard/src/components/command/cmd-stat-card.ts
@@ -1,0 +1,24 @@
+// CmdStatCard — command plane stat box (label/value/detail).
+// Replaces 21x inline bg-[var(--white-4)] border ... cmd-stat-card patterns.
+// Typography (span/strong/small sizing) is handled by the cmd-stat-card @utility in global.css.
+
+import { html } from 'htm/preact'
+import type { ComponentChildren } from 'preact'
+
+interface CmdStatCardProps {
+  label: string
+  value: ComponentChildren
+  detail?: ComponentChildren
+  tone?: string
+  highlight?: boolean
+}
+
+export function CmdStatCard({ label, value, detail, tone, highlight }: CmdStatCardProps) {
+  return html`
+    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl p-4 flex flex-col gap-2 cmd-stat-card ${tone ?? ''} ${highlight ? 'highlight' : ''}">
+      <span>${label}</span>
+      <strong>${value}</strong>
+      ${detail != null ? html`<small>${detail}</small>` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { CmdStatCard } from './cmd-stat-card'
 import {
   commandPlaneChainSummary,
   commandPlaneSurface,
@@ -245,13 +246,13 @@ export function SummaryCards() {
   const cache = microarch?.cache
   return html`
     <div class="grid grid-cols-[repeat(auto-fit,minmax(140px,1fr))] gap-3">
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>유닛</span><strong>${topology?.total_units ?? 0}</strong><small>${topology?.managed_unit_count ?? 0}개 관리 중</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>작전</span><strong>${ops?.active ?? 0}</strong><small>${summary?.detachments.summary?.active ?? 0}개 실행체</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>승인</span><strong>${decisions?.pending ?? 0}</strong><small>${decisions?.total ?? 0}개 추적 중</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card ${highlightKey === 'alerts' ? 'highlight' : ''}"><span>알림</span><strong>${alerts?.bad ?? 0}</strong><small>${alerts?.warn ?? 0}건 주의</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>체인</span><strong>${chainSummary?.summary?.active_chains ?? 0}</strong><small>${chainSummary?.summary?.linked_operations ?? 0}개 연결</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card ${highlightKey === 'swarm' ? 'highlight' : ''}"><span>스웜</span><strong>${swarm?.active_lanes ?? 0}</strong><small>${swarm ? `${swarm.stalled_lanes ?? 0}개 정체 · ${relativeTime(swarm.last_movement_at)}` : 'lane snapshot 없음'}</small></div>
-      <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card ${highlightKey === 'microarch' ? 'highlight' : ''}"><span>마이크로아크</span><strong>${issuePressure?.pending_ops ?? 0}</strong><small>${cache?.l1_hit_rate != null ? `${formatPercent(cache.l1_hit_rate)} L1 적중` : '캐시 데이터 없음'} · ${issuePressure?.tone ?? '정보 없음'}</small></div>
+      <${CmdStatCard} label="유닛" value=${topology?.total_units ?? 0} detail=${`${topology?.managed_unit_count ?? 0}개 관리 중`} />
+      <${CmdStatCard} label="작전" value=${ops?.active ?? 0} detail=${`${summary?.detachments.summary?.active ?? 0}개 실행체`} />
+      <${CmdStatCard} label="승인" value=${decisions?.pending ?? 0} detail=${`${decisions?.total ?? 0}개 추적 중`} />
+      <${CmdStatCard} label="알림" value=${alerts?.bad ?? 0} detail=${`${alerts?.warn ?? 0}건 주의`} highlight=${highlightKey === 'alerts'} />
+      <${CmdStatCard} label="체인" value=${chainSummary?.summary?.active_chains ?? 0} detail=${`${chainSummary?.summary?.linked_operations ?? 0}개 연결`} />
+      <${CmdStatCard} label="스웜" value=${swarm?.active_lanes ?? 0} detail=${swarm ? `${swarm.stalled_lanes ?? 0}개 정체 · ${relativeTime(swarm.last_movement_at)}` : 'lane snapshot 없음'} highlight=${highlightKey === 'swarm'} />
+      <${CmdStatCard} label="마이크로아크" value=${issuePressure?.pending_ops ?? 0} detail=${`${cache?.l1_hit_rate != null ? `${formatPercent(cache.l1_hit_rate)} L1 적중` : '캐시 데이터 없음'} · ${issuePressure?.tone ?? '정보 없음'}`} highlight=${highlightKey === 'microarch'} />
     </div>
   `
 }

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { CmdStatCard } from './cmd-stat-card'
 import { EmptyState } from '../common/empty-state'
 import {
   commandPlaneSwarm,
@@ -57,11 +58,11 @@ export function SwarmLivePanels() {
                     이 화면은 swarm-live의 사회 truth 자체가 아니라, 실험적 오케스트레이션을 읽기 위한 파생 관찰면입니다.
                   </div>
                   <div class="command-summary-grid">
-                    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>실행 런</span><strong>${swarm.run_id ?? runId ?? 'swarm-live'}</strong><small>${swarm.room_id ?? 'room 정보 없음'}</small></div>
-                    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>워커</span><strong>${swarm.summary?.joined_workers ?? 0}/${swarm.summary?.expected_workers ?? 0}</strong><small>${swarm.summary?.live_workers ?? 0}개 가동 · ${swarm.summary?.completed_workers ?? 0}개 완료</small></div>
-                    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>런타임</span><strong>${runtimeState}</strong><small>slots ${actualSlots}/${expectedSlots} · ctx ${actualCtx}/${expectedCtx}</small></div>
-                    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>고동시성</span><strong>${swarm.summary?.pass_hot_concurrency ? '통과' : '확인 필요'}</strong><small>${swarm.provider?.slot_url ?? 'slot 정보 없음'}</small></div>
-                    <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>종단 점검</span><strong>${swarm.summary?.pass_end_to_end ? '통과' : '확인 필요'}</strong><small>${swarm.recommended_next_tool ?? 'masc_observe_traces'}</small></div>
+                    <${CmdStatCard} label="실행 런" value=${swarm.run_id ?? runId ?? 'swarm-live'} detail=${swarm.room_id ?? 'room 정보 없음'} />
+                    <${CmdStatCard} label="워커" value=${`${swarm.summary?.joined_workers ?? 0}/${swarm.summary?.expected_workers ?? 0}`} detail=${`${swarm.summary?.live_workers ?? 0}개 가동 · ${swarm.summary?.completed_workers ?? 0}개 완료`} />
+                    <${CmdStatCard} label="런타임" value=${runtimeState} detail=${`slots ${actualSlots}/${expectedSlots} · ctx ${actualCtx}/${expectedCtx}`} />
+                    <${CmdStatCard} label="고동시성" value=${swarm.summary?.pass_hot_concurrency ? '통과' : '확인 필요'} detail=${swarm.provider?.slot_url ?? 'slot 정보 없음'} />
+                    <${CmdStatCard} label="종단 점검" value=${swarm.summary?.pass_end_to_end ? '통과' : '확인 필요'} detail=${swarm.recommended_next_tool ?? 'masc_observe_traces'} />
                   </div>
                   <div class="cmd-card rounded-xl-grid">
                     <span>작전</span><span>${swarm.operation?.operation_id ?? operationId ?? '없음'}</span>

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { CmdStatCard } from './cmd-stat-card'
 import { EmptyState } from '../common/empty-state'
 import { route } from '../../router'
 import { workflowContextForRoute } from '../../workflow-context'
@@ -41,10 +42,10 @@ export function SwarmOverviewPanel() {
         ? html`
             <${SwarmStoryboard} lanes=${lanes} />
             <div class="command-summary-grid mt-3">
-              <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>활성 레인</span><strong>${overview?.active_lanes ?? 0}</strong><small>${overview?.moving_lanes ?? 0}개 이동 중</small></div>
-              <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>정체</span><strong>${overview?.stalled_lanes ?? 0}</strong><small>${overview?.projected_lanes ?? 0}개 예상 레인</small></div>
-              <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>마지막 이동</span><strong>${relativeTime(overview?.last_movement_at)}</strong><small>${swarm.generated_at ? `스냅샷 ${relativeTime(swarm.generated_at)}` : '방금 스냅샷'}</small></div>
-              <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card"><span>다음 액션</span><strong>${recommendation?.label ?? '운영자 상태 확인'}</strong><small>${recommendation?.tool ?? 'masc_operator_snapshot'}</small></div>
+              <${CmdStatCard} label="활성 레인" value=${overview?.active_lanes ?? 0} detail=${`${overview?.moving_lanes ?? 0}개 이동 중`} />
+              <${CmdStatCard} label="정체" value=${overview?.stalled_lanes ?? 0} detail=${`${overview?.projected_lanes ?? 0}개 예상 레인`} />
+              <${CmdStatCard} label="마지막 이동" value=${relativeTime(overview?.last_movement_at)} detail=${swarm.generated_at ? `스냅샷 ${relativeTime(swarm.generated_at)}` : '방금 스냅샷'} />
+              <${CmdStatCard} label="다음 액션" value=${recommendation?.label ?? '운영자 상태 확인'} detail=${recommendation?.tool ?? 'masc_operator_snapshot'} />
             </div>
 
             ${lanes.length > 0 ? html`<${SwarmHealthBar} lanes=${lanes} />` : null}

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { CmdStatCard } from './cmd-stat-card'
 import type {
   CommandPlaneChainOverlay,
   CommandPlaneSwarmLane,
@@ -139,31 +140,11 @@ export function WarRoomHeroStrip({
         </div>
       </div>
       <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-3">
-        <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card">
-          <span>워커</span>
-          <strong>${workerJoined ?? 0}/${workerExpected ?? 0}</strong>
-          <small>${swarmHasEvidence ? (swarm?.summary?.completed_workers ?? 0) : 0} 완료 · ${workerCardCount} 카드</small>
-        </div>
-        <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card">
-          <span>런타임</span>
-          <strong>${swarmHasEvidence ? (swarm?.provider?.runtime_blocker ? '막힘' : swarm?.provider?.provider_reachable ? '준비됨' : selectedSession ? displayStatus(selectedSession.status) : '확인 필요') : (selectedSession ? displayStatus(selectedSession.status) : '확인 필요')}</strong>
-          <small>${swarmHasEvidence ? `설정 ${swarm?.provider?.configured_capacity ?? 'n/a'} · 실제 ${swarm?.provider?.actual_slots ?? swarm?.provider?.total_slots ?? 0} · hot ${swarm?.summary?.peak_hot_slots ?? swarm?.provider?.peak_active_slots ?? 0}` : `세션 워커 ${workerCardCount}`}</small>
-        </div>
-        <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card ${toneClass(blockersCount > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')}">
-          <span>압력</span>
-          <strong>${blockersCount + pendingApprovals + pendingConfirmTotal}</strong>
-          <small>막힘 ${blockersCount} · 승인 ${pendingApprovals} · 확인 ${pendingConfirmVisible}${pendingConfirmHidden > 0 ? `/${pendingConfirmTotal}` : ''}</small>
-        </div>
-        <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card ${toneClass(guidanceLayerTone(guidanceLayer))}">
-          <span>상주 판정기</span>
-          <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
-          <small>${guidanceFreshnessLabel(activeSummary)}${residentRuntime?.model_used ? ` · ${residentRuntime.model_used}` : ''}</small>
-        </div>
-        <div class="bg-[var(--white-4)] border border-[var(--white-8)] rounded-[14px] p-[14px_16px] flex flex-col gap-1.5 cmd-stat-card">
-          <span>마지막 신호</span>
-          <strong>${relativeTime(latestSignal)}</strong>
-          <small>${latestMessage ? '메시지' : latestTrace ? '트레이스' : '대기 중'}</small>
-        </div>
+        <${CmdStatCard} label="워커" value=${`${workerJoined ?? 0}/${workerExpected ?? 0}`} detail=${`${swarmHasEvidence ? (swarm?.summary?.completed_workers ?? 0) : 0} 완료 · ${workerCardCount} 카드`} />
+        <${CmdStatCard} label="런타임" value=${swarmHasEvidence ? (swarm?.provider?.runtime_blocker ? '막힘' : swarm?.provider?.provider_reachable ? '준비됨' : selectedSession ? displayStatus(selectedSession.status) : '확인 필요') : (selectedSession ? displayStatus(selectedSession.status) : '확인 필요')} detail=${swarmHasEvidence ? `설정 ${swarm?.provider?.configured_capacity ?? 'n/a'} · 실제 ${swarm?.provider?.actual_slots ?? swarm?.provider?.total_slots ?? 0} · hot ${swarm?.summary?.peak_hot_slots ?? swarm?.provider?.peak_active_slots ?? 0}` : `세션 워커 ${workerCardCount}`} />
+        <${CmdStatCard} label="압력" value=${blockersCount + pendingApprovals + pendingConfirmTotal} detail=${`막힘 ${blockersCount} · 승인 ${pendingApprovals} · 확인 ${pendingConfirmVisible}${pendingConfirmHidden > 0 ? `/${pendingConfirmTotal}` : ''}`} tone=${toneClass(blockersCount > 0 || pendingApprovals > 0 || pendingConfirmTotal > 0 ? 'warn' : 'ok')} />
+        <${CmdStatCard} label="상주 판정기" value=${runtimeJudgeLabel(residentRuntime)} detail=${`${guidanceFreshnessLabel(activeSummary)}${residentRuntime?.model_used ? ` · ${residentRuntime.model_used}` : ''}`} tone=${toneClass(guidanceLayerTone(guidanceLayer))} />
+        <${CmdStatCard} label="마지막 신호" value=${relativeTime(latestSignal)} detail=${latestMessage ? '메시지' : latestTrace ? '트레이스' : '대기 중'} />
       </div>
     </section>
   `


### PR DESCRIPTION
## Summary
- `CmdStatCard` 컴포넌트 추출 → 4개 command 파일에서 21x 동일 인라인 패턴 제거
- 스페이싱 정규화: `p-[14px_16px]`→`p-4`, `rounded-[14px]`→`rounded-xl`, `gap-1.5`→`gap-2`
- 기존 `cmd-stat-card` CSS @utility는 그대로 유지 (타이포그래피 담당)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] Command Plane (war-room, summary, swarm) stat 카드 렌더링 확인
- [ ] highlight 상태 (알림/스웜/마이크로아크) 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)