### PR TITLE
refactor(research): replace direct curl with OAS cascade

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -545,8 +545,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           start_team_session = None } in
         Tool_autoresearch.dispatch ctx ~name ~args:arguments
     | Mod_research ->
+        let net = match state.Mcp_server.net with
+          | Some n -> n
+          | None -> Eio_context.get_net ()
+        in
         let ctx : Tool_research.context = { base_path = config.base_path;
-          agent_name = Some agent_name } in
+          agent_name = Some agent_name; sw; net; clock } in
         Tool_research.dispatch ctx ~name ~args:arguments
     | Mod_shard ->
         let (ok, json) = Tool_shard.execute name arguments in

--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -16,11 +16,10 @@ type t = {
   max_iterations : int;
   time_budget_per_experiment_sec : float;
   results_file : string;
-  cascade_name : string;       (** model name for LLM calls *)
-  llm_url : string;            (** OpenAI-compatible endpoint URL *)
-  llm_api_key : string;        (** API key (empty = no auth header) *)
-  llm_timeout_sec : float;     (** per-request timeout *)
-  llm_max_tokens : int;        (** max tokens per LLM response (reasoning + output) *)
+  cascade_name : string;       (** OAS cascade profile name (e.g. "research", "llama") *)
+  cascade_defaults : string list;  (** fallback model labels when no cascade config file *)
+  timeout_sec : int;           (** per-request timeout (seconds) *)
+  max_tokens : int;            (** max tokens per LLM response *)
   system_prompt : string;
 }
 
@@ -39,15 +38,10 @@ let default ?(repo = default_repo_config ()) () : t =
     max_iterations = 20;
     time_budget_per_experiment_sec = 600.0;
     results_file = "research_results.tsv";
-    cascade_name = "llama";
-    llm_url = (match Sys.getenv_opt "RESEARCH_LLM_URL" with
-      | Some u -> u
-      | None -> "http://127.0.0.1:8085/v1/chat/completions");
-    llm_api_key = (match Sys.getenv_opt "RESEARCH_LLM_API_KEY" with
-      | Some k -> k
-      | None -> "");
-    llm_timeout_sec = 120.0;
-    llm_max_tokens = 8192;
+    cascade_name = "research";
+    cascade_defaults = ["llama:auto"; "glm:auto"];
+    timeout_sec = 120;
+    max_tokens = 8192;
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -1,8 +1,8 @@
-(** Research_loop — Automated code improvement via local LLM.
+(** Research_loop — Automated code improvement via LLM.
 
     Core loop:
     1. Gather repo context (recent commits, TODOs, file list)
-    2. Ask LLM to propose a hypothesis (via llama-server HTTP)
+    2. Ask LLM to propose a hypothesis (via OAS cascade)
     3. Create isolated worktree
     4. Apply proposed change
     5. Build + test → measure metrics
@@ -165,8 +165,8 @@ let history_context (history : experiment_entry list) : string =
     Buffer.contents buf
   end
 
-(** Call LLM via direct HTTP to llama-server (OpenAI-compatible). *)
-let generate_hypothesis ~(config : Research_config.t)
+(** Call LLM via OAS cascade (provider-agnostic). *)
+let generate_hypothesis ~sw ~net ~clock ~(config : Research_config.t)
     ~context ~history : hypothesis option =
   let history_text = history_context history in
   let user_msg = Printf.sprintf
@@ -175,53 +175,36 @@ let generate_hypothesis ~(config : Research_config.t)
      or obvious simplification opportunities. Respond with a JSON object."
     context history_text
   in
-  let payload = `Assoc [
-    ("model", `String config.cascade_name);
-    ("messages", `List [
-      `Assoc [("role", `String "system"); ("content", `String config.system_prompt)];
-      `Assoc [("role", `String "user"); ("content", `String user_msg)];
-    ]);
-    ("temperature", `Float 0.7);
-    ("max_tokens", `Int config.llm_max_tokens);
+  let messages : Llm_provider.Types.message list = [
+    { role = User; content = [Text user_msg]; name = None; tool_call_id = None };
   ] in
-  let body = Yojson.Safe.to_string payload in
-  let url = config.llm_url in
-  let timeout_str = Printf.sprintf "%.0f" config.llm_timeout_sec in
-  Log.Server.info "research: calling LLM at %s (timeout=%ss)" url timeout_str;
-  try
-    let auth_headers =
-      if config.llm_api_key <> "" then
-        [ "-H"; Printf.sprintf "Authorization: Bearer %s" config.llm_api_key ]
-      else []
-    in
-    let argv =
-      [ "curl"; "-s"; "-X"; "POST"; url;
-        "-H"; "Content-Type: application/json" ]
-      @ auth_headers
-      @ [ "-d"; body; "--max-time"; timeout_str ]
-    in
-    let status, stdout =
-      Process_eio.run_argv_with_status ~timeout_sec:(config.llm_timeout_sec +. 10.0) argv
-    in
-    let exit_code = match status with Unix.WEXITED c -> c | _ -> 1 in
-    if String.length (String.trim stdout) = 0 then begin
-      Log.Server.warn "research: LLM returned empty response (exit=%d, slots likely busy)" exit_code;
+  Log.Server.info "research: calling LLM via OAS cascade '%s' (timeout=%ds)"
+    config.cascade_name config.timeout_sec;
+  match
+    Llm_provider.Cascade_config.complete_named ~sw ~net ~clock
+      ~name:config.cascade_name
+      ~defaults:config.cascade_defaults
+      ~messages
+      ~system_prompt:config.system_prompt
+      ~temperature:0.7
+      ~max_tokens:config.max_tokens
+      ~timeout_sec:config.timeout_sec
+      ()
+  with
+  | Ok resp ->
+    let content = Llm_provider.Cascade_config.text_of_response resp in
+    if String.length (String.trim content) = 0 then begin
+      Log.Server.warn "research: LLM returned empty content";
       None
-    end else begin
-      let json = Yojson.Safe.from_string stdout in
-      let open Yojson.Safe.Util in
-      (* Check for API error response *)
-      match member "error" json with
-      | `Null ->
-        let content = json |> member "choices" |> index 0
-          |> member "message" |> member "content" |> to_string in
-        parse_hypothesis content
-      | err ->
-        Log.Server.warn "research: LLM API error: %s" (Yojson.Safe.to_string err);
-        None
-    end
-  with exn ->
-    Log.Server.warn "research: LLM call failed: %s" (Printexc.to_string exn);
+    end else
+      parse_hypothesis content
+  | Error err ->
+    let msg = match err with
+      | Llm_provider.Http_client.HttpError { code; _ } ->
+        Printf.sprintf "HTTP %d" code
+      | Llm_provider.Http_client.NetworkError { message } -> message
+    in
+    Log.Server.warn "research: LLM cascade failed: %s" msg;
     None
 
 (** Create an isolated worktree for the experiment. *)
@@ -332,12 +315,12 @@ let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
   with exn -> close_out_noerr oc; raise exn)
 
 (** Run a single experiment iteration. *)
-let run_experiment ~(config : Research_config.t)
+let run_experiment ~sw ~net ~clock ~(config : Research_config.t)
     ~context ~history ~experiment_id : experiment_entry option =
   Log.Server.info "research: experiment %s — generating hypothesis" experiment_id;
 
   (* 1. Generate hypothesis *)
-  match generate_hypothesis ~config ~context ~history with
+  match generate_hypothesis ~sw ~net ~clock ~config ~context ~history with
   | None ->
     Log.Server.warn "research: no hypothesis generated, skipping";
     None
@@ -416,7 +399,7 @@ let run_experiment ~(config : Research_config.t)
        Some entry)
 
 (** Run the full research loop for N iterations. *)
-let run ~(config : Research_config.t) : experiment_entry list =
+let run ~sw ~net ~clock ~(config : Research_config.t) : experiment_entry list =
   Log.Server.info "research: starting loop (target=%s, max_iter=%d)"
     config.repo.path config.max_iterations;
 
@@ -425,7 +408,7 @@ let run ~(config : Research_config.t) : experiment_entry list =
 
   for i = 0 to config.max_iterations - 1 do
     let experiment_id = Printf.sprintf "%d-%03d" (int_of_float (Unix.gettimeofday ())) i in
-    match run_experiment ~config ~context ~history:!history ~experiment_id with
+    match run_experiment ~sw ~net ~clock ~config ~context ~history:!history ~experiment_id with
     | None -> ()
     | Some entry ->
       history := !history @ [ entry ];

--- a/lib/research/tool_research.ml
+++ b/lib/research/tool_research.ml
@@ -8,9 +8,9 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_research_start";
     description = "Start an automated code improvement research loop. \
-Uses local LLM (Qwen3.5-35B via llama-server) to propose small code improvements, \
-tests them in isolated git worktrees, and keeps changes that pass all tests. \
-Results logged to research_results.tsv.";
+Uses OAS cascade to route LLM calls (local or cloud providers). \
+Proposes small code improvements, tests them in isolated git worktrees, \
+and keeps changes that pass all tests. Results logged to research_results.tsv.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -24,11 +24,7 @@ Results logged to research_results.tsv.";
         ]);
         ("cascade_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "LLM model name (default: llama)");
-        ]);
-        ("llm_url", `Assoc [
-          ("type", `String "string");
-          ("description", `String "OpenAI-compatible LLM endpoint URL (default: env RESEARCH_LLM_URL or http://127.0.0.1:8085/v1/chat/completions)");
+          ("description", `String "OAS cascade profile name (default: research)");
         ]);
       ]);
       ("required", `List []);
@@ -48,6 +44,9 @@ Returns the contents of research_results.tsv with experiment outcomes.";
 type context = {
   base_path : string;
   agent_name : string option;
+  sw : Eio.Switch.t;
+  net : Eio_context.eio_net;
+  clock : float Eio.Time.clock_ty Eio.Resource.t;
 }
 
 let dispatch (ctx : context) ~name ~args : (bool * string) option =
@@ -63,10 +62,7 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
     in
     let cascade_name =
       Yojson.Safe.Util.(member "cascade_name" args |> to_string_option)
-      |> Option.value ~default:"llama"
-    in
-    let llm_url =
-      Yojson.Safe.Util.(member "llm_url" args |> to_string_option)
+      |> Option.value ~default:"research"
     in
     let config = Research_config.default
       ~repo:(Research_config.default_repo_config ~path:repo_path ())
@@ -77,11 +73,7 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
       cascade_name;
       results_file = Printf.sprintf "%s/research_results.tsv" repo_path;
     } in
-    let config = match llm_url with
-      | Some url -> { config with llm_url = url }
-      | None -> config
-    in
-    let results = Research_loop.run ~config in
+    let results = Research_loop.run ~sw:ctx.sw ~net:ctx.net ~clock:ctx.clock ~config in
     let kept = List.filter (fun (e : Research_loop.experiment_entry) ->
       e.metric.status = Research_metric.Keep) results in
     let summary = Printf.sprintf


### PR DESCRIPTION
## Summary
- Research module의 llama-server 직접 curl 호출을 OAS `Cascade_config.complete_named`로 전환
- `llm_url`, `llm_api_key`, `llm_timeout_sec` 필드 제거, OAS cascade 파라미터로 대체
- `sw`/`net`/`clock` Eio context를 dispatch → run → generate_hypothesis로 threading

## Test plan
- [x] `dune build --root .` 빌드 성공
- [x] `rg 'curl|127.0.0.1:8085|llama-server' lib/research/` 결과 없음 확인
- [ ] llama-server 실행 상태에서 `masc_research_start` tool 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)