### PR TITLE
style(dashboard): premium visual overhaul (Phase 7)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -65,30 +65,25 @@ export function App() {
   const currentSection = currentSectionForRoute(route.value)
 
   return html`
-    <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] text-[var(--text-body)]">
-      <header class="shrink-0 border-b border-[var(--card-border)] bg-[rgba(4,9,18,0.82)] px-6 py-4 backdrop-blur-xl z-10">
+    <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
+      <header class="shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.5)] px-6 py-4 backdrop-blur-2xl z-10 relative">
+        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
         <div class="mx-auto flex w-full max-w-[1680px] items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch">
           <div class="min-w-0">
             <div class="flex items-center gap-4">
-              <div class="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-[rgba(113,214,255,0.28)] bg-[linear-gradient(145deg,rgba(61,157,255,0.34),rgba(10,28,58,0.95))] text-[18px] font-semibold text-white shadow-lg">
+              <div class="flex size-11 shrink-0 items-center justify-center rounded-[14px] border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[18px] font-bold text-[#bfe7ff] shadow-[0_0_20px_rgba(71,184,255,0.15)]">
                 ${currentView?.icon ?? 'M'}
               </div>
-              <div class="min-w-0">
-                <div class="flex flex-wrap items-center gap-2 mb-1">
-                  <span class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.7)]">MASC</span>
-                  ${currentView
-                    ? html`
-                        <span class="text-[10px] font-medium text-[rgba(154,217,255,0.4)]">/</span>
-                        <span class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[rgba(154,217,255,0.9)]">${currentView.label}</span>
-                      `
-                    : null}
+              <div class="min-w-0 flex flex-col justify-center">
+                <div class="flex flex-wrap items-center gap-2 mb-0.5">
+                  <span class="text-[10px] font-bold uppercase tracking-[0.25em] text-[rgba(154,217,255,0.6)]">MASC Control Deck</span>
                 </div>
-                <h1 class="text-[22px] font-semibold tracking-[-0.03em] text-[var(--text-strong)] leading-none">
-                  ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Room Console'}
+                <h1 class="text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none flex items-center gap-2">
+                  ${currentView?.label ?? 'Multi-Agent Room Console'}
+                  ${currentSection && currentSection.label !== currentView?.label
+                    ? html`<span class="text-[13px] font-medium text-[rgba(154,217,255,0.5)]">/</span><span class="text-[15px] font-medium text-[rgba(154,217,255,0.8)]">${currentSection.label}</span>`
+                    : null}
                 </h1>
-                <p class="mt-1.5 max-w-[760px] text-[12px] leading-relaxed text-[var(--text-muted)]">
-                  ${currentSection?.description ?? currentView?.description ?? 'Rooms, keepers, governance, and operational signals in one place.'}
-                </p>
               </div>
             </div>
           </div>
@@ -101,12 +96,16 @@ export function App() {
       </header>
 
       <div class="flex flex-1 gap-5 overflow-hidden p-5 max-[1100px]:flex-col max-[1100px]:p-4">
-        <aside class="${sidebarCollapsed.value ? 'w-14' : 'w-64'} shrink-0 overflow-y-auto overflow-x-hidden rounded-3xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,17,31,0.94),rgba(7,14,26,0.9))] shadow-xl transition-[width] duration-200 max-[1100px]:w-full max-[1100px]:max-h-[360px]">
-          <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
+        <aside class="${sidebarCollapsed.value ? 'w-16' : 'w-[260px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[20px] border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)] transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[360px] relative">
+          <div class="absolute inset-0 bg-gradient-to-b from-[rgba(255,255,255,0.03)] to-transparent pointer-events-none rounded-[20px]"></div>
+          <div class="relative h-full">
+            <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
+          </div>
         </aside>
 
-        <main class="min-w-0 flex-1 overflow-hidden rounded-3xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(8,15,28,0.92),rgba(9,14,25,0.88))] shadow-xl max-[1100px]:min-h-0">
-          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-6 lg:p-8">
+        <main class="min-w-0 flex-1 overflow-hidden rounded-[20px] border border-[rgba(255,255,255,0.06)] bg-[rgba(10,15,26,0.7)] backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)] max-[1100px]:min-h-0 relative">
+          <div class="absolute inset-0 bg-gradient-to-b from-[rgba(255,255,255,0.02)] to-transparent pointer-events-none rounded-[20px]"></div>
+          <div class="relative mx-auto h-full max-w-[1600px] overflow-y-auto p-6 lg:p-8">
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -11,6 +11,7 @@ import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import {
   DASHBOARD_SURFACES,
+  DASHBOARD_NAV_ITEMS,
   currentSectionForRoute,
   sectionItemsForTab,
 } from '../config/navigation'
@@ -126,15 +127,15 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
   return html`
     <nav class="flex flex-col h-full">
-      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-3 pt-3 pb-1">
+      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-4 pt-4 pb-2">
         ${!collapsed ? html`
           <div class="px-1">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Navigation</div>
-            <div class="mt-0.5 text-[14px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
+            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">Navigation</div>
+            <div class="mt-0.5 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] drop-shadow-[0_2px_4px_rgba(0,0,0,0.5)]">MASC Core</div>
           </div>
         ` : null}
         <button
-          class="flex size-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)] hover:text-[var(--text-body)] cursor-pointer transition-colors duration-150"
+          class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.08)] hover:text-white cursor-pointer transition-all duration-200"
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
         >
@@ -142,8 +143,8 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </button>
       </div>
 
-      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1.5' : 'px-3'} py-3">
-        <div class="flex flex-col gap-3">
+      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-2' : 'px-4'} py-3">
+        <div class="flex flex-col gap-4">
           ${DASHBOARD_SURFACES.map(surface => {
             const isSurfaceActive = surface.id === currentTab
             const sections = sectionItemsForTab(surface.id)
@@ -151,39 +152,39 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
             if (collapsed) {
               return html`
                 <button
-                  class="flex items-center justify-center w-full rounded-lg p-2 cursor-pointer transition-colors duration-150 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)]'}"
+                  class="flex items-center justify-center w-full rounded-xl p-2.5 cursor-pointer transition-all duration-200 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.18)] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                   title=${surface.label}
                 >
-                  <span class="text-[16px]">${surface.icon}</span>
+                  <span class="text-[18px] drop-shadow-md">${surface.icon}</span>
                 </button>
               `
             }
 
             return html`
-              <div class="flex flex-col gap-1">
+              <div class="flex flex-col gap-1.5">
                 <button
-                  class="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-2 text-left cursor-pointer transition-colors duration-150 ${isSurfaceActive && sections.length === 0 ? 'bg-[rgba(71,184,255,0.14)] text-[#d9f2ff]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.04)]'}"
+                  class="flex items-center gap-3 w-full rounded-xl px-3 py-2.5 text-left cursor-pointer transition-all duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.15),rgba(71,184,255,0.05))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] text-[14px]">
+                  <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.03)] text-[16px] shadow-sm">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-[13px] font-semibold truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
+                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff] drop-shadow-[0_0_8px_rgba(71,184,255,0.4)]' : ''}">${surface.label}</div>
                   </div>
                 </button>
 
                 ${sections.length > 0 ? html`
-                  <div class="flex flex-col gap-0.5 pl-10 pr-1">
+                  <div class="flex flex-col gap-0.5 pl-11 pr-1 border-l border-[rgba(255,255,255,0.05)] ml-7">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
                         <button
-                          class="w-full rounded-md px-2.5 py-1.5 text-left cursor-pointer text-[12px] transition-colors duration-150 ${isSectionActive ? 'bg-[rgba(71,184,255,0.12)] text-[#cfeaff] font-medium' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.04)] hover:text-[var(--text-body)]'}"
+                          class="w-full rounded-lg px-3 py-2 text-left cursor-pointer text-[13px] transition-all duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.15)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.15)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)] border border-transparent'}"
                           onClick=${() => navigate(surface.id, item.params)}
                         >
-                          <div class="truncate">${item.label}</div>
+                          <div class="truncate ${isSectionActive ? 'drop-shadow-[0_0_8px_rgba(71,184,255,0.3)]' : ''}">${item.label}</div>
                         </button>
                       `
                     })}
@@ -196,7 +197,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       </div>
 
       ${!collapsed ? html`
-        <div class="shrink-0 border-t border-[rgba(255,255,255,0.06)] p-3">
+        <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] p-4 bg-[rgba(0,0,0,0.1)]">
           <${SnapshotCard} currentTab=${currentTab} />
         </div>
       ` : null}
@@ -245,6 +246,25 @@ export function TabContent() {
   }
 }
 
+function SurfaceLead() {
+  const currentTab = route.value.tab
+  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
+  const currentSection = currentSectionForRoute(route.value)
+
+  return html`
+    <div class="mb-8 flex flex-wrap items-end justify-between gap-4">
+      <div class="min-w-0">
+        <h2 class="text-[32px] font-bold tracking-tight text-[var(--text-strong)] flex items-center gap-3 drop-shadow-md">
+          ${currentSection?.label ?? currentView?.label ?? '홈'}
+        </h2>
+        <p class="mt-2 max-w-[700px] text-[14px] leading-relaxed text-[rgba(255,255,255,0.5)]">
+          ${currentSection?.description ?? currentView?.description ?? '지금 필요한 신호를 가장 안정적으로 읽을 수 있는 기본 화면입니다.'}
+        </p>
+      </div>
+    </div>
+  `
+}
+
 export function DashboardMain() {
   if (dashboardLoading.value && !connected.value && !roomTruthInitializing.value) {
     return html`<div class="loading-state loading-pulse">대시보드 불러오는 중...</div>`
@@ -264,6 +284,7 @@ export function DashboardMain() {
     ${roomTruthInitializing.value ? html`
       <div class="text-center py-[6px] px-4 bg-[rgba(230,167,0,0.12)] border-b border-solid border-b-[rgba(230,167,0,0.3)] text-[#e6a700] text-[0.8rem] shrink-0 rounded-xl mb-4">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
+    <${SurfaceLead} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <${TabContent} />
     <//>


### PR DESCRIPTION
## Description
This PR addresses feedback regarding the dashboard looking 'crappy' or too flat after the structural LNB layout consolidation. It brings back the premium, cyberpunk glassmorphism aesthetic.

### Changes
- Reinstated `SurfaceLead` inside the `DashboardMain` scrollable area to provide clear, beautiful context headers for every page without sacrificing global screen real estate.
- Converted `App` shell background from a flat dark color to a rich radial gradient with inset border glows and elegant top shadows.
- Redesigned `SideRail` to float within its container, using a combination of `backdrop-blur`, translucent gradients, and inner glows to evoke a modern, cyberpunk glassmorphism aesthetic.
- Added glowing neon accents to the active navigation states.
- Enhanced header to match the new depth-focused aesthetic.