### PR TITLE
fix: QA transport fixes (PID lock, convo_list schema, agent card port)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -283,7 +283,39 @@ let base_path =
 (** Graceful shutdown exception *)
 exception Shutdown
 
+let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
+
+let acquire_pid_lock port =
+  let path = pid_lock_path port in
+  (let contents =
+     try
+       let ic = open_in path in
+       let s = In_channel.input_all ic in
+       close_in ic; Some s
+     with _ -> None
+   in
+   match contents with
+   | Some data ->
+     let pid_str = String.trim data in
+     (match int_of_string_opt pid_str with
+      | Some pid ->
+        (try Unix.kill pid 0;
+           Printf.eprintf
+             "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d\n%!"
+             pid port pid;
+           exit 1
+         with Unix.Unix_error (Unix.ESRCH, _, _) ->
+           Printf.eprintf "[WARN] Removing stale PID file (PID %d no longer running)\n%!" pid)
+      | None ->
+        Printf.eprintf "[WARN] Invalid PID file contents, overwriting\n%!")
+   | None -> ());
+  let oc = open_out path in
+  Printf.fprintf oc "%d\n" (Unix.getpid ());
+  close_out oc;
+  at_exit (fun () -> try Sys.remove path with _ -> ())
+
 let run_cmd host port base_path =
+  acquire_pid_lock port;
   Eio_main.run @@ fun env ->
   (* Initialize Mirage_crypto RNG - MUST be inside Eio_main.run for thread-local state *)
   Mirage_crypto_rng_unix.use_default ();

--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -357,7 +357,7 @@ let generate_default ?(port=8935) ?(host="127.0.0.1") ?(schemas=[]) () : agent_c
       { protocol = "SSE"; url = Printf.sprintf "%s/sse" base_url };
       { protocol = "JSONRPC"; url = Printf.sprintf "%s/mcp" base_url };
       { protocol = "REST"; url = Printf.sprintf "%s/api/v1" base_url };
-      { protocol = "GRPC"; url = Printf.sprintf "grpc://%s:%d" host (port + 1000) };
+      { protocol = "GRPC"; url = Printf.sprintf "grpc://%s:%d" host (Masc_grpc_server.configured_port ()) };
     ];
     security_schemes = [
       ("bearer", {

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -546,7 +546,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         room = current_room;
       } in
       let threads = Council.Conversation.list_active ~config:convo_config in
-      let json = `List (List.map (fun th ->
+      let threads_json = `List (List.map (fun th ->
         `Assoc [
           ("id", `String th.Council.Conversation.id);
           ("topic", `String th.Council.Conversation.topic);
@@ -555,6 +555,10 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           ("participants", `List (List.map (fun p -> `String p) th.Council.Conversation.participants));
         ]
       ) threads) in
+      let json = `Assoc [
+        ("count", `Int (List.length threads));
+        ("threads", threads_json);
+      ] in
       Some (true, Printf.sprintf "Active threads: %d\n%s"
         (List.length threads) (Yojson.Safe.pretty_to_string json))
 

--- a/test/test_agent_card_coverage.ml
+++ b/test/test_agent_card_coverage.ml
@@ -129,7 +129,7 @@ let test_binding_json_roundtrip () =
 let test_binding_grpc () =
   let b : Agent_card.binding = {
     protocol = "GRPC";
-    url = "grpc://127.0.0.1:9935";
+    url = "grpc://127.0.0.1:8936";
   } in
   let json = Agent_card.binding_to_yojson b in
   match Agent_card.binding_of_yojson json with


### PR DESCRIPTION
## Summary
QA transport layer 테스트에서 발견된 3가지 이슈 수정.

- **PID lock file**: 서버 시작 시 `/tmp/masc-{port}.pid` 생성. 기존 프로세스 존재 여부 확인. stale PID 자동 정리. 에이전트 간 포트 경합 방지.
- **convo_list schema**: `structuredContent`가 array 대신 record(`{count, threads}`)를 반환하도록 수정. MCP spec 준수.
- **agent card gRPC port**: `port + 1000` 하드코딩 → `Masc_grpc_server.configured_port()` 동적 참조. 실제 포트(기본 8936)와 일치.

## Closes
- #2598 (partial - PID lock)
- #2600 (convo_list schema)
- Relates to #2601 (agent card port)

## Test plan
- [ ] `dune build --root .` 성공 확인
- [ ] PID lock: 서버 시작 시 `/tmp/masc-8935.pid` 생성 확인
- [ ] PID lock: 중복 시작 시 에러 메시지 출력 확인
- [ ] convo_list: MCP 클라이언트에서 schema error 없이 응답 확인
- [ ] agent card: `grpc://127.0.0.1:8936` 으로 표시 확인

Generated with Claude Code