### PR TITLE
fix(dashboard): remove unlayered CSS reset overriding Tailwind v4 utilities

### DIFF
--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -214,13 +214,8 @@
   /* Overlay z-index: fallback values in each component (keeper:3020 agent:3030 trpg:3040 toast:3070 tooltip:3080) */
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+/* box-sizing/margin/padding reset removed — Tailwind v4 preflight handles this.
+   Unlayered CSS overrides @layer utilities, breaking p-*, m-*, gap-* etc. */
 
 html,
 body {


### PR DESCRIPTION
## Summary
- `* { padding: 0; margin: 0; box-sizing: border-box }` 제거
- 이 리셋은 unlayered CSS로서 CSS cascade layers 스펙상 `@layer utilities` 안의 Tailwind 유틸리티보다 항상 우선
- `.p-6`, `.gap-4`, `.m-2` 등 모든 spacing 유틸리티가 무효화되어 보더와 텍스트가 딱 붙어 보이는 현상 발생
- Tailwind v4 preflight가 `@layer base`에서 동일 리셋을 이미 처리하므로 중복이자 파괴적

## Test plan
- [ ] `cd dashboard && npm run build` 후 `localhost:8935/dashboard` 에서 카드/패널 padding 정상 확인
- [ ] overview, agents, board 등 주요 페이지에서 레이아웃 깨짐 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)