### PR TITLE
fix(shard): remove shell from default shards, make opt-in

### DIFF
--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -429,7 +429,10 @@ let default_shard_names : string list = [
   "base";
   "board";
   "filesystem";
-  "shell";
+  (* "shell" removed from defaults — opt-in via masc_tool_grant.
+     keeper_bash and keeper_github require explicit shell shard grant.
+     Defense-in-depth: even with shell shard, keeper_bash validates
+     commands against Worker_dev_tools.dev_allowed_commands allowlist. *)
   "weather";
   "voice";
   "library";

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -70,11 +70,13 @@ let test_all_shards_count () =
 
 let test_default_shard_names () =
   let defaults = Tool_shard.default_shard_names in
-  Alcotest.(check int) "8 defaults" 8 (List.length defaults);
+  Alcotest.(check int) "7 defaults (shell is opt-in)" 7 (List.length defaults);
   List.iter (fun name ->
     Alcotest.(check bool) (name ^ " in defaults") true
       (List.mem name defaults)
-  ) ["base"; "board"; "filesystem"; "shell"; "weather"; "voice"; "library"; "taskboard"]
+  ) ["base"; "board"; "filesystem"; "weather"; "voice"; "library"; "taskboard"];
+  Alcotest.(check bool) "shell NOT in defaults" false
+    (List.mem "shell" defaults)
 
 (* ============================================================
    tools_of_shards tests
@@ -99,8 +101,9 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_model_tools_count () =
   let tools = Tool_shard.keeper_model_tools in
-  (* base=3 + board=5 + filesystem=2 + shell=3 + weather=1 + voice=5 + library=2 + taskboard=7 = 28 *)
-  Alcotest.(check int) "28 total tools" 28 (List.length tools)
+  (* base=3 + board=5 + filesystem=2 + weather=1 + voice=5 + library=2 + taskboard=7 = 25
+     shell(3) removed from defaults — opt-in via masc_tool_grant *)
+  Alcotest.(check int) "25 total tools (shell opt-in)" 25 (List.length tools)
 
 (* ============================================================
    grant_shard tests
@@ -178,7 +181,7 @@ let test_revoke_unknown () =
 let test_get_agent_shards_default () =
   (* Unknown agent gets default shards *)
   let shards = Tool_shard.get_agent_shards "new-agent-never-seen" in
-  Alcotest.(check int) "defaults" 8 (List.length shards)
+  Alcotest.(check int) "defaults (7, shell opt-in)" 7 (List.length shards)
 
 let test_set_get_agent_shards () =
   Hashtbl.remove Tool_shard.agent_shards "test-agent-x";


### PR DESCRIPTION
## Summary

Shell shard (`keeper_bash`, `keeper_shell_readonly`, `keeper_github`)를 기본 shard에서 제거. Keeper/Agent가 기본적으로 shell 접근 불가.

### Defense-in-depth (2-layer)

| Layer | 보호 | PR |
|-------|------|-----|
| 1 | Shell shard 기본 미부여 (이 PR) | #2670 |
| 2 | keeper_bash allowlist (dune/git/rg 등 43개만 허용) | #2653 |

### 영향

- 기본 shard: 8 → 7개
- 기본 keeper tool: 28 → 25개
- Shell 필요 시: `masc_tool_grant agent_name=xxx shard_name=shell`

## Test plan

- [x] test_tool_shard_coverage: 42/42 pass
- [x] dune build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)