### PR TITLE
fix(dashboard): replace dynamic import with callback for keeper redirect

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -91,20 +91,15 @@ export function agentJournalEntries(agentName: string | null): JournalEntry[] {
 
 // --- Actions ---
 
+// Keeper redirect — set by agent-detail.ts to avoid circular imports.
+let _keeperRedirect: ((agentName: string) => boolean) | null = null
+
+export function setKeeperRedirect(fn: (agentName: string) => boolean): void {
+  _keeperRedirect = fn
+}
+
 export function openAgentDetail(agentName: string): void {
-  // If the agent has a linked keeper, open the richer keeper detail overlay instead
-  const keeper = keeperForAgent(agentName)
-  if (keeper) {
-    // Lazy import to avoid circular dependency
-    import('./keeper-detail').then(mod => {
-      mod.openKeeperDetail(keeper)
-    }).catch(() => {
-      // Fallback to agent detail if import fails
-      selectedAgentName.value = agentName
-      void refreshAgentDetail()
-    })
-    return
-  }
+  if (_keeperRedirect && _keeperRedirect(agentName)) return
   selectedAgentName.value = agentName
   void refreshAgentDetail()
 }

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -27,12 +27,24 @@ import {
   closeAgentDetail,
   refreshAgentDetail,
   submitMention,
+  setKeeperRedirect,
   type TaskHistoryRow,
 } from './agent-detail-state'
+import { openKeeperDetail } from './keeper-detail'
 import type { Task } from '../types'
 
 // Re-export public API for external consumers
 export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-detail-state'
+
+// Wire keeper redirect: keeper-linked agents open the keeper detail overlay
+setKeeperRedirect((agentName: string) => {
+  const keeper = keeperForAgent(agentName)
+  if (keeper) {
+    openKeeperDetail(keeper)
+    return true
+  }
+  return false
+})
 
 function TaskSummary({ task }: { task: Task }) {
   return html`


### PR DESCRIPTION
## Summary

`import('./keeper-detail')` 동적 import가 Vite chunk hash 불일치로 `Failed to fetch dynamically imported module` 에러 발생. 브라우저가 이전 빌드의 chunk hash를 캐시하면 새 빌드에서 404.

`setKeeperRedirect` callback 패턴으로 교체:
- `agent-detail-state.ts`: callback slot + setter 함수 제공
- `agent-detail.ts`: 모듈 로드 시 synchronous 등록 (이미 양쪽 import)

## Test plan

- [x] tsc --noEmit pass
- [ ] 하드 리프레시 없이 keeper-linked agent 클릭 → keeper detail 열림

🤖 Generated with [Claude Code](https://claude.com/claude-code)