### PR TITLE
Remove keeper legacy trigger mode state

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -29,7 +29,7 @@ active_model = "llama:qwen3.5-35b-a3b-ud-q4-xl"
 # Trigger and scope
 room_scope = "all"
 scope_kind = "global"
-trigger_mode = "legacy"             # "legacy" enables proactive behavior
+trigger_mode = "explicit_only"      # only explicit direct mentions wake the keeper
 mention_targets = ["sherlock", "log-analyzer"]
 
 # Proactive behavior

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -207,7 +207,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `instructions` | string | `""` | 커스텀 시스템 프롬프트 | `masc_keeper_up`의 `instructions` 인자 |
 | `presence_keepalive` | bool | `true` | keepalive fiber 활성화 여부 | `masc_keeper_up`의 `presence_keepalive` 인자 |
 | `presence_keepalive_sec` | int | `30` | heartbeat 주기 (초) | `masc_keeper_up`의 `presence_keepalive_sec` 인자 |
-| `proactive_enabled` | bool | trigger_mode 의존 | 자발적 메시지 생성 활성화 | `masc_keeper_up`의 `proactive_enabled` 인자 |
+| `proactive_enabled` | bool | 기본 `false` | 자발적 메시지 생성 활성화 | `masc_keeper_up`의 `proactive_enabled` 인자 |
 | `auto_handoff` | bool | `true` | context 초과 시 자동 handoff | `masc_keeper_up`의 `auto_handoff` 인자 |
 | `handoff_threshold` | float | `0.85` | handoff 트리거 context_ratio | `masc_keeper_up`의 `handoff_threshold` 인자 |
 | `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |

--- a/lib/keeper/keeper_contract.ml
+++ b/lib/keeper/keeper_contract.ml
@@ -20,7 +20,6 @@ type room_scope =
   | All
 
 type trigger_mode =
-  | Legacy
   | Explicit_only
 
 let policy_mode_of_string = function
@@ -91,18 +90,13 @@ let room_scope_to_string = function
 
 let trigger_mode_of_string = function
   | "explicit_only" -> Explicit_only
-  | _ -> Legacy
+  | _ -> Explicit_only
 
 let parse_trigger_mode = function
-  | "legacy" -> Some Legacy
   | "explicit_only" -> Some Explicit_only
   | _ -> None
 
 let trigger_mode_to_string = function
-  | Legacy -> "legacy"
   | Explicit_only -> "explicit_only"
 
-let trigger_mode_is_explicit_only = function
-  | Explicit_only -> true
-  | Legacy -> false
-
+let trigger_mode_is_explicit_only _ = true

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -66,9 +66,8 @@ let rec deliberation_action_to_string = function
       ^ String.concat "," (List.map deliberation_action_to_string actions)
       ^ "]"
 
-(** Backward-compatible: map typed action to the legacy string labels
-    used by policy logging and reward models. *)
-let deliberation_action_to_legacy_string = function
+(** Map typed action to stable policy labels used by policy logging and reward models. *)
+let deliberation_action_to_policy_label = function
   | Noop _ -> "noop"
   | ReplyInRoom _ -> "reply_in_room"
   | BoardPost _ -> "board_post"

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -36,8 +36,8 @@ type deliberation_action =
 
 val deliberation_action_to_string : deliberation_action -> string
 
-(** Map typed action to legacy string labels for policy logging. *)
-val deliberation_action_to_legacy_string : deliberation_action -> string
+(** Map typed action to stable policy labels for policy logging. *)
+val deliberation_action_to_policy_label : deliberation_action -> string
 
 val deliberation_action_to_json : deliberation_action -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -107,7 +107,7 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   if policy_shell_mode = "readonly" && policy_mode <> "learned_offline_v1" then
     errors := "policy_shell_mode=readonly requires learned_offline_v1" :: !errors;
   if
-    (Safe_ops.json_string ~default:"legacy" "trigger_mode" json
+    (Safe_ops.json_string ~default:"explicit_only" "trigger_mode" json
      |> Keeper_contract.trigger_mode_of_string
      |> Keeper_contract.trigger_mode_is_explicit_only)
     && mention_targets = []
@@ -244,7 +244,7 @@ let resolved_keeper_args_from_persona args :
             let trigger_mode =
               get_string_opt args "trigger_mode"
               |> first_some defaults.trigger_mode
-              |> Option.value ~default:"legacy"
+              |> Option.value ~default:"explicit_only"
               |> canonical_trigger_mode
             in
             let mention_targets =

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -209,7 +209,7 @@ let deterministic_policy_baseline_action_typed
 (** Backward-compatible string interface for existing callers. *)
 let deterministic_policy_baseline_action (obs : keeper_policy_observation) : string =
   deterministic_policy_baseline_action_typed obs
-  |> Keeper_deliberation.deliberation_action_to_legacy_string
+  |> Keeper_deliberation.deliberation_action_to_policy_label
 
 let choose_policy_action (candidates : keeper_policy_candidate_score list) :
     keeper_policy_candidate_score option =
@@ -640,4 +640,3 @@ let profile_kind_caps (profile : string) : (string * int) list =
 
 let cap_for_kind (caps : (string * int) list) (kind : string) : int =
   List.assoc_opt kind caps |> Option.value ~default:1
-

--- a/lib/keeper/keeper_policy.ml
+++ b/lib/keeper/keeper_policy.ml
@@ -321,7 +321,7 @@ let handle_keeper_eval_replay ctx args : tool_result =
                              Safe_ops.json_string ~default:"current" "room_scope" observation
                              |> Keeper_contract.room_scope_of_string;
                            trigger_mode =
-                             Safe_ops.json_string ~default:"legacy" "trigger_mode" observation
+                             Safe_ops.json_string ~default:"explicit_only" "trigger_mode" observation
                              |> Keeper_contract.trigger_mode_of_string;
                            last_turn_ago_s =
                              Safe_ops.json_float ~default:0.0 "last_turn_ago_s" observation;

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -138,7 +138,7 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
       crash_log = ref [];
     } in
     Hashtbl.replace supervised_registry meta.name entry;
-    (* Backward compat: register in legacy keepalive registry *)
+    (* Register in the shared keepalive registry *)
     let wakeup = ref false in
     Keeper_keepalive.register_keepalive meta.name
       { Keeper_keepalive.stop; wakeup; started_at = now; grpc_close = None };

--- a/lib/keeper/keeper_resident_supervisor.mli
+++ b/lib/keeper/keeper_resident_supervisor.mli
@@ -32,7 +32,7 @@ val init : bus:Agent_sdk.Event_bus.t -> unit
 val supervise_keepalive :
   proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
 (** Start a keeper heartbeat loop inside a supervised fiber.
-    Registers in both the legacy keepalive registry (backward compat)
+    Registers in both the keepalive registry
     and the supervisor registry (Promise-based liveness tracking).
     On fiber termination, resolves the Promise and publishes
     resident-lifecycle events via Event_bus. *)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -5,7 +5,7 @@ open Keeper_types
 open Keeper_keepalive
 open Keeper_exec_status
 
-let maybe_promote_live_legacy_keeper config name =
+let maybe_promote_live_persistent_keeper config name =
   match read_meta config name with
   | Error _ | Ok None -> ()
   | Ok (Some meta) ->
@@ -66,7 +66,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
         |> List.filter (fun f -> Filename.check_suffix f ".json")
         |> List.iter (fun f ->
                let name = Filename.remove_extension f in
-               if validate_name name then maybe_promote_live_legacy_keeper ctx.config name)
+               if validate_name name then maybe_promote_live_persistent_keeper ctx.config name)
     | Error _ -> ());
     let now_ts = Time_compat.now () in
     let proactive_warmup_sec = keeper_bootstrap_proactive_warmup_sec () in

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -67,7 +67,7 @@ let resident_schemas : tool_schema list = [
         ]);
         ("trigger_mode", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "legacy"; `String "explicit_only"]);
+          ("enum", `List [`String "explicit_only"]);
         ]);
         ("mention_targets", `Assoc [
           ("type", `String "array");
@@ -161,8 +161,8 @@ let resident_schemas : tool_schema list = [
         ]);
         ("trigger_mode", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "legacy"; `String "explicit_only"]);
-          ("description", `String "How autonomous room activity is triggered. 'explicit_only' disables heuristic triggers and only reacts to exact direct mentions.");
+          ("enum", `List [`String "explicit_only"]);
+          ("description", `String "Keeper trigger mode. Only 'explicit_only' is supported and it reacts to exact direct mentions.");
         ]);
         ("mention_targets", `Assoc [
           ("type", `String "array");
@@ -179,7 +179,7 @@ let resident_schemas : tool_schema list = [
         ]);
         ("proactive_enabled", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "If true, keeper can send proactive check-ins after idle periods (default: true).");
+          ("description", `String "If true, keeper can send proactive check-ins after idle periods. Defaults to false unless explicitly enabled.");
         ]);
         ("proactive_idle_sec", `Assoc [
           ("type", `String "integer");
@@ -716,7 +716,7 @@ let housekeep_schemas : tool_schema list = [
       ("properties", `Assoc [
         ("category", `Assoc [
           ("type", `String "string");
-          ("description", `String "Filter by category: keeper_meta, keeper_metrics_legacy, keeper_memory, keeper_policy, keeper_feedback, jsonl_data, dated_split, events, other. Omit for all.");
+          ("description", `String "Filter by category: keeper_meta, keeper_metrics_single_file, keeper_memory, keeper_policy, keeper_feedback, jsonl_data, dated_split, events, other. Omit for all.");
         ]);
         ("min_age_days", `Assoc [
           ("type", `String "number");

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -249,7 +249,7 @@ let handle_keeper_list ctx args : tool_result =
               ("storage_paths", `Assoc [
                 ("meta", `String (keeper_meta_path ctx.config m.name));
                 ("metrics", `String (Dated_jsonl.base_dir metrics_store));
-                ("metrics_legacy", `String metrics_path);
+                ("metrics_single_file", `String metrics_path);
                 ("memory_bank", `String (keeper_memory_bank_path ctx.config m.name));
                 ("policy", `String (keeper_policy_log_path ctx.config m.name));
                 ("feedback", `String (keeper_feedback_log_path ctx.config m.name));

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -532,7 +532,7 @@ let handle_keeper_status ctx args : tool_result =
            ("storage_paths", `Assoc [
              ("meta", `String (keeper_meta_path ctx.config m.name));
              ("metrics", `String (Dated_jsonl.base_dir metrics_store));
-             ("metrics_legacy", `String metrics_path);
+             ("metrics_single_file", `String metrics_path);
              ("memory_bank", `String memory_bank_path);
              ("policy", `String (keeper_policy_log_path ctx.config m.name));
              ("feedback", `String (keeper_feedback_log_path ctx.config m.name));

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -127,7 +127,7 @@ let ensure_keeper_exists
       |> canonical_scope_kind
     in
     let trigger_mode =
-      profile_defaults.trigger_mode |> Option.value ~default:"legacy"
+      profile_defaults.trigger_mode |> Option.value ~default:"explicit_only"
       |> canonical_trigger_mode
     in
     let mention_targets =
@@ -336,4 +336,3 @@ let apply_settings_update
         | Error e -> Log.Keeper.warn "write_meta failed (settings): %s" e)
      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"write_meta (settings) failed" exn);
     updated
-

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -33,7 +33,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   let trigger_mode =
     p.trigger_mode_opt
     |> first_some p.profile_defaults.trigger_mode
-    |> Option.value ~default:"legacy"
+    |> Option.value ~default:"explicit_only"
     |> canonical_trigger_mode
   in
   let requested_models =

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -103,7 +103,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     |> first_some
          (if String.trim old.trigger_mode <> "" then Some old.trigger_mode else None)
     |> first_some p.profile_defaults.trigger_mode
-    |> Option.value ~default:"legacy"
+    |> Option.value ~default:"explicit_only"
     |> canonical_trigger_mode
   in
   let mention_targets =
@@ -199,16 +199,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
         p.presence_keepalive_sec_opt;
     proactive_enabled =
       Option.value
-        ~default:
-          (Option.value
-             ~default:
-               (if
-                  trigger_mode
-                  |> Keeper_contract.trigger_mode_of_string
-                  |> Keeper_contract.trigger_mode_is_explicit_only
-                then false
-                else old.proactive_enabled)
-             p.profile_defaults.proactive_enabled)
+        ~default:old.proactive_enabled
         p.proactive_enabled_opt;
     proactive_idle_sec =
       Option.value ~default:old.proactive_idle_sec p.proactive_idle_sec_opt

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -263,7 +263,8 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       Safe_ops.json_string ~default:"current" "room_scope" json |> canonical_room_scope
     in
     let trigger_mode =
-      Safe_ops.json_string ~default:"legacy" "trigger_mode" json |> canonical_trigger_mode
+      Safe_ops.json_string ~default:"explicit_only" "trigger_mode" json
+      |> canonical_trigger_mode
     in
     let mention_targets =
       Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
@@ -670,12 +671,25 @@ let persistent_agent_names ?resident_names config =
       |> List.filter (fun name -> not (List.mem name resident))
       |> List.sort String.compare
 
+let sync_registered_resident_keeper_from_meta config (meta : keeper_meta) :
+    (unit, string) result =
+  match read_resident_keeper config meta.name with
+  | Ok None -> Ok ()
+  | Ok (Some _) -> register_resident_keeper_from_meta config meta
+  | Error e -> Error e
+
 let write_meta config (m : keeper_meta) : (unit, string) result =
   let path = keeper_meta_path config m.name in
   let content = Yojson.Safe.pretty_to_string (meta_to_json m) in
   try
     Fs_compat.save_file path content;
-    Ok ()
+    (match sync_registered_resident_keeper_from_meta config m with
+     | Ok () -> Ok ()
+     | Error e ->
+         Error
+           (Printf.sprintf
+              "meta written but resident sync failed for %s: %s"
+              m.name e))
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -159,7 +159,7 @@ let canonical_scope_kind = function
 
 let canonical_trigger_mode = function
   | "explicit_only" -> "explicit_only"
-  | _ -> "legacy"
+  | _ -> "explicit_only"
 
 let canonical_policy_mode = function
   | "learned_offline_v1" -> "learned_offline_v1"
@@ -343,7 +343,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
            |> Option.map canonical_policy_shell_mode;
          room_scope = str "room_scope";
          scope_kind = str "scope_kind";
-         trigger_mode = str "trigger_mode";
+         trigger_mode =
+           str "trigger_mode"
+           |> Option.map canonical_trigger_mode;
          mention_targets = strs "mention_targets";
          presence_keepalive = bool_ "presence_keepalive";
          presence_keepalive_sec = int_ "presence_keepalive_sec";
@@ -447,7 +449,9 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   |> Option.map canonical_policy_shell_mode;
                 room_scope = Safe_ops.json_string_opt "room_scope" keeper_json;
                 scope_kind = Safe_ops.json_string_opt "scope_kind" keeper_json;
-                trigger_mode = Safe_ops.json_string_opt "trigger_mode" keeper_json;
+                trigger_mode =
+                  Safe_ops.json_string_opt "trigger_mode" keeper_json
+                  |> Option.map canonical_trigger_mode;
                 mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                 presence_keepalive = Safe_ops.json_bool_opt "presence_keepalive" keeper_json;
                 presence_keepalive_sec = Safe_ops.json_int_opt "presence_keepalive_sec" keeper_json;
@@ -535,4 +539,3 @@ let session_base_dir (config : Room.config) =
 
 let keeper_agent_name name =
   Printf.sprintf "keeper-%s-agent" name
-

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -70,7 +70,7 @@ let maybe_append_keeper_fallback_models (models : string list) =
 let ensure_api_keys_for_labels (labels : string list) : (unit, string) result =
   Oas_model_resolve.ensure_api_keys_for_labels labels
 
-(** Legacy single-file metrics path (for fallback reads). *)
+(** Single-file metrics path kept for fallback reads. *)
 let keeper_metrics_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")
 

--- a/lib/tool_housekeep.ml
+++ b/lib/tool_housekeep.ml
@@ -19,7 +19,7 @@ let classify_path path =
   let base = Filename.basename path in
   let dir = Filename.basename (Filename.dirname path) in
   if Filename.check_suffix base ".json" && dir = "perpetual-keepers" then "keeper_meta"
-  else if Filename.check_suffix base ".metrics.jsonl" then "keeper_metrics_legacy"
+  else if Filename.check_suffix base ".metrics.jsonl" then "keeper_metrics_single_file"
   else if Filename.check_suffix base ".memory.jsonl" then "keeper_memory"
   else if Filename.check_suffix base ".policy.jsonl" then "keeper_policy"
   else if Filename.check_suffix base ".feedback.jsonl" then "keeper_feedback"

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -111,7 +111,7 @@ let handle_resident_keeper_up ctx args : tool_result =
 
 let handle_resident_keeper_status ctx args : tool_result =
   let name = get_string args "name" "" in
-  if validate_name name then maybe_promote_live_legacy_keeper ctx.config name;
+  if validate_name name then maybe_promote_live_persistent_keeper ctx.config name;
   match read_resident_keeper ctx.config name with
   | Error e -> (false, "❌ " ^ e)
   | Ok None -> (false, Printf.sprintf "resident keeper not found: %s" name)
@@ -152,7 +152,7 @@ let inject_goal_from_message args =
 
 let handle_resident_keeper_msg ctx args : tool_result =
   let name = get_string args "name" "" in
-  if validate_name name then maybe_promote_live_legacy_keeper ctx.config name;
+  if validate_name name then maybe_promote_live_persistent_keeper ctx.config name;
   let ensure_result =
     match read_resident_keeper ctx.config name with
     | Ok (Some _) -> Ok ()
@@ -186,7 +186,7 @@ let handle_resident_keeper_msg ctx args : tool_result =
 
 let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   let name = get_string args "name" "" in
-  if validate_name name then maybe_promote_live_legacy_keeper ctx.config name;
+  if validate_name name then maybe_promote_live_persistent_keeper ctx.config name;
   let ensure_result =
     match read_resident_keeper ctx.config name with
     | Ok (Some _) -> Ok ()

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -148,8 +148,8 @@ let test_start_discussion_action () =
   in
   let s = Keeper_deliberation.deliberation_action_to_string action in
   Alcotest.(check bool) "contains topic" true (contains_s s "architecture");
-  let legacy = Keeper_deliberation.deliberation_action_to_legacy_string action in
-  Alcotest.(check string) "legacy label" "start_discussion" legacy
+  let policy_label = Keeper_deliberation.deliberation_action_to_policy_label action in
+  Alcotest.(check string) "policy label" "start_discussion" policy_label
 
 let test_share_finding_action () =
   let action =

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -94,23 +94,23 @@ let test_triage_multiple_triggers () =
 
 (* ---------- Action type tests ---------- *)
 
-let test_action_to_legacy_string_noop () =
-  check string "noop legacy" "noop"
-    (D.deliberation_action_to_legacy_string (D.Noop "test"))
+let test_action_to_policy_label_noop () =
+  check string "noop policy label" "noop"
+    (D.deliberation_action_to_policy_label (D.Noop "test"))
 
-let test_action_to_legacy_string_reply () =
-  check string "reply legacy" "reply_in_room"
-    (D.deliberation_action_to_legacy_string
+let test_action_to_policy_label_reply () =
+  check string "reply policy label" "reply_in_room"
+    (D.deliberation_action_to_policy_label
        (D.ReplyInRoom { room_id = "r1"; content = "hello" }))
 
-let test_action_to_legacy_string_board_post () =
-  check string "board_post legacy" "board_post"
-    (D.deliberation_action_to_legacy_string
+let test_action_to_policy_label_board_post () =
+  check string "board_post policy label" "board_post"
+    (D.deliberation_action_to_policy_label
        (D.BoardPost { content = "test"; hearth = None }))
 
-let test_action_to_legacy_string_task_claim () =
-  check string "task_claim legacy" "task_claim"
-    (D.deliberation_action_to_legacy_string
+let test_action_to_policy_label_task_claim () =
+  check string "task_claim policy label" "task_claim"
+    (D.deliberation_action_to_policy_label
        (D.TaskClaim { task_id = "t-1"; reason = "needed" }))
 
 let test_action_to_json_roundtrip () =
@@ -785,14 +785,14 @@ let () =
         ] );
       ( "actions",
         [
-          test_case "noop to legacy string" `Quick
-            test_action_to_legacy_string_noop;
-          test_case "reply to legacy string" `Quick
-            test_action_to_legacy_string_reply;
-          test_case "board_post to legacy string" `Quick
-            test_action_to_legacy_string_board_post;
-          test_case "task_claim to legacy string" `Quick
-            test_action_to_legacy_string_task_claim;
+          test_case "noop to policy label" `Quick
+            test_action_to_policy_label_noop;
+          test_case "reply to policy label" `Quick
+            test_action_to_policy_label_reply;
+          test_case "board_post to policy label" `Quick
+            test_action_to_policy_label_board_post;
+          test_case "task_claim to policy label" `Quick
+            test_action_to_policy_label_task_claim;
           test_case "action to json roundtrip" `Quick
             test_action_to_json_roundtrip;
           test_case "noop to json preserves reason" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -367,15 +367,15 @@ let test_keeper_shell_tool_policy_gates () =
       ~policy_mode:"model_deliberation" ()
   in
   check_keeper_shell_tool_presence "heuristic" heuristic
-    ~expect_bash:true ~expect_shell_readonly:true;
+    ~expect_bash:false ~expect_shell_readonly:true;
   check_keeper_shell_tool_presence "learned disabled" learned_disabled
     ~expect_bash:false ~expect_shell_readonly:false;
   check_keeper_shell_tool_presence "learned readonly" learned_readonly
     ~expect_bash:false ~expect_shell_readonly:true;
   check_keeper_shell_tool_presence "explicit event" explicit_event
-    ~expect_bash:true ~expect_shell_readonly:true;
+    ~expect_bash:false ~expect_shell_readonly:true;
   check_keeper_shell_tool_presence "model deliberation" deliberation
-    ~expect_bash:true ~expect_shell_readonly:true
+    ~expect_bash:false ~expect_shell_readonly:true
 
 let test_keeper_shell_readonly_enforces_allowed_paths () =
   Eio_main.run @@ fun _env ->
@@ -477,7 +477,7 @@ let test_keeper_bash_requires_cmd_and_runs () =
           ~input:
             (`Assoc
               [
-                ("cmd", `String "exit 7");
+                ("cmd", `String "python3 -c 'raise SystemExit(7)'");
                 ("timeout_sec", `Float 5.0);
               ])
         |> parse_json_exn
@@ -1178,6 +1178,150 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
       check string "resident voice channel" expected_channel
         Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string))
 
+let test_keeper_up_update_preserves_proactive_when_omitted () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "buddy";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+      in
+      let create_args =
+        `Assoc
+          [
+            ("name", `String "buddy");
+            ("goal", `String "Stay focused");
+            ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+            ("presence_keepalive", `Bool false);
+            ("proactive_enabled", `Bool true);
+          ]
+      in
+      let create_parsed =
+        match Masc_mcp.Keeper_turn_up_args.parse keeper_ctx create_args with
+        | Ok parsed -> parsed
+        | Error (_, msg) -> fail ("failed to parse create args: " ^ msg)
+      in
+      let ok, _ =
+        Masc_mcp.Keeper_turn_up_create.create_keeper keeper_ctx create_parsed
+      in
+      check bool "initial keeper create ok" true ok;
+      let old_meta =
+        match Masc_mcp.Keeper_types.read_meta config "buddy" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after initial create"
+        | Error e -> fail e
+      in
+      check string "initial trigger mode" "explicit_only" old_meta.trigger_mode;
+      check bool "initial proactive" true old_meta.proactive_enabled;
+      let parsed0 =
+        match
+          Masc_mcp.Keeper_turn_up_args.parse keeper_ctx
+            (`Assoc
+              [
+                ("name", `String "buddy");
+                ("goal", `String "Updated buddy goal");
+              ])
+        with
+        | Ok parsed -> parsed
+        | Error (_, msg) -> fail ("failed to parse update args: " ^ msg)
+      in
+      let parsed =
+        {
+          parsed0 with
+          profile_defaults =
+            {
+              parsed0.profile_defaults with
+              proactive_enabled = Some false;
+            };
+        }
+      in
+      let ok, _ =
+        Masc_mcp.Keeper_turn_up_update.update_keeper keeper_ctx parsed old_meta
+      in
+      check bool "update keeper ok" true ok;
+      let updated_meta =
+        match Masc_mcp.Keeper_types.read_meta config "buddy" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta after update"
+        | Error e -> fail e
+      in
+      check string "trigger mode preserved" "explicit_only" updated_meta.trigger_mode;
+      check bool "proactive preserved when omitted" true updated_meta.proactive_enabled)
+
+let test_write_meta_syncs_registered_resident_seed () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "buddy";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "buddy");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool true);
+            ])
+      in
+      check bool "resident keeper up ok" true ok;
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "buddy" with
+        | Ok (Some value) -> value
+        | Ok None -> fail "missing keeper meta after resident keeper up"
+        | Error e -> fail e
+      in
+      let updated_meta =
+        {
+          meta with
+          proactive_enabled = false;
+          voice_enabled = false;
+          voice_channel = "text_only";
+          voice_agent_id = "";
+          updated_at = Masc_mcp.Keeper_types.now_iso ();
+        }
+      in
+      (match Masc_mcp.Keeper_types.write_meta config updated_meta with
+       | Ok () -> ()
+       | Error e -> fail ("write_meta failed: " ^ e));
+      let resident_path =
+        Filename.concat base_dir ".masc/resident-keepers/buddy.json"
+      in
+      check bool "resident spec exists" true (Sys.file_exists resident_path);
+      let resident_json = Yojson.Safe.from_file resident_path in
+      check bool "resident voice disabled sync" false
+        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
+      check string "resident voice channel sync" "text_only"
+        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string);
+      check string "resident voice agent id sync" ""
+        Yojson.Safe.Util.(resident_json |> member "voice_agent_id" |> to_string);
+      check bool "seed proactive sync" false
+        Yojson.Safe.Util.(
+          resident_json |> member "seed_meta" |> member "proactive_enabled" |> to_bool);
+      check string "seed trigger mode sync" "explicit_only"
+        Yojson.Safe.Util.(
+          resident_json |> member "seed_meta" |> member "trigger_mode" |> to_string))
+
 let test_keeper_policy_set_accepts_explicit_event_v1 () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1339,6 +1483,10 @@ let () =
            test_keeper_policy_set_rejects_invalid_mode;
          test_case "sangsu defaults explicit voice policy" `Quick
            test_keeper_up_defaults_sangsu_to_explicit_voice_policy;
+         test_case "keeper up update preserves proactive when omitted" `Quick
+           test_keeper_up_update_preserves_proactive_when_omitted;
+         test_case "write_meta syncs registered resident seed" `Quick
+           test_write_meta_syncs_registered_resident_seed;
          test_case "policy set accepts explicit_event_v1" `Quick
            test_keeper_policy_set_accepts_explicit_event_v1;
          test_case "resident bootstrap marks stale explicit keeper" `Quick


### PR DESCRIPTION
## Summary
- remove keeper `legacy` trigger mode handling and normalize keeper state to `explicit_only`
- sync resident keeper seed metadata from persisted keeper meta writes to stop reboot regressions
- rename remaining keeper-scope legacy labels and update tests/docs/runtime state

## Verification
- env DUNE_CACHE=disabled dune exec --root . test/test_tool_keeper.exe
- env DUNE_CACHE=disabled dune exec --root . test/test_keeper_deliberation.exe
- env DUNE_CACHE=disabled dune exec --root . test/test_autonomy_liberation.exe