### PR TITLE
feat(keeper): research profile autonomous code improvement loop

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -105,7 +105,11 @@ let proactive_seed_for_soul_profile (profile : string) : string =
   | "delivery" ->
       "Delivery hint: prioritize concrete next actions and execution momentum."
   | "research" ->
-      "Research hint: prioritize hypotheses, evidence, and validation steps."
+      "Research hint: you have access to masc_research_start and masc_research_status tools. \
+       Periodically call masc_research_start with max_iterations=5 to find code improvements. \
+       After each run, check masc_research_status and report results to the board. \
+       Prioritize hypotheses, evidence, and validation steps. \
+       Track keep rate — if it drops below 50%, adjust strategy."
   | "relationship" ->
       "Relationship hint: prioritize user intent alignment and collaboration continuity."
   | "minimal" ->


### PR DESCRIPTION
## Summary
research profile keeper의 proactive seed에 tool 호출 지시 추가.

keeper가 자율적으로:
1. `masc_research_start` 주기적 호출
2. `masc_research_status` 결과 확인
3. board에 결과 공유
4. keep rate 모니터링 + 전략 조정

## Usage
```
keeper start --soul-profile research --goal "continuous code improvement"
```

## Build
- [x] `dune build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)