### PR TITLE
fix(dashboard): add text/event-stream to MCP Accept header

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -10,7 +10,7 @@ let initPromise: Promise<void> | null = null
 function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    Accept: 'application/json',
+    Accept: 'application/json, text/event-stream',
     ...(extra ?? {}),
   }
   if (mcpSessionId) {
@@ -43,7 +43,7 @@ async function ensureSession(): Promise<void> {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Accept: 'application/json',
+          Accept: 'application/json, text/event-stream',
         },
         body: JSON.stringify({
           jsonrpc: '2.0',


### PR DESCRIPTION
## Summary

Closes #2592

Dashboard MCP 클라이언트가 `Accept: application/json`만 보내서 서버가 400 반환.
Streamable HTTP 프로토콜은 `Accept: application/json, text/event-stream` 필수.

에이전트 상세 페이지 "Direct Comms", keeper 메시지, worktree 관리 등 모든 MCP tool 호출이 영향받음.

## 변경

`dashboard/src/api/mcp.ts` — Accept 헤더 2곳 수정

## 검증

```bash
# Before: 400
curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:8935/mcp \
  -H 'Accept: application/json' -d '...'

# After: 200
curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:8935/mcp \
  -H 'Accept: application/json, text/event-stream' -d '...'
```

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>