### PR TITLE
fix(keeper): add write-operation gate to keeper_bash (Layer 3)

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -379,21 +379,37 @@ let execute_keeper_tool_call
               ("reason", `String reason);
             ])
         | Ok () ->
-          let root = project_root_of_config config in
-          let shell_cmd =
-            Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd
-          in
-          let st, out =
-            Process_eio.run_argv_with_status ~timeout_sec
-              [ "/bin/bash"; "-lc"; shell_cmd ]
-          in
-          Yojson.Safe.to_string
-            (`Assoc
-              [
-                ("ok", `Bool (st = Unix.WEXITED 0));
-                ("status", process_status_to_json st);
-                ("output", `String (truncate_tool_output out));
+          if Worker_dev_tools.is_write_operation cmd then begin
+            Log.Keeper.info
+              "keeper_bash write-gate: %s (keeper=%s)"
+              cmd (meta.name);
+            Yojson.Safe.to_string
+              (`Assoc [
+                ("ok", `Bool false);
+                ("error", `String "write_operation_gated");
+                ("reason", `String
+                  "This command modifies state (git push/commit, make deploy, etc.). \
+                   Use keeper_shell_readonly for read operations, or request \
+                   shell_mode=coding policy from the operator.");
+                ("cmd", `String cmd);
               ])
+          end else begin
+            let root = project_root_of_config config in
+            let shell_cmd =
+              Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd
+            in
+            let st, out =
+              Process_eio.run_argv_with_status ~timeout_sec
+                [ "/bin/bash"; "-lc"; shell_cmd ]
+            in
+            Yojson.Safe.to_string
+              (`Assoc
+                [
+                  ("ok", `Bool (st = Unix.WEXITED 0));
+                  ("status", process_status_to_json st);
+                  ("output", `String (truncate_tool_output out));
+                ])
+          end
       end
   | "keeper_shell_readonly" ->
       let op =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -130,6 +130,26 @@ let validate_command_with_allowlist ~allowed_commands cmd =
 let validate_command cmd =
   validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 
+(** Check if a command performs write/mutating operations.
+    Returns [true] for commands like [git push], [git commit],
+    [make deploy], [npm publish], [mv], [cp], etc.
+    Read-only commands (git status, dune build, rg) return [false]. *)
+let is_write_operation cmd =
+  let parts = String.split_on_char ' ' (String.trim cmd) in
+  match parts with
+  | "git" :: sub :: _ ->
+    List.mem sub ["push"; "commit"; "merge"; "rebase"; "reset";
+                  "checkout"; "branch"; "tag"; "stash"]
+  | "dune" :: sub :: _ ->
+    List.mem sub ["clean"; "promote"]
+  | "make" :: sub :: _ ->
+    List.mem sub ["clean"; "deploy"; "install"; "publish"]
+  | "npm" :: sub :: _ ->
+    List.mem sub ["publish"]
+  | cmd_name :: _ ->
+    List.mem cmd_name ["mv"; "cp"; "mkdir"; "touch"; "chmod"]
+  | [] -> false
+
 (* --- Recursive mkdir --- *)
 
 let mkdir_p path _perm =

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -78,6 +78,51 @@ let test_empty_command () =
   Alcotest.(check bool) "empty blocked" true (is_error (validate ""));
   Alcotest.(check bool) "whitespace blocked" true (is_error (validate "   "))
 
+let is_write = Masc_mcp.Worker_dev_tools.is_write_operation
+
+let test_write_ops_detected () =
+  let writes = [
+    "git push origin main";
+    "git commit -m 'msg'";
+    "git merge feature";
+    "git rebase main";
+    "git reset --hard HEAD~1";
+    "git checkout other-branch";
+    "git stash pop";
+    "dune clean";
+    "make deploy";
+    "make install";
+    "npm publish";
+    "mv file1 file2";
+    "cp src dst";
+    "mkdir newdir";
+    "touch newfile";
+    "chmod 755 script.sh";
+  ] in
+  List.iter (fun cmd ->
+    Alcotest.(check bool) (Printf.sprintf "write: %s" cmd) true (is_write cmd)
+  ) writes
+
+let test_read_ops_pass () =
+  let reads = [
+    "git status";
+    "git log --oneline -5";
+    "git diff HEAD";
+    "dune build";
+    "dune exec test.exe";
+    "make test";
+    "npm run build";
+    "npm run dev";
+    "rg pattern lib/";
+    "cat file.ml";
+    "ls -la";
+    "head -20 file.ml";
+    "python3 script.py";
+  ] in
+  List.iter (fun cmd ->
+    Alcotest.(check bool) (Printf.sprintf "read: %s" cmd) false (is_write cmd)
+  ) reads
+
 let () =
   Alcotest.run "Keeper bash safety" [
     ("allowlist", [
@@ -86,6 +131,10 @@ let () =
     ]);
     ("metachar", [
       Alcotest.test_case "shell metacharacters blocked" `Quick test_shell_metachar_blocked;
+    ]);
+    ("write_gate", [
+      Alcotest.test_case "write operations detected" `Quick test_write_ops_detected;
+      Alcotest.test_case "read operations pass" `Quick test_read_ops_pass;
     ]);
     ("edge", [
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;


### PR DESCRIPTION
## Summary

keeper_bash에 write-operation gate 추가 (3-layer 방어 체계 완성).

### 3-Layer Defense

| Layer | 보호 | 상태 |
|-------|------|------|
| L1 | coding shard 기본 미부여 | main에 구현됨 |
| L2 | command allowlist (43개 dev 명령만) | PR #2653 merged |
| L3 | write gate (git push/commit, make deploy 차단) | 이 PR |

### 차단되는 write 명령

`git push/commit/merge/rebase/reset/checkout/stash`, `dune clean/promote`, `make clean/deploy/install/publish`, `npm publish`, `mv`, `cp`, `mkdir`, `touch`, `chmod`

### 통과하는 read 명령

`git status/log/diff`, `dune build/exec`, `make test`, `npm run build`, `rg`, `cat`, `ls`, `python3`

## Test plan

- [x] test_keeper_bash_safety: 6/6 pass (allowlist 2 + metachar 1 + write_gate 2 + edge 1)
- [x] dune build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)