### PR TITLE
fix(server): add port guard to prevent EADDRINUSE on startup

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -423,6 +423,18 @@ if [ "$EIO_MODE" = "true" ]; then
     fi
 fi
 
+# Port guard: abort if another process already holds the port.
+if [ "$HTTP_MODE" = "true" ]; then
+    existing_pid=$(lsof -ti "tcp:$PORT" -sTCP:LISTEN 2>/dev/null | head -1)
+    if [ -n "$existing_pid" ]; then
+        existing_cmd=$(ps -p "$existing_pid" -o comm= 2>/dev/null || echo "unknown")
+        echo "Error: port $PORT already in use by PID $existing_pid ($existing_cmd)." >&2
+        echo "  Kill it first:  kill $existing_pid" >&2
+        echo "  Or use another port:  MASC_MCP_PORT=8936 $0" >&2
+        exit 1
+    fi
+fi
+
 # Eio server has different CLI format and is HTTP-only
 if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2


### PR DESCRIPTION
## Summary

Closes #2598

`start-masc-mcp.sh`에서 `exec` 전에 포트 사용 여부를 확인합니다.
이미 사용 중이면 PID, 프로세스 이름, 복구 방법을 출력하고 종료.

```
Error: port 8935 already in use by PID 12345 (main_eio.exe).
  Kill it first:  kill 12345
  Or use another port:  MASC_MCP_PORT=8936 ./start-masc-mcp.sh
```

병렬 에이전트가 서버를 동시에 restart할 때 EADDRINUSE crash를 방지.

## Test plan

- [x] 포트 미사용 시 정상 시작
- [x] 포트 사용 시 에러 메시지 + exit 1
- [x] stdio 모드에서는 guard 미적용

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>