### PR TITLE
fix(keeper): treat cascade name labels as available in API key check

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -118,7 +118,10 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
   else
     let any_available = List.exists (fun label ->
       match provider_name_of_label label with
-      | None -> false
+      | None ->
+          (* Label without "provider:model" format (e.g. cascade name "default").
+             Treat as available — the cascade resolves providers at runtime. *)
+          true
       | Some pname ->
         match Llm_provider.Provider_registry.find default_registry pname with
         | None -> false


### PR DESCRIPTION
1줄 수정. cascade name(e.g. "default")을 provider:model로 파싱 실패 → available로 간주. keeper heartbeat 반복 에러 해결.