### PR TITLE
feat(server): auto-detect HTTP/1.1 and HTTP/2 on same port

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -145,6 +145,7 @@
    hebbian_eio
    http_server_eio
    http_server_h2
+   http_protocol_detect
    institution_eio
    level2_config
    level4_config

--- a/lib/http_protocol_detect.ml
+++ b/lib/http_protocol_detect.ml
@@ -1,0 +1,59 @@
+(** HTTP protocol detection via connection preface inspection.
+
+    HTTP/2 clients using prior knowledge (h2c) send a 24-byte
+    connection preface that starts with [PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n].
+    We peek the first bytes of a newly accepted connection (using
+    [Unix.recv MSG_PEEK] so the data stays in the kernel buffer) and
+    branch to the appropriate handler. *)
+
+type protocol =
+  | Http1
+  | Http2
+
+(** The first 14 bytes of the HTTP/2 connection preface are enough to
+    disambiguate from any valid HTTP/1.x request line, which always
+    starts with a method token (GET, POST, ...). *)
+let h2_preface_prefix = "PRI * HTTP/2.0"
+
+let h2_preface_len = String.length h2_preface_prefix (* 14 *)
+
+(** [detect_from_fd fd] peeks at the first bytes on [fd] using
+    [MSG_PEEK] (non-destructive) and returns the detected protocol.
+
+    Returns [Ok Http2] if the prefix matches the HTTP/2 connection
+    preface, [Ok Http1] otherwise.  Returns [Error msg] if the peek
+    syscall fails (e.g. connection reset before any data). *)
+let detect_from_fd (fd : Unix.file_descr) : (protocol, string) result =
+  let buf = Bytes.create h2_preface_len in
+  match Unix.recv fd buf 0 h2_preface_len [ Unix.MSG_PEEK ] with
+  | n when n >= h2_preface_len ->
+    if Bytes.sub_string buf 0 h2_preface_len = h2_preface_prefix then
+      Ok Http2
+    else
+      Ok Http1
+  | n when n > 0 ->
+    (* Partial read: not enough bytes for H2 preface, treat as HTTP/1.1.
+       This can happen if the client sends a very short request, but any
+       valid HTTP/2 client sends the full preface first. *)
+    Ok Http1
+  | _ ->
+    (* 0 bytes = connection closed before sending anything *)
+    Error "connection closed before protocol detection"
+  | exception Unix.Unix_error (err, _fn, _arg) ->
+    Error (Printf.sprintf "peek failed: %s" (Unix.error_message err))
+
+(** [detect flow] extracts the underlying Unix FD from an Eio stream
+    socket, peeks at the first bytes, and returns the detected protocol.
+
+    The socket data is not consumed; both httpun-eio and h2-eio will
+    read it normally afterwards. *)
+let detect (flow : _ Eio.Net.stream_socket) : (protocol, string) result =
+  match Eio_unix.Resource.fd_opt (flow :> _ Eio.Resource.t) with
+  | None -> Error "no Unix FD available on this socket"
+  | Some eio_fd ->
+    Eio_unix.Fd.use_exn "protocol_detect" eio_fd (fun unix_fd ->
+      detect_from_fd unix_fd)
+
+let protocol_to_string = function
+  | Http1 -> "HTTP/1.1"
+  | Http2 -> "HTTP/2"

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -447,103 +447,6 @@ let serve ~sw ~clock ~socket ~request_handler =
   in
   accept_loop 0.05
 
-(** {1 Protocol Auto-Detection}
-
-    When MASC_USE_H2=1, the server accepts both HTTP/2 (h2c with prior
-    knowledge) and HTTP/1.1 on the same port.  Each accepted connection
-    is peeked via Unix MSG_PEEK to inspect the first bytes without
-    consuming them from the kernel buffer.
-
-    HTTP/2 connection preface (RFC 7540 §3.5) starts with
-    "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" — 24 bytes.  Matching the
-    first 14 bytes ("PRI * HTTP/2.0") is sufficient. *)
-
-let h2_preface_prefix = "PRI * HTTP/2.0"
-let h2_preface_len = String.length h2_preface_prefix
-
-let detect_h2 (flow : _ Eio.Net.stream_socket) =
-  try
-    match Eio_unix.Resource.fd_opt flow with
-    | None -> false
-    | Some fd ->
-      Eio_unix.Fd.use_exn "h2-detect" fd (fun unix_fd ->
-        let buf = Bytes.create h2_preface_len in
-        let n = Unix.recv unix_fd buf 0 h2_preface_len [Unix.MSG_PEEK] in
-        n >= h2_preface_len
-        && Bytes.sub_string buf 0 h2_preface_len = h2_preface_prefix)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _exn -> false
-
-let serve_auto ~sw ~clock ~socket ~request_handler
-    ~h2_request_handler ~h2_error_handler =
-  let is_cancelled exn =
-    match exn with
-    | Eio.Cancel.Cancelled _ -> true
-    | _ -> false
-  in
-  Log.Server.info "HTTP auto-detect mode: h2c + HTTP/1.1 on same port";
-  let h2_count = Atomic.make 0 in
-  let h1_count = Atomic.make 0 in
-  let rec accept_loop backoff_s =
-    try
-      let flow, client_addr = Eio.Net.accept ~sw socket in
-      Eio.Fiber.fork ~sw (fun () ->
-          Eio.Switch.run (fun conn_sw ->
-              Eio.Switch.on_release conn_sw (fun () ->
-                  try Eio.Flow.close flow
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn -> Log.Misc.warn "[auto] flow close: %s"
-                    (Printexc.to_string exn));
-              try
-                if detect_h2 flow then begin
-                  ignore (Atomic.fetch_and_add h2_count 1);
-                  H2_eio.Server.create_connection_handler ~sw:conn_sw
-                    ~request_handler:h2_request_handler
-                    ~error_handler:h2_error_handler
-                    client_addr flow
-                end else begin
-                  ignore (Atomic.fetch_and_add h1_count 1);
-                  let conn_handler =
-                    Httpun_eio.Server.create_connection_handler ~sw:conn_sw
-                      ~request_handler:(fun ca -> request_handler ca)
-                      ~error_handler:(fun _ca ?request:_ error respond ->
-                        let msg = match error with
-                          | `Exn exn -> Printexc.to_string exn
-                          | `Bad_request -> "Bad request"
-                          | `Bad_gateway -> "Bad gateway"
-                          | `Internal_server_error -> "Internal server error"
-                        in
-                        let body = respond (Httpun.Headers.of_list
-                          [("content-type", "text/plain")]) in
-                        Httpun.Body.Writer.write_string body msg;
-                        Httpun.Body.Writer.close body)
-                  in
-                  conn_handler client_addr flow
-                end
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                Log.Misc.error "[auto] Connection error: %s"
-                  (Printexc.to_string exn)));
-      accept_loop 0.05
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      if is_cancelled exn then
-        Log.Server.info "[auto] stats: h2=%d h1=%d"
-          (Atomic.get h2_count) (Atomic.get h1_count)
-      else begin
-        Log.Misc.error "[auto] Accept error: %s" (Printexc.to_string exn);
-        (try Eio.Time.sleep clock backoff_s
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> Log.Misc.warn "[auto] backoff: %s"
-           (Printexc.to_string exn));
-        accept_loop (Float.min 2.0 (backoff_s *. 1.5))
-      end
-  in
-  accept_loop 0.05
-
 let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
   let is_cancelled exn =
     match exn with
@@ -586,6 +489,95 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
   in
   accept_loop 0.05
 
+(** Accept loop with automatic HTTP/1.1 vs HTTP/2 detection.
+    Each connection is peeked (MSG_PEEK) to inspect the first bytes
+    before dispatching to httpun-eio or h2-eio.  The peek is
+    non-destructive, so both libraries read the socket normally. *)
+let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
+    ~h2_error_handler =
+  let is_cancelled exn =
+    match exn with
+    | Eio.Cancel.Cancelled _ -> true
+    | _ -> false
+  in
+  Log.Server.info "HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port";
+  let h2_count = Atomic.make 0 in
+  let h1_count = Atomic.make 0 in
+  let rec accept_loop backoff_s =
+    try
+      let flow, client_addr = Eio.Net.accept ~sw socket in
+      Eio.Fiber.fork ~sw (fun () ->
+          Eio.Switch.run (fun conn_sw ->
+              Eio.Switch.on_release conn_sw (fun () ->
+                  try Eio.Flow.close flow
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                    Log.Misc.warn "[auto] flow close: %s"
+                      (Printexc.to_string exn));
+              try
+                match Http_protocol_detect.detect flow with
+                | Ok Http_protocol_detect.Http2 ->
+                  ignore (Atomic.fetch_and_add h2_count 1);
+                  H2_eio.Server.create_connection_handler ~sw:conn_sw
+                    ~request_handler:h2_request_handler
+                    ~error_handler:h2_error_handler
+                    client_addr
+                    flow
+                | Ok Http_protocol_detect.Http1 ->
+                  ignore (Atomic.fetch_and_add h1_count 1);
+                  let conn_handler =
+                    Httpun_eio.Server.create_connection_handler ~sw:conn_sw
+                      ~request_handler:(fun client_addr ->
+                        request_handler client_addr)
+                      ~error_handler:
+                        (fun _client_addr ?request:_ error respond ->
+                        let msg =
+                          match error with
+                          | `Exn exn -> Printexc.to_string exn
+                          | `Bad_request -> "Bad request"
+                          | `Bad_gateway -> "Bad gateway"
+                          | `Internal_server_error -> "Internal server error"
+                        in
+                        let body =
+                          respond
+                            (Httpun.Headers.of_list
+                               [ ("content-type", "text/plain") ])
+                        in
+                        Httpun.Body.Writer.write_string body msg;
+                        Httpun.Body.Writer.close body)
+                  in
+                  conn_handler client_addr flow
+                | Error msg ->
+                  Log.Misc.warn "[auto] protocol detect failed: %s" msg
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Misc.error "[auto] Connection error: %s"
+                  (Printexc.to_string exn)));
+      accept_loop 0.05
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      Log.Server.info "[auto] stats: h2=%d h1=%d"
+        (Atomic.get h2_count) (Atomic.get h1_count);
+      raise e
+    | exn ->
+      if is_cancelled exn then
+        Log.Server.info "[auto] stats: h2=%d h1=%d"
+          (Atomic.get h2_count) (Atomic.get h1_count)
+      else begin
+        Log.Misc.error "[auto] Accept error: %s" (Printexc.to_string exn);
+        (try Eio.Time.sleep clock backoff_s
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Misc.warn "[auto] backoff sleep: %s"
+             (Printexc.to_string exn));
+        accept_loop (Float.min 2.0 (backoff_s *. 1.5))
+      end
+  in
+  accept_loop 0.05
+
 let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     ~make_h2_request_handler ~make_h2_error_handler =
   let clock, mono_clock, net, domain_mgr, proc_mgr, fs =
@@ -604,10 +596,14 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     make_h2_request_handler ~sw ~clock ~server_start_time
   in
   let h2_error_handler = make_h2_error_handler () in
-  let use_h2 =
+  let http_mode =
     match Sys.getenv_opt "MASC_USE_H2" with
-    | Some "1" | Some "true" -> true
-    | _ -> false
+    | Some "1" | Some "true" -> `H2_only
+    | Some "0" | Some "false" -> `H1_only
+    | Some "auto" | None -> `Auto
+    | Some other ->
+      Log.Server.warn "MASC_USE_H2=%s unrecognised, falling back to auto" other;
+      `Auto
   in
   let socket = listen_socket ~sw ~net config in
 
@@ -680,9 +676,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Log.Server.error "Background init failed (HTTP still serving): %s"
         (Printexc.to_string exn));
 
-  (* 3. Start serving — /health responds before init completes *)
-  if use_h2 then
-    serve_auto ~sw ~clock ~socket ~request_handler
-      ~h2_request_handler ~h2_error_handler
-  else
+  (* 3. Start serving -- /health responds before init completes *)
+  match http_mode with
+  | `H2_only ->
+    serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler
+  | `H1_only ->
     serve ~sw ~clock ~socket ~request_handler
+  | `Auto ->
+    serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
+      ~h2_error_handler

--- a/test/dune
+++ b/test/dune
@@ -1061,3 +1061,9 @@
  (name test_context_budget)
  (modules test_context_budget)
  (libraries masc_mcp alcotest))
+
+; HTTP protocol auto-detection (MSG_PEEK on connection preface)
+(test
+ (name test_http_protocol_detect)
+ (modules test_http_protocol_detect)
+ (libraries masc_mcp alcotest unix))

--- a/test/test_http_protocol_detect.ml
+++ b/test/test_http_protocol_detect.ml
@@ -1,0 +1,118 @@
+(** Unit tests for Http_protocol_detect.
+
+    Uses Unix.socketpair to create connected FDs, writes protocol
+    prefixes on one end, and verifies detection on the other. *)
+
+open Masc_mcp
+
+let test_detect_h2_preface () =
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd_r; Unix.close fd_w) (fun () ->
+    (* Write the full HTTP/2 connection preface prefix *)
+    let preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n" in
+    let _ = Unix.write_substring fd_w preface 0 (String.length preface) in
+    match Http_protocol_detect.detect_from_fd fd_r with
+    | Ok Http_protocol_detect.Http2 -> ()
+    | Ok Http_protocol_detect.Http1 ->
+      Alcotest.fail "expected Http2 but got Http1"
+    | Error msg ->
+      Alcotest.failf "expected Http2 but got Error: %s" msg)
+
+let test_detect_h1_get () =
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd_r; Unix.close fd_w) (fun () ->
+    let req = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n" in
+    let _ = Unix.write_substring fd_w req 0 (String.length req) in
+    match Http_protocol_detect.detect_from_fd fd_r with
+    | Ok Http_protocol_detect.Http1 -> ()
+    | Ok Http_protocol_detect.Http2 ->
+      Alcotest.fail "expected Http1 but got Http2"
+    | Error msg ->
+      Alcotest.failf "expected Http1 but got Error: %s" msg)
+
+let test_detect_h1_post () =
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd_r; Unix.close fd_w) (fun () ->
+    let req = "POST /mcp HTTP/1.1\r\nHost: localhost\r\n\r\n" in
+    let _ = Unix.write_substring fd_w req 0 (String.length req) in
+    match Http_protocol_detect.detect_from_fd fd_r with
+    | Ok Http_protocol_detect.Http1 -> ()
+    | Ok Http_protocol_detect.Http2 ->
+      Alcotest.fail "expected Http1 but got Http2"
+    | Error msg ->
+      Alcotest.failf "expected Http1 but got Error: %s" msg)
+
+let test_detect_partial_read () =
+  (* If less than 14 bytes arrive, detect should return Http1
+     (partial data cannot be an H2 preface). *)
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd_r; Unix.close fd_w) (fun () ->
+    let short = "GET /" in
+    let _ = Unix.write_substring fd_w short 0 (String.length short) in
+    (* Close writer so recv returns what's available *)
+    Unix.shutdown fd_w Unix.SHUTDOWN_SEND;
+    match Http_protocol_detect.detect_from_fd fd_r with
+    | Ok Http_protocol_detect.Http1 -> ()
+    | Ok Http_protocol_detect.Http2 ->
+      Alcotest.fail "expected Http1 for partial data but got Http2"
+    | Error _msg ->
+      (* Error is also acceptable for partial data + closed connection *)
+      ())
+
+let test_detect_closed_connection () =
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  (* Close writer immediately -- reader sees EOF *)
+  Unix.close fd_w;
+  Fun.protect ~finally:(fun () -> Unix.close fd_r) (fun () ->
+    match Http_protocol_detect.detect_from_fd fd_r with
+    | Error _ -> ()
+    | Ok Http_protocol_detect.Http1 ->
+      (* recv returning 0 on closed fd maps to Http1 in some edge cases;
+         not ideal but acceptable -- connection will fail at protocol level. *)
+      ()
+    | Ok Http_protocol_detect.Http2 ->
+      Alcotest.fail "should not detect Http2 on closed connection")
+
+let test_peek_is_non_destructive () =
+  (* After detect_from_fd, the data should still be readable from the socket
+     because MSG_PEEK does not consume bytes. *)
+  let fd_r, fd_w = Unix.socketpair Unix.PF_UNIX Unix.SOCK_STREAM 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd_r; Unix.close fd_w) (fun () ->
+    let req = "GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n" in
+    let _ = Unix.write_substring fd_w req 0 (String.length req) in
+    (* Detect first *)
+    (match Http_protocol_detect.detect_from_fd fd_r with
+     | Ok Http_protocol_detect.Http1 -> ()
+     | _ -> Alcotest.fail "expected Http1");
+    (* Now read normally -- data should still be there *)
+    let buf = Bytes.create 14 in
+    let n = Unix.recv fd_r buf 0 14 [] in
+    let read_str = Bytes.sub_string buf 0 n in
+    Alcotest.(check string) "peek preserved data"
+      "GET /health HT" read_str)
+
+let test_protocol_to_string () =
+  Alcotest.(check string) "Http1 label"
+    "HTTP/1.1"
+    (Http_protocol_detect.protocol_to_string Http_protocol_detect.Http1);
+  Alcotest.(check string) "Http2 label"
+    "HTTP/2"
+    (Http_protocol_detect.protocol_to_string Http_protocol_detect.Http2)
+
+let () =
+  Alcotest.run "http_protocol_detect"
+    [
+      ( "detection",
+        [
+          Alcotest.test_case "H2 preface" `Quick test_detect_h2_preface;
+          Alcotest.test_case "H1 GET" `Quick test_detect_h1_get;
+          Alcotest.test_case "H1 POST" `Quick test_detect_h1_post;
+          Alcotest.test_case "partial read" `Quick test_detect_partial_read;
+          Alcotest.test_case "closed connection" `Quick
+            test_detect_closed_connection;
+          Alcotest.test_case "peek non-destructive" `Quick
+            test_peek_is_non_destructive;
+          Alcotest.test_case "protocol_to_string" `Quick
+            test_protocol_to_string;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

같은 포트에서 HTTP/1.1과 HTTP/2 h2c를 자동 감지하여 동시 지원.

### Implementation
- **`Http_protocol_detect` 모듈** (59 LOC): Unix `MSG_PEEK`로 첫 14바이트를 비소비적으로 읽어 HTTP/2 connection preface 판별
- **`MASC_USE_H2` 기본값**: `auto` (자동 감지). `0`=HTTP/1.1 전용, `1`=h2c 전용도 유지
- **Eio 통합**: `Eio_unix.Fd.use_exn`으로 FD refcount 안전 관리

### HTTP/3
OCaml에 QUIC 라이브러리 없음. Cloudflare edge가 HTTP/3을 제공하므로 origin 불필요.

## Test plan
- [x] `test_http_protocol_detect` 7/7 PASS
- [x] `dune build` 성공
- [ ] `curl http://localhost:8935/health` (HTTP/1.1)
- [ ] `curl --http2-prior-knowledge http://localhost:8935/health` (h2c)
- [ ] CI green