### PR TITLE
refactor(dashboard): revamp navigation structure to single-tier LNB

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -103,8 +103,8 @@ export function closeAgentDetail(): void {
   taskHistories.value = []
   agentTimeline.value = null
   mentionText.value = ''
-  if (route.value.tab === 'status' && route.value.params.agent) {
-    navigate('status', { section: 'agents' })
+  if (route.value.tab === 'monitoring' && route.value.params.agent) {
+    navigate('monitoring', { section: 'agents' })
   }
 }
 

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -118,7 +118,7 @@ export function Command() {
   }, [])
 
   useEffect(() => {
-    if (route.value.tab !== 'operations' || route.value.params.section !== 'command') return
+    if (route.value.tab !== 'command' || route.value.params.section !== 'warroom') return
     const requestedSurface = route.value.params.surface
     const requestedOperation = route.value.params.operation
     const workflowContext = workflowContextForRoute(route.value)

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -14,7 +14,6 @@ import {
   DASHBOARD_NAV_ITEMS,
   currentSectionForRoute,
   sectionItemsForTab,
-  surfaceForTab,
 } from '../config/navigation'
 import { SnapshotCard } from './resident-runtime-rail'
 
@@ -167,91 +166,59 @@ function SurfaceLead() {
 }
 
 export function SideRail() {
-  const current = route.value.tab
-  const currentSurface = surfaceForTab(current)
-  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === current)
+  const currentTab = route.value.tab
   const currentSection = currentSectionForRoute(route.value)
-  const sectionItems = sectionItemsForTab(current)
 
   return html`
     <nav class="flex flex-col h-full">
       <div class="flex-1 overflow-y-auto px-3 py-4">
-        <div class="mb-4 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] px-3 py-3">
+        <div class="mb-4 px-3">
           <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Navigation</div>
-          <div class="mt-2 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">Surface Atlas</div>
-          <p class="mt-1 text-[11px] leading-relaxed text-[var(--text-muted)]">
-            주요 면을 먼저 고르고, 같은 맥락의 하위 섹션을 바로 이동합니다.
-          </p>
+          <div class="mt-1 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
         </div>
 
-        <div class="flex flex-col gap-2">
+        <div class="flex flex-col gap-4">
           ${DASHBOARD_SURFACES.map(surface => {
-            const isActive = surface.id === currentSurface
+            const isSurfaceActive = surface.id === currentTab
+            const sections = sectionItemsForTab(surface.id)
+
             return html`
-              <button
-                class="w-full rounded-[22px] border border-solid px-3 py-3 text-left cursor-pointer transition-all duration-150 ${isActive ? 'border-[rgba(71,184,255,0.28)] bg-[linear-gradient(135deg,rgba(71,184,255,0.18),rgba(255,255,255,0.04))] shadow-[0_14px_28px_rgba(0,0,0,0.18)]' : 'border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.02)] hover:border-[rgba(255,255,255,0.12)] hover:bg-[rgba(255,255,255,0.04)]'}"
-                key=${surface.id}
-                onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
-              >
-                <div class="flex items-start gap-3">
-                  <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[18px]">
+              <div class="flex flex-col gap-1">
+                <button
+                  class="flex items-center gap-3 w-full rounded-[14px] px-3 py-2.5 text-left cursor-pointer transition-all duration-150 ${isSurfaceActive && sections.length === 0 ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.04)]'}"
+                  onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
+                >
+                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[14px]">
                     ${surface.icon}
                   </span>
-                  <div class="min-w-0 flex-1">
-                    <div class="flex items-center justify-between gap-2">
-                      <span class="text-[13px] font-semibold ${isActive ? 'text-[#d9f2ff]' : 'text-[var(--text-strong)]'}">${surface.label}</span>
-                      ${isActive
-                        ? html`<span class="rounded-full border border-[rgba(71,184,255,0.24)] bg-[rgba(71,184,255,0.14)] px-2 py-0.5 text-[10px] font-medium text-[#9ad9ff]">active</span>`
-                        : null}
-                    </div>
-                    <p class="mt-1 text-[11px] leading-relaxed ${isActive ? 'text-[rgba(214,236,255,0.78)]' : 'text-[var(--text-muted)]'}">
-                      ${surface.description}
-                    </p>
+                  <div class="flex-1 min-w-0">
+                    <div class="text-[13px] font-semibold truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
                   </div>
-                </div>
-              </button>
+                </button>
+                
+                ${sections.length > 0 ? html`
+                  <div class="flex flex-col gap-0.5 pl-11 pr-2">
+                    ${sections.map(item => {
+                      const isSectionActive = isSurfaceActive && currentSection?.id === item.id
+                      return html`
+                        <button
+                          class="w-full rounded-[10px] px-3 py-2 text-left cursor-pointer text-[12px] transition-all duration-150 ${isSectionActive ? 'bg-[rgba(71,184,255,0.12)] text-[#cfeaff] font-medium' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
+                          onClick=${() => navigate(surface.id, item.params)}
+                        >
+                          <div class="truncate">${item.label}</div>
+                        </button>
+                      `
+                    })}
+                  </div>
+                ` : null}
+              </div>
             `
           })}
         </div>
-
-        ${(() => {
-          if (sectionItems.length === 0) return null
-          return html`
-            <div class="mt-5 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.025)] px-3 py-3">
-              <div class="flex items-center justify-between gap-2">
-                <div>
-                  <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">
-                    ${currentView?.label ?? currentSurface}
-                  </div>
-                  <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">
-                    ${currentSection?.label ?? 'Sections'}
-                  </div>
-                </div>
-                <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[10px] text-[var(--text-muted)] tabular-nums">
-                  ${sectionItems.length}
-                </span>
-              </div>
-              <div class="mt-3 flex flex-col gap-1.5">
-                ${sectionItems.map(item => html`
-                  <button
-                    class="w-full rounded-[16px] border border-solid px-3 py-2 text-left cursor-pointer text-[12px] transition-all duration-150 ${currentSection?.id === item.id ? 'border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.14)] text-[#cfeaff] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]' : 'border-transparent bg-transparent text-[var(--text-muted)] hover:border-[rgba(255,255,255,0.08)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
-                    key=${item.id}
-                    onClick=${() => navigate(currentSurface, item.params)}
-                  >
-                    <div class="font-medium">${item.label}</div>
-                    <div class="mt-1 text-[10px] leading-relaxed ${currentSection?.id === item.id ? 'text-[rgba(222,240,255,0.72)]' : 'text-[var(--text-muted)]'}">
-                      ${item.description}
-                    </div>
-                  </button>
-                `)}
-              </div>
-            </div>
-          `
-        })()}
       </div>
 
       <div class="shrink-0 border-t border-[rgba(255,255,255,0.06)] p-3">
-        <${SnapshotCard} currentTab=${current} />
+        <${SnapshotCard} currentTab=${currentTab} />
       </div>
     </nav>
   `
@@ -261,23 +228,23 @@ export function TabContent() {
   const tab = route.value.tab
 
   switch (tab) {
-    case 'home':
+    case 'overview':
       return html`<${Overview} />`
-    case 'status':
+    case 'monitoring':
       return html`
-        <${Suspense} fallback=${lazyTabFallback('현황 화면')}>
+        <${Suspense} fallback=${lazyTabFallback('모니터링 화면')}>
           <${LazyStatus} />
         <//>
       `
-    case 'work':
+    case 'workspace':
       return html`
         <${Suspense} fallback=${lazyTabFallback('작업 화면')}>
           <${LazyWork} />
         <//>
       `
-    case 'operations':
+    case 'command':
       return html`
-        <${Suspense} fallback=${lazyTabFallback('운영 화면')}>
+        <${Suspense} fallback=${lazyTabFallback('지휘 통제 화면')}>
           <${LazyOperations} />
         <//>
       `

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -1,7 +1,6 @@
 // Goal sub-components: GoalRow, HorizonGroup, FilterBar, GoalsSummary
 
 import { html } from 'htm/preact'
-import { Card } from '../common/card'
 import { StatusBadge } from '../common/status-badge'
 import { TimeAgo } from '../common/time-ago'
 import { FilterChips } from '../common/filter-chips'

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -3,7 +3,6 @@
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
 import { LoadingState } from '../common/feedback-state'
-import { CARD_STANDARD } from '../common/card'
 import {
   goals,
   goalsLoading,

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -47,7 +47,7 @@ import { OpsKeeperColumn } from './ops-keeper-column'
 
 export function Ops() {
   const snapshot = operatorSnapshot.value
-  const workflowContext = route.value.tab === 'operations' ? workflowContextForRoute(route.value) : null
+  const workflowContext = route.value.tab === 'command' ? workflowContextForRoute(route.value) : null
   const roomDigest = operatorRoomDigest.value
   const room = snapshot?.room ?? {}
   const sessions = snapshot?.sessions ?? []
@@ -71,7 +71,7 @@ export function Ops() {
   }, [])
 
   useEffect(() => {
-    if (route.value.tab !== 'operations' || route.value.params.section !== 'intervene') {
+    if (route.value.tab !== 'command' || route.value.params.section !== 'intervene') {
       hydratedWorkflowId.value = null
       return
     }

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -36,7 +36,7 @@ export function FullInventoryView({
   const listContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (route.value.tab !== 'operations' || route.value.params.section !== 'tools') return
+    if (route.value.tab !== 'lab' || route.value.params.section !== 'tools') return
     const q = route.value.params.q?.trim()
     searchQuery.value = q ?? ''
   }, [route.value.tab, route.value.params.section, route.value.params.q])

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -11,13 +11,12 @@ export type SurfaceSectionId =
   | 'planning'
   | 'worktrees'
   | 'intervene'
-  | 'command'
+  | 'warroom'
   | 'tools'
-  | 'overview'
   | 'trpg'
   | 'avatars'
 
-type NonHomeTabId = Exclude<TabId, 'home'>
+type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 const OPERATIONS_COMMAND_SURFACES = new Set([
   'warroom',
   'summary',
@@ -58,54 +57,54 @@ export interface DashboardSectionNavItem {
 
 export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
-    id: 'home',
-    label: '홈',
+    id: 'overview',
+    label: '오버뷰',
     icon: '🏠',
-    description: '지금 필요한 신호만 빠르게 보는 첫 화면',
-    defaultTab: 'home',
-    tabs: ['home'],
+    description: '빠른 신호 및 브리핑 통합 화면',
+    defaultTab: 'overview',
+    tabs: ['overview'],
   },
   {
-    id: 'status',
-    label: '현황',
+    id: 'monitoring',
+    label: '모니터링',
     icon: '📡',
-    description: '세션, 에이전트, 활동 흐름을 읽는 기본 관찰면',
-    defaultTab: 'status',
+    description: '세션 룸 및 에이전트/키퍼 현황 관찰',
+    defaultTab: 'monitoring',
     defaultParams: { section: 'sessions' },
-    tabs: ['status'],
+    tabs: ['monitoring'],
   },
   {
-    id: 'work',
+    id: 'command',
+    label: '지휘 통제',
+    icon: '🎛️',
+    description: '실시간 개입, 워룸, 거버넌스 제어',
+    defaultTab: 'command',
+    defaultParams: { section: 'intervene' },
+    tabs: ['command'],
+  },
+  {
+    id: 'workspace',
     label: '작업',
     icon: '📋',
-    description: '게시판, 거버넌스, 근거, 계획을 모아 보는 작업면',
-    defaultTab: 'work',
+    description: '작업 게시판, 근거 및 계획 이력 탐색',
+    defaultTab: 'workspace',
     defaultParams: { section: 'board' },
-    tabs: ['work'],
-  },
-  {
-    id: 'operations',
-    label: '운영',
-    icon: '🎛️',
-    description: '개입, 지휘, 도구를 다루는 운영면',
-    defaultTab: 'operations',
-    defaultParams: { section: 'intervene' },
-    tabs: ['operations'],
+    tabs: ['workspace'],
   },
   {
     id: 'lab',
-    label: '실험',
+    label: '실험실',
     icon: '🧪',
-    description: 'TRPG와 실험 기능을 분리한 실험면',
+    description: '시스템 도구 테스트 및 TRPG 실험',
     defaultTab: 'lab',
-    defaultParams: { section: 'overview' },
+    defaultParams: { section: 'tools' },
     tabs: ['lab'],
   },
   {
     id: 'logs',
     label: '로그',
     icon: '📜',
-    description: '시스템 실행 로그 (바이너리 stdout/stderr)',
+    description: '시스템 실행 로그',
     defaultTab: 'logs',
     tabs: ['logs'],
   },
@@ -120,84 +119,78 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
 }))
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
-  status: [
+  monitoring: [
     {
       id: 'sessions',
-      label: '세션',
-      description: '지금 진행 중인 세션과 attention을 먼저 읽습니다.',
+      label: '세션 & 룸',
+      description: '진행 중인 세션과 룸 현황을 봅니다.',
       params: { section: 'sessions' },
     },
     {
       id: 'agents',
-      label: '에이전트',
-      description: '에이전트, 키퍼, 세션을 한곳에서 탐색합니다.',
+      label: '에이전트 & 키퍼',
+      description: '로스터 및 활성 에이전트 상태를 탐색합니다.',
       params: { section: 'agents' },
     },
     {
       id: 'activity',
-      label: '활동',
-      description: '실시간 이벤트 흐름과 활동 그래프를 봅니다.',
+      label: '활동 그래프',
+      description: '실시간 이벤트 흐름을 봅니다.',
       params: { section: 'activity' },
     },
   ],
-  work: [
+  command: [
     {
-      id: 'board',
-      label: '게시판',
-      description: '팀 대화와 지식 공유를 보는 기본 작업면입니다.',
-      params: { section: 'board' },
+      id: 'intervene',
+      label: '실시간 개입',
+      description: '방, 세션, 키퍼에 바로 개입합니다.',
+      params: { section: 'intervene' },
+    },
+    {
+      id: 'warroom',
+      label: '워룸 & 스웜',
+      description: '워룸 상황판과 오케스트라 지휘면입니다.',
+      params: { section: 'warroom' },
     },
     {
       id: 'governance',
       label: '거버넌스',
-      description: '의사결정 기록과 판결 흐름을 봅니다.',
+      description: '의사결정 기록 및 판결 흐름 제어입니다.',
       params: { section: 'governance' },
+    },
+  ],
+  workspace: [
+    {
+      id: 'board',
+      label: '작업 게시판',
+      description: '팀 대화와 지식 공유를 봅니다.',
+      params: { section: 'board' },
     },
     {
       id: 'evidence',
-      label: '근거',
+      label: '근거 및 이력',
       description: '작업 증거와 검증 결과를 봅니다.',
       params: { section: 'evidence' },
     },
     {
       id: 'planning',
-      label: '계획',
-      description: '장기 목표와 메트릭 루프를 봅니다.',
+      label: '계획 및 메트릭',
+      description: '장기 목표와 루프를 봅니다.',
       params: { section: 'planning' },
     },
     {
       id: 'worktrees',
       label: '워크트리',
-      description: '현재 활성화된 작업 공간(Worktree)을 봅니다.',
+      description: '현재 활성화된 작업 공간입니다.',
       params: { section: 'worktrees' },
-    },
-  ],
-  operations: [
-    {
-      id: 'intervene',
-      label: '개입',
-      description: '방, 세션, 키퍼에 바로 개입하는 화면입니다.',
-      params: { section: 'intervene' },
-    },
-    {
-      id: 'command',
-      label: '지휘',
-      description: '워룸, 스웜, 오케스트라를 포함한 지휘면입니다.',
-      params: { section: 'command' },
-    },
-    {
-      id: 'tools',
-      label: '도구',
-      description: '도구 인벤토리와 도구 메트릭을 봅니다.',
-      params: { section: 'tools' },
     },
   ],
   lab: [
     {
-      id: 'overview',
-      label: '개요',
-      description: '실험면의 성격과 진입점을 먼저 보여줍니다.',
-      params: { section: 'overview' },
+      id: 'tools',
+      label: '도구 & 실험',
+      description: '도구 인벤토리와 기타 실험을 진행합니다.',
+      params: { section: 'tools' },
     },
     {
       id: 'trpg',
@@ -212,7 +205,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       params: { section: 'avatars' },
     },
   ],
-  logs: [],
 }
 
 function validSectionIds(tab: NonHomeTabId): SurfaceSectionId[] {
@@ -224,8 +216,8 @@ export function defaultParamsForTab(tabId: TabId): Record<string, string> {
 }
 
 export function sectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {
-  if (tabId === 'home') return []
-  return DASHBOARD_SECTION_ITEMS[tabId]
+  if (tabId === 'overview' || tabId === 'logs') return []
+  return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId]
 }
 
 export function surfaceForTab(tabId: TabId): SurfaceId {
@@ -235,55 +227,35 @@ export function surfaceForTab(tabId: TabId): SurfaceId {
 export function normalizeRouteParams(tabId: TabId, params: Record<string, string>): Record<string, string> {
   const next = { ...params }
 
-  if (tabId === 'home') {
+  if (tabId === 'overview' || tabId === 'logs') {
     delete next.section
     delete next.surface
     return next
   }
 
-  if (tabId === 'status') {
-    if (!validSectionIds('status').includes(next.section as SurfaceSectionId)) {
-      next.section = 'sessions'
-    }
-    delete next.surface
-    return next
+  const typedTabId = tabId as NonHomeTabId
+
+  if (!validSectionIds(typedTabId).includes(next.section as SurfaceSectionId)) {
+    next.section = defaultParamsForTab(tabId).section ?? ''
   }
 
-  if (tabId === 'work') {
-    if (!validSectionIds('work').includes(next.section as SurfaceSectionId)) {
-      next.section = 'board'
-    }
-    delete next.surface
-    return next
-  }
-
-  if (tabId === 'operations') {
-    if (!validSectionIds('operations').includes(next.section as SurfaceSectionId)) {
-      next.section =
-        typeof next.surface === 'string' && OPERATIONS_COMMAND_SURFACES.has(next.surface)
-          ? 'command'
-          : 'intervene'
-    }
-    if (next.section === 'command') {
+  if (tabId === 'command') {
+    if (next.section === 'warroom') {
       if (next.surface && !OPERATIONS_COMMAND_SURFACES.has(next.surface)) {
         delete next.surface
       }
     } else {
       delete next.surface
     }
-    return next
+  } else {
+    delete next.surface
   }
 
-  if (!validSectionIds('lab').includes(next.section as SurfaceSectionId)) {
-    if (next.surface === 'trpg' || next.surface === 'avatars') next.section = next.surface
-    else next.section = 'overview'
-  }
-  delete next.surface
   return next
 }
 
 export function currentSectionForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): DashboardSectionNavItem | null {
-  if (routeState.tab === 'home') return null
+  if (routeState.tab === 'overview' || routeState.tab === 'logs') return null
   const normalized = normalizeRouteParams(routeState.tab, routeState.params)
   return sectionItemsForTab(routeState.tab).find(item => item.params.section === normalized.section) ?? null
 }

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -7,7 +7,7 @@ import type { RouteState, TabId, AnyTabId, LegacyTabId } from './types'
 import { VALID_TABS, LEGACY_TAB_REDIRECTS } from './types'
 import { normalizeRouteParams } from './config/navigation'
 
-const DEFAULT_ROUTE: RouteState = { tab: 'home', params: {}, postId: null }
+const DEFAULT_ROUTE: RouteState = { tab: 'overview', params: {}, postId: null }
 const COMMAND_SURFACE_SEGMENTS = new Set([
   'warroom',
   'summary',
@@ -76,8 +76,8 @@ function parseSegments(
       nextParams.operation = decodeSafe(segments[2])
     }
     return {
-      tab: 'operations',
-      params: normalizeRouteParams('operations', nextParams),
+      tab: 'command',
+      params: normalizeRouteParams('command', nextParams),
       postId: null,
     }
   }
@@ -98,8 +98,8 @@ function parseSegments(
       nextParams.section = 'command'
       nextParams.surface = section
       return {
-        tab: 'operations',
-        params: normalizeRouteParams('operations', nextParams),
+        tab: 'command',
+        params: normalizeRouteParams('command', nextParams),
         postId: null,
       }
     }
@@ -115,15 +115,15 @@ function parseSegments(
       }
       nextParams.section = 'command'
       return {
-        tab: 'operations',
-        params: normalizeRouteParams('operations', nextParams),
+        tab: 'command',
+        params: normalizeRouteParams('command', nextParams),
         postId: null,
       }
     }
     if (!params.section && !params.surface) {
       return {
-        tab: 'operations',
-        params: normalizeRouteParams('operations', { ...params, section: 'command' }),
+        tab: 'command',
+        params: normalizeRouteParams('command', { ...params, section: 'command' }),
         postId: null,
       }
     }
@@ -135,7 +135,7 @@ function parseSegments(
     }
   }
 
-  if (segments[0] === 'operations' && segments[1]) {
+  if ((segments[0] === 'operations' || segments[0] === 'command') && segments[1]) {
     const nextParams = { ...params }
     const second = decodeSafe(segments[1])
     if (second === 'intervene' || second === 'command' || second === 'tools') {
@@ -145,14 +145,15 @@ function parseSegments(
       nextParams.surface = second
     }
     return {
-      tab: 'operations',
-      params: normalizeRouteParams('operations', nextParams),
+      tab: 'command',
+      params: normalizeRouteParams('command', nextParams),
       postId: null,
     }
   }
 
-  if ((segments[0] === 'status' || segments[0] === 'work') && segments[1]) {
-    const tab = segments[0] as 'status' | 'work'
+  if ((segments[0] === 'status' || segments[0] === 'monitoring' || segments[0] === 'work' || segments[0] === 'workspace') && segments[1]) {
+    const rawTab = segments[0]
+    const tab = (rawTab === 'status' ? 'monitoring' : rawTab === 'work' ? 'workspace' : rawTab) as 'monitoring' | 'workspace'
     const nextParams = { ...params, section: decodeSafe(segments[1]) }
     return {
       tab,
@@ -175,14 +176,14 @@ function parseSegments(
       }
     }
     return {
-      tab: 'operations',
-      params: normalizeRouteParams('operations', nextParams),
+      tab: 'command',
+      params: normalizeRouteParams('command', nextParams),
       postId: null,
     }
   }
 
   // Resolve with legacy redirect support
-  const resolved = resolveTab(tabFromPath) || resolveTab(tabFromQuery) || { tab: 'home' as TabId }
+  const resolved = resolveTab(tabFromPath) || resolveTab(tabFromQuery) || { tab: 'overview' as TabId }
   const mergedParams = normalizeRouteParams(resolved.tab, { ...params, ...(resolved.params ?? {}) })
 
   return { tab: resolved.tab, params: mergedParams, postId: null }
@@ -284,7 +285,7 @@ export function navigate(tab: AnyTabId, params?: Record<string, string>): void {
 }
 
 export function navigateToPost(postId: string): void {
-  window.location.hash = `#work?section=board&post=${encodeURIComponent(postId)}`
+  window.location.hash = `#workspace?section=board&post=${encodeURIComponent(postId)}`
 }
 
 export function navigateBack(): void {
@@ -332,6 +333,6 @@ export function initRouter(): void {
   }
 
   // Default route
-  window.location.hash = '#home'
+  window.location.hash = '#overview'
   route.value = parseHash(window.location.hash)
 }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -159,15 +159,19 @@ export interface DashboardSemanticsResponse {
 }
 
 export type TabId =
-  | 'home'
-  | 'status'
-  | 'work'
-  | 'operations'
+  | 'overview'
+  | 'monitoring'
+  | 'command'
+  | 'workspace'
   | 'lab'
   | 'logs'
 
 /** Pre-restructure tab IDs kept for redirect aliases. */
 export type LegacyTabId =
+  | 'home'
+  | 'status'
+  | 'work'
+  | 'operations'
   | 'situation'
   | 'agents'
   | 'activity'
@@ -181,7 +185,6 @@ export type LegacyTabId =
   | 'governance'
   | 'planning'
   | 'intervene'
-  | 'command'
   | 'social'
   | 'agent-roster'
   | 'keeper-roster'
@@ -190,33 +193,36 @@ export type LegacyTabId =
 export type AnyTabId = TabId | LegacyTabId
 
 export const VALID_TABS: TabId[] = [
-  'home',
-  'status',
-  'work',
-  'operations',
+  'overview',
+  'monitoring',
+  'command',
+  'workspace',
   'lab',
   'logs',
 ]
 
 /** Maps legacy tab IDs to new tab + optional section params. */
 export const LEGACY_TAB_REDIRECTS: Record<LegacyTabId, { tab: TabId; params?: Record<string, string> }> = {
-  'situation': { tab: 'status', params: { section: 'sessions' } },
-  'agents': { tab: 'status', params: { section: 'agents' } },
-  'activity': { tab: 'status', params: { section: 'activity' } },
-  'control': { tab: 'operations', params: { section: 'intervene' } },
-  'mission': { tab: 'status', params: { section: 'sessions' } },
-  'agent-roster': { tab: 'status', params: { section: 'agents' } },
-  'execution': { tab: 'status', params: { section: 'sessions' } },
-  'keeper-roster': { tab: 'status', params: { section: 'agents' } },
-  'live': { tab: 'status', params: { section: 'activity' } },
-  'social': { tab: 'status', params: { section: 'activity' } },
-  'proof': { tab: 'work', params: { section: 'evidence' } },
-  'memory': { tab: 'work', params: { section: 'board' } },
-  'governance': { tab: 'work', params: { section: 'governance' } },
-  'planning': { tab: 'work', params: { section: 'planning' } },
-  'tools': { tab: 'operations', params: { section: 'tools' } },
-  'intervene': { tab: 'operations', params: { section: 'intervene' } },
-  'command': { tab: 'operations', params: { section: 'command' } },
+  'home': { tab: 'overview' },
+  'status': { tab: 'monitoring', params: { section: 'sessions' } },
+  'work': { tab: 'workspace', params: { section: 'board' } },
+  'operations': { tab: 'command', params: { section: 'intervene' } },
+  'situation': { tab: 'monitoring', params: { section: 'sessions' } },
+  'agents': { tab: 'monitoring', params: { section: 'agents' } },
+  'activity': { tab: 'monitoring', params: { section: 'activity' } },
+  'control': { tab: 'command', params: { section: 'intervene' } },
+  'mission': { tab: 'monitoring', params: { section: 'sessions' } },
+  'agent-roster': { tab: 'monitoring', params: { section: 'agents' } },
+  'execution': { tab: 'monitoring', params: { section: 'sessions' } },
+  'keeper-roster': { tab: 'monitoring', params: { section: 'agents' } },
+  'live': { tab: 'monitoring', params: { section: 'activity' } },
+  'social': { tab: 'monitoring', params: { section: 'activity' } },
+  'proof': { tab: 'workspace', params: { section: 'evidence' } },
+  'memory': { tab: 'workspace', params: { section: 'board' } },
+  'governance': { tab: 'command', params: { section: 'governance' } },
+  'planning': { tab: 'workspace', params: { section: 'planning' } },
+  'tools': { tab: 'lab', params: { section: 'tools' } },
+  'intervene': { tab: 'command', params: { section: 'intervene' } },
 }
 
 // --- Activity Graph types ---

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -420,7 +420,7 @@ export function workflowCommandSurfaceLabel(surface?: string | null): string {
 }
 
 export function clearWorkflowContextForTab(tab: TabId): void {
-  if (tab === 'status') {
+  if (tab === 'monitoring') {
     persistWorkflowContext(null)
   }
 }


### PR DESCRIPTION
## Description
This PR revamps the MASC dashboard navigation by flattening the 2-tier (Tab/Surface + Section) architecture into a unified single-tier Left Navigation Bar (LNB).

### Changes
- Replaced the fragmented top tab + sidebar structure with a cohesive left navigation menu.
- Reorganized domains: `overview`, `monitoring`, `command`, `workspace`, `lab`, `logs`.
- Updated `router.ts` to maintain backward compatibility with old deep links via `LEGACY_TAB_REDIRECTS`.
- Cleaned up unused imports and fixed TypeScript type assertions to align with the new `TabId` definition.
- Fixed SideRail UI to be a nested accordion structure.

### Context
This is Phase 1 & 2 of the dashboard layout improvements.