### PR TITLE
refactor(keeper): replace match Some/None with Option.value

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -299,9 +299,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                 in
                 let agent_count_changed =
                   let last_count =
-                    match Hashtbl.find_opt last_agent_counts meta_current.name with
-                    | Some c -> c
-                    | None -> 0
+                    Hashtbl.find_opt last_agent_counts meta_current.name
+                    |> Option.value ~default:0
                   in
                   let changed =
                     last_count > 0 && current_agent_count <> last_count

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -639,7 +639,5 @@ let profile_kind_caps (profile : string) : (string * int) list =
       [ ("constraints", 2); ("decision", 2); ("next", 2); ("goal", 2); ("progress", 2); ("open_question", 2) ]
 
 let cap_for_kind (caps : (string * int) list) (kind : string) : int =
-  match List.assoc_opt kind caps with
-  | Some v -> v
-  | None -> 1
+  List.assoc_opt kind caps |> Option.value ~default:1
 

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -360,36 +360,14 @@ let apply_settings_update
     Option.value ~default:long_goal_default new_long_goal
     |> normalize_goal_horizon_text
   in
-  let soul_profile =
-    match new_soul_profile with
-    | None -> meta0.soul_profile
-    | Some sp -> sp
-  in
+  let soul_profile = Option.value ~default:meta0.soul_profile new_soul_profile in
   let instructions =
-    match get_string_opt args "new_instructions" with
-    | None -> meta0.instructions
-    | Some ni -> ni
+    Option.value ~default:meta0.instructions (get_string_opt args "new_instructions")
   in
-  let will =
-    match new_will with
-    | None -> meta0.will
-    | Some w -> w
-  in
-  let needs =
-    match new_needs with
-    | None -> meta0.needs
-    | Some n -> n
-  in
-  let desires =
-    match new_desires with
-    | None -> meta0.desires
-    | Some d -> d
-  in
-  let drift_enabled =
-    match new_drift_enabled_opt with
-    | None -> meta0.drift_enabled
-    | Some v -> v
-  in
+  let will = Option.value ~default:meta0.will new_will in
+  let needs = Option.value ~default:meta0.needs new_needs in
+  let desires = Option.value ~default:meta0.desires new_desires in
+  let drift_enabled = Option.value ~default:meta0.drift_enabled new_drift_enabled_opt in
   let drift_min_turn_gap =
     match new_drift_min_turn_gap_opt with
     | None -> meta0.drift_min_turn_gap

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -607,9 +607,8 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
     let open Yojson.Safe.Util in
     let name = json |> member "name" |> to_string in
     let persistent_name =
-      match json |> member "persistent_name" |> to_string_option with
-      | Some value -> value
-      | None -> name
+      json |> member "persistent_name" |> to_string_option
+      |> Option.value ~default:name
     in
     let desired =
       match json |> member "desired" with
@@ -627,9 +626,8 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
       | None -> default_voice_channel_for name
     in
     let voice_agent_id =
-      match json |> member "voice_agent_id" |> to_string_option with
-      | Some value -> value
-      | None -> default_voice_agent_id_for name
+      json |> member "voice_agent_id" |> to_string_option
+      |> Option.value ~default:(default_voice_agent_id_for name)
     in
     let seed_meta =
       match json |> member "seed_meta" with
@@ -637,14 +635,12 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
       | _ -> `Assoc []
     in
     let created_at =
-      match json |> member "created_at" |> to_string_option with
-      | Some value -> value
-      | None -> now_iso ()
+      json |> member "created_at" |> to_string_option
+      |> Option.value ~default:(now_iso ())
     in
     let updated_at =
-      match json |> member "updated_at" |> to_string_option with
-      | Some value -> value
-      | None -> created_at
+      json |> member "updated_at" |> to_string_option
+      |> Option.value ~default:created_at
     in
     Ok
       {


### PR DESCRIPTION
## Summary

- Replace verbose `match x with | Some v -> v | None -> default` patterns with idiomatic `Option.value ~default:` across 4 keeper modules
- 4 files changed, 17 insertions(+), 46 deletions(-), net -29 lines
- `dune build` passes with no errors

### Files
- `keeper_turn_setup.ml`: 6 match blocks replaced (soul_profile, instructions, will, needs, desires, drift_enabled)
- `keeper_types.ml`: 4 match blocks replaced (persistent_name, voice_agent_id, created_at, updated_at)
- `keeper_memory_policy.ml`: 1 match block replaced (cap_for_kind)
- `keeper_keepalive.ml`: 1 match block replaced (last_agent_count lookup)

## Test plan
- [x] `dune build --root .` passes
- [ ] `make test` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)