### PR TITLE
fix: trim agent and keeper tool surfaces

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -62,10 +62,7 @@ let spawned_agent_public_tool_names : string list =
     "masc_board_comment";
     "masc_board_vote";
     "masc_board_get";
-    "masc_tool_stats";
     "masc_tool_help";
-    "masc_tool_admin_snapshot";
-    "masc_keeper_tool_catalog";
     (* masc_tool_list, masc_tool_grant, masc_tool_revoke removed:
        no matching schema found (dead entries) *)
     "masc_portal_open";
@@ -78,12 +75,7 @@ let spawned_agent_public_tool_names : string list =
     "masc_team_session_finalize";
     "masc_team_session_stop";
     "masc_team_session_report";
-    "masc_team_session_prove";
     "masc_team_session_list";
-    "masc_team_session_compare";
-    "masc_operator_snapshot";
-    "masc_operator_action";
-    "masc_operator_confirm";
     "masc_a2a_delegate";
     "masc_a2a_subscribe";
     "masc_poll_events";
@@ -94,7 +86,6 @@ let spawned_agent_public_tool_names : string list =
     "masc_run_deliverable";
     "masc_run_get";
     "masc_spawn";
-    "masc_heartbeat_list";
     (* masc_trpg_dice_roll, masc_trpg_turn_advance, masc_trpg_stream,
        masc_trpg_round_run removed: legacy aliases deprecated in
        Tool_protocol_game_view; use canonical trpg.* names instead *)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -32,6 +32,9 @@ let keeper_read_tool_names =
     "keeper_context_status";
   ]
 
+let keeper_coordination_tool_names =
+  [ "keeper_tasks_list"; "keeper_broadcast" ]
+
 let keeper_board_tool_names =
   [
     "keeper_board_get";
@@ -64,16 +67,28 @@ let is_research_profile (meta : keeper_meta) =
 
 let keeper_coding_tool_names = Tool_code_write.tool_names
 
-(** masc_* tool bridge — expose all MCP tools to keeper.
+(** Curated masc_* bridge for keepers.
     Schema list is injected at server init to avoid cyclic dependency on Tools.
-    All masc_* tools are exposed; no Mode-based filtering. *)
+    Keep raw masc_* passthrough minimal and prefer keeper_* wrappers elsewhere. *)
+
+let keeper_passthrough_masc_tool_names =
+  [
+    "masc_status";
+    "masc_who";
+    "masc_messages";
+    "masc_poll_events";
+    "masc_relay_status";
+    "masc_relay_checkpoint";
+  ]
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []
 
 let inject_masc_schemas (schemas : Types.tool_schema list) =
   masc_schemas_ref :=
     List.filter (fun (s : Types.tool_schema) ->
-      String.starts_with ~prefix:"masc_" s.name) schemas
+      String.starts_with ~prefix:"masc_" s.name
+      && List.mem s.name keeper_passthrough_masc_tool_names)
+      schemas
 
 let keeper_masc_tool_names (_meta : keeper_meta) : string list =
   !masc_schemas_ref
@@ -90,7 +105,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
   if write_done then
     []
   else if keeper_policy_mode_is_learned meta then
-    let base = keeper_read_tool_names in
+    let base = keeper_coordination_tool_names @ keeper_read_tool_names in
     let with_voice =
       if meta.policy_voice_enabled then keeper_voice_tool_names @ base else base
     in

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -7,14 +7,18 @@ val keeper_allowed_tool_names : ?write_done:bool -> keeper_meta -> string list
 val keeper_allowed_model_tools :
   ?write_done:bool -> keeper_meta -> Types.tool_schema list
 
-(** Inject masc_* schemas for keeper profile-based tool filtering.
+(** Curated masc_* passthrough names exposed to keepers.
+    Prefer keeper_* wrappers for common flows and keep this bridge small. *)
+val keeper_passthrough_masc_tool_names : string list
+
+(** Inject curated masc_* schemas for keeper profile-based tool filtering.
     Must be called once during server initialization. *)
 val inject_masc_schemas : Types.tool_schema list -> unit
 
-(** masc_* tool names available for a keeper profile. *)
+(** Curated masc_* tool names available for a keeper profile. *)
 val keeper_masc_tool_names : keeper_meta -> string list
 
-(** masc_* tool schemas available for a keeper profile. *)
+(** Curated masc_* tool schemas available for a keeper profile. *)
 val keeper_masc_tool_schemas : keeper_meta -> Types.tool_schema list
 
 val execute_keeper_tool_call :

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -1,36 +1,58 @@
 (** Test keeper masc_* tool bridge — verifies schema injection
-    and dispatch passthrough expose all masc_* tools to keeper.
-    No Mode filtering — all masc_* tools are exposed. *)
+    and dispatch passthrough expose only the curated keeper bridge. *)
 
 module KET = Masc_mcp.Keeper_exec_tools
 
-(** Verify inject_masc_schemas filters to masc_* only. *)
-let test_inject_filters_prefix () =
-  let schemas : Types.tool_schema list = [
-    { name = "masc_join"; description = ""; input_schema = `Assoc [] };
-    { name = "masc_broadcast"; description = ""; input_schema = `Assoc [] };
-    { name = "keeper_time_now"; description = ""; input_schema = `Assoc [] };
-  ] in
+let make_meta ?(policy_mode = "learned_offline_v1") () =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc
+      [
+        ("name", `String "keeper-bridge-test");
+        ("agent_name", `String "keeper-bridge-test");
+        ("trace_id", `String "keeper-bridge-trace");
+        ("policy_mode", `String policy_mode);
+      ])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith e
+
+(** Verify inject_masc_schemas filters to the curated keeper allowlist. *)
+let test_inject_filters_allowlist () =
+  let schemas : Types.tool_schema list =
+    [
+      { name = "masc_status"; description = ""; input_schema = `Assoc [] };
+      { name = "masc_broadcast"; description = ""; input_schema = `Assoc [] };
+      { name = "masc_messages"; description = ""; input_schema = `Assoc [] };
+      { name = "keeper_time_now"; description = ""; input_schema = `Assoc [] };
+    ]
+  in
   KET.inject_masc_schemas schemas;
   let dummy_meta = Obj.magic () in
   let names = KET.keeper_masc_tool_names dummy_meta in
-  Alcotest.(check int) "2 masc tools (keeper_ filtered)" 2 (List.length names);
-  Alcotest.(check bool) "has masc_join" true (List.mem "masc_join" names);
-  Alcotest.(check bool) "no keeper_time_now" false (List.mem "keeper_time_now" names)
+  Alcotest.(check int) "2 curated masc tools" 2 (List.length names);
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "has masc_messages" true (List.mem "masc_messages" names);
+  Alcotest.(check bool) "no masc_broadcast" false (List.mem "masc_broadcast" names);
+  Alcotest.(check bool) "no keeper_time_now" false
+    (List.mem "keeper_time_now" names)
 
 (** Verify dispatch passthrough returns None for unregistered tools. *)
 let test_dispatch_unregistered () =
-  let result = Masc_mcp.Tool_dispatch.dispatch
-    ~name:"masc_nonexistent_xyz" ~args:(`Assoc []) in
+  let result =
+    Masc_mcp.Tool_dispatch.dispatch ~name:"masc_nonexistent_xyz" ~args:(`Assoc [])
+  in
   Alcotest.(check bool) "unregistered returns None" true (result = None)
 
-(** Verify real schemas injection produces 200+ masc tools. *)
-let test_inject_real_schemas_count () =
+(** Verify real schemas injection matches the curated keeper allowlist. *)
+let test_inject_real_schemas_match_curated_names () =
   KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
   let dummy_meta = Obj.magic () in
   let names = KET.keeper_masc_tool_names dummy_meta in
-  Printf.printf "  keeper sees %d masc_* tools\n" (List.length names);
-  Alcotest.(check bool) "at least 200 masc tools" true (List.length names >= 200)
+  let expected =
+    List.sort String.compare KET.keeper_passthrough_masc_tool_names
+  in
+  let actual = List.sort String.compare names in
+  Alcotest.(check (list string)) "curated passthrough names" expected actual
 
 (** Verify schemas and names are consistent. *)
 let test_schemas_match_names () =
@@ -40,30 +62,53 @@ let test_schemas_match_names () =
   let schemas = KET.keeper_masc_tool_schemas dummy_meta in
   Alcotest.(check int) "count matches"
     (List.length names) (List.length schemas);
-  List.iter (fun (s : Types.tool_schema) ->
-    Alcotest.(check bool) (s.name ^ " in names") true
-      (List.mem s.name names)) schemas
+  List.iter
+    (fun (s : Types.tool_schema) ->
+      Alcotest.(check bool) (s.name ^ " in names") true
+        (List.mem s.name names))
+    schemas
 
-(** Verify all tools have masc_ prefix. *)
+(** Verify all bridged tools still have masc_ prefix. *)
 let test_all_have_prefix () =
   KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
   let dummy_meta = Obj.magic () in
   let names = KET.keeper_masc_tool_names dummy_meta in
-  List.iter (fun name ->
-    Alcotest.(check bool) (name ^ " has masc_ prefix") true
-      (String.starts_with ~prefix:"masc_" name)) names
+  List.iter
+    (fun name ->
+      Alcotest.(check bool) (name ^ " has masc_ prefix") true
+        (String.starts_with ~prefix:"masc_" name))
+    names
+
+let test_allowed_tools_use_curated_bridge () =
+  KET.inject_masc_schemas Masc_mcp.Tools.all_schemas_extended;
+  let meta = make_meta () in
+  let names = KET.keeper_allowed_tool_names meta in
+  Alcotest.(check bool) "has masc_messages" true (List.mem "masc_messages" names);
+  Alcotest.(check bool) "has masc_status" true (List.mem "masc_status" names);
+  Alcotest.(check bool) "omits masc_join" false (List.mem "masc_join" names);
+  Alcotest.(check bool) "omits masc_broadcast" false
+    (List.mem "masc_broadcast" names)
 
 let () =
-  Alcotest.run "Keeper masc bridge" [
-    ("injection", [
-      Alcotest.test_case "filters to masc_ prefix" `Quick test_inject_filters_prefix;
-      Alcotest.test_case "real schemas 200+" `Quick test_inject_real_schemas_count;
-    ]);
-    ("dispatch", [
-      Alcotest.test_case "unregistered returns None" `Quick test_dispatch_unregistered;
-    ]);
-    ("consistency", [
-      Alcotest.test_case "schemas match names" `Quick test_schemas_match_names;
-      Alcotest.test_case "all have masc_ prefix" `Quick test_all_have_prefix;
-    ]);
-  ]
+  Alcotest.run "Keeper masc bridge"
+    [
+      ( "injection",
+        [
+          Alcotest.test_case "filters to curated allowlist" `Quick
+            test_inject_filters_allowlist;
+          Alcotest.test_case "real schemas match curated list" `Quick
+            test_inject_real_schemas_match_curated_names;
+        ] );
+      ( "dispatch",
+        [
+          Alcotest.test_case "unregistered returns None" `Quick
+            test_dispatch_unregistered;
+        ] );
+      ( "consistency",
+        [
+          Alcotest.test_case "schemas match names" `Quick test_schemas_match_names;
+          Alcotest.test_case "all have masc_ prefix" `Quick test_all_have_prefix;
+          Alcotest.test_case "allowed tools use curated bridge" `Quick
+            test_allowed_tools_use_curated_bridge;
+        ] );
+    ]

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -164,6 +164,14 @@ let test_learned_mode_has_read_tools () =
   check bool "has keeper_fs_read" true (has_tool "keeper_fs_read" tools);
   check bool "has keeper_library_search" true (has_tool "keeper_library_search" tools)
 
+let test_learned_mode_has_keeper_coordination_tools () =
+  let meta = make_meta ~policy_mode:"learned_offline_v1" () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "has keeper_tasks_list" true
+    (has_tool "keeper_tasks_list" tools);
+  check bool "has keeper_broadcast" true
+    (has_tool "keeper_broadcast" tools)
+
 let test_normal_mode_uses_shard_tools () =
   let meta = make_meta ~policy_mode:"" () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
@@ -343,6 +351,8 @@ let () =
     ("learned_mode", [
       test_case "has board tools" `Quick test_learned_mode_has_board_tools;
       test_case "has read tools" `Quick test_learned_mode_has_read_tools;
+      test_case "has keeper coordination tools" `Quick
+        test_learned_mode_has_keeper_coordination_tools;
       test_case "normal mode uses shards" `Quick test_normal_mode_uses_shard_tools;
     ]);
     ("combined_profiles", [

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -122,14 +122,18 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains board_post" true
     (List.mem "mcp__masc__masc_board_post" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains tool_stats" true
+  Alcotest.(check bool) "omits tool_stats" false
     (List.mem "mcp__masc__masc_tool_stats" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains tool_help" true
     (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains tool_admin_snapshot" true
+  Alcotest.(check bool) "omits tool_admin_snapshot" false
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools);
-  Alcotest.(check bool) "contains keeper_tool_catalog" true
+  Alcotest.(check bool) "omits keeper_tool_catalog" false
     (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "omits operator_snapshot" false
+    (List.mem "mcp__masc__masc_operator_snapshot" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "omits team_session_prove" false
+    (List.mem "mcp__masc__masc_team_session_prove" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits tool_list (no schema)" false
     (List.mem "mcp__masc__masc_tool_list" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "omits tool_grant (no schema)" false

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -168,15 +168,15 @@ let test_masc_mcp_tools_has_tool_help () =
     (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_tool_stats () =
-  check bool "has tool_stats" true
+  check bool "omits tool_stats" false
     (List.mem "mcp__masc__masc_tool_stats" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_tool_admin_snapshot () =
-  check bool "has tool_admin_snapshot" true
+  check bool "omits tool_admin_snapshot" false
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_keeper_tool_catalog () =
-  check bool "has keeper_tool_catalog" true
+  check bool "omits keeper_tool_catalog" false
     (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools)
 
 let test_masc_mcp_tools_has_tool_list () =
@@ -731,10 +731,12 @@ let () =
       test_case "has a2a_delegate" `Quick test_masc_mcp_tools_has_a2a_delegate;
       test_case "has vote_create" `Quick test_masc_mcp_tools_has_vote_create;
       test_case "has run_deliverable" `Quick test_masc_mcp_tools_has_run_deliverable;
-      test_case "has tool_stats" `Quick test_masc_mcp_tools_has_tool_stats;
+      test_case "omits tool_stats" `Quick test_masc_mcp_tools_has_tool_stats;
       test_case "has tool_help" `Quick test_masc_mcp_tools_has_tool_help;
-      test_case "has tool_admin_snapshot" `Quick test_masc_mcp_tools_has_tool_admin_snapshot;
-      test_case "has keeper_tool_catalog" `Quick test_masc_mcp_tools_has_keeper_tool_catalog;
+      test_case "omits tool_admin_snapshot" `Quick
+        test_masc_mcp_tools_has_tool_admin_snapshot;
+      test_case "omits keeper_tool_catalog" `Quick
+        test_masc_mcp_tools_has_keeper_tool_catalog;
       test_case "has tool_list" `Quick test_masc_mcp_tools_has_tool_list;
       test_case "has tool_grant" `Quick test_masc_mcp_tools_has_tool_grant;
       test_case "has tool_revoke" `Quick test_masc_mcp_tools_has_tool_revoke;

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -56,6 +56,27 @@ let () =
                 Alcotest.failf
                   "dead passthrough entries (no matching schema): %s"
                   (String.concat ", " dead));
+          test_case "agent passthrough omits operator and diagnostics" `Quick
+            (fun () ->
+              let names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+              let banned =
+                [
+                  "masc_tool_stats";
+                  "masc_tool_admin_snapshot";
+                  "masc_keeper_tool_catalog";
+                  "masc_operator_snapshot";
+                  "masc_operator_action";
+                  "masc_operator_confirm";
+                  "masc_team_session_compare";
+                  "masc_team_session_prove";
+                  "masc_heartbeat_list";
+                ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " omitted from public agent surface") false
+                    (List.mem name names))
+                banned);
         ] );
       ( "tier_inclusion",
         [


### PR DESCRIPTION
## Summary
- trim spawned agent public surface by removing operator and diagnostic tools that are not meaningful for normal agent workflows
- replace keeper's blanket masc_* bridge with a curated passthrough list
- give learned keepers keeper_tasks_list and keeper_broadcast directly so routine coordination stays on keeper_* wrappers

## Testing
- dune exec --root . ./test/test_keeper_masc_bridge.exe
- dune exec --root . ./test/test_keeper_tool_exposure.exe
- dune exec --root . ./test/test_tool_exposure.exe
- dune exec --root . ./test/test_spawn.exe
- dune exec --root . ./test/test_spawn_coverage.exe