### PR TITLE
fix(keeper): max_turns 10 + bump v2.141.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.140.0)
+(version 2.141.0)
 
 (generate_opam_files true)
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -69,7 +69,7 @@ let run_turn
     ~(user_message : string)
     ~(cascade_name : string)
     ~(generation : int)
-    ?(max_turns : int = 5)
+    ?(max_turns : int = 10)
     ?guardrails
     ?temperature
     ?max_tokens

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -554,12 +554,13 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 5.
-    Most keeper tasks (read file + post to board) need 2-3 tool calls.
-    Previous default (1000) caused 787s+ latency per turn. *)
+    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 10.
+    A productive keeper workflow (read -> edit -> build -> verify) needs 4-6 tool calls.
+    Previous default (1000) caused 787s+ latency per turn.
+    At 5, simple tasks (read + post) work but multi-step workflows are truncated. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:5
+    ~default:10
     ~min_v:1
     ~max_v:50

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -246,7 +246,7 @@ let test_unified_turn_runtime_defaults () =
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
       (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 5
+    check int "unified max_turns default" 10
       (KC.keeper_unified_max_turns ()))))
 
 (* ---------- Metrics observation tests ---------- *)


### PR DESCRIPTION
## Summary
- `max_turns` 5 → 10 (multi-step workflow 지원: read→edit→build→verify)
- Version bump 2.140.0 → 2.141.0

## Context
PR #2587에서 max_turns를 1000→5로 낮춰 latency를 787s→329s(-58%)로 개선.
하지만 5는 단순 읽기만 가능하고, keeper가 실제 작업(파일 수정, 빌드, 테스트)을
하려면 4-6 tool call이 필요하여 10으로 조정.

## Evidence
- CLAUDE.md 7328B exact match: keeper_fs_read 실제 동작 증명
- sangsu: 5 new turns, 329s/turn (vs 787s before)
- 26 Board posts from keepers (지속적 도구 사용)

## Test plan
- [ ] `dune build --root .` 성공
- [ ] 서버 재시작 후 keeper turn latency 측정
- [ ] keeper_msg로 read→edit→build 워크플로우 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)