### PR TITLE
fix(mcp): ensure structuredContent is always an object

### DIFF
--- a/lib/tool_result.ml
+++ b/lib/tool_result.ml
@@ -13,8 +13,13 @@ let structured_payload_of_message (message : string) : Yojson.Safe.t option =
     with Yojson.Json_error _ -> None
   in
   let trimmed = String.trim message in
+  let ensure_object = function
+    | `Assoc _ as obj -> Some obj
+    | `List _ as arr -> Some (`Assoc [ ("items", arr) ])
+    | _ -> None
+  in
   match parse_json trimmed with
-  | Some _ as json -> json
+  | Some json -> ensure_object json
   | None ->
       let len = String.length message in
       let rec loop from =
@@ -30,7 +35,7 @@ let structured_payload_of_message (message : string) : Yojson.Safe.t option =
               match suffix.[0] with
               | '{' | '[' -> (
                   match parse_json suffix with
-                  | Some _ as json -> json
+                  | Some json -> ensure_object json
                   | None -> loop (newline_idx + 1))
               | _ -> loop (newline_idx + 1)
       in


### PR DESCRIPTION
## Summary

Closes #2600

`structured_payload_of_message`가 JSON array를 그대로 `structuredContent`에 반환하여 MCP 클라이언트에서 스키마 검증 실패.

MCP spec: `structuredContent`는 record(object)여야 함.

## 변경

`lib/tool_result.ml` — `ensure_object` 헬퍼 추가:
- `Assoc` (object) → 그대로 반환
- `List` (array) → `{"items": [...]}` 으로 wrapping
- 그 외 → `None` (structuredContent 미포함)

## 영향 도구

`convo_list` 등 array 형태의 JSON을 응답하는 모든 도구.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>