### PR TITLE
fix(test): resolve 5 CI test failures (sandbox, mode, source guard)

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -162,6 +162,7 @@ let tool_category tool_name =
   | "masc_tasks" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"
   | "masc_task_history"
+  | "masc_fire_task"
   | "masc_status" | "masc_workflow_guide" | "masc_check"
   | "masc_room_strategy_get" | "masc_room_strategy_set"
   (* Mode management - always available via is_tool_enabled bypass *)
@@ -302,7 +303,7 @@ let tool_category tool_name =
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_status"
   | "masc_auth_create_token" | "masc_auth_refresh" | "masc_auth_revoke"
   | "masc_auth_list" | "masc_tool_admin_update"
-  | "masc_audit_query" | "masc_audit_stats"
+  | "masc_audit_query" | "masc_audit_stats" | "masc_audit_trail"
   | "masc_governance_set" | "masc_governance_report"
   | "masc_tool_grant" | "masc_tool_revoke" | "masc_tool_list" -> Auth
 
@@ -375,6 +376,11 @@ let tool_category tool_name =
   | "masc_mdal_start" | "masc_mdal_iterate"
   | "masc_mdal_status" | "masc_mdal_stop"
   | "masc_mdal_swarm_start" | "masc_mdal_swarm_status"
+  (* Autoresearch *)
+  | "masc_autoresearch_start" | "masc_autoresearch_swarm_start"
+  | "masc_autoresearch_status" | "masc_autoresearch_stop"
+  | "masc_autoresearch_inject" | "masc_autoresearch_cycle"
+  | "masc_autoresearch_record_finding" | "masc_autoresearch_search_findings"
   (* Handover *)
   | "masc_handover_create" | "masc_handover_get"
   | "masc_handover_list" | "masc_handover_claim"

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -36,13 +36,16 @@ let git_exit ~cwd args =
     constructing from a relative [.worktrees/...] segment. *)
 let extract_worktree_path ~base_path msg =
   (* Try absolute path from "Path: /..." *)
-  let abs_re = Str.regexp {|Path: \(/[^ \n]+\)|} in
+  (* Note: use regular strings so \n is actual newline, not literal \+n.
+     Raw strings {|...|} pass \n as two chars which Str treats as
+     literal backslash and 'n' inside character classes. *)
+  let abs_re = Str.regexp "Path: \\(/[^ \t\n\r]+\\)" in
   try
     let _ = Str.search_forward abs_re msg 0 in
     Some (Str.matched_group 1 msg)
   with Not_found ->
     (* Fallback: relative path *)
-    let rel_re = Str.regexp {|\.worktrees/[^ \n]+|} in
+    let rel_re = Str.regexp "\\.worktrees/[^ \t\n\r]+" in
     try
       let _ = Str.search_forward rel_re msg 0 in
       let rel = Str.matched_string msg in
@@ -52,7 +55,7 @@ let extract_worktree_path ~base_path msg =
 (** Extract branch name from success message.
     Format: "Branch: agent/task-NNN" *)
 let extract_branch_name msg =
-  let re = Str.regexp {|Branch: \([^ \n]+\)|} in
+  let re = Str.regexp "Branch: \\([^ \t\n\r]+\\)" in
   try
     let _ = Str.search_forward re msg 0 in
     Some (Str.matched_group 1 msg)

--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -186,10 +186,11 @@ let test_source_main_keeper_bootstrap () =
    eliminating Unix fd close/unlock paths and their logging. *)
 
 let test_source_model_token_parse () =
-  check bool "model_spec.ml keeps model parsing source"
+  (* model_spec.ml was retired; model parsing migrated to oas_model_resolve.ml *)
+  check bool "oas_model_resolve.ml has model label parsing"
     true (any_file_contains_pattern
-      [ "lib/model_spec.ml" ]
-      {|model_spec_of_string|})
+      [ "lib/oas_model_resolve.ml" ]
+      {|provider_name_of_label|})
 
 let test_source_keeper_proactive () =
   check bool "keeper sources have proactive emission logging"
@@ -253,7 +254,7 @@ let () =
       test_case "MA-H1: keeper bootstrap logging present"
         `Quick test_source_main_keeper_bootstrap;
       (* MA-H2a/H2b removed: Eio-native migration PR #2260 eliminated fd paths *)
-      test_case "MA-H3: model spec parse source present"
+      test_case "MA-H3: model label parse source present"
         `Quick test_source_model_token_parse;
       test_case "MA-H4: keeper proactive logging present"
         `Quick test_source_keeper_proactive;


### PR DESCRIPTION
## Summary

CI에서 발생하는 테스트 실패 일괄 수정 (PR #2474 이후 남은 건).

**Integration sandbox (2 FAIL → 0)**: `task_sandbox.ml`의 `Str.regexp`가 OCaml raw string `{|...|}`을 사용하여 `\n`이 literal `\`+`n`으로 해석 → `sandbox` 등 `n` 포함 경로가 잘림.

**Linter + Invariants (2 FAIL → 0)**: 10개 신규 도구 카테고리 미등록 → Unknown → 모든 모드 invisible.

**Source Guard (1 FAIL → 0)**: 퇴역된 `model_spec.ml` → `oas_model_resolve.ml` 참조 업데이트.

**Keeper (9 FAIL → 0)**: `oas_model_resolve.ensure_api_keys_for_labels`가 `custom:model@url`을 `Provider_registry`에서 찾으려 함 → "unknown provider". `custom`은 self-hosted이므로 항상 available로 처리.

## Changes

| File | Change |
|------|--------|
| `lib/task_sandbox.ml` | Raw string → regular string for Str.regexp |
| `lib/mode.ml` | 10 tool category mappings 추가 |
| `test/test_silent_failures_p2a.ml` | model_spec → oas_model_resolve |
| `lib/oas_model_resolve.ml` | custom provider를 항상 available로 처리 |

## Test plan

- [x] `test_tool_keeper.exe` 22/22 PASS (was 13/22)
- [x] `test_silent_failures_p2a.exe` PASS
- [x] `test_mode_coverage.exe` 52/52 PASS
- [x] `test_mode_tool_count.exe` 18/18 PASS
- [ ] CI Build and Test + Health green