### PR TITLE
fix(ci): skip keeper msg bridge in quick suite

### DIFF
--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -190,9 +190,13 @@ let test_keeper_msg_auto_team_session_bridge () =
   (* This test triggers a real LLM cascade call (keeper_msg -> run_turn).
      In CI there is no LLM server, so the cascade hangs until timeout.
      Skip when CI=true or ALCOTEST_QUICK_TESTS=1 to prevent the build
-     from timing out.  See: #1936 *)
+     from timing out. The quick-suite harness also exports
+     CI_TEST_TIMEOUT_SEC, which is more reliable than ALCOTEST_QUICK_TESTS
+     under dune test in CI. See: #1936 *)
   if Sys.getenv_opt "CI" = Some "true"
      || Sys.getenv_opt "ALCOTEST_QUICK_TESTS" = Some "1" then
+    Alcotest.skip ()
+  else if Sys.getenv_opt "CI_TEST_TIMEOUT_SEC" <> None then
     Alcotest.skip ()
   else
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- skip `keeper msg auto team session bridge` in quick-suite CI using the env that the CI harness actually exports
- keep the real integration path available for non-CI local runs
- unblock baseline `Build and Test` failure tracked in #2698

## Validation
- `CI_TEST_TIMEOUT_SEC=600 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/operator-control-keeper-msg test/test_operator_control.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/operator-control-keeper-msg`

Closes #2698