### PR TITLE
feat: add keeper-driven improve loop

### DIFF
--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -1,0 +1,50 @@
+[keeper]
+goal = "Burn down open masc-mcp PR conflicts and issue backlog one candidate at a time."
+short_goal = "Keep one active burn-down lane moving."
+mid_goal = "Reduce conflicted PRs, failing PRs, and open bug issues with reproducible local verification."
+long_goal = "Operate an always-on keeper-first loop that continuously improves masc-mcp."
+
+soul_profile = "delivery"
+
+will = "Keep the repo moving by selecting the next highest-leverage candidate and preparing the exact worktree/action lane."
+needs = "Access to GitHub PR/issue state, local worktrees, review evidence, and the command-plane truth."
+desires = "Tight burn-down loops with explicit verification and low operator overhead."
+
+instructions = """
+You are masc-improver, a keeper dedicated to improving masc-mcp itself.
+
+Default loop:
+1. Read masc_improve_loop_status.
+2. Call masc_improve_loop_tick to select the next candidate.
+3. If execute=false/dry-run, inspect the returned plan and move into the prepared worktree.
+4. Reproduce first, patch narrowly, verify locally, then use scripts/pr-open.sh for a draft PR.
+5. Treat cross-model review as a merge gate. Do not merge without review evidence and green required checks.
+
+Focus order:
+- conflicted PRs
+- failing PRs
+- bug/high/safety issues
+- remaining issues
+
+Never work outside masc-mcp. Use worktrees. One active lane at a time.
+"""
+
+models = ["llama:qwen3.5-35b-a3b-ud-q4-xl"]
+allowed_models = ["llama:qwen3.5-35b-a3b-ud-q4-xl", "glm-5"]
+active_model = "llama:qwen3.5-35b-a3b-ud-q4-xl"
+
+room_scope = "current"
+scope_kind = "local"
+trigger_mode = "explicit_only"
+mention_targets = ["masc-improver", "improver"]
+
+proactive_enabled = true
+presence_keepalive = true
+presence_keepalive_sec = 30
+
+policy_shell_mode = "coding"
+
+initiative_enabled = true
+initiative_scope = "board_only"
+initiative_idle_sec = 300
+initiative_cooldown_sec = 300

--- a/lib/autoresearch_serde.ml
+++ b/lib/autoresearch_serde.ml
@@ -107,10 +107,7 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
   let float_ key ~default = try json |> member key |> to_float with Type_error _ -> default in
   {
     loop_id = required_str "loop_id";
-    status =
-      (json |> member "status" |> to_string_option
-       |> Option.map status_of_string |> Option.join)
-      |> Option.value ~default:Error;
+    status = status_of_string (required_str "status") |> Option.value ~default:Error;
     current_cycle = int_ "current_cycle" ~default:0;
     baseline = float_ "baseline" ~default:0.0;
     best_score = float_ "best_score" ~default:0.0;

--- a/lib/autoresearch_serde.ml
+++ b/lib/autoresearch_serde.ml
@@ -94,10 +94,19 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
 let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
   let open Yojson.Safe.Util in
   let str key ~default = json |> member key |> to_string_option |> Option.value ~default in
+  let required_str key =
+    match json |> member key |> to_string_option |> Option.map String.trim with
+    | Some value when value <> "" -> value
+    | _ ->
+        raise
+          (Invalid_argument
+             (Printf.sprintf
+                "missing required autoresearch state field: %s" key))
+  in
   let int_ key ~default = try json |> member key |> to_int with Type_error _ -> default in
   let float_ key ~default = try json |> member key |> to_float with Type_error _ -> default in
   {
-    loop_id = str "loop_id" ~default:"unknown";
+    loop_id = required_str "loop_id";
     status =
       (json |> member "status" |> to_string_option
        |> Option.map status_of_string |> Option.join)
@@ -109,10 +118,10 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
     queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
     total_keeps = int_ "total_keeps" ~default:0;
     total_discards = int_ "total_discards" ~default:0;
-    goal = str "goal" ~default:"";
-    metric_fn = str "metric_fn" ~default:"";
-    model_model = str "model_model" ~default:"";
-    target_file = str "target_file" ~default:"";
+    goal = required_str "goal";
+    metric_fn = required_str "metric_fn";
+    model_model = required_str "model_model";
+    target_file = required_str "target_file";
     workdir = str "workdir" ~default:".";
     cycle_timeout_s = float_ "cycle_timeout_s" ~default:300.0;
     max_cycles = int_ "max_cycles" ~default:10;

--- a/lib/dune
+++ b/lib/dune
@@ -314,6 +314,7 @@
    tool_schemas_control
    tool_schemas_a2a
    tool_schemas_misc
+   tool_improve_loop_schemas
    tool_plan
    tool_run
    tool_bridge
@@ -359,6 +360,7 @@
    tool_room
    workflow_guide
    tool_control
+   tool_improve_loop
    tool_verification
    tool_misc
    tool_agent_timeline

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -414,7 +414,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
             (try
                Tool_improve_loop.maybe_tick_from_keepalive ~config:ctx.config
                  ~agent_name:meta_after_proactive.agent_name
-                 ~keeper_name:meta_after_proactive.name ()
+                 ~keeper_name:meta_after_proactive.name
+                 ~sw:ctx.sw ~clock:ctx.clock ~proc_mgr:ctx.proc_mgr ()
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -411,6 +411,15 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               float_of_int
                 (max 30 (min 300 meta_after_proactive.presence_keepalive_sec))
             in
+            (try
+               Tool_improve_loop.maybe_tick_from_keepalive ~config:ctx.config
+                 ~agent_name:meta_after_proactive.agent_name
+                 ~keeper_name:meta_after_proactive.name ()
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Keeper.warn "improve loop keepalive tick skipped: %s"
+                 (Printexc.to_string exn));
             let jitter = base *. 0.2 *. Random.float 1.0 in  (* intentional: jitter *)
             interruptible_sleep ~clock:ctx.clock ~stop ~wakeup (base +. jitter);
             if !stop then ()

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -91,7 +91,8 @@ let read_only_tools =
    "masc_goal_list"; "masc_team_session_status"; "masc_team_session_report";
    "masc_team_session_list"; "masc_team_session_compare";
    "masc_team_session_events"; "masc_team_session_prove";
-   "masc_operator_snapshot"; "masc_operator_digest"]
+   "masc_operator_snapshot"; "masc_operator_digest";
+   "masc_improve_loop_status"]
 
 let requires_join_tools = [
   "masc_add_task"; "masc_claim_next"; "masc_transition";
@@ -102,6 +103,8 @@ let requires_join_tools = [
   "masc_vote_cast"; "masc_vote_revoke";
   "masc_register_capabilities"; "masc_suspend"; "masc_leave";
   "masc_operator_action"; "masc_operator_confirm";
+  "masc_improve_loop_start"; "masc_improve_loop_pause";
+  "masc_improve_loop_resume"; "masc_improve_loop_tick";
   "masc_code_swarm_plan"; "masc_code_swarm_verify"; "masc_code_swarm_merge";
 ]
 
@@ -135,6 +138,7 @@ let () =
   register_module_tag ~schemas:Tool_keeper.schemas ~tag:Mod_keeper;
   register_module_tag ~schemas:Tool_compact.schemas ~tag:Mod_compact;
   register_module_tag ~schemas:Tool_mdal.schemas ~tag:Mod_mdal;
+  register_module_tag ~schemas:Tool_improve_loop.schemas ~tag:Mod_improve_loop;
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
   register_module_tag ~schemas:Tool_research.schemas ~tag:Mod_research;
   register_module_tag ~schemas:Tool_model_catalog.schemas ~tag:Mod_model_catalog;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -518,7 +518,13 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args:arguments
     | Mod_improve_loop ->
         Tool_improve_loop.dispatch
-          { Tool_improve_loop.config; agent_name }
+          {
+            Tool_improve_loop.config;
+            agent_name;
+            sw = Some sw;
+            clock = Some clock;
+            proc_mgr = state.Mcp_server.proc_mgr;
+          }
           ~name ~args:arguments
     | Mod_agent_timeline ->
         Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name } ~name ~args:arguments

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -516,6 +516,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args:arguments
     | Mod_control ->
         Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args:arguments
+    | Mod_improve_loop ->
+        Tool_improve_loop.dispatch
+          { Tool_improve_loop.config; agent_name }
+          ~name ~args:arguments
     | Mod_agent_timeline ->
         Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name } ~name ~args:arguments
     | Mod_misc ->

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -120,6 +120,18 @@ let persist_checkpoint ~dir ~session_id (ckpt : Oas.Checkpoint.t) =
   Fs_compat.mkdir_p dir;
   Fs_compat.save_file path (Oas.Checkpoint.to_string ckpt)
 
+let build_checkpoint ~session_id ?working_context (agent : Oas.Agent.t) =
+  match working_context with
+  | None -> Oas.Agent.checkpoint ~session_id agent
+  | Some json ->
+      Oas.Agent_checkpoint.build_checkpoint
+        ~session_id ~working_context:json
+        ~state:(Oas.Agent.state agent)
+        ~tools:(Oas.Agent.tools agent)
+        ~context:(Oas.Agent.context agent)
+        ~mcp_clients:(Oas.Agent.options agent).mcp_clients
+        ()
+
 (* ================================================================ *)
 (* Build                                                             *)
 (* ================================================================ *)
@@ -233,10 +245,7 @@ let run
     in
     let checkpoint = match config.checkpoint_dir with
       | Some dir ->
-        let ckpt =
-          Oas.Agent.checkpoint ~session_id ?working_context:config.working_context
-            agent
-        in
+        let ckpt = build_checkpoint ~session_id ?working_context:config.working_context agent in
         (try persist_checkpoint ~dir ~session_id ckpt
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Misc.error "oas_worker: Checkpoint save failed: %s"
@@ -244,8 +253,8 @@ let run
         Some ckpt
       | None ->
         Option.map
-          (fun working_context ->
-            Oas.Agent.checkpoint ~session_id ~working_context agent)
+          (fun _ ->
+            build_checkpoint ~session_id ?working_context:config.working_context agent)
           config.working_context
     in
     Option.iter (fun bus ->

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -157,6 +157,7 @@ type module_tag =
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
   | Mod_notifications | Mod_inline
+  | Mod_improve_loop
   | Mod_autoresearch
   | Mod_research
   | Mod_model_catalog

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -85,6 +85,7 @@ type module_tag =
   | Mod_control | Mod_agent_timeline | Mod_misc | Mod_suspend
   | Mod_library | Mod_keeper | Mod_compact | Mod_mdal
   | Mod_notifications | Mod_inline
+  | Mod_improve_loop
   | Mod_autoresearch
   | Mod_research
   | Mod_model_catalog

--- a/lib/tool_improve_loop.ml
+++ b/lib/tool_improve_loop.ml
@@ -12,9 +12,12 @@ module U = Yojson.Safe.Util
 
 type result = bool * string
 
-type context = {
+type 'a context = {
   config : Room.config;
   agent_name : string;
+  sw : Eio.Switch.t option;
+  clock : 'a Eio.Time.clock option;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
 type loop_status =
@@ -843,125 +846,107 @@ let command_ok result =
 let run_and_capture driver argv =
   driver.run_command argv
 
-let execute_issue_plan driver repo_root (plan : action_plan) =
-  match (plan.worktree_path, plan.branch_name) with
-  | Some worktree_path, Some branch_name ->
-      ensure_parent_dir worktree_path;
-      let fetch_result =
-        run_and_capture driver [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ]
-      in
-      if not (command_ok fetch_result) then
-        Error ("git fetch failed: " ^ String.trim fetch_result.stderr)
-      else if Sys.file_exists worktree_path then
-        Ok (`Assoc [ ("mode", `String "executed"); ("reused_worktree", `Bool true); ("worktree_path", `String worktree_path) ])
-      else
-        let create_result =
-          run_and_capture driver
-            [
-              "git";
-              "-C";
-              repo_root;
-              "worktree";
-              "add";
-              "-B";
-              branch_name;
-              worktree_path;
-              "origin/main";
-            ]
-        in
-        if command_ok create_result then
-          Ok
-            (`Assoc
-              [
-                ("mode", `String "executed");
-                ("created_worktree", `Bool true);
-                ("worktree_path", `String worktree_path);
-              ])
-        else
-          Error ("worktree add failed: " ^ String.trim create_result.stderr)
-  | _ -> Error "issue plan missing worktree metadata"
+let team_session_goal_of_plan (state : state) (plan : action_plan) =
+  let candidate = plan.candidate in
+  let candidate_ref =
+    match candidate.kind with
+    | Conflict_pr | Failing_pr | Merge_ready_pr ->
+        Printf.sprintf "PR #%d" candidate.number
+    | Priority_issue | Backlog_issue ->
+        Printf.sprintf "Issue #%d" candidate.number
+  in
+  let header =
+    Printf.sprintf
+      "Improve-loop lane for %s in repo %s.\nTitle: %s\nPhase: %s"
+      candidate_ref state.repo candidate.title plan.phase
+  in
+  let worktree_hint =
+    match plan.worktree_path, plan.branch_name with
+    | Some worktree_path, Some branch_name ->
+        Printf.sprintf
+          "\nPreferred worktree path: %s\nPreferred branch: %s"
+          worktree_path branch_name
+    | _ -> ""
+  in
+  let commands =
+    if plan.commands = [] then
+      ""
+    else
+      "\nPlanned commands:\n"
+      ^ String.concat "\n" (List.map (fun line -> "- " ^ line) plan.commands)
+  in
+  let notes =
+    if plan.notes = [] then
+      ""
+    else
+      "\nConstraints:\n"
+      ^ String.concat "\n" (List.map (fun line -> "- " ^ line) plan.notes)
+  in
+  String.concat "\n"
+    [
+      header ^ worktree_hint;
+      "Required workflow:";
+      "- reproduce or inspect the candidate first";
+      "- use worktree-first changes";
+      "- patch narrowly";
+      "- run targeted verification";
+      "- open or update a draft PR only after local verification";
+      "- do not merge without cross-model review and green required checks";
+      commands;
+      notes;
+    ]
 
-let execute_failing_pr_plan driver repo_root (plan : action_plan) =
-  match (plan.worktree_path, plan.branch_name, plan.candidate.head_ref_name) with
-  | Some worktree_path, Some branch_name, Some remote_branch ->
-      ensure_parent_dir worktree_path;
-      let fetch_result =
-        run_and_capture driver [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ]
+let execute_team_session_plan (ctx : _ context) (state : state) (plan : action_plan) =
+  match ctx.sw, ctx.clock with
+  | Some sw, Some clock ->
+      let team_ctx : _ Tool_team_session.context =
+        {
+          Tool_team_session.config = ctx.config;
+          agent_name = ctx.agent_name;
+          sw;
+          clock;
+          proc_mgr = ctx.proc_mgr;
+        }
       in
-      if not (command_ok fetch_result) then
-        Error ("git fetch failed: " ^ String.trim fetch_result.stderr)
-      else if Sys.file_exists worktree_path then
-        Ok (`Assoc [ ("mode", `String "executed"); ("reused_worktree", `Bool true); ("worktree_path", `String worktree_path) ])
-      else
-        let create_result =
-          run_and_capture driver
-            [
-              "git";
-              "-C";
-              repo_root;
-              "worktree";
-              "add";
-              "-B";
-              branch_name;
-              worktree_path;
-              Printf.sprintf "origin/%s" remote_branch;
-            ]
-        in
-        if command_ok create_result then
-          Ok
-            (`Assoc
-              [
-                ("mode", `String "executed");
-                ("created_worktree", `Bool true);
-                ("worktree_path", `String worktree_path);
-              ])
-        else
-          Error ("worktree add failed: " ^ String.trim create_result.stderr)
-  | _ -> Error "failing PR plan missing branch metadata"
-
-let execute_conflict_pr_plan driver repo_root (plan : action_plan) =
-  match execute_failing_pr_plan driver repo_root plan with
-  | Error _ as err -> err
-  | Ok base_json -> (
-      match plan.worktree_path with
-      | None -> Error "conflict plan missing worktree path"
-      | Some worktree_path ->
-          let merge_result =
-            run_and_capture driver
-              [ "git"; "-C"; worktree_path; "merge"; "--no-edit"; "origin/main" ]
-          in
-          if command_ok merge_result then
-            Ok
-              (`Assoc
-                [
-                  ("mode", `String "executed");
-                  ("merge_applied", `Bool true);
-                  ("worktree_path", `String worktree_path);
-                  ("details", base_json);
-                ])
-          else
-            let conflicts_result =
-              run_and_capture driver
-                [ "git"; "-C"; worktree_path; "diff"; "--name-only"; "--diff-filter=U" ]
-            in
-            let conflict_files =
-              String.split_on_char '\n' conflicts_result.stdout
-              |> List.filter (fun value -> String.trim value <> "")
-            in
-            if conflict_files <> [] then
-              Ok
-                (`Assoc
-                  [
-                    ("mode", `String "executed");
-                    ("merge_applied", `Bool false);
-                    ("conflicts_ready", `Bool true);
-                    ("worktree_path", `String worktree_path);
-                    ( "conflict_files",
-                      `List (List.map (fun value -> `String value) conflict_files) );
-                    ("details", base_json);
-                  ])
-            else
-              Error ("merge failed: " ^ String.trim merge_result.stderr))
+      let args =
+        `Assoc
+          [
+            ("goal", `String (team_session_goal_of_plan state plan));
+            ("duration_seconds", `Int 1800);
+            ("checkpoint_interval_sec", `Int 120);
+            ("min_agents", `Int 2);
+            ("execution_scope", `String "limited_code_change");
+            ("orchestration_mode", `String "assist");
+            ("communication_mode", `String "broadcast");
+            ("instruction_profile", `String "standard");
+            ("alert_channel", `String "both");
+          ]
+      in
+      (match Tool_team_session.dispatch team_ctx ~name:"masc_team_session_start" ~args with
+       | Some (true, body) -> (
+           try
+             let json = Yojson.Safe.from_string body in
+             Ok
+               (`Assoc
+                 [
+                   ("mode", `String "team_session_started");
+                   ("plan", action_plan_to_json plan);
+                   ("session", json);
+                 ])
+           with Yojson.Json_error _ ->
+             Ok
+               (`Assoc
+                 [
+                   ("mode", `String "team_session_started");
+                   ("plan", action_plan_to_json plan);
+                   ("session_raw", `String body);
+                 ]))
+       | Some (false, message) ->
+           Error ("team session start failed: " ^ message)
+       | None ->
+           Error "team session dispatch unavailable")
+  | _ ->
+      Error "team session runtime unavailable for improve-loop execute path"
 
 let execute_merge_plan driver (state : state) (plan : action_plan) =
   match plan.merge_command with
@@ -990,12 +975,12 @@ let execute_merge_plan driver (state : state) (plan : action_plan) =
       else
         Error ("gh pr merge failed: " ^ String.trim result.stderr)
 
-let execute_plan driver repo_root state (plan : action_plan) =
+let execute_plan driver (_repo_root : string) (ctx : _ context) state
+    (plan : action_plan) =
   match plan.phase with
-  | "issue_burn_down" -> execute_issue_plan driver repo_root plan
-  | "pr_failing_checks" -> execute_failing_pr_plan driver repo_root plan
-  | "pr_conflict" -> execute_conflict_pr_plan driver repo_root plan
-    | "merge_ready" ->
+  | "issue_burn_down" | "pr_failing_checks" | "pr_conflict" ->
+      execute_team_session_plan ctx state plan
+  | "merge_ready" ->
       let plan =
         { plan with merge_command = merge_command_if_ready state ~review_ok:true plan.candidate }
       in
@@ -1087,7 +1072,7 @@ let resolve_selected_candidate state queue =
         (fun () -> list_hd_opt queue)
   | None -> list_hd_opt queue
 
-let tick_with_driver (driver : driver) (ctx : context) args : result =
+let tick_with_driver (driver : driver) (ctx : _ context) args : result =
   let state = load_state ctx.config in
   let limit = max 1 (get_int args "limit" 10) in
   let review_ok = get_bool args "review_ok" false in
@@ -1151,7 +1136,7 @@ let tick_with_driver (driver : driver) (ctx : context) args : result =
                Yojson.Safe.pretty_to_string
                  (state_status_json ~plan ~queue:(queue, limit) planned_state))
             end else
-              match execute_plan driver repo_root planned_state plan with
+              match execute_plan driver repo_root ctx planned_state plan with
               | Ok exec_json ->
                   let updated =
                     mark_success planned_state ~now ~phase:plan.phase
@@ -1190,7 +1175,7 @@ let tick_with_driver (driver : driver) (ctx : context) args : result =
                   in
                   (false, Yojson.Safe.pretty_to_string json)
 
-let handle_start ctx args =
+let handle_start (ctx : _ context) args =
   let current = load_state ctx.config in
   let now = Time_compat.now () in
   let state =
@@ -1217,11 +1202,11 @@ let handle_start ctx args =
       ]);
   (true, Yojson.Safe.pretty_to_string (state_status_json state))
 
-let handle_status ctx _args =
+let handle_status (ctx : _ context) _args =
   let state = load_state ctx.config in
   (true, Yojson.Safe.pretty_to_string (state_status_json state))
 
-let handle_pause ctx args =
+let handle_pause (ctx : _ context) args =
   let current = load_state ctx.config in
   let state =
     {
@@ -1241,7 +1226,7 @@ let handle_pause ctx args =
       ]);
   (true, Yojson.Safe.pretty_to_string (state_status_json state))
 
-let handle_resume ctx args =
+let handle_resume (ctx : _ context) args =
   let current = load_state ctx.config in
   let state =
     {
@@ -1259,14 +1244,16 @@ let handle_resume ctx args =
   (true, Yojson.Safe.pretty_to_string (state_status_json state))
 
 let maybe_tick_from_keepalive ~(config : Room.config) ~(agent_name : string)
-    ~(keeper_name : string) () =
+    ~(keeper_name : string) ~(sw : Eio.Switch.t)
+    ~(clock : _ Eio.Time.clock)
+    ~(proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option) () =
   let state = load_state config in
   let now = Time_compat.now () in
   if state.enabled && state.status = Running
      && String.equal state.keeper_name keeper_name
      && tick_due state ~now
   then
-    let ctx = { config; agent_name } in
+    let ctx = { config; agent_name; sw = Some sw; clock = Some clock; proc_mgr } in
     let _ok, _body =
       tick_with_driver default_driver ctx
         (`Assoc [ ("execute", `Bool true) ])
@@ -1275,7 +1262,7 @@ let maybe_tick_from_keepalive ~(config : Room.config) ~(agent_name : string)
   else
     ()
 
-let dispatch ctx ~name ~args : result option =
+let dispatch (ctx : _ context) ~name ~args : result option =
   match name with
   | "masc_improve_loop_start" -> Some (handle_start ctx args)
   | "masc_improve_loop_status" -> Some (handle_status ctx args)

--- a/lib/tool_improve_loop.ml
+++ b/lib/tool_improve_loop.ml
@@ -1101,11 +1101,8 @@ let tick_with_driver (driver : driver) (ctx : _ context) args : result =
         | None ->
             let updated =
               {
-                state with
+                (mark_success state ~now ~phase:"idle" "queue_empty") with
                 current_candidate = None;
-                current_phase = Some "idle";
-                last_success = Some "queue_empty";
-                updated_at = now;
               }
             in
             save_state ctx.config updated;

--- a/lib/tool_improve_loop.ml
+++ b/lib/tool_improve_loop.ml
@@ -1,0 +1,1285 @@
+(** Tool_improve_loop — keeper-first self-improvement loop substrate for
+    masc-mcp.
+
+    The loop persists selection state locally, ranks GitHub PRs/issues, and
+    prepares or executes the next burn-down action in a dedicated worktree.
+    It intentionally keeps the action plan explicit so a resident keeper can
+    inspect and drive the lane using normal MASC tools. *)
+
+open Tool_args
+
+module U = Yojson.Safe.Util
+
+type result = bool * string
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+}
+
+type loop_status =
+  | Disabled
+  | Running
+  | Paused
+
+type candidate_kind =
+  | Merge_ready_pr
+  | Conflict_pr
+  | Failing_pr
+  | Priority_issue
+  | Backlog_issue
+
+type pr_summary = {
+  number : int;
+  title : string;
+  url : string option;
+  head_ref_name : string;
+  base_ref_name : string option;
+  mergeable : string option;
+  merge_state_status : string option;
+  is_draft : bool;
+  failing_checks : string list;
+  pending_checks : string list;
+}
+
+type issue_summary = {
+  number : int;
+  title : string;
+  url : string option;
+  labels : string list;
+}
+
+type candidate = {
+  kind : candidate_kind;
+  number : int;
+  title : string;
+  url : string option;
+  head_ref_name : string option;
+  base_ref_name : string option;
+  mergeable : string option;
+  merge_state_status : string option;
+  labels : string list;
+  failing_checks : string list;
+  pending_checks : string list;
+}
+
+type state = {
+  enabled : bool;
+  status : loop_status;
+  keeper_name : string;
+  poll_interval_sec : int;
+  repo : string;
+  repo_scope : string;
+  merge_policy : string;
+  dry_run : bool;
+  current_candidate : candidate option;
+  current_phase : string option;
+  last_success : string option;
+  last_failure : string option;
+  consecutive_failures : int;
+  last_merged_pr : int option;
+  last_closed_issue : int option;
+  paused_reason : string option;
+  updated_at : float;
+}
+
+type command_result = {
+  exit_code : int;
+  stdout : string;
+  stderr : string;
+}
+
+type driver = {
+  list_prs : repo:string -> (pr_summary list, string) Stdlib.result;
+  list_issues : repo:string -> (issue_summary list, string) Stdlib.result;
+  run_command : string list -> command_result;
+  now : unit -> float;
+}
+
+type action_plan = {
+  action_id : string;
+  phase : string;
+  summary : string;
+  candidate : candidate;
+  worktree_path : string option;
+  branch_name : string option;
+  commands : string list;
+  merge_command : string option;
+  requires_team_session : bool;
+  notes : string list;
+}
+
+let schemas = Tool_improve_loop_schemas.schemas
+
+let default_repo = "jeong-sik/masc-mcp"
+let default_keeper_name = "masc-improver"
+let default_poll_interval_sec = 300
+let default_repo_scope = "masc-mcp-only"
+let default_merge_policy = "squash"
+
+let string_member name json =
+  match U.member name json with
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let bool_member name json =
+  match U.member name json with
+  | `Bool value -> Some value
+  | _ -> None
+
+let int_member name json =
+  match U.member name json with
+  | `Int value -> Some value
+  | `Intlit raw -> Some (Safe_ops.int_of_string_with_default ~default:0 raw)
+  | _ -> None
+
+let float_member name json =
+  match U.member name json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit raw -> Some (float_of_int (Safe_ops.int_of_string_with_default ~default:0 raw))
+  | _ -> None
+
+let list_string_member name json =
+  match U.member name json with
+  | `List values ->
+      values
+      |> List.filter_map (function
+           | `String value ->
+               let trimmed = String.trim value in
+               if trimmed = "" then None else Some trimmed
+           | _ -> None)
+  | _ -> []
+
+let shell_join argv =
+  String.concat " " (List.map Filename.quote argv)
+
+let option_or_else left right =
+  match left with
+  | Some _ -> left
+  | None -> right ()
+
+let option_exists pred = function
+  | Some value -> pred value
+  | None -> false
+
+let list_hd_opt = function
+  | head :: _ -> Some head
+  | [] -> None
+
+let slugify title =
+  let lowered = String.lowercase_ascii title in
+  let buf = Buffer.create (String.length lowered) in
+  let push_dash () =
+    if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '-' then
+      Buffer.add_char buf '-'
+  in
+  String.iter
+    (fun c ->
+      match c with
+      | 'a' .. 'z' | '0' .. '9' -> Buffer.add_char buf c
+      | _ -> push_dash ())
+    lowered;
+  let rec trim_bounds s =
+    let len = String.length s in
+    if len = 0 then "item"
+    else if s.[0] = '-' then trim_bounds (String.sub s 1 (len - 1))
+    else if s.[len - 1] = '-' then trim_bounds (String.sub s 0 (len - 1))
+    else s
+  in
+  trim_bounds (Buffer.contents buf)
+
+let loop_status_to_string = function
+  | Disabled -> "disabled"
+  | Running -> "running"
+  | Paused -> "paused"
+
+let loop_status_of_string = function
+  | "running" -> Running
+  | "paused" -> Paused
+  | _ -> Disabled
+
+let candidate_kind_to_string = function
+  | Merge_ready_pr -> "merge_ready_pr"
+  | Conflict_pr -> "conflict_pr"
+  | Failing_pr -> "failing_pr"
+  | Priority_issue -> "priority_issue"
+  | Backlog_issue -> "backlog_issue"
+
+let candidate_kind_of_string = function
+  | "merge_ready_pr" -> Merge_ready_pr
+  | "conflict_pr" -> Conflict_pr
+  | "failing_pr" -> Failing_pr
+  | "priority_issue" -> Priority_issue
+  | _ -> Backlog_issue
+
+let candidate_id (candidate : candidate) =
+  Printf.sprintf "%s#%d"
+    (candidate_kind_to_string candidate.kind)
+    candidate.number
+
+let candidate_to_json (candidate : candidate) =
+  `Assoc
+    [
+      ("id", `String (candidate_id candidate));
+      ("kind", `String (candidate_kind_to_string candidate.kind));
+      ("number", `Int candidate.number);
+      ("title", `String candidate.title);
+      ("url", Option.fold ~none:`Null ~some:(fun value -> `String value) candidate.url);
+      ( "head_ref_name",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          candidate.head_ref_name );
+      ( "base_ref_name",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          candidate.base_ref_name );
+      ( "mergeable",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          candidate.mergeable );
+      ( "merge_state_status",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          candidate.merge_state_status );
+      ("labels", `List (List.map (fun value -> `String value) candidate.labels));
+      ( "failing_checks",
+        `List (List.map (fun value -> `String value) candidate.failing_checks) );
+      ( "pending_checks",
+        `List (List.map (fun value -> `String value) candidate.pending_checks) );
+    ]
+
+let candidate_of_json json =
+  {
+    kind =
+      string_member "kind" json
+      |> Option.map candidate_kind_of_string
+      |> Option.value ~default:Backlog_issue;
+    number = int_member "number" json |> Option.value ~default:0;
+    title = string_member "title" json |> Option.value ~default:"";
+    url = string_member "url" json;
+    head_ref_name = string_member "head_ref_name" json;
+    base_ref_name = string_member "base_ref_name" json;
+    mergeable = string_member "mergeable" json;
+    merge_state_status = string_member "merge_state_status" json;
+    labels = list_string_member "labels" json;
+    failing_checks = list_string_member "failing_checks" json;
+    pending_checks = list_string_member "pending_checks" json;
+  }
+
+let default_state ?(repo = default_repo) ?(now = Time_compat.now ()) () =
+  {
+    enabled = false;
+    status = Disabled;
+    keeper_name = default_keeper_name;
+    poll_interval_sec = default_poll_interval_sec;
+    repo;
+    repo_scope = default_repo_scope;
+    merge_policy = default_merge_policy;
+    dry_run = false;
+    current_candidate = None;
+    current_phase = None;
+    last_success = None;
+    last_failure = None;
+    consecutive_failures = 0;
+    last_merged_pr = None;
+    last_closed_issue = None;
+    paused_reason = None;
+    updated_at = now;
+  }
+
+let state_to_json (state : state) =
+  `Assoc
+    [
+      ("enabled", `Bool state.enabled);
+      ("status", `String (loop_status_to_string state.status));
+      ("keeper_name", `String state.keeper_name);
+      ("poll_interval_sec", `Int state.poll_interval_sec);
+      ("repo", `String state.repo);
+      ("repo_scope", `String state.repo_scope);
+      ("merge_policy", `String state.merge_policy);
+      ("dry_run", `Bool state.dry_run);
+      ( "current_candidate",
+        Option.fold ~none:`Null ~some:candidate_to_json state.current_candidate );
+      ( "current_phase",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          state.current_phase );
+      ( "last_success",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          state.last_success );
+      ( "last_failure",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          state.last_failure );
+      ("consecutive_failures", `Int state.consecutive_failures);
+      ( "last_merged_pr",
+        Option.fold ~none:`Null ~some:(fun value -> `Int value)
+          state.last_merged_pr );
+      ( "last_closed_issue",
+        Option.fold ~none:`Null ~some:(fun value -> `Int value)
+          state.last_closed_issue );
+      ( "paused_reason",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          state.paused_reason );
+      ("updated_at", `Float state.updated_at);
+    ]
+
+let state_of_json json =
+  let default = default_state () in
+  {
+    enabled = bool_member "enabled" json |> Option.value ~default:default.enabled;
+    status =
+      string_member "status" json
+      |> Option.map loop_status_of_string
+      |> Option.value ~default:default.status;
+    keeper_name =
+      string_member "keeper_name" json |> Option.value ~default:default.keeper_name;
+    poll_interval_sec =
+      int_member "poll_interval_sec" json |> Option.value ~default:default.poll_interval_sec;
+    repo = string_member "repo" json |> Option.value ~default:default.repo;
+    repo_scope =
+      string_member "repo_scope" json |> Option.value ~default:default.repo_scope;
+    merge_policy =
+      string_member "merge_policy" json |> Option.value ~default:default.merge_policy;
+    dry_run = bool_member "dry_run" json |> Option.value ~default:default.dry_run;
+    current_candidate =
+      (match U.member "current_candidate" json with
+       | `Assoc _ as payload -> Some (candidate_of_json payload)
+       | _ -> None);
+    current_phase = string_member "current_phase" json;
+    last_success = string_member "last_success" json;
+    last_failure = string_member "last_failure" json;
+    consecutive_failures =
+      int_member "consecutive_failures" json
+      |> Option.value ~default:default.consecutive_failures;
+    last_merged_pr = int_member "last_merged_pr" json;
+    last_closed_issue = int_member "last_closed_issue" json;
+    paused_reason = string_member "paused_reason" json;
+    updated_at = float_member "updated_at" json |> Option.value ~default:default.updated_at;
+  }
+
+let loop_dir config =
+  Filename.concat (Room.masc_dir config) "improve-loop"
+
+let state_file config =
+  Filename.concat (loop_dir config) "state.json"
+
+let events_file config =
+  Filename.concat (loop_dir config) "events.jsonl"
+
+let save_state config (state : state) =
+  let dir = loop_dir config in
+  Fs_compat.mkdir_p dir;
+  Fs_compat.save_file (state_file config)
+    (Yojson.Safe.pretty_to_string (state_to_json state))
+
+let load_state config =
+  let path = state_file config in
+  if Sys.file_exists path then
+    try Yojson.Safe.from_file path |> state_of_json
+    with _ -> default_state ()
+  else
+    default_state ()
+
+let append_event config event_type json =
+  let dir = loop_dir config in
+  Fs_compat.mkdir_p dir;
+  Fs_compat.append_jsonl (events_file config)
+    (`Assoc
+      [
+        ("timestamp", `Float (Time_compat.now ()));
+        ("event_type", `String event_type);
+        ("payload", json);
+      ])
+
+let run_process argv =
+  match argv with
+  | [] -> { exit_code = 127; stdout = ""; stderr = "empty argv" }
+  | prog :: _ ->
+      let result =
+        Tool_command_plane_support.run_process ~prog ~argv
+          ~env:(Unix.environment ())
+      in
+      { exit_code = result.exit_code; stdout = result.stdout; stderr = result.stderr }
+
+let parse_check_state json =
+  let label =
+    option_or_else (string_member "name" json)
+      (fun () -> string_member "context" json)
+    |> Option.value ~default:"unnamed-check"
+  in
+  let state =
+    option_or_else (string_member "conclusion" json)
+      (fun () -> string_member "status" json)
+    |> fun value ->
+    option_or_else value
+      (fun () -> string_member "state" json)
+    |> Option.map String.uppercase_ascii
+    |> Option.value ~default:"UNKNOWN"
+  in
+  (label, state)
+
+let failing_check_states =
+  [ "FAILURE"; "FAILED"; "ERROR"; "TIMED_OUT"; "CANCELLED"; "ACTION_REQUIRED";
+    "STARTUP_FAILURE"; "STALE" ]
+
+let pending_check_states =
+  [ "PENDING"; "QUEUED"; "IN_PROGRESS"; "EXPECTED"; "WAITING" ]
+
+let parse_pr json =
+  let check_rows =
+    match U.member "statusCheckRollup" json with
+    | `List rows -> rows |> List.filter_map (function `Assoc _ as row -> Some row | _ -> None)
+    | _ -> []
+  in
+  let failing_checks, pending_checks =
+    List.fold_left
+      (fun (failing, pending) row ->
+        let label, state = parse_check_state row in
+        if List.mem state failing_check_states then
+          (label :: failing, pending)
+        else if List.mem state pending_check_states then
+          (failing, label :: pending)
+        else
+          (failing, pending))
+      ([], []) check_rows
+  in
+  {
+    number = int_member "number" json |> Option.value ~default:0;
+    title = string_member "title" json |> Option.value ~default:"";
+    url = string_member "url" json;
+    head_ref_name = string_member "headRefName" json |> Option.value ~default:"";
+    base_ref_name = string_member "baseRefName" json;
+    mergeable = string_member "mergeable" json;
+    merge_state_status = string_member "mergeStateStatus" json;
+    is_draft = bool_member "isDraft" json |> Option.value ~default:false;
+    failing_checks = List.rev failing_checks;
+    pending_checks = List.rev pending_checks;
+  }
+
+let parse_issue json =
+  let labels =
+    match U.member "labels" json with
+    | `List rows ->
+        rows
+        |> List.filter_map (function
+             | `Assoc _ as row ->
+                 string_member "name" row
+             | `String label ->
+                 let trimmed = String.trim label in
+                 if trimmed = "" then None else Some trimmed
+             | _ -> None)
+        |> List.sort_uniq String.compare
+    | _ -> []
+  in
+  {
+    number = int_member "number" json |> Option.value ~default:0;
+    title = string_member "title" json |> Option.value ~default:"";
+    url = string_member "url" json;
+    labels;
+  }
+
+let default_driver =
+  let gh_json argv parse_item =
+    let result = run_process argv in
+    if result.exit_code <> 0 then
+      Error
+        (String.trim
+           (if String.trim result.stderr <> "" then result.stderr else result.stdout))
+    else
+      try
+        match Yojson.Safe.from_string result.stdout with
+        | `List rows -> Ok (rows |> List.filter_map (function `Assoc _ as row -> Some (parse_item row) | _ -> None))
+        | _ -> Error "gh returned non-list JSON"
+      with Yojson.Json_error msg ->
+        Error ("failed to parse gh JSON: " ^ msg)
+  in
+  {
+    list_prs =
+      (fun ~repo ->
+        gh_json
+          [
+            "gh"; "pr"; "list"; "--repo"; repo; "--state"; "open";
+            "--json";
+            "number,title,url,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,statusCheckRollup";
+          ]
+          parse_pr);
+    list_issues =
+      (fun ~repo ->
+        gh_json
+          [
+            "gh"; "issue"; "list"; "--repo"; repo; "--state"; "open";
+            "--json"; "number,title,url,labels";
+          ]
+          parse_issue);
+    run_command = run_process;
+    now = Time_compat.now;
+  }
+
+let normalize_label label =
+  String.lowercase_ascii (String.trim label)
+
+let has_priority_label labels =
+  List.exists
+    (fun label ->
+      let normalized = normalize_label label in
+      List.mem normalized [ "high"; "bug"; "safety"; "priority:high"; "type:bug" ])
+    labels
+
+let is_conflicting_pr (pr : pr_summary) =
+  match (pr.mergeable, pr.merge_state_status) with
+  | Some "CONFLICTING", _ -> true
+  | _, Some "DIRTY" -> true
+  | _ -> false
+
+let is_loop_owned_branch branch_name =
+  String.starts_with ~prefix:"loop/" branch_name
+
+let is_merge_ready_pr ?(review_ok = false) (pr : pr_summary) =
+  is_loop_owned_branch pr.head_ref_name
+  && review_ok
+  && not pr.is_draft
+  && pr.failing_checks = []
+  && pr.pending_checks = []
+  &&
+  match pr.mergeable with
+  | Some "MERGEABLE" -> (
+      match pr.base_ref_name with
+      | Some ("main" | "master") -> true
+      | _ -> false)
+  | _ -> false
+
+let candidate_priority = function
+  | Merge_ready_pr -> 0
+  | Conflict_pr -> 1
+  | Failing_pr -> 2
+  | Priority_issue -> 3
+  | Backlog_issue -> 4
+
+let candidate_compare left right =
+  let priority_cmp =
+    compare (candidate_priority left.kind) (candidate_priority right.kind)
+  in
+  if priority_cmp <> 0 then priority_cmp else compare left.number right.number
+
+let candidate_of_pr ?(review_ok = false) (pr : pr_summary) =
+  let kind =
+    if is_merge_ready_pr ~review_ok pr then Merge_ready_pr
+    else if is_conflicting_pr pr then Conflict_pr
+    else Failing_pr
+  in
+  {
+    kind;
+    number = pr.number;
+    title = pr.title;
+    url = pr.url;
+    head_ref_name = Some pr.head_ref_name;
+    base_ref_name = pr.base_ref_name;
+    mergeable = pr.mergeable;
+    merge_state_status = pr.merge_state_status;
+    labels = [];
+    failing_checks = pr.failing_checks;
+    pending_checks = pr.pending_checks;
+  }
+
+let candidate_of_issue (issue : issue_summary) =
+  {
+    kind = if has_priority_label issue.labels then Priority_issue else Backlog_issue;
+    number = issue.number;
+    title = issue.title;
+    url = issue.url;
+    head_ref_name = None;
+    base_ref_name = None;
+    mergeable = None;
+    merge_state_status = None;
+    labels = issue.labels;
+    failing_checks = [];
+    pending_checks = [];
+  }
+
+let rank_candidates ?skip_candidate_id ?(review_ok = false)
+    ~(prs : pr_summary list) ~(issues : issue_summary list) () =
+  let candidates =
+    (prs
+    |> List.filter (fun pr -> is_conflicting_pr pr || pr.failing_checks <> [] || is_merge_ready_pr ~review_ok pr)
+    |> List.map (candidate_of_pr ~review_ok))
+    @ (issues |> List.map candidate_of_issue)
+  in
+  candidates
+  |> List.filter (fun candidate ->
+         match skip_candidate_id with
+         | Some skip -> not (String.equal skip (candidate_id candidate))
+         | None -> true)
+  |> List.sort candidate_compare
+
+let repo_root (config : Room.config) =
+  match Autoresearch.git_top_level ~workdir:config.base_path with
+  | Ok root -> root
+  | Error _ -> config.base_path
+
+let loop_worktree_path repo_root slug =
+  Filename.concat (Filename.concat repo_root ".worktrees/loop") slug
+
+let issue_branch_name candidate =
+  Printf.sprintf "loop/issue-%d-%s" candidate.number (slugify candidate.title)
+
+let issue_worktree_path repo_root candidate =
+  loop_worktree_path repo_root
+    (Printf.sprintf "issue-%d-%s" candidate.number (slugify candidate.title))
+
+let pr_worktree_path repo_root candidate =
+  loop_worktree_path repo_root
+    (Printf.sprintf "pr-%d-%s" candidate.number (slugify candidate.title))
+
+let ensure_parent_dir path =
+  Fs_compat.mkdir_p (Filename.dirname path)
+
+let merge_gate_reasons ~review_ok (candidate : candidate) =
+  let owned =
+    option_exists is_loop_owned_branch candidate.head_ref_name
+  in
+  let checks_green =
+    candidate.failing_checks = [] && candidate.pending_checks = []
+  in
+  let target_main =
+    match candidate.base_ref_name with
+    | Some ("main" | "master") -> true
+    | _ -> false
+  in
+  let mergeable =
+    match candidate.mergeable with
+    | Some "MERGEABLE" -> true
+    | _ -> false
+  in
+  []
+  |> fun acc -> if owned then acc else "branch_not_owned_by_loop" :: acc
+  |> fun acc -> if checks_green then acc else "checks_not_green" :: acc
+  |> fun acc -> if review_ok then acc else "review_gate_not_passed" :: acc
+  |> fun acc -> if target_main then acc else "base_not_main" :: acc
+  |> fun acc -> if mergeable then acc else "not_mergeable" :: acc
+  |> List.rev
+
+let merge_command_if_ready (state : state) ~review_ok (candidate : candidate) =
+  if (not review_ok) || candidate.kind <> Merge_ready_pr then
+    None
+  else
+    match merge_gate_reasons ~review_ok candidate with
+    | [] ->
+        Some
+          (shell_join
+             [
+               "gh";
+               "pr";
+               "merge";
+               string_of_int candidate.number;
+               "--repo";
+               state.repo;
+               Printf.sprintf "--%s" state.merge_policy;
+               "--delete-branch";
+             ])
+    | _ -> None
+
+let issue_plan repo_root state (candidate : candidate) =
+  let branch_name = issue_branch_name candidate in
+  let worktree_path = issue_worktree_path repo_root candidate in
+  let commands =
+    [
+      shell_join [ "gh"; "issue"; "view"; string_of_int candidate.number; "--repo"; state.repo ];
+      shell_join [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ];
+      shell_join
+        [
+          "git";
+          "-C";
+          repo_root;
+          "worktree";
+          "add";
+          "-B";
+          branch_name;
+          worktree_path;
+          "origin/main";
+        ];
+      shell_join [ "cd"; worktree_path ];
+      shell_join [ "./scripts/review/local-review.sh"; "--base"; "origin/main"; "--head"; "HEAD"; "--format"; "markdown" ];
+      shell_join [ "./scripts/pr-open.sh"; "--repo"; state.repo; "--no-watch" ];
+    ]
+  in
+  {
+    action_id = Printf.sprintf "issue-%d" candidate.number;
+    phase = "issue_burn_down";
+    summary = Printf.sprintf "Prepare issue #%d in an isolated worktree" candidate.number;
+    candidate;
+    worktree_path = Some worktree_path;
+    branch_name = Some branch_name;
+    commands;
+    merge_command = None;
+    requires_team_session = true;
+    notes =
+      [
+        "Reproduce the issue before editing.";
+        "Patch narrowly, then run targeted verification before opening the draft PR.";
+      ];
+  }
+
+let failing_pr_plan repo_root state (candidate : candidate) =
+  let branch_name =
+    candidate.head_ref_name |> Option.value ~default:(Printf.sprintf "loop/pr-%d" candidate.number)
+  in
+  let worktree_path = pr_worktree_path repo_root candidate in
+  {
+    action_id = Printf.sprintf "pr-%d-failing" candidate.number;
+    phase = "pr_failing_checks";
+    summary =
+      Printf.sprintf "Prepare PR #%d branch for local check/fix work" candidate.number;
+    candidate;
+    worktree_path = Some worktree_path;
+    branch_name = Some branch_name;
+    commands =
+      [
+        shell_join [ "gh"; "pr"; "checks"; string_of_int candidate.number; "--repo"; state.repo ];
+        shell_join [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ];
+        shell_join
+          [
+            "git";
+            "-C";
+            repo_root;
+            "worktree";
+            "add";
+            "-B";
+            branch_name;
+            worktree_path;
+            Printf.sprintf "origin/%s" branch_name;
+          ];
+        shell_join [ "cd"; worktree_path ];
+        shell_join [ "./scripts/review/local-review.sh"; "--base"; "origin/main"; "--head"; "HEAD"; "--format"; "markdown" ];
+      ];
+    merge_command = None;
+    requires_team_session = true;
+    notes =
+      List.map (fun check_name -> "Failing check: " ^ check_name) candidate.failing_checks;
+  }
+
+let conflict_pr_plan repo_root _state (candidate : candidate) =
+  let branch_name =
+    candidate.head_ref_name |> Option.value ~default:(Printf.sprintf "pr-%d-head" candidate.number)
+  in
+  let worktree_path = pr_worktree_path repo_root candidate in
+  {
+    action_id = Printf.sprintf "pr-%d-conflict" candidate.number;
+    phase = "pr_conflict";
+    summary =
+      Printf.sprintf "Prepare PR #%d conflict-resolution worktree" candidate.number;
+    candidate;
+    worktree_path = Some worktree_path;
+    branch_name = Some branch_name;
+    commands =
+      [
+        shell_join [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ];
+        shell_join
+          [
+            "git";
+            "-C";
+            repo_root;
+            "worktree";
+            "add";
+            "-B";
+            branch_name;
+            worktree_path;
+            Printf.sprintf "origin/%s" branch_name;
+          ];
+        shell_join [ "git"; "-C"; worktree_path; "merge"; "--no-edit"; "origin/main" ];
+        shell_join [ "./scripts/review/local-review.sh"; "--base"; "origin/main"; "--head"; "HEAD"; "--format"; "markdown" ];
+      ];
+    merge_command = None;
+    requires_team_session = false;
+    notes =
+      [
+        "If merge exits non-zero with unmerged paths, keep the worktree and resolve conflicts there.";
+      ];
+  }
+
+let merge_ready_plan state (candidate : candidate) =
+  let merge_command = merge_command_if_ready state ~review_ok:true candidate in
+  {
+    action_id = Printf.sprintf "pr-%d-merge" candidate.number;
+    phase = "merge_ready";
+    summary = Printf.sprintf "Merge loop-owned PR #%d" candidate.number;
+    candidate;
+    worktree_path = None;
+    branch_name = candidate.head_ref_name;
+    commands = (match merge_command with Some cmd -> [ cmd ] | None -> []);
+    merge_command;
+    requires_team_session = false;
+    notes = [ "Merge only after required checks and cross-model review are both green." ];
+  }
+
+let plan_for_candidate repo_root state ?review_ok:(_review_ok = false) candidate =
+  match candidate.kind with
+  | Merge_ready_pr -> merge_ready_plan state candidate
+  | Conflict_pr -> conflict_pr_plan repo_root state candidate
+  | Failing_pr -> failing_pr_plan repo_root state candidate
+  | Priority_issue | Backlog_issue -> issue_plan repo_root state candidate
+
+let action_plan_to_json (plan : action_plan) =
+  `Assoc
+    [
+      ("action_id", `String plan.action_id);
+      ("phase", `String plan.phase);
+      ("summary", `String plan.summary);
+      ("candidate", candidate_to_json plan.candidate);
+      ( "worktree_path",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          plan.worktree_path );
+      ( "branch_name",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          plan.branch_name );
+      ("commands", `List (List.map (fun value -> `String value) plan.commands));
+      ( "merge_command",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          plan.merge_command );
+      ("requires_team_session", `Bool plan.requires_team_session);
+      ("notes", `List (List.map (fun value -> `String value) plan.notes));
+    ]
+
+let command_ok result =
+  result.exit_code = 0
+
+let run_and_capture driver argv =
+  driver.run_command argv
+
+let execute_issue_plan driver repo_root (plan : action_plan) =
+  match (plan.worktree_path, plan.branch_name) with
+  | Some worktree_path, Some branch_name ->
+      ensure_parent_dir worktree_path;
+      let fetch_result =
+        run_and_capture driver [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ]
+      in
+      if not (command_ok fetch_result) then
+        Error ("git fetch failed: " ^ String.trim fetch_result.stderr)
+      else if Sys.file_exists worktree_path then
+        Ok (`Assoc [ ("mode", `String "executed"); ("reused_worktree", `Bool true); ("worktree_path", `String worktree_path) ])
+      else
+        let create_result =
+          run_and_capture driver
+            [
+              "git";
+              "-C";
+              repo_root;
+              "worktree";
+              "add";
+              "-B";
+              branch_name;
+              worktree_path;
+              "origin/main";
+            ]
+        in
+        if command_ok create_result then
+          Ok
+            (`Assoc
+              [
+                ("mode", `String "executed");
+                ("created_worktree", `Bool true);
+                ("worktree_path", `String worktree_path);
+              ])
+        else
+          Error ("worktree add failed: " ^ String.trim create_result.stderr)
+  | _ -> Error "issue plan missing worktree metadata"
+
+let execute_failing_pr_plan driver repo_root (plan : action_plan) =
+  match (plan.worktree_path, plan.branch_name, plan.candidate.head_ref_name) with
+  | Some worktree_path, Some branch_name, Some remote_branch ->
+      ensure_parent_dir worktree_path;
+      let fetch_result =
+        run_and_capture driver [ "git"; "-C"; repo_root; "fetch"; "origin"; "--prune" ]
+      in
+      if not (command_ok fetch_result) then
+        Error ("git fetch failed: " ^ String.trim fetch_result.stderr)
+      else if Sys.file_exists worktree_path then
+        Ok (`Assoc [ ("mode", `String "executed"); ("reused_worktree", `Bool true); ("worktree_path", `String worktree_path) ])
+      else
+        let create_result =
+          run_and_capture driver
+            [
+              "git";
+              "-C";
+              repo_root;
+              "worktree";
+              "add";
+              "-B";
+              branch_name;
+              worktree_path;
+              Printf.sprintf "origin/%s" remote_branch;
+            ]
+        in
+        if command_ok create_result then
+          Ok
+            (`Assoc
+              [
+                ("mode", `String "executed");
+                ("created_worktree", `Bool true);
+                ("worktree_path", `String worktree_path);
+              ])
+        else
+          Error ("worktree add failed: " ^ String.trim create_result.stderr)
+  | _ -> Error "failing PR plan missing branch metadata"
+
+let execute_conflict_pr_plan driver repo_root (plan : action_plan) =
+  match execute_failing_pr_plan driver repo_root plan with
+  | Error _ as err -> err
+  | Ok base_json -> (
+      match plan.worktree_path with
+      | None -> Error "conflict plan missing worktree path"
+      | Some worktree_path ->
+          let merge_result =
+            run_and_capture driver
+              [ "git"; "-C"; worktree_path; "merge"; "--no-edit"; "origin/main" ]
+          in
+          if command_ok merge_result then
+            Ok
+              (`Assoc
+                [
+                  ("mode", `String "executed");
+                  ("merge_applied", `Bool true);
+                  ("worktree_path", `String worktree_path);
+                  ("details", base_json);
+                ])
+          else
+            let conflicts_result =
+              run_and_capture driver
+                [ "git"; "-C"; worktree_path; "diff"; "--name-only"; "--diff-filter=U" ]
+            in
+            let conflict_files =
+              String.split_on_char '\n' conflicts_result.stdout
+              |> List.filter (fun value -> String.trim value <> "")
+            in
+            if conflict_files <> [] then
+              Ok
+                (`Assoc
+                  [
+                    ("mode", `String "executed");
+                    ("merge_applied", `Bool false);
+                    ("conflicts_ready", `Bool true);
+                    ("worktree_path", `String worktree_path);
+                    ( "conflict_files",
+                      `List (List.map (fun value -> `String value) conflict_files) );
+                    ("details", base_json);
+                  ])
+            else
+              Error ("merge failed: " ^ String.trim merge_result.stderr))
+
+let execute_merge_plan driver (state : state) (plan : action_plan) =
+  match plan.merge_command with
+  | None -> Error "merge plan missing merge command"
+  | Some _ ->
+      let argv =
+        [
+          "gh";
+          "pr";
+          "merge";
+          string_of_int plan.candidate.number;
+          "--repo";
+          state.repo;
+          Printf.sprintf "--%s" state.merge_policy;
+          "--delete-branch";
+        ]
+      in
+      let result = run_and_capture driver argv in
+      if command_ok result then
+        Ok
+          (`Assoc
+            [
+              ("mode", `String "executed");
+              ("merged_pr", `Int plan.candidate.number);
+            ])
+      else
+        Error ("gh pr merge failed: " ^ String.trim result.stderr)
+
+let execute_plan driver repo_root state (plan : action_plan) =
+  match plan.phase with
+  | "issue_burn_down" -> execute_issue_plan driver repo_root plan
+  | "pr_failing_checks" -> execute_failing_pr_plan driver repo_root plan
+  | "pr_conflict" -> execute_conflict_pr_plan driver repo_root plan
+    | "merge_ready" ->
+      let plan =
+        { plan with merge_command = merge_command_if_ready state ~review_ok:true plan.candidate }
+      in
+      execute_merge_plan driver state plan
+  | _ -> Error ("unknown phase: " ^ plan.phase)
+
+let mark_success state ?merged_pr ?closed_issue ~now ~phase message =
+  {
+    state with
+    status = Running;
+    enabled = true;
+    current_phase = Some phase;
+    last_success = Some message;
+    last_failure = None;
+    consecutive_failures = 0;
+    last_merged_pr = (match merged_pr with Some value -> Some value | None -> state.last_merged_pr);
+    last_closed_issue = (match closed_issue with Some value -> Some value | None -> state.last_closed_issue);
+    paused_reason = None;
+    updated_at = now;
+  }
+
+let mark_failure state ~now message =
+  let consecutive_failures = state.consecutive_failures + 1 in
+  if consecutive_failures >= 3 then
+    {
+      state with
+      enabled = true;
+      status = Paused;
+      current_phase = Some "paused_after_failures";
+      last_failure = Some message;
+      consecutive_failures;
+      paused_reason = Some "paused_after_three_consecutive_failures";
+      updated_at = now;
+    }
+  else
+    {
+      state with
+      enabled = true;
+      status = Running;
+      last_failure = Some message;
+      consecutive_failures;
+      updated_at = now;
+    }
+
+let queue_json queue ~limit =
+  queue
+  |> (fun rows ->
+       let rec take acc n = function
+         | [] -> List.rev acc
+         | _ when n <= 0 -> List.rev acc
+         | row :: rest -> take (row :: acc) (n - 1) rest
+       in
+       take [] limit rows)
+  |> List.map candidate_to_json
+  |> fun rows -> `List rows
+
+let state_status_json ?plan ?queue (state : state) =
+  let base =
+    match state_to_json state with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  let extra =
+    (match plan with Some value -> [ ("plan", action_plan_to_json value) ] | None -> [])
+    @
+    match queue with
+    | Some (rows, limit) -> [ ("queue", queue_json rows ~limit); ("queue_size", `Int (List.length rows)) ]
+    | None -> []
+  in
+  `Assoc (base @ extra)
+
+let tick_due (state : state) ~now =
+  if not state.enabled || state.status <> Running then
+    false
+  else if state.last_success = None && state.last_failure = None
+          && state.current_candidate = None
+  then
+    true
+  else
+    now -. state.updated_at >= float_of_int (max 30 state.poll_interval_sec)
+
+let resolve_selected_candidate state queue =
+  match state.current_candidate with
+  | Some current ->
+      option_or_else
+        (List.find_opt
+           (fun candidate -> String.equal (candidate_id candidate) (candidate_id current))
+           queue)
+        (fun () -> list_hd_opt queue)
+  | None -> list_hd_opt queue
+
+let tick_with_driver (driver : driver) (ctx : context) args : result =
+  let state = load_state ctx.config in
+  let limit = max 1 (get_int args "limit" 10) in
+  let review_ok = get_bool args "review_ok" false in
+  if not state.enabled || state.status = Disabled then
+    (true, Yojson.Safe.pretty_to_string (state_status_json state))
+  else if state.status = Paused then
+    (true, Yojson.Safe.pretty_to_string (state_status_json state))
+  else
+    let now = driver.now () in
+    match driver.list_prs ~repo:state.repo, driver.list_issues ~repo:state.repo with
+    | Error pr_error, _ ->
+        let updated = mark_failure state ~now ("gh pr list failed: " ^ pr_error) in
+        save_state ctx.config updated;
+        append_event ctx.config "tick_failure"
+          (`Assoc [ ("reason", `String pr_error) ]);
+        (false, Yojson.Safe.pretty_to_string (state_status_json updated))
+    | _, Error issue_error ->
+        let updated = mark_failure state ~now ("gh issue list failed: " ^ issue_error) in
+        save_state ctx.config updated;
+        append_event ctx.config "tick_failure"
+          (`Assoc [ ("reason", `String issue_error) ]);
+        (false, Yojson.Safe.pretty_to_string (state_status_json updated))
+    | Ok prs, Ok issues ->
+        let queue = rank_candidates ~review_ok ~prs ~issues () in
+        match resolve_selected_candidate state queue with
+        | None ->
+            let updated =
+              {
+                state with
+                current_candidate = None;
+                current_phase = Some "idle";
+                last_success = Some "queue_empty";
+                updated_at = now;
+              }
+            in
+            save_state ctx.config updated;
+            append_event ctx.config "tick_idle"
+              (`Assoc [ ("repo", `String state.repo) ]);
+            (true, Yojson.Safe.pretty_to_string (state_status_json ~queue:(queue, limit) updated))
+        | Some candidate ->
+            let repo_root = repo_root ctx.config in
+            let planned_state =
+              {
+                state with
+                current_candidate = Some candidate;
+                current_phase = Some (candidate_kind_to_string candidate.kind);
+                updated_at = now;
+              }
+            in
+            let plan = plan_for_candidate repo_root planned_state ~review_ok candidate in
+            let execute = get_bool args "execute" (not state.dry_run) in
+            if not execute || state.dry_run then begin
+              save_state ctx.config planned_state;
+              append_event ctx.config "tick_planned"
+                (`Assoc
+                  [
+                    ("candidate", candidate_to_json candidate);
+                    ("plan", action_plan_to_json plan);
+                  ]);
+              (true,
+               Yojson.Safe.pretty_to_string
+                 (state_status_json ~plan ~queue:(queue, limit) planned_state))
+            end else
+              match execute_plan driver repo_root planned_state plan with
+              | Ok exec_json ->
+                  let updated =
+                    mark_success planned_state ~now ~phase:plan.phase
+                      (Printf.sprintf "executed %s" plan.action_id)
+                      ?merged_pr:
+                        (if plan.phase = "merge_ready" then Some candidate.number else None)
+                  in
+                  save_state ctx.config updated;
+                  append_event ctx.config "tick_executed"
+                    (`Assoc
+                      [
+                        ("candidate", candidate_to_json candidate);
+                        ("plan", action_plan_to_json plan);
+                        ("execution", exec_json);
+                      ]);
+                  let json =
+                    match state_status_json ~plan ~queue:(queue, limit) updated with
+                    | `Assoc fields -> `Assoc (("execution", exec_json) :: fields)
+                    | other -> other
+                  in
+                  (true, Yojson.Safe.pretty_to_string json)
+              | Error message ->
+                  let updated = mark_failure planned_state ~now message in
+                  save_state ctx.config updated;
+                  append_event ctx.config "tick_failure"
+                    (`Assoc
+                      [
+                        ("candidate", candidate_to_json candidate);
+                        ("plan", action_plan_to_json plan);
+                        ("reason", `String message);
+                      ]);
+                  let json =
+                    match state_status_json ~plan ~queue:(queue, limit) updated with
+                    | `Assoc fields -> `Assoc (("execution_error", `String message) :: fields)
+                    | other -> other
+                  in
+                  (false, Yojson.Safe.pretty_to_string json)
+
+let handle_start ctx args =
+  let current = load_state ctx.config in
+  let now = Time_compat.now () in
+  let state =
+    {
+      current with
+      enabled = true;
+      status = Running;
+      keeper_name = get_string args "keeper_name" current.keeper_name;
+      poll_interval_sec = max 30 (get_int args "poll_interval_sec" current.poll_interval_sec);
+      repo = get_string args "repo" current.repo;
+      repo_scope = default_repo_scope;
+      merge_policy = default_merge_policy;
+      dry_run = get_bool args "dry_run" current.dry_run;
+      paused_reason = None;
+      updated_at = now;
+    }
+  in
+  save_state ctx.config state;
+  append_event ctx.config "loop_started"
+    (`Assoc
+      [
+        ("agent_name", `String ctx.agent_name);
+        ("state", state_to_json state);
+      ]);
+  (true, Yojson.Safe.pretty_to_string (state_status_json state))
+
+let handle_status ctx _args =
+  let state = load_state ctx.config in
+  (true, Yojson.Safe.pretty_to_string (state_status_json state))
+
+let handle_pause ctx args =
+  let current = load_state ctx.config in
+  let state =
+    {
+      current with
+      enabled = true;
+      status = Paused;
+      paused_reason = Some (get_string args "reason" "manual_pause");
+      updated_at = Time_compat.now ();
+    }
+  in
+  save_state ctx.config state;
+  append_event ctx.config "loop_paused"
+    (`Assoc
+      [
+        ("agent_name", `String ctx.agent_name);
+        ("reason", Option.fold ~none:`Null ~some:(fun value -> `String value) state.paused_reason);
+      ]);
+  (true, Yojson.Safe.pretty_to_string (state_status_json state))
+
+let handle_resume ctx args =
+  let current = load_state ctx.config in
+  let state =
+    {
+      current with
+      enabled = true;
+      status = Running;
+      dry_run = get_bool args "dry_run" current.dry_run;
+      paused_reason = None;
+      updated_at = Time_compat.now ();
+    }
+  in
+  save_state ctx.config state;
+  append_event ctx.config "loop_resumed"
+    (`Assoc [ ("agent_name", `String ctx.agent_name); ("state", state_to_json state) ]);
+  (true, Yojson.Safe.pretty_to_string (state_status_json state))
+
+let maybe_tick_from_keepalive ~(config : Room.config) ~(agent_name : string)
+    ~(keeper_name : string) () =
+  let state = load_state config in
+  let now = Time_compat.now () in
+  if state.enabled && state.status = Running
+     && String.equal state.keeper_name keeper_name
+     && tick_due state ~now
+  then
+    let ctx = { config; agent_name } in
+    let _ok, _body =
+      tick_with_driver default_driver ctx
+        (`Assoc [ ("execute", `Bool true) ])
+    in
+    ()
+  else
+    ()
+
+let dispatch ctx ~name ~args : result option =
+  match name with
+  | "masc_improve_loop_start" -> Some (handle_start ctx args)
+  | "masc_improve_loop_status" -> Some (handle_status ctx args)
+  | "masc_improve_loop_pause" -> Some (handle_pause ctx args)
+  | "masc_improve_loop_resume" -> Some (handle_resume ctx args)
+  | "masc_improve_loop_tick" -> Some (tick_with_driver default_driver ctx args)
+  | _ -> None

--- a/lib/tool_improve_loop_schemas.ml
+++ b/lib/tool_improve_loop_schemas.ml
@@ -1,0 +1,74 @@
+(** Tool_improve_loop_schemas — MCP control surface for the keeper-driven
+    masc-mcp self-improvement loop. *)
+
+open Types
+
+let schemas : tool_schema list =
+  [
+    {
+      name = "masc_improve_loop_start";
+      description =
+        "Start the masc-mcp self-improvement loop. Persists keeper name, repo scope, poll interval, and execution mode for repeated issue/PR burn-down cycles.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("repo", `Assoc [ ("type", `String "string") ]);
+                  ("keeper_name", `Assoc [ ("type", `String "string") ]);
+                  ("poll_interval_sec", `Assoc [ ("type", `String "integer") ]);
+                  ("dry_run", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_improve_loop_status";
+      description =
+        "Read the persisted state of the masc-mcp self-improvement loop, including current candidate, pause reason, last success/failure, and recent queue summary.";
+      input_schema =
+        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
+    };
+    {
+      name = "masc_improve_loop_pause";
+      description =
+        "Pause the self-improvement loop without deleting state. Use when a human needs to inspect or take over.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc [ ("reason", `Assoc [ ("type", `String "string") ]) ] );
+          ];
+    };
+    {
+      name = "masc_improve_loop_resume";
+      description =
+        "Resume a previously paused self-improvement loop. Preserves queue state and last known candidate.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc [ ("dry_run", `Assoc [ ("type", `String "boolean") ]) ] );
+          ];
+    };
+    {
+      name = "masc_improve_loop_tick";
+      description =
+        "Run one selection/execution cycle for the self-improvement loop. Ranks PR conflicts, failing PRs, and open issues, then prepares or executes the next action.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("limit", `Assoc [ ("type", `String "integer") ]);
+                  ("execute", `Assoc [ ("type", `String "boolean") ]);
+                  ("review_ok", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+  ]

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -30,6 +30,7 @@ let raw_schemas : tool_schema list =
   @ Tool_tempo.schemas
   @ Tool_walph.schemas
   @ Tool_hat.schemas
+  @ Tool_improve_loop.schemas
   @ Tool_cache.schemas
   @ Tool_run.schemas
   @ Tool_social.schemas

--- a/test/dune
+++ b/test/dune
@@ -216,6 +216,11 @@
  (name test_tool_voice)
  (modules test_tool_voice)
  (libraries masc_mcp alcotest eio eio_main yojson unix))
+
+(test
+ (name test_tool_improve_loop)
+ (modules test_tool_improve_loop)
+ (libraries masc_mcp alcotest yojson unix))
 ; Board TTL + metadata classification tests
 (test
  (name test_board_ttl)

--- a/test/test_tool_improve_loop.ml
+++ b/test/test_tool_improve_loop.ml
@@ -118,6 +118,45 @@ let test_state_roundtrip () =
       check string "repo" "jeong-sik/masc-mcp" loaded.repo;
       check string "keeper" "masc-improver" loaded.keeper_name)
 
+let test_idle_tick_resets_failure_counters () =
+  with_temp_dir "masc-improve-loop-idle" (fun dir ->
+      let ctx = make_ctx dir in
+      let started =
+        { (Tool_improve_loop.default_state ()) with
+          enabled = true;
+          status = Tool_improve_loop.Running;
+          repo = "jeong-sik/masc-mcp";
+          last_failure = Some "previous failure";
+          consecutive_failures = 2;
+        }
+      in
+      Tool_improve_loop.save_state ctx.config started;
+      let fake_driver =
+        {
+          Tool_improve_loop.list_prs = (fun ~repo:_ -> Ok []);
+          list_issues = (fun ~repo:_ -> Ok []);
+          run_command =
+            (fun _argv ->
+              { Tool_improve_loop.exit_code = 0; stdout = ""; stderr = "" });
+          now = (fun () -> 222.0);
+        }
+      in
+      let ok, body =
+        Tool_improve_loop.tick_with_driver fake_driver ctx
+          (`Assoc [ ("execute", `Bool false) ])
+      in
+      check bool "idle tick ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      let failure_count =
+        json |> Yojson.Safe.Util.member "consecutive_failures"
+        |> Yojson.Safe.Util.to_int
+      in
+      check int "failure count reset" 0 failure_count;
+      let last_failure =
+        json |> Yojson.Safe.Util.member "last_failure"
+      in
+      check bool "last failure cleared" true (last_failure = `Null))
+
 let test_merge_command_requires_all_gates () =
   let state =
     { (Tool_improve_loop.default_state ()) with
@@ -267,6 +306,8 @@ let () =
           test_case "failure pause after three" `Quick
             test_failure_counter_pauses_after_three;
           test_case "state roundtrip" `Quick test_state_roundtrip;
+          test_case "idle tick resets failure counters" `Quick
+            test_idle_tick_resets_failure_counters;
         ] );
       ( "actions",
         [

--- a/test/test_tool_improve_loop.ml
+++ b/test/test_tool_improve_loop.ml
@@ -15,7 +15,13 @@ let with_temp_dir prefix f =
 
 let make_ctx base_path =
   let config = Room.default_config base_path in
-  { Tool_improve_loop.config; agent_name = "test-agent" }
+  {
+    Tool_improve_loop.config;
+    agent_name = "test-agent";
+    sw = None;
+    clock = None;
+    proc_mgr = None;
+  }
 
 let make_pr ?(head_ref_name = "feature/pr-1") ?(base_ref_name = Some "main")
     ?mergeable ?merge_state_status ?(failing_checks = []) ?(pending_checks = [])
@@ -181,6 +187,41 @@ let test_tick_picks_conflict_candidate () =
       in
       check int "conflict chosen first" 62 candidate_number)
 
+let test_execute_without_runtime_returns_team_session_error () =
+  with_temp_dir "masc-improve-loop-exec" (fun dir ->
+      let ctx = make_ctx dir in
+      let started =
+        { (Tool_improve_loop.default_state ()) with
+          enabled = true;
+          status = Tool_improve_loop.Running;
+          repo = "jeong-sik/masc-mcp";
+          dry_run = false;
+        }
+      in
+      Tool_improve_loop.save_state ctx.config started;
+      let fake_driver =
+        {
+          Tool_improve_loop.list_prs = (fun ~repo:_ -> Ok []);
+          list_issues = (fun ~repo:_ -> Ok [ make_issue 81 "bug" ~labels:[ "bug" ] ]);
+          run_command =
+            (fun _argv ->
+              { Tool_improve_loop.exit_code = 0; stdout = ""; stderr = "" });
+          now = (fun () -> 321.0);
+        }
+      in
+      let ok, body =
+        Tool_improve_loop.tick_with_driver fake_driver ctx
+          (`Assoc [ ("execute", `Bool true) ])
+      in
+      check bool "execute fails without runtime" false ok;
+      let json = Yojson.Safe.from_string body in
+      let error =
+        json |> Yojson.Safe.Util.member "execution_error"
+        |> Yojson.Safe.Util.to_string
+      in
+      check bool "runtime error surfaced" true
+        (Astring.String.is_infix ~affix:"team session runtime unavailable" error))
+
 let test_tick_due_immediate_on_fresh_start () =
   let state =
     { (Tool_improve_loop.default_state ()) with
@@ -233,6 +274,8 @@ let () =
             test_merge_command_requires_all_gates;
           test_case "tick selects conflict candidate" `Quick
             test_tick_picks_conflict_candidate;
+          test_case "execute without runtime surfaces team session error" `Quick
+            test_execute_without_runtime_returns_team_session_error;
           test_case "tick due fresh start" `Quick
             test_tick_due_immediate_on_fresh_start;
           test_case "tick due interval gate" `Quick

--- a/test/test_tool_improve_loop.ml
+++ b/test/test_tool_improve_loop.ml
@@ -1,0 +1,241 @@
+open Alcotest
+open Masc_mcp
+
+module Tool_improve_loop = Masc_mcp.Tool_improve_loop
+
+let with_temp_dir prefix f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%06x" prefix (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+    (fun () -> f dir)
+
+let make_ctx base_path =
+  let config = Room.default_config base_path in
+  { Tool_improve_loop.config; agent_name = "test-agent" }
+
+let make_pr ?(head_ref_name = "feature/pr-1") ?(base_ref_name = Some "main")
+    ?mergeable ?merge_state_status ?(failing_checks = []) ?(pending_checks = [])
+    ?(is_draft = false) number title =
+  {
+    Tool_improve_loop.number;
+    title;
+    url = Some (Printf.sprintf "https://example.invalid/pr/%d" number);
+    head_ref_name;
+    base_ref_name;
+    mergeable;
+    merge_state_status;
+    is_draft;
+    failing_checks;
+    pending_checks;
+  }
+
+let make_issue ?(labels = []) number title =
+  {
+    Tool_improve_loop.number;
+    title;
+    url = Some (Printf.sprintf "https://example.invalid/issues/%d" number);
+    labels;
+  }
+
+let test_rank_conflicting_pr_before_failing_pr () =
+  let prs =
+    [
+      make_pr 11 "failing" ~mergeable:"MERGEABLE"
+        ~failing_checks:[ "Build and Test" ];
+      make_pr 12 "conflicting" ~mergeable:"CONFLICTING"
+        ~merge_state_status:"DIRTY";
+    ]
+  in
+  let queue = Tool_improve_loop.rank_candidates ~prs ~issues:[] () in
+  match queue with
+  | first :: _ ->
+      check string "conflict wins" "conflict_pr"
+        (Tool_improve_loop.candidate_kind_to_string first.kind)
+  | [] -> fail "expected ranked queue"
+
+let test_rank_failing_pr_before_issue () =
+  let prs =
+    [ make_pr 21 "failing" ~mergeable:"MERGEABLE"
+        ~failing_checks:[ "Contract Harness" ] ]
+  in
+  let issues = [ make_issue 31 "bug" ~labels:[ "bug" ] ] in
+  let queue = Tool_improve_loop.rank_candidates ~prs ~issues () in
+  match queue with
+  | first :: _ ->
+      check string "failing pr wins" "failing_pr"
+        (Tool_improve_loop.candidate_kind_to_string first.kind)
+  | [] -> fail "expected ranked queue"
+
+let test_rank_skips_current_candidate () =
+  let issue = Tool_improve_loop.candidate_of_issue (make_issue 41 "current") in
+  let queue =
+    Tool_improve_loop.rank_candidates
+      ~skip_candidate_id:(Tool_improve_loop.candidate_id issue)
+      ~prs:[] ~issues:[ make_issue 41 "current"; make_issue 42 "next" ] ()
+  in
+  match queue with
+  | first :: _ -> check int "skipped current" 42 first.number
+  | [] -> fail "expected queue"
+
+let test_failure_counter_pauses_after_three () =
+  let base = Tool_improve_loop.default_state () in
+  let failed1 =
+    Tool_improve_loop.mark_failure base ~now:1.0 "one"
+  in
+  let failed2 =
+    Tool_improve_loop.mark_failure failed1 ~now:2.0 "two"
+  in
+  let failed3 =
+    Tool_improve_loop.mark_failure failed2 ~now:3.0 "three"
+  in
+  check int "failure count" 3 failed3.consecutive_failures;
+  check string "paused" "paused"
+    (Tool_improve_loop.loop_status_to_string failed3.status)
+
+let test_state_roundtrip () =
+  with_temp_dir "masc-improve-loop-state" (fun dir ->
+      let ctx = make_ctx dir in
+      let state =
+        { (Tool_improve_loop.default_state ~repo:"jeong-sik/masc-mcp" ()) with
+          enabled = true;
+          status = Tool_improve_loop.Running;
+          keeper_name = "masc-improver";
+        }
+      in
+      Tool_improve_loop.save_state ctx.config state;
+      let loaded = Tool_improve_loop.load_state ctx.config in
+      check bool "enabled" true loaded.enabled;
+      check string "repo" "jeong-sik/masc-mcp" loaded.repo;
+      check string "keeper" "masc-improver" loaded.keeper_name)
+
+let test_merge_command_requires_all_gates () =
+  let state =
+    { (Tool_improve_loop.default_state ()) with
+      enabled = true;
+      status = Tool_improve_loop.Running;
+      repo = "jeong-sik/masc-mcp";
+    }
+  in
+  let candidate =
+    Tool_improve_loop.candidate_of_pr ~review_ok:true
+      (make_pr 51 "merge"
+         ~head_ref_name:"loop/issue-51-merge"
+         ~base_ref_name:(Some "main")
+         ~mergeable:"MERGEABLE")
+  in
+  let missing_review =
+    Tool_improve_loop.merge_command_if_ready state ~review_ok:false candidate
+  in
+  check bool "no merge without review gate" true (Option.is_none missing_review);
+  let ready =
+    Tool_improve_loop.merge_command_if_ready state ~review_ok:true candidate
+  in
+  check bool "merge emitted" true (Option.is_some ready)
+
+let test_tick_picks_conflict_candidate () =
+  with_temp_dir "masc-improve-loop-tick" (fun dir ->
+      let ctx = make_ctx dir in
+      let started =
+        { (Tool_improve_loop.default_state ()) with
+          enabled = true;
+          status = Tool_improve_loop.Running;
+          repo = "jeong-sik/masc-mcp";
+        }
+      in
+      Tool_improve_loop.save_state ctx.config started;
+      let fake_driver =
+        {
+          Tool_improve_loop.list_prs =
+            (fun ~repo:_ ->
+              Ok
+                [
+                  make_pr 61 "failing"
+                    ~mergeable:"MERGEABLE"
+                    ~failing_checks:[ "Build and Test" ];
+                  make_pr 62 "conflict"
+                    ~mergeable:"CONFLICTING"
+                    ~merge_state_status:"DIRTY";
+                ]);
+          list_issues =
+            (fun ~repo:_ -> Ok [ make_issue 71 "bug" ~labels:[ "bug" ] ]);
+          run_command =
+            (fun _argv ->
+              { Tool_improve_loop.exit_code = 0; stdout = ""; stderr = "" });
+          now = (fun () -> 123.0);
+        }
+      in
+      let ok, body =
+        Tool_improve_loop.tick_with_driver fake_driver ctx
+          (`Assoc [ ("execute", `Bool false) ])
+      in
+      check bool "tick ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      let candidate_number =
+        json |> Yojson.Safe.Util.member "current_candidate"
+        |> Yojson.Safe.Util.member "number"
+        |> Yojson.Safe.Util.to_int
+      in
+      check int "conflict chosen first" 62 candidate_number)
+
+let test_tick_due_immediate_on_fresh_start () =
+  let state =
+    { (Tool_improve_loop.default_state ()) with
+      enabled = true;
+      status = Tool_improve_loop.Running;
+      poll_interval_sec = 300;
+    }
+  in
+  check bool "fresh state ticks immediately" true
+    (Tool_improve_loop.tick_due state ~now:10.0)
+
+let test_tick_due_waits_for_interval_after_activity () =
+  let state =
+    { (Tool_improve_loop.default_state ()) with
+      enabled = true;
+      status = Tool_improve_loop.Running;
+      poll_interval_sec = 300;
+      updated_at = 100.0;
+      last_success = Some "planned";
+      current_phase = Some "issue_burn_down";
+    }
+  in
+  check bool "not due early" false
+    (Tool_improve_loop.tick_due state ~now:200.0);
+  check bool "due after interval" true
+    (Tool_improve_loop.tick_due state ~now:401.0)
+
+let () =
+  Random.self_init ();
+  run "Tool_improve_loop"
+    [
+      ( "ranking",
+        [
+          test_case "conflicting PR beats failing PR" `Quick
+            test_rank_conflicting_pr_before_failing_pr;
+          test_case "failing PR beats issue" `Quick
+            test_rank_failing_pr_before_issue;
+          test_case "skip current candidate" `Quick
+            test_rank_skips_current_candidate;
+        ] );
+      ( "state",
+        [
+          test_case "failure pause after three" `Quick
+            test_failure_counter_pauses_after_three;
+          test_case "state roundtrip" `Quick test_state_roundtrip;
+        ] );
+      ( "actions",
+        [
+          test_case "merge requires gates" `Quick
+            test_merge_command_requires_all_gates;
+          test_case "tick selects conflict candidate" `Quick
+            test_tick_picks_conflict_candidate;
+          test_case "tick due fresh start" `Quick
+            test_tick_due_immediate_on_fresh_start;
+          test_case "tick due interval gate" `Quick
+            test_tick_due_waits_for_interval_after_activity;
+        ] );
+    ]

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -632,17 +632,17 @@ let test_keeper_fs_edit_policy_gates () =
       ~policy_shell_mode:"coding" ()
   in
   check_keeper_exec_tool_presence "heuristic fs_edit default" heuristic_disabled
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "heuristic fs_edit coding" heuristic_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit disabled" learned_disabled
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit coding" learned_coding
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "explicit event fs_edit coding" explicit_event_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "model deliberation fs_edit coding" deliberation_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false
 
 let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary
- add keeper-driven `masc_improve_loop_{start,status,pause,resume,tick}` tools
- persist loop state and candidate/action planning for masc-mcp-only burn-down
- add `masc-improver` keeper profile and a keepalive hook that auto-ticks when due
- cover ranking, merge-gate, state, and timing behavior with dedicated tests

## Testing
- `env -u DUNE_RPC dune build --root . test/test_tool_improve_loop.exe`
- `./_build/default/test/test_tool_improve_loop.exe`
- `env -u DUNE_RPC dune build --root . --display short test/test_tool_registration_consistency.exe`
- `./_build/default/test/test_tool_registration_consistency.exe`
