### PR TITLE
feat(keeper): auto-boot resident keepers at server startup

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -296,6 +296,52 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
       ());
   fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
+  (* Auto-boot resident keepers: read .masc/resident-keepers/*.json,
+     load or parse each keeper's meta, and start keepalive loops. *)
+  fork_subsystem "keeper_autoboot" (fun () ->
+    (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
+    Eio.Time.sleep clock 5.0;
+    let config = state.room_config in
+    let specs = Keeper_types.list_resident_keepers config in
+    let booted = ref 0 in
+    List.iter (fun (spec : Keeper_types.resident_keeper_spec) ->
+      if not spec.desired then
+        Log.Keeper.info "autoboot: skipping %s (desired=false)" spec.name
+      else
+        try
+          (* Prefer persisted meta on disk; fall back to seed_meta from resident spec. *)
+          let meta =
+            match Keeper_types.read_meta config spec.name with
+            | Ok (Some m) -> Ok m
+            | Ok None -> Keeper_types.meta_of_json spec.seed_meta
+            | Error e -> Error e
+          in
+          match meta with
+          | Error e ->
+            Log.Keeper.error "autoboot: failed to load meta for %s: %s" spec.name e
+          | Ok m ->
+            if not m.presence_keepalive then
+              Log.Keeper.info "autoboot: skipping %s (presence_keepalive=false)" spec.name
+            else begin
+              let ctx : _ Keeper_types.context = {
+                config;
+                agent_name = m.agent_name;
+                sw;
+                clock;
+                proc_mgr = Some proc_mgr;
+              } in
+              Keeper_keepalive.start_keepalive ~proactive_warmup_sec:60 ctx m;
+              incr booted;
+              Log.Keeper.info "autoboot: started keepalive for %s" m.name
+            end
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Keeper.error "autoboot: exception for %s: %s" spec.name
+            (Printexc.to_string exn)
+    ) specs;
+    Log.Keeper.info "autoboot: %d/%d resident keepers started"
+      !booted (List.length specs));
   (* Phase 5: unified startup subsystem summary *)
   Log.info ~ctx:"startup" "subsystems: resident loops started"
 


### PR DESCRIPTION
## Summary
- 서버 시작 시 `.masc/resident-keepers/*.json`을 읽고 keepalive 루프를 자동 시작
- 이전: 외부 MCP 호출 없이는 keeper가 자율 턴을 실행하지 않음
- 이후: 서버 부트 후 65초(5s settle + 60s warmup)부터 자율 실행 시작

## Changes (1 file, +46 lines)
- `lib/server/server_runtime_bootstrap.ml`: `keeper_autoboot` subsystem 추가

## 동작
1. 5초 대기 (SSE, board, orchestrator 안정화)
2. `list_resident_keepers` → 디스크 meta 로드 또는 seed_meta fallback
3. `desired=true` + `presence_keepalive=true` 인 keeper만 시작
4. `start_keepalive ~proactive_warmup_sec:60` — 60초 후 자율 턴 시작
5. keeper별 에러 격리, 로그 요약

## Test plan
- [x] `dune build --root .` 성공
- [ ] CI Build and Test 통과
- [ ] 서버 재시작 후 5개 keeper keepalive 시작 확인
- [ ] 65초 후 sangsu 자율 턴 실행 확인 (trajectory 파일 갱신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)