### PR TITLE
test: harden harness RPC error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ test-contract:
 test-contract-live:
 	bash scripts/harness/contract/streamable_http_contract.sh
 	bash scripts/harness/contract/team_session_contract.sh
-	bash scripts/harness/contract/game_view_precondition.sh
-	bash scripts/harness/contract/trpg_session_contract.sh
+	bash scripts/harness/contract/golden_path_1_contract.sh
 
 # All tests: unit + contract
 test-all: test-unit test-contract

--- a/docs/VERIFICATION-MATRIX.md
+++ b/docs/VERIFICATION-MATRIX.md
@@ -13,11 +13,10 @@
   - 실행 진입점은 `make test` 또는 `scripts/ci-run-tests.sh "opam exec -- dune test"`를 기준으로 본다
 - `./_build/default/test/test_sse_storm_e2e.exe`
   - server executable 기반 SSE reconnect e2e
-- contract harness 4종
+- contract harness 3종
   - `scripts/harness/contract/streamable_http_contract.sh`
   - `scripts/harness/contract/team_session_contract.sh`
-  - `scripts/harness/contract/game_view_precondition.sh`
-  - `scripts/harness/contract/trpg_session_contract.sh`
+  - `scripts/harness/contract/golden_path_1_contract.sh`
 
 로컬 진입점:
 
@@ -30,8 +29,9 @@ make test-contract
 
 의도:
 
-- 기본 브랜치가 초록이면 core MCP/HTTP/team-session/TRPG 계약이 깨지지 않았다고 볼 수 있어야 한다.
+- 기본 브랜치가 초록이면 core MCP/HTTP/team-session/golden-path 계약이 깨지지 않았다고 볼 수 있어야 한다.
 - contract harness는 “서버가 이미 떠 있음”을 전제로 하지 않고 hermetic bootstrap 경로로 실행돼야 한다.
+- `archive/trpg/scripts/` 아래의 game-view/TRPG 계약 스크립트는 active CI-required contract suite가 아니라 archive/manual 성격으로 본다.
 
 ## 2. Optional Env-Gated
 
@@ -91,7 +91,7 @@ make test-contract
 
 - `make test`
 - `test_sse_storm_e2e.exe`
-- contract harness 4종
+- contract harness 3종
 
 그리고 이번 변경에서 **필수로 올리지 않는 것**은:
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -57,6 +57,7 @@ CI 필수 게이트. 외부 의존성 없이 재현 가능.
 | Contract Harness (3종) | `make test-contract` | Streamable HTTP, Team Session, Golden Path |
 
 Contract harness는 서버가 이미 떠 있다고 가정하지 않고 hermetic bootstrap 경로로 실행된다.
+`archive/trpg/scripts/` 아래의 game-view/TRPG 계약 스크립트는 현재 active contract suite가 아니라 archive/manual 검증으로 분류한다.
 
 **판정 기준**: main 브랜치가 green이면 core MCP/HTTP/Team-Session 계약이 깨지지 않았다.
 

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -21,14 +21,23 @@ source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 PASS=0
 FAIL=0
+JOINED=0
 
 step_pass() { PASS=$((PASS + 1)); echo "  PASS"; }
 step_fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
+cleanup() {
+  if [ "$JOINED" -eq 1 ]; then
+    call_tool 1099 "masc_leave" "{\"agent_name\":\"$AGENT_NAME\"}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
 # ── Step 1/8: join ──
 echo "[1/8] masc_join"
 r1="$(call_tool 1001 "masc_join" "{\"agent_name\":\"$AGENT_NAME\",\"capabilities\":[\"test\",\"contract\"]}")"
-if require_ok "$r1" 2>/dev/null; then
+if require_ok "$r1"; then
+  JOINED=1
   step_pass
 else
   step_fail "join rejected"
@@ -39,7 +48,7 @@ fi
 # ── Step 2/8: add_task ──
 echo "[2/8] masc_add_task"
 r2="$(call_tool 1002 "masc_add_task" "{\"title\":\"GP1 contract task $(date +%s)\",\"priority\":2,\"description\":\"Automated golden path 1 contract verification\"}")"
-if require_ok "$r2" 2>/dev/null; then
+if require_ok "$r2"; then
   step_pass
 else
   step_fail "add_task failed"
@@ -47,11 +56,8 @@ else
   exit 1
 fi
 # Extract task_id from response
-task_id="$(printf "%s" "$r2" | jq -r 'try (.result.content[0].text | capture("task-[0-9]+-[0-9]+") | .string) catch empty' 2>/dev/null || true)"
-if [ -z "$task_id" ]; then
-  # Fallback: try to find task_id in raw text
-  task_id="$(printf "%s" "$r2" | grep -oE 'task-[0-9]+-[0-9]+' | head -1 || true)"
-fi
+task_text="$(printf "%s" "$r2" | extract_text)"
+task_id="$(printf "%s\n" "$task_text" | rg -o 'task-[0-9]+(-[0-9]+)?' | head -n1 || true)"
 if [ -z "$task_id" ]; then
   step_fail "could not extract task_id from add_task response"
   echo "$r2"
@@ -62,7 +68,7 @@ echo "  task_id=$task_id"
 # ── Step 3/8: claim ──
 echo "[3/8] masc_transition (claim)"
 r3="$(call_tool 1003 "masc_transition" "{\"task_id\":\"$task_id\",\"action\":\"claim\",\"notes\":\"GP1 contract claim\"}")"
-if require_ok "$r3" 2>/dev/null; then
+if require_ok "$r3"; then
   step_pass
 else
   step_fail "claim failed"
@@ -73,7 +79,7 @@ fi
 # ── Step 4/8: plan_set_task ──
 echo "[4/8] masc_plan_set_task"
 r4="$(call_tool 1004 "masc_plan_set_task" "{\"task_id\":\"$task_id\"}")"
-if require_ok "$r4" 2>/dev/null; then
+if require_ok "$r4"; then
   step_pass
 else
   step_fail "plan_set_task failed"
@@ -83,7 +89,7 @@ fi
 # ── Step 5/8: heartbeat ──
 echo "[5/8] masc_heartbeat"
 r5="$(call_tool 1005 "masc_heartbeat" "{\"agent_name\":\"$AGENT_NAME\",\"status\":\"working\",\"progress\":\"GP1 contract step 5/8\"}")"
-if require_ok "$r5" 2>/dev/null; then
+if require_ok "$r5"; then
   step_pass
 else
   step_fail "heartbeat failed"
@@ -93,7 +99,7 @@ fi
 # ── Step 6/8: broadcast ──
 echo "[6/8] masc_broadcast"
 r6="$(call_tool 1006 "masc_broadcast" "{\"message\":\"GP1 contract verification in progress\"}")"
-if require_ok "$r6" 2>/dev/null; then
+if require_ok "$r6"; then
   step_pass
 else
   step_fail "broadcast failed"
@@ -103,7 +109,7 @@ fi
 # ── Step 7/8: status ──
 echo "[7/8] masc_status"
 r7="$(call_tool 1007 "masc_status" "{}")"
-if require_ok "$r7" 2>/dev/null; then
+if require_ok "$r7"; then
   step_pass
 else
   step_fail "status failed"
@@ -113,7 +119,7 @@ fi
 # ── Step 8/8: done ──
 echo "[8/8] masc_transition (done)"
 r8="$(call_tool 1008 "masc_transition" "{\"task_id\":\"$task_id\",\"action\":\"done\",\"notes\":\"GP1 contract verification complete\"}")"
-if require_ok "$r8" 2>/dev/null; then
+if require_ok "$r8"; then
   step_pass
 else
   step_fail "done transition failed"

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -17,6 +17,7 @@ export MCP_URL="${MCP_URL:-http://127.0.0.1:${PORT}/mcp}"
 export CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
 export CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
 export CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-25}"
+export HARNESS_LOG_FILE="${HARNESS_LOG_FILE:-$LOG_FILE}"
 
 SERVER_PID=""
 
@@ -56,7 +57,8 @@ if ! harness_wait_for_health "$PORT" 25; then
   exit 1
 fi
 
-run_contract 1 2 "streamable_http_contract.sh"
-run_contract 2 2 "team_session_contract.sh"
+run_contract 1 3 "streamable_http_contract.sh"
+run_contract 2 3 "team_session_contract.sh"
+run_contract 3 3 "golden_path_1_contract.sh"
 
 echo "PASS: contract harness suite"

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+
+: "${MCP_URL:=http://127.0.0.1:8935/mcp}"
+: "${CURL_RETRY_COUNT:=4}"
+: "${CURL_RETRY_DELAY_SEC:=1}"
+: "${CURL_TIMEOUT_SEC:=25}"
+: "${HTTP_TIMEOUT_SEC:=$CURL_TIMEOUT_SEC}"
+: "${MCP_SESSION_ID:=}"
+: "${HARNESS_LOG_FILE:=}"
+: "${HARNESS_LOG_TAIL_LINES:=120}"
+: "${MCP_CURL_EXTRA_ARGS:=}"
+
+_HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${_HARNESS_DIR}/jsonrpc_sse.sh"
+
+mcp_print_log_tail() {
+  local log_file="${1:-${HARNESS_LOG_FILE:-}}"
+  local lines="${2:-${HARNESS_LOG_TAIL_LINES:-120}}"
+  if [[ -n "$log_file" && -f "$log_file" ]]; then
+    echo "---- tail -n ${lines} ${log_file} ----" >&2
+    tail -n "$lines" "$log_file" >&2 || true
+  fi
+}
+
+mcp_fail_with_context() {
+  local message="$1"
+  local payload="${2:-}"
+  echo "FAIL: ${message}" >&2
+  if [[ -n "$payload" ]]; then
+    if printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
+      printf '%s\n' "$payload" | jq . >&2 || printf '%s\n' "$payload" >&2
+    else
+      printf '%s\n' "$payload" >&2
+    fi
+  fi
+  mcp_print_log_tail
+  return 1
+}
+
+mcp_extract_text() {
+  jq -r 'if ._harness_error? then empty else try (.result.content[0].text) catch empty end'
+}
+
+mcp_extract_result() {
+  jq -c '
+    if ._harness_error? then
+      empty
+    else
+      try (
+        .result.content[0].text
+        | fromjson
+        | if has("result") and .result != null then .result else . end
+      ) catch empty
+    end
+  '
+}
+
+mcp_extract_payload() {
+  jq -c '
+    if ._harness_error? then
+      empty
+    else
+      try (.result.content[0].text | fromjson | .payload) catch empty
+    end
+  '
+}
+
+mcp_extract_error() {
+  jq -r '
+    if ._harness_error? then
+      ._harness_error.message // ""
+    elif (.error | type) == "object" and (.error.message | type) == "string" then
+      .error.message
+    else
+      try (.result.content[0].text | fromjson | .message) catch ""
+    end
+  '
+}
+
+mcp_require_json() {
+  local payload="$1"
+  local label="${2:-response}"
+  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
+    mcp_fail_with_context "${label}: invalid JSON payload" "$payload"
+    return 1
+  fi
+}
+
+mcp_require_jsonrpc_ok() {
+  local payload="$1"
+  local label="${2:-response}"
+  mcp_require_json "$payload" "$label" || return 1
+
+  if printf '%s' "$payload" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
+    local details
+    details="$(printf '%s' "$payload" | jq -r '
+      ._harness_error as $e
+      | [
+          ($e.category // "transport"),
+          ("endpoint=" + ($e.endpoint // "")),
+          ("curl_exit=" + ($e.curl_exit // "")),
+          (if ($e.stderr // "") = "" then empty else "stderr=" + $e.stderr end)
+        ]
+      | join(", ")
+    ')"
+    mcp_fail_with_context "${label}: ${details}" "$payload"
+    return 1
+  fi
+
+  if ! printf '%s' "$payload" | jq -e '.error == null' >/dev/null 2>&1; then
+    local err
+    err="$(printf '%s' "$payload" | jq -c '.error')"
+    mcp_fail_with_context "${label}: JSON-RPC error" "$err"
+    return 1
+  fi
+}
+
+mcp_require_tool_ok() {
+  local payload="$1"
+  local label="${2:-tool call}"
+  mcp_require_jsonrpc_ok "$payload" "$label" || return 1
+
+  if printf '%s' "$payload" | jq -e '.result.isError == true' >/dev/null 2>&1; then
+    local text
+    text="$(printf '%s' "$payload" | mcp_extract_text)"
+    if [[ -n "$text" ]]; then
+      mcp_fail_with_context "${label}: tool returned isError=true" "$text"
+    else
+      mcp_fail_with_context "${label}: tool returned isError=true" "$payload"
+    fi
+    return 1
+  fi
+}
+
+_mcp_build_transport_error() {
+  local message="$1"
+  local endpoint="$2"
+  local curl_exit="$3"
+  local stderr_text="$4"
+  local timeout_sec="$5"
+  jq -cn \
+    --arg message "$message" \
+    --arg endpoint "$endpoint" \
+    --arg curl_exit "$curl_exit" \
+    --arg stderr_text "$stderr_text" \
+    --arg timeout_sec "$timeout_sec" \
+    '{
+      _harness_error: {
+        category: "transport",
+        message: $message,
+        endpoint: $endpoint,
+        curl_exit: $curl_exit,
+        stderr: $stderr_text,
+        timeout_sec: $timeout_sec
+      }
+    }'
+}
+
+_mcp_build_request_body() {
+  local id="$1"
+  local method="$2"
+  local params_json="$3"
+  jq -cn \
+    --argjson id "$id" \
+    --arg method "$method" \
+    --argjson params "$params_json" \
+    '{jsonrpc:"2.0", id:$id, method:$method, params:$params}'
+}
+
+mcp_jsonrpc_call() {
+  local id="$1"
+  local method="$2"
+  local params_json="$3"
+  local session_id="${4:-${MCP_SESSION_ID:-}}"
+  local token="${5:-}"
+  local endpoint="${6:-${MCP_URL:-}}"
+  local timeout_sec="${HTTP_TIMEOUT_SEC:-${CURL_TIMEOUT_SEC:-25}}"
+
+  local request_body
+  if ! request_body="$(_mcp_build_request_body "$id" "$method" "$params_json" 2>/dev/null)"; then
+    _mcp_build_transport_error \
+      "failed to build JSON-RPC request" \
+      "$endpoint" \
+      "local" \
+      "invalid id or params JSON" \
+      "$timeout_sec"
+    return 0
+  fi
+
+  local attempt=1
+  local max_attempts="${CURL_RETRY_COUNT:-1}"
+  local retry_delay="${CURL_RETRY_DELAY_SEC:-1}"
+  local raw=""
+  local status=0
+  local stderr_text=""
+  local -a extra_args=()
+  if [[ -n "${MCP_CURL_EXTRA_ARGS:-}" ]]; then
+    read -r -a extra_args <<< "${MCP_CURL_EXTRA_ARGS}"
+  fi
+
+  while :; do
+    local body_file stderr_file
+    body_file="$(mktemp "${TMPDIR:-/tmp}/masc-jsonrpc-body.XXXXXX.json")"
+    stderr_file="$(mktemp "${TMPDIR:-/tmp}/masc-jsonrpc-stderr.XXXXXX.log")"
+    printf '%s' "$request_body" >"$body_file"
+
+    local -a cmd=(
+      curl -sS --max-time "$timeout_sec"
+      -X POST "$endpoint"
+      -H 'Content-Type: application/json'
+      -H 'Accept: application/json, text/event-stream'
+    )
+    if [[ -n "$session_id" ]]; then
+      cmd+=( -H "Mcp-Session-Id: $session_id" )
+    fi
+    if [[ -n "$token" ]]; then
+      cmd+=( -H "Authorization: Bearer $token" )
+    fi
+    if [[ "${#extra_args[@]}" -gt 0 ]]; then
+      cmd+=( "${extra_args[@]}" )
+    fi
+    cmd+=( --data-binary "@$body_file" )
+
+    set +e
+    raw="$("${cmd[@]}" 2>"$stderr_file")"
+    status=$?
+    set -e
+    stderr_text="$(cat "$stderr_file" 2>/dev/null || true)"
+    rm -f "$body_file" "$stderr_file"
+
+    if [[ "$status" -eq 0 ]]; then
+      jsonrpc_normalize_response "$raw" "$id"
+      return 0
+    fi
+
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
+      break
+    fi
+    case "$status" in
+      7|28)
+        sleep "$retry_delay"
+        attempt=$((attempt + 1))
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  _mcp_build_transport_error \
+    "curl failed after ${attempt}/${max_attempts} attempts" \
+    "$endpoint" \
+    "$status" \
+    "$stderr_text" \
+    "$timeout_sec"
+}
+
+mcp_call_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  local session_id="${4:-${MCP_SESSION_ID:-}}"
+  local token="${5:-}"
+  local endpoint="${6:-${MCP_URL:-}}"
+
+  local params_json
+  if ! params_json="$(jq -cn --arg name "$tool_name" --argjson arguments "$args_json" '{name:$name, arguments:$arguments}' 2>/dev/null)"; then
+    _mcp_build_transport_error \
+      "failed to build tools/call params" \
+      "$endpoint" \
+      "local" \
+      "invalid tool args JSON" \
+      "${HTTP_TIMEOUT_SEC:-${CURL_TIMEOUT_SEC:-25}}"
+    return 0
+  fi
+
+  mcp_jsonrpc_call "$id" "tools/call" "$params_json" "$session_id" "$token" "$endpoint"
+}

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -2,7 +2,6 @@
 # Shared test framework for MCP contract harness scripts.
 #
 # Source this file after setting MCP_URL and other env vars.
-# Depends on: jsonrpc_sse.sh (auto-sourced)
 
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
 : "${CURL_RETRY_COUNT:=4}"
@@ -10,43 +9,13 @@
 : "${CURL_TIMEOUT_SEC:=25}"
 : "${MCP_SESSION_ID:=}"
 
-_HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source "${_HARNESS_DIR}/jsonrpc_sse.sh"
+_HARNESS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_HARNESS_LIB_DIR}/mcp_jsonrpc.sh"
 
 # Contract harness validates MCP semantics, not h2c prior-knowledge support.
 # Use normal HTTP negotiation here so the suite doesn't hang when the server
 # speaks HTTP/1.1 on localhost.
-# POST a JSON body to the MCP endpoint with retry logic.
-# Includes mcp-session-id header when MCP_SESSION_ID is set.
-# Usage: curl_post_mcp '{"jsonrpc":"2.0",...}'
-curl_post_mcp() {
-  local body="$1"
-  local attempt=1
-  local output=""
-  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    if [ -n "$MCP_SESSION_ID" ]; then
-      output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-        -H 'Content-Type: application/json' \
-        -H 'Accept: application/json, text/event-stream' \
-        -H "mcp-session-id: $MCP_SESSION_ID" \
-        -d "$body" 2>/dev/null)" && {
-          printf "%s" "$output"
-          return 0
-        }
-    elif output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -d "$body" 2>/dev/null)"; then
-      printf "%s" "$output"
-      return 0
-    fi
-    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
-      sleep "$CURL_RETRY_DELAY_SEC"
-    fi
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:-}"
 
 # Call an MCP tool and normalize SSE/JSON response.
 # Usage: call_tool <jsonrpc_id> <tool_name> <args_json>
@@ -54,38 +23,36 @@ call_tool() {
   local id="$1"
   local name="$2"
   local args_json="$3"
-  local raw
-  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
-  jsonrpc_normalize_response "$raw" "$id"
+  mcp_call_tool "$id" "$name" "$args_json"
+}
+
+extract_text() {
+  mcp_extract_text
 }
 
 # Extract .result from MCP tool response content.
 # Usage: echo "$response" | extract_result
 extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
+  mcp_extract_result
 }
 
 # Extract .payload from MCP tool response content.
 # Usage: echo "$response" | extract_payload
 extract_payload() {
-  jq -c 'try (.result.content[0].text | fromjson | .payload) catch empty'
+  mcp_extract_payload
 }
 
 # Extract error message from MCP tool response.
 # Usage: echo "$response" | extract_error
 extract_error() {
-  jq -r 'try (.result.content[0].text | fromjson | .message) catch (.error.message // "")'
+  mcp_extract_error
 }
 
-# Assert that a payload is valid JSON. Exits 1 on failure.
+# Assert that a payload is a successful tool response.
 # Usage: require_ok "$response"
 require_ok() {
   local payload="$1"
-  if ! printf "%s" "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid json payload"
-    printf "%s\n" "$payload"
-    exit 1
-  fi
+  mcp_require_tool_ok "$payload" "contract tool call"
 }
 
 # Print pass/fail summary line.

--- a/scripts/harness/workload/team_session_failed_batch_spawn.sh
+++ b/scripts/harness/workload/team_session_failed_batch_spawn.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 SERVER_EXE="${SERVER_EXE:-${ROOT_DIR}/_build/default/bin/main_eio.exe}"
 PORT="${PORT:-}"
 BASE_PATH="${BASE_PATH:-}"
@@ -76,6 +76,8 @@ if [ -z "$LOG_FILE" ]; then
 else
   LOG_FILE_WAS_EXPLICIT="true"
 fi
+HARNESS_LOG_FILE="${HARNESS_LOG_FILE:-$LOG_FILE}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http1.1}"
 
 MCP_URL="http://127.0.0.1:${PORT}/mcp"
 OPERATOR_URL="http://127.0.0.1:${PORT}/mcp/operator"
@@ -83,36 +85,6 @@ SERVER_PID=""
 
 read_file() {
   cat "$1"
-}
-
-jsonrpc_call() {
-  local session_id="$1"
-  local token="$2"
-  local id="$3"
-  local method="$4"
-  local params="$5"
-  local endpoint="${6:-$MCP_URL}"
-  local body_file
-  body_file="$(mktemp "${TMPDIR:-/tmp}/masc-jsonrpc-body.XXXXXX.json")"
-  printf '{"jsonrpc":"2.0","id":%s,"method":"%s","params":%s}' "$id" "$method" "$params" >"$body_file"
-  local cmd=(curl -sS --http2-prior-knowledge --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$endpoint" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -H "Mcp-Session-Id: $session_id" \
-    --data-binary "@$body_file")
-  if [ -n "$token" ]; then
-    cmd+=( -H "Authorization: Bearer $token" )
-  fi
-  local response
-  set +e
-  response="$("${cmd[@]}")"
-  local curl_status=$?
-  set -e
-  rm -f "$body_file"
-  if [ "$curl_status" -ne 0 ]; then
-    return "$curl_status"
-  fi
-  jsonrpc_normalize_response "$response" "$id"
 }
 
 allocate_port() {
@@ -132,56 +104,33 @@ call_tool() {
   local tool_name="$4"
   local args_json="$5"
   local endpoint="${6:-$MCP_URL}"
-  jsonrpc_call "$session_id" "$token" "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}" "$endpoint"
+  mcp_call_tool "$id" "$tool_name" "$args_json" "$session_id" "$token" "$endpoint"
 }
 
 extract_tool_text() {
-  jq -r 'try (.result.content[0].text) catch empty'
+  mcp_extract_text
 }
 
 extract_tool_result() {
-  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
-}
-
-extract_response_error() {
-  jq -r 'if (.error | type) == "object" and (.error.message | type) == "string" then .error.message else empty end'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "false"'
+  mcp_extract_result
 }
 
 require_json() {
   local payload="$1"
-  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid JSON payload"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
+  local label="${2:-team_session_failed_batch_spawn}"
+  mcp_require_json "$payload" "$label"
 }
 
 require_success_response() {
   local payload="$1"
-  require_json "$payload"
-  local err
-  err="$(printf '%s' "$payload" | extract_response_error)"
-  if [ -n "$err" ]; then
-    echo "FAIL: JSON-RPC error: $err"
-    printf '%s\n' "$payload"
-    exit 1
-  fi
+  local label="${2:-team_session_failed_batch_spawn response}"
+  mcp_require_jsonrpc_ok "$payload" "$label"
 }
 
 require_tool_success() {
   local payload="$1"
-  require_success_response "$payload"
-  local is_error
-  is_error="$(printf '%s' "$payload" | extract_is_error)"
-  if [ "$is_error" = "true" ]; then
-    echo "FAIL: tool returned isError=true"
-    printf '%s\n' "$payload" | extract_tool_text
-    exit 1
-  fi
+  local label="${2:-team_session_failed_batch_spawn tool}"
+  mcp_require_tool_ok "$payload" "$label"
 }
 
 require_json_condition() {

--- a/scripts/harness/workload/team_session_real_spawn.sh
+++ b/scripts/harness/workload/team_session_real_spawn.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 COORD_AGENT="${COORD_AGENT:-team-session-real-spawn}"
@@ -18,6 +18,7 @@ MCP_SESSION_ID="${MCP_SESSION_ID:-team-session-harness-$(date +%s)-$RANDOM}"
 RUN_TAG="${RUN_TAG:-$(date +%s)-$RANDOM}"
 DEFAULT_PARTICIPANTS_CSV="proof-a-${RUN_TAG},proof-b-${RUN_TAG},proof-c-${RUN_TAG},proof-d-${RUN_TAG}"
 PARTICIPANTS_CSV="${PARTICIPANTS_CSV:-$DEFAULT_PARTICIPANTS_CSV}"
+MCP_CURL_EXTRA_ARGS="${MCP_CURL_EXTRA_ARGS:---http2-prior-knowledge}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"
@@ -52,54 +53,25 @@ if [ "$EFFECTIVE_SESSION_DURATION_SEC" -lt "$required_duration_sec" ]; then
   EFFECTIVE_SESSION_DURATION_SEC="$required_duration_sec"
 fi
 
-jsonrpc_call() {
-  local id="$1"
-  local method="$2"
-  local params="$3"
-  local attempts=0
-  local max_attempts=4
-  local raw=""
-  while [ "$attempts" -lt "$max_attempts" ]; do
-    if raw="$(curl -sS --http2-prior-knowledge -m "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -H "mcp-session-id: $MCP_SESSION_ID" \
-      -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}" 2>/dev/null)"; then
-      jsonrpc_normalize_response "$raw" "$id"
-      return 0
-    fi
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  return 1
-}
-
 call_tool() {
   local id="$1"
   local tool_name="$2"
   local args_json="$3"
-  jsonrpc_call "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
+  mcp_call_tool "$id" "$tool_name" "$args_json"
 }
 
 extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
+  mcp_extract_result
 }
 
 extract_text() {
-  jq -r 'try (.result.content[0].text) catch empty'
-}
-
-extract_is_error() {
-  jq -r 'try (.result.isError) catch "true"'
+  mcp_extract_text
 }
 
 require_json() {
   local payload="$1"
-  if ! printf "%s" "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid payload"
-    printf "%s\n" "$payload"
-    exit 1
-  fi
+  local label="${2:-team_session_real_spawn}"
+  mcp_require_tool_ok "$payload" "$label"
 }
 
 cleanup() {
@@ -114,9 +86,9 @@ trap cleanup EXIT
 
 echo "[1/9] init + join coordinator"
 r1="$(call_tool 90001 "masc_init" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a}')")"
-require_json "$r1"
+require_json "$r1" "masc_init"
 r2="$(call_tool 90002 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
-require_json "$r2"
+require_json "$r2" "masc_join"
 
 echo "[2/9] preflight cleanup"
 call_tool 90011 "masc_cleanup_zombies" "{}" >/dev/null 2>&1 || true
@@ -143,7 +115,7 @@ start_args="$(jq -cn \
      agents:$participants
    }')"
 start_raw="$(call_tool 90003 "masc_team_session_start" "$start_args")"
-require_json "$start_raw"
+require_json "$start_raw" "masc_team_session_start"
 SESSION_ID="$(printf "%s" "$start_raw" | extract_result | jq -r '.session_id // empty')"
 if [ -z "$SESSION_ID" ]; then
   echo "FAIL: session_id missing"
@@ -177,13 +149,7 @@ for i in "${!PARTICIPANTS[@]}"; do
     --argjson timeout "$SPAWN_TIMEOUT_SEC" \
     '{agent_name:$runtime,prompt:$prompt,timeout_seconds:$timeout,working_dir:$wd}')"
   spawn_raw="$(call_tool $((90100 + i)) "masc_spawn" "$spawn_args")"
-  require_json "$spawn_raw"
-  spawn_is_error="$(printf "%s" "$spawn_raw" | extract_is_error)"
-  if [ "$spawn_is_error" = "true" ]; then
-    echo "FAIL: spawned agent ${actor} returned isError=true"
-    printf "%s\n" "$spawn_raw"
-    exit 1
-  fi
+  require_json "$spawn_raw" "masc_spawn(${actor})"
   spawn_text="$(printf "%s" "$spawn_raw" | extract_text)"
   if ! printf "%s" "$spawn_text" | rg -q "✅ Agent completed|done:${actor}"; then
     echo "WARN: spawned agent ${actor} completion text did not match strict pattern"
@@ -192,11 +158,11 @@ done
 
 echo "[5/9] restore coordinator identity"
 restore_raw="$(call_tool 90012 "masc_join" "$(jq -cn --arg a "$COORD_AGENT" '{agent_name:$a,capabilities:["team-session","proof-harness"]}')")"
-require_json "$restore_raw"
+require_json "$restore_raw" "restore masc_join"
 
 echo "[6/9] verify team_turn actor diversity"
 events_raw="$(call_tool 90004 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:400}')")"
-require_json "$events_raw"
+require_json "$events_raw" "masc_team_session_events"
 events_result="$(printf "%s" "$events_raw" | extract_result)"
 team_turn_count="$(printf "%s" "$events_result" | jq -r '.count // 0')"
 unique_turn_actors="$(printf "%s" "$events_result" | jq -r '[.events[]? | .detail.actor // empty | select(. != "")] | unique | length')"
@@ -233,18 +199,12 @@ if [ "$unique_turn_actors" -lt "${#PARTICIPANTS[@]}" ]; then
         --argjson timeout "$SPAWN_TIMEOUT_SEC" \
         '{agent_name:$runtime,prompt:$prompt,timeout_seconds:$timeout,working_dir:$wd}')"
       recovery_raw="$(call_tool $((90200 + recovery_idx)) "masc_spawn" "$recovery_args")"
-      require_json "$recovery_raw"
-      recovery_is_error="$(printf "%s" "$recovery_raw" | extract_is_error)"
-      if [ "$recovery_is_error" = "true" ]; then
-        echo "FAIL: recovery spawn for ${actor} returned isError=true"
-        printf "%s\n" "$recovery_raw"
-        exit 1
-      fi
+      require_json "$recovery_raw" "recovery masc_spawn(${actor})"
       recovery_idx=$((recovery_idx + 1))
     done
 
     events_raw="$(call_tool 90013 "masc_team_session_events" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:600}')")"
-    require_json "$events_raw"
+    require_json "$events_raw" "recovery masc_team_session_events"
     events_result="$(printf "%s" "$events_raw" | extract_result)"
     team_turn_count="$(printf "%s" "$events_result" | jq -r '.count // 0')"
     unique_turn_actors="$(printf "%s" "$events_result" | jq -r '[.events[]? | .detail.actor // empty | select(. != "")] | unique | length')"
@@ -261,7 +221,7 @@ fi
 
 echo "[7/9] stop session + report"
 stop_raw="$(call_tool 90005 "masc_team_session_stop" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,reason:"real_spawn_harness_done",generate_report:true}')")"
-require_json "$stop_raw"
+require_json "$stop_raw" "masc_team_session_stop"
 stop_result="$(printf "%s" "$stop_raw" | extract_result)"
 if [ -z "$stop_result" ]; then
   echo "FAIL: stop_session did not return result payload"
@@ -271,7 +231,7 @@ fi
 stop_deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
 while :; do
   stop_status_raw="$(call_tool 90008 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-  require_json "$stop_status_raw"
+  require_json "$stop_status_raw" "stop poll masc_team_session_status"
   stop_status_result="$(printf "%s" "$stop_status_raw" | extract_result)"
   stop_status="$(printf "%s" "$stop_status_result" | jq -r '.session.status // empty')"
   if [ "$stop_status" != "running" ]; then
@@ -287,7 +247,7 @@ done
 
 echo "[8/9] generate proof"
 prove_raw="$(call_tool 90006 "masc_team_session_prove" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s,generate_report_if_missing:true}')")"
-require_json "$prove_raw"
+require_json "$prove_raw" "masc_team_session_prove"
 prove_result="$(printf "%s" "$prove_raw" | extract_result)"
 verdict="$(printf "%s" "$prove_result" | jq -r '.proof.verdict // empty')"
 required_turn_actors="$(printf "%s" "$prove_result" | jq -r '.proof.evidence.required_turn_actors // 0')"
@@ -307,7 +267,7 @@ fi
 
 echo "[9/9] final status snapshot"
 status_raw="$(call_tool 90007 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
-require_json "$status_raw"
+require_json "$status_raw" "final masc_team_session_status"
 status_result="$(printf "%s" "$status_raw" | extract_result)"
 session_status="$(printf "%s" "$status_result" | jq -r '.session.status // empty')"
 model_cache_hits="$(printf "%s" "$status_result" | jq -r '.inference_cache_metrics.hits // 0')"


### PR DESCRIPTION
## Summary
- add a shared shell MCP JSON-RPC helper that normalizes transport failures, JSON-RPC errors, and tool `isError` handling
- move contract harness helpers and representative workload harnesses onto the shared layer
- align active contract gate/docs around streamable HTTP, team session, and golden path

## Verification
- `bash -n scripts/harness/lib/mcp_jsonrpc.sh scripts/harness/lib/test_framework.sh scripts/harness/contract/run_all.sh scripts/harness/contract/golden_path_1_contract.sh scripts/harness/workload/team_session_real_spawn.sh scripts/harness/workload/team_session_failed_batch_spawn.sh`
- `scripts/harness/contract/run_all.sh`
