### PR TITLE
research(e2e-009): O(n^2) → O(n) in unique_preserve_order

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -64,15 +64,18 @@ let max_risk left right =
   if risk_rank left >= risk_rank right then left else right
 
 let unique_preserve_order items =
-  let rec loop seen rev_items = function
+  let seen = Hashtbl.create (List.length items) in
+  let rec loop rev_items = function
     | [] -> List.rev rev_items
     | x :: xs ->
-        if List.mem x seen then
-          loop seen rev_items xs
-        else
-          loop (x :: seen) (x :: rev_items) xs
+        if Hashtbl.mem seen x then
+          loop rev_items xs
+        else begin
+          Hashtbl.add seen x ();
+          loop (x :: rev_items) xs
+        end
   in
-  loop [] [] items
+  loop [] items
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
   let seen = Hashtbl.create (List.length schemas) in


### PR DESCRIPTION
## Summary
`capability_registry.ml`의 `unique_preserve_order`가 `List.mem` (O(n))을 루프 안에서 사용 → O(n^2).
`Hashtbl.mem` (O(1))로 교체하여 O(n).

## LLM
Qwen3.5-35B (local). 방향 제시 + 인간이 OCaml 문법 보정.

## Build
- [x] `dune build` pass

🤖 Generated by research loop (Qwen3.5-35B)