### PR TITLE
fix(keeper): autoboot guard + start_keepalive defer

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -299,6 +299,9 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   (* Auto-boot resident keepers: read .masc/resident-keepers/*.json,
      load or parse each keeper's meta, and start keepalive loops. *)
   fork_subsystem "keeper_autoboot" (fun () ->
+    if not Env_config.KeeperBootstrap.enabled then
+      Log.Keeper.info "autoboot: disabled via MASC_KEEPER_BOOTSTRAP_ENABLED=false"
+    else begin
     (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
     Eio.Time.sleep clock 5.0;
     let config = state.room_config in
@@ -341,7 +344,8 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
             (Printexc.to_string exn)
     ) specs;
     Log.Keeper.info "autoboot: %d/%d resident keepers started"
-      !booted (List.length specs));
+      !booted (List.length specs)
+    end);
   (* Phase 5: unified startup subsystem summary *)
   Log.info ~ctx:"startup" "subsystems: resident loops started"
 


### PR DESCRIPTION
## Summary
- autoboot에 `MASC_KEEPER_BOOTSTRAP_ENABLED=false` guard 추가
- `server_runtime_bootstrap.ml`의 `keeper_autoboot` 서브시스템이 env var 체크 없이 실행되던 버그 수정

## Verified
- 서버 로그: `autoboot: disabled via MASC_KEEPER_BOOTSTRAP_ENABLED=false`
- keeper 자동 시작 안 됨 → LLM 슬롯 깨끗한 상태에서 keeper_msg turn 실행 확인

## Related
- Issue #2610 (keeper slot starvation)
- PR #2620 (start_keepalive defer — 별도 브랜치)

Generated with [Claude Code](https://claude.com/claude-code)