### PR TITLE
research(e2e-002): fix TOCTOU race in log_result

### DIFF
--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -310,8 +310,14 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
 (** Log a result to the TSV file. *)
 let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
   let header = "experiment\tbuild_ok\ttest_pass_rate\tloc_delta\tfiles_changed\tstatus\tdescription\n" in
-  let needs_header = not (Sys.file_exists results_file) in
   let oc = open_out_gen [ Open_append; Open_creat ] 0o644 results_file in
+  (* Check file size after open to avoid TOCTOU race on needs_header *)
+  let needs_header =
+    try
+      let pos = LargeFile.pos_out oc in
+      pos = Int64.zero
+    with _ -> false
+  in
   (try
     if needs_header then output_string oc header;
     Printf.fprintf oc "%s\t%d\t%.4f\t%d\t%d\t%s\t%s\n"


### PR DESCRIPTION
## Summary
Research loop 두 번째 실험. GLM-5가 TOCTOU race condition 발견.

## Change
`log_result`에서 `Sys.file_exists` → `LargeFile.pos_out` 전환.
파일 open 후 position이 0이면 빈 파일 → header 작성.

## Experiment
- **LLM**: GLM-5 (sb glm-text, reasoning mode)
- **Issue**: GLM이 race condition을 정확히 식별했지만 max_tokens로 패치가 잘림. 인간이 마무리.
- **Pattern**: LLM이 방향 제시 → 인간이 정확한 OCaml 구현

## Build
- [x] `dune build` pass

🤖 Generated by research loop (GLM-5 + Claude Opus 4.6)