### PR TITLE
refactor(board): replace exception-driven Hashtbl lookups with Option combinators

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -72,9 +72,9 @@ let sweep store =
            let post_key = Post_id.to_string c.post_id in
            (match Hashtbl.find_opt store.comments_by_post post_key with
             | Some ids ->
-                let filtered = List.filter (fun id -> not (String.equal id cid)) ids in
-                if filtered = [] then Hashtbl.remove store.comments_by_post post_key
-                else Hashtbl.replace store.comments_by_post post_key filtered
+                (match List.filter (fun id -> not (String.equal id cid)) ids with
+                 | [] -> Hashtbl.remove store.comments_by_post post_key
+                 | filtered -> Hashtbl.replace store.comments_by_post post_key filtered)
             | None -> ())
        | None -> ());
       Hashtbl.remove store.comments cid
@@ -190,6 +190,15 @@ let contains_substring haystack needle =
       else loop (idx + 1)
     in
     loop 0
+
+(** Take at most [n] elements from a list. *)
+let take n lst =
+  let rec go n acc = function
+    | _ when n <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: xs -> go (n - 1) (x :: acc) xs
+  in
+  go n [] lst
 
 let author_looks_automation author =
   String.starts_with ~prefix:"auto-" author
@@ -509,11 +518,6 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
           let h_norm = String.lowercase_ascii (String.trim h) in
           List.filter (fun (p : post) -> p.hearth = Some h_norm) filtered
     in
-    (* Take first N *)
-    let rec take n lst = match n, lst with
-      | 0, _ | _, [] -> []
-      | n, x :: xs -> x :: take (n-1) xs
-    in
     take (min limit 100) filtered  (* Hard cap at 100 *)
   )
 
@@ -529,10 +533,6 @@ let search_posts store ~predicate ~limit : post list =
     let sorted = List.sort (fun (a : post) (b : post) ->
       compare b.created_at a.created_at
     ) matches in
-    let rec take n lst = match n, lst with
-      | 0, _ | _, [] -> []
-      | n, x :: xs -> x :: take (n-1) xs
-    in
     take limit sorted
   )
 
@@ -576,8 +576,8 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
         (* Check comment count using index *)
         let post_key = Post_id.to_string pid in
         let post_comment_count =
-          try List.length (Hashtbl.find store.comments_by_post post_key)
-          with Not_found -> 0
+          Hashtbl.find_opt store.comments_by_post post_key
+          |> Option.value ~default:[] |> List.length
         in
         if post_comment_count >= Limits.max_comments_per_post then
           Error (Capacity_exceeded { current = post_comment_count; max = Limits.max_comments_per_post })
@@ -598,7 +598,7 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
           Hashtbl.add store.comments (Comment_id.to_string comment.id) comment;
           (* Update comments_by_post index *)
           let post_key = Post_id.to_string pid in
-          let existing = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+          let existing = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
           Hashtbl.replace store.comments_by_post post_key (Comment_id.to_string comment.id :: existing);
           (* Update post reply count and updated_at *)
           Hashtbl.replace store.posts post_key
@@ -617,7 +617,7 @@ let get_comments store ~post_id : (comment list, board_error) result =
   | Ok pid ->
       with_lock store (fun () ->
         let post_key = Post_id.to_string pid in
-        let comment_ids = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+        let comment_ids = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
         let comments = List.filter_map (fun cid ->
           Hashtbl.find_opt store.comments cid
         ) comment_ids in

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -148,11 +148,7 @@ let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot
       let posts = Board.list_posts store ~visibility_filter ?hearth ~limit:fetch_limit () in
       let sorted = sort_posts_in_memory ~sort_by posts in
       let filtered = apply_post_kind_filter sorted in
-      let rec take n lst = match n, lst with
-        | 0, _ | _, [] -> []
-        | n, x :: xs -> x :: take (n - 1) xs
-      in
-      take limit filtered
+      Board.take limit filtered
   | Postgres t ->
       let pg_sort = match sort_by with
         | Hot -> Board_pg.Hot
@@ -168,11 +164,7 @@ let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot
       let fetch_limit = if needs_filter then max limit (limit * 3) else limit in
       let posts = Board_pg.list_posts t ~visibility_filter ?hearth ~sort_by:pg_sort ~limit:fetch_limit () in
       let filtered = apply_post_kind_filter posts in
-      let rec take n lst = match n, lst with
-        | 0, _ | _, [] -> []
-        | n, x :: xs -> x :: take (n - 1) xs
-      in
-      take limit filtered
+      Board.take limit filtered
 
 let get_comments ~post_id =
   match backend () with

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -306,7 +306,7 @@ let load_persisted_comments store =
             Hashtbl.replace store.comments cid c;
             (* Build comments_by_post index *)
             let post_key = Post_id.to_string c.post_id in
-            let existing = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+            let existing = Hashtbl.find_opt store.comments_by_post post_key |> Option.value ~default:[] in
             Hashtbl.replace store.comments_by_post post_key (cid :: existing);
             incr loaded
         | _ -> ()
@@ -374,7 +374,7 @@ let list_hearths store : (string * int) list =
     Hashtbl.iter (fun _ (p : post) ->
       match p.hearth with
       | Some h ->
-          let c = try Hashtbl.find counts h with Not_found -> 0 in
+          let c = Hashtbl.find_opt counts h |> Option.value ~default:0 in
           Hashtbl.replace counts h (c + 1)
       | None -> ()
     ) store.posts;
@@ -503,12 +503,12 @@ let get_all_karma store =
       let karma_map = Hashtbl.create 64 in
       Hashtbl.iter (fun _ (p : post) ->
         let author = Agent_id.to_string p.author in
-        let current = try Hashtbl.find karma_map author with Not_found -> 0 in
+        let current = Hashtbl.find_opt karma_map author |> Option.value ~default:0 in
         Hashtbl.replace karma_map author (current + p.votes_up)
       ) store.posts;
       Hashtbl.iter (fun _ (c : comment) ->
         let author = Agent_id.to_string c.author in
-        let current = try Hashtbl.find karma_map author with Not_found -> 0 in
+        let current = Hashtbl.find_opt karma_map author |> Option.value ~default:0 in
         Hashtbl.replace karma_map author (current + c.votes_up)
       ) store.comments;
       let result = Hashtbl.fold (fun k v acc -> (k, v) :: acc) karma_map [] in


### PR DESCRIPTION
## Summary

- Replace 7 `try Hashtbl.find ... with Not_found` with `Hashtbl.find_opt |> Option.value ~default:` across `board_core.ml` and `board_votes.ml`
- Extract shared `take` helper in `board_core.ml` to eliminate 4 duplicate inline definitions (2 in board_core, 2 in board_dispatch)
- Replace `filtered = []` structural equality with pattern match in sweep cleanup (`board_core.ml`)

All changes are behavior-preserving. `dune build --root . lib/ bin/` passes.

## Test plan

- [x] `dune build --root . lib/` passes
- [x] `dune build --root . bin/` passes
- [ ] Verify existing board tests still pass

Generated with [Claude Code](https://claude.com/claude-code)