### PR TITLE
fix: target keeper chat by canonical keeper name

### DIFF
--- a/dashboard/src/components/agent-profile.test.ts
+++ b/dashboard/src/components/agent-profile.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { keeperChatTargetName } from './agent-profile'
+
+describe('keeperChatTargetName', () => {
+  it('prefers the canonical keeper name over the runtime agent name', () => {
+    expect(
+      keeperChatTargetName('keeper-tool-test-agent', { name: 'tool-test' }),
+    ).toBe('tool-test')
+  })
+
+  it('falls back to the provided name when no keeper mapping exists', () => {
+    expect(keeperChatTargetName('plain-agent', null)).toBe('plain-agent')
+  })
+})

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -72,6 +72,13 @@ function findKeeper(name: string): Keeper | null {
   ) ?? null
 }
 
+export function keeperChatTargetName(
+  fallbackName: string,
+  keeper: Pick<Keeper, 'name'> | null,
+): string {
+  return keeper?.name ?? fallbackName
+}
+
 function missionBrief(name: string): DashboardMissionAgentBrief | null {
   const mission = missionSnapshot.value
   if (!mission) return null
@@ -308,6 +315,7 @@ export function AgentProfile({ name }: { name: string }) {
   const lines = roomActivity.value
   const timeline = agentTimeline.value
   const keeper = findKeeper(name)
+  const keeperChatName = keeperChatTargetName(name, keeper)
   const isKeeper = keeper != null
 
   return html`
@@ -416,7 +424,7 @@ export function AgentProfile({ name }: { name: string }) {
       </div>
 
       ${isKeeper ? html`
-        <${KeeperChatPanel} name=${name} />
+        <${KeeperChatPanel} name=${keeperChatName} />
       ` : html`
         <div class="flex gap-2 items-center px-3.5 py-2.5 bg-[rgba(10,22,40,0.8)] border border-[var(--ff-gold-15)] rounded-lg">
           <span class="text-[13px] font-semibold text-[var(--ff-gold)] whitespace-nowrap">@${name}</span>


### PR DESCRIPTION
## Summary
- send keeper direct-chat requests using the canonical keeper name instead of the runtime agent name
- keep the existing fallback behavior when no keeper mapping exists
- add a regression test for keeper chat target resolution

## Testing
- PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin:$PATH vitest run src/components/agent-profile.test.ts src/components/keeper-chat-panel.test.ts
- PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin:$PATH tsc --noEmit