### PR TITLE
fix(pg): drain Caqti pools on exit to prevent connection leaks

### DIFF
--- a/lib/backend/backend_eio_pg.ml
+++ b/lib/backend/backend_eio_pg.ml
@@ -129,7 +129,11 @@ let create ~sw ~env ~url ~cluster_name ~node_id =
       ) pool in
       (match init_result with
        | Error err -> Error (caqti_error_to_masc err)
-       | Ok () -> Ok { pool; namespace = cluster_name; node_id })
+       | Ok () ->
+           at_exit (fun () ->
+             try Caqti_eio.Pool.drain pool
+             with _ -> ());
+           Ok { pool; namespace = cluster_name; node_id })
 
 let get t key =
   let nkey = namespaced_key t.namespace key in

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -255,6 +255,9 @@ let create_eio ~sw ~env (cfg : config) : (t, error) result =
                Error (caqti_error_to_masc err)
            | Ok () ->
                Log.Backend.info "[PG] connected and schema ready";
+               at_exit (fun () ->
+                 try Caqti_eio.Pool.drain pool
+                 with _ -> ());
                Ok { pool; namespace = cfg.cluster_name; clock = env#clock; _sw = sw })
 
 (** Lightweight pool creation for use in a different Eio domain.

--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -289,6 +289,12 @@ let get_pg_pool ~sw ~env =
       match Caqti_eio_unix.connect_pool ~sw ~pool_config uri ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;
+        (* Register shutdown hook to drain PG connections.
+           Without this, force-exit leaves TCP connections as zombies
+           and Supabase session pooler hits MaxClientsInSessionMode. *)
+        at_exit (fun () ->
+          try Caqti_eio.Pool.drain pool
+          with _ -> ());
         Ok pool
       | Error e -> Error (Caqti_error.show e)
 


### PR DESCRIPTION
## Summary
PG pool `at_exit` drain 등록. force-exit 시 Supabase connection 좀비 방지.

## Root Cause
- 3곳에서 독립 PG pool 생성 (archive, backend_pg, backend_eio_pg)
- Shutdown force timeout(10s) 후 `exit 1` → Eio Switch release 안 됨 → Caqti drain 안 됨
- TCP 연결 좀비 → Supabase `MaxClientsInSessionMode`
- 빈번한 재시작으로 누적

## Fix
`at_exit` hook으로 `Caqti_eio.Pool.drain` 등록. `exit 1`에서도 실행됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)