### PR TITLE
feat(transport): enable all 4 protocols by default

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -19,11 +19,11 @@ let configured_port () =
       default_port)
   | None -> default_port
 
-(** Check whether gRPC is enabled (default: disabled, opt-in via env). *)
+(** Check whether gRPC is enabled (default: enabled, opt-out via env). *)
 let is_enabled () =
   match Sys.getenv_opt "MASC_GRPC_ENABLED" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
+  | Some "0" | Some "false" -> false
+  | _ -> true
 
 (** Start the gRPC coordination server.
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -679,7 +679,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     | Some "1" | Some "true" -> `H2_only
     | Some "0" | Some "false" -> `H1_only
     | Some "auto" -> `Auto
-    | None -> `H1_only
+    | None -> `Auto
     | Some other ->
       Log.Server.warn "MASC_USE_H2=%s unrecognised, falling back to auto" other;
       `Auto

--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -14,13 +14,13 @@
     This module manages the signaling state, peer registry, and live
     WebRTC connections via ocaml-webrtc (Webrtc.Webrtc_eio).
 
-    Opt-in via MASC_WEBRTC_ENABLED=1. *)
+    Enabled by default. Opt-out via MASC_WEBRTC_ENABLED=0. *)
 
-(** Whether WebRTC transport is enabled. *)
+(** Whether WebRTC transport is enabled (default: true). *)
 let is_enabled () =
   match Sys.getenv_opt "MASC_WEBRTC_ENABLED" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
+  | Some "0" | Some "false" -> false
+  | _ -> true
 
 (** {1 Signaling State} *)
 

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -213,12 +213,16 @@ let test_grpc_default_port () =
   Alcotest.(check int) "default port" 8936
     Masc_mcp.Masc_grpc_server.default_port
 
-let test_grpc_disabled_by_default () =
-  (* With no MASC_GRPC_ENABLED env var, should be disabled *)
+let test_grpc_enabled_by_default () =
+  (* With no MASC_GRPC_ENABLED env var, should be enabled *)
   let was_set = Sys.getenv_opt "MASC_GRPC_ENABLED" in
   (match was_set with Some _ -> Unix.putenv "MASC_GRPC_ENABLED" "" | None -> ());
   let result = Masc_mcp.Masc_grpc_server.is_enabled () in
-  Alcotest.(check bool) "disabled by default" false result;
+  Alcotest.(check bool) "enabled by default" true result;
+  (* Verify opt-out works *)
+  Unix.putenv "MASC_GRPC_ENABLED" "0";
+  let disabled = Masc_mcp.Masc_grpc_server.is_enabled () in
+  Alcotest.(check bool) "disabled via env" false disabled;
   (* Restore *)
   (match was_set with Some v -> Unix.putenv "MASC_GRPC_ENABLED" v | None -> ())
 
@@ -275,6 +279,6 @@ let () =
       ( "server_config",
         [
           Alcotest.test_case "default_port" `Quick test_grpc_default_port;
-          Alcotest.test_case "disabled_by_default" `Quick test_grpc_disabled_by_default;
+          Alcotest.test_case "enabled_by_default" `Quick test_grpc_enabled_by_default;
         ] );
     ]


### PR DESCRIPTION
## Summary

4개 전송 프로토콜을 env var 없이 기본 활성화.

| Protocol | Before | After | Opt-out |
|----------|--------|-------|---------|
| HTTP/2 h2c | `MASC_USE_H2=1` 필요 | Auto (H1+H2 동시) | `MASC_USE_H2=0` |
| gRPC | `MASC_GRPC_ENABLED=1` 필요 | 기본 활성 | `MASC_GRPC_ENABLED=0` |
| WebRTC | `MASC_WEBRTC_ENABLED=1` 필요 | 기본 활성 | `MASC_WEBRTC_ENABLED=0` |
| WebSocket | 이미 기본 활성 | 변경 없음 | — |

### 검증
- gRPC 17/17 tests PASS (enabled_by_default + opt-out 검증)
- WS 10/10, WebRTC 15/15 PASS
- h2c auto-detect 수동 검증 완료 (prior-knowledge + MCP POST)

## Test plan
- [x] `dune exec test/test_grpc_coordination.exe` — 17/17 PASS
- [x] `dune exec test/test_ws_transport.exe` — 10/10 PASS
- [x] `dune exec test/test_webrtc_signaling.exe` — 15/15 PASS

Generated with [Claude Code](https://claude.com/claude-code)