### PR TITLE
feat: refresh dashboard shell and log surfaces

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -60,37 +60,49 @@ export function App() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
+  const showSectionChip = currentSection != null && currentSection.label !== currentView?.label
 
   return html`
-    <div class="flex flex-col h-screen overflow-hidden bg-bg-0 text-text-body font-sans">
-      <!-- Top Bar (Modern frosted glass header) -->
-      <header class="flex items-center justify-between h-14 px-6 border-b border-card-border bg-bg-0/80 backdrop-blur-xl shrink-0 z-50 shadow-sm shadow-black/10">
-        <div class="flex items-center gap-4">
-          <div class="flex items-center gap-2">
-            <div class="size-6 rounded-md bg-gradient-to-br from-accent to-blue-600 shadow-inner flex items-center justify-center">
-              <span class="text-[10px] font-bold text-white tracking-tighter">M</span>
+    <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] text-[var(--text-body)]">
+      <header class="shrink-0 border-b border-[rgba(138,163,211,0.16)] bg-[rgba(4,9,18,0.78)] px-4 py-4 backdrop-blur-xl">
+        <div class="mx-auto flex w-full max-w-[1680px] items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch">
+          <div class="min-w-0">
+            <div class="flex items-center gap-3">
+              <div class="flex size-11 shrink-0 items-center justify-center rounded-[18px] border border-[rgba(113,214,255,0.28)] bg-[linear-gradient(145deg,rgba(61,157,255,0.34),rgba(10,28,58,0.95))] text-[15px] font-semibold text-white shadow-[0_18px_36px_rgba(3,8,18,0.38)]">
+                M
+              </div>
+              <div class="min-w-0">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.7)]">MASC Control Deck</span>
+                  ${currentView
+                    ? html`<span class="rounded-full border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-2 py-0.5 text-[10px] font-medium text-[#9ad9ff]">${currentView.label}</span>`
+                    : null}
+                  ${showSectionChip
+                    ? html`<span class="rounded-full border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.05)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">${currentSection?.label}</span>`
+                    : null}
+                </div>
+                <h1 class="mt-1 text-[20px] font-semibold tracking-[-0.03em] text-[var(--text-strong)]">Multi-Agent Room Console</h1>
+                <p class="mt-1 max-w-[760px] text-[12px] leading-relaxed text-[var(--text-muted)]">
+                  ${currentSection?.description ?? currentView?.description ?? 'Rooms, keepers, governance, and operational signals in one place.'}
+                </p>
+              </div>
             </div>
-            <h1 class="text-base font-semibold text-text-strong tracking-wide">MASC</h1>
           </div>
-          <div class="w-[1px] h-4 bg-card-border mx-1"></div>
-          <span class="text-[13px] font-medium text-text-muted hidden sm:inline">${currentSection?.description ?? currentView?.description ?? ''}</span>
-          <div class="ml-2">
+
+          <div class="flex shrink-0 flex-col items-end gap-2">
+            <${ConnectionStatus} />
             <${BuildIdentityBadge} />
           </div>
         </div>
-        <${ConnectionStatus} />
       </header>
 
-      <!-- Body: Sidebar + Main -->
-      <div class="flex flex-1 overflow-hidden relative">
-        <!-- Sidebar (fixed 260px) -->
-        <aside class="w-[260px] shrink-0 border-r border-card-border bg-bg-1/40 overflow-y-auto flex flex-col">
+      <div class="flex flex-1 gap-4 overflow-hidden px-4 pb-4 pt-4 max-[1100px]:flex-col">
+        <aside class="w-[296px] shrink-0 overflow-y-auto rounded-[28px] border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(180deg,rgba(9,17,31,0.94),rgba(7,14,26,0.9))] shadow-[0_30px_80px_rgba(2,6,14,0.42)] max-[1100px]:w-full max-[1100px]:max-h-[360px]">
           <${SideRail} />
         </aside>
 
-        <!-- Main Content -->
-        <main class="flex-1 overflow-y-auto p-8 min-w-0 bg-gradient-to-b from-transparent to-bg-0/50">
-          <div class="max-w-[1400px] mx-auto pb-12">
+        <main class="min-w-0 flex-1 overflow-hidden rounded-[30px] border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(180deg,rgba(8,15,28,0.92),rgba(9,14,25,0.88))] shadow-[0_30px_80px_rgba(2,6,14,0.4)] max-[1100px]:min-h-0">
+          <div class="mx-auto h-full max-w-[1500px] overflow-y-auto px-5 py-5 lg:px-8 lg:py-7">
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -38,15 +38,6 @@ function statusBadgeClass(status: string | undefined): string {
   return 'roster-badge--idle'
 }
 
-function pressureClass(ratio: number | null | undefined): string {
-  if (ratio == null) return ''
-  const pct = ratio * 100
-  if (pct < 50) return 'pressure--ok'
-  if (pct < 70) return 'pressure--amber'
-  if (pct < 85) return 'pressure--orange'
-  return 'pressure--red'
-}
-
 interface KeeperInfo {
   generation?: number | null
   context_ratio?: number | null

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -9,8 +9,6 @@ import { roomTruthInitializing } from '../room-truth-store'
 import { Overview } from './overview/overview'
 import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
-import { LoadingState } from './common/feedback-state'
-import { NavItem, SubNavItem, NavSectionLabel } from './common/nav-item'
 import {
   DASHBOARD_SURFACES,
   DASHBOARD_NAV_ITEMS,
@@ -18,7 +16,7 @@ import {
   sectionItemsForTab,
   surfaceForTab,
 } from '../config/navigation'
-import { InterveneRailCard, SnapshotCard } from './resident-runtime-rail'
+import { SnapshotCard } from './resident-runtime-rail'
 
 const buildIdentityOpen = signal(false)
 
@@ -29,7 +27,7 @@ const LazyLabSurface = lazy(async () => ({ default: (await import('./lab-unified
 const LazyLogViewer = lazy(async () => ({ default: (await import('./logs')).LogViewer }))
 
 function lazyTabFallback(label: string) {
-  return html`<${LoadingState}>${label} 불러오는 중...<//>`
+  return html`<div class="loading-state loading-pulse">${label} 불러오는 중...</div>`
 }
 
 function formatDisconnectDuration(): string {
@@ -52,7 +50,7 @@ export function ConnectionStatus() {
     : `재연결 중...${formatDisconnectDuration()}`
 
   return html`
-    <div class="flex items-center gap-2 text-[13px] whitespace-nowrap ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}">
+    <div class="flex items-center gap-2 text-[length:var(--fs-sm)] whitespace-nowrap ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}">
       <span class="size-[9px] rounded-full inline-block ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_9px_rgba(74,222,128,0.8)]' : 'bg-[var(--bad)]'}"></span>
       <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`
@@ -83,7 +81,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button
-        class="text-[11px] py-[2px] px-[9px] rounded-full border border-solid border-[rgba(71,184,255,0.35)] bg-[var(--accent-soft)] text-[#9ad9ff] cursor-pointer font-[inherit]"
+        class="text-[11px] py-[6px] px-[11px] rounded-full border border-solid border-[rgba(71,184,255,0.28)] bg-[rgba(71,184,255,0.12)] text-[#bfe7ff] cursor-pointer font-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition-colors duration-150 hover:bg-[rgba(71,184,255,0.18)]"
         type="button"
         aria-expanded=${buildIdentityOpen.value}
         onClick=${() => {
@@ -94,31 +92,77 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+10px)] left-0 min-w-[280px] py-3 px-3.5 border border-solid border-[var(--card-border)] rounded-xl bg-[rgba(10,18,34,0.96)] shadow-[0_18px_34px_rgba(0,0,0,0.34)] grid gap-2">
-              <div class="flex justify-between gap-3 text-xs text-[var(--text-muted)]">
+            <div class="absolute top-[calc(100%+10px)] right-0 min-w-[300px] py-3 px-3.5 border border-solid border-[var(--card-border)] rounded-[18px] bg-[rgba(6,14,28,0.97)] shadow-[0_24px_44px_rgba(0,0,0,0.36)] grid gap-2">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
-                <strong class="text-[var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>커밋</span>
-                <strong class="text-[var(--text-strong)] text-right">${build?.commit ?? 'git 미감지 (dev)'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.commit ?? 'git 미감지 (dev)'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>서버 시작</span>
-                <strong class="text-[var(--text-strong)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : '알 수 없음'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>업타임</span>
-                <strong class="text-[var(--text-strong)] text-right">${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${typeof build?.uptime_seconds === 'number' ? `${build.uptime_seconds}s` : '알 수 없음'}</strong>
               </div>
-              <div class="flex justify-between gap-3 text-xs text-[var(--text-muted)]">
+              <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>쉘 스냅샷</span>
-                <strong class="text-[var(--text-strong)] text-right">${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
+                <strong class="text-[color:var(--text-strong)] text-right">${status?.generated_at ? html`<${TimeAgo} timestamp=${status.generated_at} />` : '알 수 없음'}</strong>
               </div>
             </div>
           `
         : null}
     </div>
+  `
+}
+
+function SurfaceLead() {
+  const currentTab = route.value.tab
+  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
+  const currentSection = currentSectionForRoute(route.value)
+  const activeSectionCount = sectionItemsForTab(currentTab).length
+
+  return html`
+    <section class="mb-5 overflow-hidden rounded-[26px] border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(135deg,rgba(9,22,42,0.96),rgba(6,12,24,0.92))] px-5 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div class="min-w-0 max-w-[820px]">
+          <div class="flex flex-wrap items-center gap-2">
+            ${currentView?.icon
+              ? html`<span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)] text-[18px]">${currentView.icon}</span>`
+              : null}
+            <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.72)]">Current Surface</span>
+            ${currentSection && currentSection.label !== currentView?.label
+              ? html`<span class="rounded-full border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.05)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">${currentSection.label}</span>`
+              : null}
+          </div>
+          <h2 class="mt-3 text-[28px] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">
+            ${currentSection?.label ?? currentView?.label ?? '홈'}
+          </h2>
+          <p class="mt-2 max-w-[72ch] text-[13px] leading-relaxed text-[var(--text-muted)]">
+            ${currentSection?.description ?? currentView?.description ?? '지금 필요한 신호를 가장 안정적으로 읽을 수 있는 기본 화면입니다.'}
+          </p>
+        </div>
+
+        <div class="grid min-w-[240px] gap-2 rounded-[22px] border border-[rgba(255,255,255,0.07)] bg-[rgba(255,255,255,0.04)] p-3">
+          <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+            <span>현재 탭</span>
+            <strong class="text-[var(--text-strong)]">${currentView?.label ?? currentTab}</strong>
+          </div>
+          <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+            <span>하위 섹션</span>
+            <strong class="text-[var(--text-strong)] tabular-nums">${activeSectionCount}</strong>
+          </div>
+          <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+            <span>연결 상태</span>
+            <strong class="${connected.value ? 'text-[#91f2b4]' : 'text-[#f7b7b7]'}">${connected.value ? 'live' : 'reconnecting'}</strong>
+          </div>
+        </div>
+      </div>
+    </section>
   `
 }
 
@@ -131,38 +175,74 @@ export function SideRail() {
 
   return html`
     <nav class="flex flex-col h-full">
-      <!-- Navigation -->
-      <div class="flex-1 overflow-y-auto py-4 px-3">
-        <${NavSectionLabel}>탐색<//>
-
-        <div class="flex flex-col gap-1">
-          ${DASHBOARD_SURFACES.map(surface => html`
-            <${NavItem}
-              key=${surface.id}
-              active=${surface.id === currentSurface}
-              icon=${surface.icon}
-              onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
-            >
-              ${surface.label}
-            <//>
-          `)}
+      <div class="flex-1 overflow-y-auto px-3 py-4">
+        <div class="mb-4 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] px-3 py-3">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Navigation</div>
+          <div class="mt-2 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">Surface Atlas</div>
+          <p class="mt-1 text-[11px] leading-relaxed text-[var(--text-muted)]">
+            주요 면을 먼저 고르고, 같은 맥락의 하위 섹션을 바로 이동합니다.
+          </p>
         </div>
 
-        <!-- Sub-sections -->
+        <div class="flex flex-col gap-2">
+          ${DASHBOARD_SURFACES.map(surface => {
+            const isActive = surface.id === currentSurface
+            return html`
+              <button
+                class="w-full rounded-[22px] border border-solid px-3 py-3 text-left cursor-pointer transition-all duration-150 ${isActive ? 'border-[rgba(71,184,255,0.28)] bg-[linear-gradient(135deg,rgba(71,184,255,0.18),rgba(255,255,255,0.04))] shadow-[0_14px_28px_rgba(0,0,0,0.18)]' : 'border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] hover:border-[rgba(255,255,255,0.12)] hover:bg-[rgba(255,255,255,0.04)]'}"
+                key=${surface.id}
+                onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
+              >
+                <div class="flex items-start gap-3">
+                  <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[18px]">
+                    ${surface.icon}
+                  </span>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="text-[13px] font-semibold ${isActive ? 'text-[#d9f2ff]' : 'text-[var(--text-strong)]'}">${surface.label}</span>
+                      ${isActive
+                        ? html`<span class="rounded-full border border-[rgba(71,184,255,0.24)] bg-[rgba(71,184,255,0.14)] px-2 py-0.5 text-[10px] font-medium text-[#9ad9ff]">active</span>`
+                        : null}
+                    </div>
+                    <p class="mt-1 text-[11px] leading-relaxed ${isActive ? 'text-[rgba(214,236,255,0.78)]' : 'text-[var(--text-muted)]'}">
+                      ${surface.description}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            `
+          })}
+        </div>
+
         ${(() => {
           if (sectionItems.length === 0) return null
           return html`
-            <div class="mt-5 pt-4 mx-4 border-t border-[var(--border-slate-12)]">
-              <${NavSectionLabel}>${currentView?.label ?? currentSurface}<//>
-              <div class="flex flex-col gap-1">
+            <div class="mt-5 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.025)] px-3 py-3">
+              <div class="flex items-center justify-between gap-2">
+                <div>
+                  <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">
+                    ${currentView?.label ?? currentSurface}
+                  </div>
+                  <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">
+                    ${currentSection?.label ?? 'Sections'}
+                  </div>
+                </div>
+                <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[10px] text-[var(--text-muted)] tabular-nums">
+                  ${sectionItems.length}
+                </span>
+              </div>
+              <div class="mt-3 flex flex-col gap-1.5">
                 ${sectionItems.map(item => html`
-                  <${SubNavItem}
+                  <button
+                    class="w-full rounded-[16px] border border-solid px-3 py-2 text-left cursor-pointer text-[12px] transition-all duration-150 ${currentSection?.id === item.id ? 'border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.14)] text-[#cfeaff] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]' : 'border-transparent bg-transparent text-[var(--text-muted)] hover:border-[rgba(255,255,255,0.08)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
                     key=${item.id}
-                    active=${currentSection?.id === item.id}
                     onClick=${() => navigate(currentSurface, item.params)}
                   >
-                    ${item.label}
-                  <//>
+                    <div class="font-medium">${item.label}</div>
+                    <div class="mt-1 text-[10px] leading-relaxed ${currentSection?.id === item.id ? 'text-[rgba(222,240,255,0.72)]' : 'text-[var(--text-muted)]'}">
+                      ${item.description}
+                    </div>
+                  </button>
                 `)}
               </div>
             </div>
@@ -170,8 +250,7 @@ export function SideRail() {
         })()}
       </div>
 
-      <!-- Status Footer -->
-      <div class="shrink-0 border-t border-[var(--border-slate-12)] p-3">
+      <div class="shrink-0 border-t border-[rgba(255,255,255,0.06)] p-3">
         <${SnapshotCard} currentTab=${current} />
       </div>
     </nav>
@@ -221,7 +300,7 @@ export function TabContent() {
 
 export function DashboardMain() {
   if (dashboardLoading.value && !connected.value && !roomTruthInitializing.value) {
-    return html`<${LoadingState}>대시보드 불러오는 중...<//>`
+    return html`<div class="loading-state loading-pulse">대시보드 불러오는 중...</div>`
   }
 
   const routeLabel = [
@@ -236,8 +315,9 @@ export function DashboardMain() {
 
   return html`
     ${roomTruthInitializing.value ? html`
-      <div class="text-center py-[6px] px-4 bg-[rgba(230,167,0,0.12)] border-b border-solid border-b-[rgba(230,167,0,0.3)] text-[#e6a700] text-[13px] shrink-0">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
+      <div class="text-center py-[6px] px-4 bg-[rgba(230,167,0,0.12)] border-b border-solid border-b-[rgba(230,167,0,0.3)] text-[#e6a700] text-[0.8rem] shrink-0">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
+    <${SurfaceLead} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <${TabContent} />
     <//>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -6,7 +6,6 @@ import { TimeAgo } from './common/time-ago'
 import { EmptyState } from './common/empty-state'
 import { FilterChips } from './common/filter-chips'
 import { governanceToneClass } from '../lib/tone'
-import type { GovernanceFilter } from './governance-utils'
 import {
   governanceData,
   governanceError,

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -46,11 +46,39 @@ export function LogViewer() {
   })
 
   return html`
-    <div class="flex flex-col gap-4 h-full min-h-0">
-      <div class="flex justify-between items-center gap-4 p-3 rounded-2xl border border-card-border/50 bg-card/40 backdrop-blur-md shadow-sm shrink-0">
-        <div class="flex gap-2.5 items-center">
+    <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
+      <section class="rounded-[26px] border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(135deg,rgba(9,22,42,0.95),rgba(7,13,24,0.92))] px-5 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div class="min-w-0 max-w-[760px]">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.72)]">Observer</div>
+            <h2 class="mt-2 text-[26px] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">Execution Log Stream</h2>
+            <p class="mt-2 text-[13px] leading-relaxed text-[var(--text-muted)]">
+              backend stdout/stderr와 구조화된 런타임 로그를 같은 흐름에서 읽습니다. 에러는 빠르게 띄우고, 나머지는 모듈과 수준으로 좁혀서 봅니다.
+            </p>
+          </div>
+
+          <div class="grid min-w-[240px] gap-2 rounded-[20px] border border-[rgba(255,255,255,0.07)] bg-[rgba(255,255,255,0.04)] p-3">
+            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+              <span>현재 필터</span>
+              <strong class="text-[var(--text-strong)]">${levelFilter.value}+</strong>
+            </div>
+            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+              <span>조회 건수</span>
+              <strong class="text-[var(--text-strong)] tabular-nums">${(logTotal.value ?? 0).toLocaleString()}</strong>
+            </div>
+            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+              <span>새로고침</span>
+              <strong class="${autoRefresh.value ? 'text-[#92f3b4]' : 'text-[var(--text-strong)]'}">${autoRefresh.value ? 'auto' : 'manual'}</strong>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[26px] border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
+        <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
+          <div class="logs-filters flex flex-wrap gap-2 items-center">
           <select
-            class="py-1.5 px-3 rounded-lg border border-card-border bg-bg-1/80 text-[12px] font-semibold text-text-strong focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 cursor-pointer shadow-inner appearance-none pr-8 relative"
+            class="logs-select rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             value=${levelFilter.value}
             onChange=${(e: Event) => {
               levelFilter.value = (e.target as HTMLSelectElement).value
@@ -64,9 +92,9 @@ export function LogViewer() {
           </select>
 
           <input
-            class="py-1.5 px-4 rounded-lg border border-card-border bg-bg-1/80 text-[12px] text-text-strong font-mono placeholder:text-text-muted focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 shadow-inner w-48"
+            class="logs-module-input min-w-[220px] rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             type="text"
-            placeholder="module filter..."
+            placeholder="module filter"
             value=${moduleFilter.value}
             onInput=${(e: Event) => {
               moduleFilter.value = (e.target as HTMLInputElement).value
@@ -77,65 +105,75 @@ export function LogViewer() {
           />
 
           <select
-            class="py-1.5 px-3 rounded-lg border border-card-border bg-bg-1/80 text-[12px] font-semibold text-text-strong focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 cursor-pointer shadow-inner appearance-none pr-8"
+            class="logs-select rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             value=${String(logLimit.value)}
             onChange=${(e: Event) => {
               logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
               void loadLogs()
             }}
           >
-            <option value="100">100 rows</option>
-            <option value="500">500 rows</option>
-            <option value="1000">1000 rows</option>
-            <option value="3000">3000 rows</option>
+            <option value="100">100</option>
+            <option value="500">500</option>
+            <option value="1000">1000</option>
+            <option value="3000">3000</option>
           </select>
         </div>
 
-        <div class="flex gap-4 items-center text-[12px] font-medium text-text-muted">
-          <span class="tabular-nums px-2.5 py-1 bg-white/5 rounded-md border border-white/5 shadow-sm">${(logTotal.value ?? 0).toLocaleString()}건</span>
-          <label class="flex items-center gap-2 cursor-pointer hover:text-text-body transition-colors select-none">
-            <div class="relative w-7 h-3.5 rounded-full transition-colors duration-200 ${autoRefresh.value ? 'bg-accent' : 'bg-white/10'}">
-              <div class="absolute top-[2px] left-[2px] size-2.5 bg-white rounded-full transition-transform duration-200 shadow-sm ${autoRefresh.value ? 'translate-x-3.5' : 'translate-x-0'}"></div>
-            </div>
-            자동 갱신
+        <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
+          <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${(logTotal.value ?? 0).toLocaleString()} total</span>
+          <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
+            <input
+              type="checkbox"
+              checked=${autoRefresh.value}
+              onChange=${() => { autoRefresh.value = !autoRefresh.value }}
+            />
+            자동
           </label>
-          <button class="px-3 py-1.5 rounded-lg border border-transparent bg-white/5 hover:bg-white/10 text-text-strong transition-all duration-200 cursor-pointer shadow-sm disabled:opacity-50" onClick=${() => { void loadLogs() }}
+          <button class="logs-refresh-btn rounded-[14px] border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
             disabled=${logLoading.value}>
-            ${logLoading.value ? '가져오는 중...' : '새로고침'}
+            ${logLoading.value ? '...' : '새로고침'}
           </button>
         </div>
-      </div>
-
-      ${logError.value ? html`
-        <div class="p-3.5 bg-bad/10 border border-bad/30 text-bad text-[13px] font-medium rounded-xl shadow-sm">${logError.value}</div>
-      ` : null}
-
-      <div class="flex-1 min-h-0 rounded-2xl border border-card-border/50 bg-card/60 backdrop-blur-md shadow-inner overflow-hidden flex flex-col">
-        <div class="overflow-y-auto custom-scrollbar flex-1">
-          <table class="w-full text-left border-collapse text-[12px] font-mono leading-relaxed">
-            <thead class="sticky top-0 bg-bg-1/95 backdrop-blur-xl border-b border-card-border/80 z-10 shadow-sm">
-              <tr>
-                <th class="py-2.5 px-4 w-44 whitespace-nowrap text-text-muted font-semibold tracking-wider">TIMESTAMP</th>
-                <th class="py-2.5 px-4 w-16 whitespace-nowrap text-text-strong font-semibold tracking-wider">LEVEL</th>
-                <th class="py-2.5 px-4 w-32 whitespace-nowrap text-accent font-semibold tracking-wider">MODULE</th>
-                <th class="py-2.5 px-4 text-text-strong font-semibold tracking-wider">MESSAGE</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-card-border/30">
-              ${logEntries.value.map(entry => html`
-                <tr key=${entry.seq} class="hover:bg-white/5 transition-colors ${entry.level === 'ERROR' ? 'bg-bad/10 hover:bg-bad/20' : entry.level === 'WARN' ? 'bg-warn/10 hover:bg-warn/20' : ''}">
-                  <td class="py-1.5 px-4 w-44 whitespace-nowrap text-text-muted/80">${entry.ts.replace('T', ' ').replace('Z', '')}</td>
-                  <td class="py-1.5 px-4 w-16 whitespace-nowrap font-bold" style="color: ${LEVEL_COLORS[entry.level] ?? 'inherit'}">
-                    ${entry.level}
-                  </td>
-                  <td class="py-1.5 px-4 w-32 whitespace-nowrap text-accent/90">${entry.module}</td>
-                  <td class="py-1.5 px-4 break-words text-text-body whitespace-pre-wrap">${entry.message}</td>
-                </tr>
-              `)}
-            </tbody>
-          </table>
         </div>
-      </div>
+
+        ${logError.value ? html`
+          <div class="mx-4 mt-4 rounded-[18px] border border-solid border-[#e05050] bg-[rgba(224,80,80,0.12)] px-4 py-3 text-[12px] text-[#ffb3b3]">${logError.value}</div>
+        ` : null}
+
+        <div class="logs-table-wrap min-h-0 flex-1 overflow-auto px-3 pb-3">
+          <table class="logs-table w-full border-separate border-spacing-y-2">
+          <thead>
+            <tr>
+              <th class="logs-col-ts w-44 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-muted)]">timestamp</th>
+              <th class="logs-col-level w-20 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">level</th>
+              <th class="logs-col-module w-40 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">module</th>
+              <th class="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">message</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${logEntries.value.map(entry => html`
+              <tr
+                key=${entry.seq}
+                class="logs-row ${entry.level === 'ERROR' ? 'bg-[rgba(224,80,80,0.08)]' : entry.level === 'WARN' ? 'bg-[rgba(230,167,0,0.05)]' : 'bg-[rgba(255,255,255,0.02)]'}"
+              >
+                <td class="logs-col-ts rounded-l-[18px] border-y border-l border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] whitespace-nowrap text-[color:var(--text-muted)]">
+                  ${entry.ts.replace('T', ' ').replace('Z', '')}
+                </td>
+                <td class="logs-col-level border-y border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[entry.level] ?? 'inherit'}">
+                  ${entry.level}
+                </td>
+                <td class="logs-col-module border-y border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] whitespace-nowrap text-[color:var(--accent)]">
+                  ${entry.module}
+                </td>
+                <td class="rounded-r-[18px] border-y border-r border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[12px] leading-relaxed break-words text-[var(--text-body)]">
+                  ${entry.message}
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+        </div>
+      </section>
     </div>
   `
 }

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -2,12 +2,10 @@ import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { Card } from './common/card'
-import { KpiCard } from './common/stat-row'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
 import { EmptyState } from './common/empty-state'
-import { LoadingState } from './common/feedback-state'
 import { stripStateBlocks } from '../keeper-message'
 import {
   boardPosts,
@@ -24,15 +22,7 @@ import {
   createPost,
 } from '../api'
 import { navigate, navigateToPost, route } from '../router'
-import { findKeeper } from './execution/shared'
-import { openKeeperDetail } from './keeper-detail'
 import type { BoardComment, BoardPost, BoardSortMode } from '../types'
-
-function openAuthorDetail(name: string) {
-  const keeper = findKeeper(name)
-  if (keeper) openKeeperDetail(keeper)
-  else navigate('status', { section: 'agents', agent: name })
-}
 
 const SORT_MODES: { id: BoardSortMode; label: string }[] = [
   { id: 'recent', label: '최신순' },
@@ -135,7 +125,7 @@ function authorAvatar(name: string): string {
   for (let i = 0; i < name.length; i++) {
     hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0
   }
-  return avatars[Math.abs(hash) % avatars.length] || '🤖'
+  return avatars[Math.abs(hash) % avatars.length] ?? '🤖'
 }
 
 function kindBadgeColor(kind: string): string {
@@ -269,14 +259,14 @@ function SortBar() {
   const current = boardSortMode.value
   const hideLabel = hideAutomationPosts.value ? '자동화 글 숨김' : '자동화 글 표시 중'
   return html`
-    <div class="flex flex-col gap-3 mb-6 p-4 rounded-2xl border border-card-border/50 bg-card/30 backdrop-blur-md shadow-inner">
-      <div class="flex items-center gap-2 flex-wrap">
+    <div class="flex flex-col gap-3 mb-4 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+      <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
           <button
-            class="px-4 py-2 rounded-xl text-[12px] font-bold transition-all duration-200 border cursor-pointer shadow-sm
+            class="px-3 py-1.5 rounded-lg text-[12px] font-medium transition-all duration-150 border cursor-pointer
               ${current === mode.id
-                ? 'bg-ok/10 text-ok border-ok/30 shadow-[0_0_10px_rgba(74,222,128,0.1)]'
-                : 'bg-white/5 text-text-muted border-transparent hover:bg-white/10 hover:text-text-body hover:border-white/10'
+                ? 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
+                : 'bg-transparent text-[var(--text-muted)] border-transparent hover:bg-[var(--white-8)] hover:text-[var(--text-body)]'
               }"
             onClick=${() => {
               boardSortMode.value = mode.id
@@ -288,12 +278,12 @@ function SortBar() {
           </button>
         `)}
       </div>
-      <div class="flex items-center gap-3 flex-wrap">
+      <div class="flex items-center gap-2 flex-wrap">
         <button
-          class="px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-200 border cursor-pointer
+          class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
             ${hideAutomationPosts.value
-              ? 'bg-accent/10 text-accent border-accent/20 shadow-sm'
-              : 'bg-transparent text-text-muted border-white/10 hover:bg-white/5 hover:text-text-body'
+              ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
+              : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
             }"
           onClick=${() => {
             hideAutomationPosts.value = !hideAutomationPosts.value
@@ -302,10 +292,10 @@ function SortBar() {
           ${hideLabel}
         </button>
         <button
-          class="px-3 py-1.5 rounded-lg text-[11px] font-semibold transition-all duration-200 border cursor-pointer
+          class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
             ${boardExcludeSystem.value
-              ? 'bg-accent/10 text-accent border-accent/20 shadow-sm'
-              : 'bg-transparent text-text-muted border-white/10 hover:bg-white/5 hover:text-text-body'
+              ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
+              : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
             }"
           onClick=${() => {
             boardExcludeSystem.value = !boardExcludeSystem.value
@@ -316,7 +306,7 @@ function SortBar() {
         </button>
         <div class="ml-auto">
           <button
-            class="px-4 py-1.5 rounded-lg text-[11px] font-bold transition-all duration-200 border cursor-pointer bg-white/5 text-text-muted border-white/10 hover:bg-white/10 hover:text-text-strong shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshBoard}
             disabled=${boardLoading.value}
           >
@@ -333,12 +323,27 @@ function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
   const visibleCount = grouped.human.length + grouped.operations.length
   return html`
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-4 mb-6">
-      <${KpiCard} label="보이는 글" value=${visibleCount} />
-      <${KpiCard} label="정렬" value=${sortLabel} />
-      <${KpiCard} label="잡음 필터" value=${hideAutomationPosts.value ? `자동화 ${grouped.hiddenAutomation}건 숨김` : '분리된 레인 표시'} />
-      <${KpiCard} label="시스템 글 정책" value=${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 레인 표시'} />
-      <${KpiCard} label="최근 갱신" value=${lastBoardRefreshAt.value ? html`<${TimeAgo} timestamp=${lastBoardRefreshAt.value} />` : '아직 불러오지 않음'} />
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-3 mb-4">
+      <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">보이는 글</span>
+        <strong class="text-xl font-semibold text-[var(--text-strong)] tabular-nums">${visibleCount}</strong>
+      </div>
+      <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">정렬</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${sortLabel}</strong>
+      </div>
+      <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">잡음 필터</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${hideAutomationPosts.value ? `자동화 ${grouped.hiddenAutomation}건 숨김` : '분리된 레인 표시'}</strong>
+      </div>
+      <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">시스템 글 정책</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 레인 표시'}</strong>
+      </div>
+      <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
+        <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">최근 갱신</span>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${lastBoardRefreshAt.value ? html`<${TimeAgo} timestamp=${lastBoardRefreshAt.value} />` : '아직 불러오지 않음'}</strong>
+      </div>
     </div>
   `
 }
@@ -358,48 +363,46 @@ function PostCard({ post }: { post: BoardPost }) {
 
   return html`
     <div
-      class="group flex gap-4 rounded-2xl p-5 border border-card-border bg-card/40 backdrop-blur-md shadow-sm hover:shadow-md hover:bg-card/60 hover:-translate-y-0.5 hover:border-accent/30 transition-all duration-200 cursor-pointer"
+      class="board-post group flex gap-3 rounded-xl p-4 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--white-6)] hover:border-[rgba(71,184,255,0.26)] transition-all duration-200 cursor-pointer"
       onClick=${() => navigateToPost(post.id)}
     >
       <!-- Vote column -->
-      <div class="flex flex-col items-center gap-1.5 pt-1 min-w-[40px]">
+      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-[36px]">
         <button
-          class="w-8 h-6 flex items-center justify-center rounded-md text-[13px] font-bold text-text-muted hover:text-[#ff4500] hover:bg-[#ff4500]/10 transition-colors cursor-pointer border border-transparent hover:border-[#ff4500]/20"
+          class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[#ff4500] hover:bg-[rgba(255,69,0,0.1)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('up', event)}
         >▲</button>
-        <span class="text-[14px] font-bold tabular-nums text-text-strong bg-white/5 w-full text-center py-1 rounded-md shadow-inner">${post.votes ?? 0}</span>
+        <span class="text-[13px] font-semibold tabular-nums text-[var(--text-strong)]">${post.votes ?? 0}</span>
         <button
-          class="w-8 h-6 flex items-center justify-center rounded-md text-[13px] font-bold text-text-muted hover:text-accent hover:bg-accent/10 transition-colors cursor-pointer border border-transparent hover:border-accent/20"
+          class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[#7193ff] hover:bg-[rgba(113,147,255,0.1)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('down', event)}
         >▼</button>
       </div>
 
       <!-- Post body -->
-      <div class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 min-w-0">
         <!-- Title -->
-        <div class="text-[15px] font-bold text-text-strong leading-snug mb-2.5 group-hover:text-accent transition-colors tracking-wide">${post.title}</div>
+        <div class="text-[14px] font-medium text-[var(--text-strong)] leading-snug mb-1.5 group-hover:text-[var(--accent)] transition-colors">${post.title}</div>
 
         <!-- Content preview: max 3 lines -->
-        <div class="text-[13px] text-text-body/90 leading-relaxed mb-4 overflow-hidden font-medium" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical">${previewText(stripStateBlocks(post.body))}</div>
+        <div class="text-[13px] text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical">${previewText(stripStateBlocks(post.body))}</div>
 
         <!-- Footer: author + meta + badges -->
-        <div class="flex items-center gap-3 flex-wrap mt-auto pt-3 border-t border-card-border/50">
+        <div class="flex items-center gap-2 flex-wrap">
           <!-- Author line -->
-          <div class="flex items-center gap-1.5 bg-white/5 pl-1 pr-2 py-0.5 rounded-lg border border-white/5 shadow-sm">
-            <span class="text-[13px]">${authorAvatar(post.author)}</span>
-            <a
-              class="text-[11px] font-bold text-text-muted hover:text-accent transition-colors cursor-pointer tracking-wider"
-              onClick=${(e: Event) => { e.stopPropagation(); openAuthorDetail(post.author) }}
-            >${post.author}</a>
-          </div>
-          <span class="text-[11px] font-mono text-text-muted/60"><${TimeAgo} timestamp=${post.created_at} /></span>
-          ${isUpdated(post) ? html`<span class="text-[10px] font-semibold text-text-dim/50">(수정됨)</span>` : null}
+          <span class="text-[12px] text-[var(--text-muted)]">${authorAvatar(post.author)}</span>
+          <a
+            class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
+            onClick=${(e: Event) => { e.stopPropagation(); navigate('status', { section: 'agents', agent: post.author }) }}
+          >${post.author}</a>
+          <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
+          ${isUpdated(post) ? html`<span class="text-[10px] text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}
 
           <!-- Separator -->
-          <span class="text-white/10">|</span>
+          <span class="text-[var(--text-muted)] opacity-30">|</span>
 
           <!-- Counts -->
-          <span class="text-[11px] font-semibold text-text-muted flex items-center gap-1"><span class="text-[13px]">💬</span> ${post.comment_count}</span>
+          <span class="text-[11px] text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
           ${kind !== 'human' ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(kind)}">${kind}</span>` : null}
@@ -425,16 +428,16 @@ function CommentItem({ comment }: { comment: BoardComment }) {
   const needsTruncation = (comment.content?.length ?? 0) > 300
 
   return html`
-    <div class="board-comment rounded-2xl p-5 bg-card/60 backdrop-blur-md border border-card-border/50 shadow-sm hover:shadow-md transition-shadow">
-      <div class="flex items-center gap-3 mb-3">
-        <span class="text-[14px] bg-white/5 size-6 flex items-center justify-center rounded-lg shadow-inner border border-white/5">${authorAvatar(comment.author)}</span>
-        <a class="text-[12px] font-bold text-text-strong hover:text-accent transition-colors cursor-pointer tracking-wide" onClick=${() => openAuthorDetail(comment.author)}>${comment.author}</a>
-        <span class="text-[10px] text-text-dim/80 font-mono"><${TimeAgo} timestamp=${comment.created_at} /></span>
+    <div class="board-comment rounded-lg p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)]">
+      <div class="flex items-center gap-2 mb-1.5">
+        <span class="text-[12px]">${authorAvatar(comment.author)}</span>
+        <a class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('status', { section: 'agents', agent: comment.author })}>${comment.author}</a>
+        <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
       </div>
-      <div class="comment-text text-[13px] text-text-body/90 leading-relaxed font-medium">${comment.content}</div>
+      <div class="comment-text text-[13px] text-[var(--text-body)] leading-[1.55]">${comment.content}</div>
       ${needsTruncation ? html`
         <button
-          class="comment-expand-btn mt-2 text-[11px] font-bold text-accent hover:text-accent/80 transition-colors cursor-pointer bg-accent/10 px-2 py-0.5 rounded-md border border-accent/20"
+          class="comment-expand-btn mt-1 text-[11px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
           style="display: inline"
           onClick=${toggleCommentExpand}
         >더 보기...</button>
@@ -452,7 +455,7 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
   const visible = expanded || comments.length <= INITIAL_SHOW ? comments : comments.slice(-INITIAL_SHOW)
 
   return html`
-    <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-2">
       ${!expanded && hiddenCount > 0 ? html`
         <button
           class="text-[12px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
@@ -472,7 +475,7 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
 
 function CommentForm({ postId }: { postId: string }) {
   return html`
-    <div class="mt-5 flex gap-3">
+    <div class="mt-4 flex gap-2">
       <input
         type="text"
         class="flex-1 py-2 px-3 bg-[var(--white-5)] border border-[var(--border-slate-18)] rounded-lg text-[var(--text-body)] text-[13px] font-[inherit] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[rgba(71,184,255,0.55)] transition-colors"
@@ -519,13 +522,13 @@ function PostDetail({ post }: { post: BoardPost }) {
       >← 게시판으로 돌아가기</button>
 
       <${Card} title=${post.title}>
-        <div class="flex flex-col gap-5">
+        <div class="flex flex-col gap-4">
           <div class="text-[13px] text-[var(--text-body)] leading-[1.65]">
             <${Markdown} text=${stripStateBlocks(post.body)} />
           </div>
 
           <!-- Author and meta -->
-          <div class="flex gap-3 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
+          <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-[13px]">${authorAvatar(post.author)}</span>
             <a class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigate('status', { section: 'agents', agent: post.author })}>${post.author}</a>
             <span class="text-[11px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
@@ -573,10 +576,10 @@ function PostDetail({ post }: { post: BoardPost }) {
         </div>
       <//>
 
-      <div class="mt-6">
+      <div class="mt-4">
         <${Card} title="댓글">
           ${detailLoading.value
-            ? html`<${LoadingState}>댓글 불러오는 중...<//>`
+            ? html`<div class="loading-state loading-pulse">댓글 불러오는 중...</div>`
             : html`<${CommentThread} comments=${detailComments.value} />`}
           <${CommentForm} postId=${post.id} />
         <//>
@@ -611,7 +614,7 @@ export function Memory() {
               onClick=${() => navigate('work', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
             ${detailLoading.value
-              ? html`<${LoadingState}>글 불러오는 중...<//>`
+              ? html`<div class="loading-state loading-pulse">글 불러오는 중...</div>`
               : html`<${EmptyState} message="글을 찾지 못했습니다" compact />`}
           </div>
         `
@@ -625,7 +628,7 @@ export function Memory() {
         <${NewPostForm} />
       </div>
       ${boardLoading.value
-        ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
+        ? html`<div class="loading-state loading-pulse">메모리 피드 불러오는 중...</div>`
         : posts.length === 0
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -23,51 +23,59 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const build = serverStatus.value?.build
 
   return html`
-    <section class="grid gap-3">
-      <!-- Connection + Version row -->
-      <div class="flex items-center justify-between gap-2">
+    <section class="grid gap-3 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] p-3">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Room Pulse</div>
+          <div class="mt-1 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
+            ${liveConnected ? 'Live control room' : 'Signal recovering'}
+          </div>
+        </div>
         <div class="flex items-center gap-1.5">
-          <span class="size-[7px] rounded-full inline-block ${liveConnected ? 'bg-[var(--ok)] shadow-[0_0_6px_rgba(74,222,128,0.6)]' : 'bg-[var(--bad)]'}"></span>
-          <span class="text-[10px] ${liveConnected ? 'text-[#86efac]' : 'text-[#fda4af]'}">${liveConnected ? '연결됨' : '오프라인'}</span>
-        </div>
-        ${build
-          ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">v${build.release_version} · ${shortCommit(build.commit)}</span>`
-          : null}
-      </div>
-
-      <!-- Compact stat rows -->
-      <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 text-[11px]">
-        <div class="flex items-center justify-between">
-          <span class="text-[var(--text-muted)]">에이전트</span>
-          <strong class="text-[var(--accent)] tabular-nums">${agents.value.length}</strong>
-        </div>
-        <div class="flex items-center justify-between">
-          <span class="text-[var(--text-muted)]">키퍼</span>
-          <strong class="text-[var(--ok)] tabular-nums">${keepers.value.length}</strong>
-        </div>
-        <div class="flex items-center justify-between">
-          <span class="text-[var(--text-muted)]">태스크</span>
-          <strong class="text-[var(--warn)] tabular-nums">${tasks.value.length}</strong>
-        </div>
-        <div class="flex items-center justify-between">
-          <span class="text-[var(--text-muted)]">이벤트</span>
-          <strong class="text-[var(--text-strong)] tabular-nums">${eventCount.value}</strong>
+          <span class="size-[8px] rounded-full inline-block ${liveConnected ? 'bg-[var(--ok)] shadow-[0_0_9px_rgba(74,222,128,0.64)]' : 'bg-[var(--bad)] shadow-[0_0_9px_rgba(239,68,68,0.42)]'}"></span>
+          <span class="text-[10px] font-medium ${liveConnected ? 'text-[#92f3b4]' : 'text-[#ffb4bf]'}">${liveConnected ? 'connected' : 'offline'}</span>
         </div>
       </div>
 
-      <!-- Actions -->
-      <div class="grid grid-cols-2 gap-1.5">
+      ${build
+        ? html`
+            <div class="rounded-[18px] border border-[rgba(71,184,255,0.14)] bg-[rgba(71,184,255,0.08)] px-3 py-2 text-[10px] text-[rgba(191,231,255,0.78)]">
+              build v${build.release_version} · ${shortCommit(build.commit)}
+            </div>
+          `
+        : null}
+
+      <div class="grid grid-cols-2 gap-2 text-[11px]">
+        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+          <div class="text-[10px] text-[var(--text-muted)]">에이전트</div>
+          <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--accent)]">${agents.value.length}</strong>
+        </div>
+        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+          <div class="text-[10px] text-[var(--text-muted)]">키퍼</div>
+          <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--ok)]">${keepers.value.length}</strong>
+        </div>
+        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+          <div class="text-[10px] text-[var(--text-muted)]">태스크</div>
+          <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--warn)]">${tasks.value.length}</strong>
+        </div>
+        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+          <div class="text-[10px] text-[var(--text-muted)]">이벤트</div>
+          <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--text-strong)]">${eventCount.value}</strong>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-2">
         <button
-          class="w-full border border-solid border-[rgba(71,184,255,0.3)] rounded-lg bg-[var(--accent-12)] text-[#d7efff] py-1.5 px-2 text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--accent-20)]"
+          class="w-full rounded-[16px] border border-solid border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.14)] px-3 py-2 text-[11px] font-medium text-[#dff3ff] cursor-pointer transition-colors duration-150 hover:bg-[rgba(71,184,255,0.2)]"
           onClick=${() => {
             refreshDashboard()
             refreshForTab(currentTab)
           }}
         >
-          새로고침
+          Room sync
         </button>
         <button
-          class="w-full border border-solid border-[var(--card-border)] rounded-lg py-1.5 px-2 bg-[var(--white-4)] text-[var(--text-body)] text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--white-8)]"
+          class="w-full rounded-[16px] border border-solid border-[var(--card-border)] px-3 py-2 bg-[rgba(255,255,255,0.04)] text-[var(--text-body)] text-[11px] font-medium cursor-pointer transition-colors duration-150 hover:bg-[rgba(255,255,255,0.08)]"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >
           운영 패널

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -236,7 +236,33 @@ body {
   font-family: "IBM Plex Sans KR", "IBM Plex Sans", "Pretendard", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   color: var(--text-body);
   line-height: 1.5;
-  background: var(--bg-0);
+  background:
+    radial-gradient(circle at 12% 12%, rgba(71, 184, 255, 0.18), transparent 26%),
+    radial-gradient(circle at 88% 14%, rgba(74, 222, 128, 0.12), transparent 20%),
+    radial-gradient(circle at 50% 100%, rgba(168, 85, 247, 0.1), transparent 28%),
+    linear-gradient(180deg, #06101d 0%, #0b1220 48%, #070d18 100%);
+  background-attachment: fixed;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(rgba(255,255,255,0.024) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.024) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(circle at center, black, transparent 88%);
+  opacity: 0.28;
+  z-index: 0;
+}
+
+#app {
+  position: relative;
+  min-height: 100vh;
+  z-index: 1;
 }
 
 a {


### PR DESCRIPTION
## Summary
- refresh the dashboard shell with a stronger control-deck header, card-based navigation rail, and a surface hero
- redesign the logs screen into a clearer observer workspace with better filter controls and readable table rows
- fold in small dashboard typecheck fixes that were already blocking local verification

## Verification
- npm run typecheck
- npm run build