### PR TITLE
feat(transport): PR #2412 복구 — Transport 관측 메트릭 + 대시보드 패널

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -300,6 +300,7 @@ let run_cmd host port base_path =
 
   (* Enable Eio-aware locking in modules with dual-mode mutex guards *)
   Masc_mcp.Prometheus.enable_eio ();
+  Masc_mcp.Transport_metrics.init ();
   Masc_mcp.Chain_telemetry.enable_eio ();
   Masc_mcp.Generational_metrics.enable_eio ();
   Masc_mcp.Dashboard_cache.enable_eio ~clock:(Eio.Stdenv.clock env) ();

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -12,6 +12,7 @@ import { SituationBanner } from './situation-banner'
 import { AttentionSpotlight } from './attention-spotlight'
 import { NarrativeTimeline } from './narrative-timeline'
 import { AgentAvatar } from './agent-avatar'
+import { TransportHealthPanel } from '../transport-health'
 import type { ObservatoryAgent } from '../../observatory-store'
 import type { DashboardMissionSessionBrief } from '../../types'
 
@@ -209,6 +210,10 @@ export function Overview() {
 
       <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
         <${AgentPulse} />
+      </div>
+
+      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+        <${TransportHealthPanel} />
       </div>
 
       <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -1,0 +1,170 @@
+// MASC Dashboard -- Transport Health Panel
+// Shows SSE sessions, gRPC streams, heartbeat status, and broadcast latency.
+
+import { html } from 'htm/preact'
+import { signal, type Signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { get } from '../api/core'
+
+interface TransportHealthData {
+  sse: {
+    sessions_observer: number
+    sessions_coordinator: number
+    sessions_total: number
+    broadcast_avg_seconds: number
+    broadcast_count: number
+  }
+  grpc: {
+    active_streams: number
+    subscribers: number
+    heartbeat_avg_seconds: number
+    events_delivered: number
+  }
+  agent_health: {
+    stale_total: number
+  }
+  generated_at: string
+}
+
+const transportHealth: Signal<TransportHealthData | null> = signal(null)
+const loading: Signal<boolean> = signal(false)
+const error: Signal<string | null> = signal(null)
+
+async function refreshTransportHealth(): Promise<void> {
+  loading.value = true
+  error.value = null
+  try {
+    const data = await get<TransportHealthData>('/api/v1/dashboard/transport-health')
+    transportHealth.value = data
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+function formatLatency(seconds: number): string {
+  if (seconds === 0) return '-'
+  if (seconds < 0.001) return `${(seconds * 1_000_000).toFixed(0)}us`
+  if (seconds < 1) return `${(seconds * 1000).toFixed(1)}ms`
+  return `${seconds.toFixed(2)}s`
+}
+
+function latencyStatus(avgSeconds: number): 'ok' | 'warn' | 'bad' {
+  if (avgSeconds === 0) return 'ok'
+  if (avgSeconds < 0.1) return 'ok'
+  if (avgSeconds < 0.5) return 'warn'
+  return 'bad'
+}
+
+function statusDot(status: 'ok' | 'warn' | 'bad'): string {
+  if (status === 'ok') return 'bg-[var(--ok)]'
+  if (status === 'warn') return 'bg-[var(--warn)]'
+  return 'bg-[var(--bad)]'
+}
+
+function MetricRow({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
+  return html`
+    <div class="flex items-center justify-between py-1.5">
+      <span class="text-xs text-text-muted">${label}</span>
+      <div class="flex items-center gap-1.5">
+        <span class="text-sm font-mono font-medium text-text-strong">${value}</span>
+        ${sub ? html`<span class="text-[10px] text-text-muted">${sub}</span>` : null}
+      </div>
+    </div>
+  `
+}
+
+function SectionCard({ title, icon, children }: { title: string; icon: string; children: any }) {
+  return html`
+    <div class="rounded-lg border border-card-border bg-bg-1/60 p-4">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="text-sm">${icon}</span>
+        <span class="text-xs font-semibold text-text-strong uppercase tracking-wider">${title}</span>
+      </div>
+      <div class="divide-y divide-card-border/50">
+        ${children}
+      </div>
+    </div>
+  `
+}
+
+export function TransportHealthPanel() {
+  useEffect(() => {
+    refreshTransportHealth()
+    const interval = setInterval(() => void refreshTransportHealth(), 15_000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const data = transportHealth.value
+
+  if (loading.value && !data) {
+    return html`
+      <div class="p-6 text-center text-text-muted text-sm">
+        Transport health loading...
+      </div>
+    `
+  }
+
+  if (error.value && !data) {
+    return html`
+      <div class="p-6 text-center text-[var(--bad)] text-sm">
+        ${error.value}
+      </div>
+    `
+  }
+
+  if (!data) return null
+
+  const broadcastStatus = latencyStatus(data.sse.broadcast_avg_seconds)
+  const grpcStatus = data.grpc.active_streams > 0 ? 'ok' : 'warn'
+  const staleStatus: 'ok' | 'warn' | 'bad' = data.agent_health.stale_total === 0 ? 'ok' : data.agent_health.stale_total < 3 ? 'warn' : 'bad'
+
+  return html`
+    <div class="space-y-4">
+      <!-- Header -->
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <span class="text-base">Transport</span>
+          <div class="flex items-center gap-1">
+            <span class="w-1.5 h-1.5 rounded-full ${statusDot(broadcastStatus)}"></span>
+            <span class="w-1.5 h-1.5 rounded-full ${statusDot(grpcStatus)}"></span>
+            <span class="w-1.5 h-1.5 rounded-full ${statusDot(staleStatus)}"></span>
+          </div>
+        </div>
+        <button
+          class="text-[10px] text-text-muted hover:text-text-body transition-colors"
+          onClick=${() => refreshTransportHealth()}
+        >refresh</button>
+      </div>
+
+      <!-- SSE -->
+      <${SectionCard} title="SSE" icon="">
+        <${MetricRow} label="Observer Sessions" value=${data.sse.sessions_observer} />
+        <${MetricRow} label="Coordinator Sessions" value=${data.sse.sessions_coordinator} />
+        <${MetricRow} label="Total Sessions" value=${data.sse.sessions_total} />
+        <${MetricRow}
+          label="Broadcast Latency (avg)"
+          value=${formatLatency(data.sse.broadcast_avg_seconds)}
+          sub=${`(${data.sse.broadcast_count} events)`}
+        />
+      <//>
+
+      <!-- gRPC -->
+      <${SectionCard} title="gRPC" icon="">
+        <${MetricRow} label="Active Streams" value=${data.grpc.active_streams} />
+        <${MetricRow} label="Subscribers" value=${data.grpc.subscribers} />
+        <${MetricRow}
+          label="Heartbeat Latency (avg)"
+          value=${formatLatency(data.grpc.heartbeat_avg_seconds)}
+        />
+        <${MetricRow} label="Events Delivered" value=${data.grpc.events_delivered} />
+      <//>
+
+      <!-- Agent Health -->
+      <${SectionCard} title="Agent Health" icon="">
+        <${MetricRow} label="Stale Agents" value=${data.agent_health.stale_total} />
+      <//>
+    </div>
+  `
+}

--- a/lib/dune
+++ b/lib/dune
@@ -418,6 +418,7 @@
    social
    tool_social
    transport
+   transport_metrics
    ;; gRPC coordination transport (grpc-direct)
    masc_grpc_types
    masc_grpc_service

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -217,6 +217,12 @@ let handle_tool_call
 
 (** {1 Streaming Handlers} *)
 
+(** Active heartbeat stream count (atomic for signal safety). *)
+let active_heartbeat_streams = Atomic.make 0
+
+(** Active subscribe stream count (atomic for signal safety). *)
+let active_subscribe_streams = Atomic.make 0
+
 (** Heartbeat bidi handler: receive pings, respond with acks. *)
 let handle_heartbeat
     (room_config : Room_utils_backend_setup.config)
@@ -224,10 +230,13 @@ let handle_heartbeat
     (request_stream : string Grpc_eio.Stream.t)
   : string Grpc_eio.Stream.t =
   let response_stream = Grpc_eio.Stream.create 16 in
+  Atomic.incr active_heartbeat_streams;
+  Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with
       | bytes ->
+        let t0 = Unix.gettimeofday () in
         let ping = T.HeartbeatPing.of_bytes bytes in
         (* Update agent last_seen *)
         (try
@@ -280,8 +289,13 @@ let handle_heartbeat
           directives = [];
         } in
         Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
+        (* Record heartbeat latency *)
+        let latency = Unix.gettimeofday () -. t0 in
+        Transport_metrics.observe_grpc_heartbeat_latency latency;
         loop ()
       | exception End_of_file ->
+        Atomic.decr active_heartbeat_streams;
+        Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
         Grpc_eio.Stream.close response_stream
     in
     loop ());
@@ -294,6 +308,9 @@ let handle_subscribe
   : string Grpc_eio.Stream.t =
   let req = T.SubscribeRequest.of_bytes bytes in
   let stream = Grpc_eio.Stream.create 64 in
+  Atomic.incr active_subscribe_streams;
+  Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);
+  let events_count = ref 0 in
   (* Send initial event confirming subscription *)
   let init_event = T.Event.{
     seq = 0L;
@@ -307,6 +324,7 @@ let handle_subscribe
         (`List (List.map (fun s -> `String s) req.event_types)));
   } in
   Grpc_eio.Stream.add stream (T.Event.to_bytes init_event);
+  incr events_count;
   (* Read recent messages and push as events *)
   let backlog_file =
     Filename.concat
@@ -329,7 +347,8 @@ let handle_subscribe
               timestamp_ms = now_ms ();
               payload_json = line;
             } in
-            Grpc_eio.Stream.add stream (T.Event.to_bytes event)
+            Grpc_eio.Stream.add stream (T.Event.to_bytes event);
+            incr events_count
           end;
           seq := Int64.add !seq 1L
         end
@@ -337,6 +356,8 @@ let handle_subscribe
     with End_of_file -> ());
     close_in_noerr ic
   end;
+  (* Record delivered events from backlog replay *)
+  Transport_metrics.inc_grpc_events_delivered ~delta:!events_count ();
   (* Hook into SSE broadcast mechanism for real-time event push.
      External subscriber receives formatted SSE event strings on every
      Sse.broadcast/broadcast_to call, converts them to gRPC Event messages,

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -474,6 +474,10 @@ let make_request_handler ~sw ~clock ~server_start_time =
           let json = dashboard_proof_http_json ~state httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/transport-health" ->
+          let json = Transport_metrics.transport_health_json () in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/mdal/loops" ->
           let state = get_server_state () in
           (match mdal_loops_json ~config:state.Mcp_server.room_config httpun_request with

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -164,6 +164,11 @@ let add_routes ~sw ~clock router =
          let json = dashboard_proof_http_json ~state req in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/transport-health" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Transport_metrics.transport_health_json () in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.post "/api/v1/keepers/chat/stream" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_keeper_msg" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -362,6 +362,7 @@ let reap_dead_external_subscribers () =
     After SSE fan-out, external subscribers (gRPC streams, etc.) are
     also notified with the same formatted event string. *)
 let broadcast_impl target json =
+  let t0 = Time_compat.now () in
   let data = Yojson.Safe.to_string json in
   let current_event_id = Atomic.get event_counter + 1 in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
@@ -389,6 +390,9 @@ let broadcast_impl target json =
   ) clients_snapshot;
   (* Remove failed connections *)
   List.iter (fun sid -> unregister sid) !failed;
+  (* Record broadcast duration for transport observability *)
+  let elapsed = Time_compat.now () -. t0 in
+  Transport_metrics.observe_broadcast_duration elapsed;
   (* Notify external subscribers (gRPC streams, etc.) *)
   notify_external_subscribers event
 
@@ -463,6 +467,12 @@ let try_pop session_id =
     Uses [Atomic.get] so it is safe to call from signal handlers. *)
 let client_count () =
   Atomic.get client_count_atomic
+
+(** Return list of session_ids for all connected clients.
+    Used by transport metrics to report session count by kind. *)
+let all_session_ids () =
+  with_registry_ro (fun () ->
+    Hashtbl.fold (fun sid _client acc -> sid :: acc) clients [])
 
 (** Close all SSE clients - for graceful shutdown.
     Returns the number of clients that were closed.

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -1,0 +1,124 @@
+(** Transport Observability Metrics for 50-agent monitoring.
+
+    Collects SSE, gRPC, and agent-health transport metrics in
+    Prometheus text format via the existing Prometheus module.
+
+    Metric naming follows Prometheus conventions:
+    - masc_sse_* for SSE transport
+    - masc_grpc_* for gRPC transport
+    - masc_agent_heartbeat_* for agent liveness *)
+
+(** {1 SSE Metrics} *)
+
+let register_sse_metrics () =
+  Prometheus.register_gauge ~name:"masc_sse_sessions_total"
+    ~help:"Active SSE sessions by kind" ();
+  Prometheus.register_histogram ~name:"masc_sse_broadcast_duration_seconds"
+    ~help:"Time to fan-out a broadcast to all SSE clients" ();
+  Prometheus.register_counter ~name:"masc_sse_broadcast_events_total"
+    ~help:"Total SSE broadcast events emitted" ();
+  Prometheus.register_gauge ~name:"masc_sse_stream_queue_depth"
+    ~help:"Per-session SSE event stream queue depth" ()
+
+let set_sse_sessions ~kind count =
+  Prometheus.set_gauge "masc_sse_sessions_total"
+    ~labels:[("kind", kind)] (float_of_int count)
+
+let observe_broadcast_duration seconds =
+  Prometheus.observe_histogram "masc_sse_broadcast_duration_seconds" seconds;
+  Prometheus.inc_counter "masc_sse_broadcast_events_total" ()
+
+let set_sse_queue_depth ~session_id depth =
+  Prometheus.set_gauge "masc_sse_stream_queue_depth"
+    ~labels:[("session_id", session_id)] (float_of_int depth)
+
+(** {1 gRPC Metrics} *)
+
+let register_grpc_metrics () =
+  Prometheus.register_gauge ~name:"masc_grpc_active_streams_total"
+    ~help:"Active gRPC bidirectional streams" ();
+  Prometheus.register_histogram ~name:"masc_grpc_heartbeat_latency_seconds"
+    ~help:"gRPC heartbeat round-trip latency" ();
+  Prometheus.register_gauge ~name:"masc_grpc_subscribers_total"
+    ~help:"Active gRPC Subscribe stream subscribers" ();
+  Prometheus.register_counter ~name:"masc_grpc_events_delivered_total"
+    ~help:"Total events delivered via gRPC streams" ()
+
+let set_grpc_active_streams count =
+  Prometheus.set_gauge "masc_grpc_active_streams_total" (float_of_int count)
+
+let observe_grpc_heartbeat_latency seconds =
+  Prometheus.observe_histogram "masc_grpc_heartbeat_latency_seconds" seconds
+
+let set_grpc_subscribers count =
+  Prometheus.set_gauge "masc_grpc_subscribers_total" (float_of_int count)
+
+let inc_grpc_events_delivered ?(delta=1) () =
+  Prometheus.inc_counter "masc_grpc_events_delivered_total"
+    ~delta:(float_of_int delta) ()
+
+(** {1 Agent Health Metrics} *)
+
+let register_agent_metrics () =
+  Prometheus.register_gauge ~name:"masc_agent_heartbeat_age_seconds"
+    ~help:"Seconds since last heartbeat per agent" ();
+  Prometheus.register_counter ~name:"masc_agent_stale_total"
+    ~help:"Total agents that became stale (heartbeat age exceeded threshold)" ()
+
+let set_agent_heartbeat_age ~agent_name age_seconds =
+  Prometheus.set_gauge "masc_agent_heartbeat_age_seconds"
+    ~labels:[("agent_name", agent_name)] age_seconds
+
+let inc_agent_stale () =
+  Prometheus.inc_counter "masc_agent_stale_total" ()
+
+(** {1 Initialization} *)
+
+let init () =
+  register_sse_metrics ();
+  register_grpc_metrics ();
+  register_agent_metrics ()
+
+(** {1 Transport Health JSON Snapshot} *)
+
+let transport_health_json () =
+  let v name ?(labels=[]) () =
+    Prometheus.metric_value_or_zero name ~labels ()
+  in
+  let sse_observer = v "masc_sse_sessions_total" ~labels:[("kind", "observer")] () in
+  let sse_coordinator = v "masc_sse_sessions_total" ~labels:[("kind", "coordinator")] () in
+  let sse_total = int_of_float (sse_observer +. sse_coordinator) in
+  let broadcast_sum = v "masc_sse_broadcast_duration_seconds" () in
+  let broadcast_count = v "masc_sse_broadcast_duration_seconds_count" () in
+  let broadcast_avg =
+    if broadcast_count > 0.0 then broadcast_sum /. broadcast_count else 0.0
+  in
+  let grpc_streams = v "masc_grpc_active_streams_total" () in
+  let grpc_subscribers = v "masc_grpc_subscribers_total" () in
+  let grpc_heartbeat_sum = v "masc_grpc_heartbeat_latency_seconds" () in
+  let grpc_heartbeat_count = v "masc_grpc_heartbeat_latency_seconds_count" () in
+  let grpc_heartbeat_avg =
+    if grpc_heartbeat_count > 0.0 then grpc_heartbeat_sum /. grpc_heartbeat_count
+    else 0.0
+  in
+  let grpc_events = v "masc_grpc_events_delivered_total" () in
+  let stale_agents = v "masc_agent_stale_total" () in
+  `Assoc [
+    ("sse", `Assoc [
+      ("sessions_observer", `Int (int_of_float sse_observer));
+      ("sessions_coordinator", `Int (int_of_float sse_coordinator));
+      ("sessions_total", `Int sse_total);
+      ("broadcast_avg_seconds", `Float broadcast_avg);
+      ("broadcast_count", `Int (int_of_float broadcast_count));
+    ]);
+    ("grpc", `Assoc [
+      ("active_streams", `Int (int_of_float grpc_streams));
+      ("subscribers", `Int (int_of_float grpc_subscribers));
+      ("heartbeat_avg_seconds", `Float grpc_heartbeat_avg);
+      ("events_delivered", `Int (int_of_float grpc_events));
+    ]);
+    ("agent_health", `Assoc [
+      ("stale_total", `Int (int_of_float stale_agents));
+    ]);
+    ("generated_at", `String (Types.now_iso ()));
+  ]

--- a/test/dune
+++ b/test/dune
@@ -773,6 +773,18 @@
  (modules test_mitosis_metrics)
  (libraries masc_mcp alcotest str yojson))
 
+; Transport Observability Metrics (SSE, gRPC, agent health)
+(test
+ (name test_transport_metrics)
+ (modules test_transport_metrics)
+ (libraries masc_mcp alcotest str yojson))
+
+; Adaptive snapshot cache TTL based on broadcast latency
+(test
+ (name test_adaptive_cache_ttl)
+ (modules test_adaptive_cache_ttl)
+ (libraries masc_mcp alcotest str yojson))
+
 ; Adaptive Thresholds — P2-1 EMA-based threshold learning
 (test
  (name test_adaptive_thresholds)

--- a/test/test_adaptive_cache_ttl.ml
+++ b/test/test_adaptive_cache_ttl.ml
@@ -1,0 +1,41 @@
+(** Tests for broadcast latency metrics that support adaptive behavior.
+    The original TTL-based cache in cp_snapshot_core was replaced with
+    mtime-based per-section caching, so we test the latency metric
+    infrastructure that downstream consumers can use for load adaptation. *)
+
+open Alcotest
+
+module Prometheus = Masc_mcp.Prometheus
+module TM = Masc_mcp.Transport_metrics
+
+let test_default_latency () =
+  (* With no broadcast data, latency avg = 0. *)
+  TM.init ();
+  let sum = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds" () in
+  let count = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds_count" () in
+  let avg = if count > 0.0 then sum /. count else 0.0 in
+  check bool "avg latency is a valid float" true (avg >= 0.0)
+
+let test_high_latency_detected () =
+  TM.init ();
+  (* Inject high latency observations to push avg above 0.5s *)
+  for _ = 1 to 10 do
+    Prometheus.observe_histogram "masc_sse_broadcast_duration_seconds" 1.0
+  done;
+  let sum = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds" () in
+  let count = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds_count" () in
+  let avg = if count > 0.0 then sum /. count else 0.0 in
+  check bool "avg latency exceeds threshold" true (avg > 0.4)
+
+let () =
+  run "Adaptive_cache_ttl" [
+    ("broadcast_latency", [
+      test_case "default latency with no data" `Quick test_default_latency;
+      test_case "high latency detected via metrics" `Quick
+        test_high_latency_detected;
+    ]);
+  ]

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -1,0 +1,181 @@
+(** Tests for Transport_metrics module.
+    Verifies metric registration, updates, and JSON snapshot output. *)
+
+open Alcotest
+
+module TM = Masc_mcp.Transport_metrics
+module Prometheus = Masc_mcp.Prometheus
+
+(* ============================================================
+   Initialization
+   ============================================================ *)
+
+let test_init () =
+  TM.init ();
+  let text = Prometheus.to_prometheus_text () in
+  check bool "sse sessions metric registered" true
+    (try
+       let _ = Str.search_forward
+         (Str.regexp_string "masc_sse_sessions_total") text 0 in
+       true
+     with Not_found -> false);
+  check bool "grpc active streams metric registered" true
+    (try
+       let _ = Str.search_forward
+         (Str.regexp_string "masc_grpc_active_streams_total") text 0 in
+       true
+     with Not_found -> false);
+  check bool "agent heartbeat age metric registered" true
+    (try
+       let _ = Str.search_forward
+         (Str.regexp_string "masc_agent_heartbeat_age_seconds") text 0 in
+       true
+     with Not_found -> false)
+
+(* ============================================================
+   SSE Metrics
+   ============================================================ *)
+
+let test_sse_sessions () =
+  TM.init ();
+  TM.set_sse_sessions ~kind:"observer" 10;
+  TM.set_sse_sessions ~kind:"coordinator" 5;
+  let obs = Prometheus.metric_value_or_zero "masc_sse_sessions_total"
+    ~labels:[("kind", "observer")] () in
+  let coord = Prometheus.metric_value_or_zero "masc_sse_sessions_total"
+    ~labels:[("kind", "coordinator")] () in
+  check (float 0.01) "observer sessions" 10.0 obs;
+  check (float 0.01) "coordinator sessions" 5.0 coord
+
+let test_broadcast_duration () =
+  TM.init ();
+  TM.observe_broadcast_duration 0.05;
+  TM.observe_broadcast_duration 0.15;
+  let sum = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds" () in
+  let count = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_duration_seconds_count" () in
+  check bool "broadcast sum > 0" true (sum > 0.0);
+  check bool "broadcast count >= 2" true (count >= 2.0)
+
+let test_broadcast_events_counter () =
+  TM.init ();
+  let before = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_events_total" () in
+  TM.observe_broadcast_duration 0.01;
+  let after = Prometheus.metric_value_or_zero
+    "masc_sse_broadcast_events_total" () in
+  check bool "broadcast events incremented" true (after > before)
+
+(* ============================================================
+   gRPC Metrics
+   ============================================================ *)
+
+let test_grpc_active_streams () =
+  TM.init ();
+  TM.set_grpc_active_streams 3;
+  let v = Prometheus.metric_value_or_zero
+    "masc_grpc_active_streams_total" () in
+  check (float 0.01) "grpc active streams" 3.0 v
+
+let test_grpc_heartbeat_latency () =
+  TM.init ();
+  TM.observe_grpc_heartbeat_latency 0.002;
+  TM.observe_grpc_heartbeat_latency 0.008;
+  let sum = Prometheus.metric_value_or_zero
+    "masc_grpc_heartbeat_latency_seconds" () in
+  check bool "heartbeat latency sum > 0" true (sum > 0.0)
+
+let test_grpc_subscribers () =
+  TM.init ();
+  TM.set_grpc_subscribers 7;
+  let v = Prometheus.metric_value_or_zero
+    "masc_grpc_subscribers_total" () in
+  check (float 0.01) "grpc subscribers" 7.0 v
+
+let test_grpc_events_delivered () =
+  TM.init ();
+  let before = Prometheus.metric_value_or_zero
+    "masc_grpc_events_delivered_total" () in
+  TM.inc_grpc_events_delivered ~delta:5 ();
+  let after = Prometheus.metric_value_or_zero
+    "masc_grpc_events_delivered_total" () in
+  check (float 0.01) "grpc events delta" 5.0 (after -. before)
+
+(* ============================================================
+   Agent Health Metrics
+   ============================================================ *)
+
+let test_agent_heartbeat_age () =
+  TM.init ();
+  TM.set_agent_heartbeat_age ~agent_name:"dreamer" 42.5;
+  let v = Prometheus.metric_value_or_zero
+    "masc_agent_heartbeat_age_seconds"
+    ~labels:[("agent_name", "dreamer")] () in
+  check (float 0.01) "dreamer heartbeat age" 42.5 v
+
+let test_agent_stale_counter () =
+  TM.init ();
+  let before = Prometheus.metric_value_or_zero
+    "masc_agent_stale_total" () in
+  TM.inc_agent_stale ();
+  TM.inc_agent_stale ();
+  let after = Prometheus.metric_value_or_zero
+    "masc_agent_stale_total" () in
+  check (float 0.01) "stale count increment" 2.0 (after -. before)
+
+(* ============================================================
+   Transport Health JSON
+   ============================================================ *)
+
+let test_transport_health_json () =
+  TM.init ();
+  TM.set_sse_sessions ~kind:"observer" 3;
+  TM.set_grpc_active_streams 1;
+  let json = TM.transport_health_json () in
+  let s = Yojson.Safe.to_string json in
+  check bool "contains sse section" true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "\"sse\"") s 0 in true
+     with Not_found -> false);
+  check bool "contains grpc section" true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "\"grpc\"") s 0 in true
+     with Not_found -> false);
+  check bool "contains agent_health section" true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "\"agent_health\"") s 0 in true
+     with Not_found -> false);
+  check bool "contains generated_at" true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "\"generated_at\"") s 0 in true
+     with Not_found -> false)
+
+(* ============================================================
+   Test Runner
+   ============================================================ *)
+
+let () =
+  run "Transport_metrics" [
+    ("init", [
+      test_case "registers all metric families" `Quick test_init;
+    ]);
+    ("sse", [
+      test_case "set_sse_sessions by kind" `Quick test_sse_sessions;
+      test_case "observe_broadcast_duration accumulates" `Quick test_broadcast_duration;
+      test_case "broadcast events counter increments" `Quick test_broadcast_events_counter;
+    ]);
+    ("grpc", [
+      test_case "set_grpc_active_streams" `Quick test_grpc_active_streams;
+      test_case "observe_grpc_heartbeat_latency" `Quick test_grpc_heartbeat_latency;
+      test_case "set_grpc_subscribers" `Quick test_grpc_subscribers;
+      test_case "inc_grpc_events_delivered" `Quick test_grpc_events_delivered;
+    ]);
+    ("agent_health", [
+      test_case "set_agent_heartbeat_age" `Quick test_agent_heartbeat_age;
+      test_case "inc_agent_stale" `Quick test_agent_stale_counter;
+    ]);
+    ("json", [
+      test_case "transport_health_json structure" `Quick test_transport_health_json;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

Closed PR #2412의 변경사항 복구. Transport observability 메트릭과 대시보드 패널을 현재 main에 맞게 적용.

- `Transport_metrics` 모듈: SSE/gRPC/agent-health 10개 Prometheus 메트릭 패밀리
- `/api/v1/dashboard/transport-health` API 엔드포인트 (HTTP/1.1 + H2 게이트웨이)
- `TransportHealthPanel` 대시보드 컴포넌트 (15초 폴링)
- `sse.ml` broadcast 시간 측정 (`broadcast_impl`에 적용)
- `masc_grpc_service.ml` heartbeat latency + stream count 추적
- 13개 테스트 (메트릭 11 + broadcast latency 2)

### 스킵한 항목

- `cp_snapshot_core.ml`의 adaptive cache TTL: 캐시가 TTL 기반에서 mtime 기반 per-section 캐시로 완전 재작성됨. 기존 TTL 로직이 더 이상 적용되지 않아 스킵.

### 원본 PR 참조

- PR #2412 (closed, +602 lines, 13 files)
- Issue #2382

## Test plan

- [x] `dune build --root .` 통과
- [x] `test_transport_metrics.exe` 11 tests PASS
- [x] `test_adaptive_cache_ttl.exe` 2 tests PASS
- [x] `test_relay_coverage.exe` 71 tests PASS
- [ ] Dashboard에서 Transport Health 패널 렌더링 확인
- [ ] `/api/v1/dashboard/transport-health` JSON 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)