### PR TITLE
fix(tools): register autoresearch schemas in MCP public surface

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -124,6 +124,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_team_session.schemas
     @ Tool_voice.schemas
     @ Tool_compact.schemas
+    @ Tool_autoresearch.schemas
     )
 
 (** Validate tool schemas at module initialization time.


### PR DESCRIPTION
## Summary
- `Tool_autoresearch.schemas` (8 tools) were missing from `config.ml:raw_all_tool_schemas`
- Autoresearch tools were invisible in `tools/list` and `keeper_tool_catalog` MCP responses
- Keeper internal dispatch worked correctly (prefix matching in `keeper_exec_tools.ml`)
- Fix: 1-line addition to `config.ml` schema registry

## Affected tools
`masc_autoresearch_start`, `masc_autoresearch_swarm_start`, `masc_autoresearch_status`, `masc_autoresearch_stop`, `masc_autoresearch_inject`, `masc_autoresearch_cycle`, `masc_autoresearch_record_finding`, `masc_autoresearch_search_findings`

## Root cause
`tools.ml:all_schemas_with_perpetual` included autoresearch schemas but `config.ml:raw_all_tool_schemas` (used by MCP surface) did not.

## Test plan
- [x] `test_keeper_tools_oas.exe` — 10/10 pass (research profile access, non-research block)
- [x] `test_tool_shard_coverage.exe` — 42/42 pass
- [x] `test_auth_coverage.exe` — 81/81 pass
- [x] `dune build` — clean
- [ ] After merge + server restart: verify `masc_keeper_tool_catalog` returns 8 autoresearch tools

Generated with [Claude Code](https://claude.com/claude-code)