### PR TITLE
fix: run pre-hooks before tag dispatch

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -400,7 +400,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   (* Dispatch a single module by tag — creates only that module's context *)
   let dispatch_by_tag (tag : Tool_dispatch.module_tag) : (bool * string) option =
-    match tag with
+    match Tool_dispatch.run_pre_hooks ~name ~args:arguments with
+    | Some blocked -> Some (Tool_result.to_legacy blocked)
+    | None -> match tag with
     | Mod_plan ->
         Tool_plan.dispatch { config } ~name ~args:arguments
     | Mod_run ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -703,9 +703,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          |> String.lowercase_ascii
        in
        Governance_pipeline.install ~config:state.room_config ~governance_level);
-      (* Admin tool capability gate via dispatch_structured path.
-         execute_tool_eio tag-based dispatch bypasses pre-hooks;
-         full enforcement is a follow-up. *)
+      (* Admin tool capability gate via Tool_dispatch pre-hooks.
+         execute_tool_eio tag-based dispatch now runs the shared
+         pre-hook path before module dispatch. *)
       Tool_permissions.install ~get_agent_name:(fun () -> None);
       bootstrap_keepers ~sw ~clock state;
       init_task_backend ();

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -45,6 +45,10 @@ val register_pre_hook : pre_hook -> unit
 val register_post_hook : post_hook -> unit
 val clear_hooks : unit -> unit
 
+val run_pre_hooks : name:string -> args:Yojson.Safe.t -> Tool_result.t option
+(** Execute registered pre-hooks in order.
+    Returns the first short-circuit result, if any. *)
+
 val dispatch_structured : name:string -> args:Yojson.Safe.t -> Tool_result.t option
 (** Structured dispatch with hook support.
     Execution order: pre-hooks -> handler -> post-hooks. *)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -7,6 +7,8 @@
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
+module Tool_dispatch = Masc_mcp.Tool_dispatch
+module Tool_result = Masc_mcp.Tool_result
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
@@ -2357,6 +2359,40 @@ let test_execute_tool_help_tool () =
     Yojson.Safe.Util.(json |> member "name" |> to_string);
   cleanup_dir base_path
 
+let test_execute_tool_tag_dispatch_respects_pre_hooks () =
+  Eio_main.run @@ fun env ->
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Tool_dispatch.clear_hooks ();
+      cleanup_dir base_path)
+    (fun () ->
+      Tool_dispatch.clear_hooks ();
+      Tool_dispatch.register_pre_hook
+        (fun ~name ~args:_ ->
+          if String.equal name "masc_tool_help" then
+            Some
+              {
+                Tool_result.success = false;
+                data = `String "blocked-by-pre-hook";
+                tool_name = name;
+                duration_ms = 0.0;
+              }
+          else None);
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let room_path = Masc_mcp.Room.masc_dir state.room_config in
+      let _ = Config.switch_mode room_path Mode.Full in
+      let ok, msg =
+        Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
+          ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
+      in
+      Alcotest.(check bool) "pre-hook blocks tagged dispatch" false ok;
+      Alcotest.(check string) "blocked message returned" "blocked-by-pre-hook" msg)
+
 (* ===== Test Suites ===== *)
 
 let state_tests = [
@@ -2409,6 +2445,8 @@ let eio_tests = [
   "handle resources/subscribe roundtrip", `Quick,
     test_handle_request_resources_subscribe_roundtrip;
   "execute masc_tool_help", `Quick, test_execute_tool_help_tool;
+  "execute tag dispatch respects pre-hooks", `Quick,
+    test_execute_tool_tag_dispatch_respects_pre_hooks;
   "handle tools/list mdal descriptions", `Quick,
     test_handle_request_tools_list_mdal_descriptions;
   "handle tools/list filters requested names", `Quick,

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2384,8 +2384,7 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
               }
           else None);
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let room_path = Masc_mcp.Room.masc_dir state.room_config in
-      let _ = Config.switch_mode room_path Mode.Full in
+      let _room_path = Masc_mcp.Room.masc_dir state.room_config in
       let ok, msg =
         Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
           ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])


### PR DESCRIPTION
## Summary
- run Tool_dispatch pre-hooks before tag-based execute_tool_eio module dispatch
- preserve legacy `(bool * string)` behavior by converting blocked Tool_result values with `Tool_result.to_legacy`
- add a regression test covering a tagged tool (`masc_tool_help`) blocked by a pre-hook

Closes #2686

## Verification
- `DUNE_CACHE=disabled opam exec -- dune build --root . _build/default/test/test_mcp_server_eio.exe`
- `DUNE_CACHE=disabled opam exec -- ./_build/default/test/test_mcp_server_eio.exe`