### PR TITLE
test: realign governance claim risk expectations

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -46,12 +46,10 @@ let risk_overrides : (string * risk_level) list = [
   ("masc_a2a_query_skill", Low);       (* "skill" contains "kill" substring *)
   ("masc_keeper_tool_catalog", Low);   (* "catalog" is read-only *)
   ("masc_model_catalog", Low);         (* read-only *)
+  (* Canonical task lifecycle entrypoint after masc_claim removal. *)
+  ("masc_transition", Medium);
   ("masc_keeper_dataset_export", Medium);  (* export, not delete *)
   ("masc_persistent_agent_dataset_export", Medium);
-  (* Claim surfaces: pre-hook only sees tool names, not transition action args. *)
-  ("masc_claim_next", Medium);
-  ("masc_claim_task", Medium);
-  ("masc_transition", Low);
 ]
 
 let critical_patterns =

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -48,6 +48,10 @@ let risk_overrides : (string * risk_level) list = [
   ("masc_model_catalog", Low);         (* read-only *)
   ("masc_keeper_dataset_export", Medium);  (* export, not delete *)
   ("masc_persistent_agent_dataset_export", Medium);
+  (* Claim surfaces: pre-hook only sees tool names, not transition action args. *)
+  ("masc_claim_next", Medium);
+  ("masc_claim_task", Medium);
+  ("masc_transition", Low);
 ]
 
 let critical_patterns =

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -5,6 +5,10 @@ module Room = Masc_mcp.Room
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
 
+let explicit_claim_tool = "masc_claim_next"
+let managed_claim_tool = "masc_claim_task"
+let generic_transition_tool = "masc_transition"
+
 (* ── Helpers ────────────────────────────────────────────────── *)
 
 let make_tmpdir () =
@@ -105,8 +109,13 @@ let test_risk_high_spawn () =
     "high" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_claim_next () =
-  let risk = Gp.assess_risk ~tool_name:"masc_claim_next" ~input:`Null in
+  let risk = Gp.assess_risk ~tool_name:explicit_claim_tool ~input:`Null in
   Alcotest.(check string) "claim_next is medium"
+    "medium" (Gp.risk_level_to_string risk)
+
+let test_risk_medium_claim_task () =
+  let risk = Gp.assess_risk ~tool_name:managed_claim_tool ~input:`Null in
+  Alcotest.(check string) "claim_task is medium"
     "medium" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_join () =
@@ -155,7 +164,7 @@ let test_risk_low_query () =
     "low" (Gp.risk_level_to_string risk)
 
 let test_risk_low_transition () =
-  let risk = Gp.assess_risk ~tool_name:"masc_transition" ~input:`Null in
+  let risk = Gp.assess_risk ~tool_name:generic_transition_tool ~input:`Null in
   Alcotest.(check string) "generic transition is low"
     "low" (Gp.risk_level_to_string risk)
 
@@ -388,7 +397,7 @@ let test_blocked_response_structure () =
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
-  let result = hook ~name:"masc_claim_next" ~args:`Null in
+  let result = hook ~name:explicit_claim_tool ~args:`Null in
   (match result with
    | Some r ->
        let module U = Yojson.Safe.Util in
@@ -401,7 +410,7 @@ let test_blocked_response_structure () =
        let _tool = data |> U.member "tool_name" |> U.to_string in
        Alcotest.(check string) "governance_level" "paranoid" _gov;
        Alcotest.(check string) "risk_level" "medium" _risk;
-       Alcotest.(check string) "tool_name" "masc_claim_next" _tool
+       Alcotest.(check string) "tool_name" explicit_claim_tool _tool
    | None -> Alcotest.fail "paranoid should block medium");
   cleanup_tmpdir tmpdir
 
@@ -442,6 +451,7 @@ let () =
       Alcotest.test_case "high: send" `Quick test_risk_high_send;
       Alcotest.test_case "high: spawn" `Quick test_risk_high_spawn;
       Alcotest.test_case "medium: claim_next" `Quick test_risk_medium_claim_next;
+      Alcotest.test_case "medium: claim_task" `Quick test_risk_medium_claim_task;
       Alcotest.test_case "medium: join" `Quick test_risk_medium_join;
       Alcotest.test_case "medium: leave" `Quick test_risk_medium_leave;
       Alcotest.test_case "medium: start" `Quick test_risk_medium_start;

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -6,8 +6,6 @@ module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
 
 let explicit_claim_tool = "masc_claim_next"
-let managed_claim_tool = "masc_claim_task"
-let generic_transition_tool = "masc_transition"
 
 (* ── Helpers ────────────────────────────────────────────────── *)
 
@@ -113,9 +111,9 @@ let test_risk_medium_claim_next () =
   Alcotest.(check string) "claim_next is medium"
     "medium" (Gp.risk_level_to_string risk)
 
-let test_risk_medium_claim_task () =
-  let risk = Gp.assess_risk ~tool_name:managed_claim_tool ~input:`Null in
-  Alcotest.(check string) "claim_task is medium"
+let test_risk_medium_transition () =
+  let risk = Gp.assess_risk ~tool_name:"masc_transition" ~input:`Null in
+  Alcotest.(check string) "transition is medium"
     "medium" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_join () =
@@ -161,11 +159,6 @@ let test_risk_low_list () =
 let test_risk_low_query () =
   let risk = Gp.assess_risk ~tool_name:"masc_query_agents" ~input:`Null in
   Alcotest.(check string) "query is low"
-    "low" (Gp.risk_level_to_string risk)
-
-let test_risk_low_transition () =
-  let risk = Gp.assess_risk ~tool_name:generic_transition_tool ~input:`Null in
-  Alcotest.(check string) "generic transition is low"
     "low" (Gp.risk_level_to_string risk)
 
 let test_risk_low_unknown () =
@@ -397,7 +390,7 @@ let test_blocked_response_structure () =
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
-  let result = hook ~name:explicit_claim_tool ~args:`Null in
+  let result = hook ~name:"masc_transition" ~args:`Null in
   (match result with
    | Some r ->
        let module U = Yojson.Safe.Util in
@@ -410,8 +403,25 @@ let test_blocked_response_structure () =
        let _tool = data |> U.member "tool_name" |> U.to_string in
        Alcotest.(check string) "governance_level" "paranoid" _gov;
        Alcotest.(check string) "risk_level" "medium" _risk;
-       Alcotest.(check string) "tool_name" explicit_claim_tool _tool
+       Alcotest.(check string) "tool_name" "masc_transition" _tool
    | None -> Alcotest.fail "paranoid should block medium");
+  cleanup_tmpdir tmpdir
+
+let test_blocked_response_structure_claim_next () =
+  Eio_main.run @@ fun _env ->
+  let tmpdir = make_tmpdir () in
+  let config = Room.default_config tmpdir in
+  let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
+  let result = hook ~name:explicit_claim_tool ~args:`Null in
+  (match result with
+   | Some r ->
+       let module U = Yojson.Safe.Util in
+       let data = r.Tool_result.data in
+       let _risk = data |> U.member "risk_level" |> U.to_string in
+       let _tool = data |> U.member "tool_name" |> U.to_string in
+       Alcotest.(check string) "risk_level" "medium" _risk;
+       Alcotest.(check string) "tool_name" explicit_claim_tool _tool
+   | None -> Alcotest.fail "paranoid should block claim_next");
   cleanup_tmpdir tmpdir
 
 (* ── Unknown governance level defaults to development ──────── *)
@@ -451,14 +461,13 @@ let () =
       Alcotest.test_case "high: send" `Quick test_risk_high_send;
       Alcotest.test_case "high: spawn" `Quick test_risk_high_spawn;
       Alcotest.test_case "medium: claim_next" `Quick test_risk_medium_claim_next;
-      Alcotest.test_case "medium: claim_task" `Quick test_risk_medium_claim_task;
+      Alcotest.test_case "medium: transition" `Quick test_risk_medium_transition;
       Alcotest.test_case "medium: join" `Quick test_risk_medium_join;
       Alcotest.test_case "medium: leave" `Quick test_risk_medium_leave;
       Alcotest.test_case "medium: start" `Quick test_risk_medium_start;
       Alcotest.test_case "medium: stop" `Quick test_risk_medium_stop;
       Alcotest.test_case "medium: pause" `Quick test_risk_medium_pause;
       Alcotest.test_case "medium: resume" `Quick test_risk_medium_resume;
-      Alcotest.test_case "low: transition" `Quick test_risk_low_transition;
       Alcotest.test_case "low: status" `Quick test_risk_low_status;
       Alcotest.test_case "low: list" `Quick test_risk_low_list;
       Alcotest.test_case "low: query" `Quick test_risk_low_query;
@@ -516,5 +525,7 @@ let () =
         test_hook_paranoid_blocks_medium;
       Alcotest.test_case "blocked response structure" `Quick
         test_blocked_response_structure;
+      Alcotest.test_case "blocked response structure: claim_next" `Quick
+        test_blocked_response_structure_claim_next;
     ];
   ]

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -104,9 +104,9 @@ let test_risk_high_spawn () =
   Alcotest.(check string) "spawn is high"
     "high" (Gp.risk_level_to_string risk)
 
-let test_risk_medium_claim () =
-  let risk = Gp.assess_risk ~tool_name:"masc_transition" ~input:`Null in
-  Alcotest.(check string) "claim is medium"
+let test_risk_medium_claim_next () =
+  let risk = Gp.assess_risk ~tool_name:"masc_claim_next" ~input:`Null in
+  Alcotest.(check string) "claim_next is medium"
     "medium" (Gp.risk_level_to_string risk)
 
 let test_risk_medium_join () =
@@ -152,6 +152,11 @@ let test_risk_low_list () =
 let test_risk_low_query () =
   let risk = Gp.assess_risk ~tool_name:"masc_query_agents" ~input:`Null in
   Alcotest.(check string) "query is low"
+    "low" (Gp.risk_level_to_string risk)
+
+let test_risk_low_transition () =
+  let risk = Gp.assess_risk ~tool_name:"masc_transition" ~input:`Null in
+  Alcotest.(check string) "generic transition is low"
     "low" (Gp.risk_level_to_string risk)
 
 let test_risk_low_unknown () =
@@ -383,7 +388,7 @@ let test_blocked_response_structure () =
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
-  let result = hook ~name:"masc_transition" ~args:`Null in
+  let result = hook ~name:"masc_claim_next" ~args:`Null in
   (match result with
    | Some r ->
        let module U = Yojson.Safe.Util in
@@ -396,7 +401,7 @@ let test_blocked_response_structure () =
        let _tool = data |> U.member "tool_name" |> U.to_string in
        Alcotest.(check string) "governance_level" "paranoid" _gov;
        Alcotest.(check string) "risk_level" "medium" _risk;
-       Alcotest.(check string) "tool_name" "masc_transition" _tool
+       Alcotest.(check string) "tool_name" "masc_claim_next" _tool
    | None -> Alcotest.fail "paranoid should block medium");
   cleanup_tmpdir tmpdir
 
@@ -436,13 +441,14 @@ let () =
       Alcotest.test_case "high: merge" `Quick test_risk_high_merge;
       Alcotest.test_case "high: send" `Quick test_risk_high_send;
       Alcotest.test_case "high: spawn" `Quick test_risk_high_spawn;
-      Alcotest.test_case "medium: claim" `Quick test_risk_medium_claim;
+      Alcotest.test_case "medium: claim_next" `Quick test_risk_medium_claim_next;
       Alcotest.test_case "medium: join" `Quick test_risk_medium_join;
       Alcotest.test_case "medium: leave" `Quick test_risk_medium_leave;
       Alcotest.test_case "medium: start" `Quick test_risk_medium_start;
       Alcotest.test_case "medium: stop" `Quick test_risk_medium_stop;
       Alcotest.test_case "medium: pause" `Quick test_risk_medium_pause;
       Alcotest.test_case "medium: resume" `Quick test_risk_medium_resume;
+      Alcotest.test_case "low: transition" `Quick test_risk_low_transition;
       Alcotest.test_case "low: status" `Quick test_risk_low_status;
       Alcotest.test_case "low: list" `Quick test_risk_low_list;
       Alcotest.test_case "low: query" `Quick test_risk_low_query;


### PR DESCRIPTION
## Summary
- realign governance pipeline tests with the current claim surface split
- treat explicit `masc_claim_next` as the medium-risk claim surface
- pin generic `masc_transition` as low-risk at the tool-name classification layer

## Why
- PR #2708 post-merge CI failed in `Build and Test`
- the actual quick-suite failures were `risk_assessment 15 medium: claim` and `pre_hook_integration 5 blocked response structure`
- current `Governance_pipeline.assess_risk` classifies by tool name, so `masc_transition` is low while `masc_claim_next` carries the claim risk semantics

## Verification
- `env DUNE_CACHE=disabled dune build --root . test/test_governance_pipeline.exe`
- `env DUNE_CACHE=disabled dune exec --root . test/test_governance_pipeline.exe -- test risk_assessment 15`
- `env DUNE_CACHE=disabled dune exec --root . test/test_governance_pipeline.exe -- test pre_hook_integration 5`

Closes #2695