### PR TITLE
feat(transport): enable WebSocket by default

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -162,7 +162,7 @@ let make_extended_handler routes =
             let response = Httpun.Response.create ~headers `OK in
             Httpun.Reqd.respond_with_string reqd response body
           end else begin
-            let body = {|{"error":"websocket_disabled","message":"Set MASC_WS_ENABLED=1 to enable"}|} in
+            let body = {|{"error":"websocket_disabled","message":"WebSocket is disabled (MASC_WS_ENABLED=0)"}|} in
             let headers = Httpun.Headers.of_list [
               ("content-type", "application/json");
               ("content-length", string_of_int (String.length body));

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -1,7 +1,7 @@
 (** Standalone WebSocket server for MASC MCP.
 
     Runs on a separate port (default 8937, configurable via MASC_WS_PORT).
-    Opt-in via MASC_WS_ENABLED=1.
+    Enabled by default. Disable with MASC_WS_ENABLED=0.
 
     Unlike the /ws upgrade path on the HTTP port, this server owns the
     full TCP socket, so httpun-ws can run the HTTP->WS upgrade lifecycle
@@ -28,11 +28,12 @@ let configured_port () =
       default_port)
   | None -> default_port
 
-(** Check whether standalone WS is enabled (default: disabled). *)
+(** Check whether standalone WS is enabled (default: enabled).
+    Disable with MASC_WS_ENABLED=0 or MASC_WS_ENABLED=false. *)
 let is_enabled () =
   match Sys.getenv_opt "MASC_WS_ENABLED" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
+  | Some "0" | Some "false" -> false
+  | _ -> true
 
 (** WebSocket handler factory.
 
@@ -99,7 +100,7 @@ let start
     ~(on_message : string -> string -> unit)
   : unit =
   if not (is_enabled ()) then
-    Log.Server.info "WebSocket transport disabled (set MASC_WS_ENABLED=1 to enable)"
+    Log.Server.info "WebSocket transport disabled (MASC_WS_ENABLED=0)"
   else begin
     let port = configured_port () in
     let net = Eio.Stdenv.net env in


### PR DESCRIPTION
## Summary
WebSocket transport를 기본 활성화로 전환.

### Before
- `MASC_WS_ENABLED=1` 필수 설정
- 설정 없으면 `/ws` → 404 + "Set MASC_WS_ENABLED=1 to enable"

### After
- WS 기본 활성화 (SSE와 동일한 항시 제공)
- `MASC_WS_ENABLED=0`으로 비활성화 가능

### Rationale
QA transport 테스트에서 WS는 101 Upgrade 성공, keeper heartbeat/snapshot 실시간 수신 확인됨. SSE와 동일한 안정성. 매번 env var 설정이 불필요한 마찰이었음.

## Test plan
- [x] dune build 성공
- [ ] 서버 시작 시 WS 자동 활성화 확인 (env var 없이)
- [ ] MASC_WS_ENABLED=0 시 비활성화 확인
- [ ] 기존 SSE 동작에 영향 없음

Generated with Claude Code