### PR TITLE
fix: smooth OAS checkpoint migration and petition compat

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -126,28 +126,31 @@ let load_latest ~(session_dir : string) : Keeper_working_context.checkpoint opti
 let oas_checkpoint_path ~(session_dir : string) ~(session_id : string) =
   Filename.concat session_dir (session_id ^ ".json")
 
+let save_oas_error (detail : string) =
+  Sys_error (Printf.sprintf "save_oas: %s" detail)
+
 let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
-  match Fs_compat.get_fs_opt () with
-  | Some fs ->
-      let dir = Eio.Path.(fs / session_dir) in
-      (match Agent_sdk.Checkpoint_store.create dir with
-       | Ok store -> (
-           match Agent_sdk.Checkpoint_store.save store ckpt with
-           | Ok () -> ()
-           | Error err ->
-               raise
-                 (Sys_error
-                    (Printf.sprintf "save_oas: %s"
-                       (Agent_sdk.Error.to_string err))))
-       | Error err ->
-           raise
-             (Sys_error
-                (Printf.sprintf "save_oas: %s"
-                   (Agent_sdk.Error.to_string err))))
-  | None ->
-      Fs_compat.save_file
-        (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
-        (Agent_sdk.Checkpoint.to_string ckpt)
+  try
+    Fs_compat.mkdir_p session_dir;
+    match Fs_compat.get_fs_opt () with
+    | Some fs ->
+        let dir = Eio.Path.(fs / session_dir) in
+        (match Agent_sdk.Checkpoint_store.create dir with
+         | Ok store -> (
+             match Agent_sdk.Checkpoint_store.save store ckpt with
+             | Ok () -> ()
+             | Error err ->
+                 raise (save_oas_error (Agent_sdk.Error.to_string err)))
+         | Error err ->
+             raise (save_oas_error (Agent_sdk.Error.to_string err)))
+    | None ->
+        Fs_compat.save_file
+          (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
+          (Agent_sdk.Checkpoint.to_string ckpt)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error _ as e -> raise e
+  | exn -> raise (save_oas_error (Printexc.to_string exn))
 
 let load_oas ~(session_dir : string) ~(session_id : string) :
     Agent_sdk.Checkpoint.t option =
@@ -163,7 +166,11 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
   | None ->
       let path = oas_checkpoint_path ~session_dir ~session_id in
       if Sys.file_exists path then
-        match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
-        | Ok ckpt -> Some ckpt
-        | Error _ -> None
+        try
+          match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+          | Ok ckpt -> Some ckpt
+          | Error _ -> None
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> None
       else None

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -76,6 +76,11 @@ let context_of_oas_checkpoint
       oas_context = Agent_sdk.Context.copy cp.context;
     }
 
+let context_of_legacy_checkpoint
+    (ckpt : checkpoint)
+    ~(primary_model_max_tokens : int) : working_context =
+  restore_checkpoint ckpt ~max_tokens:primary_model_max_tokens
+
 let checkpoint_model_of_meta (meta : keeper_meta) =
   let candidates =
     [ meta.last_model_used; meta.active_model; meta.cascade_name ]
@@ -121,34 +126,42 @@ let save_oas_checkpoint
 
 let load_context_from_checkpoint ~trace_id ~primary_model_max_tokens ~base_dir =
   let session = create_session ~session_id:trace_id ~base_dir in
-  match
+  let oas_checkpoint =
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:trace_id
-  with
-  | Some checkpoint ->
+  in
+  let legacy_checkpoint =
+    try load_latest_checkpoint session
+    with ex ->
+      Log.Keeper.error "keeper:%s checkpoint load failed: %s" trace_id
+        (Printexc.to_string ex);
+      None
+  in
+  let prefer_legacy =
+    match oas_checkpoint, legacy_checkpoint with
+    | Some oas, Some legacy -> legacy.timestamp > oas.created_at
+    | _ -> false
+  in
+  if prefer_legacy then
+    Log.Keeper.info
+      "keeper:%s checkpoint migration fallback: legacy newer than OAS"
+      trace_id;
+  match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
+  | (false, Some checkpoint, _) ->
       ( session,
         Some
           (context_of_oas_checkpoint checkpoint ~primary_model_max_tokens) )
-  | None ->
-      let latest_ckpt =
-        try load_latest_checkpoint session
-        with ex ->
-          Log.Keeper.error "keeper:%s checkpoint load failed: %s" trace_id
-            (Printexc.to_string ex);
-          None
-      in
-      match latest_ckpt with
-      | None -> (session, None)
-      | Some ckpt ->
-          (try
-             let ctx =
-               restore_checkpoint ckpt ~max_tokens:primary_model_max_tokens
-             in
-             (session, Some ctx)
-           with ex ->
-             Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
-               trace_id (Printexc.to_string ex);
-             (session, None))
+  | (_, _, Some ckpt) ->
+      (try
+         let ctx =
+           context_of_legacy_checkpoint ckpt ~primary_model_max_tokens
+         in
+         (session, Some ctx)
+       with ex ->
+         Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
+           trace_id (Printexc.to_string ex);
+         (session, None))
+  | _ -> (session, None)
 
 let save_checkpoint session (ctx : working_context) ~generation =
   let ckpt = create_checkpoint ctx ~generation in

--- a/lib/tool_council_oas.ml
+++ b/lib/tool_council_oas.ml
@@ -46,6 +46,10 @@ let ensure_room_ready (ctx : context) =
     ());
   config
 
+let petition_phase_compat (_status : GV2.case_status) = "active"
+
+let petition_collaboration_id_compat (case_id : string) = case_id
+
 (* ================================================================ *)
 (* Petition — persist directly via GV2                               *)
 (* ================================================================ *)
@@ -73,11 +77,16 @@ let handle_petition_submit ctx args =
       with
       | Error msg -> json_err msg
       | Ok submit_result ->
+        let status = submit_result.case_.status in
         json_ok (`Assoc [
           ("case_id", `String submit_result.case_.id);
-          ("collaboration_id", `Null);
-          ("status", `String (GV2.case_status_to_string submit_result.case_.status));
-          ("phase", `Null);
+          (* Legacy response shape stays populated during the compatibility
+             window, but the values are derived from Governance_v2 only. *)
+          ( "collaboration_id",
+            `String
+              (petition_collaboration_id_compat submit_result.case_.id) );
+          ("status", `String (GV2.case_status_to_string status));
+          ("phase", `String (petition_phase_compat status));
           ("merged", `Bool submit_result.merged);
         ])
   end

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,6 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#a9a1b9b002078981d01d890fb49919183e970e40}"
 
 for arg in "$@"; do
   case "$arg" in

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -577,6 +577,92 @@ let test_keeper_checkpoint_legacy_fallback () =
       | None -> Alcotest.fail "expected legacy fallback context")
 
 (* ================================================================ *)
+(* Keeper checkpoint boundary tests                                  *)
+(* ================================================================ *)
+
+let make_keeper_meta ?(name = "keeper-checkpoint-test")
+    ?(trace_id = "trace-keeper-checkpoint") () =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String name);
+          ("trace_id", `String trace_id);
+          ("active_model", `String "llama:auto");
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
+
+let test_keeper_checkpoint_prefers_oas_checkpoint () =
+  let base_dir = temp_dir "keeper_oas_checkpoint" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-oas-preferred" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy system" ~max_tokens:2048
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy")
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:1);
+      let oas_ctx =
+        Keeper_exec_context.create ~system_prompt:"oas system" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "oas")
+      in
+      let meta = make_keeper_meta ~trace_id () in
+      ignore
+        (Keeper_exec_context.save_oas_checkpoint ~session
+           ~agent_name:meta.agent_name
+           ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+           ~ctx:oas_ctx ~generation:7);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | Some loaded ->
+          Alcotest.(check string) "system prompt from OAS checkpoint"
+            "oas system" loaded.system_prompt;
+          Alcotest.(check int) "max_tokens from OAS sidecar" 4096
+            loaded.max_tokens;
+          Alcotest.(check string) "loaded OAS message" "oas"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | None -> Alcotest.fail "expected checkpoint context")
+
+let test_keeper_checkpoint_legacy_fallback () =
+  let base_dir = temp_dir "keeper_legacy_checkpoint" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-legacy-fallback" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy only" ~max_tokens:2048
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "legacy-only")
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:2);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | Some loaded ->
+          Alcotest.(check string) "legacy prompt restored" "legacy only"
+            loaded.system_prompt;
+          Alcotest.(check string) "legacy message restored" "legacy-only"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | None -> Alcotest.fail "expected legacy fallback context")
+
+(* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
 
@@ -647,6 +733,12 @@ let () =
         test_governance_status_after_petition;
       Alcotest.test_case "case brief accepts evidence_refs array" `Quick
         test_case_brief_submit_accepts_evidence_refs_array;
+    ];
+    "keeper_checkpoint_boundary", [
+      Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick
+        test_keeper_checkpoint_prefers_oas_checkpoint;
+      Alcotest.test_case "legacy fallback still works" `Quick
+        test_keeper_checkpoint_legacy_fallback;
     ];
     "keeper_checkpoint_boundary", [
       Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -341,10 +341,10 @@ let test_petition_submit_creates_case () =
     let json = parse_json body in
     let case_id = json |> field "case_id" |> Yojson.Safe.Util.to_string in
     Alcotest.(check bool) "case_id non-empty" true (String.length case_id > 0);
-    Alcotest.(check bool) "collaboration_id null" true
-      (json |> field "collaboration_id" = `Null);
-    Alcotest.(check bool) "phase null" true
-      (json |> field "phase" = `Null);
+    Alcotest.(check string) "collaboration_id compatibility alias" case_id
+      (json |> field "collaboration_id" |> Yojson.Safe.Util.to_string);
+    Alcotest.(check string) "phase compatibility alias" "active"
+      (json |> field "phase" |> Yojson.Safe.Util.to_string);
     (match Council.Governance_v2.get_case_bundle base_path case_id with
      | Ok bundle ->
          let source_refs =
@@ -595,6 +595,89 @@ let make_keeper_meta ?(name = "keeper-checkpoint-test")
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
+let make_oas_checkpoint
+    ?(session_id = "trace-keeper-checkpoint")
+    ?(created_at = 1000.0)
+    ?(system_prompt = Some "oas system")
+    ?(messages = [])
+    ?(working_context = None)
+    ?(max_total_tokens = Some 4096)
+    ()
+  : Agent_sdk.Checkpoint.t =
+  {
+    Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
+    session_id;
+    agent_name = "keeper-checkpoint-test";
+    model = "llama:auto";
+    system_prompt;
+    messages;
+    usage = Agent_sdk.Types.empty_usage;
+    turn_count = List.length messages;
+    created_at;
+    tools = [];
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens;
+    context = Agent_sdk.Context.create ();
+    mcp_sessions = [];
+    working_context;
+  }
+
+let test_keeper_checkpoint_store_oas_roundtrip () =
+  let base_dir = temp_dir "keeper_oas_store" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let session_dir = Filename.concat base_dir "trace-store" in
+      let sidecar = Some (`Assoc [("max_tokens", `Int 4096)]) in
+      let checkpoint =
+        make_oas_checkpoint ~session_id:"trace-store"
+          ~messages:[Agent_sdk.Types.user_msg "roundtrip"]
+          ~working_context:sidecar ()
+      in
+      Keeper_checkpoint_store.save_oas ~session_dir checkpoint;
+      match
+        Keeper_checkpoint_store.load_oas ~session_dir ~session_id:"trace-store"
+      with
+      | Some loaded ->
+          Alcotest.(check (float 0.000001)) "created_at preserved"
+            checkpoint.created_at
+            loaded.created_at;
+          Alcotest.(check int) "message count preserved" 1
+            (List.length loaded.messages);
+          let sidecar_max_tokens =
+            Option.bind loaded.working_context (fun json ->
+                Yojson.Safe.Util.(
+                  json |> member "max_tokens" |> to_int_option))
+          in
+          Alcotest.(check (option int)) "sidecar max_tokens preserved"
+            (Some 4096)
+            sidecar_max_tokens
+      | None -> Alcotest.fail "expected OAS checkpoint roundtrip")
+
+let test_keeper_checkpoint_store_oas_missing_returns_none () =
+  let base_dir = temp_dir "keeper_oas_store_missing" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let session_dir = Filename.concat base_dir "missing-session" in
+      Alcotest.(check (option string)) "missing checkpoint"
+        None
+        (Keeper_checkpoint_store.load_oas ~session_dir
+           ~session_id:"missing-session"
+         |> Option.map (fun (cp : Agent_sdk.Checkpoint.t) -> cp.session_id)))
+
 let test_keeper_checkpoint_prefers_oas_checkpoint () =
   let base_dir = temp_dir "keeper_oas_checkpoint" in
   Fun.protect
@@ -661,6 +744,41 @@ let test_keeper_checkpoint_legacy_fallback () =
           Alcotest.(check string) "legacy message restored" "legacy-only"
             (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
       | None -> Alcotest.fail "expected legacy fallback context")
+
+let test_keeper_checkpoint_prefers_newer_legacy_during_migration () =
+  let base_dir = temp_dir "keeper_checkpoint_migration" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let trace_id = "trace-migration-prefer-legacy" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let old_oas =
+        make_oas_checkpoint ~session_id:trace_id ~created_at:10.0
+          ~system_prompt:(Some "old oas")
+          ~messages:[Agent_sdk.Types.user_msg "old-oas"]
+          ~working_context:(Some (`Assoc [("max_tokens", `Int 3000)])) ()
+      in
+      Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir old_oas;
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"new legacy" ~max_tokens:2048
+        |> fun ctx ->
+        Keeper_exec_context.append ctx (Agent_sdk.Types.user_msg "new-legacy")
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:9);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | Some loaded ->
+          Alcotest.(check string) "newer legacy prompt restored" "new legacy"
+            loaded.system_prompt;
+          Alcotest.(check string) "newer legacy message restored" "new-legacy"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | None -> Alcotest.fail "expected migration fallback context")
 
 (* ================================================================ *)
 (* Runner                                                           *)
@@ -741,9 +859,15 @@ let () =
         test_keeper_checkpoint_legacy_fallback;
     ];
     "keeper_checkpoint_boundary", [
+      Alcotest.test_case "OAS store roundtrip" `Quick
+        test_keeper_checkpoint_store_oas_roundtrip;
+      Alcotest.test_case "OAS store missing returns none" `Quick
+        test_keeper_checkpoint_store_oas_missing_returns_none;
       Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick
         test_keeper_checkpoint_prefers_oas_checkpoint;
       Alcotest.test_case "legacy fallback still works" `Quick
         test_keeper_checkpoint_legacy_fallback;
+      Alcotest.test_case "prefers newer legacy during migration" `Quick
+        test_keeper_checkpoint_prefers_newer_legacy_during_migration;
     ];
   ]


### PR DESCRIPTION
## Summary
- preserve petition submit compatibility fields without reintroducing decorative OAS collaboration records
- normalize OAS checkpoint save/load behavior in fallback file mode
- prefer the newer checkpoint during OAS/legacy migration and add regression tests
- pin `agent_sdk` CI/install to the exact OAS commit required by this branch

## Dependency
- stacked on `jeong-sik/oas#377`
- current required OAS commit: `a9a1b9b002078981d01d890fb49919183e970e40`
- `scripts/opam-pin-external-deps.sh` pins `agent_sdk` to that commit until the OAS change lands on `main`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-boundary-cleanup @all`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-boundary-cleanup ./test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe`
