### PR TITLE
fix(keeper): add paused flag to prevent bootstrap resurrection

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -94,6 +94,9 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
           match ensure_resident_meta ctx.config spec with
           | Error _ -> (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
           | Ok m ->
+              if m.paused then
+                (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
+              else
               let stale_now =
                 stale_turn_sec > 0.0
                 && (m.last_turn_ts <= 0.0

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -107,6 +107,7 @@ let handle_keeper_down ctx args : tool_result =
              active_team_session_id = None;
              last_team_session_started_at = "";
              updated_at = now_iso ();
+             paused = true;
            }
          in
          write_meta_logged ctx.config retained);

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -293,6 +293,7 @@ let ensure_keeper_exists
       active_team_session_id = None;
       last_team_session_started_at = "";
       team_session_start_count_total = 0;
+      paused = false;
     } in
     let base_dir = session_base_dir ctx.config in
     mkdir_p base_dir;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -401,6 +401,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             active_team_session_id = None;
             last_team_session_started_at = "";
             team_session_start_count_total = 0;
+            paused = false;
          } in
          match write_meta ctx.config meta with
          | Error e -> (false, e)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -105,6 +105,7 @@ type keeper_meta = {
   deliberation_cost_total_usd: float;
   last_deliberation_ts: float;
   last_triage_triggers: string;
+  paused: bool;
 }
 
 let now_iso () = Types.now_iso ()
@@ -213,6 +214,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("deliberation_cost_total_usd", `Float m.deliberation_cost_total_usd);
       ("last_deliberation_ts", `Float m.last_deliberation_ts);
       ("last_triage_triggers", `String m.last_triage_triggers);
+      ("paused", `Bool m.paused);
     ]
 
 let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
@@ -472,6 +474,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let last_triage_triggers =
       Safe_ops.json_string ~default:"" "last_triage_triggers" json
     in
+    let paused =
+      Safe_ops.json_bool ~default:false "paused" json
+    in
     if not (validate_name name) then
       Error "invalid keeper meta (bad name)"
     else if not (validate_name trace_id) then
@@ -577,6 +582,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           deliberation_cost_total_usd;
           last_deliberation_ts;
           last_triage_triggers;
+          paused;
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))


### PR DESCRIPTION
## Summary

Closes #2572

`keeper_down` 호출 시 `.json` 파일에 `"paused": true`를 설정합니다.
`bootstrap_existing_keepers`는 paused keeper를 skip합니다.
`keeper_up`/`create_from_persona`는 `paused = false`로 시작합니다.

**이전 동작**: down해도 서버 재시작 시 자동 부활
**이후 동작**: down하면 명시적 up 전까지 부팅 안 됨

5 files, +12 lines. 기존 `.json`에 `paused` 필드가 없으면 `default:false`로 처리 (하위 호환).

## Test plan

- [x] `dune build` 통과
- [x] `dune runtest` — `body_aware_accept`/`ag_ui` 실패는 main과 동일한 기존 이슈

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>