### PR TITLE
fix(keeper): move keeper_bash/keeper_github out of default shard

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -47,6 +47,10 @@ let keeper_voice_tool_names =
 
 let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
 
+let keeper_coding_shard_tool_names =
+  Tool_shard.coding_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
+
 let keeper_autoresearch_tool_names =
   Tool_shard.autoresearch_keeper_tools
   |> List.map (fun (t : Types.tool_schema) -> t.name)
@@ -84,7 +88,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     in
     let with_coding =
       if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-        keeper_coding_tool_names @ with_research
+        keeper_coding_shard_tool_names @ keeper_coding_tool_names @ with_research
       else with_research
     in
     dedupe_tool_names (keeper_board_tool_names @ with_coding)
@@ -96,7 +100,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
       else base_names
     in
     if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-      dedupe_tool_names (keeper_coding_tool_names @ with_research)
+      dedupe_tool_names (keeper_coding_shard_tool_names @ keeper_coding_tool_names @ with_research)
     else with_research
 
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
@@ -113,7 +117,7 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     in
     let all_tools =
       if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-        with_research @ Tool_code_write.schemas
+        with_research @ Tool_shard.coding_tools @ Tool_code_write.schemas
       else with_research
     in
     all_tools

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -156,6 +156,11 @@ let shell_tools : Types.tool_schema list = [
       ("required", `List [`String "op"]);
     ];
   };
+]
+
+(** Coding tools — arbitrary shell and github access.
+    NOT in default shards. Only granted when policy_shell_mode = "coding". *)
+let coding_tools : Types.tool_schema list = [
   {
     name = "keeper_bash";
     description = "Run a shell command from project root. Use for build/test/check commands.";
@@ -374,7 +379,14 @@ let shard_shell : shard = {
   name = "shell";
   tools = shell_tools;
   removable = true;
-  description = "Shell access: bash, github";
+  description = "Read-only shell: pwd, ls, cat, rg, git_status";
+}
+
+let shard_coding : shard = {
+  name = "coding";
+  tools = coding_tools;
+  removable = true;
+  description = "Coding tools: bash, github (requires policy_shell_mode=coding)";
 }
 
 let shard_weather : shard = {
@@ -451,6 +463,7 @@ let all_shards : (string, shard) Hashtbl.t =
     shard_board;
     shard_filesystem;
     shard_shell;
+    shard_coding;
     shard_weather;
     shard_voice;
     shard_library;

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -95,5 +95,12 @@ val autoresearch_keeper_tools : Types.tool_schema list
 val shard_autoresearch : shard
 (** Autoresearch shard: start, cycle, status, inject, stop. *)
 
+val coding_tools : Types.tool_schema list
+(** Coding shard tools (keeper_bash, keeper_github).
+    Not in default shards — only granted when policy_shell_mode = "coding". *)
+
+val shard_coding : shard
+(** Coding shard: bash, github (requires policy_shell_mode=coding). *)
+
 val keeper_model_tools : Types.tool_schema list
-(** Full tool set (all 11 tools) — backward compatible with existing code. *)
+(** Default tool set from default shards — excludes coding tools. *)

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -39,8 +39,22 @@ let test_shard_shell_exists () =
   match Tool_shard.get_shard "shell" with
   | Some s ->
     Alcotest.(check bool) "removable" true s.Tool_shard.removable;
-    Alcotest.(check bool) "has 3 tools" true (List.length s.Tool_shard.tools = 3)
+    Alcotest.(check bool) "has 1 tool" true (List.length s.Tool_shard.tools = 1)
   | None -> Alcotest.fail "shell shard not found"
+
+let test_shard_coding_exists () =
+  match Tool_shard.get_shard "coding" with
+  | Some s ->
+    Alcotest.(check bool) "removable" true s.Tool_shard.removable;
+    Alcotest.(check bool) "has 2 tools" true (List.length s.Tool_shard.tools = 2);
+    let names = List.map (fun (t : Types.tool_schema) -> t.name) s.tools in
+    Alcotest.(check bool) "contains keeper_bash" true (List.mem "keeper_bash" names);
+    Alcotest.(check bool) "contains keeper_github" true (List.mem "keeper_github" names)
+  | None -> Alcotest.fail "coding shard not found"
+
+let test_coding_not_in_defaults () =
+  Alcotest.(check bool) "coding not in defaults" false
+    (List.mem "coding" Tool_shard.default_shard_names)
 
 let test_shard_weather_exists () =
   match Tool_shard.get_shard "weather" with
@@ -62,7 +76,7 @@ let test_shard_unknown () =
 
 let test_all_shards_count () =
   let all = Tool_shard.list_all_shards () in
-  Alcotest.(check int) "9 predefined shards" 9 (List.length all)
+  Alcotest.(check int) "10 predefined shards" 10 (List.length all)
 
 (* ============================================================
    default_shard_names tests
@@ -99,8 +113,9 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_model_tools_count () =
   let tools = Tool_shard.keeper_model_tools in
-  (* base=3 + board=5 + filesystem=2 + shell=3 + weather=1 + voice=5 + library=2 + taskboard=7 = 28 *)
-  Alcotest.(check int) "28 total tools" 28 (List.length tools)
+  (* base=3 + board=5 + filesystem=2 + shell=1 + weather=1 + voice=5 + library=2 + taskboard=7 = 26 *)
+  (* coding shard (bash+github) is NOT in default_shard_names *)
+  Alcotest.(check int) "26 total tools" 26 (List.length tools)
 
 (* ============================================================
    grant_shard tests
@@ -201,7 +216,7 @@ let test_execute_tool_list () =
   let (ok, json) = Tool_shard.execute "masc_tool_list" (`Assoc []) in
   Alcotest.(check bool) "succeeds" true ok;
   let shards = Yojson.Safe.Util.(member "shards" json |> to_list) in
-  Alcotest.(check int) "9 shards in list" 9 (List.length shards)
+  Alcotest.(check int) "10 shards in list" 10 (List.length shards)
 
 let test_execute_tool_list_with_agent () =
   Hashtbl.remove Tool_shard.agent_shards "test-ex";
@@ -342,6 +357,8 @@ let () =
       Alcotest.test_case "board" `Quick test_shard_board_exists;
       Alcotest.test_case "filesystem" `Quick test_shard_filesystem_exists;
       Alcotest.test_case "shell" `Quick test_shard_shell_exists;
+      Alcotest.test_case "coding" `Quick test_shard_coding_exists;
+      Alcotest.test_case "coding not in defaults" `Quick test_coding_not_in_defaults;
       Alcotest.test_case "weather" `Quick test_shard_weather_exists;
       Alcotest.test_case "voice" `Quick test_shard_voice_exists;
       Alcotest.test_case "unknown" `Quick test_shard_unknown;


### PR DESCRIPTION
## Summary
- `keeper_bash`(임의 shell 실행)와 `keeper_github`(gh CLI)를 default shard에서 분리
- 새 `coding` shard 생성 — `all_shards`에 등록되지만 `default_shard_names`에는 미포함
- `policy_shell_mode = "coding"`인 keeper만 이 도구 schemas를 LLM에 노출

## Before/After
- **Before**: 모든 keeper가 `keeper_bash`, `keeper_github` schema를 봄 (25 tools)
- **After**: default keeper는 23 tools, coding-mode keeper만 25 tools

## Changed files
- `lib/tool_shard.ml`: `shell_tools` → `shell_tools` + `coding_tools` 분리, `shard_coding` 추가
- `lib/tool_shard.mli`: `coding_tools`, `shard_coding` 노출
- `lib/keeper/keeper_exec_tools.ml`: coding 조건에 `keeper_coding_shard_tool_names` 추가

## Test plan
- [ ] `dune build` 성공
- [ ] `policy_shell_mode = "coding"` keeper가 `keeper_bash`/`keeper_github` 사용 가능
- [ ] `policy_shell_mode = "readonly"` keeper가 `keeper_bash`/`keeper_github` schema를 보지 못함
- [ ] `masc_tool_list` API에서 `coding` shard가 별도 표시

Generated with [Claude Code](https://claude.com/claude-code)