### PR TITLE
fix(research): handle empty LLM response and API errors

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -158,14 +158,26 @@ let generate_hypothesis ~(config : Research_config.t)
       "-d"; body;
       "--max-time"; "120";
     ] in
-    let _status, stdout =
+    let status, stdout =
       Process_eio.run_argv_with_status ~timeout_sec:130.0 argv
     in
-    let json = Yojson.Safe.from_string stdout in
-    let open Yojson.Safe.Util in
-    let content = json |> member "choices" |> index 0
-      |> member "message" |> member "content" |> to_string in
-    parse_hypothesis content
+    let exit_code = match status with Unix.WEXITED c -> c | _ -> 1 in
+    if String.length (String.trim stdout) = 0 then begin
+      Log.Server.warn "research: LLM returned empty response (exit=%d, slots likely busy)" exit_code;
+      None
+    end else begin
+      let json = Yojson.Safe.from_string stdout in
+      let open Yojson.Safe.Util in
+      (* Check for API error response *)
+      match member "error" json with
+      | `Null ->
+        let content = json |> member "choices" |> index 0
+          |> member "message" |> member "content" |> to_string in
+        parse_hypothesis content
+      | err ->
+        Log.Server.warn "research: LLM API error: %s" (Yojson.Safe.to_string err);
+        None
+    end
   with exn ->
     Log.Server.warn "research: LLM call failed: %s" (Printexc.to_string exn);
     None


### PR DESCRIPTION
## Summary
- 빈 LLM 응답 감지: slots busy 시 빈 stdout → 명확한 로그 메시지
- API error 필드 체크: LLM 서버가 에러 JSON 반환 시 choices 파싱 전에 감지
- exit code 로깅 추가

## Root cause
llama-server 슬롯이 keeper에 의해 점유되면 curl이 빈 응답 반환.
`Yojson.Safe.from_string ""`이 unhelpful exception 발생.

## Test plan
- [x] `dune build` 통과
- [ ] 슬롯 busy 시 "slots likely busy" 로그 확인
- [ ] 에러 JSON 시 "LLM API error" 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)