### PR TITLE
[Dashboard] control-btn CSS 클래스 제거 및 ActionButton 통합

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -377,7 +377,7 @@ export function ChatComposer({
   const streamLabel = streaming
     ? `응답 중${elapsed > 0 ? ` ${elapsed}s` : '...'}`
     : '보내기'
-  const warnClass = streaming && elapsed > 60 ? ' chat-stream-warning' : ''
+  const isStreamWarning = streaming && elapsed > 60
 
   return html`
     <div class="chat-composer flex flex-col gap-3">
@@ -408,7 +408,7 @@ export function ChatComposer({
         </div>
         <div class="flex gap-2 items-center">
         <${ActionButton}
-          variant=${warnClass ? 'danger' : 'primary'}
+          variant=${isStreamWarning ? 'danger' : 'primary'}
           onClick=${onSend}
           disabled=${disabled || streaming || draft.trim() === ''}
         >

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -360,24 +360,26 @@ export function OrchestraSurface() {
           <${StatusChip} label=${`${Math.round(camera.zoom * 100)}%`} />
         </div>
         <div class="orchestra-toolbar-group">
-          <button type="button"
-            class=${`control-btn ${density === 'balanced' ? 'is-active' : 'ghost'}`}
+          <${ActionButton}
+            variant=${density === 'balanced' ? 'primary' : 'ghost'}
+            size="lg"
             onClick=${() => {
               orchestraDensity.value = 'balanced'
               orchestraSelection.value = selectedId
             }}
           >
             균형
-          </button>
-          <button type="button"
-            class=${`control-btn ${density === 'compact' ? 'is-active' : 'ghost'}`}
+          <//>
+          <${ActionButton}
+            variant=${density === 'compact' ? 'primary' : 'ghost'}
+            size="lg"
             onClick=${() => {
               orchestraDensity.value = 'compact'
               orchestraSelection.value = selectedId
             }}
           >
             집약
-          </button>
+          <//>
           <${StatusChip} label=${densityLabel(density)} />
         </div>
       </div>

--- a/dashboard/src/components/common/action-bar.ts
+++ b/dashboard/src/components/common/action-bar.ts
@@ -1,8 +1,8 @@
 // ActionBar — consistent action button row at the bottom of cards.
-// Replaces repeated flex gap-2 flex-wrap mt-3 + control-btn patterns.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
+import { ActionButton } from './button'
 
 interface ActionBarProps {
   children: ComponentChildren
@@ -25,8 +25,8 @@ interface ActionBtnProps {
 
 export function ActionBtn({ label, onClick, disabled }: ActionBtnProps) {
   return html`
-    <button type="button" class="control-btn rounded-lg ghost" onClick=${onClick} disabled=${disabled}>
+    <${ActionButton} variant="ghost" size="lg" onClick=${onClick} disabled=${disabled}>
       ${label}
-    </button>
+    <//>
   `
 }

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -5,11 +5,12 @@ import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'
 
 type ButtonVariant = 'primary' | 'ghost' | 'danger' | 'subtle'
-type ButtonSize = 'sm' | 'md'
+type ButtonSize = 'sm' | 'md' | 'lg'
 
 const SIZE_CLASSES: Record<ButtonSize, string> = {
   sm: 'py-1 px-2 text-[10px]',
   md: 'py-1.5 px-2.5 text-[11px]',
+  lg: 'py-2 px-4 text-sm',
 }
 
 const VARIANT_CLASSES: Record<ButtonVariant, string> = {

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
+import { ActionButton } from '../common/button'
 import { useRef } from 'preact/hooks'
 import { LoadingState } from '../common/feedback-state'
 import {
@@ -100,9 +101,9 @@ export function OpsRoomColumn() {
                 <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${item.reason}</div>
                 ${item.suggested_payload ? html`
                   <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
-                    <button type="button" class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
+                    <${ActionButton} variant="ghost" size="lg" onClick=${() => { hydrateRecommendedAction(item); openRoomControlDisclosure() }} disabled=${operatorActionBusy.value}>
                       폼에 채우기
-                    </button>
+                    <//>
                   </div>
                 ` : null}
               </article>
@@ -147,12 +148,12 @@ export function OpsRoomColumn() {
                 </div>
                 ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[11px] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
                 <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
-                  <button type="button" class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
+                  <${ActionButton} variant="primary" size="lg" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
                     실행
-                  </button>
-                  <button type="button" class="control-btn ghost" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
+                  <//>
+                  <${ActionButton} variant="ghost" size="lg" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
                     거부
-                  </button>
+                  <//>
                   <span class="text-[var(--text-muted)] text-[var(--fs-xs)] font-mono break-all">${item.confirm_token}</span>
                 </div>
               </article>
@@ -220,9 +221,9 @@ export function OpsRoomColumn() {
                 onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') void submitBroadcast() }}
                 disabled=${operatorActionBusy.value}
               />
-              <button type="button" class="control-btn" onClick=${() => { void submitBroadcast() }} disabled=${operatorActionBusy.value || broadcastMessage.value.trim() === ''}>
+              <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitBroadcast() }} disabled=${operatorActionBusy.value || broadcastMessage.value.trim() === ''}>
                 보내기
-              </button>
+              <//>
             </div>
 
             <label class="control-label" for="ops-pause-reason">일시정지 / 재개</label>
@@ -235,12 +236,12 @@ export function OpsRoomColumn() {
                 onInput=${(event: Event) => { pauseReason.value = (event.target as HTMLInputElement).value }}
                 disabled=${operatorActionBusy.value}
               />
-              <button type="button" class="control-btn ghost" onClick=${() => { void submitPause() }} disabled=${operatorActionBusy.value}>
+              <${ActionButton} variant="ghost" size="lg" onClick=${() => { void submitPause() }} disabled=${operatorActionBusy.value}>
                 일시정지
-              </button>
-              <button type="button" class="control-btn ghost" onClick=${() => { void submitResume() }} disabled=${operatorActionBusy.value}>
+              <//>
+              <${ActionButton} variant="ghost" size="lg" onClick=${() => { void submitResume() }} disabled=${operatorActionBusy.value}>
                 재개
-              </button>
+              <//>
             </div>
 
             <div class="mt-0.5 text-[var(--text-muted)] text-[var(--fs-xs)] tracking-[0.05em] uppercase">작업 주입</div>
@@ -273,9 +274,9 @@ export function OpsRoomColumn() {
                 <option value="4">P4</option>
                 <option value="5">P5</option>
               </select>
-              <button type="button" class="control-btn" onClick=${() => { void submitTaskInject() }} disabled=${operatorActionBusy.value || taskTitle.value.trim() === ''}>
+              <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitTaskInject() }} disabled=${operatorActionBusy.value || taskTitle.value.trim() === ''}>
                 주입
-              </button>
+              <//>
             </div>
           </div>
         </details>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -3,6 +3,7 @@
 import { signal } from '@preact/signals'
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
+import { ActionButton } from '../common/button'
 import {
   fetchAutoresearchStatus,
   injectAutoresearchHypothesis,
@@ -317,15 +318,15 @@ export function OpsSessionColumn() {
         ${linkedAutoresearch?.loop_id ? html`
           <label class="control-label" for="ops-autoresearch-hypothesis">Autoresearch 제어</label>
           <div class="control-row items-stretch">
-            <button type="button" class="control-btn ghost" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
+            <${ActionButton} variant="ghost" size="lg" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
               상태 새로고침
-            </button>
-            <button type="button" class="control-btn" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
+            <//>
+            <${ActionButton} variant="primary" size="lg" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
               1 cycle 실행
-            </button>
-            <button type="button" class="control-btn ghost" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
+            <//>
+            <${ActionButton} variant="ghost" size="lg" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
               loop 중지
-            </button>
+            <//>
           </div>
           <textarea
             id="ops-autoresearch-hypothesis"
@@ -337,9 +338,9 @@ export function OpsSessionColumn() {
             disabled=${busy}
           ></textarea>
           <div class="control-row items-stretch">
-            <button type="button" class="control-btn" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
+            <${ActionButton} variant="primary" size="lg" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
               hypothesis 주입
-            </button>
+            <//>
             <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
           </div>
           ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${autoresearchError.value}</div>` : null}
@@ -359,9 +360,9 @@ export function OpsSessionColumn() {
             <option value="task">작업</option>
             <option value="worker_spawn_batch">worker 교체</option>
           </select>
-          <button type="button" class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
+          <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
             적용
-          </button>
+          <//>
         </div>
         <div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">현재 선택: ${sessionActionLabel(teamTurnKind.value)}</div>
 
@@ -422,9 +423,9 @@ export function OpsSessionColumn() {
             onInput=${(event: Event) => { teamStopReason.value = (event.target as HTMLInputElement).value }}
             disabled=${busy || !selectedSessionActionable}
           />
-          <button type="button" class="control-btn ghost" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
+          <${ActionButton} variant="ghost" size="lg" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
             세션 중지
-          </button>
+          <//>
         </div>
       </section>
     </div>

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -85,14 +85,3 @@
   color: #95f3bc;
 }
 
-/* ── Stream Warning (60s+ elapsed) ─────────────────────── */
-.control-btn.chat-stream-warning {
-  border-color: rgba(251, 191, 36, 0.5);
-  color: var(--warn);
-  animation: chatWarnPulse 2s ease-in-out infinite;
-}
-
-@keyframes chatWarnPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -57,14 +57,6 @@
   border-color: rgba(71, 184, 255, 0.55);
 }
 
-.control-btn:hover {
-  background: rgba(71, 184, 255, 0.27);
-}
-
-.control-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 /* ── Mission Status Dot ── */
 .mission-status-dot.mission-state-alive {
@@ -86,24 +78,7 @@
   opacity: 0.85;
 }
 
-/* ── Empty state (standardized) ── */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 48px 16px;
-  text-align: center;
-}
-/* ── Loading state (standardized) ── */
-.loading-state {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 48px 16px;
-  font-size: var(--fs-sm);
-  color: var(--text-muted);
-}
+
 /* ── Responsive (layout) ── */
 @media (max-width: 880px) {
   .control-row { grid-template-columns: 1fr; }

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -452,28 +452,6 @@ a:hover {
   &:focus { outline: none; border-color: rgba(71, 184, 255, 0.55); }
 }
 
-@utility control-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border: 1px solid rgba(71, 184, 255, 0.32);
-  border-radius: 8px;
-  background: rgba(71, 184, 255, 0.14);
-  color: var(--accent);
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-  white-space: nowrap;
-  &:hover { background: rgba(71, 184, 255, 0.27); }
-  &:disabled { opacity: 0.5; cursor: not-allowed; }
-  &.ghost { background: var(--white-4); border-color: var(--border-slate-16); color: var(--text-body); }
-  &.ghost:hover { background: var(--white-8); border-color: var(--border-slate-22); }
-  &.chat-stream-warning { border-color: rgba(251, 191, 36, 0.5); color: var(--warn); animation: chatWarnPulse 2s ease-in-out infinite; }
-  &.is-active .tool-surface-count { background: rgba(14, 165, 233, 0.25); color: #7dd3fc; }
-}
 
 @utility control-row {
   display: grid;
@@ -585,9 +563,6 @@ tbody tr:hover {
 
 /* ── Command Plane utilities (migrated from command.css) ──── */
 
-@utility cmd-plane-view {
-}
-
 @utility cmd-stat-card {
   &.highlight {
     border-color: rgba(34,211,238,0.34);
@@ -653,9 +628,6 @@ tbody tr:hover {
     color: rgba(226, 232, 240, 0.76);
     line-height: 1.6;
   }
-}
-
-@utility cmd-tree-node {
 }
 
 @utility cmd-guide-card {
@@ -915,10 +887,6 @@ tbody tr:hover {
   0%, 100% { transform: scale(1); opacity: 0.92; }
   50% { transform: scale(1.06); opacity: 1; }
 }
-@keyframes chatWarnPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}
 @keyframes livePulse {
   0%, 100% { box-shadow: 0 0 0 0 var(--ok-25); }
   50% { box-shadow: 0 0 8px 2px var(--ok-12); }
@@ -974,14 +942,6 @@ tbody tr:hover {
 
 @utility keeper-field-search {
   &:focus { outline: none; border-color: var(--ok-40); }
-}
-@utility keeper-chat__msg--user {
-}
-
-@utility keeper-chat__msg--assistant {
-}
-
-@utility keeper-chat__msg--streaming {
 }
 
 @utility keeper-chat__cursor {
@@ -1072,7 +1032,6 @@ tbody tr:hover {
   background: linear-gradient(180deg, rgba(18, 42, 33, 0.55), rgba(10, 25, 20, 0.48));
 }
 
-/* control-btn.chat-stream-warning: folded into @utility control-btn above */
 
 /* ── Tools (merged from tools.css) ─────────────────────── */
 
@@ -1118,7 +1077,6 @@ tbody tr:hover {
   }
 }
 
-/* control-btn.is-active .tool-surface-count: folded into @utility control-btn above */
 
 @utility tool-metrics-summary {
   display: grid;
@@ -1328,11 +1286,6 @@ tbody tr:hover {
     min-width: 0;
     flex: 1;
   }
-  .planning-header,
-  .board-toolbar-actions .control-btn {
-    flex: 1;
-    min-width: 42px;
-  }
 }
 
 /* ── Roster (merged from roster.css) ───────────────────── */
@@ -1432,7 +1385,7 @@ tbody tr:hover {
 
 /* board-post content-visibility: folded into @utility board-post below */
 
-/* control-input/textarea :focus, control-btn :hover/:disabled: folded into @utility blocks above */
+/* control-input/textarea :focus: folded into @utility blocks above */
 
 /* ── Mission Status Dot ── */
 @utility mission-status-dot {
@@ -1829,6 +1782,7 @@ button.council-row.selected {
   .ff-plate {
     grid-template-columns: 1fr;
     text-align: center;
+  }
 }
 
 /* ── Keeper Rich Card (Overview) ──────────────────────────── */


### PR DESCRIPTION
## Summary
- `control-btn` 커스텀 CSS 클래스 17곳을 공유 `ActionButton` 컴포넌트로 전환
- `ActionButton`에 `lg` 사이즈 추가 (`py-2 px-4 text-sm`, 기존 control-btn과 동일 크기)
- 5개 빈 `@utility` 블록 제거 (cmd-plane-view, cmd-tree-node, keeper-chat__msg--*)
- dead CSS 제거: chatWarnPulse keyframes, board-toolbar-actions, planning-header, 중복 empty-state/loading-state
- 빌드 차단하던 `@media (max-width: 768px)` 미닫힘 중괄호 수정

## Changes
| 파일 | 변경 |
|------|------|
| `global.css` | 2212 -> 2166줄 (-46) |
| `dashboard.css` | 170 -> 145줄 (-25) |
| `chat.css` | 98 -> 87줄 (-11) |
| `button.ts` | `lg` 사이즈 추가 |
| `action-bar.ts` | ActionBtn에서 control-btn 제거 |
| `ops-room-column.ts` | control-btn 8곳 -> ActionButton |
| `ops-session-column.ts` | control-btn 6곳 -> ActionButton |
| `orchestra.ts` | control-btn 2곳 -> ActionButton |
| `primitives.ts` | warnClass 변수명 정리 |

## Test plan
- [x] `npm run build` 통과
- [x] `dune build --root .` 통과
- [x] `control-btn` 문자열 dashboard 전체에서 0건 확인
- [ ] dashboard UI 수동 확인 (버튼 크기/색상/hover/disabled 상태)

🤖 Generated with [Claude Code](https://claude.com/claude-code)