### PR TITLE
fix(keeper): reduce max_turns from 1000/100 to 5

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -69,7 +69,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 100)
+    ?(max_turns : int = 5)
     ?guardrails
     ?temperature
     ?max_tokens

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -554,10 +554,12 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 1000. *)
+    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 5.
+    Most keeper tasks (read file + post to board) need 2-3 tool calls.
+    Previous default (1000) caused 787s+ latency per turn. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:1000
+    ~default:5
     ~min_v:1
-    ~max_v:1000000
+    ~max_v:50

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -268,7 +268,7 @@ let test_unified_turn_runtime_defaults () =
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
       (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 1000
+    check int "unified max_turns default" 5
       (KC.keeper_unified_max_turns ()))))
 
 (* ---------- Metrics observation tests ---------- *)


### PR DESCRIPTION
## Summary
- Keeper unified turn `max_turns` 기본값: 1000 → 5 (환경변수 최대: 50)
- Keeper agent_run `max_turns` 기본값: 100 → 5

## Evidence (MASC 검증 세션)

### 문제
- `MASC_KEEPER_UNIFIED_MAX_TURNS=999999` 환경에서 keeper turn latency **787초~1173초 (13-19분)**
- `keeper_msg` MCP 호출이 "no output" 반환 (MCP client timeout < turn latency)
- Agent.run() 루프가 수백 회 LLM 호출 (각 5-10초)

### keeper가 실제 도구를 사용한 증거
Board에 8개 게시물 생성:
- qa-ui-smoke: `keeper_tools.ml` 부재 발견, 유사 파일 3개 + 53개 keeper_*.ml 파일 수 보고
- qa-surface-consistency: build config ↔ 파일시스템 불일치 버그 보고
- dm-keeper: `.masc/perpetual-keepers/dm-keeper.json` 분석 결과
- tool-test: CLAUDE.md(7328B), README.md(20902B) 읽기 성공

### 수정 근거
대부분의 keeper 작업(파일 읽기 → Board 게시)은 2-3 tool call이면 충분.
max_turns=5이면 약 25-50초 내 응답 예상 (현재 787초 대비 ~95% 감소).

## Test plan
- [ ] 빌드 성공 확인 (`dune build --root .`)
- [ ] 서버 재시작 후 keeper_msg 응답 시간 측정 (목표: 60초 이내)
- [ ] Board에 keeper 게시물 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)