### PR TITLE
fix(dashboard): QA sweep — 5 issues fixed

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -29,12 +29,18 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
   const sid = res.headers.get('Mcp-Session-Id')
   if (sid) mcpSessionId = sid
   if (!res.ok) {
+    if (res.status === 403) {
+      throw new Error('MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.')
+    }
     throw new Error(`POST /mcp: ${res.status} ${res.statusText}`)
   }
   return res.text()
 }
 
 async function ensureSession(): Promise<void> {
+  if (mcpSessionId === '__blocked__') {
+    throw new Error('MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.')
+  }
   if (mcpSessionId) return
   if (initPromise) return initPromise
   initPromise = (async () => {
@@ -69,6 +75,11 @@ async function ensureSession(): Promise<void> {
           }),
         }, 5000).catch(() => {})
       }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('403')) {
+        mcpSessionId = '__blocked__'
+      }
+      throw err
     } finally {
       initPromise = null
     }

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -147,10 +147,10 @@ export function AgentDetailOverlay() {
               : null}
           </div>
           <div class="flex gap-2 shrink-0">
-            <button class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-card-border bg-card/60 text-text-body hover:bg-white/10 hover:text-text-strong transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
+            <button type="button" class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-card-border bg-card/60 text-text-body hover:bg-white/10 hover:text-text-strong transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
               ${loading.value ? '새로고침 중...' : '새로고침'}
             </button>
-            <button class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-all duration-200 shadow-sm" onClick=${closeAgentDetail}>닫기</button>
+            <button type="button" class="px-4 py-2 text-[13px] font-semibold rounded-xl border border-transparent bg-white/10 text-text-strong hover:bg-white/20 transition-all duration-200 shadow-sm" onClick=${closeAgentDetail}>닫기</button>
           </div>
         </div>
 
@@ -191,7 +191,7 @@ export function AgentDetailOverlay() {
                 onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void submitMention() }}
                 disabled=${sendingMention.value}
               />
-              <button
+              <button type="button"
                 class="px-5 py-2.5 text-[13px] font-semibold rounded-xl border border-transparent bg-accent text-bg-0 hover:bg-accent/90 transition-all duration-200 shadow-md shadow-accent/20 disabled:opacity-50 disabled:cursor-not-allowed"
                 onClick=${() => { void submitMention() }}
                 disabled=${sendingMention.value || mentionText.value.trim() === ''}

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -133,7 +133,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
         <div class="flex items-center gap-2 text-[11px]">
           <span class="px-2 py-0.5 rounded-lg bg-[var(--white-4)] border border-[var(--white-8)] text-[var(--text-muted)] text-[10px]">${eventsPerMin}/min</span>
           <span class="text-[var(--text-muted)]">${filtered.length} events</span>
-          <button
+          <button type="button"
             class="px-2 py-0.5 rounded-lg text-[10px] border cursor-pointer transition-all duration-150 ${autoScroll.value
               ? 'border-[rgba(34,197,94,0.4)] text-[var(--ok)] bg-[var(--white-4)]'
               : 'border-[var(--white-10)] text-[var(--text-dim)] bg-[var(--white-4)]'}"

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -124,7 +124,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           />
           <div class="flex gap-1.5">
             ${(['all', 'active', 'idle', 'offline'] as StatusFilter[]).map(f => html`
-              <button
+              <button type="button"
                 key=${f}
                 class="px-2.5 py-1 text-[11px] rounded-xl border cursor-pointer transition-all duration-150 ${filter === f
                   ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -61,12 +61,16 @@ export function AgentsUnified() {
     }
   }, [routeView])
 
-  // Compute counts for chip badges
+  // Compute counts for chip badges.
+  // When agents store is empty (not yet loaded), fall back to keepers store
+  // so the tab badge matches Room Pulse sidebar counts.
   const kNames = keeperNameSet()
   const agentList = agents.value
   const totalCount = agentList.length
-  const keeperCount = agentList.filter((a: { name: string }) => kNames.has(a.name)).length
-  const agentOnlyCount = totalCount - keeperCount
+  const keeperCountFromAgents = agentList.filter((a: { name: string }) => kNames.has(a.name)).length
+  const keeperCountFallback = Math.max(keepers.value.length, missionKeeperBriefs.value.length)
+  const keeperCount = totalCount > 0 ? keeperCountFromAgents : keeperCountFallback
+  const agentOnlyCount = totalCount > 0 ? totalCount - keeperCountFromAgents : 0
 
   function chipCount(id: AgentsView): number | null {
     if (id === 'all') return totalCount
@@ -79,7 +83,7 @@ export function AgentsUnified() {
     <div class="flex flex-col gap-4">
       <div class="flex gap-1 p-1 bg-[var(--white-3)] rounded-lg w-fit">
         ${CHIPS.map(c => html`
-          <button
+          <button type="button"
             key=${c.id}
             class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all cursor-pointer border-0 ${currentView === c.id ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-transparent text-[var(--text-muted)] hover:text-[var(--text-body)]'}"
             onClick=${() => {

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -134,7 +134,7 @@ function LoopSelector() {
           ? 'px-3 py-1.5 rounded-lg text-xs font-medium border border-accent/60 bg-accent/10 text-[var(--text-strong)] cursor-pointer'
           : 'px-3 py-1.5 rounded-lg text-xs font-medium border border-card-border bg-card/60 text-[var(--text-muted)] cursor-pointer hover:border-accent/30 transition-colors'
         return html`
-          <button key=${loop.loop_id} class=${cls} onClick=${() => selectLoop(loop.loop_id)}>
+          <button type="button" key=${loop.loop_id} class=${cls} onClick=${() => selectLoop(loop.loop_id)}>
             <span class="${statusColor(loop.status)} mr-1">\u25CF</span>
             ${loop.loop_id.slice(0, 8)}
             <span class="ml-1 opacity-60">${statusLabel(loop.status)}</span>
@@ -381,7 +381,7 @@ export function Autoresearch() {
         <div class="px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
           ${loopsError.value}
         </div>
-        <button
+        <button type="button"
           class="self-start px-3 py-1.5 rounded-lg text-xs font-medium border border-card-border text-[var(--text-muted)] hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
           onClick=${() => loadLoops()}
         >
@@ -403,7 +403,7 @@ export function Autoresearch() {
         <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">
           전체 ${loops.length}개 루프
         </div>
-        <button
+        <button type="button"
           class="px-2.5 py-1 rounded text-[11px] text-[var(--text-muted)] border border-card-border hover:text-[var(--text-body)] hover:border-accent/40 transition-colors"
           onClick=${() => loadLoops()}
         >

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -132,7 +132,7 @@ export function ChatMessageBubble({
         </div>
         ${canExpand
           ? html`
-              <button
+              <button type="button"
                 type="button"
                 class="chat-disclosure-btn rounded-full"
                 onClick=${() => { setExpanded(!expanded) }}
@@ -196,7 +196,7 @@ export function ChatMessageBubble({
               ${entry.details.rawPayload
                 ? html`
                     <div class="chat-detail-section">
-                      <button
+                      <button type="button"
                         type="button"
                         class="chat-raw-toggle rounded-full"
                         onClick=${() => { setRawExpanded(!rawExpanded) }}

--- a/dashboard/src/components/command/control.ts
+++ b/dashboard/src/components/command/control.ts
@@ -56,10 +56,10 @@ function DecisionCard({ decision }: { decision: CommandPlaneDecisionRecord }) {
       ${decision.status === 'pending' && !isLegacy
         ? html`
             <div class="flex gap-3 flex-wrap mt-3">
-              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
+              <button type="button" class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(approveKey)} onClick=${() => fire(() => approveCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(approveKey) ? '승인 중…' : '승인'}
               </button>
-              <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
+              <button type="button" class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(denyKey)} onClick=${() => fire(() => denyCommandPlaneDecision(decision.decision_id))}>
                 ${actionDisabled(denyKey) ? '거부 중…' : '거부'}
               </button>
             </div>
@@ -94,10 +94,10 @@ function CapacityRowCard({ row }: { row: CommandPlaneCapacityRow }) {
         <span class="text-[var(--text-muted)]">킬 스위치</span><span class="text-[var(--text-body)]">${killSwitch ? '켜짐' : '꺼짐'}</span>
       </div>
       <div class="flex gap-3 flex-wrap mt-3">
-        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
+        <button type="button" class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(freezeKey)} onClick=${() => fire(() => toggleCommandPlaneFreeze(unit.unit_id, !frozen))}>
           ${actionDisabled(freezeKey) ? '적용 중…' : frozen ? '동결 해제' : '동결'}
         </button>
-        <button class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
+        <button type="button" class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]" disabled=${actionDisabled(killKey)} onClick=${() => fire(() => toggleCommandPlaneKillSwitch(unit.unit_id, !killSwitch))}>
           ${actionDisabled(killKey) ? '적용 중…' : killSwitch ? '킬 스위치 해제' : '킬 스위치 켜기'}
         </button>
       </div>

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -50,7 +50,7 @@ function SurfaceTabs() {
             ${COMMAND_SURFACE_META
               .filter(surface => surface.group === group.id)
               .map(surface => html`
-                <button
+                <button type="button"
                   class="border border-[var(--white-12)] bg-[var(--white-4)] text-[var(--white-72)] p-[8px_14px] capitalize rounded-full cmd-surface-tab ${commandPlaneSurface.value === surface.id ? 'active' : ''}"
                   onClick=${() => {
                     setCommandPlaneSurface(surface.id)
@@ -200,7 +200,7 @@ export function Command() {
           <p class="text-[13px] text-[var(--text-muted)] leading-relaxed max-w-[62ch]">작전, 오케스트라, 스웜, 체인, 제어 표면을 선택해 실제 MCP 도구 기반 현황을 확인합니다.</p>
         </div>
         <div class="flex gap-3 flex-wrap">
-          <button
+          <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
               void fire(() => runCommandPlaneDispatchTick())
@@ -209,7 +209,7 @@ export function Command() {
           >
             ${actionDisabled('dispatch:tick') ? '정리 중...' : 'Tick 실행'}
           </button>
-          <button
+          <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
               void refreshRoomTruth()

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -117,7 +117,7 @@ function ChainOperationListItem(
   const chain = overlay.operation.chain
   const runtime = overlay.runtime
   return html`
-    <button class="w-full text-left text-inherit font-[inherit] cursor-pointer bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-chain-item ${selected ? 'selected' : ''}" onClick=${onSelect}>
+    <button type="button" class="w-full text-left text-inherit font-[inherit] cursor-pointer bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-chain-item ${selected ? 'selected' : ''}" onClick=${onSelect}>
       <div class="cmd-card rounded-xl-head">
         <div>
           <strong>${overlay.operation.objective}</strong>

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -360,7 +360,7 @@ export function OrchestraSurface() {
           <${StatusChip} label=${`${Math.round(camera.zoom * 100)}%`} />
         </div>
         <div class="orchestra-toolbar-group">
-          <button
+          <button type="button"
             class=${`control-btn ${density === 'balanced' ? 'is-active' : 'ghost'}`}
             onClick=${() => {
               orchestraDensity.value = 'balanced'
@@ -369,7 +369,7 @@ export function OrchestraSurface() {
           >
             균형
           </button>
-          <button
+          <button type="button"
             class=${`control-btn ${density === 'compact' ? 'is-active' : 'ghost'}`}
             onClick=${() => {
               orchestraDensity.value = 'compact'

--- a/dashboard/src/components/common/action-bar.ts
+++ b/dashboard/src/components/common/action-bar.ts
@@ -25,7 +25,7 @@ interface ActionBtnProps {
 
 export function ActionBtn({ label, onClick, disabled }: ActionBtnProps) {
   return html`
-    <button class="control-btn rounded-lg ghost" onClick=${onClick} disabled=${disabled}>
+    <button type="button" class="control-btn rounded-lg ghost" onClick=${onClick} disabled=${disabled}>
       ${label}
     </button>
   `

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -51,7 +51,7 @@ export function ActionButton({
   ].filter(Boolean).join(' ')
 
   return html`
-    <button class=${cls} onClick=${onClick} disabled=${disabled}>${children}</button>
+    <button type="button" class=${cls} onClick=${onClick} disabled=${disabled}>${children}</button>
   `
 }
 

--- a/dashboard/src/components/common/error-boundary.ts
+++ b/dashboard/src/components/common/error-boundary.ts
@@ -27,7 +27,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <div class="error-card rounded-xl my-3 rounded-lg border border-[var(--bad)]/30 bg-[rgba(10,22,40,0.92)] p-4">
           <strong class="text-[var(--bad)]">${this.props.label ?? 'Component'} 렌더링 오류</strong>
           <pre class="text-xs whitespace-pre-wrap mt-2 opacity-70">${this.state.error.message}</pre>
-          <button
+          <button type="button"
             class="mt-2 px-3 py-1 cursor-pointer rounded border border-[var(--card rounded-xl-border)] bg-[var(--white-6)] text-[var(--text-body)] text-sm hover:bg-[var(--white-10)]"
             onClick=${() => this.setState({ error: null })}
           >다시 시도</button>

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -19,7 +19,7 @@ export function FilterChips<T extends string>({ chips, active, onChange }: Filte
   return html`
     <div class="flex gap-1.5 flex-wrap">
       ${chips.map(chip => html`
-        <button
+        <button type="button"
           key=${chip.key}
           class="px-2.5 py-1 text-[length:var(--fs-xs)] rounded-xl border cursor-pointer transition-all duration-150 ${active.value === chip.key
             ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'

--- a/dashboard/src/components/common/keeper-card.ts
+++ b/dashboard/src/components/common/keeper-card.ts
@@ -78,7 +78,7 @@ export function KeeperCard({ model, onClick, variant, testId }: KeeperCardProps)
 
   return html`
     <article class=${wrapperClass}>
-      <button class=${buttonClass} data-testid=${testId} onClick=${onClick}>
+      <button type="button" class=${buttonClass} data-testid=${testId} onClick=${onClick}>
         <div class=${variant === 'mission' ? 'flex justify-between gap-3 items-start' : 'monitor-row-header'}>
           <div class=${variant === 'mission' ? 'flex gap-3 items-start' : 'min-w-0'}>
             <span class="agent-emoji ${model.stateClass === 'offline' ? 'grayscale' : ''}">${model.emoji ?? ''}</span>

--- a/dashboard/src/components/common/list-item.ts
+++ b/dashboard/src/components/common/list-item.ts
@@ -22,7 +22,7 @@ export function ListItem({ title, subtitle, detail, onClick, class: className }:
   `
 
   if (onClick) {
-    return html`<button class="${base}" onClick=${onClick}>${content}</button>`
+    return html`<button type="button" class="${base}" onClick=${onClick}>${content}</button>`
   }
   return html`<div class="${base}">${content}</div>`
 }

--- a/dashboard/src/components/common/nav-item.ts
+++ b/dashboard/src/components/common/nav-item.ts
@@ -20,7 +20,7 @@ export function NavItem({ active, icon, onClick, children }: NavItemProps) {
     ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)]'
     : 'border-l-transparent bg-transparent text-[var(--text-body)] hover:bg-[var(--white-6)] hover:border-l-[var(--white-20)]'
   return html`
-    <button class="${NAV_BASE} gap-2.5 px-3 py-2.5 rounded-lg ${state}" onClick=${onClick}>
+    <button type="button" class="${NAV_BASE} gap-2.5 px-3 py-2.5 rounded-lg ${state}" onClick=${onClick}>
       ${icon ? html`<span class="text-sm w-5 text-center shrink-0">${icon}</span>` : null}
       <span class="text-[13px] font-medium truncate">${children}</span>
     </button>
@@ -33,7 +33,7 @@ export function SubNavItem({ active, onClick, children }: NavItemProps) {
     ? 'border-l-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent)] font-medium'
     : 'border-l-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'
   return html`
-    <button class="${NAV_BASE} gap-2 px-3 py-2 rounded-md text-[13px] ${state}" onClick=${onClick}>
+    <button type="button" class="${NAV_BASE} gap-2 px-3 py-2 rounded-md text-[13px] ${state}" onClick=${onClick}>
       ${children}
     </button>
   `

--- a/dashboard/src/components/common/tab-nav.ts
+++ b/dashboard/src/components/common/tab-nav.ts
@@ -10,7 +10,7 @@ export function TabNav() {
   return html`
     <div class="flex gap-2 mb-5 p-2.5 bg-white/[0.03] rounded-xl border border-white/[0.06] flex-wrap">
       ${DASHBOARD_NAV_ITEMS.map(t => html`
-        <button
+        <button type="button"
           class="px-4 py-2 border-none rounded-lg bg-transparent cursor-pointer text-[13px] transition-all duration-200 ${currentTab === t.id ? 'bg-green-400/15 text-green-400' : 'text-[var(--text-dim)] hover:bg-white/[0.05] hover:text-[#ccc]'}"
           onClick=${() => navigate(t.id)}
         >

--- a/dashboard/src/components/common/tag-badge.ts
+++ b/dashboard/src/components/common/tag-badge.ts
@@ -13,7 +13,7 @@ interface TagBadgeProps {
 export function TagBadge({ children, onClick, class: className }: TagBadgeProps) {
   const base = 'px-2.5 py-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-4)] text-[rgba(255,255,255,0.76)] text-xs leading-tight'
   if (onClick) {
-    return html`<button class="${base} cursor-pointer ${className ?? ''}" onClick=${onClick}>${children}</button>`
+    return html`<button type="button" class="${base} cursor-pointer ${className ?? ''}" onClick=${onClick}>${children}</button>`
   }
   return html`<span class="${base} ${className ?? ''}">${children}</span>`
 }

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -60,7 +60,7 @@ export function ToastContainer() {
         >
           <span class="text-xs shrink-0 ${ICON_COLOR[t.type]}">${ICON[t.type]}</span>
           <span class="flex-1 text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
-          <button
+          <button type="button"
             class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] p-0.5 transition-colors duration-150"
             onClick=${(e: Event) => { e.stopPropagation(); dismissToast(t.id) }}
             title="닫기"

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -79,7 +79,7 @@ export function BuildIdentityBadge() {
 
   return html`
     <div class="relative">
-      <button
+      <button type="button"
         class="text-[11px] py-[6px] px-[11px] rounded-md border border-solid border-[rgba(71,184,255,0.28)] bg-[rgba(71,184,255,0.12)] text-[#bfe7ff] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[rgba(71,184,255,0.18)]"
         type="button"
         aria-expanded=${buildIdentityOpen.value}
@@ -134,7 +134,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
             <div class="mt-0.5 text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] drop-shadow-[0_2px_4px_rgba(0,0,0,0.5)]">MASC Core</div>
           </div>
         ` : null}
-        <button
+        <button type="button"
           class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.08)] hover:text-white cursor-pointer transition-all duration-200"
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
@@ -151,7 +151,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
             if (collapsed) {
               return html`
-                <button
+                <button type="button"
                   class="flex items-center justify-center w-full rounded-xl p-2.5 cursor-pointer transition-all duration-200 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.18)] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                   title=${surface.label}
@@ -163,7 +163,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
             return html`
               <div class="flex flex-col gap-1.5">
-                <button
+                <button type="button"
                   class="flex items-center gap-3 w-full rounded-xl px-3 py-2.5 text-left cursor-pointer transition-all duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.15),rgba(71,184,255,0.05))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                 >
@@ -180,7 +180,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
-                        <button
+                        <button type="button"
                           class="w-full rounded-lg px-3 py-2 text-left cursor-pointer text-[13px] transition-all duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.15)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.15)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)] border border-transparent'}"
                           onClick=${() => navigate(surface.id, item.params)}
                         >

--- a/dashboard/src/components/execution/operations.ts
+++ b/dashboard/src/components/execution/operations.ts
@@ -18,7 +18,7 @@ import {
 export function OperationCard({ brief, selected }: { brief: DashboardExecutionOperationBrief; selected: boolean }) {
   const terminal = isTerminalStatus(brief.status)
   return html`
-    <button
+    <button type="button"
       class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.operation-card"
       onClick=${() => {

--- a/dashboard/src/components/execution/queue.ts
+++ b/dashboard/src/components/execution/queue.ts
@@ -20,7 +20,7 @@ import {
 export function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; selected: boolean }) {
   const terminal = isTerminalStatus(item.status)
   return html`
-    <button
+    <button type="button"
       class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.queue-card"
       onClick=${() => {

--- a/dashboard/src/components/execution/sessions.ts
+++ b/dashboard/src/components/execution/sessions.ts
@@ -21,7 +21,7 @@ export function SessionCard({ brief, selected }: { brief: DashboardExecutionSess
   const seenCount = brief.seen_count ?? liveCount
   const plannedCount = brief.planned_count ?? brief.member_names.length
   return html`
-    <button
+    <button type="button"
       class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.session-card"
       onClick=${() => {

--- a/dashboard/src/components/execution/workers.ts
+++ b/dashboard/src/components/execution/workers.ts
@@ -32,7 +32,7 @@ export function WorkerSupportRow({
   const effectiveStatus = row.state === 'offline' ? 'offline' : (row.status ?? 'unknown')
 
   return html`
-    <button class="monitor-row rounded-xl p-4 ${row.tone} state-${row.state} ${row.state === 'offline' ? 'opacity-35 border-[rgba(85,85,85,0.15)] bg-[rgba(0,0,0,0.08)] hover:opacity-55' : ''}" data-testid=${testId} onClick=${() => openAgentDetail(row.name)}>
+    <button type="button" class="monitor-row rounded-xl p-4 ${row.tone} state-${row.state} ${row.state === 'offline' ? 'opacity-35 border-[rgba(85,85,85,0.15)] bg-[rgba(0,0,0,0.08)] hover:opacity-55' : ''}" data-testid=${testId} onClick=${() => openAgentDetail(row.name)}>
       <div class="monitor-row rounded-xl-header">
         <span class="agent-emoji ${row.state === 'offline' ? 'grayscale' : ''}">${row.emoji ?? ''}</span>
         <div class="min-w-0">

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -62,7 +62,7 @@ export function Planning() {
 
       <!-- Compact refresh toolbar -->
       <div class="flex justify-end">
-        <button
+        <button type="button"
           class="px-4 py-2 rounded-xl text-[12px] font-semibold border border-transparent bg-white/5 text-text-muted hover:bg-white/10 hover:text-text-strong transition-all duration-200 cursor-pointer shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
           onClick=${() => {
             refreshGoals()

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -78,10 +78,10 @@ export function GuardrailPane({
                       <h4 class="text-[12px] font-bold text-warn uppercase tracking-wider">⚠️ 관리자 승인 대기</h4>
                       <div class="text-text-strong text-[13px] leading-relaxed">이 집행 명령은 고위험 작업으로 분류되어 승인이 필요합니다.</div>
                       <div class="flex gap-3 mt-2">
-                        <button class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-ok/30 bg-ok/20 text-ok hover:bg-ok/30" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
+                        <button type="button" class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-ok/30 bg-ok/20 text-ok hover:bg-ok/30" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '명령 승인'}
                         </button>
-                        <button class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-bad/30 bg-bad/20 text-bad hover:bg-bad/30" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
+                        <button type="button" class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-bad/30 bg-bad/20 text-bad hover:bg-bad/30" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '집행 거부'}
                         </button>
                       </div>
@@ -98,7 +98,7 @@ export function GuardrailPane({
               <div class="flex flex-col gap-4">
                 <div class="flex flex-wrap gap-2 p-1.5 bg-card/40 backdrop-blur-md rounded-xl border border-card-border/50 w-fit">
                   ${(['support', 'oppose', 'neutral'] as const).map(stance => html`
-                    <button
+                    <button type="button"
                       class="px-4 py-2 rounded-lg text-[12px] font-bold transition-all duration-200 border cursor-pointer
                         ${governanceBriefStance.value === stance
                           ? 'bg-accent/20 text-accent border-accent/30 shadow-sm'

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -91,7 +91,7 @@ function GovernanceToolbar() {
               }}
               disabled=${governanceStarting.value}
             />
-            <button
+            <button type="button"
               class="px-5 py-2.5 rounded-xl text-[13px] font-semibold border transition-all duration-200 cursor-pointer shadow-sm
                 ${governanceStarting.value || governanceTopicInput.value.trim() === ''
                   ? 'bg-card/40 text-text-muted border-card-border opacity-50 cursor-not-allowed'
@@ -102,7 +102,7 @@ function GovernanceToolbar() {
             >
               ${governanceStarting.value ? '접수 중...' : '청원 접수'}
             </button>
-            <button
+            <button type="button"
               class="px-4 py-2.5 rounded-xl text-[13px] font-semibold border border-transparent bg-white/5 text-text-muted hover:bg-white/10 hover:text-text-strong transition-all duration-200 cursor-pointer shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshGovernance}
             disabled=${governanceLoading.value}
@@ -137,7 +137,7 @@ function DecisionInbox() {
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`
-                <button
+                <button type="button"
                   class="w-full text-left flex gap-4 p-5 rounded-2xl border cursor-pointer transition-all duration-200 shadow-sm shadow-black/10 group hover:-translate-y-0.5 hover:shadow-md
                     ${selected
                       ? 'border-accent/40 bg-accent/10 shadow-[0_0_15px_rgba(71,184,255,0.15)]'

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -284,18 +284,18 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const toolbar = html`
     <div class="flex gap-2 items-center mb-3">
       ${isEditing ? html`
-        <button
+        <button type="button"
           class="${btnBase} bg-[#4ade80] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
         >${isSaving ? 'Saving...' : 'Save'}</button>
-        <button
+        <button type="button"
           class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
         >Cancel</button>
       ` : html`
-        <button
+        <button type="button"
           class="${btnBase} bg-[var(--purple)] text-[#000]"
           onClick=${enterEditMode}
         >Edit</button>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -188,7 +188,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <${SignalRow} label="Skill route" value=${skillRouteLabel} />
 
       <div class="flex justify-end mt-1">
-        <button
+        <button type="button"
           class="py-1.5 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
           onClick=${() => { openToolsInventory(openToolsQuery) }}
         >

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -183,7 +183,7 @@ export function KeeperDetailOverlay() {
               ${keeper.koreanName ? html`<span class="text-xs text-[var(--text-muted)]">${keeper.koreanName}</span>` : null}
             </div>
           </div>
-          <button
+          <button type="button"
             onClick=${() => closeKeeperDetail()}
             class="flex items-center justify-center size-8 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:text-[var(--text-strong)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-sm"
             aria-label="Close"

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -225,7 +225,7 @@ export function KeeperConversationPanel({
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex justify-end">
-        <button
+        <button type="button"
           type="button"
           class="py-1 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
           onClick=${() => { setShowMetadata(!showMetadata) }}
@@ -234,7 +234,7 @@ export function KeeperConversationPanel({
         </button>
       </div>
       ${!historyExpanded && thread.length >= 10 ? html`
-        <button
+        <button type="button"
           type="button"
           class="py-1.5 px-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer self-center"
           disabled=${hydrating}
@@ -289,7 +289,7 @@ export function KeeperRuntimeActions({
 
   return html`
     <div class="flex flex-wrap gap-2">
-      <button
+      <button type="button"
         class=${recommended === 'probe' ? activeGhostBtn : ghostBtn}
         onClick=${() => {
           void probeKeeperRuntime(keeper.name, actor).catch(err => {
@@ -301,7 +301,7 @@ export function KeeperRuntimeActions({
       >
         ${probing ? 'Probing...' : 'Probe'}
       </button>
-      <button
+      <button type="button"
         class=${recommended === 'recover' ? activeSecondaryBtn : secondaryBtn}
         onClick=${() => {
           void recoverKeeperRuntime(keeper.name, actor).catch(err => {
@@ -313,7 +313,7 @@ export function KeeperRuntimeActions({
       >
         ${recovering ? 'Recovering...' : 'Recover'}
       </button>
-      <button
+      <button type="button"
         class=${recommended === 'manual_social_sweep' ? activeGhostBtn : ghostBtn}
         onClick=${onSocialSweep}
       >

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -25,7 +25,7 @@ function FilterBar() {
   return html`
     <div class="flex gap-1.5">
       ${FILTER_OPTIONS.map(opt => html`
-        <button
+        <button type="button"
           key=${opt.kind}
           class="px-2 py-0.5 text-[11px] rounded-md border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
             ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -53,7 +53,7 @@ export function FocusSidebar() {
               ${agent.currentTask
                 ? html`<div class="text-[0.75rem] text-[var(--white-55)] py-[3px] px-2 bg-[var(--white-3)] border border-[var(--white-5)] whitespace-nowrap overflow-hidden text-ellipsis rounded-md">${agent.currentTask}</div>`
                 : null}
-              <div class="focus-agent-footer">
+              <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText
                   ? html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
                   : html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic text-[rgba(255,255,255,0.25)]">No recent activity</span>`}

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -27,7 +27,7 @@ export function PulseStrip() {
   return html`
     <div class="pulse-strip rounded-xl">
       ${pulses.map(p => html`
-        <button
+        <button type="button"
           key=${p.name}
           class="pulse-bubble ${pulseStateClass(p.state)} ${selected === p.name ? 'pulse-selected' : ''}"
           onClick=${() => openAgentDetail(p.name)}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -136,7 +136,7 @@ export function LogViewer() {
             />
             자동
           </label>
-          <button class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
+          <button type="button" class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
             disabled=${logLoading.value}>
             ${logLoading.value ? '...' : '새로고침'}
           </button>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -218,7 +218,7 @@ async function submitNewPost() {
 function NewPostForm() {
   if (!showNewPostForm.value) {
     return html`
-      <button
+      <button type="button"
         class="w-full py-2.5 rounded-lg border border-dashed border-[var(--card-border)] text-[13px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-4)] hover:text-[var(--text-body)] transition-colors bg-transparent"
         onClick=${() => { showNewPostForm.value = true }}
       >+ 새 글 작성</button>
@@ -241,11 +241,11 @@ function NewPostForm() {
         onInput=${(e: Event) => { newPostContent.value = (e.target as HTMLTextAreaElement).value }}
       ></textarea>
       <div class="flex gap-2 justify-end">
-        <button
+        <button type="button"
           class="px-3 py-1.5 rounded-lg text-[13px] border border-[var(--card-border)] bg-transparent text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]"
           onClick=${() => { showNewPostForm.value = false; newPostTitle.value = ''; newPostContent.value = '' }}
         >취소</button>
-        <button
+        <button type="button"
           class="px-4 py-1.5 rounded-lg text-[13px] font-medium border border-[rgba(71,184,255,0.4)] bg-[var(--accent-soft)] text-[var(--accent)] cursor-pointer hover:bg-[rgba(71,184,255,0.2)] disabled:opacity-50"
           disabled=${newPostSubmitting.value || !newPostTitle.value.trim() || !newPostContent.value.trim()}
           onClick=${() => { void submitNewPost() }}
@@ -262,7 +262,7 @@ function SortBar() {
     <div class="flex flex-col gap-3 mb-4 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
       <div class="flex items-center gap-1.5 flex-wrap">
         ${SORT_MODES.map(mode => html`
-          <button
+          <button type="button"
             class="px-3 py-1.5 rounded-lg text-[12px] font-medium transition-all duration-150 border cursor-pointer
               ${current === mode.id
                 ? 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
@@ -279,7 +279,7 @@ function SortBar() {
         `)}
       </div>
       <div class="flex items-center gap-2 flex-wrap">
-        <button
+        <button type="button"
           class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
             ${hideAutomationPosts.value
               ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
@@ -291,7 +291,7 @@ function SortBar() {
         >
           ${hideLabel}
         </button>
-        <button
+        <button type="button"
           class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
             ${boardExcludeSystem.value
               ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
@@ -305,7 +305,7 @@ function SortBar() {
           ${boardExcludeSystem.value ? '시스템 글 숨김' : '시스템 글 표시 중'}
         </button>
         <div class="ml-auto">
-          <button
+          <button type="button"
             class="px-3 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick=${refreshBoard}
             disabled=${boardLoading.value}
@@ -368,12 +368,12 @@ function PostCard({ post }: { post: BoardPost }) {
     >
       <!-- Vote column -->
       <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-[36px]">
-        <button
+        <button type="button"
           class="vote-btn upvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[#ff4500] hover:bg-[rgba(255,69,0,0.1)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('up', event)}
         >▲</button>
         <span class="text-[13px] font-semibold tabular-nums text-[var(--text-strong)]">${post.votes ?? 0}</span>
-        <button
+        <button type="button"
           class="vote-btn downvote w-7 h-5 flex items-center justify-center rounded text-[11px] text-[var(--text-muted)] hover:text-[#7193ff] hover:bg-[rgba(113,147,255,0.1)] transition-colors cursor-pointer border-0 bg-transparent"
           onClick=${(event: Event) => handleVote('down', event)}
         >▼</button>
@@ -436,7 +436,7 @@ function CommentItem({ comment }: { comment: BoardComment }) {
       </div>
       <div class="comment-text text-[13px] text-[var(--text-body)] leading-[1.55]">${comment.content}</div>
       ${needsTruncation ? html`
-        <button
+        <button type="button"
           class="comment-expand-btn mt-1 text-[11px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
           style="display: inline"
           onClick=${toggleCommentExpand}
@@ -457,14 +457,14 @@ function CommentThread({ comments }: { comments: BoardComment[] }) {
   return html`
     <div class="flex flex-col gap-2">
       ${!expanded && hiddenCount > 0 ? html`
-        <button
+        <button type="button"
           class="text-[12px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(true)}
         >이전 댓글 ${hiddenCount}개 더 보기</button>
       ` : null}
       ${visible.map(comment => html`<${CommentItem} key=${comment.id} comment=${comment} />`)}
       ${expanded && hiddenCount > 0 ? html`
-        <button
+        <button type="button"
           class="text-[12px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 text-left py-1"
           onClick=${() => setExpanded(false)}
         >접기</button>
@@ -485,7 +485,7 @@ function CommentForm({ postId }: { postId: string }) {
         onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') submitComment(postId) }}
         disabled=${commentSubmitting.value}
       />
-      <button
+      <button type="button"
         class="py-2 px-4 rounded-lg text-[13px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
           ${commentSubmitting.value || commentText.value.trim() === ''
             ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
@@ -516,7 +516,7 @@ function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button
+      <button type="button"
         class="mb-4 px-3 py-1.5 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
         onClick=${() => navigate('work', { section: 'board' })}
       >← 게시판으로 돌아가기</button>
@@ -564,11 +564,11 @@ function PostDetail({ post }: { post: BoardPost }) {
 
           <!-- Vote buttons -->
           <div class="flex gap-2">
-            <button
+            <button type="button"
               class="vote-btn upvote px-3 py-1.5 rounded-lg text-[12px] font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[#ff4500] hover:border-[rgba(255,69,0,0.3)] hover:bg-[rgba(255,69,0,0.08)] transition-all cursor-pointer"
               onClick=${() => handleVote('up')}
             >▲ 추천</button>
-            <button
+            <button type="button"
               class="vote-btn downvote px-3 py-1.5 rounded-lg text-[12px] font-medium border border-[var(--border-slate-16)] bg-transparent text-[var(--text-muted)] hover:text-[#7193ff] hover:border-[rgba(113,147,255,0.3)] hover:bg-[rgba(113,147,255,0.08)] transition-all cursor-pointer"
               onClick=${() => handleVote('down')}
             >▼ 비추천</button>
@@ -609,7 +609,7 @@ export function Memory() {
       : html`
           <div>
             <${MemorySummary} />
-            <button
+            <button type="button"
               class="mb-4 px-3 py-1.5 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
               onClick=${() => navigate('work', { section: 'board' })}
             >← 게시판으로 돌아가기</button>
@@ -638,7 +638,7 @@ export function Memory() {
                 </div>
                 ${grouped.human.length > visibleLimit.value ? html`
                   <div class="text-center py-4">
-                    <button
+                    <button type="button"
                       class="px-4 py-2 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
                       onClick=${() => { visibleLimit.value = visibleLimit.value + PAGE_SIZE }}
                     >

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -36,7 +36,7 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
       : toolAuditStateLabel(observedToolsEmptyState(row.keeper, row.brief.tool_audit_source))
   return html`
     <article class="w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.agent?.status)}">
-      <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => openAgentDetail(row.brief.agent_name)}>
+      <button type="button" class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => openAgentDetail(row.brief.agent_name)}>
         <div class="flex justify-between gap-3 items-start">
           <div class="flex gap-3 items-start">
             <span class="agent-emoji">${row.agent?.emoji ?? row.keeper?.emoji ?? ''}</span>
@@ -100,7 +100,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
 
   return html`
     <article class="w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.keeper?.status)} ${liveStateClass(row.brief.status, row.keeper?.status)}">
-      <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => {
+      <button type="button" class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => {
         const keeper: Keeper = row.keeper ?? {
           name: row.brief.name,
           agent_name: row.brief.agent_name ?? row.brief.name,

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -37,11 +37,11 @@ export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
   return html`
     <article class="w-full p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] grid gap-3 text-inherit text-left cursor-pointer ${toneClass(row.brief.status ?? row.agent?.status)}">
       <button type="button" class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => openAgentDetail(row.brief.agent_name)}>
-        <div class="flex justify-between gap-3 items-start">
-          <div class="flex gap-3 items-start">
+        <div class="flex justify-between gap-3 items-start flex-nowrap">
+          <div class="flex gap-3 items-start min-w-0">
             <span class="agent-emoji">${row.agent?.emoji ?? row.keeper?.emoji ?? ''}</span>
-            <div>
-              <strong>${row.brief.agent_name}</strong>
+            <div class="min-w-0">
+              <strong class="block truncate">${row.brief.agent_name}</strong>
               <span>${info.model !== info.nickname ? `${info.model} · ` : ''}${info.nickname}</span>
             </div>
           </div>

--- a/dashboard/src/components/mission-attention-card.ts
+++ b/dashboard/src/components/mission-attention-card.ts
@@ -44,7 +44,7 @@ export function AttentionCard({
 
   return html`
     <article class="mission-attention-card p-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-6),var(--white-3))] grid gap-3 ${toneClass(action?.severity ?? item.severity)} ${selected ? 'is-selected' : ''}">
-      <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleAttention(item.id)}>
+      <button type="button" class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleAttention(item.id)}>
         <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
             <strong>${item.summary}</strong>

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -40,7 +40,7 @@ export function SessionBriefCard({
 
   return html`
     <article class="mission-crew-card p-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(180deg,var(--white-5),var(--white-3))] grid gap-3 ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${liveStateClass(brief.status, brief.health)} ${selected ? 'is-selected' : ''}">
-      <button class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleSession(brief.session_id)}>
+      <button type="button" class="w-full p-0 border-0 bg-transparent text-inherit grid gap-3 text-left cursor-pointer" onClick=${() => toggleSession(brief.session_id)}>
         <div class="flex justify-between gap-3 items-start flex-wrap">
           <div>
             <div class="flex items-center gap-2">

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -157,7 +157,7 @@ export function Mission() {
           { id: 'mission-output', label: '활동', count: focusSessionOutputs.length + keeperOutputRows.length },
           { id: 'mission-attention', label: '우선순위', count: attentionQueue.length },
         ].map(item => html`
-          <button
+          <button type="button"
             key=${item.id}
             class="px-2.5 py-1 rounded-full border border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)] transition-colors"
             onClick=${(e: Event) => { e.preventDefault(); document.getElementById(item.id)?.scrollIntoView({ behavior: 'smooth' }) }}
@@ -170,7 +170,7 @@ export function Mission() {
         ? html`
             <div class="flex items-center justify-between gap-3 px-4 py-2.5 rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] text-xs text-[var(--text-body)]">
               <span class="truncate">관찰 세션: ${focusSession?.goal ?? activeSessionId}${activeAttention ? ` / ${activeAttention.summary}` : ''}</span>
-              <button class="shrink-0 px-2 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${clearMissionSelection}>해제</button>
+              <button type="button" class="shrink-0 px-2 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${clearMissionSelection}>해제</button>
             </div>
           `
         : null}
@@ -213,8 +213,8 @@ export function Mission() {
               : html`<div class="text-xs text-[var(--text-muted)] py-4 text-center">키퍼 없음.</div>`}
           </div>
           <div class="flex gap-2 flex-wrap mt-3">
-            <button class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('status', { section: 'sessions' })}>세션 보기</button>
-            <button class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('operations', { section: 'command' })}>지휘 진단면</button>
+            <button type="button" class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('status', { section: 'sessions' })}>세션 보기</button>
+            <button type="button" class="px-2.5 py-1 rounded border border-[var(--card-border)] bg-transparent text-[10px] text-[var(--text-muted)] cursor-pointer hover:bg-[var(--white-6)]" onClick=${() => navigate('operations', { section: 'command' })}>지휘 진단면</button>
           </div>
         </div>
       </details>

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -174,7 +174,7 @@ export function Ops() {
             value=${actorName.value}
             onInput=${(event: Event) => persistActorName((event.target as HTMLInputElement).value)}
           />
-          <button
+          <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
               void refreshRoomTruth()
@@ -254,7 +254,7 @@ export function Ops() {
             <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">지금 할 수 있는 것</h3>
             <div class="flex flex-col gap-2">
               ${actions.slice(0, 3).map(action => html`
-                <button class="ops-action-guide-item rounded-lg ${action.tone}" onClick=${action.onClick}>
+                <button type="button" class="ops-action-guide-item rounded-lg ${action.tone}" onClick=${action.onClick}>
                   <strong class="font-semibold">${action.label}</strong>
                   <span>${action.desc}</span>
                 </button>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -58,7 +58,7 @@ export function OpsKeeperColumn() {
               const tone = keeperPriorityTone(keeper)
               const prioritySummary = keeperPrioritySummary(keeper)
               return html`
-            <button
+            <button type="button"
               key=${keeper.name}
               class="ops-entity-card p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] text-inherit text-left cursor-pointer w-full ${selectedKeeper?.name === keeper.name ? 'active' : ''}"
               onClick=${() => { selectedKeeperName.value = keeper.name }}
@@ -70,7 +70,7 @@ export function OpsKeeperColumn() {
                     <span class="w-2 h-2 rounded-full ${keeper.status === 'offline' ? 'bg-[var(--text-muted)]' : keeper.status === 'active' || keeper.status === 'running' ? 'bg-[var(--ok)]' : 'bg-[var(--warn)]'}"></span>
                     ${displayStatus(keeper.status)}
                   </span>
-                  <button
+                  <button type="button"
                     class="text-[11px] py-0.5 px-2 rounded-md border border-[rgba(71,184,255,0.25)] bg-[rgba(71,184,255,0.08)] text-[#9ad9ff] hover:bg-[rgba(71,184,255,0.18)] cursor-pointer transition-colors"
                     onClick=${(e: Event) => { e.stopPropagation(); openOpsKeeperDetail(keeper) }}
                   >상세 보기</button>
@@ -135,7 +135,7 @@ export function OpsKeeperColumn() {
                     <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">${targetTypeLabel(targetType)}</div>
                     <div class="flex flex-wrap gap-1">
                       ${group.map((action: OperatorActionDescriptor) => html`
-                        <button key=${action.action_type}
+                        <button type="button" key=${action.action_type}
                           type="button"
                           title=${action.description ?? ''}
                           onClick=${() => {

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -100,7 +100,7 @@ export function OpsRoomColumn() {
                 <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${item.reason}</div>
                 ${item.suggested_payload ? html`
                   <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
-                    <button class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
+                    <button type="button" class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
                       폼에 채우기
                     </button>
                   </div>
@@ -147,10 +147,10 @@ export function OpsRoomColumn() {
                 </div>
                 ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[11px] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
                 <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
-                  <button class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
+                  <button type="button" class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
                     실행
                   </button>
-                  <button class="control-btn ghost" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
+                  <button type="button" class="control-btn ghost" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
                     거부
                   </button>
                   <span class="text-[var(--text-muted)] text-[var(--fs-xs)] font-mono break-all">${item.confirm_token}</span>
@@ -220,7 +220,7 @@ export function OpsRoomColumn() {
                 onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') void submitBroadcast() }}
                 disabled=${operatorActionBusy.value}
               />
-              <button class="control-btn" onClick=${() => { void submitBroadcast() }} disabled=${operatorActionBusy.value || broadcastMessage.value.trim() === ''}>
+              <button type="button" class="control-btn" onClick=${() => { void submitBroadcast() }} disabled=${operatorActionBusy.value || broadcastMessage.value.trim() === ''}>
                 보내기
               </button>
             </div>
@@ -235,10 +235,10 @@ export function OpsRoomColumn() {
                 onInput=${(event: Event) => { pauseReason.value = (event.target as HTMLInputElement).value }}
                 disabled=${operatorActionBusy.value}
               />
-              <button class="control-btn ghost" onClick=${() => { void submitPause() }} disabled=${operatorActionBusy.value}>
+              <button type="button" class="control-btn ghost" onClick=${() => { void submitPause() }} disabled=${operatorActionBusy.value}>
                 일시정지
               </button>
-              <button class="control-btn ghost" onClick=${() => { void submitResume() }} disabled=${operatorActionBusy.value}>
+              <button type="button" class="control-btn ghost" onClick=${() => { void submitResume() }} disabled=${operatorActionBusy.value}>
                 재개
               </button>
             </div>
@@ -273,7 +273,7 @@ export function OpsRoomColumn() {
                 <option value="4">P4</option>
                 <option value="5">P5</option>
               </select>
-              <button class="control-btn" onClick=${() => { void submitTaskInject() }} disabled=${operatorActionBusy.value || taskTitle.value.trim() === ''}>
+              <button type="button" class="control-btn" onClick=${() => { void submitTaskInject() }} disabled=${operatorActionBusy.value || taskTitle.value.trim() === ''}>
                 주입
               </button>
             </div>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -122,7 +122,7 @@ export function OpsSessionColumn() {
     session: typeof sessions[number],
     archived = false,
   ) => html`
-    <button
+    <button type="button"
       key=${session.session_id}
       class="ops-entity-card p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] text-inherit text-left cursor-pointer ${selectedSession?.session_id === session.session_id ? 'active' : ''}"
       onClick=${() => { selectedSessionId.value = session.session_id }}
@@ -317,13 +317,13 @@ export function OpsSessionColumn() {
         ${linkedAutoresearch?.loop_id ? html`
           <label class="control-label" for="ops-autoresearch-hypothesis">Autoresearch 제어</label>
           <div class="control-row items-stretch">
-            <button class="control-btn ghost" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
+            <button type="button" class="control-btn ghost" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
               상태 새로고침
             </button>
-            <button class="control-btn" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
+            <button type="button" class="control-btn" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
               1 cycle 실행
             </button>
-            <button class="control-btn ghost" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
+            <button type="button" class="control-btn ghost" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
               loop 중지
             </button>
           </div>
@@ -337,7 +337,7 @@ export function OpsSessionColumn() {
             disabled=${busy}
           ></textarea>
           <div class="control-row items-stretch">
-            <button class="control-btn" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
+            <button type="button" class="control-btn" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
               hypothesis 주입
             </button>
             <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
@@ -359,7 +359,7 @@ export function OpsSessionColumn() {
             <option value="task">작업</option>
             <option value="worker_spawn_batch">worker 교체</option>
           </select>
-          <button class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
+          <button type="button" class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
             적용
           </button>
         </div>
@@ -422,7 +422,7 @@ export function OpsSessionColumn() {
             onInput=${(event: Event) => { teamStopReason.value = (event.target as HTMLInputElement).value }}
             disabled=${busy || !selectedSessionActionable}
           />
-          <button class="control-btn ghost" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
+          <button type="button" class="control-btn ghost" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
             세션 중지
           </button>
         </div>

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -116,7 +116,7 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
         </div>
       `)}
       ${hasMore ? html`
-        <button
+        <button type="button"
           class="w-full py-2 bg-transparent border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-xs cursor-pointer text-center rounded-md hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors"
           onClick=${() => { expandedItems.value += baseLimit }}
         >

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -76,7 +76,7 @@ function HomeSectionHeader({
         ${count != null ? html`<${CountBadge}>${count}<//>` : null}
       </div>
       ${linkLabel && onLink
-        ? html`<button class="text-[10px] text-[var(--accent)] cursor-pointer bg-transparent border-0 p-0 hover:underline" onClick=${onLink}>${linkLabel}</button>`
+        ? html`<button type="button" class="text-[10px] text-[var(--accent)] cursor-pointer bg-transparent border-0 p-0 hover:underline" onClick=${onLink}>${linkLabel}</button>`
         : null}
     </div>
   `

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -65,16 +65,17 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
       </div>
 
       <div class="grid grid-cols-2 gap-2">
-        <button
+        <button type="button"
           class="w-full rounded-md border border-solid border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.14)] px-3 py-2 text-[11px] font-medium text-[#dff3ff] cursor-pointer transition-colors duration-150 hover:bg-[rgba(71,184,255,0.2)]"
-          onClick=${() => {
-            refreshDashboard()
-            refreshForTab(currentTab)
+          onClick=${(e: Event) => {
+            e.preventDefault()
+            void refreshDashboard().catch(() => {})
+            try { refreshForTab(currentTab) } catch {}
           }}
         >
           Room sync
         </button>
-        <button
+        <button type="button"
           class="w-full rounded-md border border-solid border-[var(--card-border)] px-3 py-2 bg-[rgba(255,255,255,0.04)] text-[var(--text-body)] text-[11px] font-medium cursor-pointer transition-colors duration-150 hover:bg-[rgba(255,255,255,0.08)]"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >
@@ -112,7 +113,7 @@ export function InterveneRailCard() {
         </div>
       </div>
       <div class="grid grid-cols-2 gap-1.5">
-        <button
+        <button type="button"
           class="w-full border border-solid border-[rgba(71,184,255,0.3)] rounded-lg bg-[var(--accent-12)] text-[#d7efff] py-1.5 px-2 text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--accent-20)]"
           onClick=${() => {
             refreshOperatorSnapshot()
@@ -121,7 +122,7 @@ export function InterveneRailCard() {
         >
           갱신
         </button>
-        <button
+        <button type="button"
           class="w-full border border-solid border-[var(--card-border)] rounded-lg py-1.5 px-2 bg-[var(--white-4)] text-[var(--text-body)] text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--white-8)]"
           onClick=${() => navigate('operations', { section: 'intervene' })}
         >

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -118,25 +118,25 @@ export function ToolMetrics() {
 
       ${data ? html`
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
-          <div class="tool-metrics-stat">
+          <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>
-            <span class="stat-label">총 호출 수</span>
+            <span class="text-[11px] text-[var(--text-muted)] font-medium">총 호출 수</span>
           </div>
-          <div class="tool-metrics-stat">
+          <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.distinct_tools_called}</span>
-            <span class="stat-label">사용된 도구</span>
+            <span class="text-[11px] text-[var(--text-muted)] font-medium">사용된 도구</span>
           </div>
-          <div class="tool-metrics-stat">
+          <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.never_called_count}</span>
-            <span class="stat-label">미사용 도구</span>
+            <span class="text-[11px] text-[var(--text-muted)] font-medium">미사용 도구</span>
           </div>
-          <div class="tool-metrics-stat">
+          <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.registered_count}</span>
-            <span class="stat-label">등록됨 (v2)</span>
+            <span class="text-[11px] text-[var(--text-muted)] font-medium">등록됨 (v2)</span>
           </div>
-          <div class="tool-metrics-stat">
+          <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.dispatch_v2_enabled ? 'ON' : 'OFF'}</span>
-            <span class="stat-label">Dispatch v2</span>
+            <span class="text-[11px] text-[var(--text-muted)] font-medium">Dispatch v2</span>
           </div>
         </div>
 

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -111,7 +111,7 @@ export function FullInventoryView({
 
       <div class="flex flex-wrap gap-2 mb-4">
         ${(Object.keys(SURFACE_LABELS) as SurfaceFilter[]).map(key => html`
-          <button
+          <button type="button"
             class=${`px-3 py-1.5 rounded-lg text-[13px] font-medium border transition-colors cursor-pointer ${surfaceFilter.value === key ? 'border-[var(--accent)]/40 text-[var(--accent)] bg-[var(--accent-8)]' : 'border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] text-[var(--text-body)]'}`}
             onClick=${() => { surfaceFilter.value = key }}
           >
@@ -181,7 +181,7 @@ export function FullInventoryView({
           />
           <span>지원 중단 표시</span>
         </label>
-        <button
+        <button type="button"
           class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
           onClick=${() => { void loadTools() }}
           disabled=${loading}
@@ -205,7 +205,7 @@ export function FullInventoryView({
         : html`<${EmptyState} message="조건에 맞는 도구가 없습니다." compact />`}
     </div>
 
-    <button
+    <button type="button"
       class=${`tool-back-to-top${showBackToTop.value ? ' visible' : ''}`}
       onClick=${scrollToTop}
       title="맨 위로"

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -37,7 +37,7 @@ export function Tools() {
               ? 'hidden/deprecated 포함 전체 도구 surface를 봅니다.'
               : '필수 도구와 사용 현황 요약입니다.'}
           </p>
-          <button
+          <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)] mt-2"
             onClick=${() => { showFullInventory.value = !showFullInventory.value }}
           >

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -44,7 +44,7 @@ export function Trpg() {
   if (!state) {
     return html`<${EmptyState}
       message="활성 TRPG 세션이 없습니다."
-      action=${html`<button class="px-3 py-1.5 text-xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] rounded-lg cursor-pointer hover:bg-[var(--white-8)]" onClick=${() => void safeFetchTrpg()}>새로고침</button>`}
+      action=${html`<button type="button" class="px-3 py-1.5 text-xs border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] rounded-lg cursor-pointer hover:bg-[var(--white-8)]" onClick=${() => void safeFetchTrpg()}>새로고침</button>`}
     />`
   }
 

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -168,15 +168,33 @@ function handleReconnect(): void {
   const label = durationSec > 0 ? `${durationSec}초 단절 후 재연결됨` : '서버 연결 복구됨'
   showToast(label, 'success', 3000)
 
-  // Refresh all data to recover events missed during disconnect
+  // Refresh all data to recover events missed during disconnect.
+  // If the server is still warming up after restart, the first fetch may fail.
+  // Schedule a single retry after 3s to cover the warm-up window.
   invalidateDashboardCache()
-  void refreshRoomTruth({ force: true })
-  refreshDashboard()
-  refreshExecution()
-  refreshBoard()
-  _refreshCommandPlaneFn?.()
-  _refreshOperatorFn?.()
-  _refreshMissionFn?.()
+  void hydrateAfterReconnect()
+}
+
+async function hydrateAfterReconnect(): Promise<void> {
+  try {
+    await Promise.all([
+      refreshRoomTruth({ force: true }),
+      refreshDashboard(),
+      refreshExecution(),
+      refreshBoard(),
+    ])
+    _refreshCommandPlaneFn?.()
+    _refreshOperatorFn?.()
+    _refreshMissionFn?.()
+  } catch {
+    // First attempt failed (server may still be warming up) — retry once.
+    setTimeout(() => {
+      void refreshRoomTruth({ force: true })
+      refreshDashboard()
+      refreshExecution()
+      _refreshOperatorFn?.()
+    }, 3000)
+  }
 }
 
 // --- SSE reaction setup ---

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -8,7 +8,9 @@ import {
   updateOasKeeperSnapshot,
   oasLastKeeperTick,
   oasTotalEvents,
+  refreshDashboard,
 } from './store'
+import { refreshRoomTruth } from './room-truth-store'
 import type { OasKeeperSnapshot } from './types/oas'
 
 const SSE_SESSION_KEY = 'masc_dashboard_sse_session_id'
@@ -157,6 +159,9 @@ export function connectSSE(): void {
     connected.value = true
     if (wasDisconnected) {
       reconnectCount.value++
+      // Refetch all data after reconnection so counts don't stay at 0
+      void refreshDashboard().catch(() => {})
+      void refreshRoomTruth().catch(() => {})
     }
   }
 


### PR DESCRIPTION
## Summary

Dashboard QA 이슈 5건 수정 (53 파일).

### 수정된 이슈

| 이슈 | 심각도 | 수정 내용 |
|------|--------|---------|
| #2554 | P0 | `type="button"` 117개 버튼 전수 추가 — form submit 방지 |
| #2544 | P0 | Governance loading/error gate — API 502 시 insertBefore 크래시 방지 |
| #2555 | P1 | SSE reconnect 후 `refreshDashboard` + `refreshRoomTruth` + 3초 retry |
| #2545 | P0 | MCP 403 graceful handling — `__blocked__` sentinel로 반복 호출 차단 |
| #2546 | P1 | PR #2604 keeperNameSet 수정 검증 완료 (이미 현재 코드에 반영됨) |

### 미수정 (별도 조사 필요)
- #2547: API 502 — 서버 라우트 존재 확인됨, v2.138.0 시점 이슈로 후속 PR에서 개선된 것으로 추정
- #2564: CI contract harness timeout — 테스트 인프라 이슈

### 변경 범위
- `dashboard/src/` 전역: `<button>` → `<button type="button">` (50 files)
- `governance.ts`: loading/error 게이트 추가
- `sse.ts`: reconnect 시 데이터 재로드
- `sse-store.ts`: `hydrateAfterReconnect()` retry 로직
- `api/mcp.ts`: 403 에러 처리 + `__blocked__` sentinel

## Test plan
- [ ] `npx tsc --noEmit` 통과 확인
- [ ] Governance 페이지: API 502 시 에러 메시지 표시 (크래시 없음)
- [ ] SSE 재연결: F5 후 3초 내 데이터 복구 확인
- [ ] Room sync 버튼: 클릭 시 about:blank 이동 없음
- [ ] Cloudflare tunnel 경유: MCP 기능 차단 메시지 표시

Closes #2554, Closes #2544, Closes #2555, Closes #2545, Closes #2546

Generated with [Claude Code](https://claude.com/claude-code)