### PR TITLE
style(dashboard): increase spacing for breathing room

### DIFF
--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -126,7 +126,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
 
       ${hasDetailDisclosure
         ? html`
-            <details class="pt-2 border-t border-[var(--white-6)] mt-3">
+            <details class="pt-3 border-t border-[var(--white-6)] mt-4">
               <summary>${model.disclosureLabel ?? '세부 정보'}</summary>
               <div class="flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]">
                 ${model.recentEvent ? html`<span>최근 일 · ${model.recentEvent}</span>` : null}

--- a/dashboard/src/components/common/list-item.ts
+++ b/dashboard/src/components/common/list-item.ts
@@ -13,7 +13,7 @@ interface ListItemProps {
 }
 
 export function ListItem({ title, subtitle, detail, onClick, class: className }: ListItemProps) {
-  const base = `w-full p-4 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-1.5 text-left text-inherit ${onClick ? 'cursor-pointer' : 'cursor-default'} ${className ?? ''}`
+  const base = `w-full p-4 rounded-xl border border-[var(--white-6)] bg-[var(--white-3)] grid gap-2.5 text-left text-inherit ${onClick ? 'cursor-pointer' : 'cursor-default'} ${className ?? ''}`
 
   const content = html`
     <strong class="text-[var(--text-strong)]">${title}</strong>

--- a/dashboard/src/components/common/nav-item.ts
+++ b/dashboard/src/components/common/nav-item.ts
@@ -20,7 +20,7 @@ export function NavItem({ active, icon, onClick, children }: NavItemProps) {
     ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]'
     : 'border-l-transparent bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)] hover:border-l-[var(--white-20)]'
   return html`
-    <button class="${NAV_BASE} gap-2.5 px-2.5 py-2 rounded-lg ${state}" onClick=${onClick}>
+    <button class="${NAV_BASE} gap-2.5 px-3 py-2.5 rounded-lg ${state}" onClick=${onClick}>
       ${icon ? html`<span class="text-sm w-5 text-center shrink-0">${icon}</span>` : null}
       <span class="text-[13px] font-medium truncate">${children}</span>
     </button>
@@ -33,7 +33,7 @@ export function SubNavItem({ active, onClick, children }: NavItemProps) {
     ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] font-medium'
     : 'border-l-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'
   return html`
-    <button class="${NAV_BASE} gap-2 px-2.5 py-1.5 rounded-md text-[13px] ${state}" onClick=${onClick}>
+    <button class="${NAV_BASE} gap-2 px-3 py-2 rounded-md text-[13px] ${state}" onClick=${onClick}>
       ${children}
     </button>
   `

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -26,7 +26,7 @@ const LABEL_STYLES = {
 
 export function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
   return html`
-    <div class="flex flex-col items-center px-3 py-2 rounded-lg border ${VARIANT_STYLES[variant]}">
+    <div class="flex flex-col items-center px-4 py-3 rounded-lg border ${VARIANT_STYLES[variant]}">
       <span class="text-base font-bold tabular-nums leading-tight">${value}</span>
       <span class="text-[length:var(--fs-2xs)] tracking-wider uppercase ${LABEL_STYLES[variant]}">${label}</span>
       ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}
@@ -41,7 +41,7 @@ interface StatGridProps {
 
 export function StatGrid({ items, cols = 4 }: StatGridProps) {
   return html`
-    <div class="grid gap-2" style="grid-template-columns: repeat(${cols}, 1fr)">
+    <div class="grid gap-3" style="grid-template-columns: repeat(${cols}, 1fr)">
       ${items.map(item => html`<${StatTile} ...${item} />`)}
     </div>
   `

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -369,10 +369,10 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Post body -->
       <div class="flex-1 min-w-0">
         <!-- Title -->
-        <div class="text-[14px] font-medium text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${post.title}</div>
+        <div class="text-[14px] font-medium text-[var(--text-strong)] leading-snug mb-2 group-hover:text-[var(--accent)] transition-colors">${post.title}</div>
 
         <!-- Content preview: max 3 lines -->
-        <div class="text-[13px] text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical">${previewText(stripStateBlocks(post.body))}</div>
+        <div class="text-[13px] text-[var(--text-body)] leading-[1.55] mb-3 overflow-hidden" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical">${previewText(stripStateBlocks(post.body))}</div>
 
         <!-- Footer: author + meta + badges -->
         <div class="flex items-center gap-2 flex-wrap">
@@ -415,8 +415,8 @@ function CommentItem({ comment }: { comment: BoardComment }) {
   const needsTruncation = (comment.content?.length ?? 0) > 300
 
   return html`
-    <div class="board-comment rounded-lg p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)]">
-      <div class="flex items-center gap-2 mb-1.5">
+    <div class="board-comment rounded-lg p-4 bg-[var(--white-3)] border border-[var(--border-slate-12)]">
+      <div class="flex items-center gap-2.5 mb-2">
         <span class="text-[12px]">${authorAvatar(comment.author)}</span>
         <a class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a>
         <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
@@ -442,7 +442,7 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
   const visible = expanded || comments.length <= INITIAL_SHOW ? comments : comments.slice(-INITIAL_SHOW)
 
   return html`
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-3">
       ${!expanded && hiddenCount > 0 ? html`
         <button
           class="text-[12px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
@@ -462,7 +462,7 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
 
 function CommentForm({ postId }: { postId: string }) {
   return html`
-    <div class="mt-4 flex gap-2">
+    <div class="mt-5 flex gap-3">
       <input
         type="text"
         class="flex-1 py-2 px-3 bg-[var(--white-5)] border border-[var(--border-slate-18)] rounded-lg text-[var(--text-body)] text-[13px] font-[inherit] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[rgba(71,184,255,0.55)] transition-colors"
@@ -509,7 +509,7 @@ function PostDetail({ post }: { post: BoardPost }) {
       >← 게시판으로 돌아가기</button>
 
       <${Card} title=${post.title}>
-        <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-5">
           <div class="text-[13px] text-[var(--text-body)] leading-[1.65]">
             <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
@@ -563,7 +563,7 @@ function PostDetail({ post }: { post: BoardPost }) {
         </div>
       <//>
 
-      <div class="mt-4">
+      <div class="mt-6">
         <${Card} title="댓글">
           ${detailLoading.value
             ? html`<${LoadingState}>댓글 불러오는 중...<//>`


### PR DESCRIPTION
## Summary
- Dashboard UI가 전반적으로 빡빡함 → 핵심 컴포넌트 spacing 증가
- Tailwind utility class만 변경 (커스텀 CSS 무변경)
- 5개 파일, 14줄 수정

## Changes

| Component | Before | After | Effect |
|-----------|--------|-------|--------|
| StatTile | py-2, gap-2 | py-3, gap-3 | KPI 타일 수직 여백 50% 증가 |
| ListItem | gap-1.5 | gap-2.5 | 제목/부제 간격 67% 증가 |
| KeeperCard details | pt-2, mt-3 | pt-3, mt-4 | 세부정보 영역 분리감 향상 |
| NavItem | py-2, py-1.5 | py-2.5, py-2 | 사이드바 버튼 터치 영역 확대 |
| Board comments | p-3, gap-2 | p-4, gap-3 | 댓글 카드 내부 여백 확대 |
| PostDetail | gap-4 | gap-5 | 게시글 상세 섹션 간 간격 확대 |
| PostCard title | mb-1.5 | mb-2 | 제목-본문 간 간격 확대 |

## Test plan
- [x] `npm run build` — Vite 빌드 성공
- [ ] `npm run dev` — HMR 확인 후 각 화면 비교
- [ ] 게시판 상세, 현황, 키퍼 카드 시각적 확인

Generated with [Claude Code](https://claude.com/claude-code)