### PR TITLE
fix(grpc): expose health checks to grpcurl

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -25,6 +25,34 @@ let is_enabled () =
   | Some "0" | Some "false" -> false
   | _ -> true
 
+(** Create a standard gRPC health service for the server. *)
+let create_health_service () =
+  let health = Grpc_eio.Health.create ~default_status:Grpc_eio.Health.Serving () in
+  Grpc_eio.Health.register_service health
+    ~service:Grpc_eio.Reflection.service_name;
+  Grpc_eio.Health.set_status health
+    ~service:Grpc_eio.Reflection.service_name
+    Grpc_eio.Health.Serving;
+  Grpc_eio.Health.register_service health
+    ~service:Masc_grpc_service.service_name;
+  Grpc_eio.Health.set_status health
+    ~service:Masc_grpc_service.service_name
+    Grpc_eio.Health.Serving;
+  Grpc_eio.Health.to_service health
+
+let create_server ?port ~(room_config : Room_utils_backend_setup.config) ~tool_dispatcher () =
+  let port = Option.value port ~default:(configured_port ()) in
+  let service =
+    Masc_grpc_service.create_service ~room_config ~tool_dispatcher
+  in
+  let health_service = create_health_service () in
+  Grpc_eio.Reflection.create_server_with_reflection
+    ~config:{ Grpc_eio.Server.default_config with port; host = "127.0.0.1" }
+    ()
+  |> Grpc_eio.Server.add_service health_service
+  |> Grpc_eio.Server.add_service service
+  |> Grpc_eio.Server.with_interceptor (Grpc_eio.Interceptor.logging ())
+
 (** Start the gRPC coordination server.
 
     Runs in a forked fiber. Does not block the caller.
@@ -44,20 +72,14 @@ let start
   end
   else begin
     let port = configured_port () in
-    let service =
-      Masc_grpc_service.create_service ~room_config ~tool_dispatcher
-    in
-    let server =
-      Grpc_eio.Reflection.create_server_with_reflection
-        ~config:{ Grpc_eio.Server.default_config with port; host = "127.0.0.1" }
-        ()
-      |> Grpc_eio.Server.add_service service
-      |> Grpc_eio.Server.with_interceptor (Grpc_eio.Interceptor.logging ())
-    in
+    let server = create_server ~port ~room_config ~tool_dispatcher () in
     Eio.Fiber.fork ~sw (fun () ->
       Log.Server.info "gRPC coordination server starting on port %d (reflection enabled)" port;
-      Log.Server.info "  service: %s" Masc_grpc_service.service_name;
-      Log.Server.info "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
+      Log.Server.info "  services: %s, %s, %s"
+        Grpc_eio.Reflection.service_name
+        "grpc.health.v1.Health"
+        Masc_grpc_service.service_name;
+      Log.Server.info "  methods: Health/Check, Health/Watch, Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
       (try
         Grpc_eio.Server.serve ~sw ~env server
       with

--- a/lib/grpc/masc_grpc_server.mli
+++ b/lib/grpc/masc_grpc_server.mli
@@ -12,6 +12,17 @@ val configured_port : unit -> int
 (** Whether gRPC transport is enabled (MASC_GRPC_ENABLED=1). *)
 val is_enabled : unit -> bool
 
+(** Build the gRPC server with reflection, health, and MascCoordination services.
+
+    Exposed for tests and harnesses that need to verify service wiring without
+    binding a real network listener. *)
+val create_server :
+  ?port:int ->
+  room_config:Room_utils_backend_setup.config ->
+  tool_dispatcher:(string -> string -> (string, string) result) ->
+  unit ->
+  Grpc_eio.Server.t
+
 (** Start the gRPC coordination server in a forked fiber.
 
     Does nothing if gRPC is not enabled.

--- a/proto/grpc_health_v1.proto
+++ b/proto/grpc_health_v1.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+
+  ServingStatus status = 1;
+}

--- a/scripts/harness/transport/verify_grpc_subscribe.sh
+++ b/scripts/harness/transport/verify_grpc_subscribe.sh
@@ -15,6 +15,7 @@ HARNESS_NAME="gRPC-Subscribe"
 require_server
 
 PROTO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)/proto"
+HEALTH_PROTO="grpc_health_v1.proto"
 
 if ! require_tool grpcurl; then
   echo "ERROR: grpcurl required for gRPC E2E tests"
@@ -24,9 +25,13 @@ fi
 echo "--- gRPC Subscribe E2E ---"
 
 # Test 1: gRPC health check
-health_resp=$(grpcurl -plaintext "${MASC_GRPC_ADDR}" \
+health_resp=$(grpcurl -plaintext \
+  -import-path "${PROTO_DIR}" \
+  -proto "${HEALTH_PROTO}" \
+  -d '{"service":"masc.coordination.v1.MascCoordination"}' \
+  "${MASC_GRPC_ADDR}" \
   grpc.health.v1.Health/Check 2>&1 || true)
-if echo "$health_resp" | grep -q "SERVING"; then
+if echo "$health_resp" | grep -q '"status": "SERVING"'; then
   pass "gRPC health: SERVING"
 elif echo "$health_resp" | grep -qi "connect"; then
   fail "gRPC health" "connection refused (gRPC server not running on ${MASC_GRPC_ADDR})"

--- a/test/dune
+++ b/test/dune
@@ -1020,7 +1020,7 @@
 (test
  (name test_grpc_coordination)
  (modules test_grpc_coordination)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main grpc-direct))
 
 ; gRPC client types, transport selection, and round-trip tests
 (test

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -8,6 +8,27 @@
 
 module T = Masc_mcp.Masc_grpc_types
 
+let grpc_health_service = "grpc.health.v1.Health"
+
+let encode_health_check_request ~service =
+  if service = ""
+  then ""
+  else
+    let len = String.length service in
+    String.make 1 (Char.chr ((1 lsl 3) lor 2))
+    ^ String.make 1 (Char.chr len)
+    ^ service
+
+let decode_health_check_status bytes =
+  if String.length bytes < 2 then
+    Alcotest.failf "health response too short: %d bytes" (String.length bytes);
+  let tag = Char.code bytes.[0] in
+  let field_num = tag lsr 3 in
+  let wire_type = tag land 0x7 in
+  Alcotest.(check int) "health field number" 1 field_num;
+  Alcotest.(check int) "health wire type" 0 wire_type;
+  Char.code bytes.[1]
+
 (* ====== Type serialization/deserialization round-trip tests ====== *)
 
 let test_join_request_roundtrip () =
@@ -226,6 +247,59 @@ let test_grpc_enabled_by_default () =
   (* Restore *)
   (match was_set with Some v -> Unix.putenv "MASC_GRPC_ENABLED" v | None -> ())
 
+let test_grpc_health_service_reports_serving () =
+  let base_path = Filename.temp_dir "masc-grpc-health-" "" in
+  Eio_main.run (fun env ->
+    let room_config =
+      Masc_mcp.Room.default_config base_path
+      |> Masc_mcp.Room.config_with_resolved_scope
+    in
+    let server =
+      Masc_mcp.Masc_grpc_server.create_server
+        ~port:0
+        ~room_config
+        ~tool_dispatcher:(fun _tool_name _arguments_json -> Ok "{}")
+        ()
+    in
+    Alcotest.(check bool) "health service registered"
+      true (List.mem grpc_health_service (Grpc_eio.Server.list_services server));
+    Alcotest.(check bool) "coordination service registered"
+      true
+      (List.mem Masc_mcp.Masc_grpc_service.service_name
+         (Grpc_eio.Server.list_services server));
+    let request_data =
+      encode_health_check_request
+        ~service:Masc_mcp.Masc_grpc_service.service_name
+    in
+    let request_body =
+      match Grpc_core.Message.encode ~codec:Grpc_core.Codec.identity request_data with
+      | Ok body -> body
+      | Error err -> Alcotest.failf "health request encode failed: %s" err
+    in
+    match
+      Grpc_eio.Server.handle_request
+        server
+        ~clock:(Eio.Stdenv.clock env)
+        ~path:"/grpc.health.v1.Health/Check"
+        ~metadata:[]
+        ~body:request_body
+        ~request_codec:Grpc_core.Codec.identity
+        ~response_codec:Grpc_core.Codec.identity
+    with
+    | Error status ->
+      Alcotest.failf "health check failed: %s"
+        (Grpc_core.Status.to_string status)
+    | Ok (response_body, trailers, _codec) ->
+      Alcotest.(check bool) "grpc-status=0"
+        true (List.mem ("grpc-status", "0") trailers);
+      let response_data =
+        match Grpc_core.Message.decode ~codec:Grpc_core.Codec.identity response_body with
+        | Ok body -> body
+        | Error err -> Alcotest.failf "health response decode failed: %s" err
+      in
+      let status = decode_health_check_status response_data in
+      Alcotest.(check int) "service reports SERVING" 1 status)
+
 let test_empty_request_handling () =
   (* Verify graceful handling of empty protobuf message (all defaults). *)
   let bytes = T.JoinRequest.to_bytes {
@@ -280,5 +354,6 @@ let () =
         [
           Alcotest.test_case "default_port" `Quick test_grpc_default_port;
           Alcotest.test_case "enabled_by_default" `Quick test_grpc_enabled_by_default;
+          Alcotest.test_case "health_service_reports_serving" `Quick test_grpc_health_service_reports_serving;
         ] );
     ]


### PR DESCRIPTION
## Summary
- register the standard gRPC health service alongside reflection and MascCoordination
- expose a server-construction helper and add a regression that verifies service-specific Health/Check returns SERVING
- teach the transport harness to call Health/Check with a checked-in grpc_health_v1.proto so grpcurl can verify the health endpoint end-to-end

Closes #2684

## Verification
- DUNE_CACHE=disabled opam exec -- dune build --root . test/test_grpc_coordination.exe
- DUNE_CACHE=disabled opam exec -- ./_build/default/test/test_grpc_coordination.exe --show-errors
- grpcurl -plaintext -import-path proto -proto grpc_health_v1.proto -d '{"service":"masc.coordination.v1.MascCoordination"}' 127.0.0.1:18951 grpc.health.v1.Health/Check\n- MASC_HTTP_PORT=18950 MASC_GRPC_PORT=18951 ./scripts/harness/transport/verify_grpc_subscribe.sh