### PR TITLE
refactor(dashboard): remove hardcoded inference from judge modules (#2408 Phase 4)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -318,7 +318,7 @@ let compute_judgments
   match
     Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
       ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-      ~temperature:0.2 ~max_tokens:4096 ()
+      ()
   with
   | Error message -> Error message
   | Ok result -> (

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -282,7 +282,7 @@ let compute_judgments
   match
     Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
       ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
-      ~temperature:0.2 ~max_tokens:4096 ()
+      ()
   with
   | Error message -> Error message
   | Ok result -> (


### PR DESCRIPTION
Final phase. 2 files, 2 lines removed. All 4 phases of inference→OAS migration complete.