### PR TITLE
fix(dashboard): unify refresh and ops state

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -8,7 +8,7 @@ import { route, initRouter } from './router'
 import { connectSSE, disconnectSSE } from './sse'
 import { refreshRoomTruth } from './room-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
-import { refreshForTab } from './tab-refresh'
+import { refreshForRoute } from './tab-refresh'
 import { refreshMissionSnapshot } from './mission-store'
 import {
   BuildIdentityBadge,
@@ -58,7 +58,7 @@ export function App() {
     // Cancel any pending SSE-triggered refreshes from the previous tab
     // to prevent stale fetch results arriving after navigation (C-4/M-12).
     cancelPendingSSERefreshes()
-    refreshForTab(route.value.tab)
+    refreshForRoute(route.value)
   }, [route.value.tab, route.value.params.section, route.value.params.surface, route.value.params.q])
 
   const currentTab = route.value.tab

--- a/dashboard/src/command-store.ts
+++ b/dashboard/src/command-store.ts
@@ -60,8 +60,39 @@ export const commandPlaneChainRunError = signal<string | null>(null)
 export const commandPlaneChainFocusOperationId = signal<string | null>(null)
 let activeChainRunRequestId: string | null = null
 
+interface RefreshOptions {
+  force?: boolean
+}
+
+const COMMAND_REFRESH_TTL_MS = 1_000
+const COMMAND_HELP_TTL_MS = 60_000
+
+let summaryRefreshInflight: Promise<void> | null = null
+let detailRefreshInflight: Promise<void> | null = null
+let helpRefreshInflight: Promise<void> | null = null
+let chainRefreshInflight: Promise<void> | null = null
+let swarmRefreshInflight: Promise<void> | null = null
+let orchestraRefreshInflight: Promise<void> | null = null
+
+let lastSummaryRefreshAt = 0
+let lastDetailRefreshAt = 0
+let lastHelpRefreshAt = 0
+let lastChainRefreshAt = 0
+let lastSwarmRefreshAt = 0
+let lastOrchestraRefreshAt = 0
+let lastSwarmRefreshKey = ''
+let lastOrchestraRefreshKey = ''
+
 function surfaceNeedsDetail(surface: CommandPlaneSurface): boolean {
   return surface !== 'swarm' && surface !== 'orchestra'
+}
+
+function isFresh(lastAt: number, ttlMs: number, opts?: RefreshOptions): boolean {
+  return !opts?.force && Date.now() - lastAt < ttlMs
+}
+
+function refreshKey(runId?: string, operationId?: string): string {
+  return `${runId ?? ''}:${operationId ?? ''}`
 }
 
 function currentLocationParams(): URLSearchParams {
@@ -97,36 +128,50 @@ export function setCommandPlaneSurface(surface: CommandPlaneSurface): void {
   }
 }
 
-export async function refreshCommandPlaneSummary(): Promise<void> {
+export async function refreshCommandPlaneSummary(opts?: RefreshOptions): Promise<void> {
+  if (summaryRefreshInflight) return summaryRefreshInflight
+  if (isFresh(lastSummaryRefreshAt, COMMAND_REFRESH_TTL_MS, opts)) return
   commandPlaneLoading.value = true
   commandPlaneError.value = null
-  try {
-    const raw = await fetchCommandPlaneSummary()
-    commandPlaneSummary.value = normalizeSummarySnapshot(raw)
-  } catch (err) {
-    commandPlaneError.value =
-      err instanceof Error ? err.message : 'Failed to load command-plane summary'
-  } finally {
-    commandPlaneLoading.value = false
-  }
+  summaryRefreshInflight = (async () => {
+    try {
+      const raw = await fetchCommandPlaneSummary()
+      commandPlaneSummary.value = normalizeSummarySnapshot(raw)
+      lastSummaryRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneError.value =
+        err instanceof Error ? err.message : 'Failed to load command-plane summary'
+    } finally {
+      commandPlaneLoading.value = false
+      summaryRefreshInflight = null
+    }
+  })()
+  return summaryRefreshInflight
 }
 
 export function focusCommandPlaneChainOperation(operationId: string | null): void {
   commandPlaneChainFocusOperationId.value = operationId
 }
 
-export async function refreshCommandPlaneSnapshot(): Promise<void> {
+export async function refreshCommandPlaneSnapshot(opts?: RefreshOptions): Promise<void> {
+  if (detailRefreshInflight) return detailRefreshInflight
+  if (isFresh(lastDetailRefreshAt, COMMAND_REFRESH_TTL_MS, opts)) return
   commandPlaneDetailLoading.value = true
   commandPlaneDetailError.value = null
-  try {
-    const raw = await fetchCommandPlaneSnapshot()
-    commandPlaneSnapshot.value = normalizeSnapshot(raw)
-  } catch (err) {
-    commandPlaneDetailError.value =
-      err instanceof Error ? err.message : 'Failed to load command-plane snapshot'
-  } finally {
-    commandPlaneDetailLoading.value = false
-  }
+  detailRefreshInflight = (async () => {
+    try {
+      const raw = await fetchCommandPlaneSnapshot()
+      commandPlaneSnapshot.value = normalizeSnapshot(raw)
+      lastDetailRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneDetailError.value =
+        err instanceof Error ? err.message : 'Failed to load command-plane snapshot'
+    } finally {
+      commandPlaneDetailLoading.value = false
+      detailRefreshInflight = null
+    }
+  })()
+  return detailRefreshInflight
 }
 
 export async function ensureCommandPlaneDetail(): Promise<void> {
@@ -134,32 +179,39 @@ export async function ensureCommandPlaneDetail(): Promise<void> {
   await refreshCommandPlaneSnapshot()
 }
 
-export async function refreshCommandPlaneCurrentSurface(): Promise<void> {
-  await refreshCommandPlaneSummary()
+export async function refreshCommandPlaneCurrentSurface(opts?: RefreshOptions): Promise<void> {
+  await refreshCommandPlaneSummary(opts)
   if (surfaceNeedsDetail(commandPlaneSurface.value)) {
-    await refreshCommandPlaneSnapshot()
+    await refreshCommandPlaneSnapshot(opts)
   }
 }
 
-export async function refreshCommandPlaneChainSummary(): Promise<void> {
+export async function refreshCommandPlaneChainSummary(opts?: RefreshOptions): Promise<void> {
+  if (chainRefreshInflight) return chainRefreshInflight
+  if (isFresh(lastChainRefreshAt, COMMAND_REFRESH_TTL_MS, opts)) return
   commandPlaneChainLoading.value = true
   commandPlaneChainError.value = null
-  try {
-    const raw = await fetchChainSummary()
-    const normalized = normalizeChainSummary(raw)
-    commandPlaneChainSummary.value = normalized
-    const focused = commandPlaneChainFocusOperationId.value
-    if (normalized.operations.length === 0) {
-      commandPlaneChainFocusOperationId.value = null
-    } else if (!focused || !normalized.operations.some(item => item.operation.operation_id === focused)) {
-      commandPlaneChainFocusOperationId.value = normalized.operations[0]?.operation.operation_id ?? null
+  chainRefreshInflight = (async () => {
+    try {
+      const raw = await fetchChainSummary()
+      const normalized = normalizeChainSummary(raw)
+      commandPlaneChainSummary.value = normalized
+      const focused = commandPlaneChainFocusOperationId.value
+      if (normalized.operations.length === 0) {
+        commandPlaneChainFocusOperationId.value = null
+      } else if (!focused || !normalized.operations.some(item => item.operation.operation_id === focused)) {
+        commandPlaneChainFocusOperationId.value = normalized.operations[0]?.operation.operation_id ?? null
+      }
+      lastChainRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneChainError.value =
+        err instanceof Error ? err.message : 'Failed to load chain summary'
+    } finally {
+      commandPlaneChainLoading.value = false
+      chainRefreshInflight = null
     }
-  } catch (err) {
-    commandPlaneChainError.value =
-      err instanceof Error ? err.message : 'Failed to load chain summary'
-  } finally {
-    commandPlaneChainLoading.value = false
-  }
+  })()
+  return chainRefreshInflight
 }
 
 export function clearCommandPlaneChainRun(): void {
@@ -189,52 +241,79 @@ export async function loadCommandPlaneChainRun(runId: string): Promise<void> {
   }
 }
 
-export async function refreshCommandPlaneHelp(): Promise<void> {
+export async function refreshCommandPlaneHelp(opts?: RefreshOptions): Promise<void> {
+  if (helpRefreshInflight) return helpRefreshInflight
+  if (isFresh(lastHelpRefreshAt, COMMAND_HELP_TTL_MS, opts)) return
   commandPlaneHelpLoading.value = true
   commandPlaneHelpError.value = null
-  try {
-    const raw = await fetchCommandPlaneHelp()
-    commandPlaneHelp.value = normalizeHelp(raw)
-  } catch (err) {
-    commandPlaneHelpError.value =
-      err instanceof Error ? err.message : 'Failed to load command-plane help'
-  } finally {
-    commandPlaneHelpLoading.value = false
-  }
+  helpRefreshInflight = (async () => {
+    try {
+      const raw = await fetchCommandPlaneHelp()
+      commandPlaneHelp.value = normalizeHelp(raw)
+      lastHelpRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneHelpError.value =
+        err instanceof Error ? err.message : 'Failed to load command-plane help'
+    } finally {
+      commandPlaneHelpLoading.value = false
+      helpRefreshInflight = null
+    }
+  })()
+  return helpRefreshInflight
 }
 
 export async function refreshCommandPlaneSwarm(
   runId = currentSwarmRunId(),
   operationId = currentSwarmOperationId(),
+  opts?: RefreshOptions,
 ): Promise<void> {
+  const key = refreshKey(runId, operationId)
+  if (swarmRefreshInflight && key === lastSwarmRefreshKey) return swarmRefreshInflight
+  if (key === lastSwarmRefreshKey && isFresh(lastSwarmRefreshAt, COMMAND_REFRESH_TTL_MS, opts)) return
   commandPlaneSwarmLoading.value = true
   commandPlaneSwarmError.value = null
-  try {
-    const raw = await fetchCommandPlaneSwarm(runId, operationId)
-    commandPlaneSwarm.value = normalizeSwarm(raw)
-  } catch (err) {
-    commandPlaneSwarmError.value =
-      err instanceof Error ? err.message : 'Failed to load command-plane swarm view'
-  } finally {
-    commandPlaneSwarmLoading.value = false
-  }
+  lastSwarmRefreshKey = key
+  swarmRefreshInflight = (async () => {
+    try {
+      const raw = await fetchCommandPlaneSwarm(runId, operationId)
+      commandPlaneSwarm.value = normalizeSwarm(raw)
+      lastSwarmRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneSwarmError.value =
+        err instanceof Error ? err.message : 'Failed to load command-plane swarm view'
+    } finally {
+      commandPlaneSwarmLoading.value = false
+      swarmRefreshInflight = null
+    }
+  })()
+  return swarmRefreshInflight
 }
 
 export async function refreshCommandPlaneOrchestra(
   runId = currentSwarmRunId(),
   operationId = currentSwarmOperationId(),
+  opts?: RefreshOptions,
 ): Promise<void> {
+  const key = refreshKey(runId, operationId)
+  if (orchestraRefreshInflight && key === lastOrchestraRefreshKey) return orchestraRefreshInflight
+  if (key === lastOrchestraRefreshKey && isFresh(lastOrchestraRefreshAt, COMMAND_REFRESH_TTL_MS, opts)) return
   commandPlaneOrchestraLoading.value = true
   commandPlaneOrchestraError.value = null
-  try {
-    const raw = await fetchCommandPlaneOrchestra(runId, operationId)
-    commandPlaneOrchestra.value = normalizeOrchestra(raw)
-  } catch (err) {
-    commandPlaneOrchestraError.value =
-      err instanceof Error ? err.message : 'Failed to load orchestra map'
-  } finally {
-    commandPlaneOrchestraLoading.value = false
-  }
+  lastOrchestraRefreshKey = key
+  orchestraRefreshInflight = (async () => {
+    try {
+      const raw = await fetchCommandPlaneOrchestra(runId, operationId)
+      commandPlaneOrchestra.value = normalizeOrchestra(raw)
+      lastOrchestraRefreshAt = Date.now()
+    } catch (err) {
+      commandPlaneOrchestraError.value =
+        err instanceof Error ? err.message : 'Failed to load orchestra map'
+    } finally {
+      commandPlaneOrchestraLoading.value = false
+      orchestraRefreshInflight = null
+    }
+  })()
+  return orchestraRefreshInflight
 }
 
 async function runAction(key: string, path: string, body: Record<string, unknown>): Promise<void> {
@@ -242,13 +321,13 @@ async function runAction(key: string, path: string, body: Record<string, unknown
   commandPlaneActionError.value = null
   try {
     await runCommandPlaneAction(path, body)
-    await refreshCommandPlaneSummary()
+    await refreshCommandPlaneSummary({ force: true })
     if (commandPlaneSnapshot.value || surfaceNeedsDetail(commandPlaneSurface.value)) {
-      await refreshCommandPlaneSnapshot()
+      await refreshCommandPlaneSnapshot({ force: true })
     }
-    await refreshCommandPlaneSwarm()
-    await refreshCommandPlaneOrchestra()
-    await refreshCommandPlaneChainSummary()
+    await refreshCommandPlaneSwarm(undefined, undefined, { force: true })
+    await refreshCommandPlaneOrchestra(undefined, undefined, { force: true })
+    await refreshCommandPlaneChainSummary({ force: true })
   } catch (err) {
     commandPlaneActionError.value =
       err instanceof Error ? err.message : 'Failed to execute command-plane action'
@@ -312,16 +391,16 @@ export function toggleCommandPlaneKillSwitch(unitId: string, enabled: boolean): 
 }
 
 registerCommandPlaneRefresh(() => {
-  void refreshCommandPlaneCurrentSurface()
-  void refreshCommandPlaneChainSummary()
+  void refreshCommandPlaneCurrentSurface({ force: true })
+  void refreshCommandPlaneChainSummary({ force: true })
   if (
     commandPlaneSurface.value === 'swarm'
     || commandPlaneSurface.value === 'orchestra'
     || commandPlaneSwarm.value !== null
   ) {
-    void refreshCommandPlaneSwarm()
+    void refreshCommandPlaneSwarm(undefined, undefined, { force: true })
   }
   if (commandPlaneSurface.value === 'orchestra' || commandPlaneOrchestra.value !== null) {
-    void refreshCommandPlaneOrchestra()
+    void refreshCommandPlaneOrchestra(undefined, undefined, { force: true })
   }
 })

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -90,11 +90,7 @@ function SurfaceBody() {
 
 export function Command() {
   useEffect(() => {
-    void refreshCommandPlaneCurrentSurface()
-    void refreshCommandPlaneChainSummary()
     void refreshCommandPlaneHelp()
-    void refreshCommandPlaneSwarm()
-    void refreshCommandPlaneOrchestra()
   }, [])
 
   useEffect(() => {
@@ -118,10 +114,10 @@ export function Command() {
       focusCommandPlaneChainOperation(requestedOperation)
     }
     if (requestedSurface === 'swarm' || requestedSurface === 'orchestra' || commandPlaneSurface.value === 'orchestra') {
-      void refreshCommandPlaneSwarm()
+      void refreshCommandPlaneSwarm(undefined, undefined, { force: true })
     }
     if (requestedSurface === 'orchestra' || commandPlaneSurface.value === 'orchestra') {
-      void refreshCommandPlaneOrchestra()
+      void refreshCommandPlaneOrchestra(undefined, undefined, { force: true })
     }
   }, [
     route.value.tab,
@@ -143,13 +139,13 @@ export function Command() {
       if (refreshTimer) return
       refreshTimer = window.setTimeout(() => {
         refreshTimer = null
-        void refreshCommandPlaneCurrentSurface()
-        void refreshCommandPlaneChainSummary()
+        void refreshCommandPlaneCurrentSurface({ force: true })
+        void refreshCommandPlaneChainSummary({ force: true })
         if (commandPlaneSurface.value === 'swarm' || commandPlaneSurface.value === 'orchestra') {
-          void refreshCommandPlaneSwarm()
+          void refreshCommandPlaneSwarm(undefined, undefined, { force: true })
         }
         if (commandPlaneSurface.value === 'orchestra') {
-          void refreshCommandPlaneOrchestra()
+          void refreshCommandPlaneOrchestra(undefined, undefined, { force: true })
         }
       }, 250)
     }
@@ -212,10 +208,10 @@ export function Command() {
           <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
-              void refreshRoomTruth()
-              void refreshCommandPlaneCurrentSurface()
-              void refreshCommandPlaneChainSummary()
-              void refreshCommandPlaneSwarm()
+              void refreshRoomTruth({ force: true })
+              void refreshCommandPlaneCurrentSurface({ force: true })
+              void refreshCommandPlaneChainSummary({ force: true })
+              void refreshCommandPlaneSwarm(undefined, undefined, { force: true })
             }}
             disabled=${commandPlaneLoading.value}
           >

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -198,7 +198,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
       ${!collapsed ? html`
         <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] p-4 bg-[rgba(0,0,0,0.1)]">
-          <${SnapshotCard} currentTab=${currentTab} />
+          <${SnapshotCard} />
         </div>
       ` : null}
     </nav>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -64,7 +64,7 @@ async function runSocialSweep(): Promise<void> {
       payload: {},
     })
     invalidateDashboardCache()
-    await refreshDashboard()
+    await refreshDashboard({ force: true })
     showToast('Social sweep finished', 'success')
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to run social sweep'

--- a/dashboard/src/components/ops/helpers.test.ts
+++ b/dashboard/src/components/ops/helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import * as helpers from './helpers'
+import * as opsState from './ops-state'
+
+describe('ops helper state exports', () => {
+  it('re-exports the canonical ops state signals', () => {
+    expect(helpers.actorName).toBe(opsState.actorName)
+    expect(helpers.broadcastMessage).toBe(opsState.broadcastMessage)
+    expect(helpers.pauseReason).toBe(opsState.pauseReason)
+    expect(helpers.taskTitle).toBe(opsState.taskTitle)
+    expect(helpers.taskDescription).toBe(opsState.taskDescription)
+    expect(helpers.taskPriority).toBe(opsState.taskPriority)
+    expect(helpers.selectedSessionId).toBe(opsState.selectedSessionId)
+    expect(helpers.teamTurnKind).toBe(opsState.teamTurnKind)
+    expect(helpers.teamMessage).toBe(opsState.teamMessage)
+    expect(helpers.teamTaskTitle).toBe(opsState.teamTaskTitle)
+    expect(helpers.teamTaskDescription).toBe(opsState.teamTaskDescription)
+    expect(helpers.teamTaskPriority).toBe(opsState.teamTaskPriority)
+    expect(helpers.teamSpawnBatchJson).toBe(opsState.teamSpawnBatchJson)
+    expect(helpers.teamStopReason).toBe(opsState.teamStopReason)
+    expect(helpers.selectedKeeperName).toBe(opsState.selectedKeeperName)
+    expect(helpers.keeperMessage).toBe(opsState.keeperMessage)
+    expect(helpers.hydratedWorkflowId).toBe(opsState.hydratedWorkflowId)
+  })
+
+  it('re-exports the canonical actor persistence function', () => {
+    expect(helpers.persistActorName).toBe(opsState.persistActorName)
+  })
+})

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -1,6 +1,5 @@
-// Ops helpers — signals, types, utilities, action dispatch
+// Ops helpers — shared view helpers built on top of the canonical ops state.
 
-import { signal } from '@preact/signals'
 import { showToast } from '../common/toast'
 import { prettyJson, displayStatus, statusLabel } from '../../lib/status-label'
 import type {
@@ -17,41 +16,46 @@ import {
   operatorSnapshot,
 } from '../../operator-store'
 import type { DashboardWorkflowContext } from '../../workflow-context'
+import {
+  actorName,
+  broadcastMessage,
+  pauseReason,
+  taskTitle,
+  taskDescription,
+  taskPriority,
+  selectedSessionId,
+  teamTurnKind,
+  teamMessage,
+  teamTaskTitle,
+  teamTaskDescription,
+  teamTaskPriority,
+  teamSpawnBatchJson,
+  teamStopReason,
+  selectedKeeperName,
+  keeperMessage,
+  hydratedWorkflowId,
+  persistActorName,
+} from './ops-state'
 
-const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
-
-function initialActorName(): string {
-  const params = new URLSearchParams(window.location.search)
-  return (
-    params.get('agent')?.trim()
-    || params.get('agent_name')?.trim()
-    || localStorage.getItem(AGENT_NAME_KEY)?.trim()
-    || 'dashboard'
-  )
-}
-
-export const actorName = signal(initialActorName())
-export const broadcastMessage = signal('')
-export const pauseReason = signal('운영 점검')
-export const taskTitle = signal('')
-export const taskDescription = signal('')
-export const taskPriority = signal('2')
-export const selectedSessionId = signal('')
-export const teamTurnKind = signal<'note' | 'broadcast' | 'task' | 'worker_spawn_batch'>('note')
-export const teamMessage = signal('')
-export const teamTaskTitle = signal('')
-export const teamTaskDescription = signal('')
-export const teamTaskPriority = signal('2')
-export const teamSpawnBatchJson = signal('')
-export const teamStopReason = signal('운영자 중지 요청')
-export const selectedKeeperName = signal('')
-export const keeperMessage = signal('')
-export const hydratedWorkflowId = signal<string | null>(null)
-
-export function persistActorName(value: string): void {
-  const trimmed = value.trim() || 'dashboard'
-  actorName.value = trimmed
-  localStorage.setItem(AGENT_NAME_KEY, trimmed)
+export {
+  actorName,
+  broadcastMessage,
+  pauseReason,
+  taskTitle,
+  taskDescription,
+  taskPriority,
+  selectedSessionId,
+  teamTurnKind,
+  teamMessage,
+  teamTaskTitle,
+  teamTaskDescription,
+  teamTaskPriority,
+  teamSpawnBatchJson,
+  teamStopReason,
+  selectedKeeperName,
+  keeperMessage,
+  hydratedWorkflowId,
+  persistActorName,
 }
 
 export { prettyJson, displayStatus }

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -67,10 +67,6 @@ export function Ops() {
   const workflowReady = workflowTargetReady(workflowContext, sessions, keepers)
 
   useEffect(() => {
-    void refreshOperatorRoomDigest()
-  }, [])
-
-  useEffect(() => {
     if (route.value.tab !== 'command' || route.value.params.section !== 'intervene') {
       hydratedWorkflowId.value = null
       return
@@ -177,10 +173,10 @@ export function Ops() {
           <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
-              void refreshRoomTruth()
-              void refreshOperatorSnapshot()
-              void refreshOperatorRoomDigest()
-              void refreshOperatorSessionDigest(selectedSession?.session_id ?? null)
+              void refreshRoomTruth({ force: true })
+              void refreshOperatorSnapshot({ force: true })
+              void refreshOperatorRoomDigest({ force: true })
+              void refreshOperatorSessionDigest(selectedSession?.session_id ?? null, { force: true })
             }}
             disabled=${operatorLoading.value || operatorActionBusy.value}
           >

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -71,9 +71,9 @@ export function OpsSessionColumn() {
       : sessionDigest?.recommended_actions ?? []
 
   const refreshSelectedSession = async () => {
-    await refreshOperatorSnapshot()
+    await refreshOperatorSnapshot({ force: true })
     if (selectedSession?.session_id) {
-      await refreshOperatorSessionDigest(selectedSession.session_id)
+      await refreshOperatorSessionDigest(selectedSession.session_id, { force: true })
     }
   }
 

--- a/dashboard/src/components/ops/ops-state.ts
+++ b/dashboard/src/components/ops/ops-state.ts
@@ -2,12 +2,23 @@ import { signal } from '@preact/signals'
 
 const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
+function safeStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const storage = window.localStorage
+    return storage && typeof storage.getItem === 'function' ? storage : null
+  } catch {
+    return null
+  }
+}
+
 function initialActorName(): string {
   const params = new URLSearchParams(window.location.search)
+  const storage = safeStorage()
   return (
     params.get('agent')?.trim()
     || params.get('agent_name')?.trim()
-    || localStorage.getItem(AGENT_NAME_KEY)?.trim()
+    || storage?.getItem(AGENT_NAME_KEY)?.trim()
     || 'dashboard'
   )
 }
@@ -39,5 +50,5 @@ export const hydratedWorkflowId = signal<string | null>(null)
 export function persistActorName(value: string): void {
   const trimmed = value.trim() || 'dashboard'
   actorName.value = trimmed
-  localStorage.setItem(AGENT_NAME_KEY, trimmed)
+  safeStorage()?.setItem(AGENT_NAME_KEY, trimmed)
 }

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -7,8 +7,8 @@ import {
   keepers,
   serverStatus,
 } from '../store'
-import { refreshForTab } from '../tab-refresh'
-import { navigate } from '../router'
+import { refreshForRoute } from '../tab-refresh'
+import { navigate, route } from '../router'
 import { operatorSnapshot, refreshOperatorRoomDigest, refreshOperatorSnapshot } from '../operator-store'
 import { selectPendingConfirmState } from '../pending-confirm'
 
@@ -18,7 +18,7 @@ function shortCommit(commit: string | null | undefined): string {
   return value.length > 10 ? value.slice(0, 10) : value
 }
 
-export function SnapshotCard({ currentTab }: { currentTab: string }) {
+export function SnapshotCard() {
   const liveConnected = connected.value
   const build = serverStatus.value?.build
 
@@ -69,8 +69,8 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
           class="w-full rounded-md border border-solid border-[rgba(71,184,255,0.26)] bg-[rgba(71,184,255,0.14)] px-3 py-2 text-[11px] font-medium text-[#dff3ff] cursor-pointer transition-colors duration-150 hover:bg-[rgba(71,184,255,0.2)]"
           onClick=${(e: Event) => {
             e.preventDefault()
-            void refreshDashboard().catch(() => {})
-            try { refreshForTab(currentTab) } catch {}
+            void refreshDashboard({ force: true }).catch(() => {})
+            refreshForRoute(route.value)
           }}
         >
           Room sync
@@ -116,8 +116,8 @@ export function InterveneRailCard() {
         <button type="button"
           class="w-full border border-solid border-[rgba(71,184,255,0.3)] rounded-lg bg-[var(--accent-12)] text-[#d7efff] py-1.5 px-2 text-[11px] cursor-pointer transition-colors duration-150 hover:bg-[var(--accent-20)]"
           onClick=${() => {
-            refreshOperatorSnapshot()
-            refreshOperatorRoomDigest()
+            void refreshOperatorSnapshot({ force: true })
+            void refreshOperatorRoomDigest({ force: true })
           }}
         >
           갱신

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -36,7 +36,7 @@ import { abortKeeperThreadMessage, applyKeeperStreamEvent } from './keeper-strea
 async function refreshDashboardState(): Promise<void> {
   invalidateDashboardCache()
   try {
-    await refreshDashboard()
+    await refreshDashboard({ force: true })
   } catch (err) {
     console.warn('[keeper-runtime] dashboard refresh failed', err)
   }

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -42,6 +42,20 @@ export const operatorActionLog = signal<OperatorActionLogEntry[]>([])
 
 let nextLogId = 1
 
+interface RefreshOptions {
+  force?: boolean
+}
+
+const OPERATOR_REFRESH_TTL_MS = 1_000
+
+let snapshotRefreshInflight: Promise<void> | null = null
+let roomDigestRefreshInflight: Promise<void> | null = null
+let sessionDigestRefreshInflight: Promise<void> | null = null
+let lastSnapshotRefreshAt = 0
+let lastRoomDigestRefreshAt = 0
+let lastSessionDigestRefreshAt = 0
+let lastSessionDigestId: string | null = null
+
 function normalizeMessage(raw: unknown): Message | null {
   if (!isRecord(raw)) return null
   return {
@@ -409,52 +423,79 @@ function logMessageFromResult(result: OperatorActionResult): string {
     || result.status
 }
 
-export async function refreshOperatorSnapshot(): Promise<void> {
+function isFresh(lastAt: number, opts?: RefreshOptions): boolean {
+  return !opts?.force && Date.now() - lastAt < OPERATOR_REFRESH_TTL_MS
+}
+
+export async function refreshOperatorSnapshot(opts?: RefreshOptions): Promise<void> {
+  if (snapshotRefreshInflight) return snapshotRefreshInflight
+  if (isFresh(lastSnapshotRefreshAt, opts)) return
   operatorLoading.value = true
   operatorError.value = null
-  try {
-    const raw = await fetchOperatorSnapshot()
-    operatorSnapshot.value = normalizeOperatorSnapshot(raw)
-  } catch (err) {
-    operatorError.value = err instanceof Error ? err.message : 'Failed to load operator snapshot'
-  } finally {
-    operatorLoading.value = false
-  }
+  snapshotRefreshInflight = (async () => {
+    try {
+      const raw = await fetchOperatorSnapshot()
+      operatorSnapshot.value = normalizeOperatorSnapshot(raw)
+      lastSnapshotRefreshAt = Date.now()
+    } catch (err) {
+      operatorError.value = err instanceof Error ? err.message : 'Failed to load operator snapshot'
+    } finally {
+      operatorLoading.value = false
+      snapshotRefreshInflight = null
+    }
+  })()
+  return snapshotRefreshInflight
 }
 
-export async function refreshOperatorRoomDigest(): Promise<void> {
+export async function refreshOperatorRoomDigest(opts?: RefreshOptions): Promise<void> {
+  if (roomDigestRefreshInflight) return roomDigestRefreshInflight
+  if (isFresh(lastRoomDigestRefreshAt, opts)) return
   operatorDigestLoading.value = true
   operatorDigestError.value = null
-  try {
-    const raw = await fetchOperatorDigest({ targetType: 'room' })
-    operatorRoomDigest.value = normalizeOperatorDigest(raw)
-  } catch (err) {
-    operatorDigestError.value = err instanceof Error ? err.message : 'Failed to load operator digest'
-  } finally {
-    operatorDigestLoading.value = false
-  }
+  roomDigestRefreshInflight = (async () => {
+    try {
+      const raw = await fetchOperatorDigest({ targetType: 'room' })
+      operatorRoomDigest.value = normalizeOperatorDigest(raw)
+      lastRoomDigestRefreshAt = Date.now()
+    } catch (err) {
+      operatorDigestError.value = err instanceof Error ? err.message : 'Failed to load operator digest'
+    } finally {
+      operatorDigestLoading.value = false
+      roomDigestRefreshInflight = null
+    }
+  })()
+  return roomDigestRefreshInflight
 }
 
-export async function refreshOperatorSessionDigest(sessionId: string | null): Promise<void> {
+export async function refreshOperatorSessionDigest(sessionId: string | null, opts?: RefreshOptions): Promise<void> {
   if (!sessionId) {
     operatorSessionDigest.value = null
+    lastSessionDigestId = null
     return
   }
+  if (sessionDigestRefreshInflight && lastSessionDigestId === sessionId) return sessionDigestRefreshInflight
+  if (lastSessionDigestId === sessionId && isFresh(lastSessionDigestRefreshAt, opts)) return
 
   operatorDigestLoading.value = true
   operatorDigestError.value = null
-  try {
-    const raw = await fetchOperatorDigest({
-      targetType: 'team_session',
-      targetId: sessionId,
-      includeWorkers: true,
-    })
-    operatorSessionDigest.value = normalizeOperatorDigest(raw)
-  } catch (err) {
-    operatorDigestError.value = err instanceof Error ? err.message : 'Failed to load session digest'
-  } finally {
-    operatorDigestLoading.value = false
-  }
+  lastSessionDigestId = sessionId
+  sessionDigestRefreshInflight = (async () => {
+    try {
+      const raw = await fetchOperatorDigest({
+        targetType: 'team_session',
+        targetId: sessionId,
+        includeWorkers: true,
+      })
+      operatorSessionDigest.value = normalizeOperatorDigest(raw)
+      lastSessionDigestRefreshAt = Date.now()
+    } catch (err) {
+      operatorDigestError.value = err instanceof Error ? err.message : 'Failed to load session digest'
+    } finally {
+      operatorDigestLoading.value = false
+      sessionDigestRefreshInflight = null
+    }
+  })()
+  return sessionDigestRefreshInflight
 }
 
 export async function dispatchOperatorAction(request: OperatorActionRequest): Promise<OperatorActionResult> {
@@ -470,10 +511,10 @@ export async function dispatchOperatorAction(request: OperatorActionRequest): Pr
       message: logMessageFromResult(result),
       delegated_tool: result.delegated_tool,
     })
-    await refreshOperatorSnapshot()
-    await refreshOperatorRoomDigest()
+    await refreshOperatorSnapshot({ force: true })
+    await refreshOperatorRoomDigest({ force: true })
     if (operatorSessionDigest.value?.target_id) {
-      await refreshOperatorSessionDigest(operatorSessionDigest.value.target_id)
+      await refreshOperatorSessionDigest(operatorSessionDigest.value.target_id, { force: true })
     }
     return result
   } catch (err) {
@@ -509,10 +550,10 @@ export async function confirmOperatorPendingAction(
       message: logMessageFromResult(result),
       delegated_tool: result.delegated_tool,
     })
-    await refreshOperatorSnapshot()
-    await refreshOperatorRoomDigest()
+    await refreshOperatorSnapshot({ force: true })
+    await refreshOperatorRoomDigest({ force: true })
     if (operatorSessionDigest.value?.target_id) {
-      await refreshOperatorSessionDigest(operatorSessionDigest.value.target_id)
+      await refreshOperatorSessionDigest(operatorSessionDigest.value.target_id, { force: true })
     }
     return result
   } catch (err) {
@@ -532,9 +573,9 @@ export async function confirmOperatorPendingAction(
 }
 
 registerOperatorRefresh(() => {
-  void refreshOperatorSnapshot()
-  void refreshOperatorRoomDigest()
+  void refreshOperatorSnapshot({ force: true })
+  void refreshOperatorRoomDigest({ force: true })
   if (operatorSessionDigest.value?.target_id) {
-    void refreshOperatorSessionDigest(operatorSessionDigest.value.target_id)
+    void refreshOperatorSessionDigest(operatorSessionDigest.value.target_id, { force: true })
   }
 })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -101,7 +101,7 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 ]
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
-  execution: refreshExecution,
+  execution: () => { void refreshExecution({ force: true }) },
   board:     refreshBoard,
   mdal:      refreshMdal,
   operator:  () => _refreshOperatorFn?.(),
@@ -144,7 +144,7 @@ function handleDashboardRefresh(): void {
   invalidateDashboardCache()
   if (!_fetchDebounce) {
     _fetchDebounce = setTimeout(() => {
-      refreshDashboard()
+      void refreshDashboard({ force: true })
       _refreshCommandPlaneFn?.()
       _refreshOperatorFn?.()
       _fetchDebounce = null
@@ -179,8 +179,8 @@ async function hydrateAfterReconnect(): Promise<void> {
   try {
     await Promise.all([
       refreshRoomTruth({ force: true }),
-      refreshDashboard(),
-      refreshExecution(),
+      refreshDashboard({ force: true }),
+      refreshExecution({ force: true }),
       refreshBoard(),
     ])
     _refreshCommandPlaneFn?.()
@@ -190,8 +190,8 @@ async function hydrateAfterReconnect(): Promise<void> {
     // First attempt failed (server may still be warming up) — retry once.
     setTimeout(() => {
       void refreshRoomTruth({ force: true })
-      refreshDashboard()
-      refreshExecution()
+      void refreshDashboard({ force: true })
+      void refreshExecution({ force: true })
       _refreshOperatorFn?.()
     }, 3000)
   }
@@ -276,7 +276,7 @@ export function startPeriodicRefresh(): void {
     if (!connected.value) {
       invalidateDashboardCache()
     }
-    refreshDashboard()
+    void refreshDashboard()
     _refreshMissionFn?.()
   }, PERIODIC_REFRESH_MS)
 }

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -160,8 +160,8 @@ export function connectSSE(): void {
     if (wasDisconnected) {
       reconnectCount.value++
       // Refetch all data after reconnection so counts don't stay at 0
-      void refreshDashboard().catch(() => {})
-      void refreshRoomTruth().catch(() => {})
+      void refreshDashboard({ force: true }).catch(() => {})
+      void refreshRoomTruth({ force: true }).catch(() => {})
     }
   }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -295,6 +295,18 @@ export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
 
 // --- Refresh orchestration ---
 
+interface RefreshOptions {
+  force?: boolean
+}
+
+const SHELL_TTL_MS = 5_000
+const EXECUTION_TTL_MS = 30_000
+
+let inflightDashboardRefresh: Promise<void> | null = null
+let inflightShellRefresh: Promise<void> | null = null
+let inflightExecutionRefresh: Promise<void> | null = null
+let lastShellRefreshAt = 0
+
 export function isDashboardRefreshEvent(eventType: string): boolean {
   return (
     eventType === 'dashboard_refresh'
@@ -314,16 +326,21 @@ export function invalidateDashboardCache(): void {
   // Projection endpoints are intentionally fresh-first after the operator-console rewrite.
 }
 
-export async function refreshDashboard(): Promise<void> {
+export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
+  if (inflightDashboardRefresh) return inflightDashboardRefresh
   dashboardLoading.value = true
-  try {
-    await Promise.all([refreshShell(), refreshExecution()])
-    lastDashboardRefreshAt.value = new Date().toISOString()
-  } catch (err) {
-    console.warn('[Dashboard] refresh error:', err)
-  } finally {
-    dashboardLoading.value = false
-  }
+  inflightDashboardRefresh = (async () => {
+    try {
+      await Promise.all([refreshShell(opts), refreshExecution(opts)])
+      lastDashboardRefreshAt.value = new Date().toISOString()
+    } catch (err) {
+      console.warn('[Dashboard] refresh error:', err)
+    } finally {
+      dashboardLoading.value = false
+      inflightDashboardRefresh = null
+    }
+  })()
+  return inflightDashboardRefresh
 }
 
 export function findDashboardSemanticPanel(panelId: string): DashboardSemanticPanel | null {
@@ -387,28 +404,36 @@ function applyPlanningEnvelope(data: {
         : 'ready'
 }
 
-export async function refreshShell(): Promise<void> {
-  try {
-    const data = await fetchDashboardShell()
-    const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
-    if (normalizedStatus) {
-      serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
-    }
-    // Extract lightweight counts for fast initial render (before execution loads)
-    if (data.counts) {
-      shellCounts.value = {
-        agents: data.counts.agents ?? 0,
-        tasks: data.counts.tasks ?? 0,
-        keepers: data.counts.keepers ?? 0,
+export async function refreshShell(opts?: RefreshOptions): Promise<void> {
+  if (inflightShellRefresh) return inflightShellRefresh
+  if (!opts?.force && Date.now() - lastShellRefreshAt < SHELL_TTL_MS) return
+  inflightShellRefresh = (async () => {
+    try {
+      const data = await fetchDashboardShell()
+      const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
+      if (normalizedStatus) {
+        serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
       }
+      // Extract lightweight counts for fast initial render (before execution loads)
+      if (data.counts) {
+        shellCounts.value = {
+          agents: data.counts.agents ?? 0,
+          tasks: data.counts.tasks ?? 0,
+          keepers: data.counts.keepers ?? 0,
+        }
+      }
+      if (data.providers) {
+        providerCapacity.value = data.providers as unknown as ProviderCapacity
+      }
+      lastShellRefreshAt = Date.now()
+    } catch (err) {
+      console.warn('[Dashboard] shell fetch error:', err)
+      showToast('서버 연결 실패 — 데이터를 불러올 수 없습니다', 'error', 6000)
+    } finally {
+      inflightShellRefresh = null
     }
-    if (data.providers) {
-      providerCapacity.value = data.providers as unknown as ProviderCapacity
-    }
-  } catch (err) {
-    console.warn('[Dashboard] shell fetch error:', err)
-    showToast('서버 연결 실패 — 데이터를 불러올 수 없습니다', 'error', 6000)
-  }
+  })()
+  return inflightShellRefresh
 }
 
 export async function refreshAgentActivity(): Promise<void> {
@@ -420,64 +445,68 @@ export async function refreshAgentActivity(): Promise<void> {
   }
 }
 
-const EXECUTION_TTL_MS = 30_000
-
-export async function refreshExecution(opts?: { force?: boolean }): Promise<void> {
+export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
+  if (inflightExecutionRefresh) return inflightExecutionRefresh
   if (!opts?.force && Date.now() - lastExecutionRefreshAt.value < EXECUTION_TTL_MS) return
-  try {
-    const data = await fetchDashboardExecution()
-    const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
-    const previousRoom = serverStatus.value?.room
-    if (normalizedStatus) {
-      serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
+  inflightExecutionRefresh = (async () => {
+    try {
+      const data = await fetchDashboardExecution()
+      const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
+      const previousRoom = serverStatus.value?.room
+      if (normalizedStatus) {
+        serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
+      }
+      const roomChanged = previousRoom != null && normalizedStatus?.room != null && previousRoom !== normalizedStatus.room
+      const normalizedAgents = (Array.isArray(data.agents) ? data.agents : [])
+        .map(normalizeAgent)
+        .filter((row): row is Agent => row !== null)
+      setArrayByKeyIfChanged(agents, normalizedAgents, a => a.name)
+      const normalizedTasks = (Array.isArray(data.tasks) ? data.tasks : [])
+        .map(normalizeTask)
+        .filter((row): row is Task => row !== null)
+      setArrayByKeyIfChanged(tasks, normalizedTasks, t => t.id)
+      const executionMessages = (Array.isArray(data.messages) ? data.messages : [])
+        .map(normalizeMessage)
+        .filter((row): row is Message => row !== null)
+      messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
+      keepers.value = normalizeKeepers(data.keepers)
+      executionSummary.value = normalizeExecutionSummary(data.summary)
+      const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
+        .map(normalizeExecutionQueueItem)
+        .filter((row): row is DashboardExecutionQueueItem => row !== null)
+      setArrayByKeyIfChanged(executionQueue, normalizedQueue, q => q.id)
+      const normalizedSessionBriefs = (Array.isArray(data.session_briefs) ? data.session_briefs : [])
+        .map(normalizeExecutionSessionBrief)
+        .filter((row): row is DashboardExecutionSessionBrief => row !== null)
+      setArrayByKeyIfChanged(executionSessionBriefs, normalizedSessionBriefs, s => s.session_id)
+      const normalizedOpBriefs = (Array.isArray(data.operation_briefs) ? data.operation_briefs : [])
+        .map(normalizeExecutionOperationBrief)
+        .filter((row): row is DashboardExecutionOperationBrief => row !== null)
+      setArrayByKeyIfChanged(executionOperationBriefs, normalizedOpBriefs, o => o.operation_id)
+      const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
+        .map(normalizeExecutionWorkerSupportBrief)
+        .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
+      setArrayByKeyIfChanged(executionWorkerSupportBriefs, normalizedWorkerBriefs, w => w.name)
+      const normalizedContinuityBriefs = (Array.isArray(data.continuity_briefs) ? data.continuity_briefs : [])
+        .map(normalizeExecutionContinuityBrief)
+        .filter((row): row is DashboardExecutionContinuityBrief => row !== null)
+      setArrayByKeyIfChanged(executionContinuityBriefs, normalizedContinuityBriefs, c => c.name)
+      const normalizedOfflineBriefs = (Array.isArray(data.offline_worker_briefs) ? data.offline_worker_briefs : [])
+        .map(normalizeExecutionWorkerSupportBrief)
+        .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
+      setArrayByKeyIfChanged(executionOfflineWorkerBriefs, normalizedOfflineBriefs, w => w.name)
+      perpetualStatus.value = null
+      executionLoaded.value = true
+      lastExecutionRefreshAt.value = Date.now()
+      lastDashboardRefreshAt.value = new Date().toISOString()
+    } catch (err) {
+      console.warn('[Dashboard] execution fetch error:', err)
+      showToast('실행 데이터 로드 실패', 'error', 5000)
+    } finally {
+      inflightExecutionRefresh = null
     }
-    const roomChanged = previousRoom != null && normalizedStatus?.room != null && previousRoom !== normalizedStatus.room
-    const normalizedAgents = (Array.isArray(data.agents) ? data.agents : [])
-      .map(normalizeAgent)
-      .filter((row): row is Agent => row !== null)
-    setArrayByKeyIfChanged(agents, normalizedAgents, a => a.name)
-    const normalizedTasks = (Array.isArray(data.tasks) ? data.tasks : [])
-      .map(normalizeTask)
-      .filter((row): row is Task => row !== null)
-    setArrayByKeyIfChanged(tasks, normalizedTasks, t => t.id)
-    const executionMessages = (Array.isArray(data.messages) ? data.messages : [])
-      .map(normalizeMessage)
-      .filter((row): row is Message => row !== null)
-    messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
-    keepers.value = normalizeKeepers(data.keepers)
-    executionSummary.value = normalizeExecutionSummary(data.summary)
-    const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
-      .map(normalizeExecutionQueueItem)
-      .filter((row): row is DashboardExecutionQueueItem => row !== null)
-    setArrayByKeyIfChanged(executionQueue, normalizedQueue, q => q.id)
-    const normalizedSessionBriefs = (Array.isArray(data.session_briefs) ? data.session_briefs : [])
-      .map(normalizeExecutionSessionBrief)
-      .filter((row): row is DashboardExecutionSessionBrief => row !== null)
-    setArrayByKeyIfChanged(executionSessionBriefs, normalizedSessionBriefs, s => s.session_id)
-    const normalizedOpBriefs = (Array.isArray(data.operation_briefs) ? data.operation_briefs : [])
-      .map(normalizeExecutionOperationBrief)
-      .filter((row): row is DashboardExecutionOperationBrief => row !== null)
-    setArrayByKeyIfChanged(executionOperationBriefs, normalizedOpBriefs, o => o.operation_id)
-    const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
-      .map(normalizeExecutionWorkerSupportBrief)
-      .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
-    setArrayByKeyIfChanged(executionWorkerSupportBriefs, normalizedWorkerBriefs, w => w.name)
-    const normalizedContinuityBriefs = (Array.isArray(data.continuity_briefs) ? data.continuity_briefs : [])
-      .map(normalizeExecutionContinuityBrief)
-      .filter((row): row is DashboardExecutionContinuityBrief => row !== null)
-    setArrayByKeyIfChanged(executionContinuityBriefs, normalizedContinuityBriefs, c => c.name)
-    const normalizedOfflineBriefs = (Array.isArray(data.offline_worker_briefs) ? data.offline_worker_briefs : [])
-      .map(normalizeExecutionWorkerSupportBrief)
-      .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)
-    setArrayByKeyIfChanged(executionOfflineWorkerBriefs, normalizedOfflineBriefs, w => w.name)
-    perpetualStatus.value = null
-    executionLoaded.value = true
-    lastExecutionRefreshAt.value = Date.now()
-    lastDashboardRefreshAt.value = new Date().toISOString()
-  } catch (err) {
-    console.warn('[Dashboard] execution fetch error:', err)
-    showToast('실행 데이터 로드 실패', 'error', 5000)
-  }
+  })()
+  return inflightExecutionRefresh
 }
 
 export async function refreshAgents(): Promise<void> {

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { refreshPlanForRoute } from './tab-refresh'
+
+describe('refreshPlanForRoute', () => {
+  it('hydrates overview from room truth and mission snapshot', () => {
+    expect(refreshPlanForRoute({
+      tab: 'overview',
+      params: {},
+    })).toEqual(['roomTruth', 'missionSnapshot'])
+  })
+
+  it('uses the current monitoring sections', () => {
+    expect(refreshPlanForRoute({
+      tab: 'monitoring',
+      params: { section: 'agents' },
+    })).toEqual(['roomTruth', 'execution', 'missionSnapshot'])
+
+    expect(refreshPlanForRoute({
+      tab: 'monitoring',
+      params: { section: 'activity' },
+    })).toEqual(['execution', 'activityGraph'])
+  })
+
+  it('uses the current command sections', () => {
+    expect(refreshPlanForRoute({
+      tab: 'command',
+      params: { section: 'intervene' },
+    })).toEqual(['roomTruth', 'operatorSnapshot', 'operatorRoomDigest'])
+
+    expect(refreshPlanForRoute({
+      tab: 'command',
+      params: { section: 'warroom' },
+    })).toEqual(['roomTruth', 'commandCurrentSurface', 'commandChainSummary'])
+  })
+
+  it('refreshes the new workspace and lab sections only where store-backed data is needed', () => {
+    expect(refreshPlanForRoute({
+      tab: 'workspace',
+      params: { section: 'planning' },
+    })).toEqual(['goals', 'execution'])
+
+    expect(refreshPlanForRoute({
+      tab: 'workspace',
+      params: { section: 'board' },
+    })).toEqual(['board'])
+
+    expect(refreshPlanForRoute({
+      tab: 'lab',
+      params: { section: 'avatars' },
+    })).toEqual(['execution'])
+
+    expect(refreshPlanForRoute({
+      tab: 'lab',
+      params: { section: 'tools' },
+    })).toEqual([])
+  })
+})

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -1,9 +1,8 @@
-import { route } from './router'
-import { refreshExecution, refreshBoard, refreshGoals, refreshTrpg } from './store'
+import type { RouteState } from './types'
+import { refreshExecution, refreshBoard, refreshGoals } from './store'
 import { refreshRoomTruth } from './room-truth-store'
 import { refreshOperatorRoomDigest, refreshOperatorSnapshot } from './operator-store'
-import { refreshMissionBriefing, refreshMissionSnapshot } from './mission-store'
-import { refreshProofSnapshot } from './proof-store'
+import { refreshMissionSnapshot } from './mission-store'
 import {
   commandPlaneSurface,
   refreshCommandPlaneChainSummary,
@@ -12,90 +11,98 @@ import {
   refreshCommandPlaneSwarm,
 } from './command-store'
 
-async function refreshGovernanceSurface(): Promise<void> {
-  const { refreshGovernance } = await import('./components/governance')
-  await refreshGovernance()
-}
-
-async function refreshToolsSurface(): Promise<void> {
-  const { refreshTools } = await import('./components/tools')
-  await refreshTools()
-}
-
 async function refreshActivityGraphSurface(): Promise<void> {
   const { refreshActivityGraph } = await import('./components/activity-graph')
   await refreshActivityGraph()
 }
 
-export function refreshForTab(tab: string) {
-  if (tab === 'home') {
-    refreshRoomTruth()
-    refreshExecution()
-    refreshMissionSnapshot()
-  }
+export type RefreshTask =
+  | 'roomTruth'
+  | 'missionSnapshot'
+  | 'execution'
+  | 'activityGraph'
+  | 'board'
+  | 'goals'
+  | 'commandCurrentSurface'
+  | 'commandChainSummary'
+  | 'commandSwarm'
+  | 'commandOrchestra'
+  | 'operatorSnapshot'
+  | 'operatorRoomDigest'
 
-  if (tab === 'status') {
-    const section = route.value.params.section
-    if (section === 'activity') {
-      refreshExecution()
-      void refreshActivityGraphSurface()
-    } else if (section === 'agents') {
-      refreshRoomTruth()
-      refreshExecution()
-      refreshMissionSnapshot()
-    } else {
-      refreshRoomTruth()
-      refreshMissionSnapshot()
-      refreshMissionBriefing()
-    }
-  }
-
-  if (tab === 'work') {
-    const section = route.value.params.section
-    if (section === 'evidence') {
-      refreshProofSnapshot(route.value.params.session_id, route.value.params.operation_id)
-    } else if (section === 'governance') {
-      void refreshGovernanceSurface()
-    } else if (section === 'planning') {
-      refreshGoals()
-      refreshExecution()
-    } else {
-      refreshBoard()
-    }
-  }
-
-  if (tab === 'operations') {
-    const section = route.value.params.section
-    if (section === 'command') {
-      refreshRoomTruth()
-      refreshCommandPlaneCurrentSurface()
-      refreshCommandPlaneChainSummary()
-      if (
-        commandPlaneSurface.value === 'swarm'
-        || commandPlaneSurface.value === 'orchestra'
-      ) {
-        refreshCommandPlaneSwarm()
+export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
+  switch (routeState.tab) {
+    case 'overview':
+      return ['roomTruth', 'missionSnapshot']
+    case 'monitoring':
+      if (routeState.params.section === 'activity') {
+        return ['execution', 'activityGraph']
       }
-      if (commandPlaneSurface.value === 'orchestra') {
-        refreshCommandPlaneOrchestra()
+      if (routeState.params.section === 'agents') {
+        return ['roomTruth', 'execution', 'missionSnapshot']
       }
-    } else if (section === 'tools') {
-      void refreshToolsSurface()
-    } else {
-      refreshRoomTruth()
-      refreshOperatorSnapshot()
-      refreshOperatorRoomDigest()
-    }
+      return ['roomTruth', 'missionSnapshot']
+    case 'command':
+      if (routeState.params.section === 'warroom') {
+        const tasks: RefreshTask[] = [
+          'roomTruth',
+          'commandCurrentSurface',
+          'commandChainSummary',
+        ]
+        if (
+          commandPlaneSurface.value === 'swarm'
+          || commandPlaneSurface.value === 'orchestra'
+        ) {
+          tasks.push('commandSwarm')
+        }
+        if (commandPlaneSurface.value === 'orchestra') {
+          tasks.push('commandOrchestra')
+        }
+        return tasks
+      }
+      if (routeState.params.section === 'intervene') {
+        return ['roomTruth', 'operatorSnapshot', 'operatorRoomDigest']
+      }
+      return []
+    case 'workspace':
+      if (routeState.params.section === 'planning') {
+        return ['goals', 'execution']
+      }
+      if (routeState.params.section === 'board') {
+        return ['board']
+      }
+      return []
+    case 'lab':
+      if (routeState.params.section === 'avatars') {
+        return ['execution']
+      }
+      if (routeState.params.section === 'overview') {
+        return ['roomTruth']
+      }
+      return []
+    case 'logs':
+    default:
+      return []
   }
+}
 
-  if (tab === 'lab') {
-    const section = route.value.params.section
-    if (section === 'trpg') {
-      refreshTrpg()
-    } else if (section === 'avatars' || section === 'overview') {
-      refreshRoomTruth()
-    } else {
-      refreshRoomTruth()
-    }
-  }
+const REFRESHERS: Record<RefreshTask, () => void> = {
+  roomTruth: () => { void refreshRoomTruth() },
+  missionSnapshot: () => { void refreshMissionSnapshot() },
+  execution: () => { void refreshExecution({ force: true }) },
+  activityGraph: () => { void refreshActivityGraphSurface() },
+  board: () => { void refreshBoard() },
+  goals: () => { void refreshGoals() },
+  commandCurrentSurface: () => { void refreshCommandPlaneCurrentSurface({ force: true }) },
+  commandChainSummary: () => { void refreshCommandPlaneChainSummary({ force: true }) },
+  commandSwarm: () => { void refreshCommandPlaneSwarm(undefined, undefined, { force: true }) },
+  commandOrchestra: () => { void refreshCommandPlaneOrchestra(undefined, undefined, { force: true }) },
+  operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
+  operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },
+}
+
+export function refreshForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): void {
+  refreshPlanForRoute(routeState).forEach(task => {
+    REFRESHERS[task]()
+  })
 }


### PR DESCRIPTION
## Summary
- unify ops dashboard form state behind a single canonical signal module
- rebuild tab refresh routing for the current dashboard IA and move refresh ownership to route-aware planning
- add inflight dedupe + force-refresh paths for dashboard, operator, and command-plane stores to cut redundant fetches

## Testing
- npm run typecheck
- npm test