### PR TITLE
fix(keeper): defer start_keepalive to prevent keeper_msg slot starvation

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -83,7 +83,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~new_soul_profile ~new_will ~new_needs ~new_desires
           ~config:ctx.config
       in
-      start_keepalive ctx meta;
+      (* start_keepalive is deferred AFTER run_turn completes.
+         Starting it here causes the heartbeat fiber to immediately grab LLM
+         slots, starving the synchronous run_turn call (Issue #2610). *)
       match maybe_handle_auto_team_session ctx meta message with
       | Error err -> (false, "❌ " ^ err)
       | Ok (Some result, _) -> result
@@ -203,12 +205,14 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                  (Trajectory.Failed e))
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run error)" exn);
+              start_keepalive ctx meta;
               (false, Printf.sprintf "❌ Agent.run failed: %s" e)
             | Ok result ->
               (try ignore (Trajectory.finalize trajectory_acc
                  Trajectory.Completed)
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run ok)" exn);
+              start_keepalive ctx meta;
               let reply_json = `Assoc [
                 ("reply", `String result.response_text);
                 ("model", `String result.model_used);


### PR DESCRIPTION
## Summary
- `start_keepalive`를 `run_turn` 이후로 이동하여 keeper_msg LLM 슬롯 기아 해소
- heartbeat fiber가 먼저 슬롯을 잡아 run_turn이 영구 블로킹되던 문제 수정

## Root cause (Issue #2610)
```
handle_keeper_msg
  → start_keepalive (heartbeat fiber 시작, LLM 슬롯 즉시 점유)
  → run_turn (슬롯 획득 불가 → 영구 블로킹 → empty 응답)
```

## Fix
```
handle_keeper_msg
  → run_turn (슬롯 확보, 응답 생성)
  → start_keepalive (응답 반환 후 heartbeat 시작)
```

## Test plan
- [ ] `dune build` 성공
- [ ] keeper_msg via localhost: 응답 수신 확인
- [ ] 기존 keeper heartbeat 정상 동작 확인

Fixes #2610

Generated with [Claude Code](https://claude.com/claude-code)