### PR TITLE
fix(board): respect stored post_kind in serialization

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -332,7 +332,7 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
     ("author", `String (Agent_id.to_string p.author));
     ("title", `String p.title);
     ("body", `String p.body);
-    ("post_kind", `String (post_kind_to_string (classify_post_kind p)));
+    ("post_kind", `String (post_kind_to_string p.post_kind));
     ("content", `String p.content);
     ("visibility", `String (visibility_to_string p.visibility));
     ("created_at", `Float p.created_at);


### PR DESCRIPTION
## Summary
board_post에서 명시적으로 지정한 post_kind가 직렬화 시 무시되는 버그 수정.

### Before
- post_kind=human으로 생성해도 응답에 automation으로 반환
- 원인: post_to_yojson이 classify_post_kind()를 호출하여 author 이름 기반으로 재분류
- "qa-" prefix 작성자는 author_looks_automation에 의해 항상 automation으로 덮어씌워짐

### After
- post_to_yojson이 저장된 p.post_kind를 직접 사용
- classify_post_kind는 list 필터링/정렬 용도로 유지

## Test plan
- [ ] dune build 성공
- [ ] post_kind=human으로 post 생성 시 응답에 "human" 반환 확인
- [ ] exclude_automation 필터 동작 확인

Generated with Claude Code