### PR TITLE
fix(keeper): recognize coding in canonical_policy_shell_mode

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -76,8 +76,9 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     let with_voice =
       if meta.policy_voice_enabled then keeper_voice_tool_names @ base else base
     in
+    let shell_mode = canonical_policy_shell_mode meta.policy_shell_mode in
     let with_shell =
-      if canonical_policy_shell_mode meta.policy_shell_mode = "readonly" then
+      if shell_mode = "readonly" || shell_mode = "coding" then
         keeper_shell_readonly_tool_names @ with_voice
       else with_voice
     in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -187,6 +187,7 @@ let default_voice_agent_id_for name =
 let canonical_policy_shell_mode = function
   | "readonly" -> "readonly"
   | "sandboxed" -> "sandboxed"
+  | "coding" -> "coding"
   | _ -> "disabled"
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -264,16 +264,15 @@ let test_learned_readonly_combined_voice () =
   check bool "has voice_speak" true (List.mem "keeper_voice_speak" tools);
   check bool "has board tools" true (List.mem "keeper_board_post" tools)
 
-let test_coding_mode_canonical_is_disabled () =
-  (* canonical_policy_shell_mode maps "coding" to "disabled",
-     so coding tools are NOT added *)
+let test_coding_mode_grants_tools () =
+  (* canonical_policy_shell_mode now recognizes "coding" — grants
+     coding tools plus all lower-tier tools *)
   let meta = make_meta ~policy_shell_mode:"coding"
     ~policy_mode:"learned_offline_v1" () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  (* Since "coding" → canonical "disabled", no shell_readonly either *)
-  check bool "no keeper_shell_readonly" false (List.mem "keeper_shell_readonly" tools);
-  (* masc_code_write etc. not granted because canonical never returns "coding" *)
-  check bool "no masc_code_write" false (List.mem "masc_code_write" tools)
+  check bool "keeper_shell_readonly included" true (List.mem "keeper_shell_readonly" tools);
+  check bool "keeper_fs_read included" true (List.mem "keeper_fs_read" tools);
+  check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 
 let test_sandboxed_mode () =
   (* "sandboxed" is preserved by canonical but treated same as disabled for tool grants *)
@@ -444,7 +443,7 @@ let () =
       test_case "learned non-research profile" `Quick test_learned_non_research_profile;
       test_case "heuristic mode" `Quick test_heuristic_mode_tools;
       test_case "readonly + voice combined" `Quick test_learned_readonly_combined_voice;
-      test_case "coding canonical is disabled" `Quick test_coding_mode_canonical_is_disabled;
+      test_case "coding mode grants tools" `Quick test_coding_mode_grants_tools;
       test_case "sandboxed mode" `Quick test_sandboxed_mode;
     ]);
     ("extract_command_from_input", [


### PR DESCRIPTION
## Summary

`canonical_policy_shell_mode`가 "coding"을 인식하지 못해 "disabled"로 매핑되고 있었다. coding tool grant path가 dead branch였음.

- `canonical_policy_shell_mode`에 `"coding" -> "coding"` 추가
- coding mode에서 shell_readonly tools도 포함 (readonly의 상위 집합)
- safety gate 테스트를 실제 동작에 맞게 업데이트

Closes #2659 (별도 이슈로 추적됨)

## Test plan
- [x] `dune build --root .` 통과
- [x] 56/56 safety gate tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)