### PR TITLE
feat(dashboard): unify keeper/agent detail, metadata default ON

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -92,6 +92,19 @@ export function agentJournalEntries(agentName: string | null): JournalEntry[] {
 // --- Actions ---
 
 export function openAgentDetail(agentName: string): void {
+  // If the agent has a linked keeper, open the richer keeper detail overlay instead
+  const keeper = keeperForAgent(agentName)
+  if (keeper) {
+    // Lazy import to avoid circular dependency
+    import('./keeper-detail').then(mod => {
+      mod.openKeeperDetail(keeper)
+    }).catch(() => {
+      // Fallback to agent detail if import fails
+      selectedAgentName.value = agentName
+      void refreshAgentDetail()
+    })
+    return
+  }
   selectedAgentName.value = agentName
   void refreshAgentDetail()
 }

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -6,8 +6,9 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { runOperatorAction } from '../api'
 import { TimeAgo } from './common/time-ago'
-import type { Keeper } from '../types'
-import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { StatusBadge } from './common/status-badge'
+import type { Keeper, Task } from '../types'
+import { invalidateDashboardCache, refreshDashboard, tasks } from '../store'
 import { selectKeeper } from '../keeper-runtime'
 import {
   KeeperConversationPanel,
@@ -198,6 +199,27 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Pipeline stage indicator ── */}
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
+
+        ${'' /* ── Assigned tasks (keeper = agent, may have claimed tasks) ── */}
+        ${(() => {
+          const agentName = keeper.agent_name ?? keeper.name
+          const ownedTasks: Task[] = tasks.value.filter(
+            (t: Task) => t.assignee === agentName || t.assignee === keeper.name
+          )
+          return ownedTasks.length > 0 ? html`
+            <${SectionCard} title="할당된 작업 (${ownedTasks.length})">
+              <div class="flex flex-col gap-2">
+                ${ownedTasks.map((t: Task) => html`
+                  <div key=${t.id} class="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-5)] transition-colors">
+                    <span class="text-[10px] font-medium py-1 px-2.5 border border-[rgba(71,184,255,0.2)] bg-[rgba(71,184,255,0.08)] text-[#9ad9ff] whitespace-nowrap rounded-md">${t.id}</span>
+                    <span class="flex-1 text-[13px] text-[var(--text-strong)] font-medium truncate">${t.title}</span>
+                    <${StatusBadge} status=${t.status} />
+                  </div>
+                `)}
+              </div>
+            <//>
+          ` : null
+        })()}
 
         ${'' /* ── KPIs ── */}
         <${KpiGrid} keeper=${keeper} />

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -24,9 +24,11 @@ const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
 
 function readKeeperChatMetadataVisible(): boolean {
   try {
-    return localStorage.getItem(KEEPER_CHAT_METADATA_VISIBLE_KEY) === 'true'
+    const stored = localStorage.getItem(KEEPER_CHAT_METADATA_VISIBLE_KEY)
+    // Default to visible (true) when no preference is stored
+    return stored === null ? true : stored === 'true'
   } catch {
-    return false
+    return true
   }
 }
 


### PR DESCRIPTION
## Summary

- **Agent → Keeper 리다이렉트**: keeper-linked agent 클릭 시 keeper 상세 오버레이로 전환. keeper가 없는 agent는 기존 agent-detail 유지.
- **Keeper 상세에 작업 섹션 추가**: keeper의 agent_name으로 할당된 작업 표시 (Pipeline stage 아래).
- **Chat metadata 기본 ON**: 대화에서 모델, 토큰, 비용, latency 정보가 기본으로 표시. 사용자가 끄면 localStorage에 저장.

## 변경 사항

| 파일 | 변경 |
|------|------|
| agent-detail-state.ts | openAgentDetail에서 keeper-linked → keeper-detail 리다이렉트 |
| keeper-detail.ts | 할당된 작업 섹션 추가 (SectionCard + StatusBadge) |
| keeper-shared.ts | metadata 기본값 false → true |

## Test plan

- [x] tsc --noEmit pass
- [ ] Non-keeper agent 클릭 → agent-detail 열림 (기존 동작 유지)
- [ ] Keeper-linked agent 클릭 → keeper-detail 열림 (리다이렉트)
- [ ] Keeper detail에서 할당 작업 표시
- [ ] Chat metadata 기본 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)