### PR TITLE
fix(dashboard): collapsible sidebar, reduce border-radius, improve toast

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import { route, initRouter } from './router'
 import { connectSSE, disconnectSSE } from './sse'
 import { refreshRoomTruth } from './room-truth-store'
@@ -19,6 +20,8 @@ import { KeeperDetailOverlay } from './components/keeper-detail'
 import { AgentDetailOverlay } from './components/agent-detail'
 import { ToastContainer } from './components/common/toast'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
+
+export const sidebarCollapsed = signal(false)
 
 export function App() {
   useEffect(() => {
@@ -67,7 +70,7 @@ export function App() {
         <div class="mx-auto flex w-full max-w-[1680px] items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch">
           <div class="min-w-0">
             <div class="flex items-center gap-4">
-              <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-[rgba(113,214,255,0.28)] bg-[linear-gradient(145deg,rgba(61,157,255,0.34),rgba(10,28,58,0.95))] text-[18px] font-semibold text-white shadow-lg">
+              <div class="flex size-12 shrink-0 items-center justify-center rounded-xl border border-[rgba(113,214,255,0.28)] bg-[linear-gradient(145deg,rgba(61,157,255,0.34),rgba(10,28,58,0.95))] text-[18px] font-semibold text-white shadow-lg">
                 ${currentView?.icon ?? 'M'}
               </div>
               <div class="min-w-0">
@@ -97,13 +100,13 @@ export function App() {
         </div>
       </header>
 
-      <div class="flex flex-1 gap-5 overflow-hidden p-5 max-[1100px]:flex-col max-[1100px]:p-4">
-        <aside class="w-72 shrink-0 overflow-y-auto rounded-3xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,17,31,0.94),rgba(7,14,26,0.9))] shadow-xl max-[1100px]:w-full max-[1100px]:max-h-[360px]">
-          <${SideRail} />
+      <div class="flex flex-1 gap-4 overflow-hidden p-4 max-[1100px]:flex-col">
+        <aside class="${sidebarCollapsed.value ? 'w-14' : 'w-64'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,17,31,0.94),rgba(7,14,26,0.9))] transition-[width] duration-200 max-[1100px]:w-full max-[1100px]:max-h-[360px]">
+          <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 
-        <main class="min-w-0 flex-1 overflow-hidden rounded-3xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(8,15,28,0.92),rgba(9,14,25,0.88))] shadow-xl max-[1100px]:min-h-0">
-          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-6 lg:p-8">
+        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(8,15,28,0.92),rgba(9,14,25,0.88))] max-[1100px]:min-h-0">
+          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-5 lg:p-6">
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -6,7 +6,7 @@ import type { ComponentChildren } from 'preact'
 import { SectionHeader } from './section-header'
 
 // ── Exported class constants for non-component usage ──
-export const CARD_BASE = 'rounded-2xl border border-card-border shadow-sm'
+export const CARD_BASE = 'rounded-xl border border-card-border shadow-sm'
 export const CARD_STANDARD = `${CARD_BASE} p-6 bg-card/90 backdrop-blur-sm`
 export const CARD_LIGHT = `${CARD_BASE} p-6 bg-card/90 backdrop-blur-none`
 export const CARD_COMPACT = `${CARD_BASE} p-5 bg-card/90 backdrop-blur-sm`

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -24,9 +24,9 @@ const BORDER_COLOR: Record<ToastType, string> = {
 }
 
 const ICON: Record<ToastType, string> = {
-  success: '✓',
-  warning: '⚠',
-  error: '✕',
+  success: '\u2713',
+  warning: '\u26A0',
+  error: '\u2715',
 }
 
 const ICON_COLOR: Record<ToastType, string> = {
@@ -52,15 +52,19 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-3">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2">
       ${items.map(t => html`
         <div
           key=${t.id}
-          class="flex items-center gap-3 py-2.5 px-3.5 min-w-[240px] max-w-[380px] rounded-lg border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.95)] shadow-[0_8px_24px_rgba(0,0,0,0.35),0_2px_8px_rgba(0,0,0,0.2)] backdrop-blur-sm cursor-pointer transition-opacity duration-200 hover:opacity-90 animate-[slideInRight_0.25s_ease-out] ${BORDER_COLOR[t.type]}"
-          onClick=${() => dismissToast(t.id)}
+          class="flex items-center gap-2.5 py-2 px-3 min-w-[220px] max-w-[360px] rounded-md border-l-[3px] border-l-solid border border-solid border-[var(--card-border)] bg-[rgba(10,18,34,0.96)] shadow-lg animate-[slideInRight_0.2s_ease-out] ${BORDER_COLOR[t.type]}"
         >
-          <span class="text-sm shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
-          <span class="text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+          <span class="text-xs shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
+          <span class="flex-1 text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
+          <button
+            class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] p-0.5 transition-colors duration-150"
+            onClick=${(e: Event) => { e.stopPropagation(); dismissToast(t.id) }}
+            title="닫기"
+          >\u2715</button>
         </div>
       `)}
     </div>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -79,7 +79,7 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button
-        class="text-[11px] py-[6px] px-[11px] rounded-full border border-solid border-[rgba(71,184,255,0.28)] bg-[rgba(71,184,255,0.12)] text-[#bfe7ff] cursor-pointer font-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition-colors duration-150 hover:bg-[rgba(71,184,255,0.18)]"
+        class="text-[11px] py-[6px] px-[11px] rounded-md border border-solid border-[rgba(71,184,255,0.28)] bg-[rgba(71,184,255,0.12)] text-[#bfe7ff] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[rgba(71,184,255,0.18)]"
         type="button"
         aria-expanded=${buildIdentityOpen.value}
         onClick=${() => {
@@ -90,7 +90,7 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+10px)] right-0 min-w-[300px] py-3 px-3.5 border border-solid border-[var(--card-border)] rounded-[18px] bg-[rgba(6,14,28,0.97)] shadow-[0_24px_44px_rgba(0,0,0,0.36)] grid gap-2">
+            <div class="absolute top-[calc(100%+10px)] right-0 min-w-[300px] py-3 px-3.5 border border-solid border-[var(--card-border)] rounded-lg bg-[rgba(6,14,28,0.97)] shadow-lg grid gap-2">
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
                 <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
@@ -120,44 +120,67 @@ export function BuildIdentityBadge() {
 
 
 
-export function SideRail() {
+export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggle?: () => void }) {
   const currentTab = route.value.tab
   const currentSection = currentSectionForRoute(route.value)
 
   return html`
     <nav class="flex flex-col h-full">
-      <div class="flex-1 overflow-y-auto px-4 py-5">
-        <div class="mb-5 px-2">
-          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Navigation</div>
-          <div class="mt-1 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
-        </div>
+      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-3 pt-3 pb-1">
+        ${!collapsed ? html`
+          <div class="px-1">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Navigation</div>
+            <div class="mt-0.5 text-[14px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
+          </div>
+        ` : null}
+        <button
+          class="flex size-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)] hover:text-[var(--text-body)] cursor-pointer transition-colors duration-150"
+          onClick=${onToggle}
+          title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+        >
+          ${collapsed ? '\u25B6' : '\u25C0'}
+        </button>
+      </div>
 
-        <div class="flex flex-col gap-4">
+      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1.5' : 'px-3'} py-3">
+        <div class="flex flex-col gap-3">
           ${DASHBOARD_SURFACES.map(surface => {
             const isSurfaceActive = surface.id === currentTab
             const sections = sectionItemsForTab(surface.id)
 
-            return html`
-              <div class="flex flex-col gap-1.5">
+            if (collapsed) {
+              return html`
                 <button
-                  class="flex items-center gap-3 w-full rounded-2xl px-3 py-3 text-left cursor-pointer transition-all duration-150 ${isSurfaceActive && sections.length === 0 ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.04)]'}"
+                  class="flex items-center justify-center w-full rounded-lg p-2 cursor-pointer transition-colors duration-150 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)]'}"
+                  onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
+                  title=${surface.label}
+                >
+                  <span class="text-[16px]">${surface.icon}</span>
+                </button>
+              `
+            }
+
+            return html`
+              <div class="flex flex-col gap-1">
+                <button
+                  class="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-2 text-left cursor-pointer transition-colors duration-150 ${isSurfaceActive && sections.length === 0 ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.04)]'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                 >
-                  <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[16px]">
+                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[14px]">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-[14px] font-semibold truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
+                    <div class="text-[13px] font-semibold truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
                   </div>
                 </button>
-                
+
                 ${sections.length > 0 ? html`
-                  <div class="flex flex-col gap-1 pl-12 pr-1">
+                  <div class="flex flex-col gap-0.5 pl-10 pr-1">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
                         <button
-                          class="w-full rounded-xl px-3 py-2 text-left cursor-pointer text-[13px] transition-all duration-150 ${isSectionActive ? 'bg-[rgba(71,184,255,0.12)] text-[#cfeaff] font-medium' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded-md px-2.5 py-1.5 text-left cursor-pointer text-[12px] transition-colors duration-150 ${isSectionActive ? 'bg-[rgba(71,184,255,0.12)] text-[#cfeaff] font-medium' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
                           onClick=${() => navigate(surface.id, item.params)}
                         >
                           <div class="truncate">${item.label}</div>
@@ -172,9 +195,11 @@ export function SideRail() {
         </div>
       </div>
 
-      <div class="shrink-0 border-t border-[rgba(255,255,255,0.06)] p-4">
-        <${SnapshotCard} currentTab=${currentTab} />
-      </div>
+      ${!collapsed ? html`
+        <div class="shrink-0 border-t border-[rgba(255,255,255,0.06)] p-3">
+          <${SnapshotCard} currentTab=${currentTab} />
+        </div>
+      ` : null}
     </nav>
   `
 }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -47,7 +47,7 @@ export function LogViewer() {
 
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
-      <section class="rounded-[26px] border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(135deg,rgba(9,22,42,0.95),rgba(7,13,24,0.92))] px-5 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <section class="rounded-xl border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(135deg,rgba(9,22,42,0.95),rgba(7,13,24,0.92))] px-5 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
         <div class="flex flex-wrap items-start justify-between gap-4">
           <div class="min-w-0 max-w-[760px]">
             <div class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.72)]">Observer</div>
@@ -57,7 +57,7 @@ export function LogViewer() {
             </p>
           </div>
 
-          <div class="grid min-w-[240px] gap-2 rounded-[20px] border border-[rgba(255,255,255,0.07)] bg-[rgba(255,255,255,0.04)] p-3">
+          <div class="grid min-w-[240px] gap-2 rounded-lg border border-[rgba(255,255,255,0.07)] bg-[rgba(255,255,255,0.04)] p-3">
             <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
               <span>현재 필터</span>
               <strong class="text-[var(--text-strong)]">${levelFilter.value}+</strong>
@@ -74,11 +74,11 @@ export function LogViewer() {
         </div>
       </section>
 
-      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[26px] border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
+      <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
           <select
-            class="logs-select rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+            class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             value=${levelFilter.value}
             onChange=${(e: Event) => {
               levelFilter.value = (e.target as HTMLSelectElement).value
@@ -92,7 +92,7 @@ export function LogViewer() {
           </select>
 
           <input
-            class="logs-module-input min-w-[220px] rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+            class="logs-module-input min-w-[220px] rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             type="text"
             placeholder="module filter"
             value=${moduleFilter.value}
@@ -105,7 +105,7 @@ export function LogViewer() {
           />
 
           <select
-            class="logs-select rounded-[14px] border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+            class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
             value=${String(logLimit.value)}
             onChange=${(e: Event) => {
               logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
@@ -129,7 +129,7 @@ export function LogViewer() {
             />
             자동
           </label>
-          <button class="logs-refresh-btn rounded-[14px] border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
+          <button class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
             disabled=${logLoading.value}>
             ${logLoading.value ? '...' : '새로고침'}
           </button>
@@ -137,7 +137,7 @@ export function LogViewer() {
         </div>
 
         ${logError.value ? html`
-          <div class="mx-4 mt-4 rounded-[18px] border border-solid border-[#e05050] bg-[rgba(224,80,80,0.12)] px-4 py-3 text-[12px] text-[#ffb3b3]">${logError.value}</div>
+          <div class="mx-4 mt-4 rounded-md border border-solid border-[#e05050] bg-[rgba(224,80,80,0.12)] px-4 py-3 text-[12px] text-[#ffb3b3]">${logError.value}</div>
         ` : null}
 
         <div class="logs-table-wrap min-h-0 flex-1 overflow-auto px-3 pb-3">

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -238,11 +238,11 @@ export function Overview() {
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
       <${AttentionSpotlight} snap=${snap} />
 
-      <div class="p-6 rounded-3xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
         <${HotSessions} />
       </div>
 
-      <div class="p-6 rounded-3xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
         <${AgentPulse} />
       </div>
 
@@ -250,7 +250,7 @@ export function Overview() {
         <${OasPipeline} />
       </div>
 
-      <div class="p-6 rounded-3xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
         <${HomeSectionHeader} label="최근 활동" />
         <${NarrativeTimeline} entries=${journal} maxItems=${8} />
       </div>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -23,7 +23,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
   const build = serverStatus.value?.build
 
   return html`
-    <section class="grid gap-3 rounded-[22px] border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] p-3">
+    <section class="grid gap-2.5 rounded-lg border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] p-3">
       <div class="flex items-start justify-between gap-3">
         <div>
           <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Room Pulse</div>
@@ -39,26 +39,26 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
 
       ${build
         ? html`
-            <div class="rounded-[18px] border border-[rgba(71,184,255,0.14)] bg-[rgba(71,184,255,0.08)] px-3 py-2 text-[10px] text-[rgba(191,231,255,0.78)]">
+            <div class="rounded-md border border-[rgba(71,184,255,0.14)] bg-[rgba(71,184,255,0.08)] px-3 py-2 text-[10px] text-[rgba(191,231,255,0.78)]">
               build v${build.release_version} · ${shortCommit(build.commit)}
             </div>
           `
         : null}
 
       <div class="grid grid-cols-2 gap-2 text-[11px]">
-        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+        <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">에이전트</div>
           <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--accent)]">${agents.value.length}</strong>
         </div>
-        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+        <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">키퍼</div>
           <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--ok)]">${keepers.value.length}</strong>
         </div>
-        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+        <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">태스크</div>
           <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--warn)]">${tasks.value.length}</strong>
         </div>
-        <div class="rounded-[16px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
+        <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">이벤트</div>
           <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--text-strong)]">${eventCount.value}</strong>
         </div>
@@ -66,7 +66,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
 
       <div class="grid grid-cols-2 gap-2">
         <button
-          class="w-full rounded-[16px] border border-solid border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.14)] px-3 py-2 text-[11px] font-medium text-[#dff3ff] cursor-pointer transition-colors duration-150 hover:bg-[rgba(71,184,255,0.2)]"
+          class="w-full rounded-md border border-solid border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.14)] px-3 py-2 text-[11px] font-medium text-[#dff3ff] cursor-pointer transition-colors duration-150 hover:bg-[rgba(71,184,255,0.2)]"
           onClick=${() => {
             refreshDashboard()
             refreshForTab(currentTab)
@@ -75,7 +75,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
           Room sync
         </button>
         <button
-          class="w-full rounded-[16px] border border-solid border-[var(--card-border)] px-3 py-2 bg-[rgba(255,255,255,0.04)] text-[var(--text-body)] text-[11px] font-medium cursor-pointer transition-colors duration-150 hover:bg-[rgba(255,255,255,0.08)]"
+          class="w-full rounded-md border border-solid border-[var(--card-border)] px-3 py-2 bg-[rgba(255,255,255,0.04)] text-[var(--text-body)] text-[11px] font-medium cursor-pointer transition-colors duration-150 hover:bg-[rgba(255,255,255,0.08)]"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >
           운영 패널

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -34,9 +34,9 @@
   /* Tone variants */
   --bad-light: #f87171;
   --warn-bright: #f97316;
-  --radius-lg: 16px;
-  --radius-md: 12px;
-  --radius-sm: 10px;
+  --radius-lg: 12px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
 
   --font-size-2xs: 11px;
   --font-size-xs: 12px;
@@ -64,9 +64,9 @@
   --ok: #4ade80;
   --warn: #fbbf24;
   --bad: #ef4444;
-  --radius-lg: 16px;
-  --radius-md: 12px;
-  --radius-sm: 10px;
+  --radius-lg: 12px;
+  --radius-md: 8px;
+  --radius-sm: 6px;
   --header-h: 94px;
 
   /* Agent status (soft tones) */


### PR DESCRIPTION
## Summary
- 사이드바 접기/펼치기 토글 추가 (signal 기반, `w-64` <-> `w-14` 전환)
- 접힌 상태에서 아이콘만 표시, Room Pulse 카드 숨김
- border-radius 남용 정리: `rounded-3xl`(24px) → `rounded-xl`(12px), 임의 px 값 → Tailwind 표준 scale
- CSS 커스텀 radius 변수 축소: `--radius-lg` 16→12, `--radius-md` 12→8, `--radius-sm` 10→6
- Toast: 닫기(X) 버튼 추가, `backdrop-blur-sm` 제거, shadow 단순화

## 변경 파일 (8개)
| 파일 | 변경 |
|------|------|
| `app.ts` | `sidebarCollapsed` signal, aside width/radius |
| `dashboard-shell.ts` | SideRail collapsed/onToggle prop, nav radius |
| `toast.ts` | dismiss 버튼, layout 정리 |
| `card.ts` | CARD_BASE `rounded-2xl` → `rounded-xl` |
| `logs.ts` | arbitrary radius → Tailwind scale |
| `overview.ts` | `rounded-3xl` → `rounded-xl` |
| `resident-runtime-rail.ts` | arbitrary radius → Tailwind scale |
| `global.css` | CSS custom property radius 값 축소 |

## Test plan
- [ ] `npm run dev` 로컬 확인: 사이드바 접기/펼치기 동작
- [ ] 접힌 상태에서 각 nav 아이콘 클릭 시 올바른 페이지 이동
- [ ] Toast 표시 + X 버튼 닫기 동작
- [ ] 반응형(1100px 이하) 레이아웃 확인
- [ ] 기존 카드/컴포넌트 radius 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)