### PR TITLE
refactor(keeper): rebalance keeper tool surface

### DIFF
--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -5,32 +5,52 @@ Tool availability for keepers is determined by two axes:
 
 Research profile (`soul_profile = "research"`) adds autoresearch/research tools regardless of other settings.
 
-## Tool Shards (keeper_model_tools: 28 tools total)
+## Tool Shards (keeper_model_tools: 26 tools total)
 
 | Shard | Tools | Count | Removable |
 |-------|-------|-------|-----------|
 | **base** | `keeper_time_now`, `keeper_context_status`, `keeper_memory_search` | 3 | No |
 | **board** | `keeper_board_{get,post,list,comment,vote}` | 5 | Yes |
-| **filesystem** | `keeper_fs_{read,edit}` | 2 | Yes |
-| **shell** | `keeper_shell_readonly`, `keeper_bash`, `keeper_github` | 3 | Yes |
-| **voice** | `keeper_voice_{speak,agent,sessions,session_start,session_end}` | 5 | Yes |
-| **weather** | `keeper_weather_note` | 1 | Yes |
+| **filesystem** | `keeper_fs_read` | 1 | Yes |
+| **shell** | `keeper_shell_readonly` | 1 | Yes |
 | **library** | `keeper_library_{search,read}` | 2 | Yes |
 | **taskboard** | `keeper_tasks_{list,audit}`, `keeper_task_{force_release,force_done,claim,done}`, `keeper_broadcast` | 7 | Yes |
+| **governance** | `masc_{cases,case_status,ruling_status,governance_status,governance_feed,case_brief_submit,petition_submit}` | 7 | Yes |
+| **voice** | `keeper_voice_{speak,agent,sessions,session_start,session_end}` | 5 | Yes |
+| **weather** | `keeper_weather_note` | 1 | Yes |
+| **coding** | `keeper_{bash,github}`, `masc_{worktree_create,worktree_list,code_search,code_symbols,code_read}` | 7 | Yes |
+
+Notes:
+- `voice` and `weather` shards still exist, but they are no longer part of the default keeper surface.
+- `keeper_fs_edit` remains a legacy internal tool but is intentionally excluded from default keeper exposure.
+- Code mutation uses `masc_code_{write,edit,delete,shell,git}` in addition to the `coding` shard above.
 
 ## Policy Mode × Shell Mode Matrix
 
 | | `disabled` | `readonly` | `sandboxed` / default | `coding` |
 |---|---|---|---|---|
-| **Heuristic** (default) | base + board + fs + shell + voice + weather + library + taskboard (28 tools) | same | same | same + code_write |
-| **Learned_offline_v1** | read + board (12 tools) | read + board + shell_readonly (13) | read + board (12) | read + board + code_write |
+| **Heuristic** (default) | base + board + fs + shell + library + taskboard + governance (26 tools) | same | same | default + coding shard + `masc_code_*` (38 tools) |
+| **Learned_offline_v1** | read + coordination + board + governance (23 tools) | + `keeper_shell_readonly` (24) | same as `disabled` | readonly set + coding shard + `masc_code_*` (36 tools) |
 | **Explicit_event_v1** | same as Heuristic | same | same | same |
 | **Model_deliberation** | same as Heuristic | same | same | same |
 
 Notes:
 - "read" = `keeper_read_tool_names` (7 tools: `keeper_read`, `keeper_fs_read`, `keeper_memory_search`, `keeper_library_search`, `keeper_library_read`, `keeper_time_now`, `keeper_context_status`)
-- Voice tools added when `policy_voice_enabled = true` (any mode)
+- "coordination" = `keeper_tasks_list`, `keeper_task_claim`, `keeper_task_done`, `keeper_broadcast`
+- Voice tools are added only when `policy_voice_enabled = true`
+- Coding mode is the preferred path for code writing, test execution, and GitHub issue/PR work because it exposes `masc_worktree_create` plus the worktree-restricted `masc_code_*` tools
 - `write_done = true` returns empty tool list (session terminated)
+
+## Keeper Workflows
+
+| Workflow | Primary tools |
+|----------|---------------|
+| 의견 내기 / 토론 참여 | `keeper_board_post`, `keeper_board_comment` |
+| 찬성 / 반대 신호 | `keeper_board_vote`, `masc_case_brief_submit` (`stance = support|oppose|neutral`) |
+| 거버넌스 의견 제출 | `masc_petition_submit`, `masc_case_brief_submit`, `masc_case_status`, `masc_governance_feed` |
+| 코드 작성 / 수정 | `masc_worktree_create` -> `masc_code_write` / `masc_code_edit` / `masc_code_git` |
+| 테스트 실행 | `masc_code_shell` (worktree `cwd` required) |
+| GitHub 이슈 작성 | `keeper_github` with `gh issue create ...` |
 
 ## Research Profile Additions
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -191,7 +191,8 @@ let privileged_public_tool_names : string list =
   [ "masc_spawn"; "masc_worktree_create"; "masc_worktree_remove" ]
 
 let privileged_keeper_tool_names : string list =
-  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit"; "keeper_github" ]
+  [ "keeper_bash"; "keeper_fs_edit"; "keeper_edit"; "keeper_github";
+    "masc_worktree_create" ]
 
 let keeper_backend_tool_name = function
   | "keeper_board_get" -> "masc_board_get"
@@ -417,7 +418,12 @@ let keeper_wrapped_server_tools : string list =
   [ "masc_board_post"; "masc_board_comment"; "masc_board_list";
     "masc_voice_speak"; "masc_voice_agent"; "masc_voice_sessions";
     "masc_voice_session_start"; "masc_voice_session_end";
-    "masc_tasks"; "masc_broadcast" ]
+    "masc_tasks"; "masc_broadcast";
+    "masc_worktree_create"; "masc_worktree_list";
+    "masc_code_search"; "masc_code_symbols"; "masc_code_read";
+    "masc_cases"; "masc_case_status"; "masc_ruling_status";
+    "masc_governance_status"; "masc_governance_feed";
+    "masc_case_brief_submit"; "masc_petition_submit" ]
 
 let keeper_wrapped_internal_tools : string list =
   keeper_all_tool_names

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -33,7 +33,7 @@ let keeper_read_tool_names =
   ]
 
 let keeper_coordination_tool_names =
-  [ "keeper_tasks_list"; "keeper_broadcast" ]
+  [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_task_done"; "keeper_broadcast" ]
 
 let keeper_board_tool_names =
   [
@@ -49,6 +49,10 @@ let keeper_voice_tool_names =
     "keeper_voice_session_start"; "keeper_voice_session_end" ]
 
 let keeper_shell_readonly_tool_names = [ "keeper_shell_readonly" ]
+
+let keeper_governance_tool_names =
+  Tool_shard.governance_tools
+  |> List.map (fun (t : Types.tool_schema) -> t.name)
 
 let keeper_coding_shard_tool_names =
   Tool_shard.coding_tools
@@ -67,9 +71,15 @@ let is_research_profile (meta : keeper_meta) =
 
 let keeper_coding_tool_names = Tool_code_write.tool_names
 
+let keeper_voice_tool_schemas =
+  match Tool_shard.get_shard "voice" with
+  | Some shard -> shard.tools
+  | None -> []
+
 (** Curated masc_* bridge for keepers.
     Schema list is injected at server init to avoid cyclic dependency on Tools.
-    Keep raw masc_* passthrough minimal and prefer keeper_* wrappers elsewhere. *)
+    Keep raw masc_* passthrough minimal and move keeper-visible workflows into
+    dedicated shards whenever possible. *)
 
 let keeper_passthrough_masc_tool_names =
   [
@@ -100,6 +110,19 @@ let keeper_masc_tool_schemas (_meta : keeper_meta) : Types.tool_schema list =
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)
 
+let keeper_default_tool_names (meta : keeper_meta) : string list =
+  let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
+  if meta.policy_voice_enabled then
+    dedupe_tool_names (keeper_voice_tool_names @ base_names)
+  else
+    base_names
+
+let keeper_default_model_tools (meta : keeper_meta) : Types.tool_schema list =
+  if meta.policy_voice_enabled then
+    keeper_model_tools @ keeper_voice_tool_schemas
+  else
+    keeper_model_tools
+
 let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     string list =
   if write_done then
@@ -115,10 +138,12 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
         keeper_shell_readonly_tool_names @ with_voice
       else with_voice
     in
+    let with_governance = keeper_governance_tool_names @ with_shell in
     let with_research =
       if is_research_profile meta then
-        keeper_research_loop_tool_names @ keeper_autoresearch_tool_names @ with_shell
-      else with_shell
+        keeper_research_loop_tool_names @ keeper_autoresearch_tool_names
+        @ with_governance
+      else with_governance
     in
     let with_coding =
       if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
@@ -127,7 +152,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     in
     dedupe_tool_names (keeper_masc_tool_names meta @ keeper_board_tool_names @ with_coding)
   else
-    let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
+    let base_names = keeper_default_tool_names meta in
     let with_research =
       if is_research_profile meta then
         keeper_research_loop_tool_names @ keeper_autoresearch_tool_names @ base_names
@@ -146,7 +171,7 @@ let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
   if allowed = [] then
     []
   else
-    let base = keeper_model_tools in
+    let base = keeper_default_model_tools meta in
     let with_research =
       if is_research_profile meta then
         base @ Tool_research.schemas @ Tool_shard.autoresearch_keeper_tools

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -63,7 +63,10 @@ let _gen_case_id () =
 
 let handle_petition_submit ctx args =
   let title = get_string args "title" "" in
-  let subject = get_string args "subject" "" in
+  let subject =
+    let by_schema = get_string args "subject_type" "" in
+    if by_schema <> "" then by_schema else get_string args "subject" ""
+  in
   let risk = get_string args "risk_class" "low" in
   let _config = ensure_room_ready ctx in
   if title = "" then json_err "title is required"
@@ -108,7 +111,16 @@ let handle_case_brief_submit ctx args =
   let case_id = get_string args "case_id" "" in
   let stance = get_string args "stance" "neutral" in
   let summary = get_string args "summary" "" in
-  let evidence = get_string args "evidence_refs" "" in
+  let evidence_refs =
+    match member "evidence_refs" args with
+    | `List items ->
+        items
+        |> List.filter_map (function
+             | `String value when String.trim value <> "" -> Some value
+             | _ -> None)
+    | `String value when String.trim value <> "" -> [ value ]
+    | _ -> []
+  in
   if case_id = "" then json_err "case_id is required"
   else begin
     match GV2.brief_stance_of_string stance with
@@ -118,7 +130,7 @@ let handle_case_brief_submit ctx args =
         ~case_id ~author:ctx.agent_name
         ~stance:stance_val
         ~summary
-        ~evidence_refs:(if evidence = "" then [] else [evidence])
+        ~evidence_refs
       in
       match brief_result with
       | Error msg -> json_err msg

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -112,6 +112,14 @@ let board_tools : Types.tool_schema list = [
   };
 ]
 
+let select_named_schemas (names : string list) (schemas : Types.tool_schema list) :
+    Types.tool_schema list =
+  names
+  |> List.filter_map (fun name ->
+         List.find_opt
+           (fun (schema : Types.tool_schema) -> String.equal schema.name name)
+           schemas)
+
 let filesystem_tools : Types.tool_schema list = [
   {
     name = "keeper_fs_read";
@@ -123,19 +131,6 @@ let filesystem_tools : Types.tool_schema list = [
         ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String "Max bytes to return (default: 20000)")]);
       ]);
       ("required", `List [`String "path"]);
-    ];
-  };
-  {
-    name = "keeper_fs_edit";
-    description = "Write/append a file under current project root. Use for concrete code changes.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path")]);
-        ("content", `Assoc [("type", `String "string"); ("description", `String "New file content or append payload")]);
-        ("mode", `Assoc [("type", `String "string"); ("description", `String "overwrite (default) or append")]);
-      ]);
-      ("required", `List [`String "path"; `String "content"]);
     ];
   };
 ]
@@ -158,9 +153,7 @@ let shell_tools : Types.tool_schema list = [
   };
 ]
 
-(** Coding tools — arbitrary shell and github access.
-    NOT in default shards. Only granted when policy_shell_mode = "coding". *)
-let coding_tools : Types.tool_schema list = [
+let coding_keeper_bridge_tools : Types.tool_schema list = [
   {
     name = "keeper_bash";
     description = "Run a shell command from project root. Use for build/test/check commands.";
@@ -175,17 +168,30 @@ let coding_tools : Types.tool_schema list = [
   };
   {
     name = "keeper_github";
-    description = "Run gh CLI commands from project root. Use for PR/review/comment operations.";
+    description = "Run gh CLI commands from project root. Use for issue/PR/review/comment operations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand string, e.g. 'pr view 123 --comments'")]);
+        ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand string, e.g. 'issue create --title ...'")]);
         ("args", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Optional argv list for gh (without leading gh)")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
       ]);
     ];
   };
 ]
+
+let coding_workspace_tool_names : string list =
+  [ "masc_worktree_create"; "masc_worktree_list"; "masc_code_search";
+    "masc_code_symbols"; "masc_code_read" ]
+
+let coding_workspace_tools : Types.tool_schema list =
+  select_named_schemas coding_workspace_tool_names
+    (Tool_schemas_worktree.schemas @ Tool_code.schemas)
+
+(** Coding tools — shell/github bridges plus worktree-first code workflow.
+    NOT in default shards. Only granted when policy_shell_mode = "coding". *)
+let coding_tools : Types.tool_schema list =
+  coding_keeper_bridge_tools @ coding_workspace_tools
 
 let voice_tools : Types.tool_schema list = [
   {
@@ -372,7 +378,7 @@ let shard_filesystem : shard = {
   name = "filesystem";
   tools = filesystem_tools;
   removable = true;
-  description = "File I/O: read, edit";
+  description = "File I/O: read only";
 }
 
 let shard_shell : shard = {
@@ -386,7 +392,9 @@ let shard_coding : shard = {
   name = "coding";
   tools = coding_tools;
   removable = true;
-  description = "Coding tools: bash, github (requires policy_shell_mode=coding)";
+  description =
+    "Coding tools: github/shell bridge + worktree/code inspection \
+     (requires policy_shell_mode=coding)";
 }
 
 let shard_weather : shard = {
@@ -410,11 +418,34 @@ let shard_library : shard = {
   description = "Knowledge library: search, read documents";
 }
 
+let governance_keeper_tool_names : string list =
+  [
+    "masc_cases";
+    "masc_case_status";
+    "masc_ruling_status";
+    "masc_governance_status";
+    "masc_governance_feed";
+    "masc_case_brief_submit";
+    "masc_petition_submit";
+  ]
+
+let governance_tools : Types.tool_schema list =
+  select_named_schemas governance_keeper_tool_names
+    Tool_council_internal_schemas.schemas
+
 let shard_taskboard : shard = {
   name = "taskboard";
   tools = taskboard_tools;
   removable = true;
   description = "Task board management: list, audit, force-release, force-done, broadcast";
+}
+
+let shard_governance : shard = {
+  name = "governance";
+  tools = governance_tools;
+  removable = true;
+  description =
+    "Governance workflow: cases, briefs, petitions, rulings, feed, status";
 }
 
 (** Autoresearch tools: filtered subset for keeper use (excludes swarm_start). *)
@@ -430,22 +461,19 @@ let shard_autoresearch : shard = {
   description = "Autonomous experiment loop: start, cycle, status, inject, stop";
 }
 
-
-
 let agent_shards : (string, string list) Hashtbl.t = Hashtbl.create 32
 
-
-
-(** Default shards for a new keeper (full access) *)
+(** Default shards for a new keeper.
+    Keep the default surface focused on coordination/governance. Voice,
+    weather, and coding are opt-in. *)
 let default_shard_names : string list = [
   "base";
   "board";
   "filesystem";
   "shell";
-  "weather";
-  "voice";
   "library";
   "taskboard";
+  "governance";
 ]
 
 let get_agent_shards (agent_name : string) : string list =
@@ -468,6 +496,7 @@ let all_shards : (string, shard) Hashtbl.t =
     shard_voice;
     shard_library;
     shard_taskboard;
+    shard_governance;
     shard_autoresearch;
   ];
   tbl
@@ -516,7 +545,7 @@ let list_all_shards () : (string * bool * int) list =
     (name, shard.removable, List.length shard.tools) :: acc
   ) all_shards []
 
-(** Full tool set (all 11 tools) — backward compatible *)
+(** Default keeper tool set from [default_shard_names]. *)
 let keeper_model_tools : Types.tool_schema list =
   tools_of_shards default_shard_names
 
@@ -526,7 +555,7 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_tool_grant";
     description = "Grant a tool shard to an agent. \
-Shards: base (core), board, filesystem, shell, weather, voice, taskboard.";
+Shards: base (core), board, filesystem, shell, governance, weather, voice, taskboard, coding, autoresearch.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -536,7 +565,7 @@ Shards: base (core), board, filesystem, shell, weather, voice, taskboard.";
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Shard to grant: base, board, filesystem, shell, weather, voice, taskboard");
+          ("description", `String "Shard to grant: base, board, filesystem, shell, governance, weather, voice, taskboard, coding, autoresearch");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);
@@ -555,7 +584,7 @@ Cannot revoke 'base' shard (always present).";
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Shard to revoke (must be removable). One of: board, filesystem, shell, weather, voice, taskboard");
+          ("description", `String "Shard to revoke (must be removable). One of: board, filesystem, shell, governance, weather, voice, taskboard, coding, autoresearch");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -19,10 +19,13 @@ val shard_board : shard
 (** MASC Board: post, list, comment. *)
 
 val shard_filesystem : shard
-(** File I/O: read, edit. *)
+(** File I/O: read-only inspection. *)
 
 val shard_shell : shard
-(** Shell access: bash, github. *)
+(** Structured read-only shell access. *)
+
+val shard_governance : shard
+(** Governance workflow: cases, briefs, petitions, status/feed. *)
 
 val shard_weather : shard
 (** Weather queries. *)
@@ -38,7 +41,8 @@ val all_shards : (string, shard) Hashtbl.t
 (** {1 Tool Composition} *)
 
 val default_shard_names : string list
-(** Default shards for a new keeper: base, board, filesystem, shell, weather. *)
+(** Default shards for a new keeper: base, board, filesystem, shell,
+    library, taskboard, governance. *)
 
 val tools_of_shards : string list -> Types.tool_schema list
 (** Combine tools from multiple shard names. *)
@@ -80,6 +84,9 @@ val base_tools : Types.tool_schema list
 val board_tools : Types.tool_schema list
 (** Board tools: board_post, board_list, board_comment, board_vote. *)
 
+val governance_tools : Types.tool_schema list
+(** Governance tools exposed to keepers by default. *)
+
 (** {1 MCP Interface} *)
 
 val schemas : Types.tool_schema list
@@ -96,11 +103,12 @@ val shard_autoresearch : shard
 (** Autoresearch shard: start, cycle, status, inject, stop. *)
 
 val coding_tools : Types.tool_schema list
-(** Coding shard tools (keeper_bash, keeper_github).
+(** Coding shard tools (keeper_github/keeper_bash + worktree/code inspection).
     Not in default shards — only granted when policy_shell_mode = "coding". *)
 
 val shard_coding : shard
-(** Coding shard: bash, github (requires policy_shell_mode=coding). *)
+(** Coding shard: github/shell bridge + worktree/code inspection
+    (requires policy_shell_mode=coding). *)
 
 val keeper_model_tools : Types.tool_schema list
 (** Default tool set from default shards — excludes coding tools. *)

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -54,32 +54,46 @@ let has_keeper_prefix name =
     Derived from actual module exports — no prefix guessing. *)
 let known_non_keeper_tool_names : string list =
   List.concat [
+    Tool_shard.governance_tools
+    |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_shard.autoresearch_keeper_tools
     |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_research.schemas
+    |> List.map (fun (t : Types.tool_schema) -> t.name);
+    Tool_shard.coding_tools
     |> List.map (fun (t : Types.tool_schema) -> t.name);
     Tool_code_write.tool_names;
   ]
   |> List.sort_uniq String.compare
 
+let known_shared_agent_keeper_tool_names : string list =
+  [ "masc_worktree_create"; "masc_worktree_list" ]
+
 (* ============================================================
-   Invariant 1: Non-research keepers only get keeper_* tools
+   Invariant 1: Non-research keepers only get keeper_* tools plus
+   curated canonical masc_* keeper workflows
    ============================================================ *)
 
 let test_heuristic_only_keeper_prefixed () =
   let meta = make_meta ~policy_mode:"Heuristic" () in
   let names = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let non_keeper = List.filter (fun n -> not (has_keeper_prefix n)) names in
+  let unexpected =
+    List.filter (fun n -> not (List.mem n known_non_keeper_tool_names)) non_keeper
+  in
   Alcotest.(check (list string))
-    "heuristic keeper only has keeper_* tools" [] non_keeper
+    "heuristic keeper only has keeper_* or curated masc_* tools" [] unexpected
 
 let test_learned_only_keeper_prefixed () =
   let meta = make_meta ~policy_mode:"Learned_offline_v1"
       ~policy_shell_mode:"readonly" ~policy_voice_enabled:true () in
   let names = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let non_keeper = List.filter (fun n -> not (has_keeper_prefix n)) names in
+  let unexpected =
+    List.filter (fun n -> not (List.mem n known_non_keeper_tool_names)) non_keeper
+  in
   Alcotest.(check (list string))
-    "learned keeper only has keeper_* tools" [] non_keeper
+    "learned keeper only has keeper_* or curated masc_* tools" [] unexpected
 
 (* ============================================================
    Invariant 2: Research keepers only add research/autoresearch tools
@@ -134,9 +148,16 @@ let test_no_overlap_research_vs_agent () =
       ~soul_profile:"research" () in
   let keeper_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let agent_names = Agent_tool_surfaces.spawned_agent_public_tool_names in
-  let overlap = List.filter (fun n -> List.mem n agent_names) keeper_names in
+  let overlap =
+    List.filter
+      (fun n ->
+        List.mem n agent_names
+        && not (List.mem n known_shared_agent_keeper_tool_names))
+      keeper_names
+  in
   Alcotest.(check (list string))
-    "research keeper disjoint from agent coordination" [] overlap
+    "research keeper only shares approved worktree tools with agent surface"
+    [] overlap
 
 let test_shard_tools_disjoint_from_agent () =
   let keeper_tools = Tool_shard.keeper_model_tools

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -189,7 +189,7 @@ let test_write_done_kills_all () =
   check (list string) "write_done returns empty" [] tools
 
 let test_learned_disabled_mode () =
-  (* learned + disabled: read tools + board tools only *)
+  (* learned + disabled: read + coordination + board + governance *)
   let meta = make_meta ~policy_shell_mode:"disabled"
     ~policy_mode:"learned_offline_v1" () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -62,12 +62,18 @@ let test_default_has_base_tools () =
   check bool "has keeper_context_status" true (has_tool "keeper_context_status" tools)
 
 let test_default_has_no_voice () =
-  (* Non-learned default mode uses shard-based tools which may include
-     voice if voice shard is in defaults. Check learned mode instead. *)
-  let meta = make_meta ~policy_voice_enabled:false
-    ~policy_mode:"learned_offline_v1" () in
+  let meta = make_meta ~policy_voice_enabled:false () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "no voice tools in learned mode" false (has_tool "keeper_voice_speak" tools)
+  check bool "no voice tools in default mode" false
+    (has_tool "keeper_voice_speak" tools)
+
+let test_default_has_governance_tools () =
+  let meta = make_meta () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "has governance status" true
+    (has_tool "masc_governance_status" tools);
+  check bool "has case brief submit" true
+    (has_tool "masc_case_brief_submit" tools)
 
 let test_default_has_no_research () =
   let meta = make_meta ~soul_profile:"default" () in
@@ -123,7 +129,11 @@ let test_coding_shell_adds_coding_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let coding_names = Tool_code_write.tool_names in
   let has_any_coding = List.exists (fun n -> has_tool n tools) coding_names in
-  check bool "coding tools present" true has_any_coding
+  check bool "coding tools present" true has_any_coding;
+  check bool "has worktree create" true
+    (has_tool "masc_worktree_create" tools);
+  check bool "has code search" true
+    (has_tool "masc_code_search" tools)
 
 let test_disabled_shell_no_coding_tools () =
   let meta = make_meta ~policy_shell_mode:"disabled"
@@ -169,8 +179,18 @@ let test_learned_mode_has_keeper_coordination_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has keeper_tasks_list" true
     (has_tool "keeper_tasks_list" tools);
+  check bool "has keeper_task_claim" true
+    (has_tool "keeper_task_claim" tools);
   check bool "has keeper_broadcast" true
     (has_tool "keeper_broadcast" tools)
+
+let test_learned_mode_has_governance_tools () =
+  let meta = make_meta ~policy_mode:"learned_offline_v1" () in
+  let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "has governance status" true
+    (has_tool "masc_governance_status" tools);
+  check bool "has petition submit" true
+    (has_tool "masc_petition_submit" tools)
 
 let test_normal_mode_uses_shard_tools () =
   let meta = make_meta ~policy_mode:"" () in
@@ -330,6 +350,7 @@ let () =
     ("default_profile", [
       test_case "has base tools" `Quick test_default_has_base_tools;
       test_case "no voice tools" `Quick test_default_has_no_voice;
+      test_case "has governance tools" `Quick test_default_has_governance_tools;
       test_case "no research tools" `Quick test_default_has_no_research;
     ]);
     ("voice_profile", [
@@ -353,6 +374,8 @@ let () =
       test_case "has read tools" `Quick test_learned_mode_has_read_tools;
       test_case "has keeper coordination tools" `Quick
         test_learned_mode_has_keeper_coordination_tools;
+      test_case "has governance tools" `Quick
+        test_learned_mode_has_governance_tools;
       test_case "normal mode uses shards" `Quick test_normal_mode_uses_shard_tools;
     ]);
     ("combined_profiles", [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -347,6 +347,22 @@ let test_petition_submit_creates_case () =
       (Yojson.Safe.Util.member "merged" json <> `Null)
   | None -> Alcotest.fail "dispatch returned None"
 
+let test_petition_submit_accepts_subject_type () =
+  with_council_base @@ fun base_path ->
+  let ctx = make_council_ctx ~base_path in
+  let args = `Assoc [
+    ("title", `String "Schema-aligned petition");
+    ("subject_type", `String "policy");
+    ("risk_class", `String "low");
+  ] in
+  match Tool_council_oas.dispatch ctx ~name:"masc_petition_submit" ~args with
+  | Some (ok, body) ->
+    Alcotest.(check bool) "petition ok" true ok;
+    let json = parse_json body in
+    let case_id = json |> field "case_id" |> Yojson.Safe.Util.to_string in
+    Alcotest.(check bool) "case_id non-empty" true (String.length case_id > 0)
+  | None -> Alcotest.fail "dispatch returned None"
+
 let test_petition_submit_empty_title_err () =
   with_council_base @@ fun base_path ->
   let ctx = make_council_ctx ~base_path in
@@ -429,6 +445,40 @@ let test_governance_status_after_petition () =
       (json |> field "open_cases" |> Yojson.Safe.Util.to_int >= 1)
   | None -> Alcotest.fail "dispatch returned None"
 
+let test_case_brief_submit_accepts_evidence_refs_array () =
+  with_council_base @@ fun base_path ->
+  let ctx = make_council_ctx ~base_path in
+  let petition_args = `Assoc [
+    ("title", `String "Brief evidence case");
+    ("subject_type", `String "task");
+    ("risk_class", `String "low");
+  ] in
+  let case_id =
+    match Tool_council_oas.dispatch ctx ~name:"masc_petition_submit"
+            ~args:petition_args with
+    | Some (true, body) ->
+      parse_json body |> field "case_id" |> Yojson.Safe.Util.to_string
+    | Some (false, body) ->
+      Alcotest.failf "petition failed: %s" body
+    | None -> Alcotest.fail "petition dispatch returned None"
+  in
+  let brief_args = `Assoc [
+    ("case_id", `String case_id);
+    ("stance", `String "support");
+    ("summary", `String "Ship it");
+    ("evidence_refs", `List [ `String "trace:abc"; `String "doc:123" ]);
+  ] in
+  match Tool_council_oas.dispatch ctx ~name:"masc_case_brief_submit"
+          ~args:brief_args with
+  | Some (ok, body) ->
+    Alcotest.(check bool) "brief ok" true ok;
+    let json = parse_json body in
+    Alcotest.(check string) "case_id preserved" case_id
+      (json |> field "case_id" |> Yojson.Safe.Util.to_string);
+    Alcotest.(check string) "stance preserved" "support"
+      (json |> field "stance" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "dispatch returned None"
+
 (* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
@@ -484,6 +534,8 @@ let () =
     "tool_council_oas", [
       Alcotest.test_case "petition creates case with collaboration_id" `Quick
         test_petition_submit_creates_case;
+      Alcotest.test_case "petition accepts subject_type" `Quick
+        test_petition_submit_accepts_subject_type;
       Alcotest.test_case "petition empty title error" `Quick
         test_petition_submit_empty_title_err;
       Alcotest.test_case "cases list empty" `Quick
@@ -496,5 +548,7 @@ let () =
         test_council_dispatch_unknown;
       Alcotest.test_case "governance status after petition" `Quick
         test_governance_status_after_petition;
+      Alcotest.test_case "case brief accepts evidence_refs array" `Quick
+        test_case_brief_submit_accepts_evidence_refs_array;
     ];
   ]

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -32,7 +32,12 @@ let test_shard_filesystem_exists () =
   match Tool_shard.get_shard "filesystem" with
   | Some s ->
     Alcotest.(check bool) "removable" true s.Tool_shard.removable;
-    Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1)
+    Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1);
+    let names = List.map (fun (t : Types.tool_schema) -> t.name) s.tools in
+    Alcotest.(check bool) "contains fs_read" true
+      (List.mem "keeper_fs_read" names);
+    Alcotest.(check bool) "excludes fs_edit" false
+      (List.mem "keeper_fs_edit" names)
   | None -> Alcotest.fail "filesystem shard not found"
 
 let test_shard_shell_exists () =
@@ -42,6 +47,18 @@ let test_shard_shell_exists () =
     Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1)
   | None -> Alcotest.fail "shell shard not found"
 
+let test_shard_governance_exists () =
+  match Tool_shard.get_shard "governance" with
+  | Some s ->
+    Alcotest.(check bool) "removable" true s.Tool_shard.removable;
+    Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1);
+    let names = List.map (fun (t : Types.tool_schema) -> t.name) s.tools in
+    Alcotest.(check bool) "contains petition_submit" true
+      (List.mem "masc_petition_submit" names);
+    Alcotest.(check bool) "contains case_brief_submit" true
+      (List.mem "masc_case_brief_submit" names)
+  | None -> Alcotest.fail "governance shard not found"
+
 let test_shard_coding_exists () =
   match Tool_shard.get_shard "coding" with
   | Some s ->
@@ -49,7 +66,11 @@ let test_shard_coding_exists () =
     Alcotest.(check bool) "has tools" true (List.length s.Tool_shard.tools >= 1);
     let names = List.map (fun (t : Types.tool_schema) -> t.name) s.tools in
     Alcotest.(check bool) "contains keeper_bash" true (List.mem "keeper_bash" names);
-    Alcotest.(check bool) "contains keeper_github" true (List.mem "keeper_github" names)
+    Alcotest.(check bool) "contains keeper_github" true (List.mem "keeper_github" names);
+    Alcotest.(check bool) "contains worktree_create" true
+      (List.mem "masc_worktree_create" names);
+    Alcotest.(check bool) "contains code_search" true
+      (List.mem "masc_code_search" names)
   | None -> Alcotest.fail "coding shard not found"
 
 let test_coding_not_in_defaults () =
@@ -86,7 +107,13 @@ let test_default_shard_names () =
   let defaults = Tool_shard.default_shard_names in
   Alcotest.(check bool) "at least 6 defaults" true (List.length defaults >= 6);
   (* base is always required as the non-removable foundation shard *)
-  Alcotest.(check bool) "base in defaults" true (List.mem "base" defaults)
+  Alcotest.(check bool) "base in defaults" true (List.mem "base" defaults);
+  Alcotest.(check bool) "governance in defaults" true
+    (List.mem "governance" defaults);
+  Alcotest.(check bool) "voice not in defaults" false
+    (List.mem "voice" defaults);
+  Alcotest.(check bool) "weather not in defaults" false
+    (List.mem "weather" defaults)
 
 (* ============================================================
    tools_of_shards tests
@@ -302,6 +329,15 @@ let test_board_tools_names () =
   Alcotest.(check bool) "has board_comment" true (List.mem "keeper_board_comment" names);
   Alcotest.(check bool) "has board_vote" true (List.mem "keeper_board_vote" names)
 
+let test_governance_tools_names () =
+  let names = List.map (fun (t : Types.tool_schema) -> t.name)
+    Tool_shard.governance_tools in
+  Alcotest.(check bool) "has cases" true (List.mem "masc_cases" names);
+  Alcotest.(check bool) "has governance_status" true
+    (List.mem "masc_governance_status" names);
+  Alcotest.(check bool) "has brief submit" true
+    (List.mem "masc_case_brief_submit" names)
+
 (* ============================================================
    Voice tools content tests (#3: all 5 voice tools present)
    ============================================================ *)
@@ -317,21 +353,20 @@ let test_voice_tools_names () =
   Alcotest.(check bool) "has voice_session_start" true (List.mem "keeper_voice_session_start" names);
   Alcotest.(check bool) "has voice_session_end" true (List.mem "keeper_voice_session_end" names)
 
-let test_keeper_model_has_voice_tools () =
+let test_keeper_model_excludes_voice_tools () =
   let names = List.map (fun (t : Types.tool_schema) -> t.name)
     Tool_shard.keeper_model_tools in
-  Alcotest.(check bool) "keeper_model has voice_speak" true (List.mem "keeper_voice_speak" names);
-  Alcotest.(check bool) "keeper_model has voice_agent" true (List.mem "keeper_voice_agent" names);
-  Alcotest.(check bool) "keeper_model has voice_sessions" true (List.mem "keeper_voice_sessions" names);
-  Alcotest.(check bool) "keeper_model has voice_session_start" true (List.mem "keeper_voice_session_start" names);
-  Alcotest.(check bool) "keeper_model has voice_session_end" true (List.mem "keeper_voice_session_end" names)
+  Alcotest.(check bool) "keeper_model no voice_speak" false
+    (List.mem "keeper_voice_speak" names);
+  Alcotest.(check bool) "keeper_model has governance_status" true
+    (List.mem "masc_governance_status" names)
 
 (* ============================================================
    Shard revoke voice (#6: revoke removes all 5 voice tools)
    ============================================================ *)
 
 let test_revoke_voice_removes_all_tools () =
-  let all_shards = Tool_shard.default_shard_names in
+  let all_shards = Tool_shard.default_shard_names @ [ "voice" ] in
   let tools_before = Tool_shard.tools_of_shards all_shards in
   let voice_before = List.filter (fun (t : Types.tool_schema) ->
     let n = t.name in
@@ -368,15 +403,24 @@ let all_keeper_shard_tool_names () : string list =
   |> List.sort_uniq String.compare
 
 (** Verify that every keeper_ tool in any shard also appears in
-    keeper_model_tools (default) or coding_tools. This ensures no
+    one of the effective keeper shard bundles. This ensures no
     tool schema is orphaned from the dispatch pipeline. *)
 let test_keeper_dispatch_coverage () =
   let names = all_keeper_shard_tool_names () in
   Alcotest.(check bool) "at least 25 keeper tools" true (List.length names >= 25);
+  let shard_tool_names shard_name =
+    match Tool_shard.get_shard shard_name with
+    | Some shard ->
+      shard.Tool_shard.tools
+      |> List.map (fun (t : Types.tool_schema) -> t.name)
+    | None -> []
+  in
   let reachable =
     List.concat [
       (Tool_shard.keeper_model_tools
        |> List.map (fun (t : Types.tool_schema) -> t.name));
+      shard_tool_names "voice";
+      shard_tool_names "weather";
       (Tool_shard.coding_tools
        |> List.map (fun (t : Types.tool_schema) -> t.name));
     ]
@@ -415,6 +459,7 @@ let () =
       Alcotest.test_case "board" `Quick test_shard_board_exists;
       Alcotest.test_case "filesystem" `Quick test_shard_filesystem_exists;
       Alcotest.test_case "shell" `Quick test_shard_shell_exists;
+      Alcotest.test_case "governance" `Quick test_shard_governance_exists;
       Alcotest.test_case "coding" `Quick test_shard_coding_exists;
       Alcotest.test_case "coding not in defaults" `Quick test_coding_not_in_defaults;
       Alcotest.test_case "weather" `Quick test_shard_weather_exists;
@@ -489,8 +534,10 @@ let () =
     ("tool_content", [
       Alcotest.test_case "base tools" `Quick test_base_tools_names;
       Alcotest.test_case "board tools" `Quick test_board_tools_names;
+      Alcotest.test_case "governance tools" `Quick test_governance_tools_names;
       Alcotest.test_case "voice tools" `Quick test_voice_tools_names;
-      Alcotest.test_case "keeper_model has voice" `Quick test_keeper_model_has_voice_tools;
+      Alcotest.test_case "keeper_model excludes voice" `Quick
+        test_keeper_model_excludes_voice_tools;
     ]);
     ("voice_shard_revoke", [
       Alcotest.test_case "revoke removes all voice tools" `Quick test_revoke_voice_removes_all_tools;


### PR DESCRIPTION
## Summary
- rebalance the default keeper surface around governance and coordination workflows
- make coding mode worktree-first by exposing worktree/code inspection tools while keeping voice and weather opt-in
- align governance OAS parsing with keeper-facing schema fields and update keeper exposure/isolation tests

## Validation
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-surface-rebalance test/test_tool_shard_coverage.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-surface-rebalance test/test_keeper_tool_exposure.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-surface-rebalance test/test_keeper_safety_gates.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-surface-rebalance test/test_keeper_agent_isolation.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-tool-surface-rebalance test/test_oas_worker.exe -- test tool_council_oas

## Notes
- full dune build was attempted twice but was slow in this worktree; targeted tests above cover the touched keeper/governance/capability paths