### PR TITLE
fix: suppress shutdown WARN spam in room message reader

### DIFF
--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -214,6 +214,7 @@ let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
               (match message_of_yojson json with
                | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
                | _ -> loop remaining acc rest)
+          | exception (Eio.Cancel.Cancelled _ as e) -> raise e
           | exception e ->
               Eio.traceln "[WARN] Failed to read %s %s: %s" warn_label name (Printexc.to_string e);
               loop remaining acc rest


### PR DESCRIPTION
## Summary
- `room_query.ml`의 `collect_recent_messages`에서 `Eio.Cancel.Cancelled`를 re-raise하도록 수정
- 셧다운 시 30+줄 WARN 로그 스팸이 사라짐
- `safe_ops.ml`과 동일한 패턴 적용

## Root Cause
`exception e` catch-all이 `Cancelled`를 삼키고 다음 파일로 넘어가면서, room에 메시지가 많을수록 WARN이 비례하여 출력됨.

## Test plan
- [ ] `dune build` 통과
- [ ] MASC 서버 시작 후 Ctrl+C로 종료 시 WARN 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)