### PR TITLE
refactor(dashboard): consolidate cmd-chip inline patterns to StatusChip component

### DIFF
--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneCapacityRow,
   CommandPlaneDecisionRecord,
@@ -42,7 +43,7 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
           <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${decision.requested_action}</strong>
           <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${decision.scope_type}:${decision.scope_id}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(decision.status)}">${controlStatusLabel(decision.status ?? 'pending')}</span>
+        <${StatusChip} label=${controlStatusLabel(decision.status ?? 'pending')} tone=${toneClass(decision.status)} />
       </div>
       <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
         <span class="text-[var(--text-muted)]">결정 ID</span><span class="text-[var(--text-body)]">${decision.decision_id}</span>
@@ -83,7 +84,7 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
           <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${unit.label}</strong>
           <div class="text-[11px] text-[var(--text-muted)] mt-0.5">${unit.unit_id}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')}">${utilization}%</span>
+        <${StatusChip} label=${`${utilization}%`} tone=${toneClass(utilization > 100 ? 'bad' : utilization > 70 ? 'warn' : 'ok')} />
       </div>
       <div class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] mt-2">
         <span class="text-[var(--text-muted)]">편성</span><span class="text-[var(--text-body)]">${row.roster_live ?? 0}/${row.roster_total ?? 0}</span>

--- a/dashboard/src/components/command/guided-panel.ts
+++ b/dashboard/src/components/command/guided-panel.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import type { CommandPlaneHelpPath } from '../../types'
 import {
   commandPlaneDetailError,
@@ -200,7 +201,7 @@ function GuidedPanel() {
         <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card highlight mb-3">
           <div class="flex justify-between gap-3 items-start">
             <strong>${nextStep?.title ?? nextTool}</strong>
-            <span class="cmd-chip rounded-full ok">${nextTool}</span>
+            <${StatusChip} label=${nextTool} tone="ok" />
           </div>
           <p>${nextStep?.summary ?? '지금 막고 있는 병목을 풀기 위해 canonical flow의 다음 tool부터 실행합니다.'}</p>
           ${nextStep?.success_signals?.length
@@ -216,7 +217,7 @@ function GuidedPanel() {
               <div>
                 <div class="flex justify-between gap-3 items-start">
                   <strong>${item.title}</strong>
-                  <span class="cmd-chip rounded-full ${toneClass(item.tone)}">${item.tone}</span>
+                  <${StatusChip} label=${item.tone} tone=${toneClass(item.tone)} />
                 </div>
                 <p>${item.detail}</p>
               </div>
@@ -230,7 +231,7 @@ function GuidedPanel() {
               <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card warn">
                 <div class="flex justify-between gap-3 items-start">
                   <strong>자주 막히는 지점</strong>
-                  <span class="cmd-chip rounded-full warn">${pitfalls.length}</span>
+                  <${StatusChip} label=${String(pitfalls.length)} tone="warn" />
                 </div>
                 <div class="flex flex-col gap-3">
                   ${pitfalls.map(pitfall => html`
@@ -260,7 +261,7 @@ function GuidedPanel() {
                     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card">
                       <div class="flex justify-between gap-3 items-start">
                         <strong>${path.title}</strong>
-                        <span class="cmd-chip rounded-full">${path.id}</span>
+                        <${StatusChip} label=${path.id} />
                       </div>
                       <p>${path.summary}</p>
                       <div class="cmd-card rounded-xl-sub">${path.when_to_use}</div>

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { ActionButton } from '../common/button'
 import { CARD_STANDARD } from '../common/card'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type {
   ChainHistoryEventSummary,
@@ -122,7 +123,7 @@ function ChainOperationListItem(
           <strong>${overlay.operation.objective}</strong>
           <div class="cmd-card rounded-xl-sub">${overlay.operation.operation_id}</div>
         </div>
-        <span class="cmd-chip rounded-full ${chainStatusTone(chain?.status)}">${chain?.status ?? overlay.operation.status}</span>
+        <${StatusChip} label=${chain?.status ?? overlay.operation.status} tone=${chainStatusTone(chain?.status)} />
       </div>
       <div class="cmd-tag rounded-full-row">
         <span class="cmd-tag rounded-full">${chain?.kind ?? 'chain_dsl'}</span>
@@ -139,7 +140,7 @@ function ChainHistoryRow({ item }: { item: ChainHistoryEventSummary }) {
     <article class="cmd-chain-history-row text-red-300">
       <div class="flex justify-between gap-3 items-start">
         <strong>${item.chain_id ?? '알 수 없는 체인'}</strong>
-        <span class="cmd-chip rounded-full ${chainStatusTone(item.event)}">${item.event}</span>
+        <${StatusChip} label=${item.event} tone=${chainStatusTone(item.event)} />
       </div>
       <div class="cmd-card rounded-xl-sub">${relativeTime(item.timestamp)}</div>
       <div class="cmd-card rounded-xl-sub">${historySummary(item)}</div>
@@ -152,7 +153,7 @@ function ChainRunNodeRow({ node }: { node: CommandPlaneChainRunNode }) {
     <article class="p-3 rounded-[10px] bg-[rgba(9,12,20,0.5)] border border-solid border-[var(--white-6)]">
       <div class="flex justify-between gap-3 items-start">
         <strong>${node.id}</strong>
-        <span class="cmd-chip rounded-full ${chainStatusTone(node.status)}">${node.status ?? '확인 필요'}</span>
+        <${StatusChip} label=${node.status ?? '확인 필요'} tone=${chainStatusTone(node.status)} />
       </div>
       <div class="cmd-card rounded-xl-sub">
         ${node.type ?? '노드'}
@@ -177,7 +178,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
           <strong>${op.objective}</strong>
           <div class="cmd-card rounded-xl-sub">${op.operation_id}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(op.status === 'active' ? 'ok' : op.status === 'paused' ? 'warn' : op.status === 'failed' ? 'bad' : 'ok')}">${operationStatusLabel(op.status)}</span>
+        <${StatusChip} label=${operationStatusLabel(op.status)} tone=${toneClass(op.status === 'active' ? 'ok' : op.status === 'paused' ? 'warn' : op.status === 'failed' ? 'bad' : 'ok')} />
       </div>
       <div class="cmd-card rounded-xl-grid">
         <span>유닛</span><span>${card.assigned_unit_label ?? op.assigned_unit_id}</span>
@@ -259,7 +260,7 @@ function DetachmentCard({ card }: { card: CommandPlaneDetachmentCard }) {
           <strong>${detachment.detachment_id}</strong>
           <div class="cmd-card rounded-xl-sub">${card.operation?.objective ?? detachment.operation_id}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(detachment.status)}">${detachment.status ?? 'active'}</span>
+        <${StatusChip} label=${detachment.status ?? 'active'} tone=${toneClass(detachment.status)} />
       </div>
       <div class="cmd-card rounded-xl-grid">
         <span>유닛</span><span>${card.assigned_unit_label ?? detachment.assigned_unit_id}</span>
@@ -340,7 +341,7 @@ export function ChainsSurface() {
         <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${chainStatusTone(summary?.connection.status)}">
           <div class="flex justify-between gap-3 items-start">
             <strong>native chain 연결</strong>
-            <span class="cmd-chip rounded-full ${chainStatusTone(summary?.connection.status)}">${summary?.connection.status ?? 'disconnected'}</span>
+            <${StatusChip} label=${summary?.connection.status ?? 'disconnected'} tone=${chainStatusTone(summary?.connection.status)} />
           </div>
           <p>${summary?.connection.message ?? '체인 요약은 MASC 프록시를 통해 집계됩니다.'}</p>
           <div class="cmd-card rounded-xl-grid">
@@ -375,7 +376,7 @@ export function ChainsSurface() {
         <div class="flex flex-col gap-3 mt-3.5">
           <div class="flex justify-between gap-3 items-start">
             <strong>최근 이력</strong>
-            <span class="cmd-chip rounded-full">${summary?.recent_history.length ?? 0}</span>
+            <${StatusChip} label=${String(summary?.recent_history.length ?? 0)} />
           </div>
           ${summary && summary.recent_history.length > 0
             ? html`
@@ -399,9 +400,7 @@ export function ChainsSurface() {
                     <strong>${selectedOverlay.operation.objective}</strong>
                     <div class="cmd-card rounded-xl-sub">${selectedOverlay.operation.operation_id}</div>
                   </div>
-                  <span class="cmd-chip rounded-full ${chainStatusTone(selectedOverlay.operation.chain?.status)}">
-                    ${selectedOverlay.operation.chain?.status ?? selectedOverlay.operation.status}
-                  </span>
+                  <${StatusChip} label=${selectedOverlay.operation.chain?.status ?? selectedOverlay.operation.status} tone=${chainStatusTone(selectedOverlay.operation.chain?.status)} />
                 </div>
                 <div class="cmd-card rounded-xl-grid">
                   <span>종류</span><span>${selectedOverlay.operation.chain?.kind ?? 'chain_dsl'}</span>
@@ -421,7 +420,7 @@ export function ChainsSurface() {
                     <div class="mt-3.5 p-4 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
                       <div class="flex justify-between gap-3 items-start">
                         <strong>Mermaid 그래프</strong>
-                        <span class="cmd-chip rounded-full">${selectedOverlay.operation.chain?.chain_id ?? 'graph'}</span>
+                        <${StatusChip} label=${selectedOverlay.operation.chain?.chain_id ?? 'graph'} />
                       </div>
                       <${MermaidGraph} source=${selectedOverlay.mermaid} />
                     </div>
@@ -431,11 +430,9 @@ export function ChainsSurface() {
               <div class="mt-3.5 p-4 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
                 <div class="flex justify-between gap-3 items-start">
                   <strong>실행 상세</strong>
-                  <span class="cmd-chip rounded-full ${run?.success === false ? 'bad' : 'ok'}">
-                    ${run
+                  <${StatusChip} label=${run
                       ? (run.success === false ? '실패' : isPreviewRun ? '미리보기' : '기록됨')
-                      : '대기 중'}
-                  </span>
+                      : '대기 중'} tone=${run?.success === false ? 'bad' : 'ok'} />
                 </div>
                 ${commandPlaneChainRunLoading.value
                   ? html`<${EmptyState} message="실행 상세 불러오는 중…" compact />`

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { ActionButton } from '../common/button'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneOrchestraEdge,
   CommandPlaneOrchestraNode,
@@ -372,7 +373,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
       <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl ${toneClass(signalNode.tone)}">
         <div class="card rounded-xl-title-row">
           <div class="card rounded-xl-title">${signalNode.label}</div>
-          <span class="cmd-chip rounded-full ${toneClass(signalNode.tone)}">${orchestraNodeKindLabel(signalNode.kind)}</span>
+          <${StatusChip} label=${orchestraNodeKindLabel(signalNode.kind)} tone=${toneClass(signalNode.tone)} />
         </div>
         <p>${signalNode.detail ?? '세부 설명이 없습니다.'}</p>
         ${signalNode.suggested_surface
@@ -397,7 +398,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
     <aside class="orchestra-drawer flex flex-col gap-3 min-h-[720px] card rounded-xl ${toneClass(node.tone)}">
       <div class="card rounded-xl-title-row">
         <div class="card rounded-xl-title">${node.label}</div>
-        <span class="cmd-chip rounded-full ${toneClass(node.tone)}">${orchestraNodeKindLabel(node.kind)}</span>
+        <${StatusChip} label=${orchestraNodeKindLabel(node.kind)} tone=${toneClass(node.tone)} />
       </div>
       ${node.subtitle ? html`<p class="cmd-card rounded-xl-sub">${node.subtitle}</p>` : null}
       <div class="orchestra-fact-list flex flex-col gap-2">
@@ -410,7 +411,7 @@ export function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOr
       </div>
       ${relatedSignals.length > 0 ? html`
         <div class="cmd-tag rounded-full-row">
-          ${relatedSignals.map(signalNode => html`<span class="cmd-chip rounded-full ${toneClass(signalNode.tone)}">${signalNode.label}</span>`)}
+          ${relatedSignals.map(signalNode => html`<${StatusChip} label=${signalNode.label} tone=${toneClass(signalNode.tone)} />`)}
         </div>
       ` : null}
       <div class="cmd-card rounded-xl-sub">연결 ${relatedEdges.length}개 · 근거 ${node.provenance}</div>

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { ActionButton } from '../common/button'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { groupByKey } from '../common/collection'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import type {
@@ -356,7 +357,7 @@ export function OrchestraSurface() {
           >
             축소
           <//>
-          <span class="cmd-chip rounded-full">${Math.round(camera.zoom * 100)}%</span>
+          <${StatusChip} label=${`${Math.round(camera.zoom * 100)}%`} />
         </div>
         <div class="orchestra-toolbar-group">
           <button
@@ -377,7 +378,7 @@ export function OrchestraSurface() {
           >
             집약
           </button>
-          <span class="cmd-chip rounded-full">${densityLabel(density)}</span>
+          <${StatusChip} label=${densityLabel(density)} />
         </div>
       </div>
 
@@ -422,13 +423,11 @@ export function OrchestraSurface() {
             </g>
           </svg>
           <div class="absolute left-3.5 right-3.5 bottom-3 flex flex-wrap gap-2 pointer-events-none">
-            <span class="cmd-chip rounded-full pointer-events-auto bg-[rgba(15,23,42,0.8)]">세션 ${orchestra.summary?.session_count ?? 0}</span>
-            <span class="cmd-chip rounded-full pointer-events-auto bg-[rgba(15,23,42,0.8)]">워커 ${orchestra.summary?.worker_count ?? 0}</span>
-            <span class="cmd-chip rounded-full pointer-events-auto bg-[rgba(15,23,42,0.8)]">키퍼 ${orchestra.summary?.keeper_count ?? 0}</span>
-            <span class="cmd-chip rounded-full pointer-events-auto bg-[rgba(15,23,42,0.8)] ${toneClass(orchestra.signals.some(signalNode => signalNode.tone === 'bad') ? 'bad' : orchestra.signals.length > 0 ? 'warn' : 'ok')}">
-              신호 ${orchestra.summary?.signal_count ?? orchestra.signals.length}
-            </span>
-            <span class="cmd-chip rounded-full pointer-events-auto bg-[rgba(15,23,42,0.8)]">갱신 ${relativeTime(orchestra.generated_at)}</span>
+            <${StatusChip} label=${`세션 ${orchestra.summary?.session_count ?? 0}`} class="pointer-events-auto bg-[rgba(15,23,42,0.8)]" />
+            <${StatusChip} label=${`워커 ${orchestra.summary?.worker_count ?? 0}`} class="pointer-events-auto bg-[rgba(15,23,42,0.8)]" />
+            <${StatusChip} label=${`키퍼 ${orchestra.summary?.keeper_count ?? 0}`} class="pointer-events-auto bg-[rgba(15,23,42,0.8)]" />
+            <${StatusChip} label=${`신호 ${orchestra.summary?.signal_count ?? orchestra.signals.length}`} tone=${toneClass(orchestra.signals.some(signalNode => signalNode.tone === 'bad') ? 'bad' : orchestra.signals.length > 0 ? 'warn' : 'ok')} class="pointer-events-auto bg-[rgba(15,23,42,0.8)]" />
+            <${StatusChip} label=${`갱신 ${relativeTime(orchestra.generated_at)}`} class="pointer-events-auto bg-[rgba(15,23,42,0.8)]" />
           </div>
         </div>
 

--- a/dashboard/src/components/command/summary-hero.ts
+++ b/dashboard/src/components/command/summary-hero.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from '../common/status-chip'
 import { CmdStatCard } from './cmd-stat-card'
 import {
   commandPlaneChainSummary,
@@ -31,9 +32,9 @@ export function CommandWorkflowBanner() {
     <section class="rounded-xl border border-[rgba(34,211,238,0.26)] bg-[linear-gradient(180deg,rgba(34,211,238,0.1),var(--white-3))] p-4 grid gap-3">
       <div class="flex gap-3 flex-wrap items-center">
         <strong>${context.source_label}</strong>
-        <span class="cmd-chip rounded-full">${workflowActionLabel(context.action_type)}</span>
-        <span class="cmd-chip rounded-full">${workflowTargetLabel(context)}</span>
-        <span class="cmd-chip rounded-full">${workflowCommandSurfaceLabel(route.value.params.surface ?? 'warroom')}</span>
+        <${StatusChip} label=${workflowActionLabel(context.action_type)} />
+        <${StatusChip} label=${workflowTargetLabel(context)} />
+        <${StatusChip} label=${workflowCommandSurfaceLabel(route.value.params.surface ?? 'warroom')} />
       </div>
       <div class="text-[rgba(255,255,255,0.84)] leading-normal">${context.summary}</div>
       ${context.payload_preview
@@ -160,10 +161,10 @@ export function SummaryHero() {
         <h3>${headline}</h3>
         <p>${subcopy}</p>
         <div class="flex flex-wrap gap-2">
-        <span class="cmd-chip rounded-full ${toneClass(activeOps > 0 ? 'ok' : 'warn')}">활성 작전 ${activeOps}</span>
-          <span class="cmd-chip rounded-full ${toneClass(movingLanes > 0 ? 'ok' : activeLanes > 0 ? 'warn' : 'warn')}">이동 레인 ${movingLanes}/${Math.max(activeLanes, movingLanes)}</span>
-          <span class="cmd-chip rounded-full ${toneClass(badAlerts > 0 ? 'bad' : warnAlerts > 0 ? 'warn' : 'ok')}">치명 알림 ${badAlerts}</span>
-          <span class="cmd-chip rounded-full ${toneClass(pendingApprovals > 0 ? 'warn' : 'ok')}">승인 대기 ${pendingApprovals}</span>
+        <${StatusChip} label=${`활성 작전 ${activeOps}`} tone=${toneClass(activeOps > 0 ? 'ok' : 'warn')} />
+          <${StatusChip} label=${`이동 레인 ${movingLanes}/${Math.max(activeLanes, movingLanes)}`} tone=${toneClass(movingLanes > 0 ? 'ok' : activeLanes > 0 ? 'warn' : 'warn')} />
+          <${StatusChip} label=${`치명 알림 ${badAlerts}`} tone=${toneClass(badAlerts > 0 ? 'bad' : warnAlerts > 0 ? 'warn' : 'ok')} />
+          <${StatusChip} label=${`승인 대기 ${pendingApprovals}`} tone=${toneClass(pendingApprovals > 0 ? 'warn' : 'ok')} />
         </div>
       </div>
 

--- a/dashboard/src/components/command/swarm-cards.ts
+++ b/dashboard/src/components/command/swarm-cards.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneSwarmBlocker,
   CommandPlaneSwarmChecklistItem,
@@ -14,7 +15,7 @@ export function SwarmChecklistCard({ item }: { item: CommandPlaneSwarmChecklistI
     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${toneClass(item.status)}">
       <div class="flex justify-between gap-3 items-start">
         <strong>${item.title}</strong>
-        <span class="cmd-chip rounded-full ${toneClass(item.status)}">${item.status}</span>
+        <${StatusChip} label=${item.status} tone=${toneClass(item.status)} />
       </div>
       <p>${item.detail}</p>
       <div class="cmd-card rounded-xl-foot">Next tool: ${item.next_tool}</div>
@@ -27,7 +28,7 @@ export function SwarmBlockerCard({ blocker }: { blocker: CommandPlaneSwarmBlocke
     <article class="cmd-alert ${toneClass(blocker.severity)} ${alertBorderTone(toneClass(blocker.severity))}">
       <div class="cmd-card rounded-xl-head">
         <strong>${blocker.title}</strong>
-        <span class="cmd-chip rounded-full ${toneClass(blocker.severity)}">${blocker.severity}</span>
+        <${StatusChip} label=${blocker.severity} tone=${toneClass(blocker.severity)} />
       </div>
       <div class="flex justify-between items-start">
         <span>${blocker.code}</span>
@@ -46,9 +47,7 @@ export function SwarmWorkerCard({ worker }: { worker: CommandPlaneSwarmWorker })
           <strong>${worker.name}</strong>
           <div class="cmd-card rounded-xl-sub">${worker.role} · ${worker.lane}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(worker.joined ? (worker.heartbeat_fresh ? 'ok' : 'warn') : 'bad')}">
-          ${worker.status}
-        </span>
+        <${StatusChip} label=${worker.status} tone=${toneClass(worker.joined ? (worker.heartbeat_fresh ? 'ok' : 'warn') : 'bad')} />
       </div>
       <div class="cmd-card rounded-xl-grid">
         <span>Joined</span><span>${worker.joined ? 'yes' : 'no'}</span>
@@ -111,7 +110,7 @@ export function SwarmGapDot({ gap }: { gap: CommandPlaneSwarmGap }) {
   return html`
     <div class="flex items-center gap-1.5 py-[3px] text-[0.78rem]">
       <span class="swarm-gap-dot"></span>
-      <span class="cmd-chip rounded-full ${toneClass(gap.severity)}">${gap.code} (${gap.count})</span>
+      <${StatusChip} label=${`${gap.code} (${gap.count})`} tone=${toneClass(gap.severity)} />
       <span class="cmd-card rounded-xl-sub">${gap.summary}</span>
     </div>
   `
@@ -130,7 +129,7 @@ export function SwarmProofPanel({ proof }: { proof?: CommandPlaneSwarmProof }) {
     <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${toneClass(tone)}">
         <div class="flex justify-between gap-3 items-start">
           <strong>Hot Proof / 가동 증거</strong>
-          <span class="cmd-chip rounded-full ${toneClass(tone)}">${proof?.status ?? 'missing'}</span>
+          <${StatusChip} label=${proof?.status ?? 'missing'} tone=${toneClass(tone)} />
         </div>
       ${proof
         ? html`

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { CmdStatCard } from './cmd-stat-card'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import {
   commandPlaneSwarm,
   commandPlaneSwarmError,
@@ -138,7 +139,7 @@ export function SwarmLivePanels() {
                         <div class="min-w-0 [overflow-wrap:anywhere] break-words">
                           <div class="flex justify-between items-start">
                             <strong>${sample.active_slots} active</strong>
-                            <span class="cmd-chip rounded-full">${relativeTime(sample.timestamp)}</span>
+                            <${StatusChip} label=${relativeTime(sample.timestamp)} />
                           </div>
                           <div class="cmd-card rounded-xl-sub">slots ${sample.active_slot_ids.join(', ') || 'none'}</div>
                         </div>
@@ -172,7 +173,7 @@ export function SwarmLivePanels() {
                   <div class="min-w-0 [overflow-wrap:anywhere] break-words">
                     <div class="flex justify-between items-start">
                       <strong>${message.from}</strong>
-                      <span class="cmd-chip rounded-full">${relativeTime(message.timestamp)}</span>
+                      <${StatusChip} label=${relativeTime(message.timestamp)} />
                     </div>
                     <div class="cmd-card rounded-xl-sub">seq ${message.seq}</div>
                   </div>

--- a/dashboard/src/components/command/swarm-overview-panel.ts
+++ b/dashboard/src/components/command/swarm-overview-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { CmdStatCard } from './cmd-stat-card'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { route } from '../../router'
 import { workflowContextForRoute } from '../../workflow-context'
 import {
@@ -61,7 +62,7 @@ export function SwarmOverviewPanel() {
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card highlight ${focusKey === 'recommendation' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
                   <div class="flex justify-between gap-3 items-start">
                     <strong>${recommendation?.label ?? '운영자 상태 확인'}</strong>
-                    <span class="cmd-chip rounded-full">${recommendation?.lane_id ?? '전체'}</span>
+                    <${StatusChip} label=${recommendation?.lane_id ?? '전체'} />
                   </div>
                   <p>${recommendation?.reason ?? '보이는 활성 스웜 레인이 아직 없습니다.'}</p>
                   <div class="cmd-card rounded-xl-foot">${recommendation?.tool ?? 'masc_operator_snapshot'}</div>
@@ -72,7 +73,7 @@ export function SwarmOverviewPanel() {
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${gaps.length > 0 ? 'warn' : 'ok'} ${focusKey === 'gaps' ? 'shadow-[0_0_0_1px_rgba(34,211,238,0.16)]' : ''}">
                   <div class="flex justify-between gap-3 items-start">
                     <strong>핵심 공백</strong>
-                    <span class="cmd-chip rounded-full ${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')}">${gaps.length}</span>
+                    <${StatusChip} label=${String(gaps.length)} tone=${toneClass(gaps.some(gap => gap.severity === 'bad') ? 'bad' : gaps.length > 0 ? 'warn' : 'ok')} />
                   </div>
                   ${gaps.length > 0
                     ? html`<div class="border-l-2 border-[var(--card-border,var(--white-10))] pl-4 flex flex-col gap-0.5">${gaps.slice(0, 4).map(gap => html`<${SwarmGapDot} gap=${gap} />`)}</div>`
@@ -82,7 +83,7 @@ export function SwarmOverviewPanel() {
                 <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card">
                   <div class="flex justify-between gap-3 items-start">
                     <strong>이동 타임라인</strong>
-                    <span class="cmd-chip rounded-full">${timeline.length}</span>
+                    <${StatusChip} label=${String(timeline.length)} />
                   </div>
                   ${timeline.length > 0
                     ? html`<div class="border-l-2 border-[var(--card-border,var(--white-10))] pl-4 flex flex-col gap-0.5">${timeline.map(event => html`<${SwarmEventNode} event=${event} />`)}</div>`

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { ActionButton } from '../common/button'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneRunResolutionRecommendation,
   CommandPlaneRunResolutionState,
@@ -52,9 +53,9 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
           </div>
         </div>
         <div class="cmd-tag rounded-full-row">
-          <span class="cmd-chip rounded-full ${toneClass(tone)}">${lane.phase}</span>
-          <span class="cmd-chip rounded-full ${toneClass(tone)}">${lane.motion_state}</span>
-          <span class="cmd-chip rounded-full">${relativeTime(lane.last_movement_at)}</span>
+          <${StatusChip} label=${lane.phase} tone=${toneClass(tone)} />
+          <${StatusChip} label=${lane.motion_state} tone=${toneClass(tone)} />
+          <${StatusChip} label=${relativeTime(lane.last_movement_at)} />
         </div>
       </div>
       <p class="mt-3 mb-0 text-[var(--frost-72)] leading-[1.5]">${lane.movement_reason}</p>
@@ -92,7 +93,7 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
       ${lane.hard_flags.length > 0
         ? html`
             <div class="flex flex-wrap gap-1 mt-1">
-              ${lane.hard_flags.map((flag: CommandPlaneSwarmFlag) => html`<span class="cmd-chip rounded-full ${toneClass(flag.severity)}">${flag.code}</span>`)}
+              ${lane.hard_flags.map((flag: CommandPlaneSwarmFlag) => html`<${StatusChip} label=${flag.code} tone=${toneClass(flag.severity)} />`)}
             </div>
           `
         : null}
@@ -113,8 +114,8 @@ export function SwarmStoryboard({ lanes }: { lanes: CommandPlaneSwarmLane[] }) {
         return html`
           <article class="swarm-story-card rounded-xl ${toneClass(tone)}">
             <div class="swarm-story-topline flex justify-between gap-1.5 flex-wrap">
-              <span class="cmd-chip rounded-full ${toneClass(tone)}">${lane.motion_state}</span>
-              <span class="cmd-chip rounded-full">${lane.phase}</span>
+              <${StatusChip} label=${lane.motion_state} tone=${toneClass(tone)} />
+              <${StatusChip} label=${lane.phase} />
             </div>
             <strong class="text-[var(--text-near-white)] text-lg leading-[1.3]">${lane.label}</strong>
             <p class="m-0 text-[var(--frost-72)] leading-[1.5]">${lane.current_step}</p>
@@ -233,9 +234,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${toneClass(tone)}">
       <div class="flex justify-between gap-3 items-start">
         <strong>Run Resolution</strong>
-        <span class="cmd-chip rounded-full ${toneClass(tone)}">
-          ${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)}
-        </span>
+        <${StatusChip} label=${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)} tone=${toneClass(tone)} />
       </div>
       <p>
         ${resolution?.status === 'abandoned'
@@ -265,7 +264,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
             <div class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card warn">
               <div class="flex justify-between gap-3 items-start">
                 <strong>확인 대기</strong>
-                <span class="cmd-chip rounded-full warn">${pendingConfirm.confirm_token}</span>
+                <${StatusChip} label=${pendingConfirm.confirm_token} tone="warn" />
               </div>
               ${pendingConfirm.preview ? html`<pre class="m-0 p-3 rounded-[10px] bg-[rgba(9,12,20,0.75)] text-[rgba(224,242,254,0.92)] text-[13px] leading-[1.45] max-h-[220px] overflow-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere]">${previewText(pendingConfirm.preview)}</pre>` : null}
               <div class="flex gap-3 flex-wrap mt-3">

--- a/dashboard/src/components/command/topology.ts
+++ b/dashboard/src/components/command/topology.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneAlert,
   CommandPlaneTraceEvent,
@@ -77,12 +78,12 @@ function TopologyNode({ node, depth = 0 }: { node: CommandPlaneTreeNode; depth?:
         <div>
           <div class="flex justify-between items-start flex-wrap gap-2">
             <strong>${node.unit.label}</strong>
-            <span class="cmd-chip rounded-full">${unitKindLabel(node.unit.kind)}</span>
-            <span class="cmd-chip rounded-full ${toneClass(node.health)}">${node.health ?? 'ok'}</span>
-            <span class="cmd-chip rounded-full ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
-            <span class="cmd-chip rounded-full ${activeOps > 0 ? 'ok' : 'warn'}">${connectionLabel}</span>
-            ${policy?.frozen ? html`<span class="cmd-chip rounded-full warn">동결됨</span>` : null}
-            ${policy?.kill_switch ? html`<span class="cmd-chip rounded-full bad">킬 스위치</span>` : null}
+            <${StatusChip} label=${unitKindLabel(node.unit.kind)} />
+            <${StatusChip} label=${node.health ?? 'ok'} tone=${toneClass(node.health)} />
+            <${StatusChip} label=${topologySourceLabel(source)} tone=${topologySourceTone(source)} />
+            <${StatusChip} label=${connectionLabel} tone=${activeOps > 0 ? 'ok' : 'warn'} />
+            ${policy?.frozen ? html`<${StatusChip} label="동결됨" tone="warn" />` : null}
+            ${policy?.kill_switch ? html`<${StatusChip} label="킬 스위치" tone="bad" />` : null}
           </div>
           <div class="flex gap-2 flex-wrap mt-2 text-[var(--white-56)] text-[13px]">
             <span>ID ${node.unit.unit_id}</span>
@@ -113,7 +114,7 @@ function AlertCard({ alert }: { alert: CommandPlaneAlert }) {
     <article class="cmd-alert ${toneClass(alert.severity)} ${alertBorderTone(toneClass(alert.severity))}">
       <div class="cmd-card rounded-xl-head">
         <strong>${alert.title ?? alert.kind ?? alert.alert_id}</strong>
-        <span class="cmd-chip rounded-full ${toneClass(alert.severity)}">${alert.severity ?? 'warn'}</span>
+        <${StatusChip} label=${alert.severity ?? 'warn'} tone=${toneClass(alert.severity)} />
       </div>
       <div class="flex justify-between items-start">
         <span>${alert.scope_type ?? '범위'}:${alert.scope_id ?? '정보 없음'}</span>
@@ -130,8 +131,8 @@ export function TraceRow({ event }: { event: CommandPlaneTraceEvent }) {
       <div class="min-w-0 [overflow-wrap:anywhere] break-words">
         <div class="flex justify-between items-start">
           <strong>${event.event_type}</strong>
-          <span class="cmd-chip rounded-full">${event.source ?? 'control_plane'}</span>
-          <span class="cmd-chip rounded-full">${relativeTime(event.timestamp)}</span>
+          <${StatusChip} label=${event.source ?? 'control_plane'} />
+          <${StatusChip} label=${relativeTime(event.timestamp)} />
         </div>
         <div class="cmd-card rounded-xl-sub">
           ${event.operation_id ?? event.trace_id}
@@ -160,9 +161,9 @@ export function TopologySurface() {
         ? html`
             <div class="mb-4 p-4 bg-[var(--white-4)] border border-[var(--white-8)] rounded-xl">
               <div class="flex justify-between items-start flex-wrap gap-2">
-                <span class="cmd-chip rounded-full ${topologySourceTone(source)}">${topologySourceLabel(source)}</span>
-                <span class="cmd-chip rounded-full">관리 유닛 ${managedUnits}</span>
-                <span class="cmd-chip rounded-full ${activeOps > 0 ? 'ok' : 'warn'}">활성 작전 ${activeOps}</span>
+                <${StatusChip} label=${topologySourceLabel(source)} tone=${topologySourceTone(source)} />
+                <${StatusChip} label=${`관리 유닛 ${managedUnits}`} />
+                <${StatusChip} label=${`활성 작전 ${activeOps}`} tone=${activeOps > 0 ? 'ok' : 'warn'} />
               </div>
               <p>${topologySourceExplanation(source)}</p>
             </div>

--- a/dashboard/src/components/command/war-room-body.ts
+++ b/dashboard/src/components/command/war-room-body.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import type {
   CommandPlaneChainOverlay,
   CommandPlaneSwarmBlocker,
@@ -94,7 +95,7 @@ export function WarRoomBodyGrid({
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card">
                     <div class="flex justify-between gap-3 items-start">
                       <strong>${selectedSession.session_id}</strong>
-                      <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                      <${StatusChip} label=${displayStatus(selectedSession.status)} tone=${toneClass(sessionStatusTone(selectedSession.status))} />
                     </div>
                     <p>스웜 실시간 증거는 아직 약합니다. 이 카드는 세션 요약과 워커 기록을 기준으로 유지합니다.</p>
                     <div class="cmd-card rounded-xl-grid">
@@ -187,7 +188,7 @@ export function WarRoomBodyGrid({
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card warn">
                     <div class="flex justify-between gap-3 items-start">
                       <strong>승인 대기</strong>
-                      <span class="cmd-chip rounded-full warn">${pendingApprovals}</span>
+                      <${StatusChip} label=${String(pendingApprovals)} tone="warn" />
                     </div>
                     <p>엄격 액션이 묶여 있습니다. 실제 승인 처리는 제어 표면에서 합니다.</p>
                   </article>
@@ -198,7 +199,7 @@ export function WarRoomBodyGrid({
                   <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card warn">
                     <div class="flex justify-between gap-3 items-start">
                       <strong>확인 대기</strong>
-                      <span class="cmd-chip rounded-full warn">${pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal}</span>
+                      <${StatusChip} label=${String(pendingConfirmHidden > 0 ? `${pendingConfirmVisible}/${pendingConfirmTotal}` : pendingConfirmTotal)} tone="warn" />
                     </div>
                     <p>
                       운영자 미리보기가 사람 확인을 기다리고 있습니다.
@@ -218,7 +219,7 @@ export function WarRoomBodyGrid({
                         <strong>${activeLane.label}</strong>
                         <div class="cmd-card rounded-xl-sub">${activeLane.kind} · ${activeLane.phase}</div>
                       </div>
-                      <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(activeLane.motion_state))}">${displayStatus(activeLane.motion_state)}</span>
+                      <${StatusChip} label=${displayStatus(activeLane.motion_state)} tone=${toneClass(sessionStatusTone(activeLane.motion_state))} />
                     </div>
                     <div class="cmd-card rounded-xl-grid">
                       <span>현재 단계</span><span>${activeLane.current_step}</span>
@@ -237,7 +238,7 @@ export function WarRoomBodyGrid({
                         <strong>${swarm.detachment.detachment_id}</strong>
                         <div class="cmd-card rounded-xl-sub">${swarm.detachment.assigned_unit_id}</div>
                       </div>
-                      <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(swarm.detachment.status))}">${displayStatus(swarm.detachment.status ?? 'active')}</span>
+                      <${StatusChip} label=${displayStatus(swarm.detachment.status ?? 'active')} tone=${toneClass(sessionStatusTone(swarm.detachment.status))} />
                     </div>
                     <div class="cmd-card rounded-xl-grid">
                       <span>리더</span><span>${swarm.detachment.leader_id ?? '미지정'}</span>
@@ -255,7 +256,7 @@ export function WarRoomBodyGrid({
                           <strong>${selectedSession.session_id}</strong>
                           <div class="cmd-card rounded-xl-sub">현재 세션 기준</div>
                         </div>
-                        <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(selectedSession.status))}">${displayStatus(selectedSession.status)}</span>
+                        <${StatusChip} label=${displayStatus(selectedSession.status)} tone=${toneClass(sessionStatusTone(selectedSession.status))} />
                       </div>
                       <div class="cmd-card rounded-xl-grid">
                         <span>진행률</span><span>${selectedSession.progress_pct != null ? `${selectedSession.progress_pct}%` : '정보 없음'}</span>

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { ActionButton } from '../common/button'
+import { StatusChip } from '../common/status-chip'
 import type {
   Agent,
   CommandPlaneChainOverlay,
@@ -392,7 +393,7 @@ export function WarRoomOrchestrationRail({
                   <strong>Chain Orchestration</strong>
                   <div class="cmd-card rounded-xl-sub">${chainOverlay.operation.operation_id}</div>
                 </div>
-                <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(chainOverlay.operation.status))}">${displayStatus(chainOverlay.operation.status)}</span>
+                <${StatusChip} label=${displayStatus(chainOverlay.operation.status)} tone=${toneClass(sessionStatusTone(chainOverlay.operation.status))} />
               </div>
               <div class="cmd-card rounded-xl-grid">
                 <span>Chain</span><span>${chainOverlay.runtime?.chain_id ?? chainOverlay.preview_run?.chain_id ?? 'n/a'}</span>
@@ -418,7 +419,7 @@ export function WarRoomOrchestrationRail({
                   <strong>Autoresearch Loop</strong>
                   <div class="cmd-card rounded-xl-sub">${linkedAutoresearch.loop_id ?? linkedAutoresearch.session_id ?? 'linked session'}</div>
                 </div>
-                <span class="cmd-chip rounded-full ${linkedAutoresearch.error ? 'bad' : linkedAutoresearch.status === 'running' ? 'warn' : 'ok'}">${linkedAutoresearch.status ?? 'unknown'}</span>
+                <${StatusChip} label=${linkedAutoresearch.status ?? 'unknown'} tone=${linkedAutoresearch.error ? 'bad' : linkedAutoresearch.status === 'running' ? 'warn' : 'ok'} />
               </div>
               <div class="cmd-card rounded-xl-grid">
                 <span>Cycle</span><span>${linkedAutoresearch.current_cycle ?? 0}</span>

--- a/dashboard/src/components/command/war-room-panels.ts
+++ b/dashboard/src/components/command/war-room-panels.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from '../common/status-chip'
 import { displayStatus, relativeTime, sessionStatusTone, toneClass, toneBorder } from './helpers'
 import { truncate } from '../../lib/truncate'
 
@@ -84,7 +85,7 @@ export function WarRoomWorkerCard({ worker }: { worker: WarRoomWorkerView }) {
           <strong>${worker.name}</strong>
           <div class="cmd-card rounded-xl-sub">${worker.role} · ${worker.lane}</div>
         </div>
-        <span class="cmd-chip rounded-full ${toneClass(sessionStatusTone(worker.status))}">${displayStatus(worker.status)}</span>
+        <${StatusChip} label=${displayStatus(worker.status)} tone=${toneClass(sessionStatusTone(worker.status))} />
       </div>
       <div class="cmd-card rounded-xl-grid">
         <span>출처</span><span>${warRoomSourceLabel(worker.source)}</span>
@@ -110,7 +111,7 @@ export function WarRoomPresenceCard({ item }: { item: WarRoomPresenceView }) {
           <strong>${item.name}</strong>
           <div class="cmd-card rounded-xl-sub">${item.role} · ${item.source}</div>
         </div>
-        <span class="cmd-chip rounded-full ${item.tone}">${item.status}</span>
+        <${StatusChip} label=${item.status} tone=${item.tone} />
       </div>
       <div class="cmd-card rounded-xl-grid">
         <span>현재 과업</span><span>${item.task}</span>
@@ -131,7 +132,7 @@ export function WarRoomFeedCard({ item }: { item: WarRoomFeedItem }) {
       <div class="min-w-0 [overflow-wrap:anywhere] break-words">
         <div class="flex justify-between items-start">
           <strong>${item.title}</strong>
-          <span class="cmd-chip rounded-full ${item.tone}">${item.timestamp ? relativeTime(item.timestamp) : item.source}</span>
+          <${StatusChip} label=${item.timestamp ? relativeTime(item.timestamp) : item.source} tone=${item.tone} />
         </div>
         <div class="cmd-card rounded-xl-sub">${item.meta}</div>
       </div>

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from './status-chip'
 import { MitosisRing } from './mitosis-ring'
 import { StatCell } from './stat-cell'
 import { StatusBadge } from './status-badge'
@@ -97,7 +98,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
                 ${model.pipelineStage ? html`<${PipelineStageBadge} stage=${model.pipelineStage} />` : null}
                 ${model.stateLabel ? html`<span class="monitor-pill ${toneClass} inline-flex items-center rounded-full px-2 py-[3px] text-[length:var(--fs-xs)] uppercase tracking-[0.06em]">${model.stateLabel}</span>` : null}
               `
-            : html`<span class="cmd-chip rounded-full ${toneClass}">${model.statusLabel}</span>`}
+            : html`<${StatusChip} label=${model.statusLabel} tone=${toneClass} />`}
         </div>
 
         <div class=${variant === 'mission' ? 'flex flex-wrap gap-3 text-[rgba(255,255,255,0.68)] text-[length:var(--fs-sm)] leading-[1.45]' : 'monitor-meta'}>

--- a/dashboard/src/components/common/provenance-strip.ts
+++ b/dashboard/src/components/common/provenance-strip.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from './status-chip'
 
 type ProvenanceItem = {
   kind?: string | null
@@ -25,25 +26,6 @@ function provenanceTone(value?: string | null): string {
   }
 }
 
-function provenanceDetail(value?: string | null): string {
-  switch (normalizeProvenance(value)) {
-    case 'truth':
-      return '직접 수집한 source of truth'
-    case 'derived':
-      return 'truth를 바탕으로 계산한 read-model'
-    case 'fallback':
-      return '직접 truth가 비어 있을 때 쓰는 대체 경로'
-    case 'recorded':
-      return '이미 기록된 결정 또는 증거'
-    case 'narrative':
-      return 'MODEL 해석 레이어'
-    case 'judgment':
-      return '판단 레이어'
-    default:
-      return '근거 계층'
-  }
-}
-
 function provenanceLabel(item: ProvenanceItem): string {
   const explicit = (item.label ?? '').trim()
   if (explicit) return explicit
@@ -53,11 +35,7 @@ function provenanceLabel(item: ProvenanceItem): string {
 export function ProvenanceChip({ item }: { item: ProvenanceItem }) {
   const label = provenanceLabel(item)
   const tone = provenanceTone(item.kind)
-  return html`
-    <span class="cmd-chip rounded-full ${tone}" title=${provenanceDetail(item.kind)}>
-      ${label}
-    </span>
-  `
+  return html`<${StatusChip} label=${label} tone=${tone} />`
 }
 
 export function ProvenanceStrip({

--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from './status-chip'
 import { roomTruth, roomTruthError, roomTruthLoading } from '../../room-truth-store'
 import { toneClass } from '../../lib/tone'
 
@@ -31,9 +32,7 @@ export function RoomTruthStrip() {
         <span class="room-truth-label">세션</span>
         <strong>활성 ${execution?.active_sessions ?? 0} · 막힘 ${blocked}</strong>
         <div class="flex flex-wrap gap-2">
-          <span class="cmd-chip rounded-full ${toneClass(blocked > 0 ? 'warn' : 'ok')}">
-            우선 ${execution?.priority_items ?? 0}
-          </span>
+          <${StatusChip} label=${`우선 ${execution?.priority_items ?? 0}`} tone=${toneClass(blocked > 0 ? 'warn' : 'ok')} />
         </div>
       </article>
     </section>

--- a/dashboard/src/components/common/status-chip.ts
+++ b/dashboard/src/components/common/status-chip.ts
@@ -1,0 +1,15 @@
+// StatusChip -- read-only badge for status, model, tags
+// Replaces 90+ inline `<span class="cmd-chip rounded-full ${tone}">` patterns.
+
+import { html } from 'htm/preact'
+
+interface StatusChipProps {
+  label: string
+  tone?: string
+  class?: string
+}
+
+export function StatusChip({ label, tone = '', class: extraClass = '' }: StatusChipProps) {
+  const cls = `cmd-chip rounded-full ${tone} ${extraClass}`.replace(/\s+/g, ' ').trim()
+  return html`<span class="${cls}">${label}</span>`
+}

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionOperationBrief } from '../../types'
 import {
@@ -30,7 +31,7 @@ export function OperationCard({ brief, selected }: { brief: DashboardExecutionOp
           <div class="text-[var(--text-muted)] text-[13px]">${brief.operation_id}${brief.assigned_unit_label ? ` · ${brief.assigned_unit_label}` : ''}</div>
           <div class="mission-card rounded-xl-title">${brief.objective}</div>
         </div>
-        <span class="cmd-chip rounded-full ${terminal ? 'muted' : toneClass(brief.blocker_summary ? 'warn' : brief.status)}">${statusLabel(brief.status)}</span>
+        <${StatusChip} label=${statusLabel(brief.status)} tone=${terminal ? 'muted' : toneClass(brief.blocker_summary ? 'warn' : brief.status)} />
       </div>
       <div class="mission-card rounded-xl-meta">
         ${brief.stage ? html`<span>단계 · ${brief.stage}</span>` : null}

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionQueueItem } from '../../types'
 import {
@@ -33,7 +34,7 @@ export function QueueCard({ item, selected }: { item: DashboardExecutionQueueIte
           <div class="text-[var(--text-muted)] text-[13px]">${item.kind === 'session' ? item.target_id : item.linked_session_id ?? item.target_id}</div>
           <div class="mission-card rounded-xl-title">${item.summary}</div>
         </div>
-        <span class="cmd-chip rounded-full ${terminal ? 'muted' : toneClass(item.severity)}">${statusLabel(item.status ?? item.severity)}</span>
+        <${StatusChip} label=${statusLabel(item.status ?? item.severity)} tone=${terminal ? 'muted' : toneClass(item.severity)} />
       </div>
       <div class="mission-card rounded-xl-meta">
         <span>${queueKindLabel(item.kind)}</span>

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { EmptyState } from '../common/empty-state'
+import { StatusChip } from '../common/status-chip'
 import { TimeAgo } from '../common/time-ago'
 import type { DashboardExecutionSessionBrief } from '../../types'
 import {
@@ -33,7 +34,7 @@ export function SessionCard({ brief, selected }: { brief: DashboardExecutionSess
           <div class="text-[var(--text-muted)] text-[13px]">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
           <div class="mission-card rounded-xl-title">${brief.goal}</div>
         </div>
-        <span class="cmd-chip rounded-full ${terminal ? 'muted' : toneClass(brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
+        <${StatusChip} label=${statusLabel(brief.status)} tone=${terminal ? 'muted' : toneClass(brief.health ?? brief.status)} />
       </div>
       <div class="mission-card rounded-xl-meta">
         <span>건강도 · ${statusLabel(brief.health ?? 'ok')}</span>

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -3,6 +3,7 @@ import { extractAgentInfo } from './common/agent-info'
 import { linkedRecentToolsEmptyState, observedToolsEmptyState, toolAuditStateLabel } from './common/tool-audit'
 import { StatCell } from './common/stat-cell'
 import { ActionBar, ActionBtn } from './common/action-bar'
+import { StatusChip } from './common/status-chip'
 import { openAgentDetail } from './agent-detail'
 import { openKeeperDetail } from './keeper-detail'
 import { workflowActionLabel } from '../workflow-context'
@@ -44,7 +45,7 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
               <span>${info.model !== info.nickname ? `${info.model} · ` : ''}${info.nickname}</span>
             </div>
           </div>
-          <span class="cmd-chip rounded-full ${toneClass(row.brief.status ?? row.agent?.status)}">${statusLabel(row.brief.status ?? row.agent?.status)}</span>
+          <${StatusChip} label=${statusLabel(row.brief.status ?? row.agent?.status)} tone=${toneClass(row.brief.status ?? row.agent?.status)} />
         </div>
 
         <div class="flex flex-wrap gap-3 text-[var(--text-body)] text-[13px] leading-snug">
@@ -117,7 +118,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
               ${row.keeper?.koreanName ? html`<span>${row.keeper.koreanName}</span>` : null}
             </div>
           </div>
-          <span class="cmd-chip rounded-full ${toneClass(row.brief.status ?? row.keeper?.status)}">${statusLabel(row.brief.status ?? row.keeper?.status)}</span>
+          <${StatusChip} label=${statusLabel(row.brief.status ?? row.keeper?.status)} tone=${toneClass(row.brief.status ?? row.keeper?.status)} />
         </div>
 
         <div class="flex flex-wrap gap-3 text-[var(--text-body)] text-[13px] leading-snug">
@@ -159,9 +160,7 @@ export function InternalSignalCard({ item }: { item: DashboardMissionInternalSig
   return html`
     <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 ${toneClass(item.severity)}">
       <div class="flex justify-between gap-3 items-start flex-wrap">
-        <span class="cmd-chip rounded-full ${toneClass(item.severity)}">
-          ${item.signal_type === 'action' && action ? workflowActionLabel(action.action_type) : attention?.kind ?? '내부 신호'}
-        </span>
+        <${StatusChip} label=${item.signal_type === 'action' && action ? workflowActionLabel(action.action_type) : attention?.kind ?? '내부 신호'} tone=${toneClass(item.severity)} />
         <span class="text-[var(--text-muted)] text-[13px]">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
       </div>
       <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${item.summary}</p>

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -4,6 +4,7 @@ import { StatCell } from './common/stat-cell'
 import { TagBadge } from './common/tag-badge'
 import { ListItem } from './common/list-item'
 import { ActionBar, ActionBtn } from './common/action-bar'
+import { StatusChip } from './common/status-chip'
 import { openAgentDetail } from './agent-detail'
 import { workflowActionLabel } from '../workflow-context'
 import type {
@@ -49,7 +50,7 @@ export function AttentionCard({
             <strong>${item.summary}</strong>
             <div class="text-[var(--text-muted)] text-[13px] mt-1">${missionTargetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</div>
           </div>
-          <span class="cmd-chip rounded-full ${toneClass(action?.severity ?? item.severity)}">${action ? actionModeLabel(action) : item.severity}</span>
+          <${StatusChip} label=${action ? actionModeLabel(action) : item.severity} tone=${toneClass(action?.severity ?? item.severity)} />
         </div>
 
         <div class="grid grid-cols-2 gap-3">

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -4,6 +4,7 @@ import { EmptyState } from './common/empty-state'
 import { TagBadge } from './common/tag-badge'
 import { ActionBar, ActionBtn } from './common/action-bar'
 import { ProvenanceStrip } from './common/provenance-strip'
+import { StatusChip } from './common/status-chip'
 import {
   missionBriefing,
   missionBriefingError,
@@ -34,14 +35,12 @@ export function MissionBriefingCard() {
       </div>
 
       <div class="flex gap-3 flex-wrap mb-4">
-        <span class="cmd-chip rounded-full ${briefingTone}">
-          ${statusLabel(briefing?.status ?? (missionBriefingError.value ? 'error' : 'loading'))}
-        </span>
-        ${briefing?.model ? html`<span class="cmd-chip rounded-full">${briefing.model}</span>` : null}
-        ${briefing?.generated_at ? html`<span class="cmd-chip rounded-full">${relativeTime(briefing.generated_at)}</span>` : null}
-        ${briefing?.cached ? html`<span class="cmd-chip rounded-full">캐시</span>` : null}
-        ${briefing?.stale ? html`<span class="cmd-chip rounded-full warn">오래됨</span>` : null}
-        ${briefing?.refreshing ? html`<span class="cmd-chip rounded-full warn">갱신 중</span>` : null}
+        <${StatusChip} label=${statusLabel(briefing?.status ?? (missionBriefingError.value ? 'error' : 'loading'))} tone=${briefingTone} />
+        ${briefing?.model ? html`<${StatusChip} label=${briefing.model} />` : null}
+        ${briefing?.generated_at ? html`<${StatusChip} label=${relativeTime(briefing.generated_at)} />` : null}
+        ${briefing?.cached ? html`<${StatusChip} label="캐시" />` : null}
+        ${briefing?.stale ? html`<${StatusChip} label="오래됨" tone="warn" />` : null}
+        ${briefing?.refreshing ? html`<${StatusChip} label="갱신 중" tone="warn" />` : null}
       </div>
 
       ${missionBriefingError.value ? html`<${EmptyState} message=${missionBriefingError.value} compact />` : null}
@@ -59,11 +58,11 @@ export function MissionBriefingCard() {
                   <div class="flex justify-between gap-3 items-start flex-wrap">
                     <strong>${section.label}</strong>
                     <div class="flex gap-2 flex-wrap justify-end">
-                      <span class="cmd-chip rounded-full ${toneClass(section.status)}">${statusLabel(section.status)}</span>
+                      <${StatusChip} label=${statusLabel(section.status)} tone=${toneClass(section.status)} />
                       ${signalClassLabel(section.signal_class)
-                        ? html`<span class="cmd-chip rounded-full ${section.signal_class === 'mixed' ? 'warn' : ''}">${signalClassLabel(section.signal_class)}</span>`
+                        ? html`<${StatusChip} label=${signalClassLabel(section.signal_class)} tone=${section.signal_class === 'mixed' ? 'warn' : ''} />`
                         : null}
-                      ${section.evidence_quality ? html`<span class="cmd-chip rounded-full">${section.evidence_quality}</span>` : null}
+                      ${section.evidence_quality ? html`<${StatusChip} label=${section.evidence_quality} />` : null}
                     </div>
                   </div>
                   <p class="m-0 text-[rgba(255,255,255,0.8)] leading-normal">${section.summary}</p>
@@ -98,7 +97,7 @@ export function MissionBriefingCard() {
                   <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] grid gap-3 ${item.severity === 'watch' ? 'warn' : ''}">
                     <div class="flex justify-between gap-3 items-start flex-wrap">
                       <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
-                      <span class="cmd-chip rounded-full ${item.severity === 'watch' ? 'warn' : ''}">${statusLabel(item.severity)}</span>
+                      <${StatusChip} label=${statusLabel(item.severity)} tone=${item.severity === 'watch' ? 'warn' : ''} />
                     </div>
                     <p class="m-0 text-[rgba(255,255,255,0.78)] leading-snug">${item.summary}</p>
                   </article>

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -6,6 +6,7 @@ import { StatCell } from './common/stat-cell'
 import { TagBadge } from './common/tag-badge'
 import { ListItem } from './common/list-item'
 import { ActionBar, ActionBtn } from './common/action-bar'
+import { StatusChip } from './common/status-chip'
 import { openAgentDetail } from './agent-detail'
 import type {
   DashboardMissionSessionCard,
@@ -48,7 +49,7 @@ export function SessionBriefCard({
             </div>
             <div class="text-[var(--text-muted)] text-[13px] mt-1">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
           </div>
-          <span class="cmd-chip rounded-full ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
+          <${StatusChip} label=${statusLabel(brief.status)} tone=${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} />
         </div>
 
         <div class="grid grid-cols-2 gap-3">
@@ -147,7 +148,7 @@ export function SessionDetailCard({
         <div class="grid gap-3">
           <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>타임라인</strong>
-            <span class="cmd-chip rounded-full">${detail.timeline.length}</span>
+            <${StatusChip} label=${String(detail.timeline.length)} />
           </div>
           <div class="flex flex-col gap-3">
             ${detail.timeline.length > 0
@@ -165,7 +166,7 @@ export function SessionDetailCard({
         <div class="grid gap-3">
           <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>참여자</strong>
-            <span class="cmd-chip rounded-full">${detail.participants.length}</span>
+            <${StatusChip} label=${String(detail.participants.length)} />
           </div>
           <div class="flex flex-col gap-3">
             ${detail.participants.length > 0
@@ -186,7 +187,7 @@ export function SessionDetailCard({
         <div class="grid gap-3">
           <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>연결된 작전</strong>
-            <span class="cmd-chip rounded-full">${detail.operations.length}</span>
+            <${StatusChip} label=${String(detail.operations.length)} />
           </div>
           <div class="flex flex-col gap-3">
             ${detail.operations.length > 0
@@ -205,7 +206,7 @@ export function SessionDetailCard({
         <div class="grid gap-3">
           <div class="flex justify-between gap-3 items-start flex-wrap">
             <strong>연속성 관찰</strong>
-            <span class="cmd-chip rounded-full">${detail.keepers.length}</span>
+            <${StatusChip} label=${String(detail.keepers.length)} />
           </div>
           <div class="flex flex-col gap-3">
             ${detail.keepers.length > 0

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { StatusChip } from './common/status-chip'
 import type {
   DashboardProofActorContribution,
   DashboardProofArtifactRef,
@@ -169,9 +170,7 @@ export function ActorContributionRow({ item }: { item: DashboardProofActorContri
             <span>${lastSeen ? relativeTime(lastSeen) : '기록 없음'}</span>
           </div>
         </div>
-        <span class="cmd-chip rounded-full ${actorActivityTone(item)}">
-          ${actorActivityLabel(item)}
-        </span>
+        <${StatusChip} label=${actorActivityLabel(item)} tone=${actorActivityTone(item)} />
       </div>
       <div class="grid gap-1">
         <span>${actorActivityMeta(item)}</span>
@@ -225,7 +224,7 @@ export function ArtifactRow({ item }: { item: DashboardProofArtifactRef }) {
             <span>${compactPath(item.path)}</span>
           </div>
         </div>
-        <span class="cmd-chip rounded-full ${item.exists ? 'ok' : 'warn'}">${item.exists ? '존재함' : '없음'}</span>
+        <${StatusChip} label=${item.exists ? '존재함' : '없음'} tone=${item.exists ? 'ok' : 'warn'} />
       </div>
     </article>
   `


### PR DESCRIPTION
## Summary

대시보드 컴포넌트 통합 — 인라인 중복 패턴을 공통 컴포넌트로 정규화.

### Phase 1: cmd-chip → StatusChip (25파일, 90+ 패턴)
- `common/status-chip.ts` 신규 생성 (label, tone, class props)
- 25파일에서 인라인 `<span class="cmd-chip rounded-full">` → `<StatusChip />`

### Phase 2: rounded-full stats → StatCell (7파일, 25 stat boxes)
- `common/stat-cell.ts` 확장 (size: sm/xl/2xl/3xl, bg: card/card-blur/none, density)
- border를 `--card-border`로 통일 (139건 패턴과 일치)
- 구조가 너무 특수화된 파일(keeper-detail, proof, resident-runtime 등)은 스킵

### Fix: Governance 렌더링 에러
- Preact fragment ↔ 단일 VNode 전환 시 `insertBefore` DOM 에러
- 3파일에서 multi-root branch를 `<div>` wrapper로 감쌈

## Stats
- **37파일** 수정, **-57 LOC** (net)
- 8 커밋, 각 배치 후 빌드 검증

## Test plan
- [x] 각 배치 후 `npm run build` 성공
- [x] governance 렌더링 에러 해결
- [ ] CI green
- [ ] 브라우저 visual regression 확인