### PR TITLE
fix: stream keepalives for POST /mcp tools/call

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -22,6 +22,11 @@ let env_int_or ~name ~default =
   | Some raw -> (
       try int_of_string raw with _ -> default)
 
+let post_sse_keepalive_interval_s =
+  env_float_or ~name:"MASC_POST_SSE_KEEPALIVE_SEC"
+    ~default:sse_ping_interval_s
+  |> Float.max 0.1
+
 let sse_reconnect_min_interval_s =
   env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:0.0
   |> Float.max 0.0
@@ -37,6 +42,16 @@ let get_last_event_id (request : Httpun.Request.t) =
   | Some id -> (
       try Some (int_of_string id) with Failure _ -> None)
   | None -> None
+
+let body_jsonrpc_method body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc fields -> (
+        match List.assoc_opt "method" fields with
+        | Some (`String method_) -> Some (method_, List.mem_assoc "id" fields)
+        | _ -> None)
+    | _ -> None
+  with Yojson.Json_error _ -> None
 
 let mcp_headers session_id protocol_version =
   [ ("mcp-session-id", session_id); ("mcp-protocol-version", protocol_version) ]
@@ -254,6 +269,85 @@ let send_raw info data =
       close_sse_conn info;
       false
 
+let make_inline_sse_conn ~session_id writer =
+  {
+    session_id;
+    client_id = -1;
+    writer;
+    mutex = Eio.Mutex.create ();
+    stop = ref false;
+    closed = false;
+  }
+
+let stream_post_sse_headers ~deps ~origin ~session_id ~protocol_version
+    ~accept_warn_headers =
+  Httpun.Headers.of_list
+    (accept_warn_headers
+    @ [
+        ("content-type", Http_negotiation.sse_content_type);
+        ("cache-control", "no-cache");
+        ("connection", "close");
+        ("x-accel-buffering", "no");
+        session_cookie_header session_id;
+      ]
+      @ mcp_headers session_id protocol_version
+      @ deps.cors_headers origin)
+
+let stream_post_sse_start ~deps ~origin ~session_id ~protocol_version
+    ~accept_warn_headers reqd =
+  let headers =
+    stream_post_sse_headers ~deps ~origin ~session_id ~protocol_version
+      ~accept_warn_headers
+  in
+  let response = Httpun.Response.create ~headers `OK in
+  let writer = Httpun.Reqd.respond_with_streaming reqd response in
+  let info = make_inline_sse_conn ~session_id writer in
+  ignore (send_raw info (sse_prime_event ()));
+  info
+
+let spawn_post_sse_keepalive ~sw ~clock info =
+  Eio.Fiber.fork ~sw (fun () ->
+      let rec loop () =
+        if not !(info.stop) then (
+          (try
+             Eio.Time.sleep clock post_sse_keepalive_interval_s
+           with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | _ -> ());
+          if info.closed then
+            close_sse_conn info
+          else if not !(info.stop) then
+            ignore (send_raw info ": keepalive\n\n");
+          loop ())
+      in
+      try loop ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> close_sse_conn info)
+
+let stream_post_sse_finish info = close_sse_conn info
+
+let stream_post_sse_json info (json : Yojson.Safe.t) =
+  ignore
+    (send_raw info
+       (Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json)))
+
+let mcp_internal_error_json msg =
+  `Assoc
+    [
+      ("jsonrpc", `String "2.0");
+      ("error", `Assoc [ ("code", `Int (-32603)); ("message", `String msg) ]);
+    ]
+
+let should_stream_post_tools_call request body_str accept_mode =
+  should_use_sse_for_body request body_str accept_mode
+  && not force_json_response
+  && not (request_force_json_response request)
+  &&
+  match body_jsonrpc_method body_str with
+  | Some ("tools/call", true) -> true
+  | _ -> false
+
 let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
   let session_id_opt = get_session_id_any request in
   let session_was_provided = Option.is_some session_id_opt in
@@ -293,22 +387,6 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
       Httpun.Reqd.respond_with_string reqd response body
   | Ok () ->
       match validate_protocol_version_continuity ~session_id request with
-      | Error msg ->
-          let body =
-            Printf.sprintf
-              {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
-              (Yojson.Safe.to_string (`String msg))
-          in
-          let headers =
-            Httpun.Headers.of_list
-              (("content-length", string_of_int (String.length body))
-              :: json_headers ~deps session_id protocol_version origin)
-          in
-          let response = Httpun.Response.create ~headers `Bad_request in
-          Httpun.Reqd.respond_with_string reqd response body
-      | Ok () ->
-          remember_mcp_profile session_id profile;
-          match auth_result with
       | Error msg ->
           let body =
             Printf.sprintf
@@ -389,109 +467,157 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                           (* Fork a fiber so Eio I/O in handle_request does not
                              block httpun's schedule_read callback chain. *)
                           Eio.Fiber.fork ~sw (fun () ->
-                          try
-                            let response_json =
-                              Mcp_eio.handle_request ~clock ~sw ~profile
-                                ~mcp_session_id:session_id ?auth_token state body_str
+                            let response_protocol_version =
+                              match protocol_version_from_body body_str with
+                              | Some v ->
+                                  remember_protocol_version session_id v;
+                                  v
+                              | None ->
+                                  get_protocol_version_for_session ~session_id request
                             in
-                            (match protocol_version_from_body body_str with
-                            | Some v -> remember_protocol_version session_id v
-                            | None -> ());
-                            let protocol_version =
-                              get_protocol_version_for_session ~session_id request
+                            let wants_streaming_post =
+                              should_stream_post_tools_call request body_str
+                                accept_mode
                             in
-                            let wants_sse =
-                              should_use_sse_for_body request body_str accept_mode
-                              && not force_json_response
-                              && not (request_force_json_response request)
-                            in
-                            if wants_sse then
-                              match response_json with
-                              | `Null ->
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", "0")
-                                      :: accept_warn_headers
-                                      @ mcp_headers session_id protocol_version )
-                                  in
-                                  let response =
-                                    Httpun.Response.create ~headers `Accepted
-                                  in
-                                  Httpun.Reqd.respond_with_string reqd response ""
-                              | json when is_http_error_response json ->
-                                  let body = Yojson.Safe.to_string json in
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", string_of_int (String.length body))
-                                      :: accept_warn_headers
-                                      @ json_headers ~deps session_id protocol_version
-                                          origin )
-                                  in
-                                  let response =
-                                    Httpun.Response.create ~headers `Bad_request
-                                  in
-                                  Httpun.Reqd.respond_with_string reqd response body
-                              | json ->
-                                  let event =
-                                    Sse.format_event ~event_type:"message"
-                                      (Yojson.Safe.to_string json)
-                                  in
-                                  let body = sse_prime_event () ^ event in
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", string_of_int (String.length body))
-                                      :: accept_warn_headers
-                                      @ sse_headers ~deps session_id protocol_version
-                                          origin )
-                                  in
-                                  let response = Httpun.Response.create ~headers `OK in
-                                  Httpun.Reqd.respond_with_string reqd response body
-                            else
-                              match response_json with
-                              | `Null ->
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", "0")
-                                      :: accept_warn_headers
-                                      @ mcp_headers session_id protocol_version )
-                                  in
-                                  let response =
-                                    Httpun.Response.create ~headers `Accepted
-                                  in
-                                  Httpun.Reqd.respond_with_string reqd response ""
-                              | json when is_http_error_response json ->
-                                  let body = Yojson.Safe.to_string json in
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", string_of_int (String.length body))
-                                      :: accept_warn_headers
-                                      @ json_headers ~deps session_id protocol_version
-                                          origin )
-                                  in
-                                  let response =
-                                    Httpun.Response.create ~headers `Bad_request
-                                  in
-                                  Httpun.Reqd.respond_with_string reqd response body
-                              | json ->
-                                  let body = Yojson.Safe.to_string json in
-                                  let headers =
-                                    Httpun.Headers.of_list
-                                      ( ("content-length", string_of_int (String.length body))
-                                      :: accept_warn_headers
-                                      @ json_headers ~deps session_id protocol_version
-                                          origin )
-                                  in
-                                  let response = Httpun.Response.create ~headers `OK in
-                                  Httpun.Reqd.respond_with_string reqd response body
-                      with
-                      | Eio.Cancel.Cancelled _ as e -> raise e
-                      | exn ->
-                        let protocol_version =
-                          get_protocol_version_for_session ~session_id request
-                        in
-                        respond_mcp_internal_error ~deps request reqd ~session_id
-                          ~protocol_version
-                          ("Internal error: " ^ Printexc.to_string exn)))
+                            let inline_sse : sse_conn_info option ref = ref None in
+                            try
+                              if wants_streaming_post then (
+                                let info =
+                                  stream_post_sse_start ~deps ~origin ~session_id
+                                    ~protocol_version:response_protocol_version
+                                    ~accept_warn_headers reqd
+                                in
+                                inline_sse := Some info;
+                                spawn_post_sse_keepalive ~sw ~clock info);
+                              let response_json =
+                                Mcp_eio.handle_request ~clock ~sw ~profile
+                                  ~mcp_session_id:session_id ?auth_token state
+                                  body_str
+                              in
+                              let protocol_version =
+                                get_protocol_version_for_session ~session_id request
+                              in
+                              let wants_sse =
+                                should_use_sse_for_body request body_str accept_mode
+                                && not force_json_response
+                                && not (request_force_json_response request)
+                              in
+                              if wants_streaming_post then
+                                match !inline_sse with
+                                | Some info ->
+                                    if response_json <> `Null then
+                                      stream_post_sse_json info response_json;
+                                    stream_post_sse_finish info
+                                | None -> ()
+                              else if wants_sse then
+                                match response_json with
+                                | `Null ->
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length", "0")
+                                        :: accept_warn_headers
+                                        @ mcp_headers session_id protocol_version)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `Accepted
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response ""
+                                | json when is_http_error_response json ->
+                                    let body = Yojson.Safe.to_string json in
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length",
+                                          string_of_int (String.length body))
+                                        :: accept_warn_headers
+                                        @ json_headers ~deps session_id
+                                            protocol_version origin)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `Bad_request
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response
+                                      body
+                                | json ->
+                                    let event =
+                                      Sse.format_event ~event_type:"message"
+                                        (Yojson.Safe.to_string json)
+                                    in
+                                    let body = sse_prime_event () ^ event in
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length",
+                                          string_of_int (String.length body))
+                                        :: accept_warn_headers
+                                        @ sse_headers ~deps session_id
+                                            protocol_version origin)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `OK
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response
+                                      body
+                              else
+                                match response_json with
+                                | `Null ->
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length", "0")
+                                        :: accept_warn_headers
+                                        @ mcp_headers session_id protocol_version)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `Accepted
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response ""
+                                | json when is_http_error_response json ->
+                                    let body = Yojson.Safe.to_string json in
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length",
+                                          string_of_int (String.length body))
+                                        :: accept_warn_headers
+                                        @ json_headers ~deps session_id
+                                            protocol_version origin)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `Bad_request
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response
+                                      body
+                                | json ->
+                                    let body = Yojson.Safe.to_string json in
+                                    let headers =
+                                      Httpun.Headers.of_list
+                                        (("content-length",
+                                          string_of_int (String.length body))
+                                        :: accept_warn_headers
+                                        @ json_headers ~deps session_id
+                                            protocol_version origin)
+                                    in
+                                    let response =
+                                      Httpun.Response.create ~headers `OK
+                                    in
+                                    Httpun.Reqd.respond_with_string reqd response
+                                      body
+                            with
+                            | Eio.Cancel.Cancelled _ as e -> raise e
+                            | exn ->
+                                (match !inline_sse with
+                                | Some info ->
+                                    stream_post_sse_json info
+                                      (mcp_internal_error_json
+                                         ("Internal error: "
+                                        ^ Printexc.to_string exn));
+                                    stream_post_sse_finish info
+                                | None ->
+                                    let protocol_version =
+                                      get_protocol_version_for_session ~session_id
+                                        request
+                                    in
+                                    respond_mcp_internal_error ~deps request reqd
+                                      ~session_id ~protocol_version
+                                      ("Internal error: "
+                                     ^ Printexc.to_string exn))))
 
 let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
     ?(sse_kind = Sse.Coordinator) request reqd =

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -53,6 +53,13 @@ let body_jsonrpc_method body_str =
     | _ -> None
   with Yojson.Json_error _ -> None
 
+let body_jsonrpc_id body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc fields -> List.assoc_opt "id" fields
+    | _ -> None
+  with Yojson.Json_error _ -> None
+
 let mcp_headers session_id protocol_version =
   [ ("mcp-session-id", session_id); ("mcp-protocol-version", protocol_version) ]
 
@@ -332,10 +339,11 @@ let stream_post_sse_json info (json : Yojson.Safe.t) =
     (send_raw info
        (Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json)))
 
-let mcp_internal_error_json msg =
+let mcp_internal_error_json ?id msg =
   `Assoc
     [
       ("jsonrpc", `String "2.0");
+      ("id", Option.value ~default:`Null id);
       ("error", `Assoc [ ("code", `Int (-32603)); ("message", `String msg) ]);
     ]
 
@@ -479,6 +487,7 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                               should_stream_post_tools_call request body_str
                                 accept_mode
                             in
+                            let response_id = body_jsonrpc_id body_str in
                             let inline_sse : sse_conn_info option ref = ref None in
                             try
                               if wants_streaming_post then (
@@ -605,7 +614,7 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                                 (match !inline_sse with
                                 | Some info ->
                                     stream_post_sse_json info
-                                      (mcp_internal_error_json
+                                      (mcp_internal_error_json ?id:response_id
                                          ("Internal error: "
                                         ^ Printexc.to_string exn));
                                     stream_post_sse_finish info

--- a/test/dune
+++ b/test/dune
@@ -693,6 +693,13 @@
  (modules test_mcp_full_cycle)
  (libraries masc_mcp alcotest eio eio_main yojson))
 
+; MCP POST streamable HTTP keepalive regression test
+(test
+ (name test_mcp_post_sse_e2e)
+ (modules test_mcp_post_sse_e2e)
+ (libraries alcotest yojson unix)
+ (deps ../bin/main_eio.exe))
+
 ; SSE storm guard endpoint-level integration tests
 (test
  (name test_sse_storm_e2e)

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -1,0 +1,382 @@
+open Alcotest
+
+module U = Yojson.Safe.Util
+
+type http_result = {
+  status : int option;
+  body : string;
+  curl_exit : int;
+  stderr : string;
+}
+
+let read_all ic =
+  let buf = Buffer.create 1024 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 4096
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let trim_cr s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
+
+let parse_status header_raw =
+  let lines = String.split_on_char '\n' header_raw |> List.map trim_cr in
+  let rec find_http = function
+    | [] -> None
+    | line :: rest ->
+        if String.length line >= 5 && String.sub line 0 5 = "HTTP/" then
+          match String.split_on_char ' ' line with
+          | _proto :: code :: _ -> (try Some (int_of_string code) with _ -> None)
+          | _ -> None
+        else
+          find_http rest
+  in
+  find_http lines
+
+let run_curl_post ?(max_time_sec = 8) ~port ~path ~session_id ~payload () =
+  let header_file = Filename.temp_file "mcp-post-sse-header-" ".txt" in
+  let body_file = Filename.temp_file "mcp-post-sse-body-" ".txt" in
+  let data_file = Filename.temp_file "mcp-post-sse-request-" ".json" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let oc = open_out_bin data_file in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc payload);
+  let args =
+    [|
+      "curl";
+      "-sS";
+      "-N";
+      "--http1.1";
+      "--max-time";
+      string_of_int max_time_sec;
+      "-X";
+      "POST";
+      "-H";
+      "Content-Type: application/json";
+      "-H";
+      "Accept: application/json, text/event-stream";
+      "-H";
+      Printf.sprintf "Mcp-Session-Id: %s" session_id;
+      "-H";
+      "Mcp-Protocol-Version: 2025-11-25";
+      "-o";
+      body_file;
+      "-D";
+      header_file;
+      "--data-binary";
+      "@" ^ data_file;
+      url;
+    |]
+  in
+  let (ic, oc2, ec) =
+    Unix.open_process_args_full "curl" args (Unix.environment ())
+  in
+  close_out_noerr oc2;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc2, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let status = parse_status (read_file header_file) in
+  let body = read_file body_file in
+  (try Sys.remove header_file with _ -> ());
+  (try Sys.remove body_file with _ -> ());
+  (try Sys.remove data_file with _ -> ());
+  { status; body; curl_exit; stderr }
+
+let run_curl_get ?(max_time_sec = 1) ~port ~path () =
+  let header_file = Filename.temp_file "mcp-post-sse-get-header-" ".txt" in
+  let body_file = Filename.temp_file "mcp-post-sse-get-body-" ".txt" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let args =
+    [|
+      "curl";
+      "-sS";
+      "--http1.1";
+      "--max-time";
+      string_of_int max_time_sec;
+      "-X";
+      "GET";
+      "-o";
+      body_file;
+      "-D";
+      header_file;
+      url;
+    |]
+  in
+  let (ic, oc, ec) =
+    Unix.open_process_args_full "curl" args (Unix.environment ())
+  in
+  close_out_noerr oc;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let status = parse_status (read_file header_file) in
+  let body = read_file body_file in
+  (try Sys.remove header_file with _ -> ());
+  (try Sys.remove body_file with _ -> ());
+  { status; body; curl_exit; stderr }
+
+let contains_substr needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else loop (i + 1)
+  in
+  n = 0 || loop 0
+
+let normalize_mcp_body body =
+  let lines = String.split_on_char '\n' body |> List.map trim_cr in
+  let prefix = "data: " in
+  let prefix_len = String.length prefix in
+  let data_lines =
+    List.filter_map
+      (fun line ->
+        if String.length line >= prefix_len
+           && String.sub line 0 prefix_len = prefix
+        then
+          Some (String.sub line prefix_len (String.length line - prefix_len))
+        else
+          None)
+      lines
+  in
+  match List.rev data_lines with
+  | last :: _ -> last
+  | [] -> body
+
+let find_main_eio_exe () =
+  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
+  let candidates =
+    match env_override with
+    | Some p -> [ p ]
+    | None ->
+        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
+        let build_candidates =
+          List.map
+            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
+            build_roots
+        in
+        [
+          "./bin/main_eio.exe";
+          "../bin/main_eio.exe";
+          "../../bin/main_eio.exe";
+          "../../../bin/main_eio.exe";
+          "../../../../bin/main_eio.exe";
+        ]
+        @ build_candidates
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+      fail
+        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close socket)
+    (fun () ->
+      Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
+      | () -> (
+          match Unix.getsockname socket with
+          | Unix.ADDR_INET (_, port) -> Some port
+          | _ -> fail "unexpected socket address")
+      | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) ->
+          None)
+
+let wait_for_health ~port ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if Unix.gettimeofday () > deadline then
+      false
+    else
+      let res = run_curl_get ~max_time_sec:1 ~port ~path:"/health" () in
+      match res.status with
+      | Some 200 -> true
+      | _ ->
+          Unix.sleepf 0.1;
+          loop ()
+  in
+  loop ()
+
+let wait_pid_exit ~pid ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    match Unix.waitpid [ Unix.WNOHANG ] pid with
+    | 0, _ ->
+        if Unix.gettimeofday () > deadline then false
+        else (
+          Unix.sleepf 0.05;
+          loop ())
+    | _pid, _status -> true
+    | exception Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  in
+  loop ()
+
+let merge_env_overrides overrides =
+  let override_keys = List.map fst overrides in
+  let is_override_key entry =
+    match String.index_opt entry '=' with
+    | None -> false
+    | Some idx ->
+        let key = String.sub entry 0 idx in
+        List.mem key override_keys
+  in
+  let base =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun entry -> not (is_override_key entry))
+  in
+  let injected = List.map (fun (k, v) -> k ^ "=" ^ v) overrides in
+  Array.of_list (base @ injected)
+
+let with_server f =
+  let exe = find_main_eio_exe () in
+  let port =
+    match find_free_port () with
+    | Some p -> p
+    | None -> Alcotest.skip ()
+  in
+  let log_file = Filename.temp_file "mcp-post-sse-e2e-" ".log" in
+  let base_path = Filename.temp_file "mcp-post-sse-base-" "" in
+  (try Sys.remove base_path with _ -> ());
+  Unix.mkdir base_path 0o755;
+  let log_fd =
+    Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+  in
+  let env =
+    merge_env_overrides
+      [
+        ("MASC_LODGE_ENABLED", "0");
+        ("MASC_LODGE_DAEMON_ENABLED", "0");
+        ("GRAPHQL_API_KEY", "");
+        ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+        ("MASC_POSTGRES_URL", "");
+        ("DATABASE_URL", "");
+        ("SUPABASE_DB_URL", "");
+        ("SB_PG_URL", "");
+        ("MASC_BOARD_BACKEND", "jsonl");
+        ("MASC_POST_SSE_KEEPALIVE_SEC", "1.0");
+      ]
+  in
+  let argv =
+    [| exe; "--port"; string_of_int port; "--base-path"; base_path |]
+  in
+  let pid = Unix.create_process_env exe argv env Unix.stdin log_fd log_fd in
+  Unix.close log_fd;
+  let cleanup () =
+    (try Unix.kill pid Sys.sigterm with _ -> ());
+    if not (wait_pid_exit ~pid ~timeout_s:2.0) then
+      (try Unix.kill pid Sys.sigkill with _ -> ());
+    ignore (wait_pid_exit ~pid ~timeout_s:1.0)
+  in
+  if not (wait_for_health ~port ~timeout_s:20.0) then (
+    cleanup ();
+    let logs = read_file log_file in
+    fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs)
+  );
+  Fun.protect ~finally:cleanup (fun () -> f ~port)
+
+let require_http_ok label result =
+  match result.status with
+  | Some 200 -> ()
+  | Some code ->
+      fail
+        (Printf.sprintf "%s returned HTTP %d (curl_exit=%d stderr=%s body=%s)"
+           label code result.curl_exit result.stderr result.body)
+  | None ->
+      fail
+        (Printf.sprintf "%s missing HTTP status (curl_exit=%d stderr=%s body=%s)"
+           label result.curl_exit result.stderr result.body)
+
+let parse_json_body label result =
+  require_http_ok label result;
+  let normalized = normalize_mcp_body result.body in
+  try Yojson.Safe.from_string normalized
+  with Yojson.Json_error err ->
+    fail
+      (Printf.sprintf "%s invalid JSON: %s\nbody=%s\nnormalized=%s" label err
+         result.body normalized)
+
+let tool_payload ~id ~name ~arguments =
+  Yojson.Safe.to_string
+    (`Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ("id", `Int id);
+        ("method", `String "tools/call");
+        ( "params",
+          `Assoc
+            [ ("name", `String name); ("arguments", arguments) ] );
+      ])
+
+let rec call_until_ready ~port ~retries_left =
+  let result =
+    run_curl_post ~max_time_sec:8 ~port ~path:"/mcp"
+      ~session_id:"post-sse-keepalive"
+      ~payload:
+        (tool_payload ~id:201 ~name:"masc_listen"
+           ~arguments:
+             (`Assoc [ ("agent_name", `String "slowpoke"); ("timeout", `Int 4) ]))
+      ()
+  in
+  match (result.status, retries_left) with
+  | Some 500, retries
+    when retries > 0
+         && contains_substr "Server state not initialized" result.body ->
+      Unix.sleepf 0.5;
+      call_until_ready ~port ~retries_left:(retries - 1)
+  | _ -> result
+
+let test_post_tools_call_streams_keepalive_before_result () =
+  with_server @@ fun ~port ->
+  let result = call_until_ready ~port ~retries_left:10 in
+  require_http_ok "streaming tools/call" result;
+  check int "curl exits cleanly" 0 result.curl_exit;
+  check bool "prime event sent" true (contains_substr "retry: 3000" result.body);
+  check bool "keepalive sent" true (contains_substr ": keepalive" result.body);
+  check bool "message event sent" true
+    (contains_substr "event: message" result.body);
+  let json = parse_json_body "streaming tools/call" result in
+  check bool "json-rpc error absent" true (json |> U.member "error" = `Null);
+  check bool "tool succeeded" false
+    (json |> U.member "result" |> U.member "isError" |> U.to_bool);
+  let text =
+    json |> U.member "result" |> U.member "content" |> U.index 0
+    |> U.member "text" |> U.to_string
+  in
+  check bool "listen timeout surfaced" true
+    (contains_substr "Listening timed out after 4s" text)
+
+let () =
+  run "mcp_post_sse_e2e"
+    [
+      ( "mcp",
+        [
+          test_case "post tools/call streams keepalive before result" `Slow
+            test_post_tools_call_streams_keepalive_before_result;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- stream inline SSE responses for POST /mcp tools/call requests before the tool finishes
- emit periodic : keepalive comments while long-running tool calls are in flight
- add an endpoint-level regression test for streamable POST keepalive delivery

## Testing
- DUNE_CACHE=disabled opam exec -- dune build --root . bin/main_eio.exe test/test_mcp_post_sse_e2e.exe
- DUNE_CACHE=disabled opam exec -- ./_build/default/test/test_mcp_post_sse_e2e.exe --show-errors
- manual curl against ./_build/default/bin/main_eio.exe on :18960 verifying retry/id, : keepalive, final event: message, and curl exit 0

Closes #2663