### PR TITLE
fix(dashboard): simplify keeper direct comms chat surface

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1,0 +1,77 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { KeeperConversationEntry } from '../../types'
+import { ChatTranscript } from './primitives'
+
+function entry(
+  overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
+): KeeperConversationEntry {
+  const { id, text, ...rest } = overrides
+  return {
+    id,
+    role: 'user',
+    source: 'direct_user',
+    label: '사용자',
+    text,
+    rawText: rest.rawText ?? text,
+    timestamp: '2026-03-24T00:00:00.000Z',
+    delivery: 'history',
+    streamState: null,
+    details: null,
+    error: null,
+    ...rest,
+  }
+}
+
+describe('ChatTranscript', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('keeps saved delivery badges in the default transcript', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[entry({ id: 'u1', text: 'ping' })]}
+        emptyText="empty"
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('[data-chat-delivery="saved"]')).not.toBeNull()
+  })
+
+  it('hides saved badges in messenger mode but keeps live state badges', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({ id: 'u1', text: 'ping' }),
+          entry({
+            id: 'a1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: 'pong',
+            delivery: 'streaming',
+            streamState: 'streaming',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('[data-chat-variant="messenger"]')).not.toBeNull()
+    expect(container.querySelector('[data-chat-delivery="saved"]')).toBeNull()
+    expect(container.querySelector('[data-chat-delivery="live"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
 import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
+export type ChatTranscriptVariant = 'default' | 'messenger'
+
 function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
   const value = new Date(timestamp)
@@ -32,6 +34,11 @@ function bubbleTone(entry: KeeperConversationEntry): string {
   if (entry.role === 'user') return 'user'
   if (entry.role === 'assistant') return 'assistant'
   return 'system'
+}
+
+function showDeliveryBadge(entry: KeeperConversationEntry, variant: ChatTranscriptVariant): boolean {
+  if (variant !== 'messenger') return true
+  return entry.delivery !== 'history' && entry.delivery !== 'delivered'
 }
 
 function avatarLabel(entry: KeeperConversationEntry): string {
@@ -98,16 +105,22 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
 export function ChatMessageBubble({
   entry,
   showMetadata = true,
+  variant = 'default',
 }: {
   entry: KeeperConversationEntry
   showMetadata?: boolean
+  variant?: ChatTranscriptVariant
 }) {
   const [expanded, setExpanded] = useState(false)
   const [rawExpanded, setRawExpanded] = useState(false)
+  const tone = bubbleTone(entry)
+  const isMessenger = variant === 'messenger'
   const detailItems = detailSummary(entry.details)
   const canExpand = showMetadata && !!entry.details
   const overview = entry.details ? overviewRows(entry.details) : []
   const state = stateRows(entry.details?.stateBlock)
+  const delivery = deliveryLabel(entry)
+  const timestamp = timeLabel(entry.timestamp)
 
   useEffect(() => {
     if (!showMetadata) {
@@ -118,43 +131,82 @@ export function ChatMessageBubble({
 
   return html`
     <article
-      class=${`chat-bubble ${bubbleTone(entry)} flex w-full max-w-[90%] flex-col gap-3 rounded-[20px] border px-4 py-3 backdrop-blur-sm`}
+      class=${`chat-bubble ${tone} flex w-full flex-col border backdrop-blur-sm ${
+        isMessenger
+          ? 'max-w-[82%] gap-2.5 rounded-[24px] px-4 py-3.5'
+          : 'max-w-[90%] gap-3 rounded-[20px] px-4 py-3'
+      }`}
+      data-chat-variant=${variant}
     >
-      <div class="flex items-start justify-between gap-3">
-        <div class="flex min-w-0 flex-1 items-start gap-3">
+      <div class=${`flex justify-between gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
+        <div class=${`flex min-w-0 flex-1 gap-3 ${isMessenger ? 'items-center' : 'items-start'}`}>
           <div
-            class=${`chat-avatar ${bubbleTone(entry)} flex size-10 shrink-0 items-center justify-center rounded-2xl border text-[11px] font-semibold uppercase tracking-[0.08em]`}
+            class=${`chat-avatar ${tone} flex shrink-0 items-center justify-center border text-[11px] font-semibold uppercase tracking-[0.08em] ${
+              isMessenger ? 'size-8 rounded-[18px]' : 'size-10 rounded-2xl'
+            }`}
           >
             ${avatarMonogram(entry)}
           </div>
           <div class="min-w-0 flex-1">
-            <div class="flex flex-wrap items-center gap-1.5">
-              <span
-                class=${`chat-role-chip ${bubbleTone(entry)} inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]`}
-              >
-                ${entry.label}
-              </span>
-              <span class="inline-flex items-center rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">
-                ${deliveryLabel(entry)}
-              </span>
-              ${entry.timestamp
-                ? html`
-                    <span class="inline-flex items-center rounded-full border border-[rgba(148,163,184,0.16)] bg-[rgba(148,163,184,0.08)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
-                      ${timeLabel(entry.timestamp)}
+            ${isMessenger
+              ? html`
+                  <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span class="truncate text-[12px] font-semibold text-[var(--text-strong)]">
+                      ${avatarLabel(entry)}
                     </span>
-                  `
-                : null}
-            </div>
-            <div class="mt-2 truncate text-[13px] font-semibold text-[var(--text-strong)]">
-              ${avatarLabel(entry)}
-            </div>
+                    ${timestamp
+                      ? html`<span class="text-[11px] tabular-nums text-[var(--text-muted)]">${timestamp}</span>`
+                      : null}
+                    ${showDeliveryBadge(entry, variant)
+                      ? html`
+                          <span
+                            class="inline-flex items-center rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]"
+                            data-chat-delivery=${delivery}
+                          >
+                            ${delivery}
+                          </span>
+                        `
+                      : null}
+                  </div>
+                `
+              : html`
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    <span
+                      class=${`chat-role-chip ${tone} inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em]`}
+                    >
+                      ${entry.label}
+                    </span>
+                    ${showDeliveryBadge(entry, variant)
+                      ? html`
+                          <span
+                            class="inline-flex items-center rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]"
+                            data-chat-delivery=${delivery}
+                          >
+                            ${delivery}
+                          </span>
+                        `
+                      : null}
+                    ${timestamp
+                      ? html`
+                          <span class="inline-flex items-center rounded-full border border-[rgba(148,163,184,0.16)] bg-[rgba(148,163,184,0.08)] px-2.5 py-1 text-[10px] font-medium tabular-nums text-[var(--text-muted)]">
+                            ${timestamp}
+                          </span>
+                        `
+                      : null}
+                  </div>
+                  <div class="mt-2 truncate text-[13px] font-semibold text-[var(--text-strong)]">
+                    ${avatarLabel(entry)}
+                  </div>
+                `}
           </div>
         </div>
         ${canExpand
           ? html`
               <button
                 type="button"
-                class="rounded-full border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] px-3 py-1 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)]"
+                class=${`border border-[var(--card-border)] bg-[rgba(255,255,255,0.04)] text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[var(--text-body)] ${
+                  isMessenger ? 'rounded-xl px-2.5 py-1' : 'rounded-full px-3 py-1'
+                }`}
                 onClick=${() => { setExpanded(!expanded) }}
               >
                 ${expanded ? '상세 숨기기' : '상세 보기'}
@@ -164,7 +216,7 @@ export function ChatMessageBubble({
       </div>
 
       ${showMetadata && detailItems.length > 0
-        ? html`<div class="flex flex-wrap gap-1.5">
+        ? html`<div class=${`flex flex-wrap gap-1.5 ${isMessenger ? 'pt-0.5' : ''}`}>
             ${detailItems.map(item => html`
               <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.16)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[10px] font-medium text-[#bfe8ff]">
                 ${item}
@@ -252,10 +304,12 @@ export function ChatTranscript({
   entries,
   emptyText,
   showMetadata,
+  variant = 'default',
 }: {
   entries: KeeperConversationEntry[]
   emptyText: string
   showMetadata?: boolean
+  variant?: ChatTranscriptVariant
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
   const lastSignature = entries.map(entry => `${entry.id}:${entry.text.length}:${entry.delivery}`).join('|')
@@ -268,7 +322,12 @@ export function ChatTranscript({
 
   return html`
     <div
-      class="chat-transcript flex min-h-[300px] max-h-[520px] flex-col gap-3 overflow-y-auto rounded-[22px] border border-[rgba(148,163,184,0.14)] px-3 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
+      class=${`chat-transcript flex min-h-[300px] max-h-[520px] flex-col overflow-y-auto border border-[rgba(148,163,184,0.14)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] ${
+        variant === 'messenger'
+          ? 'gap-4 rounded-[26px] px-4 py-5 sm:px-5'
+          : 'gap-3 rounded-[22px] px-3 py-4'
+      }`}
+      data-chat-variant=${variant}
       ref=${scrollerRef}
     >
       ${entries.length === 0
@@ -278,7 +337,7 @@ export function ChatTranscript({
               <div class="mt-3 max-w-[34rem] text-[13px] leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
             </div>
           `
-        : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} />`)}
+        : entries.map(entry => html`<${ChatMessageBubble} key=${entry.id} entry=${entry} showMetadata=${showMetadata !== false} variant=${variant} />`)}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1,0 +1,119 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../keeper-runtime', async () => {
+  const { signal } = await import('@preact/signals')
+  return {
+    abortKeeperThreadMessage: vi.fn(),
+    hydrateKeeperStatus: vi.fn(async () => null),
+    loadFullKeeperHistory: vi.fn(async () => null),
+    keeperActionErrors: signal({}),
+    keeperHydrating: signal({}),
+    keeperProbing: signal({}),
+    keeperRecovering: signal({}),
+    keeperSending: signal({}),
+    keeperStatusDetails: signal({}),
+    keeperStreamStartedAt: signal({}),
+    keeperThreads: signal({}),
+    probeKeeperRuntime: vi.fn(),
+    recoverKeeperRuntime: vi.fn(),
+    sendKeeperThreadMessage: vi.fn(async () => null),
+  }
+})
+
+vi.mock('./common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
+import { KeeperConversationPanel } from './keeper-shared'
+
+describe('KeeperConversationPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    })
+    keeperThreads.value = {}
+    keeperSending.value = {}
+    keeperHydrating.value = {}
+    keeperActionErrors.value = {}
+    keeperStreamStartedAt.value = {}
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a chat-first shell and removes the old KPI header cards', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'world',
+          role: 'user',
+          source: 'world_state_prompt',
+          label: 'system',
+          text: '## Current World State',
+          rawText: '## Current World State',
+          timestamp: '2026-03-24T00:00:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'direct-user',
+          role: 'user',
+          source: 'direct_user',
+          label: '사용자',
+          text: '지금 상태 어때?',
+          rawText: '지금 상태 어때?',
+          timestamp: '2026-03-24T00:01:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'direct-assistant',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'sangsu',
+          text: '대화 UI를 정리하고 있습니다.',
+          rawText: '대화 UI를 정리하고 있습니다.',
+          timestamp: '2026-03-24T00:02:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    expect(container.textContent).toContain('Direct Chat')
+    expect(container.textContent).toContain('@sangsu')
+    expect(container.textContent).toContain('Show metadata')
+    expect(container.textContent).toContain('1 internal history entries are hidden')
+    expect(container.textContent).not.toContain('Conversation Lane')
+    expect(container.textContent).not.toContain('Visible thread')
+    expect(container.textContent).not.toContain('Hidden internal')
+    expect(container.textContent).not.toContain('Lane state')
+    expect(container.querySelector('[data-chat-variant="messenger"]')).not.toBeNull()
+    expect(container.querySelector('textarea')?.getAttribute('placeholder')).toBe('메시지 입력...')
+  })
+})

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -26,10 +26,10 @@ const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
 function readKeeperChatMetadataVisible(): boolean {
   try {
     const stored = localStorage.getItem(KEEPER_CHAT_METADATA_VISIBLE_KEY)
-    // Default to visible (true) when no preference is stored
-    return stored === null ? true : stored === 'true'
+    // Default to hidden so the direct lane reads like chat first.
+    return stored === null ? false : stored === 'true'
   } catch {
-    return true
+    return false
   }
 }
 
@@ -241,16 +241,21 @@ export function KeeperConversationPanel({
 
   return html`
     <div class="flex flex-col gap-3">
-      <div class="rounded-[22px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(12,20,38,0.96),rgba(8,13,24,0.9))] px-4 py-4 shadow-[0_18px_48px_rgba(0,0,0,0.22)]">
-        <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
+        <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
           <div class="min-w-[220px] flex-1">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Conversation Lane</div>
-            <div class="mt-2 text-[16px] font-semibold text-[var(--text-strong)]">Direct messages only</div>
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Direct Chat</div>
+            <div class="mt-2 flex flex-wrap items-center gap-2">
+              <div class="text-[15px] font-semibold text-[var(--text-strong)]">@${keeperName}</div>
+              <span class=${`inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
+                ${conversationStateLabel(sending, hydrating)}
+              </span>
+            </div>
             <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
-              This panel is for explicit operator-to-keeper conversation. Internal world-state prompts, tool chatter, and keeper self-deliberation are hidden on purpose.
+              Keeper 상세 안에서 직접 주고받은 대화만 보여줍니다. 내부 프롬프트와 tool chatter는 자동으로 숨깁니다.
             </div>
           </div>
-          <div class="flex flex-wrap items-center gap-2 text-[11px]">
+          <div class="flex flex-wrap items-center gap-2">
             <button
               type="button"
               class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
@@ -258,48 +263,6 @@ export function KeeperConversationPanel({
             >
               ${showMetadata ? 'Hide metadata' : 'Show metadata'}
             </button>
-          </div>
-        </div>
-
-        <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
-          <div class="rounded-[18px] border border-[rgba(71,184,255,0.18)] bg-[rgba(71,184,255,0.08)] px-3 py-3">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#9ad9ff]">Visible thread</div>
-            <div class="mt-1 text-[22px] font-semibold text-[var(--text-strong)]">${thread.length}</div>
-            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-secondary)]">Direct user prompts and keeper replies currently shown.</div>
-          </div>
-          <div class="rounded-[18px] border border-[rgba(245,158,11,0.2)] bg-[rgba(245,158,11,0.08)] px-3 py-3">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#f5d089]">Hidden internal</div>
-            <div class="mt-1 text-[22px] font-semibold text-[var(--text-strong)]">${hiddenHistoryCount}</div>
-            <div class="mt-1 text-[12px] leading-[1.55] text-[var(--text-secondary)]">System prompts and internal reasoning omitted from the conversation lane.</div>
-          </div>
-          <div class="rounded-[18px] border border-[rgba(148,163,184,0.14)] bg-[rgba(255,255,255,0.04)] px-3 py-3">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Lane state</div>
-            <div class="mt-2">
-              <span class=${`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
-                ${conversationStateLabel(sending, hydrating)}
-              </span>
-            </div>
-            <div class="mt-2 text-[12px] leading-[1.55] text-[var(--text-secondary)]">
-              ${sending
-                ? 'A keeper reply is currently streaming.'
-                : hydrating
-                  ? 'History is being refreshed from keeper status.'
-                  : 'Direct message lane is ready for a new prompt.'}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.94),rgba(5,10,20,0.9))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
-        <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
-          <div class="min-w-[220px] flex-1">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Transcript</div>
-            <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${keeperName}</div>
-            <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
-              Recent direct exchange with the keeper, separated from internal control prompts.
-            </div>
-          </div>
-          <div class="flex flex-wrap items-center gap-2">
             ${!historyExpanded && rawThread.length >= 10
               ? html`
                   <button
@@ -320,13 +283,14 @@ export function KeeperConversationPanel({
             entries=${thread}
             emptyText="No direct conversation yet. Internal keeper prompts and tool chatter are hidden."
             showMetadata=${showMetadata}
+            variant="messenger"
           />
         </div>
 
         ${hiddenHistoryCount > 0
           ? html`
-              <div class="mx-4 mb-4 rounded-[18px] border border-[rgba(245,158,11,0.18)] bg-[rgba(245,158,11,0.08)] px-3 py-2.5 text-[12px] leading-[1.6] text-[#f4d79e]">
-                ${hiddenHistoryCount} internal history entries are hidden from this transcript to keep the conversation readable. Raw status and metadata still retain those traces for debugging.
+              <div class="mx-4 mb-4 rounded-[16px] border border-[rgba(245,158,11,0.16)] bg-[rgba(245,158,11,0.06)] px-3 py-2 text-[11px] leading-[1.55] text-[#f4d79e]">
+                ${hiddenHistoryCount} internal history entries are hidden from this transcript to keep the conversation readable.
               </div>
             `
           : null}


### PR DESCRIPTION
## Summary
- make keeper detail `Direct Comms` read like a chat surface instead of an ops dashboard
- add a `messenger` transcript variant that trims routine delivery chrome while keeping live/error state badges
- add regression tests for the chat-first keeper shell and messenger transcript behavior

## Testing
- `npm test -- src/components/chat/primitives.test.ts src/components/keeper-shared.test.ts src/keeper-state.test.ts`
- `npm run typecheck`
- `npm run build`
