### PR TITLE
fix(transport): gRPC reflection + shutdown stats dedup

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -48,14 +48,14 @@ let start
       Masc_grpc_service.create_service ~room_config ~tool_dispatcher
     in
     let server =
-      Grpc_eio.Server.create
+      Grpc_eio.Reflection.create_server_with_reflection
         ~config:{ Grpc_eio.Server.default_config with port; host = "127.0.0.1" }
         ()
       |> Grpc_eio.Server.add_service service
       |> Grpc_eio.Server.with_interceptor (Grpc_eio.Interceptor.logging ())
     in
     Eio.Fiber.fork ~sw (fun () ->
-      Log.Server.info "gRPC coordination server starting on port %d" port;
+      Log.Server.info "gRPC coordination server starting on port %d (reflection enabled)" port;
       Log.Server.info "  service: %s" Masc_grpc_service.service_name;
       Log.Server.info "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
       (try

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -574,6 +574,7 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
   Log.Server.info "HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port";
   let h2_count = Atomic.make 0 in
   let h1_count = Atomic.make 0 in
+  let stats_logged = Atomic.make false in
   let rec accept_loop backoff_s =
     try
       let flow, client_addr = Eio.Net.accept ~sw socket in
@@ -629,13 +630,16 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
       accept_loop 0.05
     with
     | Eio.Cancel.Cancelled _ as e ->
-      Log.Server.info "[auto] stats: h2=%d h1=%d"
-        (Atomic.get h2_count) (Atomic.get h1_count);
+      if Atomic.compare_and_set stats_logged false true then
+        Log.Server.info "[auto] stats: h2=%d h1=%d"
+          (Atomic.get h2_count) (Atomic.get h1_count);
       raise e
     | exn ->
-      if is_cancelled exn then
-        Log.Server.info "[auto] stats: h2=%d h1=%d"
-          (Atomic.get h2_count) (Atomic.get h1_count)
+      if is_cancelled exn then begin
+        if Atomic.compare_and_set stats_logged false true then
+          Log.Server.info "[auto] stats: h2=%d h1=%d"
+            (Atomic.get h2_count) (Atomic.get h1_count)
+      end
       else begin
         Log.Misc.error "[auto] Accept error: %s" (Printexc.to_string exn);
         (try Eio.Time.sleep clock backoff_s


### PR DESCRIPTION
## Summary
QA에서 발견된 마지막 2개 transport 이슈 수정.

### 1. gRPC Server Reflection 활성화
- `Grpc_eio.Reflection.create_server_with_reflection` 사용
- grpcurl이 proto 파일 없이 서비스 디스커버리 가능:
  `grpcurl -plaintext localhost:8936 list`
- QA에서 reflection 미지원으로 디스커버리 실패했던 문제 해결

### 2. Shutdown stats 로그 중복 제거
- `Atomic.compare_and_set stats_logged false true` guard 추가
- shutdown 시 모든 cancelled fiber가 동시에 stats를 로깅하여 50+줄 중복되던 문제 해결
- 이제 stats는 정확히 1회만 로깅

## Test plan
- [x] dune build 성공
- [ ] grpcurl -plaintext localhost:8936 list → 서비스 목록 반환 확인
- [ ] shutdown 시 stats 라인이 1줄만 출력되는지 확인

Generated with Claude Code