### PR TITLE
refactor(keeper): make OAS checkpoints canonical

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -146,6 +146,9 @@ let run_turn
   let user_msg = Agent_sdk.Types.user_msg user_message in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
+  let checkpoint_sidecar =
+    Keeper_exec_context.checkpoint_sidecar_json ~generation ctx_work
+  in
   (* 7. Set up agent *)
   let ctx_ref = ref ctx_work in
   let agent_name = Printf.sprintf "keeper-%s" meta.name in
@@ -195,10 +198,24 @@ let run_turn
       ?on_event
       ~agent_ref
       ~allowed_paths:meta.allowed_paths
+      ~working_context:checkpoint_sidecar
       ()
   with
   | Error e -> Error e
   | Ok result ->
+    (match result.checkpoint with
+     | Some checkpoint -> (
+         try
+           Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir
+             checkpoint
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn ->
+             Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s"
+               meta.name (Printexc.to_string exn))
+     | None ->
+         Log.Keeper.warn "keeper:%s missing OAS checkpoint after run"
+           meta.name);
     let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name in
     let text = Agent_sdk.Types.text_of_content result.response.content in
     let model = result.response.model in

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -118,3 +118,52 @@ let load_latest ~(session_dir : string) : Keeper_working_context.checkpoint opti
     let path = Filename.concat session_dir latest in
     (try Some (parse_checkpoint_file path)
      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+
+(* ================================================================ *)
+(* OAS Checkpoint Compatibility                                      *)
+(* ================================================================ *)
+
+let oas_checkpoint_path ~(session_dir : string) ~(session_id : string) =
+  Filename.concat session_dir (session_id ^ ".json")
+
+let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
+  match Fs_compat.get_fs_opt () with
+  | Some fs ->
+      let dir = Eio.Path.(fs / session_dir) in
+      (match Agent_sdk.Checkpoint_store.create dir with
+       | Ok store -> (
+           match Agent_sdk.Checkpoint_store.save store ckpt with
+           | Ok () -> ()
+           | Error err ->
+               raise
+                 (Sys_error
+                    (Printf.sprintf "save_oas: %s"
+                       (Agent_sdk.Error.to_string err))))
+       | Error err ->
+           raise
+             (Sys_error
+                (Printf.sprintf "save_oas: %s"
+                   (Agent_sdk.Error.to_string err))))
+  | None ->
+      Fs_compat.save_file
+        (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
+        (Agent_sdk.Checkpoint.to_string ckpt)
+
+let load_oas ~(session_dir : string) ~(session_id : string) :
+    Agent_sdk.Checkpoint.t option =
+  match Fs_compat.get_fs_opt () with
+  | Some fs ->
+      let dir = Eio.Path.(fs / session_dir) in
+      (match Agent_sdk.Checkpoint_store.create dir with
+       | Ok store -> (
+           match Agent_sdk.Checkpoint_store.load store session_id with
+           | Ok ckpt -> Some ckpt
+           | Error _ -> None)
+       | Error _ -> None)
+  | None ->
+      let path = oas_checkpoint_path ~session_dir ~session_id in
+      if Sys.file_exists path then
+        match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+        | Ok ckpt -> Some ckpt
+        | Error _ -> None
+      else None

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -42,30 +42,113 @@ let log_keeper_exn ~label exn =
   in
   Log.Keeper.info "%s%s: %s" tag label (Printexc.to_string exn)
 
+let checkpoint_sidecar_json ?(generation = 0) (ctx : working_context) :
+    Yojson.Safe.t =
+  `Assoc
+    [
+      ("kind", `String "keeper_working_context_v1");
+      ("max_tokens", `Int ctx.max_tokens);
+      ("generation", `Int generation);
+    ]
+
+let sidecar_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
+  let open Yojson.Safe.Util in
+  match cp.working_context with
+  | Some (`Assoc _ as sidecar) ->
+      sidecar |> member "max_tokens" |> to_int_option |> Option.value ~default:fallback
+  | _ -> fallback
+
+let context_of_oas_checkpoint
+    (cp : Agent_sdk.Checkpoint.t)
+    ~(primary_model_max_tokens : int) : working_context =
+  let system_prompt = Option.value ~default:"" cp.system_prompt in
+  let max_tokens =
+    sidecar_max_tokens cp ~fallback:primary_model_max_tokens
+  in
+  let token_count = count_tokens system_prompt cp.messages in
+  sync_oas_context
+    {
+      system_prompt;
+      messages = cp.messages;
+      token_count;
+      max_tokens;
+      importance_scores = [];
+      oas_context = Agent_sdk.Context.copy cp.context;
+    }
+
+let checkpoint_model_of_meta (meta : keeper_meta) =
+  let candidates =
+    [ meta.last_model_used; meta.active_model; meta.cascade_name ]
+    @ meta.models
+  in
+  List.find_opt (fun value -> String.trim value <> "") candidates
+  |> Option.value ~default:"keeper_unified"
+
+let save_oas_checkpoint
+    ~(session : session_context)
+    ~(agent_name : string)
+    ~(model : string)
+    ~(ctx : working_context)
+    ~(generation : int)
+  : Agent_sdk.Checkpoint.t =
+  let state =
+    {
+      Agent_sdk.Types.config =
+        {
+          Agent_sdk.Types.default_config with
+          name = agent_name;
+          model;
+          system_prompt = Some ctx.system_prompt;
+          max_total_tokens = Some ctx.max_tokens;
+        };
+      messages = ctx.messages;
+      turn_count = 0;
+      usage = Agent_sdk.Types.empty_usage;
+    }
+  in
+  let checkpoint =
+    Agent_sdk.Agent_checkpoint.build_checkpoint
+      ~session_id:session.session_id
+      ~working_context:(checkpoint_sidecar_json ~generation ctx)
+      ~state
+      ~tools:Agent_sdk.Tool_set.empty
+      ~context:(Agent_sdk.Context.copy ctx.oas_context)
+      ~mcp_clients:[]
+      ()
+  in
+  Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint;
+  checkpoint
+
 let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
   let session = create_session ~session_id:trace_id ~base_dir in
-  let latest_ckpt =
-    try load_latest_checkpoint session
-    with ex ->
-      Log.Keeper.error "keeper:%s checkpoint load failed: %s"
-        trace_id
-        (Printexc.to_string ex);
-      None
-  in
-  match latest_ckpt with
-  | None -> (session, None)
-  | Some ckpt ->
-      (try
-         let ctx =
-           restore_checkpoint ckpt
-             ~max_tokens:primary_model_max_tokens
-         in
-         (session, Some ctx)
-       with ex ->
-         Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
-           trace_id
-           (Printexc.to_string ex);
-         (session, None))
+  match
+    Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
+      ~session_id:trace_id
+  with
+  | Some checkpoint ->
+      ( session,
+        Some
+          (context_of_oas_checkpoint checkpoint ~primary_model_max_tokens) )
+  | None ->
+      let latest_ckpt =
+        try load_latest_checkpoint session
+        with ex ->
+          Log.Keeper.error "keeper:%s checkpoint load failed: %s" trace_id
+            (Printexc.to_string ex);
+          None
+      in
+      match latest_ckpt with
+      | None -> (session, None)
+      | Some ckpt ->
+          (try
+             let ctx =
+               restore_checkpoint ckpt ~max_tokens:primary_model_max_tokens
+             in
+             (session, Some ctx)
+           with ex ->
+             Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
+               trace_id (Printexc.to_string ex);
+             (session, None))
 
 let save_checkpoint session (ctx : working_context) ~generation =
   let ckpt = create_checkpoint ctx ~generation in
@@ -618,4 +701,3 @@ let memory_check_default_json () : Yojson.Safe.t =
     ("deterministic_fallback_applied", `Bool false);
     ("recall_fallback_applied", `Bool false);
   ]
-

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -65,6 +65,9 @@ let make_hooks
     ()
   : Agent_sdk.Hooks.hooks =
   ignore config;
+  ignore session;
+  ignore ctx_ref;
+  ignore generation;
   let board_write_tools =
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
   in
@@ -73,9 +76,6 @@ let make_hooks
     after_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.AfterTurn { turn; response } ->
-        let ctx = !ctx_ref in
-        let _ckpt = Keeper_exec_context.save_checkpoint
-          session ctx ~generation in
         let model = response.model in
         let usage = match response.usage with
           | Some u -> u.input_tokens + u.output_tokens

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -257,8 +257,18 @@ let ensure_keeper_exists
            ()
        in
        let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in
-       (try ignore (save_checkpoint session ctx0 ~generation:0)
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
+       (try
+          ignore
+            (Keeper_exec_context.save_oas_checkpoint
+               ~session
+               ~agent_name:meta.agent_name
+               ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+               ~ctx:ctx0
+               ~generation:0)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            log_keeper_exn ~label:"save_oas_checkpoint (ensure) failed" exn);
        match write_meta ctx.config meta with
        | Error e -> Error e
        | Ok () -> Ok meta)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -228,8 +228,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                ()
          in
          let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in
-         (try ignore (save_checkpoint session ctx0 ~generation:0)
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn ~label:"save_checkpoint (init) failed" exn);
          let meta = {
            name = p.name;
            agent_name = keeper_agent_name p.name;
@@ -314,6 +312,18 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             team_session_start_count_total = 0;
             paused = false;
          } in
+         (try
+            ignore
+              (Keeper_exec_context.save_oas_checkpoint
+                 ~session
+                 ~agent_name:meta.agent_name
+                 ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+                 ~ctx:ctx0
+                 ~generation:0)
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              log_keeper_exn ~label:"save_oas_checkpoint (init) failed" exn);
          match write_meta ctx.config meta with
          | Error e -> (false, e)
          | Ok () ->

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -39,6 +39,7 @@ type config = {
   raw_trace : Oas.Raw_trace.t option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;
+  working_context : Yojson.Safe.t option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -59,6 +60,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     raw_trace = None;
     transport = Masc_grpc_transport.from_env ();
     allowed_paths = [];
+    working_context = None;
   }
 
 (* ================================================================ *)
@@ -231,13 +233,20 @@ let run
     in
     let checkpoint = match config.checkpoint_dir with
       | Some dir ->
-        let ckpt = Oas.Agent.checkpoint ~session_id agent in
+        let ckpt =
+          Oas.Agent.checkpoint ~session_id ?working_context:config.working_context
+            agent
+        in
         (try persist_checkpoint ~dir ~session_id ckpt
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Misc.error "oas_worker: Checkpoint save failed: %s"
              (Printexc.to_string exn));
         Some ckpt
-      | None -> None
+      | None ->
+        Option.map
+          (fun working_context ->
+            Oas.Agent.checkpoint ~session_id ~working_context agent)
+          config.working_context
     in
     Option.iter (fun bus ->
       let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
@@ -414,6 +423,7 @@ let run_named
     ?agent_ref
     ?transport
     ?(allowed_paths = [])
+    ?working_context
     ()
   : (run_result, string) result =
   match require_eio () with
@@ -453,6 +463,7 @@ let run_named
       description = Some (Printf.sprintf "cascade:%s" cascade_name);
       transport = transport_resolved;
       allowed_paths;
+      working_context;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -52,6 +52,7 @@ val run_named :
   ?agent_ref:Oas.Agent.t option ref ->
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
+  ?working_context:Yojson.Safe.t ->
   unit ->
   (run_result, string) result
 

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -1,13 +1,8 @@
-(** Tool_council_oas — OAS Collaboration-based governance handlers.
+(** Tool_council_oas — governance handlers using the OAS-aligned tool surface.
 
-    Replaces [Tool_council] with OAS [Collaboration.t] for petition lifecycle.
-    Delegates file-based persistence to [Council.Governance_v2].
-
-    Key changes from legacy:
-    - Petition lifecycle tracked via [Collaboration.t] phases
-    - Vote collection via [Collaboration.vote] type
-    - ID generation via [Collaboration.generate_id] (no Random.int)
-    - Simpler handler code (delegate to Governance_v2 for file ops)
+    Governance persistence and lifecycle live in [Council.Governance_v2].
+    This module keeps the OAS-facing tool endpoints but does not create
+    decorative [Collaboration.t] records for petitions.
 
     @since Phase 1 — MASC->OAS migration *)
 
@@ -51,14 +46,8 @@ let ensure_room_ready (ctx : context) =
     ());
   config
 
-(** Deterministic ID generation using Collaboration.generate_id.
-    Replaces Random.int-based gen_id from legacy Tool_council. *)
-let _gen_case_id () =
-  let collab = Oas.Collaboration.create ~goal:"" () in
-  String.sub collab.id 0 (min 20 (String.length collab.id))
-
 (* ================================================================ *)
-(* Petition — create via Collaboration.t + persist via GV2           *)
+(* Petition — persist directly via GV2                               *)
 (* ================================================================ *)
 
 let handle_petition_submit ctx args =
@@ -68,16 +57,6 @@ let handle_petition_submit ctx args =
   let _config = ensure_room_ready ctx in
   if title = "" then json_err "title is required"
   else begin
-    (* Create OAS Collaboration for this petition *)
-    let collab = Oas.Collaboration.create
-      ~goal:(Printf.sprintf "Governance petition: %s" title) () in
-    let collab = Oas.Collaboration.add_participant collab
-      { name = ctx.agent_name; role = Some "petitioner";
-        state = Oas.Collaboration.Working;
-        joined_at = Some (Unix.gettimeofday ());
-        finished_at = None; summary = Some title } in
-    let collab = Oas.Collaboration.set_phase collab Oas.Collaboration.Active in
-    (* Persist via Governance_v2 *)
     match GV2.risk_class_of_string risk with
     | Error msg -> json_err msg
     | Ok risk_class ->
@@ -86,16 +65,16 @@ let handle_petition_submit ctx args =
         ~subject_type:subject
         ~risk_class
         ~requested_action:None
-        ~source_refs:[collab.id]
+        ~source_refs:[]
         ~created_by:ctx.agent_name
       with
       | Error msg -> json_err msg
       | Ok submit_result ->
         json_ok (`Assoc [
           ("case_id", `String submit_result.case_.id);
-          ("collaboration_id", `String collab.id);
+          ("collaboration_id", `Null);
           ("status", `String (GV2.case_status_to_string submit_result.case_.status));
-          ("phase", `String (Oas.Collaboration.show_phase collab.phase));
+          ("phase", `Null);
           ("merged", `Bool submit_result.merged);
         ])
   end

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -341,8 +341,19 @@ let test_petition_submit_creates_case () =
     let json = parse_json body in
     let case_id = json |> field "case_id" |> Yojson.Safe.Util.to_string in
     Alcotest.(check bool) "case_id non-empty" true (String.length case_id > 0);
-    let collab_id = json |> field "collaboration_id" |> Yojson.Safe.Util.to_string in
-    Alcotest.(check bool) "collaboration_id non-empty" true (String.length collab_id > 0);
+    Alcotest.(check bool) "collaboration_id null" true
+      (json |> field "collaboration_id" = `Null);
+    Alcotest.(check bool) "phase null" true
+      (json |> field "phase" = `Null);
+    (match Council.Governance_v2.get_case_bundle base_path case_id with
+     | Ok bundle ->
+         let source_refs =
+           bundle.Council.Governance_v2.case_
+             .Council.Governance_v2.source_refs
+         in
+         Alcotest.(check (list string)) "source_refs empty" []
+           source_refs
+     | Error err -> Alcotest.fail ("get_case_bundle failed: " ^ err));
     Alcotest.(check bool) "merged field present" true
       (Yojson.Safe.Util.member "merged" json <> `Null)
   | None -> Alcotest.fail "dispatch returned None"
@@ -430,6 +441,92 @@ let test_governance_status_after_petition () =
   | None -> Alcotest.fail "dispatch returned None"
 
 (* ================================================================ *)
+(* Keeper checkpoint boundary tests                                  *)
+(* ================================================================ *)
+
+let make_keeper_meta ?(name = "keeper-checkpoint-test")
+    ?(trace_id = "trace-keeper-checkpoint") () =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String name);
+          ("trace_id", `String trace_id);
+          ("active_model", `String "llama:auto");
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+
+let test_keeper_checkpoint_prefers_oas_checkpoint () =
+  let base_dir = temp_dir "keeper_oas_checkpoint" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-oas-preferred" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy system" ~max_tokens:2048
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy")
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:1);
+      let oas_ctx =
+        Keeper_exec_context.create ~system_prompt:"oas system" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "oas")
+      in
+      let meta = make_keeper_meta ~trace_id () in
+      ignore
+        (Keeper_exec_context.save_oas_checkpoint ~session
+           ~agent_name:meta.agent_name
+           ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+           ~ctx:oas_ctx ~generation:7);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | Some loaded ->
+          Alcotest.(check string) "system prompt from OAS checkpoint"
+            "oas system" loaded.system_prompt;
+          Alcotest.(check int) "max_tokens from OAS sidecar" 4096
+            loaded.max_tokens;
+          Alcotest.(check string) "loaded OAS message" "oas"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | None -> Alcotest.fail "expected checkpoint context")
+
+let test_keeper_checkpoint_legacy_fallback () =
+  let base_dir = temp_dir "keeper_legacy_checkpoint" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-legacy-fallback" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy only" ~max_tokens:2048
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy-only")
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:2);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | Some loaded ->
+          Alcotest.(check string) "legacy prompt restored" "legacy only"
+            loaded.system_prompt;
+          Alcotest.(check string) "legacy message restored" "legacy-only"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | None -> Alcotest.fail "expected legacy fallback context")
+
+(* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
 
@@ -482,7 +579,7 @@ let () =
         test_mitosis_dispatch_unknown;
     ];
     "tool_council_oas", [
-      Alcotest.test_case "petition creates case with collaboration_id" `Quick
+      Alcotest.test_case "petition creates case without decorative collaboration" `Quick
         test_petition_submit_creates_case;
       Alcotest.test_case "petition empty title error" `Quick
         test_petition_submit_empty_title_err;
@@ -496,5 +593,11 @@ let () =
         test_council_dispatch_unknown;
       Alcotest.test_case "governance status after petition" `Quick
         test_governance_status_after_petition;
+    ];
+    "keeper_checkpoint_boundary", [
+      Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick
+        test_keeper_checkpoint_prefers_oas_checkpoint;
+      Alcotest.test_case "legacy fallback still works" `Quick
+        test_keeper_checkpoint_legacy_fallback;
     ];
   ]


### PR DESCRIPTION
## Summary
- make OAS checkpoints the canonical keeper resume path
- keep legacy keeper checkpoint files as fallback-only reads
- remove decorative Collaboration creation from governance petition flow
- keep compatibility by returning null collaboration fields instead of synthetic IDs

## Dependency
- depends on jeong-sik/oas#377

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-boundary-cleanup ./test/test_oas_worker.exe
- ./_build/default/test/test_oas_worker.exe