### PR TITLE
fix(tools): remove dead tools, add library shard, clean stale mappings

### DIFF
--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -286,25 +286,7 @@ let local_worker_internal_seeds : capability_seed list =
              ~supports_direct_user_discovery:false ~surface:Local_worker
              schema)
   in
-  let compatibility_projection =
-    match
-      List.find_opt
-        (fun (schema : Types.tool_schema) ->
-          String.equal schema.name "masc_team_session_step")
-        local_worker_internal_schemas
-    with
-    | None -> []
-    | Some schema ->
-        [
-          make_seed ~capability_id:"masc_team_session_step" ~risk_class:Audited
-            ~audiences:[ Local_worker_agent ]
-            ~supports_audit_evidence:true
-            ~supports_direct_user_discovery:false ~surface:Local_worker
-            ~backend_tool_name:"masc_team_session_step"
-            { schema with name = "masc_team_session_turn" };
-        ]
-  in
-  base @ compatibility_projection
+  base
 
 let keeper_projection_seeds : capability_seed list =
   Tool_shard.keeper_model_tools

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -389,8 +389,7 @@ let tool_category tool_name =
   | "masc_library_add" | "masc_library_list" | "masc_library_read"
   | "masc_library_search" | "masc_library_promote"
   (* Spawn *)
-  | "masc_spawn"
-  | "masc_async_spawn" | "masc_job_status" | "masc_job_list" -> Ecosystem
+  | "masc_spawn" -> Ecosystem
 
   (* ── Voice: TTS, STT, sessions, conferences ── *)
   | "masc_voice_speak" | "masc_voice_session_start"
@@ -398,20 +397,7 @@ let tool_category tool_name =
   | "masc_voice_agent" | "masc_voice_transcript"
   | "masc_voice_conference_start" | "masc_voice_conference_end" -> Voice
 
-  (* ── TRPG (canonical + legacy masc_trpg_* names) ── *)
-  | "trpg_roleplay"
-  | "masc_trpg_actor_claim" | "masc_trpg_actor_delete"
-  | "masc_trpg_actor_match" | "masc_trpg_actor_release"
-  | "masc_trpg_actor_spawn" | "masc_trpg_actor_update"
-  | "masc_trpg_dice_roll"
-  | "masc_trpg_intervention_submit"
-  | "masc_trpg_join_eligibility" | "masc_trpg_mid_join_request"
-  | "masc_trpg_party_select" | "masc_trpg_pool_generate"
-  | "masc_trpg_preset_list"
-  | "masc_trpg_quest_update" | "masc_trpg_round_run"
-  | "masc_trpg_scene_transition"
-  | "masc_trpg_session_start" | "masc_trpg_stream"
-  | "masc_trpg_turn_advance" | "masc_trpg_world_event" -> TRPG
+  (* ── TRPG: archived (#1668), no active schemas ── *)
 
   (* ── Deprecated/archived tools (hidden via tool_catalog, excluded from presets) ── *)
 
@@ -420,8 +406,7 @@ let tool_category tool_name =
   | _ when String.starts_with ~prefix:"decision_" tool_name -> Consensus
   | _ when String.starts_with ~prefix:"experiment." tool_name -> Ecosystem
   | _ when String.starts_with ~prefix:"experiment_" tool_name -> Ecosystem
-  | _ when String.starts_with ~prefix:"trpg." tool_name -> TRPG
-  | _ when String.starts_with ~prefix:"masc_trpg_" tool_name -> TRPG
+  (* trpg.* and masc_trpg_* prefix fallbacks removed — archived (#1668) *)
   | _ when String.starts_with ~prefix:"client." tool_name -> Core_Ops
   | _ when String.starts_with ~prefix:"client_" tool_name -> Core_Ops
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -238,7 +238,7 @@ let standard_tools =
     "masc_handover_get"; "masc_handover_list";
     (* Misc *)
     "masc_spawn"; "masc_agents"; "masc_progress";
-    "masc_note_add"; "masc_batch_add_tasks"; "masc_stats";
+    "masc_note_add"; "masc_batch_add_tasks";
   ]
 
 (** Pre-built Hashtbl sets for O(1) tier lookups.

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -370,10 +370,10 @@ let dispatch (ctx : context) ~name ~args : result option =
     | "masc_case_brief_submit" -> Some handle_case_brief_submit
     | "masc_cases" -> Some handle_cases
     | "masc_case_status" -> Some handle_case_status
-    | "masc_council_route" | "masc_route" -> Some handle_route
-    | "masc_council_execute" | "masc_execute" -> Some handle_execute
-    | "masc_council_execute_dry_run" | "masc_execute_dry_run" -> Some handle_execute_dry_run
-    | "masc_governance_petition" | "masc_petition_submit" -> Some handle_petition_submit
+    | "masc_route" -> Some handle_route
+    | "masc_execute" -> Some handle_execute
+    | "masc_execute_dry_run" -> Some handle_execute_dry_run
+    | "masc_petition_submit" -> Some handle_petition_submit
     | "masc_governance_status" -> Some handle_governance_status
     | "masc_governance_feed" -> Some handle_governance_feed
     | "masc_ruling_status" -> Some handle_ruling_status

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -734,36 +734,6 @@ let handle_keeper_tool_catalog _ctx args =
   in
   (true, Yojson.Safe.pretty_to_string json)
 
-(** BUG-014: Purge test data (test-* prefix agents, tasks, messages).
-    Requires confirm=true to execute. *)
-let handle_purge_test_data ctx args =
-  let confirm = get_bool args "confirm" false in
-  if not confirm then
-    (false, "Purge requires confirm=true. This will remove all test-* agents, tasks, and messages.")
-  else begin
-    let config = ctx.config in
-    let removed = ref 0 in
-    (* Remove test-* agent files *)
-    let agents_path = Room.agents_dir config in
-    if Sys.file_exists agents_path then
-      Sys.readdir agents_path |> Array.iter (fun name ->
-        if String.length name > 5 && String.sub name 0 5 = "test-" then begin
-          (try Sys.remove (Filename.concat agents_path name)
-           with Sys_error msg -> Log.Misc.warn "purge remove %s: %s" name msg);
-          incr removed
-        end);
-    (* Remove test-* messages *)
-    let messages_path = Room.messages_dir config in
-    if Sys.file_exists messages_path then
-      Sys.readdir messages_path |> Array.iter (fun name ->
-        if String.length name > 5 && String.sub name 0 5 = "test-" then begin
-          (try Sys.remove (Filename.concat messages_path name)
-           with Sys_error msg -> Log.Misc.warn "purge remove %s: %s" name msg);
-          incr removed
-        end);
-    (true, Printf.sprintf "Purged %d test-* files" !removed)
-  end
-
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -771,7 +741,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_verify_handoff" -> Some (handle_verify_handoff ctx args)
   | "masc_gc" -> Some (handle_gc ctx args)
   | "masc_cleanup_zombies" -> Some (handle_cleanup_zombies ctx args)
-  | "masc_purge_test_data" -> Some (handle_purge_test_data ctx args)
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_tool_admin_snapshot" -> Some (handle_tool_admin_snapshot ctx args)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -245,6 +245,31 @@ let weather_tools : Types.tool_schema list = [
   };
 ]
 
+let library_tools : Types.tool_schema list = [
+  {
+    name = "keeper_library_search";
+    description = "Search agent knowledge library documents by keyword query. Returns matching titles, confidence scores, and snippets.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [("type", `String "string"); ("description", `String "Search query string")]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  };
+  {
+    name = "keeper_library_read";
+    description = "Read a specific document from the agent knowledge library by topic name.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("topic", `Assoc [("type", `String "string"); ("description", `String "Document topic name to read")]);
+      ]);
+      ("required", `List [`String "topic"]);
+    ];
+  };
+]
+
 let taskboard_tools : Types.tool_schema list = [
   {
     name = "keeper_tasks_list";
@@ -366,6 +391,13 @@ let shard_voice : shard = {
   description = "Voice bridge speak output";
 }
 
+let shard_library : shard = {
+  name = "library";
+  tools = library_tools;
+  removable = true;
+  description = "Knowledge library: search, read documents";
+}
+
 let shard_taskboard : shard = {
   name = "taskboard";
   tools = taskboard_tools;
@@ -400,6 +432,7 @@ let default_shard_names : string list = [
   "shell";
   "weather";
   "voice";
+  "library";
   "taskboard";
 ]
 
@@ -420,6 +453,7 @@ let all_shards : (string, shard) Hashtbl.t =
     shard_shell;
     shard_weather;
     shard_voice;
+    shard_library;
     shard_taskboard;
     shard_autoresearch;
   ];

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -158,7 +158,7 @@ let register_all () =
   (* ── Mod_misc: Tool_misc ──────────────────────────────────────── *)
   reg Mod_misc [
     "masc_dashboard"; "masc_verify_handoff";
-    "masc_gc"; "masc_cleanup_zombies"; "masc_purge_test_data";
+    "masc_gc"; "masc_cleanup_zombies";
     "masc_tool_stats"; "masc_tool_help";
     "masc_tool_admin_snapshot"; "masc_tool_admin_update";
     "masc_keeper_tool_catalog";

--- a/lib/tool_team_session_handlers.ml
+++ b/lib/tool_team_session_handlers.ml
@@ -118,29 +118,6 @@ let handle_compare ctx args : result =
   | Error e, _ -> (false, json_error e)
   | _, Error e -> (false, json_error e)
 
-let handle_turn ctx args : result =
-  match get_valid_session_id args with
-  | Error e -> (false, json_error e)
-  | Ok session_id -> (
-      match ensure_session_access ctx session_id with
-      | Error e -> (false, json_error e)
-      | Ok () -> (
-          match parse_turn_kind args with
-          | Error e -> (false, json_error e)
-          | Ok turn_kind ->
-              let message = get_string_opt args "message" in
-              let target_agent = get_string_opt args "target_agent" in
-              let task_title = get_string_opt args "task_title" in
-              let task_description = get_string_opt args "task_description" in
-              let task_priority = get_int args "task_priority" 3 in
-              (match
-                 record_session_turn_json ~config:ctx.config ~session_id
-                   ~actor:ctx.agent_name ~turn_kind ~message ~target_agent
-                   ~task_title ~task_description ~task_priority
-               with
-              | Ok json -> (true, json_ok [ ("result", json) ])
-              | Error e -> (false, json_error e))))
-
 (* Routing, spawn spec parsing, model inference, worker management *)
 include Tool_team_session_routing_workers
 
@@ -567,7 +544,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_team_session_report" -> Some (handle_report ctx args)
   | "masc_team_session_list" -> Some (handle_list ctx args)
   | "masc_team_session_compare" -> Some (handle_compare ctx args)
-  | "masc_team_session_turn" -> Some (handle_turn ctx args)
   | "masc_team_session_events" -> Some (handle_events ctx args)
   | "masc_team_session_prove" -> Some (handle_prove ctx args)
   | "masc_team_session_verify_trace" -> Some (handle_verify_trace ctx args)

--- a/lib/tool_unified.ml
+++ b/lib/tool_unified.ml
@@ -57,7 +57,7 @@ let tool_info_to_json (info : tool_info) : Yojson.Safe.t =
     ("call_stats", stats_json);
   ]
 
-(** Summary report for dashboard / masc_stats. *)
+(** Summary report for dashboard. *)
 let summary_report () : Yojson.Safe.t =
   let total = Tool_registry.total_calls () in
   let distinct = Tool_registry.distinct_tools_called () in

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -48,7 +48,7 @@ let test_team_session_capability_merges_public_and_local_worker_projections () =
   let names = projection_names capability in
   check bool "public canonical projection" true
     (List.mem "masc_team_session_step" names);
-  check bool "local worker compatibility projection" true
+  check bool "turn alias removed" false
     (List.mem "masc_team_session_turn" names)
 
 let test_local_worker_projection_exposes_internal_and_auditable_tools () =
@@ -77,8 +77,6 @@ let test_spawned_agent_surface_stays_curated () =
   let names = Lib.Capability_registry.spawned_agent_prefixed_tools in
   check bool "contains masc_status" true
     (List.mem "mcp__masc__masc_status" names);
-  check bool "omits team_session_turn alias" false
-    (List.mem "mcp__masc__masc_team_session_turn" names);
   check bool "contains team_session_step" true
     (List.mem "mcp__masc__masc_team_session_step" names)
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1129,15 +1129,6 @@ let test_handle_request_tools_list_hides_team_session_turn_by_default () =
              | _ -> false)
          | _ -> false)
        tools);
-  Alcotest.(check bool) "turn hidden by default" false
-    (List.exists
-       (function
-         | `Assoc fields -> (
-             match List.assoc_opt "name" fields with
-             | Some (`String "masc_team_session_turn") -> true
-             | _ -> false)
-         | _ -> false)
-       tools);
   cleanup_dir base_path
 
 let test_handle_request_tools_list_include_usage_metadata () =

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -204,8 +204,6 @@ let test_tool_category_core () =
     (Mode.tool_category "masc_team_session_step" = Mode.Core_Session);
   check bool "team_session_finalize" true
     (Mode.tool_category "masc_team_session_finalize" = Mode.Core_Session);
-  check bool "team_session_turn" true
-    (Mode.tool_category "masc_team_session_turn" = Mode.Unknown);
   check bool "team_session_events" true
     (Mode.tool_category "masc_team_session_events" = Mode.Core_Session);
   (* Core_Ops *)
@@ -293,7 +291,8 @@ let test_tool_category_ecosystem_voice () =
     (Mode.tool_category "masc_voice_conference_start" = Mode.Voice)
 
 let test_tool_category_namespace_mapping () =
-  check bool "trpg namespace" true (Mode.tool_category "trpg.dice.roll" = Mode.TRPG);
+  (* trpg.* prefix removed — TRPG archived (#1668) *)
+  check bool "trpg namespace archived" true (Mode.tool_category "trpg.dice.roll" = Mode.Unknown);
   check bool "experiment namespace" true (Mode.tool_category "experiment.start" = Mode.Ecosystem);
   check bool "decision namespace" true (Mode.tool_category "decision.create" = Mode.Consensus);
   check bool "decision underscore" true (Mode.tool_category "decision_consensus" = Mode.Consensus);

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -335,7 +335,7 @@ let test_petition_submit_creates_case () =
     ("subject", `String "task");
     ("risk_class", `String "low");
   ] in
-  match Tool_council_oas.dispatch ctx ~name:"masc_governance_petition" ~args with
+  match Tool_council_oas.dispatch ctx ~name:"masc_petition_submit" ~args with
   | Some (ok, body) ->
     Alcotest.(check bool) "petition ok" true ok;
     let json = parse_json body in
@@ -351,7 +351,7 @@ let test_petition_submit_empty_title_err () =
   with_council_base @@ fun base_path ->
   let ctx = make_council_ctx ~base_path in
   let args = `Assoc [("title", `String "")] in
-  match Tool_council_oas.dispatch ctx ~name:"masc_governance_petition" ~args with
+  match Tool_council_oas.dispatch ctx ~name:"masc_petition_submit" ~args with
   | Some (ok, body) ->
     Alcotest.(check bool) "empty title rejected" false ok;
     let json = parse_json body in
@@ -416,7 +416,7 @@ let test_governance_status_after_petition () =
     ("subject", `String "task");
     ("risk_class", `String "low");
   ] in
-  (match Tool_council_oas.dispatch ctx ~name:"masc_governance_petition" ~args with
+  (match Tool_council_oas.dispatch ctx ~name:"masc_petition_submit" ~args with
    | Some (ok, _) -> Alcotest.(check bool) "petition ok" true ok
    | None -> Alcotest.fail "petition dispatch returned None");
   match Tool_council_oas.dispatch ctx ~name:"masc_governance_status" ~args:(`Assoc []) with

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -108,8 +108,6 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_status" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits masc_claim" false
     (List.mem "mcp__masc__masc_claim" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "omits team_session_turn" false
-    (List.mem "mcp__masc__masc_team_session_turn" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains team_session_step" true
     (List.mem "mcp__masc__masc_team_session_step" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains team_session_finalize" true

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -62,7 +62,7 @@ let test_shard_unknown () =
 
 let test_all_shards_count () =
   let all = Tool_shard.list_all_shards () in
-  Alcotest.(check bool) "at least 8 shards" true (List.length all >= 8)
+  Alcotest.(check int) "9 predefined shards" 9 (List.length all)
 
 (* ============================================================
    default_shard_names tests
@@ -70,11 +70,11 @@ let test_all_shards_count () =
 
 let test_default_shard_names () =
   let defaults = Tool_shard.default_shard_names in
-  Alcotest.(check int) "7 defaults" 7 (List.length defaults);
+  Alcotest.(check int) "8 defaults" 8 (List.length defaults);
   List.iter (fun name ->
     Alcotest.(check bool) (name ^ " in defaults") true
       (List.mem name defaults)
-  ) ["base"; "board"; "filesystem"; "shell"; "weather"; "voice"; "taskboard"]
+  ) ["base"; "board"; "filesystem"; "shell"; "weather"; "voice"; "library"; "taskboard"]
 
 (* ============================================================
    tools_of_shards tests
@@ -99,8 +99,8 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_model_tools_count () =
   let tools = Tool_shard.keeper_model_tools in
-  (* base=3 + board=5 + filesystem=2 + shell=3 + weather=1 + voice=5 + taskboard=7 = 26 *)
-  Alcotest.(check int) "26 total tools" 26 (List.length tools)
+  (* base=3 + board=5 + filesystem=2 + shell=3 + weather=1 + voice=5 + library=2 + taskboard=7 = 28 *)
+  Alcotest.(check int) "28 total tools" 28 (List.length tools)
 
 (* ============================================================
    grant_shard tests
@@ -178,7 +178,7 @@ let test_revoke_unknown () =
 let test_get_agent_shards_default () =
   (* Unknown agent gets default shards *)
   let shards = Tool_shard.get_agent_shards "new-agent-never-seen" in
-  Alcotest.(check int) "defaults" 7 (List.length shards)
+  Alcotest.(check int) "defaults" 8 (List.length shards)
 
 let test_set_get_agent_shards () =
   Hashtbl.remove Tool_shard.agent_shards "test-agent-x";
@@ -201,7 +201,7 @@ let test_execute_tool_list () =
   let (ok, json) = Tool_shard.execute "masc_tool_list" (`Assoc []) in
   Alcotest.(check bool) "succeeds" true ok;
   let shards = Yojson.Safe.Util.(member "shards" json |> to_list) in
-  Alcotest.(check int) "8 shards in list" 8 (List.length shards)
+  Alcotest.(check int) "9 shards in list" 9 (List.length shards)
 
 let test_execute_tool_list_with_agent () =
   Hashtbl.remove Tool_shard.agent_shards "test-ex";

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -28,8 +28,6 @@ let () =
           Alcotest.test_case "list-and-compare" `Quick Test_tool_team_session_flow.test_list_and_compare;
           Alcotest.test_case "turn-events-prove" `Quick
             Test_tool_team_session_flow.test_turn_events_and_prove;
-          Alcotest.test_case "step-plain-turn-matches-legacy-turn" `Quick
-            Test_tool_team_session_flow.test_step_plain_turn_matches_legacy_turn;
           Alcotest.test_case "idle-session-stays-running-before-first-step"
             `Quick
             Test_tool_team_session_flow

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -183,7 +183,7 @@ let test_turn_events_and_prove () =
   let session_id = start_session_exn ctx ~goal:"turn-events-prove" |> get_session_id in
 
   let invalid_turn_ok, _ =
-    dispatch_exn ctx ~name:"masc_team_session_turn"
+    dispatch_exn ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
           [
@@ -193,7 +193,7 @@ let test_turn_events_and_prove () =
   in
   Alcotest.(check bool) "invalid turn kind rejected" false invalid_turn_ok;
   let empty_note_ok, _ =
-    dispatch_exn ctx ~name:"masc_team_session_turn"
+    dispatch_exn ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
           [
@@ -215,7 +215,7 @@ let test_turn_events_and_prove () =
 
   let check_turn turn_kind extra =
     let ok, _ =
-      dispatch_exn ctx ~name:"masc_team_session_turn"
+      dispatch_exn ctx ~name:"masc_team_session_step"
         ~args:
           (`Assoc
             ([
@@ -304,82 +304,7 @@ let test_turn_events_and_prove () =
     proof_schema_version;
   cleanup_dir base_dir
 
-let test_step_plain_turn_matches_legacy_turn () =
-  with_eio @@ fun env ->
-  Eio.Switch.run @@ fun sw ->
-  let base_dir = temp_dir () in
-  let config = Room.default_config base_dir in
-  ignore (Room.init config ~agent_name:(Some "tester"));
-  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
-  let ctx : _ Tool_team_session.context =
-    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
-  in
-  let legacy_session_id =
-    start_session_exn ctx ~goal:"legacy-turn-parity" |> get_session_id
-  in
-  let legacy_ok, legacy_body =
-    dispatch_exn ctx ~name:"masc_team_session_turn"
-      ~args:
-        (`Assoc
-          [
-            ("session_id", `String legacy_session_id);
-            ("turn_kind", `String "note");
-            ("message", `String "legacy note");
-          ])
-  in
-  Alcotest.(check bool) "legacy turn ok" true legacy_ok;
-  let legacy_turn = parse_json_exn legacy_body |> result_field in
-  Alcotest.(check string) "legacy kind" "note"
-    Yojson.Safe.Util.(legacy_turn |> member "kind" |> to_string);
-
-  let step_session_id =
-    start_session_exn ctx ~goal:"step-turn-parity" |> get_session_id
-  in
-  let step_ok, step_body =
-    dispatch_exn ctx ~name:"masc_team_session_step"
-      ~args:
-        (`Assoc
-          [
-            ("session_id", `String step_session_id);
-            ("turn_kind", `String "note");
-            ("message", `String "step note");
-          ])
-  in
-  Alcotest.(check bool) "step turn ok" true step_ok;
-  let step_turn =
-    parse_json_exn step_body |> result_field |> Yojson.Safe.Util.member "turn"
-  in
-  Alcotest.(check string) "step kind" "note"
-    Yojson.Safe.Util.(step_turn |> member "kind" |> to_string);
-  Alcotest.(check bool) "step spawn null" true
-    (parse_json_exn step_body |> result_field |> Yojson.Safe.Util.member "spawn"
-    = `Null);
-
-  let team_turn_detail_exn session_id =
-    match
-      List.find_opt
-        (fun json ->
-          Yojson.Safe.Util.(json |> member "event_type" |> to_string = "team_turn"))
-        (Team_session_store.read_events ~max_events:20 config session_id)
-    with
-    | Some event -> Yojson.Safe.Util.member "detail" event
-    | None -> Alcotest.fail "expected team_turn event"
-  in
-  let legacy_detail = team_turn_detail_exn legacy_session_id in
-  let step_detail = team_turn_detail_exn step_session_id in
-  Alcotest.(check string) "legacy detail kind" "note"
-    Yojson.Safe.Util.(legacy_detail |> member "kind" |> to_string);
-  Alcotest.(check string) "step detail kind" "note"
-    Yojson.Safe.Util.(step_detail |> member "kind" |> to_string);
-  Alcotest.(check string) "legacy actor" "tester"
-    Yojson.Safe.Util.(legacy_detail |> member "actor" |> to_string);
-  Alcotest.(check string) "step actor" "tester"
-    Yojson.Safe.Util.(step_detail |> member "actor" |> to_string);
-  Alcotest.(check string) "legacy message" "legacy note"
-    Yojson.Safe.Util.(legacy_detail |> member "message" |> to_string);
-  Alcotest.(check string) "step message" "step note"
-    Yojson.Safe.Util.(step_detail |> member "message" |> to_string);
-  cleanup_dir base_dir
+(* test_step_plain_turn_matches_legacy_turn removed — handle_turn archived *)
 
 let test_idle_session_stays_running_before_first_step () =
   with_eio @@ fun env ->

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -13,7 +13,7 @@ let test_prove_strong_requires_additional_evidence () =
   in
   let session_id = start_session_exn ctx ~goal:"prove-strong-check" |> get_session_id in
   ignore
-    (dispatch_exn ctx ~name:"masc_team_session_turn"
+    (dispatch_exn ctx ~name:"masc_team_session_step"
        ~args:
          (`Assoc
            [
@@ -122,7 +122,7 @@ let test_unauthorized_session_access () =
   Alcotest.(check bool) "unauthorized compare denied" false compare_ok;
 
   let turn_ok, _ =
-    dispatch_exn intruder_ctx ~name:"masc_team_session_turn"
+    dispatch_exn intruder_ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
           [

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -71,7 +71,7 @@ let test_proof_exposes_spawn_selection_rationale () =
            updated_at_iso = Types.now_iso ();
          }));
   let turn_ok, _ =
-    dispatch_exn ctx ~name:"masc_team_session_turn"
+    dispatch_exn ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
           [
@@ -427,7 +427,7 @@ let test_prove_requires_multi_actor_turn_coverage () =
     |> get_session_id
   in
   let single_turn_ok, _ =
-    dispatch_exn ctx ~name:"masc_team_session_turn"
+    dispatch_exn ctx ~name:"masc_team_session_step"
       ~args:
         (`Assoc
           [

--- a/test/test_tool_team_session_step_followup.ml
+++ b/test/test_tool_team_session_step_followup.ml
@@ -221,7 +221,7 @@ let test_proof_exposes_failed_spawn_and_detach_counts () =
           ("ts_iso", `String (Types.now_iso ()));
         ]);
   ignore
-    (dispatch_exn ctx ~name:"masc_team_session_turn"
+    (dispatch_exn ctx ~name:"masc_team_session_step"
        ~args:
          (`Assoc
            [
@@ -376,7 +376,7 @@ let test_report_and_proof_expose_empty_note_turn_evidence () =
           ("ts_iso", `String (Types.now_iso ()));
         ]);
   ignore
-    (dispatch_exn ctx ~name:"masc_team_session_turn"
+    (dispatch_exn ctx ~name:"masc_team_session_step"
        ~args:
          (`Assoc
            [

--- a/test/test_tool_team_session_step_validation.ml
+++ b/test/test_tool_team_session_step_validation.ml
@@ -35,7 +35,7 @@ let test_missing_required_args () =
       ~args:(`Assoc [ ("status", `String "not-a-status") ])
   in
   let ok10, _ =
-    dispatch_exn ctx ~name:"masc_team_session_turn" ~args:(`Assoc [])
+    dispatch_exn ctx ~name:"masc_team_session_step" ~args:(`Assoc [])
   in
   let ok11, _ =
     dispatch_exn ctx ~name:"masc_team_session_events" ~args:(`Assoc [])


### PR DESCRIPTION
## Summary

Tool audit 검증에서 발견된 3개 이슈를 한 번에 해결.

- **P1 (#2622)**: 7개 dead tool의 alias/handler/dispatch/catalog 제거. 테스트는 canonical 이름으로 마이그레이션 (`masc_team_session_turn`→`step`, `masc_governance_petition`→`petition_submit`)
- **P2 (#2623)**: `keeper_library_search`/`keeper_library_read` 스키마를 `tool_shard.ml`에 추가. dispatch는 이미 존재했지만 LLM이 도구를 발견할 수 없었음
- **P3 (#2624)**: mode.ml에서 21개 archived TRPG mapping + 3개 stale tool name 제거

## Changes

- 22 files changed, -145 lines net
- 빌드 성공, shard coverage 42 tests 전부 PASS
- 기존 실패 테스트(mitosis_tools, operator keeper msg, read_file_tail_lines)와 무관

## Affected tools

| Action | Tool | Reason |
|--------|------|--------|
| Removed alias | `masc_council_route/execute/execute_dry_run` | Dead dispatch aliases |
| Removed alias | `masc_governance_petition` | Dead dispatch alias |
| Removed handler | `masc_purge_test_data` | Dead tool (no schema) |
| Removed handler | `masc_team_session_turn` | Dead compatibility projection |
| Removed catalog | `masc_stats` | Ghost entry (no handler) |
| Added schema | `keeper_library_search/read` | Dispatch existed, schema missing |
| Removed mapping | 21 TRPG + 3 stale | Archived (#1668) / deleted |

## Test plan

- [x] `dune build --root .` 성공
- [x] shard coverage tests 42/42 PASS
- [x] No new test regressions
- [ ] CI green 확인

Closes #2622, closes #2623, closes #2624.