### PR TITLE
Optimize dashboard log severity and gRPC startup behavior

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -231,7 +231,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    Log.Server.error "[main] keeper bootstrap failed (continuing without keepers): %s" (Printexc.to_string exn)
+    Log.Server.warn "[main] keeper bootstrap failed (continuing without keepers): %s" (Printexc.to_string exn)
 
 (** CLI options *)
 let port =
@@ -273,14 +273,19 @@ let acquire_pid_lock port =
      (match int_of_string_opt pid_str with
       | Some pid ->
         (try Unix.kill pid 0;
-           Printf.eprintf
-             "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d\n%!"
-             pid port pid;
+           Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+             (Printf.sprintf
+                "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
+                pid port pid);
            exit 1
          with Unix.Unix_error (Unix.ESRCH, _, _) ->
-           Printf.eprintf "[WARN] Removing stale PID file (PID %d no longer running)\n%!" pid)
+           Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+             (Printf.sprintf
+                "[WARN] Removing stale PID file (PID %d no longer running)"
+                pid))
       | None ->
-        Printf.eprintf "[WARN] Invalid PID file contents, overwriting\n%!")
+        Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+          "[WARN] Invalid PID file contents, overwriting")
    | None -> ());
   let oc = open_out path in
   Printf.fprintf oc "%d\n" (Unix.getpid ());

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -48,6 +48,10 @@ export interface LogEntry {
   seq: number
   ts: string
   level: string
+  raw_level: string
+  normalized_level: string
+  source: string
+  legacy_classified: boolean
   module: string
   message: string
 }
@@ -61,11 +65,15 @@ export function fetchLogs(opts?: {
   limit?: number
   level?: string
   module?: string
+  since_seq?: number
 }): Promise<LogsResponse> {
   const params = new URLSearchParams()
   if (opts?.limit) params.set('limit', String(opts.limit))
   if (opts?.level) params.set('level', opts.level)
   if (opts?.module) params.set('module', opts.module)
+  if (typeof opts?.since_seq === 'number' && opts.since_seq >= 0) {
+    params.set('since_seq', String(opts.since_seq))
+  }
   const qs = params.toString()
   return get(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
 }

--- a/dashboard/src/components/agent-monitor/live-timeline.ts
+++ b/dashboard/src/components/agent-monitor/live-timeline.ts
@@ -8,6 +8,7 @@ import { TimeAgo } from '../common/time-ago'
 import { FilterChips } from '../common/filter-chips'
 import { EmptyState } from '../common/empty-state'
 import { journal } from '../../sse'
+import { isErrorJournalEntry } from '../../journal-entry'
 import type { JournalEntry, JournalEventType } from '../../types'
 
 type FilterKind = 'all' | 'heartbeat' | 'turn' | 'tool' | 'error' | 'lifecycle'
@@ -35,7 +36,7 @@ function eventMatchesFilter(entry: JournalEntry, filter: FilterKind): boolean {
     case 'tool':
       return entry.text.toLowerCase().includes('tool')
     case 'error':
-      return et === 'keeper_guardrail' || entry.text.toLowerCase().includes('error')
+      return et === 'keeper_guardrail' || isErrorJournalEntry(entry)
     case 'lifecycle':
       return et === 'agent_joined' || et === 'agent_left' || et === 'keeper_handoff' || et === 'keeper_compaction'
     default:
@@ -43,7 +44,9 @@ function eventMatchesFilter(entry: JournalEntry, filter: FilterKind): boolean {
   }
 }
 
-function eventKindBadgeClass(eventType: JournalEventType | undefined): string {
+function eventKindBadgeClass(entry: JournalEntry): string {
+  if (isErrorJournalEntry(entry)) return 'agent-event-badge--error'
+  const eventType = entry.eventType
   switch (eventType) {
     case 'keeper_heartbeat':
     case 'oas_keeper_snapshot':
@@ -150,7 +153,7 @@ export function AgentLiveTimeline({ name }: { name: string }) {
           ? html`<${EmptyState} message="필터에 맞는 이벤트 없음" compact />`
           : filtered.map((entry: JournalEntry, idx: number) => html`
               <div class="flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
-                <span class="agent-event-badge ${eventKindBadgeClass(entry.eventType)}">
+                <span class="agent-event-badge ${eventKindBadgeClass(entry)}">
                   ${eventKindLabel(entry.eventType)}
                 </span>
                 <span class="flex-1 text-[#c8daf7] truncate">${compactText(entry.text)}</span>

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { LogEntry } from '../api/dashboard'
+import { mergeLogEntries } from './logs'
+
+function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    seq,
+    ts: `2026-03-24T00:00:${String(seq).padStart(2, '0')}Z`,
+    level: 'INFO',
+    raw_level: 'INFO',
+    normalized_level: 'INFO',
+    source: 'structured',
+    legacy_classified: false,
+    module: 'Dashboard',
+    message: `entry-${seq}`,
+    ...overrides,
+  }
+}
+
+describe('mergeLogEntries', () => {
+  it('deduplicates by seq and keeps newest payload', () => {
+    const current = [entry(5, { message: 'old-5' }), entry(4)]
+    const incoming = [entry(6), entry(5, { message: 'new-5', source: 'legacy_stderr' })]
+
+    expect(mergeLogEntries(current, incoming, 10)).toEqual([
+      entry(6),
+      entry(5, { message: 'new-5', source: 'legacy_stderr' }),
+      entry(4),
+    ])
+  })
+
+  it('trims merged output to the requested maximum', () => {
+    const current = [entry(4), entry(3), entry(2)]
+    const incoming = [entry(5), entry(1)]
+
+    expect(mergeLogEntries(current, incoming, 3).map(item => item.seq)).toEqual([5, 4, 3])
+  })
+})

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { signal, useSignalEffect } from '@preact/signals'
 import { fetchLogs } from '../api/dashboard.js'
 import type { LogEntry } from '../api/dashboard.js'
+import { VirtualList } from './common/virtual-list'
 
 const logEntries = signal<LogEntry[]>([])
 const logTotal = signal(0)
@@ -10,9 +11,14 @@ const logError = signal<string | null>(null)
 const levelFilter = signal('INFO')
 const moduleFilter = signal('')
 const autoRefresh = signal(true)
-const logLimit = signal(500)
+const logLimit = signal(200)
+const latestSeq = signal<number | null>(null)
+
+const POLL_INTERVAL_MS = 3000
+const LOG_ROW_HEIGHT = 76
 
 let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
+let latestRequestId = 0
 
 const LEVEL_COLORS: Record<string, string> = {
   DEBUG: 'var(--text-muted)',
@@ -21,29 +27,152 @@ const LEVEL_COLORS: Record<string, string> = {
   ERROR: '#e05050',
 }
 
-async function loadLogs() {
-  logLoading.value = true
-  logError.value = null
+const SOURCE_LABELS: Record<string, string> = {
+  structured: 'structured',
+  legacy_stderr: 'legacy stderr',
+  legacy_traceln: 'legacy traceln',
+  sse: 'sse',
+}
+
+type LoadMode = 'reset' | 'delta'
+
+function normalizedLevel(entry: LogEntry): string {
+  return (entry.normalized_level || entry.level || 'INFO').toUpperCase()
+}
+
+function sortLogEntries(entries: LogEntry[]): LogEntry[] {
+  return [...entries].sort((a, b) => b.seq - a.seq)
+}
+
+function latestLogSeq(entries: LogEntry[]): number | null {
+  if (entries.length === 0) return null
+  return entries.reduce((max, entry) => Math.max(max, entry.seq), entries[0]?.seq ?? 0)
+}
+
+export function mergeLogEntries(
+  current: LogEntry[],
+  incoming: LogEntry[],
+  maxEntries: number,
+): LogEntry[] {
+  const merged = new Map<number, LogEntry>()
+  current.forEach(entry => merged.set(entry.seq, entry))
+  incoming.forEach(entry => merged.set(entry.seq, entry))
+  return [...merged.values()]
+    .sort((a, b) => b.seq - a.seq)
+    .slice(0, Math.max(1, maxEntries))
+}
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? (source || 'structured')
+}
+
+function sourceTone(source: string): string {
+  switch (source) {
+    case 'legacy_stderr':
+      return 'text-[#ffb4b4] bg-[rgba(224,80,80,0.12)] border-[rgba(224,80,80,0.18)]'
+    case 'legacy_traceln':
+      return 'text-[#ffd88a] bg-[rgba(230,167,0,0.12)] border-[rgba(230,167,0,0.18)]'
+    default:
+      return 'text-[var(--text-muted)] bg-[rgba(255,255,255,0.04)] border-[rgba(255,255,255,0.08)]'
+  }
+}
+
+async function loadLogs(mode: LoadMode = 'reset') {
+  const requestId = ++latestRequestId
+  if (mode === 'reset') {
+    logLoading.value = true
+    logError.value = null
+  }
+
   try {
     const resp = await fetchLogs({
       limit: logLimit.value,
       level: levelFilter.value,
       module: moduleFilter.value || undefined,
+      since_seq: mode === 'delta' ? latestSeq.value ?? undefined : undefined,
     })
-    logEntries.value = resp.entries
+    if (requestId !== latestRequestId) return
+
+    const incoming = sortLogEntries(resp.entries)
+    const nextEntries =
+      mode === 'delta'
+        ? mergeLogEntries(logEntries.value, incoming, logLimit.value)
+        : incoming.slice(0, Math.max(1, logLimit.value))
+
+    logEntries.value = nextEntries
+    latestSeq.value = latestLogSeq(nextEntries)
     logTotal.value = resp.total
+    logError.value = null
   } catch (err) {
+    if (requestId !== latestRequestId) return
     logError.value = err instanceof Error ? err.message : String(err)
   } finally {
-    logLoading.value = false
+    if (requestId === latestRequestId && mode === 'reset') {
+      logLoading.value = false
+    }
   }
+}
+
+function renderLogRow(entry: LogEntry) {
+  const level = normalizedLevel(entry)
+  const rawLevelChanged = entry.raw_level && entry.raw_level !== level
+  const source = entry.source || 'structured'
+  const sourceClass = sourceTone(source)
+  const backgroundClass =
+    level === 'ERROR'
+      ? 'bg-[rgba(224,80,80,0.08)]'
+      : level === 'WARN'
+        ? 'bg-[rgba(230,167,0,0.05)]'
+        : 'bg-[rgba(255,255,255,0.02)]'
+
+  return html`
+    <div
+      key=${entry.seq}
+      class="logs-row grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 rounded-[18px] border border-[rgba(255,255,255,0.05)] px-3 py-3 ${backgroundClass}"
+    >
+      <div class="font-mono text-[11px] whitespace-nowrap text-[color:var(--text-muted)]">
+        ${entry.ts.replace('T', ' ').replace('Z', '')}
+      </div>
+      <div class="font-mono text-[11px] font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[level] ?? 'inherit'}">
+        ${level}
+      </div>
+      <div class="min-w-0 font-mono text-[11px] text-[color:var(--accent)] truncate" title=${entry.module || '(root)'}>
+        ${entry.module || '(root)'}
+      </div>
+      <div class="flex flex-wrap items-start gap-1">
+        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceClass}">
+          ${sourceLabel(source)}
+        </span>
+        ${entry.legacy_classified
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">classified</span>`
+          : null}
+        ${rawLevelChanged
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
+          : null}
+      </div>
+      <div
+        class="text-[12px] leading-relaxed text-[var(--text-body)]"
+        title=${entry.message}
+        style=${{
+          display: '-webkit-box',
+          overflow: 'hidden',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: 2,
+        }}
+      >
+        ${entry.message}
+      </div>
+    </div>
+  `
 }
 
 export function LogViewer() {
   useSignalEffect(() => {
-    void loadLogs()
+    void loadLogs('reset')
     if (!autoRefresh.value) return
-    const id = setInterval(() => { void loadLogs() }, 3000)
+    const id = setInterval(() => {
+      void loadLogs('delta')
+    }, POLL_INTERVAL_MS)
     return () => clearInterval(id)
   })
 
@@ -55,7 +184,7 @@ export function LogViewer() {
             <div class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.72)]">Observer</div>
             <h2 class="mt-2 text-[26px] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">Execution Log Stream</h2>
             <p class="mt-2 text-[13px] leading-relaxed text-[var(--text-muted)]">
-              backend stdout/stderr와 구조화된 런타임 로그를 같은 흐름에서 읽습니다. 에러는 빠르게 띄우고, 나머지는 모듈과 수준으로 좁혀서 봅니다.
+              structured logger를 기본으로 보고, 남아 있는 legacy stderr/traceln도 같은 ring buffer에서 함께 봅니다. 새 항목은 delta로만 가져와서 탭 비용을 줄였습니다.
             </p>
           </div>
 
@@ -65,12 +194,12 @@ export function LogViewer() {
               <strong class="text-[var(--text-strong)]">${levelFilter.value}+</strong>
             </div>
             <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
-              <span>조회 건수</span>
+              <span>buffer total</span>
               <strong class="text-[var(--text-strong)] tabular-nums">${(logTotal.value ?? 0).toLocaleString()}</strong>
             </div>
             <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
               <span>새로고침</span>
-              <strong class="${autoRefresh.value ? 'text-[#92f3b4]' : 'text-[var(--text-strong)]'}">${autoRefresh.value ? 'auto' : 'manual'}</strong>
+              <strong class="${autoRefresh.value ? 'text-[#92f3b4]' : 'text-[var(--text-strong)]'}">${autoRefresh.value ? 'delta auto' : 'manual'}</strong>
             </div>
           </div>
         </div>
@@ -79,107 +208,114 @@ export function LogViewer() {
       <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
-          <select
-            class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
-            value=${levelFilter.value}
-            onChange=${(e: Event) => {
-              levelFilter.value = (e.target as HTMLSelectElement).value
-              void loadLogs()
-            }}
-          >
-            <option value="DEBUG">DEBUG+</option>
-            <option value="INFO">INFO+</option>
-            <option value="WARN">WARN+</option>
-            <option value="ERROR">ERROR</option>
-          </select>
+            <select
+              class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              value=${levelFilter.value}
+              onChange=${(e: Event) => {
+                levelFilter.value = (e.target as HTMLSelectElement).value
+                latestSeq.value = null
+                void loadLogs('reset')
+              }}
+            >
+              <option value="DEBUG">DEBUG+</option>
+              <option value="INFO">INFO+</option>
+              <option value="WARN">WARN+</option>
+              <option value="ERROR">ERROR</option>
+            </select>
 
-          <input
-            class="logs-module-input min-w-[220px] rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
-            type="text"
-            placeholder="module filter"
-            value=${moduleFilter.value}
-            onInput=${(e: Event) => {
-              moduleFilter.value = (e.target as HTMLInputElement).value
-              if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
-              moduleDebounceTimer = setTimeout(() => { void loadLogs() }, 300)
-            }}
-            onKeyDown=${(e: KeyboardEvent) => {
-              if (e.key === 'Enter') {
-                if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
-                void loadLogs()
-              }
-            }}
-          />
-
-          <select
-            class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
-            value=${String(logLimit.value)}
-            onChange=${(e: Event) => {
-              logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
-              void loadLogs()
-            }}
-          >
-            <option value="100">100</option>
-            <option value="500">500</option>
-            <option value="1000">1000</option>
-            <option value="3000">3000</option>
-          </select>
-        </div>
-
-        <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
-          <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${(logTotal.value ?? 0).toLocaleString()} total</span>
-          <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
             <input
-              type="checkbox"
-              checked=${autoRefresh.value}
-              onChange=${() => { autoRefresh.value = !autoRefresh.value }}
+              class="logs-module-input min-w-[220px] rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              type="text"
+              placeholder="module filter"
+              value=${moduleFilter.value}
+              onInput=${(e: Event) => {
+                moduleFilter.value = (e.target as HTMLInputElement).value
+                if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
+                moduleDebounceTimer = setTimeout(() => {
+                  latestSeq.value = null
+                  void loadLogs('reset')
+                }, 300)
+              }}
+              onKeyDown=${(e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                  if (moduleDebounceTimer) clearTimeout(moduleDebounceTimer)
+                  latestSeq.value = null
+                  void loadLogs('reset')
+                }
+              }}
             />
-            자동
-          </label>
-          <button type="button" class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]" onClick=${() => { void loadLogs() }}
-            disabled=${logLoading.value}>
-            ${logLoading.value ? '...' : '새로고침'}
-          </button>
-        </div>
+
+            <select
+              class="logs-select rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
+              value=${String(logLimit.value)}
+              onChange=${(e: Event) => {
+                logLimit.value = parseInt((e.target as HTMLSelectElement).value, 10)
+                latestSeq.value = null
+                void loadLogs('reset')
+              }}
+            >
+              <option value="100">100</option>
+              <option value="200">200</option>
+              <option value="500">500</option>
+              <option value="1000">1000</option>
+              <option value="3000">3000</option>
+            </select>
+          </div>
+
+          <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
+            <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.value.length.toLocaleString()} shown</span>
+            <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked=${autoRefresh.value}
+                onChange=${() => { autoRefresh.value = !autoRefresh.value }}
+              />
+              자동
+            </label>
+            <button
+              type="button"
+              class="logs-refresh-btn rounded-md border border-[rgba(71,184,255,0.22)] bg-[rgba(71,184,255,0.12)] px-3 py-2 text-[11px] font-medium text-[#dff3ff]"
+              onClick=${() => {
+                latestSeq.value = null
+                void loadLogs('reset')
+              }}
+              disabled=${logLoading.value}
+            >
+              ${logLoading.value ? '...' : '새로고침'}
+            </button>
+          </div>
         </div>
 
         ${logError.value ? html`
           <div class="mx-4 mt-4 rounded-md border border-solid border-[#e05050] bg-[rgba(224,80,80,0.12)] px-4 py-3 text-[12px] text-[#ffb3b3]">${logError.value}</div>
         ` : null}
 
-        <div class="logs-table-wrap min-h-0 flex-1 overflow-auto px-3 pb-3">
-          <table class="logs-table w-full border-separate border-spacing-y-2">
-          <thead>
-            <tr>
-              <th class="logs-col-ts w-44 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-muted)]">timestamp</th>
-              <th class="logs-col-level w-20 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">level</th>
-              <th class="logs-col-module w-40 whitespace-nowrap px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">module</th>
-              <th class="px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">message</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${logEntries.value.map(entry => html`
-              <tr
-                key=${entry.seq}
-                class="logs-row ${entry.level === 'ERROR' ? 'bg-[rgba(224,80,80,0.08)]' : entry.level === 'WARN' ? 'bg-[rgba(230,167,0,0.05)]' : 'bg-[rgba(255,255,255,0.02)]'}"
-              >
-                <td class="logs-col-ts rounded-l-[18px] border-y border-l border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] whitespace-nowrap text-[color:var(--text-muted)]">
-                  ${entry.ts.replace('T', ' ').replace('Z', '')}
-                </td>
-                <td class="logs-col-level border-y border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] font-semibold whitespace-nowrap" style="color: ${LEVEL_COLORS[entry.level] ?? 'inherit'}">
-                  ${entry.level}
-                </td>
-                <td class="logs-col-module border-y border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[11px] whitespace-nowrap text-[color:var(--accent)]">
-                  ${entry.module}
-                </td>
-                <td class="rounded-r-[18px] border-y border-r border-[rgba(255,255,255,0.05)] px-3 py-3 align-top font-mono text-[12px] leading-relaxed break-words text-[var(--text-body)]">
-                  ${entry.message}
-                </td>
-              </tr>
-            `)}
-          </tbody>
-        </table>
+        <div class="px-3 pt-3">
+          <div class="grid grid-cols-[11rem_5rem_10rem_8rem_minmax(0,1fr)] gap-3 px-3 py-2 text-left text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+            <div>timestamp</div>
+            <div>level</div>
+            <div>module</div>
+            <div>source</div>
+            <div>message</div>
+          </div>
         </div>
+
+        ${logEntries.value.length === 0
+          ? html`
+              <div class="flex flex-1 items-center justify-center px-6 text-[13px] text-[var(--text-muted)]">
+                ${logLoading.value ? '로그를 불러오는 중...' : '조건에 맞는 로그가 없습니다.'}
+              </div>
+            `
+          : html`
+              <${VirtualList}
+                items=${logEntries.value}
+                itemHeight=${LOG_ROW_HEIGHT}
+                overscan=${6}
+                getKey=${(entry: LogEntry) => String(entry.seq)}
+                renderItem=${(entry: LogEntry) => renderLogRow(entry)}
+                className="min-h-0 flex-1 overflow-auto px-3 pb-3"
+              />
+            `}
       </section>
     </div>
   `

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -48,10 +48,10 @@ function gatherSpotlightItems(snap: DashboardMissionResponse): SpotlightItem[] {
     }
   }
 
-  const severityOrder: Record<string, number> = { bad: 0, critical: 0, warn: 1, watch: 1, ok: 2 }
+  const severityOrder: Record<string, number> = { bad: 0, critical: 0, warn: 1, watch: 1, ok: 2, unknown: 2, info: 2 }
   items.sort((a, b) => {
-    const sa = severityOrder[a.severity] ?? 1
-    const sb = severityOrder[b.severity] ?? 1
+    const sa = severityOrder[a.severity] ?? 2
+    const sb = severityOrder[b.severity] ?? 2
     return sa - sb
   })
 
@@ -61,13 +61,13 @@ function gatherSpotlightItems(snap: DashboardMissionResponse): SpotlightItem[] {
 function severityDotColor(severity: string): string {
   if (severity === 'bad' || severity === 'critical') return 'bg-[var(--bad)]'
   if (severity === 'warn' || severity === 'watch') return 'bg-[var(--warn)]'
-  return 'bg-[var(--ok)]'
+  return 'bg-[var(--text-muted)]'
 }
 
 function severityBarColor(severity: string): string {
   if (severity === 'bad' || severity === 'critical') return 'bg-[var(--bad)]'
   if (severity === 'warn' || severity === 'watch') return 'bg-[var(--warn)]'
-  return 'bg-[var(--ok)]'
+  return 'bg-[var(--white-10)]'
 }
 
 interface AttentionSpotlightProps {

--- a/dashboard/src/journal-entry.test.ts
+++ b/dashboard/src/journal-entry.test.ts
@@ -28,4 +28,16 @@ describe('journal severity helpers', () => {
     expect(journalSeverity(makeEntry({ eventType: 'broadcast', severity: 'warn' }))).toBe('warn')
     expect(journalSeverity(makeEntry({ eventType: 'broadcast', severity: 'error' }))).toBe('error')
   })
+
+  it('falls back to conservative legacy text classification when severity is missing', () => {
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '[ERROR] gRPC server failed: bind' }))).toBe('error')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '[WARN] retrying stream reconnect' }))).toBe('warn')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: 'error budget update' }))).toBe('info')
+  })
+
+  it('handles case-insensitive legacy markers and empty text safely', () => {
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '[error] timeout waiting for stream' }))).toBe('error')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: 'Retrying stream reconnect' }))).toBe('warn')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '' }))).toBe('info')
+  })
 })

--- a/dashboard/src/journal-entry.test.ts
+++ b/dashboard/src/journal-entry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultJournalSeverity,
+  isErrorJournalEntry,
+  journalSeverity,
+  normalizeJournalSeverity,
+} from './journal-entry'
+import type { JournalEntry } from './types'
+
+function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
+  return {
+    agent: 'keeper-a',
+    text: 'test entry',
+    timestamp: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('journal severity helpers', () => {
+  it('marks keeper guardrail entries as errors even without text heuristics', () => {
+    expect(defaultJournalSeverity('keeper_guardrail')).toBe('error')
+    expect(isErrorJournalEntry(makeEntry({ eventType: 'keeper_guardrail', text: 'stopped by guardrail' }))).toBe(true)
+  })
+
+  it('prefers explicit severity when present', () => {
+    expect(normalizeJournalSeverity('warning')).toBe('warn')
+    expect(normalizeJournalSeverity('fatal')).toBe('error')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', severity: 'warn' }))).toBe('warn')
+    expect(journalSeverity(makeEntry({ eventType: 'broadcast', severity: 'error' }))).toBe('error')
+  })
+})

--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -45,11 +45,35 @@ export function defaultJournalSeverity(eventType: JournalEventType | undefined):
   }
 }
 
+function legacyJournalSeverityFromText(text: string | undefined): JournalSeverity {
+  const normalized = (text ?? '').trim().toLowerCase()
+  if (!normalized) return 'unknown'
+  if (
+    normalized.startsWith('[error]')
+    || normalized.startsWith('[fatal]')
+    || /\b(failed|failure|fatal|exception|timed out|timeout|crash(?:ed)?)\b/.test(normalized)
+  ) {
+    return 'error'
+  }
+  if (
+    normalized.startsWith('[warn]')
+    || normalized.startsWith('[warning]')
+    || /\b(warn(?:ing)?|degraded|retry(?:ing)?)\b/.test(normalized)
+  ) {
+    return 'warn'
+  }
+  return 'unknown'
+}
+
 export function journalSeverity(entry: JournalEntry): JournalSeverity {
   const explicit = normalizeJournalSeverity(entry.severity)
-  return explicit === 'unknown'
-    ? defaultJournalSeverity(entry.eventType)
-    : explicit
+  if (explicit !== 'unknown') return explicit
+
+  const fallback = defaultJournalSeverity(entry.eventType)
+  if (fallback === 'error' || fallback === 'warn') return fallback
+
+  const legacy = legacyJournalSeverityFromText(entry.text)
+  return legacy === 'unknown' ? fallback : legacy
 }
 
 export function isErrorJournalEntry(entry: JournalEntry): boolean {

--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -1,4 +1,60 @@
-import type { JournalEntry, JournalEventType } from './types'
+import type { JournalEntry, JournalEventType, JournalSeverity, JournalSource } from './types'
+
+export function normalizeJournalSeverity(value: string | null | undefined): JournalSeverity {
+  const normalized = (value ?? '').trim().toLowerCase()
+  switch (normalized) {
+    case 'debug':
+      return 'debug'
+    case 'info':
+      return 'info'
+    case 'warn':
+    case 'warning':
+    case 'degraded':
+      return 'warn'
+    case 'error':
+    case 'fatal':
+    case 'critical':
+    case 'failed':
+      return 'error'
+    default:
+      return 'unknown'
+  }
+}
+
+export function normalizeJournalSource(value: string | null | undefined): JournalSource {
+  switch ((value ?? '').trim().toLowerCase()) {
+    case 'structured':
+      return 'structured'
+    case 'legacy_stderr':
+      return 'legacy_stderr'
+    case 'legacy_traceln':
+      return 'legacy_traceln'
+    default:
+      return 'sse'
+  }
+}
+
+export function defaultJournalSeverity(eventType: JournalEventType | undefined): JournalSeverity {
+  switch (eventType) {
+    case 'keeper_guardrail':
+      return 'error'
+    case 'unknown':
+      return 'unknown'
+    default:
+      return 'info'
+  }
+}
+
+export function journalSeverity(entry: JournalEntry): JournalSeverity {
+  const explicit = normalizeJournalSeverity(entry.severity)
+  return explicit === 'unknown'
+    ? defaultJournalSeverity(entry.eventType)
+    : explicit
+}
+
+export function isErrorJournalEntry(entry: JournalEntry): boolean {
+  return journalSeverity(entry) === 'error'
+}
 
 export function classifyJournalKind(entry: JournalEntry): 'board' | 'tasks' | 'keepers' | 'system' | 'oas' {
   if (entry.kind) return entry.kind

--- a/dashboard/src/lib/tone.test.ts
+++ b/dashboard/src/lib/tone.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { toneClass } from './tone'
+
+describe('toneClass', () => {
+  it('treats error-like values as bad', () => {
+    expect(toneClass('error')).toBe('bad')
+    expect(toneClass('failed')).toBe('bad')
+    expect(toneClass('fatal')).toBe('bad')
+  })
+
+  it('treats warning-like values as warn', () => {
+    expect(toneClass('warning')).toBe('warn')
+    expect(toneClass('degraded')).toBe('warn')
+  })
+})

--- a/dashboard/src/lib/tone.ts
+++ b/dashboard/src/lib/tone.ts
@@ -6,6 +6,9 @@
 export function toneClass(tone?: string | null): string {
   if (
     tone === 'bad'
+    || tone === 'error'
+    || tone === 'failed'
+    || tone === 'fatal'
     || tone === 'offline'
     || tone === 'critical'
     || tone === 'risk'
@@ -14,6 +17,7 @@ export function toneClass(tone?: string | null): string {
   }
   if (
     tone === 'warn'
+    || tone === 'warning'
     || tone === 'pending'
     || tone === 'degraded'
     || tone === 'interrupted'

--- a/dashboard/src/mission-normalizers-entities.ts
+++ b/dashboard/src/mission-normalizers-entities.ts
@@ -26,7 +26,7 @@ export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAtten
   return {
     id,
     kind,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     summary,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
@@ -219,7 +219,7 @@ export function normalizeInternalSignal(raw: unknown): DashboardMissionInternalS
   return {
     id,
     signal_type: normalizedType,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     summary,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -101,7 +101,7 @@ function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
   if (!kind || !summary || !targetType) return null
   return {
     kind,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     summary,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
@@ -120,7 +120,7 @@ function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAction | n
     action_type: actionType,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     reason,
     confirm_required: asBoolean(raw.confirm_required),
     suggested_payload: raw.suggested_payload,

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -10,7 +10,6 @@ import {
   keeperHeartbeats,
   invalidateDashboardCache,
   isDashboardRefreshEvent,
-  refreshDashboard,
   refreshExecution,
   refreshBoard,
   refreshMdal,
@@ -18,6 +17,7 @@ import {
 import { refreshRoomTruth } from './room-truth-store'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
+import { route } from './router'
 
 // --- Refresh function registration (avoids circular imports) ---
 
@@ -144,9 +144,8 @@ function handleDashboardRefresh(): void {
   invalidateDashboardCache()
   if (!_fetchDebounce) {
     _fetchDebounce = setTimeout(() => {
-      void refreshDashboard({ force: true })
-      _refreshCommandPlaneFn?.()
-      _refreshOperatorFn?.()
+      void refreshRoomTruth({ force: true })
+      void refreshActiveRoute()
       _fetchDebounce = null
     }, 500)
   }
@@ -156,6 +155,17 @@ async function handleGovernance(): Promise<void> {
   _refreshGovernanceFn?.()
   const { loadRuntimeParams } = await import('./components/governance')
   loadRuntimeParams()
+}
+
+async function refreshActiveRoute(): Promise<void> {
+  try {
+    const { refreshForRoute } = await import('./tab-refresh')
+    refreshForRoute(route.value)
+  } catch {
+    _refreshCommandPlaneFn?.()
+    _refreshOperatorFn?.()
+    _refreshMissionFn?.()
+  }
 }
 
 // --- SSE reconnection handler ---
@@ -177,22 +187,13 @@ function handleReconnect(): void {
 
 async function hydrateAfterReconnect(): Promise<void> {
   try {
-    await Promise.all([
-      refreshRoomTruth({ force: true }),
-      refreshDashboard({ force: true }),
-      refreshExecution({ force: true }),
-      refreshBoard(),
-    ])
-    _refreshCommandPlaneFn?.()
-    _refreshOperatorFn?.()
-    _refreshMissionFn?.()
+    await refreshRoomTruth({ force: true })
+    await refreshActiveRoute()
   } catch {
     // First attempt failed (server may still be warming up) — retry once.
     setTimeout(() => {
       void refreshRoomTruth({ force: true })
-      void refreshDashboard({ force: true })
-      void refreshExecution({ force: true })
-      _refreshOperatorFn?.()
+      void refreshActiveRoute()
     }, 3000)
   }
 }
@@ -276,8 +277,8 @@ export function startPeriodicRefresh(): void {
     if (!connected.value) {
       invalidateDashboardCache()
     }
-    void refreshDashboard()
-    _refreshMissionFn?.()
+    void refreshRoomTruth()
+    void refreshActiveRoute()
   }, PERIODIC_REFRESH_MS)
 }
 

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -8,9 +8,12 @@ import {
   updateOasKeeperSnapshot,
   oasLastKeeperTick,
   oasTotalEvents,
-  refreshDashboard,
 } from './store'
-import { refreshRoomTruth } from './room-truth-store'
+import {
+  defaultJournalSeverity,
+  normalizeJournalSeverity,
+  normalizeJournalSource,
+} from './journal-entry'
 import type { OasKeeperSnapshot } from './types/oas'
 
 const SSE_SESSION_KEY = 'masc_dashboard_sse_session_id'
@@ -104,9 +107,23 @@ function addTypedJournalEntry(
   text: string,
   kind: JournalEntry['kind'],
   eventType: JournalEventType,
-  extra: Partial<JournalEntry> = {},
+  extra: (Omit<Partial<JournalEntry>, 'severity' | 'source'> & {
+    severity?: string
+    source?: string
+  }) = {},
 ): void {
-  addJournalEntry(agent, text, kind, { eventType, ...extra })
+  const explicitSeverity = normalizeJournalSeverity(
+    typeof extra.severity === 'string' ? extra.severity : undefined,
+  )
+  addJournalEntry(agent, text, kind, {
+    ...extra,
+    source: normalizeJournalSource(extra.source),
+    severity:
+      explicitSeverity === 'unknown'
+        ? defaultJournalSeverity(eventType)
+        : explicitSeverity,
+    eventType,
+  })
 }
 
 // --- SSE Manager ---
@@ -159,9 +176,6 @@ export function connectSSE(): void {
     connected.value = true
     if (wasDisconnected) {
       reconnectCount.value++
-      // Refetch all data after reconnection so counts don't stay at 0
-      void refreshDashboard({ force: true }).catch(() => {})
-      void refreshRoomTruth({ force: true }).catch(() => {})
     }
   }
 
@@ -220,6 +234,8 @@ function handleEvent(event: SSEEvent): void {
         'system',
         'broadcast',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText: `${actorLabel(agent)}가 공지/메시지를 보냈습니다${quotePreview(event.message ?? event.content)}`,
         },
       )
@@ -231,6 +247,8 @@ function handleEvent(event: SSEEvent): void {
         'tasks',
         'task_update',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText: formatTaskNarrative(agent, event.task_id, event.status),
         },
       )
@@ -244,6 +262,8 @@ function handleEvent(event: SSEEvent): void {
         'board_post',
         {
           author: event.author ?? agent,
+          severity: event.severity,
+          source: event.source,
           narrativeText: formatBoardNarrative('게시글', event.author ?? agent, event.content ?? event.message),
           preview: normalizePreview(event.content ?? event.message),
           postId: event.post_id,
@@ -259,6 +279,8 @@ function handleEvent(event: SSEEvent): void {
         'board_comment',
         {
           author: event.author ?? agent,
+          severity: event.severity,
+          source: event.source,
           narrativeText: formatBoardNarrative('댓글', event.author ?? agent, event.content ?? event.message),
           preview: normalizePreview(event.content ?? event.message),
           postId: event.post_id,
@@ -272,6 +294,8 @@ function handleEvent(event: SSEEvent): void {
         'keepers',
         'keeper_heartbeat',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText:
             `${actorLabel(event.name ?? agent)}가 하트비트를 보냈습니다`
             + ` (gen ${event.generation ?? '?'}, ctx ${event.context_ratio != null ? Math.round(event.context_ratio * 100) + '%' : '?'})`,
@@ -285,6 +309,8 @@ function handleEvent(event: SSEEvent): void {
         'keepers',
         'keeper_handoff',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText:
             `${actorLabel(event.name ?? agent)}가 keeper handoff를 수행했습니다`
             + ` (gen ${event.from_generation ?? '?'} → ${event.to_generation ?? '?'}, ${event.to_model ?? '?'})`,
@@ -298,6 +324,8 @@ function handleEvent(event: SSEEvent): void {
         'keepers',
         'keeper_compaction',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText:
             `${actorLabel(event.name ?? agent)}가 context compaction을 수행했습니다`
             + ` (${event.saved_tokens ?? '?'} tokens, ${event.trigger ?? '?'})`,
@@ -311,6 +339,8 @@ function handleEvent(event: SSEEvent): void {
         'keepers',
         'keeper_guardrail',
         {
+          severity: event.severity ?? 'error',
+          source: event.source,
           narrativeText: `${actorLabel(event.name ?? agent)}가 guardrail에 의해 중단되었습니다: ${event.reason ?? 'stopped'}`,
         },
       )
@@ -376,6 +406,8 @@ function handleEvent(event: SSEEvent): void {
         'oas',
         'oas_keeper_snapshot',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText:
             `${actorLabel(snap.keeper_name)}의 keeper snapshot이 갱신되었습니다`
             + ` (gen ${snap.generation}, ctx ${Math.round(snap.context_ratio * 100)}%)`,
@@ -404,6 +436,8 @@ function handleEvent(event: SSEEvent): void {
         'oas',
         'oas_event',
         {
+          severity: event.severity,
+          source: event.source,
           narrativeText:
             `${actorLabel(agentName)} resident lifecycle 이벤트`
             + ([lifecycleEvent, detail].filter(Boolean).length > 0

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -308,7 +308,7 @@ export function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | nu
   if (!kind || !summary || !targetType) return null
   return {
     kind,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     summary,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
@@ -327,7 +327,7 @@ export function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAct
     action_type: actionType,
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
-    severity: asString(raw.severity) ?? 'warn',
+    severity: asString(raw.severity) ?? 'unknown',
     reason,
     confirm_required: asBoolean(raw.confirm_required),
     suggested_payload: isRecord(raw.suggested_payload) ? raw.suggested_payload : undefined,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -313,8 +313,6 @@ export function isDashboardRefreshEvent(eventType: string): boolean {
     || eventType === 'masc/dashboard_refresh'
     || eventType.startsWith('goal_')
     || eventType.startsWith('masc/goal_')
-    || eventType.startsWith('mdal_')
-    || eventType.startsWith('masc/mdal_')
     || eventType.startsWith('operator_')
     || eventType.startsWith('masc/operator_')
     || eventType.startsWith('command_plane_')

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -33,8 +33,13 @@ export type SSEEventType =
   | 'oas:masc:trust_updated'
   | 'oas:masc:reputation_changed'
 
+export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
+export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse'
+
 export interface SSEEvent {
   type: SSEEventType
+  severity?: JournalSeverity | string
+  source?: JournalSource | string
   agent?: string
   from?: string
   from_agent?: string
@@ -95,6 +100,8 @@ export interface JournalEntry {
   text: string
   narrativeText?: string
   timestamp: number
+  severity?: JournalSeverity
+  source?: JournalSource
   kind?: 'board' | 'tasks' | 'keepers' | 'system' | 'oas'
   eventType?: JournalEventType
   author?: string

--- a/lib/backend/backend_eio.ml
+++ b/lib/backend/backend_eio.ml
@@ -41,7 +41,10 @@ module FileSystem = struct
     (* Ensure base directory exists *)
     (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 path
      with Eio.Cancel.Cancelled _ as e -> raise e
-        | e -> Eio.traceln "[WARN] mkdirs base failed: %s" (Printexc.to_string e));
+        | e ->
+            Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+              (Printf.sprintf "[WARN] mkdirs base failed: %s"
+                 (Printexc.to_string e)));
     {
       config;
       fs = path;
@@ -129,7 +132,10 @@ module FileSystem = struct
              | Some (parent, _) ->
                  (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
                   with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                   | e ->
+                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                         (Printf.sprintf "[WARN] mkdirs failed: %s"
+                            (Printexc.to_string e)))
              | None -> ());
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
             let compressed = Compression.compress_with_header value in
@@ -209,7 +215,10 @@ module FileSystem = struct
                  | Some (parent, _) ->
                      (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
                       with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                   | e ->
+                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                         (Printf.sprintf "[WARN] mkdirs failed: %s"
+                            (Printexc.to_string e)))
                  | None -> ());
                 (* Write with exclusive create *)
                 Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
@@ -353,7 +362,10 @@ module FileSystem = struct
            | Some (parent, _) ->
                (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
                 with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                   | e ->
+                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                         (Printf.sprintf "[WARN] mkdirs failed: %s"
+                            (Printexc.to_string e)))
            | None -> ());
 
           (* Get the actual filesystem path string *)
@@ -442,7 +454,10 @@ module FileSystem = struct
            | Some (parent, _) ->
                (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
                 with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e -> Eio.traceln "[WARN] mkdirs failed: %s" (Printexc.to_string e))
+                   | e ->
+                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                         (Printf.sprintf "[WARN] mkdirs failed: %s"
+                            (Printexc.to_string e)))
            | None -> ());
 
           let path_str = Eio.Path.native_exn path in

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -19,11 +19,19 @@ let configured_port () =
       default_port)
   | None -> default_port
 
-(** Check whether gRPC is enabled (default: enabled, opt-out via env). *)
+(** Check whether gRPC is enabled (default: disabled, opt-in via env). *)
 let is_enabled () =
   match Sys.getenv_opt "MASC_GRPC_ENABLED" with
-  | Some "0" | Some "false" -> false
-  | _ -> true
+  | Some s -> (
+    match String.trim s |> String.lowercase_ascii with
+    | "1" | "true" -> true
+    | "" | "0" | "false" -> false
+    | other ->
+      Log.Server.warn
+        "MASC_GRPC_ENABLED=%s is not recognised, defaulting to disabled"
+        other;
+      false)
+  | None -> false
 
 (** Start the gRPC coordination server.
 
@@ -44,24 +52,31 @@ let start
   end
   else begin
     let port = configured_port () in
-    let service =
-      Masc_grpc_service.create_service ~room_config ~tool_dispatcher
-    in
-    let server =
-      Grpc_eio.Reflection.create_server_with_reflection
-        ~config:{ Grpc_eio.Server.default_config with port; host = "127.0.0.1" }
-        ()
-      |> Grpc_eio.Server.add_service service
-      |> Grpc_eio.Server.with_interceptor (Grpc_eio.Interceptor.logging ())
-    in
     Eio.Fiber.fork ~sw (fun () ->
-      Log.Server.info "gRPC coordination server starting on port %d (reflection enabled)" port;
-      Log.Server.info "  service: %s" Masc_grpc_service.service_name;
-      Log.Server.info "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
       (try
+        let service =
+          Masc_grpc_service.create_service ~room_config ~tool_dispatcher
+        in
+        let server =
+          Grpc_eio.Reflection.create_server_with_reflection
+            ~config:{ Grpc_eio.Server.default_config with port; host = "127.0.0.1" }
+            ()
+          |> Grpc_eio.Server.add_service service
+          |> Grpc_eio.Server.with_interceptor (Grpc_eio.Interceptor.logging ())
+        in
+        Log.Server.info
+          "gRPC coordination server starting on port %d (reflection enabled)"
+          port;
+        Log.Server.info "  service: %s" Masc_grpc_service.service_name;
+        Log.Server.info
+          "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
         Grpc_eio.Server.serve ~sw ~env server
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
+      | Unix.Unix_error (Unix.EADDRINUSE, _, _) ->
+        Log.Server.error
+          "gRPC coordination transport unavailable on 127.0.0.1:%d: port already in use"
+          port
       | exn ->
         Log.Server.error "gRPC server failed: %s" (Printexc.to_string exn)))
   end

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -8,6 +8,11 @@ type level =
   | Warn
   | Error
 
+type source =
+  | Structured
+  | Legacy_stderr
+  | Legacy_traceln
+
 (** Current log level (Atomic for thread safety in OCaml 5) *)
 let current_level = Atomic.make 1 (* Info = 1 *)
 
@@ -33,6 +38,33 @@ let level_of_string s =
   | "warn" | "warning" -> Warn
   | "error" -> Error
   | _ -> Info  (* Default to Info *)
+
+let source_to_string = function
+  | Structured -> "structured"
+  | Legacy_stderr -> "legacy_stderr"
+  | Legacy_traceln -> "legacy_traceln"
+
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.sub value 0 prefix_len = prefix
+
+let infer_legacy_level message =
+  let trimmed = String.trim message in
+  let upper = String.uppercase_ascii trimmed in
+  if has_prefix ~prefix:"[FATAL]" upper || has_prefix ~prefix:"FATAL:" upper then
+    (Error, "FATAL")
+  else if has_prefix ~prefix:"[ERROR]" upper || has_prefix ~prefix:"ERROR:" upper then
+    (Error, "ERROR")
+  else if has_prefix ~prefix:"[WARN]" upper || has_prefix ~prefix:"[WARNING]" upper
+          || has_prefix ~prefix:"WARN:" upper || has_prefix ~prefix:"WARNING:" upper then
+    (Warn, "WARN")
+  else if has_prefix ~prefix:"[INFO]" upper || has_prefix ~prefix:"INFO:" upper then
+    (Info, "INFO")
+  else if has_prefix ~prefix:"[DEBUG]" upper || has_prefix ~prefix:"DEBUG:" upper then
+    (Debug, "DEBUG")
+  else
+    (Info, "INFO")
 
 (** Check if level should be logged *)
 let should_log level =
@@ -80,33 +112,74 @@ module Ring = struct
     seq : int;
     ts : string;
     level : string;
+    raw_level : string;
+    normalized_level : string;
+    source : string;
+    legacy_classified : bool;
     module_name : string;
     message : string;
   }
 
   let capacity = 5000
   let buf : entry array = Array.make capacity
-    { seq = 0; ts = ""; level = ""; module_name = ""; message = "" }
+    {
+      seq = 0;
+      ts = "";
+      level = "";
+      raw_level = "";
+      normalized_level = "";
+      source = "";
+      legacy_classified = false;
+      module_name = "";
+      message = "";
+    }
   let total = Atomic.make 0 (* total entries ever written *)
 
-  let push ~level_str ~module_name ~message =
+  let push
+      ?raw_level
+      ?(source = Structured)
+      ?(legacy_classified = false)
+      ~normalized_level
+      ~module_name
+      ~message
+      () =
     let seq = Atomic.fetch_and_add total 1 in
     let idx = seq mod capacity in
-    buf.(idx) <- { seq; ts = timestamp_iso (); level = level_str;
-                   module_name; message }
+    let raw_level = Option.value ~default:normalized_level raw_level in
+    let source = source_to_string source in
+    buf.(idx) <-
+      {
+        seq;
+        ts = timestamp_iso ();
+        level = normalized_level;
+        raw_level;
+        normalized_level;
+        source;
+        legacy_classified;
+        module_name;
+        message;
+      }
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
+      ?since_seq
       ?(order = `Newest_first) () : entry list =
     let t = Atomic.get total in
     if t = 0 then []
     else begin
       let start = max 0 (t - capacity) in
+      let start =
+        match since_seq with
+        | Some seq -> max start (seq + 1)
+        | None -> start
+      in
       let entries = ref [] in
       let count = ref 0 in
       let i = ref (t - 1) in
       while !i >= start && !count < limit do
         let e = buf.(!i mod capacity) in
-        let level_ok = (level_to_int (level_of_string e.level)) >= min_level in
+        let level_ok =
+          (level_to_int (level_of_string e.normalized_level)) >= min_level
+        in
         let module_ok = module_filter = "" ||
           String.lowercase_ascii e.module_name =
           String.lowercase_ascii module_filter in
@@ -127,6 +200,10 @@ module Ring = struct
       ("seq", `Int e.seq);
       ("ts", `String e.ts);
       ("level", `String e.level);
+      ("raw_level", `String e.raw_level);
+      ("normalized_level", `String e.normalized_level);
+      ("source", `String e.source);
+      ("legacy_classified", `Bool e.legacy_classified);
       ("module", `String e.module_name);
       ("message", `String e.message);
     ]
@@ -149,7 +226,8 @@ let log level ?(ctx : string option) fmt =
         | None -> Printf.sprintf "[%s] [%s]" (timestamp ()) level_str
       in
       Printf.eprintf "%s %s\n%!" prefix msg;
-      Ring.push ~level_str ~module_name ~message:msg
+      Ring.push ~raw_level:level_str ~normalized_level:level_str ~module_name
+        ~message:msg ()
     end
   ) fmt
 
@@ -158,6 +236,26 @@ let debug ?ctx fmt = log Debug ?ctx fmt
 let info ?ctx fmt = log Info ?ctx fmt
 let warn ?ctx fmt = log Warn ?ctx fmt
 let error ?ctx fmt = log Error ?ctx fmt
+
+let emit_legacy_raw ?level ?(module_name = "") ~source message =
+  let normalized_level, raw_level, legacy_classified =
+    match level with
+    | Some level ->
+        let level_str = level_to_string level in
+        (level_str, level_str, false)
+    | None ->
+        let inferred, raw_level = infer_legacy_level message in
+        (level_to_string inferred, raw_level, true)
+  in
+  Printf.eprintf "%s\n%!" message;
+  Ring.push ~raw_level ~normalized_level ~source ~legacy_classified ~module_name
+    ~message ()
+
+let legacy_stderr ?level ?module_name message =
+  emit_legacy_raw ?level ?module_name ~source:Legacy_stderr message
+
+let legacy_traceln ?level ?module_name message =
+  emit_legacy_raw ?level ?module_name ~source:Legacy_traceln message
 
 (** Module-specific loggers.
     Each module checks MASC_LOG_{NAME}_LEVEL env var for per-module override,
@@ -184,7 +282,8 @@ module Make (M : sig val name : string end) = struct
         let prefix = Printf.sprintf "[%s] [%s] [%s]"
           (timestamp ()) level_str M.name in
         Printf.eprintf "%s %s\n%!" prefix msg;
-        Ring.push ~level_str ~module_name:M.name ~message:msg
+        Ring.push ~raw_level:level_str ~normalized_level:level_str
+          ~module_name:M.name ~message:msg ()
       end
     ) fmt
 

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -39,12 +39,22 @@ val info : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 val warn : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 val error : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 
+val legacy_stderr : ?level:level -> ?module_name:string -> string -> unit
+(** Mirror a legacy stderr line into the dashboard log ring. *)
+
+val legacy_traceln : ?level:level -> ?module_name:string -> string -> unit
+(** Mirror a legacy [Eio.traceln]-style line into the dashboard log ring. *)
+
 (** In-memory ring buffer exposed for dashboard log viewer routes. *)
 module Ring : sig
   type entry = {
     seq : int;
     ts : string;
     level : string;
+    raw_level : string;
+    normalized_level : string;
+    source : string;
+    legacy_classified : bool;
     module_name : string;
     message : string;
   }
@@ -53,6 +63,7 @@ module Ring : sig
     ?limit:int ->
     ?min_level:int ->
     ?module_filter:string ->
+    ?since_seq:int ->
     ?order:[< `Newest_first | `Oldest_first > `Newest_first ] ->
     unit ->
     entry list

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -59,7 +59,10 @@ let handle_read_resource_eio state id params =
               | json -> Some json
               | exception Yojson.Json_error msg ->
                 let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
-                Eio.traceln "[WARN] Failed to parse event JSON: %s (line: %s)" msg preview;
+                Log.legacy_traceln ~level:Log.Warn ~module_name:"MCP"
+                  (Printf.sprintf
+                     "[WARN] Failed to parse event JSON: %s (line: %s)" msg
+                     preview);
                 None
             ) lines
           in

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -186,19 +186,22 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
-            Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
-              label;
+            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
+                 timeout_sec label);
             ""
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Eio.traceln
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+                (Printf.sprintf
+                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                   label (Printexc.to_string exn));
               run_unix_argv_fallback ?env argv
             ) else (
-              Eio.traceln "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
+                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
+                   (Printexc.to_string exn));
               "")
 
 let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (argv : string list) : string =
@@ -220,19 +223,22 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
-            Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
-              label;
+            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
+                 timeout_sec label);
             ""
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Eio.traceln
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+                (Printf.sprintf
+                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                   label (Printexc.to_string exn));
               run_unix_argv_with_stdin_fallback ?env ~stdin_content argv
             ) else (
-              Eio.traceln "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
+                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
+                   (Printexc.to_string exn));
               "")
 
 let run_argv_with_stdin_and_status
@@ -267,20 +273,23 @@ let run_argv_with_stdin_and_status
                   (unix_status, Buffer.contents buf)))
         with
         | Eio.Time.Timeout ->
-            Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
-              label;
+            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
+                 timeout_sec label);
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Eio.traceln
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+                (Printf.sprintf
+                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                   label (Printexc.to_string exn));
               run_unix_argv_with_stdin_and_status_fallback ?env ~stdin_content
                 argv
             ) else (
-              Eio.traceln "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
+                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
+                   (Printexc.to_string exn));
               (Unix.WEXITED 1, ""))
 
 let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.process_status * string =
@@ -309,17 +318,20 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.
                   (unix_status, Buffer.contents buf)))
         with
         | Eio.Time.Timeout ->
-            Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
-              label;
+            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
+                 timeout_sec label);
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Eio.traceln
-                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                label (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
+                (Printf.sprintf
+                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                   label (Printexc.to_string exn));
               run_unix_argv_with_status_fallback ?env argv
             ) else (
-              Eio.traceln "[Process_eio] argv error: %s — %s" label
-                (Printexc.to_string exn);
+              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
+                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
+                   (Printexc.to_string exn));
               (Unix.WEXITED 1, ""))

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -216,7 +216,9 @@ let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
                | _ -> loop remaining acc rest)
           | exception (Eio.Cancel.Cancelled _ as e) -> raise e
           | exception e ->
-              Eio.traceln "[WARN] Failed to read %s %s: %s" warn_label name (Printexc.to_string e);
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Room"
+                (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
+                   name (Printexc.to_string e));
               loop remaining acc rest
   in
   loop limit [] names
@@ -329,4 +331,3 @@ let get_messages config ~since_seq ~limit =
     Buffer.add_string buf "(no new messages)\n";
 
   Buffer.contents buf
-

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -72,16 +72,28 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/logs" (fun request reqd ->
        with_public_read (fun _state req reqd ->
-         let limit = Server_utils.int_query_param req "limit" ~default:200 in
+         let limit =
+           Server_utils.int_query_param req "limit" ~default:200
+           |> max 1 |> min 3000
+         in
          let min_level = match Server_utils.query_param req "level" with
            | Some v -> Log.level_to_int (Log.level_of_string v)
            | None -> 0
+         in
+         let since_seq =
+           match Server_utils.query_param req "since_seq" with
+           | None -> None
+           | Some _ ->
+               let seq = Server_utils.int_query_param req "since_seq" ~default:(-1) in
+               if seq < 0 then None else Some seq
          in
          let module_filter = match Server_utils.query_param req "module" with
            | Some v -> v
            | None -> ""
          in
-         let entries = Log.Ring.recent ~limit ~min_level ~module_filter () in
+         let entries =
+           Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ()
+         in
          let json = Log.Ring.to_json entries in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -165,7 +165,7 @@ let verify (req : verification_request) : verdict =
     | Ok result ->
       parse_verdict (Oas_response.text_of_response result.response)
     | Error message ->
-      Log.Verifier.error "OAS run failed: %s (defaulting to WARN)" message;
+      Log.Verifier.warn "OAS run failed: %s (defaulting to WARN)" message;
       Warn ("verifier_unavailable: " ^ message)
 
 (* ================================================================ *)

--- a/test/dune
+++ b/test/dune
@@ -160,6 +160,11 @@
  (libraries masc_mcp alcotest str yojson unix))
 
 (test
+ (name test_masc_log)
+ (modules test_masc_log)
+ (libraries masc_mcp alcotest unix))
+
+(test
  (name test_dashboard_room_truth)
  (modules test_dashboard_room_truth)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -213,13 +213,17 @@ let test_grpc_default_port () =
   Alcotest.(check int) "default port" 8936
     Masc_mcp.Masc_grpc_server.default_port
 
-let test_grpc_enabled_by_default () =
-  (* With no MASC_GRPC_ENABLED env var, should be enabled *)
+let test_grpc_opt_in_enablement () =
+  (* With no MASC_GRPC_ENABLED env var, gRPC stays disabled. *)
   let was_set = Sys.getenv_opt "MASC_GRPC_ENABLED" in
   (match was_set with Some _ -> Unix.putenv "MASC_GRPC_ENABLED" "" | None -> ());
   let result = Masc_mcp.Masc_grpc_server.is_enabled () in
-  Alcotest.(check bool) "enabled by default" true result;
-  (* Verify opt-out works *)
+  Alcotest.(check bool) "disabled by default" false result;
+  (* Verify opt-in works. *)
+  Unix.putenv "MASC_GRPC_ENABLED" "1";
+  let enabled = Masc_mcp.Masc_grpc_server.is_enabled () in
+  Alcotest.(check bool) "enabled via env" true enabled;
+  (* Verify explicit disable still works. *)
   Unix.putenv "MASC_GRPC_ENABLED" "0";
   let disabled = Masc_mcp.Masc_grpc_server.is_enabled () in
   Alcotest.(check bool) "disabled via env" false disabled;
@@ -279,6 +283,6 @@ let () =
       ( "server_config",
         [
           Alcotest.test_case "default_port" `Quick test_grpc_default_port;
-          Alcotest.test_case "enabled_by_default" `Quick test_grpc_enabled_by_default;
+          Alcotest.test_case "opt_in_enablement" `Quick test_grpc_opt_in_enablement;
         ] );
     ]

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -1,0 +1,50 @@
+let find_entry ~module_name ~message =
+  Log.Ring.recent ~limit:50 ~module_filter:module_name ()
+  |> List.find_opt (fun (entry : Log.Ring.entry) -> String.equal entry.message message)
+
+let latest_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | (entry : Log.Ring.entry) :: _ -> entry.seq
+  | [] -> -1
+
+let test_legacy_traceln_records_metadata () =
+  let module_name = "TestLogLegacy" in
+  let message =
+    Printf.sprintf "[WARN] legacy warning %f" (Unix.gettimeofday ())
+  in
+  Log.legacy_traceln ~module_name message;
+  match find_entry ~module_name ~message with
+  | None -> Alcotest.fail "legacy traceln entry not found"
+  | Some (entry : Log.Ring.entry) ->
+      Alcotest.(check string) "source" "legacy_traceln" entry.source;
+      Alcotest.(check string) "normalized level" "WARN" entry.normalized_level;
+      Alcotest.(check bool) "legacy classified" true entry.legacy_classified
+
+let test_recent_since_seq_returns_only_new_entries () =
+  let module_name = "TestLogDelta" in
+  let baseline = latest_seq () in
+  let info_message =
+    Printf.sprintf "delta info %f" (Unix.gettimeofday ())
+  in
+  let warn_message =
+    Printf.sprintf "delta warn %f" (Unix.gettimeofday ())
+  in
+  Log.info ~ctx:module_name "%s" info_message;
+  Log.warn ~ctx:module_name "%s" warn_message;
+  let entries =
+    Log.Ring.recent ~limit:10 ~module_filter:module_name ~since_seq:baseline ()
+  in
+  Alcotest.(check (list string)) "delta messages"
+    [ warn_message; info_message ]
+    (List.map (fun (entry : Log.Ring.entry) -> entry.message) entries)
+
+let () =
+  Alcotest.run "Masc_log" [
+    ( "ring",
+      [
+        Alcotest.test_case "legacy traceln records metadata" `Quick
+          test_legacy_traceln_records_metadata;
+        Alcotest.test_case "recent since_seq returns only new entries" `Quick
+          test_recent_since_seq_returns_only_new_entries;
+      ] );
+  ]


### PR DESCRIPTION
## Summary
- optimize dashboard log polling and refresh paths to reduce redundant work
- normalize dashboard log severity so error/warn/info classification is consistent across views
- make gRPC transport opt-in and keep bind failures from bubbling up as duplicate background init errors

## Validation
- ./_build/default/test/test_masc_log.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-log-severity-opt ./test/test_grpc_coordination.exe
- manual startup check: default boot does not bind gRPC; `MASC_GRPC_ENABLED=1` logs a single gRPC port-in-use error without `Background init failed`
- previous dashboard checks on this branch: `./node_modules/.bin/tsc --noEmit --pretty false`, `./node_modules/.bin/vitest run`