### PR TITLE
test(harness): keeper-agent isolation + permission enforcement tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -857,6 +857,18 @@
  (modules test_tool_permissions)
  (libraries masc_mcp alcotest yojson))
 
+; Keeper-Agent Tool Isolation — structural namespace separation
+(test
+ (name test_keeper_agent_isolation)
+ (modules test_keeper_agent_isolation)
+ (libraries masc_mcp alcotest yojson))
+
+; Tool Permissions Exhaustive — all admin tools denied by default
+(test
+ (name test_tool_permissions_exhaustive)
+ (modules test_tool_permissions_exhaustive)
+ (libraries masc_mcp alcotest str yojson))
+
 ; SSE External Subscriber — gRPC/external hooks into SSE broadcast
 (test
  (name test_sse_external_sub)

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -1,0 +1,220 @@
+(** Tests for keeper-agent tool isolation.
+
+    Validates the structural invariant that keeper tools and agent
+    coordination tools occupy disjoint namespaces.
+
+    Note: research-profile keepers intentionally receive masc_autoresearch_*
+    and masc_research_* tools via the shard system. The isolation boundary
+    is between keeper tools and agent coordination tools (spawned_agent_public).
+
+    Pure synchronous tests — no Eio or network required. *)
+
+module Keeper_exec_tools = Masc_mcp.Keeper_exec_tools
+module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
+module Tool_shard = Masc_mcp.Tool_shard
+module Tool_permissions = Masc_mcp.Tool_permissions
+module Keeper_types = Masc_mcp.Keeper_types
+
+(* ============================================================
+   Helper: create keeper_meta via meta_of_json (canonical pattern)
+   ============================================================ *)
+
+let make_meta
+    ?(name = "test-keeper")
+    ?(policy_mode = "Heuristic")
+    ?(policy_shell_mode = "disabled")
+    ?(policy_voice_enabled = false)
+    ?(soul_profile = "safety")
+    ()
+  : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+    (`Assoc [
+      ("name", `String name);
+      ("agent_name", `String name);
+      ("trace_id", `String "test-isolation-001");
+      ("soul_profile", `String soul_profile);
+      ("policy_mode", `String policy_mode);
+      ("policy_shell_mode", `String policy_shell_mode);
+      ("policy_voice_enabled", `Bool policy_voice_enabled);
+    ]) with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_meta failed: %s" e)
+
+(* ============================================================
+   Known intentional cross-namespace tools
+   (research keepers receive these via shard, not dispatch)
+   ============================================================ *)
+
+let has_keeper_prefix name =
+  String.length name >= 7 && String.sub name 0 7 = "keeper_"
+
+let is_research_shard_tool name =
+  let prefixes = ["masc_autoresearch_"; "masc_research_"] in
+  List.exists (fun prefix ->
+    String.length name >= String.length prefix &&
+    String.sub name 0 (String.length prefix) = prefix) prefixes
+
+(* ============================================================
+   Invariant 1: Non-research keepers only get keeper_* tools
+   ============================================================ *)
+
+let test_heuristic_only_keeper_prefixed () =
+  let meta = make_meta ~policy_mode:"Heuristic" () in
+  let names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let non_keeper = List.filter (fun n -> not (has_keeper_prefix n)) names in
+  Alcotest.(check (list string))
+    "heuristic keeper only has keeper_* tools" [] non_keeper
+
+let test_learned_only_keeper_prefixed () =
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"readonly" ~policy_voice_enabled:true () in
+  let names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let non_keeper = List.filter (fun n -> not (has_keeper_prefix n)) names in
+  Alcotest.(check (list string))
+    "learned keeper only has keeper_* tools" [] non_keeper
+
+(* ============================================================
+   Invariant 2: Research keepers only add research/autoresearch tools
+   ============================================================ *)
+
+let test_research_extra_tools_are_research_only () =
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" ~policy_voice_enabled:true
+      ~soul_profile:"research" () in
+  let names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let non_keeper = List.filter (fun n -> not (has_keeper_prefix n)) names in
+  let unexpected = List.filter (fun n -> not (is_research_shard_tool n)) non_keeper in
+  Alcotest.(check (list string))
+    "research keeper only adds research shard tools" [] unexpected
+
+let test_write_done_returns_empty () =
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" () in
+  let names = Keeper_exec_tools.keeper_allowed_tool_names ~write_done:true meta in
+  Alcotest.(check (list string)) "write_done returns empty" [] names
+
+(* ============================================================
+   Invariant 3: Agent coordination tools never contain keeper_*
+   ============================================================ *)
+
+let test_agent_surface_no_keeper_tools () =
+  let names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+  let leaked = List.filter has_keeper_prefix names in
+  Alcotest.(check (list string)) "no keeper_* in agent surface" [] leaked
+
+let test_mdal_surface_no_keeper_tools () =
+  let names = Agent_tool_surfaces.mdal_auditable_tool_names in
+  let leaked = List.filter has_keeper_prefix names in
+  Alcotest.(check (list string)) "no keeper_* in mdal surface" [] leaked
+
+(* ============================================================
+   Invariant 4: Keeper tools never overlap with agent coordination
+   ============================================================ *)
+
+let test_no_overlap_heuristic_vs_agent () =
+  let meta = make_meta ~policy_mode:"Heuristic" () in
+  let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+  let overlap = List.filter (fun n -> List.mem n agent_names) keeper_names in
+  Alcotest.(check (list string))
+    "heuristic keeper disjoint from agent coordination" [] overlap
+
+let test_no_overlap_research_vs_agent () =
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" ~policy_voice_enabled:true
+      ~soul_profile:"research" () in
+  let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+  let overlap = List.filter (fun n -> List.mem n agent_names) keeper_names in
+  Alcotest.(check (list string))
+    "research keeper disjoint from agent coordination" [] overlap
+
+let test_shard_tools_disjoint_from_agent () =
+  let keeper_tools = Tool_shard.keeper_model_tools
+    |> List.map (fun (t : Types.tool_schema) -> t.name) in
+  let agent_tools = Agent_tool_surfaces.spawned_agent_public_tool_names in
+  let overlap = List.filter (fun name -> List.mem name agent_tools) keeper_tools in
+  Alcotest.(check (list string))
+    "shard tools disjoint from agent surface" [] overlap
+
+(* ============================================================
+   Invariant 5: Research shard tools that overlap with admin list
+   (documenting the intentional design — keeper shard bypasses
+   the dispatch pre-hook permission check for these tools)
+   ============================================================ *)
+
+let test_research_admin_overlap_documented () =
+  let admin = Tool_permissions.admin_tools in
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" ~soul_profile:"research" () in
+  let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let overlap = List.filter (fun n -> List.mem n admin) keeper_names in
+  (* These research tools are intentionally in both lists.
+     Keepers access them via shard allocation, not dispatch pre-hook.
+     This test documents the overlap rather than preventing it. *)
+  List.iter (fun name ->
+    Alcotest.(check bool) (name ^ " is a research tool") true
+      (is_research_shard_tool name)
+  ) overlap
+
+(* ============================================================
+   Invariant 6: Non-research keepers have zero admin tool access
+   ============================================================ *)
+
+let test_non_research_no_admin_tools () =
+  let admin = Tool_permissions.admin_tools in
+  let meta = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" ~policy_voice_enabled:true () in
+  let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let leaked = List.filter (fun n -> List.mem n admin) keeper_names in
+  Alcotest.(check (list string))
+    "non-research keeper has zero admin tools" [] leaked
+
+(* ============================================================
+   Invariant 7: Tool count consistency across policy modes
+   ============================================================ *)
+
+let test_heuristic_has_fewer_tools_than_learned () =
+  let heuristic = make_meta ~policy_mode:"Heuristic" () in
+  let learned = make_meta ~policy_mode:"Learned_offline_v1"
+      ~policy_shell_mode:"coding" ~policy_voice_enabled:true
+      ~soul_profile:"research" () in
+  let h_count = List.length (Keeper_exec_tools.keeper_allowed_tool_names heuristic) in
+  let l_count = List.length (Keeper_exec_tools.keeper_allowed_tool_names learned) in
+  Alcotest.(check bool)
+    "learned mode has >= heuristic tools"
+    true (l_count >= h_count)
+
+(* ============================================================
+   Test runner
+   ============================================================ *)
+
+let () =
+  Alcotest.run "Keeper_agent_isolation" [
+    ("non_research_prefix", [
+      Alcotest.test_case "heuristic only keeper_*" `Quick test_heuristic_only_keeper_prefixed;
+      Alcotest.test_case "learned only keeper_*" `Quick test_learned_only_keeper_prefixed;
+    ]);
+    ("research_boundary", [
+      Alcotest.test_case "research extras are research-only" `Quick
+        test_research_extra_tools_are_research_only;
+      Alcotest.test_case "write_done empty" `Quick test_write_done_returns_empty;
+    ]);
+    ("agent_no_keeper_tools", [
+      Alcotest.test_case "spawned agent surface" `Quick test_agent_surface_no_keeper_tools;
+      Alcotest.test_case "mdal surface" `Quick test_mdal_surface_no_keeper_tools;
+    ]);
+    ("disjoint_namespaces", [
+      Alcotest.test_case "heuristic vs agent" `Quick test_no_overlap_heuristic_vs_agent;
+      Alcotest.test_case "research vs agent" `Quick test_no_overlap_research_vs_agent;
+      Alcotest.test_case "shard vs agent" `Quick test_shard_tools_disjoint_from_agent;
+    ]);
+    ("admin_boundary", [
+      Alcotest.test_case "research admin overlap documented" `Quick
+        test_research_admin_overlap_documented;
+      Alcotest.test_case "non-research no admin" `Quick test_non_research_no_admin_tools;
+    ]);
+    ("policy_consistency", [
+      Alcotest.test_case "learned >= heuristic" `Quick test_heuristic_has_fewer_tools_than_learned;
+    ]);
+  ]

--- a/test/test_tool_permissions_exhaustive.ml
+++ b/test/test_tool_permissions_exhaustive.ml
@@ -1,0 +1,159 @@
+(** Exhaustive permission enforcement tests.
+
+    Supplements test_tool_permissions.ml with:
+    1. Sweeps ALL 11 admin tools through deny-by-default path
+    2. Verifies error messages contain agent and tool names
+    3. Tests dispatch_structured integration for every admin tool
+    4. Validates non-admin tools pass through unimpeded
+
+    Pure synchronous tests — no Eio or network required. *)
+
+module Tool_dispatch = Masc_mcp.Tool_dispatch
+module Tool_permissions = Masc_mcp.Tool_permissions
+module Tool_result = Masc_mcp.Tool_result
+
+let setup () =
+  Tool_dispatch.clear_hooks ();
+  Tool_permissions.set_capability_checker (fun _agent _cap -> false)
+
+(* ============================================================
+   Exhaustive: every admin tool denied without capability
+   ============================================================ *)
+
+let test_all_admin_tools_denied () =
+  List.iter (fun tool_name ->
+    setup ();
+    match Tool_permissions.check ~agent_name:"test_agent" ~tool_name with
+    | Ok () ->
+      Alcotest.failf "%s should be denied for non-admin" tool_name
+    | Error msg ->
+      Alcotest.(check bool)
+        (tool_name ^ " error mentions agent")
+        true (String.length msg > 0 &&
+              try ignore (Str.search_forward
+                (Str.regexp_string "test_agent") msg 0); true
+              with Not_found -> false);
+      Alcotest.(check bool)
+        (tool_name ^ " error mentions tool")
+        true
+        (try ignore (Str.search_forward
+           (Str.regexp_string tool_name) msg 0); true
+         with Not_found -> false)
+  ) Tool_permissions.admin_tools
+
+(* ============================================================
+   Exhaustive: every admin tool allowed WITH capability
+   ============================================================ *)
+
+let test_all_admin_tools_allowed_with_cap () =
+  Tool_permissions.set_capability_checker (fun _agent cap -> cap = "admin");
+  List.iter (fun tool_name ->
+    match Tool_permissions.check ~agent_name:"admin_agent" ~tool_name with
+    | Ok () -> ()
+    | Error msg ->
+      Alcotest.failf "%s should be allowed with admin cap: %s" tool_name msg
+  ) Tool_permissions.admin_tools
+
+(* ============================================================
+   Dispatch integration: every admin tool blocked at pre-hook
+   ============================================================ *)
+
+let test_dispatch_blocks_all_admin_no_identity () =
+  List.iter (fun tool_name ->
+    setup ();
+    Tool_dispatch.register ~tool_name
+      ~handler:(fun ~name:_ ~args:_ -> Some (true, "should not reach"));
+    Tool_permissions.install ~get_agent_name:(fun () -> None);
+    match Tool_dispatch.dispatch_structured ~name:tool_name ~args:`Null with
+    | Some r ->
+      Alcotest.(check bool)
+        (tool_name ^ " blocked at dispatch")
+        false r.success;
+      let msg = match r.data with `String s -> s | _ -> "" in
+      Alcotest.(check bool)
+        (tool_name ^ " mentions permission")
+        true
+        (try ignore (Str.search_forward
+           (Str.regexp_string "permission") msg 0); true
+         with Not_found -> false)
+    | None ->
+      Alcotest.failf "%s: expected Some from short-circuit" tool_name
+  ) Tool_permissions.admin_tools
+
+(* ============================================================
+   Non-admin tools pass through: sample of common tools
+   ============================================================ *)
+
+let common_non_admin_tools =
+  [ "masc_status"; "masc_join"; "masc_leave"; "masc_heartbeat";
+    "masc_broadcast"; "masc_who"; "masc_tasks"; "masc_board_list";
+    "masc_board_post"; "masc_board_comment" ]
+
+let test_non_admin_always_allowed () =
+  setup ();
+  List.iter (fun tool_name ->
+    match Tool_permissions.check ~agent_name:"any_agent" ~tool_name with
+    | Ok () -> ()
+    | Error msg ->
+      Alcotest.failf "%s should be allowed (non-admin): %s" tool_name msg
+  ) common_non_admin_tools
+
+let test_non_admin_dispatch_passthrough () =
+  List.iter (fun tool_name ->
+    setup ();
+    Tool_dispatch.register ~tool_name
+      ~handler:(fun ~name:_ ~args:_ -> Some (true, "reached handler"));
+    Tool_permissions.install ~get_agent_name:(fun () -> Some "regular_agent");
+    match Tool_dispatch.dispatch_structured ~name:tool_name ~args:`Null with
+    | Some r ->
+      Alcotest.(check bool)
+        (tool_name ^ " handler reached")
+        true r.success
+    | None ->
+      Alcotest.failf "%s: expected dispatch result" tool_name
+  ) common_non_admin_tools
+
+(* ============================================================
+   Admin tool count integrity
+   ============================================================ *)
+
+let test_admin_tool_count () =
+  Alcotest.(check int)
+    "11 admin tools defined"
+    11 (List.length Tool_permissions.admin_tools)
+
+let test_admin_tools_all_have_masc_prefix () =
+  List.iter (fun name ->
+    Alcotest.(check bool)
+      (name ^ " has masc_ prefix")
+      true
+      (String.length name >= 5 && String.sub name 0 5 = "masc_")
+  ) Tool_permissions.admin_tools
+
+(* ============================================================
+   Test runner
+   ============================================================ *)
+
+let () =
+  Alcotest.run "Tool_permissions_exhaustive" [
+    ("deny_all_admin", [
+      Alcotest.test_case "every admin tool denied" `Quick
+        test_all_admin_tools_denied;
+      Alcotest.test_case "every admin tool allowed with cap" `Quick
+        test_all_admin_tools_allowed_with_cap;
+    ]);
+    ("dispatch_integration", [
+      Alcotest.test_case "dispatch blocks all admin (no identity)" `Quick
+        test_dispatch_blocks_all_admin_no_identity;
+    ]);
+    ("non_admin_passthrough", [
+      Alcotest.test_case "check allows common tools" `Quick
+        test_non_admin_always_allowed;
+      Alcotest.test_case "dispatch passes common tools" `Quick
+        test_non_admin_dispatch_passthrough;
+    ]);
+    ("integrity", [
+      Alcotest.test_case "admin tool count" `Quick test_admin_tool_count;
+      Alcotest.test_case "admin tools prefixed" `Quick test_admin_tools_all_have_masc_prefix;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

- **P1**: `test_keeper_agent_isolation.ml` — 12 tests proving keeper and agent tool namespaces are structurally disjoint
- **P2**: `test_tool_permissions_exhaustive.ml` — 7 tests sweeping all 11 admin tools through deny-by-default and dispatch integration

## Findings during test development

Research-profile keepers receive `masc_autoresearch_*` tools via the shard system, which bypasses the dispatch pre-hook permission check. This is by design (shard allocation happens before dispatch), but the overlap with `admin_tools` is now documented in the test suite.

## Test plan

- [x] P1: 12/12 pass — keeper-agent isolation verified across all policy modes
- [x] P2: 7/7 pass — all admin tools denied without capability, all pass with capability
- [x] Full `dune runtest` — 0 failures, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)