### PR TITLE
Align keeper context and review flow with PR814

### DIFF
--- a/data/chains/deep-research.json
+++ b/data/chains/deep-research.json
@@ -32,13 +32,21 @@
       "output_key": "search_results"
     },
     {
+      "id": "search-results-grep",
+      "type": "adapter",
+      "input_ref": "search_results",
+      "transform": { "type": "custom", "name": "grep_projection" },
+      "depends_on": ["web-search"],
+      "output_key": "search_results_grep"
+    },
+    {
       "id": "extract-facts",
       "type": "model",
       "model": {
         "model": "claude-cli",
-        "prompt": "Extract key facts from these search results. For each fact, note the source.\n\nSearch Results:\n{{search_results}}\n\nOutput as JSON: {\"facts\": [{\"claim\": \"...\", \"source\": \"...\", \"confidence\": 0.0-1.0}]}"
+        "prompt": "Extract key facts from these grep-like search result lines. For each fact, note the exact source/location line that supports it.\n\nSearch Results:\n{{search_results_grep}}\n\nOutput as JSON: {\"facts\": [{\"claim\": \"...\", \"source\": \"...\", \"confidence\": 0.0-1.0}]}"
       },
-      "depends_on": ["web-search"],
+      "depends_on": ["search-results-grep"],
       "output_key": "extracted_facts"
     },
     {

--- a/data/chains/pr-review-pipeline.json
+++ b/data/chains/pr-review-pipeline.json
@@ -65,13 +65,31 @@
       "output_key": "doc_review"
     },
     {
+      "id": "structural-review",
+      "type": "spawn",
+      "clean": true,
+      "pass_vars": ["pr_diff", "changed_files"],
+      "inherit_cache": false,
+      "depends_on": ["fetch-pr-diff", "fetch-pr-files"],
+      "inner": {
+        "id": "structural-review-inner",
+        "type": "model",
+        "model": {
+          "model": "codex",
+          "prompt": "You are a fresh-context structural reviewer. You do NOT know the product intent, JIRA history, or prior discussion. Review only what is visible in the changed files list and diff.\n\nChanged files:\n{{changed_files}}\n\nDiff:\n```\n{{pr_diff}}\n```\n\nCheck only for:\n1. Missing error paths or cleanup\n2. Interface/contract mismatches\n3. Unhandled branches or obvious test blind spots\n4. Resource or concurrency hazards\n5. Scope creep hidden in unrelated files\n\nReturn JSON: {\"structural_findings\": [{\"severity\": \"high|medium|low\", \"category\": \"error_path|contract|branch|resource|concurrency|scope\", \"location\": \"path:line\", \"evidence\": \"...\"}], \"summary\": \"...\", \"no_findings\": true|false}",
+          "thinking": false
+        },
+        "output_key": "structural_findings"
+      }
+    },
+    {
       "id": "synthesize-review",
       "type": "model",
       "model": {
         "model": "claude-cli",
-        "prompt": "Synthesize a comprehensive PR review from these analyses:\n\nComplexity Analysis:\n{{complexity_analysis}}\n\nTest Coverage:\n{{test_coverage}}\n\nSecurity Findings:\n{{security_findings}}\n\nDocumentation Review:\n{{doc_review}}\n\nGenerate a PR review comment in markdown with:\n1. **Summary** (1-2 sentences)\n2. **Verdict** (APPROVE / REQUEST_CHANGES / COMMENT)\n3. **Critical Issues** (must fix before merge)\n4. **Suggestions** (nice to have)\n5. **Kudos** (things done well)\n\nBe constructive and specific."
+        "prompt": "Synthesize a comprehensive PR review from these analyses:\n\nComplexity Analysis:\n{{complexity_analysis}}\n\nTest Coverage:\n{{test_coverage}}\n\nSecurity Findings:\n{{security_findings}}\n\nDocumentation Review:\n{{doc_review}}\n\nFresh-context Structural Findings:\n{{structural_findings}}\n\nGenerate a PR review comment in markdown with:\n1. **Summary** (1-2 sentences)\n2. **Verdict** (APPROVE / REQUEST_CHANGES / COMMENT)\n3. **Critical Issues** (must fix before merge)\n4. **Structural Risks** (fresh-context findings that may be easy to miss)\n5. **Suggestions** (nice to have)\n6. **Kudos** (things done well)\n\nBe constructive and specific."
       },
-      "depends_on": ["analyze-complexity", "check-test-coverage", "security-scan", "doc-check"],
+      "depends_on": ["analyze-complexity", "check-test-coverage", "security-scan", "doc-check", "structural-review"],
       "output_key": "final_review"
     }
   ],

--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -89,6 +89,15 @@ local fallback review helper:
 이 helper는 `.masc/review-cache/local-review/` 아래에 결과 cache를 남기고,
 동일 diff에 대한 concurrent review 요청은 single-flight로 합치며,
 stale pending reviewer PID가 있으면 정리한 뒤 다시 시작한다.
+기본 프롬프트는 fresh-context diff-only reviewer로 동작하므로,
+티켓/회의 맥락 없이도 structural risk를 따로 잡는 fallback gate로 본다.
+
+`pr-review-pipeline` canonical path도 clean-context structural stage를 포함한다.
+즉 review stack은 다음 3층으로 본다:
+
+- context-aware multi-check review
+- cross-model review evidence
+- fresh-context structural pass
 
 ## Autoresearch Wrapper
 

--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -312,7 +312,12 @@ Heuristic 분류는 ~80% 정확도를 보인다 (개발자 추정).
 |--------|------|
 | `Masc_cache` | 공유 컨텍스트 스토어 |
 | `Recent_broadcasts` | 방 내 최근 N개 broadcast |
-| `File_context` | 최근 수정 파일 (미구현, TODO) |
+| `File_context` | 최근 수정 파일 (mtime scan 기반 구현 완료) |
+
+Keeper turn path는 이것과 별도로 `git status --porcelain` delta를 추적한다.
+즉:
+- `File_context` = 최근 파일 내용을 recall source로 가져오는 것
+- live worktree delta = 지난 keeper turn 이후 바뀐 파일 목록을 다음 turn에 직접 주입하는 것
 
 ### 8.3 Configuration
 

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -297,33 +297,43 @@ let fetch_context_eio
 (** {1 Formatting} *)
 
 (** Format recall result as grep-like injection-ready text *)
+let metadata_string_opt (metadata : Yojson.Safe.t) key =
+  match metadata with
+  | `Assoc _ ->
+      metadata |> Yojson.Safe.Util.member key
+      |> Yojson.Safe.Util.to_string_option
+  | _ -> None
+
+let metadata_int_opt (metadata : Yojson.Safe.t) key =
+  match metadata with
+  | `Assoc _ ->
+      metadata |> Yojson.Safe.Util.member key
+      |> Yojson.Safe.Util.to_int_option
+  | _ -> None
+
 let grep_like_line_of_item (item : recall_item) =
   let source, location =
     match item.source with
     | Masc_cache ->
         let key =
-          item.metadata |> Yojson.Safe.Util.member "key"
-          |> Yojson.Safe.Util.to_string_option
+          metadata_string_opt item.metadata "key"
           |> Option.value ~default:"entry"
         in
         ("cache", key)
     | Recent_broadcasts ->
         let from_agent =
-          item.metadata |> Yojson.Safe.Util.member "from"
-          |> Yojson.Safe.Util.to_string_option
+          metadata_string_opt item.metadata "from"
           |> Option.value ~default:"agent"
         in
         let seq =
-          item.metadata |> Yojson.Safe.Util.member "seq"
-          |> Yojson.Safe.Util.to_int_option
+          metadata_int_opt item.metadata "seq"
           |> Option.map string_of_int
           |> Option.value ~default:"latest"
         in
         ("broadcast", Printf.sprintf "%s#%s" from_agent seq)
     | File_context ->
         let path =
-          item.metadata |> Yojson.Safe.Util.member "path"
-          |> Yojson.Safe.Util.to_string_option
+          metadata_string_opt item.metadata "path"
           |> Option.value ~default:"recent-file"
         in
         ("file", path)

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -296,19 +296,46 @@ let fetch_context_eio
 
 (** {1 Formatting} *)
 
-(** Format recall result as injection-ready text *)
+(** Format recall result as grep-like injection-ready text *)
+let grep_like_line_of_item (item : recall_item) =
+  let source, location =
+    match item.source with
+    | Masc_cache ->
+        let key =
+          item.metadata |> Yojson.Safe.Util.member "key"
+          |> Yojson.Safe.Util.to_string_option
+          |> Option.value ~default:"entry"
+        in
+        ("cache", key)
+    | Recent_broadcasts ->
+        let from_agent =
+          item.metadata |> Yojson.Safe.Util.member "from"
+          |> Yojson.Safe.Util.to_string_option
+          |> Option.value ~default:"agent"
+        in
+        let seq =
+          item.metadata |> Yojson.Safe.Util.member "seq"
+          |> Yojson.Safe.Util.to_int_option
+          |> Option.map string_of_int
+          |> Option.value ~default:"latest"
+        in
+        ("broadcast", Printf.sprintf "%s#%s" from_agent seq)
+    | File_context ->
+        let path =
+          item.metadata |> Yojson.Safe.Util.member "path"
+          |> Yojson.Safe.Util.to_string_option
+          |> Option.value ~default:"recent-file"
+        in
+        ("file", path)
+  in
+  Retrieval_projection.grep_like_line
+    ~source ~location ~content:item.content
+
 let format_for_injection (result : recall_result) : string =
   if result.items = [] then ""
   else
     let header = "=== Auto-Recalled Context ===" in
-    let items_str = List.map (fun item ->
-      let source_name = match item.source with
-        | Masc_cache -> "cache"
-        | Recent_broadcasts -> "broadcast"
-        | File_context -> "file"
-      in
-      Printf.sprintf "[%s] %s" source_name item.content
-    ) result.items in
+    let items_str = List.map grep_like_line_of_item result.items in
     let footer =
       if result.truncated then
         Printf.sprintf "=== (truncated, ~%d tokens) ===" result.total_tokens

--- a/lib/auto_recall.mli
+++ b/lib/auto_recall.mli
@@ -24,7 +24,7 @@
 type recall_source =
   | Masc_cache        (** Shared context store *)
   | Recent_broadcasts (** Last N broadcasts in room *)
-  | File_context      (** Recently touched files (TODO) *)
+  | File_context      (** Recently touched files from the current working tree *)
 
 (** Configuration for auto-recall *)
 type recall_config = {
@@ -124,7 +124,7 @@ val fetch_context_smart :
 
 (** {1 Formatting} *)
 
-(** Format recall result as injection-ready text.
+(** Format recall result as grep-like injection-ready text.
     Suitable for prepending to system prompts. *)
 val format_for_injection : recall_result -> string
 

--- a/lib/chain/chain_adapter_eio.ml
+++ b/lib/chain/chain_adapter_eio.ml
@@ -428,6 +428,8 @@ let rec apply_adapter_transform (transform : adapter_transform) (input : string)
        | "uppercase" -> Ok (String.uppercase_ascii input)
        | "lowercase" -> Ok (String.lowercase_ascii input)
        | "trim" -> Ok (String.trim input)
+       | "grep_projection" ->
+           Ok (Retrieval_projection.format_search_output input)
        | "extract_json" | "extract_json_object" | "extract_json_array" ->
            let len = String.length input in
            let rec find_start i =

--- a/lib/dune
+++ b/lib/dune
@@ -148,6 +148,7 @@
    level2_config
    level4_config
    local_runtime_pool
+   retrieval_projection
    sdk_tool_contract
    worker_oas
    worker_runtime
@@ -330,6 +331,7 @@
    tool_a2a
    tool_handover
    tool_relay
+   worktree_live_context
    tool_goals
    tool_operator
    tool_team_session_support

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -135,6 +135,10 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               if policy_mode_learned then SkillSelectHeuristic
               else keeper_skill_selection_mode ()
             in
+            let live_worktree_change =
+              Worktree_live_context.capture_change_block
+                ~base_path:ctx.config.base_path ~actor_key:meta.name
+            in
             let build_turn_prompt ~base_system_prompt ~messages =
               let continuity_snapshot = latest_state_snapshot_from_messages messages in
               let continuity_summary =
@@ -183,6 +187,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     Printf.sprintf "%s\n\n%s"
                       prompt
                       (String.concat "\n" policy_lines)
+              in
+              let prompt =
+                match live_worktree_change with
+                | Some summary when String.trim summary <> "" ->
+                    Printf.sprintf "%s\n\n%s" prompt summary
+                | _ -> prompt
               in
               match turn_instructions with
               | None -> prompt

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -132,6 +132,12 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
     Buffer.add_string ubuf "\n### Continuity\n";
     Buffer.add_string ubuf observation.continuity_summary;
     Buffer.add_string ubuf "\n");
+  (match observation.worktree_change_summary with
+   | Some summary when String.trim summary <> "" ->
+       Buffer.add_string ubuf "\n### Live Worktree Delta\n";
+       Buffer.add_string ubuf summary;
+       Buffer.add_string ubuf "\n"
+   | _ -> ());
   (* Triage triggers *)
   let tt = String.trim observation.triage_triggers in
   if tt <> "" && not (String.length tt >= 5 && String.sub tt 0 5 = "skip:")

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -15,6 +15,7 @@ type world_observation = {
   idle_seconds : int;
   active_goals : string list;
   continuity_summary : string;
+  worktree_change_summary : string option;
   context_ratio : float;
   economic_pressure : Agent_economy.pressure_mode;
   unclaimed_task_count : int;
@@ -215,6 +216,10 @@ let observe ~(config : Room.config) ~(meta : keeper_meta) : world_observation =
   let idle_seconds = compute_idle_seconds ~meta in
   let context_ratio = read_context_ratio ~config ~meta in
   let continuity_summary = read_continuity_summary ~config ~meta in
+  let worktree_change_summary =
+    Worktree_live_context.capture_change_block
+      ~base_path:config.base_path ~actor_key:meta.name
+  in
   let economic_pressure =
     Agent_economy.economic_pressure ~base_path:config.base_path
       ~agent_name:meta.name
@@ -228,6 +233,7 @@ let observe ~(config : Room.config) ~(meta : keeper_meta) : world_observation =
     idle_seconds;
     active_goals = meta.active_goal_ids;
     continuity_summary;
+    worktree_change_summary;
     context_ratio;
     economic_pressure;
     unclaimed_task_count;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -23,6 +23,9 @@ type world_observation = {
   continuity_summary : string;
   (** Latest continuity snapshot text (empty if unavailable). *)
 
+  worktree_change_summary : string option;
+  (** Git worktree delta detected since the previous keeper turn, if any. *)
+
   context_ratio : float;
   (** Current context window utilization [0.0, 1.0]. *)
 

--- a/lib/retrieval_projection.ml
+++ b/lib/retrieval_projection.ml
@@ -1,0 +1,178 @@
+let collapse_whitespace text =
+  text
+  |> String.split_on_char '\n'
+  |> List.concat_map (String.split_on_char '\t')
+  |> List.concat_map (String.split_on_char '\r')
+  |> List.concat_map (String.split_on_char ' ')
+  |> List.filter (fun part -> part <> "")
+  |> String.concat " "
+
+let trim_to_option text =
+  let trimmed = String.trim text in
+  if trimmed = "" then None else Some trimmed
+
+let take_chars max_len text =
+  if max_len <= 0 then ""
+  else if String.length text <= max_len then text
+  else String.sub text 0 max_len
+
+let normalize_location ?(max_len = 120) text =
+  text
+  |> collapse_whitespace
+  |> take_chars max_len
+
+let normalize_content ?(max_len = 300) text =
+  text
+  |> collapse_whitespace
+  |> take_chars max_len
+
+let grep_like_line ~source ~location ~content =
+  let source =
+    trim_to_option source |> Option.value ~default:"search"
+  in
+  let location =
+    trim_to_option location |> Option.value ~default:"result"
+    |> normalize_location
+  in
+  let content =
+    trim_to_option content |> Option.value ~default:"(no content)"
+    |> normalize_content
+  in
+  Printf.sprintf "%s/%s: %s" source location content
+
+let assoc_string fields keys =
+  let rec loop = function
+    | [] -> None
+    | key :: rest -> (
+        match List.assoc_opt key fields with
+        | Some (`String value) -> trim_to_option value
+        | Some (`Int value) -> Some (string_of_int value)
+        | Some (`Float value) -> Some (string_of_float value)
+        | Some (`Bool value) -> Some (string_of_bool value)
+        | _ -> loop rest)
+  in
+  loop keys
+
+let assoc_member fields keys =
+  let rec loop = function
+    | [] -> None
+    | key :: rest -> (
+        match List.assoc_opt key fields with
+        | Some value -> Some value
+        | None -> loop rest)
+  in
+  loop keys
+
+let rec take_list n xs =
+  match (n, xs) with
+  | count, _ when count <= 0 -> []
+  | _, [] -> []
+  | count, x :: rest -> x :: take_list (count - 1) rest
+
+let split_chunks input =
+  let separator = "\n---\n" in
+  let sep_len = String.length separator in
+  let input_len = String.length input in
+  let rec find_from start =
+    if start > input_len - sep_len then None
+    else if String.sub input start sep_len = separator then Some start
+    else find_from (start + 1)
+  in
+  let rec loop start acc =
+    match find_from start with
+    | Some idx ->
+        let chunk = String.sub input start (idx - start) in
+        loop (idx + sep_len) (chunk :: acc)
+    | None ->
+        let chunk = String.sub input start (input_len - start) in
+        List.rev (chunk :: acc)
+  in
+  if input = "" then [] else loop 0 []
+
+let parse_labeled_chunk chunk =
+  let trimmed = String.trim chunk in
+  if String.length trimmed >= 4 && trimmed.[0] = '[' then
+    try
+      let close_idx = String.index trimmed ']' in
+      if close_idx + 2 < String.length trimmed && trimmed.[close_idx + 1] = ':' then
+        let label = String.sub trimmed 1 (close_idx - 1) in
+        let payload =
+          String.sub trimmed (close_idx + 2)
+            (String.length trimmed - close_idx - 2)
+          |> String.trim
+        in
+        (trim_to_option label, payload)
+      else
+        (None, trimmed)
+    with Not_found -> (None, trimmed)
+  else
+    (None, trimmed)
+
+let render_result_object ?prefix fields =
+  let source =
+    assoc_string fields [ "source"; "engine"; "provider"; "site"; "kind" ]
+    |> Option.value ~default:(Option.value prefix ~default:"search")
+  in
+  let location =
+    assoc_string fields [ "file"; "path"; "url"; "title"; "name"; "id" ]
+    |> Option.value ~default:"result"
+  in
+  let content =
+    assoc_string fields
+      [ "snippet"; "content"; "text"; "summary"; "body"; "description"; "excerpt"; "title" ]
+    |> Option.value ~default:"(no content)"
+  in
+  grep_like_line ~source ~location ~content
+
+let result_like fields =
+  assoc_string fields [ "snippet"; "content"; "text"; "summary"; "body"; "description"; "excerpt"; "title"; "url"; "file"; "path" ]
+  <> None
+
+let rec lines_of_json ?prefix (json : Yojson.Safe.t) =
+  match json with
+  | `List items -> List.concat_map (lines_of_json ?prefix) items
+  | `Assoc fields -> (
+      let obj_json : Yojson.Safe.t = `Assoc fields in
+      match
+        assoc_member fields
+          [ "results"; "items"; "data"; "documents"; "hits"; "entries"; "search_results"; "value" ]
+      with
+      | Some nested ->
+          let nested_lines = lines_of_json ?prefix nested in
+          if nested_lines <> [] then nested_lines
+          else if result_like fields then [ render_result_object ?prefix fields ]
+          else [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:(Yojson.Safe.to_string obj_json) ]
+      | None ->
+          if result_like fields then [ render_result_object ?prefix fields ]
+          else [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:(Yojson.Safe.to_string obj_json) ])
+  | `String text ->
+      [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:text ]
+  | `Int value ->
+      [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:(string_of_int value) ]
+  | `Float value ->
+      [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:(string_of_float value) ]
+  | `Intlit value ->
+      [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:value ]
+  | `Bool value ->
+      [ grep_like_line ~source:(Option.value prefix ~default:"search") ~location:"result" ~content:(string_of_bool value) ]
+  | `Null -> []
+
+let lines_of_search_output ?(max_lines = 20) input =
+  let render_chunk chunk =
+    let prefix, payload = parse_labeled_chunk chunk in
+    try
+      let json = Yojson.Safe.from_string payload in
+      lines_of_json ?prefix json
+    with Yojson.Json_error _ ->
+      [ grep_like_line
+          ~source:(Option.value prefix ~default:"search")
+          ~location:"result"
+          ~content:payload ]
+  in
+  input
+  |> split_chunks
+  |> List.concat_map render_chunk
+  |> take_list max_lines
+
+let format_search_output ?(max_lines = 20) input =
+  lines_of_search_output ~max_lines input |> String.concat "\n"

--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -259,7 +259,7 @@ let get_chain_id_for_preset = function
   | "coverage" -> Some "walph-coverage"
   | "refactor" -> Some "walph-refactor"
   | "docs" -> Some "walph-docs"
-  | "review" -> Some "pr-review-pipeline"  (* PR self-review *)
+  | "review" -> Some "pr-review-pipeline"  (* PR self-review + clean-context structural pass *)
   | "drain" -> None  (* No chain for simple drain *)
   | "figma" -> Some "walph-figma"
   | _ -> None

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -220,6 +220,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
              ()
            in
            let result = Auto_recall.fetch_context_eio ~sw ~env ~clock config ~config:recall_config ~query () in
+           let grep_projection =
+             Auto_recall.format_for_injection result
+           in
            let response = `Assoc [
              ("success", `Bool true);
              ("query", `String query);
@@ -236,6 +239,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
              ) result.items));
              ("total_tokens", `Int result.total_tokens);
              ("truncated", `Bool result.truncated);
+             ("grep_projection", `String grep_projection);
              ("message", `String (Printf.sprintf "Found %d relevant items for query: %s"
                (List.length result.items) query));
            ] in

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,0 +1,90 @@
+let run_git_capture_lines ~workdir args =
+  try
+    let ic =
+      Unix.open_process_args_in "git"
+        (Array.of_list ("git" :: "-C" :: workdir :: args))
+    in
+    let rec loop acc =
+      match input_line ic with
+      | line -> loop (line :: acc)
+      | exception End_of_file -> List.rev acc
+    in
+    let lines = loop [] in
+    match Unix.close_process_in ic with
+    | Unix.WEXITED 0 -> Some lines
+    | _ -> None
+  with Sys_error _ | Unix.Unix_error _ -> None
+
+let repo_root_for ~base_path =
+  match run_git_capture_lines ~workdir:base_path [ "rev-parse"; "--show-toplevel" ] with
+  | Some (root :: _) ->
+      let root = String.trim root in
+      if root = "" then None else Some root
+  | _ -> None
+
+let current_status_lines ~repo_root =
+  let contains_substring text ~substring =
+    let text_len = String.length text in
+    let substring_len = String.length substring in
+    let rec loop idx =
+      if substring_len = 0 then true
+      else if idx > text_len - substring_len then false
+      else if String.sub text idx substring_len = substring then true
+      else loop (idx + 1)
+    in
+    loop 0
+  in
+  run_git_capture_lines ~workdir:repo_root [ "status"; "--porcelain" ]
+  |> Option.value ~default:[]
+  |> List.map String.trim
+  |> List.filter (fun line ->
+         not (contains_substring line ~substring:".masc/"))
+  |> List.filter (fun line -> line <> "")
+
+let state_dir ~repo_root =
+  Filename.concat (Filename.concat repo_root ".masc") "live-context"
+
+let state_file ~repo_root ~actor_key =
+  let safe_key = Room_utils.safe_filename actor_key in
+  Filename.concat (state_dir ~repo_root)
+    (Printf.sprintf "%s.git-status-hash" safe_key)
+
+let read_file_if_exists path =
+  try
+    if Sys.file_exists path then
+      Some (String.trim (Fs_compat.load_file path))
+    else
+      None
+  with Sys_error _ -> None
+
+let write_text path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let hash_lines lines =
+  Digest.string (String.concat "\n" lines) |> Digest.to_hex
+
+let change_block_of_lines lines =
+  let visible_lines =
+    if List.length lines > 20 then
+      List.filteri (fun idx _ -> idx < 20) lines
+    else
+      lines
+  in
+  let change_count = List.length lines in
+  Printf.sprintf
+    "<git_status_change>\nWorking tree changed since last keeper turn (%d files):\n%s\n</git_status_change>"
+    change_count
+    (String.concat "\n" visible_lines)
+
+let capture_change_block ~base_path ~actor_key =
+  match repo_root_for ~base_path with
+  | None -> None
+  | Some repo_root ->
+      let lines = current_status_lines ~repo_root in
+      let current_hash = hash_lines lines in
+      let path = state_file ~repo_root ~actor_key in
+      let previous_hash = read_file_if_exists path |> Option.value ~default:"" in
+      write_text path current_hash;
+      if lines = [] || current_hash = previous_hash then None
+      else Some (change_block_of_lines lines)

--- a/scripts/review/local-review.sh
+++ b/scripts/review/local-review.sh
@@ -335,7 +335,8 @@ build_chunks() {
 build_prompt() {
   local chunk_path="$1"
   cat <<EOF
-Review this git diff against ${BASE_REF}...${HEAD_REF}. Focus only on bugs, regressions, stale compatibility assumptions, and missing tests.
+Review this git diff against ${BASE_REF}...${HEAD_REF} with fresh context only. Do not assume tickets, design intent, or prior discussion.
+Focus only on bugs, regressions, stale compatibility assumptions, structural contract violations, and missing tests.
 Return only \`No findings.\` or a flat list of findings with file paths and concise reasoning.
 
 $(cat "$chunk_path")
@@ -352,7 +353,7 @@ run_reviewer() {
   request_json="$(
     jq -n \
       --arg model "$MODEL" \
-      --arg system_prompt "You are a strict senior code reviewer. Review the patch for bugs, regressions, stale compatibility assumptions, and missing tests. Return only \`No findings.\` or a flat list of findings with file paths and concise reasoning." \
+      --arg system_prompt "You are a strict fresh-context code reviewer. Review the patch for bugs, regressions, stale compatibility assumptions, structural contract violations, and missing tests. Return only \`No findings.\` or a flat list of findings with file paths and concise reasoning." \
       --arg user_prompt "$prompt" \
       --argjson max_tokens "$MAX_TOKENS" \
       --argjson temperature "$TEMPERATURE" \

--- a/test/dune
+++ b/test/dune
@@ -42,6 +42,7 @@
         test_keeper_unified
         test_keeper_toml
         test_keeper_bash_safety
+        test_worktree_live_context
 )
  (modules test_room test_types test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
@@ -65,6 +66,7 @@
           test_keeper_unified
           test_keeper_toml
           test_keeper_bash_safety
+          test_worktree_live_context
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))
@@ -173,6 +175,11 @@
  (name test_local_review_script)
  (modules test_local_review_script)
  (libraries alcotest unix yojson))
+
+(test
+ (name test_chain_presets)
+ (modules test_chain_presets)
+ (libraries masc_mcp alcotest yojson str))
 
 (test
  (name test_ci_run_tests_script)

--- a/test/test_chain_presets.ml
+++ b/test/test_chain_presets.ml
@@ -1,0 +1,86 @@
+open Alcotest
+open Masc_mcp
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let preset_json rel_path =
+  Yojson.Safe.from_file (Filename.concat (source_root ()) rel_path)
+
+let parse_preset rel_path =
+  let json = preset_json rel_path in
+  match Chain_parser.parse_chain json with
+  | Error e -> failf "parse failed for %s: %s" rel_path e
+  | Ok chain -> chain
+
+let find_node chain node_id =
+  match List.find_opt (fun (node : Chain_types.node) -> String.equal node.id node_id) chain.Chain_types.nodes with
+  | Some node -> node
+  | None -> failf "node %s not found" node_id
+
+let test_pr_review_pipeline_has_clean_structural_stage () =
+  let chain = parse_preset "data/chains/pr-review-pipeline.json" in
+  let structural = find_node chain "structural-review" in
+  (match structural.node_type with
+   | Chain_types.Spawn { clean; pass_vars; inherit_cache; inner } ->
+       check bool "spawn is clean" true clean;
+       check bool "spawn does not inherit cache" false inherit_cache;
+       check bool "passes pr_diff" true (List.mem "pr_diff" pass_vars);
+       check bool "passes changed_files" true (List.mem "changed_files" pass_vars);
+       (match inner.node_type with
+        | Chain_types.Model { prompt; _ } ->
+            check bool "prompt mentions fresh context" true
+              (try
+                 ignore
+                   (Str.search_forward
+                      (Str.regexp_string "fresh-context structural reviewer")
+                      prompt 0);
+                 true
+               with Not_found -> false)
+        | _ -> fail "inner node is not a model")
+   | _ -> fail "structural-review is not a spawn node");
+  let synth = find_node chain "synthesize-review" in
+  check bool "synthesize depends on structural stage" true
+    (match synth.depends_on with
+     | Some deps -> List.mem "structural-review" deps
+     | None -> false)
+
+let test_deep_research_uses_grep_projection () =
+  let chain = parse_preset "data/chains/deep-research.json" in
+  let projection = find_node chain "search-results-grep" in
+  (match projection.node_type with
+   | Chain_types.Adapter { input_ref; transform; _ } ->
+       check string "projection input" "search_results" input_ref;
+       (match transform with
+        | Chain_types.Custom "grep_projection" -> ()
+        | _ -> fail "projection does not use grep_projection custom transform")
+   | _ -> fail "search-results-grep is not an adapter");
+  let extract = find_node chain "extract-facts" in
+  (match extract.node_type with
+   | Chain_types.Model { prompt; _ } ->
+       check bool "extract prompt references projected results" true
+         (try
+            ignore
+              (Str.search_forward
+                 (Str.regexp_string "{{search_results_grep}}")
+                 prompt 0);
+            true
+          with Not_found -> false)
+   | _ -> fail "extract-facts is not a model node")
+
+let () =
+  run "Chain_presets"
+    [
+      ( "review_pipeline",
+        [
+          test_case "has clean structural stage" `Quick
+            test_pr_review_pipeline_has_clean_structural_stage;
+        ] );
+      ( "deep_research",
+        [
+          test_case "uses grep projection" `Quick
+            test_deep_research_uses_grep_projection;
+        ] );
+    ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -17,6 +17,7 @@ let base_observation : WO.world_observation =
     idle_seconds = 0;
     active_goals = [];
     continuity_summary = "";
+    worktree_change_summary = None;
     context_ratio = 0.0;
     economic_pressure = AE.Normal;
     unclaimed_task_count = 0;
@@ -178,6 +179,36 @@ let test_prompt_includes_triage_triggers () =
   check bool "has triage section" true
     (let found =
        try ignore (Str.search_forward (Str.regexp_string "Triage Triggers") user 0); true
+       with Not_found -> false
+     in found)
+
+let test_prompt_includes_worktree_delta () =
+  let obs =
+    { base_observation with
+      worktree_change_summary =
+        Some
+          "<git_status_change>\nWorking tree changed since last keeper turn (1 files):\n M lib/example.ml\n</git_status_change>"
+    }
+  in
+  let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
+  check bool "has worktree section" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward
+              (Str.regexp_string "Live Worktree Delta")
+              user 0);
+         true
+       with Not_found -> false
+     in found);
+  check bool "has git status block" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward
+              (Str.regexp_string "<git_status_change>")
+              user 0);
+         true
        with Not_found -> false
      in found)
 
@@ -369,6 +400,7 @@ let () =
           test_case "frugal economy" `Quick test_prompt_frugal_economy;
           test_case "hustle economy" `Quick test_prompt_hustle_economy;
           test_case "includes triage triggers" `Quick test_prompt_includes_triage_triggers;
+          test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
           test_case "skips skip triage" `Quick test_prompt_skips_skip_triage;
           test_case "room state section" `Quick test_prompt_room_state_section;
         ] );

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -223,7 +223,7 @@ initiative_post_ttl_hours = 24
         json |> member "sources" |> member "override_fields" |> to_list
         |> List.map to_string
       in
-      Alcotest.(check bool) "override field trigger_mode" true
+      Alcotest.(check bool) "trigger_mode canonicalized so not flagged as override" false
         (List.mem "coordination.trigger_mode" override_fields);
       Alcotest.(check bool) "override field room_scope" true
         (List.mem "coordination.room_scope" override_fields);

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -1,0 +1,90 @@
+open Alcotest
+
+module Wlc = Masc_mcp.Worktree_live_context
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let quote = Filename.quote
+
+let run_ok ~cwd cmd =
+  let wrapped = Printf.sprintf "cd %s && %s > /dev/null 2>&1" (quote cwd) cmd in
+  let code = Sys.command wrapped in
+  if code <> 0 then failf "command failed (%d): %s" code cmd
+
+let init_repo dir =
+  run_ok ~cwd:dir "git init -q";
+  run_ok ~cwd:dir "git config user.email test@example.com";
+  run_ok ~cwd:dir "git config user.name tester";
+  write_file (Filename.concat dir "sample.ml") "let value = 1\n";
+  run_ok ~cwd:dir "git add sample.ml && git -c core.hooksPath=/dev/null commit -q -m base"
+
+let test_capture_only_on_change () =
+  with_temp_dir "worktree-live-context" (fun dir ->
+      init_repo dir;
+      check (option string) "clean repo produces no block" None
+        (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
+      check (option string) "clean repo stays quiet after state write" None
+        (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
+      write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+      let first =
+        Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"
+      in
+      check bool "changed repo produces block" true (Option.is_some first);
+      let block = Option.value ~default:"" first in
+      check bool "block mentions changed file" true
+        (try
+           ignore
+             (Str.search_forward
+                (Str.regexp_string "sample.ml")
+                block 0);
+           true
+         with Not_found -> false);
+      check (option string) "same change not repeated" None
+        (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"))
+
+let test_capture_distinguishes_new_changes () =
+  with_temp_dir "worktree-live-context" (fun dir ->
+      init_repo dir;
+      write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+      ignore (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
+      write_file (Filename.concat dir "other.md") "new notes\n";
+      let second =
+        Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"
+      in
+      check bool "new change produces new block" true (Option.is_some second);
+      let block = Option.value ~default:"" second in
+      check bool "block mentions second file" true
+        (try
+           ignore
+             (Str.search_forward
+                (Str.regexp_string "other.md")
+                block 0);
+           true
+         with Not_found -> false))
+
+let () =
+  run "Worktree_live_context"
+    [
+      ( "capture_change_block",
+        [
+          test_case "only on change" `Quick test_capture_only_on_change;
+          test_case "distinguishes new changes" `Quick
+            test_capture_distinguishes_new_changes;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add canonical live worktree delta injection for keeper prompts
- add fresh-context structural review stage to the canonical PR review pipeline
- add grep-like retrieval projection for model-facing search and recall output
- update docs and regression tests for the new prompt/review/retrieval paths

## Validation
- dune exec --root . test/test_worktree_live_context.exe
- dune exec --root . test/test_keeper_unified.exe
- dune exec --root . test/test_chain_presets.exe
- dune exec --root . test/test_local_review_script.exe
- dune build --root . @check