### PR TITLE
fix: separate keeper direct comms from internal history

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -15,13 +15,13 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
     case 'sending':
       return 'sending'
     case 'streaming':
-      return entry.streamState === 'finalizing' ? 'finalizing' : 'streaming'
+      return entry.streamState === 'finalizing' ? 'finalizing' : 'live'
     case 'timeout':
       return 'timeout'
     case 'error':
       return 'error'
     case 'history':
-      return entry.role
+      return 'saved'
     default:
       return 'delivered'
   }
@@ -117,24 +117,44 @@ export function ChatMessageBubble({
   }, [showMetadata])
 
   return html`
-    <article class=${`chat-bubble ${bubbleTone(entry)}`}>
-      <div class="chat-bubble-head">
-        <div class="chat-bubble-identity">
-          <div class=${`chat-avatar ${bubbleTone(entry)}`}>${avatarMonogram(entry)}</div>
-          <div class="chat-bubble-identity-copy">
-            <div class="chat-bubble-labels">
-              <span class=${`chat-role-chip ${bubbleTone(entry)}`}>${entry.label}</span>
-              <span class="chat-delivery-chip rounded-full">${deliveryLabel(entry)}</span>
-              ${entry.timestamp ? html`<span class="chat-time-chip rounded-full">${timeLabel(entry.timestamp)}</span>` : null}
+    <article
+      class=${`chat-bubble ${bubbleTone(entry)} flex w-full max-w-[90%] flex-col gap-3 rounded-[20px] border px-4 py-3 backdrop-blur-sm`}
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex min-w-0 flex-1 items-start gap-3">
+          <div
+            class=${`chat-avatar ${bubbleTone(entry)} flex size-10 shrink-0 items-center justify-center rounded-2xl border text-[11px] font-semibold uppercase tracking-[0.08em]`}
+          >
+            ${avatarMonogram(entry)}
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex flex-wrap items-center gap-1.5">
+              <span
+                class=${`chat-role-chip ${bubbleTone(entry)} inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]`}
+              >
+                ${entry.label}
+              </span>
+              <span class="inline-flex items-center rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">
+                ${deliveryLabel(entry)}
+              </span>
+              ${entry.timestamp
+                ? html`
+                    <span class="inline-flex items-center rounded-full border border-[rgba(148,163,184,0.16)] bg-[rgba(148,163,184,0.08)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
+                      ${timeLabel(entry.timestamp)}
+                    </span>
+                  `
+                : null}
             </div>
-            <div class="chat-identity-title">${avatarLabel(entry)}</div>
+            <div class="mt-2 truncate text-[13px] font-semibold text-[var(--text-strong)]">
+              ${avatarLabel(entry)}
+            </div>
           </div>
         </div>
         ${canExpand
           ? html`
-              <button type="button"
+              <button
                 type="button"
-                class="chat-disclosure-btn rounded-full"
+                class="rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)]"
                 onClick=${() => { setExpanded(!expanded) }}
               >
                 ${expanded ? '상세 숨기기' : '상세 보기'}
@@ -144,24 +164,36 @@ export function ChatMessageBubble({
       </div>
 
       ${showMetadata && detailItems.length > 0
-        ? html`<div class="chat-detail-chip rounded-full-row">
-            ${detailItems.map(item => html`<span class="chat-detail-chip rounded-full">${item}</span>`)}
+        ? html`<div class="flex flex-wrap gap-1.5">
+            ${detailItems.map(item => html`
+              <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.16)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[10px] font-medium text-[#bfe8ff]">
+                ${item}
+              </span>
+            `)}
           </div>`
         : null}
 
-      <div class="chat-bubble-body">${entry.text || (entry.delivery === 'streaming' ? '…' : '(empty reply)')}</div>
-      ${entry.error ? html`<div class="chat-bubble-error">${entry.error}</div>` : null}
+      <div class="whitespace-pre-wrap break-words text-[14px] leading-[1.7] text-[var(--text-body)]">
+        ${entry.text || (entry.delivery === 'streaming' ? '…' : '(empty reply)')}
+      </div>
+      ${entry.error
+        ? html`
+            <div class="rounded-2xl border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.28)] px-3 py-2 text-[12px] leading-[1.55] text-[#ffb4b4]">
+              ${entry.error}
+            </div>
+          `
+        : null}
 
       ${expanded && entry.details
         ? html`
-            <div class="chat-detail-panel rounded-xl">
+            <div class="chat-detail-panel rounded-[18px] border border-[rgba(148,163,184,0.14)] px-3 py-3">
               ${overview.length > 0
                 ? html`
                     <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                       ${overview.map(item => html`
-                        <div class="chat-overview-card rounded-xl">
-                          <div class="chat-overview-label">${item.label}</div>
-                          <div class="chat-overview-value">${item.value}</div>
+                        <div class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-3 py-2.5">
+                          <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">${item.label}</div>
+                          <div class="mt-1 text-[13px] font-semibold text-[var(--text-strong)]">${item.value}</div>
                         </div>
                       `)}
                     </div>
@@ -169,24 +201,24 @@ export function ChatMessageBubble({
                 : null}
               ${entry.details.skillPrimary
                 ? html`
-                    <div class="chat-detail-callout">
-                      <div class="chat-detail-callout-label">스킬 경로</div>
-                      <div class="chat-detail-callout-value">${entry.details.skillPrimary}</div>
+                    <div class="chat-detail-callout rounded-2xl border border-[rgba(76,181,137,0.18)] px-3 py-3">
+                      <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#8fdcb3]">스킬 경로</div>
+                      <div class="mt-1 text-[13px] font-semibold text-[#d8f7e6]">${entry.details.skillPrimary}</div>
                       ${entry.details.skillReason
-                        ? html`<div class="text-[#bfe8cf] leading-[1.55]">${entry.details.skillReason}</div>`
+                        ? html`<div class="mt-1 text-[12px] leading-[1.6] text-[#bfe8cf]">${entry.details.skillReason}</div>`
                         : null}
                     </div>
                   `
                 : null}
               ${state.length > 0
                 ? html`
-                    <div class="chat-detail-section">
-                      <div class="chat-detail-section-title">상태 스냅샷</div>
+                    <div class="flex flex-col gap-2">
+                      <div class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">상태 스냅샷</div>
                       <div class="grid grid-cols-[repeat(auto-fit,minmax(116px,1fr))] gap-2">
                         ${state.map(item => html`
-                          <div class="chat-state-card rounded-xl">
-                            <div class="chat-state-label">${item.label}</div>
-                            <div class="chat-state-value">${item.value}</div>
+                          <div class="rounded-2xl border border-[rgba(71,184,255,0.14)] bg-[rgba(71,184,255,0.06)] px-3 py-2.5">
+                            <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[#9ad9ff]">${item.label}</div>
+                            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-body)]">${item.value}</div>
                           </div>
                         `)}
                       </div>
@@ -195,16 +227,16 @@ export function ChatMessageBubble({
                 : null}
               ${entry.details.rawPayload
                 ? html`
-                    <div class="chat-detail-section">
-                      <button type="button"
+                    <div class="flex flex-col gap-2">
+                      <button
                         type="button"
-                        class="chat-raw-toggle rounded-full"
+                        class="self-start rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)]"
                         onClick=${() => { setRawExpanded(!rawExpanded) }}
                       >
                         ${rawExpanded ? '원본 숨기기' : '원본 보기'}
                       </button>
                       ${rawExpanded
-                        ? html`<pre>${JSON.stringify(entry.details.rawPayload, null, 2)}</pre>`
+                        ? html`<pre class="rounded-2xl border border-[rgba(148,163,184,0.12)] bg-[rgba(2,10,24,0.84)] px-3 py-3">${JSON.stringify(entry.details.rawPayload, null, 2)}</pre>`
                         : null}
                     </div>
                   `
@@ -235,9 +267,17 @@ export function ChatTranscript({
   }, [lastSignature])
 
   return html`
-    <div class="chat-transcript" ref=${scrollerRef}>
+    <div
+      class="chat-transcript flex min-h-[300px] max-h-[520px] flex-col gap-3 overflow-y-auto rounded-[22px] border border-[rgba(148,163,184,0.14)] px-3 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+      ref=${scrollerRef}
+    >
       ${entries.length === 0
-        ? html`<div class="chat-empty-copy">${emptyText}</div>`
+        ? html`
+            <div class="flex min-h-[220px] flex-col items-center justify-center rounded-[18px] border border-dashed border-[rgba(148,163,184,0.18)] bg-[rgba(255,255,255,0.03)] px-6 text-center">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">No Direct Messages</div>
+              <div class="mt-3 max-w-[34rem] text-[13px] leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
+            </div>
+          `
         : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} />`)}
     </div>
   `
@@ -276,20 +316,38 @@ export function ChatComposer({
   }, [streaming, streamStartedAt])
 
   const streamLabel = streaming
-    ? `Streaming${elapsed > 0 ? ` ${elapsed}s` : '...'}`
-    : '전송'
+    ? `응답 중${elapsed > 0 ? ` ${elapsed}s` : '...'}`
+    : '보내기'
   const warnClass = streaming && elapsed > 60 ? ' chat-stream-warning' : ''
 
   return html`
-    <div class="chat-composer">
+    <div class="chat-composer flex flex-col gap-3">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Message</div>
+        <div class="text-[11px] text-[var(--text-muted)]">Enter to send, Shift+Enter for newline</div>
+      </div>
       <textarea
-        class="control-textarea rounded-lg min-h-[72px]"
+        class="control-textarea min-h-[96px] rounded-[18px] border border-[rgba(148,163,184,0.16)] bg-[rgba(255,255,255,0.04)] px-3 py-3 text-[14px] leading-[1.6]"
         placeholder=${placeholder}
         value=${draft}
         onInput=${(event: Event) => { onDraftChange((event.target as HTMLTextAreaElement).value) }}
+        onKeyDown=${(event: KeyboardEvent) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault()
+            if (!disabled && !streaming && draft.trim() !== '') {
+              onSend()
+            }
+          }
+        }}
         disabled=${disabled}
       ></textarea>
-      <div class="flex gap-2 items-center">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="text-[11px] leading-[1.55] text-[var(--text-muted)]">
+          ${streaming
+            ? 'Keeper reply stream is active. You can stop it if the run looks stuck.'
+            : 'Direct messages are kept in this lane. Internal keeper prompts stay hidden.'}
+        </div>
+        <div class="flex gap-2 items-center">
         <${ActionButton}
           variant=${warnClass ? 'danger' : 'primary'}
           onClick=${onSend}
@@ -307,6 +365,7 @@ export function ChatComposer({
               <//>
             `
           : null}
+        </div>
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -3,12 +3,12 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { streamKeeperMessage, type KeeperChatStreamEvent } from '../api/keeper'
 import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
-import { ActionButton } from './common/button'
-import { TextInput } from './common/input'
+import { ChatComposer, ChatTranscript } from './chat/primitives'
+import type { KeeperConversationEntry } from '../types'
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -23,6 +23,26 @@ const streamBuffer = signal('')
 const chatError = signal('')
 
 let activeAbort: AbortController | null = null
+
+function toConversationEntry(
+  keeperName: string,
+  msg: ChatMessage,
+  index: number,
+): KeeperConversationEntry {
+  const source = msg.role === 'user' ? 'direct_user' : 'direct_assistant'
+  return {
+    id: `${msg.role}-${msg.timestamp}-${index}`,
+    role: msg.role,
+    source,
+    label: msg.role === 'user' ? '사용자' : keeperName,
+    text: msg.content,
+    rawText: msg.content,
+    timestamp: new Date(msg.timestamp).toISOString(),
+    delivery: 'delivered',
+    streamState: null,
+    details: null,
+  }
+}
 
 export function isKeeperTextContentEvent(event: KeeperChatStreamEvent): boolean {
   return event.type === 'TEXT_MESSAGE_CONTENT' || event.type === 'TEXT_DELTA'
@@ -97,69 +117,77 @@ async function sendChat(keeperName: string): Promise<void> {
 }
 
 export function KeeperChatPanel({ name }: { name: string }) {
-  const scrollRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    cancelStream()
+    chatMessages.value = []
+    chatInput.value = ''
+    streamBuffer.value = ''
+    chatError.value = ''
+  }, [name])
+
   const messages = chatMessages.value
   const buffer = streamBuffer.value
   const isStreaming = streaming.value
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    }
-  }, [messages.length, buffer])
+  const entries = messages.map((msg, index) => toConversationEntry(name, msg, index))
+  const transcriptEntries =
+    isStreaming && buffer
+      ? [
+          ...entries,
+          {
+            id: `assistant-stream-${name}`,
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: name,
+            text: buffer,
+            rawText: buffer,
+            timestamp: new Date().toISOString(),
+            delivery: 'streaming',
+            streamState: 'streaming',
+            details: null,
+          } satisfies KeeperConversationEntry,
+        ]
+      : entries
 
   return html`
-    <div class="keeper-chat">
-      <div class="keeper-chat__header flex items-center justify-between py-2.5 px-3.5">
-        <span class="keeper-chat__title">@${name} 대화</span>
-        ${isStreaming ? html`
-          <${ActionButton} variant="ghost" class="keeper-chat__cancel" onClick=${cancelStream}>중단<//>
-        ` : null}
+    <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
+      <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
+        <div class="min-w-[220px] flex-1">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Direct Chat</div>
+          <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${name}</div>
+          <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
+            Live direct conversation with this keeper. Streaming responses stay in the same transcript lane.
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[11px] font-medium text-[#bfe8ff]">
+            ${entries.length} messages
+          </span>
+        </div>
       </div>
 
-      <div class="keeper-chat__messages flex-1 min-h-[200px] max-h-[400px] overflow-y-auto py-3 px-3.5 flex flex-col gap-3" ref=${scrollRef}>
-        ${messages.length === 0 && !isStreaming ? html`
-          <div class="text-[var(--white-20)] text-[var(--fs-base)] text-center py-10">keeper에게 메시지를 보내세요</div>
-        ` : null}
-
-        ${messages.map((msg, idx) => html`
-          <div key=${idx} class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--${msg.role} ${msg.role === 'user' ? 'self-end' : 'self-start'}">
-            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${msg.role === 'user' ? 'You' : name}</span>
-            <div class="keeper-chat__text rounded-lg">${msg.content}</div>
-          </div>
-        `)}
-
-        ${isStreaming && buffer ? html`
-          <div class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
-            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${name}</span>
-            <div class="keeper-chat__text rounded-lg">${buffer}<span class="keeper-chat__cursor">|</span></div>
-          </div>
-        ` : isStreaming ? html`
-          <div class="keeper-chat__msg flex flex-col gap-[3px] max-w-[85%] keeper-chat__msg--assistant keeper-chat__msg--streaming self-start">
-            <span class="keeper-chat__role text-[var(--fs-2xs)] text-[var(--white-35)] uppercase tracking-[0.5px]">${name}</span>
-            <div class="keeper-chat__text rounded-lg keeper-chat__text--thinking">thinking...</div>
-          </div>
-        ` : null}
-      </div>
-
-      ${chatError.value ? html`<div class="keeper-chat__error">${chatError.value}</div>` : null}
-
-      <div class="keeper-chat__input-row flex gap-2 py-2.5 px-3.5">
-        <${TextInput}
-          class="flex-1"
-          placeholder="메시지 입력..."
-          value=${chatInput.value}
-          onInput=${(e: Event) => { chatInput.value = (e.target as HTMLInputElement).value }}
-          onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' && !e.shiftKey) void sendChat(name) }}
-          disabled=${isStreaming}
+      <div class="px-4 py-4">
+        <${ChatTranscript}
+          entries=${transcriptEntries}
+          emptyText="Send a direct prompt to start the keeper conversation."
+          showMetadata=${false}
         />
-        <${ActionButton}
-          class="shrink-0"
-          onClick=${() => { void sendChat(name) }}
-          disabled=${isStreaming || chatInput.value.trim() === ''}
-        >
-          ${isStreaming ? '...' : '전송'}
-        <//>
+      </div>
+
+      ${chatError.value
+        ? html`<div class="mx-4 mb-4 rounded-[18px] border border-[rgba(239,68,68,0.24)] bg-[rgba(127,29,29,0.24)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#ffb4b4]">${chatError.value}</div>`
+        : null}
+
+      <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
+        <${ChatComposer}
+          draft=${chatInput.value}
+          placeholder="메시지 입력..."
+          disabled=${false}
+          streaming=${isStreaming}
+          streamStartedAt=${null}
+          onDraftChange=${(value: string) => { chatInput.value = value }}
+          onSend=${() => { void sendChat(name) }}
+          onAbort=${cancelStream}
+        />
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -17,6 +17,7 @@ import {
   recoverKeeperRuntime,
   sendKeeperThreadMessage,
 } from '../keeper-runtime'
+import { isVisibleDirectConversationEntry } from '../keeper-state'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import { showToast } from './common/toast'
 
@@ -102,6 +103,22 @@ function formatEligible(seconds?: number | null): string | null {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return null
   if (seconds < 60) return `${Math.round(seconds)}s`
   return `${Math.ceil(seconds / 60)}m`
+}
+
+function conversationStateLabel(sending: boolean, hydrating: boolean): string {
+  if (sending) return 'live reply'
+  if (hydrating) return 'syncing history'
+  return 'ready'
+}
+
+function conversationStateClass(sending: boolean, hydrating: boolean): string {
+  if (sending) {
+    return 'border-[rgba(76,181,137,0.26)] bg-[rgba(76,181,137,0.12)] text-[#b9f1d1]'
+  }
+  if (hydrating) {
+    return 'border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.12)] text-[#bfe8ff]'
+  }
+  return 'border-[rgba(148,163,184,0.18)] bg-[rgba(148,163,184,0.08)] text-[var(--text-body)]'
 }
 
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
@@ -196,10 +213,10 @@ export function KeeperConversationPanel({
 
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const rawThread = keeperThreads.value[keeperName] ?? []
-  // Filter out system/tool messages -- only show user and assistant conversation
-  const thread = rawThread.filter(
-    entry => entry.role === 'user' || entry.role === 'assistant',
-  )
+  const thread = rawThread.filter(isVisibleDirectConversationEntry)
+  const hiddenHistoryCount = rawThread.filter(
+    entry => entry.delivery === 'history' && !isVisibleDirectConversationEntry(entry),
+  ).length
   const sending = keeperSending.value[keeperName] ?? false
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
@@ -224,40 +241,110 @@ export function KeeperConversationPanel({
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="flex justify-end">
-        <button type="button"
-          type="button"
-          class="py-1 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
-          onClick=${() => { setShowMetadata(!showMetadata) }}
-        >
-          ${showMetadata ? 'Hide metadata' : 'Show metadata'}
-        </button>
+      <div class="rounded-[22px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(12,20,38,0.96),rgba(8,13,24,0.9))] px-4 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.22)]">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-[220px] flex-1">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Conversation Lane</div>
+            <div class="mt-2 text-[16px] font-semibold text-[var(--text-strong)]">Direct messages only</div>
+            <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
+              This panel is for explicit operator-to-keeper conversation. Internal world-state prompts, tool chatter, and keeper self-deliberation are hidden on purpose.
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-[11px]">
+            <button
+              type="button"
+              class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+              onClick=${() => { setShowMetadata(!showMetadata) }}
+            >
+              ${showMetadata ? 'Hide metadata' : 'Show metadata'}
+            </button>
+          </div>
+        </div>
+
+        <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
+          <div class="rounded-[18px] border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)] px-3 py-3">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#9ad9ff]">Visible thread</div>
+            <div class="mt-1 text-[22px] font-semibold text-[var(--text-strong)]">${thread.length}</div>
+            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-secondary)]">Direct user prompts and keeper replies currently shown.</div>
+          </div>
+          <div class="rounded-[18px] border border-[rgba(245,158,11,0.2)] bg-[rgba(245,158,11,0.08)] px-3 py-3">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#f5d089]">Hidden internal</div>
+            <div class="mt-1 text-[22px] font-semibold text-[var(--text-strong)]">${hiddenHistoryCount}</div>
+            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-secondary)]">System prompts and internal reasoning omitted from the conversation lane.</div>
+          </div>
+          <div class="rounded-[18px] border border-[rgba(148,163,184,0.14)] bg-[rgba(255,255,255,0.04)] px-3 py-3">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Lane state</div>
+            <div class="mt-2">
+              <span class=${`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
+                ${conversationStateLabel(sending, hydrating)}
+              </span>
+            </div>
+            <div class="mt-2 text-[12px] leading-[1.55] text-[var(--text-secondary)]">
+              ${sending
+                ? 'A keeper reply is currently streaming.'
+                : hydrating
+                  ? 'History is being refreshed from keeper status.'
+                  : 'Direct message lane is ready for a new prompt.'}
+            </div>
+          </div>
+        </div>
       </div>
-      ${!historyExpanded && thread.length >= 10 ? html`
-        <button type="button"
-          type="button"
-          class="py-1.5 px-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer self-center"
-          disabled=${hydrating}
-          onClick=${() => { void expandHistory() }}
-        >
-          ${hydrating ? 'Loading...' : `Load full history (showing ${thread.length})`}
-        </button>
-      ` : null}
-      <${ChatTranscript}
-        entries=${thread}
-        emptyText="No direct conversation history yet."
-        showMetadata=${showMetadata}
-      />
-      <${ChatComposer}
-        draft=${draft}
-        placeholder=${placeholder}
-        disabled=${!keeperName}
-        streaming=${sending}
-        streamStartedAt=${keeperStreamStartedAt.value[keeperName] ?? null}
-        onDraftChange=${setDraft}
-        onSend=${() => { void submit() }}
-        onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
-      />
+
+      <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.94),rgba(5,10,20,0.9))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
+        <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
+          <div class="min-w-[220px] flex-1">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Transcript</div>
+            <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${keeperName}</div>
+            <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
+              Recent direct exchange with the keeper, separated from internal control prompts.
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            ${!historyExpanded && rawThread.length >= 10
+              ? html`
+                  <button
+                    type="button"
+                    class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+                    disabled=${hydrating}
+                    onClick=${() => { void expandHistory() }}
+                  >
+                    ${hydrating ? 'Loading...' : `Load full history (${thread.length} direct shown)`}
+                  </button>
+                `
+              : null}
+          </div>
+        </div>
+
+        <div class="px-4 py-4">
+          <${ChatTranscript}
+            entries=${thread}
+            emptyText="No direct conversation yet. Internal keeper prompts and tool chatter are hidden."
+            showMetadata=${showMetadata}
+          />
+        </div>
+
+        ${hiddenHistoryCount > 0
+          ? html`
+              <div class="mx-4 mb-4 rounded-[18px] border border-[rgba(245,158,11,0.18)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#f4d79e]">
+                ${hiddenHistoryCount} internal history entries are hidden from this transcript to keep the conversation readable. Raw status and metadata still retain those traces for debugging.
+              </div>
+            `
+          : null}
+
+        <div class="border-t border-[rgba(148,163,184,0.12)] bg-[rgba(255,255,255,0.03)] px-4 py-4">
+          <${ChatComposer}
+            draft=${draft}
+            placeholder=${placeholder}
+            disabled=${!keeperName}
+            streaming=${sending}
+            streamStartedAt=${keeperStreamStartedAt.value[keeperName] ?? null}
+            onDraftChange=${setDraft}
+            onSend=${() => { void submit() }}
+            onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
+          />
+        </div>
+      </div>
+
       ${error ? html`<div class="text-xs text-[#ffb4b4] leading-relaxed">${error}</div>` : null}
     </div>
   `

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -119,6 +119,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
   appendThreadEntry(keeperName, {
     id: localId,
     role: 'user',
+    source: 'direct_user',
     label: 'You',
     text: message,
     timestamp: new Date().toISOString(),
@@ -129,6 +130,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
   appendThreadEntry(keeperName, {
     id: assistantId,
     role: 'assistant',
+    source: 'direct_assistant',
     label: keeperName,
     text: '',
     rawText: '',

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isVisibleDirectConversationEntry,
+  normalizeStatusDetail,
+} from './keeper-state'
+
+describe('normalizeStatusDetail', () => {
+  it('infers and hides internal keeper history from direct comms', () => {
+    const detail = normalizeStatusDetail('sangsu', '', {
+      history_tail: [
+        {
+          role: 'user',
+          content:
+            '## Current World State\n\n### Room State\n- Failed tasks: 9\n- Active agents: 5\n\n### Context\n- Utilization: 72%\n- Idle: 132s',
+          ts_unix: 10,
+        },
+        {
+          role: 'assistant',
+          content: '9개 실패 태스크가 계속되는데 왜 이걸로 하냐니? 그냥 고치거나 무시하거냐.',
+          ts_unix: 11,
+        },
+        {
+          role: 'user',
+          source: 'direct_user',
+          content: '지금 상태 어때?',
+          ts_unix: 20,
+        },
+        {
+          role: 'assistant',
+          source: 'direct_assistant',
+          content: '직접 상태는 괜찮고, 대화 UI만 정리하면 됩니다.',
+          ts_unix: 21,
+        },
+      ],
+    })
+
+    expect(detail.history.map(entry => entry.source)).toEqual([
+      'world_state_prompt',
+      'internal_assistant',
+      'direct_user',
+      'direct_assistant',
+    ])
+    expect(detail.history.filter(isVisibleDirectConversationEntry).map(entry => entry.text)).toEqual([
+      '지금 상태 어때?',
+      '직접 상태는 괜찮고, 대화 UI만 정리하면 됩니다.',
+    ])
+  })
+
+  it('keeps explicit direct history visible', () => {
+    const detail = normalizeStatusDetail('sangsu', '', {
+      history_tail: [
+        {
+          role: 'user',
+          source: 'direct_user',
+          content: 'ping',
+          ts_unix: 30,
+        },
+        {
+          role: 'assistant',
+          source: 'direct_assistant',
+          content: 'pong',
+          ts_unix: 31,
+        },
+      ],
+    })
+
+    expect(detail.history.every(isVisibleDirectConversationEntry)).toBe(true)
+  })
+})

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -5,6 +5,7 @@ import type {
   Keeper,
   KeeperConversationEntry,
   KeeperConversationRole,
+  KeeperConversationSource,
   KeeperConversationStreamState,
   KeeperConversationDelivery,
   KeeperDiagnostic,
@@ -48,7 +49,7 @@ function normalizeRole(value: unknown): KeeperConversationRole {
 function roleLabel(role: KeeperConversationRole): string {
   switch (role) {
     case 'user':
-      return 'User'
+      return '사용자'
     case 'assistant':
       return 'Keeper'
     case 'system':
@@ -58,6 +59,50 @@ function roleLabel(role: KeeperConversationRole): string {
     default:
       return 'Event'
   }
+}
+
+function looksLikeWorldStatePrompt(text: string): boolean {
+  const trimmed = text.trim()
+  return trimmed.startsWith('## Current World State')
+    || (trimmed.includes('### Room State') && trimmed.includes('### Context'))
+}
+
+function normalizeConversationSource(
+  value: unknown,
+  role: KeeperConversationRole,
+  rawText: string,
+  previousSource: KeeperConversationSource | null,
+): KeeperConversationSource {
+  const source = asString(value)?.trim()
+  if (
+    source === 'direct_user'
+    || source === 'direct_assistant'
+    || source === 'world_state_prompt'
+    || source === 'internal_assistant'
+    || source === 'tool_result'
+    || source === 'system'
+    || source === 'unknown'
+  ) {
+    return source
+  }
+
+  if (role === 'tool') return 'tool_result'
+  if (role === 'system') return 'system'
+  if (role === 'user') {
+    return looksLikeWorldStatePrompt(rawText) ? 'world_state_prompt' : 'direct_user'
+  }
+  if (role === 'assistant') {
+    return previousSource === 'world_state_prompt' ? 'internal_assistant' : 'direct_assistant'
+  }
+  return 'unknown'
+}
+
+export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry): boolean {
+  if (entry.role !== 'user' && entry.role !== 'assistant') return false
+  return entry.source !== 'world_state_prompt'
+    && entry.source !== 'internal_assistant'
+    && entry.source !== 'tool_result'
+    && entry.source !== 'system'
 }
 
 // --- Diagnostic helpers ---
@@ -229,11 +274,17 @@ export function deriveKeeperDiagnostic(
 
 // --- Thread state management ---
 
-function normalizeHistoryEntry(raw: unknown, index: number, keeperName?: string): KeeperConversationEntry | null {
+function normalizeHistoryEntry(
+  raw: unknown,
+  index: number,
+  keeperName?: string,
+  previousSource: KeeperConversationSource | null = null,
+): KeeperConversationEntry | null {
   if (!isRecord(raw)) return null
   const role = normalizeRole(raw.role)
   const rawText = asString(raw.content) ?? asString(raw.preview)
   if (!rawText) return null
+  const source = normalizeConversationSource(raw.source, role, rawText, previousSource)
   const text = formatKeeperVisibleReply(rawText)
   if (!text) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
@@ -241,6 +292,7 @@ function normalizeHistoryEntry(raw: unknown, index: number, keeperName?: string)
   return {
     id: `${role}-${timestamp ?? 'entry'}-${index}`,
     role,
+    source,
     label,
     text,
     rawText,
@@ -251,12 +303,19 @@ function normalizeHistoryEntry(raw: unknown, index: number, keeperName?: string)
   }
 }
 
-function normalizeStatusDetail(name: string, text: string, rawStatus: unknown): KeeperStatusDetail {
+export function normalizeStatusDetail(name: string, text: string, rawStatus: unknown): KeeperStatusDetail {
   const parsed = isRecord(rawStatus) ? rawStatus : null
   const history = Array.isArray(parsed?.history_tail)
-    ? parsed.history_tail
-      .map((entry, index) => normalizeHistoryEntry(entry, index, name))
-      .filter((entry): entry is KeeperConversationEntry => entry !== null)
+    ? (() => {
+        let previousSource: KeeperConversationSource | null = null
+        return parsed.history_tail
+          .map((entry, index) => {
+            const normalized = normalizeHistoryEntry(entry, index, name, previousSource)
+            previousSource = normalized?.source ?? previousSource
+            return normalized
+          })
+          .filter((entry): entry is KeeperConversationEntry => entry !== null)
+      })()
     : []
   return {
     name,
@@ -326,7 +385,7 @@ function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
 ): boolean {
-  if (left.role !== right.role || left.text !== right.text) return false
+  if (left.role !== right.role || left.source !== right.source || left.text !== right.text) return false
   if (left.timestamp && right.timestamp) return left.timestamp === right.timestamp
   return true
 }
@@ -368,8 +427,6 @@ export function updateDiagnostic(name: string, patch: Partial<KeeperDiagnostic>)
     },
   })
 }
-
-export { normalizeStatusDetail }
 
 // --- Stream controller management ---
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -228,6 +228,15 @@ export interface KeeperDiagnostic {
 
 export type KeeperConversationRole = 'user' | 'assistant' | 'system' | 'tool' | 'other'
 
+export type KeeperConversationSource =
+  | 'direct_user'
+  | 'direct_assistant'
+  | 'world_state_prompt'
+  | 'internal_assistant'
+  | 'tool_result'
+  | 'system'
+  | 'unknown'
+
 export type KeeperConversationDelivery =
   | 'history'
   | 'sending'
@@ -265,6 +274,7 @@ export type KeeperConversationStreamState =
 export interface KeeperConversationEntry {
   id: string
   role: KeeperConversationRole
+  source: KeeperConversationSource
   label: string
   text: string
   rawText?: string | null

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -70,6 +70,8 @@ let run_turn
     ~(cascade_name : string)
     ~(generation : int)
     ?(max_turns : int = 10)
+    ?(history_user_source = "direct_user")
+    ?(history_assistant_source = "direct_assistant")
     ?guardrails
     ?temperature
     ?max_tokens
@@ -143,7 +145,7 @@ let run_turn
   (* 6. Append user message and persist *)
   let user_msg = Agent_sdk.Types.user_msg user_message in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
-  Keeper_exec_context.persist_message session user_msg;
+  Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
   (* 7. Set up agent *)
   let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
@@ -210,7 +212,9 @@ let run_turn
      | Error e -> Error e
      | Ok response_text ->
          let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
-         Keeper_exec_context.persist_message session assistant_msg;
+         Keeper_exec_context.persist_message
+           ~source:history_assistant_source
+           session assistant_msg;
          ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
          Ok {
            response_text;

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -233,6 +233,10 @@ let handle_keeper_status ctx args : tool_result =
                        j |> member "content" |> to_string_option
                        |> Option.value ~default:""
                      in
+                     let source =
+                       j |> member "source" |> to_string_option
+                       |> Option.value ~default:"unknown"
+                     in
                      let ts_unix =
                        let ts0 = Safe_ops.json_float ~default:0.0 "ts_unix" j in
                        if ts0 > 0.0 then ts0
@@ -244,12 +248,18 @@ let handle_keeper_status ctx args : tool_result =
                      in
                      let role_lc = String.lowercase_ascii role in
                      let entry_kind =
-                       match role_lc with
+                       match source, role_lc with
+                       | "direct_user", _ | "direct_assistant", _ ->
+                           "direct_conversation"
+                       | "world_state_prompt", _ -> "internal_prompt"
+                       | "internal_assistant", _ -> "internal_reply"
+                       | _, _ ->
+                           (match role_lc with
                        | "assistant" -> "self_talk"
                        | "user" -> "input"
                        | "tool" -> "tool_result"
                        | "system" -> "system"
-                       | _ -> "other"
+                       | _ -> "other")
                      in
                      let is_fragment =
                        role_lc = "assistant"
@@ -264,6 +274,7 @@ let handle_keeper_status ctx args : tool_result =
                      let item =
                        `Assoc [
                          ("role", `String role);
+                         ("source", `String source);
                          ("kind", `String entry_kind);
                          ("is_fragment", `Bool is_fragment);
                          ("ts_unix", `Float ts_unix);

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -119,6 +119,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~max_context:primary_max_context ~build_turn_prompt
               ~user_message ~cascade_name:"keeper_unified"
               ~generation ~max_turns
+              ~history_user_source:"world_state_prompt"
+              ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
               ~max_cost_usd
               ())

--- a/lib/keeper/keeper_working_context.ml
+++ b/lib/keeper/keeper_working_context.ml
@@ -296,16 +296,21 @@ let create_session ~session_id ~base_dir =
   ensure_dir session_dir;
   { session_id; session_dir; checkpoints = [] }
 
-let persist_message session msg =
+let persist_message ?source session msg =
   let msg = Inference_utils.sanitize_message_utf8 msg in
   let path = Filename.concat session.session_dir "history.jsonl" in
   let now_ts = Time_compat.now () in
   let payload =
     match message_to_json msg with
     | `Assoc fields ->
+      let fields =
+        match source with
+        | Some source when String.trim source <> "" ->
+            ("source", `String source) :: fields
+        | _ -> fields
+      in
       `Assoc (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
     | j -> j
   in
   let line = Yojson.Safe.to_string payload ^ "\n" in
   Fs_compat.append_file path line
-

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -870,9 +870,9 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         ];
       write_jsonl_lines history_path
         [
-          {|{"role":"user","content":"Can you summarize the plan?","ts_unix":10.0}|};
-          {|{"role":"assistant","content":"thinking","ts_unix":20.0}|};
-          {|{"role":"assistant","content":"All done.","ts_unix":30.0}|};
+          {|{"role":"user","source":"direct_user","content":"Can you summarize the plan?","ts_unix":10.0}|};
+          {|{"role":"assistant","source":"internal_assistant","content":"thinking","ts_unix":20.0}|};
+          {|{"role":"assistant","source":"direct_assistant","content":"All done.","ts_unix":30.0}|};
         ];
       write_jsonl_lines memory_bank_path
         [
@@ -900,6 +900,12 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
         Yojson.Safe.Util.(json |> member "history_fragment_count" |> to_int);
       check int "history filtered count" 1
         Yojson.Safe.Util.(json |> member "history_fragment_filtered_count" |> to_int);
+      check string "history direct source preserved" "direct_user"
+        Yojson.Safe.Util.(json |> member "history_tail" |> index 0 |> member "source" |> to_string);
+      check string "history direct kind inferred from source" "direct_conversation"
+        Yojson.Safe.Util.(json |> member "history_tail" |> index 0 |> member "kind" |> to_string);
+      check string "history assistant source preserved" "direct_assistant"
+        Yojson.Safe.Util.(json |> member "history_tail" |> index 1 |> member "source" |> to_string);
       check int "memory note count" 2
         Yojson.Safe.Util.(json |> member "memory_bank" |> member "total_notes" |> to_int);
       check int "compaction history count" 1


### PR DESCRIPTION
## Summary
- tag keeper history entries with an explicit source so direct chat and internal prompts are distinguishable
- hide internal keeper prompts/replies from the Direct Comms transcript and infer legacy entries when source is missing
- redesign keeper chat panels to use a clearer transcript/composer layout across detail and profile views

## Testing
- dune build --root .
- ./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 14
- npm run typecheck
- npx vitest run src/keeper-state.test.ts src/components/keeper-chat-panel.test.ts