### PR TITLE
fix: always build dashboard spa on startup

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -58,6 +58,22 @@ release_build_lock() {
     _masc_cleanup_lock
 }
 
+build_dashboard_spa() {
+    local dashboard_dir="$SCRIPT_DIR/dashboard"
+
+    if [ ! -f "$dashboard_dir/package.json" ]; then
+        return 0
+    fi
+
+    echo "[dashboard] Building SPA before server start..." >&2
+    if command -v npm >/dev/null 2>&1; then
+        (cd "$dashboard_dir" && npm install --prefer-offline --no-audit 2>&1 | tail -1 >&2 && npm run build 2>&1 | tail -3 >&2) || \
+            echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
+    else
+        echo "[dashboard] npm not found, skipping dashboard build." >&2
+    fi
+}
+
 resolve_repo_env_root() {
     if command -v git >/dev/null 2>&1; then
         local common_dir
@@ -200,20 +216,8 @@ if lsof -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1 && [ "${MASC_ALLOW_PORT_RE
 fi
 
 # Dashboard SPA build (Vite) — assets/dashboard/ is no longer committed to git.
-# Build if missing or if source is newer than the build output.
-if [ -f "$SCRIPT_DIR/dashboard/package.json" ]; then
-    DASHBOARD_INDEX="$SCRIPT_DIR/assets/dashboard/index.html"
-    if [ ! -f "$DASHBOARD_INDEX" ] || \
-       find "$SCRIPT_DIR/dashboard/src" -type f -newer "$DASHBOARD_INDEX" 2>/dev/null | head -n 1 | grep -q .; then
-        echo "[dashboard] Building SPA..." >&2
-        if command -v npm >/dev/null 2>&1; then
-            (cd "$SCRIPT_DIR/dashboard" && npm install --prefer-offline --no-audit 2>&1 | tail -1 >&2 && npm run build 2>&1 | tail -3 >&2) || \
-                echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
-        else
-            echo "[dashboard] npm not found, skipping dashboard build." >&2
-        fi
-    fi
-fi
+# Always attempt the build before server startup so the served bundle matches current sources.
+build_dashboard_spa
 
 # Resolve executable path
 # Priority: 1. Release binary  2. Workspace build  3. Local build  4. Installed  5. Auto-download


### PR DESCRIPTION
## Summary
- always build the dashboard SPA before server startup
- keep dashboard build failures non-fatal so the server can still fall back cleanly
- remove the stale-check-only path that missed non-`dashboard/src` changes

## Verification
- `bash -n start-masc-mcp.sh`
- `cd dashboard && npm install --prefer-offline --no-audit`
- `cd dashboard && npm run build`
- `./start-masc-mcp.sh --http --port 8947` (confirmed dashboard build logs before server boot, then stopped)
