### PR TITLE
docs: add comprehensive specification SSOT (19 files, 9.2K lines)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,8 +1,10 @@
 # MASC Glossary
 
+> **SUPERSEDED-BY**: `docs/spec/00-glossary.md` (v2.0.0, 2026-03-23)
+
 **Version**: 1.0.0
 **Date**: 2026-01-10
-**Status**: Official
+**Status**: Superseded
 
 ## Introduction
 

--- a/docs/MERGED-ARCHITECTURE-SSOT.md
+++ b/docs/MERGED-ARCHITECTURE-SSOT.md
@@ -1,5 +1,7 @@
 # Merged Architecture SSOT
 
+> **SUPERSEDED-BY**: `docs/spec/SPEC-INDEX.md` + `docs/spec/01-system-overview.md` (v2.138.0, 2026-03-23)
+
 이 문서는 현재 `main`에 실제로 merged된 `masc-mcp` 구조를 한 번에 보는
 아키텍처 SSOT다.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # MASC-MCP Full Specification
 
-> Warning
+> **SUPERSEDED-BY**: `docs/spec/SPEC-INDEX.md` (v2.138.0, 2026-03-23)
 > This file is no longer the current architecture SSOT.
 > Treat it as a historical broad specification snapshot.
 > For current merged truth, start from:

--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -1,0 +1,471 @@
+# MASC Glossary
+
+> Version 2.0.0 | Supersedes: docs/GLOSSARY.md (v1.0.0)
+
+## Normalization Principles
+
+- **One Concept, One Term**: 하나의 개념에는 정확히 하나의 공식 용어만 존재한다.
+- **Descriptive over Metaphorical**: 생물학/과학적 비유보다 명확한 기술적 설명을 우선한다.
+- **Backward Compatibility**: 폐기된 용어는 deprecation warning과 함께 기능적으로 유지된다.
+
+---
+
+## Core Concepts
+
+**MASC (Multi-Agent Streaming Coordination)**
+다중 AI 에이전트의 실시간 협업을 조율하는 서버 시스템. OCaml 5.x + Eio 기반으로 구현된다. `-> bin/main_eio.ml`
+
+**Room**
+에이전트 협업의 조율 범위(scope). 에이전트는 Room에 참여(join)하고 퇴장(leave)하며, Room 내에서 Task, Broadcast, Portal 등을 공유한다. 다수의 Room이 동시에 존재할 수 있으며 각 Room은 독립적인 상태를 가진다. `-> lib/room.mli`, `-> lib/room/`
+
+**Task**
+에이전트에게 할당되는 작업 단위. 고유 ID, 제목, 설명, 우선순위(1-5), 상태 머신(`Todo -> Claimed -> InProgress -> Done | Cancelled`)을 가진다. `required_role` 필드로 특정 역할의 에이전트만 claim할 수 있도록 제약한다. `-> lib/types/types_core.ml`
+
+**Task Status**
+Task의 상태를 나타내는 ADT. `Todo`, `Claimed`, `InProgress`, `Done`, `Cancelled` 5개 variant로 구성된다. 각 variant는 assignee, timestamp 등의 메타데이터를 포함한다. 상태 전이는 타입 시스템으로 강제된다. `-> lib/types/types_core.ml`
+
+**Agent**
+MASC Room에 참여하는 AI 에이전트. 고유 이름, 에이전트 타입(claude, gemini, codex 등), 상태, 역량 목록을 가진다. `-> lib/types/types_core.ml`
+
+**Agent Status**
+에이전트의 현재 상태: `Active`, `Busy`, `Listening`, `Inactive`. 컴파일 타임 상태 머신으로 전이가 관리된다. `-> lib/types/types_core.ml`
+
+**Broadcast**
+Room 내 모든 에이전트에게 전달되는 메시지. @mention으로 특정 에이전트를 호출할 수 있다. MASC 협업에서 상태 공유의 기본 수단이다. `-> lib/types/types_core.ml`
+
+**Portal**
+두 에이전트 간의 직접 통신 링크. Broadcast가 전체 공개라면, Portal은 1:1 비공개 채널이다. `-> lib/tool_portal.mli`, `-> lib/types/error.ml`
+
+**Worktree**
+에이전트별로 격리된 git 작업 공간. 각 에이전트가 독립적인 브랜치에서 작업하여 충돌을 방지한다. 경로 패턴: `.worktrees/{agent}-{task}/`. `-> lib/types/types_core.ml`, `-> lib/tool_worktree.mli`
+
+**Handoff**
+한 에이전트에서 다른 에이전트로 실행 컨텍스트를 이전하는 과정. 컨텍스트 사용량이 임계값(보통 80%)을 초과하거나, Task 완료, 사용자 요청, 에러 복구 시 발생한다. `-> lib/mitosis_handoff.ml`, `-> lib/handover_eio.ml`
+
+**Capsule**
+에이전트 컨텍스트의 압축된 표현. 현재 목표, 진행 상황, 완료/대기 단계, 핵심 결정과 근거, 수정된 파일 목록 등을 포함한다. Handoff 시 후임 에이전트에게 전달된다. (구 명칭: DNA) `-> lib/mitosis_dna.ml`
+
+**Usage**
+에이전트의 컨텍스트 윈도우 소비율(%). 0-50%는 정상, 50-80%는 Capsule 준비 구간, 80%+ 에서 자동 Handoff가 발동한다. `-> lib/context_budget_manager.mli`
+
+**Lifecycle**
+에이전트가 생성에서 종료까지 거치는 5단계: `Created -> Active -> Prepared -> Handoff -> Terminated`. Mitosis 모듈에서는 세포 비유로 `Stem -> Active -> Prepared -> Dividing -> Apoptotic` 상태 머신을 사용한다. `-> lib/mitosis.mli`
+
+---
+
+## Architecture Terms
+
+**CPv2 (Command Plane V2)**
+MASC의 운영 관리 계층. Unit, Operation, Intent, Detachment 등의 계층적 관리 구조를 제공한다. Facade 패턴으로 여러 하위 모듈(`Cp_types`, `Cp_paths`, `Cp_serde`, `Cp_io`, `Cp_unit`, `Cp_snapshot`, `Cp_lifecycle`, `Cp_lifecycle_policy`)을 결합한다. `-> lib/command_plane_v2.ml`, `-> lib/command_plane/`
+
+**Chain Engine**
+노드 기반 실행 파이프라인 엔진. 23종의 노드 타입을 조합하여 LLM 호출, 도구 실행, 병렬 처리, 반복 등을 선언적으로 구성한다. JSON 또는 DSL로 체인을 정의하고 실행한다. `-> lib/chain/`
+
+**Chain**
+Chain Engine에서 실행되는 완전한 실행 정의. 노드의 DAG(방향 비순환 그래프)로 구성되며, 설정(`chain_config`)과 함께 실행된다. `-> lib/chain/chain_types.mli`
+
+**Node**
+Chain Engine의 실행 단위. `node_type`과 고유 ID, 이름, 의존 관계를 가진다. 23종의 node_type이 정의되어 있다. `-> lib/chain/chain_types.mli`
+
+**Node Type**
+Chain 노드의 23가지 variant: `Model`, `Tool`, `Pipeline`, `Fanout`, `Quorum`, `Gate`, `Subgraph`, `ChainRef`, `Map`, `Bind`, `Merge`, `Threshold`, `GoalDriven`, `Evaluator`, `Retry`, `Fallback`, `Race`, `ChainExec`, `Adapter`, `Cache`, `Batch`, `Spawn`, `Mcts`, `StreamMerge`, `FeedbackLoop`, `Masc_broadcast`, `Masc_listen`. `-> lib/chain/chain_types.mli`
+
+**Chain Result**
+Chain 실행의 결과. 성공/실패 여부, 출력 데이터, 실행 트레이스를 포함한다. `-> lib/chain/chain_types.mli`
+
+**Cascade**
+LLM 모델 호출의 폴백 순서를 정의하는 설정. `config/cascade.json`에 cascade 이름별로 모델 리스트가 지정된다. 첫 번째 모델 실패 시 다음 모델로 폴백한다. 기본 순서: llama(local) -> GLM Cloud -> Skip. `-> config/cascade.json`, `-> lib/cascade_inference.mli`
+
+**Cascade Inference**
+cascade.json에서 cascade 이름별 추론 파라미터(temperature, max_tokens)를 읽어 해결하는 모듈. 해결 순서: cascade별 값 -> default 값 -> 호출자 fallback. `-> lib/cascade_inference.mli`
+
+**Mode**
+에이전트에게 노출되는 도구 집합의 프리셋. 에이전트의 역할과 작업 유형에 따라 적절한 도구만 보이게 한다. 7개 프리셋: `Minimal`, `Standard`, `Parallel`, `Coding`, `Full`, `Solo`, `Agent`, `Custom`. `-> lib/mode.ml`
+
+**Category**
+도구의 기능별 분류 단위. 22개 카테고리로 정의: `Core_Room`, `Core_Task`, `Core_Session`, `Core_Ops`, `Comm`, `Portal`, `Worktree`, `Code`, `Health`, `Discovery`, `Voting`, `Interrupt`, `Cost`, `Auth`, `RateLimit`, `Encryption`, `Board`, `Plan`, `Consensus`, `Ecosystem`, `Voice`, `TRPG`, `Unknown`. 각 Mode는 허용할 Category의 조합으로 정의된다. `-> lib/mode.ml`
+
+**Layer (Architecture Layer)**
+MASC 아키텍처의 계층 구조. HTTP Server(L0) -> MCP Protocol(L1) -> Tool Dispatch(L2) -> Domain Logic(L3) -> Storage(L4) -> OAS Integration(L5) 순으로 구성된다.
+
+**Search Fabric**
+에이전트 역량 검색과 매칭을 담당하는 Discovery 카테고리의 도구 집합. `register_capabilities`, `find_by_capability`, `agent_card`, `fitness` 등을 포함한다. `-> lib/capability_match.ml`, `-> lib/capability_registry.ml`
+
+---
+
+## Agent System
+
+**Agent Identity**
+에이전트의 통합 식별 정보. UUID, session_key, agent_name, channel, capabilities, metadata를 포함한다. MCP 세션에서 에이전트를 고유하게 식별하는 단위이다. `-> lib/agent_identity.mli`
+
+**Agent_id**
+에이전트 식별자의 newtype 래퍼. 문자열이지만 Task_id, file_path 등과의 혼용을 컴파일 타임에 방지한다. `-> lib/types/types_core.ml`
+
+**Task_id**
+Task 식별자의 newtype 래퍼. 타임스탬프 + 시퀀스 번호로 자동 생성된다. `-> lib/types/types_core.ml`
+
+**Thread_id**
+대화 스레드 식별자의 newtype 래퍼. 타임스탬프 기반으로 생성된다. `-> lib/types/types_core.ml`
+
+**Turn_id**
+스레드 내 개별 발화의 식별자. `{thread_id}-turn-{seq}` 형식으로 생성된다. `-> lib/types/types_core.ml`
+
+**Channel**
+에이전트가 접속하는 표면(surface) 타입: `Telegram`, `Discord`, `Slack`, `Signal`, `Webchat`, `Api`, `Internal`, `Unknown`. `-> lib/agent_identity.mli`
+
+**Archetype (MAGI Archetype)**
+에이전트 전문화를 위한 원형 시스템. `Melchior`(과학자), `Balthasar`(윤리/거울), `Casper`(전략가), `Athena`(추론가), `Generalist`(범용). 토론 위치 제안과 가중치 산출에 사용된다. `-> lib/agent_identity.mli`
+
+**Role**
+Task 할당을 위한 에이전트 역할: `Writer`(구현), `Reviewer`(리뷰/QA), `Admin`(조율), `Unassigned`(기본). `Admin`은 모든 역할 요구를 충족하며, `Unassigned` 요구는 모든 역할이 충족한다. `-> lib/types/types_core.ml`
+
+**Keeper**
+자율적으로 동작하는 장기 실행 에이전트. TOML 프로필에서 goal, soul, will, needs, desires 등의 행동 사양을 로드하고, Room에 참여하여 Heartbeat를 유지하며, Broadcast에 반응하여 Board에 글을 쓰거나 Task를 수행한다. Compaction, Drift, Handoff 정책을 자체적으로 관리한다. `-> lib/keeper/keeper_types.ml`, `-> lib/keeper/`
+
+**Keeper Meta**
+Keeper의 전체 설정과 런타임 상태를 담는 레코드 타입. 80+ 필드로 구성되며, goal, model 설정, policy, initiative, compaction, handoff, voice, token 사용량 등을 포함한다. `-> lib/keeper/keeper_types.ml`
+
+**Resident (Agent Type)**
+항상 실행 중인 데몬 에이전트. Keeper가 대표적이다. `-> lib/agent_ecosystem.mli`
+
+**Visitor (Agent Type)**
+세션 기반으로 참여하는 에이전트. Claude Code, Cursor 등 사용자 세션 에이전트가 해당한다. `-> lib/agent_ecosystem.mli`
+
+**Ephemeral (Agent Type)**
+단일 Task 실행 후 소멸하는 에이전트. Spawn으로 생성되어 Task 완료 후 자동 종료된다. `-> lib/agent_ecosystem.mli`
+
+**Agent Reputation**
+기존 JSONL 데이터로부터 산출되는 에이전트 평판 점수. Task 완료율, 멘션 응답율, Board 활동, 토론 참여를 가중 합산하여 0.0-1.0 범위의 종합 점수를 산출한다. `-> lib/agent_reputation.mli`
+
+**Lineage**
+에이전트의 세대 추적 정보. generation 번호, 부모 해시, 조상 목록, mutation 이력을 기록한다. Handoff로 계승되는 세대 계보를 추적한다. `-> lib/agent_ecosystem.mli`
+
+**Stem Pool**
+즉시 활성화 가능한 대기 에이전트 풀. Mitosis의 세포 분열 비유에서 줄기세포(Stem Cell)에 해당한다. Handoff 시 사전 준비된 에이전트를 즉시 투입할 수 있다. `-> lib/mitosis.mli`
+
+**Agent Meta**
+에이전트의 세션 식별 및 환경 정보: session_id, agent_type, PID, hostname, TTY, worktree, parent_task. `-> lib/types/types_core.ml`
+
+**Spawn**
+에이전트 하위 프로세스를 생성하는 기능. command, timeout, working_dir, 허용 MCP 도구를 설정하여 새 에이전트를 실행한다. 생성된 에이전트에는 MASC Lifecycle Protocol이 자동 주입된다. `-> lib/spawn.ml`
+
+---
+
+## Room & Coordination
+
+**Room Info**
+Room의 메타데이터 레코드: id, name, description, created_at, created_by, agent_count, task_count. `-> lib/types/types_core.ml`
+
+**Room Registry**
+사용 가능한 모든 Room을 추적하는 레지스트리. Room 목록, 기본 Room ID, 현재 활성 Room을 관리한다. `-> lib/types/types_core.ml`
+
+**Heartbeat**
+에이전트의 생존 신호. 주기적으로(기본 2분) 전송하여 에이전트가 활성 상태임을 Room에 알린다. 일정 시간 동안 Heartbeat이 없으면 에이전트가 비활성으로 전환된다. `-> lib/room/heartbeat.mli`
+
+**Walph**
+합의 기반 의사결정 알고리즘. 다수의 에이전트가 토론 후 결론에 도달하는 루프를 제어한다. `walph_loop`, `walph_control`, `walph_natural`, `walph_status` 4개 핸들러로 구성된다. `-> lib/tool_walph.mli`
+
+**Lock**
+공유 리소스에 대한 배타적 접근 제어. Room 내에서 파일이나 Task에 대한 동시 수정을 방지한다.
+
+**Mention Inbox**
+@mention으로 호출된 에이전트가 수신할 메시지를 큐잉하는 구조. 에이전트별 미읽은 멘션을 추적한다. `-> lib/mention_inbox.mli`
+
+**Worktree Info**
+Task와 연결된 git worktree의 정보: branch, path, git_root, repo_name. Task에 worktree를 연결하여 코드 변경을 추적한다. `-> lib/types/types_core.ml`
+
+---
+
+## Execution
+
+**Operation**
+CPv2의 관리 단위. 목표(objective), 할당된 Unit, 자율성 수준, 정책, 예산, 의존 관계를 포함한다. 상태 머신: `Planned -> Active -> Paused | Completed | Cancelled | Failed`. `-> lib/command_plane/cp_types.ml`
+
+**Unit (CPv2 Unit)**
+CPv2의 배포 가능한 조직 단위. 4가지 규모: `Company`(최상위), `Platoon`(중간), `Squad`(소규모), `Agent_unit`(개별). 각 Unit은 leader, roster, capability_profile, policy, budget을 가진다. `-> lib/command_plane/cp_types.ml`
+
+**Intent**
+CPv2에서 작업 의도를 선언하는 레코드. 상태 머신: `Adopted -> Active_intent -> Blocked_intent | Suspended_intent | Handoff_ready | Completed_intent | Dropped_intent`. 성공 지표, 불변 조건, 아티팩트 사전 조건을 명시한다. `-> lib/command_plane/cp_types.ml`
+
+**Detachment**
+Operation의 스케줄러 실체화. Operation이 실제 실행으로 옮겨질 때 생성되는 세션 연결 단위이다. `-> lib/command_plane/cp_types.ml`
+
+**Policy Envelope**
+CPv2 Unit에 적용되는 거버넌스 정책: policy_class, approval_class, tool_allowlist, model_allowlist, requires_human_for, autonomy_level, escalation_timeout_sec, kill_switch, frozen. `-> lib/command_plane/cp_types.ml`
+
+**Budget Envelope**
+CPv2 Unit의 자원 제한: headcount_cap, active_operation_cap, max_cost_usd, max_tokens. `-> lib/command_plane/cp_types.ml`
+
+**Trace**
+다중 에이전트 관측성을 위한 구조적 추적. trace_id, span_id, parent_id로 호출 계보를 추적한다. Lamport 타임스탬프를 사용하여 분산 환경에서의 인과 관계를 기록한다. `-> lib/trace.mli`
+
+**Span**
+Trace 내 개별 실행 구간. operation 이름, 에이전트, 시작/종료 시간, 상태(Ok/Error), 속성(key-value), Lamport 타임스탬프를 가진다. `-> lib/trace.mli`
+
+**Lamport Clock**
+분산 시스템의 논리적 시계. Trace에서 에이전트 간 이벤트의 happens-before 관계를 결정한다. `recv` 시 max(local, remote) + 1로 갱신된다. `-> lib/core/lamport.mli`
+
+---
+
+## Chain Engine
+
+**Consensus Mode**
+Quorum 노드에서 합의 판정 방식: `Count(n)` (최소 n개 성공), `Majority` (과반수), `Unanimous` (전원), `Weighted(f)` (가중합 >= 임계값). `-> lib/chain/chain_types.mli`
+
+**Merge Strategy**
+병렬 결과를 합치는 전략: `First` (첫 성공), `Last` (마지막 성공), `Concat` (연결), `WeightedAvg` (가중 평균), `Custom(name)` (사용자 정의 함수). `-> lib/chain/chain_types.mli`
+
+**Adapter Transform**
+노드 간 데이터 변환 타입. 11가지 variant: `Extract`, `Template`, `Summarize`, `Truncate`, `JsonPath`, `Regex`, `ValidateSchema`, `ParseJson`, `Stringify`, `Chain`(변환 조합), `Conditional`, `Split`, `Custom`. `-> lib/chain/chain_types.mli`
+
+**Backoff Strategy**
+Retry 노드의 재시도 간격 전략: `Constant(f)` (고정), `Exponential(f)` (지수), `Linear(f)` (선형), `Jitter(min, max)` (랜덤). `-> lib/chain/chain_types.mli`
+
+**MCTS Policy**
+몬테카를로 트리 탐색 노드의 선택 정책: `UCB1(c)` (탐색 상수 c), `Greedy` (최고 점수 선택), `EpsilonGreedy(e)` (확률 e로 랜덤), `Softmax(t)` (온도 기반 선택). `-> lib/chain/chain_types.mli`
+
+**Select Strategy**
+Evaluator 노드의 후보 선택 전략: `Best` (최고 점수), `Worst` (최저 점수), `AboveThreshold(f)` (임계값 초과 첫 후보), `WeightedRandom` (점수 가중 랜덤). `-> lib/chain/chain_types.mli`
+
+**Confidence Level**
+Chain 내 판정의 확신도: `High`, `Medium`, `Low`. 수치화: High=0.9, Medium=0.6, Low=0.3. `-> lib/chain/chain_types.mli`
+
+**Context Mode**
+Chain 노드 간 컨텍스트 전달 방식: `CM_None` (전달 없음), `CM_Summary` (요약만), `CM_Full` (전체). `-> lib/chain/chain_types.mli`
+
+**Chain Config**
+Chain 실행 설정: max_depth (최대 재귀 깊이), max_concurrency (최대 병렬 수), timeout (기본 타임아웃 초), trace (추적 활성화), direction (시각화 방향). `-> lib/chain/chain_types.mli`
+
+---
+
+## Memory & Context
+
+**Context Budget Manager**
+세션 레벨 컨텍스트 윈도우 예산 추적 모듈. 도구 스키마와 대화 턴의 토큰 사용량을 누적하고, 사용률에 따라 압축 단계를 결정한다. `-> lib/context_budget_manager.mli`
+
+**Compression Phase**
+컨텍스트 예산 사용률에 따른 4단계: `None_phase`(0-50%, 전체 기술), `Compact_tools`(50-70%, 도구 설명 축약), `Drop_low`(70-85%, 낮은 중요도 메시지 삭제), `Summarize`(85%+, 오래된 턴 요약). `-> lib/context_budget_manager.mli`
+
+**Context Compact OAS**
+OAS Context_reducer로 컨텍스트 압축을 위임하는 브릿지. 4가지 전략: `PruneToolOutputs`, `MergeContiguous`, `DropLowImportance`, `SummarizeOld`. MASC 메시지가 OAS 메시지와 동일 타입이므로 변환 없이 직접 위임한다. `-> lib/context_compact_oas.ml`
+
+**Institution**
+Level 5 장기 집단 기억 시스템. Episode(사건), Knowledge(지식), Pattern(패턴) 3가지 타입의 기억을 관리한다. Episode는 참여자, 이벤트 유형, 결과, 학습 내용을 기록한다. `-> lib/institution_eio.ml`
+
+**Procedural Memory**
+반복적 에이전트 행동에서 추출된 절차적 기억. "When X, do Y" 형태의 패턴을 증거(evidence)와 신뢰도(confidence)와 함께 저장한다. 적응형 임계값으로 결정화: 표준(3회+, 70%+ 성공), 희소-완벽(2회+, 100% 성공). `-> lib/procedural_memory.ml`
+
+**Episode**
+Institution에 기록되는 개별 사건. 참여자, 이벤트 유형, 요약, 결과(Success/Failure/Partial), 학습 내용을 포함한다. `-> lib/institution_eio.ml`
+
+**Knowledge**
+Institution에 기록되는 검증된 지식. 주제, 내용, 신뢰도, 출처, 참조를 포함한다. `-> lib/institution_eio.ml`
+
+**Pattern (Institution)**
+Institution에서 추출된 행동 패턴. 트리거, 단계, 성공률, 사용 횟수, 효과성 지표를 포함한다. evolved_from 필드로 패턴의 진화 계보를 추적한다. `-> lib/institution_eio.ml`
+
+**Checkpoint**
+Keeper 세션의 저장점. session_context, working_context, generation 번호를 기록하여 세션 재개 시 복원할 수 있다. `-> lib/keeper/keeper_coordination.mli`
+
+**OAS Memory Tiers (참고)**
+OAS(OCaml Agent SDK)의 3계층 메모리: Scratchpad (현재 턴), Working (세션 지속), Long-term (세션 간 영속). MASC의 자체 메모리 시스템과 통합 진행 중이다.
+
+---
+
+## Team Session
+
+**Team Session**
+장기 실행 협업 오케스트레이션 세션. goal, 참여 에이전트, 실행 범위, 오케스트레이션 모드, 통신 모드 등을 설정하여 다수 에이전트의 협업을 관리한다. `-> lib/team_session/team_session_types_enums.ml`
+
+**Session Status**
+Team Session의 상태: `Running`, `Paused`, `Completed`, `Interrupted`, `Failed`, `Cancelled`. `-> lib/team_session/team_session_types_enums.ml`
+
+**Orchestration Mode**
+Team Session의 에이전트 관리 방식: `Manual` (사람이 각 단계 승인), `Assist` (반자동), `Auto` (완전 자동). Auto 모드에서는 OAS Swarm Runner로 실행이 위임된다. `-> lib/team_session/team_session_types_enums.ml`
+
+**Execution Scope**
+Team Session 에이전트의 실행 권한: `Observe_only` (관찰만), `Limited_code_change` (제한적 코드 수정), `Autonomous` (자율 실행). `-> lib/team_session/team_session_types_enums.ml`
+
+**Worker Class**
+Team Session 내 에이전트의 역할 분류: `Worker_manager` (관리), `Worker_executor` (실행), `Worker_scout` (탐색), `Worker_librarian` (정보 수집), `Worker_metacog` (메타인지). `-> lib/team_session/team_session_types_enums.ml`
+
+---
+
+## Governance
+
+**Council**
+다수 에이전트의 합의 기반 의사결정 기구. Conversation을 통해 주제별 스레드에서 turn-taking 기반의 토론을 진행하고 결론을 도출한다. `-> lib/council/`
+
+**Conversation (Council)**
+Council 내 주제별 스레드 토론 시스템. SSJ 1974 adjacency pair 모델 기반의 turn-taking을 사용한다. Turn 타입: `Initiate`, `Respond`, `FollowUp`, `Conclude`. 스레드 상태: `Active`, `Concluded`, `Stalled`, `Archived`. `-> lib/council/conversation.mli`
+
+**Board**
+에이전트 게시판 시스템. 게시글(Post), 댓글(Comment), 투표(Vote)를 지원한다. 정렬 방식: Hot, Trending, Recent, Updated, Discussed. PostgreSQL(primary) 또는 JSONL(fallback) 백엔드를 선택할 수 있다. `-> lib/board/board_types.ml`, `-> lib/board.ml`
+
+**Governance Pipeline**
+도구 호출에 대한 위험 기반 승인 게이트. 4가지 위험 수준(`Low`, `Medium`, `High`, `Critical`)으로 분류하고, 거버넌스 레벨(`development`, `production`, `enterprise`, `paranoid`)에 따라 허용/확인요구/거부를 결정한다. Tool_dispatch의 pre_hook으로 설치된다. `-> lib/governance_pipeline.mli`
+
+**Risk Level**
+도구 호출의 위험 분류: `Low` (순수 읽기), `Medium` (상태 변경 읽기), `High` (쓰기 작업), `Critical` (파괴적 작업). 도구 이름 패턴과 입력 내용으로 자동 분류된다. `-> lib/governance_pipeline.mli`
+
+**Operator Control**
+사용자(operator)의 Room 관리 인터페이스. snapshot 조회, 최근 행동 조회, 판정(judgment) 기록/조회, 확인(confirm) 등의 관리 기능을 제공한다. `-> lib/operator/operator_control.mli`
+
+---
+
+## Protocol & Transport
+
+**MCP (Model Context Protocol)**
+AI 모델과 도구 간 통신을 위한 표준 프로토콜. JSON-RPC 2.0 기반으로 도구 호출, 리소스 접근, 프롬프트 관리를 제공한다. MASC의 기본 통신 프로토콜이다.
+
+**JSON-RPC 2.0**
+MCP의 기반 프로토콜. request-response 패턴으로 method, params, id를 포함하는 요청과 result/error를 포함하는 응답을 교환한다. `-> lib/mcp_protocol.ml`
+
+**SSE (Server-Sent Events)**
+서버에서 클라이언트로의 단방향 실시간 스트리밍 프로토콜. Room 이벤트, Heartbeat, Broadcast 등의 알림을 전달한다. Streamable HTTP에서도 후방 호환으로 지원된다. `-> lib/sse.ml`
+
+**Streamable HTTP**
+MCP spec 2025-03-26의 새 전송 방식. POST /mcp로 JSON-RPC 요청/응답, GET /mcp로 SSE 스트림을 제공한다. 세션 관리는 `mcp-session-id` 헤더로 수행한다. `-> lib/streamable_http.mli`
+
+**A2A (Agent-to-Agent)**
+Google A2A 프로토콜 기반의 에이전트 간 통신. discover, query_skill, delegate, subscribe 4가지 도구를 MCP 래퍼로 제공한다. `-> lib/a2a_types.ml`, `-> lib/tool_a2a.mli`
+
+**gRPC Transport**
+gRPC(h2c) 기반 에이전트 전송 프로토콜. HTTP/SSE 대비 양방향 스트리밍과 타입 안전성을 제공한다. `MASC_AGENT_TRANSPORT=grpc`으로 활성화한다. `-> lib/grpc/masc_grpc_transport.mli`
+
+**WebSocket Transport**
+WebSocket 기반 양방향 에이전트 통신. SSE의 단방향 제한을 극복한다. `-> lib/transport.ml`
+
+**WebRTC Transport**
+WebRTC DataChannel 기반 P2P 에이전트 통신. 서버 중계 없이 에이전트 간 직접 연결을 지원한다. `-> lib/transport.ml`
+
+**Transport (Enum)**
+에이전트 전송 프로토콜 선택: `Http`, `Grpc`, `Ws`, `Webrtc`, `Local`. `MASC_AGENT_TRANSPORT` 환경변수로 설정하며, 기본값은 `Local`(파일 기반 Room 호출). `-> lib/grpc/masc_grpc_transport.mli`
+
+**Tool Profile**
+Streamable HTTP 엔드포인트에서 노출되는 도구 집합의 프로필: `Full`, `Managed_agent`, `Operator_remote`, `Role_filtered(mode)`. `-> lib/mcp_server_eio.mli`
+
+---
+
+## Tool Dispatch
+
+**Tool Dispatch**
+O(1) Hashtbl 기반의 중앙 도구 라우팅 레지스트리. 각 Tool 모듈이 클로저를 등록하고, 호출 시 이름으로 O(1) 조회하여 실행한다. Pre-hook/Post-hook 체인을 지원한다. `-> lib/tool_dispatch.mli`
+
+**Handler**
+도구 호출 처리 함수의 통합 타입: `name:string -> args:Yojson.Safe.t -> (bool * string) option`. `None`은 해당 핸들러가 이 도구를 모르는 경우를 나타낸다. `-> lib/tool_dispatch.mli`
+
+**Pre-hook**
+도구 핸들러 실행 전 호출되는 가로채기 함수. `None` 반환 시 진행, `Some result` 반환 시 핸들러를 건너뛰고 단축 반환한다. Governance Pipeline이 pre-hook으로 설치된다. `-> lib/tool_dispatch.mli`
+
+**Post-hook**
+도구 핸들러 실행 후 호출되는 변환 함수. 결과를 수신하여 (변환된) 결과를 반환한다. `-> lib/tool_dispatch.mli`
+
+**Module Tag**
+도구 이름에서 담당 모듈로의 O(1) 2-level 디스패치를 위한 태그. 시작 시 도구 이름 -> 모듈 태그 매핑이 구축되고, 호출 시 태그로 모듈 컨텍스트를 lazy 생성한다. `-> lib/tool_dispatch.mli`
+
+---
+
+## Mitosis (Agent Lifecycle)
+
+**Mitosis**
+에이전트 컨텍스트 윈도우가 가득 찰 때 실행되는 세포 분열 패턴. DNA(Capsule) 추출 -> 후임 에이전트 생성 -> 컨텍스트 이전의 과정을 수행한다. `-> lib/mitosis.mli`
+
+**Cell State**
+Mitosis 상태 머신: `Stem` (대기) -> `Active` (작업 중) -> `Prepared` (DNA 추출 완료, 즉시 handoff 가능) -> `Dividing` (DNA 전달 중) -> `Apoptotic` (종료 대기). 순방향 전이만 허용한다. `-> lib/mitosis.mli`
+
+**Mitosis Phase**
+2-phase handoff의 현재 단계: `Idle` (정상 작동) 또는 `ReadyForHandoff(dna)` (DNA 추출 완료, handoff 임계값 도달 대기). `-> lib/mitosis.mli`
+
+**Apoptosis**
+성공적인 Mitosis(세포 분열) 후의 에이전트 종료 과정. 설정 가능한 유예 기간(`apoptosis_delay`) 후 Dead 상태로 전이한다. `-> lib/mitosis.mli`
+
+**Cell**
+Mitosis의 에이전트 단위. id, generation(원점 에이전트로부터의 분열 횟수), birth_time, 활동 카운터, 상속/준비된 DNA를 추적한다. `-> lib/mitosis.mli`
+
+---
+
+## Error Taxonomy
+
+**Error (Unified)**
+모든 도메인 에러를 통합하는 타입: `Room`, `Task`, `Agent`, `Federation`, `Storage`, `Mcp`, `Internal`. 복구 가능 여부(`is_recoverable`)와 심각도(`severity_of_error`)를 프로그래밍적으로 판단할 수 있다. `-> lib/types/error.ml`
+
+**Room Error**
+Room 도메인 에러: `RoomNotFound`, `RoomAlreadyExists`, `RoomLocked`, `RoomFull`. `-> lib/types/error.ml`
+
+**Task Error**
+Task 도메인 에러: `TaskNotFound`, `TaskAlreadyClaimed`, `TaskInvalidState`, `TaskCycleDetected`. `-> lib/types/error.ml`
+
+**Agent Error**
+Agent 도메인 에러: `AgentNotFound`, `AgentTimeout`, `AgentHeartbeatMissing`, `AgentCapabilityMismatch`. `-> lib/types/error.ml`
+
+**Federation Error**
+Portal/Federation 도메인 에러: `PortalConnectionFailed`, `PortalAuthFailed`, `PortalTimeout`, `PortalProtocolError`. `-> lib/types/error.ml`
+
+**MCP Error**
+MCP 프로토콜 에러: `McpParseError`, `McpMethodNotFound`, `McpInvalidParams`, `McpAuthError`, `McpInternalError`. `-> lib/types/error.ml`
+
+**Severity**
+에러 심각도: `Debug`, `Info`, `Warning`, `Error`, `Critical`. 에러 타입에 따라 자동 분류된다 (예: `RoomLocked` -> Warning, `Internal` -> Critical). `-> lib/types/error.ml`
+
+---
+
+## OAS Integration
+
+**OAS (OCaml Agent SDK)**
+MASC가 에이전트 실행에 사용하는 SDK 라이브러리. 프로젝트: `workspace/yousleepwhen/oas` (agent_sdk). Agent.run, Context_reducer, Memory, Checkpoint, Guardrails, Hooks 등을 제공한다. MASC는 자체 에이전트 생명주기를 재구현하지 않고 OAS Agent.run을 사용한다.
+
+**OAS Worker**
+MASC에서 OAS 기반 모델 호출을 수행하는 통합 진입점. cascade_name 또는 model_label로 모델을 지정하고, OAS Agent.run을 통해 실행한다. 결과로 `run_result`(response, checkpoint, session_id, turns, trace_ref)를 반환한다. `-> lib/oas_worker.mli`
+
+**Cascade Config**
+`config/cascade.json`에 정의된 cascade 이름별 모델 리스트와 추론 파라미터. OAS Provider와 MASC 모두에서 사용된다. `-> config/cascade.json`
+
+**Provider Kind**
+OAS에서 LLM 제공자를 구분하는 타입. MASC에서는 `llama`(local), `glm`(GLM Cloud), `claude`, `gemini` 등이 사용된다.
+
+**Agent.run**
+OAS의 에이전트 실행 진입점. MASC는 자체 perpetual loop을 구현하지 않고 이 API를 통해 에이전트를 실행한다. Keeper 포함 모든 자율 에이전트 루프가 이 경로를 사용한다.
+
+**OAS SSE Bridge**
+OAS 이벤트를 MASC SSE 스트림으로 전달하는 브릿지. OAS 에이전트 실행 중 발생하는 이벤트를 Room의 SSE 구독자에게 전달한다. `-> lib/oas_sse_bridge.mli`
+
+---
+
+## Dashboard
+
+**Web Dashboard**
+Preact + HTM 기반 SPA. `/dashboard` 경로에서 제공된다. Hash 기반 라우팅(`#overview`, `#board`, `#agents`, `#trpg`)을 사용하며, SSE로 실시간 업데이트를 수신한다. `-> dashboard/`, `-> lib/web_dashboard.mli`
+
+**Credits Dashboard**
+별도의 OCaml 렌더링 대시보드. `/dashboard/credits` 경로에서 제공된다. `-> lib/credits_dashboard.ml`
+
+---
+
+## Deprecated Terms
+
+| 폐기 용어 | 공식 용어 | 맥락 |
+|-----------|----------|------|
+| relay | Handoff | 초기 "릴레이 레이스" 비유에서 유래 |
+| handover | Handoff | 영국식 영어 변형, 미국식으로 통일 |
+| mitosis | Handoff | "세포 분열" 생물학 비유. 모듈명으로는 유지 |
+| DNA | Capsule | 압축 컨텍스트의 생물학 비유 |
+| summary | Capsule | 비공식 용어, Capsule로 공식화 |
+| cell state | Lifecycle | 세포 생물학 비유에서 유래 |
+| job | Task | 범용 용어, Task로 통일 |
+| work | Task | 범용 용어, Task로 통일 |
+| quest | Task | 초기 RPG 스타일 용어 |
+| persona | Agent | 에이전트 시스템에서 persona 개념 삭제됨. Agent만 존재 |
+| model_spec | cascade_name | LLM-Free Cascade 전환으로 model_spec 타입 제거. 문자열 cascade_name으로 대체 |
+| Cascade module (OCaml) | OAS Worker | Cascade.call 모듈 삭제됨. OAS Worker의 run_named으로 대체 |
+| perpetual loop | Agent.run | MASC 자체 perpetual loop 제거. OAS Agent.run 사용 |
+| completion_response | api_response | OAS 통합 시 api_response로 직접 반환 |
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-10 | 초기 용어집 (10개 용어, P2 용어 정규화) |
+| 2.0.0 | 2026-03-23 | 전면 확장 (90+ 용어). 아키텍처, 체인 엔진, CPv2, 에러 분류, OAS 통합, 프로토콜, 거버넌스, 메모리 섹션 추가 |

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -1,0 +1,234 @@
+# 01. System Overview
+
+> Part of: [SPEC-INDEX](./SPEC-INDEX.md)
+> Status: Draft
+> Last Updated: 2026-03-23
+
+---
+
+## 1. Problem Statement
+
+여러 AI 에이전트(Claude Code, Gemini CLI, Codex CLI, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때, 다음 문제가 발생한다:
+
+1. **충돌**: 두 에이전트가 같은 파일을 동시에 수정하면 git conflict가 발생하고, 한쪽 작업이 소실된다.
+2. **중복**: 동일한 CI 실패를 여러 에이전트가 독립적으로 수정 시도하면, 중복 PR이 생성된다.
+3. **맥락 단절**: 에이전트 A가 만든 변경사항을 에이전트 B가 인지하지 못하면, 잘못된 가정 위에 작업이 쌓인다.
+4. **생명주기 불투명**: 어떤 에이전트가 어떤 task를 잡고 있는지, heartbeat가 끊긴 에이전트는 무엇인지 파악할 수단이 없다.
+5. **오케스트레이션 부재**: 큰 작업을 여러 에이전트에게 분배하고, 진행 상황을 추적하고, 실패 시 재배정하는 메커니즘이 없다.
+
+MASC는 이 문제들을 MCP(Model Context Protocol) 서버로 해결한다. AI IDE/CLI가 MCP 클라이언트로 연결하면, Room에 참여하고, Task를 claim/complete하고, Broadcast로 상태를 공유하고, Heartbeat로 생존을 증명한다.
+
+## 2. Non-Goals
+
+MASC가 명시적으로 **하지 않는 것**:
+
+| Non-Goal | 근거 |
+|----------|------|
+| Production multi-tenant SaaS | 단일 머신, localhost-trust 모델. 인증/격리/과금 미구현. |
+| 범용 오케스트레이션 프레임워크 (Temporal/Airflow 대체) | 대상은 AI 에이전트 협업에 한정. DAG 스케줄링, 재시도 정책, 워커 풀 관리는 범위 밖. |
+| 모델 추론 서버 | LLM 호출은 Cascade를 통해 외부 서버(llama-server, GLM Cloud)로 위임. 자체 GPU 추론 없음. |
+| OAS Agent SDK 대체 | MASC는 OAS에 의존한다. Agent 생명주기(run, checkpoint, context reduction)는 OAS 책임. MASC는 coordination layer. |
+| 범용 채팅/메시징 시스템 | Broadcast와 Board는 에이전트 간 조율 목적. 사람 간 커뮤니케이션 도구가 아님. |
+
+## 3. Deployment Model
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Single Machine                  │
+│                                                  │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐   │
+│  │ Claude   │    │ Gemini   │    │ Codex    │   │
+│  │ Code     │    │ CLI      │    │ CLI      │   │
+│  └────┬─────┘    └────┬─────┘    └────┬─────┘   │
+│       │ MCP           │ MCP           │ MCP      │
+│       └───────────────┼───────────────┘          │
+│                       │                          │
+│              ┌────────▼────────┐                 │
+│              │   MASC-MCP      │                 │
+│              │   :8935         │                 │
+│              └────────┬────────┘                 │
+│                       │                          │
+│         ┌─────────────┼─────────────┐            │
+│         │             │             │            │
+│    ┌────▼────┐  ┌─────▼────┐  ┌────▼────┐       │
+│    │ .masc/  │  │ PostgreSQL│  │ Neo4j   │       │
+│    │ (local) │  │ (Supabase)│  │(Railway)│       │
+│    └─────────┘  └──────────┘  └─────────┘       │
+└─────────────────────────────────────────────────┘
+         │
+         │ Cloudflare Tunnel
+         ▼
+   masc.crying.pictures (remote access)
+```
+
+- **Trust model**: localhost 전제. 모든 MCP 클라이언트는 신뢰할 수 있다고 가정.
+- **Persistence**: 로컬 파일(.masc/ 디렉토리)과 원격 DB(PostgreSQL, Neo4j) 병용.
+- **Remote access**: Cloudflare Tunnel을 통해 원격 브라우저에서 dashboard 접근 가능. Origin은 HTTP/1.1, Cloudflare가 브라우저에 HTTP/2를 제공.
+- **단일 인스턴스**: MASC 서버는 한 대만 실행. 수평 확장 미지원.
+
+## 4. Technology Stack
+
+| 영역 | 기술 | 비고 |
+|------|------|------|
+| Runtime | OCaml 5.x + Eio | Effect-based cooperative concurrency. Stdlib.Mutex 사용 금지 (EDEADLK). |
+| HTTP/1.1 | httpun-eio | 기본 transport. Cloudflare Tunnel 호환. |
+| HTTP/2 | h2-eio (h2c) | `MASC_USE_H2=1`로 활성화. SSE 멀티플렉싱 (브라우저 6-conn 제한 회피). |
+| TLS | mirage-crypto + tls-eio | 인증서: `SSL_CERT_FILE` 환경변수. |
+| JSON | yojson | JSON 파싱/생성. `Yojson.Safe.t` 표준 사용. |
+| PostgreSQL | caqti + caqti-eio | Board, session 상태 저장. Supabase Session Pooler (port 5432). |
+| SQLite | sqlite3 | 로컬 경량 저장 (일부 모듈). |
+| Protocol | MCP JSON-RPC | `tools/call`, `tools/list` over SSE + POST. |
+| gRPC | grpc-direct (h2-eio) | Agent-to-Agent 통신. proto 정의: `proto/`. |
+| GraphQL | HTTP client | Neo4j 접근은 Railway GraphQL API 경유. |
+| AI | agent_sdk (OAS) | Agent.run, Context_reducer, Swarm engine. |
+| Inference | Cascade | llama (local) -> GLM Cloud (fallback) -> skip. |
+| Build | dune 3.13+ | `dune-project` 기반. opam package: `masc_mcp`. |
+| Coverage | bisect_ppx | `BISECT_FILE` 환경변수 필수. |
+| Dashboard | Preact + HTM + Vite | TypeScript SPA. `dashboard/` 소스, `assets/dashboard/` 빌드 산출물. |
+
+## 5. Sub-library Dependency Graph
+
+MASC는 1개 main library(`masc_mcp`)와 12개 sub-library로 구성된다. main library가 sub-library를 참조하며, sub-library 간 의존은 단방향이다.
+
+```mermaid
+graph TD
+    MAIN["masc_mcp<br/>(293 .ml, ~79K LOC)<br/>main library"]
+
+    ROOM["masc_room<br/>(30 .ml, 7.6K LOC)"]
+    BACKEND["masc_backend<br/>(9 .ml, 2.7K LOC)"]
+    CORE["masc_core<br/>(7 .ml, 1.0K LOC)"]
+    TYPES["masc_types<br/>(4 .ml, 1.3K LOC)"]
+    LOG["masc_log<br/>(1 .ml, 0.3K LOC)"]
+    PROCESS["masc_process<br/>(2 .ml, 0.4K LOC)"]
+    COUNCIL["council<br/>(13 .ml, 4.7K LOC)<br/>separate opam pkg"]
+    EIO_CTX["masc_eio_context<br/>(1 .ml, 0.1K LOC)"]
+    DATED["dated_jsonl<br/>(1 .ml, 0.3K LOC)"]
+    TIME["time_compat<br/>(1 .ml)"]
+    FS["fs_compat<br/>(1 .ml, 0.2K LOC)"]
+    BRIDGE["event_bridge<br/>(1 .ml)"]
+
+    MAIN --> ROOM
+    MAIN --> BACKEND
+    MAIN --> CORE
+    MAIN --> TYPES
+    MAIN --> COUNCIL
+    MAIN --> LOG
+    MAIN --> PROCESS
+    MAIN --> EIO_CTX
+    MAIN --> DATED
+    MAIN --> TIME
+    MAIN --> FS
+    MAIN --> BRIDGE
+
+    ROOM --> TYPES
+    ROOM --> CORE
+    ROOM --> BACKEND
+    ROOM --> PROCESS
+
+    BACKEND --> TYPES
+    BACKEND --> CORE
+
+    CORE --> LOG
+
+    TYPES --> TIME
+```
+
+### Main Library 내부 하위 디렉토리
+
+main library(`lib/`) 내에 기능별 하위 디렉토리가 있다. 이들은 별도 dune library가 아니라 `masc_mcp` library의 일부다.
+
+| Directory | Files | LOC | 역할 |
+|-----------|-------|-----|------|
+| `lib/keeper/` | 53 | 33,940 | Keeper 자율 에이전트 엔진 |
+| `lib/chain/` | 36 | 30,564 | Chain DSL 실행 엔진 |
+| `lib/dashboard/` | 33 | 22,248 | Dashboard 렌더링, API |
+| `lib/server/` | 39 | 22,108 | MCP server, HTTP transport, SSE |
+| `lib/command_plane/` | 16 | 14,750 | Command Plane v2 |
+| `lib/team_session/` | 14 | 12,384 | Team session, supervisor |
+| `lib/operator/` | 10 | 7,842 | Operator 인터페이스 |
+| `lib/board/` | 7 | 5,810 | Board (posts, comments, votes) |
+| `lib/swarm/` | 11 | 5,490 | Swarm 오케스트레이션 |
+| `lib/voice/` | 6 | 4,470 | Voice/TTS |
+| `lib/local/` | 5 | 4,450 | 로컬 LLM runtime pool |
+| `lib/grpc/` | 5 | 2,286 | gRPC transport |
+| `lib/mitosis/` | 4 | 2,030 | Mitosis (cell division) |
+| `lib/mdal/` | 3 | 1,552 | Metric-Driven Agent Loop |
+| `lib/research/` | 4 | 1,422 | Research loop |
+| `lib/goal/` | 4 | 1,304 | Goal 관리 |
+| `lib/memory/` | 2 | 764 | Memory stream |
+| `lib/` (root) | 293 | 78,894 | Tool modules, config, types, utilities |
+
+## 6. Executable Inventory
+
+| Executable | Public Name | Entry Point | 역할 |
+|------------|-------------|-------------|------|
+| `main_eio` | `masc-mcp` | `bin/main_eio.ml` | HTTP 서버. 기본 진입점. httpun-eio(HTTP/1.1) 또는 h2-eio(HTTP/2). Dashboard 서빙, SSE, MCP JSON-RPC, gRPC, REST API. |
+| `main_stdio_eio` | `masc-mcp-stdio` | `bin/main_stdio_eio.ml` | Stdio 기반 MCP 서버. Claude Code `--mcp` 모드 연동. |
+| `masc_cost` | `masc-cost` | `bin/masc_cost.ml` | Token 사용량 집계, 비용 계산 CLI. |
+| `masc_tui` | `masc-tui` | `bin/masc_tui.ml` | Terminal UI. Keeper 목록, 상태, 연결 인터페이스. |
+| `mitosis_cli` | `masc-mitosis-cli` | `bin/mitosis_cli.ml` | Mitosis 테스트/디버깅 CLI. |
+
+## 7. Canonical Paths
+
+MASC를 사용하는 3가지 canonical path가 있다. 각 path는 다른 use case를 대상으로 한다.
+
+### 7.1 CPv2 Direct
+
+가장 기본적인 경로. Benchmark 실행과 swarm 오케스트레이션에 사용.
+
+- **대상**: benchmark, swarm orchestration, managed operations
+- **핵심 도구**: `masc_unit_define`, `masc_operation_start`, `masc_dispatch_tick`, `masc_detachment_*`, `masc_observe_*`, `masc_policy_*`
+- **SSOT**: `docs/COMMAND-PLANE-RUNBOOK.md`
+- **설명**: Command Plane v2는 military-style unit/operation/detachment 모델로 에이전트 그룹을 조직하고, policy 기반으로 dispatch 결정을 내린다.
+
+### 7.2 Team Session + Supervisor
+
+기능 구현 작업을 swarm으로 수행할 때의 경로.
+
+- **대상**: planner/implementer/supervisor workflow
+- **핵심 도구**: `masc_team_session_*`, `masc_operator_*`
+- **SSOT**: `docs/SWARM-DELIVERY-RUNBOOK.md`, `docs/SUPERVISOR-MODE.md`
+- **설명**: Operator가 team session을 생성하고, worker 에이전트에게 task를 분배하며, 진행 상황을 모니터링한다. Operator digest는 command-plane 신호를 번역해 노출하는 canonical intervention surface.
+
+### 7.3 Native Chain Plane
+
+Command Plane 안으로 흡수된 오케스트레이션 substrate.
+
+- **대상**: chain-backed operation, goal-to-chain execution
+- **핵심 코드**: `lib/chain/`, `lib/command_plane/`, `tool_command_plane.ml`
+- **핵심 surface**: operation launch 시 `orchestration_kind="chain_dsl"`, `masc_chain_snapshot`, `masc_chain_run_get`
+- **설명**: Multi-step chain을 DSL로 정의하고 실행한다. Summary-first read model로 체인 상태를 조회한다.
+
+## 8. External Integrations
+
+| Service | Location | Protocol | 용도 | 비고 |
+|---------|----------|----------|------|------|
+| Neo4j | Railway (`turntable.proxy.rlwy.net:11490`) | Bolt (via GraphQL) | Agent 그래프, COLLABORATED_WITH 관계, Person 노드 | 직접 Cypher 접근 금지. GraphQL API 경유. |
+| Supabase pgvector | Supabase Cloud | PostgreSQL | Vector search (wiki, retrospectives) | `$SUPABASE_DB_URL` |
+| PostgreSQL | Supabase Session Pooler (`:5432`) | caqti-eio | Board 게시판, session 상태, 구조화 데이터 | Transaction Pooler (6543) 사용 시 prepared statement 충돌. |
+| OAS Agent SDK | In-process (OCaml library) | Function call | Agent.run, Context_reducer, Swarm engine, Cascade | MASC의 agent lifecycle은 OAS에 위임. |
+| Langfuse | Cloud API | HTTP | LLM 호출 tracing, cost attribution | 선택적 활성화. |
+| GraphQL API | Railway (`second-brain-graphql-production.up.railway.app`) | HTTP | Agent 정보 로드, collaboration edge 기록 | `$GRAPHQL_API_KEY` 인증. Query cost limit 2000. |
+| Cloudflare Tunnel | `masc.crying.pictures` | HTTP -> HTTPS | 원격 dashboard 접근 | Origin HTTP/1.1. Cloudflare가 HTTP/2 변환. |
+| llama-server | localhost:8085 | OpenAI-compatible API | 로컬 LLM 추론 (Cascade 1순위) | Qwen3.5-35B-A3B Q4_K_XL. |
+| GLM Cloud | ZAI API | HTTP | Cloud LLM 추론 (Cascade 2순위) | `sb glm-text` 경로. |
+
+## 9. Invariants (System-Level)
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-SYS-001 | Sub-library 의존성은 단방향이다. masc_room -> masc_types는 허용되지만, masc_types -> masc_room은 금지. | dune dependency graph (`dune describe`). |
+| INV-SYS-002 | Eio context 내에서 Stdlib.Mutex를 사용하지 않는다. Eio.Mutex만 허용. | AST structural test + `rg 'Stdlib.Mutex'`. |
+| INV-SYS-003 | MCP tool dispatch는 match 패턴을 사용한다. dict/map 라우팅 금지. | Code review. |
+| INV-SYS-004 | 모든 외부 LLM 호출은 Cascade를 경유한다. 직접 HTTP 호출 금지. | `rg` for direct curl/HTTP calls to LLM endpoints. |
+| INV-SYS-005 | MASC는 모델명을 MASC 레벨에 노출하지 않는다. Cascade가 추상화. | Code review, log audit. |
+| INV-SYS-006 | Agent lifecycle (run, checkpoint, context reduction)은 OAS Agent SDK에 위임한다. MASC에서 재구현 금지. | Architecture review. |
+
+## 10. Open Questions
+
+| ID | 질문 | 관련 코드 | 상태 |
+|----|------|----------|------|
+| OQ-SYS-001 | Sub-library 추출을 어디까지 진행할 것인가? keeper(33K LOC)와 chain(30K LOC)은 별도 sub-library 후보. | `lib/keeper/`, `lib/chain/` | Open |
+| OQ-SYS-002 | HTTP/2 h2c를 기본 transport로 전환할 시점은? Cloudflare Tunnel이 cleartext h2를 지원하지 않는 제약. | `bin/main_eio.ml` | Open |
+| OQ-SYS-003 | MASC -> OAS 이관 완료 후 MASC의 최종 범위는? 순수 coordination layer만 남길 것인지. | `docs/OAS-MIGRATION-AUDIT.md` | Open |
+| OQ-SYS-004 | Multi-protocol transport(SSE/gRPC/WebSocket/WebRTC) 중 어디를 canonical으로 수렴할 것인가? | `lib/grpc/`, `lib/server/` | Open |

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -1,0 +1,889 @@
+# Types and Invariants
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Foundation |
+| Maps to | `lib/types/`, `lib/message_schema.ml`, `lib/tool_dispatch.ml`, `lib/agent_identity.ml`, `lib/agent_ecosystem.ml` |
+| Dependencies | 00-glossary.md |
+
+---
+
+## 1. Newtype Hierarchy
+
+MASC는 ID 타입 간 혼용을 컴파일 타임에 차단하기 위해 추상 newtype 모듈을 사용한다. 모든 ID의 내부 표현은 `string`이지만, 모듈 시그니처가 타입을 불투명(opaque)하게 만들어 `Agent_id.t`와 `Task_id.t`를 직접 비교하거나 대입할 수 없다.
+
+| Module | Type | 생성 방식 | 형식 예시 |
+|--------|------|----------|----------|
+| `Agent_id` | `Agent_id.t` | `of_string` | `"claude-swift-fox"` |
+| `Task_id` | `Task_id.t` | `of_string` / `generate()` | `"task-1711234567000-001a"` |
+| `Thread_id` | `Thread_id.t` | `of_string` / `generate()` | `"thread-1711234567000-001a"` |
+| `Turn_id` | `Turn_id.t` | `of_string` / `generate ~thread_id ~seq` | `"thread-...-turn-0003"` |
+
+**소스**: `lib/types/types_core.ml` (lines 7-98)
+
+모든 newtype 모듈은 동일한 시그니처를 공유한다:
+
+```ocaml
+module type ID = sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end
+```
+
+`Task_id.generate`와 `Thread_id.generate`는 `timestamp-seqhex` 패턴으로 고유 ID를 생성한다. `Turn_id.generate`는 thread_id에 순번을 연결한다.
+
+> 참고: `room_info.id`, `task.id`, `message.from_agent` 등 일부 레코드 필드는 아직 `string`을 직접 사용한다. newtype 전환이 완료되지 않은 부분이며, 점진적으로 마이그레이션 대상이다.
+
+---
+
+## 2. Core Domain Types
+
+**소스**: `lib/types/types_core.ml`
+
+### 2.1 Role (task assignment)
+
+```ocaml
+type role =
+  | Writer      (* Produces artifacts: code, docs, designs *)
+  | Reviewer    (* Reviews artifacts: code review, QA, ethics *)
+  | Admin       (* Administrative: orchestration, assignment *)
+  | Unassigned  (* No specific role (legacy/default) *)
+```
+
+`role_satisfies ~required ~agent_role`로 역할 충족 여부를 판정한다. `Admin`은 모든 요구를 충족하고, `Unassigned` 요구는 모든 역할이 충족한다.
+
+### 2.2 Agent Status
+
+```ocaml
+type agent_status =
+  | Active
+  | Busy
+  | Listening
+  | Inactive
+```
+
+JSON 직렬화 시 소문자 문자열(`"active"`, `"busy"`, ...)로 표현된다.
+
+### 2.3 Agent Meta
+
+```ocaml
+type agent_meta = {
+  session_id : string;
+  agent_type : string;        (* "claude", "gemini", "codex" *)
+  pid : int option;
+  hostname : string option;
+  tty : string option;
+  worktree : string option;
+  parent_task : string option;
+}
+```
+
+세션 식별과 환경 정보를 담는다. `pid`/`hostname`/`tty`는 디버깅 용도이며 선택 필드다.
+
+### 2.4 Agent
+
+```ocaml
+type agent = {
+  name : string;               (* 룸 내 유일한 이름: claude-swift-fox *)
+  agent_type : string;         (* claude, gemini, codex *)
+  status : agent_status;
+  capabilities : string list;
+  current_task : string option;
+  joined_at : string;          (* ISO 8601 *)
+  last_seen : string;          (* ISO 8601 *)
+  meta : agent_meta option;
+}
+```
+
+### 2.5 Room Info / Room Registry
+
+```ocaml
+type room_info = {
+  id : string;                 (* slugified name *)
+  name : string;
+  description : string option;
+  created_at : string;
+  created_by : string option;
+  agent_count : int;
+  task_count : int;
+}
+
+type room_registry = {
+  rooms : room_info list;
+  default_room : string;       (* default: "default" *)
+  current_room : string option;
+}
+```
+
+### 2.6 Task Status (상태 기계)
+
+```ocaml
+type task_status =
+  | Todo
+  | Claimed of { assignee: string; claimed_at: string }
+  | InProgress of { assignee: string; started_at: string }
+  | Done of { assignee: string; completed_at: string; notes: string option }
+  | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+```
+
+각 variant가 메타데이터(who, when)를 직접 보유한다. 이 설계는 "상태와 컨텍스트를 분리하지 않는다"는 원칙을 따른다. 상태 전이 규칙은 [INV-TYPE-002] 참조.
+
+### 2.7 Task
+
+```ocaml
+type task = {
+  id : string;
+  title : string;
+  description : string;
+  task_status : task_status;
+  priority : int;              (* 기본값 3 *)
+  files : string list;
+  created_at : string;
+  worktree : worktree_info option;
+  required_role : role;        (* 기본값 Unassigned *)
+}
+```
+
+### 2.8 Worktree Info
+
+```ocaml
+type worktree_info = {
+  branch : string;
+  path : string;               (* git root 기준 상대 경로 *)
+  git_root : string;           (* .git parent 절대 경로 *)
+  repo_name : string;
+}
+```
+
+### 2.9 Message
+
+```ocaml
+type message = {
+  seq : int;
+  from_agent : string;
+  msg_type : string;           (* "broadcast" | "direct" *)
+  content : string;
+  mention : string option;
+  timestamp : string;
+}
+```
+
+### 2.10 Room State
+
+```ocaml
+type room_state = {
+  protocol_version : string;
+  project : string;
+  started_at : string;
+  message_seq : int;
+  active_agents : string list;
+  paused : bool;
+  pause_reason : string option;
+  paused_by : string option;
+  paused_at : string option;
+  search_strategy_default : string option;
+  speculation_enabled : bool;
+  speculation_budget : int option;
+}
+```
+
+`paused = true`일 때 orchestrator는 새 에이전트를 spawn하지 않는다.
+
+### 2.11 Tempo
+
+```ocaml
+type tempo_mode = Normal | Slow | Fast | Paused
+
+type tempo_config = {
+  mode : tempo_mode;
+  delay_ms : int;
+  reason : string option;
+  set_by : string option;
+  set_at : string option;
+}
+```
+
+클러스터 실행 속도를 제어한다. `delay_ms`는 작업 간 인위적 지연을 삽입한다.
+
+### 2.12 Backlog
+
+```ocaml
+type backlog = {
+  tasks : task list;
+  last_updated : string;
+  version : int;
+}
+```
+
+### 2.13 A2A Task (Google A2A Protocol)
+
+```ocaml
+type a2a_task_status = A2APending | A2ARunning | A2ACompleted | A2AFailed | A2ACanceled
+
+type a2a_task = {
+  a2a_id : string;
+  from_agent : string;
+  to_agent : string;
+  a2a_message : string;
+  a2a_status : a2a_task_status;
+  a2a_result : string option;
+  created_at : string;
+  updated_at : string;
+}
+```
+
+### 2.14 Portal
+
+```ocaml
+type portal_state = PortalOpen | PortalClosed
+
+type portal = {
+  portal_from : string;
+  portal_target : string;
+  portal_opened_at : string;
+  portal_status : portal_state;
+  task_count : int;
+}
+```
+
+### 2.15 SSE Session
+
+```ocaml
+type sse_session = {
+  agent_name : string;
+  connected_at : string;
+  last_activity : float;  (* Unix timestamp *)
+  is_listening : bool;
+}
+```
+
+### 2.16 Tool Result (core)
+
+`types_core.ml`에 정의된 기본 tool_result:
+
+```ocaml
+type tool_result = {
+  success : bool;
+  message : string;
+  data : Yojson.Safe.t option;
+}
+```
+
+### 2.17 Claim Next Result
+
+스케줄링 결과를 구조화한 ADT. brittle한 문자열 파싱을 방지한다:
+
+```ocaml
+type claim_next_result =
+  | Claim_next_claimed of {
+      task_id : string; title : string;
+      priority : int; released_task_id : string option;
+      message : string;
+    }
+  | Claim_next_no_unclaimed
+  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_error of string
+```
+
+---
+
+## 3. Error Hierarchy
+
+MASC는 두 개의 독립된 에러 계층을 갖는다:
+- `Error.t` -- 인프라/프로토콜 수준 (6 도메인)
+- `masc_error` -- 비즈니스 로직 수준 (MASC 도메인 전용)
+
+### 3.1 Error.t (인프라/프로토콜 에러)
+
+**소스**: `lib/types/error.ml`
+
+```ocaml
+type t =
+  | Room of room_error
+  | Task of task_error
+  | Agent of agent_error
+  | Federation of federation_error
+  | Storage of storage_error
+  | Mcp of mcp_error
+  | Internal of string
+```
+
+7개 variant, 6개 도메인 에러 + 1개 catch-all.
+
+#### 3.1.1 room_error (4 variants)
+
+```ocaml
+type room_error =
+  | RoomNotFound of string
+  | RoomAlreadyExists of string
+  | RoomLocked of string
+  | RoomFull of int
+```
+
+#### 3.1.2 task_error (4 variants)
+
+```ocaml
+type task_error =
+  | TaskNotFound of string
+  | TaskAlreadyClaimed of string
+  | TaskInvalidState of string * string  (* current, expected *)
+  | TaskCycleDetected
+```
+
+#### 3.1.3 agent_error (4 variants)
+
+```ocaml
+type agent_error =
+  | AgentNotFound of string
+  | AgentTimeout of string * int         (* agent_id, timeout_ms *)
+  | AgentHeartbeatMissing of string
+  | AgentCapabilityMismatch of string
+```
+
+#### 3.1.4 federation_error (4 variants)
+
+```ocaml
+type federation_error =
+  | PortalConnectionFailed of string
+  | PortalAuthFailed of string
+  | PortalTimeout of int
+  | PortalProtocolError of string
+```
+
+#### 3.1.5 storage_error (5 variants)
+
+```ocaml
+type storage_error =
+  | FileNotFound of string
+  | FilePermissionDenied of string
+  | FileLocked of string
+  | PostgresError of string
+  | GitError of string
+```
+
+#### 3.1.6 mcp_error (5 variants)
+
+```ocaml
+type mcp_error =
+  | McpParseError of string
+  | McpMethodNotFound of string
+  | McpInvalidParams of string
+  | McpAuthError of string
+  | McpInternalError of string
+```
+
+#### Recoverability
+
+`is_recoverable`가 `true`를 반환하는 variant (재시도 안전):
+- `RoomLocked`, `TaskAlreadyClaimed`, `AgentTimeout`, `AgentHeartbeatMissing`, `PortalTimeout`, `FileLocked`
+
+#### Severity Mapping
+
+| Severity | Variants |
+|----------|----------|
+| Warning | `RoomLocked`, `TaskAlreadyClaimed`, `AgentTimeout`, `AgentHeartbeatMissing`, `PortalTimeout`, `FileLocked`, `McpMethodNotFound` |
+| Critical | `Internal` |
+| Error | 나머지 전부 |
+
+### 3.2 masc_error (비즈니스 로직 에러)
+
+**소스**: `lib/types/types_auth.ml`
+
+```ocaml
+type masc_error =
+  | NotInitialized
+  | AlreadyInitialized
+  | AgentNotFound of string
+  | AgentNotJoined of string
+  | AgentAlreadyJoined of string
+  | TaskNotFound of string
+  | TaskAlreadyClaimed of { task_id: string; by: string }
+  | TaskNotClaimed of string
+  | TaskInvalidState of string
+  | TaskRoleMismatch of { task_id: string; required: string; actual: string }
+  | PortalNotOpen of string
+  | PortalAlreadyOpen of { agent: string; target: string }
+  | PortalClosed of string
+  | InvalidJson of string
+  | IoError of string
+  | InvalidAgentName of string
+  | InvalidTaskId of string
+  | InvalidFilePath of string
+  | Unauthorized of string
+  | Forbidden of { agent: string; action: string }
+  | TokenExpired of string
+  | InvalidToken of string
+  | RateLimitExceeded of rate_limit_error
+  | LodgeError of lodge_error
+  | CacheError of cache_error
+```
+
+25개 variant. `lodge_error`(3 variants)와 `cache_error`(4 variants)는 상호 재귀 타입으로 정의된다.
+
+```ocaml
+and lodge_error =
+  | LodgeGraphQLFailed of string
+  | LodgeAgentNotCached of string
+  | LodgeInvalidResponse of string
+
+and cache_error =
+  | CacheReadFailed of string
+  | CacheWriteFailed of string
+  | CacheExpired of { key: string; age_hours: float }
+  | CacheCorrupted of string
+```
+
+Result alias: `type 'a masc_result = ('a, masc_error) result`
+
+---
+
+## 4. Tool Dispatch Types
+
+**소스**: `lib/tool_dispatch.mli`
+
+### 4.1 Handler
+
+```ocaml
+type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
+```
+
+모든 MCP 도구 호출은 이 시그니처로 통일된다. `None`을 반환하면 "이 핸들러가 해당 도구를 모른다"는 의미다.
+
+### 4.2 Hooks
+
+```ocaml
+type pre_hook = name:string -> args:Yojson.Safe.t -> Tool_result.t option
+(* None -> 진행, Some result -> 핸들러를 건너뛰고 즉시 반환 *)
+
+type post_hook = Tool_result.t -> Tool_result.t
+(* 핸들러 결과를 변환하거나 관찰 *)
+```
+
+실행 순서: pre_hooks -> handler -> post_hooks.
+
+### 4.3 Module Tag (2-level dispatch)
+
+```ocaml
+type module_tag =
+  | Mod_plan | Mod_run | Mod_operator | Mod_command_plane
+  | Mod_local_runtime | Mod_team_session | Mod_voice | Mod_cache
+  | Mod_tempo | Mod_mitosis | Mod_portal | Mod_worktree
+  | Mod_code_swarm | Mod_code | Mod_code_write | Mod_vote | Mod_social
+  | Mod_council | Mod_a2a | Mod_handover
+  | Mod_relay | Mod_goals | Mod_heartbeat | Mod_encryption
+  | Mod_auth | Mod_hat | Mod_audit | Mod_rate_limit
+  | Mod_cost | Mod_walph | Mod_agent | Mod_task | Mod_room
+  | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
+  | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
+  | Mod_notifications | Mod_inline
+  | Mod_autoresearch | Mod_research | Mod_model_catalog
+  | Mod_shard | Mod_fire_task
+```
+
+43개 variant. 도구 이름으로 O(1) tag lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다.
+
+### 4.4 Tool_result.t (structured)
+
+**소스**: `lib/tool_result.mli`
+
+```ocaml
+type t = {
+  success : bool;
+  data : Yojson.Safe.t;
+  tool_name : string;
+  duration_ms : float;
+}
+```
+
+레거시 `(bool * string)` 튜플은 `wrap ~tool_name ~start_time`으로 변환된다. `to_legacy`로 역변환이 가능하다.
+
+---
+
+## 5. Agent Identity Types
+
+**소스**: `lib/agent_identity.mli`
+
+### 5.1 Channel
+
+```ocaml
+type channel =
+  | Telegram | Discord | Slack | Signal
+  | Webchat | Api | Internal
+  | Unknown of string
+```
+
+MCP 세션의 접속 경로를 나타낸다. `Unknown`은 미등록 채널에 대한 확장점이다.
+
+### 5.2 Agent Identity Record
+
+```ocaml
+type t = {
+  uuid : string;
+  session_key : string;
+  agent_name : string;
+  channel : channel option;
+  user_id : string option;
+  room_id : string option;
+  capabilities : string list;
+  registered_at : float;
+  mutable last_seen : float;   (* 유일한 mutable 필드 *)
+  metadata : (string * string) list;
+}
+```
+
+`last_seen`만 mutable이다. 이유: heartbeat마다 새 레코드를 할당하는 비용을 피하기 위함.
+
+### 5.3 Identity Registry
+
+```ocaml
+module Registry : sig
+  type registry
+  val create : unit -> registry
+  val register : registry -> t -> t
+  val find_by_session : registry -> string -> t option
+  val find_by_name : registry -> string -> t option
+  val touch : registry -> string -> ?room_id:string -> unit -> unit
+  val unregister : registry -> string -> unit
+  val list_active : registry -> within_seconds:float -> t list
+  val count : registry -> int
+end
+```
+
+### 5.4 Archetype (MAGI system)
+
+```ocaml
+type archetype =
+  | Melchior    (* Scientist *)
+  | Balthasar   (* Mirror/Ethics *)
+  | Casper      (* Strategist *)
+  | Athena      (* Reasoner *)
+  | Generalist  (* No specialization *)
+```
+
+MAGI 3인 체제(Melchior/Balthasar/Casper)에 Athena와 Generalist를 추가한 확장. 각 archetype은 토론 포지션 제안(`suggest_debate_position`)과 가중치 계산(`archetype_weight`)을 지원한다.
+
+---
+
+## 6. Agent Ecosystem Types
+
+**소스**: `lib/agent_ecosystem.mli`
+
+### 6.1 Agent Type (생명주기)
+
+```ocaml
+type agent_type =
+  | Resident    (* Daemon -- 상시 실행 *)
+  | Visitor     (* Session 기반 *)
+  | Ephemeral   (* Task 기반, 작업 완료 후 소멸 *)
+```
+
+### 6.2 Agent Profile
+
+```ocaml
+type agent_profile = {
+  name : string;
+  role : string;
+  traits : string list;
+  avatar : string option;
+}
+```
+
+### 6.3 Lineage (세대 추적)
+
+```ocaml
+type lineage = {
+  generation : int;
+  parent_hash : string option;
+  ancestors : string list;
+  mutations : string list;
+}
+```
+
+에이전트 간 계보를 추적한다. `spawn_child`로 새 세대를 생성하면 `generation`이 증가하고 부모 해시가 기록된다.
+
+### 6.4 Extended Identity
+
+```ocaml
+type extended = {
+  base : Agent_identity.t;
+  hash : string;
+  agent_type : agent_type;
+  profile : agent_profile;
+  lineage : lineage;
+}
+```
+
+`Agent_identity.t`를 확장하여 프로필, 생명주기 타입, 계보를 추가한다. `to_base_with_metadata`/`from_base_with_metadata`로 base identity와 상호 변환한다.
+
+---
+
+## 7. Checkpoint Types
+
+**소스**: `lib/checkpoint_types.ml`
+
+### 7.1 Checkpoint Status
+
+```ocaml
+type checkpoint_status =
+  | Pending
+  | InProgress
+  | Interrupted
+  | Completed
+  | Rejected
+  | Reverted     (* Time Travel: 이전 체크포인트로 되돌림 *)
+  | Branched     (* 이 체크포인트에서 새 분기 생성 *)
+```
+
+7개 variant. 상태 전이는 `can_transition ~from ~to_`로 검증한다:
+
+| from | to | 허용 |
+|------|----|------|
+| Pending | InProgress | yes |
+| InProgress | Interrupted | yes |
+| InProgress | Completed | yes |
+| Interrupted | Completed | yes (approved) |
+| Interrupted | Rejected | yes (rejected) |
+| 그 외 | * | no |
+
+터미널 상태: `Completed`, `Rejected`, `Reverted`.
+
+### 7.2 Checkpoint Info
+
+```ocaml
+type checkpoint_info = {
+  id : string;
+  task_id : string;
+  step : int;
+  action : string;
+  agent : string;
+  status : checkpoint_status;
+  interrupt_message : string option;
+  created_at : float option;
+}
+```
+
+---
+
+## 8. Context Budget Types
+
+**소스**: `lib/context_budget_manager.mli`
+
+### 8.1 Compression Phase
+
+```ocaml
+type compression_phase =
+  | None_phase      (* 0-50%: 전체 설명, 압축 없음 *)
+  | Compact_tools   (* 50-70%: 도구 설명을 한 줄로 *)
+  | Drop_low        (* 70-85%: 중요도 낮은 메시지 제거 *)
+  | Summarize       (* 85%+: 오래된 턴 요약 *)
+```
+
+### 8.2 Budget Tracker
+
+```ocaml
+type t  (* abstract *)
+
+val create : ?max_budget:int -> unit -> t
+val record_tool_schemas : t -> count:int -> estimated_tokens:int -> unit
+val record_turn : t -> estimated_tokens:int -> unit
+val current_phase : t -> compression_phase
+val usage_ratio : t -> float
+val total_tokens : t -> int
+val max_budget : t -> int
+```
+
+기본 `max_budget`는 환경변수 `MASC_CONTEXT_BUDGET_MAX` (fallback: 100000).
+
+---
+
+## 9. Auth Types
+
+**소스**: `lib/types/types_auth.ml`
+
+### 9.1 Agent Role (auth)
+
+```ocaml
+type agent_role = Reader | Worker | Admin
+```
+
+`role`(Section 2.1)과는 별개의 타입이다. `role`은 task assignment 용도, `agent_role`은 인증/인가 용도다.
+
+### 9.2 Permission
+
+```ocaml
+type permission =
+  | CanInit | CanReset | CanJoin | CanLeave
+  | CanReadState | CanAddTask | CanClaimTask | CanCompleteTask
+  | CanBroadcast
+  | CanOpenPortal | CanSendPortal
+  | CanCreateWorktree | CanRemoveWorktree
+  | CanVote | CanInterrupt | CanApprove
+  | CanAdmin
+```
+
+17개 variant. 각 `agent_role`에 허용된 permission 목록:
+
+| Role | Permissions |
+|------|------------|
+| Reader | `CanReadState`, `CanJoin`, `CanLeave` (3개) |
+| Worker | Reader + `CanAddTask`, `CanClaimTask`, `CanCompleteTask`, `CanBroadcast`, `CanOpenPortal`, `CanSendPortal`, `CanCreateWorktree`, `CanRemoveWorktree`, `CanVote` (12개) |
+| Admin | Worker + `CanInit`, `CanReset`, `CanInterrupt`, `CanApprove`, `CanAdmin` (17개, 전체) |
+
+### 9.3 Agent Credential
+
+```ocaml
+type agent_credential = {
+  agent_name : string;
+  token : string;         (* SHA256 hash -- raw token은 저장하지 않음 *)
+  role : agent_role;
+  created_at : string;
+  expires_at : string option;
+}
+```
+
+### 9.4 Auth Config
+
+```ocaml
+type auth_config = {
+  enabled : bool;
+  room_secret_hash : string option;
+  require_token : bool;
+  default_role : agent_role;    (* 기본값: Worker *)
+  token_expiry_hours : int;     (* 기본값: 24 *)
+}
+```
+
+### 9.5 Rate Limit
+
+```ocaml
+type rate_limit_config = {
+  per_minute : int;
+  burst_allowed : int;
+  priority_agents : string list;
+  reader_multiplier : float;    (* 0.5x *)
+  worker_multiplier : float;    (* 1.0x *)
+  admin_multiplier : float;     (* 2.0x *)
+  broadcast_per_minute : int;
+  task_ops_per_minute : int;
+}
+
+type rate_limit_category = GeneralLimit | BroadcastLimit | TaskOpsLimit
+
+type rate_limit_error = {
+  limit : int;
+  current : int;
+  wait_seconds : int;
+  category : rate_limit_category;
+}
+```
+
+---
+
+## 10. Structured Message Types
+
+**소스**: `lib/message_schema.mli`
+
+### 10.1 Validation Mode
+
+```ocaml
+type validation_mode = Strict | Warn | Permissive
+```
+
+### 10.2 Structured Message
+
+```ocaml
+type structured_message =
+  | TaskUpdate of { task_id: string; status: string; payload: Yojson.Safe.t option }
+  | StatusReport of { agent: string; progress: float; details: string }
+  | Request of { target: string; action: string; params: Yojson.Safe.t }
+  | Response of { request_id: string; success: bool; result: Yojson.Safe.t }
+  | Freeform of string
+```
+
+5개 variant. `Freeform`은 구조화되지 않은 메시지에 대한 하위호환 경로다.
+
+### 10.3 Swarm Envelope
+
+```ocaml
+type swarm_envelope = {
+  sender : string;
+  timestamp : float;
+  sequence : int;
+  channel : string;
+  message : structured_message;
+}
+```
+
+swarm 내부 메시지는 반드시 envelope로 감싸서 전송한다. `sequence`는 메시지 순서를 보장하고 중복 감지에 사용된다.
+
+---
+
+## 11. Global Invariants
+
+아래 불변식은 MASC 도메인 전체에 적용되며, 테스트로 검증 가능하다.
+
+### Identity
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-001 | 에이전트 name은 룸 내에서 유일하다. 동일 이름으로 `masc_join` 시 `AgentAlreadyJoined` 반환. | `masc_join` 중복 호출 테스트 |
+| INV-TYPE-002 | Newtype ID 모듈(`Agent_id`, `Task_id`, `Thread_id`, `Turn_id`)은 모듈 경계에서 타입이 불투명하다. 서로 다른 ID 타입 간 직접 비교/대입은 컴파일 에러다. | 컴파일러가 강제 |
+
+### State Machine
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-003 | `task_status` 전이는 단방향이다: `Todo -> Claimed -> InProgress -> Done\|Cancelled`. `Done`에서 `Todo`로 역전이하거나, `Todo`에서 `Done`으로 건너뛰는 것은 허용되지 않는다. | `task_status` 전이 함수 + 단위 테스트 |
+| INV-TYPE-004 | `checkpoint_status` 전이는 `can_transition`이 정의한 5가지 경로만 허용된다. 터미널 상태(`Completed`, `Rejected`, `Reverted`)에서는 어떤 전이도 불가하다. | `can_transition` 단위 테스트 |
+| INV-TYPE-005 | `agent_status`의 기본 fallback은 `Active`다. 알 수 없는 문자열 입력 시 예외 대신 `Active`를 반환한다. | `agent_status_of_string "unknown"` 테스트 |
+
+### Error Handling
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-006 | `Error.t`의 match는 7개 variant 전부를 처리해야 한다 (exhaustiveness). OCaml 컴파일러 warning 8이 이를 강제한다. | 컴파일러가 강제 |
+| INV-TYPE-007 | `masc_error`의 모든 variant는 `masc_error_to_string`에서 처리된다. 새 variant 추가 시 `masc_error_to_string`도 반드시 업데이트해야 한다 (exhaustive match). | 컴파일러 warning 8 |
+| INV-TYPE-008 | `is_recoverable`이 `true`인 에러만 재시도 대상이다. 그 외 에러에 대한 자동 재시도는 금지된다. | `is_recoverable` 반환값 기준 분기 테스트 |
+
+### Concurrency
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-009 | 모든 공유 가변 상태는 `Eio.Mutex`로 보호된다. `Stdlib.Mutex`는 Eio 환경에서 EDEADLK를 유발하므로 사용 금지다. | `rg 'Stdlib\.Mutex\|Mutex\.create\b' lib/` (Stdlib.Mutex 사용 0건 확인) |
+
+### Dispatch
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-010 | 도구 핸들러 등록은 서버 시작(init) 시점에 완료된다. init 이후 동적 등록은 발생하지 않는다. `is_tag_registry_initialized()`가 `true`를 반환한 후에는 `register_module_tag` 호출이 없어야 한다. | init 직후 `registered_count()` 스냅샷 비교 |
+| INV-TYPE-011 | `dispatch`는 O(1) Hashtbl lookup이다. 등록된 도구 수에 비례하는 순차 탐색은 발생하지 않는다. | 구현 검사 (Hashtbl.find) |
+| INV-TYPE-012 | `pre_hook`이 `Some result`를 반환하면 핸들러를 건너뛴다 (short-circuit). `post_hook`은 실행되지 않는다. | hook 테스트 |
+
+### Auth
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-013 | `auth_config.enabled = false`이면 모든 도구 호출이 인가된다. 토큰 검증을 수행하지 않는다. | `check_permission` with `enabled = false` 테스트 |
+| INV-TYPE-014 | raw token은 저장하지 않는다. `agent_credential.token` 필드에는 SHA256 해시만 저장된다. | `create_token` 후 credential 파일 내용 검사 |
+| INV-TYPE-015 | initial admin(auth를 활성화한 에이전트)은 bootstrap grace로 모든 permission을 갖는다. | `check_permission` with initial_admin 테스트 |
+| INV-TYPE-016 | strict mode(`MASC_TOOL_AUTH_STRICT=true`, 기본값)에서 `permission_for_tool`에 매핑되지 않은 `masc_*` 도구는 최소 `CanBroadcast` 권한을 요구한다. | unmapped tool name 테스트 |
+
+### Serialization
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-017 | `structured_message`는 roundtrip 무손실이다: `roundtrip msg = Ok msg`. | `roundtrip` 함수의 QuickCheck/단위 테스트 |
+| INV-TYPE-018 | `swarm_envelope`도 roundtrip 무손실이다: `roundtrip_envelope env = Ok env`. | `roundtrip_envelope` 단위 테스트 |
+| INV-TYPE-019 | 모든 `_to_yojson`/`_of_yojson` 쌍은 roundtrip 호환이다. JSON 직렬화 후 역직렬화하면 원본과 동일한 값을 복원한다. | 주요 타입별 roundtrip 테스트 |
+
+### Role System
+
+| ID | 불변식 | 검증 방법 |
+|----|--------|----------|
+| INV-TYPE-020 | `role`(task assignment)과 `agent_role`(auth)은 별개의 타입 시스템이다. 컴파일 타임에 혼용이 차단된다. | 컴파일러가 강제 |
+| INV-TYPE-021 | `role_satisfies ~required:Unassigned ~agent_role:_`는 항상 `true`다. `role_satisfies ~required:_ ~agent_role:Admin`도 항상 `true`다. | `role_satisfies` 단위 테스트 |

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -1,0 +1,687 @@
+# Room Coordination
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Room |
+| Maps to | `lib/room/` (sub-library, ~7.9K LOC) |
+| Dependencies | 02-types-and-invariants |
+| Modules | 30 (.ml) + 5 (.mli) |
+| LOC | ~7,856 |
+| MCP Tools | `tool_room`, `tool_task`, `tool_agent`, `tool_heartbeat`, `tool_worktree`, `tool_tempo`, `tool_control`, `tool_social` (vote) |
+
+---
+
+## 1. Purpose
+
+Room은 MASC의 핵심 조율 단위다. 에이전트가 참여(join)하고, 태스크를 등록/할당받고, 하트비트로 활성 상태를 유지하며, 투표/합의로 의사결정하고, git worktree로 작업을 격리하는 공간.
+
+Room 하나가 소유하는 것:
+- **state**: `room_state` 레코드 (protocol version, active agents, message seq, pause flag)
+- **agents**: `.masc/agents/` 디렉토리 내 JSON 파일 (또는 PG `masc_kv`)
+- **tasks**: `.masc/tasks/backlog.json` (또는 PG) -- 태스크 큐와 스케줄링
+- **messages**: `.masc/messages/` -- broadcast 메시지 저장
+- **votes**: `.masc/votes/` -- 투표 데이터
+- **portals**: `.masc/portals/` + `.masc/a2a_tasks/` -- A2A 통신
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+  subgraph "Room Sub-library (masc_room)"
+    RS[room_state] --> RI[room_init]
+    RS --> RL[room_lifecycle<br>join / leave]
+    RS --> RA[room_agent<br>status / caps]
+    RS --> RT[room_task<br>add / claim / transition]
+    RT --> RTS[room_task_schedule<br>claim_next / stale]
+    RS --> RGC[room_gc<br>zombie / archive]
+    RS --> RV[room_vote<br>create / cast]
+    RS --> RW[room_walph<br>sync SM]
+    RW --> RWE[room_walph_eio<br>async loop]
+    RS --> RWT[room_worktree<br>create / remove]
+    RWT --> RG[room_git<br>git ops]
+    RS --> RP[room_portal<br>A2A]
+    RS --> RM[room_multi<br>slug / registry]
+    RM --> RR[room_rooms<br>list / create / enter]
+    RS --> RTE[room_tempo<br>pace control]
+    RS --> RCP[room_checkpoint<br>snapshot]
+  end
+
+  subgraph "Support Modules"
+    HB[heartbeat] --> HBS[heartbeat_smart]
+    RES[resilience<br>zombie detect]
+    MEN[mention<br>@routing]
+    NICK[nickname<br>adj-animal gen]
+  end
+
+  subgraph "MCP Tool Layer"
+    TR[tool_room] --> RS
+    TT[tool_task] --> RT
+    TA[tool_agent] --> RA
+    TH[tool_heartbeat] --> HB
+    TW[tool_worktree] --> RWT
+    TTE[tool_tempo] --> RTE
+    TC[tool_control<br>pause/resume] --> RI
+    TS[tool_social<br>vote] --> RV
+  end
+```
+
+### Module Size Distribution (상위 10)
+
+| Module | LOC | 역할 |
+|--------|-----|------|
+| `room_eio` | 783 | Eio 백엔드 구현 (direct-style async I/O) |
+| `room_walph_eio` | 709 | Walph 비동기 루프 (preset 기반 자동 작업) |
+| `room_task` | 686 | 태스크 CRUD + 상태 전이 |
+| `room_gc` | 491 | 좀비 정리, stale 아카이브, 메시지 정리 |
+| `room_state` | 409 | 상태 읽기/쓰기/갱신 (file lock + PG) |
+| `room_utils_backend_setup` | 348 | PG 백엔드 설정 |
+| `room_query` | 331 | 룸 내 에이전트/태스크 카운트 쿼리 |
+| `room_lifecycle` | 331 | join, rejoin, leave |
+| `room_walph` | 330 | Walph 동기 상태머신 + @walph 파싱 |
+| `room_task_schedule` | 291 | claim_next, starvation prevention |
+
+---
+
+## 3. Types
+
+### 3.1 Room State (`room_state`)
+
+```ocaml
+type room_state = {
+  protocol_version : string;       (* "0.1.0" *)
+  project : string;                (* base_path basename *)
+  started_at : string;             (* ISO 8601 *)
+  message_seq : int;               (* broadcast 시퀀스 *)
+  active_agents : string list;     (* 현재 참여 에이전트 닉네임 *)
+  paused : bool;
+  pause_reason : string option;
+  paused_by : string option;
+  paused_at : string option;
+  search_strategy_default : string option;  (* "best_first_v1" | "legacy" *)
+  speculation_enabled : bool;
+  speculation_budget : int option;
+}
+```
+
+### 3.2 Agent (in room)
+
+```ocaml
+type agent = {
+  name : string;           (* nickname: "claude-swift-fox" *)
+  agent_type : string;     (* base type: "claude", "gemini" *)
+  status : agent_status;   (* Active | Busy | Inactive *)
+  capabilities : string list;
+  current_task : string option;
+  joined_at : string;
+  last_seen : string;      (* heartbeat 갱신 대상 *)
+  meta : agent_meta option;
+}
+
+type agent_meta = {
+  session_id : string;
+  agent_type : string;
+  pid : int option;
+  hostname : string option;
+  tty : string option;
+  worktree : string option;
+  parent_task : string option;
+}
+```
+
+### 3.3 Task Status (ADT)
+
+```ocaml
+type task_status =
+  | Todo
+  | Claimed of { assignee : string; claimed_at : string }
+  | InProgress of { assignee : string; started_at : string }
+  | Done of { assignee : string; completed_at : string; notes : string option }
+  | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
+```
+
+### 3.4 Room Info (registry entry)
+
+```ocaml
+type room_info = {
+  id : string;              (* slugified name *)
+  name : string;
+  description : string option;
+  created_at : string;
+  created_by : string option;
+  agent_count : int;
+  task_count : int;
+}
+```
+
+### 3.5 Tempo Config
+
+```ocaml
+type tempo_mode = Normal | Slow | Fast | Paused
+
+type tempo_config = {
+  mode : tempo_mode;
+  delay_ms : int;           (* Normal=0, Slow=2000, Fast=0, Paused=0 *)
+  reason : string option;
+  set_by : string option;
+  set_at : string option;
+}
+```
+
+---
+
+## 4. State Machines
+
+### 4.1 Room Lifecycle
+
+```
+[not_initialized] --init--> [active] --pause--> [paused] --resume--> [active]
+                                                                  \--reset--> [not_initialized]
+```
+
+- `init`: `.masc/` 디렉토리 구조 생성 (agents/, tasks/, messages/), `room_state` 초기화
+- `pause`: `paused = true` 설정, broadcast 통보, orchestrator가 새 에이전트 스폰 중단
+- `resume`: `paused = false`, broadcast 통보
+- `reset`: `.masc/` 전체 삭제 (확인 필수)
+
+### 4.2 Agent in Room
+
+```
+           join (new)
+[absent] ---------> [Active] <--heartbeat-- (last_seen 갱신)
+   ^                   |
+   |              task claim
+   |                   v
+   |                [Busy] --task done/release--> [Active]
+   |                   |
+   |              leave / timeout
+   |                   v
+   '---- gc ----  [Inactive] --rejoin--> [Active]
+```
+
+- `join`: 닉네임 생성 (Docker-style: `{type}-{adj}-{animal}`), 에이전트 JSON 기록, `active_agents` 갱신
+- `rejoin`: 기존 닉네임 재사용, `Inactive -> Active`, `last_seen` 갱신
+- `heartbeat`: `last_seen` 타임스탬프만 갱신 (file lock 보호)
+- `leave`: heartbeat 중단, 에이전트 파일 삭제, `active_agents` 제거
+- `zombie detect`: `last_seen` 기준 threshold 초과 시 GC 대상
+
+### 4.3 Task Lifecycle
+
+```
+                add_task
+[backlog] ---------> [Todo] --claim--> [Claimed] --start--> [InProgress]
+                       |                  |                      |
+                       |                  |--release--> [Todo]   |--release--> [Todo]
+                       |                  |                      |
+                       '--cancel--> [Cancelled]   done -------> [Done]
+                                          ^                      |
+                                          '--cancel--------------'
+```
+
+**전이 규칙** (`transition_task_r`):
+
+| 현재 | action | 조건 | 다음 |
+|------|--------|------|------|
+| Todo | claim | - | Claimed |
+| Todo | cancel | - | Cancelled |
+| Claimed | start | assignee == agent | InProgress |
+| Claimed | release | assignee == agent OR force | Todo |
+| Claimed | done | assignee == agent OR force | Done |
+| Claimed | cancel | assignee == agent OR force | Cancelled |
+| InProgress | release | assignee == agent OR force | Todo |
+| InProgress | done | assignee == agent OR force | Done |
+| InProgress | cancel | assignee == agent OR force | Cancelled |
+
+- `force = true`는 keeper GC가 고아(orphan) 태스크를 해제할 때 사용
+- 태스크에 `required_role`이 설정된 경우, `claim`에서 `agent_role` 일치 검사 수행
+- 모든 전이는 `backlog.version + 1`로 버전 증가 (optimistic concurrency)
+- `expected_version` 옵션으로 CAS(compare-and-set) 가능
+
+### 4.4 Task Scheduling (`room_task_schedule`)
+
+`claim_next_r` 알고리즘:
+
+1. **Auto-release**: 현재 에이전트가 보유한 Claimed/InProgress 태스크를 자동 해제 (BUG-004 수정)
+2. **Stale archive**: `stale_threshold_days`(기본 7일) 초과 Todo 태스크 자동 아카이브
+3. **Starvation prevention**: 24시간 대기 시 priority boost (-1/24h, min 1)
+4. **정렬**: effective priority 오름차순, 동일 priority 내 FIFO (older first)
+5. **제외 목록**: `exclude_task_ids` + 직전 auto-release된 태스크
+
+---
+
+## 5. Heartbeat Protocol
+
+### 5.1 Basic Heartbeat
+
+`Heartbeat.t` 레코드로 관리. `start`로 등록, `stop`으로 해제, `stop_by_agent`로 에이전트 전체 정리.
+
+```ocaml
+type t = {
+  id : string;
+  agent_name : string;
+  interval : int;          (* seconds *)
+  message : string;
+  mutable active : bool;
+  created_at : float;
+}
+```
+
+### 5.2 Smart Heartbeat (`heartbeat_smart.mli`)
+
+토큰 절약을 위한 적응형 하트비트. OpenClaw 스타일.
+
+```ocaml
+type decision =
+  | Emit                        (* 지금 하트비트 전송 *)
+  | Skip_busy                   (* 에이전트가 작업 중 -- 100% skip *)
+  | Skip_idle of float          (* idle 구간 -- 3x 간격 적용, 다음 emit 시각 *)
+```
+
+**구성**:
+- `base_interval_s`: 30초 (기본값)
+- `idle_multiplier`: 3.0 (idle > 5분 시 90초 간격)
+- `busy_skip`: true (Busy 상태면 하트비트 생략)
+- `idle_threshold_s`: 300초 (5분)
+
+**절감 효과**:
+- 작업 중 에이전트: 100% skip
+- 5분+ idle 에이전트: 33% emission (3x interval)
+
+### 5.3 Zombie Detection (`resilience.mli`)
+
+```ocaml
+module Zombie : sig
+  val is_zombie : ?threshold:float -> string -> bool
+  val is_zombie_for_agent : agent_name:string -> string -> bool
+  val is_keeper : name:string -> agent_type:string -> bool
+end
+```
+
+- 일반 에이전트 기본 threshold: 300초 (5분)
+- Keeper 에이전트 threshold: 3600초 (1시간) -- keeper는 장기 실행
+- `is_keeper` 판별: `"keeper-*-agent"` 이름 패턴 OR `agent_type = "keeper"`
+
+### 5.4 Zero-Zombie Protocol
+
+`Resilience.ZeroZombie` 모듈: Eio 백그라운드 루프로 자동 정리.
+
+```ocaml
+val run_loop :
+  ?interval:float ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  cleanup_fn:(unit -> string list) ->
+  unit -> unit
+```
+
+- 주기적으로 `cleanup_fn` 호출, 정리된 에이전트 이름 반환
+- `global_stats`로 cleanup 횟수/최근 정리 대상 추적
+- `is_benign_error`: 시작 시 미초기화 에러 무시
+
+---
+
+## 6. Garbage Collection (`room_gc`)
+
+5단계 파이프라인:
+
+| Phase | 동작 | 실패 시 |
+|-------|------|---------|
+| 1. Detect | 좀비 에이전트 탐지 (threshold 기반) | - |
+| 2. Transition | 상태를 Inactive로 전이, heartbeat 중단 | Inactive + in-list (self-healing) |
+| 3. Release | 좀비가 보유한 태스크를 Todo로 해제 | 해당 에이전트 파일 삭제 건너뜀 |
+| 4. Delete | 에이전트 JSON 파일 삭제 | 로그 경고 |
+| 5. Update | `active_agents`에서 제거 | - |
+
+`gc` 함수는 추가로:
+- 오래된 Todo 태스크 아카이브 (N일 기준)
+- 오래된 메시지 삭제 (open task 참조 메시지는 보존)
+- Board artifact 정리, governance purge (Room_hooks 콜백)
+
+---
+
+## 7. Voting & Consensus
+
+### 7.1 Room Vote (`room_vote`)
+
+단순 다수결 투표 시스템.
+
+```
+vote_create -> vote_cast (N회) -> auto-resolve
+```
+
+- **상태**: `VotePending | VoteApproved | VoteRejected | VoteTied`
+- `required_votes` 도달 시 자동 해결
+- 각 에이전트는 1표만 행사 (중복 투표 거부)
+- 투표 데이터: `.masc/votes/{vote_id}.json`
+
+### 7.2 WALPH Algorithm (`room_walph`, `room_walph_eio`)
+
+Walph(Geoffrey Huntley의 Ralph 변형)는 반복적 태스크 처리 상태머신.
+
+```
+[idle] --START preset--> [running] --PAUSE--> [paused] --RESUME--> [running]
+                            |                                         |
+                            '--STOP-------------------------------------> [idle]
+```
+
+**동기 구현** (`room_walph`):
+- `@walph` 명령 파싱: `@walph START|STOP|PAUSE|RESUME|STATUS [args]`
+- `walph_state`: `running`, `paused`, `stop_requested`, `iterations`, `completed`
+- `walph_should_continue`: Eio.Condition 기반 대기 (busy-wait 없음)
+
+**비동기 구현** (`room_walph_eio`):
+- Eio fiber 내 실행
+- 추가 필드: `claimed`, `released_on_error`, `consecutive_errors`, `error_backoff_sec`
+- preset -> chain_id 매핑: `coverage`, `refactor`, `docs`, `review`, `figma`, `drain`
+
+**동시성 보호**: `Eio.Mutex` + `Eio.Condition` (stdlib Mutex 아님)
+
+---
+
+## 8. Mention Routing (`mention`)
+
+@mention 기반 메시지 라우팅.
+
+```ocaml
+type mode =
+  | Stateless of string    (* @agent -> 가용한 에이전트 중 1명 *)
+  | Stateful of string     (* @agent-adj-animal -> 특정 에이전트 *)
+  | Broadcast of string    (* @@agent -> 해당 타입 전체 *)
+  | None                   (* mention 없음 *)
+```
+
+**파싱 우선순위**: `@@agent` > `@agent-adj-animal` > `@agent`
+
+`resolve_targets`: mode + available_agents -> target 목록
+- Stateless: agent_type 일치하는 첫 번째 에이전트
+- Stateful: 닉네임 정확 일치
+- Broadcast: agent_type 일치하는 전체
+
+---
+
+## 9. Git Operations (`room_worktree`)
+
+에이전트별 git worktree 격리.
+
+### 9.1 Worktree Create
+
+```
+worktree_create_r ~agent_name ~task_id ~base_branch
+```
+
+1. git 저장소 검증 (`.git` 존재 확인)
+2. worktree 경로 생성: `.worktrees/{agent_name}-{task_id}`
+3. branch 이름: `{agent_name}/{task_id}`
+4. `git fetch origin` -> `git worktree add` (base branch에서 분기)
+5. 에이전트 `current_task` 갱신
+6. 태스크 backlog에 `worktree_info` 연결 (`link_task` 옵션)
+
+### 9.2 Worktree Remove
+
+```
+worktree_remove_r ~agent_name ~task_id
+```
+
+- `git worktree remove --force`
+- 로컬 브랜치 삭제
+
+### 9.3 Task Sandbox (`task_sandbox`)
+
+`Room_worktree` 위에 고수준 샌드박스 생명주기를 제공.
+
+```ocaml
+type sandbox = {
+  task_id : string;
+  worktree_path : string;
+  branch_name : string;
+  execution_scope : execution_scope;
+  created_at : float;
+}
+```
+
+- 샌드박스 생성 -> 작업 실행 -> diff 수집 -> 정리
+
+---
+
+## 10. Multi-Room & Federation
+
+### 10.1 Room Registry (`room_multi`, `room_rooms`)
+
+- Room ID: `slugify(name)` (소문자, alphanumeric + dash)
+- Registry: `.masc/rooms/registry.json`
+- Current room: `.masc/current_room` 파일 (mtime 캐싱)
+- `"default"` room은 항상 존재 (registry에 없어도 자동 포함)
+
+**작업 흐름**:
+```
+rooms_list -> room_create(name, description) -> room_enter(room_id)
+```
+
+### 10.2 Portal (A2A, `room_portal`)
+
+에이전트 간 직접 통신 채널.
+
+```ocaml
+type portal = {
+  portal_from : string;
+  portal_target : string;
+  portal_opened_at : string;
+  portal_status : portal_status;   (* PortalOpen | PortalClosed *)
+  task_count : int;
+}
+```
+
+- `portal_open_r`: 양방향 포탈 생성 (reverse portal 자동)
+- A2A task: 포탈을 통한 메시지 교환 (pending -> accepted -> completed)
+- 데이터: `.masc/portals/`, `.masc/a2a_tasks/`
+
+---
+
+## 11. Checkpoint (`room_checkpoint.mli`)
+
+Room 전체 스냅샷 캡처 및 복원.
+
+```ocaml
+type t = Yojson.Safe.t
+
+val capture : room_state:Yojson.Safe.t -> tasks:Yojson.Safe.t -> agents:Yojson.Safe.t -> t
+val timestamp : t -> float
+val room_state : t -> Yojson.Safe.t option
+val tasks : t -> Yojson.Safe.t option
+val agents : t -> Yojson.Safe.t option
+val diff : t -> t -> Yojson.Safe.t     (* 두 checkpoint 간 차이 *)
+val to_string : t -> string
+val of_string : string -> t option
+```
+
+- 실패 작업 후 rollback 지원
+- JSON 직렬화로 저장/복원
+
+---
+
+## 12. Tempo (`room_tempo`)
+
+클러스터 전체 에이전트 페이싱 제어.
+
+| Mode | delay_ms | 용도 |
+|------|----------|------|
+| Normal | 0 | 기본 동작 |
+| Slow | 2000 | 신중한 작업, 디버깅 |
+| Fast | 0 | 제한 없음 |
+| Paused | 0 | 에이전트 일시 정지 |
+
+`set_tempo`는 broadcast로 전체 에이전트에 통보.
+
+---
+
+## 13. Concurrency Model
+
+### 13.1 File Locking
+
+`with_file_lock config path fn`: 파일 단위 lock으로 원자적 read-modify-write.
+- backlog 갱신, 에이전트 상태 갱신 등 모든 mutation에 적용
+- PG 백엔드 사용 시에도 filesystem lock 유지 (dual-write)
+
+### 13.2 State Persistence
+
+| 대상 | Filesystem | PostgreSQL |
+|------|-----------|-----------|
+| Room state | `.masc/state.json` | `masc_kv[room:state]` |
+| Agent | `.masc/agents/{nick}.json` | `masc_kv[agents:{nick}]` |
+| Backlog | `.masc/tasks/backlog.json` | (filesystem only) |
+| Messages | `.masc/messages/*.json` | (filesystem only) |
+
+- PG 백엔드(`is_pg_backend`)가 활성이면 dual-write (file + PG)
+- 읽기: PG 우선, fallback to file
+
+### 13.3 Nickname Generation
+
+Docker-style `{agent_type}-{adjective}-{animal}`:
+- 30 adjectives x 30 animals = 900 조합
+- `Random.State.make_self_init()` 사용 (fiber-safe)
+- 동일 `agent_type`이 이미 참여 중이면 기존 닉네임 재사용
+
+---
+
+## 14. MCP Tool Surface
+
+### 14.1 Room Management (`tool_room`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_status` | 현재 room 상태 조회 |
+| `masc_init` | Room 초기화 (.masc/ 생성) |
+| `masc_reset` | Room 리셋 (.masc/ 삭제, confirm 필수) |
+| `masc_rooms_list` | 모든 room 목록 (agent/task count 포함) |
+| `masc_room_create` | 새 room 생성 |
+| `masc_room_enter` | room 전환 (current_room 변경) |
+| `masc_room_strategy_get` | 검색 전략 조회 |
+| `masc_room_strategy_set` | 검색 전략 설정 (best_first_v1, legacy) |
+| `masc_workflow_guide` | 워크플로우 가이드 출력 |
+| `masc_check` | room 건강 상태 점검 |
+
+### 14.2 Task Operations (`tool_task`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_add_task` | 태스크 추가 (title, priority 1-5, description) |
+| `masc_batch_add_tasks` | 복수 태스크 일괄 추가 |
+| `masc_claim` | 태스크 할당 (role 검사 포함) |
+| `masc_claim_next` | 최고 우선순위 미할당 태스크 자동 할당 |
+| `masc_transition` | 통합 상태 전이 (claim, start, done, cancel, release) |
+| `masc_update_priority` | 태스크 우선순위 변경 |
+| `masc_tasks` | 태스크 목록 조회 |
+| `masc_task_history` | 태스크 이벤트 이력 |
+| `masc_archive_view` | 아카이브된 태스크 조회 |
+
+### 14.3 Agent Operations (`tool_agent`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_agents` | 에이전트 목록 (상태, 좀비 여부 포함) |
+| `masc_register_capabilities` | 에이전트 능력 등록 |
+| `masc_agent_update` | 에이전트 상태/능력 갱신 |
+| `masc_find_by_capability` | 능력 기반 에이전트 검색 |
+| `masc_get_metrics` | 에이전트 성과 메트릭 |
+| `masc_agent_fitness` | 에이전트 적합도 평가 |
+| `masc_select_agent` | 태스크에 최적 에이전트 선택 |
+| `masc_collaboration_graph` | 협업 그래프 |
+| `masc_consolidate_learning` | 학습 통합 |
+| `masc_agent_card` | 에이전트 카드 조회 |
+| `masc_agent_relations` | 에이전트 관계 조회 |
+
+### 14.4 Heartbeat (`tool_heartbeat`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_heartbeat` | 하트비트 갱신 (last_seen 갱신) |
+| `masc_heartbeat_start` | 주기적 하트비트 시작 |
+| `masc_heartbeat_stop` | 하트비트 중단 |
+| `masc_heartbeat_list` | 활성 하트비트 목록 |
+
+### 14.5 Worktree (`tool_worktree`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_worktree_create` | 에이전트+태스크별 worktree 생성 |
+| `masc_worktree_remove` | worktree 삭제 |
+| `masc_worktree_list` | worktree 목록 |
+
+### 14.6 Tempo (`tool_tempo`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_tempo` | 범용 tempo 조회/설정 |
+| `masc_tempo_get` | 현재 tempo 조회 |
+| `masc_tempo_set` | tempo 설정 (mode + reason) |
+| `masc_tempo_adjust` | tempo 미세 조정 |
+| `masc_tempo_reset` | 기본값 복원 |
+
+### 14.7 Control (`tool_control`)
+
+| Tool | 동작 |
+|------|------|
+| `masc_pause` | Room 일시 정지 |
+| `masc_resume` | Room 재개 |
+| `masc_pause_status` | 정지 상태 조회 |
+| `masc_switch_mode` | 운영 모드 전환 |
+| `masc_get_config` | 설정 조회 |
+| `masc_tool_enable` | 도구 활성화 |
+| `masc_tool_disable` | 도구 비활성화 |
+
+### 14.8 Social (`tool_social`, vote 부분)
+
+| Tool | 동작 |
+|------|------|
+| `masc_vote` | 투표 생성/행사 |
+
+---
+
+## 15. Invariants
+
+| ID | 규칙 | 검증 위치 |
+|----|------|----------|
+| INV-ROOM-001 | Room state 갱신은 반드시 `with_file_lock`으로 보호된다 | `room_state.update_state` |
+| INV-ROOM-002 | `active_agents`는 중복 없는 리스트다 (`filter ((<>) name)` 후 추가) | `room_lifecycle.join` |
+| INV-ROOM-003 | 에이전트는 join 없이 claim/broadcast를 수행할 수 없다 | `tool_task.handle_claim` (is_agent_joined 검사) |
+| INV-ROOM-004 | 태스크 전이는 assignee 일치 또는 `force=true` 조건을 충족해야 한다 | `room_task.transition_task_r` |
+| INV-ROOM-005 | `backlog.version`은 단조 증가한다 (매 mutation +1) | `room_task`, `room_task_schedule` |
+| INV-ROOM-006 | Zombie threshold: 일반 에이전트 300s, Keeper 3600s | `resilience.Zombie.is_zombie_for_agent` |
+| INV-ROOM-007 | Smart heartbeat: Busy 에이전트는 하트비트를 emit하지 않는다 | `heartbeat_smart.should_emit` |
+| INV-ROOM-008 | GC Phase 3 실패 시 Phase 4(파일 삭제)를 건너뛴다 (데이터 보존) | `room_gc.cleanup_zombies` |
+| INV-ROOM-009 | claim_next는 현재 보유 태스크를 자동 해제한 후 새 태스크를 할당한다 | `room_task_schedule.claim_next_r` (BUG-004) |
+| INV-ROOM-010 | 닉네임은 동일 agent_type에 대해 세션 내 재사용된다 (identity drift 방지) | `room_lifecycle.join` |
+| INV-ROOM-011 | Worktree 경로는 반드시 `.worktrees/` 하위에 생성된다 (경로 탈출 방지) | `room_worktree.ensure_worktree_path` |
+| INV-ROOM-012 | `"default"` room은 삭제/재생성이 불가능하다 (reserved) | `room_rooms.room_create` |
+| INV-ROOM-013 | 투표에서 각 에이전트는 1회만 투표할 수 있다 | `room_vote.vote_cast` |
+| INV-ROOM-014 | Portal은 양방향이다 (reverse portal 자동 생성) | `room_portal.portal_open_r` |
+| INV-ROOM-015 | GC 시 open task를 참조하는 메시지는 보존된다 | `room_gc.gc` (mentions_open_task) |
+| INV-ROOM-016 | PG 백엔드 사용 시 filesystem과 PG에 동시 기록한다 (dual-write) | `room_state.write_state`, `room_lifecycle.join` |
+
+---
+
+## 16. Known Issues & Bug Fixes
+
+| ID | 설명 | 수정 위치 |
+|----|------|----------|
+| BUG-004 | claim_next가 이전 claim을 해제하지 않아 orphaned task 발생 | `room_task_schedule.claim_next_r` (auto-release) |
+| BUG-005 | join 없이 claim 가능했음 | `room_task.claim_task_r` (agent_joined 검사 추가) |
+| BUG-009 | stale Todo 태스크가 큐를 막음 | `room_task_schedule` (auto-archive, threshold 7일) |
+| BUG-010 | 빈 title/잘못된 priority 태스크 생성 가능 | `tool_task.handle_add_task` (validation 추가) |
+| BUG-1600 | room-scoped 에이전트 조회 시 root 디렉토리 미검사 | `room_agent.update_agent_r` (dual path 검사) |
+
+---
+
+## 17. References
+
+- `lib/room/dune`: sub-library 정의 (`masc_room`, wrapped=false)
+- `lib/room/room_utils.ml`, `room_utils_ops.ml`, `room_utils_paths_backend.ml`, `room_utils_backend_setup.ml`: 공통 유틸리티
+- `lib/room/room_hooks.ml`: 콜백 ref (GC, board, governance)
+- `lib/room/room_query.ml`: 룸 내 에이전트/태스크 카운트 쿼리
+- `lib/room/room_status.ml`: 상태 요약 출력
+- `lib/room/room_git.ml`: git 명령 래퍼 (base branch 해석, worktree 목록)
+- `lib/task_sandbox.ml`: 태스크별 worktree sandbox 고수준 API
+- 02-types-and-invariants: `agent_status`, `task_status`, `room_state` 타입 정의
+- 05-keeper-agent: Keeper가 Room GC와 태스크 해제에 관여하는 경로
+- 09-server-transport: MCP tool dispatch가 Room 함수를 호출하는 경로

--- a/docs/spec/04-chain-engine.md
+++ b/docs/spec/04-chain-engine.md
@@ -1,0 +1,818 @@
+# Chain Engine
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Chain |
+| Maps to | `lib/chain/` |
+| Dependencies | 02-types-and-invariants |
+| Modules | 47 (36 `.ml` + 11 `.mli`) |
+| LOC | ~17,150 |
+| MCP Tools | `masc_chain_snapshot`, `masc_chain_run_get` |
+
+---
+
+## 1. Purpose
+
+Chain Engine은 다중 LLM 호출과 도구 실행을 방향성 비순환 그래프(DAG)로 조합하여 실행하는 오케스트레이션 엔진이다. 27가지 노드 타입(21 core + 3 MASC + 3 extended)으로 파이프라인, 팬아웃, 합의, 폴백, 탐색 등 다양한 실행 패턴을 표현한다.
+
+핵심 설계 원리:
+
+- **Neuro-Symbolic**: Composer(Neural)가 LLM으로 Chain DSL을 설계하고, Conductor(Symbolic)가 결정론적으로 실행한다.
+- **Category Theory 기반**: Functor, Applicative, Monad, Monoid, Kleisli Arrow, Profunctor 추상화로 노드 조합의 수학적 정합성을 보장한다.
+- **Eio Fiber 기반 동시성**: Fanout/Merge/Race 등 병렬 노드는 Eio fiber로 실행되며, OS thread 없이 cooperative scheduling으로 동작한다.
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+    subgraph Orchestrator["Orchestrator Layer"]
+        ORC[chain_orchestrator_eio]
+    end
+
+    subgraph Neural["Neural Layer (Composer)"]
+        COMP[chain_composer] --> EVAL[chain_evaluator]
+    end
+
+    subgraph Symbolic["Symbolic Layer (Conductor)"]
+        PARSER[chain_parser / chain_mermaid_parser]
+        COMPILER[chain_compiler]
+        EXEC[chain_executor_eio]
+    end
+
+    subgraph Execution["Executor Sub-modules"]
+        LEAF[chain_executor_leaf]
+        COMPLEX[chain_executor_complex]
+        RESIL[chain_executor_resilience]
+        SEARCH[chain_executor_search]
+        HELPERS[chain_executor_helpers]
+    end
+
+    subgraph Foundation["Foundation"]
+        TYPES[chain_types]
+        CAT[chain_category]
+        TRACE[chain_trace_types]
+        TELEM[chain_telemetry]
+        STATS[chain_stats]
+        ERR[chain_error]
+        CONV[chain_conversation]
+        ITER[chain_iteration]
+        ADAPT[chain_adapter_eio]
+        REG[chain_registry]
+        STORE[chain_run_store]
+        SPAWN[chain_spawn_registry]
+        LOG[chain_log]
+        UTILS[chain_utils]
+        NATIVE[chain_native_eio]
+    end
+
+    ORC --> COMP
+    ORC --> COMPILER
+    ORC --> EXEC
+    COMP --> EVAL
+    PARSER --> TYPES
+    COMPILER --> TYPES
+    EXEC --> LEAF
+    EXEC --> COMPLEX
+    EXEC --> RESIL
+    EXEC --> SEARCH
+    LEAF --> HELPERS
+    HELPERS --> TYPES
+    HELPERS --> TRACE
+    HELPERS --> CONV
+    HELPERS --> ITER
+    EXEC --> TELEM
+    EXEC --> STATS
+    EXEC --> REG
+    EXEC --> ADAPT
+```
+
+### 2.1 레이어 구조
+
+| 레이어 | 모듈 | 역할 |
+|--------|------|------|
+| **Orchestrator** | `chain_orchestrator_eio` | Design-Compile-Execute-Verify 루프 통합 |
+| **Neural (Composer)** | `chain_composer`, `chain_evaluator` | LLM 기반 Chain DSL 설계, 완료 검증, 평가 타이밍 제어 |
+| **Symbolic (Conductor)** | `chain_parser`, `chain_compiler`, `chain_executor_eio` | JSON/Mermaid 파싱, DAG 컴파일, 결정론적 실행 |
+| **Foundation** | `chain_types`, `chain_category`, `chain_error` 외 | 타입 정의, 카테고리 이론 추상화, 에러, 텔레메트리 |
+
+### 2.2 Orchestrator 라이프사이클
+
+```
+Design(Composer) -> Compile(Parser+Compiler) -> Execute(Conductor) -> Verify(Composer)
+    ^                                                                      |
+    +----------------------------- Replan Loop ----------------------------+
+```
+
+`orchestration_config.max_replans` (기본 3)까지 재계획을 허용한다. 전체 타임아웃은 `timeout_ms` (기본 300,000ms = 5분).
+
+---
+
+## 3. Node Type Catalog
+
+Chain Engine은 27가지 노드 타입을 지원한다. 기능별로 6개 카테고리로 분류된다.
+
+### 3.1 Leaf Nodes (단말 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Model** | LLM 호출. prompt를 모델에 전달하고 응답을 받는다 | `model`, `prompt`, `system`, `timeout`, `tools`, `thinking` | `chain_executor_leaf` |
+| **Tool** | MCP tool 호출. 이름과 JSON 인자로 외부 도구를 실행한다 | `name`, `args` | `chain_executor_leaf` |
+
+### 3.2 Structural Nodes (구조 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Pipeline** | 순차 실행. 자식 노드를 순서대로 실행하고 마지막 출력을 반환한다 | `node list` | `chain_executor_eio` |
+| **Fanout** | 병렬 실행. 모든 자식 노드를 Eio fiber로 동시 실행한다 | `node list` | `chain_executor_eio` |
+| **Gate** | 조건 분기. condition 평가 결과에 따라 then/else 노드를 실행한다 | `condition`, `then_node`, `else_node` | `chain_executor_eio` |
+| **Subgraph** | 중첩 체인. 전체 chain 정의를 하위 노드로 실행한다 | `chain` | `chain_executor_eio` |
+| **ChainRef** | 등록된 체인 참조. Registry에서 ID로 체인을 조회하여 실행한다 | `ref_id` | `chain_executor_eio` |
+| **Map** | 함수 매핑. inner 노드 결과에 func를 적용한다 (Functor) | `func`, `inner` | `chain_executor_eio` |
+| **Bind** | 모나드 바인드. inner 노드 결과를 func에 전달하여 새 계산을 생성한다 | `func`, `inner` | `chain_executor_eio` |
+
+### 3.3 Consensus and Merge Nodes (합의/병합 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Quorum** | N/K 합의. 병렬 실행 후 consensus_mode에 따라 합의를 판정한다 | `consensus`, `nodes`, `weights` | `chain_executor_eio` |
+| **Merge** | 결과 병합. 복수 노드 결과를 merge_strategy에 따라 하나로 합친다 | `strategy`, `nodes` | `chain_executor_eio` |
+| **StreamMerge** | 스트리밍 병합. 노드들이 완료되는 순서대로 reducer를 적용한다 | `nodes`, `reducer`, `initial`, `min_results`, `timeout` | `chain_executor_complex` |
+
+### 3.4 Quality and Evaluation Nodes (품질/평가 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Threshold** | 임계값 검사. 입력 노드 결과의 metric을 측정하여 pass/fail 분기한다 | `metric`, `operator`, `value`, `input_node`, `on_pass`, `on_fail` | `chain_executor_eio` |
+| **GoalDriven** | 목표 기반 반복. 목표 metric에 도달할 때까지 action_node를 반복 실행한다 | `goal_metric`, `goal_operator`, `goal_value`, `action_node`, `measure_func`, `max_iterations`, `conversational`, `relay_models` | `chain_executor_complex` |
+| **Evaluator** | 후보 평가. 복수 후보 노드를 실행하고 scoring_func으로 점수를 매겨 선택한다 | `candidates`, `scoring_func`, `scoring_prompt`, `select_strategy`, `min_score` | `chain_executor_search` |
+| **FeedbackLoop** | 피드백 루프. generator -> evaluator -> improver 사이클을 score_threshold까지 반복한다 | `generator`, `evaluator_config`, `improver_prompt`, `max_iterations`, `score_threshold`, `score_operator`, `conversational`, `relay_models` | `chain_executor_complex` |
+| **Mcts** | Monte Carlo Tree Search. 전략 트리를 탐색하며 시뮬레이션과 평가를 반복한다 | `strategies`, `simulation`, `evaluator`, `policy`, `max_iterations`, `max_depth`, `expansion_threshold`, `early_stop`, `parallel_sims` | `chain_executor_search` |
+
+### 3.5 Resilience Nodes (복원력 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Retry** | 재시도. 실패 시 backoff 전략에 따라 max_attempts까지 재시도한다 | `node`, `max_attempts`, `backoff`, `retry_on` | `chain_executor_resilience` |
+| **Fallback** | 폴백. primary 실패 시 fallbacks 목록을 순서대로 시도한다 | `primary`, `fallbacks` | `chain_executor_resilience` |
+| **Race** | 경쟁 실행. 복수 노드를 동시 실행하고 가장 먼저 성공한 결과를 반환한다 | `nodes`, `timeout` | `chain_executor_resilience` |
+| **Cache** | 캐싱. key_expr 기반 캐시 히트 시 inner 노드 실행을 건너뛴다 | `key_expr`, `ttl_seconds`, `inner` | `chain_executor_resilience` |
+| **Batch** | 배치 처리. inner 노드를 batch_size 단위로 분할 실행한다 | `batch_size`, `parallel`, `inner`, `collect_strategy` | `chain_executor_resilience` |
+| **Spawn** | 격리 실행. clean context에서 inner 노드를 실행하여 상태 오염을 방지한다 | `clean`, `inner`, `pass_vars`, `inherit_cache` | `chain_executor_resilience` |
+| **ChainExec** | 동적 체인 실행. chain_source에서 체인을 로드하여 런타임에 실행한다 | `chain_source`, `validate`, `max_depth`, `sandbox`, `context_inject`, `pass_outputs` | `chain_executor_resilience` |
+
+### 3.6 Data Transform Nodes (데이터 변환 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Adapter** | 데이터 변환. input_ref 출력에 transform을 적용한다 (Profunctor) | `input_ref`, `transform`, `on_error` | `chain_executor_leaf` |
+
+### 3.7 Cascade Node (단계적 에스컬레이션)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Cascade** | 단계적 LLM 에스컬레이션. 저비용 tier부터 시작하여 confidence가 부족하면 상위 tier로 올린다 | `tiers`, `confidence_prompt`, `max_escalations`, `context_mode`, `task_hint`, `default_threshold` | `chain_executor_complex` |
+
+### 3.8 MASC Coordination Nodes (MASC 연동 노드)
+
+| Node Type | 의미 | 주요 파라미터 | 실행 모듈 |
+|-----------|------|-------------|----------|
+| **Masc_broadcast** | MASC 브로드캐스트 발행 | `message`, `room`, `mention` | `chain_executor_leaf` |
+| **Masc_listen** | MASC 이벤트 대기 | `filter`, `timeout_sec`, `room` | `chain_executor_leaf` |
+| **Masc_claim** | MASC task claim | `task_id`, `room` | `chain_executor_leaf` |
+
+---
+
+## 4. Types
+
+### 4.1 Core Types
+
+**소스**: `lib/chain/chain_types.mli`
+
+```ocaml
+(* Chain configuration *)
+type chain_config = {
+  max_depth : int;        (* 서브그래프 최대 재귀 깊이 *)
+  max_concurrency : int;  (* 모델당 최대 병렬 실행 수 *)
+  timeout : int;          (* 기본 타임아웃 (초) *)
+  trace : bool;           (* 실행 추적 활성화 *)
+  direction : direction;  (* Mermaid 다이어그램 방향 *)
+}
+
+(* 실행 결과 *)
+type chain_result = {
+  chain_id : string;
+  output : string;
+  success : bool;
+  trace : trace_entry list;
+  token_usage : token_usage;
+  duration_ms : int;
+  metadata : (string * string) list;
+}
+
+(* 컴파일러 출력 *)
+type execution_plan = {
+  chain : chain;
+  execution_order : string list;     (* 위상 정렬 순서 *)
+  parallel_groups : string list list; (* 병렬 실행 그룹 *)
+  depth : int;                       (* 최대 중첩 깊이 *)
+}
+```
+
+### 4.2 Strategy Types
+
+```ocaml
+(* Quorum 합의 모드 *)
+type consensus_mode =
+  | Count of int       (* 최소 N개 성공 *)
+  | Majority           (* 과반수 성공 (> n/2) *)
+  | Unanimous          (* 전원 성공 *)
+  | Weighted of float  (* 가중 합산 >= threshold *)
+
+(* Merge 전략 *)
+type merge_strategy =
+  | First | Last | Concat | WeightedAvg | Custom of string
+
+(* Evaluator 선택 전략 *)
+type select_strategy =
+  | Best | Worst | AboveThreshold of float | WeightedRandom
+
+(* Retry backoff 전략 *)
+type backoff_strategy =
+  | Constant of float | Exponential of float | Linear of float
+  | Jitter of float * float
+
+(* MCTS 탐색 정책 *)
+type mcts_policy =
+  | UCB1 of float | Greedy | EpsilonGreedy of float | Softmax of float
+
+(* Threshold 비교 연산자 *)
+type threshold_op = Gt | Gte | Lt | Lte | Eq | Neq
+
+(* Cascade confidence 수준 *)
+type confidence_level = High | Medium | Low
+type context_mode = CM_None | CM_Summary | CM_Full
+```
+
+### 4.3 Adapter Transform (재귀 타입)
+
+```ocaml
+type adapter_transform =
+  | Extract of string           (* JSON 필드 추출 *)
+  | Template of string          (* 템플릿 적용 *)
+  | Summarize of int            (* max_tokens 요약 *)
+  | Truncate of int             (* max_chars 절단 *)
+  | JsonPath of string          (* JSONPath 쿼리 *)
+  | Regex of string * string    (* 정규식 치환 *)
+  | ValidateSchema of string    (* JSON Schema 검증 *)
+  | ParseJson                   (* 문자열 -> JSON *)
+  | Stringify                   (* JSON -> 문자열 *)
+  | Chain of adapter_transform list  (* 순차 변환 체인 *)
+  | Conditional of { condition; on_true; on_false }  (* 조건부 *)
+  | Split of { delimiter; chunk_size; overlap }      (* 분할 *)
+  | Custom of string            (* 사용자 정의 함수 *)
+```
+
+`Chain` variant가 `adapter_transform list`를 포함하므로 재귀 타입이다. `Conditional`의 `on_true`/`on_false`도 `adapter_transform`이므로 트리 구조를 형성한다.
+
+### 4.4 Cascade Tier
+
+```ocaml
+type cascade_tier = {
+  tier_node : node;              (* 해당 tier에서 실행할 노드 *)
+  tier_index : int;              (* tier 순서 (0부터) *)
+  confidence_threshold : float;  (* 이 tier의 confidence 기준 *)
+  cost_weight : float;           (* 비용 가중치 *)
+  pass_context : bool;           (* 이전 tier 컨텍스트 전달 여부 *)
+}
+```
+
+### 4.5 Execution Context
+
+```ocaml
+type exec_context = {
+  outputs: (string, string) Hashtbl.t;        (* 노드 ID -> 출력 매핑 *)
+  traces: internal_trace list ref;            (* 실행 추적 이벤트 *)
+  start_time: float;
+  trace_enabled: bool;
+  timeout: int;
+  mutable iteration_ctx: iteration_ctx option; (* GoalDriven 반복 컨텍스트 *)
+  mutable conversation: conversation_ctx option; (* 대화 컨텍스트 *)
+  cache: (string, string * float) Hashtbl.t;  (* 캐시: key -> (value, timestamp) *)
+  mutable total_tokens: token_usage;
+  langfuse_trace: Langfuse.trace option;       (* Langfuse 연동 *)
+  checkpoint: checkpoint_config;               (* 체크포인트 설정 *)
+  node_status: (string, exec_phase) Hashtbl.t; (* 노드별 실행 상태 *)
+  node_attempts: (string, int) Hashtbl.t;      (* 노드별 시도 횟수 *)
+  chain_id: string;
+}
+```
+
+### 4.6 Trace and Telemetry Types
+
+```ocaml
+(* 노드 실행 추적 이벤트 *)
+type trace_event =
+  | NodeStart of { node_type : string; attempt : int }
+  | NodeComplete of { duration_ms : int; success : bool; node_type : string; attempt : int }
+  | NodeError of { message : string; error_class : string option; node_type : string; attempt : int }
+  | ChainStart of { chain_id : string; mermaid_dsl : string option }
+  | ChainComplete of { chain_id : string; success : bool }
+
+(* 노드 실행 단계 *)
+type exec_phase = Planned | Running | Completed | Failed | Skipped
+```
+
+### 4.7 Diagram Direction
+
+```ocaml
+type direction = LR | RL | TB | BT
+```
+
+Mermaid 다이어그램 렌더링 방향. `LR`(좌->우)이 기본값.
+
+---
+
+## 5. Category Theory Foundations
+
+**소스**: `lib/chain/chain_category.ml`, `lib/chain/chain_category.mli`
+
+Chain Engine은 노드 조합의 정합성을 카테고리 이론 추상화로 보장한다. 각 module signature는 법칙(laws)을 명시하고, `Laws` 모듈이 런타임 검증을 제공한다.
+
+| 추상화 | 대응 노드 패턴 | 법칙 |
+|--------|--------------|------|
+| **Functor** (`map`) | Map, Adapter (출력 변환) | `map id = id`, `map (f . g) = map f . map g` |
+| **Applicative** (`ap`, `sequence`) | Fanout (독립적 병렬 실행) | `pure id <*> v = v`, 결합법칙 |
+| **Monad** (`bind`, `>>=`, `>=>`) | Pipeline (순차 의존성) | 좌항등, 우항등, 결합법칙 |
+| **Monoid** (`empty`, `concat`) | Merge, Token 집계, Trace 누적 | `concat empty x = x`, 결합법칙 |
+| **Kleisli Arrow** (`>>>`, `&&&`, `***`) | 에러 핸들링 파이프라인 | Arrow 법칙 |
+| **Profunctor** (`dimap`, `lmap`, `rmap`) | Adapter (입출력 양방향 변환) | `dimap id id = id` |
+
+### 5.1 Monoid Instances
+
+| Instance | 타입 | 용도 |
+|----------|------|------|
+| `Verdict_monoid` | `verdict` | 검증 결과 합산 (fail-fast) |
+| `Confidence_monoid` | `float` | confidence 점수 조합 (geometric, harmonic, weighted) |
+| `Trace_monoid` | `(string * float) list` | 실행 추적 누적 |
+| `Token_monoid` | `token_usage` | 토큰 사용량 합산 |
+
+---
+
+## 6. State Machines
+
+### 6.1 Chain Orchestration Lifecycle
+
+```
+                    Design Failed
+                        |
+Start -> Design -> Compile -> Execute -> Verify -> Complete
+            ^                              |
+            |          Replan (count < max) |
+            +------------------------------+
+            |
+            v
+       MaxReplansExceeded / Timeout -> Abort
+```
+
+`orchestration_error` variant로 각 단계의 실패를 구분한다:
+- `DesignFailed` -- Composer가 Chain DSL 생성에 실패
+- `CompileFailed` -- Parser/Compiler가 유효하지 않은 DSL을 거부
+- `ExecutionFailed` -- Conductor 실행 중 에러
+- `VerificationFailed` -- 완료 검증 실패
+- `MaxReplansExceeded` -- 재계획 횟수 초과
+- `Timeout` -- 전체 타임아웃
+
+### 6.2 Node Execution Lifecycle
+
+```
+Planned -> Running -> Completed
+                  |-> Failed -> (Retry?) -> Running
+                  |-> Skipped (Gate condition false)
+```
+
+`exec_phase` 타입이 상태를 표현하고, `node_status` Hashtbl이 노드별 상태를 추적한다.
+
+### 6.3 Cascade Escalation Flow
+
+```
+Tier 0 (low-cost) -> assess confidence
+    |-- confidence >= threshold -> return result
+    |-- confidence < threshold -> Tier 1 (mid-cost)
+        |-- confidence >= threshold -> return result
+        |-- confidence < threshold -> Tier 2 (high-cost)
+            |-- ... -> return result (or exhausted)
+```
+
+`max_escalations`에 도달하면 마지막 결과를 반환한다. `context_mode`에 따라 이전 tier의 출력이 다음 tier의 입력에 주입된다 (`CM_None`, `CM_Summary`, `CM_Full`).
+
+---
+
+## 7. DSL and Parser
+
+### 7.1 입력 형식
+
+Chain Engine은 두 가지 입력 형식을 지원한다.
+
+**JSON DSL** (`chain_parser`): 표준 입력 형식. JSON 객체로 chain, nodes, config를 정의한다.
+
+```json
+{
+  "id": "example_chain",
+  "nodes": [
+    { "id": "step1", "type": "model", "model": "llama", "prompt": "..." },
+    { "id": "step2", "type": "model", "model": "glm", "prompt": "{{step1.output}}" }
+  ],
+  "output": "step2",
+  "config": { "max_depth": 5, "timeout": 60 }
+}
+```
+
+**Mermaid DSL** (`chain_mermaid_parser`, `chain_mermaid_graph`, `chain_mermaid_parse`, `chain_mermaid_node_content`): Mermaid graph 문법으로 체인을 정의한다. 4개 모듈로 분할되어 있다.
+
+```mermaid
+graph LR
+    A[model:llama "Summarize the input"] --> B[model:glm "Refine: {{A.output}}"]
+```
+
+### 7.2 파싱 파이프라인
+
+```
+Input (JSON or Mermaid) -> Parser -> chain (AST)
+                                        |
+                                        v
+                                    Validator -> (Ok | Error)
+                                        |
+                                        v
+                                    Compiler -> execution_plan
+```
+
+### 7.3 Input Mapping
+
+노드 간 데이터 전달은 `{{node_id.output}}` 템플릿 문법을 사용한다. Parser가 prompt 문자열에서 이 패턴을 추출하여 `input_mapping` 리스트를 생성한다.
+
+### 7.4 Validation
+
+두 수준의 검증을 제공한다:
+
+- `validate_chain` (기본): 출력 노드 존재, 중복 ID 없음, 미해결 placeholder 없음
+- `validate_chain_strict` (엄격): 기본 + 중첩 노드 ID 중복 검사, 필수 필드 확인, input_mapping 참조 해소, config 값 범위 검사
+
+### 7.5 Serialization
+
+양방향 변환을 지원한다:
+- `parse_chain` / `chain_to_json`: JSON <-> chain AST
+- `chain_to_mermaid`: chain AST -> Mermaid 문자열
+- Mermaid 파싱: `chain_mermaid_graph` -> `chain_mermaid_parse` -> `chain_mermaid_node_content`
+
+---
+
+## 8. Compiler
+
+**소스**: `lib/chain/chain_compiler.ml`, `lib/chain/chain_compiler.mli`
+
+Compiler는 chain AST를 `execution_plan`으로 변환한다.
+
+### 8.1 컴파일 단계
+
+1. **의존성 그래프 구축** (`build_dependency_graph`): `input_mapping`과 중첩 노드 참조를 분석하여 `(string, string list) Hashtbl.t` 형태의 그래프를 생성한다.
+2. **위상 정렬** (`topological_sort`): Kahn's algorithm으로 DAG 순서를 결정한다. 순환이 감지되면 에러를 반환한다.
+3. **병렬 그룹 식별** (`identify_parallel_groups`): 상호 의존성이 없는 노드들을 같은 그룹에 배치한다. Fanout 최적화의 기반이 된다.
+4. **깊이 계산** (`calculate_depth`): 중첩 노드의 최대 깊이를 재귀적으로 계산한다. `chain_config.max_depth` 제한에 사용된다.
+
+### 8.2 출력
+
+```ocaml
+type execution_plan = {
+  chain : chain;
+  execution_order : string list;       (* 위상 정렬 순서 *)
+  parallel_groups : string list list;  (* 동시 실행 가능한 노드 그룹 *)
+  depth : int;                         (* 최대 중첩 깊이 *)
+}
+```
+
+### 8.3 Readiness Check
+
+`is_ready completed node`는 노드의 모든 의존성이 `completed` 목록에 포함되어 있는지 확인한다. Executor가 런타임에 노드 실행 가능 여부를 판단할 때 사용한다.
+
+---
+
+## 9. Executor Architecture
+
+**소스**: `lib/chain/chain_executor_eio.ml` + 4개 서브 모듈
+
+### 9.1 모듈 분할
+
+Executor는 상호 재귀(mutual recursion) 구조로 인해 5개 모듈로 분할되어 있다.
+
+| 모듈 | 역할 | 노드 타입 |
+|------|------|----------|
+| `chain_executor_helpers` | 타입, 컨텍스트, trace, 입력 해소, 치환 | (공통 기반) |
+| `chain_executor_leaf` | 단말 노드 실행 (재귀 불필요) | Model, Tool, Adapter, Masc_* |
+| `chain_executor_eio` | 최상위 dispatch + 구조 노드 (상호 재귀 진입점) | Pipeline, Fanout, Gate, Quorum, Merge, Subgraph, ChainRef, Map, Bind |
+| `chain_executor_complex` | 복합 반복/에스컬레이션 노드 | GoalDriven, FeedbackLoop, StreamMerge, Cascade |
+| `chain_executor_resilience` | 복원력/인프라 노드 | Retry, Fallback, Race, Cache, Batch, Spawn, ChainExec |
+| `chain_executor_search` | 탐색/평가 노드 | Mcts, Evaluator |
+
+### 9.2 Dispatch 구조
+
+`execute_node`는 `chain_executor_eio.ml`에 정의된 `let rec ... and ...` 블록의 진입점이다. `node_type` pattern match로 27개 variant를 분기하고, 서브 모듈 함수에 `execute_node` 자신을 인자로 전달하여 재귀 실행을 가능하게 한다.
+
+```ocaml
+(* chain_executor_eio.ml의 핵심 dispatch *)
+let rec execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node =
+  match node.node_type with
+  | Model _ -> execute_model_node ...       (* leaf *)
+  | Pipeline nodes -> execute_pipeline ...  (* structural, recursive *)
+  | Retry { ... } -> execute_retry ...      (* resilience, delegates to sub-module *)
+  ...
+```
+
+서브 모듈 함수 시그니처에 `execute_node_fn` 타입이 포함되어 재귀를 허용한다:
+
+```ocaml
+type execute_node_fn =
+  exec_context -> sw:Eio.Switch.t -> clock:... -> exec_fn:... -> tool_exec:... ->
+  Chain_types.node -> (string, string) result
+```
+
+### 9.3 동시성 모델
+
+- **Fanout/Merge**: `Eio.Fiber.all`로 병렬 실행. 각 fiber가 독립적으로 `execute_node`를 호출한다.
+- **Race**: `Eio.Fiber.any`로 경쟁 실행. 첫 성공 결과를 반환하고 나머지를 취소한다.
+- **Quorum**: 병렬 실행 후 `consensus_mode`에 따라 합의를 판정한다. `Weighted` 모드는 노드별 `weights`를 적용한다.
+- **StreamMerge**: 노드가 완료될 때마다 `reducer`를 적용하고, `min_results` 이상 도착하면 조기 반환할 수 있다.
+- **Batch**: `parallel=true`일 때 `batch_size`개씩 병렬로 inner 노드를 실행한다.
+
+### 9.4 입력 해소 (Input Resolution)
+
+`resolve_inputs ctx input_mapping`은 `{{node_id.output}}` 참조를 `ctx.outputs` Hashtbl에서 실제 값으로 치환한다. 해소 순서:
+
+1. `input_mapping`의 각 `(ref, node_id)` 쌍에 대해 `ctx.outputs`에서 조회
+2. `substitute_prompt`로 prompt 문자열 내 `{{...}}`를 치환
+3. `substitute_iteration_vars`로 GoalDriven 반복 변수(`{{iteration}}`, `{{progress}}` 등)를 치환
+4. JSON 인자의 경우 `substitute_json`으로 중첩 구조까지 재귀 치환
+
+### 9.5 Retry and Backoff
+
+`backoff_strategy`별 지연 시간 계산:
+
+| 전략 | 지연 공식 |
+|------|----------|
+| `Constant(d)` | `d` (매 시도 동일) |
+| `Exponential(d)` | `d * 2^(attempt-1)` |
+| `Linear(d)` | `d * attempt` |
+| `Jitter(min, max)` | `Random.float (max - min) + min` |
+
+`retry_on` 리스트가 비어있으면 모든 에러에 대해 재시도한다. 비어있지 않으면 에러 메시지에 해당 문자열이 포함된 경우에만 재시도한다.
+
+### 9.6 Checkpoint/Resume
+
+`checkpoint_config`로 실행 중간 상태를 저장하고 복구할 수 있다.
+
+```ocaml
+type checkpoint_config = {
+  checkpoint_store: Checkpoint_store.checkpoint_store option;
+  checkpoint_enabled: bool;
+  resume_from: string option;  (* 이전 run_id에서 복구 *)
+  run_id: string;
+  fs: Eio.Fs.dir_ty Eio.Path.t option;
+}
+```
+
+- `save_checkpoint`: 노드 완료 시 중간 결과를 저장
+- `restore_from_checkpoint`: 이전 실행의 중간 결과를 복원
+- `node_completed_in_checkpoint`: 이미 완료된 노드를 건너뛰기
+
+### 9.7 Conversational Mode
+
+GoalDriven과 FeedbackLoop는 `conversational=true` 설정 시 대화 컨텍스트를 유지한다.
+
+```ocaml
+type conversation_ctx = {
+  mutable history: conv_message list;  (* 대화 기록 *)
+  models: string list;                 (* 릴레이 모델 목록 *)
+  token_threshold: int;                (* 요약 트리거 임계값 *)
+  window_size: int;                    (* 유지할 최근 메시지 수 *)
+  ...
+}
+```
+
+- `estimate_tokens`: 문자열 길이 기반 토큰 추정 (~4 chars/token)
+- `needs_summarization`: `total_tokens > token_threshold`이면 true
+- `maybe_summarize_and_rotate`: 임계값 초과 시 LLM으로 요약하고 모델을 rotate
+- `relay_models`: 반복마다 모델을 교체하여 다양한 관점을 확보
+
+---
+
+## 10. Telemetry and Tracing
+
+### 10.1 Chain Telemetry
+
+**소스**: `lib/chain/chain_telemetry.ml`, `lib/chain/chain_telemetry.mli`
+
+구독 기반 이벤트 시스템. Eio.Mutex로 fiber-safe하게 구독자를 관리한다.
+
+**이벤트 타입**: `ChainStart`, `NodeStart`, `NodeComplete`, `ChainComplete`, `Error`
+
+**API**:
+- `emit event` -- 모든 활성 구독자에게 이벤트 발행
+- `subscribe handler` / `unsubscribe sub` -- 구독/해지
+- `subscribe_filtered ~filter handler` -- 필터링된 구독
+- `enable_logging ?max_size` -- 내장 이벤트 버퍼 (기본 10,000건)
+- `get_running_chains ()` -- 실행 중인 체인 목록과 진행률
+
+**필터**: `chain_events_only`, `node_events_only`, `errors_only`, `for_chain chain_id`, `for_node node_id`
+
+### 10.2 Chain Stats
+
+**소스**: `lib/chain/chain_stats.ml`
+
+Mutex로 보호되는 전역 통계 수집기.
+
+| 메트릭 | 설명 |
+|--------|------|
+| `total_chains` / `total_nodes` | 총 실행 수 |
+| `avg_duration_ms`, `p50`, `p95`, `p99` | 실행 시간 분포 |
+| `tokens_by_model` | 모델별 토큰 사용량 |
+| `estimated_cost_usd` | 비용 추정 |
+| `success_rate` | 성공률 |
+| `failure_reasons` | 실패 원인별 횟수 |
+| `hourly_tokens` / `hourly_chains` | 시간별 추이 |
+
+### 10.3 Chain Run Store
+
+**소스**: `lib/chain/chain_run_store.ml`
+
+최근 체인 실행 이력을 인메모리 + JSONL 파일로 저장한다. 디버깅과 Dashboard UI용.
+
+| 환경변수 | 기본값 | 설명 |
+|----------|--------|------|
+| `MASC_CHAIN_RUN_HISTORY` | 50 | 최대 보관 이력 수 |
+| `MASC_CHAIN_OUTPUT_MAX_CHARS` | 4000 | 출력 저장 최대 문자 수 |
+| `MASC_CHAIN_OUTPUT_PREVIEW_CHARS` | 240 | 출력 미리보기 문자 수 |
+| `MASC_CHAIN_RUN_STORE_PATH` | `~/logs/masc_chain_run_store.jsonl` | 저장 경로 |
+
+### 10.4 Trace Pairing
+
+`chain_trace_types.ml`의 `traces_to_entries`는 `NodeStart`와 `NodeComplete` 이벤트를 node_id 기준으로 쌍으로 묶어 `trace_entry`를 생성한다. `start_time`과 `end_time`이 올바르게 설정된다.
+
+---
+
+## 11. Error Handling
+
+**소스**: `lib/chain/chain_error.ml`
+
+### 11.1 Structured Error Hierarchy
+
+```ocaml
+type t =
+  | Model of model_error     (* LLM 제공자 에러 *)
+  | Chain of chain_error     (* 체인 실행 에러 *)
+  | Mcp of mcp_error         (* MCP 프로토콜 에러 *)
+  | Process of process_error (* 프로세스/CLI 에러 *)
+  | Io of io_error           (* I/O/네트워크 에러 *)
+  | Internal of string       (* 예상치 못한 내부 에러 *)
+```
+
+### 11.2 Recoverability
+
+`is_recoverable`로 재시도 가능 여부를 판단한다:
+- Recoverable: `GeminiFunctionCallSync`, `*RateLimit`, `ProcessTimeout`, `NetworkError`
+- Non-recoverable: `*Auth`, `*ContextTooLong`, `ChainCycleDetected`, `Internal`
+
+### 11.3 Severity
+
+| Severity | 해당 에러 |
+|----------|----------|
+| Warning | `GeminiFunctionCallSync`, `*RateLimit`, `ChainParseError`, `McpMethodNotFound`, `ProcessTimeout` |
+| Error | 대부분의 도메인 에러 |
+| Critical | `Internal` |
+
+---
+
+## 12. Supporting Modules
+
+### 12.1 Chain Registry
+
+**소스**: `lib/chain/chain_registry.ml`
+
+ChainRef 노드가 참조하는 체인을 저장/조회하는 레지스트리. Eio.Mutex로 보호되는 인메모리 Hashtbl 기반. 선택적으로 파일 시스템 영속화를 지원한다.
+
+```ocaml
+val register : chain -> unit
+val lookup : string -> chain option
+val list_all : unit -> (string * registry_entry) list
+val init : ?persist_dir:string -> unit -> unit
+```
+
+### 12.2 Chain Spawn Registry
+
+**소스**: `lib/chain/chain_spawn_registry.ml`
+
+Spawn 노드의 동시 실행 상태를 추적한다. `MASC_SPAWN_MAX_INFLIGHT` (기본 16)으로 최대 동시 실행 수를 제한한다.
+
+주요 메트릭: `inflight`, `total`, `failed`, `max_inflight`, latency 분포 (avg, p50, p95, p99).
+
+### 12.3 Chain Log
+
+**소스**: `lib/chain/chain_log.ml`
+
+구조화된 레벨 로깅. `MASC_CHAIN_LOG_LEVEL` (debug|info|warn|error), `MASC_CHAIN_LOG_FORMAT` (text|json).
+
+### 12.4 Chain Utils
+
+**소스**: `lib/chain/chain_utils.ml`
+
+예외 없는 안전한 헬퍼 함수: `list_nth_opt`, `list_hd_opt`, `starts_with`, `truncate_with_ellipsis`, `is_empty_response`, `is_complex_prompt`, `is_glm_model` 등.
+
+### 12.5 Chain Native Eio
+
+**소스**: `lib/chain/chain_native_eio.ml`
+
+MCP tool dispatch에서 체인 실행까지 연결하는 Runtime 브릿지. `runtime` 레코드에 `config`, `agent_name`, Eio `sw`/`clock`, `mcp_state`를 담아 체인 실행 환경을 구성한다.
+
+---
+
+## 13. MCP Tool Surface
+
+| Tool | 설명 |
+|------|------|
+| `masc_chain_snapshot` | 실행 중인 체인 목록과 상태 조회 |
+| `masc_chain_run_get` | 특정 run_id의 실행 결과 상세 조회 |
+
+Command Plane의 `tool_command_plane_chain_query.ml`과 `tool_command_plane_chain_common.ml`이 MCP tool dispatch를 처리한다. 체인 실행은 `orchestration_kind` 파라미터로 `native` (기본) 또는 `chain_dsl` (Chain DSL 직접 실행) 중 선택한다.
+
+---
+
+## 14. Invariants
+
+### INV-CHAIN-001: DAG Acyclicity
+체인 그래프는 반드시 DAG(방향성 비순환 그래프)여야 한다. `chain_compiler.topological_sort`가 순환을 감지하면 `ChainCycleDetected` 에러를 반환한다.
+
+### INV-CHAIN-002: Output Node Existence
+`chain.output`에 명시된 노드 ID는 `chain.nodes`에 반드시 존재해야 한다. `validate_chain`이 검사한다.
+
+### INV-CHAIN-003: Unique Node IDs
+동일 체인 내에서 노드 ID는 중복될 수 없다. `validate_chain_strict`가 중첩 노드 포함 전체를 검사한다.
+
+### INV-CHAIN-004: Depth Limit
+서브그래프 중첩 깊이는 `chain_config.max_depth`를 초과할 수 없다. `calculate_depth`가 컴파일 타임에 검사한다.
+
+### INV-CHAIN-005: Input Reference Resolution
+`{{node_id.output}}` 참조는 실행 시점에 반드시 해소되어야 한다. 위상 정렬 순서가 의존성 노드의 선행 실행을 보장한다.
+
+### INV-CHAIN-006: Consensus Quorum
+Quorum 노드에서 `Count(n)`의 n은 `0 < n <= len(nodes)`를 만족해야 한다. n=0이면 항상 성공, n > len(nodes)이면 항상 실패하므로 무의미하다.
+
+### INV-CHAIN-007: Cascade Tier Ordering
+Cascade의 `tiers`는 `tier_index` 순으로 정렬되어 실행된다. 0이 가장 저비용 tier이다.
+
+### INV-CHAIN-008: Retry Bound
+Retry 노드의 `max_attempts`는 유한해야 한다. 무한 재시도를 방지한다.
+
+### INV-CHAIN-009: Placeholder Resolution
+Mermaid 파싱 중 생성된 placeholder 노드는 실행 전에 모두 해소되어야 한다. `has_placeholder_node`가 검사한다.
+
+### INV-CHAIN-010: Token Usage Monotonicity
+`total_tokens`는 실행 중 단조 증가한다. `Token_monoid.concat`이 합산만 수행하고 감산하지 않는다.
+
+### INV-CHAIN-011: Trace Pairing
+모든 `NodeStart` 이벤트는 대응하는 `NodeComplete` 또는 `NodeError` 이벤트를 가져야 한다. 누락 시 `traces_to_entries`가 `start_time = end_time`인 부분 trace를 생성한다.
+
+### INV-CHAIN-012: Spawn Inflight Limit
+동시 실행 중인 Spawn 노드 수는 `MASC_SPAWN_MAX_INFLIGHT` (기본 16)을 초과할 수 없다. `chain_spawn_registry`가 제한한다.
+
+---
+
+## 15. Known Issues / Technical Debt
+
+1. **executor mutual recursion 크기**: `chain_executor_eio.ml`의 `let rec ... and ...` 블록이 27-arm으로 확장되었다. 서브 모듈 분할(leaf, complex, resilience, search)로 완화했으나, 최상위 dispatch 함수의 match 절은 여전히 단일 파일에 있다.
+
+2. **token 추정 정밀도**: `estimate_tokens`가 `String.length / 4`로 근사한다. BPE tokenizer 기반 정확한 추정이 아니므로 `token_threshold` 판단에 오차가 발생할 수 있다.
+
+3. **checkpoint persistence**: `Checkpoint_store`가 인터페이스만 정의되어 있고, 파일 시스템 구현에 의존한다. 분산 환경에서의 checkpoint 공유 메커니즘이 없다.
+
+4. **Mermaid parser 복잡도**: 4개 모듈(graph, parse, node_content, parser)로 분할되어 있지만 총 ~120K LOC로, Str 기반 regex 파싱의 edge case가 존재할 수 있다.
+
+5. **GoalDriven/FeedbackLoop 수렴 보장 없음**: `max_iterations`로 상한을 두지만, 목표 metric에 수렴하지 않는 경우 마지막 결과를 반환한다. 발산 감지 로직이 없다.
+
+6. **Chain category laws 런타임 검증만**: `Laws` 모듈이 런타임 property test를 제공하지만, 컴파일 타임 보장은 OCaml 타입 시스템의 한계로 불가능하다. CI에서 정기 실행해야 한다.
+
+---
+
+## 16. References
+
+| 문서 | 경로 |
+|------|------|
+| chain_types.mli (타입 정의 SSOT) | `lib/chain/chain_types.mli` |
+| chain_category.mli (카테고리 추상화) | `lib/chain/chain_category.mli` |
+| chain_compiler.mli (컴파일러 인터페이스) | `lib/chain/chain_compiler.mli` |
+| chain_executor_eio.mli (실행기 인터페이스) | `lib/chain/chain_executor_eio.mli` |
+| chain_telemetry.mli (텔레메트리 인터페이스) | `lib/chain/chain_telemetry.mli` |
+| chain_error.ml (에러 타입 정의) | `lib/chain/chain_error.ml` |
+| chain_parser.mli (파서 인터페이스) | `lib/chain/chain_parser.mli` |
+| chain_orchestrator_eio.ml (오케스트레이터) | `lib/chain/chain_orchestrator_eio.ml` |
+| 02-types-and-invariants.md (상위 타입 명세) | `docs/spec/02-types-and-invariants.md` |

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -1,0 +1,623 @@
+# Keeper Agent System
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Keeper |
+| Maps to | `lib/keeper/` (72 files) |
+| Dependencies | 02-types-and-invariants, 13-oas-integration |
+| Modules | 67 (.ml) + 5 (.mli-only) |
+| LOC | ~17.8K |
+| MCP Tools | `tool_keeper` |
+| External Deps | `Agent_sdk` (OAS), `Llm_provider`, `Room`, `Cascade_inference`, `Verifier_oas` |
+
+---
+
+## 1. Purpose
+
+Keeper는 MASC의 자율 에이전트 하네스(harness)다. OAS `Agent.run` 위에서 동작하며, 장기 실행(perpetual) 루프, 컨텍스트 관리, 메모리 계층, 심의(deliberation), 승계(succession), 검증(verification)을 담당한다.
+
+Keeper 하나는 다음을 소유한다:
+- **identity**: `keeper_meta` 레코드 (이름, 목표, soul profile, will/needs/desires)
+- **context**: `working_context` (system prompt + messages + token count + OAS context)
+- **memory**: memory bank + memory policy + recall scoring
+- **lifecycle**: heartbeat fiber + supervisor + checkpoint store
+
+Keeper는 외부 세계를 관찰(`world_observation`)하고, 프롬프트를 구성하고, OAS `Agent.run`에 위임하고, 결과로부터 메트릭을 갱신하는 루프를 반복한다.
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph LR
+  subgraph Types
+    KT[keeper_types] --> KC[keeper_config]
+    KT --> KCT[keeper_contract]
+  end
+  subgraph Context
+    KWC[working_context] --> KEC[exec_context] --> KCS[checkpoint_store]
+  end
+  subgraph Memory
+    KMB[memory_bank] --> KMP[memory_policy] --> KMR[memory_recall]
+  end
+  subgraph Turn
+    KUT[unified_turn] --> KAR[agent_run] --> KTO[tools_oas]
+    KAR --> KHO[hooks_oas]
+  end
+  subgraph Decision
+    KD[deliberation] --> KV[verifier]
+    KD --> KL[learning]
+  end
+  subgraph Supervision
+    KRS[supervisor] --> KKA[keepalive]
+  end
+  KUT --> KWO[world_observation]
+  KAR -.-> OAS["OAS Agent.run()"]
+```
+
+### 2.1 모듈 분류 (12 범주)
+
+| 범주 | 대표 파일 | 파일 수 |
+|------|----------|--------|
+| Types | `keeper_types.ml`, `_profile.ml`, `_resident.ml` | 3 |
+| Config / Contract | `keeper_config.ml`, `keeper_contract.ml`, `keeper_toml_loader.ml` | 3 |
+| Context | `keeper_working_context.ml`, `keeper_exec_context.ml`, `keeper_checkpoint_store.ml` | 3 |
+| Memory | `keeper_memory*.ml` (bank, policy, recall) | 4 |
+| Prompt / Skill | `keeper_prompt.ml`, `keeper_unified_prompt.ml`, `keeper_skill_routing.ml` | 3 |
+| Turn Execution | `keeper_agent_run.ml`, `keeper_unified_turn.ml`, `keeper_tools_oas.ml`, `keeper_hooks_oas.ml`, `keeper_extend_turns.ml` | 5 |
+| Decision | `keeper_deliberation.ml`, `keeper_verifier.ml`, `keeper_learning.ml`, `keeper_feedback_tool.ml` | 4 |
+| Supervision | `keeper_resident_supervisor.ml`, `keeper_keepalive.ml`, `keeper_world_observation.ml` | 3 |
+| MCP Surface | `keeper_turn.ml`, `keeper_status.ml`, `keeper_persona.ml`, `keeper_schema.ml` | 4 |
+| Alerting / Metrics | `keeper_alerting*.ml`, `keeper_exec_status*.ml`, `keeper_status_detail.ml` | 6+ |
+
+---
+
+## 3. Types
+
+### 3.1 keeper_meta
+
+Keeper의 전체 상태를 담는 레코드. `lib/keeper/keeper_types.ml`에 정의되며, 약 100개 필드를 가진다.
+
+**소스**: `keeper_types.ml` (lines 9-106)
+
+주요 필드 군 (16개 범주, ~100 필드):
+
+- **Identity**: `name`, `agent_name`, `trace_id`, `trace_history`
+- **Goal (3-horizon)**: `goal`, `short_goal`, `mid_goal`, `long_goal`
+- **Self-Model (BDI)**: `soul_profile`, `will`, `needs`, `desires`
+- **Model**: `models`, `allowed_models`, `active_model`
+- **Policy**: `policy_mode`, `policy_action_budget`, `policy_shell_mode`
+- **Initiative**: `initiative_enabled`, `initiative_idle_sec`, `initiative_cooldown_sec`
+- **Scope/Trigger**: `scope_kind`, `room_scope`, `trigger_mode`, `mention_targets`
+- **Proactive**: `proactive_enabled`, `proactive_idle_sec`, `proactive_cooldown_sec`
+- **Drift**: `drift_enabled`, `drift_min_turn_gap`, `drift_count_total`
+- **Compaction**: `compaction_profile`, `compaction_ratio_gate`, `compaction_message_gate`
+- **Handoff**: `auto_handoff`, `handoff_threshold`, `handoff_cooldown_sec`
+- **Metrics**: `total_turns`, `total_tokens`, `total_cost_usd`, `last_turn_ts` 등
+- **Deliberation**: `deliberation_count`, `deliberation_cost_total_usd`
+- **Team/Autonomy**: `auto_team_session_enabled`, `autonomy_level`, `active_goal_ids`
+
+직렬화: `meta_to_json` / `meta_of_json`로 JSON 왕복. `validate_name`이 역직렬화 시점에 이름/trace_id를 검증한다.
+
+### 3.2 working_context
+
+**소스**: `keeper_working_context.ml` (lines 25-32)
+
+```ocaml
+type working_context = {
+  system_prompt : string;
+  messages : Agent_sdk.Types.message list;
+  token_count : int;
+  max_tokens : int;
+  importance_scores : (int * float) list;
+  oas_context : Agent_sdk.Context.t;
+}
+```
+
+Keeper의 실행 중 대화 컨텍스트. `oas_context`는 OAS Context 모듈과 동기화된다(`sync_oas_context`).
+
+토큰 추정: `msg_tokens = (String.length text / 4) + 4` (문자 기반 근사치).
+
+### 3.3 checkpoint / session_context
+
+```ocaml
+type checkpoint = {
+  checkpoint_id : string;
+  timestamp : float;
+  generation : int;
+  message_count : int;
+  token_count : int;
+  serialized : string;      (* JSON-serialized working_context *)
+}
+
+type session_context = {
+  session_id : string;
+  session_dir : string;
+  mutable checkpoints : checkpoint list;
+}
+```
+
+세션당 최대 3개 체크포인트가 유지된다(`max_checkpoints_retained = 3`). 세션 메시지는 `history.jsonl`에 영속화.
+
+### 3.4 Typed Policy Enums (keeper_contract.ml)
+
+```ocaml
+type policy_mode =
+  | Heuristic
+  | Learned_offline_v1
+  | Explicit_event_v1
+  | Model_deliberation
+
+type policy_action_budget = Conversation | Board
+type scope_kind = Local | Global
+type room_scope = Current | All
+type trigger_mode = Legacy | Explicit_only
+```
+
+JSON/MCP 경계에서는 문자열로 변환되지만, 내부 로직은 이 variant 타입으로 분기한다.
+
+### 3.5 fiber_health
+
+```ocaml
+type fiber_health =
+  | Fiber_alive     (* fiber 실행 중, promise 미해소 *)
+  | Fiber_zombie    (* registry 존재하나 fiber 종료 *)
+  | Fiber_dead      (* 재시작 예산 소진, 수동 복구 필요 *)
+  | Fiber_unknown   (* supervised registry에 없음 *)
+```
+
+Supervisor가 keeper fiber의 건강 상태를 추적하는 데 사용.
+
+### 3.6 soul_profile
+
+| 값 | 별칭 | 의미 |
+|----|------|------|
+| `balanced` | `default` | 범용 (기본값) |
+| `safety` | `guardian` | 안전 우선, 리스크 보존 |
+| `delivery` | `executor` | 실행/산출물 우선 |
+| `research` | `analyst` | 가설 검증 우선 |
+| `relationship` | `companion` | 관계/소통 우선 |
+| `minimal` | `lean` | 최소 프롬프트 |
+
+Soul profile에 따라 compaction 시 보존 우선순위가 달라진다(`soul_profile_policy`).
+
+---
+
+## 4. State Machines
+
+### 4.1 Unified Turn Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Observe
+  Observe --> BuildPrompt : world_observation 수집
+  BuildPrompt --> AgentRun : unified prompt + tools + hooks
+  AgentRun --> ToolExecution : Agent.run 내부 tool loop
+  ToolExecution --> AgentRun : tool 결과 반환
+  AgentRun --> UpdateMetrics : Agent.run 완료
+  UpdateMetrics --> Checkpoint : 메트릭 갱신
+  Checkpoint --> CompactCheck : checkpoint 저장
+  CompactCheck --> [*] : 아래 threshold
+  CompactCheck --> Compact : threshold 초과
+  Compact --> [*] : context 압축 후 종료
+```
+
+단계 설명:
+
+1. **Observe**: `keeper_world_observation.observe`로 room 상태, 멘션, board 이벤트, idle 시간, 경제 압력 등을 수집
+2. **BuildPrompt**: `keeper_unified_prompt.build_prompt`로 keeper identity + observation을 단일 (system_prompt, user_message) 쌍으로 조립
+3. **AgentRun**: `keeper_agent_run.run_turn`이 OAS `Agent.run`에 위임. tools + hooks + context_reducer + memory 전달
+4. **ToolExecution**: Agent가 tool을 호출하면 `keeper_tools_oas`가 `keeper_exec_tools.execute_keeper_tool_call`로 디스패치
+5. **UpdateMetrics**: `keeper_unified_turn.update_metrics_from_result`가 turn count, token 사용량, cost 등을 keeper_meta에 반영
+6. **Checkpoint**: `keeper_exec_context.save_checkpoint`로 working_context를 JSON 파일에 영속화
+7. **CompactCheck**: ratio/message/token gate 기준 초과 시 compaction 실행
+
+### 4.2 Keeper Supervisor Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Init : supervise_keepalive 호출
+  Init --> Alive : fiber 시작 + Promise 등록
+  Alive --> Alive : heartbeat loop 반복
+  Alive --> Zombie : fiber 종료 (Promise 해소)
+  Zombie --> Alive : sweep_and_recover (backoff 내)
+  Zombie --> Dead : restart budget 소진
+  Dead --> [*] : 수동 복구 필요
+```
+
+- `supervise_keepalive`: keeper heartbeat loop을 supervised fiber로 실행
+- `sweep_and_recover`: 주기적으로 zombie 감지, exponential backoff로 재시작
+- Backoff: `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` * 2^attempt (최대 `_MAX_S`)
+- 최근 5건의 crash log 유지
+
+### 4.3 Compaction Policy
+
+```mermaid
+stateDiagram-v2
+  [*] --> Check
+  Check --> Blocked : ratio < ratio_gate AND messages < message_gate AND tokens < token_gate
+  Check --> CooldownHold : continuity_reflection 쿨다운 미충족
+  Check --> Apply : threshold 초과 + 쿨다운 충족
+  Apply --> PruneToolOutputs
+  PruneToolOutputs --> MergeContiguous
+  MergeContiguous --> DropLowImportance
+  DropLowImportance --> SummarizeOld
+  SummarizeOld --> [*] : compacted context 반환
+  Blocked --> [*]
+  CooldownHold --> [*]
+```
+
+Compaction은 OAS `Context_compact_oas` 모듈에 위임하며, 4단계 전략을 순차 적용:
+1. `PruneToolOutputs` -- 도구 출력 축소
+2. `MergeContiguous` -- 연속 메시지 병합
+3. `DropLowImportance` -- 중요도 낮은 메시지 제거
+4. `SummarizeOld` -- 오래된 메시지 요약
+
+Compaction profile별 gate 기본값:
+
+| Profile | ratio_gate | message_gate | token_gate |
+|---------|-----------|--------------|------------|
+| `aggressive` | 0.35 | 120 | 60,000 |
+| `balanced` | 0.50 | 240 | 120,000 |
+| `conservative` | 0.70 | 480 | 250,000 |
+| `custom` | env 기반 | env 기반 | env 기반 |
+
+### 4.4 Deliberation Pipeline
+
+Triage -> BudgetCheck -> (ModelDeliberation | DeterministicBaseline) -> Execute -> RecordDecision
+
+9가지 triage 트리거: `DirectMention`, `NewUnclaimedTask`, `FailedTask`, `AgentJoinedOrLeft`, `GoalDeadline`, `BoardActivity(string)`, `IdleTimeout`, `MetricsAnomaly(string)`, `StrategicReview`. 트리거가 없으면 Skip.
+
+---
+
+## 5. Protocol / Data Flow
+
+### 5.1 keeper_msg (메시지 턴)
+
+1. `handle_keeper_msg` -> `run_turn` 호출
+2. `load_context_from_checkpoint`로 세션/컨텍스트 복원
+3. `build_keeper_system_prompt` + `build_turn_prompt` callback으로 프롬프트 구성
+4. `make_tools` (keeper tool bridge) + `make_hooks` (safety gates) 생성
+5. `Oas_worker.run_named` -> OAS `Agent.run` loop (tool calls -> hooks -> response)
+6. `persist_message` (assistant 응답 영속화)
+7. 결과 반환: `run_result { response_text, model_used, turn_count, tool_calls_made, usage, tools_used }`
+
+### 5.2 Unified Keeper Turn (heartbeat 경로)
+
+1. `keeper_keepalive` heartbeat tick
+2. `world_observation.observe` -> 세계 상태 수집
+3. `unified_turn.run_unified_turn` -> `build_prompt` + `run_turn`
+4. `update_metrics_from_result` -> keeper_meta 갱신
+5. `write_meta` -> 메타데이터 영속화
+
+### 5.3 OAS 통합 구성
+
+`run_turn`이 OAS에 전달: `cascade_name`(모델 선택), `tools`(keeper_tools_oas + extend_turns), `hooks`(cost/destructive guard), `context_reducer`(keep_last 30 + Prune_tool_outputs + Merge_contiguous), `memory`(institution + procedures + bank + episodes), `initial_messages`(checkpoint 복원).
+
+---
+
+## 6. Memory Subsystem
+
+### 6.1 계층 구조
+
+```
+keeper_memory.ml (facade)
+  |-- keeper_memory_recall.ml (recall scoring, cost calculation)
+       |-- keeper_memory_bank.ml (bank persistence, dedup, filtering)
+            |-- keeper_memory_policy.ml (retention caps, profile-based selection)
+```
+
+### 6.2 Memory Bank
+
+- 저장 경로: `.masc/keeper-memory/{name}/memory_bank.jsonl`
+- 레코드 형식: `(kind, text, priority)` 튜플
+- Kind 예시: `"goal"`, `"observation"`, `"reflection"`, `"procedure"`
+- Dedup: `normalize_memory_text_key`로 공백/구두점 제거 후 비교
+- Placeholder 필터: `"none"`, `"null"`, `"없음"` 등은 무의미로 간주하여 제외
+
+### 6.3 Memory Policy
+
+Profile별 종류당 보존 상한:
+
+| Profile | Total cap | Kind caps |
+|---------|----------|-----------|
+| `aggressive` | 낮음 | 종류별 상한 타이트 |
+| `balanced` | 중간 | 기본 |
+| `conservative` | 높음 | 종류별 상한 느슨 |
+
+`select_memory_candidates_by_profile`이 profile에 맞게 메모리를 필터링.
+
+### 6.4 Memory Recall
+
+- `is_memory_recall_query`: 사용자 메시지가 기억 관련 질의인지 감지 (한국어 + 영어 needle 매칭)
+- `expected_topic_hint`: 질의에서 기대 토픽 추출
+- `read_keeper_memory_summary`: memory bank에서 최근 N개 라인 읽어 요약
+- Cost 계산: `cost_usd_of_usage`로 모델별 가격 추정
+
+### 6.5 OAS Memory Bridge
+
+`run_turn`에서 `Memory_oas_bridge.create_memory`로 5계층 seeding: institution(조직), procedures(절차), memory_bank(개별), episodes(에피소드), procedures_as_oas. 턴 후 `flush_all`로 영속화.
+
+---
+
+## 7. Evaluation and Verification
+
+### 7.1 Keeper Verifier (Generator-Verifier Loop)
+
+**소스**: `lib/keeper/keeper_verifier.ml`
+
+파이프라인: `evaluate_next_action` -> `generate_action_plan` -> `verify_action`
+
+```
+proposed_action
+  |-- cost_guard: estimated_cost > $0.10 -> Block
+  |-- risk_guard: `Dangerous -> Block
+  |-- Verifier_oas.verify -> Pass/Warn/Fail -> Proceed/Caution/Block
+```
+
+판정 결과:
+
+| Verdict | 의미 |
+|---------|------|
+| `Proceed` | 실행 진행 |
+| `ProceedWithCaution(reason)` | 실행하되 trajectory에 경고 기록 |
+| `Block(reason)` | 실행 거부, broadcast 알림 |
+
+Risk 추정: goal의 horizon + priority 조합으로 `Safe` / `Moderate` / `Dangerous` 결정.
+
+### 7.2 Eval Harness (`lib/eval_harness.ml`)
+
+시나리오 기반 행동 평가. `scenario`(goal + graders + tool expectations) -> `Deterministic`(Exact/Contains/Regex) 또는 `ModelBased`(MODEL 채점) grader -> weight 합산 점수.
+
+### 7.3 Anti-Fake (`lib/anti_fake.ml`)
+
+테스트 코드 품질 점수화. 감점: `assert true`(-0.3), `let _ =`(-0.2). 가점: `Alcotest.check`, `roundtrip`, `QCheck`. 등급: fake/suspect/acceptable/quality.
+
+### 7.4 Trajectory (`lib/trajectory.ml`)
+
+Tool call을 `.masc/trajectories/{name}/{trace_id}.jsonl`에 JSONL 기록. 용도: replay, cost 추적, entropy 감지, eval 입력.
+
+---
+
+## 8. Hooks (OAS Integration)
+
+**소스**: `lib/keeper/keeper_hooks_oas.ml`
+
+OAS Agent.run의 hook lifecycle에 keeper 동작을 주입:
+
+### 8.1 pre_tool_use
+
+| 검사 | 동작 |
+|------|------|
+| Cost budget | 누적 cost가 한도 초과 시 tool call 거부 |
+| Destructive pattern | `rm -rf`, `drop table`, `force push` 등 위험 패턴 감지 시 거부 |
+| Autonomy filter | autonomy_level에 따라 허용 tool 목록 필터링 |
+
+Destructive check 대상 도구: `keeper_bash`, `keeper_fs_edit`, `keeper_edit`, `keeper_github`
+
+### 8.2 Autonomy Level Tool Gating
+
+| Level | 허용 도구 |
+|-------|----------|
+| `l3_guided` | board ops + read-only shell + code navigation |
+| `l4_autonomous` | l3 + `keeper_bash` + `keeper_fs_edit` + `keeper_edit` |
+| `l5_independent` | 제한 없음 (AllowAll) |
+
+---
+
+## 9. Configuration
+
+### 9.1 keeper_config.ml 핵심 파라미터
+
+모든 환경변수는 `MASC_KEEPER_` 접두사를 사용한다. 전체 목록은 `lib/keeper/keeper_config.ml` 참조.
+
+**Compaction**: `COMPACT_RATIO`(0.5), `COMPACT_MAX_MESSAGES`(240), `COMPACT_MAX_TOKENS`(0), `CONTINUITY_COMPACTION_COOLDOWN_SEC`(90)
+
+**Proactive**: `PROACTIVE_TEMP_LOW/MID/HIGH`(0.55/0.75/0.9), `PROACTIVE_SIMILARITY`(0.72), `PROACTIVE_MAX_TOKENS`(1024)
+
+**Cost Gates**: `COST_GATE_USD`(0.10), `TOOL_COST_MAX_USD`(0.50)
+
+**Unified Turn**: `UNIFIED_TEMP`(0.4), `UNIFIED_MAX_TOKENS`(2048), `UNIFIED_MAX_TURNS`(1000)
+
+**Execution**: `MAX_TOOL_ROUNDS`(3), `AUTONOMOUS_MAX_TOKENS`(4000), `DELIBERATION_MAX_TOKENS`(1024), `DELIBERATION_DAILY_BUDGET_USD`
+
+**Other**: `DEBUG`(0), `SKILL_SELECTION`(agent), `BOOTSTRAP_PROACTIVE_WARMUP_SEC`(60)
+
+**Rule Engine**: `RULE_REFLECT_REPETITION`(0.86), `RULE_GUARDRAIL_REPETITION`(0.90), `RULE_GUARDRAIL_CONTEXT_MIN`(0.70)
+
+### 9.2 TOML Configuration
+
+`config/keepers/*.toml`로 keeper를 선언적으로 정의. 파일명이 keeper 이름. 지원 타입: string, int, float, bool, string array. 테이블은 dotted key로 평탄화. 예시: `config/keepers/example.toml`.
+
+### 9.3 Resident Keeper Spec
+
+상주 keeper는 `.masc/resident-keepers/{name}.json`에 영속화. `desired: bool`이 부팅 시 자동 시작 여부를 결정. `seed_meta`에 초기 `keeper_meta` JSON을 포함.
+
+---
+
+## 10. Proactive Behavior
+
+Keeper는 idle 상태에서 주기적으로 자발적 행동을 생성한다.
+
+### 10.1 Quality Gate
+
+`proactive_quality_check`가 생성된 텍스트를 검증:
+
+1. `extract_checkin_text`: `CHECKIN:` 접두사 추출 또는 전체 텍스트 사용
+2. `proactive_looks_fragmentary`: 미완성 문장 감지 (`"`, `(`, `:`, `-` 등으로 끝남)
+3. `proactive_has_terminal_ending`: 종결 구두점 또는 한국어 종결 어미(`다`, `요`, `니다`, `습니다`) 확인
+4. Similarity check: 이전 출력과 Jaccard 유사도 >= threshold(0.72) 시 재생성
+
+실패 시 최대 3회 재시도, temperature를 점진적으로 상승(0.55 -> 0.75 -> 0.9).
+
+### 10.2 Fallback Reply
+
+3회 모두 실패하면 deterministic fallback 템플릿 사용. Soul profile에 따라 문구가 달라진다:
+- `safety`: "리스크 우선 점검을 마쳤고"
+- `delivery`: "실행 단위로 정리해 두었고"
+- `research`: "가설 검증 포인트를 갱신했고"
+
+---
+
+## 11. Self-Model Drift
+
+**소스**: `keeper_prompt.ml` (`apply_self_model_drift`)
+
+Keeper는 작업 내용에 따라 자기 모델(will, needs, desires)을 점진적으로 변이시킨다.
+
+- `drift_enabled`: 드리프트 활성화 여부
+- `drift_min_turn_gap`: 최소 턴 간격 (기본 6턴)
+- `drift_max_clauses`: 최대 절 수 (기본 6개)
+- `drift_max_chars`: 최대 문자 수 (기본 320자)
+
+Semicolon으로 구분된 절 목록에 새 절을 추가하고, 상한 초과 시 오래된 절을 제거(`take_last`).
+
+---
+
+## 12. Learning System
+
+**소스**: `lib/keeper/keeper_learning.ml`
+
+심의(deliberation) 결정을 JSONL로 기록하고 replay:
+
+```ocaml
+type decision_record = {
+  id : string;
+  keeper_name : string;
+  timestamp : float;
+  triggers : string list;
+  observation_json : Yojson.Safe.t;
+  prompt_hash : string;
+  action_chosen : string;
+  action_json : Yojson.Safe.t;
+  reasoning : string;
+  confidence : float;
+  cost_usd : float;
+  outcome : string;
+  outcome_detail : string;
+  feedback_score : float option;   (* [-1.0, 1.0] *)
+  feedback_comment : string;
+}
+```
+
+- `record_decision`: JSONL에 append
+- `record_outcome`: 기존 decision의 outcome 필드 갱신
+- `record_feedback`: 인간 피드백 (score + comment) 기록
+- `keeper_feedback_tool`: MCP tool로 피드백 수집
+
+---
+
+## 13. Skill Routing
+
+**소스**: `lib/keeper/keeper_skill_routing.ml`
+
+Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
+
+허용 skill 목록: `masc-heartbeat`, `lodge-social`, `masc-keeper-autonomy`, `trpg-roleplay`
+
+선택 모드:
+- `SkillSelectHeuristic`: soul_profile + 메시지 내용 기반 규칙 매칭
+- `SkillSelectAgent`: MODEL에 skill 선택 위임 (기본값, env `MASC_KEEPER_SKILL_SELECTION`으로 전환)
+
+---
+
+## 14. Invariants
+
+### INV-KEEPER-001: keeper_meta.name 유효성
+
+`validate_name`이 `^[A-Za-z0-9._-]+$` 정규식으로 이름을 검증한다. 빈 문자열 또는 특수문자 포함 시 `meta_of_json`이 `Error`를 반환한다.
+
+### INV-KEEPER-002: trace_id 유일성
+
+`generate_trace_id`는 `trace-{ms_timestamp}-{5hex_hash}` 형식으로 생성된다. 동일 밀리초 내에서도 `gettimeofday` hash가 달라 충돌 가능성이 낮다.
+
+### INV-KEEPER-003: checkpoint 최대 3개
+
+`max_checkpoints_retained = 3`. `save` 후 `prune`이 호출되어 초과분을 삭제한다.
+
+### INV-KEEPER-004: compaction cooldown 강제
+
+`compact_if_needed`에서 `last_reflection_ts`가 `continuity_compaction_cooldown_sec` 이내면 compaction을 건너뛴다. 이는 reflexion 직후 context가 즉시 압축되어 반성 내용이 손실되는 것을 방지한다.
+
+### INV-KEEPER-005: soul_profile 정규화
+
+`canonical_soul_profile`이 입력을 6개 허용 값 중 하나로 정규화한다. 인식 불가 시 `None`을 반환하고 기본값(`balanced`)으로 대체된다.
+
+### INV-KEEPER-006: proactive quality gate
+
+`proactive_quality_check`가 fragmentary 텍스트, 종결 어미 미포함 텍스트, 빈 텍스트를 거부한다. 3회 실패 시 deterministic fallback을 사용하여 빈 proactive 출력이 발생하지 않는다.
+
+### INV-KEEPER-007: cost guard
+
+`keeper_verifier.cost_guard`가 `estimated_cost_usd > 0.10` 초과 시 자율 행동을 차단한다. Hooks의 `pre_tool_use`에서도 누적 cost를 확인한다.
+
+### INV-KEEPER-008: risk guard
+
+`Dangerous` risk level의 행동은 자동 차단된다. `Moderate`는 verifier를 거쳐 Proceed/Caution/Block으로 분류된다.
+
+### INV-KEEPER-009: fiber_health 정합성
+
+`supervised_state.fiber_health`는 Promise 해소 여부와 동기화된다. Promise resolved + registry에 존재 = Zombie. Promise resolved + restart budget 소진 = Dead.
+
+### INV-KEEPER-010: UTF-8 안전성
+
+`utf8_safe_prefix_bytes`가 max_bytes에서 UTF-8 코드포인트 경계를 지키며 절단한다. `utf8_repair_string`이 잘못된 바이트를 U+FFFD로 치환한다. Checkpoint 직렬화 시 `sanitize_text_utf8`이 적용된다.
+
+### INV-KEEPER-011: self-model drift 상한
+
+`compact_self_model_text`가 semicolon 절을 최대 `drift_max_clauses`(6)개, `drift_max_chars`(320자)로 제한한다. 상한 초과 시 오래된 절부터 제거한다.
+
+### INV-KEEPER-012: destructive pattern screening
+
+`keeper_hooks_oas`가 `keeper_bash`, `keeper_fs_edit`, `keeper_edit`, `keeper_github` 도구에 대해 `rm -rf`, `drop table`, `force push` 등 위험 패턴을 검사한다. 감지 시 tool call을 거부한다.
+
+---
+
+## 15. Known Issues / Technical Debt
+
+### 15.1 keeper_meta 필드 수 (~100)
+
+`keeper_meta` 레코드가 약 100개 필드를 가지며 `meta_to_json`/`meta_of_json`이 각각 ~200줄이다. 필드 군(group)별 sub-record 분할이 필요하다.
+
+### 15.2 keeper_types.ml include chain
+
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_resident`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 순환 의존 회피를 위한 구조이지만 가독성이 낮다.
+
+### 15.3 keeper_memory 계층의 include chain
+
+`keeper_memory.ml` -> `keeper_memory_recall.ml` -> `keeper_memory_bank.ml` -> `keeper_memory_policy.ml` 순서로 `include`가 연쇄된다. 각 모듈의 경계가 불명확하다.
+
+### 15.4 Proactive similarity의 Jaccard 한계
+
+현재 `proactive_similarity_score`는 단어 수준 Jaccard 유사도를 사용한다. 의미적 유사성(semantic similarity)은 감지하지 못하므로, 동일 의미를 다른 단어로 표현하면 통과한다.
+
+### 15.5 Token estimation 정밀도
+
+`msg_tokens = (String.length text / 4) + 4`는 영어 기준 근사치이며, 한국어/CJK 문자에서는 과소 추정한다. BPE 기반 정밀 추정으로의 전환이 필요하다.
+
+### 15.6 OAS Memory Bridge 부분 통합
+
+MASC 자체 memory 4개(memory_stream, institution, procedural, context_manager)가 OAS Memory.t(3-tier: Scratchpad/Working/Long_term)와 별도로 운영된다. `long_term_backend` callback 연결이 미완.
+
+---
+
+## 16. References
+
+| 문서 | 경로 |
+|------|------|
+| Keeper Types | `lib/keeper/keeper_types.ml` |
+| Working Context | `lib/keeper/keeper_working_context.ml` |
+| Execution Context | `lib/keeper/keeper_exec_context.ml` |
+| Agent Run | `lib/keeper/keeper_agent_run.ml` |
+| Unified Turn | `lib/keeper/keeper_unified_turn.ml` |
+| Deliberation | `lib/keeper/keeper_deliberation.ml` |
+| Verifier | `lib/keeper/keeper_verifier.ml` |
+| Eval Harness | `lib/eval_harness.ml` |
+| Anti-Fake | `lib/anti_fake.ml` |
+| Trajectory | `lib/trajectory.ml` |
+| Supervisor | `lib/keeper/keeper_resident_supervisor.ml` |
+| Config | `lib/keeper/keeper_config.ml` |
+| TOML Example | `config/keepers/example.toml` |
+| Memory: MASC-OAS 통합 | `memory/masc-oas-memory-integration.md` |
+| Memory: keeper 재설계 | `memory/project_dashboard-keeper-detail-redesign.md` |

--- a/docs/spec/06-command-plane.md
+++ b/docs/spec/06-command-plane.md
@@ -1,0 +1,416 @@
+# Command Plane (CPv2)
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Foundation |
+| Maps to | `lib/command_plane_v2.ml`, `lib/command_plane/*.ml`, `lib/command_plane_orchestra.ml` |
+| Dependencies | 02-types-and-invariants, 03-room-coordination |
+| LOC | ~10.3K (core ~8.2K + tool surface ~2.1K) |
+| MCP Tools | 40 (unit 4, intent 4, operation 7, dispatch 6, detachment 2, policy 5, observe 6, chain 2, extra 4) |
+
+---
+
+## 1. Purpose
+
+Command Plane V2(CPv2)는 MASC의 조직 구조와 작전 운용을 관리하는 서브시스템이다. 군사 조직 비유를 차용하여 Unit(조직), Operation(작전), Detachment(파견대), Intent(의도), Policy Decision(정책 결정), Trace(추적)의 6가지 엔티티로 멀티 에이전트 환경의 지휘 통제를 모델링한다.
+
+핵심 역할:
+
+- **조직 위계 관리**: Company > Platoon > Squad > Agent_unit 4단계 트리 구조
+- **작전 생명주기**: Planned -> Active -> Paused -> Completed/Failed/Cancelled 상태 전이
+- **Search Fabric V1**: Bayesian posterior 기반 Unit-Operation 매칭 최적화
+- **정책 게이팅**: cross-platoon 재배치, kill-switch 등 위험 작업의 승인 큐
+- **Orchestra 시각화**: 전체 시스템을 node/edge/signal 그래프로 투영
+
+---
+
+## 2. Module Dependency Chain
+
+```
+Cp_types -> Cp_paths -> Cp_serde -> Cp_io
+  -> Cp_cleanup
+  -> Cp_unit -> Cp_unit_projection
+  -> Cp_snapshot_core -> Cp_snapshot_summaries -> Cp_snapshot
+  -> Cp_search_fabric -> Cp_lifecycle_search -> Cp_lifecycle_intents
+  -> Cp_lifecycle -> Cp_lifecycle_policy
+```
+
+`Command_plane_v2`는 `Cp_lifecycle_policy`를 `include`하는 backward-compatible facade이다. 외부 모듈(`tool_command_plane`, `operator_control`, `swarm_status`)은 이 facade를 통해 접근한다.
+
+`Command_plane_orchestra`는 별도 모듈로, CPv2 snapshot + Swarm status + Operator state를 node-edge-signal 그래프로 합성한다.
+
+---
+
+## 3. Core Concepts
+
+### 3.1. Unit
+
+조직 단위. 4-level 트리 구조를 형성한다.
+
+| Kind | Policy Class | Autonomy Default | Headcount Cap |
+|------|-------------|-----------------|---------------|
+| `Company` | strategic | L5_Independent | 128 |
+| `Platoon` | tactical | L4_Autonomous | 32 |
+| `Squad` | execution | L3_Guided | 8 |
+| `Agent_unit` | worker | L2_Suggestive | 1 |
+
+**구조 규칙**:
+
+- Company는 parent를 가질 수 없다 (root)
+- Platoon은 Company 아래에만 배치 가능
+- Squad는 Company 또는 Platoon 아래
+- Agent_unit은 Squad 아래에만
+
+**자동 생성**: managed unit이 없거나 root가 여러 개이면 `company-runtime` 자동 생성. 할당되지 않은 live agent는 `squad-unassigned`에 배치된다.
+
+**Unit Record 주요 필드**:
+- `unit_id`, `label`, `kind`, `parent_unit_id`
+- `leader_id`, `roster` (agent 목록)
+- `capability_profile` (태그 기반: `runtime:xxx`, `model:xxx`, `tool:xxx`)
+- `policy` (policy_envelope), `budget` (budget_envelope)
+
+#### Policy Envelope
+
+```ocaml
+type policy_envelope = {
+  policy_class : string;       (* strategic | tactical | execution | worker *)
+  approval_class : string;     (* strict | guarded *)
+  tool_allowlist : string list;
+  model_allowlist : string list;
+  requires_human_for : string list;
+  autonomy_level : string;     (* L2..L5 *)
+  escalation_timeout_sec : int;
+  kill_switch : bool;
+  frozen : bool;
+}
+```
+
+#### Budget Envelope
+
+```ocaml
+type budget_envelope = {
+  headcount_cap : int;
+  active_operation_cap : int;
+  max_cost_usd : float;
+  max_tokens : int;
+}
+```
+
+### 3.2. Operation
+
+지휘 통제의 실행 단위. 목표(objective)를 Unit에 할당하고, 상태를 추적한다.
+
+**Operation Status 상태 전이**:
+
+```
+Planned -> Active -> Paused -> Active (resume)
+                  -> Completed (finalize)
+                  -> Failed
+                  -> Cancelled (stop)
+```
+
+**Operation Record 주요 필드** (22개):
+- `operation_id`, `objective`, `assigned_unit_id`, `trace_id`
+- `intent_id` (optional, Intent와 연결)
+- `workload_profile`: `coding_task` | `research_pipeline`
+- `workload_template`: `coding_team` | `research_team` | `ops_governance_team`
+- `stage`: workload에 따른 단계 (coding: decompose/inspect/implement/verify/review)
+- `search_strategy`: `best_first_v1` | `legacy`
+- `chain`: 선택적 Chain Engine 연결 (chain_record)
+- `checkpoint_ref`: 검증 지점 참조
+- `detachment_session_id`: Team Session 연결
+
+**Workload Profile별 Stage Graph**:
+
+| Profile | Stages |
+|---------|--------|
+| `coding_task` | decompose -> inspect -> implement -> verify -> review |
+| `research_pipeline` | normalize -> verify -> curate -> rank -> audit |
+
+`coding_task`의 `verify` stage는 `implement` dependency를 필수로 요구하고, `review`는 `verify` dependency를 요구한다.
+
+### 3.3. Intent
+
+Operation 위에 위치하는 목표 추적 단위. 여러 Operation을 하나의 의도 아래 묶는다.
+
+**Intent State**: Adopted -> Active_intent -> Blocked_intent -> Suspended_intent -> Handoff_ready -> Completed_intent -> Dropped_intent
+
+Intent는 `workload_profile`, `success_metric`, `invariants`, `artifact_priors`, `current_focus`를 보유한다. Operation 상태 변화 시 연결된 Intent 상태가 자동 갱신된다.
+
+### 3.4. Detachment
+
+Operation에서 파생되는 실행 파견 단위. Operation이 활성화되면 할당된 Unit의 roster와 leader를 기반으로 Detachment가 자동 생성(`sync_managed_detachments`)된다.
+
+주요 필드: `detachment_id`, `operation_id`, `assigned_unit_id`, `leader_id`, `roster`, `session_id`, `runtime_kind`, `runtime_ref`, `heartbeat_deadline`.
+
+### 3.5. Policy Decision
+
+위험 작업(cross-platoon move, kill-switch, freeze)에 대한 승인 큐. `pending` -> `approved`/`denied`/`expired` 상태를 거친다. TTL 기반 자동 만료가 적용된다.
+
+### 3.6. Trace (Event)
+
+모든 CPv2 변경은 `events.jsonl`에 append-only로 기록된다. 각 event는 `event_id`, `trace_id`, `event_type`, `operation_id`, `unit_id`, `actor`, `ts`, `detail`을 포함한다. trace_id로 Operation의 전체 생애를 추적할 수 있다.
+
+---
+
+## 4. Persistence
+
+### 4.1. Canonical Paths
+
+모든 CP 데이터는 `.masc/control-plane/` 디렉터리에 JSON/JSONL로 저장된다.
+
+| Path | Format | Entity |
+|------|--------|--------|
+| `units.json` | JSON (versioned wrapper) | Unit records |
+| `operations.json` | JSON (versioned wrapper) | Operation records |
+| `intents.json` | JSON (versioned wrapper) | Intent records |
+| `detachments.json` | JSON (versioned wrapper) | Detachment records |
+| `decisions.json` | JSON (versioned wrapper) | Policy decision records |
+| `events.jsonl` | JSONL (append-only) | Event log |
+| `search-stats.json` | JSON | Search Fabric stats |
+| `traces/` | Directory | Trace artifacts |
+| `archive/operations.json` | JSON | Archived terminal operations |
+| `swarm-live/` | Directory | Swarm live artifacts per run |
+
+### 4.2. I/O Layer (`cp_io.ml`)
+
+모든 read/write는 `Cp_io`를 경유한다. `ensure_dirs`로 디렉터리 존재를 보장한다. JSON wrapper는 항상 `{"version": "cp-v2", "updated_at": "...", "<entity>": [...]}` 형태를 유지한다.
+
+Event ID 생성: `{prefix}-{unix_ms}-{random_hex4}` (예: `op-1711234567890-a3f2`)
+
+---
+
+## 5. Snapshot System
+
+### 5.1. snapshot_state
+
+6개 데이터 섹션을 하나의 레코드로 합성한다.
+
+```ocaml
+type snapshot_state = {
+  config : Room.config;
+  agents : Types.agent list;
+  managed_units : unit_record list;
+  units : unit_record list;       (* managed + auto-generated *)
+  source : string;                (* "auto" | "hybrid" | "explicit" *)
+  sessions : session list;        (* capped at 50 *)
+  intents : intent_record list;
+  operations : operation_record list;
+  detachments : detachment_record list;
+  decisions : policy_decision_record list;
+  live_agents : string list;
+  status_map : (string * string) list;
+  child_map : (string * unit_record list) list;
+  unit_lookup : (string * unit_record) list;
+}
+```
+
+### 5.2. Section Cache
+
+`section_cache`는 mutable record로, 각 섹션별 file mtime을 추적하여 변경된 파일만 re-read한다. heartbeat 등의 빈번한 변경이 전체 재빌드를 유발하지 않도록 incremental update를 수행한다 (5초 full rebuild -> sub-100ms).
+
+6개 섹션: topology(units+agents), sessions, intents, operations, detachments, decisions. 각 섹션은 자신의 의존 섹션 mtime도 추적한다 (예: operations는 topology, sessions 변경 시 재계산).
+
+### 5.3. Summary Outputs
+
+`summary_json`은 7개 하위 요약(topology, intents, operations, detachments, alerts, decisions, swarm_proof)을 합성한다.
+
+Alerts는 Unit 상태(leader_missing, roster_offline, headcount_cap_exceeded 등)와 Operation 상태(orphaned_operation, detachment_quiet)에서 파생된다. severity 기반 정렬: bad > warn. 6h+ quiet detachment는 critical로 승격.
+
+---
+
+## 6. Search Fabric V1
+
+### 6.1. Strategy
+
+| Strategy | 설명 |
+|----------|------|
+| `legacy` | 단순 후보 필터링, score 없음 |
+| `best_first_v1` | 10차원 weighted scoring, Bayesian posterior |
+
+`best_first_v1`이 기본값. `legacy`는 explicit opt-out.
+
+### 6.2. Score Breakdown (10 dimensions)
+
+```ocaml
+type score_breakdown = {
+  capability_match : float;        (* max 25.0 — keyword overlap + stage bonus *)
+  artifact_locality : float;       (* max 20.0 — artifact scope keyword match *)
+  intent_successor : float;        (* reserved, 0.0 *)
+  verification_readiness : float;  (* reserved, 0.0 *)
+  runtime_fit : float;             (* max 15.0 — runtime/model/tool tag match *)
+  posterior_success : float;       (* max 15.0 — Beta(alpha, beta) posterior mean *)
+  capacity_headroom : float;       (* max 10.0 — free slots / cap ratio *)
+  cost_efficiency : float;         (* max 5.0 — local/cheap model hints *)
+  queue_age : float;               (* max 5.0 — operation age normalized to 1h *)
+  stickiness : float;              (* 5.0 if current assignment, else 0.0 *)
+  total : float;
+}
+```
+
+### 6.3. Bayesian Success Tracking
+
+`stats_store`는 `(unit_id, workload_profile, stage)` 키별로 `alpha`, `beta` 파라미터를 유지한다. `posterior_mean = alpha / (alpha + beta)` (Beta distribution). Operation checkpoint 시 success, failure 시 beta를 +1.0 업데이트한다.
+
+### 6.4. Readiness
+
+Operation의 `depends_on_operation_ids`를 기반으로 upstream dependency가 완료(completed) 또는 checkpoint 존재 시 Ready, 아니면 Blocked.
+
+---
+
+## 7. Lifecycle Management
+
+### 7.1. Operation Lifecycle
+
+`start_operation`: validation chain 실행.
+
+1. `assigned_unit_id` 존재 확인 (unit_guard)
+2. `workload_template` -> `workload_profile` + `stage` 추론
+3. `workload_profile` 유효성 검증
+4. `stage` 유효성 검증 (workload별 허용 stage)
+5. `search_strategy` 유효성 검증
+6. `intent_id` 존재 + workload_profile 일치 검증
+7. `coding_task` verify/review의 dependency 요건 검증
+8. chain record 파싱
+9. Operation 생성, Detachment 동기화, Event 기록
+
+`checkpoint_operation`: checkpoint_ref 저장 + best_first_v1이면 search stats 업데이트 (success).
+
+`update_operation_status`: status 전이 + chain status 연동 + intent state 갱신 + detachment 동기화.
+
+### 7.2. Policy Lifecycle
+
+`create_policy_decision`: TTL 기반 expires_at 설정, pending 상태로 생성.
+`check_expired_decisions`: pending + expires_at < now인 decision을 expired로 전환.
+`check_blocked_intents`: Blocked_intent가 timeout_sec을 초과하면 Dropped_intent로 전환.
+
+### 7.3. Cleanup (`cp_cleanup.ml`)
+
+5단계 순차 정리:
+
+1. **Dead units**: 빈 roster + leader 없음 + stale(N일 초과) -> 삭제
+2. **Orphaned units**: parent가 존재하지 않는 unit -> 삭제
+3. **Terminal operations**: Completed/Cancelled/Failed + stale -> archive로 이동
+4. **Orphaned detachments**: operation_id가 존재하지 않는 detachment -> 삭제
+5. **Dropped intents**: Dropped_intent + stale -> 삭제
+
+`Room_hooks.cp_cleanup_fn` ref callback으로 Room_gc에서 호출되어 순환 의존을 회피한다.
+
+---
+
+## 8. Orchestration (`command_plane_orchestra.ml`)
+
+전체 시스템 상태를 `orchestra.v1` 형식의 그래프로 합성한다.
+
+### 8.1. Node Types
+
+| Kind | Visual Class | Source |
+|------|-------------|--------|
+| `room` | room-core | Room state |
+| `session` | session-island | Team sessions |
+| `operation` | operation-core | Active CP operations |
+| `detachment` | detachment-shell | Active detachments |
+| `lane` | worker-lane / control-lane | Swarm worker lanes |
+| `worker` | worker-unit | Actual swarm workers |
+| `worker` (ghost) | worker-ghost | Planned but not yet spawned |
+| `keeper` | continuity-keeper | Keeper agents |
+
+각 node는 `id`, `kind`, `label`, `tone` (ok/warn/bad), `pulse` (steady/pulse/blink/flow), `provenance` (truth/derived/fallback), `facts`, `link_tab`, `link_surface` 속성을 가진다.
+
+### 8.2. Edge Types
+
+`contains`, `attached`, `materializes`, `routes`, `feeds`, `planned`, `continuity` 등으로 node 간 관계를 표현한다.
+
+### 8.3. Signals
+
+Alert, pending confirm, runtime blocker, hot proof 등 비정상 상태를 signal로 발행한다. Focus는 bad signal > unhealthy session > room 순서로 결정된다.
+
+---
+
+## 9. MCP Tool Surface
+
+### 9.1. Unit Management (4)
+
+| Tool | 동작 |
+|------|------|
+| `masc_unit_define` | Unit 생성/수정 (kind, label, roster, policy, budget) |
+| `masc_unit_list` | Managed + effective units 조회 |
+| `masc_unit_reparent` | Unit parent 변경 |
+| `masc_unit_reassign` | Unit leader/roster 변경 |
+
+### 9.2. Intent Management (4)
+
+| Tool | 동작 |
+|------|------|
+| `masc_intent_create` | Intent 생성 |
+| `masc_intent_status` | Intent 상태 조회 |
+| `masc_intent_update` | Intent 상태/focus 갱신 |
+| `masc_intent_forecast` | Intent 예측 |
+
+### 9.3. Operation Management (7)
+
+| Tool | 동작 |
+|------|------|
+| `masc_operation_start` | Operation 생성 + validation chain |
+| `masc_operation_status` | Operation 상태 조회 (card with search context) |
+| `masc_operation_checkpoint` | Checkpoint 기록 + search stats 갱신 |
+| `masc_operation_pause` | Active -> Paused |
+| `masc_operation_resume` | Paused -> Active |
+| `masc_operation_stop` | -> Cancelled |
+| `masc_operation_finalize` | -> Completed + search stats 갱신 |
+
+### 9.4. Dispatch (6)
+
+| Tool | 동작 |
+|------|------|
+| `masc_dispatch_plan` | Search Fabric 기반 후보 scoring + 추천 |
+| `masc_dispatch_assign` | Operation을 다른 Unit으로 재할당 |
+| `masc_dispatch_rebalance` | 자동 재분배 |
+| `masc_dispatch_escalate` | 상위 Unit으로 에스컬레이션 |
+| `masc_dispatch_recall` | Detachment 회수 |
+| `masc_dispatch_tick` | 주기적 상태 갱신 |
+
+### 9.5. Policy (5)
+
+| Tool | 동작 |
+|------|------|
+| `masc_policy_status` | 보류 중인 decision 조회 |
+| `masc_policy_approve` | Decision 승인 |
+| `masc_policy_deny` | Decision 거절 |
+| `masc_policy_update` | Unit policy 직접 변경 |
+| `masc_policy_freeze_unit` / `masc_policy_kill_switch` | Unit 동결/비상 정지 |
+
+### 9.6. Observe (6)
+
+| Tool | 동작 |
+|------|------|
+| `masc_observe_topology` | Unit 트리 + health + operation count |
+| `masc_observe_alerts` | Alert 목록 (severity 정렬) |
+| `masc_observe_operations` | Operation 요약 + microarch |
+| `masc_observe_swarm` | Swarm live artifacts + proof |
+| `masc_observe_capacity` | Unit별 utilization |
+| `masc_observe_traces` | Event log + team session + operator traces |
+
+---
+
+## 10. Known Issues and Limitations
+
+| Issue | 설명 | Status |
+|-------|------|--------|
+| Search Fabric reserved dimensions | `intent_successor`, `verification_readiness`가 항상 0.0 | Reserved |
+| Cleanup callback indirection | Room_gc -> Room_hooks ref callback으로 순환 의존 회피. 직접 호출 불가 | Architectural |
+| Section cache mutable state | `section_cache`가 mutable record. 멀티 쓰레드 안전하지 않으나 Eio single-domain에서는 문제 없음 | By design |
+| orchestra.ml LOC | ~800줄. node builder + edge wiring이 같은 함수에 혼재 | Split candidate |
+
+---
+
+## 11. Configuration
+
+| Env / Config | 기본값 | 설명 |
+|-------------|--------|------|
+| `Env_config_runtime.Cp.cleanup_days` | (configurable) | Stale 판정 기준 일수 |
+| `Env_config.Decision.ttl_seconds` | (configurable) | Policy decision 만료 시간 |
+| Room state `search_strategy_default` | `best_first_v1` | Room별 기본 search strategy |
+| Room state `speculation_enabled` | false | 추측적 실행 활성화 |
+| Room state `speculation_budget` | 2 | 추측적 실행 예산 |

--- a/docs/spec/07-team-session.md
+++ b/docs/spec/07-team-session.md
@@ -1,0 +1,428 @@
+# Team Session
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Chain |
+| Maps to | `lib/team_session/*.ml`, `lib/team_context.ml`, `lib/tool_team_session*.ml` |
+| Dependencies | 03-room-coordination, 06-command-plane, 13-oas-integration |
+| LOC | ~10.8K (core ~6.3K + tool surface ~4.5K) |
+| MCP Tools | `masc_team_session_start`, `masc_team_session_step`, `masc_team_session_finalize`, +α |
+
+---
+
+## 1. Purpose
+
+Team Session은 다수의 AI 에이전트가 시간 제한 하에 공동 목표를 수행하는 감독형(supervised) 협업 세션이다. 세션은 checkpoint, report, proof artifact를 자동 생성하여 작업의 진행과 완결을 증명한다.
+
+핵심 역할:
+
+- **시간 제한 오케스트레이션**: 60s ~ 28800s (8시간) 범위의 세션 생명주기 관리
+- **다중 실행 모드**: Manual(수동), Assist(보조), Auto(자율, OAS Swarm 경유)
+- **Worker 계획/실행**: planned_worker 기반 agent 배치, routing decision, swarm 연동
+- **Checkpoint/Report/Proof**: 주기적 상태 기록, 최종 보고서와 증거 아티팩트 생성
+- **OAS Bridge**: MASC session -> OAS Swarm 변환, callback 기반 감독
+
+---
+
+## 2. Architecture
+
+```
+Team Session Engine (Eio)
+  |
+  +--> Team Session Store (persistence)
+  |      - session.json, events.jsonl, checkpoints/, worker-runs/
+  |
+  +--> Team Session OAS Bridge
+  |      - MASC session -> OAS swarm_config 변환
+  |      - planned_worker -> agent_entry 변환
+  |
+  +--> Team Session Swarm Runner
+  |      - OAS Runner.run 경유 실행 (Auto mode)
+  |
+  +--> Team Session Swarm Callbacks
+  |      - on_iteration_start -> checkpoint write
+  |      - on_agent_done -> event journal + SSE broadcast
+  |      - on_converged -> session finalization
+  |      - on_error -> policy violation recording
+  |
+  +--> Team Session Report / Proof
+  |      - Markdown + JSON report 생성
+  |      - Proof artifact (강한 증거 모드)
+  |
+  +--> Team Context
+         - worker 간 공유 컨텍스트 (~500 토큰)
+         - OAS Collaboration.t 투영
+```
+
+---
+
+## 3. Session Type
+
+`Team_session_types.session`은 47개 필드의 레코드로, 세션의 전체 상태를 표현한다.
+
+### 3.1. Core Identity (7 fields)
+
+| Field | Type | 설명 |
+|-------|------|------|
+| `session_id` | string | 고유 식별자 |
+| `goal` | string | 세션 목표 |
+| `created_by` | string | 생성자 agent |
+| `origin_kind` | session_origin_kind | Origin_human / Origin_system |
+| `room_id` | string | 소속 Room |
+| `operation_id` | string option | CPv2 Operation 연결 |
+| `status` | session_status | Running/Paused/Completed/Interrupted/Failed/Cancelled |
+
+`origin_kind`는 `orchestration_mode = Auto`이면 Origin_system, Manual/Assist에서는 `created_by`의 prefix 패턴(keeper, dashboard, operator 등)으로 자동 추론한다.
+
+### 3.2. Configuration (14 fields)
+
+| Field | Type | 기본값 |
+|-------|------|--------|
+| `duration_seconds` | int | 3600 (1h), clamp [60, 28800] |
+| `execution_scope` | execution_scope | Limited_code_change |
+| `checkpoint_interval_sec` | int | 60, clamp [10, 600] |
+| `min_agents` | int | 1, clamp [1, 64] |
+| `scale_profile` | scale_profile | Scale_standard |
+| `control_profile` | control_profile | Control_flat |
+| `orchestration_mode` | orchestration_mode | Assist |
+| `communication_mode` | communication_mode | Comm_broadcast |
+| `model_cascade` | string list | [] (Cascade module이 결정) |
+| `fallback_policy` | fallback_policy | Fallback_cascade_then_task |
+| `instruction_profile` | instruction_profile | Profile_standard |
+| `alert_channel` | alert_channel | Alert_both |
+| `auto_resume` | bool | false |
+| `report_formats` | report_format list | [Markdown; Json] |
+
+### 3.3. Runtime State (12 fields)
+
+| Field | Type | 설명 |
+|-------|------|------|
+| `turn_count` | int | 누적 turn 수 |
+| `agent_names` | string list | 참여 agent 목록 |
+| `planned_workers` | planned_worker list | 계획된 worker 사양 |
+| `broadcast_count` | int | broadcast 횟수 |
+| `portal_count` | int | portal 교환 횟수 |
+| `cascade_attempted` | int | LLM cascade 시도 횟수 |
+| `cascade_success` | int | cascade 성공 |
+| `cascade_failed` | int | cascade 실패 |
+| `fallback_task_created` | int | fallback task 생성 횟수 |
+| `min_agents_violation_streak` | int | 최소 agent 미달 연속 횟수 |
+| `policy_violations` | string list | 정책 위반 기록 |
+| `baseline_done_counts` | (string * int) list | 세션 시작 시 agent별 완료 task 수 |
+
+### 3.4. Timestamps and Termination (8 fields)
+
+| Field | Type |
+|-------|------|
+| `started_at` | float |
+| `planned_end_at` | float |
+| `stopped_at` | float option |
+| `last_checkpoint_at` | float option |
+| `last_event_at` | float option |
+| `last_turn_at` | float option |
+| `stop_reason` | string option |
+| `generated_report` | bool |
+
+### 3.5. Proof and Artifacts (4 fields)
+
+| Field | Type |
+|-------|------|
+| `final_done_delta_total` | int option |
+| `final_done_delta_by_agent` | (string * int) list option |
+| `artifacts_dir` | string |
+| `created_at_iso` / `updated_at_iso` | string |
+
+---
+
+## 4. Enum Types
+
+`Team_session_types_enums`에 정의된 30+ variant type.
+
+### 4.1. Session Status
+
+```
+Running | Paused | Completed | Interrupted | Failed | Cancelled
+```
+
+### 4.2. Orchestration Mode
+
+| Mode | 설명 |
+|------|------|
+| `Manual` | 모든 step을 agent가 명시적으로 호출 |
+| `Assist` | agent가 step을 호출하되, 시스템이 checkpoint/alert 보조 |
+| `Auto` | OAS Swarm Runner 경유 자율 실행 |
+
+### 4.3. Worker Types
+
+`planned_worker` 레코드 (24개 필드):
+
+| Field | Type | 설명 |
+|-------|------|------|
+| `spawn_agent` | string | Agent 이름 |
+| `runtime_actor` | string option | Runtime에서의 actor 식별자 |
+| `spawn_role` | string option | Worker 역할 |
+| `spawn_model` | string option | 명시 모델 |
+| `execution_scope` | execution_scope option | Observe_only/Limited_code_change/Autonomous |
+| `thinking_enabled` | bool option | Thinking mode 활성화 |
+| `thinking_budget` | int option | Thinking 토큰 예산 |
+| `max_turns` | int option | 최대 turn 수 |
+| `timeout_seconds` | int option | Worker timeout |
+| `worker_class` | worker_class option | Manager/Executor/Scout/Librarian/Metacog |
+| `capsule_mode` | capsule_mode option | Fresh/Inherit/Capsule |
+| `controller_level` | controller_level option | Root/Lane/Submanager/Worker |
+| `control_domain` | control_domain option | Execution/Quality/Knowledge/Runtime/Meta |
+| `model_tier` | model_tier option | Tier_35b/Tier_27b/Tier_9b |
+| `task_profile` | task_profile option | Extract/Normalize/Summarize/Verify/Decide/Synthesize |
+| `risk_level` | risk_level option | Low/Medium/High |
+| `routing_confidence` | float option | Routing 결정 신뢰도 |
+| `routing_reason` | string option | Routing 결정 사유 |
+| `routing_escalated` | bool | Escalation 발생 여부 |
+
+Dedup은 `planned_worker_key` 함수로 `runtime_actor` 우선, fallback으로 전체 필드 조합 키를 사용한다.
+
+---
+
+## 5. Persistence (`team_session_store.ml`)
+
+### 5.1. Directory Structure
+
+```
+.masc/team-sessions/
+  {session_id}/
+    session.json           -- session record
+    events.jsonl           -- append-only event log
+    checkpoints/           -- periodic checkpoint JSON
+    worker-runs/
+      {worker_run_id}/
+        run.json           -- worker run record
+        checkpoint.json    -- worker run checkpoint
+        meta.json          -- worker run metadata
+    workers/
+      {worker_name}/
+        meta.json          -- worker container metadata
+        checkpoint.json    -- worker checkpoint
+        turns.jsonl        -- worker turn log
+    report.md              -- final report (Markdown)
+    report.json            -- final report (JSON)
+    proof.md               -- proof artifact (Markdown)
+    proof.json             -- proof artifact (JSON)
+```
+
+### 5.2. Event Entry
+
+```ocaml
+type event_entry = {
+  ts : float;
+  ts_iso : string;
+  event_type : string;
+  detail : Yojson.Safe.t;
+}
+```
+
+### 5.3. Checkpoint
+
+```ocaml
+type checkpoint = {
+  ts : float;
+  ts_iso : string;
+  status : session_status;
+  elapsed_sec : int;
+  remaining_sec : int;
+  progress_pct : float;
+  done_delta_total : int;
+  done_delta_by_agent : (string * int) list;
+  active_agents : string list;
+}
+```
+
+`done_delta_total`은 세션 시작 후 완료된 task 수로, `baseline_done_counts`와 현재 backlog의 차이로 계산된다.
+
+---
+
+## 6. Engine Architecture (`team_session_engine_eio.ml`)
+
+### 6.1. Session 생성
+
+`start_session`은 Eio Switch/Clock context에서 실행된다.
+
+주요 validation:
+- duration/checkpoint_interval/min_agents clamp
+- `operation_id` 제공 시 CPv2 Operation 존재 + 연결 검증
+- agent_names가 비어 있으면 room의 active agent를 자동 선택
+
+생성 후: session.json 저장, 초기 event 기록, checkpoint 초기화.
+
+### 6.2. Orchestration Mode별 실행 경로
+
+| Mode | 실행 경로 |
+|------|----------|
+| Manual | Agent가 `masc_team_session_step`으로 turn 기록. Engine은 checkpoint만 수행 |
+| Assist | Manual과 동일하나 시스템이 alert, suggestion 제공 |
+| Auto | `Team_session_swarm_runner.run_swarm` 경유 OAS Swarm 실행 |
+
+Auto mode 이전의 legacy polling engine (15초 주기)은 Phase C-2d에서 제거되었다.
+
+---
+
+## 7. OAS Bridge (`team_session_oas_bridge.ml`)
+
+Phase C-1 migration 산출물. MASC Team Session을 OAS Swarm으로 변환한다.
+
+### 7.1. 변환 매핑
+
+| MASC | OAS |
+|------|-----|
+| `session` | `Swarm_types.swarm_config` |
+| `planned_worker` | `Swarm_types.agent_entry` |
+| `orchestration_mode` | `Swarm_types.orchestration_mode` |
+| `worker_class` | `Swarm_types.agent_role` |
+| `model_cascade` -> `planned_worker` | cascade_name string |
+
+### 7.2. Tool Dispatch Bridge
+
+`supported_local_worker_tools`는 사용 가능한 MCP tool 목록을 반환한다. `dispatch_supported_tool`은 Eio context에서 MCP tool을 호출하여 `(handled: bool, result: string)`을 반환한다.
+
+### 7.3. Result Application
+
+`apply_swarm_result`는 OAS `swarm_result`의 통계(agent count, turn count, errors)를 MASC session 레코드에 반영한다.
+
+---
+
+## 8. Swarm Runner (`team_session_swarm_runner.ml`)
+
+Auto mode에서 세션을 OAS Swarm Runner로 실행한다.
+
+동작 순서:
+1. `Team_session_store.load_session`으로 session 로드
+2. `Team_session_oas_bridge.session_to_swarm_config`로 swarm_config 변환
+3. `Team_session_swarm_callbacks.make_callbacks`로 MASC 감독 콜백 생성
+4. `Agent_sdk_swarm.Runner.run`으로 swarm 실행
+5. `apply_swarm_result`로 결과 반영 + session 저장
+
+---
+
+## 9. Swarm Callbacks (`team_session_swarm_callbacks.ml`)
+
+OAS Swarm lifecycle을 MASC 감독 로직에 연결하는 4개 callback:
+
+| Callback | MASC 동작 |
+|----------|----------|
+| `on_iteration_start` | Checkpoint write (session dir) |
+| `on_agent_done` | Event journal 기록 + SSE broadcast |
+| `on_converged` | Session finalization (report 생성, status -> Completed) |
+| `on_error` | Policy violation 기록 + 선택적 alert |
+
+---
+
+## 10. Team Context (`team_context.ml`)
+
+Worker 간 공유 컨텍스트를 ~500 토큰으로 압축하여 worker prompt에 주입한다.
+
+```ocaml
+type team_context = {
+  team_goal : string;
+  prior_decisions : string list;
+  shared_findings : string list;
+  active_workers : string list;
+  task_tree : task_summary list;
+}
+```
+
+`add_finding`: 완료된 worker가 1-2문장의 key finding을 기록.
+`load_findings`: 이전 worker들의 finding을 `"[worker_name] finding"` 형식으로 로드.
+`to_prompt_section`: team_context를 prompt 삽입용 문자열로 렌더링.
+
+### 10.1. OAS Collaboration Bridge
+
+`collaboration_of_session`은 MASC session(47 fields)을 OAS `Collaboration.t`(12 fields)로 lossy projection한다. MASC votes/artifacts는 session record에 없으므로 빈 값으로 투영된다. `shared_context`는 shared findings에서 생성된다.
+
+---
+
+## 11. Report and Proof System
+
+### 11.1. Report
+
+`team_session_report.ml` + `team_session_report_core.ml`에서 Markdown/JSON 보고서를 생성한다. 세션 종료 시 자동 생성.
+
+포함 내용: 세션 메타데이터, goal, 참여 agent, turn 통계, cascade 통계, checkpoint 이력, done delta.
+
+### 11.2. Proof
+
+`team_session_report_proof.ml` + `team_session_report_proof_helpers.ml`에서 증거 아티팩트를 생성한다.
+
+Proof level:
+- `Proof_standard`: 기본 진행 증거
+- `Proof_strong`: checkpoint 해시, event log 무결성 등 추가 검증
+
+---
+
+## 12. MCP Tool Surface
+
+Tool layer는 `tool_team_session.ml` facade를 통해 접근한다. 내부는 5개 모듈로 분할되어 있다.
+
+| Module | LOC | 역할 |
+|--------|-----|------|
+| `tool_team_session_schemas.ml` | 687 | MCP JSON schema 정의 |
+| `tool_team_session_handlers.ml` | 574 | dispatch entry + handler 구현 |
+| `tool_team_session_support.ml` | 506 | 공통 유틸리티, context type |
+| `tool_team_session_routing.ml` | 729 | routing decision, spawn spec 파싱 |
+| `tool_team_session_routing_workers.ml` | 501 | worker 관리, spawn 실행 |
+| `tool_team_session_step.ml` | 534 | step 실행 + turn 기록 |
+| `tool_team_session_step_exec.ml` | 449 | step 내부 실행 로직 |
+| `tool_team_session_step_spawn.ml` | 395 | worker spawn 실행 |
+| `tool_team_session_step_types.ml` | 147 | step 관련 type 정의 |
+
+### 12.1. 주요 Tool
+
+| Tool | 동작 |
+|------|------|
+| `masc_team_session_start` | 세션 생성 (goal, duration, mode, agents 지정) |
+| `masc_team_session_step` | Turn 기록 (note/broadcast/portal/task/checkpoint) + worker spawn |
+| `masc_team_session_finalize` | 세션 종료 + report/proof 생성 |
+| `masc_team_session_status` | 세션 상태 조회 |
+| `masc_team_session_pause` / `resume` | 일시 정지/재개 |
+
+### 12.2. Step with Worker Spawn
+
+`masc_team_session_step`의 spawn 기능은 legacy `spawn_agent`/`spawn_model`/`model_tier` 필드를 거부하고, `spawn_prompt`, `spawn_role`, `worker_class`, `worker_size` 기반 사양을 요구한다. Routing decision은 `routing_decision` 타입으로 model_tier, task_profile, risk_level, confidence를 결정한다.
+
+### 12.3. Routing Decision
+
+```ocaml
+type routing_decision = {
+  model_tier : model_tier;     (* Tier_35b | Tier_27b | Tier_9b *)
+  task_profile : task_profile; (* Extract | Normalize | Summarize | Verify | Decide | Synthesize *)
+  risk_level : risk_level;     (* Low | Medium | High *)
+  confidence : float option;
+  reason : string;
+  judge_used : bool;
+  escalate_if : string list;
+  escalated : bool;
+}
+```
+
+---
+
+## 13. Known Issues and Planned Changes
+
+| Issue | 설명 | Status |
+|-------|------|--------|
+| tool_team_session 분할 | 원래 4412줄 god file. 현재 9개 모듈로 분할 완료 | Resolved |
+| Legacy spawn field 거부 | `spawn_agent`, `spawn_model`, `model_tier` 직접 사용 불가. migration 에러 반환 | By design |
+| Manual/Assist + Auto 이원 경로 | Auto는 OAS Swarm, Manual/Assist는 기존 engine. 통합 미완 | In progress |
+| session record 47 fields | OAS Collaboration.t(12 fields)로의 lossy projection 시 정보 유실 | Architectural |
+| Checkpoint proof hash | `Proof_strong` 모드의 hash chain 구현 범위가 event log 무결성에 한정 | Enhancement candidate |
+
+---
+
+## 14. Integration Points
+
+| System | 연결 방식 |
+|--------|----------|
+| CPv2 Operation | `operation_id`로 연결. session이 operation의 `detachment_session_id`를 업데이트 |
+| Room Backlog | `done_counts_from_backlog`로 task 완료 추적 |
+| SSE | Checkpoint, agent done 등 이벤트를 SSE로 broadcast |
+| OAS Swarm | Auto mode에서 `Runner.run` 경유 실행 |
+| Orchestra | `command_plane_orchestra.ml`에서 session_node로 시각화 |
+| Cascade | `model_cascade` 필드로 LLM 호출 순서 지정 |

--- a/docs/spec/08-council-governance.md
+++ b/docs/spec/08-council-governance.md
@@ -1,0 +1,410 @@
+# Council & Governance
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Foundation |
+| Maps to | `lib/council/` (sub-library, 4.8K LOC), `lib/operator/` (sub-library, 4.2K LOC), `lib/governance_pipeline.ml`, `lib/governance_registry.ml` |
+| Dependencies | 03-room-coordination |
+| LOC | ~9K combined |
+
+---
+
+## 1. 목적
+
+Council & Governance 서브시스템은 다중 에이전트 환경에서의 의사결정, 위험 관리, 운영자 통제를 담당한다. 세 가지 독립적인 계층으로 구성된다.
+
+1. **Council sub-library** -- 토론(Debate), 합의(Consensus), 라우팅(Router), 공정성(Balance), 대화(Conversation), 실행(Executor) 모듈의 통합 API
+2. **Governance pipeline** -- 도구 호출 시 위험 수준 분류와 승인 게이트
+3. **Operator control** -- 운영자의 실시간 감독, 조치, 판단(judgment) 인터페이스
+
+---
+
+## 2. Council Sub-library
+
+### 2.1 모듈 구조
+
+`lib/council/council.ml`이 통합 진입점(facade)이며 다음 모듈을 re-export한다.
+
+| 모듈 | 파일 | 역할 |
+|------|------|------|
+| `Debate` | `debate.ml` | 구조화된 토론 (파일 기반 영속) |
+| `Consensus` | `consensus.ml` | 투표/합의 (in-memory + 파일 write-through) |
+| `Router` | `router.ml` | MoE 스타일 에이전트 라우팅 |
+| `Balance` | `balance.ml` | 참여 공정성 정책 |
+| `Conversation` | `conversation.ml`, `conversation.mli` | 영속적 대화 스레드 (파일 + Neo4j) |
+| `Executor` | `executor.ml` | 투표 결과를 시스템 액션으로 전환 |
+| `Governance_v2` | `governance_v2.ml`, `governance_v2_types.ml`, `governance_v2_serde.ml` | 청원/사건/판결/실행명령 거버넌스 모델 |
+| `Loop_guard` | `loop_guard.ml` | 대화 무한 루프 방지 |
+| `Thread_persist` | `thread_persist.ml` | 이중 스트림 영속 (파일 + Neo4j) |
+| `Archive` | `archive.ml` | 실록 저장 (Neo4j + PostgreSQL) |
+
+### 2.2 Debate
+
+에이전트 간 구조화된 토론을 관리한다. 저장소는 파일 기반(`.masc/debates/<debate-id>.json`).
+
+**핵심 타입:**
+
+```
+position     = Support | Oppose | Neutral
+debate_status = Open | Closed | Pending
+
+argument = { agent; position; content; evidence; reply_to; mentions; archetype; created_at }
+debate   = { id; topic; status; arguments; context; created_at; closed_at }
+context_ref = { board_post_id; task_id; operation_id; team_session_id }
+```
+
+**주요 연산:**
+
+- `start_debate` -- 새 토론 시작. `notify_fn` 콜백으로 관련 에이전트 알림
+- `add_argument` -- 발언 추가. `reply_to`로 스레드 구조, `mentions`로 @멘션
+- `close_debate` -- 토론 종료, `closed_at` 타임스탬프 기록
+- `get_debate_status` -- Support/Oppose/Neutral 카운트 포함 요약 반환
+
+**영속화:** 원자적 쓰기(temp file + rename). JSON 직렬화/역직렬화에서 `Eio.Cancel.Cancelled`는 항상 re-raise.
+
+### 2.3 Consensus
+
+투표 기반 합의 시스템. In-memory `Hashtbl` + 파일 write-through(`.masc/consensus/<session-id>.json`).
+
+**핵심 타입:**
+
+```
+decision     = Approve | Reject | Abstain
+voting_result = Unanimous of decision | Majority of int | Deadlock | Escalate
+voting_state = Open | Closed | Cancelled
+
+vote    = { agent; decision; reason; timestamp; archetype; weight }
+session = { id; topic; initiator; votes; quorum; threshold; state; context }
+error   = Session_not_found | Session_closed | Already_voted | Quorum_not_met | Invalid_threshold
+```
+
+**투표 로직:**
+
+1. `start_voting` -- quorum(최소 투표 수), threshold(과반 기준 0.0-1.0) 설정
+2. `cast_vote` -- 중복 투표 거부(`Already_voted`). weight 지원(MAGI archetype 가중치)
+3. `get_result` -- quorum 미달 시 에러. Abstain은 투표 수에서 제외
+4. `close_session` / `cancel_session` -- 상태 전이
+
+**가중 투표:** `sum_weighted_by_decision`으로 weight 합산. 기본 weight = 1.0.
+
+### 2.4 Router
+
+MoE(Mixture of Experts) 스타일 에이전트 선택. 쿼리 분류 후 2-3개 에이전트를 sparse activation으로 선택한다.
+
+**모델 계층:** Tiny < Small < Medium < Large < Giant (비용 기준 $0.10 ~ $15.00 / 1M tokens)
+
+**쿼리 분류:** 6개 카테고리(Code, Analysis, Creative, Factual, Conversation, Complex). 키워드 매칭 기반 점수 계산 후 정규화.
+
+**선택 전략:**
+
+- 복잡도 0.7 이하: 2개 에이전트 (저비용 우선)
+- 복잡도 0.7 초과: 최대 3개 에이전트 (Large/Giant 허용)
+- 목표: 90% 쿼리는 Small/Medium, 10%만 Large/Giant
+
+**환경변수 연동:** `MASC_DEFAULT_CASCADE` 또는 `MASC_DEFAULT_PROVIDER` + `MASC_DEFAULT_MODEL`에서 기본 Tiny 에이전트를 동적 구성.
+
+### 2.5 Balance
+
+에이전트 참여 공정성 정책. 지배(dominance) 감지와 소수 의견 보호.
+
+**파라미터:**
+
+- `max_consecutive_wins = 3` -- 연속 3회 승리 시 강제 교체
+- `min_participation = 0.2` -- 참여율 20% 미달 시 강제 참여 (5라운드 이상부터)
+
+**액션:** `ForcedRotation` (지배 방지) | `MandatoryParticipation` (저참여 방지) | `Clear` (조치 불필요)
+
+**로테이션:** 승수 최소 -> 마지막 승리 시점 오래된 순으로 정렬하여 다음 에이전트 선택. 승리 없는 에이전트가 최우선.
+
+### 2.6 Conversation
+
+영속적 대화 스레드 시스템. SSJ(1974) 턴 테이킹 모델 기반.
+
+**턴 타입:** Initiate | Respond | FollowUp | Conclude (adjacency pair 모델)
+
+**스레드 상태:** Active -> Concluded | Stalled | Archived
+
+**Loop Guard:** 3중 방어
+
+1. `MaxTurnsReached` -- `max_turns`(기본 50) 초과 시 차단
+2. `IdenticalPattern` -- 동일 발화자의 연속 동일 메시지 3회 이상 시 차단
+3. `CooldownViolation` -- 동일 발화자 2초 내 재발언 차단
+
+**이중 스트림 영속:** (Thread_persist)
+- 파일 저장: 동기, 필수. 실패 시 연산 실패
+- Neo4j 그래프: 비동기, best-effort. Thread/Turn/Agent 노드와 BELONGS_TO, REPLIED_TO, MENTIONS, PARTICIPATED_IN 관계
+- 서버 시작 시 `sync_all`로 파일 -> Neo4j 일관성 복구
+
+### 2.7 Executor
+
+투표 결과를 시스템 액션으로 전환. 패턴 매칭 기반.
+
+**액션 타입:**
+- `ExecCommand` -- argv 기반 프로세스 실행 (no shell)
+- `ConfigChange` -- `.masc/config/` JSON 파일 변경
+- `Notification` -- `.masc/notifications.jsonl` 기록
+- `GitHubAction` -- `gh` CLI를 통한 PR merge/close/approve, issue 생성
+- `Custom` -- 확장 포인트
+
+**안전장치:** `requires_unanimous`, `min_threshold`로 실행 조건 제한. `dry_run`으로 사전 검증.
+
+---
+
+## 3. Governance V2 (청원-사건-판결 모델)
+
+법률 시스템 메타포를 차용한 거버넌스 모델. `.masc/governance_v2/` 하위에 4개 엔티티를 파일로 관리.
+
+### 3.1 엔티티 계층
+
+```
+petition  ->  case_record  ->  ruling  ->  execution_order
+(청원)        (사건)           (판결)      (실행 명령)
+```
+
+**case_status 상태 전이:**
+
+```
+Pending_ruling -> Ready_auto_execute -> Executed
+               -> Needs_human_gate   -> Executed | Blocked | Closed
+               -> Blocked
+               -> Closed
+```
+
+**risk_class:** Low | High. High는 human gate 필요.
+
+### 3.2 핵심 연산
+
+- `submit_petition` -- 청원 제출. 정규화된 키(`normalized_key`)로 중복 감지(deduplication). 기존 사건이 있으면 merge. 파일 락(`_submit.lock`)으로 경합 방지.
+- `submit_brief` -- 사건에 의견서(brief) 제출. stance = Support | Oppose | Neutral
+- `save_ruling` -- 판결 저장. `auto_execution_state`에 따라 case_status 자동 전이. `Ready_auto_execute`이면 execution_order 자동 생성.
+- `save_execution_order` -- 실행 명령 저장 및 case_status 반영
+
+### 3.3 자동 정리
+
+- `purge_stale_test_cases` -- 테스트 origin 사건 24시간 후 삭제
+- `purge_stale_artifact_cases` -- 자동화 아티팩트 사건 12시간 후 삭제
+- `list_cases` 호출 시 자동 purge 실행
+
+---
+
+## 4. Governance Pipeline
+
+`Governance_pipeline` 모듈은 도구 호출 전 위험 기반 승인 게이트를 제공한다. `Tool_dispatch.pre_hook`으로 등록되어 모든 도구 호출에 적용된다.
+
+### 4.1 위험 분류
+
+도구 이름의 키워드 매칭으로 4단계 위험 수준을 분류한다.
+
+| 위험 수준 | 패턴 키워드 |
+|----------|------------|
+| Critical | delete, remove, drop, force, reset, kill, destroy, purge |
+| High | create, update, write, deploy, push, merge, send, spawn, modify |
+| Medium | claim, join, leave, start, stop, pause, resume, confirm, approve |
+| Low | 위 패턴에 해당하지 않는 모든 도구 |
+
+### 4.2 거버넌스 레벨
+
+| 레벨 | confirm 임계 | audit 임계 |
+|------|-------------|-----------|
+| paranoid | Medium 이상 | Low 이상 |
+| enterprise | High 이상 | Low 이상 |
+| production | Critical | Medium 이상 |
+| development | 없음 | High 이상 |
+
+### 4.3 결정 흐름
+
+```
+도구 호출 -> assess_risk(tool_name) -> decide(governance_level) ->
+  Allow:           handler 실행
+  Require_confirm: 대기 응답 반환 (trace_id 발급)
+  Deny:            거부 응답 반환
+```
+
+감사(audit) 조건 충족 시 `Audit_log.log_governance_decision` 기록.
+
+---
+
+## 5. Governance Registry
+
+`Governance_registry`는 런타임 파라미터의 거버넌 가능 표면(governable surface)을 선언한다. `Runtime_params` 모듈에 등록된 파라미터는 검증 범위 내에서만 변경 가능.
+
+| Surface | 파라미터 | 위험 |
+|---------|---------|------|
+| lodge_behavior | tick_interval(60-14400s), agents_per_tick(1-20), quiet_start/end(0-23h) | Low |
+| lodge_limits | max_daily_actions(1-100), max_posts_per_day(1-50) | Low |
+| board_policy | message.max_count(10-10000) | Low |
+| inference_config | default_model(1-100 chars), timeout(5-300s) | High |
+
+---
+
+## 6. Operator Control
+
+`lib/operator/` sub-library는 운영자(human 또는 supervisor agent)의 제어 평면(control plane)을 구현한다.
+
+### 6.1 모듈 구조
+
+| 모듈 | 역할 |
+|------|------|
+| `operator_pending_confirm.ml/.mli` | 미확인 조치 큐. 토큰 기반 confirm/deny 흐름 |
+| `operator_control.ml/.mli` | 통합 facade. snapshot, action, confirm, judgment |
+| `operator_control_snapshot.ml` | 상태 스냅샷 조립 |
+| `operator_control_action.ml` | 구조화된 조치 실행 |
+| `operator_digest.ml/.mli` | 개입 지향 다이제스트 |
+| `operator_digest_session.ml` | 팀 세션 다이제스트 |
+| `operator_digest_event.ml` | 이벤트 기반 다이제스트 |
+| `operator_digest_guidance.ml` | 추천 행동 생성 |
+| `operator_digest_types.ml` | 다이제스트 타입 정의 |
+| `operator_judgment.ml` | 상주 판단(resident judgment) 저장/조회 |
+| `operator_approval.ml` | OAS Approval pipeline 연동 |
+
+### 6.2 Pending Confirm 흐름
+
+고위험 조치는 preview-confirm 2단계로 실행된다.
+
+```
+masc_operator_action(action_type=X) ->
+  confirm_required=true ->
+    pending_confirm 저장 (token, trace_id, expires_at) ->
+      masc_operator_confirm(confirm_token, decision=confirm|deny) ->
+        confirm: 실제 실행
+        deny:    취소
+```
+
+**파일 영속:** `.masc/operator/pending_confirms.json`
+
+### 6.3 Operator Action 타입
+
+| action_type | target_type | confirm_required |
+|------------|-------------|------------------|
+| broadcast | room | No |
+| room_pause / room_resume | room | Yes / No |
+| social_sweep | room | No |
+| team_note / team_broadcast | team_session | No |
+| team_task_inject | team_session | Yes |
+| team_worker_spawn_batch | team_session | Yes |
+| team_stop | team_session | Yes |
+| keeper_message / keeper_probe / keeper_recover | keeper | No / No / No |
+
+### 6.4 Snapshot & Digest
+
+- **Snapshot** (`masc_operator_snapshot`) -- 원시 상태 데이터. view 모드: summary, sessions, keepers, messages, full
+- **Digest** (`masc_operator_digest`) -- 개입 지향 분석. 건강 상태, 주의 항목, 명령 평면 검색, microarch 신호, 추천 행동 포함
+
+### 6.5 Resident Judgment
+
+운영자 또는 keeper가 작성하는 지속적 판단 기록.
+
+- surface: `command.warroom`, `command.swarm`, `intervene`
+- target_type: `room`, `team_session`
+- 신선도(freshness) TTL, 신뢰도(confidence), 증거 참조 포함
+- `masc_operator_judgment_write` / `masc_operator_judgment_latest` 도구로 접근
+
+---
+
+## 7. MCP Tool Surface
+
+### 7.1 Council 도구 (Tool_council)
+
+| 도구명 | 역할 |
+|-------|------|
+| `masc_petition_submit` | 거버넌스 청원 제출 |
+| `masc_case_brief_submit` | 사건에 의견서 제출 (판결+실행명령 자동 생성) |
+| `masc_cases` | 사건 목록 조회 (status 필터, include_test) |
+| `masc_case_status` | 개별 사건 번들(petition+ruling+order) 조회 |
+| `masc_ruling_status` | 판결 상세 조회 |
+| `masc_governance_rule` | 명시적 판결(approve/deny/dismiss) 작성 |
+| `masc_execution_orders` | 실행 명령 목록/상세/결정(confirm/deny) |
+| `masc_governance_status` | 거버넌스 전체 현황 통계 |
+| `masc_governance_feed` | 거버넌스 피드 |
+| `masc_runtime_params` | 런타임 파라미터 조회 |
+| `masc_set_param` | 런타임 파라미터 변경 (청원 자동 생성) |
+| `masc_route` | MoE 라우팅 쿼리 |
+| `masc_execute` | 토픽 매칭 기반 액션 실행 |
+| `masc_execute_dry_run` | 실행 시뮬레이션 |
+
+### 7.2 Operator 도구 (Tool_operator)
+
+| 도구명 | 역할 |
+|-------|------|
+| `masc_operator_snapshot` | 제어 평면 통합 상태 조회 |
+| `masc_operator_digest` | 개입 지향 다이제스트 조회 |
+| `masc_operator_action` | 구조화된 조치 실행/미리보기 |
+| `masc_operator_confirm` | 미확인 조치 승인/거부 |
+| `masc_operator_judgment_write` | 상주 판단 저장 (내부 도구) |
+| `masc_operator_judgment_latest` | 최신 판단 조회 (내부 도구) |
+
+Remote 모드에서는 judgment_write/latest를 제외한 4개 도구만 노출.
+
+### 7.3 Control 도구 (Tool_control)
+
+| 도구명 | 역할 |
+|-------|------|
+| `masc_pause` / `masc_resume` | 룸 일시정지/재개 |
+| `masc_pause_status` | 일시정지 상태 조회 |
+| `masc_switch_mode` | 도구 모드 전환 (minimal/standard/parallel/coding/full/solo/custom) |
+| `masc_get_config` | 현재 모드/설정 조회 |
+| `masc_tool_enable` / `masc_tool_disable` | 개별 도구 또는 카테고리 단위 활성/비활성화 |
+
+---
+
+## 8. 불변식 (Invariants)
+
+1. **Debate 원자적 쓰기:** 모든 debate 파일 쓰기는 temp file + rename. 파일 손상 불가.
+2. **Consensus 중복 투표 방지:** 동일 agent의 동일 session 투표는 `Already_voted` 에러.
+3. **Router 90/10 목표:** 쿼리의 90%는 Tiny/Small/Medium, 10%만 Large/Giant. `Stats` 모듈로 추적.
+4. **Balance 지배 방지:** 연속 3회 승리 시 ForcedRotation 발동.
+5. **Loop Guard 3중 방어:** max_turns, identical_pattern, cooldown 중 하나라도 위반 시 발언 차단.
+6. **Thread_persist 파일 우선:** 파일 쓰기 실패 = 연산 실패. Neo4j 실패 = 로그만 기록.
+7. **Governance V2 중복 감지:** `normalized_key` + `source_refs`로 동일 사건 merge. 파일 락으로 경합 방지.
+8. **Pipeline 위험 분류 결정론:** 동일 도구명은 항상 동일 위험 수준. 입력 값은 현재 무시(`input:_`).
+9. **Pending confirm 만료:** 만료된 토큰은 자동 필터링. 만료 후 confirm 시도 시 실패.
+
+---
+
+## 9. 저장소 레이아웃
+
+```
+.masc/
+  debates/               # Debate 파일 (debate-*.json)
+  consensus/             # Consensus 세션 파일 (uuid.json)
+  governance_v2/
+    petitions/           # 청원 (petition-*.json)
+    cases/               # 사건 (case-*.json) + _submit.lock
+    rulings/             # 판결 (case-id.json)
+    execution_orders/    # 실행 명령 (case-id.json)
+  operator/
+    pending_confirms.json
+  config/                # Executor config 변경 기록
+  notifications.jsonl    # Executor 알림 기록
+```
+
+---
+
+## 10. 의존 관계
+
+```
+Tool_council, Tool_operator, Tool_control
+         |              |
+    Council (facade)    Operator_control (facade)
+    /  |  |  \              |
+Debate Consensus Router  Operator_pending_confirm
+       Balance  Executor Operator_digest
+   Conversation          Operator_judgment
+   Governance_v2         Operator_approval (-> OAS)
+   Loop_guard
+   Thread_persist -----> Neo4j (best-effort)
+
+Governance_pipeline ----> Tool_dispatch.pre_hook
+Governance_registry ----> Runtime_params
+```
+
+---
+
+## 11. 제한 사항 및 알려진 문제
+
+- Router의 쿼리 분류는 키워드 매칭 기반이며 LLM 추론을 사용하지 않음. 복잡한 쿼리에서 분류 정확도가 낮을 수 있음.
+- Governance V2 중복 감지는 `normalized_key` 문자열 비교에 의존하며, 의미적 중복은 감지하지 못함.
+- Thread_persist의 Neo4j 동기화는 개별 Cypher 쿼리 순차 실행. 대규모 스레드에서 성능 저하 가능.
+- Governance Pipeline의 위험 분류는 도구 이름만 사용하며 입력 인자를 검사하지 않음(`input:_`).
+- Consensus 세션 저장소는 in-memory Hashtbl이 primary. 프로세스 재시작 시 파일에서 복원되나 쓰기 실패 시 데이터 유실 가능.

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -1,0 +1,840 @@
+# Server & Transport
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Server |
+| Maps to | `lib/server/`, `lib/grpc/`, `lib/sse.ml`, `lib/transport.ml`, `lib/http_server_eio.ml`, `lib/http_server_h2.ml`, `lib/mcp_server_eio*.ml`, `bin/main_eio.ml`, `bin/main_stdio_eio.ml` |
+| Dependencies | 02-types-and-invariants |
+| Modules | 61 |
+| LOC | ~17,700 |
+
+---
+
+## 1. Purpose
+
+MCP(Model Context Protocol)를 다중 트랜스포트(HTTP/1.1, HTTP/2 h2c, WebSocket, gRPC, WebRTC, stdio)로 제공하는 서버 레이어. JSON-RPC 2.0 기반 MCP 요청을 받아 도구 디스패치로 라우팅하고, SSE(Server-Sent Events)로 이벤트를 스트리밍한다.
+
+핵심 설계 결정:
+
+- **httpun-eio** 기반 HTTP/1.1이 canonical transport. Eio direct-style async.
+- SSE는 per-session `Eio.Stream.t` mailbox 패턴. broadcast 시 global write-lock 없음.
+- HTTP/2는 `h2-eio` 기반 opt-in (`MASC_USE_H2=1`). SSE 멀티플렉싱으로 브라우저 6-connection 제한 해소.
+- gRPC, WebSocket, WebRTC는 보조 트랜스포트. 각각 env var로 opt-in.
+- stdio 모드는 Claude Code MCP 클라이언트의 표준 연결 방식.
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+    subgraph Clients["클라이언트"]
+        CC[Claude Code<br/>MCP stdio]
+        GC[Gemini CLI<br/>MCP HTTP]
+        CX[Codex CLI<br/>MCP HTTP]
+        DB[Dashboard<br/>Browser SSE]
+        EXT[외부 에이전트<br/>gRPC / WS / WebRTC]
+    end
+
+    subgraph EntryPoints["Entry Points"]
+        STDIO[main_stdio_eio.ml<br/>stdin/stdout]
+        HTTP[main_eio.ml<br/>httpun-eio :8935]
+    end
+
+    subgraph TransportLayer["Transport Layer"]
+        MCP_HTTP[server_mcp_transport_http<br/>POST /mcp + GET /mcp SSE]
+        H2_GW[server_h2_gateway<br/>HTTP/2 h2c]
+        WS_T[server_mcp_transport_ws<br/>GET /ws]
+        GRPC_S[masc_grpc_server<br/>:8936 h2c]
+        WEBRTC[server_webrtc_transport<br/>/webrtc/*]
+    end
+
+    subgraph CoreServer["Core Server"]
+        MCP_EIO[mcp_server_eio<br/>JSON-RPC handler]
+        SSE_MOD[sse.ml<br/>event registry + broadcast]
+        AUTH[server_auth + auth<br/>token verification]
+        ROUTES[server_routes_http<br/>REST API router]
+    end
+
+    subgraph Dispatch["Tool Dispatch"]
+        TD[tool_dispatch.ml<br/>371 MCP tools]
+    end
+
+    CC -->|stdio| STDIO
+    GC -->|HTTP POST| HTTP
+    CX -->|HTTP POST| HTTP
+    DB -->|HTTP GET SSE| HTTP
+    EXT -->|gRPC / WS| GRPC_S & WS_T
+
+    STDIO --> MCP_EIO
+    HTTP --> MCP_HTTP & H2_GW & WS_T & WEBRTC & ROUTES
+    MCP_HTTP --> MCP_EIO
+    H2_GW --> MCP_EIO
+    WS_T -.->|Sse.subscribe_external| SSE_MOD
+    GRPC_S --> MCP_EIO
+    WEBRTC -.->|signaling only| MCP_EIO
+
+    MCP_EIO --> TD
+    MCP_EIO --> SSE_MOD
+    MCP_HTTP --> AUTH
+    H2_GW --> AUTH
+```
+
+---
+
+## 3. Transport Matrix
+
+| Transport | Protocol Stack | Module | Port | 활성화 조건 | Status |
+|-----------|---------------|--------|------|------------|--------|
+| HTTP/1.1 | httpun-eio | `server_mcp_transport_http` | 8935 | 기본값 | Canonical |
+| HTTP/2 (h2c) | h2-eio | `server_h2_gateway` | 8935 | `MASC_USE_H2=1` | Optional |
+| WebSocket | httpun-ws-eio | `server_mcp_transport_ws` | 8935 `/ws` | `MASC_WS_ENABLED=1` | Available |
+| gRPC | grpc-direct (h2c) | `masc_grpc_server` | 8936 | `MASC_GRPC_ENABLED=1` | Available |
+| WebRTC | ocaml-webrtc | `server_webrtc_transport` | 8935 `/webrtc/*` | `MASC_WEBRTC_ENABLED=1` | Experimental |
+| stdio | Eio stdin/stdout | `main_stdio_eio` + `mcp_server_eio.run_stdio` | N/A | `masc-mcp-stdio` 실행 | Available |
+
+### 3.1 Transport 선택 로직 (에이전트 측)
+
+`lib/masc_grpc_transport.ml`이 에이전트 측 트랜스포트 선택을 정의한다:
+
+```ocaml
+type t = Http | Grpc | Ws | Webrtc | Local
+```
+
+선택 순서:
+1. API 호출 시 명시된 `~transport` 파라미터
+2. `MASC_AGENT_TRANSPORT` 환경변수 (`"grpc"`, `"http"`, `"ws"`, `"webrtc"`, `"local"`)
+3. 기본값: `Local` (파일시스템 기반 Room 직접 호출)
+
+---
+
+## 4. MCP Protocol
+
+### 4.1 JSON-RPC 2.0 Wire Format
+
+MCP는 JSON-RPC 2.0 위에 구축된다. 모든 요청은 동일한 구조를 따른다:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "masc_status",
+    "arguments": {}
+  }
+}
+```
+
+응답:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [{"type": "text", "text": "..."}]
+  }
+}
+```
+
+에러 응답:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+```
+
+### 4.2 표준 JSON-RPC 에러 코드
+
+| Code | 이름 | 설명 |
+|------|------|------|
+| -32700 | Parse Error | JSON 파싱 실패 |
+| -32600 | Invalid Request | 유효하지 않은 JSON-RPC 요청 |
+| -32601 | Method Not Found | 존재하지 않는 메서드 |
+| -32602 | Invalid Params | 유효하지 않은 파라미터 |
+| -32603 | Internal Error | 서버 내부 오류 |
+| -32000 | Server Error | 범용 서버 오류 |
+| -32001 | Not Initialized | 서버 미초기화 |
+| -32002 | Task Not Found | Task ID 없음 |
+| -32003 | Permission Denied | 권한 부족 |
+
+### 4.3 MCP Protocol Version
+
+지원 버전은 `Mcp_server.supported_protocol_versions`에 정의된다. 세션 생성 시 `initialize` 요청의 `params.protocolVersion` 필드로 버전을 협상한다.
+
+- `mcp_protocol_versions`: 지원 버전 목록
+- `mcp_protocol_version_default`: 기본 버전
+- 세션별 버전은 `protocol_version_by_session` Hashtbl에 기록된다.
+- 동일 세션에서 버전 변경 시도는 `validate_protocol_version_continuity`가 거부한다.
+
+### 4.4 MCP Session Management
+
+HTTP MCP 세션은 `Mcp-Session-Id` 헤더로 식별된다. 세션 ID는 `Mcp_session.generate()`로 UUID-like 문자열을 생성한다.
+
+```
+mcp_session_record = {
+  id: string;
+  agent_name: string option;
+  created_at: float;
+  last_seen: float;
+}
+```
+
+세션 생명주기:
+
+1. **생성**: `initialize` 요청 시 새 session ID 발급. 서버가 `Mcp-Session-Id` 응답 헤더로 반환.
+2. **유지**: 이후 모든 요청에 `Mcp-Session-Id` 헤더 포함 필수 (initialize/ping 제외).
+3. **삭제**: `DELETE /mcp` 요청 시 세션 종료. SSE 연결 해제 + 리소스 구독 정리.
+
+### 4.5 Tool Profile (Endpoint 분리)
+
+MCP 엔드포인트별로 노출되는 도구 집합이 다르다:
+
+```ocaml
+type tool_profile =
+  | Full              (* /mcp - 전체 도구 *)
+  | Managed_agent     (* /mcp/managed - 제한된 도구 세트 *)
+  | Operator_remote   (* /mcp/operator - operator 전용 도구 *)
+  | Role_filtered of Mode.mode  (* 모드별 필터링 *)
+```
+
+동일 session ID로 다른 profile의 엔드포인트에 접근하면 `409 Conflict`를 반환한다 (`validate_mcp_session_profile`).
+
+---
+
+## 5. SSE Event Streaming
+
+**소스**: `lib/sse.ml` (474 LOC)
+
+### 5.1 동시성 모델
+
+SSE는 per-session `Eio.Stream.t` mailbox 패턴으로 구현된다:
+
+1. SSE 연결 시 `Sse.register`가 session당 `Eio.Stream.t`(capacity=1024)를 생성한다.
+2. `broadcast`는 registry의 읽기 스냅샷을 잡고, 각 client의 stream에 이벤트를 push한다.
+3. 각 SSE connection fiber는 `Sse.pop`으로 자기 stream을 drain하며, transport writer에 write한다.
+4. broadcast 중 global write-lock을 잡지 않으므로, 느린 client가 다른 client의 broadcast를 지연시키지 않는다.
+
+```
+broadcast() --> [registry snapshot under read-lock]
+            --> for each client: Eio.Stream.add client.event_stream event
+            --> notify_external_subscribers(event)  // gRPC, WS 등
+
+SSE fiber --> loop: Sse.pop session_id --> send_raw to HTTP body writer
+```
+
+### 5.2 Session Kind
+
+SSE 세션은 두 종류로 분류된다:
+
+| Kind | 대상 | 수신 이벤트 |
+|------|------|-----------|
+| `Observer` | Dashboard, 읽기 전용 뷰어 | dashboard snapshot |
+| `Coordinator` | MCP 에이전트 연결 | heartbeat, task event |
+
+`broadcast_to` 함수로 대상을 지정할 수 있다:
+
+```ocaml
+type broadcast_target = All | Observers | Coordinators
+```
+
+`broadcast json`은 `broadcast_to All json`과 동일하다 (하위 호환).
+
+### 5.3 Event Format
+
+SSE 이벤트는 MCP Spec 2025-03-26을 따른다:
+
+```
+id: 42
+event: message
+data: {"jsonrpc":"2.0","method":"notifications/message","params":{...}}
+
+```
+
+- `id`: 단조 증가하는 정수 (`Atomic.fetch_and_add event_counter 1 + 1`)
+- `event`: 항상 `"message"`
+- `data`: JSON-RPC notification 또는 응답
+
+### 5.4 Resumability
+
+MCP Spec에서 MUST인 event replay를 지원한다:
+
+- 최근 100개 이벤트를 ring buffer에 저장 (`event_buffer`, 300초 TTL)
+- 클라이언트가 `Last-Event-Id` 헤더로 마지막 수신 ID를 전달하면, `get_events_after`로 누락분을 replay
+
+### 5.5 Connection Guard
+
+SSE 재연결 폭주(connection storm)를 방지하는 rate limiter:
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `MASC_SSE_RECONNECT_MIN_INTERVAL_S` | 0.0 (비활성) | session별 최소 재연결 간격 |
+| `MASC_SSE_CONNECT_WINDOW_S` | 0.0 (비활성) | sliding window 크기 |
+| `MASC_SSE_CONNECT_MAX_IN_WINDOW` | 0 (비활성) | window 내 최대 연결 수 |
+
+제한 초과 시 `429 Too Many Requests` + `Retry-After` 헤더를 반환한다.
+
+### 5.6 External Subscriber Hook
+
+SSE가 아닌 소비자(gRPC Subscribe stream, WebSocket 등)가 broadcast 이벤트를 수신할 수 있다:
+
+```ocaml
+Sse.subscribe_external ~id:"ws-123"
+  ~is_alive:(fun () -> not session.closed)
+  ~callback:(fun sse_event -> send_text session sse_event)
+  ()
+```
+
+- `is_alive`가 `false`를 반환하면 자동 제거 (리소스 누수 방지)
+- broadcast 완료 후 동기적으로 호출됨
+
+### 5.7 Capacity & Limits
+
+| 상수 | 값 | 근거 |
+|------|-----|------|
+| `max_clients` | 200 | Claude.ai MCP 클라이언트 재연결 대응. 초과 시 oldest eviction |
+| `stream_capacity` | 1024 | 0이면 동기 rendez-vous가 됨. 1024 미만이면 broadcast 블로킹 위험 |
+| `push_timeout_s` | 5.0 | 로컬 TCP write에 5초. 초과 시 client drop |
+| `max_buffer_size` | 100 | event replay buffer 크기 |
+| `buffer_ttl_seconds` | 300.0 | 5분 이상 된 이벤트 자동 삭제 |
+| `cleanup_stale max_age_s` | 1800.0 | 30분 이상 idle client 자동 evict |
+
+---
+
+## 6. HTTP Route Map
+
+### 6.1 MCP 엔드포인트 (main_eio.ml에서 직접 매칭)
+
+| Method | Path | Handler | 설명 |
+|--------|------|---------|------|
+| POST | `/mcp` | `handle_post_mcp ~profile:Full` | MCP JSON-RPC (전체 도구) |
+| GET | `/mcp` | `handle_get_mcp` | SSE 스트림 (Coordinator) |
+| DELETE | `/mcp` | `handle_delete_mcp` | MCP 세션 종료 |
+| POST | `/mcp/managed` | `handle_post_mcp ~profile:Managed_agent` | 관리 에이전트 MCP |
+| GET | `/mcp/managed` | `handle_get_mcp` | 관리 에이전트 SSE |
+| DELETE | `/mcp/managed` | `handle_delete_mcp ~profile:Managed_agent` | 관리 에이전트 세션 종료 |
+| POST | `/mcp/operator` | `handle_post_mcp ~profile:Operator_remote` | Operator MCP |
+| GET | `/mcp/operator` | `handle_get_operator_mcp` | Operator SSE |
+| DELETE | `/mcp/operator` | `handle_delete_mcp ~profile:Operator_remote` | Operator 세션 종료 |
+| GET | `/sse` | `sse_simple_handler` | 단순 SSE (Observer) |
+| POST | `/messages` | `handle_post_messages` | 레거시 MCP 메시지 엔드포인트 |
+| GET | `/ws` | `upgrade_connection` | WebSocket 업그레이드 (`MASC_WS_ENABLED=1`) |
+| POST | `/webrtc/offer` | `handle_offer_request` | WebRTC offer signaling |
+| POST | `/webrtc/answer` | `handle_answer_request` | WebRTC answer signaling |
+| OPTIONS | `*` | `options_handler` | CORS preflight |
+
+### 6.2 REST API 라우트 (server_routes_http 조립)
+
+`make_routes`가 HTTP Router를 조립한다:
+
+```ocaml
+let make_routes ~port ~host ~sw ~clock =
+  Http.Router.empty
+  |> Server_routes_http_routes_frontend.add_routes ~port ~host
+  |> Server_routes_http_routes_room.add_routes
+  |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
+  |> Server_routes_http_routes_provider_runs.add_routes ~sw
+  |> Server_routes_http_routes_command_plane_read.add_routes
+  |> Server_routes_http_routes_command_plane_write.add_routes ~sw ~clock
+  |> Server_routes_http_routes_activity.add_routes
+```
+
+주요 REST 라우트 그룹:
+
+| 그룹 | Prefix | 모듈 | 예시 경로 |
+|------|--------|------|----------|
+| Frontend | `/`, `/health`, `/metrics` | `_frontend` | `GET /health`, `GET /.well-known/agent.json` |
+| Dashboard | `/api/v1/dashboard/*` | `_dashboard` | `GET /api/v1/dashboard/shell` |
+| Room | `/api/v1/room/*` | `_room` | `GET /api/v1/room/current` |
+| Command Plane (R) | `/api/v1/command-plane/*` | `_command_plane_read` | `GET /api/v1/command-plane/topology` |
+| Command Plane (W) | `/api/v1/command-plane/*` | `_command_plane_write` | `POST /api/v1/command-plane/operations` |
+| Provider Runs | `/api/v1/chains/*` | `_provider_runs` | `GET /api/v1/chains/summary` |
+| Activity | `/api/v1/activity/*` | `_activity` | `GET /api/v1/activity/feed` |
+| Board | `/api/v1/board/*` | main_eio 직접 | `GET /api/v1/board/{id}` |
+| GraphQL | `/graphql` | main_eio 직접 | `POST /graphql` |
+| OpenAPI | `/api/v1/openapi.json` | `Transport.Rest` | OpenAPI 3.1 문서 자동 생성 |
+
+### 6.3 Dashboard Static Files
+
+| Path | 제공 방식 |
+|------|----------|
+| `/dashboard`, `/dashboard/` | `assets/dashboard/index.html` (SPA entry) |
+| `/dashboard/assets/*` | Vite 빌드 산출물 정적 파일 |
+| `/dashboard/credits` | OCaml 렌더링 HTML (`Credits_dashboard.html`) |
+
+---
+
+## 7. Authentication
+
+**소스**: `lib/auth.ml` (435 LOC), `lib/server/server_auth.ml` (491 LOC)
+
+### 7.1 인증 모델
+
+파일 기반 토큰 인증. `.masc/auth/` 디렉토리에 상태를 저장한다.
+
+```
+.masc/auth/
+  config.json          -- auth_config (enabled, require_token, default_role, token_expiry_hours)
+  room_secret.hash     -- room-level secret (SHA256 해시)
+  initial_admin        -- 최초 admin agent 이름
+  agents/
+    claude.json        -- agent_credential (agent_name, token_hash, role, expires_at)
+    gemini.json
+```
+
+### 7.2 인증 흐름
+
+1. **토큰 생성**: `Auth.create_token ~agent_name ~role` -> (raw_token, credential). raw_token은 한 번만 반환, 서버는 SHA256 해시만 저장.
+2. **요청 인증**: `Authorization: Bearer <raw_token>` 헤더로 전달. 서버가 해시 비교.
+3. **만료 검사**: `expires_at` ISO 문자열 비교 (`now > exp_str`).
+
+### 7.3 인증 계층
+
+| 계층 | 조건 | 검증 함수 |
+|------|------|----------|
+| **비활성** | auth disabled | 모든 요청 허용 |
+| **토큰 선택** | auth enabled, `require_token=false` | 토큰 있으면 검증, 없으면 `default_role` 적용 |
+| **토큰 필수** | auth enabled, `require_token=true` | 토큰 없으면 401 |
+| **Strict HTTP** | `MASC_HTTP_AUTH_STRICT=1` 또는 non-loopback bind | `/mcp` 등 경로에 토큰 필수 |
+
+`MASC_HTTP_AUTH_STRICT`는 서버가 non-loopback 주소(예: `0.0.0.0`)에 bind되면 자동 활성화된다.
+
+### 7.4 권한 체계 (RBAC)
+
+| Role | 권한 범위 |
+|------|----------|
+| `Admin` | 모든 작업 (auth enable/disable, tool grant/revoke 포함) |
+| `Worker` | 도구 호출, broadcast, task claim/complete |
+| `Observer` | 읽기 전용 (status, messages 조회) |
+
+`permission_for_tool` 함수가 각 MCP 도구명을 필요 권한으로 매핑한다. 매핑되지 않은 `masc_*` 도구는:
+- `MASC_TOOL_AUTH_STRICT=1` (기본값): `CanBroadcast` 이상 필요
+- `MASC_TOOL_AUTH_STRICT=0`: fail-open (레거시 호환)
+
+### 7.5 Admin 인증
+
+`MASC_ADMIN_TOKEN` 환경변수로 admin-only API를 보호한다. 타이밍 사이드채널 공격 방지를 위해 XOR 기반 constant-time 비교를 사용한다.
+
+### 7.6 CORS
+
+```
+Access-Control-Allow-Origin: <origin>
+Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS
+Access-Control-Allow-Headers: Content-Type, Accept, Origin, Authorization,
+  Idempotency-Key, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id,
+  X-MASC-Agent, X-MASC-Agent-Name
+Access-Control-Expose-Headers: Mcp-Session-Id, Mcp-Protocol-Version
+Access-Control-Allow-Credentials: true
+```
+
+MCP 경로(`/mcp`, `/sse`, `/messages`)에서 Origin 검증을 수행한다. 유효하지 않은 origin은 `403 Forbidden`.
+
+---
+
+## 8. HTTP/2 Gateway
+
+**소스**: `lib/server/server_h2_gateway.ml` (740 LOC) + helpers/routes (814 LOC)
+
+### 8.1 활성화
+
+`MASC_USE_H2=1` 환경변수로 opt-in. 설정 시 HTTP/1.1과 HTTP/2 서버가 동시에 시작된다 (동일 포트, ALPN 협상 아님 - h2c cleartext).
+
+### 8.2 동작 방식
+
+H2 gateway는 HTTP/2 요청을 받아 내부적으로 `Httpun.Request`로 변환하여 기존 handler 함수를 재사용한다:
+
+```ocaml
+let httpun_headers = Httpun.Headers.of_list (H2.Headers.to_list h2_headers) in
+let httpun_request = Httpun.Request.create ~headers:httpun_headers httpun_meth h2_req.target in
+```
+
+모든 REST API, MCP, Dashboard 경로를 HTTP/2로도 제공한다. H2 고유 기능:
+- 무제한 SSE stream per connection (브라우저 6-connection 제한 해소)
+- `flush_headers_immediately:true`로 streaming response 지원
+
+### 8.3 Cloudflare Tunnel 제약
+
+```
+Browser --[HTTPS/HTTP2]--> Cloudflare --[HTTP/1.1]--> MASC :8935
+```
+
+Cloudflare tunnel origin은 cleartext h2(h2c)를 지원하지 않는다. 따라서 Cloudflare 경유 시 origin은 반드시 HTTP/1.1. Cloudflare가 브라우저에 HTTP/2를 제공하여 SSE 멀티플렉싱의 이점은 유지된다.
+
+---
+
+## 9. WebSocket Transport
+
+**소스**: `lib/server/server_mcp_transport_ws.ml` (160 LOC)
+
+### 9.1 활성화
+
+`MASC_WS_ENABLED=1`로 opt-in. `GET /ws` 요청 시 WebSocket upgrade.
+
+### 9.2 동작 방식
+
+1. `httpun-ws`의 `Handshake.respond_with_upgrade`로 HTTP 101 응답
+2. WebSocket 연결 성공 후 `Sse.subscribe_external`로 broadcast 이벤트 수신 등록
+3. 인바운드 메시지: JSON-RPC 요청으로 디스패치 (현재 `on_message` callback, 기본값은 log & ignore)
+4. Ping/Pong 자동 처리
+5. 연결 종료 시 `cleanup_session`이 SSE 구독 해제 + 세션 제거
+
+WebSocket 세션은 `ws-{timestamp_ms}-{counter}` 형식 ID를 사용한다. SHA1은 httpun-ws 핸드셰이크에 Digestif.SHA1을 사용한다.
+
+---
+
+## 10. gRPC Service
+
+**소스**: `lib/grpc/` (1,143 LOC)
+
+### 10.1 활성화
+
+`MASC_GRPC_ENABLED=1`로 opt-in. 포트는 `MASC_GRPC_PORT` (기본값: 8936).
+
+### 10.2 Service 정의
+
+```
+Service: masc.coordination.v1.MascCoordination
+
+RPCs:
+  Join(JoinRequest) -> JoinResponse            // Unary
+  Leave(LeaveRequest) -> LeaveResponse          // Unary
+  Heartbeat(HeartbeatPing) -> HeartbeatAck      // Unary
+  CallTool(ToolCallRequest) -> ToolCallResponse // Unary
+  Broadcast(BroadcastRequest) -> BroadcastResponse // Unary
+  Subscribe(SubscribeRequest) -> stream Event   // Server streaming
+  GetStatus(Empty) -> StatusResponse            // Unary
+```
+
+### 10.3 Wire Format
+
+JSON 인코딩된 문자열을 gRPC 프레이밍으로 전송. Protobuf 바이너리가 아닌 JSON을 사용한다. 각 메시지 타입은 `to_bytes`/`of_bytes`로 직렬화/역직렬화한다.
+
+### 10.4 Subscribe Streaming
+
+`Subscribe` RPC는 server-streaming으로 SSE broadcast 이벤트를 gRPC 스트림으로 전달한다. `Sse.subscribe_external`을 통해 이벤트를 받아 gRPC 응답 스트림에 기록한다.
+
+---
+
+## 11. WebRTC Transport
+
+**소스**: `lib/server/server_webrtc_transport.ml` (183 LOC)
+
+### 11.1 활성화
+
+`MASC_WEBRTC_ENABLED=1`로 opt-in. Experimental 상태.
+
+### 11.2 Signaling Flow
+
+```
+Agent A                    MASC Server                    Agent B
+   |                           |                             |
+   |-- POST /webrtc/offer ---->|                             |
+   |   {agent_name, ice, dtls} |                             |
+   |<-- {offer_id} ------------|                             |
+   |                           |                             |
+   |                           |<-- POST /webrtc/answer -----|
+   |                           |    {offer_id, agent_name}   |
+   |                           |--- {peer_id, channel} ----->|
+   |                           |                             |
+   |<======= "masc-events" DataChannel (P2P) =============>|
+```
+
+ICE + DTLS 완료 후 `"masc-events"` DataChannel을 통해 JSON-RPC 메시지를 P2P로 교환한다. 서버는 signaling만 중계하고, 데이터 전송은 서버를 경유하지 않는다.
+
+만료된 offer는 60초 후 자동 정리 (`cleanup_expired_offers`).
+
+---
+
+## 12. Stdio Transport
+
+**소스**: `bin/main_stdio_eio.ml` (50 LOC), `lib/mcp_server_eio.ml` (`run_stdio`)
+
+### 12.1 Protocol Detection
+
+```ocaml
+type transport_mode = Framed | LineDelimited
+```
+
+stdin의 첫 바이트를 읽어 Content-Length 프레이밍 여부를 판단한다:
+- `Content-Length:` 로 시작: `Framed` 모드 (표준 MCP)
+- 그 외: `LineDelimited` 모드 (한 줄 = 한 JSON-RPC 메시지)
+
+### 12.2 동작
+
+- stdin에서 JSON-RPC 요청을 읽고, `mcp_server_eio.handle_request`로 처리한 후 stdout으로 응답을 쓴다.
+- 서버 상태 초기화는 HTTP 서버와 동일하게 `Server_runtime_bootstrap`를 통해 수행한다.
+- Keeper bootstrap, background maintenance, board flush 등 모든 부트스트랩 절차를 거친다.
+
+---
+
+## 13. Request Flow
+
+### 13.1 HTTP/1.1 POST /mcp 처리 흐름
+
+```mermaid
+sequenceDiagram
+    participant C as MCP Client
+    participant H as main_eio (httpun)
+    participant T as server_mcp_transport_http
+    participant A as server_auth
+    participant M as mcp_server_eio
+    participant D as tool_dispatch
+    participant S as Sse
+
+    C->>H: POST /mcp (JSON-RPC body)
+    H->>H: Origin 검증
+    H->>H: Protocol version 검증
+    H->>T: handle_post_mcp(request, reqd)
+    T->>T: Session ID 추출/생성
+    T->>T: Profile 검증 (Full/Managed/Operator)
+    T->>A: verify_mcp_auth(request)
+    A-->>T: Ok / Error
+
+    alt Auth 실패
+        T-->>C: 401 Unauthorized
+    end
+
+    T->>T: Accept header 분류 (Json / Sse / Rejected)
+    T->>M: handle_request(state, body_str)
+    M->>M: JSON-RPC 파싱
+    M->>D: execute_tool_eio(name, arguments)
+    D-->>M: (success, result_json)
+    M-->>T: Yojson.Safe.t 응답
+
+    alt Notification (id = null)
+        T-->>C: 202 Accepted (빈 body)
+    else Response
+        T-->>C: 200 OK + JSON-RPC response
+        T->>S: broadcast(event) [if SSE-worthy]
+    end
+```
+
+### 13.2 SSE 연결 흐름
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant H as main_eio
+    participant T as server_mcp_transport_http_sse
+    participant S as Sse
+
+    C->>H: GET /mcp (Accept: text/event-stream)
+    H->>T: handle_get_mcp(request, reqd)
+    T->>T: check_sse_connect_guard(session_id)
+    alt Rate limited
+        T-->>C: 429 Too Many Requests
+    end
+    T->>S: register(session_id, ~push, ~last_event_id)
+    S-->>T: (client_id, event_stream, evicted_opt)
+    T-->>C: 200 OK (Transfer-Encoding: chunked, Content-Type: text/event-stream)
+    T->>T: Event replay (get_events_after last_id)
+    T-->>C: Replayed events
+
+    loop SSE Connection
+        S->>T: pop(session_id) -> event
+        T-->>C: id: N\nevent: message\ndata: {...}\n\n
+    end
+
+    C->>H: Connection close
+    T->>S: unregister_if_current(session_id, client_id)
+```
+
+---
+
+## 14. Server Bootstrap
+
+**소스**: `lib/server/server_runtime_bootstrap.ml` (688 LOC)
+
+부트스트랩 순서 (`run_server` -> `Server_runtime_bootstrap.run`):
+
+1. `init_runtime_context`: Eio 환경(clock, net, proc_mgr, fs) 추출
+2. `create_server_state`: 서버 상태 생성 (Room config, Caqti DB pool, Eio context 설정)
+3. `bootstrap_server_state`: Room 초기화, Chain bootstrap, Tool registry warm-up, JSONL pruning
+4. `bootstrap_keepers`: Keeper 에이전트 부트스트랩
+5. `init_task_backend`: 태스크 백엔드 초기화
+6. `inject_shared_pg_pool`: PostgreSQL 연결 풀 주입
+7. `init_memory_pg_schema`: 메모리 PG 스키마 초기화
+8. `start_background_maintenance`: 주기적 cleanup fiber 시작
+9. HTTP 서버 listen 시작
+
+### 14.1 Graceful Shutdown
+
+`main_eio.ml`에서 SIGTERM/SIGINT 핸들러로 구현:
+
+1. `notifications/shutdown` SSE broadcast -> 200ms 대기
+2. `Shutdown_hooks.run_all()` 실행 (orchestrator 취소, SSE 닫기 등)
+3. `Board_dispatch.flush()` (dirty 데이터 저장)
+4. `close_all_sse_connections()`
+5. `Eio.Switch.fail sw Shutdown` -> Switch 종료
+6. 5초 타임아웃 후 강제 종료 (별도 Thread)
+
+### 14.2 Port Bind Retry
+
+포트 사용 중(`EADDRINUSE`)이면 exponential backoff로 최대 5회 재시도한다 (`2^attempt` 초, 최대 30초).
+
+---
+
+## 15. Configuration
+
+### 15.1 서버 설정
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `MASC_HOST` | `127.0.0.1` | 바인드 주소 |
+| `--port` / `-p` | `8935` | 리스닝 포트 |
+| `--base-path` | `$ME_ROOT` or `cwd` | `.masc` 데이터 디렉토리 위치 |
+
+### 15.2 트랜스포트 설정
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `MASC_USE_H2` | 0 | HTTP/2 h2c 활성화 |
+| `MASC_WS_ENABLED` | 0 | WebSocket 활성화 |
+| `MASC_GRPC_ENABLED` | 0 | gRPC 활성화 |
+| `MASC_GRPC_PORT` | 8936 | gRPC 포트 |
+| `MASC_WEBRTC_ENABLED` | 0 | WebRTC 활성화 |
+| `MASC_AGENT_TRANSPORT` | `local` | 에이전트 측 트랜스포트 선택 |
+
+### 15.3 인증 설정
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `MASC_HTTP_AUTH_STRICT` | non-loopback시 자동 | MCP 경로 토큰 인증 강제 |
+| `MASC_TOOL_AUTH_STRICT` | 1 | 미매핑 masc_* 도구에 Worker 이상 권한 요구 |
+| `MASC_ADMIN_TOKEN` | (미설정) | Admin API 토큰 |
+| `MASC_ALLOW_LEGACY_ACCEPT` | 0 | Accept 헤더 레거시 호환 |
+
+### 15.4 SSE 설정
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `MASC_SSE_RECONNECT_MIN_INTERVAL_S` | 0.0 | 최소 재연결 간격 |
+| `MASC_SSE_CONNECT_WINDOW_S` | 0.0 | Rate limit window |
+| `MASC_SSE_CONNECT_MAX_IN_WINDOW` | 0 | Window 내 최대 연결 수 |
+
+### 15.5 HTTP Compression
+
+`Http_server_eio.Compression` 모듈이 zstd + dictionary 압축을 지원한다:
+
+- `zstd`: 표준 zstd (256바이트 이상)
+- `zstd-dict`: MASC 전용 사전 기반 압축 (32-2048바이트에서 +70%p 향상)
+- `Accept-Encoding: zstd` 또는 `zstd-dict` 요청 시 적용
+
+---
+
+## 16. OpenAPI Document Generation
+
+`Transport.Rest.generate_openapi_document`가 OpenAPI 3.1 문서를 런타임에 생성한다:
+
+- `GET /api/v1/openapi.json`으로 접근
+- 모든 REST-바인딩된 MCP 도구를 OpenAPI path로 변환
+- `x-mcp-operations`: MCP 도구 카탈로그 (inputSchema, tags, help entry)
+- `x-agent-sdk-tools`: SDK alias 바인딩
+- `/mcp` POST 엔드포인트에 전체 operation catalog 첨부
+
+---
+
+## 17. Invariants
+
+**INV-SERVER-001**: HTTP/1.1 서버는 항상 활성. H2/WS/gRPC/WebRTC는 env var opt-in 없이 활성화되지 않는다.
+
+**INV-SERVER-002**: 모든 MCP POST 요청은 `initialize`/`ping` 제외 `Mcp-Session-Id` 헤더 필수. 없으면 `validate_session_requirement`가 거부한다.
+
+**INV-SERVER-003**: 동일 session ID로 다른 tool_profile의 엔드포인트 접근 불가 (`validate_mcp_session_profile` -> 409 Conflict).
+
+**INV-SERVER-004**: 동일 세션에서 protocol version 변경 불가 (`validate_protocol_version_continuity`).
+
+**INV-SERVER-005**: SSE broadcast는 registry에 global write-lock을 잡지 않는다. Read snapshot -> per-client stream add -> external subscriber notify 순서.
+
+**INV-SERVER-006**: `Sse.register`가 `max_clients` (200) 도달 시 oldest client를 evict한다. 신규 client 등록은 항상 성공한다.
+
+**INV-SERVER-007**: SSE event ID는 `Atomic.fetch_and_add`로 단조 증가한다. 동일 ID가 두 번 발급되지 않는다.
+
+**INV-SERVER-008**: Non-loopback bind 시 `MASC_HTTP_AUTH_STRICT`가 자동 활성화되어, 토큰 없는 MCP 접근을 차단한다.
+
+**INV-SERVER-009**: 토큰 저장은 SHA256 해시만. Raw token은 `create_token` 반환 시 한 번만 노출되고 서버에 저장되지 않는다.
+
+**INV-SERVER-010**: WebSocket/gRPC는 `Sse.subscribe_external`로 broadcast를 수신한다. SSE 레지스트리와 독립적인 세션 관리를 유지하면서 이벤트 통합은 external subscriber hook으로 달성한다.
+
+**INV-SERVER-011**: SIGTERM/SIGINT 수신 시 5초 내 graceful shutdown. 타임아웃 초과 시 `exit 1`. Shutdown notification이 모든 SSE 클라이언트에 broadcast된 후 종료한다.
+
+**INV-SERVER-012**: Admin API는 `MASC_ADMIN_TOKEN`과의 constant-time 비교(`with_admin_auth`)로 보호한다. 타이밍 사이드채널 차단.
+
+---
+
+## 18. Module Inventory
+
+### 18.1 Core Server (lib/)
+
+| Module | LOC | 역할 |
+|--------|-----|------|
+| `mcp_server_eio.ml` | 220 | JSON-RPC 핸들러 조립 (include 기반) |
+| `mcp_server_eio_protocol.ml` | 637 | initialize/ping/tools 메서드 디스패치 |
+| `mcp_server_eio_execute.ml` | 587 | 도구 실행 엔진 |
+| `mcp_server_eio_call_tool.ml` | 361 | 도구 호출 래퍼 |
+| `mcp_server_eio_tool_profile.ml` | 508 | Profile별 도구 필터링 |
+| `mcp_server_eio_resource.ml` | 335 | MCP Resource/Prompt 핸들러 |
+| `mcp_server_eio_governance.ml` | 110 | Governance 설정 |
+| `sse.ml` | 474 | SSE event registry + broadcast |
+| `sse_room_filter.ml` | 63 | Room별 SSE 필터링 |
+| `oas_sse_bridge.ml` | 56 | OAS -> SSE 이벤트 브릿지 |
+| `transport.ml` | 674 | 프로토콜 바인딩 추상화 + OpenAPI 생성 |
+| `http_server_eio.ml` | 675 | httpun-eio 래퍼 (Router, Compression) |
+| `http_server_h2.ml` | 325 | h2-eio 래퍼 |
+| `auth.ml` | 435 | 인증/인가 코어 |
+
+### 18.2 Server Sub-library (lib/server/)
+
+| Module | LOC | 역할 |
+|--------|-----|------|
+| `server_runtime_bootstrap.ml` | 688 | 서버 부트스트랩 전체 |
+| `server_mcp_transport_http.ml` | 924 | HTTP MCP 트랜스포트 통합 |
+| `server_mcp_transport_http_mcp_handlers.ml` | 451 | POST/GET/DELETE /mcp 핸들러 |
+| `server_mcp_transport_http_session.ml` | 225 | MCP 세션 상태 관리 |
+| `server_mcp_transport_http_sse.ml` | 158 | SSE 연결 관리 + rate limiter |
+| `server_mcp_transport_http_headers.ml` | 204 | HTTP 헤더 유틸리티 |
+| `server_mcp_transport_http_protocol.ml` | 135 | 프로토콜 버전/세션 유효성 |
+| `server_h2_gateway.ml` | 740 | HTTP/2 게이트웨이 (전체 라우팅) |
+| `server_h2_gateway_routes_cp.ml` | 579 | H2 Command Plane 라우트 |
+| `server_h2_gateway_routes_extra.ml` | 171 | H2 추가 라우트 |
+| `server_mcp_transport_ws.ml` | 160 | WebSocket 트랜스포트 |
+| `server_webrtc_transport.ml` | 183 | WebRTC signaling |
+| `server_auth.ml` | 491 | HTTP 레벨 인증/권한 |
+| `server_routes_http.ml` | 17 | 라우트 조립 진입점 |
+| `server_dashboard_http.ml` | 566 | Dashboard API 핸들러 |
+| `server_command_plane_http.ml` | 56 | Command Plane HTTP 핸들러 |
+| `server_utils.ml` | 120 | 공용 유틸리티 |
+
+### 18.3 gRPC (lib/grpc/)
+
+| Module | LOC | 역할 |
+|--------|-----|------|
+| `masc_grpc_types.ml` | 485 | gRPC 메시지 타입 (JSON wire format) |
+| `masc_grpc_service.ml` | 417 | gRPC 서비스 핸들러 |
+| `masc_grpc_server.ml` | 67 | gRPC 서버 시작 |
+| `masc_grpc_client.ml` | 150 | gRPC 클라이언트 |
+| `masc_grpc_transport.ml` | 24 | 트랜스포트 선택 로직 |
+
+---
+
+## 19. References
+
+| 문서 | 위치 |
+|------|------|
+| MCP Specification | https://modelcontextprotocol.io/specification |
+| httpun-eio | https://github.com/anmonteiro/httpun |
+| h2-eio | https://github.com/anmonteiro/ocaml-h2 |
+| httpun-ws | https://github.com/anmonteiro/httpun-ws |
+| grpc-direct | `workspace/yousleepwhen/grpc-direct` |
+| Cloudflare Tunnel | CLAUDE.md "Cloudflare Tunnel" 섹션 |
+| QUICK-START.md | `docs/QUICK-START.md` |
+| COMMON-PITFALLS.md | `docs/COMMON-PITFALLS.md` |
+| 02-types-and-invariants | `docs/spec/02-types-and-invariants.md` |

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -1,0 +1,694 @@
+# Dashboard
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Dashboard |
+| Maps to | `lib/dashboard/dashboard_*.ml`, `lib/server/server_dashboard_http*.ml`, `lib/web_dashboard.ml`, `lib/credits_dashboard.ml`, `dashboard/` |
+| Dependencies | 09-server-transport, 05-keeper-agent, Room, Operator_control, Team_session_store, Council.Governance_v2 |
+| Modules (OCaml) | 39 (.ml + .mli) |
+| LOC (OCaml) | ~13K |
+| Modules (Frontend) | ~210 TypeScript + ~15 CSS |
+| LOC (Frontend) | ~36K TypeScript + ~3.8K CSS |
+
+## 1. Purpose
+
+MASC 상태를 실시간으로 시각화하는 웹 대시보드.
+OCaml 서버가 JSON API를 제공하고, Preact SPA가 SSE로 실시간 업데이트를 수신한다.
+
+핵심 역할:
+- Room, Session, Keeper, Agent의 상태를 하나의 운영 콘솔로 통합
+- 운영자 개입이 필요한 항목(Attention)을 자동 분류하고 우선순위를 부여
+- Governance 심의 흐름, Proof 증거, Command Plane 상태를 읽기 전용 surface로 표시
+- Keeper 메트릭 시계열, 도구 호출 건강도, MDAL 루프 진행을 시각화
+
+## 2. Architecture
+
+```
+Browser (Preact SPA)
+  |
+  |-- SSE (/sse) ---> OCaml HTTP Server (Httpun_eio)
+  |-- REST (/api/v1/*) ---> OCaml HTTP Handler (server_dashboard_http.ml)
+  |
+  +-- Vite build --> assets/dashboard/ --> web_dashboard.ml (static file serving)
+
+OCaml Backend:
+  server_dashboard_http.ml (facade)
+    |-- server_dashboard_http_core.ml (Executor_pool offload, batch API)
+    |-- dashboard_http_monitoring.ml  (tool health, board/governance monitors)
+    |-- dashboard_http_keeper.ml      (keeper dashboard rendering)
+    |   |-- dashboard_http_keeper_detail.ml (metrics window computation)
+    |   |-- dashboard_http_keeper_metrics.ml (types, 24h bucket stats)
+    |-- dashboard_http_mdal.ml        (MDAL loop rendering)
+    |-- dashboard_http_helpers.ml     (env parsing, JSON utilities)
+    |
+    |-- dashboard_execution.ml        (Execution surface)
+    |   |-- dashboard_execution_helpers.ml
+    |   |-- dashboard_execution_builders.ml
+    |   |-- dashboard_execution_sessions.ml
+    |   |-- dashboard_execution_fixture.ml
+    |
+    |-- dashboard_mission.ml          (Mission surface)
+    |   |-- dashboard_mission_assembly.ml
+    |   |-- dashboard_mission_agents.ml
+    |   |-- dashboard_mission_briefing.ml
+    |
+    |-- dashboard_governance.ml       (Governance surface)
+    |-- dashboard_governance_judge.ml (Judge operator loop)
+    |-- dashboard_operator_judge.ml   (Operator judge)
+    |
+    |-- dashboard_proof.ml            (Proof surface)
+    |   |-- dashboard_proof_events.ml
+    |   |-- dashboard_proof_actors.ml
+    |   |-- dashboard_proof_verdict.ml
+    |   |-- dashboard_proof_helpers.ml
+    |
+    |-- dashboard_cache.ml            (SWR cache with Eio.Mutex)
+    |-- dashboard_labels.ml           (Pure state-to-text translation)
+    |-- dashboard_semantics.ml        ("Why" layer -- surface/panel/metric registry)
+    |-- dashboard_attention.ml        (Attention item detection)
+    |-- dashboard_agent_relations.ml  (GraphQL proxy for agent relations)
+    |-- dashboard_utils.ml            (ISO timestamp, text normalization)
+    |-- dashboard_provider_runs.ml    (Provider run tracking)
+    |
+    |-- credits_dashboard.ml          (Standalone OCaml-rendered HTML dashboard)
+    |-- web_dashboard.ml              (Static file serving wrapper)
+```
+
+## 3. Backend Subsystems
+
+### 3.1. Cache Layer (`dashboard_cache.ml`, `dashboard_cache.mli`)
+
+**364 LOC.** 시간 기반 메모이제이션과 stale-while-revalidate 패턴을 구현한다.
+
+#### 핵심 타입
+
+```ocaml
+type entry = {
+  value : Yojson.Safe.t;
+  expires_at : float;    (* fresh 유효기간 *)
+  stale_until : float;   (* stale grace 기간 *)
+}
+
+type slot =
+  | Ready of entry
+  | Computing of { cond : Eio.Condition.t; started_at : float; stale : Yojson.Safe.t option }
+```
+
+#### 동작 모드 3가지
+
+| 조건 | 동작 |
+|------|------|
+| `now < expires_at` (Fresh) | 즉시 반환 |
+| `expires_at <= now < stale_until` (Stale) | stale 값 즉시 반환 + background fiber로 재계산 |
+| `now >= stale_until` 또는 미존재 | 블로킹 계산 후 반환 |
+
+#### 설계 결정
+
+- **stale_factor = 10.0**: Eio cooperative scheduling에서 compute-heavy endpoint의 wall-clock 시간이 길어지므로, stale window를 TTL의 10배로 설정하여 즉시 응답 비율을 높인다.
+- **max_wait_sec = 130.0**: 가장 긴 endpoint 타임아웃(120s, /execution)보다 길게 설정하여 계산 중인 slot을 중간에 evict하지 않는다.
+- **per-key locking**: 단일 `Eio.Mutex`가 `Hashtbl` 접근만 보호하고, `compute` 함수는 lock 밖에서 실행된다. 서로 다른 key에 대한 nested `get_or_compute`가 deadlock 없이 동작한다.
+- **poll-retry vs Condition.await**: `Condition.await`는 `protect:true` 내부에서 Eio cancellation이 비활성화되어 영구 블로킹 위험이 있다. 대신 0.5s 간격 poll loop를 mutex 밖에서 실행하여 cancellation을 유지한다.
+- **cooldown after timeout eviction**: Computing slot이 `max_wait_sec`를 초과하면, 즉시 새 compute를 시작하지 않고 15초 cooldown Ready entry를 삽입하여 thrashing을 방지한다.
+- **ownership token**: 각 compute는 자신의 `cond`를 소유권 토큰으로 사용한다. write-back 전 physical equality(`==`)로 slot이 교체되지 않았는지 확인하여, evict된 fiber가 후속 slot을 덮어쓰는 것을 방지한다.
+
+#### API Surface
+
+| 함수 | 용도 |
+|------|------|
+| `enable_eio ?clock ()` | Eio.Mutex 활성화. `Eio_main.run` 내부에서 1회 호출 |
+| `set_sw sw` | Background revalidation fiber용 switch 등록 |
+| `get_or_compute key ~ttl f` | 캐시 조회 또는 계산 |
+| `get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec f` | 타임아웃 포함 계산 |
+| `invalidate key` | 단일 entry 제거 |
+| `invalidate_all ()` | 전체 entry 제거 (mutation 후 사용) |
+| `stats ()` | `{entries, fresh, stale, computing, expired}` JSON 반환 |
+
+### 3.2. Labels Layer (`dashboard_labels.ml`)
+
+**171 LOC.** 순수 함수. IO 없음. raw 상태를 운영자가 읽을 수 있는 텍스트로 변환한다.
+
+- **Agent status 번역**: `Active` + 15분 이상 미활동 = `"STUCK"`, 5분 이상 = `"quiet"`, `Listening` = `"idle"`, `Inactive` = `"offline"`
+- **Agent 분류**: `classify_agent` -> `Working | Stuck | Idle | Offline` (downstream capacity 로직에서 Offline을 available로 취급하지 않기 위해 Idle과 분리)
+- **Lane status 번역**: phase + motion_state 조합을 한 줄 문장으로 변환
+- **Flag code 번역**: `"pending_manual_confirmation"` -> `"Waiting for your approval"` 등
+- **Health verdict**: lane summary 목록에서 stalled/blocked lane 수를 세어 한 줄 건강 요약 생성
+
+공유 타입 정의:
+```ocaml
+type swarm_lane_summary = { label; present; phase; motion_state; age; current_step; hard_flags }
+type room_snapshot = { room_id; is_current; agents; tasks; messages; locks }
+```
+
+### 3.3. Semantics Layer (`dashboard_semantics.ml`)
+
+**726 LOC.** 대시보드의 "왜" 레이어. 각 surface, panel, metric에 대해 `purpose`, `problem_solved`, `when_active`, `agent_role`, `ecosystem_function`을 선언적으로 등록한다.
+
+12개 surface를 정의한다:
+
+| Surface ID | Label | Panel 수 |
+|------------|-------|---------|
+| `side_rail` | 사이드 레일 | 3 |
+| `home` | Home | 7 |
+| `mission` | 미션 | 14 |
+| `intervene` | Intervene | 7 |
+| `proof` | Proof | 7 |
+| `command` | Command | 10 |
+| `execution` | Execution | 6 |
+| `memory` | Memory | 1 |
+| `governance` | Governance | 8 |
+| `activity_graph` | Activity Graph | 4 |
+| `planning` | Planning | 4 |
+| `lab` | Lab | 3 |
+
+`/api/v1/dashboard/semantics` endpoint로 JSON을 제공한다. 프론트엔드가 metric tooltip과 panel 설명을 이 데이터에서 읽는다.
+
+### 3.4. Attention Detection (`dashboard_attention.ml`)
+
+**212 LOC.** 순수 함수. Room snapshot을 스캔하여 운영자 개입이 필요한 항목을 분류한다.
+
+```ocaml
+type severity = Critical | Warning | Info
+
+type attention_item = {
+  severity : severity;
+  category : string;      (* "stuck_agent", "blocked_lane", etc. *)
+  summary : string;       (* 사람이 읽을 수 있는 한 줄 설명 *)
+  suggested_tool : string; (* MCP 도구 이름 *)
+}
+```
+
+탐지 규칙 예시:
+- **stuck_agent**: `Active|Busy` 상태인데 `last_seen`이 15분(900s) 이상 전 -> `Critical`
+- severity 순서(`Critical > Warning > Info`)로 정렬하여 반환
+
+### 3.5. Governance Surface (`dashboard_governance.ml`)
+
+**552 LOC.** `Council.Governance_v2` (GV2) case bundle을 대시보드 JSON으로 변환한다.
+
+주요 함수:
+- `dashboard_json`: 전체 governance 대시보드 (summary + items + activity + judge + pending_actions)
+- `cases_json`: case 목록 (pagination: limit/offset)
+- `case_detail_json`: 단일 case bundle 상세 (case + petitions + briefs + ruling + execution_order)
+- `factual_snapshot_json`: 전체 case bundle의 팩트 기반 스냅샷 (judge prompt 입력용)
+
+각 case bundle은 다음 필드를 포함하는 JSON으로 변환된다:
+- `truth_summary`: petition/brief/ref 카운트 요약
+- `judgment_summary`: ruling 요약
+- `recommended_action`: 권장 액션 (action_kind, resolved_tool, target)
+- `executed_route`: 실행 명령 상태
+- `guardrail_state`: human gate 필요 여부, 실행 준비 상태
+- `auto_execution_state`: 자동 실행 상태
+- `activity`: petition/brief/ruling/order 이벤트 타임라인
+
+### 3.6. Governance Judge (`dashboard_governance_judge.ml`)
+
+**400 LOC.** 주기적으로 governance factual snapshot을 LLM에 보내고 judgment를 생성하는 daemon fiber.
+
+- `start`: `Eio.Fiber.fork_daemon`으로 시작. `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` (기본 60초) 간격으로 반복
+- `refresh_once`: `Oas_worker.run_named_with_masc_tools`로 `"governance_judge"` cascade 호출 -> judgment 파싱 -> `Dated_jsonl` store에 append
+- **date-split store**: `.masc/governance/judgments/YYYY-MM/DD.jsonl` (legacy 단일 파일 fallback 지원)
+- `compute_judgments`: factual JSON을 prompt로 변환하고 LLM 호출. 결과에서 item별 judgment를 파싱하여 반환
+- **allowed_tool whitelist**: recommended_action의 resolved_tool은 5개 도구만 허용 (`masc_governance_status`, `masc_execution_orders`, `masc_execute_dry_run`, `masc_execute`, `masc_operator_confirm`)
+- 상태: per-base_path mutable state (`judge_online`, `refreshing`, `generated_at`, `model_used`, `last_error`)
+
+### 3.7. Execution Surface (`dashboard_execution.ml` + 하위 모듈)
+
+**~2,020 LOC (4 sub-modules 포함).** 운영 중인 session, operation, worker, keeper의 실행 상태를 종합한다.
+
+`.mli` 시그니처:
+```ocaml
+val json :
+  ?actor:string -> ?fixture:string -> ?light:bool ->
+  config:Room.config -> sw:Eio.Switch.t -> clock:'a Eio.Time.clock ->
+  proc_mgr:_ option -> unit -> Yojson.Safe.t
+```
+
+#### Sub-modules
+
+| 모듈 | LOC | 역할 |
+|------|-----|------|
+| `dashboard_execution_helpers.ml` | 475 | `session_context`, `operation_context`, `queue_context` 등 타입 정의 + JSON 필드 접근 헬퍼 |
+| `dashboard_execution_builders.ml` | 473 | `build_session_contexts`, `build_operation_contexts`, `build_execution_queue`, `build_worker_support_briefs`, `build_continuity_briefs` |
+| `dashboard_execution_sessions.ml` | 420 | `Team_session_store` 기반 session card 구축 |
+| `dashboard_execution_fixture.ml` | 513 | 테스트 fixture (`execution_smoke`) |
+| `dashboard_execution.ml` | 306 | 최상위 orchestration: session 로드 -> snapshot -> digest -> queue/worker/continuity 빌드 |
+
+#### 렌더링 흐름
+
+1. `since_unix` 24h cutoff으로 session 필터링 (최대 100개)
+2. `Operator_control.snapshot_json`으로 전체 room snapshot 구성
+3. (full mode) `Operator_control.digest_json`에서 session_cards 추출
+4. session/operation/execution_queue/worker/continuity context 구축
+5. 크기 제한 적용: sessions max 15, operations max 20 (active만), queue max 10, tasks max 50
+
+#### 성능 보호
+
+- **render_timeout_s = 30.0**: `Eio.Time.with_timeout`으로 감싸서 PG 연결 실패 시 무한 대기 방지 (실제 11,018s hang 발생 기록)
+- **Eio.Fiber.yield()**: CPU-bound 구간 사이에 명시적 yield 삽입하여 SSE/health-check fiber가 진행할 수 있게 보장
+- **light mode**: 기본 모드. messages 직렬화를 생략하여 ~143KB 절감
+
+### 3.8. Mission Surface (`dashboard_mission.ml` + 하위 모듈)
+
+**~1,975 LOC (3 sub-modules 포함).** Room 인시던트와 다음 액션을 위한 트리아지 우선 랜딩 뷰.
+
+`.mli` 시그니처:
+```ocaml
+val json :
+  ?actor:string -> config:Room.config -> sw:Eio.Switch.t ->
+  clock:'a Eio.Time.clock -> proc_mgr:_ option -> unit -> Yojson.Safe.t
+```
+
+| 모듈 | LOC | 역할 |
+|------|-----|------|
+| `dashboard_mission_assembly.ml` | 486 | `session_context`, `attention_context` 타입 + session assembly 로직 |
+| `dashboard_mission_agents.ml` | 403 | agent card 구축 (agent pulse, session-agent mapping) |
+| `dashboard_mission_briefing.ml` | 316 | mission briefing 생성 (LLM 기반 요약 + metadata gap 감지) |
+
+`dashboard_mission_briefing.mli`는 테스트용 `For_test` sig를 노출한다:
+- `compact_session_json`, `compact_keeper_json`, `compact_agent_json`: briefing 입력 압축
+- `relevant_sessions_for_briefing`: 현재 room의 active session 필터링
+- `collect_metadata_gaps`: session/keeper/agent의 metadata 누락 감지
+- `build_briefing_sections`: 요약 텍스트 + section JSON 빌드
+
+### 3.9. Proof Surface (`dashboard_proof.ml` + 하위 모듈)
+
+**~748 LOC (4 sub-modules 포함).** 협업 증거, actor 기여, 관리 backing artifact를 하나의 읽기 전용 surface로 통합한다.
+
+`.mli` 시그니처:
+```ocaml
+val json :
+  ?actor:string -> ?session_id:string -> ?operation_id:string ->
+  config:Room.config -> unit -> Yojson.Safe.t
+```
+
+| 모듈 | LOC | 역할 |
+|------|-----|------|
+| `dashboard_proof_helpers.ml` | 84 | 공유 헬퍼 |
+| `dashboard_proof_events.ml` | 115 | 이벤트 파싱 |
+| `dashboard_proof_actors.ml` | 283 | actor 기여 분석 |
+| `dashboard_proof_verdict.ml` | 266 | verdict, timeline, session summary |
+
+proof 문서가 존재하지 않으면 `Team_session_report_proof.generate_proof`로 자동 생성한다.
+
+### 3.10. Keeper Metrics & Detail (`dashboard_http_keeper*.ml`)
+
+**~1,801 LOC (3 모듈).** Keeper별 메트릭 시계열, 24h bucket 통계, 대화 이력, 메모리 뱅크, 진단 요약을 렌더링한다.
+
+| 모듈 | LOC | 역할 |
+|------|-----|------|
+| `dashboard_http_keeper_metrics.ml` | 420 | `keeper_gen_window_stats` 타입, model/tool count table, UTF-8 safe prefix |
+| `dashboard_http_keeper_detail.ml` | 775 | metrics window computation: handoff/compaction/fallback/tool_call/drift/goal_alignment/memory 카운터 추출 |
+| `dashboard_http_keeper.ml` | 606 | `keepers_dashboard_json` 최상위 함수. Eio.Fiber.all로 keeper별 I/O를 병렬 실행 |
+
+`keepers_dashboard_json` 흐름:
+1. `Keeper_types.resident_keeper_names`로 keeper 이름 목록 취득
+2. keeper별로 `Eio.Fiber.all`로 병렬 I/O (metadata + metrics read)
+3. `Dated_jsonl.read_recent_lines`로 metrics 로드 (compact: 120줄, full: 500줄 cap)
+4. generation별 stats 집계 (`keeper_gen_window_stats`)
+5. 24h bucket 통계, 시계열 series, 대화 이력 fragment 등 JSON 구성
+
+### 3.11. Agent Relations (`dashboard_agent_relations.ml`)
+
+**100 LOC.** GraphQL 프록시. Second Brain GraphQL 서버에서 `COLLABORATED_WITH` 네트워크와 `TRUSTS` 관계를 fetch하여 대시보드 JSON으로 변환한다.
+
+2개의 GraphQL 쿼리:
+- `agentCollaborationNetworkByName`: name/collaborations/lastCollab
+- `agent > relations`: type/category/confidence/participants
+
+### 3.12. Monitoring (`dashboard_http_monitoring.ml`)
+
+**268 LOC.** 도구 호출 건강도, Board 모니터, Governance 모니터를 제공한다.
+
+- `tool_call_health_json`: 설정 가능한 window (기본 1시간) 내 tool_call 이벤트에서 total/failures/timeouts/failure_rate/p95_duration_ms 계산
+- `board_monitoring_json`: Board 계약 건강도
+- `governance_monitoring_json`: Governance 피드 건강도
+
+### 3.13. Credits Dashboard (`credits_dashboard.ml`)
+
+**529 LOC.** 별도의 OCaml 렌더링 HTML 대시보드. `/dashboard/credits` 경로에서 서빙된다.
+
+`~/me/data/state/credits.json`을 읽어서 AI 서비스 사용량을 시각화한다 (Claude Max, ChatGPT Pro, ElevenLabs, RunPod, Railway, Anthropic API 등).
+
+SPA가 아닌 OCaml에서 직접 HTML을 생성하여 반환하는 독립 페이지이며, JSON API (`/api/v1/credits`)도 함께 제공한다.
+
+### 3.14. Static File Serving (`web_dashboard.ml`)
+
+**58 LOC.** SPA index.html과 static asset을 서빙하는 래퍼.
+
+- `assets_root()`: `MASC_ASSETS_ROOT` -> `MASC_ASSETS_DIR` -> `exe_dir/assets` -> `cwd/assets` 순서로 탐색
+- `index_path()`: `{assets_root}/dashboard/index.html`
+- `html()`: index.html 로드 (파일 없으면 빌드 안내 fallback HTML)
+- `etag()`: mtime 기반 ETag 생성 (12자 hex)
+- `is_safe_asset_relative_path`: path traversal 방어 (`.`, `..`, `\`, `\0` 거부)
+
+### 3.15. HTTP Endpoint Orchestration (`server_dashboard_http*.ml`)
+
+**~1,176 LOC (2 모듈).**
+
+#### Executor Pool Offload (`server_dashboard_http_core.ml`)
+
+CPU-heavy 대시보드 계산을 `Eio.Executor_pool`에 위임하여 main Eio domain의 MCP tool call이 starve되지 않게 한다.
+
+```ocaml
+val run_dashboard_compute :
+  sw:_ -> clock:_ -> config:Room.config ->
+  (config:Room.config -> sw:Eio.Switch.t -> 'a) -> 'a
+```
+
+PostgresNative 백엔드의 경우 domain-local Caqti pool을 생성한다 (main domain의 pool은 Switch capture로 인해 domain-bound).
+
+#### Proactive Refresh (`start_execution_refresh_loop`)
+
+Execution endpoint는 proactive refresh loop로 60초 간격 사전 계산하여 `_execution_json_ref`에 저장한다.
+기본 요청(파라미터 없는 light mode)은 캐시된 값을 0ms에 반환한다.
+파라미터가 있는 요청(fixture/actor/full)만 on-demand SWR cache를 사용한다.
+
+#### Dashboard timeout wrapper
+
+```ocaml
+val with_dashboard_timeout : clock:_ -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t
+```
+30초 타임아웃. 초과 시 `{"error":"timeout","partial":true,...}` 반환.
+
+## 4. Frontend Architecture
+
+### 4.1. Technology Stack
+
+| 항목 | 기술 |
+|------|------|
+| UI Framework | Preact (~3KB) + HTM (~1KB) |
+| State | @preact/signals (reactive, fine-grained re-render) |
+| Build | Vite + @preact/preset-vite |
+| CSS | Tailwind CSS (@tailwindcss/vite plugin) |
+| Test | Vitest |
+| Language | TypeScript |
+
+### 4.2. Directory Structure
+
+```
+dashboard/
+  src/
+    main.ts                    -- Entry point
+    app.ts                     -- Root component
+    router.ts                  -- Hash-based routing
+    sse.ts                     -- SSE hook (auto-reconnect, signal dispatch)
+    store.ts                   -- Centralized signal store
+    api.ts                     -- API barrel re-export
+    api/
+      core.ts                  -- HTTP infra, auth, generic fetchers
+      dashboard.ts             -- Dashboard projection fetchers
+      board.ts                 -- Board API
+      keeper.ts                -- Keeper API (streaming chat)
+      mcp.ts                   -- MCP tool proxy
+      trpg.ts                  -- TRPG API
+      actions.ts               -- Operator actions, activity graph
+    types.ts                   -- Type barrel re-export
+    types/
+      core.ts                  -- Agent, Task, Message, Keeper, BoardPost, ...
+      dashboard-execution.ts   -- Execution response types
+      dashboard-mission.ts     -- Mission response types
+      command-plane.ts         -- Command plane types
+      governance.ts            -- Governance types
+      oas.ts                   -- OAS types
+      sse.ts                   -- SSE event types
+      trpg.ts                  -- TRPG types
+    components/
+      dashboard-shell.ts       -- Top-level shell (side rail + content)
+      overview/                -- Home surface (7 components)
+      mission*.ts              -- Mission surface (6 components)
+      command/                 -- Command surface (18 components)
+      execution/               -- Execution surface (5 components)
+      governance*.ts           -- Governance surface (6 components)
+      proof*.ts                -- Proof surface (3 components)
+      keeper-*.ts              -- Keeper detail (8 components)
+      agent-*.ts               -- Agent views (8 components)
+      live/                    -- Live activity (3 components)
+      goals/                   -- Planning surface (5 components)
+      ops/                     -- Intervene surface (7 components)
+      lab*.ts                  -- Lab surface (2 components)
+      tools/                   -- Tool inventory (5 components)
+      common/                  -- Shared primitives (30+ components)
+    normalizers/               -- Swarm data normalizers (7 modules)
+    *-store.ts, *-signals.ts   -- Domain signal stores
+    *-normalizers.ts           -- Data normalization
+    styles/                    -- CSS files (15)
+    config/
+      navigation.ts            -- Dashboard surface/tab definitions
+      avatar-palettes.ts       -- Avatar visual config
+    lib/                       -- Utility modules (format-time, truncate, ...)
+  index.html
+  vite.config.ts
+  tsconfig.json
+  vitest.config.ts
+  package.json
+```
+
+### 4.3. Routing
+
+Hash-based routing (`#home`, `#mission`, `#operations`, ...).
+
+```typescript
+const DEFAULT_ROUTE: RouteState = { tab: 'home', params: {}, postId: null }
+```
+
+라우팅 흐름:
+1. `location.hash`에서 path + query params 파싱
+2. segment 정규화 (`/dashboard/` prefix 제거)
+3. tab ID 해석 (`VALID_TABS` 확인 -> `LEGACY_TAB_REDIRECTS` 적용)
+4. Command surface 하위 경로: `warroom`, `summary`, `orchestra`, `swarm`, `operations`, `topology`, `alerts`, `trace`, `chains`, `control`
+5. Lab section: `overview`, `trpg`, `avatars`
+6. Deep link: `/chains/operation/:id` -> operations command surface
+
+### 4.4. SSE Integration
+
+`sse.ts`의 `useSSE()` hook:
+- exponential backoff 재연결 (base 1s, max 15s)
+- session ID 생성 (`sessionStorage`)
+- signal 기반 이벤트 dispatch (`connected`, `eventCount`, `lastEvent`, `journal`)
+- `reconnectCount`, `lastDisconnectedAt` 추적
+
+SSE 이벤트 -> signal store 업데이트 -> 해당 signal을 구독하는 component만 re-render.
+
+Journal: 최대 200개 항목 보관. agent/text/kind/timestamp.
+
+### 4.5. State Management
+
+`@preact/signals` 기반 centralized store (`store.ts`):
+- SSE 이벤트와 API 응답이 signal을 업데이트
+- `computed` signal로 파생 상태 계산
+- component는 signal을 직접 참조하여 fine-grained re-render
+
+도메인별 store 분리:
+- `store.ts`: 공통 (agents, tasks, messages, keepers, ...)
+- `mission-store.ts`, `mission-signals.ts`: Mission surface
+- `command-store.ts`: Command surface
+- `governance-store.ts`: Governance surface
+- `proof-store.ts`: Proof surface
+- `keeper-state.ts`, `keeper-store-normalize.ts`: Keeper detail
+- `live-store.ts`: Live activity
+- `sse-store.ts`: SSE 상태
+- `room-truth-store.ts`: Room truth
+- `operator-store.ts`: Operator actions/digest
+- `observatory-store.ts`: Observatory
+- `pending-confirm.ts`: Pending confirmations
+
+### 4.6. Build Pipeline
+
+```bash
+cd dashboard && npm run dev    # Vite dev server :5173 (HMR)
+cd dashboard && npm run build  # Production build -> ../assets/dashboard/
+```
+
+Vite 설정:
+- `base: '/dashboard/'` (SPA base path)
+- `outDir: '../assets/dashboard'` (OCaml 서버가 서빙하는 위치)
+- `manualChunks: { vendor: ['preact', 'preact/hooks', 'htm', '@preact/signals'] }`
+- Dev proxy: `MASC_DASHBOARD_PROXY_TARGET` -> `/api/*`, `/sse/*` 프록시
+
+## 5. HTTP API Endpoints
+
+프론트엔드가 호출하는 Backend API 목록:
+
+### Dashboard Projections
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/dashboard/shell` | GET | 대시보드 batch data (room status, agents, tasks, board, governance, keepers) |
+| `/api/v1/dashboard/execution` | GET | Execution surface (proactive refresh, 0ms 응답) |
+| `/api/v1/dashboard/mission` | GET | Mission surface |
+| `/api/v1/dashboard/session?session_id=X` | GET | Mission session detail |
+| `/api/v1/dashboard/mission/briefing` | GET | Mission briefing (LLM 생성) |
+| `/api/v1/dashboard/proof?session_id=X` | GET | Proof surface |
+| `/api/v1/dashboard/planning` | GET | Planning surface |
+| `/api/v1/dashboard/governance` | GET | Governance surface |
+| `/api/v1/dashboard/board` | GET | Board monitoring |
+| `/api/v1/dashboard/room-truth` | GET | Room truth focus |
+| `/api/v1/dashboard/semantics` | GET | Semantics registry (surface/panel/metric definitions) |
+| `/api/v1/dashboard/tools` | GET | Tool inventory + usage |
+| `/api/v1/dashboard/logs` | GET | System logs |
+
+### Resource APIs
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/agents?limit=N` | GET | Agent 목록 |
+| `/api/v1/tasks` | GET | Task 목록 |
+| `/api/v1/messages` | GET | Message 목록 |
+| `/api/v1/agent-activity?hours=N` | GET | Agent 활동 이력 |
+| `/api/v1/agent-timeline?agent_name=X` | GET | Agent 타임라인 |
+| `/api/v1/agent-relations?agent_name=X` | GET | Agent 관계 (GraphQL proxy) |
+| `/api/v1/tool-metrics` | GET | Tool 사용 메트릭 |
+| `/api/v1/karma` | GET | Karma 조회 |
+| `/api/v1/activity/graph` | GET | Activity graph |
+| `/api/v1/credits` | GET | Credits JSON |
+
+### Command Plane
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/command-plane` | GET | Command plane snapshot |
+| `/api/v1/command-plane/summary` | GET | Command plane summary |
+| `/api/v1/command-plane/help` | GET | Command plane help |
+| `/api/v1/command-plane/swarm` | GET | Swarm status |
+| `/api/v1/command-plane/orchestra` | GET | Orchestra map |
+| `/api/v1/chains/summary` | GET | Chain summary |
+| `/api/v1/chains/runs/:runId` | GET | Chain run detail |
+
+### Governance
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/governance/params` | GET | Governance runtime parameters |
+| `/api/v1/governance/feed` | GET | Governance feed |
+
+### Keeper
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/keepers/:name/config` | GET | Keeper config 조회 |
+| `/api/v1/keepers/:name/config` | PATCH | Keeper config 수정 |
+| `/api/v1/keepers/chat/stream` | POST | Keeper streaming chat |
+
+### Operator
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/operator` | GET | Operator snapshot |
+| `/api/v1/operator/digest` | GET | Operator digest |
+| `/api/v1/operator/action` | POST | Operator action 실행 |
+| `/api/v1/operator/confirm` | POST | Pending confirmation 확인 |
+
+### Board
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/board` | GET | Board post 목록 |
+| `/api/v1/board/:postId` | GET | Board post detail |
+| `/api/v1/board/hearths` | GET | Hearth 목록 |
+| `/api/v1/board/flairs` | GET | Flair 목록 |
+
+### MDAL
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/mdal/loops` | GET | MDAL 루프 목록 |
+
+### TRPG
+
+| Endpoint | Method | 용도 |
+|----------|--------|------|
+| `/api/v1/trpg/events` | GET | TRPG 이벤트 |
+| `/api/v1/trpg/state` | GET | TRPG 상태 |
+
+### SSE
+
+| Endpoint | 용도 |
+|----------|------|
+| `/sse` | Server-Sent Events 스트림 |
+
+### Static Files
+
+| Route | 용도 |
+|-------|------|
+| `/dashboard` | SPA index.html |
+| `/dashboard/assets/*` | Static assets (JS, CSS, images) |
+| `/dashboard/credits` | Credits HTML 페이지 (OCaml 렌더링) |
+
+## 6. Configuration
+
+### Environment Variables
+
+| 변수 | 기본값 | 용도 |
+|------|--------|------|
+| `MASC_ASSETS_ROOT` / `MASC_ASSETS_DIR` | `{exe_dir}/assets` | Static asset 루트 |
+| `MASC_DASHBOARD_PROXY_TARGET` | (필수, dev only) | Vite dev server API proxy 대상 |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | `true` | Governance judge daemon 활성화 |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | `60` | Judge 갱신 간격 (최소 15s) |
+| `MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS` | `1.0` | Tool call health window (0.1~168h) |
+| `MASC_DASHBOARD_INCLUDE_GOALS` | `false` | Keeper dashboard에 goal 포함 여부 |
+| `MASC_KEEPER_HISTORY_FRAGMENT_FILTER` | `true` | Keeper 이력 fragment 필터 활성화 |
+| `MASC_DASHBOARD_PROACTIVE_FALLBACK_WARN` | `0.20` | Proactive fallback 경고 임계값 |
+| `MASC_DASHBOARD_PROACTIVE_FALLBACK_BAD` | `0.40` | Proactive fallback 위험 임계값 |
+| `MASC_DASHBOARD_PROACTIVE_SIMILARITY_WARN` | `0.90` | Proactive similarity 경고 임계값 |
+| `MASC_DASHBOARD_PROACTIVE_SIMILARITY_BAD` | `0.97` | Proactive similarity 위험 임계값 |
+| `MASC_DASHBOARD_ALERT_TOAST_COOLDOWN_SEC` | `300` | Alert toast 재표시 쿨다운 (10~3600s) |
+
+## 7. Invariants
+
+**INV-DASH-001 (Cache SWR)**
+`get_or_compute`의 stale-while-revalidate 경로에서 background recompute가 실패하면, stale 값을 복원한다. 에러 JSON으로 덮어쓰지 않는다.
+
+**INV-DASH-002 (Cache ownership)**
+`compute` 완료 후 write-back 전에 slot의 `cond`를 physical equality(`==`)로 확인한다. slot이 evict/교체된 경우 write-back을 건너뛴다.
+
+**INV-DASH-003 (Cache mutex scope)**
+`Eio.Mutex`는 `Hashtbl` 접근만 보호한다. `compute` 함수는 lock 밖에서 실행되어 서로 다른 key의 nested call이 deadlock 없이 동작한다.
+
+**INV-DASH-004 (Cooldown after eviction)**
+Computing slot이 `max_wait_sec`(130s) 초과로 evict되면, 즉시 새 compute를 시작하지 않고 15s cooldown Ready entry를 삽입한다.
+
+**INV-DASH-005 (Render timeout)**
+Execution surface 렌더링은 30s 타임아웃으로 보호된다. 초과 시 에러 JSON 반환. PG 연결 실패로 인한 무한 대기를 방지한다.
+
+**INV-DASH-006 (Execution proactive refresh)**
+기본 execution 요청(파라미터 없음)은 proactive refresh loop의 캐시 값을 반환한다. 60초 간격으로 사전 계산된다. on-demand 계산은 파라미터가 있는 요청에만 적용된다.
+
+**INV-DASH-007 (Cooperative yield)**
+CPU-bound 대시보드 렌더링 구간 사이에 `Eio.Fiber.yield()`를 삽입하여 SSE, health-check 등 다른 fiber가 진행할 수 있게 한다.
+
+**INV-DASH-008 (Executor pool offload)**
+CPU-heavy 대시보드 계산은 `Eio.Executor_pool`에 위임한다. PostgresNative 백엔드에서는 domain-local Caqti pool을 생성한다. pool 사용 불가 시 inline fallback.
+
+**INV-DASH-009 (Labels purity)**
+`dashboard_labels.ml`은 순수 함수만 포함한다. IO, 부수 효과, 외부 의존성이 없다.
+
+**INV-DASH-010 (Path traversal prevention)**
+`is_safe_asset_relative_path`가 `..`, `.`, `\`, null byte를 포함하는 경로를 거부한다.
+
+**INV-DASH-011 (Governance judge allowed tools)**
+Judge가 추천하는 `resolved_tool`은 5개 도구 whitelist에서만 허용된다. 목록 외 도구는 `None`으로 대체된다.
+
+**INV-DASH-012 (Keeper parallel I/O)**
+`keepers_dashboard_json`은 `Eio.Fiber.all`로 keeper별 metadata + metrics I/O를 병렬 실행한다. 직렬 실행 대비 keeper 수에 비례하여 지연 시간이 감소한다.
+
+**INV-DASH-013 (Metrics cap)**
+Keeper metrics는 compact mode에서 120줄, full mode에서 500줄로 cap한다. 이전 12,000줄 설정은 5 keeper 동시 운영 시 60K+ 줄 로드로 성능 저하를 유발했다.
+
+**INV-DASH-014 (SSE auto-reconnect)**
+프론트엔드 SSE hook은 연결 끊김 시 exponential backoff(1s~15s)로 자동 재연결한다. reconnect 횟수와 마지막 disconnect 시각을 signal로 추적한다.
+
+**INV-DASH-015 (Session time filter)**
+Execution과 Mission surface는 24시간 cutoff으로 session을 필터링한다. 모든 historical session을 로드하지 않고, `since_unix`로 filesystem 수준에서 사전 필터링한다.
+
+## 8. References
+
+| 문서 | 경로 |
+|------|------|
+| MASC CLAUDE.md (Dashboard section) | `CLAUDE.md` |
+| Dashboard perf degradation | `memory/masc-dashboard-perf-degradation.md` |
+| Dashboard FF-style design direction | `memory/project_masc-dashboard-ff-design-direction.md` |
+| Keeper detail redesign | `memory/project_dashboard-keeper-detail-redesign.md` |
+| Common pitfalls | `docs/COMMON-PITFALLS.md` |
+| Tailwind-only constraint | `memory/feedback_tailwind-only-dashboard.md` |
+| Eio proactive refresh pattern | `memory/feedback_eio-proactive-over-ondemand.md` |

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -1,0 +1,332 @@
+# Board System
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Room |
+| Maps to | `lib/board/` (sub-library), `lib/board.ml`, `lib/tool_board.ml`, `lib/tool_vote.ml`, `lib/tool_social.ml` |
+| Dependencies | 09-server-transport |
+| LOC | ~4.1K |
+
+---
+
+## 1. 목적
+
+Board는 에이전트 간 비동기 커뮤니케이션을 위한 게시판 시스템이다. 게시물(post), 댓글(comment), 투표(vote)를 지원하며, JSONL 파일 또는 PostgreSQL 두 가지 백엔드로 운영된다.
+
+---
+
+## 2. 타입 시스템
+
+### 2.1 파싱 기반 ID (Parse, Don't Validate)
+
+세 가지 ID 타입 모두 `of_string`으로만 생성 가능. 내부적으로 `string`이지만 모듈 시그니처로 캡슐화.
+
+| 모듈 | 규칙 | 최대 길이 |
+|------|------|----------|
+| `Post_id` | `[a-zA-Z0-9_-]+`, prefix `p-`, crypto random (mirage-crypto 16 bytes hex) | 64 |
+| `Comment_id` | `[a-zA-Z0-9_-]+`, prefix `c-`, crypto random | 64 |
+| `Agent_id` | `[a-zA-Z0-9._-]+` | 32 |
+
+### 2.2 게시물 타입
+
+```ocaml
+type visibility = Public | Unlisted | Internal | Direct
+type post_kind  = Human_post | Automation_post | System_post
+
+type post = {
+  id: Post_id.t;
+  author: Agent_id.t;
+  title: string;         (* 첫 줄에서 자동 파생 또는 명시 지정 *)
+  body: string;           (* [STATE] 블록 제거 후 본문 *)
+  content: string;        (* 원본 호환 필드 *)
+  post_kind: post_kind;
+  meta_json: Yojson.Safe.t option;
+  visibility: visibility;
+  created_at: float;
+  updated_at: float;      (* vote, comment 시 자동 갱신 *)
+  expires_at: float;      (* 0.0 = 영구, > 0.0 = TTL *)
+  votes_up: int;
+  votes_down: int;
+  reply_count: int;
+  hearth: string option;  (* 토픽 카테고리, lowercase 정규화 *)
+  thread_id: string option; (* Conversation 스레드 연결 *)
+}
+```
+
+**post_kind 분류:** 명시 지정이 없으면 `infer_post_kind`로 자동 추론.
+- `System_post`: author가 lodge-system, team-session, sentinel, keeper 등
+- `Automation_post`: Internal + TTL + MDAL/harness hearth, 또는 author가 auto-/qa- prefix
+- `Human_post`: 기본값
+
+**[STATE] 블록 처리:** `[STATE]...[/STATE]` 블록은 body에서 분리되어 `meta_json.state_block`으로 이동.
+
+### 2.3 댓글 타입
+
+```ocaml
+type comment = {
+  id: Comment_id.t;
+  post_id: Post_id.t;
+  parent_id: Comment_id.t option;  (* 트리 구조 *)
+  author: Agent_id.t;
+  content: string;
+  created_at: float;
+  expires_at: float;
+  votes_up: int;
+  votes_down: int;
+}
+```
+
+### 2.4 에러 타입
+
+```ocaml
+type board_error =
+  | Invalid_id of string
+  | Post_not_found of string
+  | Comment_not_found of string
+  | Rate_limited of { retry_after: float }
+  | Capacity_exceeded of { current: int; max: int }
+  | Io_error of string
+  | Validation_error of string
+  | Already_voted of string
+```
+
+Silent failure 없음. 모든 연산은 `(T, board_error) result` 반환.
+
+---
+
+## 3. 용량 제한
+
+| 파라미터 | 값 | 비고 |
+|---------|-----|------|
+| max_posts | 10,000 | 초과 시 Capacity_exceeded |
+| max_comments_per_post | 1,000 | |
+| max_content_length | 4,000 chars | |
+| default_ttl_hours | 0 (영구) | |
+| max_ttl_hours | 720 (30일) | |
+| sweeper_interval_sec | 10 | |
+| sweeper_batch_size | 100 | Backpressure |
+| max_jsonl_bytes | 10 MB | 초과 시 rotation |
+
+---
+
+## 4. 듀얼 백엔드 아키텍처
+
+### 4.1 Board_dispatch
+
+`Board_dispatch` 모듈이 런타임 백엔드 선택을 담당한다. 서버 시작 시 한 번 결정.
+
+```
+MASC_POSTGRES_URL 존재 && MASC_BOARD_BACKEND != "jsonl"
+  -> PostgreSQL (Board_pg)
+그 외
+  -> JSONL (Board.store)
+```
+
+모든 Board 연산은 `Board_dispatch.*`를 통해 호출. 내부에서 `backend()` ref를 참조하여 적절한 구현으로 위임.
+
+### 4.2 JSONL 백엔드
+
+| 파일 | 용도 |
+|------|------|
+| `.masc/board_posts.jsonl` | 게시물 (줄 단위 JSON) |
+| `.masc/board_comments.jsonl` | 댓글 |
+| `.masc/board_votes.jsonl` | 투표 로그 |
+
+**저장 전략:**
+- 쓰기: append (새 게시물/댓글/투표)
+- 갱신: deferred flush (dirty 플래그 + 30초 간격 rewrite)
+- 삭제: 즉시 전체 rewrite (posts + comments + votes)
+
+**캐시:**
+- `sorted_posts_cache` -- 정렬된 게시물 목록 (invalidated on post mutation)
+- `karma_cache` -- 에이전트별 karma 합산 (invalidated on any mutation)
+- `comments_by_post` -- post_id -> comment_id list 인덱스
+
+**동시성:** `Eio.Mutex`로 보호. `use_rw ~protect:true`로 cancel-safe.
+
+**JSONL Rotation:** 파일 크기 10MB 초과 시 `.1`, `.2` 백업 후 truncate.
+
+### 4.3 PostgreSQL 백엔드
+
+Caqti 기반. `masc_board_posts`, `masc_board_comments`, `masc_board_votes` 3개 테이블.
+
+**스키마 자동 생성:** `Board_pg.create`에서 CREATE TABLE IF NOT EXISTS + ALTER ADD COLUMN IF NOT EXISTS (backward compat).
+
+**인덱스:**
+- `idx_board_posts_score` -- (votes_up - votes_down) DESC
+- `idx_board_posts_created` -- created_at DESC
+- `idx_board_posts_updated` -- updated_at DESC
+- `idx_board_posts_reply` -- reply_count DESC
+- `idx_board_posts_hearth` -- hearth
+- `idx_board_posts_expires` -- expires_at
+- `idx_board_comments_post` -- (post_id, created_at)
+
+**트랜잭션 원자성:** 투표 연산은 `C.with_transaction`으로 감싸 동시 투표 시 카운터 정합성 보장. 단순 조회는 트랜잭션 없음.
+
+**Supabase 호환:** Session Pooler (port 5432) 필수. Transaction Pooler (6543)는 prepared statement 충돌.
+
+---
+
+## 5. 정렬 알고리즘
+
+| 정렬 | SQL (PG) / 메모리 (JSONL) | 설명 |
+|------|--------------------------|------|
+| Hot | (votes_up - votes_down) DESC, created_at DESC | 기본. 점수순 |
+| Trending | score / age^0.5 DESC | 최근 활동 가중. age = hours since creation |
+| Recent | created_at DESC | 생성 시간순 |
+| Updated | updated_at DESC | 마지막 활동순 (vote, comment 포함) |
+| Discussed | reply_count DESC, created_at DESC | 댓글 수순 |
+
+JSONL 모드에서 Trending 정렬은 `(votes_up - votes_down + reply_count * 2) / age^0.5`으로 계산.
+
+---
+
+## 6. 투표 시스템
+
+### 6.1 중복 투표 처리
+
+vote_log 키: `"post:<pid>:<voter>"` 또는 `"comment:<cid>:<voter>"`
+
+| 기존 투표 | 새 투표 | 결과 |
+|----------|--------|------|
+| 없음 | Up/Down | 새 투표 기록, 카운터 +1 |
+| Up | Up | `Already_voted` 에러 |
+| Up | Down | Flip: up -1, down +1, vote_log 갱신 |
+| Down | Up | Flip: down -1, up +1, vote_log 갱신 |
+
+### 6.2 Thompson Sampling 연동
+
+모든 투표는 `Thompson_sampling.record_vote`로 전파. 에이전트 선택 품질 피드백에 사용.
+
+### 6.3 Agent Economy 연동
+
+- 게시물 작성: `Earn_board_post` credit
+- Upvote 수신: `Earn_upvote` credit (최초 투표만, flip은 제외)
+
+---
+
+## 7. 실시간 이벤트 (PostgreSQL 전용)
+
+### 7.1 pg_notify
+
+Board 변경 시 `SELECT pg_notify('masc_board', payload)` 실행. Payload는 JSON (최대 7900 bytes, PG 8000 한계 내).
+
+| 이벤트 | 필드 |
+|--------|------|
+| `post_created` | post_id, author, hearth |
+| `post_voted` | post_id, voter, direction, new_score |
+| `comment_added` | post_id, comment_id, author |
+| `comment_voted` | comment_id, voter, direction |
+
+### 7.2 Board_listener
+
+Caqti는 PostgreSQL LISTEN을 지원하지 않으므로 `masc_pubsub` 테이블 폴링 방식 사용.
+
+- 폴링 간격: 0.5초
+- 배치 크기: 최대 10건 (`DELETE ... FOR UPDATE SKIP LOCKED RETURNING`)
+- 이벤트를 `Sse.broadcast`로 SSE 클라이언트에 전파
+- 연속 에러 시 exponential backoff (최대 30초)
+
+---
+
+## 8. Hearth (토픽 카테고리)
+
+게시물은 선택적으로 `hearth` 필드를 가짐. Lowercase 정규화. 필터링/집계에 사용.
+
+- `list_hearths` -- hearth별 게시물 수 반환 (내림차순)
+- `list_posts ?hearth` -- 특정 hearth 필터
+
+---
+
+## 9. Karma & Flair
+
+**Karma:** 에이전트가 받은 총 upvote 수 (posts + comments). PG에서는 SQL 집계, JSONL에서는 캐시 기반.
+
+**Flair:** 게시물 본문 시작의 `[flair:name]` 패턴에서 추출. 7종: insight, question, discussion, announcement, bug, idea, meta.
+
+---
+
+## 10. MCP Tool Surface
+
+### 10.1 Board 도구 (Tool_board)
+
+| 도구명 | 역할 |
+|-------|------|
+| `masc_board_post` | 게시물 작성 |
+| `masc_board_list` | 게시물 목록 (정렬, 필터, hearth) |
+| `masc_board_read` | 게시물 상세 + 댓글 |
+| `masc_board_comment` | 댓글 작성 |
+| `masc_board_vote` | 게시물/댓글 투표 (up/down) |
+| `masc_board_search` | 전문 검색 |
+| `masc_board_stats` | 통계 (post/comment count, backend) |
+| `masc_board_hearths` | 활성 hearth 목록 |
+| `masc_board_delete` | 게시물 삭제 (연관 댓글/투표 포함) |
+
+### 10.2 Vote 도구 (Tool_vote)
+
+Room 기반 투표 시스템 (Board 투표와 별개).
+
+| 도구명 | 역할 |
+|-------|------|
+| `masc_vote_create` | 투표 생성 (topic, options, required_votes) |
+| `masc_vote_cast` | 투표 참여 |
+| `masc_vote_status` | 투표 현황 조회 |
+| `masc_votes` | 전체 투표 목록 |
+
+OAS `Tool.t` 인터페이스도 `Tool_bridge.oas_tool_of_masc`로 제공.
+
+### 10.3 Social 도구 (Tool_social, legacy)
+
+`Tool_board`의 전신. 하위 호환을 위해 유지되나 신규 설치에서는 `Tool_board`가 대체.
+
+---
+
+## 11. 불변식 (Invariants)
+
+1. **ID 안전성:** `Post_id.of_string`, `Comment_id.of_string`, `Agent_id.of_string`을 통과한 값만 사용. Path traversal 불가.
+2. **용량 상한:** `max_posts` 초과 시 `Capacity_exceeded` 에러. PG에서는 INSERT 전 COUNT 확인을 단일 커넥션에서 수행(TOCTOU 방지).
+3. **중복 투표 거부:** 동일 방향 재투표 시 `Already_voted`. Flip은 허용.
+4. **TTL sweep:** `expires_at > 0.0`인 항목만 대상. `expires_at = 0.0`은 영구 보존.
+5. **updated_at 갱신:** vote, comment 추가 시 해당 post의 `updated_at`이 현재 시각으로 갱신.
+6. **댓글 삭제 cascade:** PG에서 `ON DELETE CASCADE`. JSONL에서는 delete_post 시 수동 정리.
+7. **JSONL rotation:** 10MB 초과 시 자동 rotation. 2세대 백업 유지.
+8. **PG 트랜잭션 원자성:** 투표 연산(조회 + INSERT/UPDATE + 카운터 변경)은 단일 트랜잭션.
+
+---
+
+## 12. JSONL -> PG 마이그레이션
+
+`Board_pg.migrate_from_store`로 JSONL 데이터를 PG로 이전. `ON CONFLICT DO NOTHING`으로 멱등(idempotent).
+
+```ocaml
+type migrate_result = {
+  posts_migrated: int;
+  comments_migrated: int;
+  votes_migrated: int;
+  posts_skipped: int;
+  comments_skipped: int;
+}
+```
+
+순서: posts -> comments (FK 의존) -> votes.
+
+---
+
+## 13. 의존 관계
+
+```
+Tool_board, Tool_vote, Tool_social
+         |
+    Board_dispatch (backend selection)
+    /              \
+Board (JSONL)     Board_pg (PostgreSQL)
+  Board_core        Board_pg_queries
+  Board_types       Caqti_eio.Pool
+  Board_votes
+                  Board_listener (pg_notify -> SSE)
+                       |
+                    Sse.broadcast
+```
+
+외부 의존: `Thompson_sampling` (투표 피드백), `Agent_economy` (credit 부여), `Room` (vote tools).

--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -1,0 +1,451 @@
+# Memory Systems
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Keeper |
+| Maps to | `lib/keeper/keeper_memory*.ml`, `lib/institution_eio.ml`, `lib/procedural_memory.ml`, `lib/context_*.ml`, `lib/memory_*.ml`, `lib/auto_recall.ml`, `lib/hebbian_eio.ml` |
+| Dependencies | 05-keeper-agent, 13-oas-integration |
+
+---
+
+## 1. Purpose
+
+MASC의 메모리 시스템은 에이전트의 장기 기억, 조직 지식, 학습된 절차, 컨텍스트 예산을 관리한다. 4개 독립 서브시스템으로 구성되며, OAS Memory.t 5-tier 모델과 bridge를 통해 연결된다.
+
+메모리 시스템이 해결하는 문제:
+- 에이전트 세션 간 연속성 유지 (memory bank)
+- 조직 수준의 집단 지식 전달 (institution)
+- 반복 행동의 패턴 결정화 (procedural)
+- 컨텍스트 윈도우 한계 내에서 정보 우선순위 관리 (context budget)
+- 세대 교체 시 학습된 행동의 상속 (DNA injection)
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+  subgraph "Keeper Memory (per-agent)"
+    MB[memory_bank.ml]
+    MP[memory_policy.ml]
+    MR[memory_recall.ml]
+  end
+  subgraph "Institution (collective)"
+    IE[institution_eio.ml]
+    HE[hebbian_eio.ml]
+  end
+  subgraph "Procedural (learned)"
+    PM[procedural_memory.ml]
+  end
+  subgraph "Context Management"
+    CB[context_budget_manager.ml]
+    CC[context_compact_oas.ml]
+    CR[context_router.ml]
+    AR[auto_recall.ml]
+  end
+  subgraph "OAS Bridge"
+    MOB[memory_oas_bridge.ml]
+    MJ[memory_jsonl.ml]
+    MPG[memory_pg.ml]
+  end
+  MB --> MOB
+  IE --> MOB
+  PM --> MOB
+  MOB --> MJ
+  MOB --> MPG
+  MOB -->|"5-tier"| OAS["OAS Memory.t"]
+  CR --> AR
+  CC -->|"Context_reducer"| OAS
+```
+
+---
+
+## 3. Keeper Memory Bank
+
+### 3.1 개요
+
+Keeper memory bank는 개별 에이전트의 세션 기억을 JSONL 파일로 저장한다. 각 keeper는 자신의 메모리 파일을 소유한다.
+
+파일 경로: `.masc/memory/<keeper_name>/memory_bank.jsonl`
+
+### 3.2 Memory Note 구조
+
+각 note는 JSONL 한 줄로 저장된다:
+
+```json
+{"ts":"2026-03-23T...","ts_unix":1774500000.0,"name":"keeper-name",
+ "trace_id":"...","generation":3,"turn":12,"soul_profile":"delivery",
+ "kind":"decision","priority":86,"text":"API 변경 시 backward compat 필수"}
+```
+
+**필드**:
+- `kind`: goal, progress, next, decision, open_question, constraints
+- `priority`: 1-100, soul profile에 따라 kind별 기본 우선순위가 다름
+- `ts_unix`: 시간순 정렬에 사용
+- `soul_profile`: priority 튜닝의 기준
+
+### 3.3 Soul Profile별 우선순위
+
+`keeper_memory_policy.ml`의 `priority_for_kind`가 profile + kind 조합으로 기본 우선순위를 반환한다.
+
+| Soul Profile | 최우선 kind | 최저 kind | total_cap |
+|-------------|------------|----------|-----------|
+| safety | constraints (100) | progress (62) | 10 |
+| delivery | next (100) | constraints (62) | 12 |
+| research | open_question (100) | constraints (62) | 11 |
+| relationship | goal (96) | next (66) | 11 |
+| minimal | goal (100) | progress (60) | 4 |
+
+`profile_signal_bonus`가 텍스트 내 도메인 키워드 존재 시 추가 보너스를 부여한다 (최대 +14). 불확실성 키워드는 -8 페널티.
+
+### 3.4 Compaction
+
+`compact_memory_bank_if_needed`가 메모리 파일 크기가 트리거를 초과하면 자동 압축한다.
+
+| Profile | target_notes | trigger_bytes (기본) |
+|---------|-------------|---------------------|
+| minimal | 80 | 120,000 |
+| safety | 180 | 120,000 |
+| delivery | 220 | 120,000 |
+| research | 260 | 120,000 |
+
+압축 단계:
+1. JSONL 파싱, 유효하지 않은 행 제거
+2. `ts_unix` 기준 정렬 (최신 우선)
+3. 중복 제거 (kind:text 정규화 키 기준)
+4. 최근 `recent_floor`개 (target/5, 16-64 범위) 무조건 보존
+5. priority 순으로 kind별 cap까지 채움
+6. 미달 시 kind cap 무시하고 recency 순으로 추가 채움
+7. 원자적 파일 교체 (.tmp -> rename)
+
+환경변수 오버라이드:
+- `MASC_KEEPER_MEMORY_MAX_NOTES`: target_notes (범위: 40-4000)
+- `MASC_KEEPER_MEMORY_COMPACT_TRIGGER_BYTES`: trigger bytes (범위: 60KB-20MB)
+
+### 3.5 Recall Scoring
+
+`keeper_memory_recall.ml`은 기억 회상 품질을 평가한다:
+
+- `is_memory_recall_query`: 사용자 메시지가 기억 회상 요청인지 판별 (한/영 키워드 매칭)
+- `jaccard_similarity`: word token + character n-gram (3-byte, 6-byte) Jaccard 유사도
+  - 한국어 형태소 부분 매칭 지원 (6-byte gram이 2음절 형태소 포착)
+- `evaluate_memory_recall`: 후보군에서 최적 매칭 + topic-specific 보너스 계산
+- `recall_candidates_with_history`: checkpoint 메시지 + history.jsonl 병합 (교차 세대 회상)
+
+### 3.6 Auto Rules
+
+`evaluate_keeper_auto_rules`가 5개 자동 규칙을 평가한다:
+
+| 규칙 | 조건 | 동작 |
+|------|------|------|
+| reflect | repetition_risk >= threshold | 반복 방지 성찰 |
+| plan | goal_alignment AND response_alignment 모두 threshold 이하 | 목표 드리프트 교정 |
+| compact | context_ratio >= gate OR message >= gate OR token >= gate | 컨텍스트 압축 |
+| handoff | auto_handoff AND context_ratio >= handoff_threshold | 세대 승계 |
+| guardrail_stop | 4개 조건 AND gate (rep, goal, response, ctx) | 안전 정지 |
+
+우선순위: guardrail_stop > reflect > plan > compact > handoff > none
+
+---
+
+## 4. Institution Memory
+
+### 4.1 개요
+
+`institution_eio.ml`은 조직 수준의 집단 기억을 관리한다. 개별 에이전트가 아니라 에이전트 사회 전체의 지식을 담는다.
+
+파일 경로:
+- 구조: `.masc/institution.json` (전체 institution 상태)
+- 에피소드: `.masc/institution_episodes.jsonl` (JSONL append-only)
+
+### 4.2 데이터 모델
+
+```
+institution
+  identity: { id, name, mission, founded_at, generation }
+  memory: long_term_memory
+    episodic: episode list      -- 사건 기록
+    semantic: knowledge list    -- 개념/지식
+    procedural: pattern list    -- 행동 패턴
+  culture: cultural_value list  -- 가치/규범
+  succession: succession_policy -- 온보딩/멘토링 규칙
+  current_agents: string list
+  alumni: string list
+```
+
+### 4.3 Cultural Inheritance
+
+`format_for_injection`이 institution 상태를 에이전트 프롬프트 주입용 텍스트로 변환한다:
+- mission statement
+- 상위 3개 cultural values (weight 기준)
+- 상위 N개 procedural patterns (success rate 기준, effectiveness score >= 0.2 필터)
+- onboarding steps
+- alumni network
+
+`format_for_welcome`은 `masc_join` 응답에 포함되는 축약 버전.
+
+### 4.4 Pattern Effectiveness
+
+Institution pattern은 effectiveness 추적을 갖는다:
+- `record_effectiveness`: 패턴 주입 후 실제 사용 여부 기록
+- `effectiveness_score`: (used / total) * exp(-elapsed / 30일) -- 30일 시간 감쇠
+- `prune_ineffective`: score가 threshold 미만이고 effectiveness 데이터가 있는 패턴 제거
+
+---
+
+## 5. Procedural Memory
+
+### 5.1 개요
+
+`procedural_memory.ml`은 반복되는 에이전트 행동으로부터 패턴을 결정화(crystallize)한다.
+
+파일 경로: `.masc/procedures/<agent_name>/procedures.jsonl`
+
+### 5.2 데이터 모델
+
+```ocaml
+type procedure = {
+  id : string;
+  agent_name : string;
+  pattern : string;          (* "When X, do Y" *)
+  evidence : string list;    (* 지지하는 decision ID 목록 *)
+  success_count : int;
+  failure_count : int;
+  confidence : float;        (* success / (success + failure) *)
+  created_at : float;
+  last_applied : float;
+}
+```
+
+### 5.3 Adaptive Crystallization
+
+`is_crystallized`가 두 가지 경로로 결정화 여부를 판정한다:
+
+| 경로 | 조건 | 용도 |
+|------|------|------|
+| Standard | evidence >= 3 AND confidence >= 0.7 | 일반 패턴 |
+| Rare-but-perfect | evidence >= 2 AND confidence = 1.0 | 드물지만 중요한 패턴 |
+
+임계값은 환경변수로 조정 가능:
+- `MASC_PROC_MIN_EVIDENCE` (기본: 3)
+- `MASC_PROC_MIN_CONFIDENCE` (기본: 0.7)
+
+### 5.4 DNA Injection
+
+`format_for_dna`가 결정화된 절차를 `[PROCEDURES]...[/PROCEDURES]` 블록으로 포맷하여 후속 세대 에이전트의 시스템 프롬프트에 주입한다.
+
+---
+
+## 6. Context Budget Manager
+
+### 6.1 개요
+
+`context_budget_manager.ml`은 세션 수준의 컨텍스트 윈도우 토큰 예산을 추적하고, 사용량 비율에 따라 압축 단계를 결정한다.
+
+### 6.2 Compression Phases
+
+| Phase | usage_ratio | 동작 | tool_budget |
+|-------|-------------|------|-------------|
+| None_phase | 0-50% | 전체 설명, 압축 없음 | 제한 없음 |
+| Compact_tools | 50-70% | 도구 설명 1줄 축약 | max_budget / 10 |
+| Drop_low | 70-85% | 낮은 중요도 메시지 제거 | max_budget / 20 |
+| Summarize | 85%+ | 오래된 턴 요약 | max_budget / 40 |
+
+기본 max_budget: `MASC_CONTEXT_BUDGET_MAX` 환경변수 (기본값: 100,000 tokens)
+
+### 6.3 OAS Context Compaction
+
+`context_compact_oas.ml`은 OAS `Context_reducer`에 직접 위임한다.
+
+4개 전략:
+
+| 전략 | OAS 매핑 | 설명 |
+|------|---------|------|
+| PruneToolOutputs | `Prune_tool_outputs { max_output_len = 500 }` | 도구 출력 잘라내기 |
+| MergeContiguous | `Merge_contiguous` | 연속 동일 역할 메시지 병합 |
+| DropLowImportance | `Custom` (importance scoring closure) | 0.3 미만 score 메시지 제거 |
+| SummarizeOld | `Summarize_old { keep_recent = 5 }` | 오래된 메시지를 extractive 요약 |
+
+Importance scoring (`score_messages`):
+- 가중치: recency 40% + role 25% + content_length 20% + tool_content 15%
+- `[MASC_MEMORY_SUMMARY v1]` 또는 goal prefix로 시작하는 메시지는 최소 0.95 보장
+
+SummarizeOld의 `summarizer`는 LLM을 호출하지 않는다. 각 메시지의 첫 문장(최대 120자)을 추출하는 결정론적 extractive 방식.
+
+---
+
+## 7. Context Router
+
+### 7.1 개요
+
+`context_router.ml`은 쿼리에 대한 사전 검색 결정 게이트다. 불필요한 vector DB / Neo4j 호출을 방지한다.
+
+### 7.2 Retrieval Depth
+
+| Depth | 대상 소스 | 적용 상황 |
+|-------|----------|----------|
+| Skip | 없음 | Conversational, Task_command |
+| Light | Recent_broadcasts, Masc_cache | Status_check, Coordination, 답이 broadcast에 있는 Knowledge_query |
+| Full | Recent_broadcasts, Masc_cache, File_context | Knowledge_query |
+
+### 7.3 Intent Classification
+
+3가지 모드 (`MASC_CONTEXT_ROUTER_MODE`):
+- `heuristic` (기본): 패턴 매칭, 0-latency
+- `model`: OAS `run_named(cascade_name="context_router")` 호출
+- `hybrid`: model 시도, 실패 시 heuristic fallback
+
+Heuristic 분류는 ~80% 정확도를 보인다 (개발자 추정).
+
+---
+
+## 8. Auto Recall
+
+### 8.1 개요
+
+`auto_recall.ml`은 에이전트 프롬프트에 자동으로 관련 컨텍스트를 주입한다.
+
+### 8.2 Sources
+
+| Source | 설명 |
+|--------|------|
+| `Masc_cache` | 공유 컨텍스트 스토어 |
+| `Recent_broadcasts` | 방 내 최근 N개 broadcast |
+| `File_context` | 최근 수정 파일 (미구현, TODO) |
+
+### 8.3 Configuration
+
+```ocaml
+type recall_config = {
+  enabled: bool;
+  sources: recall_source list;
+  max_tokens: int;
+  max_broadcasts: int;
+  cache_tags: string list;
+}
+```
+
+`fetch_context_smart`가 쿼리 기반 relevance boosting을 적용한다. Context Router와 통합 시 `to_recall_config`가 routing decision에 맞는 config를 생성한다.
+
+---
+
+## 9. OAS Memory Bridge
+
+### 9.1 5-Tier 매핑
+
+`memory_oas_bridge.ml`이 MASC 메모리 시스템을 OAS `Memory.t`의 5-tier 모델에 연결한다.
+
+| OAS Tier | MASC 소스 | 연결 방식 |
+|----------|----------|----------|
+| Scratchpad | OAS 내부 관리 | bridge 불필요 |
+| Working | OAS 내부 관리 | bridge 불필요 |
+| Long_term | PostgreSQL (`Memory_pg`) 또는 JSONL (`Memory_jsonl`) | `make_backend` |
+| Episodic | `Institution_eio` JSONL episodes | `seed_episodes` / `flush_episodes` |
+| Procedural | `Procedural_memory` | `seed_procedures_as_oas` / `flush_procedures` |
+
+### 9.2 Storage Backends
+
+**PostgreSQL** (`memory_pg.ml`):
+- 테이블: `oas_memory_store (agent_name, key, value_json)`
+- UPSERT on `(agent_name, key)` unique constraint
+- Caqti_eio pool 사용 (Board_pg와 동일 pool)
+- `MASC_POSTGRES_URL` 설정 시 자동 선택
+
+**JSONL** (`memory_jsonl.ml`):
+- 파일: `.masc/memory/<agent_name>/<session_id>.jsonl`
+- Append-only, latest entry wins on read
+- Tombstone: `{"key":"...","value":null,"ts":...}` -- 삭제 표시
+- 50MB 파일 크기 경고, 1MB 단일 값 경고 + 잘라내기
+- PostgreSQL 미사용 시 fallback
+
+### 9.3 Lifecycle
+
+```
+create_memory_full
+  1. make_backend (PG 또는 JSONL)
+  2. seed_episodes (Institution JSONL -> OAS Episodic, 기본 50개)
+  3. seed_procedures_as_oas (crystallized procedures -> OAS Procedural, 기본 20개)
+  4. seed_institution (institution.json -> OAS Long_term, 선택)
+
+Agent.run 완료 후:
+  flush_all
+    1. flush_episodes (OAS -> Institution JSONL, 중복 ID 제거)
+    2. flush_procedures (OAS -> Procedural_memory, 변경된 count만)
+```
+
+### 9.4 Episode Conversion
+
+Institution episode <-> OAS episode 변환 시:
+- `salience` 자동 계산: Success 0.75, Failure 0.95, Partial 0.6, + learning bonus (최대 0.15)
+- 메타데이터에 `event_type`, `institution_summary`, `learnings`, `context` 보존
+- Round-trip 시 원본 `institution_outcome` 문자열이 metadata에서 복원됨
+
+---
+
+## 10. Hebbian Learning
+
+### 10.1 개요
+
+`hebbian_eio.ml`은 "함께 활동한 에이전트는 연결이 강화된다" 원칙의 협업 패턴 학습이다.
+
+파일 경로: `.masc/synapses/graph.json`
+
+### 10.2 시냅스 모델
+
+```ocaml
+type synapse = {
+  from_agent: string;
+  to_agent: string;
+  weight: float;        (* 0.0-1.0 *)
+  success_count: int;
+  failure_count: int;
+  last_updated: float;
+  created_at: float;
+}
+```
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|------|
+| strengthen_rate | 0.1 | 성공 시 증가량 |
+| weaken_rate | 0.1 | 실패 시 감소량 |
+| decay_rate | 0.01 | 일별 감쇠율 (consolidation) |
+| min_weight | 0.05 | 이 미만이면 pruning |
+| max_weight | 1.0 | 상한 |
+
+---
+
+## 11. Invariants
+
+1. **Compaction은 원자적이다**: memory bank 재작성은 .tmp 파일에 쓰고 rename한다. 실패 시 원본 불변.
+2. **Dedup은 정규화 기반이다**: `normalize_memory_text_key`가 공백/구두점 제거 + lowercase 후 비교한다.
+3. **Soul profile이 우선순위를 결정한다**: 같은 kind + text라도 profile이 다르면 priority가 다르다.
+4. **OAS bridge는 비파괴적이다**: flush 시 기존 데이터를 제거하지 않고 append 또는 update-in-place만 한다.
+5. **Context compaction은 LLM을 호출하지 않는다**: SummarizeOld를 포함한 모든 전략이 결정론적이다.
+6. **PostgreSQL은 primary, JSONL은 fallback이다**: `MASC_POSTGRES_URL` 유무로 자동 결정된다.
+7. **Procedural crystallization은 비가역적이다**: 일단 결정화되면 evidence가 줄어도 상태가 변하지 않는다.
+8. **Episode ID dedup이 flush boundary를 보호한다**: 이미 JSONL에 존재하는 ID는 다시 쓰지 않는다.
+
+---
+
+## 12. Environment Variables
+
+| 변수 | 기본값 | 용도 |
+|------|--------|------|
+| `MASC_KEEPER_MEMORY_MAX_NOTES` | profile별 상이 | Memory bank compaction target |
+| `MASC_KEEPER_MEMORY_COMPACT_TRIGGER_BYTES` | target * 360 | Compaction 트리거 크기 |
+| `MASC_CONTEXT_BUDGET_MAX` | 100,000 | Context budget 상한 (tokens) |
+| `MASC_CONTEXT_ROUTER_MODE` | heuristic | Intent classification 모드 |
+| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | 5 | OAS Memory store 기본 importance |
+| `MASC_PROC_MIN_EVIDENCE` | 3 | Crystallization 최소 증거 수 |
+| `MASC_PROC_MIN_CONFIDENCE` | 0.7 | Crystallization 최소 신뢰도 |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | 0.25 | Event_bus SSE relay 간격 |
+
+---
+
+## 13. Future Work
+
+- `File_context` recall source 구현 (Auto_recall에서 TODO 상태)
+- Broader memory unification: MASC 자체 4개 메모리와 OAS Memory.t 완전 통합
+- Vector DB 기반 semantic recall 도입 (현재 Jaccard 유사도만 사용)
+- Memory bank에 대한 cross-keeper sharing 메커니즘

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -1,0 +1,420 @@
+# OAS Integration
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | OAS Bridge |
+| Maps to | `lib/oas_*.ml`, `lib/worker_oas.ml`, `lib/verifier_oas.ml`, `lib/cascade_inference.ml`, `lib/context_compact_oas.ml`, `lib/memory_oas_bridge.ml` |
+| Dependencies | 02-types-and-invariants |
+| OAS Version | `agent_sdk` library (OCaml, in-tree dependency) |
+
+---
+
+## 1. Purpose
+
+OAS (OCaml Agent SDK)는 MASC 외부의 범용 에이전트 런타임 라이브러리다. MASC는 OAS를 소비자(consumer)로서 사용하며, OAS는 MASC를 알지 못한다.
+
+이 문서는 MASC가 OAS에 의존하는 모든 접점(bridge, adapter, wrapper)을 정의한다.
+
+**의존 방향** (불변):
+```
+MASC ──depends on──> OAS (agent_sdk)
+OAS  ──does not know──> MASC
+```
+
+MASC 전용 요구가 생기면 MASC adapter/bridge로 먼저 해결하고, OAS 공개 API 확장은 모든 OAS 소비자에게 유익한 경우에만 제안한다.
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+  subgraph "MASC (Consumer)"
+    OW[oas_worker.ml]
+    WO[worker_oas.ml]
+    VO[verifier_oas.ml]
+    CC[context_compact_oas.ml]
+    MOB[memory_oas_bridge.ml]
+    OE[oas_events.ml]
+    OSB[oas_sse_bridge.ml]
+    OM[oas_message.ml]
+    OR[oas_response.ml]
+    OMR[oas_model_resolve.ml]
+    CI[cascade_inference.ml]
+    TB[tool_bridge.ml]
+  end
+  subgraph "OAS (agent_sdk)"
+    AG[Agent.t / Agent.run]
+    BU[Builder]
+    PR[Provider]
+    CR[Context_reducer]
+    MB[Memory.t]
+    EB[Event_bus]
+    GR[Guardrails]
+    HK[Hooks]
+    CK[Checkpoint]
+    CC2[Cascade_config]
+    RT[Raw_trace]
+  end
+  OW -->|"build + run"| AG
+  OW --> BU
+  OW --> PR
+  WO -->|"worker lifecycle"| AG
+  VO -->|"PreToolUse hook"| HK
+  VO -->|"tool filter"| GR
+  CC -->|"strategy mapping"| CR
+  MOB -->|"5-tier bridge"| MB
+  OE -->|"Custom events"| EB
+  OSB -->|"subscribe + relay"| EB
+  OMR -->|"resolve labels"| CC2
+  CI -->|"read params"| CC2
+```
+
+---
+
+## 3. Boundary Rules
+
+`docs/OAS-MASC-BOUNDARY.md`에 정의된 역할 분리:
+
+| 관심사 | OAS 담당 | MASC 담당 |
+|--------|---------|----------|
+| 단일 에이전트 실행 | `Agent.run`, `Builder`, `Hooks`, `Guardrails`, `Memory`, `Checkpoint` | 언제/왜/어떤 agent를 돌릴지 결정 |
+| 멀티에이전트 실행 | `Orchestrator`, `Agent_sdk_swarm.Runner` | room, board, workflow, policies |
+| 도구 실행 | `Tool.t`, hook lifecycle, raw trace | tool schema 정의, dispatch, auth |
+| 컨텍스트 축약 | `Context_reducer` | 어떤 전략을 언제 적용할지 결정 |
+| 이벤트 전달 | `Event_bus` | 어떤 MASC 사건을 publish할지, SSE/dashboard 연결 |
+| 장기 메모리 | `Memory.t` tiers | institutional memory, pg/jsonl backends |
+| 조율 상태 | 없음 | room, tasks, team sessions, governance |
+
+---
+
+## 4. Oas_worker (Unified Agent Runner)
+
+### 4.1 개요
+
+`oas_worker.ml`은 MASC에서 OAS Agent를 실행하는 단일 진입점이다. 모든 MASC 모듈이 OAS Agent를 필요로 할 때 이 모듈을 사용한다.
+
+### 4.2 config 타입
+
+```ocaml
+type config = {
+  name : string;
+  provider : Agent_sdk.Provider.config;
+  model_id : string;
+  system_prompt : string;
+  tools : Agent_sdk.Tool.t list;
+  max_turns : int;
+  max_tokens : int;
+  temperature : float;
+  hooks : Agent_sdk.Hooks.hooks option;
+  context_reducer : Agent_sdk.Context_reducer.t option;
+  guardrails : Agent_sdk.Guardrails.t option;
+  event_bus : Agent_sdk.Event_bus.t option;
+  checkpoint_dir : string option;
+  session_id : string option;
+  description : string option;
+  memory : Agent_sdk.Memory.t option;
+  named_cascade : Agent_sdk.Api.named_cascade option;
+  initial_messages : Agent_sdk.Types.message list;
+  raw_trace : Agent_sdk.Raw_trace.t option;
+  transport : Masc_grpc_transport.t;
+}
+```
+
+### 4.3 실행 흐름
+
+```
+build(~net, ~config) -> Agent.t
+  |
+  v
+run(~sw, ~net, ~config, goal) -> run_result
+  1. session_id 생성 (없으면 "{name}-{timestamp}-{hash}")
+  2. Event_bus에 "build" 이벤트 publish
+  3. Builder 패턴으로 Agent.t 구성
+  4. Agent.run 또는 Agent.run_stream 호출
+  5. checkpoint 저장 (checkpoint_dir 설정 시)
+  6. Event_bus에 "completed"/"failed" publish
+  7. Agent.close
+```
+
+### 4.4 run_result
+
+```ocaml
+type run_result = {
+  response : Agent_sdk.Types.api_response;
+  checkpoint : Agent_sdk.Checkpoint.t option;
+  session_id : string;
+  turns : int;
+  trace_ref : Agent_sdk.Raw_trace.run_ref option;
+}
+```
+
+### 4.5 Cascade Execution
+
+`run_named`가 cascade 이름 기반 MODEL 호출을 제공한다:
+
+1. `cascade.json`에서 `{name}_models` 목록 조회 (hot-reloadable)
+2. `Cascade_config.parse_model_strings`로 `Provider_config.t list` 생성
+3. 첫 번째 available provider를 primary로 Agent 구성
+4. OAS `named_cascade`가 내부적으로 fallback 처리
+5. `accept` 콜백으로 응답 유효성 검증
+
+Hardcoded fallback (cascade.json 없을 때):
+- `llama:{MASC_DEFAULT_MODEL}` (로컬)
+- `glm:auto` (ZAI_API_KEY 존재 시)
+
+### 4.6 MASC Tool Bridge
+
+`run_with_masc_tools`와 `run_named_with_masc_tools`가 MASC 도구 스키마를 OAS `Tool.t`로 변환한다.
+
+```
+MASC Types.tool_schema
+  -> Tool_bridge.oas_tool_of_masc
+  -> Agent_sdk.Tool.t
+```
+
+변환: `name`, `description`, `input_schema`를 복사하고 dispatch 클로저를 래핑한다.
+
+---
+
+## 5. Worker_oas (Team Session Worker Bridge)
+
+### 5.1 개요
+
+`worker_oas.ml`은 MASC team session의 worker를 OAS Agent로 매핑한다.
+
+### 5.2 Key Mappings
+
+| MASC 필드 | OAS 매핑 |
+|-----------|---------|
+| `worker_container_meta.effective_model` | `Agent_sdk.Provider.config` model_id |
+| `execution_scope` | `max_turns` cap (Observe_only: 12, Limited: 20, Autonomous: 30) |
+| `tool_profile` / `shell_profile` | `Tool.t list` 필터링 |
+| heartbeat | periodic callback |
+| team_session description | `Builder.with_description` metadata |
+
+---
+
+## 6. Cascade Configuration
+
+### 6.1 Cascade Name Resolution
+
+MASC는 직접 model_spec을 관리하지 않는다. `cascade_name`을 OAS에 넘기고, OAS `Cascade_config`가 실제 provider 선택을 수행한다.
+
+```
+cascade_name (e.g. "keeper", "verifier", "context_router")
+  -> config/cascade.json 에서 "{name}_models" 목록 조회
+  -> OAS Cascade_config.resolve_model_strings
+  -> OAS Cascade_config.parse_model_strings
+  -> Provider_config.t list (ordered by priority)
+```
+
+### 6.2 Cascade Inference Parameters
+
+`cascade_inference.ml`이 cascade.json에서 per-cascade 추론 파라미터를 읽는다:
+
+```json
+{
+  "keeper_models": ["llama:qwen3.5", "glm:auto"],
+  "keeper_temperature": 0.7,
+  "keeper_max_tokens": 4096,
+  "default_temperature": 0.5,
+  "default_max_tokens": 2048
+}
+```
+
+Resolution 순서:
+1. `{name}_temperature` / `{name}_max_tokens`
+2. `default_temperature` / `default_max_tokens`
+3. 호출자 제공 fallback 값
+
+### 6.3 Model Label Resolution
+
+`oas_model_resolve.ml`이 모델 레이블 문자열을 OAS `Provider_registry`를 통해 해석한다:
+
+- `provider_name_of_label`: "llama:qwen3.5" -> Some "llama"
+- `max_context_of_label`: label -> Provider_registry.find -> entry.max_context (fallback: 128,000)
+- `resolve_primary_max_context`: label list에서 available한 첫 모델의 max_context
+- `ensure_api_keys_for_labels`: 사용 가능한 API key 존재 여부 검증
+
+---
+
+## 7. Message/Response Conversion
+
+### 7.1 Oas_message
+
+`oas_message.ml`은 OAS 메시지 생성 헬퍼를 제공한다. 다른 MASC 코드가 provider-specific 이름을 직접 참조하지 않도록 한다.
+
+```ocaml
+val tool_result : ?is_error:bool -> tool_use_id:string -> content:string
+  -> unit -> Agent_sdk.Types.message
+```
+
+### 7.2 Oas_response
+
+`oas_response.ml`은 OAS 응답 읽기 헬퍼:
+
+```ocaml
+type api_response = Agent_sdk.Types.api_response
+val text_of_response : api_response -> string
+val model_used : api_response -> string option
+val usage_or_zero : api_response -> Agent_sdk.Types.api_usage
+```
+
+### 7.3 Type Compatibility
+
+MASC와 OAS는 `Agent_sdk.Types.message` 타입을 공유한다. 4개 역할(System, User, Assistant, Tool)과 ToolUse/ToolResult content block이 동일하므로, message 변환이 불필요하다. `context_compact_oas.ml` 주석에서 명시: "No role conversion or sentinel tagging is needed."
+
+---
+
+## 8. Event Bus Bridge
+
+### 8.1 Publishing (oas_events.ml)
+
+MASC 조율 이벤트를 OAS `Event_bus`에 `Custom("masc:<type>", json)` 형식으로 publish한다.
+
+| Event Type | 발생 시점 |
+|-----------|----------|
+| `masc:broadcast` | agent broadcast 전송 |
+| `masc:heartbeat` | keeper heartbeat |
+| `masc:board_post` | board post 생성 |
+| `masc:task_transition` | task 상태 변경 |
+| `masc:heartbeat_recovered` | timeout 복구 |
+| `masc:lodge:agent_selected` | Thompson Sampling 선택 |
+| `masc:lodge:agent_decision` | MODEL 행동 결정 |
+| `masc:lodge:agent_action_executed` | 행동 실행 완료 |
+| `masc:keeper:snapshot` | keeper 상태 스냅샷 |
+| `masc:keeper:resident_lifecycle` | resident 시작/중단/충돌/재시작 |
+| `masc:trust_updated` | 신뢰 점수 갱신 |
+| `masc:reputation_changed` | 평판 변경 |
+| `masc:institution_episode` | institution 에피소드 기록 |
+
+### 8.2 SSE Relay (oas_sse_bridge.ml)
+
+`oas_sse_bridge.ml`이 Event_bus의 `masc:*` 이벤트를 SSE로 중계한다.
+
+동작:
+1. `Event_bus.subscribe`로 `masc:` prefix 필터 구독
+2. 배경 fiber가 `drain_interval_s` (기본 0.25초) 간격으로 poll
+3. `Custom(name, payload)` -> `{"type":"oas:<name>","payload":...,"ts_unix":...}` SSE broadcast
+4. `Sse.broadcast_to Coordinators`로 dashboard 클라이언트에 전달
+
+환경변수: `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` (범위: 0.05-5.0초)
+
+---
+
+## 9. Verifier Integration
+
+### 9.1 개요
+
+`verifier_oas.ml`은 cheap-model 기반 action verification 엔진이다. OAS Hooks와 Guardrails에 bridge된다.
+
+### 9.2 Verification Flow
+
+```
+PreToolUse event
+  -> should_skip? (read-only 패턴 매칭)
+    -> Yes: Pass (MODEL 호출 없음)
+    -> No: build_prompt -> Oas_worker.run_named(cascade="verifier")
+      -> parse_verdict (PASS/WARN/FAIL)
+```
+
+Read-only 패턴: read, glob, grep, search, find, list, ls, cat, git status, git log, git diff, status, view, get, fetch, query
+
+Budget: max 200 output tokens per verification.
+
+### 9.3 Verdict to Hook Decision
+
+| Verdict | Hook Decision | 동작 |
+|---------|--------------|------|
+| Pass | Continue | 도구 실행 진행 |
+| Warn | Continue | 경고 로그, 실행 진행 |
+| Fail | Skip | 도구 실행 차단 |
+
+### 9.4 Eval_gate -> Guardrails Bridge
+
+`eval_gate_to_oas_guardrails`가 MASC의 `Eval_gate.gate_config`를 OAS `Guardrails.t`로 변환한다:
+
+| MASC Eval_gate 상태 | OAS Guardrails.tool_filter |
+|--------------------|---------------------------|
+| allowlist_enabled + allowed_tools | AllowList |
+| denied_tools only | DenyList |
+| 둘 다 enabled | AllowList (stricter) |
+| 둘 다 없음 | AllowAll |
+
+`max_tool_calls_per_turn`도 함께 매핑된다.
+
+Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate가 담당한다. Defense-in-depth.
+
+---
+
+## 10. Context Compaction
+
+`context_compact_oas.ml`은 MASC 컨텍스트 전략을 OAS `Context_reducer`에 위임한다. 상세는 12-memory-systems.md 6.3절 참조.
+
+핵심: MASC `strategy` variant -> OAS `Context_reducer.strategy` 매핑. MASC-specific 로직(importance scoring, extractive summarizer)은 OAS `Custom` closure로 주입된다.
+
+---
+
+## 11. Memory Bridge
+
+`memory_oas_bridge.ml`은 MASC 메모리를 OAS `Memory.t` 5-tier에 연결한다. 상세는 12-memory-systems.md 9절 참조.
+
+핵심 API:
+- `create_memory_full`: 5-tier 전체를 seed하는 팩토리
+- `flush_all`: Agent.run 완료 후 episodic + procedural flush
+- `make_backend`: PG primary, JSONL fallback long_term_backend 선택
+
+---
+
+## 12. Integration Status
+
+| 영역 | 상태 | 설명 |
+|------|------|------|
+| Agent 실행 | Complete | `oas_worker.ml`이 모든 MODEL 호출을 Agent.run으로 라우팅 |
+| Context compaction | Complete | OAS Context_reducer 직접 위임, MASC Custom closure 주입 |
+| Event_bus bridge | Complete | `masc:*` 이벤트 13종 publish + SSE relay |
+| Checkpoint | Complete | OAS Checkpoint persist in shared worker paths |
+| Memory bridge | Partial | Long_term + Episodic + Procedural bridged. Working/Scratchpad는 OAS 내부. 전체 통합은 미완 |
+| Team-session swarm | Partial | OAS Swarm runner 활성, bridge fidelity 불완전 |
+| Cascade config | Complete | cascade_name -> OAS Provider_registry -> Provider_config.t |
+| Verifier | Complete | PreToolUse hook + Guardrails adapter |
+| Model resolution | Complete | oas_model_resolve.ml이 Provider_Registry SSOT 사용 |
+| Tool bridge | Complete | MASC tool_schema -> OAS Tool.t 변환 |
+
+---
+
+## 13. Invariants
+
+1. **의존 방향은 단방향이다**: MASC -> OAS. OAS 코드에 MASC import가 존재하면 설계 위반이다.
+2. **MASC는 OAS Agent.run을 사용한다**: 에이전트 생명주기를 자체 재구현하지 않는다. `Cascade.call` 직접 사용은 금지.
+3. **Message 타입은 공유한다**: `Agent_sdk.Types.message`가 MASC와 OAS 모두의 메시지 타입이다. 변환 레이어 없음.
+4. **Cascade name이 model을 추상화한다**: MASC 코드에 구체적 모델 이름이 하드코딩되지 않는다. cascade_name -> cascade.json -> Provider_Registry 체인.
+5. **Event_bus prefix는 `masc:`이다**: MASC 이벤트는 반드시 이 prefix를 사용한다. SSE bridge가 이 prefix로 필터링한다.
+6. **Verifier는 read-only를 건너뛴다**: read/grep/search/status 류 도구는 MODEL 호출 없이 Pass를 반환한다.
+7. **Checkpoint는 session_id로 네임스페이스된다**: 동일 agent의 다른 세션 checkpoint와 충돌하지 않는다.
+8. **OAS API 확장 제안 전에 adapter를 먼저 시도한다**: MASC-specific 개념을 OAS public contract에 밀어넣지 않는다.
+
+---
+
+## 14. Environment Variables
+
+| 변수 | 기본값 | 용도 |
+|------|--------|------|
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | 0.25 | Event_bus -> SSE relay poll 간격 |
+| `MASC_CONTEXT_BUDGET_MAX` | 100,000 | Context budget 상한 |
+| `MASC_CONTEXT_ROUTER_MODE` | heuristic | Intent classification 모드 |
+| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | 5 | OAS Memory store 기본 importance |
+| `ZAI_API_KEY` | (없음) | GLM Cloud cascade fallback 활성화 |
+
+cascade.json 기반 변수는 환경변수가 아니라 config 파일에서 관리된다.
+
+---
+
+## 15. Future Work
+
+- Team-session swarm bridge fidelity 완성
+- MASC 자체 메모리 4개와 OAS Memory.t 완전 통합 (Working/Scratchpad 활용)
+- Perpetual loop -> OAS Agent.run 전환 완료 (일부 경로 남음)
+- OAS Orchestrator를 MASC team session에 직접 활용

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -1,0 +1,453 @@
+# Configuration
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Foundation |
+| Maps to | `lib/env_config*.ml`, `lib/mode.ml`, `lib/capability_registry.ml`, `lib/tool_catalog.ml`, `lib/runtime_params.ml`, `config/` |
+| Dependencies | 02-types-and-invariants |
+
+---
+
+## 1. 목적
+
+설정 시스템은 MASC MCP 서버의 모든 조정 가능한 동작을 12-Factor App 원칙에 따라 환경변수로 외부화한다. 5개 계층(Core, Runtime, Governance, Keeper, Level2/Level4)으로 분류되며, 런타임 오버라이드 + 감사 경로를 제공한다.
+
+---
+
+## 2. 설정 해석 계층
+
+```
+┌────────────────────────────────────────────────────┐
+│ Layer 1: Env_config_core        (경로, 포트, 네트워크)  │
+│ Layer 2: Env_config_runtime     (타이머, 캐시, 세션)    │
+│ Layer 3: Env_config_governance  (모델, 추론, Lodge)     │
+│ Layer 4: Env_config_keeper      (Keeper 부트/알림/감독)  │
+│ Layer 5: Level2/Level4_config   (메트릭, Swarm, 학습)   │
+│ Layer 6: Runtime_params         (런타임 오버라이드)       │
+│ Layer 7: config/cascade.json    (Cascade 모델 순서)     │
+└────────────────────────────────────────────────────┘
+```
+
+해석 우선순위: `Runtime_params override > env var > default value`.
+
+---
+
+## 3. 환경변수 레퍼런스
+
+### 3.1 Core (Env_config_core)
+
+경로 해석, 네트워크 주소, 외부 서비스 연결 설정.
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_WORKSPACE_ROOT` | string | - | 작업 공간 루트 (최우선) |
+| `ME_ROOT` | string | - | Second Brain 루트 (2순위) |
+| `DUNE_SOURCEROOT` | string | - | 테스트 환경 fallback (3순위) |
+| `MASC_SB_PATH` | string | `{root}/scripts/sb` | sb CLI 경로 |
+| `MASC_HTTP_PORT` / `MASC_PORT` | string | `"8935"` | HTTP 서버 포트 |
+| `MASC_HTTP_BASE_URL` | string | - | 전체 base URL (설정 시 host/port 무시) |
+| `MASC_HOST` | string | - | 바인드 호스트 (base URL 미설정 시 필수) |
+| `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |
+
+경로 해석 체인: `MASC_WORKSPACE_ROOT` -> `ME_ROOT` -> `DUNE_SOURCEROOT`. 세 곳 모두 미설정 시 `failwith`.
+
+### 3.2 Runtime (Env_config_runtime)
+
+타이머, 세션, 캐시, 프로세스 관리 파라미터.
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_ZOMBIE_THRESHOLD_SEC` | float | 300.0 | 좀비 감지 임계값 (초) |
+| `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | float | 3600.0 | Keeper 좀비 감지 (1시간) |
+| `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | float | 60.0 | 좀비 정리 루프 주기 |
+| `MASC_LOCK_TIMEOUT_SEC` | float | 1800.0 | 잠금 만료 (30분) |
+| `MASC_LOCK_EXPIRY_WARNING_SEC` | float | 300.0 | 만료 경고 임계값 |
+| `MASC_SESSION_MAX_AGE_SEC` | float | 3600.0 | 세션 최대 수명 |
+| `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | float | 60.0 | 속도 제한 윈도우 |
+| `MASC_TEMPO_MIN_INTERVAL_SEC` | float | 60.0 | 최소 폴링 주기 |
+| `MASC_TEMPO_MAX_INTERVAL_SEC` | float | 600.0 | 최대 폴링 주기 |
+| `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | float | 300.0 | 기본 폴링 주기 |
+| `MASC_DECISION_TTL_SEC` | float | 3600.0 | 결정 TTL (1시간) |
+| `MASC_CACHE_MAX_ENTRY_SIZE` | int | 102400 | 캐시 엔트리 최대 크기 (100KB) |
+| `MASC_CACHE_MAX_ENTRIES` | int | 1000 | 캐시 최대 항목 수 |
+| `MASC_CLAIM_TTL_SECONDS` | float | 3600.0 | Task claim 자동 해제 TTL |
+| `MASC_ORCHESTRATOR_INTERVAL` | float | 300.0 | Orchestrator 점검 주기 |
+| `MASC_ORCHESTRATOR_AGENT` | string | `"orchestrator"` | Orchestrator 에이전트명 |
+| `MASC_MITOSIS_INTERVAL_SEC` | float | 300.0 | Mitosis 트리거 주기 |
+| `MASC_MITOSIS_HANDOFF_COOLDOWN_SEC` | float | 60.0 | 핸드오프 쿨다운 |
+| `MASC_MITOSIS_EXPERIMENT_ENABLED` | bool | false | 실험적 mitosis 경로 |
+| `MASC_ADAPTIVE_THRESHOLDS_ENABLED` | bool | false | 적응형 임계값 학습 |
+| `MASC_SPAWN_TIMEOUT_SEC` | float | 600.0 | 스폰 기본 타임아웃 (10분) |
+| `MASC_SPAWN_CODING_TIMEOUT_SEC` | float | 7200.0 | 코딩 모드 타임아웃 (2시간) |
+| `MASC_SPAWN_GRACE_PERIOD_SEC` | float | 60.0 | SIGTERM 유예 기간 |
+| `LLAMA_SERVER_URL` | string | `http://127.0.0.1:8085` | 로컬 LLM 서버 URL |
+| `LLAMA_DEFAULT_MODEL` | string | `explicit-model-required` | 로컬 기본 모델 |
+| `MASC_LLAMA_MAX_TOKENS` | int | 32768 | 로컬 LLM max_tokens 상한 |
+| `MASC_FEDERATION_TIMEOUT_SEC` | float | 3600.0 | Federation 요청 타임아웃 |
+| `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | float | 3600.0 | 취소 토큰 최대 수명 |
+| `NEO4J_URI` | string | `bolt://turntable.proxy.rlwy.net:11490` | Neo4j 접속 URI |
+| `NEO4J_HTTP_URI` | string | `""` | Neo4j HTTP API URI |
+| `NEO4J_USER` | string | `"neo4j"` | Neo4j 사용자 |
+| `NEO4J_PASSWORD` | string | (필수) | Neo4j 비밀번호 |
+| `VOICE_MCP_HOST` | string | `"127.0.0.1"` | Voice MCP 호스트 |
+| `VOICE_MCP_PORT` | int | 8936 | Voice MCP 포트 |
+| `CUSTOM_MODEL_SERVER_URL` | string | `http://127.0.0.1:8080` | 커스텀 모델 서버 URL |
+
+**Timeout 모듈** (통합 타임아웃):
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_TIMEOUT_GCLOUD_AUTH_SEC` | float | 15.0 | GCP 인증 타임아웃 |
+| `MASC_TIMEOUT_ANTHROPIC_SEC` | int | 120 | Anthropic API 타임아웃 |
+| `MASC_TIMEOUT_OPENAI_COMPAT_SEC` | int | 60 | OpenAI 호환 API 타임아웃 |
+| `MASC_TIMEOUT_MODEL_GRACE_SEC` | float | 5.0 | 모델 호출 네트워크 유예 |
+| `MASC_TIMEOUT_GRAPHQL_SEC` | float | 5.0 | GraphQL 쿼리 타임아웃 |
+| `MASC_TIMEOUT_KEEPER_STATUS_SEC` | float | 5.0 | Keeper 상태 확인 타임아웃 |
+
+**Inference Defaults**:
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_INFERENCE_DEFAULT_MAX_TOKENS` | int | 4096 | 기본 max_tokens |
+| `MASC_SSE_RETRY_MS` | int | 3000 | SSE 재접속 힌트 (ms) |
+| `MASC_LOG_TRUNCATION_LEN` | int | 1500 | 로그 출력 절삭 길이 |
+| `MASC_CP_CLEANUP_DAYS` | int | 14 | CP 데이터 정리 임계일 |
+| `MASC_MESSAGE_MAX_COUNT` | int | 200 | Room당 메시지 최대 보유 수 |
+| `MASC_CHAIN_JUDGE_MODEL` | string | `"gemini"` | Chain judge 모델 |
+
+### 3.3 Governance (Env_config_governance)
+
+모델 선택, 추론 캐시, Lodge 자율 에이전트, Thompson Sampling 설정.
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_INFERENCE_TIMEOUT_SEC` | float | 30.0 | 모델 API 호출 타임아웃 |
+| `MASC_OPERATOR_JUDGE_TIMEOUT_SEC` | int | (inference fallback) | Operator judge 타임아웃 |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC` | int | (inference fallback) | Dashboard governance judge 타임아웃 |
+| `MASC_INFERENCE_CACHE_ENABLED` | bool | true | 추론 캐시 활성화 |
+| `MASC_INFERENCE_CACHE_TTL_SEC` | int | 300 | 캐시 TTL (초) |
+| `MASC_INFERENCE_CACHE_MAX_PROMPT_CHARS` | int | 48000 | 캐시 대상 최대 프롬프트 길이 |
+| `MASC_INFERENCE_CACHE_MAX_TEMP` | float | 0.0 | 캐시 허용 최대 온도 |
+| `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | int | 512 | L1 인메모리 캐시 상한 |
+| `MASC_SPAWN_CACHE_POLICY` | string | `"safe_only"` | Spawn 캐시 정책 (`off`/`safe_only`) |
+| `MASC_GLM_DEFAULT_MODEL` | string | `"glm-4.7"` | GLM 기본 모델 |
+| `MASC_GLM_FLASH_MODEL` | string | `"glm-4.7-flash"` | GLM flash 모델 |
+| `MASC_GEMINI_DEFAULT_MODEL` | string | `"gemini-2.5-pro"` | Gemini 기본 모델 |
+| `MASC_GEMINI_FLASH_MODEL` | string | `"gemini-2.5-flash"` | Gemini flash 모델 |
+| `MASC_CLAUDE_DEFAULT_MODEL` | string | `"claude-sonnet-4-6"` | Claude 기본 모델 |
+| `MASC_OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | OpenAI 기본 모델 |
+
+**Lodge (자율 에이전트)**: `MASC_LODGE_*` prefix.
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_LODGE_TICK_INTERVAL_SEC` | float | 2700.0 | Tick 주기 (45분) |
+| `MASC_LODGE_AGENTS_PER_TICK` | int | 3 | Tick당 활성화 에이전트 수 |
+| `MASC_LODGE_MAX_POSTS_PER_TICK` | int | 1 | Tick당 게시물 상한 |
+| `MASC_LODGE_MAX_COMMENTS_PER_TICK` | int | 3 | Tick당 댓글 상한 |
+| `MASC_LODGE_MAX_DAILY_ACTIONS` | int | 10 | 일일 총 행동 상한 |
+| `MASC_LODGE_REFLECTION_THRESHOLD` | int | 100 | 회고 트리거 임계값 |
+| `MASC_LODGE_USE_PLANNER` | bool | true | Planner 기반 선택 |
+| `MASC_LODGE_ENABLED` | bool | true | 하트비트 활성화 |
+| `MASC_LODGE_QUIET_START` | int | 3 | 조용한 시간대 시작 (KST) |
+| `MASC_LODGE_QUIET_END` | int | 7 | 조용한 시간대 종료 (KST) |
+| `MASC_DELEGATE_INFERENCE` | bool | false | Worker 위임 모드 (Soul+Body) |
+
+**Thompson Sampling** (`MASC_LODGE_*` prefix 유지):
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_LODGE_MAX_STARVATION_TICKS` | int | 12 | 기아 방지 최대 tick 수 |
+| `MASC_LODGE_THOMPSON_WEIGHT` | float | 0.7 | Thompson score 비중 |
+| `MASC_LODGE_VOTE_DECAY_FACTOR` | float | 0.95 | Vote decay 계수 |
+
+### 3.4 Keeper (Env_config_keeper)
+
+Keeper 부트스트랩, 메트릭 로테이션, 알림 팬아웃, Supervisor 설정.
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_KEEPER_BOOTSTRAP_ENABLED` | bool | true | 부트스트랩 스캔 활성화 |
+| `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | float | 3600.0 | Stale turn 임계값 |
+| `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | int | 10000 | 최대 스캔 파일 수 |
+| `MASC_KEEPER_METRICS_MAX_BYTES` | int | 10485760 | 메트릭 파일 로테이션 크기 (10MB) |
+| `MASC_KEEPER_METRICS_MAX_ROTATED` | int | 1 | 보관할 로테이션 파일 수 |
+| `MASC_KEEPER_ALERT_ENABLED` | bool | true | 알림 마스터 스위치 |
+| `MASC_KEEPER_ALERT_MIN_SCORE` | float | 0.70 | 알림 최소 점수 |
+| `MASC_KEEPER_ALERT_BOARD_ENABLED` | bool | true | Board 팬아웃 |
+| `MASC_KEEPER_ALERT_SLACK_ENABLED` | bool | true | Slack 팬아웃 |
+| `MASC_KEEPER_ALERT_GITHUB_ENABLED` | bool | false | GitHub Issue 팬아웃 |
+| `MASC_KEEPER_ALERT_GITHUB_MIN_SCORE` | float | 0.85 | GitHub 최소 점수 |
+| `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | int | 5 | 최대 재시작 시도 |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | float | 10.0 | 지수 백오프 기본 지연 |
+| `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | float | 300.0 | 백오프 상한 |
+| `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | float | 30.0 | Supervisor sweep 주기 |
+
+### 3.5 Level2 / Level4 Config
+
+L2는 메트릭/드리프트/학습 튜닝, L4는 Swarm 행동 파라미터.
+
+**Level2** (`lib/level2_config.ml`):
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_METRICS_CACHE_TTL` | float | 300.0 | 메트릭 캐시 TTL |
+| `MASC_TOKEN_CACHE_SIZE` | int | 1000 | 토큰 캐시 최대 항목 |
+| `MASC_DRIFT_THRESHOLD` | float | 0.85 | 드리프트 감지 임계값 |
+| `MASC_LOCK_WARN_MS` | float | 100.0 | 잠금 경합 경고 임계 (ms) |
+| `MASC_HEBBIAN_RATE` | float | 0.075 | Hebbian 학습률 |
+| `MASC_HEBBIAN_DECAY` | float | 0.01 | Hebbian 감쇠율 |
+| `MASC_FITNESS_HALFLIFE` | float | 7.0 | Fitness 반감기 (일) |
+
+**Level4** (`lib/level4_config.ml`):
+
+| 환경변수 | 타입 | 기본값 | 설명 |
+|----------|------|--------|------|
+| `MASC_SWARM_SEED` | int | (시각 기반) | RNG 시드 (재현성) |
+| `MASC_SWARM_INITIAL_FITNESS` | float | 0.5 | 신규 에이전트 초기 fitness |
+| `MASC_SWARM_SELECTION_PRESSURE` | float | 0.3 | 선택 압력 |
+| `MASC_SWARM_MUTATION_RATE` | float | 0.1 | 변이율 |
+| `MASC_SWARM_QUORUM_THRESHOLD` | float | 0.6 | 정족수 임계값 |
+| `MASC_SWARM_MAX_AGENTS` | int | 50 | Swarm 최대 에이전트 |
+| `MASC_FLOCK_SEPARATION` | float | 1.5 | 분리 가중치 |
+| `MASC_FLOCK_ALIGNMENT` | float | 1.0 | 정렬 가중치 |
+| `MASC_FLOCK_COHESION` | float | 1.0 | 응집 가중치 |
+| `MASC_STIG_DEPOSIT` | float | 0.2 | 페로몬 증착율 |
+| `MASC_STIG_THRESHOLD` | float | 0.1 | 페로몬 추종 임계값 |
+
+Level4는 `Normalized.t` (0.0-1.0 범위 보장) 추상 타입을 제공한다. `of_float`는 범위 밖 입력에 `None`을 반환하고, `of_float_clamped`는 clamping한다.
+
+---
+
+## 4. Mode System
+
+### 4.1 개요
+
+300+ 도구를 22개 category로 분류하고, 8개 preset mode로 필터링한다. Serena MCP의 `switch_modes` 패턴에서 영감.
+
+### 4.2 Category 목록
+
+| Category | 설명 | 대표 도구 |
+|----------|------|----------|
+| `Core_Room` | Room 진입/퇴장 | `masc_join`, `masc_leave`, `masc_rooms_list` |
+| `Core_Task` | Task 생명주기 | `masc_add_task`, `masc_claim`, `masc_transition` |
+| `Core_Session` | Team session | `masc_team_session_start/step/finalize` |
+| `Core_Ops` | 고급 운영 | `masc_run_init`, `masc_operator_snapshot`, dispatch, policy |
+| `Comm` | 커뮤니케이션 | `masc_broadcast`, `masc_messages`, `masc_lock` |
+| `Portal` | A2A 직접 통신 | `masc_portal_open/send/close`, `masc_a2a_delegate` |
+| `Worktree` | Git worktree | `masc_worktree_create/remove/list` |
+| `Code` | 코드 탐색/편집 | `masc_code_search/symbols/read/write` |
+| `Health` | 유지보수 | `masc_heartbeat`, `masc_gc`, `masc_metrics_record` |
+| `Discovery` | 에이전트 검색 | `masc_agent_card`, `masc_agent_fitness` |
+| `Voting` | Room 투표 | `masc_vote_create/cast/status` |
+| `Interrupt` | 체크포인트 | `masc_interrupt`, `masc_approve/reject` |
+| `Cost` | 비용 추적 | `masc_cost_log/report` |
+| `Auth` | 인증/거버넌스 | `masc_auth_*`, `masc_audit_*`, `masc_governance_set` |
+| `RateLimit` | 속도 제한 | `masc_rate_limit_status/config` |
+| `Encryption` | 암호화 | `masc_encryption_*`, `masc_generate_key` |
+| `Board` | 게시판 | `masc_board_post/list/comment/vote` |
+| `Plan` | 계획/목표 | `masc_plan_*`, `masc_goal_*`, `masc_intent_*` |
+| `Consensus` | 합의/토론 | `masc_walph_*`, `masc_convo_*`, `masc_petition_submit` |
+| `Ecosystem` | Keeper/MDAL/Spawn | `masc_keeper_*`, `masc_mdal_*`, `masc_spawn` |
+| `Voice` | 음성 브릿지 | `masc_voice_speak/session_start/conference_*` |
+| `TRPG` | 탁상 RPG | `masc_trpg_session_start/round_run/dice_roll` |
+| `Unknown` | 미매핑 (차단됨) | 새 도구 추가 시 명시적 매핑 필수 |
+
+`Core`는 가상 슈퍼카테고리로, `Core_Room + Core_Task + Core_Session + Core_Ops`를 포함한다.
+
+### 4.3 Mode Presets
+
+| Mode | 포함 category | 예상 도구 수 | 용도 |
+|------|---------------|-------------|------|
+| `minimal` | Core_Room, Core_Task, Health | ~20 | 최소 운영 |
+| `standard` | Core 전체, Comm, Worktree, Health, Plan, Board, Consensus, Voice | ~100 | 일반 협업 |
+| `parallel` | Standard + Portal, Discovery, Voting, Interrupt | ~150 | 멀티 에이전트 |
+| `coding` | Core 전체, Worktree, Code, Health, Plan, Consensus | ~80 | 개발 전용 |
+| `full` | 전체 22개 category | ~322 | 기본값 (v2.99 이후) |
+| `solo` | Core_Room, Core_Task, Worktree | ~23 | 단독 작업 |
+| `agent` | Core_Room, Core_Task, Worktree, Board, Comm | ~30 | 에이전트 최적화 |
+| `custom` | 사용자 정의 | - | category 직접 지정 |
+
+### 4.4 3-Layer Filter Architecture
+
+```
+raw_all_tool_schemas (전체 등록 도구)
+  -> capability_registry (surface projection: Public_mcp / Keeper / Worker)
+  -> tool_catalog (visibility: Default/Hidden, lifecycle: Active/Deprecated)
+  -> mode filter (category 체크)
+```
+
+`masc_switch_mode`, `masc_get_config`, `masc_tool_enable`, `masc_tool_disable`는 mode filter를 bypass한다 (항상 사용 가능).
+
+### 4.5 Progressive Disclosure
+
+`Mode.extra_enabled_tools` Hashtbl로 세션별 도구를 개별 활성화할 수 있다.
+
+```
+masc_tool_enable("masc_spawn")  -> 현재 세션에서 masc_spawn 활성화
+masc_tool_disable("masc_spawn") -> 비활성화
+```
+
+이 메커니즘은 mode category 필터를 bypass하므로, 좁은 mode에서도 특정 도구를 추가 노출할 수 있다.
+
+---
+
+## 5. Capability Registry
+
+### 5.1 구조
+
+```ocaml
+type risk_class = Safe | Audited | Privileged
+type audience   = External_mcp_client | Spawned_managed_agent
+                | Local_worker_agent | Keeper_agent
+                | Strict_mdal_worker | Privileged_executor
+type surface    = Public_mcp | Spawned_agent_mcp | Local_worker
+                | Keeper_standard | Keeper_privileged
+                | Mdal_auditable | Privileged_executor_surface
+```
+
+하나의 capability는 여러 surface에 projection을 가진다. 같은 도구가 `Public_mcp`와 `Keeper_standard`에 서로 다른 schema로 노출될 수 있다.
+
+### 5.2 Surface 매핑 규칙
+
+| Surface | Audience | Risk | 용도 |
+|---------|----------|------|------|
+| Public_mcp | External_mcp_client | Safe | 외부 MCP 클라이언트 |
+| Spawned_agent_mcp | Spawned_managed_agent | Audited | 스폰된 에이전트 |
+| Local_worker | Local_worker_agent | Audited | 로컬 워커 |
+| Keeper_standard | Keeper_agent | Audited | Keeper 표준 도구 |
+| Keeper_privileged | Keeper_agent + Privileged_executor | Privileged | Keeper 특권 도구 (`keeper_bash` 등) |
+| Mdal_auditable | Strict_mdal_worker | Audited | MDAL 감사 대상 |
+| Privileged_executor_surface | Privileged_executor | Privileged | 특권 실행 전용 |
+
+---
+
+## 6. Tool Catalog
+
+### 6.1 Metadata 구조
+
+```ocaml
+type visibility = Default | Hidden
+type lifecycle  = Active | Deprecated
+type implementation_status = Real | Adapter | Simulation | Placeholder
+type tier = Essential | Standard | Full
+```
+
+### 6.2 Lifecycle 관리
+
+| 상태 | 가시성 | 동작 |
+|------|--------|------|
+| Active + Default | 도구 목록에 노출 | 정상 사용 |
+| Active + Hidden | 목록 비노출 | `allow_direct_call_when_hidden=true`이면 직접 호출 가능 |
+| Deprecated + Default | 목록 노출 (경고) | canonical_name/replacement 안내 |
+| Deprecated + Hidden | 목록 비노출 | 호환성 유지, 내부 호출만 |
+
+### 6.3 3-Tier System
+
+| Tier | 도구 수 | 용도 |
+|------|---------|------|
+| Essential | ~21 | 핵심 워크플로우 (`join`, `add_task`, `broadcast`, `heartbeat`, `worktree_create` 등) |
+| Standard | ~50 | Essential + Board, Team Session, Governance V2, Handover, Spawn |
+| Full | 전체 | 모든 등록 도구 |
+
+Tier는 mode/category와 독립적으로 적용되는 추가 필터 레이어다.
+
+---
+
+## 7. Cascade Configuration
+
+### 7.1 config/cascade.json 구조
+
+JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_name}_models`.
+
+```json
+{
+  "default_models": ["llama:auto", "glm:auto"],
+  "keeper_turn_models": ["llama:auto", "glm:auto"],
+  "briefing_models": ["llama:auto", "glm:auto", "gemini:auto"],
+  "auto_responder_claude_models": ["claude:auto", "glm:auto"],
+  "keeper_unified_temperature": 0.4,
+  "keeper_unified_max_tokens": 2048
+}
+```
+
+### 7.2 모델 식별자 형식
+
+`{provider}:{model_id}` 형식. `auto`는 해당 provider의 env_config 기본 모델을 사용한다.
+
+| Provider | Env Config 모듈 | 기본 모델 |
+|----------|----------------|----------|
+| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` |
+| `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
+| `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
+| `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |
+
+### 7.3 Per-cascade 추론 파라미터
+
+`{cascade_name}_temperature`, `{cascade_name}_max_tokens` 키로 cascade별 온도와 토큰 수를 오버라이드할 수 있다. 미설정 시 호출자 기본값 사용.
+
+---
+
+## 8. Runtime Parameters
+
+### 8.1 아키텍처
+
+`Runtime_params` 모듈은 환경변수 기본값 위에 런타임 오버라이드를 제공한다.
+
+- **등록**: `register ~key ~default ~validate ~serialize ~deserialize`로 파라미터 정의
+- **읽기/쓰기**: `get`, `set`, `set_by_key` (JSON 경유)
+- **동시성**: `Eio.Mutex`로 보호. Eio 스케줄러 부재 시 lock-free fallback.
+- **영속화**: `.masc/runtime_params.json`에 atomic write (rename)
+- **감사**: `.masc/param_audit.jsonl`에 변경 이력 기록
+
+### 8.2 오버라이드 흐름
+
+```
+masc_set_param(key, value)
+  -> validate(value)
+  -> entry.override <- Some value
+  -> persist(base_path)
+  -> record_audit(key, old, new, actor)
+```
+
+### 8.3 거버넌스 연동
+
+`masc_runtime_params`로 현재 값 조회, `masc_set_param`으로 변경. Council/Governance 결정(`case_id`)과 연결하여 감사 추적이 가능하다.
+
+---
+
+## 9. CLI Arguments
+
+서버 바이너리(`bin/main_eio.ml`)는 Cmdliner로 CLI 인자를 받는다.
+
+| Flag | 기본값 | 설명 |
+|------|--------|------|
+| `-p`, `--port` | 8935 | HTTP 리스닝 포트 |
+| `--host` | `127.0.0.1` | 바인드 주소 |
+| `--base-path` | `me_root()` 기반 | `.masc` 폴더 위치 |
+
+---
+
+## 10. 불변식
+
+- **INV-C1**: 모든 `MASC_*` 환경변수는 `get_string/get_int/get_float/get_bool` 헬퍼를 통해 읽힌다. `Sys.getenv` 직접 호출은 `Env_config_core`의 해석 함수에서만 허용.
+- **INV-C2**: `Runtime_params.set`은 반드시 `validate`를 통과해야 한다. 검증 실패 시 `Error`를 반환하고 값은 변경되지 않는다.
+- **INV-C3**: `Unknown` category에 매핑된 도구는 어떤 mode preset에서도 노출되지 않는다.
+- **INV-C4**: `tool_catalog.is_visible`이 false를 반환하는 도구는 `allow_direct_call_when_hidden=true`가 아닌 한 MCP 클라이언트에 노출되지 않는다.
+- **INV-C5**: Cascade JSON의 모델 목록은 순서대로 시도되며, 전부 실패 시 skip한다 (error propagation, fallback 없음).
+- **INV-C6**: `Normalized.t` 값은 항상 [0.0, 1.0] 범위이다. `of_float`는 NaN/Inf/범위 밖에 `None`을 반환한다.
+
+---
+
+## 11. Capability Match 설정
+
+`MASC_CAPABILITY_MATCH_MODE` 환경변수로 Task-Agent 매칭 전략을 선택한다.
+
+| 값 | 동작 |
+|------|------|
+| `keyword` | 키워드 오버랩 휴리스틱. 0 지연, 외부 호출 없음. |
+| `model` | LLM semantic scoring. 실패 시 0점 반환. |
+| `hybrid` (기본값) | LLM 우선, 실패 시 keyword fallback. |
+
+점수 공식 (keyword mode): `total = trait_overlap * 0.4 + interest_overlap * 0.4 + capability_match * 0.2`.

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -1,0 +1,374 @@
+# Testing
+
+| 항목 | 값 |
+|------|-----|
+| Status | Draft |
+| Team | Foundation |
+| Maps to | `test/`, `lib/eval_gate.ml`, `lib/eval_harness.ml`, `lib/anti_fake.ml`, `lib/trajectory.ml`, `lib/keeper/keeper_verifier.ml`, `lib/keeper/keeper_contract.ml` |
+| Dependencies | (all subsystem specs) |
+| Test Files | 319 (.ml), 6 (bench), 3 (fixtures/other) |
+
+---
+
+## 1. 목적
+
+MASC MCP의 검증 전략을 정의한다. 테스트는 3개 계층(Hermetic Required, Optional Env-Gated, Manual Experiment)으로 분리되며, Keeper 에이전트에 대해서는 별도의 Eval Harness(시나리오 기반 행동 평가)를 운영한다.
+
+---
+
+## 2. 검증 철학
+
+### 2.1 원칙
+
+1. **Hermetic first**: 외부 DB, 네트워크, LLM 런타임 없이 재현 가능한 테스트가 CI 필수 게이트.
+2. **Env-gated 분리**: PostgreSQL, live network, local LLM 등 환경 의존 테스트는 별도 계층으로 분리. CI 기본 green과 동일시하지 않는다.
+3. **실험은 실험**: benchmark, swarm proof, TRPG workload는 pass/fail이 아니라 proof artifact와 함께 해석한다.
+4. **Anti-fake 검증**: `assert true` 같은 허위 테스트를 자동 탐지하고 점수화한다.
+5. **Agent harness**: Keeper 에이전트의 행동 품질은 시나리오 기반 eval harness로 측정한다.
+
+### 2.2 테스트 환경 격리
+
+`test/dune`의 `(env)` 섹션이 테스트 환경을 강제 격리한다:
+
+```
+MASC_STORAGE_TYPE=filesystem     (파일시스템 백엔드 강제)
+MASC_POSTGRES_URL=""             (PG 자동 감지 차단)
+DATABASE_URL=""                  (PG cascade 차단)
+SUPABASE_DB_URL=""               (Supabase 차단)
+SB_PG_URL=""                     (SB PostgreSQL 차단)
+GRAPHQL_API_KEY=""               (GraphQL API 비활성화)
+ZAI_API_KEY=""                   (ZAI API 비활성화)
+```
+
+이 격리는 비결정적 외부 네트워크 호출을 단위 테스트에서 제거한다.
+
+---
+
+## 3. Verification Matrix (3 계층)
+
+### 3.1 Layer 1: Hermetic Required
+
+CI 필수 게이트. 외부 의존성 없이 재현 가능.
+
+| 항목 | 실행 방법 | 범위 |
+|------|----------|------|
+| 단위/통합 테스트 묶음 | `dune test --root .` / `make test` | 40+ 테스트 바이너리 |
+| SSE Storm E2E | `./_build/default/test/test_sse_storm_e2e.exe` | SSE reconnect 시나리오 |
+| Contract Harness (3종) | `make test-contract` | Streamable HTTP, Team Session, Golden Path |
+
+Contract harness는 서버가 이미 떠 있다고 가정하지 않고 hermetic bootstrap 경로로 실행된다.
+
+**판정 기준**: main 브랜치가 green이면 core MCP/HTTP/Team-Session 계약이 깨지지 않았다.
+
+### 3.2 Layer 2: Optional Env-Gated
+
+특정 환경이 있을 때만 의미가 있는 테스트. CI 기본 green에 포함되지 않는다.
+
+| 게이트 | 테스트 파일 | 필요 환경 |
+|--------|-----------|----------|
+| PostgreSQL | `test_board_pg.ml`, `test_tool_mdal_pg.ml`, `test_pubsub_postgres.ml` | `MASC_POSTGRES_URL` |
+| Live network | `test_ice_eio.ml`, `test_stun.ml` | 네트워크 접근 |
+| Local viewer | `scripts/viewer-local-e2e-check.sh` | 빌드 도구 |
+
+규칙: env 미설정 시 skip 또는 not run. CI 로그에 "왜 안 돌았는지"가 명시되어야 한다.
+
+### 3.3 Layer 3: Manual Experiment
+
+Correctness gate가 아닌 orchestration/benchmark/behavior 실험. Runbook과 함께 해석한다.
+
+| 실험 | 스크립트 | 참조 문서 |
+|------|---------|----------|
+| Agent swarm proof | `scripts/harness_agent_swarm_live.sh` | `docs/BENCHMARK-RUNBOOK.md` |
+| Supervised delivery | `scripts/harness_supervisor_team_session.sh` | `docs/SUPERVISOR-MODE.md` |
+| TRPG smoke | `scripts/run_trpg_grimland_smoke.sh` | - |
+| Local64 model matrix | `scripts/harness_local64_model_matrix.sh` | - |
+
+규칙: proof artifact, report, runtime 전제, 모델 선택 근거를 함께 남긴다.
+
+---
+
+## 4. 테스트 파일 인벤토리
+
+### 4.1 총계
+
+| 카테고리 | 파일 수 | 비고 |
+|---------|--------|------|
+| `test_*.ml` (전체) | 313 | 단위/통합/E2E 혼합 |
+| `bench_*.ml` | 6 | 성능 벤치마크 |
+| `*_coverage.ml` | 100 | 커버리지 보강 테스트 |
+| `*_e2e.ml` | 6 | 종단간 시나리오 |
+| fixtures/ | 1 dir | 테스트 데이터 |
+| 합계 | ~322 항목 | |
+
+### 4.2 서브시스템별 분포
+
+| 서브시스템 | 파일 수 | 대표 파일 |
+|-----------|--------|----------|
+| Tool (`test_tool_*`) | 64 | `test_tool_board.ml`, `test_tool_mdal.ml`, `test_tool_voice.ml` |
+| Dashboard (`test_dashboard_*`) | 13 | `test_dashboard_cache.ml`, `test_dashboard_proof.ml` |
+| Room (`test_room_*`) | 8 | `test_room.ml`, `test_room_coverage.ml` |
+| Agent (`test_agent_*`) | 7 | `test_agent_identity.ml`, `test_agent_registry_eio.ml` |
+| SSE (`test_sse_*`) | 7 | `test_sse.ml`, `test_sse_storm_e2e.ml`, `test_sse_qw.ml` |
+| Keeper (`test_keeper_*`) | 6 | `test_keeper_memory.ml`, `test_keeper_unified.ml` |
+| Chain (`test_chain_*`) | 6 | `test_chain_coverage.ml`, `test_chain_native_eio_bootstrap.ml` |
+| Swarm (`test_swarm_*`) | 6 | `test_swarm.ml`, `test_swarm_checkpoint.ml` |
+| Board (`test_board_*`) | 4 | `test_board_api_e2e.ml`, `test_board_pg.ml` |
+| OAS (`test_oas_*`) | 3 | `test_oas_integration.ml`, `test_oas_worker.ml` |
+| MDAL (`test_mdal_*`) | 3 | `test_mdal.ml`, `test_mdal_store.ml` |
+| Worker (`test_worker_*`) | 3 | `test_worker_runtime.ml`, `test_worker_dev_tools.ml` |
+| Verification (`test_verif*`) | 3 | `test_verifier_oas_bridge.ml` |
+| Team (`test_team_*`) | 2 | `test_team_session_oas_bridge.ml` |
+| Memory (`test_memory_*`) | 1 | `test_memory_oas_5tier.ml` |
+| 기타 | ~50+ | auth, encryption, spawn, mitosis, bounded, etc. |
+
+### 4.3 dune 테스트 그룹
+
+`test/dune`은 다음 구조로 테스트를 구성한다:
+
+1. **Pure synchronous tests** (최대 묶음, `(tests ...)` 블록): 44개 테스트를 단일 `(libraries masc_mcp alcotest ...)` 의존으로 묶음
+2. **Eio-dependent tests** (개별 `(test ...)` 블록): Eio.Mutex, Session.with_lock 등을 사용하는 테스트는 `eio eio_main` 의존으로 개별 빌드
+3. **OAS bridge tests**: `agent_sdk`, `agent_sdk.swarm` 의존
+4. **Script tests**: CI/harness 스크립트의 동작을 검증하는 테스트 (`test_ci_hardening_source.ml`, `test_ci_run_tests_script.ml`)
+
+---
+
+## 5. Test Harness Architecture
+
+### 5.1 Eval Gate (lib/eval_gate.ml)
+
+Keeper tool call의 사전/사후 실행 게이트. Swiss Cheese Model (다중 방어층).
+
+```
+Tool call -> Cost budget check
+          -> Destructive pattern detection
+          -> Tool allowlist check
+          -> Entropy check (동일 도구 N회 연속 호출)
+          -> [모두 Pass] -> 실행 허용
+          -> [하나라도 Reject] -> 실행 차단
+```
+
+**gate_config 기본값**:
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|------|
+| `max_cost_usd` | 0.50 | 세션 비용 한도 |
+| `max_tool_calls_per_turn` | 10 | 턴당 도구 호출 상한 |
+| `entropy_threshold` | 3 | 동일 도구 연속 호출 임계값 |
+| `destructive_check_enabled` | true | 파괴적 명령 탐지 |
+| `allowlist_enabled` | false | 도구 허용 목록 사용 |
+
+**Destructive patterns** (18개): `rm -rf`, `drop table`, `git push --force`, `chmod 777`, `mkfs`, `dd if=`, `shutdown` 등. 문자열 부분 매칭으로 탐지. AST 수준 파싱은 아니지만 일반적 패턴을 차단한다.
+
+### 5.2 Eval Harness (lib/eval_harness.ml)
+
+시나리오 기반 Keeper 행동 평가. METR Task Standard와 OpenAI Harness 패턴에서 영감.
+
+**구성 요소**:
+
+```
+Scenario -> goal + setup_messages + tool_expectations + graders
+Runner   -> 시나리오 실행, grader 적용, EvalResult 생산
+Grader   -> Deterministic (Exact/Contains/Regex/NotContains)
+         -> ModelBased (LLM 프롬프트 + rubric)
+Metrics  -> pass@k, mean score, consistency
+```
+
+**Scenario 구조**:
+
+```ocaml
+type scenario = {
+  id : string;                    (* 고유 식별자 *)
+  category : string;              (* "safety" | "capability" | "efficiency" *)
+  goal : string;                  (* Keeper에 주어지는 목표 *)
+  tool_expectations : tool_expectation list;
+  graders : grader list;
+  max_turns : int;
+  max_cost_usd : float;
+  tags : string list;             (* "regression" | "smoke" 등 *)
+}
+```
+
+**Grader 타입**:
+- `Deterministic`: 필드(result/tool_name/error)에 대한 Exact/Contains/Regex/NotContains 매칭. 0 지연.
+- `ModelBased`: LLM에 rubric과 결과를 제출하여 0.0-1.0 점수 산출. 비용 발생.
+
+### 5.3 Anti-Fake (lib/anti_fake.ml)
+
+테스트 코드 품질 자동 점수화. 허위 테스트 패턴을 감지한다.
+
+**감점 패턴 (penalties)**:
+
+| 패턴 | 감점 | 심각도 |
+|------|------|--------|
+| `assert true` | -0.3 | Critical |
+| `assert_bool "" true` | -0.3 | Critical |
+| `let _ =` | -0.2 | Warning |
+| `(* TODO` / `(* FIXME` | -0.15 | Warning |
+| `skip` / `ignore` | -0.1 | Info |
+| `fun _ ->` | -0.05 | Info |
+
+**가점 지표** (rewards): `Alcotest.check`, `assert_equal`, `roundtrip`, `property`, `QCheck`.
+
+**결과 타입**:
+
+```ocaml
+type score_result = {
+  file_path : string;
+  raw_score : float;
+  final_score : float;
+  findings : finding list;
+  quality_tier : string;      (* 점수 구간에 따른 등급 *)
+}
+```
+
+`audit_summary`는 전체 파일에 대한 avg/min/max 점수와 fake_count/suspect_count를 집계한다.
+
+### 5.4 Trajectory (lib/trajectory.ml)
+
+Keeper tool call의 JSONL 기반 궤적 로깅. 결정적 재생, 비용 누적, 엔트로피 탐지, eval_harness 연동을 지원한다.
+
+**기록 위치**: `.masc/trajectories/{keeper_name}/{trace_id}.jsonl`
+
+**tool_call_entry 필드**:
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `ts` | float | Unix 타임스탬프 |
+| `turn` | int | 세션 내 턴 번호 |
+| `round` | int | 턴 내 도구 라운드 (1-3) |
+| `tool_name` | string | 호출된 도구 |
+| `gate_decision` | Pass/Reject | 사전 게이트 결과 |
+| `result` | string option | 실행 결과 (게이트 차단 시 None) |
+| `duration_ms` | int | 실행 시간 |
+| `cost_usd` | float | 추정 비용 |
+
+**trajectory_outcome**: `Completed | Failed | Timeout | CostExceeded | Gated`.
+
+### 5.5 Keeper Verifier (lib/keeper/keeper_verifier.ml)
+
+Generator-Verifier 루프. Keeper 자율 행동의 사전 검증.
+
+```
+proposed_action -> risk_level 분류 (Safe/Moderate/Dangerous)
+               -> cost 추정
+               -> Verifier 판정: PASS / WARN / FAIL
+```
+
+- **PASS**: 실행 진행
+- **WARN**: 실행하되 trajectory에 concern 기록
+- **FAIL**: 실행 차단, broadcast로 통보
+
+Budget: 검증당 max 200 output tokens (~$0.01).
+
+### 5.6 Keeper Contract (lib/keeper/keeper_contract.ml)
+
+Keeper 정책/런타임 열거형의 typed 정의. JSON 및 MCP 문자열 표현과의 경계를 타입으로 관리한다.
+
+| 타입 | 값 | 설명 |
+|------|-----|------|
+| `policy_mode` | Heuristic, Learned_offline_v1, Explicit_event_v1, Model_deliberation | 정책 모드 |
+| `policy_action_budget` | Conversation, Board | 행동 예산 타입 |
+| `scope_kind` | Local, Global | 범위 |
+| `trigger_mode` | Legacy, Explicit_only | 트리거 방식 |
+
+---
+
+## 6. CI Pipeline
+
+### 6.1 스크립트: scripts/ci-run-tests.sh
+
+CI 테스트 실행기. 다음 기능을 제공한다:
+
+| 기능 | 설명 |
+|------|------|
+| Heartbeat logging | `CI_TEST_HEARTBEAT_SEC` (기본 30초) 간격으로 진행 상태 출력. "silent hang" 방지. |
+| Timeout | `CI_TEST_TIMEOUT_SEC` (기본 1200초). 초과 시 진단 덤프. |
+| Diagnostics dump | 실패/타임아웃 시 프로세스 스냅샷, 로그 파일 경로, 빌드 디렉토리 정보 출력. |
+| Clean retry | `CI_TEST_ALLOW_CLEAN_RETRY=1`이면 실패 시 clean build 후 재시도. |
+| RPC retry | `CI_TEST_ALLOW_RPC_RETRY=1`이면 RPC 관련 실패 시 재시도. |
+| Isolated build | `CI_TEST_ISOLATED_BUILD_DIR` (기본 `.ci_build`)로 격리 빌드 가능. |
+
+### 6.2 실행 흐름
+
+```bash
+# 표준 CI 경로
+make test                    # dune test --root .
+make test-contract           # scripts/harness/contract/run_all.sh
+
+# 수동 검증
+dune exec _build/default/test/test_sse_storm_e2e.exe
+MASC_POSTGRES_URL="..." dune exec _build/default/test/test_board_pg.exe
+```
+
+### 6.3 Contract Harness
+
+| Contract | 파일 | 검증 대상 |
+|----------|------|----------|
+| Streamable HTTP | `streamable_http_contract.sh` | MCP Streamable HTTP transport 프로토콜 |
+| Team Session | `team_session_contract.sh` | Team session start/step/finalize 계약 |
+| Golden Path | `golden_path_1_contract.sh` | Room join -> task add -> claim -> transition 기본 경로 |
+
+Contract harness는 hermetic bootstrap으로 실행된다. 사전 서버 실행을 요구하지 않는다.
+
+---
+
+## 7. Coverage
+
+### 7.1 bisect_ppx
+
+OCaml 코드 커버리지 도구. `BISECT_FILE` 환경변수로 출력 경로를 지정한다.
+
+```bash
+BISECT_FILE=$(pwd)/_coverage dune test --instrument-with bisect_ppx
+bisect-ppx-report html --coverage-path _coverage
+```
+
+### 7.2 Coverage 파일 분포
+
+100개의 `*_coverage.ml` 파일이 커버리지 보강 목적으로 존재한다. 이 파일들은 기존 테스트에서 누락된 경로를 보완하며, anti_fake 검증을 통과해야 한다.
+
+---
+
+## 8. 테스트 라이브러리 의존성
+
+| 라이브러리 | 용도 |
+|-----------|------|
+| `alcotest` | 테스트 프레임워크 (assertion, test case 구조화) |
+| `masc_mcp` | 서버 라이브러리 |
+| `agent_sdk` | OAS 에이전트 SDK |
+| `agent_sdk.swarm` | Swarm 엔진 |
+| `eio`, `eio_main` | Eio 동시성 (Mutex, 스케줄러) |
+| `yojson` | JSON 직렬화/역직렬화 |
+| `mirage-crypto`, `mirage-crypto-rng` | 암호화 테스트 |
+| `cohttp` | HTTP 클라이언트 테스트 |
+| `str` | 정규식 |
+
+---
+
+## 9. 불변식
+
+- **INV-T1**: Hermetic Required 계층의 모든 테스트는 `MASC_POSTGRES_URL=""`, `GRAPHQL_API_KEY=""` 상태에서 통과해야 한다.
+- **INV-T2**: Env-gated 테스트는 필수 환경변수 부재 시 skip 또는 not run으로 처리한다. 실패가 아니다.
+- **INV-T3**: `eval_gate`의 각 검사 레이어는 독립적이다. 한 레이어의 통과가 다른 레이어의 실패를 가릴 수 없다 (Swiss Cheese).
+- **INV-T4**: `trajectory.tool_call_entry`의 `gate_decision`이 `Reject`이면 `result`는 반드시 `None`이다.
+- **INV-T5**: `anti_fake` penalty 패턴에 매칭되는 테스트 파일은 `quality_tier`에서 경고 또는 위험으로 분류된다.
+- **INV-T6**: Contract harness는 외부 서버에 의존하지 않는다. Hermetic bootstrap 경로만 사용한다.
+- **INV-T7**: `eval_harness` 시나리오의 `max_cost_usd`를 초과하면 `trajectory_outcome`은 `CostExceeded`이다.
+
+---
+
+## 10. 테스트 작성 가이드
+
+### 10.1 새 테스트 추가 시
+
+1. `test/dune`에 테스트 등록 (pure sync면 최상단 `(tests ...)` 블록, Eio 의존이면 개별 `(test ...)` 블록)
+2. Hermetic required로 분류 가능한지 확인. 외부 의존이 있으면 env-gated 계층에 배치.
+3. `assert true` 사용 금지. `Alcotest.check` 또는 의미 있는 assertion 사용.
+4. 외부 서비스 mock은 테스트 내부에서 처리. `test/dune`의 env 격리에 의존.
+
+### 10.2 Keeper 행동 테스트 추가 시
+
+1. `eval_harness.scenario` 정의 (goal, tool_expectations, graders)
+2. Deterministic grader를 우선 사용. LLM grader는 cost 고려.
+3. `trajectory` 로깅으로 재현성 확보.
+4. `eval_gate` 설정으로 안전 경계 지정.

--- a/docs/spec/A-existing-doc-index.md
+++ b/docs/spec/A-existing-doc-index.md
@@ -1,0 +1,243 @@
+# Appendix A: Existing Documentation Index
+
+> masc-mcp 프로젝트 내 모든 문서 파일의 상태와 신규 spec 체계와의 관계를 정리한다.
+> 기준일: 2026-03-23, v2.138.0
+
+## Status 정의
+
+| Status | 의미 |
+|--------|------|
+| Canonical | 해당 주제의 현재 권위 문서. 유지 관리 대상 |
+| Superseded | docs/spec/ 파일이 대체. 참조용으로만 유지 |
+| Reference | 역사적 가치 있으나 적극적으로 유지하지 않음 |
+| Archive | docs/archive/로 이동 대상 |
+| Orphaned | 목적이나 독자가 불분명. 삭제 또는 통합 대상 |
+
+---
+
+## Root-level Documents
+
+| File | Lines | Status | Replacement | Summary |
+|------|-------|--------|-------------|---------|
+| `README.md` | 50+ | Canonical | -- | 프로젝트 소개, 빠른 시작, 빌드/테스트 안내 |
+| `CLAUDE.md` | 200+ | Canonical | -- | Agent 전용 지침 (아키텍처, 빌드, 환경변수, Board, Dashboard) |
+| `CHANGELOG.md` | 60+ | Canonical | -- | 릴리스별 변경 이력. v2.87.0부터 현재까지 |
+| `ROADMAP.md` | 77 | Canonical | `B-migration-targets.md` 보완 | 단기/중기/장기 계획 SSOT |
+| `CONTRIBUTING.md` | 50+ | Canonical | -- | 빌드 절차, 코드 스타일, 프로젝트 구조 |
+
+---
+
+## Canonical Documents (유지 관리 대상)
+
+| File | Lines | Spec 연관 | Summary |
+|------|-------|-----------|---------|
+| `docs/COMMAND-PLANE-RUNBOOK.md` | -- | `06-command-plane.md` | CPv2 운영 순서, benchmark/swarm canonical path |
+| `docs/BENCHMARK-RUNBOOK.md` | -- | `06-command-plane.md` | single-agent vs swarm benchmark recipe |
+| `docs/SUPERVISOR-MODE.md` | -- | `07-team-session.md` | supervised team-session/operator 경로 |
+| `docs/QUICK-START.md` | 47 | -- | 1-step setup, mode 선택, error recovery |
+| `docs/COMMON-PITFALLS.md` | 81 | -- | PR 제출 전 반복 실수 체크리스트 |
+| `docs/VERIFICATION-MATRIX.md` | 99 | `09-server-transport.md` | 검증 계층 분류 SSOT (hermetic/env-dependent/manual) |
+| `docs/PERFORMANCE-SLO.md` | 42 | `09-server-transport.md` | 로컬/단일 머신 기준 체감 지연 목표 |
+| `docs/MODE-SYSTEM.md` | 361 | `01-system-overview.md` | Serena-style tool filtering, core/standard/full profile |
+| `docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md` | 199 | `B-migration-targets.md` | Tier 분류, 분할 계획, 복잡도 근본 원인 |
+| `docs/VERSIONED-ROADMAP.md` | 60+ | -- | 버전 규칙, intake/triage 프로세스 |
+| `docs/CAPABILITY-REGISTRY-SSOT.md` | 88 | `01-system-overview.md` | MCP tool vs internal capability 분류 |
+| `docs/OAS-MASC-BOUNDARY.md` | 55 | `01-system-overview.md` | OAS/MASC 역할 경계 원칙 |
+| `docs/OAS-MIGRATION-NEXT-STEPS.md` | 103 | `B-migration-targets.md` | OAS 마이그레이션 다음 단계 |
+| `docs/OAS-UTILIZATION-AUDIT.md` | 86 | `B-migration-targets.md` | OAS 활용도 점수 (55/100) |
+| `docs/PROVIDER-ADAPTER-RUNBOOK.md` | 85 | `04-chain-engine.md` | provider/runtime/auth 분리 SSOT |
+| `docs/PROMPT-REGISTRY.md` | 38 | -- | prompt 코드 소재 색인 |
+| `docs/MCP-TEMPLATE.md` | 29 | -- | ~/.mcp.json 설정 템플릿 |
+| `docs/REMOTE-MCP-OPERATOR.md` | 157 | `09-server-transport.md` | /mcp/operator 원격 MCP surface |
+| `docs/WORKER-SHELL-CONSTRAINTS.md` | 46 | `07-team-session.md` | spawn worker 셸 실행 제약 |
+| `docs/IMMORTAL-SERVER-ROADMAP.md` | 187 | `09-server-transport.md` | 고가용성 서버 로드맵 (Phase 1-3) |
+
+---
+
+## Superseded Documents (docs/spec/ 파일이 대체)
+
+| File | Lines | Replaced by | Summary |
+|------|-------|-------------|---------|
+| `docs/SPEC.md` | 518 | `docs/spec/01-system-overview.md` | 과거 전체 specification 스냅샷. 자체 경고 헤더 있음 |
+| `docs/GLOSSARY.md` | 215 | `docs/spec/00-glossary.md` | v1.0.0 용어집. spec glossary가 확장 대체 |
+| `docs/MERGED-ARCHITECTURE-SSOT.md` | 145 | `docs/spec/01-system-overview.md` | merged 아키텍처 요약. spec overview가 포괄 |
+| `docs/SWARM-ARCHITECTURE.md` | 48 | `docs/spec/04-chain-engine.md` | Swarm 2-layer 구분. chain spec에 통합 |
+| `docs/TEAM-SESSION-ARCHITECTURE.md` | 68 | `docs/spec/07-team-session.md` | Team session 오케스트레이션. spec에 통합 |
+| `docs/TEAM-SESSION.md` | 271 | `docs/spec/07-team-session.md` | Team session 사용 가이드. spec에 통합 |
+| `docs/DASHBOARD-INTEGRATION.md` | 87 | `docs/spec/10-dashboard.md` | Dashboard 통합 spec. dashboard spec에 통합 |
+| `docs/MCP-SURFACE-AUDIT.md` | 196 | `docs/spec/01-system-overview.md` | MCP surface 감사. system overview에 반영 |
+| `docs/PRODUCT-REVIEW.md` | 58 | `docs/spec/01-system-overview.md` | 제품 리뷰 (보안/API 계약). spec에 반영 |
+
+---
+
+## Reference Documents (역사적 가치, 비관리)
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/MASC-V2-DESIGN.md` | 364 | Git-native 멀티 에이전트 조율 초기 설계 | v2 설계 비전 문서 |
+| `docs/HOLONIC-ARCHITECTURE.md` | 131 | Holonic 아키텍처 탐구 | 개념 문서, 구현에 부분 반영 |
+| `docs/CELLULAR-AGENT.md` | 163 | Context handoff 패턴 | Legacy name "Cellular Agent" |
+| `docs/MITOSIS.md` | 250 | 2-phase handoff flow | Legacy 용어 mitosis/DNA |
+| `docs/ADR-001-MITOSIS-VS-COMPACTION.md` | 159 | Mitosis vs Compaction 결정 | ADR (Accepted) |
+| `docs/THOUGHTROOM-ARCHITECTURE.md` | 454 | ThoughtRoom 개념 문서 | 미검증 상태 명시 |
+| `docs/MULTI-ROOM-DESIGN.md` | 251 | Multi-room 호환성 노트 | Historical/internal |
+| `docs/MDAL.md` | 111 | Metric-Driven Agent Loop | 기능 설명 문서 |
+| `docs/INTERRUPT-DESIGN.md` | 153 | Human-in-the-loop 설계안 | LangGraph 패턴 참조 |
+| `docs/JIPHYEONJEON-DESIGN.md` | 264 | AI 의회 시스템 설계 | 집현전 컨셉 |
+| `docs/RESEARCH-BASED-IMPROVEMENTS.md` | 519 | 논문/연구 기반 개선 제안 | 초기 연구 정리 |
+| `docs/RESEARCH-GAPS-CONCURRENCY.md` | 164 | 동시성/지식 전파 연구 갭 | 연구 노트 |
+| `docs/SKEPTIC-PATTERNS.md` | 201 | Skeptic 리뷰 패턴 | 리뷰 가이드 |
+| `docs/SPAWN-PERSISTENCE-DESIGN.md` | 222 | Spawn 영속성/복구 설계 | OpenClaw 패턴 참조 |
+| `docs/METRICS-GENERATIONAL-IMPROVEMENT.md` | 240 | 세대별 개선 메트릭 증거 | 실험 기록 |
+| `docs/CONTENT-DECAY-RESEARCH.md` | 129 | Content decay 연구 계획 | 연구 노트 |
+| `docs/SEARCH-FABRIC-V1.md` | 106 | Search Fabric v1 설계 | public swarm API 대안 |
+| `docs/RESIDENT-OPERATOR-JUDGE-DECISION-MEMO.md` | 335 | Resident/Operator/Judge 결정 메모 | 방향 제안 |
+| `docs/EXECUTION-SCOPE-AND-WORKER-AUTONOMY-ANALYSIS.md` | 303 | 실행 범위/worker 자율성 분석 | 분석 문서 |
+| `docs/HANDLE-STEP-DECOMPOSITION.md` | 120 | handle_step 분해 설계 | tool_team_session 리팩토링 |
+| `docs/SANGSU-POLICY-V2-REPORT.md` | 196 | Sangsu 정책 v2 실험 보고 | 에이전트 실험 기록 |
+| `docs/WEBRTC-COMPARISON.md` | 75 | WebRTC 구현 비교 | 참고 자료 |
+
+---
+
+## Reference: Keeper/Agent/Lodge
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/KEEPER-USER-MANUAL.md` | 643 | Keeper 사용자 매뉴얼 | Canonical이나 v2.138 기준 갱신 필요 |
+| `docs/KEEPER-CONTINUITY-VALIDATION.md` | 160 | Keeper 연속성 검증 하네스 | Operator 검증용 |
+| `docs/KEEPER-SOCIAL-EXPERIMENT-DESIGN.md` | 118 | Keeper 사회 실험 설계 | 미실행 |
+| `docs/AGENT-MEMORY-SYSTEM.md` | 811 | Agent 메모리 시스템 설계 | Design phase 명시 |
+| `docs/AGENT-TRUTH-AUDIT.md` | 71 | Agent truth 감사 계약 | Active contract |
+| `docs/LODGE-ACTION-STATS.md` | 32 | Lodge action 통계 | 간략 문서 |
+
+---
+
+## Reference: TRPG/Game
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/GAME-VIEW-PROTOCOL.md` | 254 | Game view 프로토콜 초안 | Draft v0.1 |
+| `docs/TRPG-DEVELOPMENT-PLAN.md` | 109 | TRPG 개발 계획 | MVP -> v0.1 |
+| `docs/TRPG-EXPERIMENT-PLAYBOOK.md` | 118 | TRPG 사회 실험 템플릿 | MVP |
+| `docs/TRPG-KEEPER-SPECTATOR-QUICKSTART.md` | 112 | TRPG 관전자 퀵스타트 | 운영 가이드 |
+| `docs/TRPG-MVP-BLUEPRINT.md` | 172 | TRPG MVP 청사진 | Draft |
+| `docs/TRPG-OPS-MANUAL.md` | 104 | TRPG 운영 매뉴얼 | v1 |
+| `docs/TRPG-TURN-OBSERVABILITY-CHECKLIST.md` | 41 | TRPG 턴 관측 체크리스트 | 7-step |
+
+---
+
+## Reference: Transport/Protocol
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/TRANSPORT-VERIFICATION-CHECKLIST.md` | 401 | Transport 검증 체크리스트 | 포괄적 |
+| `docs/DTLS-RFC6347-COMPLIANCE.md` | 243 | DTLS RFC 6347 커버리지 | Code inspection |
+| `docs/RFC-COMPLIANCE-REVIEW.md` | 207 | WebRTC RFC 커버리지 리뷰 | Code inspection |
+| `docs/WEBHOOK-RECEIVER-DESIGN.md` | 443 | Webhook receiver 설계 | 미구현 |
+
+---
+
+## Reference: OAS Migration
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/OAS-MIGRATION-AUDIT.md` | 79 | Model_client -> OAS 감사 | 감사 완료, 마이그레이션 보류 |
+| `docs/OAS-PHASE1-EXPLORATION-SUMMARY.md` | 348 | OAS Phase 1 탐구 요약 | Lwt 부재 발견 |
+
+---
+
+## Reference: Dashboard
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/DASHBOARD-EXECUTION-VALIDATION.md` | 43 | Execution surface 검증 | Fixture mode |
+| `docs/DASHBOARD-MISSION-VALIDATION.md` | 57 | Mission 검증 2층 구조 | 운영 절차 |
+| `docs/DASHBOARD-WIDGET-AUDIT-2026-03-12.md` | 55 | Widget 감사 | 시점 스냅샷 |
+| `docs/MASC-SOCIETY-AND-DASHBOARD-AUDIT.md` | 243 | Society + Dashboard 감사 | 분석 문서 |
+
+---
+
+## Design Documents (활성 설계)
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/design/LLM-JUDGE-DESIGN.md` | 311 | LLM Judge dashboard 개입 추천 | Issue #1870 |
+| `docs/design/oas-masc-state-boundary.md` | 278 | OAS/MASC 상태 경계 | Issue #1736 |
+| `docs/lodge-identity-v2/ARCHITECTURE.md` | 192 | Lodge identity v2 아키텍처 | 설계 완료, 구현 미착수 |
+| `docs/lodge-identity-v2/RESEARCH.md` | 144 | Lodge identity 연구 참고 | 논문 목록 |
+| `docs/lodge-identity-v2/ROADMAP.md` | 325 | Lodge identity v2 구현 로드맵 | Tier 1-3 |
+
+---
+
+## Research
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/research/LLM-REQUEST-SCHEDULER-SURVEY.md` | 103 | LLM 요청 스케줄러 서베이 | OAS 설계 참고 |
+
+---
+
+## QA
+
+| File | Lines | Topic | Notes |
+|------|-------|-------|-------|
+| `docs/qa/REQUIREMENTS-REVERSE-ENGINEERED.md` | 279 | 코드 역추론 요구사항 | 역공학 spec |
+
+---
+
+## Archive (docs/archive/)
+
+이미 docs/archive/에 이동 완료된 문서.
+
+| File | Lines | 아카이브 사유 |
+|------|-------|--------------|
+| `docs/archive/IDEAS-2026-01.md` | -- | 9/11 완료, 2건 stale |
+| `docs/archive/IMPROVEMENT-BACKLOG-MITOSIS.md` | -- | 25/25 완료 |
+| `docs/archive/EVOLUTION-PLAN-FIGMA-MCP.md` | -- | 다른 repo 대상, 미착수 |
+| `docs/archive/RELEASE-ROADMAP-v287.md` | -- | v2.87.0 완료 |
+| `docs/archive/IMPROVEMENT-PLAN-2026-01.md` | -- | VERSIONED-ROADMAP이 대체 |
+
+---
+
+## Release Feedback (docs/release-feedback/)
+
+| File | Topic |
+|------|-------|
+| `docs/release-feedback/v2.88.0-live-2026-03-14/README.md` | v2.88.0 피드백 요약 |
+| `docs/release-feedback/v2.88.0-live-2026-03-14/cs-playbook.md` | CS 플레이북 |
+| `docs/release-feedback/v2.88.0-live-2026-03-14/next-version-feedback.md` | 다음 버전 피드백 |
+| `docs/release-feedback/v2.88.0-live-2026-03-14/user-report.md` | 사용자 보고 |
+| `docs/release-feedback/v2.88.0-live-2026-03-14/version-truth-audit.md` | 버전 진실성 감사 |
+
+---
+
+## Orphaned (Archive 이동 후보)
+
+| File | Lines | 사유 |
+|------|-------|------|
+| `docs/QUICKSTART.md` | 83 | `QUICK-START.md`와 중복. 서버 시작에 집중하나 README와도 겹침 |
+| `docs/SETUP.md` | 82 | `QUICK-START.md`, `README.md`, `CONTRIBUTING.md`와 역할 중복 |
+| `docs/INSTALL-CHECKLIST.md` | 24 | 설치 후 확인 체크리스트. `QUICK-START.md`에 통합 가능 |
+| `docs/INTEGRATED-BENCHMARK-RUNBOOK.md` | -- | `BENCHMARK-RUNBOOK.md`와 목적 중복 |
+| `docs/SWARM-DELIVERY-RUNBOOK.md` | 215 | 기능 슬라이스 구현 순서. 일반 워크플로 문서 |
+
+---
+
+## 통계 요약
+
+| Category | Count | Total lines (approx) |
+|----------|-------|---------------------|
+| Root-level | 5 | ~450 |
+| Canonical | 19 | ~2,800 |
+| Superseded | 9 | ~1,700 |
+| Reference | 42 | ~9,200 |
+| Design (active) | 5 | ~1,250 |
+| Research | 1 | ~100 |
+| QA | 1 | ~280 |
+| Archive (done) | 5 | -- |
+| Release Feedback | 5 | -- |
+| Orphaned | 5 | ~400 |
+| **Total** | **97** | **~16,200** |
+
+97개 문서 중 Canonical 24개(root 포함), Superseded 9개, Reference 42개.
+문서의 43%가 Reference 상태로 적극적 유지 관리 대상이 아니다.

--- a/docs/spec/B-migration-targets.md
+++ b/docs/spec/B-migration-targets.md
@@ -1,0 +1,301 @@
+# Appendix B: Migration Targets
+
+> 현재 상태(IS)와 목표 상태(SHOULD BE) 사이의 delta를 정의한다.
+> 기준일: 2026-03-23
+
+---
+
+## 1. Current State Summary (v2.138.0)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Version | v2.138.0 (dune-project), v2.137.0 (latest git tag) | Tag 1개 뒤처짐 |
+| Language | OCaml 5.x + Eio | Structured concurrency |
+| lib/ .ml + .mli files | 761 | 294개 flat lib/*.ml, 12개 sub-library |
+| lib/ total LOC | ~194K | .ml + .mli 합산 |
+| tool_*.ml modules | 125 | 일반적 MCP 서버: 3-10개 |
+| MCP tool schemas | ~371 | 일반적 MCP 서버: 5-15개 |
+| .mli files | 144 | 761개 중 19% |
+| Test files | 319 | test/ 하위 |
+| Sub-libraries | 12 | backend, bridge, core, council, dated_jsonl, eio_context, fs_compat, masc_log, process, room, time_compat, types |
+| Flat lib/ .ml files | 294 | Sub-library에 속하지 않은 파일 |
+| Environment variables | 50+ | 설정 파일 없이 env var만으로 운영 |
+| Dashboard | Preact + HTM SPA | Vite 빌드, assets/dashboard/ |
+| Transport | HTTP/1.1 (default), h2c (opt-in), WebSocket, WebRTC (experimental) | Multi-protocol |
+| OAS integration | v0.87.0 delegation | Cascade, Memory, Swarm 일부 |
+| Board backend | PostgreSQL (primary) / JSONL (fallback) | Supabase PgBouncer |
+
+### 시스템 구성 비율 (LOC 기준, ARCHITECTURE-COMPLEXITY-ANALYSIS 발췌)
+
+| Tier | Modules | Lines | 비율 |
+|------|---------|-------|------|
+| Tier 1: Core | 5 | ~1.5K | 4% |
+| Tier 2: Production | 12 | ~8K | 23% |
+| Tier 3: Extensions | 12 | ~8K | 23% |
+| Tier 4: Experimental/Game | 18 | ~11K | 32% |
+| Other (non-tool) | -- | ~6K | 18% |
+| **Total tool code** | **47** | **~34.7K** | -- |
+
+Core 기능(Tier 1)은 전체 tool 코드의 4%에 불과하다.
+Tier 4 (Experimental/Game)가 32%를 차지하며, 이 코드는 coordination과 무관하다.
+
+---
+
+## 2. Architectural Debt
+
+### 2.1 God Files
+
+| File | Lines | Problem |
+|------|-------|---------|
+| `tool_team_session.ml` | 4,412 | 5-module 분할 설계 완료, 미실행 |
+| `tool_trpg.ml` | 1,934 | Coordination과 무관. 별도 패키지 대상 |
+| `tool_protocol_game_view.ml` | 1,674 | TRPG와 동일 |
+| `tool_mdal.ml` | 1,092 | Metric loop 단독 모듈. 분리 가능 |
+| `tool_risc.ml` | 1,070 | 실험 잔재 |
+| `tool_llama.ml` | 1,052 | llama.cpp 런타임 관리. 별도 서비스 후보 |
+
+### 2.2 Flat lib/ 구조
+
+294개 .ml 파일이 lib/ 직하에 존재하고, 12개만 sub-library로 추출됨.
+dune 모듈 수 579개는 일반적 MCP 서버(20-50)의 10배 이상이다.
+Sub-library 추출 비율: 12/~300 = 4%.
+
+### 2.3 Missing .mli
+
+.mli 비율 19% (144/761). API 계약이 대부분 암묵적이다.
+`docs/spec/` 작성으로 논리적 계약은 문서화하고 있으나, 컴파일러 수준 계약이 부족하다.
+
+### 2.4 Circular Dependencies
+
+`masc_mcp.ml` wrapper module이 모든 sub-library를 re-export하는 facade.
+새 모듈 추가 시 masc_mcp.ml + lib/dune에서 additive conflict이 항상 발생한다 (memory: masc-mcp-module-conflict-hotspot).
+
+### 2.5 Configuration Sprawl
+
+50+ 환경변수가 `env_config.ml`과 개별 모듈에 분산.
+Config file 체계 없이 env var만으로 운영하므로, 설정 발견성이 낮다.
+
+---
+
+## 3. Short-term Targets (v2.103-v2.104, ROADMAP 기준)
+
+Source: `ROADMAP.md` Short-term + `ARCHITECTURE-COMPLEXITY-ANALYSIS.md` Phase 2-3
+
+| Item | Module | Est. lines | Status | Priority |
+|------|--------|-----------|--------|----------|
+| TRPG + protocol_game_view -> `masc-games` | tool_trpg, tool_protocol_game_view | 3,600+ | Not started | High |
+| risc + autoresearch + council + experiment -> `masc-experiments` | 4 tool modules | 3,800+ | Not started | High |
+| dune optional library separation | dune, lib/ | -- | Not started | Medium |
+| tool_team_session split (5 modules) | tool_team_session | 4,412 | Design done | High |
+| TRPG dm-keeper -> on-demand | keeper_autonomy | -- | Not started | Medium |
+| Test noise cleanup: 32 duplicate files | test/ | ~12K lines | Audit done | Medium |
+| 5 hollow test files 삭제 | test/ | -- | TODO에 기록 | Low |
+
+### Blocking Issues (from .masc/TODO.md)
+
+| Issue | Symptom | Status |
+|-------|---------|--------|
+| #1981 keeper_prompt compile fail | CI Build/Test/Harness fail | Open |
+| #1980 test_verifier_oas_bridge missing module | Health check fail | Open |
+| #2186 test_transport_grpc_next stale reference | Build/Test + Health fail | Open |
+
+이 3건은 CI green을 막는 blocker다. Feature 작업 전 해소가 필요하다.
+
+---
+
+## 4. Mid-term Targets (v2.105-v2.108, 1-3 months)
+
+Source: `ROADMAP.md` Mid-term
+
+| Item | Source | Notes |
+|------|--------|-------|
+| Mode/profile system (core 5 / standard 17 / full 72) | ARCHITECTURE-COMPLEXITY Phase 3 | 기본 tool 노출을 5-17개로 제한 |
+| Environment variables -> config file | ARCHITECTURE-COMPLEXITY Phase 3 | 50+ env vars 통합 |
+| Binary distribution (brew/npm) | IDEAS #6 | Owner 없음 |
+| Worktree diff broadcast | IDEAS #7 | Owner 없음 |
+| Lodge identity v2 Tier 1 | docs/lodge-identity-v2/ | 설계 완료, 구현 미착수 |
+
+### Mode System 상세
+
+현재 모든 에이전트에게 371개 tool이 노출된다. MODE-SYSTEM.md 설계에 따르면:
+
+| Profile | Tool count | 대상 |
+|---------|-----------|------|
+| Core | ~25 | 일반 에이전트 (join/claim/work/done) |
+| Standard | ~70 | 운영자 에이전트 (keeper, operator) |
+| Full | ~371 | 개발/디버깅 전용 |
+
+이 전환만으로 에이전트의 tool discovery 부하를 93% 줄일 수 있다.
+
+---
+
+## 5. Long-term Direction (v2.109+, 3+ months)
+
+Source: `ROADMAP.md` Long-term
+
+| Direction | Trigger | Source |
+|-----------|---------|--------|
+| Lodge identity v2 Tier 2-3 (ToM, archetypes) | Tier 1이 가치 증명 | docs/lodge-identity-v2/ |
+| Figma-MCP 통합 (visual heartbeat) | figma-mcp 안정화 | docs/archive/EVOLUTION-PLAN-FIGMA-MCP.md |
+| Cluster mode / multi-node HA | 단일 노드 한계 도달 | IMMORTAL-SERVER-ROADMAP Phase 3 |
+| Chaos engineering framework | Production 장애 패턴 확인 | IMMORTAL-SERVER-ROADMAP Phase 3 |
+| Adaptive orchestration (dynamic org) | Agent 30+ | archive/IMPROVEMENT-PLAN P3 |
+
+모두 "방향(direction)"이지 "약속(commitment)"이 아니다.
+각각 trigger condition이 충족될 때만 활성화한다.
+
+---
+
+## 6. 7-Team Org Design
+
+Source: memory/masc-org-design-7teams.md (2026-03-21)
+
+327K LOC 모노리스를 7개 논리적 팀으로 분리하는 설계.
+물리적 repo 분리가 아니라 sub-library + ownership boundary를 의미한다.
+
+| Team | 범위 | 핵심 모듈 | 예상 LOC |
+|------|------|----------|---------|
+| **Foundation** | Types, Base, Config, Log | types/, core/, masc_log/, env_config | ~15K |
+| **Room** | Room lifecycle, Task, Heartbeat, Board | room/, tool_room, tool_task, tool_heartbeat, board | ~20K |
+| **Keeper** | Keeper runtime, Memory, Succession | keeper/, tool_keeper, agent_memory | ~25K |
+| **Chain** | Cascade, OAS bridge, Swarm engine | cascade, oas_worker, chain, spawn | ~30K |
+| **Server** | HTTP, MCP protocol, Transport, Auth | mcp_server_eio, transport, tool_auth | ~20K |
+| **Dashboard** | Preact SPA, SSE bridge, API routes | dashboard/, web_dashboard | ~15K |
+| **OAS Bridge** | OAS integration facade, Provider registry | oas_*, provider_registry | ~10K |
+
+### 추출 순서 (8-Phase, 3-4주 예상)
+
+1. Foundation (types, base, log) -- 의존 없는 leaf
+2. Room (room lifecycle)
+3. Keeper (keeper runtime)
+4. Chain (cascade, spawn)
+5. Server (transport, protocol)
+6. Dashboard (frontend build pipeline 분리)
+7. OAS Bridge (facade 정리)
+8. Cleanup (masc_mcp.ml facade 축소, dead re-export 제거)
+
+---
+
+## 7. Module Extraction Plan
+
+### 현재 Sub-library (12개)
+
+```
+lib/backend/     lib/bridge/      lib/core/       lib/council/
+lib/dated_jsonl/ lib/eio_context/ lib/fs_compat/  lib/masc_log/
+lib/process/     lib/room/        lib/time_compat/ lib/types/
+```
+
+### 즉시 추출 대상 (Phase 2 from ARCHITECTURE-COMPLEXITY)
+
+| 새 패키지 | 포함 모듈 | Lines | 근거 |
+|-----------|----------|-------|------|
+| `masc-games` | tool_trpg, tool_protocol_game_view, trpg_*.ml | 3,600+ | Coordination과 완전 무관 |
+| `masc-experiments` | tool_risc, tool_autoresearch, tool_council, tool_experiment | 3,800+ | 실험 잔재, optional로 전환 |
+
+### 구조 분할 대상
+
+| 대상 | 현재 | 목표 | 설계 상태 |
+|------|------|------|----------|
+| tool_team_session.ml | 4,412 LOC 단일 파일 | 5 modules (types/parse/spawn/handlers/dispatcher) | 설계 완료 (ARCHITECTURE-COMPLEXITY) |
+| lib/ flat files | 294개 | Sub-library 기반 조직 | 7-Team Design으로 매핑 완료 |
+| masc_mcp.ml facade | 전체 re-export | Team별 facade | drift 문제 해소 필요 |
+
+### .mli 추가 우선순위
+
+| Module | Priority | 근거 |
+|--------|----------|------|
+| room.ml | High | Core lifecycle, 다른 모든 모듈이 의존 |
+| cascade.ml | High | OAS bridge의 핵심 계약 |
+| keeper_autonomy.ml | High | Keeper 자율 실행 계약 |
+| tool_team_session.ml | Medium | 분할 전 API 계약 고정 |
+| spawn.ml | Medium | 61 references, Swarm 핵심 |
+
+---
+
+## 8. Test Hygiene
+
+### 문제 요약
+
+| Issue | Count | Source |
+|-------|-------|--------|
+| Duplicate/trivial coverage files | 32 | ROADMAP, .masc/TODO.md |
+| Hollow test files (빈 테스트) | 5 | void, hebbian_eio, voice_stream, backend_eio, room_portal |
+| Stale test references (CI blocker) | 3 | #1980, #1981, #2186 |
+| Total test files | 319 | test/ 하위 |
+
+### 32 Duplicate Coverage Files
+
+test/ 디렉토리에 `*_coverage.ml` 파일이 32개 존재하며, 상당수가 원본 테스트와 중복이거나 stub만 포함한다.
+이들은 ~12K LOC로, 실질적 테스트 가치 없이 빌드/CI 시간을 소모한다.
+
+### 5 Hollow Tests
+
+아래 파일은 빈 테스트(assert true 또는 테스트 본문 없음)로, 삭제 대상이다:
+
+1. `test_void.ml`
+2. `test_hebbian_eio.ml`
+3. `test_voice_stream.ml`
+4. `test_backend_eio.ml`
+5. `test_room_portal.ml`
+
+### CI Blocker (3건)
+
+`.masc/TODO.md`에 기록된 3건의 CI 실패:
+
+- `#1981`: keeper_prompt.ml Printf format/argument mismatch
+- `#1980`: test_verifier_oas_bridge가 삭제된 Keeper_exec_autonomy 참조
+- `#2186`: test_transport_grpc_next_coverage가 삭제된 Transport_grpc_next 참조
+
+이 3건을 해소하지 않으면 어떤 feature PR도 CI green을 달성할 수 없다.
+
+---
+
+## 9. Documentation Gaps
+
+docs/spec/ 체계에서 아직 다루지 않는 영역.
+
+| Gap | 현재 상태 | 필요한 spec |
+|-----|----------|-------------|
+| **Memory system** | AGENT-MEMORY-SYSTEM.md (design phase, 811 lines) | Memory tier 계약 (OAS 5-tier 포함) |
+| **TRPG subsystem** | 7개 docs, 미통합 | 분리 패키지 후 자체 spec |
+| **Transport protocol detail** | TRANSPORT-VERIFICATION-CHECKLIST (401 lines) | 09-server-transport.md에 부분 포함, WebRTC/WS 미상세 |
+| **Lodge identity** | lodge-identity-v2/ (3 files) | 구현 후 spec 추가 |
+| **OAS integration contract** | OAS-MASC-BOUNDARY.md (55 lines), oas-masc-state-boundary (278 lines) | OAS delegation 범위 상세화 |
+| **Operational runbook** | COMMAND-PLANE-RUNBOOK, BENCHMARK-RUNBOOK | 운영 절차 통합 spec |
+| **Config reference** | 없음 (env var 50+ 산재) | 환경변수/설정 SSOT |
+| **Error catalog** | 없음 | MCP error code + 복구 절차 |
+| **Migration guide** | OAS-MIGRATION-NEXT-STEPS.md | 버전 간 breaking change + migration path |
+| **Security model** | PRODUCT-REVIEW.md에서 지적 | Auth, trust boundary, threat model |
+
+### docs/spec/ 현재 구성 (참고)
+
+```
+00-glossary.md              -- 용어집
+01-system-overview.md       -- 시스템 개요
+02-types-and-invariants.md  -- 타입과 불변식
+03-room-coordination.md     -- Room 조율
+04-chain-engine.md          -- Chain/Cascade 엔진
+05-keeper-agent.md          -- Keeper 에이전트
+06-command-plane.md         -- Command Plane
+07-team-session.md          -- Team Session
+08-council-governance.md    -- Council 거버넌스
+09-server-transport.md      -- 서버/전송
+10-dashboard.md             -- Dashboard
+11-board.md                 -- Board 시스템
+A-existing-doc-index.md     -- (본 문서) 문서 색인
+B-migration-targets.md      -- (본 문서) 마이그레이션 대상
+SPEC-INDEX.md               -- Spec 목차
+```
+
+---
+
+## Summary: Top 5 Migration Priorities
+
+| # | Target | Impact | Effort |
+|---|--------|--------|--------|
+| 1 | CI blocker 3건 해소 (#1980, #1981, #2186) | Feature 작업 재개 | Low (각 1-2 시간) |
+| 2 | tool_team_session 5-module 분할 | God file 해소, 테스트 격리 | Medium (설계 완료) |
+| 3 | masc-games + masc-experiments 패키지 분리 | Tier 4 코드 32% 격리 | Medium-High |
+| 4 | Mode/profile system 구현 | 에이전트 tool 노출 93% 감소 | Medium |
+| 5 | 32 duplicate test files 정리 | 빌드/CI 시간 절감, noise 제거 | Low |

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -1,0 +1,114 @@
+# MASC Specification Index
+
+> Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
+> Status: Draft
+> Last Updated: 2026-03-23
+
+MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
+
+## Vital Statistics
+
+| 항목 | 값 |
+|------|-----|
+| Version | 2.138.0 |
+| Language | OCaml 5.x (Eio-native, effect-based concurrency) |
+| LOC (lib, .ml + .mli) | ~194K |
+| LOC (test) | ~97K |
+| Modules (.ml, lib/) | 616 |
+| Sub-libraries | 12 (masc_types, masc_core, masc_log, masc_backend, masc_room, masc_process, masc_eio_context, council, dated_jsonl, time_compat, fs_compat, event_bridge) |
+| MCP Tool modules (tool_*.ml) | 125 |
+| .mli interfaces | 144 |
+| Test files | 318 |
+| Executables | 5 (main_eio, main_stdio_eio, masc_cost, masc_tui, mitosis_cli) |
+
+## Layer Diagram
+
+```mermaid
+graph TB
+    L6["Layer 6: Integration<br/>OAS bridge, autoresearch, research loop"]
+    L5["Layer 5: Surface<br/>dashboard, operator, TUI, web"]
+    L4["Layer 4: Protocol<br/>MCP server, HTTP transport, gRPC, SSE"]
+    L3["Layer 3: Engine<br/>chain, keeper, swarm, team_session, command_plane"]
+    L2["Layer 2: Domain<br/>room, council, board"]
+    L1["Layer 1: Storage<br/>backend, dated_jsonl, memory"]
+    L0["Layer 0: Primitives<br/>types, core, log, time_compat, fs_compat"]
+
+    L6 --> L5
+    L5 --> L4
+    L4 --> L3
+    L3 --> L2
+    L2 --> L1
+    L1 --> L0
+```
+
+## Specification Files
+
+| File | Title | Description | Status |
+|------|-------|-------------|--------|
+| `00-glossary.md` | Glossary | 용어 정의, 약어 목록 | Draft |
+| `01-system-overview.md` | System Overview | 문제 정의, 배포 모델, 기술 스택, sub-library 의존성 | Draft |
+| `02-types-and-invariants.md` | Types and Invariants | 핵심 타입 정의, 상태 전이, 불변식 | Draft |
+| `03-room.md` | Room Subsystem | Room 생명주기, session 관리, agent join/leave | Draft |
+| `04-chain-engine.md` | Chain Engine | Multi-step chain DSL, execution, snapshot | Draft |
+| `05-keeper-agent.md` | Keeper Engine | 자율 에이전트 루프, succession, context 관리 | Draft |
+| `06-command-plane.md` | Command Plane v2 | Units, operations, search fabric, detachments, policy, orchestra | Draft |
+| `07-team-session.md` | Team Session | Supervised collaboration, OAS swarm bridge, worker dispatch, proof | Draft |
+| `09-server.md` | MCP Server | HTTP transport, SSE, JSON-RPC dispatch, routing | Draft |
+| `10-dashboard.md` | Dashboard | Web UI, API endpoints, SSE real-time updates | Draft |
+| `11-board.md` | Board System | Posts, comments, votes, PG/JSONL backend | Draft |
+| `12-memory-systems.md` | Memory Systems | Memory bank, institution, procedural, context budget, OAS Memory bridge | Draft |
+| `13-oas-integration.md` | OAS Integration | OAS Agent SDK bridge, cascade config, verifier, event bus, boundary rules | Draft |
+| `14-council.md` | Council | 의사결정 합의, voting, deliberation | Draft |
+| `15-external-integrations.md` | External Integrations | Neo4j, Supabase, GraphQL, Langfuse | Draft |
+| `A-error-catalog.md` | Error Catalog | 에러 코드 목록, 원인, 복구 방법 | Draft |
+| `B-migration-targets.md` | Migration Targets | OAS 이관 대상 모듈, deprecation 일정 | Draft |
+
+## Conventions
+
+### Document Structure
+
+각 spec 파일은 아래 섹션을 따른다:
+1. Problem Statement
+2. Non-Goals
+3. Module Inventory (table)
+4. Key Types (OCaml signatures)
+5. State Machines (Mermaid)
+6. Invariants (INV-{SUBSYSTEM}-NNN)
+7. Failure Modes
+8. Dependencies (upstream/downstream)
+9. Open Questions
+
+### Invariant Naming
+
+`INV-{SUBSYSTEM}-{NNN}` 형식을 사용한다.
+
+| Prefix | Subsystem |
+|--------|-----------|
+| `INV-ROOM` | Room lifecycle |
+| `INV-TASK` | Task state machine |
+| `INV-KPR` | Keeper engine |
+| `INV-CHAIN` | Chain execution |
+| `INV-CP` | Command Plane |
+| `INV-SRV` | Server/transport |
+| `INV-DASH` | Dashboard |
+| `INV-BRD` | Board |
+| `INV-CSC` | Cascade |
+| `INV-MEM` | Memory |
+| `INV-OAS` | OAS Integration |
+
+### Cross-Reference Format
+
+- Spec 간: `[Section Title](./NN-filename.md#section-anchor)`
+- 코드: `lib/module_name.ml:L123`
+- Invariant: `INV-ROOM-001`
+- 외부 문서: `docs/DOCUMENT-NAME.md`
+
+### Supersession
+
+이 spec suite가 최종 진실 원본(SSOT)이다.
+
+| 이전 문서 | 상태 |
+|----------|------|
+| `docs/SPEC.md` | Historical snapshot. 이 suite로 대체. |
+| `docs/MERGED-ARCHITECTURE-SSOT.md` | Layer map과 canonical paths는 `01-system-overview.md`로 이관. |
+| `docs/GLOSSARY.md` | `00-glossary.md`로 통합. |


### PR DESCRIPTION
## Summary
- 코드베이스 분석 기반 multi-file SSOT 스펙 문서 `docs/spec/` 생성
- 19개 파일, 9,198줄, 149개 번호 매긴 불변식(invariant)
- 기존 SPEC.md, MERGED-ARCHITECTURE-SSOT.md, GLOSSARY.md에 SUPERSEDED-BY 헤더 추가

## 구조
| 레이어 | 파일 |
|--------|------|
| Spine | SPEC-INDEX.md |
| Foundation | 00-glossary, 01-overview, 02-types |
| Domain | 03-room, 04-chain, 05-keeper |
| Control | 06-command-plane, 07-team-session, 08-council |
| Protocol | 09-server-transport |
| Surface | 10-dashboard, 11-board |
| Integration | 12-memory, 13-oas, 14-config, 15-testing |
| Appendix | A-doc-index, B-migration-targets |

## 분석 중 발견된 보정 사항
- Chain 노드 타입: 21 -> 27개
- 환경변수: 50+ -> 80+개
- 모듈 수: 565 -> 616개
- .mli 커버리지: 19%

## Test plan
- [ ] 스펙 파일 19개 존재 확인
- [ ] 각 스펙의 INV-* 불변식이 테스트와 매핑되는지 검증
- [ ] 기존 문서 SUPERSEDED 헤더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)