### PR TITLE
refactor(dashboard): normalize keeper-card spacing and use StatCell

### DIFF
--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -28,8 +28,8 @@ export function CommandWorkflowBanner() {
   const context = workflowContextForRoute(route.value)
   if (!context) return null
   return html`
-    <section class="rounded-[14px] border border-[rgba(34,211,238,0.26)] bg-[linear-gradient(180deg,rgba(34,211,238,0.1),var(--white-3))] p-[14px_16px] grid gap-2">
-      <div class="flex gap-2 flex-wrap items-center">
+    <section class="rounded-xl border border-[rgba(34,211,238,0.26)] bg-[linear-gradient(180deg,rgba(34,211,238,0.1),var(--white-3))] p-4 grid gap-3">
+      <div class="flex gap-3 flex-wrap items-center">
         <strong>${context.source_label}</strong>
         <span class="cmd-chip rounded-full">${workflowActionLabel(context.action_type)}</span>
         <span class="cmd-chip rounded-full">${workflowTargetLabel(context)}</span>
@@ -37,7 +37,7 @@ export function CommandWorkflowBanner() {
       </div>
       <div class="text-[rgba(255,255,255,0.84)] leading-normal">${context.summary}</div>
       ${context.payload_preview
-        ? html`<div class="p-[10px_12px] border border-[var(--white-8)] bg-[var(--white-5)] text-[color:var(--text-strong)] leading-[1.45] rounded-xl">${context.payload_preview}</div>`
+        ? html`<div class="py-3 px-3 border border-[var(--white-8)] bg-[var(--white-5)] text-[color:var(--text-strong)] leading-snug rounded-xl">${context.payload_preview}</div>`
         : null}
     </section>
   `
@@ -50,12 +50,12 @@ export function CommandEntryStrip() {
 
   return html`
     <section class="grid grid-cols-2 gap-3">
-      <article class="p-[14px_16px] rounded-[14px] border border-[var(--border-slate-16)] bg-[var(--white-3h)] grid gap-1.5">
+      <article class="p-4 rounded-xl border border-[var(--border-slate-16)] bg-[var(--white-3h)] grid gap-2">
         <span class="text-[rgba(148,163,184,0.92)] text-[length:var(--fs-xs)] uppercase tracking-[0.08em]">현재 표면</span>
         <strong class="text-[color:var(--text-near-white)] text-lg leading-[1.2] break-words">${guide.title}</strong>
         <p class="m-0 text-[color:var(--frost-72)] leading-normal">${guide.description}</p>
       </article>
-      <article class="p-[14px_16px] rounded-[14px] border border-[var(--border-slate-16)] bg-[var(--white-3h)] grid gap-1.5">
+      <article class="p-4 rounded-xl border border-[var(--border-slate-16)] bg-[var(--white-3h)] grid gap-2">
         <span class="text-[rgba(148,163,184,0.92)] text-[length:var(--fs-xs)] uppercase tracking-[0.08em]">다음 추천</span>
         <strong class="text-[color:var(--text-near-white)] text-lg leading-[1.2] break-words">${recommendation.tool}</strong>
         <p class="m-0 text-[color:var(--frost-72)] leading-normal">${recommendation.reason}</p>

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -103,7 +103,7 @@ export function WarRoomHeroStrip({
           </div>
           <div class="mt-3 text-[rgba(226,232,240,0.86)] leading-[1.55] max-w-[82ch]">${heroSummary}</div>
           ${activeSummary?.summary
-            ? html`<div class="grid gap-1 mt-2.5 p-[10px_12px] rounded-[10px] border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.84)] text-[length:var(--fs-sm)] leading-[1.45] cmd-warroom-guidance ${guidanceLayerTone(guidanceLayer)}">
+            ? html`<div class="grid gap-1 mt-2.5 py-3 px-3 rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.84)] text-[length:var(--fs-sm)] leading-snug cmd-warroom-guidance ${guidanceLayerTone(guidanceLayer)}">
                 <strong>${guidanceLayerLabel(guidanceLayer)}</strong>
                 <span>${activeSummary.summary}</span>
               </div>`

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { MitosisRing } from './mitosis-ring'
+import { StatCell } from './stat-cell'
 import { StatusBadge } from './status-badge'
 import { TimeAgo } from './time-ago'
 import { PipelineStageBadge } from '../keeper-pipeline-stage'
@@ -67,7 +68,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
   const toneClass = model.tone ?? ''
   const wrapperClass =
     variant === 'mission'
-      ? `w-full p-3.5 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass}`
+      ? `w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass}`
       : 'keeper-canonical-card'
   const buttonClass =
     variant === 'mission'
@@ -77,8 +78,8 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
   return html`
     <article class=${wrapperClass}>
       <button class=${buttonClass} data-testid=${testId} onClick=${onClick}>
-        <div class=${variant === 'mission' ? 'flex justify-between gap-2.5 items-start' : 'monitor-row-header'}>
-          <div class=${variant === 'mission' ? 'flex gap-2.5 items-start' : 'min-w-0'}>
+        <div class=${variant === 'mission' ? 'flex justify-between gap-3 items-start' : 'monitor-row-header'}>
+          <div class=${variant === 'mission' ? 'flex gap-3 items-start' : 'min-w-0'}>
             <span class="agent-emoji ${model.stateClass === 'offline' ? 'grayscale' : ''}">${model.emoji ?? ''}</span>
             <div>
               <div class=${variant === 'mission' ? '' : 'monitor-name-line'}>
@@ -99,7 +100,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
             : html`<span class="cmd-chip rounded-full ${toneClass}">${model.statusLabel}</span>`}
         </div>
 
-        <div class=${variant === 'mission' ? 'flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]' : 'monitor-meta'}>
+        <div class=${variant === 'mission' ? 'flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]' : 'monitor-meta'}>
           ${model.lastActivityAt
             ? html`<span>최근 활동 <${TimeAgo} timestamp=${model.lastActivityAt} /></span>`
             : html`<span>${model.lastActivityFallback ?? '최근 활동 없음'}</span>`}
@@ -109,7 +110,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
           <span>컨텍스트 ${formatContext(model.contextRatio)}</span>
         </div>
 
-        <div class=${variant === 'mission' ? 'grid gap-1' : 'monitor-focus'}>
+        <div class=${variant === 'mission' ? 'grid gap-1.5' : 'monitor-focus'}>
           ${variant === 'mission'
             ? html`
                 <span>무엇을</span>
@@ -119,15 +120,15 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
         </div>
 
         ${model.summary
-          ? html`<div class=${variant === 'mission' ? 'grid gap-1' : 'monitor-footnote'}>${model.summary}</div>`
+          ? html`<div class=${variant === 'mission' ? 'grid gap-1.5' : 'monitor-footnote'}>${model.summary}</div>`
           : null}
       </button>
 
       ${hasDetailDisclosure
         ? html`
-            <details class="pt-1 border-t border-[var(--white-6)] mt-2">
+            <details class="pt-2 border-t border-[var(--white-6)] mt-3">
               <summary>${model.disclosureLabel ?? '세부 정보'}</summary>
-              <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+              <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
                 ${model.recentEvent ? html`<span>최근 일 · ${model.recentEvent}</span>` : null}
                 ${model.routeSummary ? html`<span>route · ${model.routeSummary}</span>` : null}
                 ${model.auditSource ? html`<span>audit · ${model.auditSource}</span>` : null}
@@ -135,21 +136,15 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
               </div>
               ${model.recentInput || model.recentOutput
                 ? html`
-                    <div class="grid grid-cols-2 gap-2.5">
-                      <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-                        <span>최근 입력</span>
-                        <strong>${model.recentInput ?? '표시 가능한 최근 입력이 없습니다'}</strong>
-                      </div>
-                      <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
-                        <span>최근 응답</span>
-                        <strong>${model.recentOutput ?? '표시 가능한 최근 응답이 없습니다'}</strong>
-                      </div>
+                    <div class="grid grid-cols-2 gap-3">
+                      <${StatCell} label="최근 입력" value=${model.recentInput ?? '표시 가능한 최근 입력이 없습니다'} bg="white-3" />
+                      <${StatCell} label="최근 응답" value=${model.recentOutput ?? '표시 가능한 최근 응답이 없습니다'} bg="white-3" />
                     </div>
                   `
                 : null}
               ${(model.recentTools?.length ?? 0) > 0 || (model.allowedTools?.length ?? 0) > 0
                 ? html`
-                    <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+                    <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
                       <span>최근 도구 · ${renderToolSummary(model.recentTools)}</span>
                       <span>허용 도구 · ${renderToolSummary(model.allowedTools)}</span>
                     </div>


### PR DESCRIPTION
## Summary
- `keeper-card.ts` 스페이싱 정규화: `gap-2.5`→`gap-3`, `p-3.5`→`p-4`, `gap-1`→`gap-1.5`
- 인라인 stat box 2개 → `StatCell` 컴포넌트 교체 (bg="white-3")
- details 섹션 여백 확대: `pt-1 mt-2`→`pt-2 mt-3`

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] 키퍼 카드(mission/execution variant) 렌더링 확인
- [ ] details 펼침 시 입력/응답 셀 간격 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)