### PR TITLE
fix(model): treat custom:model@url as always available in oas_model_resolve

### DIFF
--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -123,9 +123,13 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
              Treat as available — the cascade resolves providers at runtime. *)
           true
       | Some pname ->
-        match Llm_provider.Provider_registry.find default_registry pname with
-        | None -> false
-        | Some entry -> entry.is_available ()
+        if pname = "custom" then
+          (* custom:model@url is self-hosted; always considered available *)
+          true
+        else
+          match Llm_provider.Provider_registry.find default_registry pname with
+          | None -> false
+          | Some entry -> entry.is_available ()
     ) labels in
     if any_available then Ok ()
     else
@@ -133,12 +137,14 @@ let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
         match provider_name_of_label label with
         | None -> None
         | Some pname ->
-          match Llm_provider.Provider_registry.find default_registry pname with
-          | None -> Some (Printf.sprintf "%s (unknown provider)" pname)
-          | Some entry ->
-            if entry.defaults.api_key_env = "" then None
-            else if entry.is_available () then None
-            else Some entry.defaults.api_key_env
+          if pname = "custom" then None  (* self-hosted, no API key needed *)
+          else
+            match Llm_provider.Provider_registry.find default_registry pname with
+            | None -> Some (Printf.sprintf "%s (unknown provider)" pname)
+            | Some entry ->
+              if entry.defaults.api_key_env = "" then None
+              else if entry.is_available () then None
+              else Some entry.defaults.api_key_env
       ) labels in
       Error (Printf.sprintf "No valid/available model specs for labels: %s (missing: %s)"
         (String.concat ", " labels)


### PR DESCRIPTION
## Summary

`oas_model_resolve.ensure_api_keys_for_labels`가 `custom:model@url`을 `Provider_registry`에서 찾으려 하여 "unknown provider" 에러 발생.

`custom` provider는 self-hosted이고 URL이 임베딩되어 있어 API 키가 불필요합니다. `parse_model_string`은 이미 `custom`을 특별 처리하지만, `oas_model_resolve`는 registry만 조회하여 불일치 발생.

## Root cause

PR #2466 (delegate provider_config_to_oas)에서 keeper model resolution이 `oas_model_resolve`를 경유하도록 변경되었으나, `custom:` 처리가 누락됨.

## Test plan

- [x] `test_tool_keeper.exe` 22/22 PASS (was 13/22)
- [ ] CI Build and Test + Health green