### PR TITLE
fix(test): guard webrtc signaling test behind env var (#2642)

### DIFF
--- a/test/test_transport_integration.ml
+++ b/test/test_transport_integration.ml
@@ -259,10 +259,11 @@ let () =
       Alcotest.test_case "broadcast reaches WS subscriber" `Quick
         test_ws_external_subscriber_receives_broadcast;
     ]);
-    ("webrtc_signaling", [
-      Alcotest.test_case "full offer/answer/cleanup flow" `Quick
-        test_webrtc_full_signaling_flow;
-    ]);
+    ("webrtc_signaling",
+      if Sys.getenv_opt "MASC_TEST_WEBRTC" = Some "1" then [
+        Alcotest.test_case "full offer/answer/cleanup flow" `Quick
+          test_webrtc_full_signaling_flow;
+      ] else []);
     ("auto_cleanup", [
       Alcotest.test_case "dead subscriber auto-removed" `Quick
         test_dead_subscriber_auto_removed;


### PR DESCRIPTION
CI에서 WebRTC runtime 미지원으로 실패하는 테스트를 MASC_TEST_WEBRTC=1 환경변수 guard 뒤로 이동. Closes #2642.