### PR TITLE
research(e2e-003): configurable max_tokens (4096→8192)

### DIFF
--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -20,6 +20,7 @@ type t = {
   llm_url : string;            (** OpenAI-compatible endpoint URL *)
   llm_api_key : string;        (** API key (empty = no auth header) *)
   llm_timeout_sec : float;     (** per-request timeout *)
+  llm_max_tokens : int;        (** max tokens per LLM response (reasoning + output) *)
   system_prompt : string;
 }
 
@@ -46,6 +47,7 @@ let default ?(repo = default_repo_config ()) () : t =
       | Some k -> k
       | None -> "");
     llm_timeout_sec = 120.0;
+    llm_max_tokens = 8192;
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -182,7 +182,7 @@ let generate_hypothesis ~(config : Research_config.t)
       `Assoc [("role", `String "user"); ("content", `String user_msg)];
     ]);
     ("temperature", `Float 0.7);
-    ("max_tokens", `Int 4096);
+    ("max_tokens", `Int config.llm_max_tokens);
   ] in
   let body = Yojson.Safe.to_string payload in
   let url = config.llm_url in


### PR DESCRIPTION
## Summary
- `llm_max_tokens` config 필드 추가 (default: 8192)
- 하드코딩 4096 제거
- GLM-5 reasoning mode에서 truncation 방지

## Root cause
GLM-5의 reasoning_tokens가 500+를 소비하여 max_tokens=4096에서 output이 잘림.
8192로 올리면 reasoning + output 모두 수용 가능.

## Build
- [x] `dune build` pass

🤖 Generated by research loop (experiment 003)