### PR TITLE
refactor(keeper): route proactive_temperature through Cascade_inference

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -261,10 +261,13 @@ let proactive_retry_instruction attempt ~(reason : string) =
       "Retry policy: previous attempts failed (%s). You MUST output one decisive check-in now, materially different from the last preview."
       reason
 
-let proactive_temperature attempt =
-  if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
-  else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
-  else Keeper_config.keeper_proactive_temperature_high ()
+let proactive_temperature ~cascade_name attempt =
+  let fallback () =
+    if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
+    else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
+    else Keeper_config.keeper_proactive_temperature_high ()
+  in
+  Cascade_inference.resolve_temperature ~cascade_name ~fallback
 
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
@@ -499,7 +502,7 @@ let run_proactive_generation
         if String.trim retry_hint = "" then base_prompt
         else Printf.sprintf "%s\n\n%s" base_prompt retry_hint
       in
-      let temperature = proactive_temperature attempt in
+      let temperature = proactive_temperature ~cascade_name:"heartbeat_action" attempt in
       let max_tokens =
         Cascade_inference.resolve_max_tokens
           ~cascade_name:"keeper_turn"

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -128,4 +128,4 @@ val proactive_prompt_for_keeper :
 val proactive_retry_instruction : int -> reason:string -> string
 
 (** Get temperature for proactive attempt. *)
-val proactive_temperature : int -> float
+val proactive_temperature : cascade_name:string -> int -> float

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -348,10 +348,13 @@ let proactive_retry_instruction attempt ~(reason : string) =
       "Retry policy: previous attempts failed (%s). You MUST output one decisive check-in now, materially different from the last preview."
       reason
 
-let proactive_temperature attempt =
-  if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
-  else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
-  else Keeper_config.keeper_proactive_temperature_high ()
+let proactive_temperature ~cascade_name attempt =
+  let fallback () =
+    if attempt <= 1 then Keeper_config.keeper_proactive_temperature_low ()
+    else if attempt = 2 then Keeper_config.keeper_proactive_temperature_mid ()
+    else Keeper_config.keeper_proactive_temperature_high ()
+  in
+  Cascade_inference.resolve_temperature ~cascade_name ~fallback
 
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -48,7 +48,7 @@ type proactive_generation_result = {
 
 val proactive_retry_instruction : int -> reason:string -> string
 
-val proactive_temperature : int -> float
+val proactive_temperature : cascade_name:string -> int -> float
 
 val strip_state_blocks_text : string -> string
 


### PR DESCRIPTION
Keeper proactive temp now configurable via cascade.json. Part of #2408 Phase 3.