### PR TITLE
refactor: deduplicate string_contains (Phase 1, -21 LOC)

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -11,18 +11,7 @@
 
 (** {1 String Helpers} *)
 
-(** Check if haystack contains needle *)
-let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len > haystack_len then false
-  else
-    let rec check i =
-      if i > haystack_len - needle_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else check (i + 1)
-    in
-    check 0
+let string_contains = Dashboard_utils.string_contains
 
 
 (** {1 Types} *)

--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -626,21 +626,8 @@ let list_alerts_json_from_state config (state : snapshot_state) =
 let list_alerts_json config =
   list_alerts_json_from_state config (build_snapshot_state config)
 
-let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      if idx + needle_len > haystack_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-
-let string_contains_ci ~needle haystack =
-  string_contains ~needle:(String.lowercase_ascii needle)
-    (String.lowercase_ascii haystack)
+let string_contains = Dashboard_utils.string_contains
+let string_contains_ci = Dashboard_utils.string_contains_ci
 
 let json_string_opt key = function
   | `Assoc fields -> List.assoc_opt key fields

--- a/lib/dashboard/dashboard_utils.ml
+++ b/lib/dashboard/dashboard_utils.ml
@@ -12,6 +12,22 @@ let parse_iso_opt = function
 let first_some left right =
   match left with Some _ -> left | None -> right
 
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len > haystack_len then false
+  else if needle_len = 0 then true
+  else
+    let rec check i =
+      if i > haystack_len - needle_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else check (i + 1)
+    in
+    check 0
+
+let string_contains_ci ~needle haystack =
+  string_contains ~needle:(String.lowercase_ascii needle) (String.lowercase_ascii haystack)
+
 let trim_to_option text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some trimmed

--- a/lib/mcp_prompt_surface.ml
+++ b/lib/mcp_prompt_surface.ml
@@ -84,21 +84,8 @@ let assoc_string args key =
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
-let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else
-    let rec loop idx =
-      if idx + needle_len > haystack_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
-    in
-    loop 0
-
-let string_contains_ci ~needle haystack =
-  string_contains ~needle:(String.lowercase_ascii needle)
-    (String.lowercase_ascii haystack)
+let string_contains = Dashboard_utils.string_contains
+let string_contains_ci = Dashboard_utils.string_contains_ci
 
 let run_tokens run_id =
   let safe = Room_utils.safe_filename run_id |> String.lowercase_ascii in


### PR DESCRIPTION
## Summary
`string_contains` + `string_contains_ci`가 10+곳에 복사됨.
Phase 1: `Dashboard_utils`에 canonical 정의, 3파일 위임 전환.

## Files
- `dashboard_utils.ml`: +16 (canonical 정의)
- `auto_recall.ml`: -12
- `mcp_prompt_surface.ml`: -15
- `cp_snapshot_core.ml`: -15

## Remaining (Phase 2)
tool_library (~sub), chain_utils (~substring), keeper_exec_status, tool_local_runtime_core

## Build
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)