### PR TITLE
research(agent-dash): remove any types and unsafe cast in dashboard

### DIFF
--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -9,7 +9,7 @@ import {
   operatorActionLog,
   operatorSnapshot,
 } from '../../operator-store'
-import type { Keeper, OperatorKeeperSnapshot } from '../../types'
+import type { Keeper, OperatorActionDescriptor, OperatorKeeperSnapshot } from '../../types'
 import {
   actionTypeLabel,
   displayStatus,
@@ -31,10 +31,9 @@ function openOpsKeeperDetail(opsKeeper: OperatorKeeperSnapshot): void {
     name: opsKeeper.name,
     agent_name: opsKeeper.agent_name ?? opsKeeper.name,
     status: opsKeeper.status ?? 'unknown',
-    context_ratio: opsKeeper.context_ratio ?? null,
-    model: opsKeeper.model ?? null,
-    goal: opsKeeper.goal ?? null,
-  } as Keeper
+    context_ratio: opsKeeper.context_ratio,
+    model: opsKeeper.model,
+  }
   openKeeperDetail(keeper)
 }
 
@@ -154,13 +153,13 @@ export function OpsKeeperColumn() {
         ${availableActions.length
           ? html`<div class="flex flex-col gap-2">
               ${['room', 'keeper', 'team_session'].map(targetType => {
-                const group = availableActions.filter((a: any) => a.target_type === targetType)
+                const group = availableActions.filter((a: OperatorActionDescriptor) => a.target_type === targetType)
                 if (group.length === 0) return null
                 return html`
                   <div key=${targetType}>
                     <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">${targetTypeLabel(targetType)}</div>
                     <div class="flex flex-wrap gap-1">
-                      ${group.map((action: any) => html`
+                      ${group.map((action: OperatorActionDescriptor) => html`
                         <span key=${action.action_type}
                           title=${action.description ?? ''}
                           class="text-[12px] px-2 py-0.5 rounded cursor-default ${action.confirm_required ? 'bg-[var(--warn-12)] border border-[var(--warn-28)] text-[var(--warn)]' : 'bg-[var(--accent-8)] border border-[var(--accent-12)] text-[var(--accent)]'}">

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -29,8 +29,8 @@ export function Worktrees() {
         } catch {
           setWorktrees([{ id: 'raw', branch: 'Unknown', path: resText }])
         }
-      } catch (err: any) {
-        setError(err.message || 'Failed to load worktrees')
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to load worktrees')
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary
- Replace `err: any` with `err: unknown` + `instanceof Error` narrowing in `worktrees.ts`
- Replace `(a: any)` and `(action: any)` with `OperatorActionDescriptor` in `ops-keeper-column.ts`
- Remove `as Keeper` type assertion and phantom `goal` field (not present on `Keeper` interface) from `openOpsKeeperDetail`

## Details
- 2 files, 8 insertions / 9 deletions
- No new tsc errors (pre-existing errors in `dashboard-shell.ts` are unchanged)

## Test plan
- [ ] `npm run build` in dashboard/ (pre-existing tsc errors in dashboard-shell.ts unrelated)
- [ ] Verify ops keeper column renders correctly in browser

Generated with [Claude Code](https://claude.com/claude-code)