### PR TITLE
fix: update OAS pin to a68a6fd (Agent.checkpoint ?working_context)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="cda9f343891a8b408b6566fbe340f0247340ddc5"
+readonly OAS_AGENT_SDK_SHA="a68a6fd1e40e4496f76c493931d0ed0de3611a63"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"


### PR DESCRIPTION
## Summary
- Update OAS pin SHA from `cda9f34` to `a68a6fd` (includes OAS PR #378)
- OAS #378 added `?working_context:Yojson.Safe.t` to `Agent.checkpoint`
- This unblocks main CI which has been broken since PR #2734 was merged

## Context
PR #2734 (`refactor(keeper): make OAS checkpoints canonical`) added `?working_context` to `Oas.Agent.checkpoint` calls in `oas_worker.ml`, but OAS did not expose this parameter. All CI has been failing with type error since.

## Test plan
- [ ] MASC CI passes with updated OAS pin
- [x] OAS PR #378 CI: all 4 checks green (Build 5.1.x, 5.4.x, Lint, Version)

Generated with [Claude Code](https://claude.com/claude-code)