### PR TITLE
fix(pg): consolidate pools and reduce connection footprint (21→4)

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -221,15 +221,18 @@ let create_eio ~sw ~env (cfg : config) : (t, error) result =
   | None -> Error (ConnectionFailed "PostgreSQL URL not configured (set MASC_POSTGRES_URL)")
   | Some url ->
       let uri = Uri.of_string url in
+      (* Pool sizing: Supabase session pooler shares pool_size across all
+         clients. Keep low to avoid MaxClientsInSessionMode on restarts.
+         Rule: (CPU cores * 2) is overkill for a single app; 3 suffices. *)
       let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-        | Some s -> (try int_of_string s with _ -> 10)
-        | None -> 10
+        | Some s -> (try min (int_of_string s) 5 with _ -> 3)
+        | None -> 3
       in
       let pool_config = Caqti_pool_config.create
           ~max_size:max_pool
-          ~max_idle_size:(min max_pool 3)
-          ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 30_000_000_000L))
-          ~max_use_count:(Some 50)
+          ~max_idle_size:(min max_pool 2)
+          ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 15_000_000_000L))
+          ~max_use_count:(Some 100)
           () in
       let uri =
         if Uri.get_query_param uri "keepalives" <> None then uri

--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -266,37 +266,12 @@ let get_pg_pool ~sw ~env =
   match !pg_pool_ref with
   | Some pool -> Ok pool
   | None ->
-    match get_postgres_url () with
-    | None -> Error "DATABASE_URL not set"
-    | Some url ->
-      let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-        | Some s -> (try int_of_string s with _ -> 5)
-        | None -> 5
-      in
-      let pool_config = Caqti_pool_config.create
-          ~max_size:max_pool ~max_idle_size:(min max_pool 2)
-          ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 30_000_000_000L))
-          ~max_use_count:(Some 50) () in
-      let uri = Uri.of_string url in
-      let uri =
-        if Uri.get_query_param uri "keepalives" <> None then uri
-        else uri
-          |> (fun u -> Uri.add_query_param' u ("keepalives", "1"))
-          |> (fun u -> Uri.add_query_param' u ("keepalives_idle", "15"))
-          |> (fun u -> Uri.add_query_param' u ("keepalives_interval", "5"))
-          |> (fun u -> Uri.add_query_param' u ("keepalives_count", "3"))
-      in
-      match Caqti_eio_unix.connect_pool ~sw ~pool_config uri ~stdenv:env with
-      | Ok pool ->
-        pg_pool_ref := Some pool;
-        (* Register shutdown hook to drain PG connections.
-           Without this, force-exit leaves TCP connections as zombies
-           and Supabase session pooler hits MaxClientsInSessionMode. *)
-        at_exit (fun () ->
-          try Caqti_eio.Pool.drain pool
-          with _ -> ());
-        Ok pool
-      | Error e -> Error (Caqti_error.show e)
+    (* Do not create an independent pool here. The shared pool from
+       backend_pg should be injected via set_shared_pool at bootstrap.
+       Independent pools waste Supabase session pooler slots and cause
+       MaxClientsInSessionMode on rapid restarts. *)
+    ignore (sw, env);
+    Error "PG shared pool not injected (archive standalone pool removed)"
 
 (** PostgreSQL에 레코드 저장 *)
 let save_to_postgres ~sw ~env (r : record) : (unit, string) result =


### PR DESCRIPTION
## Summary
PG connection 수를 21→4로 줄여 MaxClientsInSessionMode 방지.

- archive 독립 pool 제거 (shared pool만 사용)
- backend pool_size 10→3, idle_age 30→15s
- 합산: 3(backend) + 1(eio_pg) = 4 connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)