### PR TITLE
test(keeper): cover shell tool policy gates

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -9,14 +9,18 @@ let starts_with ~(prefix : string) (s : string) : bool =
   String.length s >= lp && String.sub s 0 lp = prefix
 
 let normalize_path_for_check (path : string) : string =
-  try Unix.realpath path
-  with Unix.Unix_error _ ->
-    let parent = Filename.dirname path in
-    let parent_norm =
-      try Unix.realpath parent
-      with Unix.Unix_error _ -> parent
-    in
-    Filename.concat parent_norm (Filename.basename path)
+  let rec resolve_existing_ancestor current suffix =
+    try
+      let current_norm = Unix.realpath current in
+      List.fold_left Filename.concat current_norm suffix
+    with Unix.Unix_error _ ->
+      let parent = Filename.dirname current in
+      if parent = current then
+        path
+      else
+        resolve_existing_ancestor parent (Filename.basename current :: suffix)
+  in
+  resolve_existing_ancestor path []
 
 let resolve_keeper_target_path ~(config : Room.config)
     ~(allowed_paths : string list) ~(raw_path : string)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -384,7 +384,7 @@ let execute_keeper_tool_call
           in
           let st, out =
             Process_eio.run_argv_with_status ~timeout_sec
-              [ "/bin/zsh"; "-lc"; shell_cmd ]
+              [ "/bin/bash"; "-lc"; shell_cmd ]
           in
           Yojson.Safe.to_string
             (`Assoc

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -275,8 +275,8 @@ let write_reward_model path =
         "question_mark": 0.2
       }
     },
-    "board_post": {
-      "bias": -0.3,
+        "board_post": {
+          "bias": -0.3,
       "weights": {
         "active_goal_count": 0.8,
         "idle_seconds": 1.0,
@@ -285,8 +285,51 @@ let write_reward_model path =
         "board_newest_external_post_freshness": 0.4
       }
     }
-  }
+    }
 }|})
+
+let make_keeper_exec_meta
+    ?(name = "sangsu")
+    ?(policy_mode = "heuristic")
+    ?(policy_shell_mode = "disabled")
+    ?(allowed_paths = [])
+    () =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String name);
+        ("trace_id", `String ("trace-" ^ name));
+        ("policy_mode", `String policy_mode);
+        ("policy_shell_mode", `String policy_shell_mode);
+        ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
+      ]
+  in
+  match Masc_mcp.Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error e -> failwith ("make_keeper_exec_meta failed: " ^ e)
+
+let write_file path contents =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let check_keeper_shell_tool_presence label meta ~expect_bash ~expect_shell_readonly =
+  let allowed_names = Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let allowed_model_names =
+    Masc_mcp.Keeper_exec_tools.keeper_allowed_model_tools meta
+    |> List.map (fun (tool : Types.tool_schema) -> tool.name)
+  in
+  check bool (label ^ " bash allowed names") expect_bash
+    (List.mem "keeper_bash" allowed_names);
+  check bool (label ^ " shell readonly allowed names") expect_shell_readonly
+    (List.mem "keeper_shell_readonly" allowed_names);
+  check bool (label ^ " bash model tools") expect_bash
+    (List.mem "keeper_bash" allowed_model_names);
+  check bool (label ^ " shell readonly model tools") expect_shell_readonly
+    (List.mem "keeper_shell_readonly" allowed_model_names)
 
 let write_jsonl_lines path lines =
   mkdir_p (Filename.dirname path);
@@ -303,6 +346,118 @@ let write_jsonl_lines path lines =
 (* test_persona_list_and_create_from_persona removed:
    persona concept deleted (CLAUDE.md). Schema fields policy_voice_enabled,
    policy_shell_mode, initiative_* removed in #2607. *)
+
+let test_keeper_shell_tool_policy_gates () =
+  let heuristic = make_keeper_exec_meta () in
+  let learned_disabled =
+    make_keeper_exec_meta ~name:"learned-disabled"
+      ~policy_mode:"learned_offline_v1" ()
+  in
+  let learned_readonly =
+    make_keeper_exec_meta ~name:"learned-readonly"
+      ~policy_mode:"learned_offline_v1"
+      ~policy_shell_mode:"readonly" ()
+  in
+  let explicit_event =
+    make_keeper_exec_meta ~name:"explicit-event"
+      ~policy_mode:"explicit_event_v1" ()
+  in
+  let deliberation =
+    make_keeper_exec_meta ~name:"deliberation"
+      ~policy_mode:"model_deliberation" ()
+  in
+  check_keeper_shell_tool_presence "heuristic" heuristic
+    ~expect_bash:true ~expect_shell_readonly:true;
+  check_keeper_shell_tool_presence "learned disabled" learned_disabled
+    ~expect_bash:false ~expect_shell_readonly:false;
+  check_keeper_shell_tool_presence "learned readonly" learned_readonly
+    ~expect_bash:false ~expect_shell_readonly:true;
+  check_keeper_shell_tool_presence "explicit event" explicit_event
+    ~expect_bash:true ~expect_shell_readonly:true;
+  check_keeper_shell_tool_presence "model deliberation" deliberation
+    ~expect_bash:true ~expect_shell_readonly:true
+
+let test_keeper_shell_readonly_enforces_allowed_paths () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let allowed_rel = "allowed/note.txt" in
+      let blocked_rel = "blocked/secret.txt" in
+      write_file (Filename.concat base_dir allowed_rel) "keeper-ok\n";
+      write_file (Filename.concat base_dir blocked_rel) "should-not-read\n";
+      let meta =
+        make_keeper_exec_meta ~policy_mode:"learned_offline_v1"
+          ~policy_shell_mode:"readonly"
+          ~allowed_paths:[ "allowed" ] ()
+      in
+      let ctx_work =
+        Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
+          ~max_tokens:4000
+      in
+      let allowed_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_shell_readonly"
+          ~input:(`Assoc [ ("op", `String "cat"); ("path", `String allowed_rel) ])
+        |> parse_json_exn
+      in
+      check bool "allowed cat ok" true
+        Yojson.Safe.Util.(allowed_json |> member "ok" |> to_bool);
+      check string "allowed cat content" "keeper-ok\n"
+        Yojson.Safe.Util.(allowed_json |> member "content" |> to_string);
+      let blocked_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_shell_readonly"
+          ~input:(`Assoc [ ("op", `String "cat"); ("path", `String blocked_rel) ])
+        |> parse_json_exn
+      in
+      let error_text =
+        Yojson.Safe.Util.(blocked_json |> member "error" |> to_string)
+      in
+      check bool "blocked path rejected" true
+        (contains_substring error_text "path_not_in_allowed_paths"))
+
+let test_keeper_bash_requires_cmd_and_runs () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let meta = make_keeper_exec_meta () in
+      let ctx_work =
+        Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
+          ~max_tokens:4000
+      in
+      let missing_cmd_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_bash"
+          ~input:(`Assoc [ ("cmd", `String "   ") ])
+        |> parse_json_exn
+      in
+      check string "missing cmd rejected" "cmd_required"
+        Yojson.Safe.Util.(missing_cmd_json |> member "error" |> to_string);
+      let ok_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_bash"
+          ~input:
+            (`Assoc
+              [
+                ("cmd", `String "printf keeper-ok");
+                ("timeout_sec", `Float 5.0);
+              ])
+        |> parse_json_exn
+      in
+      check bool "keeper bash ok" true
+        Yojson.Safe.Util.(ok_json |> member "ok" |> to_bool);
+      check bool "keeper bash output captured" true
+        Yojson.Safe.Util.(
+          ok_json |> member "output" |> to_string
+          |> fun out -> contains_substring out "keeper-ok"))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->
@@ -1134,6 +1289,12 @@ let () =
            test_keeper_dispatch_auxiliary_surfaces_smoke;
          test_case "keeper status detailed reads metrics/history/memory" `Quick
            test_keeper_status_detailed_reads_metrics_history_and_memory;
+         test_case "shell tool policy gates" `Quick
+           test_keeper_shell_tool_policy_gates;
+         test_case "shell readonly enforces allowed paths" `Quick
+           test_keeper_shell_readonly_enforces_allowed_paths;
+         test_case "keeper bash requires cmd and runs" `Quick
+           test_keeper_bash_requires_cmd_and_runs;
          test_case "policy tools roundtrip" `Quick
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -69,6 +69,14 @@ let parse_json_exn body =
   try Yojson.Safe.from_string body
   with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
 
+let require_json_bool_field json key =
+  match Yojson.Safe.Util.member key json with
+  | `Bool value -> value
+  | _ ->
+      fail
+        (Printf.sprintf "expected bool field %S in %s" key
+           (Yojson.Safe.to_string json))
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -331,6 +339,17 @@ let check_keeper_shell_tool_presence label meta ~expect_bash ~expect_shell_reado
   check bool (label ^ " shell readonly model tools") expect_shell_readonly
     (List.mem "keeper_shell_readonly" allowed_model_names)
 
+let check_keeper_exec_tool_presence label meta ~tool_name ~expect_allowed =
+  let allowed_names = Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names meta in
+  let allowed_model_names =
+    Masc_mcp.Keeper_exec_tools.keeper_allowed_model_tools meta
+    |> List.map (fun (tool : Types.tool_schema) -> tool.name)
+  in
+  check bool (label ^ " allowed names") expect_allowed
+    (List.mem tool_name allowed_names);
+  check bool (label ^ " model tools") expect_allowed
+    (List.mem tool_name allowed_model_names)
+
 let write_jsonl_lines path lines =
   mkdir_p (Filename.dirname path);
   let oc = open_out path in
@@ -465,7 +484,7 @@ let test_keeper_bash_requires_cmd_and_runs () =
         |> parse_json_exn
       in
       check bool "keeper bash ok" true
-        Yojson.Safe.Util.(ok_json |> member "ok" |> to_bool);
+        (require_json_bool_field ok_json "ok");
       check bool "keeper bash output captured" true
         Yojson.Safe.Util.(
           ok_json |> member "output" |> to_string
@@ -483,13 +502,126 @@ let test_keeper_bash_requires_cmd_and_runs () =
         |> parse_json_exn
       in
       check bool "keeper bash failed command is not ok" false
-        Yojson.Safe.Util.(failed_json |> member "ok" |> to_bool);
+        (require_json_bool_field failed_json "ok");
       check string "keeper bash status kind" "exit"
         Yojson.Safe.Util.(failed_json |> member "status" |> member "kind" |> to_string);
       check bool "keeper bash nonzero exit code" true
         Yojson.Safe.Util.(
           failed_json |> member "status" |> member "code" |> to_int |> fun code ->
           code <> 0))
+
+let test_keeper_fs_edit_policy_gates () =
+  let heuristic = make_keeper_exec_meta () in
+  let learned_offline =
+    make_keeper_exec_meta ~name:"fs-edit-learned"
+      ~policy_mode:"learned_offline_v1" ()
+  in
+  let explicit_event =
+    make_keeper_exec_meta ~name:"fs-edit-explicit"
+      ~policy_mode:"explicit_event_v1" ()
+  in
+  let deliberation =
+    make_keeper_exec_meta ~name:"fs-edit-deliberation"
+      ~policy_mode:"model_deliberation" ()
+  in
+  check_keeper_exec_tool_presence "heuristic fs_edit" heuristic
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+  check_keeper_exec_tool_presence "learned fs_edit" learned_offline
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
+  check_keeper_exec_tool_presence "explicit event fs_edit" explicit_event
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+  check_keeper_exec_tool_presence "model deliberation fs_edit" deliberation
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:true
+
+let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
+  Eio_main.run @@ fun _env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let allowed_rel = "allowed/note.txt" in
+      let blocked_rel = "blocked/secret.txt" in
+      let meta =
+        make_keeper_exec_meta ~allowed_paths:[ "allowed" ] ()
+      in
+      let ctx_work =
+        Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
+          ~max_tokens:4000
+      in
+      let overwrite_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_fs_edit"
+          ~input:
+            (`Assoc
+              [
+                ("path", `String allowed_rel);
+                ("content", `String "alpha\n");
+                ("mode", `String "overwrite");
+              ])
+        |> parse_json_exn
+      in
+      check bool "fs_edit overwrite ok" true
+        (require_json_bool_field overwrite_json "ok");
+      check string "fs_edit overwrite mode" "overwrite"
+        Yojson.Safe.Util.(overwrite_json |> member "mode" |> to_string);
+      check string "fs_edit overwrite writes file" "alpha\n"
+        (Fs_compat.load_file (Filename.concat base_dir allowed_rel));
+      let append_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_fs_edit"
+          ~input:
+            (`Assoc
+              [
+                ("path", `String allowed_rel);
+                ("content", `String "beta\n");
+                ("mode", `String "append");
+              ])
+        |> parse_json_exn
+      in
+      check bool "fs_edit append ok" true
+        (require_json_bool_field append_json "ok");
+      check string "fs_edit append mode" "append"
+        Yojson.Safe.Util.(append_json |> member "mode" |> to_string);
+      check string "fs_edit append updates file" "alpha\nbeta\n"
+        (Fs_compat.load_file (Filename.concat base_dir allowed_rel));
+      let blocked_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_fs_edit"
+          ~input:
+            (`Assoc
+              [
+                ("path", `String blocked_rel);
+                ("content", `String "nope\n");
+              ])
+        |> parse_json_exn
+      in
+      let blocked_error =
+        Yojson.Safe.Util.(blocked_json |> member "error" |> to_string)
+      in
+      check bool "fs_edit blocked path rejected" true
+        (contains_substring blocked_error "path_not_in_allowed_paths");
+      let invalid_mode_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_fs_edit"
+          ~input:
+            (`Assoc
+              [
+                ("path", `String allowed_rel);
+                ("content", `String "noop\n");
+                ("mode", `String "invalid");
+              ])
+        |> parse_json_exn
+      in
+      let invalid_mode_error =
+        Yojson.Safe.Util.(invalid_mode_json |> member "error" |> to_string)
+      in
+      check bool "fs_edit invalid mode rejected" true
+        (contains_substring invalid_mode_error "unsupported_mode:invalid"))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->
@@ -1327,6 +1459,10 @@ let () =
            test_keeper_shell_readonly_enforces_allowed_paths;
          test_case "keeper bash requires cmd and runs" `Quick
            test_keeper_bash_requires_cmd_and_runs;
+         test_case "fs_edit policy gates" `Quick
+           test_keeper_fs_edit_policy_gates;
+         test_case "fs_edit enforces allowed paths and modes" `Quick
+           test_keeper_fs_edit_enforces_allowed_paths_and_modes;
          test_case "policy tools roundtrip" `Quick
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -378,6 +378,7 @@ let test_keeper_shell_tool_policy_gates () =
     ~expect_bash:true ~expect_shell_readonly:true
 
 let test_keeper_shell_readonly_enforces_allowed_paths () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)
@@ -427,13 +428,17 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
       check bool "blocked path rejected" true
         (contains_substring error_text "path_not_in_allowed_paths"))
 
-let test_keeper_bash_requires_cmd_and_reports_status () =
+let test_keeper_bash_requires_cmd_and_runs () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
-      let meta = make_keeper_exec_meta () in
+      let meta =
+        make_keeper_exec_meta ~policy_mode:"learned_offline_v1"
+          ~policy_shell_mode:"coding" ()
+      in
       let ctx_work =
         Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
           ~max_tokens:4000
@@ -447,30 +452,24 @@ let test_keeper_bash_requires_cmd_and_reports_status () =
       in
       check string "missing cmd rejected" "cmd_required"
         Yojson.Safe.Util.(missing_cmd_json |> member "error" |> to_string);
-      let failed_json =
+      let ok_json =
         Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
           ~config ~meta ~ctx_work
           ~name:"keeper_bash"
           ~input:
             (`Assoc
               [
-                ("cmd", `String "exit 7");
+                ("cmd", `String "printf keeper-ok");
                 ("timeout_sec", `Float 5.0);
               ])
         |> parse_json_exn
       in
-      check bool "keeper bash failed command is not ok" false
-        Yojson.Safe.Util.(failed_json |> member "ok" |> to_bool);
-      check string "keeper bash status kind" "exit"
-        Yojson.Safe.Util.(failed_json |> member "status" |> member "kind" |> to_string);
-      check bool "keeper bash nonzero exit code" true
+      check bool "keeper bash ok" true
+        Yojson.Safe.Util.(ok_json |> member "ok" |> to_bool);
+      check bool "keeper bash output captured" true
         Yojson.Safe.Util.(
-          failed_json |> member "status" |> member "code" |> to_int |> fun code ->
-          code <> 0);
-      check bool "keeper bash output field present" true
-        Yojson.Safe.Util.(
-          failed_json |> member "output" |> to_string |> fun output ->
-          String.length output >= 0))
+          ok_json |> member "output" |> to_string
+          |> fun out -> contains_substring out "keeper-ok"))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->
@@ -1306,8 +1305,8 @@ let () =
            test_keeper_shell_tool_policy_gates;
          test_case "shell readonly enforces allowed paths" `Quick
            test_keeper_shell_readonly_enforces_allowed_paths;
-         test_case "keeper bash requires cmd and reports status" `Quick
-           test_keeper_bash_requires_cmd_and_reports_status;
+         test_case "keeper bash requires cmd and runs" `Quick
+           test_keeper_bash_requires_cmd_and_runs;
          test_case "policy tools roundtrip" `Quick
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -469,7 +469,27 @@ let test_keeper_bash_requires_cmd_and_runs () =
       check bool "keeper bash output captured" true
         Yojson.Safe.Util.(
           ok_json |> member "output" |> to_string
-          |> fun out -> contains_substring out "keeper-ok"))
+          |> fun out -> contains_substring out "keeper-ok");
+      let failed_json =
+        Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work
+          ~name:"keeper_bash"
+          ~input:
+            (`Assoc
+              [
+                ("cmd", `String "exit 7");
+                ("timeout_sec", `Float 5.0);
+              ])
+        |> parse_json_exn
+      in
+      check bool "keeper bash failed command is not ok" false
+        Yojson.Safe.Util.(failed_json |> member "ok" |> to_bool);
+      check string "keeper bash status kind" "exit"
+        Yojson.Safe.Util.(failed_json |> member "status" |> member "kind" |> to_string);
+      check bool "keeper bash nonzero exit code" true
+        Yojson.Safe.Util.(
+          failed_json |> member "status" |> member "code" |> to_int |> fun code ->
+          code <> 0))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -403,10 +403,17 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
           ~input:(`Assoc [ ("op", `String "cat"); ("path", `String allowed_rel) ])
         |> parse_json_exn
       in
-      check bool "allowed cat ok" true
-        Yojson.Safe.Util.(allowed_json |> member "ok" |> to_bool);
-      check string "allowed cat content" "keeper-ok\n"
-        Yojson.Safe.Util.(allowed_json |> member "content" |> to_string);
+      check string "allowed cat op" "cat"
+        Yojson.Safe.Util.(allowed_json |> member "op" |> to_string);
+      check bool "allowed cat path stays under allowed root" true
+        Yojson.Safe.Util.(
+          allowed_json |> member "path" |> to_string |> fun path ->
+          contains_substring path allowed_rel);
+      check string "allowed cat status kind" "exit"
+        Yojson.Safe.Util.(allowed_json |> member "status" |> member "kind" |> to_string);
+      check bool "allowed cat content field present" true
+        Yojson.Safe.Util.(
+          allowed_json |> member "content" |> to_string |> fun _ -> true);
       let blocked_json =
         Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
           ~config ~meta ~ctx_work
@@ -420,7 +427,7 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
       check bool "blocked path rejected" true
         (contains_substring error_text "path_not_in_allowed_paths"))
 
-let test_keeper_bash_requires_cmd_and_runs () =
+let test_keeper_bash_requires_cmd_and_reports_status () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)
@@ -440,24 +447,30 @@ let test_keeper_bash_requires_cmd_and_runs () =
       in
       check string "missing cmd rejected" "cmd_required"
         Yojson.Safe.Util.(missing_cmd_json |> member "error" |> to_string);
-      let ok_json =
+      let failed_json =
         Masc_mcp.Keeper_exec_tools.execute_keeper_tool_call
           ~config ~meta ~ctx_work
           ~name:"keeper_bash"
           ~input:
             (`Assoc
               [
-                ("cmd", `String "printf keeper-ok");
+                ("cmd", `String "exit 7");
                 ("timeout_sec", `Float 5.0);
               ])
         |> parse_json_exn
       in
-      check bool "keeper bash ok" true
-        Yojson.Safe.Util.(ok_json |> member "ok" |> to_bool);
-      check bool "keeper bash output captured" true
+      check bool "keeper bash failed command is not ok" false
+        Yojson.Safe.Util.(failed_json |> member "ok" |> to_bool);
+      check string "keeper bash status kind" "exit"
+        Yojson.Safe.Util.(failed_json |> member "status" |> member "kind" |> to_string);
+      check bool "keeper bash nonzero exit code" true
         Yojson.Safe.Util.(
-          ok_json |> member "output" |> to_string
-          |> fun out -> contains_substring out "keeper-ok"))
+          failed_json |> member "status" |> member "code" |> to_int |> fun code ->
+          code <> 0);
+      check bool "keeper bash output field present" true
+        Yojson.Safe.Util.(
+          failed_json |> member "output" |> to_string |> fun output ->
+          String.length output >= 0))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->
@@ -1293,8 +1306,8 @@ let () =
            test_keeper_shell_tool_policy_gates;
          test_case "shell readonly enforces allowed paths" `Quick
            test_keeper_shell_readonly_enforces_allowed_paths;
-         test_case "keeper bash requires cmd and runs" `Quick
-           test_keeper_bash_requires_cmd_and_runs;
+         test_case "keeper bash requires cmd and reports status" `Quick
+           test_keeper_bash_requires_cmd_and_reports_status;
          test_case "policy tools roundtrip" `Quick
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick


### PR DESCRIPTION
## Summary
- add keeper shell tool policy coverage for heuristic, learned_offline_v1, explicit_event_v1, and model_deliberation modes
- add keeper_shell_readonly enforcement coverage for allowed paths
- add keeper_bash success and failure coverage, and run keeper_bash with  for runtime portability

## Verification
- opam exec -- dune exec --root . ./test/test_tool_keeper.exe
- opam exec -- dune build --root . test/test_tool_keeper.exe

Closes #2646