### PR TITLE
feat(grpc): replace JSON wire format with protobuf binary

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -357,7 +357,7 @@ let generate_default ?(port=8935) ?(host="127.0.0.1") ?(schemas=[]) () : agent_c
       { protocol = "SSE"; url = Printf.sprintf "%s/sse" base_url };
       { protocol = "JSONRPC"; url = Printf.sprintf "%s/mcp" base_url };
       { protocol = "REST"; url = Printf.sprintf "%s/api/v1" base_url };
-      { protocol = "GRPC"; url = Printf.sprintf "grpc://%s:%d" host (port + 1000) };
+      { protocol = "GRPC"; url = Printf.sprintf "grpc://%s:%d" host (Masc_grpc_server.configured_port ()) };
     ];
     security_schemes = [
       ("bearer", {

--- a/lib/dune
+++ b/lib/dune
@@ -727,6 +727,8 @@
    cstruct
    digestif
    ocaml-protoc-plugin
+   ;; Protobuf-generated types from proto/masc_coordination.proto
+   masc_proto
    ;; grpc grpc-lwt - disabled (h2 version conflict with httpun-eio)
    ;; grpc-direct (native Eio gRPC from lib/grpc-direct)
    grpc-direct

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -63,7 +63,8 @@ let leave t ~sw ~env ~agent_name ~session_id =
     ~decode:T.LeaveResponse.of_bytes
 
 let get_status t ~sw ~env =
-  let request = "{}" in
+  (* StatusRequest is an empty protobuf message: 0 bytes on the wire. *)
+  let request = "" in
   call_unary_safe t ~sw ~env ~method_:"GetStatus" ~request
     ~decode:T.StatusResponse.of_bytes
 

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -1,11 +1,30 @@
 (** MASC gRPC Coordination Types.
 
-    Wire format: JSON-encoded strings over gRPC framing.
-    This avoids a protobuf codegen dependency while keeping the proto file
-    as the canonical API contract.
+    Wire format: protobuf binary over gRPC framing.
+    Types are generated from proto/masc_coordination.proto via ocaml-protoc-plugin.
 
     Each message type provides [to_bytes] and [of_bytes] for the
-    grpc-direct handler interface (string -> string). *)
+    grpc-direct handler interface (string -> string).
+
+    The generated protobuf modules live under [Masc_proto.Masc_coordination.Masc.Coordination.V1]. *)
+
+module P = Masc_proto.Masc_coordination.Masc.Coordination.V1
+
+(** {1 Protobuf Serialization Helpers} *)
+
+(** Serialize a protobuf message to a binary string. *)
+let encode to_proto msg =
+  Ocaml_protoc_plugin.Writer.contents (to_proto msg)
+
+(** Deserialize a protobuf message from a binary string.
+    Raises [Failure] on parse error for backward compatibility. *)
+let decode from_proto bytes =
+  let reader = Ocaml_protoc_plugin.Reader.create bytes in
+  match from_proto reader with
+  | Ok v -> v
+  | Error e ->
+    failwith (Printf.sprintf "protobuf decode error: %s"
+      (Ocaml_protoc_plugin.Result.show_error e))
 
 (** {1 Shared Types} *)
 
@@ -26,60 +45,41 @@ type task_info = {
   priority : int;
 }
 
-(** {1 JSON Helpers} *)
+(** Convert our [agent_info] to a protobuf AgentInfo and back. *)
+let agent_info_to_proto (a : agent_info) : P.AgentInfo.t =
+  { name = a.name;
+    status = a.status;
+    capabilities = a.capabilities;
+    last_heartbeat_ms = a.last_heartbeat_ms;
+    joined_at_ms = a.joined_at_ms;
+    current_task_id = a.current_task_id;
+  }
 
-let string_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`String s) -> s
-    | _ -> "")
-  | _ -> ""
+let agent_info_of_proto (p : P.AgentInfo.t) : agent_info =
+  { name = p.name;
+    status = p.status;
+    capabilities = p.capabilities;
+    last_heartbeat_ms = p.last_heartbeat_ms;
+    joined_at_ms = p.joined_at_ms;
+    current_task_id = p.current_task_id;
+  }
 
-let string_list_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`List items) ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-    | _ -> [])
-  | _ -> []
+(** Convert our [task_info] to a protobuf TaskInfo and back. *)
+let task_info_to_proto (t : task_info) : P.TaskInfo.t =
+  { id = t.id;
+    title = t.title;
+    status = t.status;
+    assigned_to = t.assigned_to;
+    priority = t.priority;
+  }
 
-let int64_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`Int n) -> Int64.of_int n
-    | Some (`Intlit s) -> (
-      match Int64.of_string_opt s with Some n -> n | None -> 0L)
-    | _ -> 0L)
-  | _ -> 0L
-
-let int_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`Int n) -> n
-    | _ -> 0)
-  | _ -> 0
-
-let bool_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`Bool b) -> b
-    | _ -> false)
-  | _ -> false
-
-let string_map_of_json key json =
-  match json with
-  | `Assoc fields -> (
-    match List.assoc_opt key fields with
-    | Some (`Assoc pairs) ->
-      List.filter_map (fun (k, v) ->
-        match v with `String s -> Some (k, s) | _ -> None) pairs
-    | _ -> [])
-  | _ -> []
+let task_info_of_proto (p : P.TaskInfo.t) : task_info =
+  { id = p.id;
+    title = p.title;
+    status = p.status;
+    assigned_to = p.assigned_to;
+    priority = p.priority;
+  }
 
 (** {1 Agent Lifecycle} *)
 
@@ -91,41 +91,19 @@ module JoinRequest = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      capabilities = string_list_of_json "capabilities" json;
-      metadata = string_map_of_json "metadata" json;
+    let p = decode P.JoinRequest.from_proto bytes in
+    { agent_name = p.agent_name;
+      capabilities = p.capabilities;
+      metadata = p.metadata;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("capabilities", `List (List.map (fun s -> `String s) t.capabilities));
-      ("metadata", `Assoc (List.map (fun (k, v) -> (k, `String v)) t.metadata));
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.JoinRequest.to_proto
+      { agent_name = t.agent_name;
+        capabilities = t.capabilities;
+        metadata = t.metadata;
+      }
 end
-
-let agent_info_to_json (a : agent_info) : Yojson.Safe.t =
-  `Assoc [
-    ("name", `String a.name);
-    ("status", `String a.status);
-    ("capabilities", `List (List.map (fun s -> `String s) a.capabilities));
-    ("last_heartbeat_ms", `Intlit (Int64.to_string a.last_heartbeat_ms));
-    ("joined_at_ms", `Intlit (Int64.to_string a.joined_at_ms));
-    ("current_task_id", `String a.current_task_id);
-  ]
-
-let agent_info_of_json (json : Yojson.Safe.t) : agent_info =
-  {
-    name = string_of_json "name" json;
-    status = string_of_json "status" json;
-    capabilities = string_list_of_json "capabilities" json;
-    last_heartbeat_ms = int64_of_json "last_heartbeat_ms" json;
-    joined_at_ms = int64_of_json "joined_at_ms" json;
-    current_task_id = string_of_json "current_task_id" json;
-  }
 
 module JoinResponse = struct
   type t = {
@@ -136,29 +114,20 @@ module JoinResponse = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    let active_agents = match json with
-      | `Assoc fields -> (
-        match List.assoc_opt "active_agents" fields with
-        | Some (`List items) -> List.map agent_info_of_json items
-        | _ -> [])
-      | _ -> []
-    in
-    {
-      success = bool_of_json "success" json;
-      message = string_of_json "message" json;
-      session_id = string_of_json "session_id" json;
-      active_agents;
+    let p = decode P.JoinResponse.from_proto bytes in
+    { success = p.success;
+      message = p.message;
+      session_id = p.session_id;
+      active_agents = List.map agent_info_of_proto p.active_agents;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("success", `Bool t.success);
-      ("message", `String t.message);
-      ("session_id", `String t.session_id);
-      ("active_agents", `List (List.map agent_info_to_json t.active_agents));
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.JoinResponse.to_proto
+      { success = t.success;
+        message = t.message;
+        session_id = t.session_id;
+        active_agents = List.map agent_info_to_proto t.active_agents;
+      }
 end
 
 module LeaveRequest = struct
@@ -168,18 +137,16 @@ module LeaveRequest = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      session_id = string_of_json "session_id" json;
+    let p = decode P.LeaveRequest.from_proto bytes in
+    { agent_name = p.agent_name;
+      session_id = p.session_id;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("session_id", `String t.session_id);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.LeaveRequest.to_proto
+      { agent_name = t.agent_name;
+        session_id = t.session_id;
+      }
 end
 
 module LeaveResponse = struct
@@ -189,18 +156,16 @@ module LeaveResponse = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      success = bool_of_json "success" json;
-      message = string_of_json "message" json;
+    let p = decode P.LeaveResponse.from_proto bytes in
+    { success = p.success;
+      message = p.message;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("success", `Bool t.success);
-      ("message", `String t.message);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.LeaveResponse.to_proto
+      { success = t.success;
+        message = t.message;
+      }
 end
 
 (** {1 Heartbeat} *)
@@ -214,22 +179,20 @@ module HeartbeatPing = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      session_id = string_of_json "session_id" json;
-      timestamp_ms = int64_of_json "timestamp_ms" json;
-      current_task_id = string_of_json "current_task_id" json;
+    let p = decode P.HeartbeatPing.from_proto bytes in
+    { agent_name = p.agent_name;
+      session_id = p.session_id;
+      timestamp_ms = p.timestamp_ms;
+      current_task_id = p.current_task_id;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("session_id", `String t.session_id);
-      ("timestamp_ms", `Intlit (Int64.to_string t.timestamp_ms));
-      ("current_task_id", `String t.current_task_id);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.HeartbeatPing.to_proto
+      { agent_name = t.agent_name;
+        session_id = t.session_id;
+        timestamp_ms = t.timestamp_ms;
+        current_task_id = t.current_task_id;
+      }
 end
 
 module HeartbeatAck = struct
@@ -241,22 +204,20 @@ module HeartbeatAck = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      timestamp_ms = int64_of_json "timestamp_ms" json;
-      active_agent_count = int_of_json "active_agent_count" json;
-      pending_task_count = int_of_json "pending_task_count" json;
-      directives = string_list_of_json "directives" json;
+    let p = decode P.HeartbeatAck.from_proto bytes in
+    { timestamp_ms = p.timestamp_ms;
+      active_agent_count = p.active_agent_count;
+      pending_task_count = p.pending_task_count;
+      directives = p.directives;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("timestamp_ms", `Intlit (Int64.to_string t.timestamp_ms));
-      ("active_agent_count", `Int t.active_agent_count);
-      ("pending_task_count", `Int t.pending_task_count);
-      ("directives", `List (List.map (fun s -> `String s) t.directives));
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.HeartbeatAck.to_proto
+      { timestamp_ms = t.timestamp_ms;
+        active_agent_count = t.active_agent_count;
+        pending_task_count = t.pending_task_count;
+        directives = t.directives;
+      }
 end
 
 (** {1 Event Subscription} *)
@@ -270,24 +231,22 @@ module SubscribeRequest = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      session_id = string_of_json "session_id" json;
-      event_types = string_list_of_json "event_types" json;
-      since_seq = int64_of_json "since_seq" json;
+    let p = decode P.SubscribeRequest.from_proto bytes in
+    { agent_name = p.agent_name;
+      session_id = p.session_id;
+      event_types = p.event_types;
+      since_seq = p.since_seq;
     }
 end
 
 module SubscribeRequest_serde = struct
   let to_bytes (t : SubscribeRequest.t) =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("session_id", `String t.session_id);
-      ("event_types", `List (List.map (fun s -> `String s) t.event_types));
-      ("since_seq", `Intlit (Int64.to_string t.since_seq));
-    ]
-    |> Yojson.Safe.to_string
+    encode P.SubscribeRequest.to_proto
+      { agent_name = t.agent_name;
+        session_id = t.session_id;
+        event_types = t.event_types;
+        since_seq = t.since_seq;
+      }
 end
 
 module Event = struct
@@ -300,24 +259,22 @@ module Event = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      seq = int64_of_json "seq" json;
-      event_type = string_of_json "event_type" json;
-      source_agent = string_of_json "source_agent" json;
-      timestamp_ms = int64_of_json "timestamp_ms" json;
-      payload_json = string_of_json "payload_json" json;
+    let p = decode P.Event.from_proto bytes in
+    { seq = p.seq;
+      event_type = p.event_type;
+      source_agent = p.source_agent;
+      timestamp_ms = p.timestamp_ms;
+      payload_json = p.payload_json;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("seq", `Intlit (Int64.to_string t.seq));
-      ("event_type", `String t.event_type);
-      ("source_agent", `String t.source_agent);
-      ("timestamp_ms", `Intlit (Int64.to_string t.timestamp_ms));
-      ("payload_json", `String t.payload_json);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.Event.to_proto
+      { seq = t.seq;
+        event_type = t.event_type;
+        source_agent = t.source_agent;
+        timestamp_ms = t.timestamp_ms;
+        payload_json = t.payload_json;
+      }
 end
 
 (** {1 Tool Call} *)
@@ -331,22 +288,20 @@ module ToolCallRequest = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      session_id = string_of_json "session_id" json;
-      tool_name = string_of_json "tool_name" json;
-      arguments_json = string_of_json "arguments_json" json;
+    let p = decode P.ToolCallRequest.from_proto bytes in
+    { agent_name = p.agent_name;
+      session_id = p.session_id;
+      tool_name = p.tool_name;
+      arguments_json = p.arguments_json;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("session_id", `String t.session_id);
-      ("tool_name", `String t.tool_name);
-      ("arguments_json", `String t.arguments_json);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.ToolCallRequest.to_proto
+      { agent_name = t.agent_name;
+        session_id = t.session_id;
+        tool_name = t.tool_name;
+        arguments_json = t.arguments_json;
+      }
 end
 
 module ToolCallResponse = struct
@@ -358,22 +313,20 @@ module ToolCallResponse = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      success = bool_of_json "success" json;
-      result_json = string_of_json "result_json" json;
-      error_message = string_of_json "error_message" json;
-      error_code = int_of_json "error_code" json;
+    let p = decode P.ToolCallResponse.from_proto bytes in
+    { success = p.success;
+      result_json = p.result_json;
+      error_message = p.error_message;
+      error_code = p.error_code;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("success", `Bool t.success);
-      ("result_json", `String t.result_json);
-      ("error_message", `String t.error_message);
-      ("error_code", `Int t.error_code);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.ToolCallResponse.to_proto
+      { success = t.success;
+        result_json = t.result_json;
+        error_message = t.error_message;
+        error_code = t.error_code;
+      }
 end
 
 (** {1 Broadcast} *)
@@ -386,20 +339,18 @@ module BroadcastRequest = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      agent_name = string_of_json "agent_name" json;
-      message = string_of_json "message" json;
-      mentions = string_list_of_json "mentions" json;
+    let p = decode P.BroadcastRequest.from_proto bytes in
+    { agent_name = p.agent_name;
+      message = p.message;
+      mentions = p.mentions;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agent_name", `String t.agent_name);
-      ("message", `String t.message);
-      ("mentions", `List (List.map (fun s -> `String s) t.mentions));
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.BroadcastRequest.to_proto
+      { agent_name = t.agent_name;
+        message = t.message;
+        mentions = t.mentions;
+      }
 end
 
 module BroadcastResponse = struct
@@ -409,39 +360,19 @@ module BroadcastResponse = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    {
-      success = bool_of_json "success" json;
-      seq = int64_of_json "seq" json;
+    let p = decode P.BroadcastResponse.from_proto bytes in
+    { success = p.success;
+      seq = p.seq;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("success", `Bool t.success);
-      ("seq", `Intlit (Int64.to_string t.seq));
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.BroadcastResponse.to_proto
+      { success = t.success;
+        seq = t.seq;
+      }
 end
 
 (** {1 Status} *)
-
-let task_info_to_json (t : task_info) : Yojson.Safe.t =
-  `Assoc [
-    ("id", `String t.id);
-    ("title", `String t.title);
-    ("status", `String t.status);
-    ("assigned_to", `String t.assigned_to);
-    ("priority", `Int t.priority);
-  ]
-
-let task_info_of_json (json : Yojson.Safe.t) : task_info =
-  {
-    id = string_of_json "id" json;
-    title = string_of_json "title" json;
-    status = string_of_json "status" json;
-    assigned_to = string_of_json "assigned_to" json;
-    priority = int_of_json "priority" json;
-  }
 
 module StatusResponse = struct
   type t = {
@@ -452,34 +383,18 @@ module StatusResponse = struct
   }
 
   let of_bytes bytes =
-    let json = Yojson.Safe.from_string bytes in
-    let agents = match json with
-      | `Assoc fields -> (
-        match List.assoc_opt "agents" fields with
-        | Some (`List items) -> List.map agent_info_of_json items
-        | _ -> [])
-      | _ -> []
-    in
-    let tasks = match json with
-      | `Assoc fields -> (
-        match List.assoc_opt "tasks" fields with
-        | Some (`List items) -> List.map task_info_of_json items
-        | _ -> [])
-      | _ -> []
-    in
-    {
-      agents;
-      tasks;
-      message_count = int_of_json "message_count" json;
-      room_path = string_of_json "room_path" json;
+    let p = decode P.StatusResponse.from_proto bytes in
+    { agents = List.map agent_info_of_proto p.agents;
+      tasks = List.map task_info_of_proto p.tasks;
+      message_count = p.message_count;
+      room_path = p.room_path;
     }
 
-  let to_bytes t =
-    `Assoc [
-      ("agents", `List (List.map agent_info_to_json t.agents));
-      ("tasks", `List (List.map task_info_to_json t.tasks));
-      ("message_count", `Int t.message_count);
-      ("room_path", `String t.room_path);
-    ]
-    |> Yojson.Safe.to_string
+  let to_bytes (t : t) =
+    encode P.StatusResponse.to_proto
+      { agents = List.map agent_info_to_proto t.agents;
+        tasks = List.map task_info_to_proto t.tasks;
+        message_count = t.message_count;
+        room_path = t.room_path;
+      }
 end

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -1,7 +1,7 @@
 (** MASC gRPC Coordination Types.
 
-    Wire format: JSON-encoded strings over gRPC framing.
-    See proto/masc_coordination.proto for the canonical API contract.
+    Wire format: protobuf binary over gRPC framing.
+    Types are generated from proto/masc_coordination.proto via ocaml-protoc-plugin.
 
     Each message provides [to_bytes] and [of_bytes] for both server
     (request decode + response encode) and client (request encode +
@@ -37,9 +37,6 @@ module JoinRequest : sig
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
-
-val agent_info_to_json : agent_info -> Yojson.Safe.t
-val agent_info_of_json : Yojson.Safe.t -> agent_info
 
 module JoinResponse : sig
   type t = {
@@ -169,9 +166,6 @@ module BroadcastResponse : sig
 end
 
 (** {1 Status} *)
-
-val task_info_to_json : task_info -> Yojson.Safe.t
-val task_info_of_json : Yojson.Safe.t -> task_info
 
 module StatusResponse : sig
   type t = {

--- a/proto/dune
+++ b/proto/dune
@@ -1,0 +1,13 @@
+;; Protobuf code generation for MASC coordination protocol.
+;; Uses ocaml-protoc-plugin to generate OCaml types with binary serialization.
+
+(library
+ (name masc_proto)
+ (public_name masc_mcp.proto)
+ (libraries ocaml-protoc-plugin))
+
+(rule
+ (targets masc_coordination.ml)
+ (deps masc_coordination.proto)
+ (action
+  (run protoc --ocaml_out=int64_as_int=false:. -I . masc_coordination.proto)))

--- a/test/test_agent_card_coverage.ml
+++ b/test/test_agent_card_coverage.ml
@@ -129,7 +129,7 @@ let test_binding_json_roundtrip () =
 let test_binding_grpc () =
   let b : Agent_card.binding = {
     protocol = "GRPC";
-    url = "grpc://127.0.0.1:9935";
+    url = "grpc://127.0.0.1:8936";
   } in
   let json = Agent_card.binding_to_yojson b in
   match Agent_card.binding_of_yojson json with

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -1,7 +1,10 @@
 (** Tests for MASC gRPC Coordination Service.
 
     Tests the types, service construction, and handler logic without
-    requiring a running gRPC server or network connections. *)
+    requiring a running gRPC server or network connections.
+
+    Wire format: protobuf binary (not JSON). Tests verify roundtrip
+    serialization/deserialization via of_bytes/to_bytes. *)
 
 module T = Masc_mcp.Masc_grpc_types
 
@@ -32,7 +35,7 @@ let test_leave_request_roundtrip () =
   Alcotest.(check string) "agent_name" req.agent_name decoded.agent_name;
   Alcotest.(check string) "session_id" req.session_id decoded.session_id
 
-let test_join_response_serialization () =
+let test_join_response_roundtrip () =
   let resp = T.JoinResponse.{
     success = true;
     message = "Joined room";
@@ -49,15 +52,15 @@ let test_join_response_serialization () =
     ];
   } in
   let bytes = T.JoinResponse.to_bytes resp in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check bool) "success" true (json |> member "success" |> to_bool);
-  Alcotest.(check string) "message" "Joined room" (json |> member "message" |> to_string);
-  Alcotest.(check string) "session_id" "grpc-test-001" (json |> member "session_id" |> to_string);
-  let agents = json |> member "active_agents" |> to_list in
-  Alcotest.(check int) "active_agents count" 1 (List.length agents);
-  let agent = List.hd agents in
-  Alcotest.(check string) "agent name" "claude-swift-fox" (agent |> member "name" |> to_string)
+  let decoded = T.JoinResponse.of_bytes bytes in
+  Alcotest.(check bool) "success" true decoded.success;
+  Alcotest.(check string) "message" "Joined room" decoded.message;
+  Alcotest.(check string) "session_id" "grpc-test-001" decoded.session_id;
+  Alcotest.(check int) "active_agents count" 1 (List.length decoded.active_agents);
+  let agent = List.hd decoded.active_agents in
+  Alcotest.(check string) "agent name" "claude-swift-fox" agent.T.name;
+  Alcotest.(check string) "agent status" "active" agent.T.status;
+  Alcotest.(check (list string)) "agent capabilities" ["code"] agent.T.capabilities
 
 let test_broadcast_request_roundtrip () =
   let req = T.BroadcastRequest.{
@@ -65,31 +68,34 @@ let test_broadcast_request_roundtrip () =
     message = "CI fixed, ready to merge";
     mentions = ["claude"; "gemini"];
   } in
-  let bytes = T.BroadcastRequest.of_bytes (T.BroadcastRequest.(
-    `Assoc [
-      ("agent_name", `String req.agent_name);
-      ("message", `String req.message);
-      ("mentions", `List (List.map (fun s -> `String s) req.mentions));
-    ] |> Yojson.Safe.to_string)) in
-  Alcotest.(check string) "agent_name" req.agent_name bytes.agent_name;
-  Alcotest.(check string) "message" req.message bytes.message;
-  Alcotest.(check (list string)) "mentions" req.mentions bytes.mentions
+  let bytes = T.BroadcastRequest.to_bytes req in
+  let decoded = T.BroadcastRequest.of_bytes bytes in
+  Alcotest.(check string) "agent_name" req.agent_name decoded.agent_name;
+  Alcotest.(check string) "message" req.message decoded.message;
+  Alcotest.(check (list string)) "mentions" req.mentions decoded.mentions
 
-let test_broadcast_response_serialization () =
+let test_broadcast_response_roundtrip () =
   let resp = T.BroadcastResponse.{ success = true; seq = 42L } in
   let bytes = T.BroadcastResponse.to_bytes resp in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check bool) "success" true (json |> member "success" |> to_bool)
+  let decoded = T.BroadcastResponse.of_bytes bytes in
+  Alcotest.(check bool) "success" true decoded.success;
+  Alcotest.(check int64) "seq" 42L decoded.seq
 
-let test_heartbeat_ping_deserialization () =
-  let json_str = {|{"agent_name":"test-agent","session_id":"sess-1","timestamp_ms":1700000000000,"current_task_id":"task-42"}|} in
-  let ping = T.HeartbeatPing.of_bytes json_str in
-  Alcotest.(check string) "agent_name" "test-agent" ping.agent_name;
-  Alcotest.(check string) "session_id" "sess-1" ping.session_id;
-  Alcotest.(check string) "current_task_id" "task-42" ping.current_task_id
+let test_heartbeat_ping_roundtrip () =
+  let ping = T.HeartbeatPing.{
+    agent_name = "test-agent";
+    session_id = "sess-1";
+    timestamp_ms = 1700000000000L;
+    current_task_id = "task-42";
+  } in
+  let bytes = T.HeartbeatPing.to_bytes ping in
+  let decoded = T.HeartbeatPing.of_bytes bytes in
+  Alcotest.(check string) "agent_name" "test-agent" decoded.agent_name;
+  Alcotest.(check string) "session_id" "sess-1" decoded.session_id;
+  Alcotest.(check int64) "timestamp_ms" 1700000000000L decoded.timestamp_ms;
+  Alcotest.(check string) "current_task_id" "task-42" decoded.current_task_id
 
-let test_heartbeat_ack_serialization () =
+let test_heartbeat_ack_roundtrip () =
   let ack = T.HeartbeatAck.{
     timestamp_ms = 1700000000001L;
     active_agent_count = 5;
@@ -97,20 +103,26 @@ let test_heartbeat_ack_serialization () =
     directives = ["rebalance"];
   } in
   let bytes = T.HeartbeatAck.to_bytes ack in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check int) "active_agent_count" 5 (json |> member "active_agent_count" |> to_int);
-  Alcotest.(check int) "pending_task_count" 3 (json |> member "pending_task_count" |> to_int);
-  let dirs = json |> member "directives" |> to_list |> List.map to_string in
-  Alcotest.(check (list string)) "directives" ["rebalance"] dirs
+  let decoded = T.HeartbeatAck.of_bytes bytes in
+  Alcotest.(check int64) "timestamp_ms" 1700000000001L decoded.timestamp_ms;
+  Alcotest.(check int) "active_agent_count" 5 decoded.active_agent_count;
+  Alcotest.(check int) "pending_task_count" 3 decoded.pending_task_count;
+  Alcotest.(check (list string)) "directives" ["rebalance"] decoded.directives
 
-let test_subscribe_request_deserialization () =
-  let json_str = {|{"agent_name":"test","session_id":"s1","event_types":["message","task"],"since_seq":100}|} in
-  let req = T.SubscribeRequest.of_bytes json_str in
-  Alcotest.(check string) "agent_name" "test" req.agent_name;
-  Alcotest.(check (list string)) "event_types" ["message"; "task"] req.event_types
+let test_subscribe_request_roundtrip () =
+  let req = T.SubscribeRequest.{
+    agent_name = "test";
+    session_id = "s1";
+    event_types = ["message"; "task"];
+    since_seq = 100L;
+  } in
+  let bytes = Masc_mcp.Masc_grpc_types.SubscribeRequest_serde.to_bytes req in
+  let decoded = T.SubscribeRequest.of_bytes bytes in
+  Alcotest.(check string) "agent_name" "test" decoded.agent_name;
+  Alcotest.(check (list string)) "event_types" ["message"; "task"] decoded.event_types;
+  Alcotest.(check int64) "since_seq" 100L decoded.since_seq
 
-let test_event_serialization () =
+let test_event_roundtrip () =
   let event = T.Event.{
     seq = 42L;
     event_type = "broadcast";
@@ -119,19 +131,27 @@ let test_event_serialization () =
     payload_json = {|{"text":"hello"}|};
   } in
   let bytes = T.Event.to_bytes event in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string) "event_type" "broadcast" (json |> member "event_type" |> to_string);
-  Alcotest.(check string) "source_agent" "claude" (json |> member "source_agent" |> to_string);
-  Alcotest.(check string) "payload_json" {|{"text":"hello"}|} (json |> member "payload_json" |> to_string)
+  let decoded = T.Event.of_bytes bytes in
+  Alcotest.(check int64) "seq" 42L decoded.seq;
+  Alcotest.(check string) "event_type" "broadcast" decoded.event_type;
+  Alcotest.(check string) "source_agent" "claude" decoded.source_agent;
+  Alcotest.(check int64) "timestamp_ms" 1700000000000L decoded.timestamp_ms;
+  Alcotest.(check string) "payload_json" {|{"text":"hello"}|} decoded.payload_json
 
-let test_tool_call_request_deserialization () =
-  let json_str = {|{"agent_name":"test","session_id":"s1","tool_name":"masc_status","arguments_json":"{}"}|} in
-  let req = T.ToolCallRequest.of_bytes json_str in
-  Alcotest.(check string) "tool_name" "masc_status" req.tool_name;
-  Alcotest.(check string) "arguments_json" "{}" req.arguments_json
+let test_tool_call_request_roundtrip () =
+  let req = T.ToolCallRequest.{
+    agent_name = "test";
+    session_id = "s1";
+    tool_name = "masc_status";
+    arguments_json = "{}";
+  } in
+  let bytes = T.ToolCallRequest.to_bytes req in
+  let decoded = T.ToolCallRequest.of_bytes bytes in
+  Alcotest.(check string) "agent_name" "test" decoded.agent_name;
+  Alcotest.(check string) "tool_name" "masc_status" decoded.tool_name;
+  Alcotest.(check string) "arguments_json" "{}" decoded.arguments_json
 
-let test_tool_call_response_serialization () =
+let test_tool_call_response_roundtrip () =
   let resp = T.ToolCallResponse.{
     success = true;
     result_json = {|{"status":"ok"}|};
@@ -139,12 +159,13 @@ let test_tool_call_response_serialization () =
     error_code = 0;
   } in
   let bytes = T.ToolCallResponse.to_bytes resp in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check bool) "success" true (json |> member "success" |> to_bool);
-  Alcotest.(check string) "result_json" {|{"status":"ok"}|} (json |> member "result_json" |> to_string)
+  let decoded = T.ToolCallResponse.of_bytes bytes in
+  Alcotest.(check bool) "success" true decoded.success;
+  Alcotest.(check string) "result_json" {|{"status":"ok"}|} decoded.result_json;
+  Alcotest.(check string) "error_message" "" decoded.error_message;
+  Alcotest.(check int) "error_code" 0 decoded.error_code
 
-let test_status_response_serialization () =
+let test_status_response_roundtrip () =
   let resp = T.StatusResponse.{
     agents = [
       {
@@ -169,16 +190,15 @@ let test_status_response_serialization () =
     room_path = "/tmp/test";
   } in
   let bytes = T.StatusResponse.to_bytes resp in
-  let json = Yojson.Safe.from_string bytes in
-  let open Yojson.Safe.Util in
-  Alcotest.(check int) "message_count" 10 (json |> member "message_count" |> to_int);
-  Alcotest.(check string) "room_path" "/tmp/test" (json |> member "room_path" |> to_string);
-  let agents = json |> member "agents" |> to_list in
-  Alcotest.(check int) "agents count" 1 (List.length agents);
-  let tasks = json |> member "tasks" |> to_list in
-  Alcotest.(check int) "tasks count" 1 (List.length tasks);
-  let task = List.hd tasks in
-  Alcotest.(check string) "task title" "Fix bug" (task |> member "title" |> to_string)
+  let decoded = T.StatusResponse.of_bytes bytes in
+  Alcotest.(check int) "message_count" 10 decoded.message_count;
+  Alcotest.(check string) "room_path" "/tmp/test" decoded.room_path;
+  Alcotest.(check int) "agents count" 1 (List.length decoded.agents);
+  Alcotest.(check int) "tasks count" 1 (List.length decoded.tasks);
+  let task = List.hd decoded.tasks in
+  Alcotest.(check string) "task title" "Fix bug" task.T.title;
+  Alcotest.(check string) "task assigned_to" "a1" task.T.assigned_to;
+  Alcotest.(check int) "task priority" 2 task.T.priority
 
 (* ====== Service construction test ====== *)
 
@@ -203,37 +223,28 @@ let test_grpc_disabled_by_default () =
   (match was_set with Some v -> Unix.putenv "MASC_GRPC_ENABLED" v | None -> ())
 
 let test_empty_request_handling () =
-  (* Verify graceful handling of minimal JSON input *)
-  let req = T.JoinRequest.of_bytes {|{"agent_name":""}|} in
+  (* Verify graceful handling of empty protobuf message (all defaults). *)
+  let bytes = T.JoinRequest.to_bytes {
+    agent_name = "";
+    capabilities = [];
+    metadata = [];
+  } in
+  let req = T.JoinRequest.of_bytes bytes in
   Alcotest.(check string) "empty agent_name" "" req.agent_name;
   Alcotest.(check (list string)) "empty capabilities" [] req.capabilities
 
-let test_agent_info_to_json () =
-  let info : T.agent_info = {
-    name = "test";
-    status = "active";
-    capabilities = ["a"; "b"];
-    last_heartbeat_ms = 100L;
-    joined_at_ms = 50L;
-    current_task_id = "t1";
+let test_protobuf_binary_format () =
+  (* Verify that serialized output is protobuf binary, not JSON. *)
+  let req = T.JoinRequest.{
+    agent_name = "test";
+    capabilities = [];
+    metadata = [];
   } in
-  let json = T.agent_info_to_json info in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string) "name" "test" (json |> member "name" |> to_string);
-  Alcotest.(check string) "status" "active" (json |> member "status" |> to_string)
-
-let test_task_info_to_json () =
-  let info : T.task_info = {
-    id = "task-1";
-    title = "Review PR";
-    status = "pending";
-    assigned_to = "";
-    priority = 3;
-  } in
-  let json = T.task_info_to_json info in
-  let open Yojson.Safe.Util in
-  Alcotest.(check string) "id" "task-1" (json |> member "id" |> to_string);
-  Alcotest.(check int) "priority" 3 (json |> member "priority" |> to_int)
+  let bytes = T.JoinRequest.to_bytes req in
+  (* Protobuf binary does not start with '{' like JSON. *)
+  Alcotest.(check bool) "not JSON"
+    true
+    (String.length bytes = 0 || bytes.[0] <> '{')
 
 (* ====== Test suite ====== *)
 
@@ -244,19 +255,18 @@ let () =
         [
           Alcotest.test_case "JoinRequest" `Quick test_join_request_roundtrip;
           Alcotest.test_case "LeaveRequest" `Quick test_leave_request_roundtrip;
-          Alcotest.test_case "JoinResponse" `Quick test_join_response_serialization;
+          Alcotest.test_case "JoinResponse" `Quick test_join_response_roundtrip;
           Alcotest.test_case "BroadcastRequest" `Quick test_broadcast_request_roundtrip;
-          Alcotest.test_case "BroadcastResponse" `Quick test_broadcast_response_serialization;
-          Alcotest.test_case "HeartbeatPing" `Quick test_heartbeat_ping_deserialization;
-          Alcotest.test_case "HeartbeatAck" `Quick test_heartbeat_ack_serialization;
-          Alcotest.test_case "SubscribeRequest" `Quick test_subscribe_request_deserialization;
-          Alcotest.test_case "Event" `Quick test_event_serialization;
-          Alcotest.test_case "ToolCallRequest" `Quick test_tool_call_request_deserialization;
-          Alcotest.test_case "ToolCallResponse" `Quick test_tool_call_response_serialization;
-          Alcotest.test_case "StatusResponse" `Quick test_status_response_serialization;
+          Alcotest.test_case "BroadcastResponse" `Quick test_broadcast_response_roundtrip;
+          Alcotest.test_case "HeartbeatPing" `Quick test_heartbeat_ping_roundtrip;
+          Alcotest.test_case "HeartbeatAck" `Quick test_heartbeat_ack_roundtrip;
+          Alcotest.test_case "SubscribeRequest" `Quick test_subscribe_request_roundtrip;
+          Alcotest.test_case "Event" `Quick test_event_roundtrip;
+          Alcotest.test_case "ToolCallRequest" `Quick test_tool_call_request_roundtrip;
+          Alcotest.test_case "ToolCallResponse" `Quick test_tool_call_response_roundtrip;
+          Alcotest.test_case "StatusResponse" `Quick test_status_response_roundtrip;
           Alcotest.test_case "empty_request" `Quick test_empty_request_handling;
-          Alcotest.test_case "agent_info_to_json" `Quick test_agent_info_to_json;
-          Alcotest.test_case "task_info_to_json" `Quick test_task_info_to_json;
+          Alcotest.test_case "protobuf_binary" `Quick test_protobuf_binary_format;
         ] );
       ( "service",
         [


### PR DESCRIPTION
## Summary
gRPC 서버의 wire format을 JSON → protobuf binary로 전환. 표준 gRPC 클라이언트(grpcurl, grpcio-python 등)와 호환.

### Before
- `masc_grpc_types.ml`에서 Yojson으로 JSON 직렬화
- `grpcurl` 호출 시 `Yojson.Json_error` (protobuf bytes를 JSON으로 파싱 시도)
- 표준 gRPC 에코시스템과 완전히 호환 불가

### After
- `ocaml-protoc-plugin`으로 `proto/masc_coordination.proto`에서 OCaml 타입 자동 생성
- `of_bytes`/`to_bytes`가 protobuf binary Writer/Reader 사용
- `grpcurl -plaintext` 표준 호출 가능

## Changes
- `proto/dune`: protoc codegen 룰 추가
- `lib/grpc/masc_grpc_types.ml`: JSON 헬퍼 제거, protobuf 직렬화로 교체 (-402/+324 줄)
- `lib/grpc/masc_grpc_client.ml`: JSON `"{}"` → 빈 protobuf
- `lib/agent_card.ml`: gRPC 포트 `port+1000` → `configured_port()` (9935→8936)
- `test/test_grpc_coordination.ml`: protobuf roundtrip 테스트로 전면 재작성

## Closes
- #2599 (gRPC never initializes)
- #2601 (gRPC JSON/protobuf wire format mismatch)

## Test plan
- [x] `dune build --root .` 성공
- [x] 17 gRPC 테스트 통과
- [ ] `grpcurl -plaintext` E2E 테스트 (서버 기동 후)
- [ ] protobuf roundtrip: Join, Leave, Broadcast, GetStatus, ToolCall 검증

Generated with Claude Code