### PR TITLE
fix(test): decouple MDAL model validation from runtime API key availability

### DIFF
--- a/lib/mdal/mdal_worker.ml
+++ b/lib/mdal/mdal_worker.ml
@@ -70,14 +70,21 @@ let validate_model_label (label : string) : (string, string) result =
          "MDAL strict worker does not support provider `%s`. Use claude, openai, gemini, llama:<model>, or glm."
          provider_prefix)
 
+(** Validate model label syntax: must be "provider:model" with non-empty parts.
+    Unlike [Cascade_config.parse_model_string], does not check runtime availability
+    (API key presence) because MDAL delegates actual model calls to its worker runner. *)
+let validate_model_label_syntax (raw : string) : (string, string) result =
+  match String.index_opt raw ':' with
+  | None -> Error (sprintf "Model label must be provider:model, got: %s" raw)
+  | Some idx ->
+    if idx = 0 || idx >= String.length raw - 1 then
+      Error (sprintf "Model label has empty provider or model: %s" raw)
+    else validate_model_label raw
+
 (** Resolve agent name + optional worker_model to a validated model label string. *)
 let resolve_model_label ~(agent : string) ~(worker_model : string option) :
     (string, string) result =
-  let parse_worker_model raw =
-    match Llm_provider.Cascade_config.parse_model_string raw with
-    | None -> Error (sprintf "Cannot parse model label: %s" raw)
-    | Some _cfg -> validate_model_label raw
-  in
+  let parse_worker_model raw = validate_model_label_syntax raw in
   match worker_model with
   | Some raw when String.trim raw <> "" -> parse_worker_model (String.trim raw)
   | _ ->
@@ -145,10 +152,11 @@ let run ~(sw : Eio.Switch.t) ~(config : Room.config) (state : Mdal.loop_state)
         in
         raise (Invalid_argument message)
   in
-  (* Validate the label parses as a known provider:model *)
-  (match Llm_provider.Cascade_config.parse_model_string model_label with
-   | Some _ -> ()
-   | None -> raise (Invalid_argument (sprintf "Cannot parse model: %s" model_label)));
+  (* Validate the label is a known provider:model syntax.
+     Runtime availability (API key) is checked by the worker at call time. *)
+  (match validate_model_label_syntax model_label with
+   | Ok _ -> ()
+   | Error msg -> raise (Invalid_argument msg));
   let prompt =
     Mdal.render_worker_prompt state.profile state.history current_metric
   in

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -41,7 +41,7 @@ let test_snapshot_has_expected_sections () =
         (Yojson.Safe.Util.member "recommendation_summary" json <> `Null);
       Alcotest.(check bool) "resident judge runtime present" true
         (Yojson.Safe.Util.member "resident_judge_runtime" json <> `Null);
-      Alcotest.(check bool) "resident judge disabled by default" false
+      Alcotest.(check bool) "resident judge enabled by default" true
         Yojson.Safe.Util.
           (json |> member "resident_judge_runtime" |> member "enabled" |> to_bool);
       Alcotest.(check string) "judgment owner" "fallback_read_model"


### PR DESCRIPTION
## Summary

CI에서 7건의 테스트 실패 수정:

**MDAL (9 FAIL → 0)**:
- `resolve_model_label`이 `Cascade_config.parse_model_string`을 사용하여 런타임 API 키 가용성까지 체크 → CI에 `ANTHROPIC_API_KEY` 없어 실패
- `validate_model_label_syntax`로 교체: 구문 검증만 수행

**Operator (1 FAIL → 0)**:
- `resident_judge` 기본값이 `true`로 변경되었으나 테스트 미업데이트

**Integration (2 FAIL → 0)**:
- `task_sandbox.ml`의 `Str.regexp`가 raw string `{|...|}`을 사용하여 `\n`이 literal `\`+`n`으로 해석됨
- 경로에 `n`이 포함되면 잘림 (`sandbox` 등)

**Linter + Invariants (2 FAIL → 0)**:
- 10개 신규 도구(`masc_fire_task`, `masc_audit_trail`, 8 `masc_autoresearch_*`)의 카테고리 미등록

**Source Guard (1 FAIL → 0)**:
- 퇴역된 `model_spec.ml` 참조를 `oas_model_resolve.ml`로 업데이트

## Changes

| File | Change |
|------|--------|
| `lib/mdal/mdal_worker.ml` | `parse_model_string` → `validate_model_label_syntax` |
| `test/test_operator_control_snapshot.ml` | `resident_judge` enabled default true |
| `lib/task_sandbox.ml` | Raw string → regular string for `Str.regexp` |
| `lib/mode.ml` | 10 tool category mappings 추가 |
| `test/test_silent_failures_p2a.ml` | `model_spec.ml` → `oas_model_resolve.ml` |

## Test plan

- [x] `test_tool_mdal.exe` 12/12 PASS (was 3/12)
- [x] `test_operator_control.exe` 28/28 PASS (was 27/28)
- [x] Integration, linter, invariants, source guard PASS locally
- [ ] CI Build and Test + Health green