### PR TITLE
feat(research): add code snippets around TODOs to LLM context

### DIFF
--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -44,6 +44,10 @@ let default ?(repo = default_repo_config ()) () : t =
        CRITICAL: Only use functions that appear in the 'Public API signatures' section. \
        Do NOT invent module names or function names. If a function does not appear \
        in the .mli signatures provided, it does not exist. \
+       The 'Code around' sections show actual code near TODOs — use this to write \
+       precise patches that fit the existing style and indentation. \
+       The 'patch' field should contain the COMPLETE new content for the target file, \
+       or a unified diff (starting with '---'). \
        Respond ONLY with a JSON object: \
        {\"description\": \"...\", \"target_file\": \"...\", \"rationale\": \"...\", \"patch\": \"...\"}";
   }

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -84,7 +84,37 @@ let gather_context ~(config : Research_config.repo_config) : string =
       Buffer.add_string parts (Printf.sprintf "## TODOs/FIXMEs (%d total)\n```\n" count);
       List.iter (fun t -> Buffer.add_string parts t; Buffer.add_char parts '\n') sample;
       Buffer.add_string parts "```\n\n"
-    end
+    end;
+    (* Code snippets around TODOs — gives LLM actual code context *)
+    let snippets_added = ref 0 in
+    let max_snippets = 3 in
+    List.iter (fun todo_line ->
+      if !snippets_added < max_snippets then begin
+        (* Parse "file:line:content" format *)
+        match String.split_on_char ':' todo_line with
+        | file :: line_str :: _ ->
+          (try
+            let line_num = int_of_string (String.trim line_str) in
+            let start_line = max 1 (line_num - 15) in
+            let end_line = line_num + 15 in
+            let file_path = Printf.sprintf "%s/%s" config.path file in
+            if Sys.file_exists file_path then begin
+              let _, snippet =
+                Process_eio.run_argv_with_status ~timeout_sec:5.0
+                  [ "sed"; "-n"; Printf.sprintf "%d,%dp" start_line end_line; file_path ]
+              in
+              if String.length snippet > 0 then begin
+                Buffer.add_string parts
+                  (Printf.sprintf "## Code around %s:%d\n```ocaml\n" file line_num);
+                Buffer.add_string parts snippet;
+                Buffer.add_string parts "```\n\n";
+                incr snippets_added
+              end
+            end
+          with _ -> ())
+        | _ -> ()
+      end
+    ) (if count > 3 then List.filteri (fun i _ -> i < 3) todos else todos)
   with _ -> ());
   Buffer.contents parts
 


### PR DESCRIPTION
## Summary
- `gather_context`가 TODO 주변 ±15줄의 실제 코드를 context에 포함
- LLM이 파일 이름만이 아닌 실제 코드를 보고 패치 작성 가능
- 최대 3개 TODO 스니펫 (토큰 절약)
- 시스템 프롬프트에 "Code around 섹션 참고" 지시 추가

## Why
E2E 시뮬레이션에서 LLM이 코드를 보지 못해 존재하지 않는 API를 제안.
실제 코드 context가 있으면 스타일/인덴트/API 일관성 향상.

## Test plan
- [x] `dune build` 통과
- [ ] llama-server idle 시 E2E: 코드 스니펫 포함 context로 가설 생성 품질 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)