### PR TITLE
Move dashboard SSE off legacy /sse

### DIFF
--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { buildDashboardSseUrl } from './sse'
+
+describe('buildDashboardSseUrl', () => {
+  it('uses /mcp observer stream with dashboard query params', () => {
+    expect(
+      buildDashboardSseUrl(
+        'dash_test',
+        '?agent=keeper-a&token=secret',
+      ),
+    ).toBe('/mcp?agent=keeper-a&token=secret&session_id=dash_test&sse_kind=observer')
+  })
+
+  it('omits optional params when they are absent', () => {
+    expect(buildDashboardSseUrl('dash_test', '')).toBe(
+      '/mcp?session_id=dash_test&sse_kind=observer',
+    )
+  })
+})

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -132,6 +132,18 @@ let source: EventSource | null = null
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let reconnectAttempts = 0
 
+export function buildDashboardSseUrl(sessionId: string, locationSearch = window.location.search): string {
+  const urlParams = new URLSearchParams(locationSearch)
+  const sseParams = new URLSearchParams()
+  const agent = urlParams.get('agent') ?? urlParams.get('agent_name')
+  const token = urlParams.get('token')
+  if (agent) sseParams.set('agent', agent)
+  if (token) sseParams.set('token', token)
+  sseParams.set('session_id', sessionId)
+  sseParams.set('sse_kind', 'observer')
+  return `/mcp?${sseParams.toString()}`
+}
+
 function clearReconnectTimer(): void {
   if (reconnectTimer) {
     clearTimeout(reconnectTimer)
@@ -157,15 +169,7 @@ export function connectSSE(): void {
     source = null
   }
 
-  const urlParams = new URLSearchParams(window.location.search)
-  const sseParams = new URLSearchParams()
-  const agent = urlParams.get('agent') ?? urlParams.get('agent_name')
-  const token = urlParams.get('token')
-  if (agent) sseParams.set('agent', agent)
-  if (token) sseParams.set('token', token)
-  sseParams.set('session_id', getOrCreateSessionId())
-
-  const sseUrl = sseParams.toString() ? `/sse?${sseParams.toString()}` : '/sse'
+  const sseUrl = buildDashboardSseUrl(getOrCreateSessionId())
   const es = new EventSource(sseUrl)
   source = es
 

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig(({ command }) => {
       ? {
           proxy: {
             '/api': proxyTarget,
+            '/mcp': {
+              target: proxyTarget,
+            },
             '/sse': {
               target: proxyTarget,
             },

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -11,6 +11,14 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 
+let is_dashboard_observer_stream request =
+  match Server_utils.query_param request "sse_kind" with
+  | Some raw ->
+      let normalized = String.trim raw |> String.lowercase_ascii in
+      String.equal normalized "observer"
+      || String.equal normalized "dashboard"
+  | None -> false
+
 let add_routes ~port ~host router =
   router
   |> Http.Router.get "/health" health_handler
@@ -95,7 +103,12 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/graphiql/react-dom.production.min.js"
        (serve_graphiql_asset "react-dom.production.min.js")
   |> Http.Router.get "/mcp" (fun request reqd ->
-       with_read_auth (fun _state req reqd -> handle_get_mcp req reqd) request reqd)
+       if is_dashboard_observer_stream request then
+         with_public_read (fun _state req reqd ->
+           handle_get_mcp ~sse_kind:Sse.Observer req reqd
+         ) request reqd
+       else
+         with_read_auth (fun _state req reqd -> handle_get_mcp req reqd) request reqd)
   |> Http.Router.get "/mcp/operator" handle_get_operator_mcp
   |> Http.Router.post "/" handle_post_mcp
   |> Http.Router.post "/mcp" handle_post_mcp


### PR DESCRIPTION
## Summary
- switch the dashboard EventSource URL from `/sse` to `/mcp?sse_kind=observer`
- preserve observer-session routing on the server so the dashboard keeps its existing event surface without legacy deprecation headers
- proxy `/mcp` in Vite dev and add a focused dashboard SSE URL test

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-mcp-observer-sse ./bin/main_eio.exe`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/vitest run src/sse.test.ts`
- manual header check: `curl -s -D - -o /dev/null --max-time 2 "http://127.0.0.1:39125/mcp?sse_kind=observer&session_id=dash_test"` returns SSE headers without legacy `deprecation` / `warning` / `link` headers