### PR TITLE
feat: introduce Base library, delegate utils to Base.{Option,String}

### DIFF
--- a/lib/dashboard/dashboard_utils.ml
+++ b/lib/dashboard/dashboard_utils.ml
@@ -9,24 +9,16 @@ let parse_iso_opt = function
       try Some (Types.parse_iso8601 raw) with Failure _ -> None)
   | _ -> None
 
-let first_some left right =
-  match left with Some _ -> left | None -> right
+(* Delegate to Base — qualified access, no `open Base` *)
+let first_some = Base.Option.first_some
 
 let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len > haystack_len then false
-  else if needle_len = 0 then true
-  else
-    let rec check i =
-      if i > haystack_len - needle_len then false
-      else if String.sub haystack i needle_len = needle then true
-      else check (i + 1)
-    in
-    check 0
+  Base.String.is_substring haystack ~substring:needle
 
 let string_contains_ci ~needle haystack =
-  string_contains ~needle:(String.lowercase_ascii needle) (String.lowercase_ascii haystack)
+  Base.String.is_substring
+    (Base.String.lowercase haystack)
+    ~substring:(Base.String.lowercase needle)
 
 let trim_to_option text =
   let trimmed = String.trim text in

--- a/lib/dune
+++ b/lib/dune
@@ -753,6 +753,8 @@
    h2
    h2-eio
    ;; ctypes/ctypes-foreign removed (was only used by webrtc_bindings.ml)
+   ;; Jane Street Base — qualified access only (no `open Base`)
+   base
    ;; OCaml 5.x Eio concurrency (required for *_eio.ml modules)
    eio
    eio_main


### PR DESCRIPTION
## Summary
`base` 라이브러리를 dune 의존성에 추가. qualified access만 사용 (`open Base` 금지).

`Dashboard_utils`의 수동 구현 3개를 Base 위임으로 교체:
- `first_some` → `Base.Option.first_some`
- `string_contains` → `Base.String.is_substring`
- `string_contains_ci` → `Base.String.is_substring` + `Base.String.lowercase`

## Design decisions
- **`open Base` 금지**: stdlib shadow 방지. 모든 Base 호출은 `Base.Module.fn` 형식.
- **facade 유지**: `Dashboard_utils.string_contains` 인터페이스 불변. 호출자 수정 없음.
- **점진적**: 이 PR은 3개 함수만. 향후 다른 수동 구현도 Base 위임으로 전환 가능.

## Build
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)