### PR TITLE
feat(research): configurable LLM endpoint with env var fallback

### DIFF
--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -16,7 +16,10 @@ type t = {
   max_iterations : int;
   time_budget_per_experiment_sec : float;
   results_file : string;
-  cascade_name : string;       (** OAS cascade name for LLM calls *)
+  cascade_name : string;       (** model name for LLM calls *)
+  llm_url : string;            (** OpenAI-compatible endpoint URL *)
+  llm_api_key : string;        (** API key (empty = no auth header) *)
+  llm_timeout_sec : float;     (** per-request timeout *)
   system_prompt : string;
 }
 
@@ -36,6 +39,13 @@ let default ?(repo = default_repo_config ()) () : t =
     time_budget_per_experiment_sec = 600.0;
     results_file = "research_results.tsv";
     cascade_name = "llama";
+    llm_url = (match Sys.getenv_opt "RESEARCH_LLM_URL" with
+      | Some u -> u
+      | None -> "http://127.0.0.1:8085/v1/chat/completions");
+    llm_api_key = (match Sys.getenv_opt "RESEARCH_LLM_API_KEY" with
+      | Some k -> k
+      | None -> "");
+    llm_timeout_sec = 120.0;
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -180,16 +180,23 @@ let generate_hypothesis ~(config : Research_config.t)
     ("max_tokens", `Int 4096);
   ] in
   let body = Yojson.Safe.to_string payload in
-  let url = "http://127.0.0.1:8085/v1/chat/completions" in
+  let url = config.llm_url in
+  let timeout_str = Printf.sprintf "%.0f" config.llm_timeout_sec in
+  Log.Server.info "research: calling LLM at %s (timeout=%ss)" url timeout_str;
   try
-    let argv = [
-      "curl"; "-s"; "-X"; "POST"; url;
-      "-H"; "Content-Type: application/json";
-      "-d"; body;
-      "--max-time"; "120";
-    ] in
+    let auth_headers =
+      if config.llm_api_key <> "" then
+        [ "-H"; Printf.sprintf "Authorization: Bearer %s" config.llm_api_key ]
+      else []
+    in
+    let argv =
+      [ "curl"; "-s"; "-X"; "POST"; url;
+        "-H"; "Content-Type: application/json" ]
+      @ auth_headers
+      @ [ "-d"; body; "--max-time"; timeout_str ]
+    in
     let status, stdout =
-      Process_eio.run_argv_with_status ~timeout_sec:130.0 argv
+      Process_eio.run_argv_with_status ~timeout_sec:(config.llm_timeout_sec +. 10.0) argv
     in
     let exit_code = match status with Unix.WEXITED c -> c | _ -> 1 in
     if String.length (String.trim stdout) = 0 then begin

--- a/lib/research/tool_research.ml
+++ b/lib/research/tool_research.ml
@@ -24,7 +24,11 @@ Results logged to research_results.tsv.";
         ]);
         ("cascade_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "LLM cascade name (default: llama)");
+          ("description", `String "LLM model name (default: llama)");
+        ]);
+        ("llm_url", `Assoc [
+          ("type", `String "string");
+          ("description", `String "OpenAI-compatible LLM endpoint URL (default: env RESEARCH_LLM_URL or http://127.0.0.1:8085/v1/chat/completions)");
         ]);
       ]);
       ("required", `List []);
@@ -61,6 +65,9 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
       Yojson.Safe.Util.(member "cascade_name" args |> to_string_option)
       |> Option.value ~default:"llama"
     in
+    let llm_url =
+      Yojson.Safe.Util.(member "llm_url" args |> to_string_option)
+    in
     let config = Research_config.default
       ~repo:(Research_config.default_repo_config ~path:repo_path ())
       ()
@@ -70,6 +77,10 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
       cascade_name;
       results_file = Printf.sprintf "%s/research_results.tsv" repo_path;
     } in
+    let config = match llm_url with
+      | Some url -> { config with llm_url = url }
+      | None -> config
+    in
     let results = Research_loop.run ~config in
     let kept = List.filter (fun (e : Research_loop.experiment_entry) ->
       e.metric.status = Research_metric.Keep) results in


### PR DESCRIPTION
## Summary
- `llm_url`, `llm_api_key`, `llm_timeout_sec` config 필드 추가
- 환경변수 fallback: `RESEARCH_LLM_URL`, `RESEARCH_LLM_API_KEY`
- MCP tool `masc_research_start`에 `llm_url` 파라미터 추가
- curl 호출에 configurable auth header + timeout 적용

## Solves
keeper가 llama-server 슬롯을 점유할 때 research loop가 다른 endpoint로 우회 가능.
예: GLM direct, Anthropic API, 또는 별도 llama-server 인스턴스.

## Test plan
- [x] `dune build` 통과
- [ ] `RESEARCH_LLM_URL` 환경변수로 다른 endpoint 사용 확인
- [ ] `llm_url` 파라미터로 tool 호출 시 해당 URL 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)