### PR TITLE
fix(startup): remove blocking GC that prevents keeper bootstrap

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -133,17 +133,9 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Misc.error "startup checkpoint prune failed: %s" (Printexc.to_string exn));
-  (* Startup GC: archive stale rooms, tasks, sessions, etc.
-     Prevents .masc/ from growing unbounded and slowing snapshots.
-     Runs at server start so no manual masc_gc invocation is needed. *)
-  (try
-     let gc_days = Safe_ops.get_env_int_logged "MASC_GC_RETENTION_DAYS" ~default:7 in
-     let (_gc_result : string) = Room.gc state.room_config ~days:gc_days () in
-     Log.Misc.info "startup gc completed (retention=%dd)" gc_days
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Log.Misc.error "startup gc failed: %s" (Printexc.to_string exn));
+  (* Startup GC removed: Room.gc includes PG pubsub cleanup which can
+     block for seconds, delaying keeper bootstrap. The orchestrator's
+     periodic-gc Pulse consumer (hourly) handles cleanup instead. *)
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =


### PR DESCRIPTION
startup GC 제거. keeper가 안 뜨는 원인. orchestrator 주기적 GC로 대체.