### PR TITLE
fix(board): replace Lazy.t with ref to prevent CamlinternalLazy.Undefined

### DIFF
--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -438,25 +438,33 @@ let delete_post store ~post_id : (unit, board_error) result =
             store.last_flush <- Time_compat.now ();
             Ok ())
 
-(** {1 Global Store} *)
+(** {1 Global Store}
 
-let make_global_lazy () = lazy (
-  let store = create_store () in
-  load_persisted_posts store;
-  load_persisted_comments store;
-  recalculate_reply_counts store;
-  load_persisted_votes store;
-  store
-)
+    Uses [ref option] instead of [Lazy.t] because [Lazy.force] is not
+    fiber-safe: when two Eio fibers force the same lazy concurrently,
+    the second raises [CamlinternalLazy.Undefined].
 
-let global_lazy = ref (make_global_lazy ())
+    Initialization is idempotent — the first call creates and stores the
+    instance, subsequent calls return it immediately. *)
 
-let global () = Lazy.force !global_lazy
+let global_store : store option ref = ref None
+
+let global () =
+  match !global_store with
+  | Some store -> store
+  | None ->
+    let store = create_store () in
+    load_persisted_posts store;
+    load_persisted_comments store;
+    recalculate_reply_counts store;
+    load_persisted_votes store;
+    global_store := Some store;
+    store
 
 (** Reset global store for test isolation. Next [global ()] call creates fresh store.
     Safe: only called from test setup before concurrent fibers exist. *)
 let reset_global_for_test () =
-  global_lazy := make_global_lazy ()
+  global_store := None
 
 (** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)
 let flush_dirty store =


### PR DESCRIPTION
## Summary
- Board global store의 `Lazy.t`를 `ref option`으로 교체
- `Lazy.force`는 Eio fiber-safe하지 않음: 두 fiber가 동시에 force하면 `CamlinternalLazy.Undefined` 발생
- 이 exception이 httpun error_handler로 전파되어 404 대신 500 반환

## Root Cause
```
500 Internal Server Error: CamlinternalLazy.Undefined
```
서버 시작 시 bootstrap fiber가 `Board.global()`을 초기화하는 동안
HTTP 요청 fiber가 같은 lazy를 force → `Undefined` exception

## Fix
`Lazy.t` → `ref option` + idempotent init. 동시 init 시 worst case는 두 fiber가 동등한 store를 생성하고 마지막 write가 승리 (데이터 동일).

## Test
- [x] `dune build` 성공
- [x] `test_board_api_e2e` 로컬 PASS (2.6초)
- [ ] CI Build and Test

Fixes #2597

Generated with [Claude Code](https://claude.com/claude-code)