### PR TITLE
Tighten MCP shutdown and best-effort error handling

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -275,64 +275,58 @@ let run_cmd host port base_path =
   (* Initialize thread-safe token store for cancellation support *)
   Masc_mcp.Cancellation.TokenStore.init ();
 
-  (* Graceful shutdown setup *)
-  let switch_ref = ref None in
-  let shutdown_initiated = ref false in
-  let force_exit_timer_started = ref false in
-  let initiate_shutdown signal_name =
-    if not !shutdown_initiated then begin
-      shutdown_initiated := true;
-      Log.Server.info "[MASC] Received %s, shutting down gracefully..." signal_name;
-
-      (* Start force-exit timer: if shutdown doesn't complete in 5s, force exit *)
-      if not !force_exit_timer_started then begin
-        force_exit_timer_started := true;
-        ignore (Thread.create (fun () ->
-          Unix.sleepf 5.0;
-          Log.Server.error "[MASC] Graceful shutdown timed out after 5s, forcing exit.";
-          exit 1
-        ) ())
-      end;
-
-      (* Broadcast shutdown notification to all SSE clients *)
-      let shutdown_data = Printf.sprintf
-        {|{"jsonrpc":"2.0","method":"notifications/shutdown","params":{"reason":"%s","message":"Server is shutting down, please reconnect"}}|}
-        signal_name
-      in
-      Sse.broadcast (Yojson.Safe.from_string shutdown_data);
-      Log.Server.info "[MASC] Sent shutdown notification to %d SSE clients" (Sse.client_count ());
-
-      (* Give clients 200ms to receive the notification *)
-      Unix.sleepf 0.2;
-
-      (* Run all shutdown hooks (cancel orchestrator, close SSE, etc.) *)
-      Masc_mcp.Shutdown_hooks.run_all ();
-
-      (* Flush dirty board data to prevent data loss *)
-      (try Board_dispatch.flush ()
-       with _ -> Log.Server.warn "[Shutdown] Board flush skipped (not initialized)");
-
-      (* Also close local SSE connections tracked in main_eio *)
-      close_all_sse_connections ();
-
-      (* Give connections 200ms to complete close handshake *)
-      Unix.sleepf 0.2;
-
-      match !switch_ref with
-      | Some sw -> Eio.Switch.fail sw Shutdown
-      | None -> ()
-    end
+  (* Signal handlers stay side-effect free. The Eio watcher fiber performs
+     all shutdown work inside the event loop. *)
+  let pending_shutdown_signal = Atomic.make None in
+  let request_shutdown signal_name =
+    if Option.is_none (Atomic.get pending_shutdown_signal) then
+      Atomic.set pending_shutdown_signal (Some signal_name)
   in
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGTERM"));
-  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> initiate_shutdown "SIGINT"));
+  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> request_shutdown "SIGTERM"));
+  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> request_shutdown "SIGINT"));
 
   let max_bind_retries = 5 in
   let rec try_start attempt =
     (try
       Eio.Switch.run @@ fun sw ->
-      switch_ref := Some sw;
       Masc_mcp.Dashboard_cache.set_sw sw;
-      run_server ~sw ~env ~host ~port ~base_path
+      let clock = Eio.Stdenv.clock env in
+      let rec await_shutdown_signal () =
+        match Atomic.exchange pending_shutdown_signal None with
+        | None ->
+            Eio.Time.sleep clock 0.05;
+            await_shutdown_signal ()
+        | Some signal_name ->
+            Log.Server.info
+              "[MASC] Received %s, shutting down gracefully..."
+              signal_name;
+            Eio.Fiber.fork_daemon ~sw (fun () ->
+                Eio.Time.sleep clock 5.0;
+                Log.Server.error
+                  "[MASC] Graceful shutdown timed out after 5s, forcing exit.";
+                exit 1);
+            let shutdown_data =
+              Printf.sprintf
+                {|{"jsonrpc":"2.0","method":"notifications/shutdown","params":{"reason":"%s","message":"Server is shutting down, please reconnect"}}|}
+                signal_name
+            in
+            Sse.broadcast (Yojson.Safe.from_string shutdown_data);
+            Log.Server.info
+              "[MASC] Sent shutdown notification to %d SSE clients"
+              (Sse.client_count ());
+            Eio.Time.sleep clock 0.2;
+            Masc_mcp.Shutdown_hooks.run_all ();
+            (try Board_dispatch.flush ()
+             with _ ->
+               Log.Server.warn
+                 "[Shutdown] Board flush skipped (not initialized)");
+            close_all_sse_connections ();
+            Eio.Time.sleep clock 0.2;
+            raise Shutdown
+      in
+      Eio.Fiber.first
+        (fun () -> run_server ~sw ~env ~host ~port ~base_path)
+        await_shutdown_signal
     with
     | Shutdown ->
         Log.Server.info "MASC MCP: Shutdown complete."

--- a/lib/mcp_protocol.ml
+++ b/lib/mcp_protocol.ml
@@ -7,77 +7,56 @@ module Http_negotiation = struct
     | Legacy_accepted
     | Rejected
 
-  (** Standard SSE content type *)
   let sse_content_type = "text/event-stream"
-
-  (** JSON content type *)
   let json_content_type = "application/json"
 
-  (** Parse Accept header value into list of (media_type, q_value) *)
   let parse_accept_header accept_header =
     match accept_header with
     | None -> []
     | Some header ->
-      header
-      |> String.split_on_char ','
-      |> List.map String.trim
-      |> List.filter_map (fun part ->
-        let part = String.lowercase_ascii part in
-        (* Extract media type and parameters *)
-        let parts = String.split_on_char ';' part in
-        match parts with
-        | [] -> None
-        | media_type :: params ->
-          let media_type = String.trim media_type in
-          (* Find q parameter if present *)
-          let q_value =
-            List.find_map (fun param ->
-              let param = String.trim param in
-              if String.length param >= 2 && param.[0] = 'q' && param.[1] = '=' then
-                let q_str = String.sub param 2 (String.length param - 2) in
-                try Some (float_of_string q_str)
-                with Failure _ -> None
-              else None
-            ) params
-            |> Option.value ~default:1.0
-          in
-          Some (media_type, q_value)
-      )
+        header
+        |> String.split_on_char ','
+        |> List.map String.trim
+        |> List.filter_map (fun part ->
+               let lowered = String.lowercase_ascii part in
+               let parts = String.split_on_char ';' lowered in
+               match parts with
+               | [] -> None
+               | media_type :: params ->
+                   let q_value =
+                     List.find_map
+                       (fun param ->
+                         let param = String.trim param in
+                         if String.length param >= 2 && param.[0] = 'q'
+                            && param.[1] = '='
+                         then
+                           let q_str =
+                             String.sub param 2 (String.length param - 2)
+                           in
+                           try Some (float_of_string q_str) with Failure _ -> None
+                         else None)
+                       params
+                     |> Option.value ~default:1.0
+                   in
+                   Some (String.trim media_type, q_value))
 
-  (** Check if a media type is accepted (q > 0) *)
   let is_media_type_accepted media_types target =
     let target = String.lowercase_ascii target in
-    List.exists (fun (media_type, q) ->
-      q > 0.0 && media_type = target
-    ) media_types
+    List.exists
+      (fun (media_type, q) -> q > 0.0 && String.equal media_type target)
+      media_types
 
-  (** Check if Accept header accepts SSE (text/event-stream with q > 0)
-      Wildcards (*/*) are NOT sufficient for SSE *)
   let accepts_sse_header accept_header =
     let media_types = parse_accept_header accept_header in
     is_media_type_accepted media_types sse_content_type
 
-  (** Check if Accept header accepts MCP Streamable HTTP
-      Requires BOTH application/json AND text/event-stream (with q > 0)
-      This distinguishes streamable from legacy SSE-only clients *)
   let accepts_streamable_mcp accept_header =
     let media_types = parse_accept_header accept_header in
-    let accepts_json = is_media_type_accepted media_types json_content_type in
-    let accepts_sse = is_media_type_accepted media_types sse_content_type in
-    accepts_json && accepts_sse
+    is_media_type_accepted media_types json_content_type
+    && is_media_type_accepted media_types sse_content_type
 
-  (** Classify Accept header against streamable policy.
-      - Streamable: Accept has both JSON + SSE
-      - Legacy_accepted: not streamable, but explicitly allowed or JSON-only
-      - Rejected: not streamable, no JSON, and legacy disabled *)
   let classify_mcp_accept ~allow_legacy accept_header =
     if accepts_streamable_mcp accept_header then Streamable
     else if allow_legacy then Legacy_accepted
-    else
-      (* MCP Streamable HTTP spec (2025-03-26) allows JSON-only Accept.
-         Clients like Claude Code may send Accept: application/json without
-         text/event-stream. Treat as Legacy_accepted rather than rejecting. *)
-      let media_types = parse_accept_header accept_header in
-      if is_media_type_accepted media_types json_content_type then Legacy_accepted
-      else Rejected
+    else Rejected
 end

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -25,6 +25,9 @@ type experiment_entry = {
   metric : Research_metric.t;
 }
 
+let log_best_effort_failure step exn =
+  Log.Server.warn "research: %s failed: %s" step (Printexc.to_string exn)
+
 (** Gather minimal context about the repo for the LLM. *)
 let gather_context ~(config : Research_config.repo_config) : string =
   let parts = Buffer.create 2048 in
@@ -37,7 +40,7 @@ let gather_context ~(config : Research_config.repo_config) : string =
     Buffer.add_string parts "## Recent commits\n```\n";
     Buffer.add_string parts stdout;
     Buffer.add_string parts "```\n\n"
-  with _ -> ());
+  with exn -> log_best_effort_failure "git log context" exn);
   (* OCaml source files *)
   (try
     let _, stdout =
@@ -53,7 +56,7 @@ let gather_context ~(config : Research_config.repo_config) : string =
     if count > 30 then
       Buffer.add_string parts (Printf.sprintf "... and %d more\n" (count - 30));
     Buffer.add_string parts "```\n\n"
-  with _ -> ());
+  with exn -> log_best_effort_failure "source file context" exn);
   (* API surface from .mli files — prevents LLM from hallucinating APIs *)
   (try
     let _, stdout =
@@ -71,7 +74,7 @@ let gather_context ~(config : Research_config.repo_config) : string =
         Buffer.add_string parts (Printf.sprintf "... and %d more\n" (count - 40));
       Buffer.add_string parts "```\n\n"
     end
-  with _ -> ());
+  with exn -> log_best_effort_failure "signature context" exn);
   (* TODOs *)
   (try
     let _, stdout =
@@ -113,11 +116,11 @@ let gather_context ~(config : Research_config.repo_config) : string =
                 incr snippets_added
               end
             end
-          with _ -> ())
+          with exn -> log_best_effort_failure "TODO snippet context" exn)
         | _ -> ()
       end
     ) (if count > 3 then List.filteri (fun i _ -> i < 3) todos else todos)
-  with _ -> ());
+  with exn -> log_best_effort_failure "TODO context" exn);
   Buffer.contents parts
 
 (** Parse a JSON hypothesis from LLM response. *)
@@ -145,7 +148,9 @@ let parse_hypothesis (response : string) : hypothesis option =
       old_text = str_or_empty "old_text";
       new_text = str_or_empty "new_text";
     }
-  with _ -> None
+  with exn ->
+    log_best_effort_failure "hypothesis parse" exn;
+    None
 
 (** Detect no-op hypotheses that would not change any code. *)
 let is_noop_hypothesis (h : hypothesis) : bool =
@@ -235,7 +240,9 @@ let create_worktree ~(repo_path : string) ~(experiment_id : string) : string opt
       [ "git"; "-C"; repo_path; "worktree"; "add"; worktree_path; "-b"; branch; "HEAD" ]
     in
     Some worktree_path
-  with _ -> None
+  with exn ->
+    log_best_effort_failure "worktree creation" exn;
+    None
 
 (** Remove experiment worktree. *)
 let cleanup_worktree ~(repo_path : string) ~(worktree_path : string) : unit =
@@ -243,7 +250,7 @@ let cleanup_worktree ~(repo_path : string) ~(worktree_path : string) : unit =
     let _ = Process_eio.run_argv_with_status ~timeout_sec:30.0
       [ "git"; "-C"; repo_path; "worktree"; "remove"; worktree_path ]
     in ()
-  with _ -> ())
+  with exn -> log_best_effort_failure "worktree cleanup" exn)
 
 (** Apply a patch to the target file in the worktree.
     Supports (in priority order):
@@ -306,7 +313,9 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
           output_string oc patch; close_out oc;
           true
         end
-    with _ -> false
+    with exn ->
+      log_best_effort_failure "patch application" exn;
+      false
   end
 
 (** Log a result to the TSV file. *)
@@ -318,7 +327,9 @@ let log_result ~(results_file : string) ~(entry : experiment_entry) : unit =
     try
       let pos = LargeFile.pos_out oc in
       pos = Int64.zero
-    with _ -> false
+      with exn ->
+        log_best_effort_failure "results header check" exn;
+        false
   in
   (try
     if needs_header then output_string oc header;
@@ -443,7 +454,7 @@ let run ~sw ~net ~clock ~(config : Research_config.t) : experiment_entry list =
           (Research_metric.status_to_string entry.metric.status)
           (entry.metric.test_pass_rate *. 100.0) in
         Log.Server.info "%s" msg
-      with _ -> ())
+      with exn -> log_best_effort_failure "research status broadcast" exn)
   done;
 
   let kept = List.filter (fun e -> e.metric.status = Research_metric.Keep) !history in

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -110,7 +110,7 @@ let test_notification_body_relaxes_accept () =
     | _ -> false)
 
 let test_request_json_only_accepted () =
-  (* JSON-only Accept is now Legacy_accepted per MCP Streamable HTTP spec (2025-03-26) *)
+  (* JSON-only Accept no longer qualifies as streamable MCP and should be rejected. *)
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
@@ -118,13 +118,13 @@ let test_request_json_only_accepted () =
     {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
   in
   let mode = Transport.classify_mcp_accept_for_body request body in
-  check bool "json-only accept is legacy_accepted" true
+  check bool "json-only accept is rejected" true
     (match mode with
-    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
 let test_initialize_json_only_accepted () =
-  (* JSON-only Accept is now Legacy_accepted per MCP Streamable HTTP spec (2025-03-26) *)
+  (* Initialize with JSON-only Accept is also rejected under the stricter transport rule. *)
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
@@ -132,9 +132,9 @@ let test_initialize_json_only_accepted () =
     {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
   in
   let mode = Transport.classify_mcp_accept_for_body request body in
-  check bool "initialize with json-only is legacy_accepted" true
+  check bool "initialize with json-only is rejected" true
     (match mode with
-    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
 let test_no_accept_header_rejected () =
@@ -179,8 +179,8 @@ let () =
       ]);
       ("body_aware_accept", [
         test_case "notification relaxes accept" `Quick test_notification_body_relaxes_accept;
-        test_case "json-only accept is legacy_accepted" `Quick test_request_json_only_accepted;
-        test_case "initialize json-only is legacy_accepted" `Quick test_initialize_json_only_accepted;
+        test_case "json-only accept is rejected" `Quick test_request_json_only_accepted;
+        test_case "initialize json-only is rejected" `Quick test_initialize_json_only_accepted;
         test_case "no accept header rejected" `Quick test_no_accept_header_rejected;
         test_case "initialize disables sse" `Quick test_initialize_never_uses_sse;
       ]);


### PR DESCRIPTION
## Summary
- move shutdown side effects out of the POSIX signal handler and let Eio fibers own cleanup
- tighten local MCP HTTP negotiation semantics to match the shared SDK behavior
- stop silently swallowing best-effort failures in research and MCP paths

## Verification
- dune build --root .
- opam exec -- dune exec --root . ./test/test_http_negotiation.exe
