### PR TITLE
feat(dashboard): expand keeper conversation history with load-more

### DIFF
--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -4,6 +4,7 @@ import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
   hydrateKeeperStatus,
+  loadFullKeeperHistory,
   keeperActionErrors,
   keeperHydrating,
   keeperProbing,
@@ -191,13 +192,20 @@ export function KeeperConversationPanel({
     writeKeeperChatMetadataVisible(showMetadata)
   }, [showMetadata])
 
+  const [historyExpanded, setHistoryExpanded] = useState(false)
   const rawThread = keeperThreads.value[keeperName] ?? []
   // Filter out system/tool messages -- only show user and assistant conversation
   const thread = rawThread.filter(
     entry => entry.role === 'user' || entry.role === 'assistant',
   )
   const sending = keeperSending.value[keeperName] ?? false
+  const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
+
+  const expandHistory = async () => {
+    setHistoryExpanded(true)
+    await loadFullKeeperHistory(keeperName)
+  }
 
   const submit = async () => {
     const prompt = draft.trim()
@@ -223,6 +231,16 @@ export function KeeperConversationPanel({
           ${showMetadata ? 'Hide metadata' : 'Show metadata'}
         </button>
       </div>
+      ${!historyExpanded && thread.length >= 10 ? html`
+        <button
+          type="button"
+          class="py-1.5 px-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer self-center"
+          disabled=${hydrating}
+          onClick=${() => { void expandHistory() }}
+        >
+          ${hydrating ? 'Loading...' : `Load full history (showing ${thread.length})`}
+        </button>
+      ` : null}
       <${ChatTranscript}
         entries=${thread}
         emptyText="No direct conversation history yet."

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -62,7 +62,7 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
       include_history_tail: true,
       include_compaction_history: false,
       tail_turns: 5,
-      tail_messages: 10,
+      tail_messages: 50,
     })
     let parsed: unknown = null
     try {
@@ -77,6 +77,33 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
     const message = err instanceof Error ? err.message : `Failed to inspect ${keeperName}`
     setRecordValue(keeperActionErrors, keeperName, message)
     return null
+  } finally {
+    setRecordValue(keeperHydrating, keeperName, false)
+  }
+}
+
+export async function loadFullKeeperHistory(name: string): Promise<void> {
+  const keeperName = name.trim()
+  if (!keeperName) return
+  setRecordValue(keeperHydrating, keeperName, true)
+  try {
+    const text = await callMcpTool('masc_keeper_status', {
+      name: keeperName,
+      fast: true,
+      include_context: false,
+      include_metrics_overview: false,
+      include_memory_bank: false,
+      include_history_tail: true,
+      include_compaction_history: false,
+      tail_turns: 0,
+      tail_messages: 200,
+    })
+    let parsed: unknown = null
+    try { parsed = JSON.parse(text) } catch { parsed = null }
+    const detail = normalizeStatusDetail(keeperName, text, parsed)
+    setStatusDetail(keeperName, detail)
+  } catch {
+    // ignore — best effort
   } finally {
     setRecordValue(keeperHydrating, keeperName, false)
   }

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -19,6 +19,7 @@ export { abortKeeperThreadMessage } from './keeper-stream'
 export {
   selectKeeper,
   hydrateKeeperStatus,
+  loadFullKeeperHistory,
   sendKeeperThreadMessage,
   probeKeeperRuntime,
   recoverKeeperRuntime,


### PR DESCRIPTION
## Summary
- Initial keeper message load: 10 → 50 messages
- "Load full history" button fetches up to 200 messages
- Button appears when 10+ messages are visible (indicates truncation)
- Loading state shown during fetch

## Context
Keeper 대화 이력이 최근 10개만 보여서 전체 대화를 볼 수 없었다.

## Test plan
- [ ] KeeperDetail 열기 → 최대 50개 메시지 표시
- [ ] "Load full history" 클릭 → 200개까지 확장
- [ ] 10개 미만일 때 버튼 미표시

Generated with [Claude Code](https://claude.com/claude-code)