### PR TITLE
fix(cascade): add missing keeper_unified and research model keys

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -39,6 +39,8 @@
   "auto_responder_glm_models": ["glm:auto"],
   "spawn_glm_models": ["glm:auto"],
   "materialized_procedure_models": ["llama:auto", "glm:auto"],
+  "keeper_unified_models": ["llama:auto", "glm:auto"],
+  "research_models": ["llama:auto", "glm:auto"],
 
   "_comment_inference": "Per-cascade inference parameters (temperature, max_tokens). Falls back to caller defaults when absent.",
   "keeper_unified_temperature": 0.4,


### PR DESCRIPTION
## Summary
- Add `keeper_unified_models` and `research_models` to cascade.json
- Code uses these cascade names but json had no `_models` keys
- Both silently fell back to `default_models` - now explicit

## Found by
Cross-referencing all `cascade_name:"X"` in code vs `X_models` keys in cascade.json.

Generated with [Claude Code](https://claude.com/claude-code)