### PR TITLE
fix(server): treat EAGAIN as HTTP/1.1 in protocol auto-detect

### DIFF
--- a/lib/http_protocol_detect.ml
+++ b/lib/http_protocol_detect.ml
@@ -39,6 +39,12 @@ let detect_from_fd (fd : Unix.file_descr) : (protocol, string) result =
   | _ ->
     (* 0 bytes = connection closed before sending anything *)
     Error "connection closed before protocol detection"
+  | exception Unix.Unix_error (Unix.EAGAIN, _, _)
+  | exception Unix.Unix_error (Unix.EWOULDBLOCK, _, _) ->
+    (* Non-blocking socket has no data yet.  HTTP/2 h2c clients send the
+       connection preface immediately, so absence of data means HTTP/1.1.
+       This is the common path for SSE/EventSource connections. *)
+    Ok Http1
   | exception Unix.Unix_error (err, _fn, _arg) ->
     Error (Printf.sprintf "peek failed: %s" (Unix.error_message err))
 


### PR DESCRIPTION
## Summary
- non-blocking socket에서 EAGAIN → Error → 로그 스팸 + SSE 연결 드롭
- HTTP/2 h2c는 connection preface를 즉시 보내므로, 데이터 없음 = HTTP/1.1 확실
- EAGAIN/EWOULDBLOCK → `Ok Http1` fallback으로 변경

## Impact
- SSE 클라이언트 연결 안정화
- `[auto] protocol detect failed` 로그 스팸 제거
- 대시보드 거버넌스 등 SSE 의존 페이지 정상화

Generated with [Claude Code](https://claude.com/claude-code)