### PR TITLE
chore: remove deprecated masc_claim tool (#2636)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -274,7 +274,7 @@ let permission_for_tool = function
       Some CanReadState
   | "masc_autoresearch_status" -> Some CanReadState
   | "masc_add_task" -> Some CanAddTask
-  | "masc_claim" | "masc_claim_next" -> Some CanClaimTask
+  | "masc_claim_next" -> Some CanClaimTask
   | "masc_done" | "masc_update_priority" | "masc_transition" | "masc_release" ->
       Some CanCompleteTask
   | "masc_keeper_action_explain"

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -68,7 +68,7 @@ let conversational_patterns = [
 
 (** Task command patterns — operate on existing state, no search *)
 let command_patterns = [
-  "masc_claim"; "masc_done"; "masc_join"; "masc_leave";
+  "masc_done"; "masc_join"; "masc_leave";
   "masc_broadcast"; "masc_lock"; "masc_unlock"; "masc_vote";
   "masc_add_task"; "masc_cancel"; "masc_transition";
   "claim "; "done "; "cancel "; "broadcast ";

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -95,7 +95,7 @@ let read_only_tools =
    "masc_operator_snapshot"; "masc_operator_digest"]
 
 let requires_join_tools = [
-  "masc_add_task"; "masc_claim"; "masc_claim_next"; "masc_transition";
+  "masc_add_task"; "masc_claim_next"; "masc_transition";
   "masc_broadcast"; "masc_listen"; "masc_heartbeat";
   "masc_plan_set_task"; "masc_plan_clear_task";
   "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -158,7 +158,6 @@ let tool_category tool_name =
 
   (* ── Core_Task: task lifecycle ── *)
   | "masc_add_task" | "masc_batch_add_tasks"
-  | "masc_claim"
   | "masc_tasks" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"
   | "masc_task_history"

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -123,11 +123,6 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_votes",
       hidden_active
         "Low-usage room vote utility hidden from the default tool list; prefer decision.* or governance V2 tools for primary coordination workflows." );
-    ( "masc_claim",
-      deprecated_default
-        ~canonical_name:"masc_transition"
-        ~replacement:"masc_transition(action=claim)"
-        "Compatibility alias for specific-task claim. Prefer masc_transition(action=claim) for exact task ownership; use masc_claim_next when any queued task is acceptable." );
     ( "masc_rooms_list",
       hidden_active
         "Named-room inventory is an internal compatibility surface. Repo-root room semantics remain the canonical default workflow." );

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -585,28 +585,6 @@ Tip: Look for status='todo' tasks to claim.";
     ];
   };
   {
-    name = "masc_claim";
-    description = "Deprecated compatibility alias for claiming a specific task by task_id. Prefer masc_transition with action='claim' for exact task ownership.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Your agent name");
-        ]);
-        ("task_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Task ID to claim");
-        ]);
-        ("agent_role", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional semantic role for the claim");
-        ]);
-      ]);
-      ("required", `List [`String "agent_name"; `String "task_id"]);
-    ];
-  };
-  {
     name = "masc_claim_next";
     description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level.";
     input_schema = `Assoc [
@@ -686,7 +664,6 @@ let dispatch ctx ~name ~args : result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ctx args)
-  | "masc_claim" -> Some (handle_claim ctx args)
   | "masc_claim_next" -> Some (handle_claim_next ctx args)
   | "masc_transition" -> Some (handle_transition ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ctx args)

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -72,7 +72,6 @@ let limit_for_category config = function
 let category_for_tool = function
   | "masc_broadcast" | "masc_listen" -> BroadcastLimit
   | "masc_add_task"
-  | "masc_claim"
   | "masc_done"
   | "masc_claim_next"
   | "masc_claim_task"

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -378,7 +378,7 @@ let next_steps ~tool_name ~success =
   | "masc_set_room" -> after_set_room ~success
   | "masc_join" -> after_join ~success
   | "masc_status" -> after_status ~success
-  | "masc_claim" | "masc_claim_next" -> after_claim_auto_bound ~success
+  | "masc_claim_next" -> after_claim_auto_bound ~success
   | "masc_add_task" | "masc_batch_add_tasks" -> after_add_task ~success
   | "masc_plan_set_task" | "masc_set_current_task" -> after_plan_set_task ~success
   | "masc_heartbeat" -> after_heartbeat ~success
@@ -443,7 +443,7 @@ let workflow_context ~tool_name =
   let before = match tool_name with
     | "masc_join" -> [ "masc_set_room" ]
     | "masc_status" -> [ "masc_set_room"; "masc_join" ]
-    | "masc_claim" | "masc_claim_next" ->
+    | "masc_claim_next" ->
         [ "masc_join"; "masc_status" ]
     | "masc_plan_set_task" | "masc_set_current_task" ->
         [ "masc_transition" ]

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -201,7 +201,7 @@ let test_permission_for_tool_add_task () =
   | _ -> fail "expected CanAddTask"
 
 let test_permission_for_tool_claim () =
-  match Auth.permission_for_tool "masc_claim" with
+  match Auth.permission_for_tool "masc_claim_next" with
   | Some Types.CanClaimTask -> ()
   | _ -> fail "expected CanClaimTask"
 

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -14,18 +14,7 @@ let test_public_visible_surface_hides_deprecated_aliases () =
     |> List.map (fun (schema : Types.tool_schema) -> schema.name)
   in
   check bool "public contains masc_transition" true
-    (List.mem "masc_transition" names);
-  check bool "public hides masc_claim alias" false
-    (List.mem "masc_claim" names)
-
-let test_include_deprecated_surface_exposes_claim_alias () =
-  let names =
-    Lib.Capability_registry.visible_public_tool_schemas_from
-      ~include_deprecated:true Lib.Config.raw_all_tool_schemas
-    |> List.map (fun (schema : Types.tool_schema) -> schema.name)
-  in
-  check bool "deprecated surface contains masc_claim" true
-    (List.mem "masc_claim" names)
+    (List.mem "masc_transition" names)
 
 let test_board_post_capability_merges_public_and_keeper_projections () =
   let capability =
@@ -107,8 +96,6 @@ let () =
         [
           test_case "public surface hides deprecated aliases" `Quick
             test_public_visible_surface_hides_deprecated_aliases;
-          test_case "include_deprecated exposes claim alias" `Quick
-            test_include_deprecated_surface_exposes_claim_alias;
           test_case "board capability merges public and keeper projections"
             `Quick
             test_board_post_capability_merges_public_and_keeper_projections;

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -105,7 +105,7 @@ let test_risk_high_spawn () =
     "high" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_claim () =
-  let risk = Gp.assess_risk ~tool_name:"masc_claim" ~input:`Null in
+  let risk = Gp.assess_risk ~tool_name:"masc_transition" ~input:`Null in
   Alcotest.(check string) "claim is medium"
     "medium" (Gp.risk_level_to_string risk)
 
@@ -383,7 +383,7 @@ let test_blocked_response_structure () =
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
-  let result = hook ~name:"masc_claim" ~args:`Null in
+  let result = hook ~name:"masc_transition" ~args:`Null in
   (match result with
    | Some r ->
        let module U = Yojson.Safe.Util in
@@ -396,7 +396,7 @@ let test_blocked_response_structure () =
        let _tool = data |> U.member "tool_name" |> U.to_string in
        Alcotest.(check string) "governance_level" "paranoid" _gov;
        Alcotest.(check string) "risk_level" "medium" _risk;
-       Alcotest.(check string) "tool_name" "masc_claim" _tool
+       Alcotest.(check string) "tool_name" "masc_transition" _tool
    | None -> Alcotest.fail "paranoid should block medium");
   cleanup_tmpdir tmpdir
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -480,10 +480,6 @@ let test_handle_request_tools_list () =
     false
     (List.mem "experiment_start" names);
   Alcotest.(check bool)
-    "superseded masc_claim hidden from list"
-    false
-    (List.mem "masc_claim" names);
-  Alcotest.(check bool)
     "named room list hidden from list"
     false
     (List.mem "masc_rooms_list" names);
@@ -952,7 +948,7 @@ let test_handle_request_tools_call_deprecated_claim_alias () =
           ( "params",
             `Assoc
               [
-                ("name", `String "masc_claim");
+                ("name", `String "masc_transition");
                 ("arguments", `Assoc [ ("task_id", `String "task-001") ]);
               ] );
         ])
@@ -1096,19 +1092,19 @@ let test_handle_request_tools_list_include_deprecated_claim_alias_metadata () =
             `Assoc
               [
                 ("include_deprecated", `Bool true);
-                ("names", `List [ `String "masc_claim" ]);
+                ("names", `List [ `String "masc_transition" ]);
               ] );
         ])
   in
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   let tools = tools_from_response response in
-  let claim_tool = find_tool_exn tools "masc_claim" in
+  let transition_tool = find_tool_exn tools "masc_transition" in
   Alcotest.(check string) "claim lifecycle" "deprecated"
-    (tool_string_field claim_tool "lifecycle");
+    (tool_string_field transition_tool "lifecycle");
   Alcotest.(check string) "claim canonicalName" "masc_transition"
-    (tool_string_field claim_tool "canonicalName");
+    (tool_string_field transition_tool "canonicalName");
   Alcotest.(check string) "claim replacement" "masc_transition(action=claim)"
-    (tool_string_field claim_tool "replacement");
+    (tool_string_field transition_tool "replacement");
   cleanup_dir base_path
 
 let test_handle_request_tools_list_hides_team_session_turn_by_default () =

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -191,7 +191,6 @@ let test_tool_category_core () =
   check bool "join" true (Mode.tool_category "masc_join" = Mode.Core_Room);
   (* Core_Task *)
   check bool "status" true (Mode.tool_category "masc_status" = Mode.Core_Task);
-  check bool "claim" true (Mode.tool_category "masc_claim" = Mode.Core_Task);
   check bool "done" true (Mode.tool_category "masc_done" = Mode.Unknown);
   check bool "tasks" true (Mode.tool_category "masc_tasks" = Mode.Core_Task);
   check bool "add_task" true (Mode.tool_category "masc_add_task" = Mode.Core_Task);

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -126,7 +126,7 @@ let test_make_orchestrator_prompt_contains_claim () =
   let prompt = Orchestrator.make_orchestrator_prompt ~port:8935 in
   check bool "mentions masc_claim" true
     (try
-      let _ = Str.search_forward (Str.regexp "masc_claim") prompt 0 in true
+      let _ = Str.search_forward (Str.regexp "masc_transition") prompt 0 in true
     with Not_found -> false)
 
 let test_make_orchestrator_prompt_contains_done () =

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -104,9 +104,7 @@ let () =
           test_case "known join-required tools" `Quick (fun () ->
               (* Simulate server init: populate the requires_join set *)
               Tool_dispatch.init_requires_join_set
-                [ "masc_claim"; "masc_broadcast"; "masc_done" ];
-              check bool "masc_claim" true
-                (Tool_dispatch.is_join_required "masc_claim");
+                [ "masc_broadcast"; "masc_done" ];
               check bool "masc_broadcast" true
                 (Tool_dispatch.is_join_required "masc_broadcast");
               check bool "masc_done" true

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -146,11 +146,5 @@ let () =
                   check bool (name ^ " should be visible with flag") true
                     (Tool_catalog.is_visible ~include_hidden:true name))
                 hidden_names);
-          test_case "deprecated claim alias is hidden by default but visible with include_deprecated" `Quick
-            (fun () ->
-              check bool "masc_claim hidden by default" false
-                (Tool_catalog.is_visible "masc_claim");
-              check bool "masc_claim visible with include_deprecated" true
-                (Tool_catalog.is_visible ~include_deprecated:true "masc_claim"));
         ] );
     ]

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -141,7 +141,6 @@ let test_docs_do_not_reintroduce_ghost_claim_surface () =
          if contains_substring contents "masc_task_list" then
            Alcotest.failf "doc %s reintroduces ghost tool masc_task_list" name;
 	         if (not (List.mem name allowed_claim_docs))
-	            && contains_token contents "masc_claim"
 	         then
 	           Alcotest.failf
 	             "doc %s reintroduces normative masc_claim usage outside compatibility docs"
@@ -160,7 +159,7 @@ let test_front_door_surfaces_do_not_reintroduce_claim_alias () =
   List.iter
     (fun relative ->
       let contents = read_file (repo_path relative) in
-      if contains_token contents "masc_claim" then
+      if contains_token contents "masc_transition" then
         Alcotest.failf
           "front-door surface %s reintroduces deprecated masc_claim alias"
           relative)

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -22,9 +22,9 @@ let test_wrap_json_response () =
 let test_wrap_plain_string () =
   let start = Time_compat.now () in
   let raw = (false, "Something went wrong") in
-  let r = Tool_result.wrap ~tool_name:"masc_claim" ~start_time:start raw in
+  let r = Tool_result.wrap ~tool_name:"masc_transition" ~start_time:start raw in
   Alcotest.(check bool) "failure" false r.success;
-  Alcotest.(check string) "tool_name" "masc_claim" r.tool_name;
+  Alcotest.(check string) "tool_name" "masc_transition" r.tool_name;
   (* Non-JSON string should be wrapped as `String *)
   (match r.data with
    | `String s ->

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -439,7 +439,7 @@ let test_rest_tool_to_endpoint_add_task () =
   check string "path" "/mcp" path
 
 let test_rest_tool_to_endpoint_claim () =
-  let (m, path) = Transport.Rest.tool_to_endpoint "masc_claim" in
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_transition" in
   check string "method" "POST" (Transport.Rest.method_to_string m);
   check string "path" "/mcp" path
 

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1010,7 +1010,6 @@ let test_category_for_tool_broadcast () =
 
 let test_category_for_tool_task_ops () =
   check bool "masc_add_task" true (Types.category_for_tool "masc_add_task" = Types.TaskOpsLimit);
-  check bool "masc_claim" true (Types.category_for_tool "masc_claim" = Types.TaskOpsLimit);
   check bool "masc_done" true (Types.category_for_tool "masc_done" = Types.TaskOpsLimit);
   check bool "masc_transition" true (Types.category_for_tool "masc_transition" = Types.TaskOpsLimit)
 

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -366,7 +366,6 @@ let test_limit_for_category () =
 
 let test_category_for_tool () =
   check bool "broadcast" true (Types.category_for_tool "masc_broadcast" = Types.BroadcastLimit);
-  check bool "claim" true (Types.category_for_tool "masc_claim" = Types.TaskOpsLimit);
   check bool "status" true (Types.category_for_tool "masc_status" = Types.GeneralLimit)
 
 let test_multiplier_for_role () =

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -41,7 +41,7 @@ let test_join_failure () =
   check_has_tool g.next_steps "masc_set_room"
 
 let test_claim_success () =
-  let g = WG.next_steps ~tool_name:"masc_claim" ~success:true in
+  let g = WG.next_steps ~tool_name:"masc_claim_next" ~success:true in
   check_has_tool g.next_steps "masc_worktree_create";
   check bool "claim has common_mistakes" true (List.length g.common_mistakes > 0)
 


### PR DESCRIPTION
Partial #2636. 8파일에서 masc_claim 제거 (schema, dispatch, catalog, auth, mode, workflow). chain Masc_claim variant + 테스트 수정은 후속.