### PR TITLE
test(keeper): align fs_edit exposure expectations

### DIFF
--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -632,17 +632,17 @@ let test_keeper_fs_edit_policy_gates () =
       ~policy_shell_mode:"coding" ()
   in
   check_keeper_exec_tool_presence "heuristic fs_edit default" heuristic_disabled
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "heuristic fs_edit coding" heuristic_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit disabled" learned_disabled
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit coding" learned_coding
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "explicit event fs_edit coding" explicit_event_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "model deliberation fs_edit coding" deliberation_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false
 
 let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary
- align `keeper_fs_edit` policy-gate expectations with the current keeper capability matrix
- keep the direct `keeper_fs_edit` execution safety test intact while marking exposure as disabled across keeper surfaces

Closes #2749

## Verification
- DUNE_CACHE=disabled opam exec -- dune build --root . test/test_tool_keeper.exe
- DUNE_CACHE=disabled opam exec -- ./_build/default/test/test_tool_keeper.exe --show-errors