### PR TITLE
style(dashboard): normalize gap-2.5 to gap-3 across all components

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -176,7 +176,7 @@ export function GraphView({ data }: GraphViewProps) {
     <div ref=${containerRef} class="relative w-full overflow-hidden bg-[#0f1117] my-3 rounded-xl">
       <canvas ref=${canvasRef} class="block w-full cursor-crosshair" />
       ${hoveredNode ? html`
-        <div class="absolute bottom-3 left-3 flex items-center gap-2.5 py-2 px-3.5 rounded-[10px] bg-[rgba(15,23,42,0.92)] border border-[var(--slate-gray-20)] text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)] pointer-events-none">
+        <div class="absolute bottom-3 left-3 flex items-center gap-3 py-2 px-3.5 rounded-[10px] bg-[rgba(15,23,42,0.92)] border border-[var(--slate-gray-20)] text-[length:var(--fs-sm)] text-[color:var(--text-slate-light)] pointer-events-none">
           <strong class="text-[length:var(--fs-base)] text-[color:var(--text-near-white)]">${hoveredNode.label}</strong>
           <span class="py-0.5 px-[7px] bg-[var(--slate-gray-15)] text-[length:var(--fs-xs)] text-[color:var(--text-slate)] rounded-md">${hoveredNode.kind}</span>
           <span>weight ${hoveredNode.weight}</span>

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -120,7 +120,7 @@ function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
     return html`<${EmptyState} message="최근 실행 이벤트가 없습니다." compact />`
   }
   return html`
-    <div class="flex flex-col gap-2.5">
+    <div class="flex flex-col gap-3">
       ${events.map(event => {
         const actor = eventActor(event)
         return html`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -106,7 +106,7 @@ export function AgentDetailOverlay() {
             <div class="flex items-center gap-4">
               ${agentEmoji ? html`<div class="size-12 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center text-3xl shadow-inner">${agentEmoji}</div>` : ''}
               <div>
-                <h2 class="m-0 flex items-baseline gap-2.5 text-text-strong text-2xl font-bold tracking-tight">
+                <h2 class="m-0 flex items-baseline gap-3 text-text-strong text-2xl font-bold tracking-tight">
                   ${displayName}
                   ${koreanName ? html`<span class="text-sm text-text-dim font-medium tracking-normal">(${koreanName})</span>` : ''}
                   ${secondaryLabel ? html`<span class="font-mono text-xs text-text-dim bg-white/5 px-2 py-0.5 rounded-md">${secondaryLabel}</span>` : ''}
@@ -155,7 +155,7 @@ export function AgentDetailOverlay() {
           <${Card} title="할당된 작업">
             ${ownedTasks.length === 0
               ? html`<div class="h-full min-h-[120px]"><${EmptyState} message="할당된 작업이 없습니다" compact /></div>`
-              : html`<div class="flex flex-col gap-2.5">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
+              : html`<div class="flex flex-col gap-3">${ownedTasks.map(t => html`<${TaskSummary} key=${t.id} task=${t} />`)}</div>`}
           <//>
 
           <${Card} title="최근 활동">

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -262,14 +262,14 @@ function CharacterPlate({ name }: { name: string }) {
         </div>
 
         ${lastSeenAt || lastActivity != null ? html`
-          <div class="flex gap-2.5 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
             ${lastSeenAt ? html`<span>마지막 확인: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
             ${lastActivity != null ? html`<span>${formatDuration(lastActivity)} 전 활동</span>` : null}
           </div>
         ` : null}
 
         ${keeperIdent || continuitySummary || brief?.related_session_id ? html`
-          <div class="flex gap-2.5 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex gap-3 flex-wrap text-[length:var(--fs-sm)] text-[var(--text-muted)]">
             ${keeperIdent ? html`<span>${keeperIdent}</span>` : null}
             ${brief?.related_session_id ? html`<span>세션 ${brief.related_session_id}</span>` : null}
             ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -161,7 +161,7 @@ export function Execution() {
          
           testId="execution.worker-support"
         >
-          <div class="flex flex-col gap-2.5">
+          <div class="flex flex-col gap-3">
             ${workerSupportRows.length === 0
               ? html`<${EmptyState} message="참여 에이전트가 없습니다." compact />`
               : workerSupportRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.worker-card" />`)}
@@ -174,7 +174,7 @@ export function Execution() {
          
           testId="execution.continuity"
         >
-          <div class="flex flex-col gap-2.5">
+          <div class="flex flex-col gap-3">
             ${continuityRows.length === 0
               ? html`<${EmptyState} message="연속성 경고 없음" compact />`
               : continuityRows.map(row => html`<${ContinuityRow} key=${row.name} row=${row} />`)}
@@ -187,7 +187,7 @@ export function Execution() {
          
           testId="execution.offline-workers"
         >
-          <div class="flex flex-col gap-2.5">
+          <div class="flex flex-col gap-3">
             ${offlineRows.length === 0
               ? html`<${EmptyState} message="오프라인 에이전트 없음" compact />`
               : offlineRows.map(row => html`<${WorkerSupportRow} key=${row.name} row=${row} testId="execution.offline-worker-card" />`)}

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -53,7 +53,7 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
       </div>
       ${decision.status === 'pending' && !isLegacy
         ? html`
-            <div class="flex gap-2.5 flex-wrap mt-3">
+            <div class="flex gap-3 flex-wrap mt-3">
               <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
@@ -92,7 +92,7 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
         <span class="text-[var(--text-muted)]">동결</span><span class="text-[var(--text-body)]">${frozen ? '예' : '아니오'}</span>
         <span class="text-[var(--text-muted)]">킬 스위치</span><span class="text-[var(--text-body)]">${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
-      <div class="flex gap-2.5 flex-wrap mt-3">
+      <div class="flex gap-3 flex-wrap mt-3">
         <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -198,7 +198,7 @@ function GuidedPanel() {
           <div class="card rounded-xl-title">즉시 조치</div>
         </div>
         <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card highlight mb-3">
-          <div class="flex justify-between gap-2.5 items-start">
+          <div class="flex justify-between gap-3 items-start">
             <strong>${nextStep?.title ?? nextTool}</strong>
             <span class="cmd-chip rounded-full ok">${nextTool}</span>
           </div>
@@ -210,11 +210,11 @@ function GuidedPanel() {
             : null}
         </div>
 
-        <div class="flex flex-col gap-2.5">
+        <div class="flex flex-col gap-3">
           ${readiness.map(item => html`
-            <article class="flex flex-col gap-2.5 p-3.5 border border-[var(--white-8)] bg-[var(--white-3)] rounded-xl cmd-readiness-row ${toneClass(item.tone)}">
+            <article class="flex flex-col gap-3 p-3.5 border border-[var(--white-8)] bg-[var(--white-3)] rounded-xl cmd-readiness-row ${toneClass(item.tone)}">
               <div>
-                <div class="flex justify-between gap-2.5 items-start">
+                <div class="flex justify-between gap-3 items-start">
                   <strong>${item.title}</strong>
                   <span class="cmd-chip rounded-full ${toneClass(item.tone)}">${item.tone}</span>
                 </div>
@@ -228,7 +228,7 @@ function GuidedPanel() {
         ${pitfalls.length > 0
           ? html`
               <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card warn">
-                <div class="flex justify-between gap-2.5 items-start">
+                <div class="flex justify-between gap-3 items-start">
                   <strong>자주 막히는 지점</strong>
                   <span class="cmd-chip rounded-full warn">${pitfalls.length}</span>
                 </div>
@@ -258,7 +258,7 @@ function GuidedPanel() {
                 <div class="grid gap-3">
                   ${renderedPaths.map(path => html`
                     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card">
-                      <div class="flex justify-between gap-2.5 items-start">
+                      <div class="flex justify-between gap-3 items-start">
                         <strong>${path.title}</strong>
                         <span class="cmd-chip rounded-full">${path.id}</span>
                       </div>
@@ -266,7 +266,7 @@ function GuidedPanel() {
                       <div class="cmd-card rounded-xl-sub">${path.when_to_use}</div>
                       <div class="flex flex-col gap-1.5 mt-3">
                         ${path.steps.slice(0, 4).map(step => html`
-                          <div class="flex gap-2.5 flex-wrap items-baseline">
+                          <div class="flex gap-3 flex-wrap items-baseline">
                             <span class="font-mono text-[#67e8f9] text-[length:var(--fs-sm)]">${step.tool}</span>
                             <span>${step.title}</span>
                           </div>

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -228,7 +228,7 @@ export function Command() {
             <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">지휘면</h2>
             <p class="text-[13px] text-[var(--text-muted)] leading-relaxed max-w-[62ch]">기본 진입은 라이브 워룸입니다. 실제 run, worker, message, trace를 먼저 보고 필요할 때만 detail surface로 내려갑니다.</p>
           </div>
-          <div class="flex gap-2.5 flex-wrap">
+          <div class="flex gap-3 flex-wrap">
             <button
               class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
               onClick=${() => {

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -135,7 +135,7 @@ function ChainOperationListItem(
 function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
   return html`
     <article class="cmd-chain-history-row text-red-300">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <strong>${item.chain_id ?? '알 수 없는 체인'}</strong>
         <span class="cmd-chip rounded-full ${chainStatusTone(item.event)}">${item.event}</span>
       </div>
@@ -148,7 +148,7 @@ function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
 function ChainRunNodeRow({ node }: { node: CommandPlaneChainRunNode }) {
   return html`
     <article class="p-3 rounded-[10px] bg-[rgba(9,12,20,0.5)] border border-solid border-[var(--white-6)]">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <strong>${node.id}</strong>
         <span class="cmd-chip rounded-full ${chainStatusTone(node.status)}">${node.status ?? '확인 필요'}</span>
       </div>
@@ -198,7 +198,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
       ${op.checkpoint_ref
         ? html`<div class="cmd-card rounded-xl-foot">체크포인트 ${op.checkpoint_ref}</div>`
         : null}
-      <div class="flex gap-2.5 flex-wrap mt-3">
+      <div class="flex gap-3 flex-wrap mt-3">
         <button
           class="control-btn rounded-lg ghost"
           onClick=${() => {
@@ -336,7 +336,7 @@ export function ChainsSurface() {
           <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Chains</h3>
         </div>
         <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${chainStatusTone(summary?.connection.status)}">
-          <div class="flex justify-between gap-2.5 items-start">
+          <div class="flex justify-between gap-3 items-start">
             <strong>native chain 연결</strong>
             <span class="cmd-chip rounded-full ${chainStatusTone(summary?.connection.status)}">${summary?.connection.status ?? 'disconnected'}</span>
           </div>
@@ -371,7 +371,7 @@ export function ChainsSurface() {
             : html`<${EmptyState} message="체인 기반 작전이 아직 없습니다." compact />`}
 
         <div class="flex flex-col gap-3 mt-3.5">
-          <div class="flex justify-between gap-2.5 items-start">
+          <div class="flex justify-between gap-3 items-start">
             <strong>최근 이력</strong>
             <span class="cmd-chip rounded-full">${summary?.recent_history.length ?? 0}</span>
           </div>
@@ -417,7 +417,7 @@ export function ChainsSurface() {
               ${selectedOverlay.mermaid
                 ? html`
                     <div class="mt-3.5 p-3.5 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
-                      <div class="flex justify-between gap-2.5 items-start">
+                      <div class="flex justify-between gap-3 items-start">
                         <strong>Mermaid 그래프</strong>
                         <span class="cmd-chip rounded-full">${selectedOverlay.operation.chain?.chain_id ?? 'graph'}</span>
                       </div>
@@ -427,7 +427,7 @@ export function ChainsSurface() {
                 : html`<${EmptyState} message="기록된 Mermaid 그래프가 아직 없습니다." compact />`}
 
               <div class="mt-3.5 p-3.5 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
-                <div class="flex justify-between gap-2.5 items-start">
+                <div class="flex justify-between gap-3 items-start">
                   <strong>실행 상세</strong>
                   <span class="cmd-chip rounded-full ${run?.success === false ? 'bad' : 'ok'}">
                     ${run

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -376,7 +376,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
         <p>${signalNode.detail ?? '세부 설명이 없습니다.'}</p>
         ${signalNode.suggested_surface
           ? html`
-              <div class="flex gap-2.5 flex-wrap mt-3">
+              <div class="flex gap-3 flex-wrap mt-3">
                 <button
                   class="control-btn rounded-lg"
                   onClick=${() => jumpTo('command', signalNode.suggested_surface, signalNode.suggested_params ?? {})}
@@ -416,7 +416,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
       <div class="cmd-card rounded-xl-sub">연결 ${relatedEdges.length}개 · 근거 ${node.provenance}</div>
       ${(node.link_tab && (node.link_surface || Object.keys(node.link_params ?? {}).length > 0))
         ? html`
-            <div class="flex gap-2.5 flex-wrap mt-3">
+            <div class="flex gap-3 flex-wrap mt-3">
               <button
                 class="control-btn rounded-lg"
                 onClick=${() => jumpTo(node.link_tab ?? 'command', node.link_surface, node.link_params ?? {})}

--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -107,8 +107,8 @@ function SignalRail({
   tone: string
 }) {
   return html`
-    <article class="p-3.5 rounded-[14px] bg-[var(--white-3h)] border border-[var(--white-8)] grid gap-2.5 cmd-signal-rail ${toneClass(tone)}">
-      <div class="flex items-baseline justify-between gap-2.5">
+    <article class="p-3.5 rounded-[14px] bg-[var(--white-3h)] border border-[var(--white-8)] grid gap-3 cmd-signal-rail ${toneClass(tone)}">
+      <div class="flex items-baseline justify-between gap-3">
         <span>${label}</span>
         <strong>${value}</strong>
       </div>
@@ -155,7 +155,7 @@ export function SummaryHero() {
 
   return html`
     <section class="relative overflow-hidden border border-[rgba(103,232,249,0.16)] rounded-[18px] p-[18px] mb-4 shadow-[inset_0_1px_0_var(--white-4)] cmd-hero grid grid-cols-[minmax(0,1.1fr)_minmax(300px,0.9fr)] gap-[18px] items-center">
-      <div class="relative z-[1] grid gap-2.5">
+      <div class="relative z-[1] grid gap-3">
         <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">현재 지휘 상태</span>
         <h3>${headline}</h3>
         <p>${subcopy}</p>

--- a/dashboard/src/components/command/swarm-cards.ts
+++ b/dashboard/src/components/command/swarm-cards.ts
@@ -12,7 +12,7 @@ import { alertBorderTone, relativeTime, toneClass } from './helpers'
 export function SwarmChecklistCard({ item }: { item: CommandPlaneSwarmChecklistItem }) {
   return html`
     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${toneClass(item.status)}">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <strong>${item.title}</strong>
         <span class="cmd-chip rounded-full ${toneClass(item.status)}">${item.status}</span>
       </div>
@@ -128,7 +128,7 @@ export function SwarmProofPanel({ proof }: { proof?: CommandPlaneSwarmProof }) {
           : 'warn'
   return html`
     <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${toneClass(tone)}">
-        <div class="flex justify-between gap-2.5 items-start">
+        <div class="flex justify-between gap-3 items-start">
           <strong>Hot Proof / 가동 증거</strong>
           <span class="cmd-chip rounded-full ${toneClass(tone)}">${proof?.status ?? 'missing'}</span>
         </div>

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -59,7 +59,7 @@ export function SwarmOverviewPanel() {
 
               <div class="cmd-card rounded-xl-stack">
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card highlight ${focusKey === 'recommendation' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
-                  <div class="flex justify-between gap-2.5 items-start">
+                  <div class="flex justify-between gap-3 items-start">
                     <strong>${recommendation?.label ?? '운영자 상태 확인'}</strong>
                     <span class="cmd-chip rounded-full">${recommendation?.lane_id ?? '전체'}</span>
                   </div>
@@ -70,7 +70,7 @@ export function SwarmOverviewPanel() {
                 <${SwarmProofPanel} proof=${proof} />
 
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${gaps.length > 0 ? 'warn' : 'ok'} ${focusKey === 'gaps' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
-                  <div class="flex justify-between gap-2.5 items-start">
+                  <div class="flex justify-between gap-3 items-start">
                     <strong>핵심 공백</strong>
                     <span class="cmd-chip rounded-full ${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')}">${gaps.length}</span>
                   </div>
@@ -80,7 +80,7 @@ export function SwarmOverviewPanel() {
                 </div>
 
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card">
-                  <div class="flex justify-between gap-2.5 items-start">
+                  <div class="flex justify-between gap-3 items-start">
                     <strong>이동 타임라인</strong>
                     <span class="cmd-chip rounded-full">${timeline.length}</span>
                   </div>

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -103,7 +103,7 @@ export function SwarmStoryboard({ lanes }: { lanes: CommandPlaneSwarmLane[] }) {
   const featured = lanes.slice(0, 4)
   if (featured.length === 0) return null
   return html`
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-2.5 mb-3.5">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-3.5">
       ${featured.map(lane => {
         const tone = swarmLaneTone(lane)
         const workers = lane.counts.workers ?? 0
@@ -230,7 +230,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
 
   return html`
     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card ${toneClass(tone)}">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <strong>Run Resolution</strong>
         <span class="cmd-chip rounded-full ${toneClass(tone)}">
           ${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)}
@@ -262,12 +262,12 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
       ${pendingConfirm
         ? html`
             <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card warn">
-              <div class="flex justify-between gap-2.5 items-start">
+              <div class="flex justify-between gap-3 items-start">
                 <strong>확인 대기</strong>
                 <span class="cmd-chip rounded-full warn">${pendingConfirm.confirm_token}</span>
               </div>
               ${pendingConfirm.preview ? html`<pre class="m-0 p-3 rounded-[10px] bg-[rgba(9,12,20,0.75)] text-[rgba(224,242,254,0.92)] text-[length:var(--fs-sm)] leading-[1.45] max-h-[220px] overflow-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]">${previewText(pendingConfirm.preview)}</pre>` : null}
-              <div class="flex gap-2.5 flex-wrap mt-3">
+              <div class="flex gap-3 flex-wrap mt-3">
                 <button class="control-btn rounded-lg" onClick=${() => { void confirmPending('confirm') }} disabled=${operatorActionBusy.value}>확인 실행</button>
                 <button class="control-btn rounded-lg ghost" onClick=${() => { void confirmPending('deny') }} disabled=${operatorActionBusy.value}>취소</button>
               </div>

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -100,7 +100,7 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
         </div>
       </div>
       ${node.children.length > 0
-        ? html`<div class="flex flex-col gap-2.5 mt-3 pl-4 border-l border-[var(--white-8)]">
+        ? html`<div class="flex flex-col gap-3 mt-3 pl-4 border-l border-[var(--white-8)]">
             ${node.children.map(child => html`<${TopologyNode} node=${child} depth=${depth + 1} />`)}
           </div>`
         : null}

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -92,7 +92,7 @@ export function WarRoomBodyGrid({
             : selectedSession
               ? html`
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card">
-                    <div class="flex justify-between gap-2.5 items-start">
+                    <div class="flex justify-between gap-3 items-start">
                       <strong>${selectedSession.session_id}</strong>
                       <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
                     </div>
@@ -185,7 +185,7 @@ export function WarRoomBodyGrid({
             ${pendingApprovals > 0
               ? html`
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card warn">
-                    <div class="flex justify-between gap-2.5 items-start">
+                    <div class="flex justify-between gap-3 items-start">
                       <strong>승인 대기</strong>
                       <span class="cmd-chip rounded-full warn">${pendingApprovals}</span>
                     </div>
@@ -196,7 +196,7 @@ export function WarRoomBodyGrid({
             ${pendingConfirmTotal > 0
               ? html`
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-3.5 rounded-xl cmd-guide-card warn">
-                    <div class="flex justify-between gap-2.5 items-start">
+                    <div class="flex justify-between gap-3 items-start">
                       <strong>확인 대기</strong>
                       <span class="cmd-chip rounded-full warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
                     </div>

--- a/dashboard/src/components/command/war-room-hero.ts
+++ b/dashboard/src/components/command/war-room-hero.ts
@@ -109,7 +109,7 @@ export function WarRoomHeroStrip({
               </div>`
             : null}
         </div>
-        <div class="flex gap-2.5 flex-wrap items-start justify-end">
+        <div class="flex gap-3 flex-wrap items-start justify-end">
           <button class="control-btn rounded-lg ghost" onClick=${onRefresh}>새로고침</button>
           ${wallboard
             ? html`

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -399,7 +399,7 @@ export function WarRoomOrchestrationRail({
                 <span>Elapsed</span><span>${formatElapsed(chainOverlay.runtime?.elapsed_sec)}</span>
                 <span>최근 이벤트</span><span>${historySummary(chainOverlay.history)}</span>
               </div>
-              <div class="flex gap-2.5 flex-wrap mt-3">
+              <div class="flex gap-3 flex-wrap mt-3">
                 <${WarRoomJumpButton}
                   label="체인 상세"
                   surface="chains"
@@ -425,7 +425,7 @@ export function WarRoomOrchestrationRail({
                 <span>Target</span><span>${linkedAutoresearch.target_file ?? 'n/a'}</span>
                 <span>Last decision</span><span>${linkedAutoresearch.last_decision ?? linkedAutoresearch.error ?? '기록 없음'}</span>
               </div>
-              <div class="flex gap-2.5 flex-wrap mt-3">
+              <div class="flex gap-3 flex-wrap mt-3">
                 <${WarRoomJumpButton} label="세션 개입" />
                 ${linkedAutoresearch.operation_id
                   ? html`<${WarRoomJumpButton}

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -197,12 +197,12 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
         <div class="card rounded-xl-title-row">
           <div class="card rounded-xl-title">실시간 워룸</div>
         </div>
-        <div class="flex flex-col gap-2.5 max-w-[520px]">
+        <div class="flex flex-col gap-3 max-w-[520px]">
           <span class="inline-flex w-fit items-center gap-2 py-[5px] px-[10px] rounded-full text-[#7dd3fc] bg-[rgba(14,116,144,0.22)] border border-solid border-[rgba(125,211,252,0.18)] text-[length:var(--fs-xs)] tracking-[0.08em] uppercase">Narrative Playback</span>
           <strong>지금 붙잡을 live swarm 또는 team session이 없습니다</strong>
           <p>chain, autoresearch, worker wallboard는 활성 작전 또는 세션이 생기면 자동으로 붙습니다. 지금은 drill-down surface로 이동하는 편이 맞습니다.</p>
         </div>
-        <div class="flex gap-2.5 flex-wrap mt-3">
+        <div class="flex gap-3 flex-wrap mt-3">
           <${WarRoomJumpButton} label="작전 보기" surface="operations" />
           <${WarRoomJumpButton} label="스웜 보기" surface="swarm" />
           <${WarRoomJumpButton} label="체인 보기" surface="chains" />

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -52,11 +52,11 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2.5">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-3">
       ${items.map(t => html`
         <div
           key=${t.id}
-          class="flex items-center gap-2.5 py-2.5 px-3.5 min-w-[240px] max-w-[380px] rounded-lg border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.95)] shadow-[0_8px_24px_rgba(0,0,0,0.35),0_2px_8px_rgba(0,0,0,0.2)] backdrop-blur-sm cursor-pointer transition-opacity duration-200 hover:opacity-90 animate-[slideInRight_0.25s_ease-out] ${BORDER_COLOR[t.type]}"
+          class="flex items-center gap-3 py-2.5 px-3.5 min-w-[240px] max-w-[380px] rounded-lg border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.95)] shadow-[0_8px_24px_rgba(0,0,0,0.35),0_2px_8px_rgba(0,0,0,0.2)] backdrop-blur-sm cursor-pointer transition-opacity duration-200 hover:opacity-90 animate-[slideInRight_0.25s_ease-out] ${BORDER_COLOR[t.type]}"
           onClick=${() => dismissToast(t.id)}
         >
           <span class="text-sm shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -138,7 +138,7 @@ export function SideRail() {
             const isActive = surface.id === currentSurface
             return html`
               <button
-                class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-left cursor-pointer border-l-2 border-t-0 border-r-0 border-b-0 border-solid transition-all duration-150 ${isActive ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]' : 'border-l-transparent bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)] hover:border-l-[var(--white-20)]'}"
+                class="w-full flex items-center gap-3 px-2.5 py-2 rounded-lg text-left cursor-pointer border-l-2 border-t-0 border-r-0 border-b-0 border-solid transition-all duration-150 ${isActive ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]' : 'border-l-transparent bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)] hover:border-l-[var(--white-20)]'}"
                 key=${surface.id}
                 onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
               >

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -54,7 +54,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
       <h2 class="monitor-headline">영향받는 작전</h2>
       <p class="monitor-subheadline">지휘 평면 작전의 막힘과 다음 도구만 얇게 보여주고, 자세한 근거는 원인 화면으로 넘깁니다.</p>
     </div>
-    <div class="flex flex-col gap-2.5">
+    <div class="flex flex-col gap-3">
       ${hasActive
         ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
         : html`<${EmptyState} message=${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'} compact />`}
@@ -63,7 +63,7 @@ export function OperationBriefsBody({ operationRows }: { operationRows: Dashboar
       ? html`
           <details class="mt-1" data-testid="execution.operations-terminal">
             <summary class="runtime-summary">종료된 작전 ${terminalOps.length}건</summary>
-            <div class="flex flex-col gap-2.5">
+            <div class="flex flex-col gap-3">
               ${terminalOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -58,7 +58,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
       <h2 class="monitor-headline">개입이 필요한 실행</h2>
       <p class="monitor-subheadline">진행 중인 세션과 작전 중 막힌 항목을 보여줍니다.${hasTerminal ? ' 종료된 항목은 하단에 접혀 있습니다.' : ''}</p>
     </div>
-    <div class="flex flex-col gap-2.5">
+    <div class="flex flex-col gap-3">
       ${hasActive
         ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
         : html`<${EmptyState} message="지금은 개입이 필요한 실행이 없습니다." compact />`}
@@ -67,7 +67,7 @@ export function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutio
       ? html`
           <details class="mt-1" data-testid="execution.queue-terminal">
             <summary class="runtime-summary">종료된 항목 ${terminalItems.length}건</summary>
-            <div class="flex flex-col gap-2.5">
+            <div class="flex flex-col gap-3">
               ${terminalItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -67,7 +67,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
       <h2 class="monitor-headline">영향받는 세션</h2>
       <p class="monitor-subheadline">대기열에서 고른 실행이 어떤 세션 목표와 실행 막힘을 갖는지 요약합니다.</p>
     </div>
-    <div class="flex flex-col gap-2.5">
+    <div class="flex flex-col gap-3">
       ${hasActive
         ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
         : html`<${EmptyState} message=${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'} compact />`}
@@ -76,7 +76,7 @@ export function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecu
       ? html`
           <details class="mt-1" data-testid="execution.sessions-terminal">
             <summary class="runtime-summary">종료된 세션 ${terminalSessions.length}건</summary>
-            <div class="flex flex-col gap-2.5">
+            <div class="flex flex-col gap-3">
               ${terminalSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
             </div>
           </details>

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -28,7 +28,7 @@ export function GoalRow({ goal }: { goal: Goal }) {
           </span>
           <span class="text-[length:var(--fs-base)] font-medium text-[color:var(--text-near-white)]">${goal.title}</span>
         </div>
-        <div class="flex gap-2.5 flex-wrap mt-1 text-[length:var(--fs-xs)] text-[var(--text-dim)]">
+        <div class="flex gap-3 flex-wrap mt-1 text-[length:var(--fs-xs)] text-[var(--text-dim)]">
           <span class="text-amber-500 tracking-[1px]" title="Priority ${goal.priority}">${priorityStars(goal.priority)}</span>
           ${goal.metric ? html`<span class="text-cyan">${goal.metric}${goal.target_value ? ` \u2192 ${goal.target_value}` : ''}</span>` : null}
           ${goal.due_date ? html`<span class="text-[var(--bad-light)]">Due: <${TimeAgo} timestamp=${goal.due_date} /></span>` : null}

--- a/dashboard/src/components/goals/mdal-components.ts
+++ b/dashboard/src/components/goals/mdal-components.ts
@@ -15,7 +15,7 @@ export function LoopRow({ loop }: { loop: MdalLoop }) {
 
   return html`
     <div class="planning-loop-row rounded-xl">
-      <div class="grid gap-2.5">
+      <div class="grid gap-3">
         <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
             <div class="text-[color:var(--text-strong)] text-[length:var(--fs-lg)] font-semibold capitalize">${loop.profile}</div>
@@ -27,7 +27,7 @@ export function LoopRow({ loop }: { loop: MdalLoop }) {
           </div>
         </div>
 
-        <div class="flex gap-2.5 flex-wrap text-[#b9c9ea] text-[length:var(--fs-sm)]">
+        <div class="flex gap-3 flex-wrap text-[#b9c9ea] text-[length:var(--fs-sm)]">
           <span>Baseline ${formatMetric(loop.baseline_metric)}</span>
           <span>현재 ${formatMetric(loop.current_metric)}</span>
           <span class=${formatMetricDelta(loop).startsWith('+') ? 'text-[#9af3ba]' : 'text-[#fda4af]'}>

--- a/dashboard/src/components/governance-detail.ts
+++ b/dashboard/src/components/governance-detail.ts
@@ -88,12 +88,12 @@ export function DecisionDetail() {
                   <span class="border border-[var(--card-border)] rounded-[10px] py-2 px-2.5 bg-[var(--white-4)] text-[#c8daf7] text-[length:var(--fs-sm)]"><strong>${orderStatusLabel(detail.execution_order?.status)}</strong></span>
                 </div>
               </div>
-              <div class="flex flex-col gap-2.5">
+              <div class="flex flex-col gap-3">
                 ${petitions.length === 0
                   ? html`<${EmptyState} message="기록된 청원이 없습니다." compact />`
                   : petitions.map(petition => html`<${PetitionEntry} key=${petition.id} petition=${petition} />`)}
               </div>
-              <div class="flex flex-col gap-2.5">
+              <div class="flex flex-col gap-3">
                 ${briefs.length === 0
                   ? html`<${EmptyState} message="심의 의견이 아직 없습니다." compact />`
                   : briefs.map(brief => html`<${BriefEntry} key=${brief.id} brief=${brief} />`)}

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -115,7 +115,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
         ` : null}
       </div>
 
-      <div class="keeper-chat__messages flex-1 min-h-[200px] max-h-[400px] overflow-y-auto py-3 px-3.5 flex flex-col gap-2.5" ref=${scrollRef}>
+      <div class="keeper-chat__messages flex-1 min-h-[200px] max-h-[400px] overflow-y-auto py-3 px-3.5 flex flex-col gap-3" ref=${scrollRef}>
         ${messages.length === 0 && !isStreaming ? html`
           <div class="text-[var(--white-20)] text-[var(--fs-base)] text-center py-10">keeper에게 메시지를 보내세요</div>
         ` : null}

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -42,7 +42,7 @@ export function ActivityStream() {
   const entries = filteredJournal.value
 
   return html`
-    <div class="grid gap-2.5 grid-rows-[auto_auto_1fr] min-h-0">
+    <div class="grid gap-3 grid-rows-[auto_auto_1fr] min-h-0">
       <div class="activity-stream-head">
         <h3 class="m-0 text-[0.95rem] font-semibold">Activity Stream</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${entries.length} events</span>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -26,7 +26,7 @@ export function FocusSidebar() {
   const selected = selectedAgentName.value
 
   return html`
-    <div class="grid gap-2.5 grid-rows-[auto_1fr] min-h-0">
+    <div class="grid gap-3 grid-rows-[auto_1fr] min-h-0">
       <div class="focus-sidebar-head">
         <h3 class="m-0 text-[0.95rem] font-semibold">Agents</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length} active</span>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -528,7 +528,7 @@ function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Author and meta -->
-          <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
+          <div class="flex gap-3 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-[13px]">${authorAvatar(post.author)}</span>
             <a class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a>
             <span class="text-[11px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -164,7 +164,7 @@ export function Ops() {
             방, 세션, 키퍼를 나눠 보고 바로 개입합니다.
           </p>
         </div>
-        <div class="flex items-end gap-2.5 flex-wrap max-[880px]:w-full">
+        <div class="flex items-end gap-3 flex-wrap max-[880px]:w-full">
           <label class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium" for="ops-actor">개입 ID</label>
           <input
             id="ops-actor"
@@ -266,7 +266,7 @@ export function Ops() {
       <section class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
         <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">개입 우선순위</h2>
         <p class="text-[12px] text-[var(--text-muted)] mb-3.5">지금 가장 먼저 손댈 대상이 방인지, 세션인지, 키퍼인지 먼저 좁힙니다.</p>
-        <div class="ops-priority-grid grid grid-cols-4 gap-2.5 max-[1200px]:grid-cols-2 max-[880px]:grid-cols-1">
+        <div class="ops-priority-grid grid grid-cols-4 gap-3 max-[1200px]:grid-cols-2 max-[880px]:grid-cols-1">
           ${priorityCards.map(card => html`
             <div key=${card.key} class="ops-priority-card p-3.5 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-1.5 ${card.tone}">
               <span class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.06em] font-medium">${card.label}</span>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -61,7 +61,7 @@ export function OpsKeeperColumn() {
               class="ops-entity-card p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] text-inherit text-left cursor-pointer w-full ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
               onClick=${() => { selectedKeeperName.value = keeper.name }}
             >
-              <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
+              <div class="flex justify-between items-center gap-3 max-[880px]:flex-col max-[880px]:items-start">
                 <strong class="text-[13px] font-semibold">${keeper.name}</strong>
                 <div class="flex items-center gap-2 ml-auto">
                   <span class="inline-flex items-center gap-1.5 text-[11px]">
@@ -102,7 +102,7 @@ export function OpsKeeperColumn() {
             ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">분리된 persistent agent는 없습니다.</div>`
             : persistentAgents.map(agent => html`
                 <article key=${agent.name} class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-                  <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
+                  <div class="flex justify-between items-center gap-3 max-[880px]:flex-col max-[880px]:items-start">
                     <strong class="text-[13px] font-semibold">${agent.name}</strong>
                     <span class="inline-flex items-center gap-1.5 text-[11px]">
                       <span class="w-2 h-2 rounded-full ${agent.status === 'offline' ? 'bg-[var(--text-muted)]' : 'bg-[var(--warn)]'}"></span>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -135,7 +135,7 @@ export function OpsRoomColumn() {
           </div>
         ` : null}
         ${pendingConfirms.length > 0 ? html`
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${pendingConfirms.map(item => html`
               <article key=${item.confirm_token} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
                 <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
@@ -171,7 +171,7 @@ export function OpsRoomColumn() {
         </div>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">평소에는 추천 개입만 보면 됩니다. room 전체를 건드릴 때만 아래 고급 제어를 여세요.</p>
 
-        <div class="grid grid-cols-2 gap-2.5 max-[880px]:grid-cols-1">
+        <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>Room</span>
             <strong>${room.current_room ?? room.room_id ?? 'default'}</strong>
@@ -285,7 +285,7 @@ export function OpsRoomColumn() {
         </div>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
         ${roomFeed.length > 0 ? html`
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${roomFeed.map(message => html`
               <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -126,7 +126,7 @@ export function OpsSessionColumn() {
       class="ops-entity-card p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
       onClick=${() => { selectedSessionId.value = session.session_id }}
     >
-      <div class="flex justify-between items-center gap-2.5 max-[880px]:flex-col max-[880px]:items-start">
+      <div class="flex justify-between items-center gap-3 max-[880px]:flex-col max-[880px]:items-start">
         <strong>${session.session_id}</strong>
         <span class="border border-solid border-[var(--card-border)] ${session.status ?? 'idle'} ${session.status === 'offline' ? 'text-[#8da4cc]' : ''}">${displayStatus(session.status)}</span>
       </div>
@@ -147,11 +147,11 @@ export function OpsSessionColumn() {
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">지금 개입 가능한 세션만 위에 두고, 종료된 세션은 아래에 접어 둡니다.</p>
 
         <div class="flex flex-col gap-2">
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
             <strong>${'개입 가능한 세션'}</strong>
             <span>${liveSessions.length}</span>
           </div>
-          <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${liveSessions.length === 0
               ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 바로 개입할 live team session이 없습니다.</div>`
               : liveSessions.map(session => renderSessionCard(session))}
@@ -162,7 +162,7 @@ export function OpsSessionColumn() {
           <details class="ops-archive-panel">
             <summary class="cursor-pointer text-[var(--text-muted)] text-[var(--fs-sm)] list-none">최근 종료 세션 ${archivedSessions.length}</summary>
             <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">완료/중단된 세션은 읽기 전용 참고용입니다. 새 노트, 작업, 중지는 위 live 세션에만 적용하세요.</p>
-            <div class="flex items-center justify-between gap-2.5 text-[var(--fs-sm)] text-[var(--text-muted)]">
+            <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
               ${archivedSessions.slice(0, 8).map(session => renderSessionCard(session, true))}
             </div>
           </details>

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -90,10 +90,10 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
   const toolNames = Array.isArray(item.tool_names) ? item.tool_names : []
   return html`
     <article class="proof-actor-row">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <div>
           <strong>${item.worker_name ?? item.worker_run_id}</strong>
-          <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+          <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
             <span>${item.worker_run_id}</span>
             <span>${item.ts_iso ? relativeTime(item.ts_iso) : '기록 없음'}</span>
           </div>
@@ -158,10 +158,10 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
   const isPlanned = item.activity_state === 'planned_only'
   return html`
     <article class="proof-actor-row" style="${isPlanned ? 'opacity: 0.45;' : ''}">
-      <div class="flex justify-between gap-2.5 items-start">
+      <div class="flex justify-between gap-3 items-start">
         <div>
           <strong>${item.actor}</strong>
-          <div class="flex flex-wrap gap-2.5 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
+          <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
             <span>${item.role ?? '참여자'}</span>
             <span>${lastSeen ? relativeTime(lastSeen) : '기록 없음'}</span>
           </div>
@@ -192,7 +192,7 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
           </div>`
         : null}
       ${(input || output)
-        ? html`<div class="grid grid-cols-2 gap-2.5">
+        ? html`<div class="grid grid-cols-2 gap-3">
             <div class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-6)] grid gap-1">
               <strong>최근 입력</strong>
               <span>${input ?? '표시 가능한 입력 없음'}</span>
@@ -237,7 +237,7 @@ export function KeyValueGrid({
 }) {
   if (rows.length === 0) return null
   return html`
-    <div class="grid gap-2.5">
+    <div class="grid gap-3">
       ${title ? html`<strong>${title}</strong>` : null}
       <div class="grid grid-cols-[132px_minmax(0,1fr)] gap-x-3 gap-y-2">
         ${rows.map(row => html`

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -201,7 +201,7 @@ export function Proof() {
             <h3 class="text-[14px] font-semibold text-[var(--text-strong)]">핵심 증명</h3>
             <p class="text-[12px] text-[var(--text-muted)] leading-relaxed">결론, 왜 아직 부족한지, 다음에 무엇을 남겨야 하는지만 먼저 봅니다.</p>
           </div>
-          <div class="grid gap-2.5">
+          <div class="grid gap-3">
             ${reasonLines.map((line, idx) => html`
               <article class="grid gap-1.5 py-3 px-3.5 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] ${idx === 1 && verdict !== 'proven' ? verdictTone(verdict) : ''}">
                 <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${idx === 0 ? '지금 결론' : idx === 1 ? '왜 이렇게 판정됐나' : '다음 보강 포인트'}</strong>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -23,7 +23,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const build = serverStatus.value?.build
 
   return html`
-    <section class="grid gap-2.5">
+    <section class="grid gap-3">
       <!-- Connection + Version row -->
       <div class="flex items-center justify-between gap-2">
         <div class="flex items-center gap-1.5">

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -70,17 +70,17 @@ function TierDistribution({ dist }: { dist: Record<string, number> }) {
   const fullOnlyPct = total > 0 ? ((fullOnly / total) * 100).toFixed(1) : '0'
   return html`
     <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2.5">
+      <div class="flex items-center gap-3">
         <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-essential">필수</span>
         <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${essential}</span>
         <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${essentialPct}%</span>
       </div>
-      <div class="flex items-center gap-2.5">
+      <div class="flex items-center gap-3">
         <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-standard">표준</span>
         <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${standardOnly}</span>
         <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${standardPct}%</span>
       </div>
-      <div class="flex items-center gap-2.5">
+      <div class="flex items-center gap-3">
         <span class="inline-block min-w-[72px] px-2 py-0.5 text-[length:var(--fs-xs)] font-semibold text-center rounded badge-full">전체 전용</span>
         <span class="text-[color:var(--text-strong)] text-[length:var(--fs-md)] font-semibold min-w-9 text-right">${fullOnly}</span>
         <span class="text-[color:var(--text-muted)] text-[length:var(--fs-sm)] min-w-12 text-right">${fullOnlyPct}%</span>
@@ -116,7 +116,7 @@ export function ToolMetrics() {
       ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-[length:var(--fs-base)] rounded-lg">${error}</div>` : null}
 
       ${data ? html`
-        <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-2.5 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
+        <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
           <div class="tool-metrics-stat">
             <span class="mt-1.5 text-[color:var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>
             <span class="stat-label">총 호출 수</span>

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -121,7 +121,7 @@ export function FullInventoryView({
         `)}
       </div>
 
-      <div class="flex flex-wrap gap-2.5 items-center">
+      <div class="flex flex-wrap gap-3 items-center">
         <input
           class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none max-w-[320px]"
           type="text"

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -40,7 +40,7 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
           <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">필수 도구 (상위 ${essential.length}개)</h4>
           <div class="flex flex-col">
             ${essential.map(item => html`
-              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+              <div class="flex items-center gap-3 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
                 <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
                 <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
@@ -55,7 +55,7 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
           <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">미사용 도구 (${neverUsed.length}개)</h4>
           <div class="flex flex-col">
             ${neverUsed.map(item => html`
-              <div class="flex items-center gap-2.5 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
+              <div class="flex items-center gap-3 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
                 <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
                 <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
                 ${toolBadge(item.category)}

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -71,7 +71,7 @@ export function Worktrees() {
         ${worktrees.map(wt => html`
           <div key=${wt.id || wt.branch} class="flex flex-col gap-3 p-5 rounded-2xl border border-card-border bg-card/60 backdrop-blur-md hover:border-accent/40 hover:-translate-y-0.5 hover:shadow-md transition-all duration-200 shadow-sm shadow-black/10 group">
             <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2.5">
+              <div class="flex items-center gap-3">
                 <div class="size-7 rounded-lg bg-accent/10 flex items-center justify-center border border-accent/20">
                   <span class="text-[14px]">🌿</span>
                 </div>


### PR DESCRIPTION
## Summary
- `gap-2.5`(10px) → `gap-3`(12px) 전체 정규화: 94건/42파일
- 3-tier gap 스케일 확립: `gap-1.5`(tight), `gap-3`(standard), `gap-5`(section)
- 순수 스페이싱 변경, 기능 영향 없음

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `gap-2.5` 잔여 0건 확인
- [ ] 전체 대시보드 시각 확인 (간격 2px 증가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)