### PR TITLE
test: align keeper fs_edit exposure gates

### DIFF
--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -607,6 +607,8 @@ let test_keeper_bash_requires_cmd_and_runs () =
           code <> 0))
 
 let test_keeper_fs_edit_policy_gates () =
+  (* keeper_fs_edit remains an internal legacy handler rather than part of the
+     default keeper-exposed filesystem/coding shard surface. *)
   let heuristic_disabled = make_keeper_exec_meta () in
   let heuristic_coding =
     make_keeper_exec_meta ~name:"fs-edit-heuristic"
@@ -632,17 +634,17 @@ let test_keeper_fs_edit_policy_gates () =
       ~policy_shell_mode:"coding" ()
   in
   check_keeper_exec_tool_presence "heuristic fs_edit default" heuristic_disabled
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "heuristic fs_edit coding" heuristic_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit disabled" learned_disabled
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "learned fs_edit coding" learned_coding
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "explicit event fs_edit coding" explicit_event_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true;
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
   check_keeper_exec_tool_presence "model deliberation fs_edit coding" deliberation_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:true
+    ~tool_name:"keeper_fs_edit" ~expect_allowed:false
 
 let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary
- align `test_tool_keeper` fs_edit exposure expectations with the current keeper shard matrix
- document in the test that `keeper_fs_edit` stays an internal legacy handler
- keep the functional `keeper_fs_edit` execution test untouched

## Testing
- `DUNE_CACHE=disabled opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/oas-worker-checkpoint-compat ./test/test_tool_keeper.exe`
- `./_build/default/test/test_tool_keeper.exe --show-errors`

Fixes #2749
