### PR TITLE
fix(governance): default level development → production

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -687,10 +687,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       bootstrap_server_state state;
       (* Install governance pipeline pre_hook before any tool calls are served.
-         Reads MASC_GOVERNANCE_LEVEL env var; defaults to "development". *)
+         Defaults to "production": Critical-risk tools (delete/reset/kill/destroy)
+         require operator confirmation. Set MASC_GOVERNANCE_LEVEL=development
+         to disable for local testing. *)
       (let governance_level =
          Sys.getenv_opt "MASC_GOVERNANCE_LEVEL"
-         |> Option.value ~default:"development"
+         |> Option.value ~default:"production"
          |> String.lowercase_ascii
        in
        Governance_pipeline.install ~config:state.room_config ~governance_level);


### PR DESCRIPTION
## Summary
- governance 기본값을 `development` → `production`으로 변경
- Critical-risk 도구(delete/reset/kill/destroy) 호출 시 operator 확인 필요
- `MASC_GOVERNANCE_LEVEL=development`로 기존 동작 복원 가능

## 안전 구조 (3-tier)
```
Layer 1: tools/list   — 프로필별 필터링 (이미 구현)
Layer 2: governance   — risk-based gate (이 PR로 기본값 강화)
Layer 3: keeper allow — 코드 allowlist (이미 동작)
```

## Test plan
- [ ] 서버 시작 시 `governance installed: level=production` 로그 확인
- [ ] `masc_gc` 등 Critical tool 호출 시 confirmation 요구 확인
- [ ] `MASC_GOVERNANCE_LEVEL=development` 설정 시 기존처럼 전체 허용

🤖 Generated with [Claude Code](https://claude.com/claude-code)