### PR TITLE
refactor: deduplicate first_some across 4 files (-7 LOC)

### DIFF
--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -2,10 +2,7 @@ module U = Yojson.Safe.Util
 
 let trim_to_option = Dashboard_utils.trim_to_option
 
-let first_some left right =
-  match left with
-  | Some _ -> left
-  | None -> right
+let first_some = Dashboard_utils.first_some
 
 let string_opt json key =
   match U.member key json with

--- a/lib/dashboard/dashboard_utils.ml
+++ b/lib/dashboard/dashboard_utils.ml
@@ -9,6 +9,9 @@ let parse_iso_opt = function
       try Some (Types.parse_iso8601 raw) with Failure _ -> None)
   | _ -> None
 
+let first_some left right =
+  match left with Some _ -> left | None -> right
+
 let trim_to_option text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some trimmed

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -135,10 +135,7 @@ let dedupe_keep_order items =
         true))
     items
 
-let first_some a b =
-  match a with
-  | Some _ -> a
-  | None -> b
+let first_some = Dashboard_utils.first_some
 
 let resolve_allowed_models ~explicit_allowed_models ~seed_allowed_models ~models =
   if explicit_allowed_models <> [] then

--- a/lib/swarm/swarm_status_json.ml
+++ b/lib/swarm/swarm_status_json.ml
@@ -132,10 +132,7 @@ let get_detail_string json key =
       | _ -> None)
   | _ -> None
 
-let first_some left right =
-  match left with
-  | Some _ -> left
-  | None -> right
+let first_some = Dashboard_utils.first_some
 
 let parse_timestamp timestamp =
   Option.bind timestamp Command_plane_v2.parse_iso_timestamp

--- a/lib/tool_council_helpers.ml
+++ b/lib/tool_council_helpers.ml
@@ -62,8 +62,7 @@ let extract_task_id text =
   in
   seek 0
 
-let first_some left right =
-  match left with Some _ -> left | None -> right
+let first_some = Dashboard_utils.first_some
 
 let supported_execution_action_types =
   [


### PR DESCRIPTION
## Summary
`first_some` (두 option 중 첫 번째 Some 선택)이 4곳에 복사됨.
`Dashboard_utils.first_some`로 통합, 4곳에서 위임.

## Files
- `dashboard_utils.ml`: canonical 정의 추가
- `command_plane_orchestra.ml`: -4 LOC
- `swarm_status_json.ml`: -4 LOC
- `keeper_types_profile.ml`: -4 LOC
- `tool_council_helpers.ml`: -2 LOC

## Origin
Research loop experiment 003에서 GLM-5가 codebase 분석 중 발견.

## Build
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)