### PR TITLE
fix(server): handle EAGAIN in protocol detection

### DIFF
--- a/lib/http_protocol_detect.ml
+++ b/lib/http_protocol_detect.ml
@@ -39,6 +39,11 @@ let detect_from_fd (fd : Unix.file_descr) : (protocol, string) result =
   | _ ->
     (* 0 bytes = connection closed before sending anything *)
     Error "connection closed before protocol detection"
+  | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) ->
+    (* Non-blocking socket with no data yet. Default to HTTP/1.1 —
+       any HTTP/2 client sends the connection preface immediately,
+       so EAGAIN means a normal HTTP/1.1 request in flight. *)
+    Ok Http1
   | exception Unix.Unix_error (err, _fn, _arg) ->
     Error (Printf.sprintf "peek failed: %s" (Unix.error_message err))
 


### PR DESCRIPTION
## Summary
- `recv(MSG_PEEK)`가 non-blocking 소켓에서 EAGAIN 반환 시 HTTP/1.1로 기본 처리
- 기존: `Error` 반환 → 매 연결마다 WARN 로그 도배
- 수정: `EAGAIN`/`EWOULDBLOCK` → `Ok Http1` (HTTP/2 클라이언트는 연결 즉시 preface를 보내므로 EAGAIN = HTTP/1.1)

## Test plan
- [ ] 서버 재시작 후 `[auto] protocol detect failed` WARN 로그가 사라지는지 확인
- [ ] `curl http://localhost:8935/health` 정상 동작 확인
- [ ] SSE 연결 (`/sse`, `/dashboard`) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)