### PR TITLE
research(e2e-004): Server_utils.drop → stdlib List.drop

### DIFF
--- a/lib/activity_graph.ml
+++ b/lib/activity_graph.ml
@@ -301,7 +301,7 @@ let list_events config ?room_id ?(kinds = []) ~after_seq ~limit () =
     Server_utils.take limit all
   else
     let total = List.length all in
-    all |> Server_utils.drop (max 0 (total - limit))
+    all |> List.drop (max 0 (total - limit))
 
 let latest_seq config = read_current_seq config
 
@@ -708,7 +708,7 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
   in
   let timeline =
     let total = List.length events in
-    events |> Server_utils.drop (max 0 (total - timeline_limit))
+    events |> List.drop (max 0 (total - timeline_limit))
   in
   let count_kind prefix =
     nodes_json


### PR DESCRIPTION
## Summary
`activity_graph.ml`에서 `Server_utils.drop` 2곳을 OCaml 5.4 stdlib `List.drop`으로 교체.

## Origin
Research loop experiment 004. GLM-5가 코드 분석 중 stdlib 대체 가능 함수 발견.

## Build
- [x] `dune build` pass

🤖 Generated by research loop (GLM-5 + Claude Opus 4.6)