### PR TITLE
feat(keeper): add allowed_paths for filesystem access control

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -18,7 +18,8 @@ let normalize_path_for_check (path : string) : string =
     in
     Filename.concat parent_norm (Filename.basename path)
 
-let resolve_keeper_target_path ~(config : Room.config) ~(raw_path : string)
+let resolve_keeper_target_path ~(config : Room.config)
+    ~(allowed_paths : string list) ~(raw_path : string)
     : (string, string) result =
   let raw = String.trim raw_path in
   if raw = "" then Error "path_required"
@@ -29,17 +30,33 @@ let resolve_keeper_target_path ~(config : Room.config) ~(raw_path : string)
     in
     let root_norm = normalize_path_for_check root in
     let target_norm = normalize_path_for_check candidate in
-    let allowed =
+    let within_root =
       target_norm = root_norm
       || starts_with ~prefix:(root_norm ^ "/") target_norm
     in
-    if allowed then Ok candidate
-    else
+    if not within_root then
       Error
-        (Printf.sprintf
-           "path_outside_project_root: %s (root=%s)"
-           target_norm
-           root_norm)
+        (Printf.sprintf "path_outside_project_root: %s (root=%s)"
+           target_norm root_norm)
+    else if allowed_paths = [] then
+      Ok candidate
+    else
+      let rel =
+        let prefix = root_norm ^ "/" in
+        if starts_with ~prefix target_norm then
+          String.sub target_norm (String.length prefix)
+            (String.length target_norm - String.length prefix)
+        else ""
+      in
+      let matches_any =
+        List.exists (fun ap -> starts_with ~prefix:ap rel) allowed_paths
+      in
+      if matches_any then Ok candidate
+      else
+        Error
+          (Printf.sprintf
+             "path_not_in_allowed_paths: %s (allowed: [%s])"
+             raw (String.concat ", " allowed_paths))
 
 let truncate_tool_output ?(max_len = 12000) (s : string) : string =
   if String.length s <= max_len then s

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -292,7 +292,7 @@ let execute_keeper_tool_call
         Safe_ops.json_int ~default:20000 "max_bytes" args
         |> fun n -> max 512 (min 200000 n)
       in
-      (match resolve_keeper_target_path ~config ~raw_path:path with
+      (match resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path:path with
       | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
       | Ok target -> (
           match Safe_ops.read_file_safe target with
@@ -321,7 +321,7 @@ let execute_keeper_tool_call
         Safe_ops.json_string ~default:"overwrite" "mode" args
         |> String.lowercase_ascii
       in
-      (match resolve_keeper_target_path ~config ~raw_path:path with
+      (match resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path:path with
       | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e) ])
       | Ok target ->
           (try
@@ -387,7 +387,7 @@ let execute_keeper_tool_call
       let root = project_root_of_config config in
       let read_target () =
         let raw_path = Safe_ops.json_string ~default:"." "path" args in
-        resolve_keeper_target_path ~config ~raw_path
+        resolve_keeper_target_path ~config ~allowed_paths:meta.allowed_paths ~raw_path
       in
       let render_process_result ~cmd argv =
         let st, out =

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -67,6 +67,10 @@ let resident_schemas : tool_schema list = [
           ("type", `String "string");
           ("enum", `List [`String "disabled"; `String "readonly"]);
         ]);
+        ("allowed_paths", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
         ("initiative_enabled", `Assoc [("type", `String "boolean")]);
         ("initiative_scope", `Assoc [
           ("type", `String "string");
@@ -190,6 +194,11 @@ let resident_schemas : tool_schema list = [
           ("type", `String "string");
           ("enum", `List [`String "disabled"; `String "readonly"]);
           ("description", `String "Keeper shell wrapper mode. readonly adds a structured read-only shell tool without enabling raw bash.");
+        ]);
+        ("allowed_paths", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Relative path prefixes the keeper may access via fs_read/shell_readonly. Empty means unrestricted within project root.");
         ]);
         ("initiative_enabled", `Assoc [
           ("type", `String "boolean");

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -469,6 +469,7 @@ let handle_keeper_status ctx args : tool_result =
                else `String m.policy_reward_model_path);
              ("voice_enabled", `Bool m.policy_voice_enabled);
              ("shell_mode", `String m.policy_shell_mode);
+             ("allowed_paths", string_list_to_json m.allowed_paths);
              ("allowed_tools", string_list_to_json allowed_tools);
              ("available_internal_tools", string_list_to_json all_internal_tools);
              ("blocked_internal_tools", string_list_to_json blocked_internal_tools);

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -135,6 +135,7 @@ let ensure_keeper_exists
       |> Option.value ~default:"disabled"
       |> canonical_policy_shell_mode
     in
+    let allowed_paths = [] in
     let initiative_enabled =
       (if use_profile_policy_defaults then profile_defaults.initiative_enabled else None)
       |> Option.value ~default:false
@@ -207,6 +208,7 @@ let ensure_keeper_exists
       policy_reward_model_path;
       policy_voice_enabled;
       policy_shell_mode;
+      allowed_paths;
       initiative_enabled;
       initiative_scope;
       initiative_idle_sec;

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -23,6 +23,7 @@ type parsed_args = {
   policy_reward_model_path_opt : string option;
   policy_voice_enabled_opt : bool option;
   policy_shell_mode_opt : string option;
+  allowed_paths_opt : string list option;
   initiative_enabled_opt : bool option;
   initiative_scope_opt : string option;
   initiative_idle_sec_opt : int option;
@@ -85,6 +86,10 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let policy_reward_model_path_opt = get_string_opt args "policy_reward_model_path" in
     let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
     let policy_shell_mode_opt = get_string_opt args "policy_shell_mode" in
+    let allowed_paths_opt =
+      let raw = get_string_list args "allowed_paths" in
+      if raw = [] then None else Some raw
+    in
     let initiative_enabled_opt = get_bool_opt args "initiative_enabled" in
     let initiative_scope_opt = get_string_opt args "initiative_scope" in
     let initiative_idle_sec_opt = Safe_ops.json_int_opt "initiative_idle_sec" args in
@@ -164,6 +169,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       policy_reward_model_path_opt;
       policy_voice_enabled_opt;
       policy_shell_mode_opt;
+      allowed_paths_opt;
       initiative_enabled_opt;
       initiative_scope_opt;
       initiative_idle_sec_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -100,6 +100,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     |> Option.value ~default:"disabled"
     |> canonical_policy_shell_mode
   in
+  let allowed_paths =
+    Option.value ~default:[] p.allowed_paths_opt
+  in
   let initiative_enabled =
     first_some
       p.initiative_enabled_opt
@@ -322,6 +325,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            policy_reward_model_path;
            policy_voice_enabled;
            policy_shell_mode;
+           allowed_paths;
            initiative_enabled;
            initiative_scope;
            initiative_idle_sec;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -97,6 +97,9 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     |> Option.value ~default:"disabled"
     |> canonical_policy_shell_mode
   in
+  let allowed_paths =
+    Option.value ~default:old.allowed_paths p.allowed_paths_opt
+  in
   let initiative_enabled =
     first_some
       p.initiative_enabled_opt
@@ -228,6 +231,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     policy_reward_model_path;
     policy_voice_enabled;
     policy_shell_mode;
+    allowed_paths;
     initiative_enabled;
     initiative_scope;
     initiative_idle_sec;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -29,6 +29,7 @@ type keeper_meta = {
   policy_reward_model_path: string;
   policy_voice_enabled: bool;
   policy_shell_mode: string;
+  allowed_paths: string list;
   initiative_enabled: bool;
   initiative_scope: string;
   initiative_idle_sec: int;
@@ -132,6 +133,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("policy_reward_model_path", `String m.policy_reward_model_path);
       ("policy_voice_enabled", `Bool m.policy_voice_enabled);
       ("policy_shell_mode", `String m.policy_shell_mode);
+      ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
       ("initiative_enabled", `Bool m.initiative_enabled);
       ("initiative_scope", `String m.initiative_scope);
       ("initiative_idle_sec", `Int m.initiative_idle_sec);
@@ -273,6 +275,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
       |> canonical_policy_shell_mode
     in
+    let allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let initiative_enabled =
       Safe_ops.json_bool ~default:false "initiative_enabled" json
     in
@@ -489,6 +492,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           policy_reward_model_path;
           policy_voice_enabled;
           policy_shell_mode;
+          allowed_paths;
           initiative_enabled;
           initiative_scope;
           initiative_idle_sec;


### PR DESCRIPTION
## Summary
- Keeper의 `keeper_fs_read`, `keeper_shell_readonly` 도구에 경로 접근 제어(allowlist) 추가
- `allowed_paths` (상대 경로 prefix 목록)가 비어있으면 기존 동작 유지 (project root 전체 접근)
- 비어있지 않으면 허용 목록 밖 접근 시 거부 + 허용 경로 목록을 에러 메시지에 포함 (LLM self-correction 유도)

## Motivation
`qa-harness-drift` keeper가 Qwen3.5 로컬 모델로 720 turns 돌면서 존재하지 않는 `qa/` 경로를 반복 접근.
레포에 실제 harness는 `scripts/harness_*.sh`에 있지만 keeper에게 이 정보가 전달되지 않았음.
프롬프트에 레포 구조 전체를 넣는 것은 정보 노출 문제가 있어, 허용 경로만 enforcement하는 방식 채택.

## Changes (9 files)
- `keeper_types.ml` — `allowed_paths: string list` 필드 추가 + ser/deser
- `keeper_alerting_path.ml` — `resolve_keeper_target_path`에 allowlist enforcement
- `keeper_exec_tools.ml` — 호출부 3곳에 `~allowed_paths:meta.allowed_paths` 전달
- `keeper_turn_up_args.ml` — `allowed_paths_opt` 파싱
- `keeper_turn_up_create.ml` / `keeper_turn_up_update.ml` — create/update 반영
- `keeper_turn_setup.ml` — 기본값 `[]` (무제한)
- `keeper_schema.ml` — MCP tool schema에 파라미터 등록
- `keeper_status_detail.ml` — status 응답에 포함

## Usage
```
masc_keeper_up(name="qa-harness-drift", allowed_paths=["scripts/", "test/", "dashboard/src/"])
```

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 통과
- [ ] 서버 재빌드 후 `masc_keeper_up`으로 `allowed_paths` 설정
- [ ] keeper가 허용 경로 밖 접근 시 에러 메시지에 허용 목록 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)