### PR TITLE
research(e2e-007): simplify flush_interval_sec env var parsing

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -5,9 +5,8 @@ include Board_types
 
 (** Flush interval in seconds - configurable via MASC_BOARD_FLUSH_INTERVAL_SEC env var *)
 let flush_interval_sec =
-  match Sys.getenv_opt "MASC_BOARD_FLUSH_INTERVAL_SEC" with
-  | Some s -> (try float_of_string s with Failure _ -> 30.0)
-  | None -> 30.0
+  try float_of_string (Sys.getenv_opt "MASC_BOARD_FLUSH_INTERVAL_SEC" |> Option.value ~default:"30")
+  with Failure _ -> 30.0
 
 let create_store () = {
   posts = Hashtbl.create 1024;


### PR DESCRIPTION
## Summary
`board_core.ml`의 `flush_interval_sec` 환경변수 파싱을 4줄 match에서 2줄 pipeline으로 단순화.

## LLM
- **Model**: Qwen3.5-35B (local llama-server)
- **Response time**: ~3s
- **Accuracy**: old_text 100% 일치, build pass

## Comparison (Qwen vs GLM)
첫 Qwen3.5-35B 성공 실험. GLM-5 대비:
- Qwen: reasoning 없이 직접 JSON 출력 (토큰 효율)
- GLM: reasoning mode에서 토큰 소비 문제
- 둘 다 old_text/new_text 형식 준수

## Build
- [x] `dune build` pass

🤖 Generated by research loop (Qwen3.5-35B)