### PR TITLE
refactor: Server_utils.take/drop → stdlib aliases (-17 LOC)

### DIFF
--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -20,25 +20,8 @@ let bool_query_param request key ~default =
 
 let clamp ~min_v ~max_v v = max min_v (min max_v v)
 
-let take n lst =
-  let rec loop acc remaining xs =
-    if remaining <= 0 then List.rev acc
-    else
-      match xs with
-      | [] -> List.rev acc
-      | x :: rest -> loop (x :: acc) (remaining - 1) rest
-  in
-  loop [] n lst
-
-let drop n lst =
-  let rec loop remaining xs =
-    if remaining <= 0 then xs
-    else
-      match xs with
-      | [] -> []
-      | _ :: rest -> loop (remaining - 1) rest
-  in
-  loop n lst
+let take = List.take
+let drop = List.drop
 
 let iso8601_of_unix ts =
   let tm = Unix.gmtime ts in


### PR DESCRIPTION
## Summary
Custom `take`/`drop` 구현 19줄을 `List.take`/`List.drop` 별칭 2줄로 교체.
`open Server_utils` 사용 10곳은 수정 없이 동작.

## Context
- e2e-004: `Server_utils.drop` → `List.drop` (직접 호출 교체)
- e2e-010: `Server_utils.take` → `List.take` (직접 호출 교체)
- 이 PR: 구현체 자체를 stdlib 별칭으로 교체

## Build
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)