### PR TITLE
fix: tolerate broken autoresearch loop metadata

### DIFF
--- a/lib/autoresearch_storage.ml
+++ b/lib/autoresearch_storage.ml
@@ -73,17 +73,32 @@ let load_json_file path =
       Some (Yojson.Safe.from_string content)
     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
 
+let decode_json_file ~path ~kind decode =
+  match load_json_file path with
+  | None -> None
+  | Some json ->
+      (try Some (decode json)
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Autoresearch.warn "%s decode failed for %s: %s"
+             kind path (Printexc.to_string exn);
+           None)
+
 let load_swarm_link_by_loop ~base_path loop_id =
-  load_json_file (loop_link_file ~base_path loop_id)
-  |> Option.map Autoresearch_serde.swarm_link_of_yojson
+  let path = loop_link_file ~base_path loop_id in
+  decode_json_file ~path ~kind:"swarm link"
+    Autoresearch_serde.swarm_link_of_yojson
 
 let load_swarm_link_by_session ~base_path session_id =
-  load_json_file (session_link_file ~base_path session_id)
-  |> Option.map Autoresearch_serde.swarm_link_of_yojson
+  let path = session_link_file ~base_path session_id in
+  decode_json_file ~path ~kind:"swarm link"
+    Autoresearch_serde.swarm_link_of_yojson
 
 let load_state ~base_path loop_id =
-  load_json_file (state_file ~base_path loop_id)
-  |> Option.map Autoresearch_serde.state_of_yojson
+  let path = state_file ~base_path loop_id in
+  decode_json_file ~path ~kind:"autoresearch state"
+    Autoresearch_serde.state_of_yojson
 
 let latest_cycle_record ~base_path loop_id =
   let path = results_file ~base_path loop_id in

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -97,6 +97,46 @@ let persisted_to_loop_summary_json (base_path : string)
 (** Sort key: (status_rank, negative_elapsed) for running-first, newest-first ordering. *)
 type sort_key = { status_rank : int; neg_elapsed : float }
 
+let safe_active_entry_json ~(base_path : string)
+    (state : Autoresearch_types.loop_state) =
+  try
+    let json = loop_summary_json base_path state in
+    let sk =
+      {
+        status_rank =
+          (match state.status with Running -> 0 | _ -> 1);
+        neg_elapsed = -. (Time_compat.now () -. state.start_time);
+      }
+    in
+    Some (state.loop_id, sk, json)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Autoresearch.warn
+        "dashboard autoresearch list skipped active loop %s: %s"
+        state.loop_id (Printexc.to_string exn);
+      None
+
+let safe_persisted_entry_json ~(base_path : string)
+    (summary : Autoresearch_types.persisted_summary) =
+  try
+    let json = persisted_to_loop_summary_json base_path summary in
+    let sk =
+      {
+        status_rank =
+          (match summary.status with Running -> 0 | _ -> 1);
+        neg_elapsed = -. summary.elapsed_s;
+      }
+    in
+    Some (summary.loop_id, sk, json)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Autoresearch.warn
+        "dashboard autoresearch list skipped persisted loop %s: %s"
+        summary.loop_id (Printexc.to_string exn);
+      None
+
 (** Build the loops list JSON for GET /api/v1/autoresearch/loops.
     Merges in-memory active loops with persisted-only loops.
     Converts to JSON early to avoid polymorphic variant type mismatch. *)
@@ -106,14 +146,9 @@ let autoresearch_loops_json ~(base_path : string) : Yojson.Safe.t =
     Autoresearch.with_loops_ro (fun () ->
       Hashtbl.fold
         (fun _id (state : Autoresearch_types.loop_state) acc ->
-          let json = loop_summary_json base_path state in
-          let sk =
-            { status_rank =
-                (match state.status with Running -> 0 | _ -> 1);
-              neg_elapsed = -. (Time_compat.now () -. state.start_time);
-            }
-          in
-          (state.loop_id, sk, json) :: acc)
+          match safe_active_entry_json ~base_path state with
+          | Some entry -> entry :: acc
+          | None -> acc)
         Autoresearch.active_loops [])
   in
   let active_ids =
@@ -129,14 +164,7 @@ let autoresearch_loops_json ~(base_path : string) : Yojson.Safe.t =
       (fun loop_id ->
         match Autoresearch.load_state ~base_path loop_id with
         | Some summary ->
-            let json = persisted_to_loop_summary_json base_path summary in
-            let sk =
-              { status_rank =
-                  (match summary.status with Running -> 0 | _ -> 1);
-                neg_elapsed = -. summary.elapsed_s;
-              }
-            in
-            Some (loop_id, sk, json)
+            safe_persisted_entry_json ~base_path summary
         | None -> None)
       persisted_ids
   in

--- a/test/dune
+++ b/test/dune
@@ -134,6 +134,11 @@
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
+ (name test_dashboard_autoresearch)
+ (modules test_dashboard_autoresearch)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_dashboard_tools)
  (modules test_dashboard_tools)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -1,0 +1,116 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_dashboard_autoresearch" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let rec mkdir_p path =
+  if path = "" || path = "/" || Sys.file_exists path then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755)
+
+let write_file path contents =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let with_temp_base f =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () -> f dir)
+
+let clear_active_loops () =
+  Lib.Autoresearch.with_loops_rw (fun () ->
+    Hashtbl.reset Lib.Autoresearch.active_loops;
+    Lib.Autoresearch.latest_loop_id := None)
+
+let with_clean_loops f =
+  clear_active_loops ();
+  Fun.protect
+    ~finally:clear_active_loops
+    f
+
+let with_eio_test f =
+  Eio_main.run @@ fun _env ->
+  f ()
+
+let test_loops_json_skips_invalid_persisted_state () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let state_path =
+    Filename.concat base_path ".masc/autoresearch/bad-loop/state.json"
+  in
+  (* Valid JSON but missing required fields used by state_of_yojson. *)
+  write_file state_path {|{"loop_id":"bad-loop","status":"running"}|};
+  let json =
+    Lib.Dashboard_http_autoresearch.autoresearch_loops_json ~base_path
+  in
+  check int "total skips broken persisted loop" 0
+    Yojson.Safe.Util.(json |> member "total" |> to_int);
+  check int "no loop entries" 0
+    Yojson.Safe.Util.(json |> member "loops" |> to_list |> List.length)
+
+let test_loops_json_tolerates_invalid_swarm_link_for_active_loop () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"autoresearch smoke"
+      ~metric_fn:"echo 1"
+      ~model_model:"glm:test"
+      ~target_file:"README.md"
+      ~cycle_timeout_s:10.0
+      ~max_cycles:3
+      ~workdir:base_path
+      ()
+  in
+  Lib.Autoresearch.with_loops_rw (fun () ->
+    Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state);
+  let swarm_path =
+    Lib.Autoresearch.loop_link_file ~base_path state.loop_id
+  in
+  (* Missing required session_id should not crash the loops list. *)
+  write_file swarm_path
+    (Printf.sprintf {|{"loop_id":"%s","linked_at":0}|} state.loop_id);
+  let json =
+    Lib.Dashboard_http_autoresearch.autoresearch_loops_json ~base_path
+  in
+  check int "active loop still listed" 1
+    Yojson.Safe.Util.(json |> member "total" |> to_int);
+  check bool "session id falls back to null" true
+    Yojson.Safe.Util.(json |> member "loops" |> index 0 |> member "session_id" = `Null)
+
+let () =
+  run "dashboard_autoresearch"
+    [
+      ( "loops_json",
+        [
+          test_case "skips invalid persisted state" `Quick
+            test_loops_json_skips_invalid_persisted_state;
+          test_case "tolerates invalid swarm link for active loop" `Quick
+            test_loops_json_tolerates_invalid_swarm_link_for_active_loop;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- prevent  from crashing when a persisted autoresearch  or  is malformed
- treat broken persisted loop metadata as skippable and log a warning instead of bubbling an exception into a 500
- add dashboard autoresearch tests covering invalid persisted state and invalid swarm link files

## Testing
- dune build --root .
- ./_build/default/test/test_dashboard_autoresearch.exe test loops_json