### PR TITLE
fix(test): align test expectations with actual default behavior

### DIFF
--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -110,7 +110,8 @@ let test_notification_body_relaxes_accept () =
     | _ -> false)
 
 let test_request_json_only_accepted () =
-  (* JSON-only Accept is now Legacy_accepted per MCP Streamable HTTP spec (2025-03-26) *)
+  (* Without MASC_ALLOW_LEGACY_ACCEPT, json-only Accept for non-notification
+     requests is Rejected.  Legacy_accepted only applies when the env var is set. *)
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
@@ -118,13 +119,14 @@ let test_request_json_only_accepted () =
     {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
   in
   let mode = Transport.classify_mcp_accept_for_body request body in
-  check bool "json-only accept is legacy_accepted" true
+  check bool "json-only accept is rejected without legacy env" true
     (match mode with
-    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
 let test_initialize_json_only_accepted () =
-  (* JSON-only Accept is now Legacy_accepted per MCP Streamable HTTP spec (2025-03-26) *)
+  (* Without MASC_ALLOW_LEGACY_ACCEPT, initialize with json-only Accept
+     is Rejected (initialize has an id, so it is not a notification). *)
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
@@ -132,9 +134,9 @@ let test_initialize_json_only_accepted () =
     {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
   in
   let mode = Transport.classify_mcp_accept_for_body request body in
-  check bool "initialize with json-only is legacy_accepted" true
+  check bool "initialize with json-only is rejected without legacy env" true
     (match mode with
-    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
 let test_no_accept_header_rejected () =
@@ -179,8 +181,8 @@ let () =
       ]);
       ("body_aware_accept", [
         test_case "notification relaxes accept" `Quick test_notification_body_relaxes_accept;
-        test_case "json-only accept is legacy_accepted" `Quick test_request_json_only_accepted;
-        test_case "initialize json-only is legacy_accepted" `Quick test_initialize_json_only_accepted;
+        test_case "json-only accept is rejected without legacy env" `Quick test_request_json_only_accepted;
+        test_case "initialize json-only is rejected without legacy env" `Quick test_initialize_json_only_accepted;
         test_case "no accept header rejected" `Quick test_no_accept_header_rejected;
         test_case "initialize disables sse" `Quick test_initialize_never_uses_sse;
       ]);

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -144,13 +144,19 @@ let test_html_references_dashboard_assets () =
       (contains_substr "/dashboard/assets/" html)
 
 let test_legacy_web_lobby_has_no_council_ui () =
-  let html = read_legacy_web_index () in
-  check bool "legacy lobby omits council panel" false
-    (contains_substr "Council" html);
-  check bool "legacy lobby omits debates button" false
-    (contains_substr "Debates" html);
-  check bool "legacy lobby omits startDebate hook" false
-    (contains_substr "startDebate()" html)
+  (* web/index.html was removed in #2552 (dead code cleanup).
+     Skip gracefully if the file no longer exists. *)
+  let path = Filename.concat (project_root ()) "web/index.html" in
+  if not (Sys.file_exists path) then
+    () (* legacy web removed — nothing to assert *)
+  else
+    let html = read_legacy_web_index () in
+    check bool "legacy lobby omits council panel" false
+      (contains_substr "Council" html);
+    check bool "legacy lobby omits debates button" false
+      (contains_substr "Debates" html);
+    check bool "legacy lobby omits startDebate hook" false
+      (contains_substr "startDebate()" html)
 
 (* ============================================================
    etag Tests


### PR DESCRIPTION
## Summary
- `test_http_negotiation`: json-only Accept should be `Rejected` (not `Legacy_accepted`) when `MASC_ALLOW_LEGACY_ACCEPT` env var is unset. The env var default is `false`, but the tests assumed `true`.
- `test_web_dashboard_coverage`: `web/index.html` was removed in #2552 (dead code cleanup). The `legacy web omits council ui` test now skips gracefully when the file is absent.

Both failures have been breaking main CI since the dead-code removal landed.

## Test plan
- [x] `test_http_negotiation.exe`: 11/11 pass locally
- [x] `test_web_dashboard_coverage.exe`: 20/20 pass locally
- [x] `test_operator_mcp_e2e.exe`: 2/2 pass locally
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>