### PR TITLE
feat(ws): standalone WebSocket server on separate port

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -147,47 +147,20 @@ let make_extended_handler routes =
         match request.meth, path with
         | `OPTIONS, _ -> options_handler request reqd
         | `GET, "/ws" ->
-          (* WebSocket upgrade — opt-in via MASC_WS_ENABLED=1 *)
-          let ws_enabled = match Sys.getenv_opt "MASC_WS_ENABLED" with
-            | Some "1" | Some "true" -> true
-            | _ -> false
-          in
-          if ws_enabled then begin
-            let on_message ws_session_id body_str =
-              match (!Masc_mcp.Server_auth.server_state,
-                     Eio_context.get_switch_opt (),
-                     Eio_context.get_clock_opt ()) with
-              | Some state, Some sw, Some clock ->
-                Eio.Fiber.fork ~sw (fun () ->
-                  try
-                    let response_json =
-                      Mcp_eio.handle_request ~clock ~sw
-                        ~mcp_session_id:ws_session_id
-                        state body_str
-                    in
-                    let response_str = Yojson.Safe.to_string response_json in
-                    if response_str <> "null" then
-                      ignore (Masc_mcp.Server_mcp_transport_ws.send_to_session
-                        ws_session_id response_str)
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                    Log.Server.warn "WS dispatch error %s: %s"
-                      ws_session_id (Printexc.to_string exn))
-              | _ ->
-                Log.Server.warn "WS: server not ready for dispatch"
+          (* WebSocket runs on a separate standalone port (not HTTP upgrade).
+             This endpoint returns connection info or disabled status. *)
+          if Masc_mcp.Server_ws_standalone.is_enabled () then begin
+            let ws_port = Masc_mcp.Server_ws_standalone.configured_port () in
+            let body = Printf.sprintf
+              {|{"ws_port":%d,"message":"Connect to ws://localhost:%d/"}|}
+              ws_port ws_port
             in
-            match Masc_mcp.Server_mcp_transport_ws.upgrade_connection
-              ~on_message reqd with
-            | Ok () -> ()
-            | Error msg ->
-              let body = Printf.sprintf {|{"error":"ws_upgrade_failed","message":"%s"}|} msg in
-              let headers = Httpun.Headers.of_list [
-                ("content-type", "application/json");
-                ("content-length", string_of_int (String.length body));
-              ] in
-              let response = Httpun.Response.create ~headers `Bad_request in
-              Httpun.Reqd.respond_with_string reqd response body
+            let headers = Httpun.Headers.of_list [
+              ("content-type", "application/json");
+              ("content-length", string_of_int (String.length body));
+            ] in
+            let response = Httpun.Response.create ~headers `OK in
+            Httpun.Reqd.respond_with_string reqd response body
           end else begin
             let body = {|{"error":"websocket_disabled","message":"Set MASC_WS_ENABLED=1 to enable"}|} in
             let headers = Httpun.Headers.of_list [

--- a/lib/dune
+++ b/lib/dune
@@ -123,6 +123,7 @@
    server_mcp_transport_http_headers
    server_mcp_transport_http_sse
    server_mcp_transport_ws
+   server_ws_standalone
    server_webrtc_transport
    web_dashboard
    credits_dashboard

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -753,7 +753,23 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         if success then Ok result_str else Error result_str
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config
-        ~tool_dispatcher
+        ~tool_dispatcher;
+      (* Standalone WebSocket transport (opt-in via MASC_WS_ENABLED=1) *)
+      Server_ws_standalone.start ~sw ~env
+        ~on_message:(fun ws_session_id body_str ->
+          Eio.Fiber.fork ~sw (fun () ->
+            try
+              let response_json =
+                Mcp_eio.handle_request ~clock ~sw
+                  ~mcp_session_id:ws_session_id state body_str
+              in
+              let response_str = Yojson.Safe.to_string response_json in
+              if response_str <> "null" then
+                ignore (Server_mcp_transport_ws.send_to_session ws_session_id response_str)
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Server.warn "WS dispatch error %s: %s" ws_session_id (Printexc.to_string exn)))
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -1,0 +1,140 @@
+(** Standalone WebSocket server for MASC MCP.
+
+    Runs on a separate port (default 8937, configurable via MASC_WS_PORT).
+    Opt-in via MASC_WS_ENABLED=1.
+
+    Unlike the /ws upgrade path on the HTTP port, this server owns the
+    full TCP socket, so httpun-ws can run the HTTP->WS upgrade lifecycle
+    end-to-end without conflicting with gluten's protocol management.
+
+    Session state is shared with {!Server_mcp_transport_ws}: the same
+    [sessions] hashtable, [send_to_session], and [cleanup_session] are
+    reused.  This module only handles TCP accept + connection handler
+    wiring. *)
+
+module Ws = Httpun_ws
+module Ws_eio = Httpun_ws_eio
+
+let default_port = 8937
+
+(** Read the configured WS port from environment or use default. *)
+let configured_port () =
+  match Sys.getenv_opt "MASC_WS_PORT" with
+  | Some s -> (
+    match int_of_string_opt s with
+    | Some p when p > 0 && p < 65536 -> p
+    | _ ->
+      Log.Server.warn "MASC_WS_PORT=%s is not a valid port, using %d" s default_port;
+      default_port)
+  | None -> default_port
+
+(** Check whether standalone WS is enabled (default: disabled). *)
+let is_enabled () =
+  match Sys.getenv_opt "MASC_WS_ENABLED" with
+  | Some "1" | Some "true" -> true
+  | _ -> false
+
+(** WebSocket handler factory.
+
+    For each accepted connection, httpun-ws-eio calls this with the
+    client address and a [Wsd.t].  We create a session in the shared
+    registry and wire frame callbacks to [on_message]. *)
+let make_websocket_handler ~on_message _client_addr (wsd : Ws.Wsd.t) :
+    Ws.Websocket_connection.input_handlers =
+  let session_id = Server_mcp_transport_ws.next_id () in
+  let session : Server_mcp_transport_ws.ws_session =
+    { id = session_id; wsd; closed = false }
+  in
+  Server_mcp_transport_ws.with_sessions_rw (fun () ->
+    Hashtbl.replace Server_mcp_transport_ws.sessions session_id session);
+  (* Register as SSE external subscriber for broadcast events *)
+  Sse.subscribe_external ~id:session_id
+    ~is_alive:(fun () ->
+      not session.closed && not (Ws.Wsd.is_closed session.wsd))
+    ~callback:(fun sse_event ->
+      if not session.closed then
+        ignore (Server_mcp_transport_ws.send_text session sse_event))
+    ();
+  Log.Server.info "WebSocket session %s connected (standalone port)" session_id;
+  let buf = Buffer.create 4096 in
+  { Ws.Websocket_connection.
+    frame = (fun ~opcode ~is_fin:_ ~len:_ payload ->
+      match opcode with
+      | `Text | `Binary ->
+        Buffer.clear buf;
+        Ws.Payload.schedule_read payload
+          ~on_eof:(fun () ->
+            let text = Buffer.contents buf in
+            if String.length text > 0 then
+              on_message session_id text)
+          ~on_read:(fun bs ~off ~len ->
+            Buffer.add_string buf
+              (Bigstringaf.substring bs ~off ~len))
+      | `Ping ->
+        Ws.Wsd.send_pong wsd;
+        Ws.Payload.close payload
+      | `Connection_close ->
+        Server_mcp_transport_ws.cleanup_session session_id;
+        Ws.Payload.close payload
+      | `Pong | `Continuation | `Other _ ->
+        Ws.Payload.close payload
+    );
+    eof = (fun ?error:_ () ->
+      Server_mcp_transport_ws.cleanup_session session_id)
+  }
+
+(** Start the standalone WebSocket server.
+
+    Forks a fiber that listens for TCP connections and runs the
+    httpun-ws-eio connection handler for each.  Does nothing if
+    [MASC_WS_ENABLED] is not set.
+
+    @param sw Eio switch for structured concurrency.
+    @param env Eio environment (for network access).
+    @param on_message Called with [(session_id, body_str)] for each
+      inbound text frame. *)
+let start
+    ~(sw : Eio.Switch.t)
+    ~(env : Eio_unix.Stdenv.base)
+    ~(on_message : string -> string -> unit)
+  : unit =
+  if not (is_enabled ()) then
+    Log.Server.info "WebSocket transport disabled (set MASC_WS_ENABLED=1 to enable)"
+  else begin
+    let port = configured_port () in
+    let net = Eio.Stdenv.net env in
+    let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
+    let socket =
+      Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:128 addr
+    in
+    let connection_handler =
+      Ws_eio.Server.create_connection_handler ~sw
+        (make_websocket_handler ~on_message)
+    in
+    Eio.Fiber.fork ~sw (fun () ->
+      Log.Server.info "WebSocket server starting on port %d" port;
+      let rec accept_loop backoff_s =
+        try
+          let flow, client_addr = Eio.Net.accept ~sw socket in
+          Eio.Fiber.fork ~sw (fun () ->
+            try connection_handler client_addr flow
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Server.warn "WS standalone handler error: %s"
+                (Printexc.to_string exn));
+          accept_loop 0.05
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Server.error "WS standalone accept error: %s"
+            (Printexc.to_string exn);
+          (* Backoff to avoid tight error loops *)
+          (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s
+           with Eio.Cancel.Cancelled _ as e -> raise e
+              | _ -> ());
+          let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
+          accept_loop next_backoff
+      in
+      accept_loop 0.05)
+  end


### PR DESCRIPTION
## Summary
- 별도 포트(8937)에서 WS 서버 실행 (gRPC가 8936 쓰는 것과 동일 패턴)
- 같은 포트 upgrade가 안 되는 이유: gluten `upgrade_protocol`이 기존 httpun을 shutdown → IO 루프 종료
- `Httpun_ws_eio`가 전체 HTTP→WS lifecycle을 내부 관리
- `GET /ws`는 WS 포트 정보를 JSON으로 반환 (안내용)

## 변경 파일
- **new** `lib/server/server_ws_standalone.ml`: TCP accept + Httpun_ws_eio per connection
- `lib/server/server_runtime_bootstrap.ml`: WS 서버 시작 + on_message dispatch
- `bin/main_eio.ml`: `/ws` 핸들러를 info endpoint로 변경
- `lib/dune`: 모듈 추가

## 환경변수
- `MASC_WS_ENABLED=1` — WS 활성화
- `MASC_WS_PORT=8937` — WS 포트 (기본 8937)

## Test plan
- [ ] `MASC_WS_ENABLED=1 ./start-masc-mcp.sh` 후 `websocat ws://localhost:8937/` 연결
- [ ] JSON-RPC initialize + tools/call 전송 → 응답 수신 확인
- [ ] SSE broadcast 이벤트가 WS 클라이언트에 전달되는지 확인
- [ ] `curl localhost:8935/ws` → WS 포트 안내 JSON 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)