### PR TITLE
feat(keeper): bridge allowed_paths through OAS Agent.options

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -192,6 +192,7 @@ let run_turn
       ?guardrails
       ?on_event
       ~agent_ref
+      ~allowed_paths:meta.allowed_paths
       ()
   with
   | Error e -> Error e

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -38,6 +38,7 @@ type config = {
   initial_messages : Oas.Types.message list;
   raw_trace : Oas.Raw_trace.t option;
   transport : Masc_grpc_transport.t;
+  allowed_paths : string list;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -57,6 +58,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     initial_messages = [];
     raw_trace = None;
     transport = Masc_grpc_transport.from_env ();
+    allowed_paths = [];
   }
 
 (* ================================================================ *)
@@ -172,6 +174,11 @@ let build
   let builder =
     if config.initial_messages <> [] then
       Oas.Builder.with_initial_messages config.initial_messages builder
+    else builder
+  in
+  let builder =
+    if config.allowed_paths <> [] then
+      Oas.Builder.with_allowed_paths config.allowed_paths builder
     else builder
   in
   Oas.Builder.build_safe builder
@@ -406,6 +413,7 @@ let run_named
     ?on_event
     ?agent_ref
     ?transport
+    ?(allowed_paths = [])
     ()
   : (run_result, string) result =
   match require_eio () with
@@ -444,6 +452,7 @@ let run_named
       guardrails; hooks; context_reducer; memory;
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
       transport = transport_resolved;
+      allowed_paths;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -51,6 +51,7 @@ val run_named :
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?agent_ref:Oas.Agent.t option ref ->
   ?transport:Masc_grpc_transport.t ->
+  ?allowed_paths:string list ->
   unit ->
   (run_result, string) result
 


### PR DESCRIPTION
## Summary
- `Oas_worker.config`에 `allowed_paths` 필드 추가
- `run_named`에 `?allowed_paths` optional 파라미터 추가
- `build` 함수에서 `Builder.with_allowed_paths` 호출
- `keeper_agent_run.ml`에서 `meta.allowed_paths` 전달

## Flow
```
keeper_meta.allowed_paths
  → Oas_worker.run_named ~allowed_paths
    → Oas_worker.config.allowed_paths
      → Builder.with_allowed_paths
        → Agent.options.allowed_paths
```

OAS Agent.options가 source of truth, MASC keeper_meta가 configuration surface.

## Test plan
- [x] `dune build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)