### PR TITLE
fix(keeper): use Log.Keeper instead of Log.Trpg for board post logging

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -234,7 +234,7 @@ let execute_keeper_tool_call
       else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])
   | "keeper_board_post" ->
       let author = meta.name in
-      Log.Trpg.info "keeper_board_post called by %s, raw args: %s"
+      Log.Keeper.info "keeper_board_post called by %s, raw args: %s"
         author (Yojson.Safe.to_string args);
       let board_args =
         match args with
@@ -247,10 +247,10 @@ let execute_keeper_tool_call
         ensure_keeper_board_post_args
           ~author ~source:"keeper_board_post" board_args
       in
-      Log.Trpg.info "board_args: %s"
+      Log.Keeper.info "board_args: %s"
         (Yojson.Safe.to_string board_args);
       let ok, msg = Tool_board.handle_tool "masc_board_post" board_args in
-      Log.Trpg.info "handle_tool result: ok=%b msg=%s" ok
+      Log.Keeper.info "handle_tool result: ok=%b msg=%s" ok
         (if String.length msg > 200 then String.sub msg 0 200 ^ "..." else msg);
       if ok then msg
       else Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ])


### PR DESCRIPTION
## Summary

`keeper_board_post` 호출 시 로그가 `Log.Trpg.info`로 찍혀서 TRPG 카테고리에 keeper 활동이 노출되는 버그 수정.

3건 `Log.Trpg.info` → `Log.Keeper.info` 변경.

## Test plan

- [x] `dune build` 통과
- [x] keeper board post 로그가 Keeper 카테고리로 출력되는지 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>