### PR TITLE
feat(keeper): taskboard shard + task_claim/done tools

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -694,6 +694,31 @@ let execute_keeper_tool_call
         let _ = Room.broadcast config ~from_agent:agent ~content:message in
         Yojson.Safe.to_string
           (`Assoc [ ("ok", `Bool true); ("broadcast", `String message) ])
+  | "keeper_task_claim" ->
+      let result = Room.claim_next config ~agent_name:meta.agent_name in
+      Yojson.Safe.to_string (`Assoc [ ("result", `String result) ])
+  | "keeper_task_done" ->
+      let task_id =
+        Safe_ops.json_string ~default:"" "task_id" args |> String.trim
+      in
+      let result_text =
+        Safe_ops.json_string ~default:"" "result" args |> String.trim
+      in
+      if task_id = "" then
+        Yojson.Safe.to_string (`Assoc [ ("error", `String "task_id required") ])
+      else
+        let agent = Printf.sprintf "keeper:%s" meta.name in
+        let notes = if result_text = "" then "" else result_text in
+        (match
+           Room.force_done_task_r config ~agent_name:agent ~task_id ~notes ()
+         with
+         | Ok msg ->
+             Yojson.Safe.to_string
+               (`Assoc [ ("ok", `Bool true); ("result", `String msg) ])
+         | Error e ->
+             Yojson.Safe.to_string
+               (`Assoc [ ("ok", `Bool false);
+                          ("error", `String (Types.masc_error_to_string e)) ]))
   | name when String.starts_with ~prefix:"masc_autoresearch_" name ->
       let ctx : Tool_autoresearch.context = {
         base_path = project_root_of_config config;

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -300,6 +300,26 @@ let taskboard_tools : Types.tool_schema list = [
       ("required", `List [`String "message"]);
     ];
   };
+  {
+    name = "keeper_task_claim";
+    description = "Claim the next unclaimed task from the backlog that matches your capabilities. Returns the claimed task details or empty if none available.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+  {
+    name = "keeper_task_done";
+    description = "Mark a claimed task as done with a result summary.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID to complete")]);
+        ("result", `Assoc [("type", `String "string"); ("description", `String "Summary of what was accomplished")]);
+      ]);
+      ("required", `List [`String "task_id"]);
+    ];
+  };
 ]
 
 (** Predefined shards *)
@@ -380,6 +400,7 @@ let default_shard_names : string list = [
   "shell";
   "weather";
   "voice";
+  "taskboard";
 ]
 
 let get_agent_shards (agent_name : string) : string list =


### PR DESCRIPTION
## Summary
- `taskboard` shard를 keeper 기본 shard에 추가 (기존: 등록만 되고 미활성)
- `keeper_task_claim`: task queue에서 다음 미할당 task를 자동 claim
- `keeper_task_done`: claim한 task를 완료 처리

## 동기
keeper가 task 수(unclaimed_task_count)는 볼 수 있지만, 직접 claim하거나 완료할 수 없었음.
keeper_msg로 마이크로매니징하는 대신, keeper가 스스로 일감을 챙기는 pull 모델로 전환.

```
이전: 사용자 → keeper_msg("이거 해") → keeper 수동 반응
이후: task queue에 일 등록 → keeper가 heartbeat에서 발견 → claim → 실행 → done
```

## 변경 파일
- `lib/tool_shard.ml`: default_shard_names에 "taskboard" 추가, keeper_task_claim/done schema
- `lib/keeper/keeper_exec_tools.ml`: keeper_task_claim → Room.claim_next, keeper_task_done → Room.force_done_task_r

## Test plan
- [ ] `dune build --root .` 성공
- [ ] task 등록 후 keeper가 자동 claim하는지 확인
- [ ] claim한 task를 keeper가 완료 처리하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)