### PR TITLE
sec(auth): chmod 0600 on initial_admin file

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -38,8 +38,10 @@ let ensure_auth_dirs config =
     The agent who enables auth is always granted full permission. *)
 let write_initial_admin config agent_name =
   ensure_auth_dirs config;
-  Out_channel.with_open_text (initial_admin_file config) (fun oc ->
-    output_string oc (String.trim agent_name))
+  let file = initial_admin_file config in
+  Out_channel.with_open_text file (fun oc ->
+    output_string oc (String.trim agent_name));
+  Unix.chmod file 0o600
 
 (** Read the initial admin agent name, if set. *)
 let read_initial_admin config : string option =


### PR DESCRIPTION
## Summary
`write_initial_admin`이 관리자 인증 파일을 기본 umask 권한으로 생성.
`Unix.chmod file 0o600` 추가하여 owner-only read/write로 제한.

## Security
- **Issue**: 다른 시스템 사용자가 admin agent name을 읽을 수 있음
- **Severity**: Low (로컬 단일 사용자 환경이 일반적)
- **Fix**: 파일 쓰기 직후 `chmod 0600`

## Origin
Research loop experiment 005. GLM-5에 "security researcher" 프롬프트 사용.

## Build
- [x] `dune build` pass

🤖 Generated by research loop (GLM-5 security review)