### PR TITLE
fix(ci): stop forcing h2 prior knowledge in contract harness

### DIFF
--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -17,7 +17,7 @@ curl_with_retry() {
   local timeout_sec="${CURL_TIMEOUT_SEC:-25}"
 
   while true; do
-    if curl --http2-prior-knowledge --max-time "$timeout_sec" "$@"; then
+    if curl --max-time "$timeout_sec" "$@"; then
       return 0
     fi
     local status=$?
@@ -40,7 +40,7 @@ wait_for_mcp_ready() {
   local timeout_sec="${MCP_READY_TIMEOUT_SEC:-20}"
   local deadline=$(( $(date +%s) + timeout_sec ))
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
-    if curl -fsS --http2-prior-knowledge --max-time 2 "$BASE_URL/health" >/dev/null 2>&1; then
+    if curl -fsS --max-time 2 "$BASE_URL/health" >/dev/null 2>&1; then
       return 0
     fi
     sleep 1
@@ -267,7 +267,7 @@ fi
 
 echo "[8/8] /sse deprecation headers"
 h8="$tmpdir/sse.headers"
-curl -sS --http2-prior-knowledge -D "$h8" -o /dev/null --max-time 1 \
+curl -sS -D "$h8" -o /dev/null --max-time 1 \
   -H 'Accept: text/event-stream' \
   "$BASE_URL/sse" || true
 require_header_contains "$h8" "Deprecation" "true"
@@ -276,7 +276,7 @@ require_header_contains "$h8" "Link" "</mcp>; rel=\"successor-version\""
 echo "[legacy] /messages deprecation headers"
 h9="$tmpdir/messages.headers"
 b9="$tmpdir/messages.body"
-curl -sS --http2-prior-knowledge -D "$h9" -o "$b9" \
+curl -sS -D "$h9" -o "$b9" \
   -X POST "$BASE_URL/messages" \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":9,"method":"ping"}'

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -71,7 +71,7 @@ harness_wait_for_health() {
   local timeout_sec="${2:-20}"
   local deadline=$(( $(date +%s) + timeout_sec ))
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
-    if curl -fsS --http2-prior-knowledge "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+    if curl -fsS --max-time 2 "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
       return 0
     fi
     sleep 1

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -13,6 +13,9 @@
 _HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${_HARNESS_DIR}/jsonrpc_sse.sh"
 
+# Contract harness validates MCP semantics, not h2c prior-knowledge support.
+# Use normal HTTP negotiation here so the suite doesn't hang when the server
+# speaks HTTP/1.1 on localhost.
 # POST a JSON body to the MCP endpoint with retry logic.
 # Includes mcp-session-id header when MCP_SESSION_ID is set.
 # Usage: curl_post_mcp '{"jsonrpc":"2.0",...}'
@@ -22,7 +25,7 @@ curl_post_mcp() {
   local output=""
   while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
     if [ -n "$MCP_SESSION_ID" ]; then
-      output="$(curl -sS --http2-prior-knowledge -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+      output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json, text/event-stream' \
         -H "mcp-session-id: $MCP_SESSION_ID" \
@@ -30,7 +33,7 @@ curl_post_mcp() {
           printf "%s" "$output"
           return 0
         }
-    elif output="$(curl -sS --http2-prior-knowledge -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+    elif output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
       -H 'Content-Type: application/json' \
       -H 'Accept: application/json, text/event-stream' \
       -d "$body" 2>/dev/null)"; then


### PR DESCRIPTION
## Summary
- stop forcing `curl --http2-prior-knowledge` in the contract harness bootstrap and MCP POST helpers
- use normal HTTP negotiation for `/health`, `/mcp`, `/sse`, and legacy `/messages` checks in the contract harness path
- keep the scope limited to the contract harness scripts that are timing out across unrelated PRs

## Why
Recent open PRs are being blocked by the same `Contract Harness` timeout pattern even when `Build and Test`, `Lint`, and `Health` are green. Local reproduction showed the harness hanging while talking to a localhost server that responds correctly over normal HTTP but not with forced h2 prior knowledge.

## Evidence
- local repro before patch: bootstrap succeeded, then harness stalled; direct `curl --http2-prior-knowledge http://127.0.0.1:<port>/health` failed with protocol mismatch
- local repro after patch: `scripts/harness/contract/run_all.sh` completed successfully end-to-end

## Local verification
- [x] `LOG_FILE=$(mktemp /tmp/masc-contract-server-run.XXXXXX.log) scripts/harness/contract/run_all.sh`

