### PR TITLE
refactor(dashboard): remove redundant page headers duplicating SurfaceLead

### DIFF
--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -190,11 +190,7 @@ export function Command() {
 
   return html`
     <section class="flex flex-col gap-[18px]">
-      <div class="${CARD_STANDARD} flex justify-between gap-4 items-start max-[880px]:flex-col">
-        <div>
-          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">지휘면</h2>
-          <p class="text-[13px] text-[var(--text-muted)] leading-relaxed max-w-[62ch]">작전, 오케스트라, 스웜, 체인, 제어 표면을 선택해 실제 MCP 도구 기반 현황을 확인합니다.</p>
-        </div>
+      <div class="${CARD_STANDARD} flex justify-end gap-4 items-center flex-wrap">
         <div class="flex gap-3 flex-wrap">
           <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -178,33 +178,6 @@ export function LogViewer() {
 
   return html`
     <div class="logs-viewer flex h-full min-h-0 flex-col gap-4">
-      <section class="rounded-xl border border-[rgba(138,163,211,0.16)] bg-[linear-gradient(135deg,rgba(9,22,42,0.95),rgba(7,13,24,0.92))] px-5 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-        <div class="flex flex-wrap items-start justify-between gap-4">
-          <div class="min-w-0 max-w-[760px]">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.22em] text-[rgba(154,217,255,0.72)]">Observer</div>
-            <h2 class="mt-2 text-[26px] font-semibold tracking-[-0.04em] text-[var(--text-strong)]">Execution Log Stream</h2>
-            <p class="mt-2 text-[13px] leading-relaxed text-[var(--text-muted)]">
-              structured logger를 기본으로 보고, 남아 있는 legacy stderr/traceln도 같은 ring buffer에서 함께 봅니다. 새 항목은 delta로만 가져와서 탭 비용을 줄였습니다.
-            </p>
-          </div>
-
-          <div class="grid min-w-[240px] gap-2 rounded-lg border border-[rgba(255,255,255,0.07)] bg-[rgba(255,255,255,0.04)] p-3">
-            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
-              <span>현재 필터</span>
-              <strong class="text-[var(--text-strong)]">${levelFilter.value}+</strong>
-            </div>
-            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
-              <span>buffer total</span>
-              <strong class="text-[var(--text-strong)] tabular-nums">${(logTotal.value ?? 0).toLocaleString()}</strong>
-            </div>
-            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
-              <span>새로고침</span>
-              <strong class="${autoRefresh.value ? 'text-[#92f3b4]' : 'text-[var(--text-strong)]'}">${autoRefresh.value ? 'delta auto' : 'manual'}</strong>
-            </div>
-          </div>
-        </div>
-      </section>
-
       <section class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[rgba(138,163,211,0.16)] bg-[rgba(7,13,24,0.86)]">
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
@@ -263,7 +236,7 @@ export function LogViewer() {
           </div>
 
           <div class="logs-actions flex flex-wrap gap-3 items-center text-[11px] text-[color:var(--text-muted)]">
-            <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.value.length.toLocaleString()} shown</span>
+            <span class="rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 tabular-nums">${logEntries.value.length.toLocaleString()} / ${(logTotal.value ?? 0).toLocaleString()}</span>
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
                 type="checkbox"

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -99,19 +99,12 @@ export function Mission() {
 
   return html`
     <section class="flex flex-col gap-5">
-      <!-- Header -->
-      <div class="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h2 class="m-0 text-lg font-semibold text-[var(--text-strong)]">상황판</h2>
-          <p class="m-0 mt-1 text-xs text-[var(--text-muted)] leading-relaxed">세션, 에이전트, 키퍼 현황.</p>
-        </div>
-        <div class="flex gap-2 flex-wrap items-center">
-          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-body)]">
-            <span class="w-1.5 h-1.5 rounded-full ${toneClass(mission.summary.room_health) === 'ok' ? 'bg-[var(--ok)]' : toneClass(mission.summary.room_health) === 'warn' ? 'bg-[var(--warn)]' : 'bg-[var(--bad)]'}"></span>
-            ${statusLabel(mission.summary.room_health)}
-          </span>
-          <span class="text-[10px] text-[var(--text-muted)]">${mission.generated_at ? relativeTime(mission.generated_at) : ''}</span>
-        </div>
+      <div class="flex items-center justify-end gap-2 flex-wrap">
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium border border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-body)]">
+          <span class="w-1.5 h-1.5 rounded-full ${toneClass(mission.summary.room_health) === 'ok' ? 'bg-[var(--ok)]' : toneClass(mission.summary.room_health) === 'warn' ? 'bg-[var(--warn)]' : 'bg-[var(--bad)]'}"></span>
+          ${statusLabel(mission.summary.room_health)}
+        </span>
+        <span class="text-[10px] text-[var(--text-muted)]">${mission.generated_at ? relativeTime(mission.generated_at) : ''}</span>
       </div>
 
       <${MissionContextBar}

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -154,13 +154,7 @@ export function Ops() {
 
   return html`
     <section class="flex flex-col gap-4">
-      <div class="${CARD_STANDARD} flex justify-between items-start gap-4 max-[880px]:flex-col">
-        <div>
-          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">개입</h2>
-          <p class="text-[13px] text-[var(--text-muted)] max-w-[62ch] leading-relaxed">
-            방, 세션, 키퍼를 나눠 보고 바로 개입합니다.
-          </p>
-        </div>
+      <div class="${CARD_STANDARD} flex justify-end items-center gap-4 flex-wrap">
         <div class="flex items-end gap-3 flex-wrap max-[880px]:w-full">
           <label class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium" for="ops-actor">개입 ID</label>
           <input

--- a/dashboard/src/components/proof.ts
+++ b/dashboard/src/components/proof.ts
@@ -111,17 +111,10 @@ export function Proof() {
 
   return html`
     <section class="flex flex-col gap-6">
-      <!-- Header -->
-      <div class="flex items-start justify-between gap-5 flex-wrap px-1">
-        <div class="max-w-2xl">
-          <h2 class="text-xl font-bold text-text-strong tracking-wide mb-2">근거 <span class="text-text-muted font-normal text-sm ml-2">Evidence & Context</span></h2>
-          <p class="text-[13px] text-text-muted leading-relaxed">이 세션이 실제로 여러 참여자의 흔적, 상호작용, 산출물, 실행 backing을 남겼는지 읽는 표면입니다.</p>
-        </div>
-        <div class="flex gap-2 flex-wrap items-center pt-1">
-          <span class="px-3 py-1.5 rounded-full text-[11px] font-bold border shadow-sm ${verdictTone(verdict)}">${verdictChipLabel(verdict)}</span>
-          ${snapshot?.session_id ? html`<span class="px-2.5 py-1 rounded-md bg-white/5 border border-white/10 text-text-muted text-[11px] font-mono shadow-sm">${snapshot.session_id}</span>` : null}
-          ${snapshot?.generated_at ? html`<span class="px-2.5 py-1 rounded-md bg-white/5 border border-white/10 text-text-muted text-[11px] font-mono shadow-sm">${relativeTime(snapshot.generated_at)}</span>` : null}
-        </div>
+      <div class="flex items-center justify-end gap-2 flex-wrap px-1">
+        <span class="px-3 py-1.5 rounded-full text-[11px] font-bold border shadow-sm ${verdictTone(verdict)}">${verdictChipLabel(verdict)}</span>
+        ${snapshot?.session_id ? html`<span class="px-2.5 py-1 rounded-md bg-white/5 border border-white/10 text-text-muted text-[11px] font-mono shadow-sm">${snapshot.session_id}</span>` : null}
+        ${snapshot?.generated_at ? html`<span class="px-2.5 py-1 rounded-md bg-white/5 border border-white/10 text-text-muted text-[11px] font-mono shadow-sm">${relativeTime(snapshot.generated_at)}</span>` : null}
       </div>
 
       ${proofError.value

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -31,7 +31,6 @@ export function Tools() {
     <div>
       <${Card} title="시스템 도구 목록" class="section mb-4">
         <div class="mb-4">
-          <h2 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-1">시스템 도구 목록</h2>
           <p class="text-[12px] text-[var(--text-muted)] leading-relaxed">
             ${showFullInventory.value
               ? 'hidden/deprecated 포함 전체 도구 surface를 봅니다.'

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -63,8 +63,7 @@ export function Worktrees() {
 
   return html`
     <div class="grid gap-5">
-      <div class="flex items-center justify-between">
-        <h2 class="text-lg font-semibold tracking-wide text-text-strong">활성 워크트리</h2>
+      <div class="flex items-center justify-end">
         <span class="text-xs font-medium px-2.5 py-1 bg-white/10 rounded-full text-text-muted border border-white/5">${worktrees.length}개</span>
       </div>
       


### PR DESCRIPTION
## Summary
- SurfaceLead(dashboard-shell.ts)가 navigation config 기반으로 모든 페이지의 제목+설명을 이미 렌더링하는데, 7개 컴포넌트가 자체 h2/description을 중복 표시하고 있었음
- 중복 제목 블록을 전부 제거하고, 기능적 UI(배지/버튼/입력)만 보존
- logs.ts의 stats 패널(필터/buffer/새로고침)은 toolbar과도 중복 → buffer total만 toolbar 배지에 "shown / total" 형태로 통합

### 변경 파일 (7개)
| 파일 | 제거된 h2 | 보존된 기능 요소 |
|------|----------|---------------|
| logs.ts | "Execution Log Stream" + stats 패널 | buffer total → toolbar 배지 |
| mission.ts | "상황판" | health badge, timestamp |
| proof.ts | "근거 / Evidence & Context" | verdict chip, session badges |
| worktrees.ts | "활성 워크트리" | count badge |
| command/index.ts | "지휘면" | Tick/새로고침 buttons |
| ops/index.ts | "개입" | actor input, 새로고침 button |
| tools/tools-main.ts | "시스템 도구 목록" | Card title, toggle button |

## Test plan
- [x] `tsc --noEmit` pass
- [x] `vite build` pass
- [ ] 브라우저에서 각 페이지 확인 (제목이 SurfaceLead에서만 표시되는지, 기능 요소가 정상 동작하는지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)