### PR TITLE
fix(server+dashboard): API 502 timeout + mobile responsive sidebar

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -22,6 +22,7 @@ import { ToastContainer } from './components/common/toast'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 
 export const sidebarCollapsed = signal(false)
+export const mobileMenuOpen = signal(false)
 
 export function App() {
   useEffect(() => {
@@ -71,6 +72,12 @@ export function App() {
         <div class="mx-auto flex w-full max-w-[1680px] items-start justify-between gap-6 max-[860px]:flex-col max-[860px]:items-stretch">
           <div class="min-w-0">
             <div class="flex items-center gap-4">
+              <button type="button"
+                class="hidden max-[768px]:flex size-10 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] text-[var(--text-body)] cursor-pointer hover:bg-[rgba(255,255,255,0.1)]"
+                onClick=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
+              >
+                ${mobileMenuOpen.value ? '\u2715' : '\u2630'}
+              </button>
               <div class="flex size-11 shrink-0 items-center justify-center rounded-[14px] border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[18px] font-bold text-[#bfe7ff] shadow-[0_0_20px_rgba(71,184,255,0.15)]">
                 ${currentView?.icon ?? 'M'}
               </div>
@@ -96,7 +103,7 @@ export function App() {
       </header>
 
       <div class="flex flex-1 gap-5 overflow-hidden p-5 max-[1100px]:flex-col max-[1100px]:p-4">
-        <aside class="${sidebarCollapsed.value ? 'w-16' : 'w-[260px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[20px] border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)] transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[360px] relative">
+        <aside class="${sidebarCollapsed.value ? 'w-16' : 'w-[260px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[20px] border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)] transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[360px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'} relative">
           <div class="absolute inset-0 bg-gradient-to-b from-[rgba(255,255,255,0.03)] to-transparent pointer-events-none rounded-[20px]"></div>
           <div class="relative h-full">
             <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -193,7 +193,19 @@ let command_plane_orchestra_http_json ~deps ~state request =
       mcp_session_id = deps.get_session_id_any request;
     }
   in
-  let full = Command_plane_orchestra.json ?run_id ?operation_id ctx in
+  let clock = deps.get_clock () in
+  let full =
+    match Eio.Time.with_timeout clock 30.0 (fun () ->
+      Ok (Command_plane_orchestra.json ?run_id ?operation_id ctx)
+    ) with
+    | Ok v -> v
+    | Error `Timeout ->
+        `Assoc [
+          ("error", `String "timeout");
+          ("message", `String "Orchestra computation timed out after 30s");
+          ("generated_at", `String (Types.now_iso ()));
+        ]
+  in
   if summary_only then
     (* Strip heavy nodes/edges for lightweight summary response *)
     match full with

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -319,8 +319,17 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
       | Some ("0" | "false" | "no") -> false
       | _ -> true
     in
-    Operator_control.snapshot_json ?actor
-      ~include_messages ~include_sessions ~include_keepers ctx
+    match Eio.Time.with_timeout clock 30.0 (fun () ->
+      Ok (Operator_control.snapshot_json ?actor
+        ~include_messages ~include_sessions ~include_keepers ctx)
+    ) with
+    | Ok v -> v
+    | Error `Timeout ->
+        `Assoc [
+          ("error", `String "timeout");
+          ("message", `String "Operator snapshot timed out after 30s");
+          ("generated_at", `String (Types.now_iso ()));
+        ]
   end
 
 let operator_digest_http_json ~state ~sw ~clock request =


### PR DESCRIPTION
## Summary
1. **API 502 timeout** (#2547): orchestra와 operator 핸들러에 30초 타임아웃 추가. 타임아웃 시 502 대신 `{"error":"timeout"}` JSON 반환.
2. **반응형 사이드바** (#2548): 768px 이하에서 사이드바 숨김 + 헤더 햄버거 토글 추가.

## Changed files
- `lib/server/server_command_plane_http_support.ml` — orchestra 30s timeout
- `lib/server/server_dashboard_http_core.ml` — operator snapshot 30s timeout
- `dashboard/src/app.ts` — mobileMenuOpen signal + hamburger button + conditional sidebar hide

## Test plan
- [ ] `dune build` 성공
- [ ] `npm run build` (dashboard) 성공
- [ ] 워룸 & 스웜 페이지에서 502 에러 해소 확인
- [ ] 768px 이하 뷰포트에서 사이드바 숨겨지고 햄버거로 토글되는지 확인
- [ ] 1100px+ 에서 기존 레이아웃 유지 확인

Closes #2547, closes #2548

🤖 Generated with [Claude Code](https://claude.com/claude-code)