### PR TITLE
fix(dashboard): wire keeper action buttons and fix conversation avatar

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -415,7 +415,7 @@ export function workflowTargetReady(
   return true
 }
 
-async function executeAction(input: {
+export async function executeAction(input: {
   action_type: 'broadcast' | 'room_pause' | 'room_resume' | 'task_inject' | 'team_note' | 'team_broadcast' | 'team_task_inject' | 'team_worker_spawn_batch' | 'team_stop' | 'keeper_message'
   target_type: 'room' | 'team_session' | 'keeper'
   target_id?: string

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
+import { showToast } from '../common/toast'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { openKeeperDetail } from '../keeper-detail'
 import { findKeeper } from '../execution/shared'
@@ -13,10 +14,12 @@ import type { Keeper, OperatorActionDescriptor, OperatorKeeperSnapshot } from '.
 import {
   actionTypeLabel,
   displayStatus,
+  executeAction,
   keeperPrioritySummary,
   keeperPriorityTone,
   relativeAge,
   selectedKeeperName,
+  selectedSessionId,
   targetTypeLabel,
   logEntryBorderClass,
 } from './helpers'
@@ -160,11 +163,30 @@ export function OpsKeeperColumn() {
                     <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">${targetTypeLabel(targetType)}</div>
                     <div class="flex flex-wrap gap-1">
                       ${group.map((action: OperatorActionDescriptor) => html`
-                        <span key=${action.action_type}
+                        <button key=${action.action_type}
+                          type="button"
                           title=${action.description ?? ''}
-                          class="text-[12px] px-2 py-0.5 rounded cursor-default ${action.confirm_required ? 'bg-[var(--warn-12)] border border-[var(--warn-28)] text-[var(--warn)]' : 'bg-[var(--accent-8)] border border-[var(--accent-12)] text-[var(--accent)]'}">
+                          onClick=${() => {
+                            const targetId =
+                              action.target_type === 'keeper' ? selectedKeeperName.value
+                              : action.target_type === 'team_session' ? selectedSessionId.value
+                              : undefined
+                            if ((action.target_type === 'keeper' || action.target_type === 'team_session') && !targetId) {
+                              const what = action.target_type === 'keeper' ? 'keeper' : '세션'
+                              showToast(`먼저 ${what}를 선택하세요`, 'warning')
+                              return
+                            }
+                            void executeAction({
+                              action_type: action.action_type as Parameters<typeof executeAction>[0]['action_type'],
+                              target_type: action.target_type as 'room' | 'team_session' | 'keeper',
+                              target_id: targetId,
+                              payload: {},
+                              successMessage: `${actionTypeLabel(action.action_type)} 실행 완료`,
+                            })
+                          }}
+                          class="text-[12px] px-2 py-0.5 rounded cursor-pointer hover:brightness-125 transition-all ${action.confirm_required ? 'bg-[var(--warn-12)] border border-[var(--warn-28)] text-[var(--warn)]' : 'bg-[var(--accent-8)] border border-[var(--accent-12)] text-[var(--accent)]'}">
                           ${actionTypeLabel(action.action_type)}
-                        </span>
+                        </button>
                       `)}
                     </div>
                   </div>

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -229,7 +229,7 @@ export function deriveKeeperDiagnostic(
 
 // --- Thread state management ---
 
-function normalizeHistoryEntry(raw: unknown, index: number): KeeperConversationEntry | null {
+function normalizeHistoryEntry(raw: unknown, index: number, keeperName?: string): KeeperConversationEntry | null {
   if (!isRecord(raw)) return null
   const role = normalizeRole(raw.role)
   const rawText = asString(raw.content) ?? asString(raw.preview)
@@ -237,10 +237,11 @@ function normalizeHistoryEntry(raw: unknown, index: number): KeeperConversationE
   const text = formatKeeperVisibleReply(rawText)
   if (!text) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
+  const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   return {
     id: `${role}-${timestamp ?? 'entry'}-${index}`,
     role,
-    label: roleLabel(role),
+    label,
     text,
     rawText,
     timestamp,
@@ -254,7 +255,7 @@ function normalizeStatusDetail(name: string, text: string, rawStatus: unknown): 
   const parsed = isRecord(rawStatus) ? rawStatus : null
   const history = Array.isArray(parsed?.history_tail)
     ? parsed.history_tail
-      .map((entry, index) => normalizeHistoryEntry(entry, index))
+      .map((entry, index) => normalizeHistoryEntry(entry, index, name))
       .filter((entry): entry is KeeperConversationEntry => entry !== null)
     : []
   return {


### PR DESCRIPTION
## Summary

- **액션 버튼 클릭 가능**: ops-keeper-column의 액션 배지를 static `<span>` → clickable `<button>`으로 교체. `executeAction`에 올바른 `target_id` 전달 (keeper → keeper name, team_session → session ID). 미선택 시 toast 경고.
- **대화 아바타 "KE" 수정**: keeper history 로드 시 assistant 메시지의 label을 generic "Keeper" 대신 실제 keeper 이름으로 설정. 모노그램이 "KE" 대신 keeper 이름 첫 2글자 표시.
- **승인 대기 동작 검증**: `room_pause` → confirm → 실제 pause 실행 E2E 확인 완료.
- **운영자 중지 검증**: `team_stop`은 `target_id` (session ID) 필수. 기존 dashboard helpers.ts는 이미 올바르게 전달하고 있었으나, ops-keeper-column의 새 버튼에서는 누락 가능했음 → 수정 완료.

## E2E 검증 결과

```
POST /api/v1/operator/action {action_type: "room_pause"} → confirm_required: true
POST /api/v1/operator/confirm {confirm_token: "..."} → paused: true
POST /api/v1/operator/action {action_type: "team_stop"} → confirm_required: true  
POST /api/v1/operator/confirm (no target_id) → 400 "target_id is required"
```

## Test plan

- [x] TypeScript type check (tsc --noEmit) pass
- [x] Vite production build pass
- [x] room_pause → confirm → paused:true E2E
- [x] team_stop → confirm (with target_id) E2E
- [ ] Visual check in browser (keeper detail → conversation avatar, ops column → action buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)