### PR TITLE
Reduce autoresearch log noise

### DIFF
--- a/lib/autoresearch_serde.ml
+++ b/lib/autoresearch_serde.ml
@@ -7,6 +7,11 @@
 
 include Autoresearch_types
 
+type state_decode = {
+  summary : persisted_summary;
+  used_legacy_model_key : bool;
+}
+
 let decision_to_string = function Keep -> "keep" | Discard -> "discard"
 
 let decision_of_string = function
@@ -91,44 +96,59 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
       | Some e -> `String e | None -> `Null);
   ]
 
-let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
+let state_decode_of_yojson (json : Yojson.Safe.t) : state_decode =
   let open Yojson.Safe.Util in
+  let model_model, used_legacy_model_key =
+    match json |> member "model_model" |> to_string_option with
+    | Some value -> (value, false)
+    | None -> (
+        match json |> member "llm_model" |> to_string_option with
+        | Some value -> (value, true)
+        | None -> (json |> member "model_model" |> to_string, false))
+  in
   {
-    loop_id = json |> member "loop_id" |> to_string;
-    status =
-      (json |> member "status" |> to_string |> status_of_string)
-      |> Option.value ~default:Error;
-    current_cycle = json |> member "current_cycle" |> to_int;
-    baseline = json |> member "baseline" |> to_float;
-    best_score = json |> member "best_score" |> to_float;
-    best_cycle = json |> member "best_cycle" |> to_int;
-    queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
-    total_keeps = json |> member "total_keeps" |> to_int;
-    total_discards = json |> member "total_discards" |> to_int;
-    goal = json |> member "goal" |> to_string;
-    metric_fn = json |> member "metric_fn" |> to_string;
-    model_model = json |> member "model_model" |> to_string;
-    target_file = json |> member "target_file" |> to_string;
-    workdir = json |> member "workdir" |> to_string;
-    cycle_timeout_s = json |> member "cycle_timeout_s" |> to_float;
-    max_cycles = json |> member "max_cycles" |> to_int;
-    error_message = json |> member "error" |> to_string_option;
-    elapsed_s = json |> member "elapsed_s" |> to_float;
-    source_workdir =
-      json |> member "source_workdir" |> to_string_option
-      |> Option.value ~default:(json |> member "workdir" |> to_string);
-    program_note = json |> member "program_note" |> to_string_option;
-    warnings =
-      match json |> member "warnings" with
-      | `List items ->
-          items
-          |> List.filter_map (function
-               | `String value ->
-                   let trimmed = String.trim value in
-                   if trimmed = "" then None else Some trimmed
-               | _ -> None)
-      | _ -> [];
+    summary =
+      {
+        loop_id = json |> member "loop_id" |> to_string;
+        status =
+          (json |> member "status" |> to_string |> status_of_string)
+          |> Option.value ~default:Error;
+        current_cycle = json |> member "current_cycle" |> to_int;
+        baseline = json |> member "baseline" |> to_float;
+        best_score = json |> member "best_score" |> to_float;
+        best_cycle = json |> member "best_cycle" |> to_int;
+        queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
+        total_keeps = json |> member "total_keeps" |> to_int;
+        total_discards = json |> member "total_discards" |> to_int;
+        goal = json |> member "goal" |> to_string;
+        metric_fn = json |> member "metric_fn" |> to_string;
+        model_model;
+        target_file = json |> member "target_file" |> to_string;
+        workdir = json |> member "workdir" |> to_string;
+        cycle_timeout_s = json |> member "cycle_timeout_s" |> to_float;
+        max_cycles = json |> member "max_cycles" |> to_int;
+        error_message = json |> member "error" |> to_string_option;
+        elapsed_s = json |> member "elapsed_s" |> to_float;
+        source_workdir =
+          json |> member "source_workdir" |> to_string_option
+          |> Option.value ~default:(json |> member "workdir" |> to_string);
+        program_note = json |> member "program_note" |> to_string_option;
+        warnings =
+          match json |> member "warnings" with
+          | `List items ->
+              items
+              |> List.filter_map (function
+                   | `String value ->
+                       let trimmed = String.trim value in
+                       if trimmed = "" then None else Some trimmed
+                   | _ -> None)
+          | _ -> [];
+      };
+    used_legacy_model_key;
   }
+
+let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
+  (state_decode_of_yojson json).summary
 
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
   `Assoc

--- a/lib/autoresearch_serde.ml
+++ b/lib/autoresearch_serde.ml
@@ -7,11 +7,6 @@
 
 include Autoresearch_types
 
-type state_decode = {
-  summary : persisted_summary;
-  used_legacy_model_key : bool;
-}
-
 let decision_to_string = function Keep -> "keep" | Discard -> "discard"
 
 let decision_of_string = function
@@ -96,59 +91,44 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
       | Some e -> `String e | None -> `Null);
   ]
 
-let state_decode_of_yojson (json : Yojson.Safe.t) : state_decode =
-  let open Yojson.Safe.Util in
-  let model_model, used_legacy_model_key =
-    match json |> member "model_model" |> to_string_option with
-    | Some value -> (value, false)
-    | None -> (
-        match json |> member "llm_model" |> to_string_option with
-        | Some value -> (value, true)
-        | None -> (json |> member "model_model" |> to_string, false))
-  in
-  {
-    summary =
-      {
-        loop_id = json |> member "loop_id" |> to_string;
-        status =
-          (json |> member "status" |> to_string |> status_of_string)
-          |> Option.value ~default:Error;
-        current_cycle = json |> member "current_cycle" |> to_int;
-        baseline = json |> member "baseline" |> to_float;
-        best_score = json |> member "best_score" |> to_float;
-        best_cycle = json |> member "best_cycle" |> to_int;
-        queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
-        total_keeps = json |> member "total_keeps" |> to_int;
-        total_discards = json |> member "total_discards" |> to_int;
-        goal = json |> member "goal" |> to_string;
-        metric_fn = json |> member "metric_fn" |> to_string;
-        model_model;
-        target_file = json |> member "target_file" |> to_string;
-        workdir = json |> member "workdir" |> to_string;
-        cycle_timeout_s = json |> member "cycle_timeout_s" |> to_float;
-        max_cycles = json |> member "max_cycles" |> to_int;
-        error_message = json |> member "error" |> to_string_option;
-        elapsed_s = json |> member "elapsed_s" |> to_float;
-        source_workdir =
-          json |> member "source_workdir" |> to_string_option
-          |> Option.value ~default:(json |> member "workdir" |> to_string);
-        program_note = json |> member "program_note" |> to_string_option;
-        warnings =
-          match json |> member "warnings" with
-          | `List items ->
-              items
-              |> List.filter_map (function
-                   | `String value ->
-                       let trimmed = String.trim value in
-                       if trimmed = "" then None else Some trimmed
-                   | _ -> None)
-          | _ -> [];
-      };
-    used_legacy_model_key;
-  }
-
 let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
-  (state_decode_of_yojson json).summary
+  let open Yojson.Safe.Util in
+  {
+    loop_id = json |> member "loop_id" |> to_string;
+    status =
+      (json |> member "status" |> to_string |> status_of_string)
+      |> Option.value ~default:Error;
+    current_cycle = json |> member "current_cycle" |> to_int;
+    baseline = json |> member "baseline" |> to_float;
+    best_score = json |> member "best_score" |> to_float;
+    best_cycle = json |> member "best_cycle" |> to_int;
+    queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
+    total_keeps = json |> member "total_keeps" |> to_int;
+    total_discards = json |> member "total_discards" |> to_int;
+    goal = json |> member "goal" |> to_string;
+    metric_fn = json |> member "metric_fn" |> to_string;
+    model_model = json |> member "model_model" |> to_string;
+    target_file = json |> member "target_file" |> to_string;
+    workdir = json |> member "workdir" |> to_string;
+    cycle_timeout_s = json |> member "cycle_timeout_s" |> to_float;
+    max_cycles = json |> member "max_cycles" |> to_int;
+    error_message = json |> member "error" |> to_string_option;
+    elapsed_s = json |> member "elapsed_s" |> to_float;
+    source_workdir =
+      json |> member "source_workdir" |> to_string_option
+      |> Option.value ~default:(json |> member "workdir" |> to_string);
+    program_note = json |> member "program_note" |> to_string_option;
+    warnings =
+      match json |> member "warnings" with
+      | `List items ->
+          items
+          |> List.filter_map (function
+               | `String value ->
+                   let trimmed = String.trim value in
+                   if trimmed = "" then None else Some trimmed
+               | _ -> None)
+      | _ -> [];
+  }
 
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
   `Assoc

--- a/lib/autoresearch_storage.ml
+++ b/lib/autoresearch_storage.ml
@@ -95,10 +95,46 @@ let load_swarm_link_by_session ~base_path session_id =
   decode_json_file ~path ~kind:"swarm link"
     Autoresearch_serde.swarm_link_of_yojson
 
+let canonicalize_state_json ~model_model = function
+  | `Assoc fields ->
+      let fields =
+        ("model_model", `String model_model)
+        :: List.filter
+             (fun (key, _) -> key <> "model_model" && key <> "llm_model")
+             fields
+      in
+      `Assoc fields
+  | json -> json
+
 let load_state ~base_path loop_id =
   let path = state_file ~base_path loop_id in
-  decode_json_file ~path ~kind:"autoresearch state"
-    Autoresearch_serde.state_of_yojson
+  match load_json_file path with
+  | None -> None
+  | Some json ->
+      (try
+         let decoded = Autoresearch_serde.state_decode_of_yojson json in
+         if decoded.used_legacy_model_key then (
+           let canonical_json =
+             canonicalize_state_json ~model_model:decoded.summary.model_model json
+           in
+           try
+             Fs_compat.save_file path (Yojson.Safe.pretty_to_string canonical_json);
+             Log.Autoresearch.info
+               "migrated legacy autoresearch state schema for %s"
+               path
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               Log.Autoresearch.warn
+                 "failed to rewrite migrated autoresearch state for %s: %s"
+                 path (Printexc.to_string exn));
+         Some decoded.summary
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Autoresearch.warn "%s decode failed for %s: %s"
+             "autoresearch state" path (Printexc.to_string exn);
+           None)
 
 let latest_cycle_record ~base_path loop_id =
   let path = results_file ~base_path loop_id in

--- a/lib/autoresearch_storage.ml
+++ b/lib/autoresearch_storage.ml
@@ -95,44 +95,25 @@ let load_swarm_link_by_session ~base_path session_id =
   decode_json_file ~path ~kind:"swarm link"
     Autoresearch_serde.swarm_link_of_yojson
 
-let canonicalize_state_json ~model_model = function
-  | `Assoc fields ->
-      let fields =
-        ("model_model", `String model_model)
-        :: List.filter
-             (fun (key, _) -> key <> "model_model" && key <> "llm_model")
-             fields
-      in
-      `Assoc fields
-  | json -> json
-
 let load_state ~base_path loop_id =
   let path = state_file ~base_path loop_id in
   match load_json_file path with
   | None -> None
   | Some json ->
       (try
-         let decoded = Autoresearch_serde.state_decode_of_yojson json in
-         if decoded.used_legacy_model_key then (
-           let canonical_json =
-             canonicalize_state_json ~model_model:decoded.summary.model_model json
-           in
-           try
-             Fs_compat.save_file path (Yojson.Safe.pretty_to_string canonical_json);
-             Log.Autoresearch.info
-               "migrated legacy autoresearch state schema for %s"
-               path
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               Log.Autoresearch.warn
-                 "failed to rewrite migrated autoresearch state for %s: %s"
-                 path (Printexc.to_string exn));
-         Some decoded.summary
+         match json with
+         | `Assoc fields
+           when List.mem_assoc "llm_model" fields
+                && not (List.mem_assoc "model_model" fields) ->
+             Log.Autoresearch.error
+               "unsupported legacy autoresearch state schema for %s: found llm_model; expected model_model"
+               path;
+             None
+         | _ -> Some (Autoresearch_serde.state_of_yojson json)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           Log.Autoresearch.warn "%s decode failed for %s: %s"
+           Log.Autoresearch.error "%s decode failed for %s: %s"
              "autoresearch state" path (Printexc.to_string exn);
            None)
 

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -426,7 +426,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     let result = f () in
     let elapsed = Time_compat.now () -. t_start in
     if elapsed > 0.5 then
-      Log.Dashboard.warn "[snapshot_json] %s: %.0fms" label (elapsed *. 1000.0);
+      Log.Dashboard.info "[snapshot_json] %s: %.0fms" label (elapsed *. 1000.0);
     result
   in
   let config = ctx.config in
@@ -562,7 +562,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
   in
   let elapsed_total = Time_compat.now () -. t0 in
   if elapsed_total > 1.0 then
-    Log.Dashboard.warn "[snapshot_json] total: %.0fms (sessions=%d keepers=%d)"
+    Log.Dashboard.info "[snapshot_json] total: %.0fms (sessions=%d keepers=%d)"
       (elapsed_total *. 1000.0)
       (List.length tracked_sessions) (List.length keeper_names);
   _snapshot_cache := Some (cache_key, result, now);

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -34,6 +34,12 @@ let write_file path contents =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc contents)
 
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
 let with_temp_base f =
   let dir = test_dir () in
   Fun.protect
@@ -55,6 +61,58 @@ let with_eio_test f =
   Eio_main.run @@ fun _env ->
   f ()
 
+let legacy_state_json ?(loop_id = "legacy-loop") ?(model = "glm:legacy") () =
+  Printf.sprintf
+    {|
+{
+  "loop_id": "%s",
+  "goal": "Improve code quality",
+  "metric_fn": "echo 0.75",
+  "llm_model": "%s",
+  "target_file": "README.md",
+  "status": "running",
+  "current_cycle": 0,
+  "baseline": 0.75,
+  "best_score": 0.75,
+  "best_cycle": 0,
+  "queued_hypothesis": null,
+  "total_keeps": 0,
+  "total_discards": 0,
+  "max_cycles": 1,
+  "cycle_timeout_s": 30.0,
+  "workdir": "/tmp/autoresearch/worktree",
+  "source_workdir": "/tmp/autoresearch",
+  "elapsed_s": 0.5,
+  "history_count": 0,
+  "insights_count": 0,
+  "program_note": null,
+  "warnings": [ "source_workdir_dirty" ],
+  "error": null
+}
+|}
+    loop_id model
+
+let test_load_state_migrates_legacy_model_key () =
+  with_eio_test @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let loop_id = "legacy-loop" in
+  let state_path =
+    Filename.concat base_path (Printf.sprintf ".masc/autoresearch/%s/state.json" loop_id)
+  in
+  write_file state_path (legacy_state_json ~loop_id ());
+  let summary = Lib.Autoresearch.load_state ~base_path loop_id in
+  let summary =
+    match summary with
+    | Some value -> value
+    | None -> fail "expected legacy autoresearch state to load"
+  in
+  check string "legacy key loads into canonical field" "glm:legacy" summary.model_model;
+  let migrated = Yojson.Safe.from_string (read_file state_path) in
+  check string "canonical key written back" "glm:legacy"
+    Yojson.Safe.Util.(migrated |> member "model_model" |> to_string);
+  check bool "legacy key removed after rewrite" true
+    Yojson.Safe.Util.(migrated |> member "llm_model" = `Null)
+
 let test_loops_json_skips_invalid_persisted_state () =
   with_eio_test @@ fun () ->
   with_clean_loops @@ fun () ->
@@ -71,6 +129,23 @@ let test_loops_json_skips_invalid_persisted_state () =
     Yojson.Safe.Util.(json |> member "total" |> to_int);
   check int "no loop entries" 0
     Yojson.Safe.Util.(json |> member "loops" |> to_list |> List.length)
+
+let test_loops_json_loads_legacy_persisted_state () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let loop_id = "legacy-loop" in
+  let state_path =
+    Filename.concat base_path (Printf.sprintf ".masc/autoresearch/%s/state.json" loop_id)
+  in
+  write_file state_path (legacy_state_json ~loop_id ());
+  let json =
+    Lib.Dashboard_http_autoresearch.autoresearch_loops_json ~base_path
+  in
+  check int "legacy persisted loop is listed" 1
+    Yojson.Safe.Util.(json |> member "total" |> to_int);
+  check string "legacy model surfaces as canonical field" "glm:legacy"
+    Yojson.Safe.Util.(json |> member "loops" |> index 0 |> member "model_model" |> to_string)
 
 let test_loops_json_tolerates_invalid_swarm_link_for_active_loop () =
   with_eio_test @@ fun () ->
@@ -108,8 +183,12 @@ let () =
     [
       ( "loops_json",
         [
+          test_case "migrates legacy model key on load" `Quick
+            test_load_state_migrates_legacy_model_key;
           test_case "skips invalid persisted state" `Quick
             test_loops_json_skips_invalid_persisted_state;
+          test_case "loads legacy persisted state" `Quick
+            test_loops_json_loads_legacy_persisted_state;
           test_case "tolerates invalid swarm link for active loop" `Quick
             test_loops_json_tolerates_invalid_swarm_link_for_active_loop;
         ] );

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -34,12 +34,6 @@ let write_file path contents =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc contents)
 
-let read_file path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> really_input_string ic (in_channel_length ic))
-
 let with_temp_base f =
   let dir = test_dir () in
   Fun.protect
@@ -92,27 +86,6 @@ let legacy_state_json ?(loop_id = "legacy-loop") ?(model = "glm:legacy") () =
 |}
     loop_id model
 
-let test_load_state_migrates_legacy_model_key () =
-  with_eio_test @@ fun () ->
-  with_temp_base @@ fun base_path ->
-  let loop_id = "legacy-loop" in
-  let state_path =
-    Filename.concat base_path (Printf.sprintf ".masc/autoresearch/%s/state.json" loop_id)
-  in
-  write_file state_path (legacy_state_json ~loop_id ());
-  let summary = Lib.Autoresearch.load_state ~base_path loop_id in
-  let summary =
-    match summary with
-    | Some value -> value
-    | None -> fail "expected legacy autoresearch state to load"
-  in
-  check string "legacy key loads into canonical field" "glm:legacy" summary.model_model;
-  let migrated = Yojson.Safe.from_string (read_file state_path) in
-  check string "canonical key written back" "glm:legacy"
-    Yojson.Safe.Util.(migrated |> member "model_model" |> to_string);
-  check bool "legacy key removed after rewrite" true
-    Yojson.Safe.Util.(migrated |> member "llm_model" = `Null)
-
 let test_loops_json_skips_invalid_persisted_state () =
   with_eio_test @@ fun () ->
   with_clean_loops @@ fun () ->
@@ -130,7 +103,7 @@ let test_loops_json_skips_invalid_persisted_state () =
   check int "no loop entries" 0
     Yojson.Safe.Util.(json |> member "loops" |> to_list |> List.length)
 
-let test_loops_json_loads_legacy_persisted_state () =
+let test_loops_json_skips_legacy_persisted_state () =
   with_eio_test @@ fun () ->
   with_clean_loops @@ fun () ->
   with_temp_base @@ fun base_path ->
@@ -142,10 +115,10 @@ let test_loops_json_loads_legacy_persisted_state () =
   let json =
     Lib.Dashboard_http_autoresearch.autoresearch_loops_json ~base_path
   in
-  check int "legacy persisted loop is listed" 1
+  check int "legacy persisted loop is skipped" 0
     Yojson.Safe.Util.(json |> member "total" |> to_int);
-  check string "legacy model surfaces as canonical field" "glm:legacy"
-    Yojson.Safe.Util.(json |> member "loops" |> index 0 |> member "model_model" |> to_string)
+  check int "no legacy loop entries" 0
+    Yojson.Safe.Util.(json |> member "loops" |> to_list |> List.length)
 
 let test_loops_json_tolerates_invalid_swarm_link_for_active_loop () =
   with_eio_test @@ fun () ->
@@ -183,12 +156,10 @@ let () =
     [
       ( "loops_json",
         [
-          test_case "migrates legacy model key on load" `Quick
-            test_load_state_migrates_legacy_model_key;
           test_case "skips invalid persisted state" `Quick
             test_loops_json_skips_invalid_persisted_state;
-          test_case "loads legacy persisted state" `Quick
-            test_loops_json_loads_legacy_persisted_state;
+          test_case "skips legacy persisted state" `Quick
+            test_loops_json_skips_legacy_persisted_state;
           test_case "tolerates invalid swarm link for active loop" `Quick
             test_loops_json_tolerates_invalid_swarm_link_for_active_loop;
         ] );


### PR DESCRIPTION
## Summary
- downgrade dashboard snapshot timing logs from WARN to INFO
- treat unsupported legacy autoresearch state schema as ERROR instead of WARN noise
- keep legacy autoresearch state unsupported and skip it explicitly

## Validation
- built `test/test_dashboard_autoresearch.exe` with isolated dune build dir
- ran `./_build-autoresearch/default/test/test_dashboard_autoresearch.exe`
- verified 3/3 tests passed
