### PR TITLE
feat(transport): wire WS and gRPC tool dispatch to MCP

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -5,7 +5,7 @@
  (modules main_eio)
  (public_name masc-mcp)
  (package masc_mcp)
- (libraries masc_mcp council cmdliner eio eio_main h2 h2-eio httpun-eio gluten-eio caqti-eio dune-build-info))
+ (libraries masc_mcp masc_eio_context council cmdliner eio eio_main h2 h2-eio httpun-eio gluten-eio caqti-eio dune-build-info))
 
 (executable
  (name main_stdio_eio)

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -153,7 +153,32 @@ let make_extended_handler routes =
             | _ -> false
           in
           if ws_enabled then begin
-            match Masc_mcp.Server_mcp_transport_ws.upgrade_connection reqd with
+            let on_message ws_session_id body_str =
+              match (!Masc_mcp.Server_auth.server_state,
+                     Eio_context.get_switch_opt (),
+                     Eio_context.get_clock_opt ()) with
+              | Some state, Some sw, Some clock ->
+                Eio.Fiber.fork ~sw (fun () ->
+                  try
+                    let response_json =
+                      Mcp_eio.handle_request ~clock ~sw
+                        ~mcp_session_id:ws_session_id
+                        state body_str
+                    in
+                    let response_str = Yojson.Safe.to_string response_json in
+                    if response_str <> "null" then
+                      ignore (Masc_mcp.Server_mcp_transport_ws.send_to_session
+                        ws_session_id response_str)
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                    Log.Server.warn "WS dispatch error %s: %s"
+                      ws_session_id (Printexc.to_string exn))
+              | _ ->
+                Log.Server.warn "WS: server not ready for dispatch"
+            in
+            match Masc_mcp.Server_mcp_transport_ws.upgrade_connection
+              ~on_message reqd with
             | Ok () -> ()
             | Error msg ->
               let body = Printf.sprintf {|{"error":"ws_upgrade_failed","message":"%s"}|} msg in

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -136,6 +136,16 @@ let upgrade_connection
        httpun-ws handles this internally when using respond_with_upgrade. *)
     ignore ws_conn)
 
+(** Send a text frame to a specific session by ID.
+    Returns [false] if the session is not found or the send fails. *)
+let send_to_session session_id text =
+  let session_opt =
+    with_sessions_rw (fun () -> Hashtbl.find_opt sessions session_id)
+  in
+  match session_opt with
+  | None -> false
+  | Some session -> send_text session text
+
 (** Broadcast a JSON string to all WebSocket sessions.
     Independent of SSE -- for WS-only messages. *)
 let broadcast_ws json_str =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -681,8 +681,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
       start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state;
       (* gRPC coordination transport (opt-in via MASC_GRPC_ENABLED=1) *)
-      let tool_dispatcher _tool_name _args_json =
-        Error "gRPC tool dispatch not yet wired to MCP dispatcher"
+      let tool_dispatcher tool_name args_json =
+        let arguments =
+          try Yojson.Safe.from_string args_json
+          with _ -> `Assoc []
+        in
+        let (success, result_str) =
+          Mcp_server_eio_execute.execute_tool_eio ~sw ~clock state
+            ~name:tool_name ~arguments
+        in
+        if success then Ok result_str else Error result_str
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config
         ~tool_dispatcher


### PR DESCRIPTION
## Summary
- **WebSocket**: `on_message` 콜백에 `Mcp_server_eio.handle_request` 연결. JSON-RPC 요청 수신 → MCP tool dispatch → WS 응답 전송
- **gRPC**: `tool_dispatcher` stub를 `execute_tool_eio` 실제 호출로 교체. `MASC_GRPC_ENABLED=1`로 활성화 시 tool 호출 동작
- **WebRTC**: signaling 라우트(`/webrtc/offer`, `/webrtc/answer`)는 이미 동작 중. 변경 없음

## 변경 파일
- `bin/main_eio.ml`: WS on_message dispatch 로직 추가
- `bin/dune`: `masc_eio_context` 의존성 추가
- `lib/server/server_mcp_transport_ws.ml`: `send_to_session` 헬퍼 추가
- `lib/server/server_runtime_bootstrap.ml`: gRPC tool_dispatcher 실제 배선

## Test plan
- [ ] `MASC_WS_ENABLED=1 ./start-masc-mcp.sh` 후 `websocat ws://localhost:8935/ws`로 JSON-RPC 전송 확인
- [ ] `MASC_GRPC_ENABLED=1 ./start-masc-mcp.sh` 후 `grpcurl`로 ToolCall RPC 확인
- [ ] 기존 SSE/HTTP MCP 통신 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)