### PR TITLE
ci: enable dune cache + fix upload-artifact version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: false
+          dune-cache: true
 
       - name: Pin external dependencies
         run: |
@@ -87,7 +87,7 @@ jobs:
           fi
 
       - name: Upload health snapshot
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: health-snapshot
           path: .health/health-snapshot.json
@@ -155,7 +155,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: false
+          dune-cache: true
 
       - name: Pin external dependencies
         run: |
@@ -240,7 +240,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: false
+          dune-cache: true
 
       - name: Pin external dependencies
         run: |
@@ -309,7 +309,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: false
+          dune-cache: true
 
       - name: Pin external dependencies
         run: |
@@ -351,7 +351,7 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4.x
-          dune-cache: false
+          dune-cache: true
 
       - name: Pin external dependencies
         run: |


### PR DESCRIPTION
## Summary
- `dune-cache: true` 활성화 (health + build 두 job)
- `upload-artifact@v7` → `@v4` (v4가 실제 latest stable)

## Expected impact
- dune cache hit 시 빌드 시간 단축 (rebuild 방지)
- artifact upload 안정성 개선

## Not changed (별도 PR)
- PR sync 중복 (3곳) — 제거 시 영향 범위 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)