### PR TITLE
feat(keeper): repeated-failure guardrail prevents tool retry loops (#2691)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -18,6 +18,12 @@
     @param config Room configuration for tool dispatch
     @param meta Keeper metadata (determines which tools are allowed)
     @param ctx_ref Mutable ref to current working context *)
+(** Repeated-failure guardrail: blocks a tool after [max_consecutive]
+    consecutive failures with the same (tool_name, args_hash) key.
+    Resets on success. Prevents infinite retry loops (e.g. keeper
+    reading a non-existent file 400+ times). *)
+let max_consecutive_failures = 3
+
 let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -29,6 +35,11 @@ let make_tools
   let tool_defs =
     Keeper_exec_tools.keeper_allowed_model_tools meta
   in
+  let failure_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  let args_key name input =
+    let h = Hashtbl.hash (Yojson.Safe.to_string input) in
+    Printf.sprintf "%s:%d" name h
+  in
   List.filter_map (fun (td : Types.tool_schema) ->
     if List.mem td.name allowed_names then
       Some (Tool_bridge.oas_tool_of_masc
@@ -36,17 +47,33 @@ let make_tools
         ~description:td.description
         ~input_schema:td.input_schema
         (fun input ->
-          try
-            let result =
-              Keeper_exec_tools.execute_keeper_tool_call
-                ~config ~meta ~ctx_work:(!ctx_ref)
-                ~name:td.name ~input
-            in
-            (true, result)
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            let msg = Printf.sprintf "tool %s failed: %s"
-              td.name (Printexc.to_string exn) in
-            Log.Keeper.error "%s" msg;
-            (false, msg)))
+          let key = args_key td.name input in
+          let prior_fails =
+            match Hashtbl.find_opt failure_counts key with
+            | Some n -> n | None -> 0
+          in
+          if prior_fails >= max_consecutive_failures then begin
+            Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
+              td.name prior_fails;
+            (false, Printf.sprintf
+              "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
+              prior_fails)
+          end else
+            try
+              let result =
+                Keeper_exec_tools.execute_keeper_tool_call
+                  ~config ~meta ~ctx_work:(!ctx_ref)
+                  ~name:td.name ~input
+              in
+              Hashtbl.remove failure_counts key;
+              (true, result)
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+              let count = prior_fails + 1 in
+              Hashtbl.replace failure_counts key count;
+              let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
+                td.name count max_consecutive_failures
+                (Printexc.to_string exn) in
+              Log.Keeper.error "%s" msg;
+              (false, msg)))
     else None
   ) tool_defs

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -24,6 +24,28 @@
     reading a non-existent file 400+ times). *)
 let max_consecutive_failures = 3
 
+let keeper_tool_result_is_failure (result : string) : bool =
+  try
+    let json = Yojson.Safe.from_string result in
+    let has_error_field =
+      match Safe_ops.json_string_opt "error" json with
+      | Some msg -> String.trim msg <> ""
+      | None -> false
+    in
+    let has_error_status =
+      match Safe_ops.json_string_opt "status" json with
+      | Some status ->
+          String.equal (String.lowercase_ascii (String.trim status)) "error"
+      | None -> false
+    in
+    let has_ok_false =
+      match Safe_ops.json_bool_opt "ok" json with
+      | Some false -> true
+      | Some true | None -> false
+    in
+    has_error_field || has_error_status || has_ok_false
+  with Yojson.Json_error _ -> false
+
 let make_tools
     ~(config : Room.config)
     ~(meta : Keeper_types.keeper_meta)
@@ -65,8 +87,17 @@ let make_tools
                   ~config ~meta ~ctx_work:(!ctx_ref)
                   ~name:td.name ~input
               in
-              Hashtbl.remove failure_counts key;
-              (true, result)
+              if keeper_tool_result_is_failure result then begin
+                let count = prior_fails + 1 in
+                Hashtbl.replace failure_counts key count;
+                Log.Keeper.warn
+                  "tool %s returned error result (%d/%d) for same args"
+                  td.name count max_consecutive_failures;
+                (false, result)
+              end else begin
+                Hashtbl.remove failure_counts key;
+                (true, result)
+              end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               let count = prior_fails + 1 in
               Hashtbl.replace failure_counts key count;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -58,6 +58,18 @@ let make_tools
     Keeper_exec_tools.keeper_allowed_model_tools meta
   in
   let failure_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  let failure_counts_mu : Eio.Mutex.t option ref = ref None in
+  let with_failure_counts f =
+    match !failure_counts_mu with
+    | Some mu -> Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
+    | None -> (
+        match Eio_context.get_switch_opt () with
+        | Some _ ->
+            let mu = Eio.Mutex.create () in
+            failure_counts_mu := Some mu;
+            Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
+        | None -> f ())
+  in
   let args_key name input =
     let h = Hashtbl.hash (Yojson.Safe.to_string input) in
     Printf.sprintf "%s:%d" name h
@@ -71,8 +83,9 @@ let make_tools
         (fun input ->
           let key = args_key td.name input in
           let prior_fails =
-            match Hashtbl.find_opt failure_counts key with
-            | Some n -> n | None -> 0
+            with_failure_counts (fun () ->
+              match Hashtbl.find_opt failure_counts key with
+              | Some n -> n | None -> 0)
           in
           if prior_fails >= max_consecutive_failures then begin
             Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
@@ -89,18 +102,21 @@ let make_tools
               in
               if keeper_tool_result_is_failure result then begin
                 let count = prior_fails + 1 in
-                Hashtbl.replace failure_counts key count;
+                with_failure_counts (fun () ->
+                  Hashtbl.replace failure_counts key count);
                 Log.Keeper.warn
                   "tool %s returned error result (%d/%d) for same args"
                   td.name count max_consecutive_failures;
                 (false, result)
               end else begin
-                Hashtbl.remove failure_counts key;
+                with_failure_counts (fun () ->
+                  Hashtbl.remove failure_counts key);
                 (true, result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               let count = prior_fails + 1 in
-              Hashtbl.replace failure_counts key count;
+              with_failure_counts (fun () ->
+                Hashtbl.replace failure_counts key count);
               let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
                 td.name count max_consecutive_failures
                 (Printexc.to_string exn) in

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1,5 +1,6 @@
 (** Tests for Keeper_tools_oas — OAS Tool.t wrapping of keeper tools. *)
 
+open Agent_sdk
 open Alcotest
 open Masc_mcp
 
@@ -69,6 +70,76 @@ let test_tool_count_matches_allowed () =
       check bool "all tools are in allowed list" true
         (List.for_all (fun name -> List.mem name allowed) tool_names))
 
+let find_tool name tools =
+  List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
+
+let string_contains ~sub text =
+  let text_len = String.length text in
+  let sub_len = String.length sub in
+  let rec loop idx =
+    if idx + sub_len > text_len then false
+    else if String.sub text idx sub_len = sub then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+
+let test_error_json_is_returned_as_tool_error () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_error_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tool = find_tool "keeper_fs_read" tools in
+      match Tool.execute tool
+              (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
+      with
+      | Error { Agent_sdk.Types.message; _ } ->
+          let json = Yojson.Safe.from_string message in
+          check bool "error field preserved" true
+            (Option.is_some (Safe_ops.json_string_opt "error" json));
+          check bool "path field preserved" true
+            (Option.is_some (Safe_ops.json_string_opt "path" json))
+      | Ok _ -> fail "missing file should be surfaced as tool error")
+
+let test_repeated_error_results_are_blocked () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_guard_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tool = find_tool "keeper_fs_read" tools in
+      let args =
+        `Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")]
+      in
+      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+        match Tool.execute tool args with
+        | Error _ -> ()
+        | Ok _ -> fail "missing file should be counted as a failure"
+      done;
+      match Tool.execute tool args with
+      | Error { Agent_sdk.Types.message; _ } ->
+          check bool "guardrail blocks repeated failures" true
+            (string_contains
+               ~sub:"failed 3 times in a row with the same arguments"
+               message)
+      | Ok _ -> fail "guardrail should block the repeated failure")
+
 let make_research_meta () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String "test-researcher");
@@ -99,7 +170,7 @@ let test_non_research_keeper_no_autoresearch () =
 let test_research_model_tools_include_autoresearch () =
   let meta = make_research_meta () in
   let tools = Keeper_exec_tools.keeper_allowed_model_tools meta in
-  let has_cycle = List.exists (fun (t : Types.tool_schema) ->
+  let has_cycle = List.exists (fun (t : Types_core.tool_schema) ->
     t.name = "masc_autoresearch_cycle") tools in
   check bool "model tools have cycle" true has_cycle
 
@@ -178,6 +249,8 @@ let () =
       test_case "returns nonempty" `Quick test_make_tools_returns_nonempty;
       test_case "valid schemas" `Quick test_tools_have_valid_schemas;
       test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
+      test_case "error json becomes tool error" `Quick test_error_json_is_returned_as_tool_error;
+      test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -83,6 +83,11 @@ let string_contains ~sub text =
   in
   sub_len = 0 || loop 0
 
+let is_guardrail_message message =
+  string_contains
+    ~sub:"failed 3 times in a row with the same arguments"
+    message
+
 let test_error_json_is_returned_as_tool_error () =
   let meta = make_test_meta () in
   let ctx_ref = ref (make_test_ctx ()) in
@@ -135,10 +140,85 @@ let test_repeated_error_results_are_blocked () =
       match Tool.execute tool args with
       | Error { Agent_sdk.Types.message; _ } ->
           check bool "guardrail blocks repeated failures" true
-            (string_contains
-               ~sub:"failed 3 times in a row with the same arguments"
-               message)
+            (is_guardrail_message message)
       | Ok _ -> fail "guardrail should block the repeated failure")
+
+let test_failure_count_resets_after_success () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_reset_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      let reset_path = Filename.concat dir "reset-after-success.txt" in
+      (try Sys.remove reset_path with _ -> ());
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tool = find_tool "keeper_fs_read" tools in
+      let path = "reset-after-success.txt" in
+      let args = `Assoc [("path", `String path)] in
+      for _ = 1 to Keeper_tools_oas.max_consecutive_failures - 1 do
+        match Tool.execute tool args with
+        | Error _ -> ()
+        | Ok _ -> fail "missing file should fail before reset"
+      done;
+      let abs_path = Filename.concat dir path in
+      Out_channel.with_open_text abs_path
+        (fun oc -> Out_channel.output_string oc "ok");
+      (match Tool.execute tool args with
+       | Ok _ -> ()
+       | Error _ -> fail "existing file should reset failure count");
+      Sys.remove abs_path;
+      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+        match Tool.execute tool args with
+        | Error { Agent_sdk.Types.message; _ } when is_guardrail_message message ->
+            fail "failure count should have reset after success"
+        | Error _ -> ()
+        | Ok _ -> fail "missing file should fail after removing reset file"
+      done;
+      match Tool.execute tool args with
+      | Error { Agent_sdk.Types.message; _ } ->
+          check bool "guardrail triggers only after fresh streak" true
+            (is_guardrail_message message)
+      | Ok _ -> fail "guardrail should eventually re-trigger after reset")
+
+let test_failure_tracking_is_independent_per_args () =
+  let meta = make_test_meta () in
+  let ctx_ref = ref (make_test_ctx ()) in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_independent_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      let config = Room.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
+      let tool = find_tool "keeper_fs_read" tools in
+      let args_a = `Assoc [("path", `String "missing-a.txt")] in
+      let args_b = `Assoc [("path", `String "missing-b.txt")] in
+      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+        match Tool.execute tool args_a with
+        | Error _ -> ()
+        | Ok _ -> fail "first path should fail before guardrail"
+      done;
+      (match Tool.execute tool args_b with
+       | Error { Agent_sdk.Types.message; _ } ->
+           check bool "different args are not blocked by prior failures" false
+             (is_guardrail_message message)
+       | Ok _ -> fail "second path should still fail normally");
+      match Tool.execute tool args_a with
+      | Error { Agent_sdk.Types.message; _ } ->
+          check bool "original args are blocked" true
+            (is_guardrail_message message)
+      | Ok _ -> fail "guardrail should block original failing args")
 
 let make_research_meta () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
@@ -251,6 +331,8 @@ let () =
       test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
       test_case "error json becomes tool error" `Quick test_error_json_is_returned_as_tool_error;
       test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;
+      test_case "failure count resets after success" `Quick test_failure_count_resets_after_success;
+      test_case "failure tracking is independent per args" `Quick test_failure_tracking_is_independent_per_args;
     ];
     "research_profile", [
       test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;


### PR DESCRIPTION
## Summary

Closes #2691

상수 keeper가 존재하지 않는 파일을 466 turn 동안 반복 시도한 문제의 근본 수리.

### 구현

`keeper_tools_oas.ml`에서 tool call마다 `(tool_name, args_hash)` 키로 연속 실패 횟수를 추적.
3회 연속 같은 args로 실패하면 tool call을 차단하고 LLM에게 다른 접근을 요청하는 메시지를 반환.
성공 시 카운터 리셋.

### 동작

```
[1/3] keeper_fs_read("keeper_msg.ml") → fail (파일 없음)
[2/3] keeper_fs_read("keeper_msg.ml") → fail (파일 없음)
[3/3] keeper_fs_read("keeper_msg.ml") → fail (파일 없음)
[BLOCKED] "This tool has failed 3 times in a row. Try a different approach."
```

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>