### PR TITLE
fix(keeper): restore auto team session bridge for keeper_msg

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -2,6 +2,8 @@
 
 open Keeper_types
 
+let auto_team_session_enabled (_meta : keeper_meta) = true
+
 let linked_team_session config (meta : keeper_meta) =
   match meta.active_team_session_id with
   | Some session_id -> Team_session_store.load_session config session_id
@@ -24,7 +26,7 @@ let team_session_bridge_json config (meta : keeper_meta) =
   in
   `Assoc
     [
-      ("enabled", `Bool false);
+      ("enabled", `Bool (auto_team_session_enabled meta));
       ("active_session_id",
        match meta.active_team_session_id with
        | Some session_id -> `String session_id

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -485,7 +485,7 @@ let handle_keeper_status ctx args : tool_result =
              ("context_mode", `String "board_snapshot");
              ("post_ttl_hours", `Int 24);
            ]);
-           ("auto_team_session_enabled", `Bool false);
+           ("auto_team_session_enabled", `Bool (auto_team_session_enabled m));
            ("active_team_session_id",
              match m.active_team_session_id with
              | Some session_id -> `String session_id

--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -275,28 +275,24 @@ let append_keeper_auto_team_session_note (ctx : _ context) (meta : keeper_meta)
 let maybe_handle_auto_team_session (ctx : _ context) (meta : keeper_meta)
     (message : string) :
     ((tool_result option * keeper_meta), string) result =
-  if true then
-    Ok (None, meta)
-  else
-    let linked_meta, running_session = running_session_for_keeper ctx.config meta in
-    match running_session with
-    | Some session -> (
-        match append_keeper_auto_team_session_note ctx linked_meta session message with
-        | Error err -> Error err
-        | Ok session' ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
-    | None -> (
-        match start_keeper_auto_team_session ctx linked_meta message with
-        | Error err -> Error err
-        | Ok (updated_meta, session, spawn_error) ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:updated_meta ~session ~created:true ~reused:false
-                ?spawn_error ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))
-
+  let linked_meta, running_session = running_session_for_keeper ctx.config meta in
+  match running_session with
+  | Some session -> (
+      match append_keeper_auto_team_session_note ctx linked_meta session message with
+      | Error err -> Error err
+      | Ok session' ->
+          let json =
+            keeper_auto_team_session_response_json
+              ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
+          in
+          Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
+  | None -> (
+      match start_keeper_auto_team_session ctx linked_meta message with
+      | Error err -> Error err
+      | Ok (updated_meta, session, spawn_error) ->
+          let json =
+            keeper_auto_team_session_response_json
+              ~meta:updated_meta ~session ~created:true ~reused:false
+              ?spawn_error ()
+          in
+          Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -277,7 +277,6 @@ let test_keeper_msg_auto_team_session_bridge () =
         | Ok None -> Alcotest.fail "keeper meta missing after keeper_msg"
         | Error err -> Alcotest.fail ("meta read failed: " ^ err)
       in
-      (* auto_team_session_enabled field removed *)
       Alcotest.(check (option string)) "linked session id"
         (Some session_id) meta.active_team_session_id;
       Alcotest.(check int) "start count" 1 meta.team_session_start_count_total;
@@ -296,10 +295,13 @@ let test_keeper_msg_auto_team_session_bridge () =
       in
       Alcotest.(check bool) "keeper status ok" true status_ok;
       let status_json = parse_json_exn status_body in
-      Alcotest.(check bool) "status exposes opt-in" false
+      Alcotest.(check bool) "status exposes auto team session enabled" true
         Yojson.Safe.Util.(status_json |> member "auto_team_session_enabled" |> to_bool);
       Alcotest.(check string) "status exposes running bridge" "running"
         Yojson.Safe.Util.(status_json |> member "team_session_state" |> to_string);
+      Alcotest.(check bool) "status exposes bridge enabled" true
+        Yojson.Safe.Util.(
+          status_json |> member "team_session_bridge" |> member "enabled" |> to_bool);
       let events = Team_session_store.read_recent_events config session_id ~max_count:10 in
       let note_events =
         List.filter


### PR DESCRIPTION
## Summary

Closes #2698

Restore the `masc_keeper_msg` auto team-session bridge path that had been short-circuited on `main`.
Expose the restored bridge as enabled in keeper status output so operator control sees the same state the runtime uses.

## Changes

- re-enable `maybe_handle_auto_team_session` for `keeper_msg`
- report `auto_team_session_enabled=true` and `team_session_bridge.enabled=true`
- update the operator-control keeper bridge assertion to match the restored behavior

## Verification

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/operator-control-keeper-msg-revive`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/operator-control-keeper-msg-revive test/test_operator_control.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/operator-control-keeper-msg-revive test/test_tool_keeper.exe`
