### PR TITLE
refactor(keeper): mode 기반 도구 카테고리화 제거

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -82,14 +82,14 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let active_model =
     Safe_ops.json_string ~default:"" "active_model" json |> String.trim
   in
-  let policy_mode =
+  let _policy_mode =
     Safe_ops.json_string ~default:"heuristic" "policy_mode" json
     |> canonical_policy_mode
   in
-  let policy_voice_enabled =
+  let _policy_voice_enabled =
     Safe_ops.json_bool ~default:false "policy_voice_enabled" json
   in
-  let policy_shell_mode =
+  let _policy_shell_mode =
     Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
     |> canonical_policy_shell_mode
   in
@@ -102,10 +102,6 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   if models = [] then errors := "models is required" :: !errors;
   if active_model <> "" && not (List.mem active_model (allowed_models @ models)) then
     errors := "active_model must be included in models or allowed_models" :: !errors;
-  if policy_voice_enabled && policy_mode <> "learned_offline_v1" then
-    errors := "policy_voice_enabled=true requires learned_offline_v1" :: !errors;
-  if policy_shell_mode = "readonly" && policy_mode <> "learned_offline_v1" then
-    errors := "policy_shell_mode=readonly requires learned_offline_v1" :: !errors;
   if
     (Safe_ops.json_string ~default:"explicit_only" "trigger_mode" json
      |> Keeper_contract.trigger_mode_of_string

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -66,9 +66,6 @@ let keeper_research_loop_tool_names =
   Tool_research.schemas
   |> List.map (fun (t : Types.tool_schema) -> t.name)
 
-let is_research_profile (meta : keeper_meta) =
-  meta.soul_profile = "research"
-
 let keeper_coding_tool_names = Tool_code_write.tool_names
 
 let keeper_voice_tool_schemas =
@@ -123,67 +120,51 @@ let keeper_default_model_tools (meta : keeper_meta) : Types.tool_schema list =
   else
     keeper_model_tools
 
+(** Return all keeper tool names unconditionally.
+    Mode-based categorization removed: every keeper gets the full tool set.
+    Safety is handled by eval_gate deny lists (kept intact). *)
 let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
     string list =
   if write_done then
     []
-  else if keeper_policy_mode_is_learned meta then
-    let base = keeper_coordination_tool_names @ keeper_read_tool_names in
-    let with_voice =
-      if meta.policy_voice_enabled then keeper_voice_tool_names @ base else base
-    in
-    let shell_mode = canonical_policy_shell_mode meta.policy_shell_mode in
-    let with_shell =
-      if shell_mode = "readonly" || shell_mode = "coding" then
-        keeper_shell_readonly_tool_names @ with_voice
-      else with_voice
-    in
-    let with_governance = keeper_governance_tool_names @ with_shell in
-    let with_research =
-      if is_research_profile meta then
-        keeper_research_loop_tool_names @ keeper_autoresearch_tool_names
-        @ with_governance
-      else with_governance
-    in
-    let with_coding =
-      if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-        keeper_coding_shard_tool_names @ keeper_coding_tool_names @ with_research
-      else with_research
-    in
-    dedupe_tool_names (keeper_masc_tool_names meta @ keeper_board_tool_names @ with_coding)
   else
-    let base_names = keeper_default_tool_names meta in
-    let with_research =
-      if is_research_profile meta then
-        keeper_research_loop_tool_names @ keeper_autoresearch_tool_names @ base_names
-      else base_names
+    let all_names =
+      keeper_read_tool_names
+      @ keeper_coordination_tool_names
+      @ keeper_board_tool_names
+      @ keeper_shell_readonly_tool_names
+      @ keeper_governance_tool_names
+      @ keeper_coding_shard_tool_names
+      @ keeper_coding_tool_names
+      @ keeper_autoresearch_tool_names
+      @ keeper_research_loop_tool_names
+      @ (keeper_masc_tool_names meta)
+      @ (keeper_default_tool_names meta)
     in
-    let with_coding =
-      if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-        keeper_coding_shard_tool_names @ keeper_coding_tool_names @ with_research
-      else with_research
+    let with_voice =
+      if meta.policy_voice_enabled then keeper_voice_tool_names @ all_names
+      else all_names
     in
-    dedupe_tool_names (keeper_masc_tool_names meta @ with_coding)
+    dedupe_tool_names with_voice
 
+(** Return all keeper model tool schemas unconditionally.
+    Mode-based categorization removed: every keeper gets the full tool set.
+    Safety is handled by eval_gate deny lists (kept intact). *)
 let keeper_allowed_model_tools ?(write_done = false) (meta : keeper_meta) :
     Types.tool_schema list =
   let allowed = keeper_allowed_tool_names ~write_done meta in
   if allowed = [] then
     []
   else
-    let base = keeper_default_model_tools meta in
-    let with_research =
-      if is_research_profile meta then
-        base @ Tool_research.schemas @ Tool_shard.autoresearch_keeper_tools
-      else base
+    let all_schemas =
+      (keeper_default_model_tools meta)
+      @ Tool_research.schemas
+      @ Tool_shard.autoresearch_keeper_tools
+      @ Tool_shard.coding_tools
+      @ Tool_code_write.schemas
+      @ (keeper_masc_tool_schemas meta)
     in
-    let with_coding =
-      if canonical_policy_shell_mode meta.policy_shell_mode = "coding" then
-        with_research @ Tool_shard.coding_tools @ Tool_code_write.schemas
-      else with_research
-    in
-    let with_masc = with_coding @ keeper_masc_tool_schemas meta in
-    with_masc
+    all_schemas
     |> List.filter (fun tool -> List.mem tool.Types.name allowed)
 
 let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -36,11 +36,8 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
 
 (** Build OAS hooks for a keeper agent.
 
-    Tool availability is determined at keeper creation time by
-    [keeper_exec_tools] based on policy_shell_mode. No secondary
-    autonomy-level filtering — industry standard is binary tool grants.
-
-    Safety gates:
+    All keepers receive the full tool set unconditionally.
+    Safety is enforced through eval_gate deny lists and these hooks:
     1. Cost budget — reject when accumulated cost exceeds limit
     2. Destructive pattern detection — reject dangerous bash/edit commands
 

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -99,23 +99,13 @@ let ensure_keeper_exists
               | model :: _ -> model
               | [] -> "")
     in
-    let policy_mode =
-      (if default_voice_enabled_for name then None else profile_defaults.policy_mode)
-      |> Option.value
-           ~default:
-             (if default_voice_enabled_for name then "explicit_event_v1"
-              else "heuristic")
-      |> canonical_policy_mode
-    in
+    (* Mode categorization removed: always use fixed values. *)
+    let policy_mode = canonical_policy_mode "heuristic" in
     let policy_voice_enabled =
-      (if not (default_voice_enabled_for name) then profile_defaults.policy_voice_enabled else None)
+      profile_defaults.policy_voice_enabled
       |> Option.value ~default:false
     in
-    let policy_shell_mode =
-      (if not (default_voice_enabled_for name) then profile_defaults.policy_shell_mode else None)
-      |> Option.value ~default:"disabled"
-      |> canonical_policy_shell_mode
-    in
+    let policy_shell_mode = canonical_policy_shell_mode "coding" in
     let allowed_paths = [] in
     let room_scope =
       profile_defaults.room_scope |> Option.value ~default:"current"

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -59,17 +59,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            | model :: _ -> model
             | [] -> "")
   in
-  let policy_mode =
-    let default_policy_mode =
-      if default_voice_enabled_for p.name then "explicit_event_v1" else "heuristic"
-    in
-    p.policy_mode_opt
-    |> first_some
-         (if default_voice_enabled_for p.name then None else p.profile_defaults.policy_mode)
-    |> Option.value
-         ~default:default_policy_mode
-    |> canonical_policy_mode
-  in
+  (* Mode categorization removed: always use fixed values. *)
+  let policy_mode = canonical_policy_mode "heuristic" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
@@ -77,14 +68,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
        then p.profile_defaults.policy_voice_enabled else None)
     |> Option.value ~default:false
   in
-  let policy_shell_mode =
-    first_some
-      p.policy_shell_mode_opt
-      (if not (default_voice_enabled_for p.name && Option.is_none p.policy_mode_opt)
-       then p.profile_defaults.policy_shell_mode else None)
-    |> Option.value ~default:"disabled"
-    |> canonical_policy_shell_mode
-  in
+  let policy_shell_mode = canonical_policy_shell_mode "coding" in
   let allowed_paths =
     Option.value ~default:[] p.allowed_paths_opt
   in

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -57,28 +57,15 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
             | model :: _ -> model
             | [] -> "")
   in
-  let policy_mode =
-    first_some
-      p.policy_mode_opt
-      (first_some
-         (if String.trim old.policy_mode <> "" then Some old.policy_mode else None)
-         p.profile_defaults.policy_mode)
-    |> Option.value ~default:"heuristic"
-    |> canonical_policy_mode
-  in
+  (* Mode categorization removed: always use fixed values. *)
+  let policy_mode = canonical_policy_mode "heuristic" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
       (first_some (Some old.policy_voice_enabled) p.profile_defaults.policy_voice_enabled)
     |> Option.value ~default:false
   in
-  let policy_shell_mode =
-    first_some
-      p.policy_shell_mode_opt
-      (first_some (Some old.policy_shell_mode) p.profile_defaults.policy_shell_mode)
-    |> Option.value ~default:"disabled"
-    |> canonical_policy_shell_mode
-  in
+  let policy_shell_mode = canonical_policy_shell_mode "coding" in
   let allowed_paths =
     Option.value ~default:old.allowed_paths p.allowed_paths_opt
   in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -161,10 +161,9 @@ let canonical_trigger_mode = function
   | "explicit_only" -> "explicit_only"
   | _ -> "explicit_only"
 
+(** Mode categorization removed. Always returns "heuristic" regardless of input.
+    Field kept for JSON backward compatibility. *)
 let canonical_policy_mode = function
-  | "learned_offline_v1" -> "learned_offline_v1"
-  | "explicit_event_v1" -> "explicit_event_v1"
-  | "model_deliberation" -> "model_deliberation"
   | _ -> "heuristic"
 
 let canonical_voice_channel = function
@@ -184,11 +183,10 @@ let default_voice_channel_for name =
 let default_voice_agent_id_for name =
   if default_voice_enabled_for name then name else ""
 
+(** Mode categorization removed. Always returns "coding" (full access) regardless
+    of input. Field kept for JSON backward compatibility. *)
 let canonical_policy_shell_mode = function
-  | "readonly" -> "readonly"
-  | "sandboxed" -> "sandboxed"
-  | "coding" -> "coding"
-  | _ -> "disabled"
+  | _ -> "coding"
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -60,20 +60,17 @@ let auth_snapshot_json ctx =
       ("credentials", `List credentials);
     ]
 
-(** Flat default keeper gate config. No autonomy level dispatch. *)
+(** Flat default keeper gate config.
+    allowlist_enabled=false: all tools are available by default.
+    Safety is enforced through the denied_tools list (eval_gate). *)
 let keeper_default_gate_config () : Eval_gate.gate_config =
   {
     max_cost_usd = 0.10;
     max_tool_calls_per_turn = 5;
     entropy_threshold = 2;
     destructive_check_enabled = true;
-    allowlist_enabled = true;
-    allowed_tools = [
-      "keeper_board_get"; "keeper_board_post"; "keeper_board_comment"; "keeper_board_list";
-      "keeper_read"; "keeper_fs_read";
-      "keeper_memory_search";
-      "keeper_time_now"; "keeper_context_status";
-    ];
+    allowlist_enabled = false;
+    allowed_tools = [];
     denied_tools = [
       "keeper_bash"; "keeper_edit"; "keeper_fs_edit"; "keeper_github";
     ];

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -393,8 +393,7 @@ let shard_coding : shard = {
   tools = coding_tools;
   removable = true;
   description =
-    "Coding tools: github/shell bridge + worktree/code inspection \
-     (requires policy_shell_mode=coding)";
+    "Coding tools: github/shell bridge + worktree/code inspection";
 }
 
 let shard_weather : shard = {
@@ -464,8 +463,8 @@ let shard_autoresearch : shard = {
 let agent_shards : (string, string list) Hashtbl.t = Hashtbl.create 32
 
 (** Default shards for a new keeper.
-    Keep the default surface focused on coordination/governance. Voice,
-    weather, and coding are opt-in. *)
+    All keepers get all shards unconditionally. Safety is handled by
+    eval_gate deny lists, not by shard membership. *)
 let default_shard_names : string list = [
   "base";
   "board";
@@ -474,6 +473,9 @@ let default_shard_names : string list = [
   "library";
   "taskboard";
   "governance";
+  "coding";
+  "autoresearch";
+  "weather";
 ]
 
 let get_agent_shards (agent_name : string) : string list =


### PR DESCRIPTION
## Summary

- 모든 keeper에게 모든 도구를 무조건 제공하도록 변경
- mode 기반 조건 분기(policy_mode, policy_shell_mode, soul_profile) 제거
- 안전성은 eval_gate deny list가 그대로 담당 (eval_gate.ml 미변경)
- policy_mode/policy_shell_mode 필드는 JSON 하위 호환성을 위해 유지 (값만 고정)

### 변경 파일 (9개)

| 파일 | 변경 |
|------|------|
| `keeper_exec_tools.ml` | tool name/schema 반환을 무조건 전체 합집합으로 평탄화 |
| `keeper_types_profile.ml` | canonical_policy_mode→"heuristic", canonical_policy_shell_mode→"coding" 고정 |
| `tool_shard.ml` | default_shard_names에 coding/autoresearch/weather 추가 |
| `tool_misc.ml` | allowlist_enabled=false 설정 |
| `keeper_turn_up_create.ml` | policy_mode/shell_mode 고정값 사용 |
| `keeper_turn_up_update.ml` | 동일 |
| `keeper_turn_setup.ml` | 동일 (autoboot 경로) |
| `keeper_exec_persona.ml` | mode 의존 검증 제거 |
| `keeper_hooks_oas.ml` | 주석 정리 |

## Test plan

- [x] `dune build` 통과
- [x] `test_relay_coverage` 72/72 통과
- [x] `test_keeper_tool_exposure` 24/28 통과 (4 실패는 mode 제한 assertions → PR 2에서 수정)
- [x] `test_keeper_safety_gates` 52/56 통과 (4 실패는 mode grant assertions → PR 2에서 수정)
- [ ] PR 2: 테스트 코드를 새 동작에 맞게 업데이트

Generated with [Claude Code](https://claude.com/claude-code)