### PR TITLE
fix(webrtc): handle missing ice_candidates in answer request

### DIFF
--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -295,9 +295,9 @@ let handle_answer_request body =
       Yojson.Safe.Util.(member "agent_name" json |> to_string) in
     (* Also accept optional answerer ICE candidates *)
     let answer_ice =
-      Yojson.Safe.Util.(member "ice_candidates" json |> to_list
-        |> List.map to_string)
-      |> (fun l -> l)
+      match Yojson.Safe.Util.member "ice_candidates" json with
+      | `Null -> []
+      | candidates -> Yojson.Safe.Util.(to_list candidates |> List.map to_string)
     in
     ignore answer_ice;
     match accept_offer ~offer_id ~answerer_agent:answerer with


### PR DESCRIPTION
## Summary
- `handle_answer_request` in `server_webrtc_transport.ml` called `Yojson.Safe.Util.to_list` on the `ice_candidates` field without null-checking. When the answerer omits the optional field (which is the normal case), `member` returns `` `Null `` and `to_list` throws `Type_error`, causing the entire answer flow to return `Error`.
- Fix: match on `` `Null `` explicitly and default to an empty list.
- Root cause introduced in #2634 (feat(webrtc): integrate ocaml-webrtc DataChannel).

## Test plan
- [x] `dune exec test/test_transport_integration.exe` — all 9 tests pass (was 8/9)
- [x] `dune build` — clean compilation


Generated with [Claude Code](https://claude.com/claude-code)