### PR TITLE
fix(dashboard): improve intervene page UX — 5 fixes

### DIFF
--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -24,7 +24,7 @@ export function RoomTruthStrip() {
     <section class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3 mb-4">
       <article class="room-truth-card rounded-xl">
         <span class="room-truth-label">현황</span>
-        <strong>에이전트 ${counts?.agents ?? 0} · 태스크 ${counts?.tasks ?? 0} · 키퍼 ${counts?.keepers ?? 0}</strong>
+        <strong>에이전트 ${counts?.agents ?? 0} · 키퍼 ${counts?.keepers ?? 0}${(counts?.tasks ?? 0) > 0 ? ` · 태스크 ${counts?.tasks}` : ''}</strong>
         <p>${status?.project ?? 'project'} · ${status?.paused ? '일시정지' : '활성'}</p>
       </article>
 

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -3,7 +3,6 @@
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
 import { showToast } from '../common/toast'
-import { KeeperConversationPanel } from '../keeper-shared'
 import { openKeeperDetail } from '../keeper-detail'
 import { findKeeper } from '../execution/shared'
 import {
@@ -119,31 +118,6 @@ export function OpsKeeperColumn() {
                 </article>
               `)}
         </div>
-      </section>
-
-      <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel">
-        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">선택한 Keeper 액션</h3>
-        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">선택한 keeper에만 직접 메시지를 보내서 probe, 수정, 재지시를 합니다.</p>
-
-        ${selectedKeeper ? html`
-          <div class="flex flex-col gap-2">
-            <div class="text-[13px] font-semibold text-[var(--text-strong)]">${selectedKeeper.name}</div>
-            <div class="text-[11px] text-[var(--text-muted)] flex flex-wrap gap-2">
-              <span>세대: ${selectedKeeper.generation ?? 0}</span>
-              <span>활성 목표: ${selectedKeeper.active_goal_ids?.length ?? 0}</span>
-              ${typeof selectedKeeper.turn_count === 'number' ? html`<span>턴: ${selectedKeeper.turn_count}</span>` : null}
-              ${selectedKeeper.last_model_used ? html`<span>모델: ${selectedKeeper.last_model_used}</span>` : null}
-            </div>
-            ${keeperPriorityTone(selectedKeeper) !== 'ok'
-              ? html`<div class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-1">현재 점검 이유: ${keeperPrioritySummary(selectedKeeper)}</div>`
-              : null}
-            ${selectedKeeper.goal ? html`<div class="whitespace-normal mt-1.5 py-1 px-1.5 bg-[var(--white-3)] rounded text-[11px] text-[var(--text-muted)]">${selectedKeeper.goal}</div>` : null}
-          </div>
-          <${KeeperConversationPanel}
-            keeperName=${selectedKeeper.name}
-            placeholder="구조화된 probe, 방향 수정, 재지시 내용을 적으세요"
-          />
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 keeper를 하나 고르세요.</div>`}
       </section>
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -97,7 +97,7 @@ export function OpsRoomColumn() {
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
                 </div>
-                <div class="mt-1.5 whitespace-pre-wrap break-words">${item.reason}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${item.reason}</div>
                 ${item.suggested_payload ? html`
                   <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
                     <button class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
@@ -125,21 +125,21 @@ export function OpsRoomColumn() {
         ${confirmRequiredActions.length > 0 ? html`
           <div class="flex flex-col gap-2">
             ${confirmRequiredActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] min-w-0 flex-shrink-0">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}</span>
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
                 </div>
-                <div class="mt-1.5 whitespace-pre-wrap break-words">${item.description ?? '설명 확인 필요'}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${item.description ?? '설명 확인 필요'}</div>
               </article>
             `)}
           </div>
         ` : null}
         ${pendingConfirms.length > 0 ? html`
-          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex flex-col gap-3 max-h-[400px] overflow-y-auto min-w-0 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${pendingConfirms.map(item => html`
-              <article key=${item.confirm_token} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+              <article key=${item.confirm_token} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] min-w-0 flex-shrink-0">
                 <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
@@ -287,14 +287,14 @@ export function OpsRoomColumn() {
         </div>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">room 맥락은 참고만 하고, 실제 판단은 위의 개입 큐 기준으로 합니다.</p>
         ${roomFeed.length > 0 ? html`
-          <div class="flex items-center justify-between gap-3 text-[var(--fs-sm)] text-[var(--text-muted)]">
+          <div class="flex flex-col gap-3 max-h-[400px] overflow-y-auto min-w-0 text-[var(--fs-sm)] text-[var(--text-muted)]">
             ${roomFeed.map(message => html`
-              <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
+              <article key=${message.seq ?? message.id ?? message.timestamp} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] min-w-0 flex-shrink-0">
                 <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                   <strong>${message.from}</strong>
                   <span>${message.timestamp}</span>
                 </div>
-                <div class="mt-1.5 whitespace-pre-wrap break-words">${formatMessageContent(message.content)}</div>
+                <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${formatMessageContent(message.content)}</div>
               </article>
             `)}
           </div>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -139,6 +139,19 @@ export function OpsSessionColumn() {
     </button>
   `
 
+  if (sessions.length === 0) {
+    return html`
+      <div class="flex flex-col gap-4 min-w-0">
+        <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel">
+          <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+            <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Session 개입</h3>
+          </div>
+          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">활성 team session이 없습니다. keeper가 독립 운영 중입니다.</div>
+        </section>
+      </div>
+    `
+  }
+
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel">

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -56,7 +56,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
         </div>
         <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">태스크</div>
-          <strong class="mt-1 block text-[18px] font-semibold tabular-nums text-[var(--warn)]">${tasks.value.length}</strong>
+          <strong class="mt-1 block text-[18px] font-semibold tabular-nums ${tasks.value.length > 0 ? 'text-[var(--warn)]' : 'text-[var(--text-muted)]'}">${tasks.value.length}</strong>
         </div>
         <div class="rounded-md border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-3 py-2">
           <div class="text-[10px] text-[var(--text-muted)]">이벤트</div>

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -285,6 +285,7 @@ let allowed_origins = [
   "https://127.0.0.1";
   (* Cloudflare tunnel *)
   "https://masc.crying.pictures";
+  "https://masc-dev.crying.pictures";
 ]
 
 (** Validate Origin header for DNS rebinding protection *)


### PR DESCRIPTION
## Summary

실시간 개입(intervene) 페이지에서 발견된 5가지 UX 문제를 수정합니다.

- **Room 메시지 overflow**: `flex items-center justify-between` → `flex-col` + 스크롤 컨테이너 + 개별 메시지 높이 제한
- **Keeper DM 패널 제거**: keeper 상세 페이지와 중복되는 대화 패널을 개입 페이지에서 제거
- **Session column 축소**: team session이 없을 때 빈 form 대신 한 줄 메시지로 축소
- **태스크 0 노이즈**: Room Pulse에서 tasks=0일 때 warn 색상→muted, Room Truth Strip에서 0이면 비표시
- **MCP 403 수정**: `masc-dev.crying.pictures`를 allowed_origins에 추가

## Test plan

- [ ] `npm run build` 성공 확인
- [ ] `dune build --root .` 성공 확인
- [ ] `#command?section=intervene` 페이지에서 Room 메시지가 세로로 쌓이고 스크롤 가능한지 확인
- [ ] Keeper column에서 DM 패널이 없어지고 목록만 보이는지 확인
- [ ] team session 없을 때 Session column이 축소되는지 확인
- [ ] ROOM PULSE에서 태스크 0이 muted 색상인지 확인
- [ ] `masc-dev.crying.pictures`에서 MCP 호출 시 403이 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)