### PR TITLE
fix(test): remove stale council archive source guard

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -194,10 +194,8 @@ let test_dashboard_component_split_contracts () =
   (* war room surface removed — dead UI cleanup PR #2569 *)
   check bool "room backend setup normalizes postgres pooler url before connect" true
     (file_contains_pattern "lib/room/room_utils_backend_setup.ml"
-       "pooler.supabase.com");
-  check bool "council archive normalizes postgres url" true
-    (file_contains_pattern "lib/council/archive.ml"
        "pooler.supabase.com")
+  (* council archive.ml removed in dead-code sweep *)
 
 let test_activity_surface_contracts () =
   check bool "activity tab exposes activity graph label" true


### PR DESCRIPTION
## Summary
council/archive.ml이 dead-code sweep에서 삭제됐지만 source guard 테스트가 남아서 main CI 실패.

## Fix
- `test_ci_hardening_source.ml`: archive.ml pooler assertion 제거
- room_utils_backend_setup.ml의 pooler check는 유지

## Impact
main CI의 `dashboard component split contracts` 테스트 green 복구.
모든 open PR (#2660, #2666, #2670, #2671, #2673)의 Build and Test 차단 해제.

Generated with [Claude Code](https://claude.com/claude-code)