### PR TITLE
fix(keeper): make dashboard config truthful

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -34,8 +34,6 @@ type EditDraft = {
   needs: string
   desires: string
   instructions: string
-  drift_enabled: boolean
-  drift_min_turn_gap: number
 }
 
 const editDraft = signal<EditDraft | null>(null)
@@ -51,8 +49,6 @@ function initDraftFromConfig(c: KeeperConfig): EditDraft {
     needs: c.prompt.needs,
     desires: c.prompt.desires,
     instructions: c.prompt.instructions,
-    drift_enabled: c.drift.enabled,
-    drift_min_turn_gap: c.drift.min_turn_gap,
   }
 }
 
@@ -67,8 +63,6 @@ function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdateP
   if (draft.needs !== orig.prompt.needs) payload.new_needs = draft.needs
   if (draft.desires !== orig.prompt.desires) payload.new_desires = draft.desires
   if (draft.instructions !== orig.prompt.instructions) payload.new_instructions = draft.instructions
-  if (draft.drift_enabled !== orig.drift.enabled) payload.new_drift_enabled = draft.drift_enabled
-  if (draft.drift_min_turn_gap !== orig.drift.min_turn_gap) payload.new_drift_min_turn_gap = draft.drift_min_turn_gap
   return payload
 }
 
@@ -119,6 +113,23 @@ function BoolBadge({ value }: { value: boolean }) {
     : html`<span class="text-[11px] font-bold px-2 py-0.5 rounded-md bg-white/5 text-text-dim border border-white/10 shadow-sm">OFF</span>`
 }
 
+function FeatureBadge({
+  status,
+  value,
+}: {
+  status?: string
+  value: boolean | null
+}) {
+  if (status && status !== 'wired') {
+    const label = status === 'source_only' ? 'SOURCE ONLY' : 'UNWIRED'
+    return html`<span class="text-[11px] font-bold px-2 py-0.5 rounded-md bg-amber-500/10 text-amber-300 border border-amber-400/20 shadow-sm">${label}</span>`
+  }
+  if (value === null) {
+    return html`<span class="text-[11px] font-bold px-2 py-0.5 rounded-md bg-white/5 text-text-dim border border-white/10 shadow-sm">--</span>`
+  }
+  return html`<${BoolBadge} value=${value} />`
+}
+
 function ModelList({ models }: { models: string[] }) {
   if (models.length === 0) return html`<span class="text-[11px] text-text-muted italic">none</span>`
   return html`
@@ -132,6 +143,10 @@ function LongText({ text }: { text: string }) {
   if (!text || text.trim() === '') return html`<span class="text-[11px] text-text-muted italic">--</span>`
   const truncated = text.length > 200 ? text.slice(0, 200) + '...' : text
   return html`<div class="text-[12px] text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-md p-3 rounded-xl mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
+}
+
+function formatMaybeNumber(value: number | null, suffix = ''): string {
+  return value === null ? '--' : `${value}${suffix}`
 }
 
 const SOUL_PROFILES = ['balanced', 'safety', 'delivery', 'research', 'relationship', 'minimal'] as const
@@ -177,45 +192,6 @@ function EditSelect({ field, label, options }: { field: keyof EditDraft; label: 
       >
         ${options.map(o => html`<option value=${o} class="bg-bg-1">${o}</option>`)}
       </select>
-    </div>
-  `
-}
-
-function EditCheckbox({ field, label }: { field: keyof EditDraft; label: string }) {
-  const d = editDraft.value
-  if (!d) return null
-  const val = d[field] as boolean
-  return html`
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)] mt-1">
-      <span class="text-xs text-[var(--text-muted)]">${label}</span>
-      <input
-        type="checkbox"
-        checked=${val}
-        class="cursor-pointer"
-        onChange=${(e: Event) => updateDraft(field, (e.target as HTMLInputElement).checked)}
-      />
-    </div>
-  `
-}
-
-function EditNumber({ field, label, min, max }: { field: keyof EditDraft; label: string; min: number; max: number }) {
-  const d = editDraft.value
-  if (!d) return null
-  const val = d[field] as number
-  return html`
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)] mt-1">
-      <span class="text-xs text-[var(--text-muted)]">${label}</span>
-      <input
-        type="number"
-        class="w-16 bg-[rgba(11,18,32,0.8)] text-[var(--text-body)] border border-[var(--card-border)] rounded-md py-1 px-2 text-xs"
-        value=${val}
-        min=${min}
-        max=${max}
-        onInput=${(e: Event) => {
-          const n = parseInt((e.target as HTMLInputElement).value, 10)
-          if (!Number.isNaN(n)) updateDraft(field, Math.max(min, Math.min(max, n)))
-        }}
-      />
     </div>
   `
 }
@@ -342,24 +318,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     ` : null}
   `
 
-  // --- Drift section (editable) ---
-  const driftSection = isEditing ? html`
-    <${SectionHeader} title="Drift (editing)" />
-    <${EditCheckbox} field="drift_enabled" label="Enabled" />
-    <${EditNumber} field="drift_min_turn_gap" label="Min turn gap" min=${1} max=${50} />
-    <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
-    ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
-  ` : html`
-    <${SectionHeader} title="Drift" />
-    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-      <span class="text-xs text-[var(--text-muted)]">Enabled</span>
-      <${BoolBadge} value=${c.drift.enabled} />
-    </div>
-    <${ConfigRow} label="Min turn gap" value=${String(c.drift.min_turn_gap)} />
-    <${ConfigRow} label="Count total" value=${String(c.drift.count_total)} />
-    ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
-  `
-
   return html`
     <div class="flex flex-col gap-1.5">
 
@@ -401,19 +359,85 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Idle trigger" value=${c.proactive.idle_sec + 's'} />
       <${ConfigRow} label="Cooldown" value=${c.proactive.cooldown_sec + 's'} />
 
-      ${'' /* --- Drift (editable) --- */}
-      ${driftSection}
+      ${'' /* --- Runtime (read-only) --- */}
+      <${SectionHeader} title="Runtime" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Paused</span>
+        <${BoolBadge} value=${c.runtime.paused} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Desired</span>
+        <${BoolBadge} value=${c.runtime.desired} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Resident registered</span>
+        <${BoolBadge} value=${c.runtime.resident_registered} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Keepalive running</span>
+        <${BoolBadge} value=${c.runtime.keepalive_running} />
+      </div>
+      <${ConfigRow} label="Fiber health" value=${c.runtime.fiber_health || '--'} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Presence keepalive</span>
+        <${BoolBadge} value=${c.runtime.presence_keepalive} />
+      </div>
+      <${ConfigRow} label="Presence interval" value=${c.runtime.presence_keepalive_sec + 's'} />
+
+      ${'' /* --- Coordination (read-only) --- */}
+      <${SectionHeader} title="Coordination" />
+      <${ConfigRow} label="Room scope" value=${c.coordination.room_scope || '--'} />
+      <${ConfigRow} label="Scope kind" value=${c.coordination.scope_kind || '--'} />
+      <${ConfigRow} label="Trigger mode" value=${c.coordination.trigger_mode || '--'} />
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Mention targets</div>
+        <${ModelList} models=${c.coordination.mention_targets} />
+      </div>
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Joined rooms</div>
+        <${ModelList} models=${c.coordination.joined_room_ids} />
+      </div>
+
+      ${'' /* --- Drift (read-only) --- */}
+      <${SectionHeader} title="Drift" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
+      </div>
+      <${ConfigRow} label="Min turn gap" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
+      <${ConfigRow} label="Count total" value=${formatMaybeNumber(c.drift.count_total)} />
+      ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
 
       ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="Initiative" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Enabled</span>
-        <${BoolBadge} value=${c.initiative.enabled} />
+        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <${FeatureBadge} status=${c.initiative.status} value=${c.initiative.enabled} />
       </div>
       <${ConfigRow} label="Scope" value=${c.initiative.scope || '--'} />
-      <${ConfigRow} label="Idle trigger" value=${c.initiative.idle_sec + 's'} />
-      <${ConfigRow} label="Cooldown" value=${c.initiative.cooldown_sec + 's'} />
+      <${ConfigRow} label="Idle trigger" value=${formatMaybeNumber(c.initiative.idle_sec, 's')} />
+      <${ConfigRow} label="Cooldown" value=${formatMaybeNumber(c.initiative.cooldown_sec, 's')} />
       <${ConfigRow} label="Context mode" value=${c.initiative.context_mode || '--'} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Configured in defaults</span>
+        <${BoolBadge} value=${c.initiative.configured_in_source} />
+      </div>
+      ${c.initiative.source_defaults ? html`
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-1">Source defaults</div>
+        <${ConfigRow} label="Enabled" value=${c.initiative.source_defaults.enabled === null ? '--' : String(c.initiative.source_defaults.enabled)} />
+        <${ConfigRow} label="Scope" value=${c.initiative.source_defaults.scope || '--'} />
+        <${ConfigRow} label="Idle trigger" value=${formatMaybeNumber(c.initiative.source_defaults.idle_sec, 's')} />
+        <${ConfigRow} label="Cooldown" value=${formatMaybeNumber(c.initiative.source_defaults.cooldown_sec, 's')} />
+        <${ConfigRow} label="Context mode" value=${c.initiative.source_defaults.context_mode || '--'} />
+        <${ConfigRow} label="Post TTL" value=${formatMaybeNumber(c.initiative.source_defaults.post_ttl_hours, 'h')} />
+      ` : null}
+
+      ${'' /* --- Team Session (read-only) --- */}
+      <${SectionHeader} title="Auto Team Session" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <${FeatureBadge} status=${c.auto_team_session.status} value=${c.auto_team_session.enabled} />
+      </div>
 
       ${'' /* --- Handoff (read-only) --- */}
       <${SectionHeader} title="Handoff" />
@@ -431,6 +455,34 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Total tokens" value=${formatTokens(c.metrics.total_tokens)} />
       <${ConfigRow} label="Total cost" value=${'$' + c.metrics.total_cost_usd.toFixed(4)} />
       <${ConfigRow} label="Compactions" value=${String(c.metrics.compaction_count)} />
+
+      ${'' /* --- Sources (read-only) --- */}
+      <${SectionHeader} title="Sources" />
+      <${ConfigRow} label="Default source" value=${c.sources.default_source_kind || '--'} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Live override</span>
+        <${BoolBadge} value=${c.sources.has_live_override} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">Resident spec exists</span>
+        <${BoolBadge} value=${c.sources.resident_spec_exists} />
+      </div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Live meta path</div>
+      <${LongText} text=${c.sources.live_meta_path} />
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Resident spec path</div>
+      <${LongText} text=${c.sources.resident_spec_path} />
+      ${c.sources.default_manifest_path ? html`
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Default manifest path</div>
+        <${LongText} text=${c.sources.default_manifest_path} />
+      ` : null}
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Precedence</div>
+        <${ModelList} models=${c.sources.precedence} />
+      </div>
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Override fields</div>
+        <${ModelList} models=${c.sources.override_fields} />
+      </div>
 
       ${'' /* --- Prompt (editable) --- */}
       ${promptSection}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -452,25 +452,74 @@ export interface KeeperConfigProactive {
   cooldown_sec: number
 }
 
+export type KeeperFeatureStatus = 'wired' | 'source_only' | 'unwired'
+
 export interface KeeperConfigDrift {
-  enabled: boolean
-  min_turn_gap: number
-  count_total: number
+  status: KeeperFeatureStatus
+  enabled: boolean | null
+  min_turn_gap: number | null
+  count_total: number | null
   last_reason: string | null
 }
 
+export interface KeeperConfigInitiativeSourceDefaults {
+  enabled: boolean | null
+  scope: string | null
+  idle_sec: number | null
+  cooldown_sec: number | null
+  context_mode: string | null
+  post_ttl_hours: number | null
+}
+
 export interface KeeperConfigInitiative {
-  enabled: boolean
-  scope: string
-  idle_sec: number
-  cooldown_sec: number
-  context_mode: string
+  status: KeeperFeatureStatus
+  enabled: boolean | null
+  scope: string | null
+  idle_sec: number | null
+  cooldown_sec: number | null
+  context_mode: string | null
+  configured_in_source: boolean
+  source_defaults: KeeperConfigInitiativeSourceDefaults | null
 }
 
 export interface KeeperConfigHandoff {
   auto: boolean
   threshold: number
   cooldown_sec: number
+}
+
+export interface KeeperConfigAutoTeamSession {
+  status: KeeperFeatureStatus
+  enabled: boolean | null
+}
+
+export interface KeeperConfigRuntime {
+  paused: boolean
+  desired: boolean
+  resident_registered: boolean
+  keepalive_running: boolean
+  fiber_health: string
+  presence_keepalive: boolean
+  presence_keepalive_sec: number
+}
+
+export interface KeeperConfigCoordination {
+  room_scope: string
+  scope_kind: string
+  trigger_mode: string
+  mention_targets: string[]
+  joined_room_ids: string[]
+}
+
+export interface KeeperConfigSources {
+  live_meta_path: string
+  resident_spec_path: string
+  resident_spec_exists: boolean
+  default_manifest_path: string | null
+  default_source_kind: 'toml' | 'persona' | null
+  precedence: string[]
+  has_live_override: boolean
+  override_fields: string[]
 }
 
 export interface KeeperConfigMetrics {
@@ -489,6 +538,10 @@ export interface KeeperConfig {
   proactive: KeeperConfigProactive
   drift: KeeperConfigDrift
   initiative: KeeperConfigInitiative
+  auto_team_session: KeeperConfigAutoTeamSession
   handoff: KeeperConfigHandoff
+  runtime: KeeperConfigRuntime
+  coordination: KeeperConfigCoordination
+  sources: KeeperConfigSources
   metrics: KeeperConfigMetrics
 }

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -6,6 +6,7 @@
 
 
 open Dashboard_http_helpers
+open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
@@ -540,23 +541,9 @@ let keeper_config_json (config : Room.config) (name : string)
           ("cooldown_sec", `Int m.proactive_cooldown_sec);
         ]
       in
-      let drift =
-        `Assoc [
-          ("enabled", `Bool false);
-          ("min_turn_gap", `Int 0);
-          ("count_total", `Int 0);
-          ("last_reason", `Null);
-        ]
-      in
-      let initiative =
-        `Assoc [
-          ("enabled", `Bool false);
-          ("scope", `String "board_only");
-          ("idle_sec", `Int 3600);
-          ("cooldown_sec", `Int 3600);
-          ("context_mode", `String "board_snapshot");
-        ]
-      in
+      let defaults_snapshot = Keeper_types.keeper_default_source_snapshot m.name in
+      let drift = drift_surface_json () in
+      let initiative = initiative_surface_json defaults_snapshot.defaults in
       let handoff =
         `Assoc [
           ("auto", `Bool m.auto_handoff);
@@ -600,7 +587,10 @@ let keeper_config_json (config : Room.config) (name : string)
          ("proactive", proactive);
          ("drift", drift);
          ("initiative", initiative);
+         ("auto_team_session", auto_team_session_surface_json ());
          ("handoff", handoff);
+         ("runtime", runtime_surface_json config m);
+         ("coordination", coordination_surface_json m);
+         ("sources", source_provenance_json config m);
          ("metrics", metrics);
        ])
-

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -30,6 +30,12 @@ let next_model_hint_of_meta (m : keeper_meta) : string option =
       | current :: _ -> Some current
       | [] -> None)
 
+let string_of_fiber_health = function
+  | Fiber_alive -> "alive"
+  | Fiber_zombie -> "zombie"
+  | Fiber_dead -> "dead"
+  | Fiber_unknown -> "unknown"
+
 let parse_agent_status (config : Room.config) ~(agent_name : string) : Yojson.Safe.t =
   let agent_file =
     Filename.concat (Room.agents_dir config) (Room.safe_filename agent_name ^ ".json")

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -2,6 +2,7 @@ open Keeper_types
 
 val active_model_of_meta : keeper_meta -> string
 val next_model_hint_of_meta : keeper_meta -> string option
+val string_of_fiber_health : fiber_health -> string
 val parse_agent_status : Room.config -> agent_name:string -> Yojson.Safe.t
 val keeper_reply_snapshot_of_history :
   Yojson.Safe.t list -> Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -2,6 +2,9 @@
 
 open Keeper_types
 
+let string_list_to_json values =
+  `List (List.map (fun value -> `String value) values)
+
 let linked_team_session config (meta : keeper_meta) =
   match meta.active_team_session_id with
   | Some session_id -> Team_session_store.load_session config session_id
@@ -35,4 +38,216 @@ let team_session_bridge_json config (meta : keeper_meta) =
        if String.trim meta.last_team_session_started_at = "" then `Null
        else `String meta.last_team_session_started_at);
       ("start_count_total", `Int meta.team_session_start_count_total);
+    ]
+
+let unsupported_feature_status configured_in_source =
+  if configured_in_source then "source_only" else "unwired"
+
+let initiative_source_defaults_json (defaults : keeper_profile_defaults) :
+    Yojson.Safe.t =
+  let configured =
+    Option.is_some defaults.initiative_enabled
+    || Option.is_some defaults.initiative_scope
+    || Option.is_some defaults.initiative_idle_sec
+    || Option.is_some defaults.initiative_cooldown_sec
+    || Option.is_some defaults.initiative_context_mode
+    || Option.is_some defaults.initiative_post_ttl_hours
+  in
+  if not configured then `Null
+  else
+    `Assoc
+      [
+        ( "enabled",
+          match defaults.initiative_enabled with
+          | Some value -> `Bool value
+          | None -> `Null );
+        ( "scope",
+          match defaults.initiative_scope with
+          | Some value -> `String value
+          | None -> `Null );
+        ( "idle_sec",
+          match defaults.initiative_idle_sec with
+          | Some value -> `Int value
+          | None -> `Null );
+        ( "cooldown_sec",
+          match defaults.initiative_cooldown_sec with
+          | Some value -> `Int value
+          | None -> `Null );
+        ( "context_mode",
+          match defaults.initiative_context_mode with
+          | Some value -> `String value
+          | None -> `Null );
+        ( "post_ttl_hours",
+          match defaults.initiative_post_ttl_hours with
+          | Some value -> `Int value
+          | None -> `Null );
+      ]
+
+let initiative_configured_in_source (defaults : keeper_profile_defaults) =
+  initiative_source_defaults_json defaults <> `Null
+
+let initiative_surface_json (defaults : keeper_profile_defaults) =
+  let configured_in_source = initiative_configured_in_source defaults in
+  `Assoc
+    [
+      ("status", `String (unsupported_feature_status configured_in_source));
+      ("enabled", `Null);
+      ("scope", `Null);
+      ("idle_sec", `Null);
+      ("cooldown_sec", `Null);
+      ("context_mode", `Null);
+      ("configured_in_source", `Bool configured_in_source);
+      ("source_defaults", initiative_source_defaults_json defaults);
+    ]
+
+let drift_surface_json () =
+  `Assoc
+    [
+      ("status", `String "unwired");
+      ("enabled", `Null);
+      ("min_turn_gap", `Null);
+      ("count_total", `Null);
+      ("last_reason", `Null);
+    ]
+
+let auto_team_session_surface_json () =
+  `Assoc
+    [
+      ("status", `String "wired");
+      ("enabled", `Bool true);
+    ]
+
+let coordination_surface_json (meta : keeper_meta) =
+  `Assoc
+    [
+      ("room_scope", `String meta.room_scope);
+      ("scope_kind", `String meta.scope_kind);
+      ("trigger_mode", `String meta.trigger_mode);
+      ("mention_targets", string_list_to_json meta.mention_targets);
+      ("joined_room_ids", string_list_to_json meta.joined_room_ids);
+    ]
+
+let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_defaults) :
+    string list =
+  let add_if label cond acc = if cond then label :: acc else acc in
+  []
+  |> add_if "prompt.goal"
+       (match defaults.goal with
+        | Some value -> normalize_goal_horizon_text value <> meta.goal
+        | None -> false)
+  |> add_if "prompt.short_goal"
+       (match defaults.short_goal with
+        | Some value -> value <> meta.short_goal
+        | None -> false)
+  |> add_if "prompt.mid_goal"
+       (match defaults.mid_goal with
+        | Some value -> value <> meta.mid_goal
+        | None -> false)
+  |> add_if "prompt.long_goal"
+       (match defaults.long_goal with
+        | Some value -> value <> meta.long_goal
+        | None -> false)
+  |> add_if "prompt.soul_profile"
+       (match defaults.soul_profile with
+        | Some value -> value <> meta.soul_profile
+        | None -> false)
+  |> add_if "prompt.will"
+       (match defaults.will with Some value -> value <> meta.will | None -> false)
+  |> add_if "prompt.needs"
+       (match defaults.needs with Some value -> value <> meta.needs | None -> false)
+  |> add_if "prompt.desires"
+       (match defaults.desires with Some value -> value <> meta.desires | None -> false)
+  |> add_if "prompt.instructions"
+       (match defaults.instructions with
+        | Some value -> value <> meta.instructions
+        | None -> false)
+  |> add_if "execution.models"
+       (defaults.models <> [] && defaults.models <> meta.models)
+  |> add_if "execution.allowed_models"
+       (defaults.allowed_models <> [] && defaults.allowed_models <> meta.allowed_models)
+  |> add_if "execution.active_model"
+       (match defaults.active_model with
+        | Some value -> value <> meta.active_model
+        | None -> false)
+  |> add_if "execution.policy_mode"
+       (match defaults.policy_mode with
+        | Some value -> value <> meta.policy_mode
+        | None -> false)
+  |> add_if "execution.policy_shell_mode"
+       (match defaults.policy_shell_mode with
+        | Some value -> value <> meta.policy_shell_mode
+        | None -> false)
+  |> add_if "coordination.room_scope"
+       (match defaults.room_scope with
+        | Some value -> canonical_room_scope value <> meta.room_scope
+        | None -> false)
+  |> add_if "coordination.scope_kind"
+       (match defaults.scope_kind with
+        | Some value -> canonical_scope_kind value <> meta.scope_kind
+        | None -> false)
+  |> add_if "coordination.trigger_mode"
+       (match defaults.trigger_mode with
+        | Some value -> canonical_trigger_mode value <> meta.trigger_mode
+        | None -> false)
+  |> add_if "coordination.mention_targets"
+       (defaults.mention_targets <> [] && defaults.mention_targets <> meta.mention_targets)
+  |> add_if "runtime.presence_keepalive"
+       (match defaults.presence_keepalive with
+        | Some value -> value <> meta.presence_keepalive
+        | None -> false)
+  |> add_if "runtime.presence_keepalive_sec"
+       (match defaults.presence_keepalive_sec with
+        | Some value -> value <> meta.presence_keepalive_sec
+        | None -> false)
+  |> add_if "proactive.enabled"
+       (match defaults.proactive_enabled with
+        | Some value -> value <> meta.proactive_enabled
+        | None -> false)
+  |> List.rev
+
+let runtime_surface_json config (meta : keeper_meta) =
+  let resident_spec =
+    match read_resident_keeper config meta.name with
+    | Ok spec_opt -> spec_opt
+    | Error _ -> None
+  in
+  let desired =
+    match resident_spec with
+    | Some spec -> spec.desired
+    | None -> false
+  in
+  `Assoc
+    [
+      ("paused", `Bool meta.paused);
+      ("desired", `Bool desired);
+      ("resident_registered", `Bool (Option.is_some resident_spec));
+      ("keepalive_running", `Bool (Keeper_keepalive.keeper_keepalive_running meta.name));
+      ( "fiber_health",
+        `String
+          (Keeper_exec_status.string_of_fiber_health
+             (Keeper_resident_supervisor.fiber_health_of meta.name)) );
+      ("presence_keepalive", `Bool meta.presence_keepalive);
+      ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);
+    ]
+
+let source_provenance_json config (meta : keeper_meta) =
+  let snapshot = keeper_default_source_snapshot meta.name in
+  let override_fields = live_override_fields meta snapshot.defaults in
+  let resident_path = resident_keeper_path config meta.name in
+  `Assoc
+    [
+      ("live_meta_path", `String (keeper_meta_path config meta.name));
+      ("resident_spec_path", `String resident_path);
+      ("resident_spec_exists", `Bool (Sys.file_exists resident_path));
+      ( "default_manifest_path",
+        match snapshot.defaults.manifest_path with
+        | Some path -> `String path
+        | None -> `Null );
+      ( "default_source_kind",
+        match snapshot.source_kind with
+        | Some kind -> `String kind
+        | None -> `Null );
+      ("precedence", `List [ `String "live_meta"; `String "resident_spec"; `String "toml"; `String "persona" ]);
+      ("has_live_override", `Bool (override_fields <> []));
+      ("override_fields", string_list_to_json override_fields);
     ]

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -5,7 +5,6 @@ open Tool_args
 open Keeper_types
 open Keeper_memory
 open Keeper_alerting
-open Keeper_exec_persona
 open Keeper_exec_tools
 open Keeper_keepalive
 open Keeper_execution
@@ -314,6 +313,7 @@ let handle_keeper_status ctx args : tool_result =
                 ~keepalive_started_at:(keeper_keepalive_started_at m.name)
                 ~now_ts
          in
+         let defaults_snapshot = keeper_default_source_snapshot m.name in
 
          let compaction_history_tail =
            if not include_compaction_history then
@@ -427,6 +427,7 @@ let handle_keeper_status ctx args : tool_result =
              ("needs", if String.trim m.needs = "" then `Null else `String m.needs);
              ("desires", if String.trim m.desires = "" then `Null else `String m.desires);
            ]);
+           ("paused", `Bool m.paused);
            ("keepalive_running", `Bool keepalive_running);
            ("agent", agent_status);
            ("diagnostic", diagnostic);
@@ -461,13 +462,7 @@ let handle_keeper_status ctx args : tool_result =
                then `Null
                else `String m.last_proactive_preview);
            ]);
-           ("drift", `Assoc [
-             ("enabled", `Bool false);
-             ("min_turn_gap", `Int 0);
-             ("count_total", `Int 0);
-             ("last_turn", `Int 0);
-             ("last_reason", `Null);
-           ]);
+           ("drift", drift_surface_json ());
            ("policy", `Assoc [
              ("mode", `String m.policy_mode);
              ("voice_enabled", `Bool m.policy_voice_enabled);
@@ -477,15 +472,8 @@ let handle_keeper_status ctx args : tool_result =
              ("available_internal_tools", string_list_to_json all_internal_tools);
              ("blocked_internal_tools", string_list_to_json blocked_internal_tools);
            ]);
-           ("initiative", `Assoc [
-             ("enabled", `Bool false);
-             ("scope", `String "board_only");
-             ("idle_sec", `Int 3600);
-             ("cooldown_sec", `Int 3600);
-             ("context_mode", `String "board_snapshot");
-             ("post_ttl_hours", `Int 24);
-           ]);
-           ("auto_team_session_enabled", `Bool false);
+           ("initiative", initiative_surface_json defaults_snapshot.defaults);
+           ("auto_team_session", auto_team_session_surface_json ());
            ("active_team_session_id",
              match m.active_team_session_id with
              | Some session_id -> `String session_id
@@ -512,10 +500,13 @@ let handle_keeper_status ctx args : tool_result =
              ("include_history_tail", `Bool include_history_tail);
              ("include_compaction_history", `Bool include_compaction_history);
            ]);
-	           ("models_resolved", models_resolved);
-	           ("context", ctx_stats);
-	           ("skill_route", match last_skill_route with Some v -> v | None -> `Null);
-	           ("metrics_overview", metrics_summary_to_json metrics_overview);
+           ("models_resolved", models_resolved);
+           ("runtime", runtime_surface_json ctx.config m);
+           ("coordination", coordination_surface_json m);
+           ("sources", source_provenance_json ctx.config m);
+           ("context", ctx_stats);
+           ("skill_route", match last_skill_route with Some v -> v | None -> `Null);
+           ("metrics_overview", metrics_summary_to_json metrics_overview);
 	           ("memory_bank", memory_summary_to_json memory_bank_summary);
            ("metrics_tail", metrics_tail);
            ("history_tail", history_tail);

--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -275,28 +275,24 @@ let append_keeper_auto_team_session_note (ctx : _ context) (meta : keeper_meta)
 let maybe_handle_auto_team_session (ctx : _ context) (meta : keeper_meta)
     (message : string) :
     ((tool_result option * keeper_meta), string) result =
-  if true then
-    Ok (None, meta)
-  else
-    let linked_meta, running_session = running_session_for_keeper ctx.config meta in
-    match running_session with
-    | Some session -> (
-        match append_keeper_auto_team_session_note ctx linked_meta session message with
-        | Error err -> Error err
-        | Ok session' ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
-    | None -> (
-        match start_keeper_auto_team_session ctx linked_meta message with
-        | Error err -> Error err
-        | Ok (updated_meta, session, spawn_error) ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:updated_meta ~session ~created:true ~reused:false
-                ?spawn_error ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))
-
+  let linked_meta, running_session = running_session_for_keeper ctx.config meta in
+  match running_session with
+  | Some session -> (
+      match append_keeper_auto_team_session_note ctx linked_meta session message with
+      | Error err -> Error err
+      | Ok session' ->
+          let json =
+            keeper_auto_team_session_response_json
+              ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
+          in
+          Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
+  | None -> (
+      match start_keeper_auto_team_session ctx linked_meta message with
+      | Error err -> Error err
+      | Ok (updated_meta, session, spawn_error) ->
+          let json =
+            keeper_auto_team_session_response_json
+              ~meta:updated_meta ~session ~created:true ~reused:false
+              ?spawn_error ()
+          in
+          Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -233,6 +233,12 @@ type keeper_profile_defaults = {
   presence_keepalive : bool option;
   presence_keepalive_sec : int option;
   proactive_enabled : bool option;
+  initiative_enabled : bool option;
+  initiative_scope : string option;
+  initiative_idle_sec : int option;
+  initiative_cooldown_sec : int option;
+  initiative_context_mode : string option;
+  initiative_post_ttl_hours : int option;
 }
 
 type persona_summary = {
@@ -268,6 +274,12 @@ let empty_keeper_profile_defaults = {
   presence_keepalive = None;
   presence_keepalive_sec = None;
   proactive_enabled = None;
+  initiative_enabled = None;
+  initiative_scope = None;
+  initiative_idle_sec = None;
+  initiative_cooldown_sec = None;
+  initiative_context_mode = None;
+  initiative_post_ttl_hours = None;
 }
 
 let personas_root_opt () =
@@ -348,6 +360,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
          presence_keepalive = bool_ "presence_keepalive";
          presence_keepalive_sec = int_ "presence_keepalive_sec";
          proactive_enabled = bool_ "proactive_enabled";
+         initiative_enabled = bool_ "initiative_enabled";
+         initiative_scope = str "initiative_scope";
+         initiative_idle_sec = int_ "initiative_idle_sec";
+         initiative_cooldown_sec = int_ "initiative_cooldown_sec";
+         initiative_context_mode = str "initiative_context_mode";
+         initiative_post_ttl_hours = int_ "initiative_post_ttl_hours";
        })
 
 let load_keeper_toml (path : string)
@@ -452,6 +470,15 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 presence_keepalive = Safe_ops.json_bool_opt "presence_keepalive" keeper_json;
                 presence_keepalive_sec = Safe_ops.json_int_opt "presence_keepalive_sec" keeper_json;
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
+                initiative_enabled = Safe_ops.json_bool_opt "initiative_enabled" keeper_json;
+                initiative_scope = Safe_ops.json_string_opt "initiative_scope" keeper_json;
+                initiative_idle_sec = Safe_ops.json_int_opt "initiative_idle_sec" keeper_json;
+                initiative_cooldown_sec =
+                  Safe_ops.json_int_opt "initiative_cooldown_sec" keeper_json;
+                initiative_context_mode =
+                  Safe_ops.json_string_opt "initiative_context_mode" keeper_json;
+                initiative_post_ttl_hours =
+                  Safe_ops.json_int_opt "initiative_post_ttl_hours" keeper_json;
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })
 
@@ -466,6 +493,33 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
        load_keeper_profile_defaults_from_persona name)
   | None ->
     load_keeper_profile_defaults_from_persona name
+
+type keeper_default_source_snapshot = {
+  source_kind : string option;
+  defaults : keeper_profile_defaults;
+}
+
+let keeper_default_source_snapshot name : keeper_default_source_snapshot =
+  match keeper_toml_path_opt name with
+  | Some toml_path -> (
+      match load_keeper_toml toml_path with
+      | Ok (_name, defaults) ->
+          { source_kind = Some "toml"; defaults }
+      | Error e ->
+          Log.Keeper.warn
+            "toml config for %s failed (%s), falling back to persona"
+            name e;
+          let defaults = load_keeper_profile_defaults_from_persona name in
+          let source_kind =
+            if Option.is_some defaults.manifest_path then Some "persona" else None
+          in
+          { source_kind; defaults })
+  | None ->
+      let defaults = load_keeper_profile_defaults_from_persona name in
+      let source_kind =
+        if Option.is_some defaults.manifest_path then Some "persona" else None
+      in
+      { source_kind; defaults }
 
 (** Load extended persona description from AGENT.md if present.
     Truncated to [max_chars] to avoid bloating the system prompt. *)
@@ -535,4 +589,3 @@ let session_base_dir (config : Room.config) =
 
 let keeper_agent_name name =
   Printf.sprintf "keeper-%s-agent" name
-

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -68,6 +68,10 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_status_exposes_summary_and_recoverable;
+          Alcotest.test_case "keeper config exposes live runtime and sources"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_config_exposes_live_runtime_and_sources;
           Alcotest.test_case "snapshot keeper tool audit fallback" `Quick
             Test_operator_control_keeper.test_snapshot_keeper_tool_audit_fallback;
           Alcotest.test_case "keeper msg auto team session bridge" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -121,15 +121,123 @@ let test_keeper_status_exposes_summary_and_recoverable () =
               ])
       in
       Alcotest.(check bool) "persistent status ok" true ok;
-      let diagnostic = parse_json_exn body |> Yojson.Safe.Util.member "diagnostic" in
+      let status_json = parse_json_exn body in
+      let diagnostic = status_json |> Yojson.Safe.Util.member "diagnostic" in
       Alcotest.(check string) "health_state" "offline"
         Yojson.Safe.Util.(diagnostic |> member "health_state" |> to_string);
       Alcotest.(check string) "next action recover" "recover"
         Yojson.Safe.Util.(diagnostic |> member "next_action_path" |> to_string);
       Alcotest.(check bool) "recoverable true" true
         Yojson.Safe.Util.(diagnostic |> member "recoverable" |> to_bool);
+      Alcotest.(check string) "auto team session wired" "wired"
+        Yojson.Safe.Util.(
+          status_json |> member "auto_team_session" |> member "status" |> to_string);
       Alcotest.(check bool) "summary present" true
         (String.length Yojson.Safe.Util.(diagnostic |> member "summary" |> to_string) > 0))
+
+let test_keeper_config_exposes_live_runtime_and_sources () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let cwd = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.chdir cwd;
+      cleanup_dir base_dir)
+    (fun () ->
+      Unix.chdir base_dir;
+      let keepers_dir = Filename.concat (Filename.concat base_dir "config") "keepers" in
+      Fs_compat.mkdir_p keepers_dir;
+      Fs_compat.save_file
+        (Filename.concat keepers_dir "config-provenance.toml")
+        {|
+[keeper]
+goal = "Defaults goal"
+models = ["llama:qwen3.5-35b-a3b-ud-q8-xl"]
+room_scope = "all"
+trigger_mode = "legacy"
+proactive_enabled = true
+initiative_enabled = true
+initiative_scope = "board_only"
+initiative_idle_sec = 3600
+initiative_cooldown_sec = 3600
+initiative_context_mode = "board_snapshot"
+initiative_post_ttl_hours = 24
+|};
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
+      in
+      let keeper_name = "config-provenance" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing"
+        | Error err -> Alcotest.fail ("meta read failed: " ^ err)
+      in
+      let mutated =
+        {
+          meta with
+          room_scope = "current";
+          trigger_mode = "explicit_only";
+          proactive_enabled = false;
+          paused = true;
+          updated_at = Types.now_iso ();
+        }
+      in
+      (match Masc_mcp.Keeper_types.write_meta config mutated with
+      | Ok () -> ()
+      | Error err -> Alcotest.fail ("meta write failed: " ^ err));
+      let status, json =
+        Masc_mcp.Dashboard_http_keeper.keeper_config_json config keeper_name
+      in
+      Alcotest.(check bool) "config found" true (status = `OK);
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "trigger_mode from live meta" "explicit_only"
+        (json |> member "coordination" |> member "trigger_mode" |> to_string);
+      Alcotest.(check string) "room_scope from live meta" "current"
+        (json |> member "coordination" |> member "room_scope" |> to_string);
+      Alcotest.(check bool) "runtime paused from live meta" true
+        (json |> member "runtime" |> member "paused" |> to_bool);
+      Alcotest.(check bool) "proactive enabled from live meta" false
+        (json |> member "proactive" |> member "enabled" |> to_bool);
+      Alcotest.(check string) "default source kind" "toml"
+        (json |> member "sources" |> member "default_source_kind" |> to_string);
+      Alcotest.(check bool) "live override flagged" true
+        (json |> member "sources" |> member "has_live_override" |> to_bool);
+      Alcotest.(check string) "auto team session wired" "wired"
+        (json |> member "auto_team_session" |> member "status" |> to_string);
+      let override_fields =
+        json |> member "sources" |> member "override_fields" |> to_list
+        |> List.map to_string
+      in
+      Alcotest.(check bool) "override field trigger_mode" true
+        (List.mem "coordination.trigger_mode" override_fields);
+      Alcotest.(check bool) "override field room_scope" true
+        (List.mem "coordination.room_scope" override_fields);
+      Alcotest.(check bool) "override field proactive" true
+        (List.mem "proactive.enabled" override_fields);
+      Alcotest.(check string) "initiative source-only" "source_only"
+        (json |> member "initiative" |> member "status" |> to_string);
+      Alcotest.(check bool) "initiative configured in source" true
+        (json |> member "initiative" |> member "configured_in_source" |> to_bool);
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "keeper down ok" true ok)
 
 let test_snapshot_keeper_tool_audit_fallback () =
   Eio_main.run @@ fun env ->
@@ -277,7 +385,7 @@ let test_keeper_msg_auto_team_session_bridge () =
         | Ok None -> Alcotest.fail "keeper meta missing after keeper_msg"
         | Error err -> Alcotest.fail ("meta read failed: " ^ err)
       in
-      (* auto_team_session_enabled field removed *)
+      (* auto_team_session is a live bridge now and should surface as wired. *)
       Alcotest.(check (option string)) "linked session id"
         (Some session_id) meta.active_team_session_id;
       Alcotest.(check int) "start count" 1 meta.team_session_start_count_total;
@@ -296,8 +404,8 @@ let test_keeper_msg_auto_team_session_bridge () =
       in
       Alcotest.(check bool) "keeper status ok" true status_ok;
       let status_json = parse_json_exn status_body in
-      Alcotest.(check bool) "status exposes opt-in" false
-        Yojson.Safe.Util.(status_json |> member "auto_team_session_enabled" |> to_bool);
+      Alcotest.(check string) "status exposes auto team session wiring" "wired"
+        Yojson.Safe.Util.(status_json |> member "auto_team_session" |> member "status" |> to_string);
       Alcotest.(check string) "status exposes running bridge" "running"
         Yojson.Safe.Util.(status_json |> member "team_session_state" |> to_string);
       let events = Team_session_store.read_recent_events config session_id ~max_count:10 in


### PR DESCRIPTION
## Summary
- make keeper dashboard/config surfaces reflect live runtime truth instead of synthetic defaults
- expose keeper config provenance across live meta, resident spec, TOML, and persona defaults
- restore the live `masc_keeper_msg -> team session` bridge that had been hard-disabled

## What Changed
- backend:
  - added `runtime`, `coordination`, and `sources` surfaces to keeper config/detail responses
  - replaced fake `drift=false`, `initiative=false`, and `auto_team_session_enabled=false` responses with explicit feature state objects
  - surfaced live/default divergence through `has_live_override` and `override_fields`
  - added default-source snapshot loading from TOML/persona for provenance and source-only initiative reporting
  - restored `maybe_handle_auto_team_session` so keeper messages can create/reuse linked team sessions again
- frontend:
  - extended keeper config types for runtime/coordination/source provenance
  - updated keeper config panel to show real runtime state, actual storage paths, and unsupported/source-only states
  - removed drift editing UI because the backend does not support real drift patching
- tests:
  - added keeper config provenance/runtime coverage
  - added auto-team-session status coverage to persistent status
  - verified keeper team-session bridge flow again

## Behavior Changes
- dashboard now shows where keeper defaults came from and whether live state diverged
- unsupported/source-only features render as `UNWIRED` or `SOURCE ONLY`, not `OFF`
- `auto_team_session` now reports as live wired behavior, matching runtime reality
- `masc_keeper_msg` can again start and reuse linked team sessions

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-dashboard-truth ./test/test_operator_control.exe --display=short`
- `env MASC_STORAGE_TYPE=filesystem MASC_POSTGRES_URL='' DATABASE_URL='' SUPABASE_DB_URL='' SB_PG_URL='' GRAPHQL_API_KEY='' ZAI_API_KEY='' dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-dashboard-truth ./test/test_operator_control.exe -- test --color=never operator 21-24`
- `node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/typescript/bin/tsc --noEmit --pretty false -p /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-dashboard-truth/dashboard/tsconfig.json`
