### PR TITLE
chore: remove unused ~net parameter from walph (#2637)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -509,10 +509,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_cost ->
         Tool_cost.dispatch { Tool_cost.agent_name } ~name ~args:arguments
     | Mod_walph ->
-        (match state.Mcp_server.net with
-         | None -> Some (false, "walph requires net context (unavailable in stdio/test setups)")
-         | Some net ->
-           let ctx : _ Tool_walph.context = { config; agent_name; net; clock } in
+        (let ctx : _ Tool_walph.context = { config; agent_name; clock } in
            Tool_walph.dispatch ctx ~name ~args:arguments)
     | Mod_agent ->
         Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:arguments

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -278,7 +278,7 @@ let get_chain_id_for_preset = function
     @param max_iterations Maximum iterations before forced stop
     @param target Target file/directory for preset
     @return Status string with loop results *)
-let walph_loop config ~net:_net ~clock ~agent_name
+let walph_loop config ~clock ~agent_name
     ?(preset="drain") ?(max_iterations=10) ?target
     ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
     ?(default_model="explicit-model-required")

--- a/lib/tool_walph.ml
+++ b/lib/tool_walph.ml
@@ -2,11 +2,10 @@
 
 open Tool_args
 
-type ('a, 'b) context = {
+type 'a context = {
   config: Room.config;
   agent_name: string;
-  net: 'a Eio.Net.t;
-  clock: 'b Eio.Time.clock;
+  clock: 'a Eio.Time.clock;
 }
 
 (** Walph response validator — moved from room_walph_eio.ml to remove
@@ -38,7 +37,7 @@ let handle_walph_loop ctx args =
   let max_consecutive_errors = get_int args "max_consecutive_errors" 5 in
   let error_backoff_sec = get_int args "error_backoff_sec" 2 in
   let target = get_string_opt args "target" in
-  (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name
+  (true, Room_walph_eio.walph_loop ctx.config ~clock:ctx.clock ~agent_name:ctx.agent_name
     ~preset ~max_iterations ~max_consecutive_errors ~error_backoff_sec ?target
     ~model_dispatch:default_model_dispatch ())
 
@@ -91,13 +90,13 @@ let handle_walph_natural ctx args =
     | `Status ->
         (true, Room_walph_eio.walph_control ctx.config ~from_agent:ctx.agent_name ~command:"STATUS" ~args:"" ())
     | `Start_coverage ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"coverage" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
+        (true, Room_walph_eio.walph_loop ctx.config ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"coverage" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_refactor ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"refactor" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
+        (true, Room_walph_eio.walph_loop ctx.config ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"refactor" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_docs ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"docs" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
+        (true, Room_walph_eio.walph_loop ctx.config ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"docs" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
     | `Start_drain ->
-        (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"drain" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
+        (true, Room_walph_eio.walph_loop ctx.config ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"drain" ~max_iterations:10 ~model_dispatch:default_model_dispatch ())
   end
 
 (* Handle masc_walph_status *)

--- a/lib/tool_walph.mli
+++ b/lib/tool_walph.mli
@@ -1,26 +1,24 @@
 (** Tool_walph - Walph loop control handlers *)
 
-type ('a, 'b) context = {
+type 'a context = {
   config: Room.config;
   agent_name: string;
-  net: 'a Eio.Net.t;
-  clock: 'b Eio.Time.clock;
+  clock: 'a Eio.Time.clock;
 }
 
 val schemas : Types.tool_schema list
 
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
-val dispatch : ('a, 'b) context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
+val dispatch : 'a context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
 
 (** Handle masc_walph_loop *)
-val handle_walph_loop : ('a, 'b) context -> Yojson.Safe.t -> bool * string
+val handle_walph_loop : 'a context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_walph_control *)
-val handle_walph_control : ('a, 'b) context -> Yojson.Safe.t -> bool * string
+val handle_walph_control : 'a context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_walph_natural *)
-val handle_walph_natural : ('a, 'b) context -> Yojson.Safe.t -> bool * string
+val handle_walph_natural : 'a context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_walph_status *)
-val handle_walph_status : ('a, 'b) context -> Yojson.Safe.t -> bool * string
-
+val handle_walph_status : 'a context -> Yojson.Safe.t -> bool * string

--- a/test/test_dispatch_chain_evidence.ml
+++ b/test/test_dispatch_chain_evidence.ml
@@ -110,9 +110,8 @@ let () =
   Eio_main.run @@ fun env ->
   let config = make_test_room () in
   let _ = Room.init config ~agent_name:(Some "evidence-agent") in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx : _ Tool_walph.context = { config; agent_name = "evidence-agent"; net; clock } in
+  let ctx : _ Tool_walph.context = { config; agent_name = "evidence-agent"; clock } in
   let tool_name = "masc_walph_control" in
   let json_input = `Assoc [("command", `String "STATUS")] in
   match Tool_walph.dispatch ctx ~name:tool_name ~args:json_input with

--- a/test/test_tool_walph_coverage.ml
+++ b/test/test_tool_walph_coverage.ml
@@ -22,9 +22,8 @@ let () = test "dispatch_unknown_tool" (fun () ->
     (Printf.sprintf "masc-walph-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [] in
   assert (Tool_walph.dispatch ctx ~name:"unknown_tool" ~args = None)
 )
@@ -37,9 +36,8 @@ let () = test "dispatch_walph_control" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("command", `String "STATUS")] in
   match Tool_walph.dispatch ctx ~name:"masc_walph_control" ~args with
   | Some (success, _result) -> assert success
@@ -54,9 +52,8 @@ let () = test "dispatch_walph_status" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [] in
   match Tool_walph.dispatch ctx ~name:"masc_walph_status" ~args with
   | Some (success, result) ->
@@ -78,9 +75,8 @@ let () = test "walph_natural_stop" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "stop the loop")] in
   let (success, _result) = Tool_walph.handle_walph_natural ctx args in
   assert success
@@ -94,9 +90,8 @@ let () = test "walph_natural_pause" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "잠깐 일시정지")] in
   let (success, _result) = Tool_walph.handle_walph_natural ctx args in
   assert success
@@ -110,9 +105,8 @@ let () = test "walph_natural_resume" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "계속 진행해")] in
   let (success, _result) = Tool_walph.handle_walph_natural ctx args in
   assert success
@@ -126,9 +120,8 @@ let () = test "walph_natural_status" (fun () ->
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "뭐해? 상태 알려줘")] in
   let (success, _result) = Tool_walph.handle_walph_natural ctx args in
   assert success
@@ -141,9 +134,8 @@ let () = test "walph_natural_ignore" (fun () ->
     (Printf.sprintf "masc-walph-test7-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "random gibberish xyz")] in
   let (success, result) = Tool_walph.handle_walph_natural ctx args in
   assert success;
@@ -157,9 +149,8 @@ let () = test "walph_natural_empty" (fun () ->
     (Printf.sprintf "masc-walph-test8-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
-  let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
-  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; clock } in
   let args = `Assoc [("message", `String "")] in
   let (success, result) = Tool_walph.handle_walph_natural ctx args in
   (* Empty message should return failure with error message *)

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -291,7 +291,6 @@ let test_eio_error_cutoff () =
   in
   let result =
     Room_walph_eio.walph_loop config
-      ~net:(Eio.Stdenv.net env)
       ~clock:(Eio.Stdenv.clock env)
       ~agent_name:"error-agent"
       ~preset:"coverage"


### PR DESCRIPTION
walph_loop ~net:_net 제거. 시그니처, context type, 8 call sites 정리. Closes #2637 (partial).