### PR TITLE
fix: support macOS default bash in pr-open helper

### DIFF
--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -61,6 +61,15 @@ require_cmd git
 require_cmd gh
 require_cmd jq
 
+load_changed_files() {
+  local range="$1"
+  changed_files=()
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    changed_files+=("$file")
+  done < <(git diff --name-only "$range" 2>/dev/null || true)
+}
+
 branch="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "refusing to open PR from branch '$branch'" >&2
@@ -92,14 +101,9 @@ else
   pr_number="$(gh pr view "$pr_url" --repo "$repo" --json number --jq .number)"
 fi
 
-changed_files=()
-while IFS= read -r line; do
-  [[ -n "$line" ]] && changed_files+=("$line")
-done < <(git diff --name-only "origin/$base...HEAD" 2>/dev/null || true)
+load_changed_files "origin/$base...HEAD"
 if [[ ${#changed_files[@]} -eq 0 ]]; then
-  while IFS= read -r line; do
-    [[ -n "$line" ]] && changed_files+=("$line")
-  done < <(git diff --name-only "HEAD~1..HEAD" || true)
+  load_changed_files "HEAD~1..HEAD"
 fi
 
 docs_only=1

--- a/test/dune
+++ b/test/dune
@@ -197,6 +197,11 @@
  (libraries alcotest unix))
 
 (test
+ (name test_pr_open_script)
+ (modules test_pr_open_script)
+ (libraries alcotest unix))
+
+(test
  (name test_worker_runtime)
  (modules test_worker_runtime)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -1,0 +1,216 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let script_path () =
+  Filename.concat (source_root ()) "scripts/pr-open.sh"
+
+let quote = Filename.quote
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_shell ?(env = []) ~cwd cmd =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let full =
+    if env_prefix = "" then
+      Printf.sprintf "cd %s && %s" (quote cwd) cmd
+    else
+      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+  in
+  let out = Filename.temp_file "pr-open-out" ".txt" in
+  let err = Filename.temp_file "pr-open-err" ".txt" in
+  let wrapped =
+    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  in
+  let code = Sys.command wrapped in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let run_shell_ok ?(env = []) ~cwd cmd =
+  let code, stdout, stderr = run_shell ~env ~cwd cmd in
+  if code <> 0 then
+    failf "command failed (%d): %s\nstdout:\n%s\nstderr:\n%s" code cmd stdout
+      stderr;
+  (stdout, stderr)
+
+let make_fake_gh dir =
+  let bin_dir = Filename.concat dir "bin" in
+  Unix.mkdir bin_dir 0o755;
+  let gh_path = Filename.concat bin_dir "gh" in
+  write_file gh_path
+    {|
+#!/bin/sh
+set -eu
+log_file="${FAKE_GH_LOG:?}"
+labels_file="${FAKE_GH_LABELS:?}"
+cmd1="${1:-}"
+cmd2="${2:-}"
+printf '%s %s\n' "$cmd1" "$cmd2" >>"$log_file"
+case "${cmd1}:${cmd2}" in
+  pr:list)
+    exit 0
+    ;;
+  pr:create)
+    printf 'https://github.com/example/test/pull/42\n'
+    ;;
+  pr:view)
+    if [ "${3:-}" = "https://github.com/example/test/pull/42" ]; then
+      printf '42\n'
+    else
+      printf 'https://github.com/example/test/pull/42\n'
+    fi
+    ;;
+  api:*)
+    cat >"$labels_file"
+    ;;
+  pr:checks)
+    printf 'unexpected pr checks invocation\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s %s\n' "$cmd1" "$cmd2" >&2
+    exit 1
+    ;;
+esac
+|}
+  ;
+  Unix.chmod gh_path 0o755;
+  bin_dir
+
+let init_repo_with_remote dir =
+  let remote_dir = Filename.concat dir "remote.git" in
+  ignore (run_shell_ok ~cwd:dir "git init -q");
+  ignore (run_shell_ok ~cwd:dir "git config user.email test@example.com");
+  ignore (run_shell_ok ~cwd:dir "git config user.name tester");
+  ignore (run_shell_ok ~cwd:dir "git checkout -qb main");
+  mkdir_p (Filename.concat dir "docs");
+  mkdir_p (Filename.concat dir "lib");
+  write_file (Filename.concat dir "README.md") "# temp\n";
+  ignore
+    (run_shell_ok ~cwd:dir
+       "git add README.md && git -c core.hooksPath=/dev/null commit -q -m base");
+  ignore
+    (run_shell_ok ~cwd:dir
+       (Printf.sprintf "git init --bare -q %s" (quote remote_dir)));
+  ignore
+    (run_shell_ok ~cwd:dir
+       (Printf.sprintf "git remote add origin %s" (quote remote_dir)));
+  ignore (run_shell_ok ~cwd:dir "git push -u origin main");
+  ignore (run_shell_ok ~cwd:dir "git checkout -qb feature/macos-pr-open");
+  write_file (Filename.concat dir "lib/example.ml") "let value = 1\n";
+  ignore
+    (run_shell_ok ~cwd:dir
+       "git add lib/example.ml && git -c core.hooksPath=/dev/null commit -q -m feature");
+  ignore (run_shell_ok ~cwd:dir "git push -u origin feature/macos-pr-open")
+
+let test_source_avoids_mapfile_only_bash4_features () =
+  let content = read_file (script_path ()) in
+  check bool "script no longer uses mapfile" false
+    (contains_substring content "mapfile ");
+  check bool "script no longer uses readarray" false
+    (contains_substring content "readarray ");
+  check bool "script has bash-compatible changed file loader" true
+    (contains_substring content "load_changed_files()")
+
+let test_script_runs_under_system_bash_without_watch () =
+  with_temp_dir "pr-open-script" (fun dir ->
+      init_repo_with_remote dir;
+      let fake_gh_dir = make_fake_gh dir in
+      let gh_log = Filename.concat dir "gh.log" in
+      let gh_labels = Filename.concat dir "gh-labels.json" in
+      let body_file = Filename.concat dir "body.md" in
+      write_file body_file "## Summary\nTest body\n";
+      let path =
+        Printf.sprintf "%s:%s" fake_gh_dir
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_GH_LOG", gh_log);
+          ("FAKE_GH_LABELS", gh_labels);
+        ]
+      in
+      let cmd =
+        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
+          (quote (script_path ()))
+          (quote "example/test")
+          (quote "fix: macOS bash compatibility")
+          (quote body_file)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
+      if code <> 0 then
+        failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      check bool "prints PR url" true
+        (contains_substring stdout "PR: https://github.com/example/test/pull/42");
+      check bool "does not mention mapfile failure" false
+        (contains_substring stderr "mapfile: command not found");
+      let log = read_file gh_log in
+      check bool "creates draft PR" true (contains_substring log "pr create");
+      check bool "skips watched checks with --no-watch" false
+        (contains_substring log "pr checks");
+      let labels = read_file gh_labels in
+      check bool "adds enhancement label for code changes" true
+        (contains_substring labels "\"enhancement\"");
+      check bool "does not add docs label for code-only change" false
+        (contains_substring labels "\"docs\""))
+
+let () =
+  run "pr_open_script"
+    [
+      ( "script",
+        [
+          test_case "source avoids mapfile-only bash4 features" `Quick
+            test_source_avoids_mapfile_only_bash4_features;
+          test_case "runs under system bash without watch" `Quick
+            test_script_runs_under_system_bash_without_watch;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- replace `mapfile` usage in `scripts/pr-open.sh` with a Bash 3.2 compatible loader
- add a source guard preventing `mapfile`/`readarray` regressions
- add a fake-`gh` integration test that runs the helper via `/bin/bash`

## Testing
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/issue-2727-pr-open-macos ./test/test_pr_open_script.exe`
- `bash -n scripts/pr-open.sh`

Fixes #2727
