### PR TITLE
fix(governance): restore medium risk for masc_transition

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -46,6 +46,8 @@ let risk_overrides : (string * risk_level) list = [
   ("masc_a2a_query_skill", Low);       (* "skill" contains "kill" substring *)
   ("masc_keeper_tool_catalog", Low);   (* "catalog" is read-only *)
   ("masc_model_catalog", Low);         (* read-only *)
+  (* Canonical task lifecycle entrypoint after masc_claim removal. *)
+  ("masc_transition", Medium);
   ("masc_keeper_dataset_export", Medium);  (* export, not delete *)
   ("masc_persistent_agent_dataset_export", Medium);
 ]


### PR DESCRIPTION
## Summary
- restore `masc_transition` to `Medium` risk in the governance pipeline
- keep paranoid governance from silently allowing canonical task lifecycle transitions
- repair the `Governance_pipeline` baseline broken after `masc_claim` removal

## Verification
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-governance-pipeline-risk --build-dir _build-fix-governance --display short ./test/test_governance_pipeline.exe`
- `env -u DUNE_RPC opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-governance-pipeline-risk --build-dir _build-fix-governance --display short ./test/test_operator_control.exe`

## Context
- fixes #2707
- unblocks the governance-pipeline baseline failure seen after `masc_claim` removal