### PR TITLE
fix(room): add safe_yield to prevent Eio loop starvation during Sys.readdir loops

### DIFF
--- a/lib/room/room_agent.ml
+++ b/lib/room/room_agent.ml
@@ -16,6 +16,7 @@ let get_agents_status config =
   else begin
     let agents = ref [] in
     Sys.readdir agents_path |> Array.iter (fun name ->
+        Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat agents_path name in
         let json = read_json config path in
@@ -166,6 +167,7 @@ let find_agents_by_capability config ~capability =
   else begin
     let matching = ref [] in
     Sys.readdir agents_path |> Array.iter (fun name ->
+        Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat agents_path name in
         let json = read_json config path in

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -75,6 +75,7 @@ let cleanup_zombies
     let zombie_entries = ref [] in (* (name, path) list *)
     List.iter (fun agents_path ->
       Sys.readdir agents_path |> Array.iter (fun name ->
+        Room_query.safe_yield ();
         if Filename.check_suffix name ".json" then begin
           let path = Filename.concat agents_path name in
           let json = read_json config path in
@@ -249,6 +250,7 @@ let gc config ?(days=7) () =
 
   if Sys.file_exists messages_path then begin
     Sys.readdir messages_path |> Array.iter (fun name ->
+        Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat messages_path name in
         let json = read_json config path in
@@ -360,6 +362,7 @@ let gc config ?(days=7) () =
     let archive_ts_dir = Filename.concat
       (Filename.concat (Filename.concat config.base_path ".masc") "archive") "team-sessions" in
     Sys.readdir ts_root |> Array.iter (fun session_id ->
+        Room_query.safe_yield ();
       let sdir = Filename.concat ts_root session_id in
       if Sys.is_directory sdir then begin
         let sjson = Filename.concat sdir "session.json" in
@@ -447,6 +450,7 @@ let gc config ?(days=7) () =
     let now_f = Time_compat.now () in
     let threshold_sec = float_of_int days *. 86400.0 in
     Sys.readdir rooms_root |> Array.iter (fun room_id ->
+        Room_query.safe_yield ();
       let room_dir = Filename.concat rooms_root room_id in
       if Sys.is_directory room_dir then begin
         (* Find most recent mtime across all files in the room *)
@@ -454,6 +458,7 @@ let gc config ?(days=7) () =
         let rec scan dir =
           (try
             Sys.readdir dir |> Array.iter (fun name ->
+              Room_query.safe_yield ();
               let path = Filename.concat dir name in
               if Sys.is_directory path then scan path
               else

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -119,6 +119,7 @@ let reset config =
     let rec rm_rf path =
       if Sys.is_directory path then begin
         Sys.readdir path |> Array.iter (fun name ->
+          Room_query.safe_yield ();
           rm_rf (Filename.concat path name)
         );
         Unix.rmdir path

--- a/lib/room/room_vote.ml
+++ b/lib/room/room_vote.ml
@@ -180,6 +180,7 @@ let list_votes config =
   else begin
     let votes = ref [] in
     Sys.readdir votes_path |> Array.iter (fun name ->
+        Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat votes_path name in
         votes := read_json config path :: !votes


### PR DESCRIPTION
### 원인 분석 및 개선 사항
앞서 수행한 `room_query.ml`의 Eio Starvation 개선과 동일한 맥락입니다. 
`room_gc.ml`, `room_agent.ml`, `room_vote.ml`, `room_init.ml` 파일 등에서도 `Sys.readdir`를 통해 얻은 파일 목록을 순회하며(주로 `Array.iter`) 동기적 파일 읽기/삭제 등의 무거운 I/O 작업을 연속으로 수행하는 지점이 다수 존재했습니다.

파일이 수백~수천 개로 누적된 환경(특히 GC 작업 시)에서는 이러한 반복문이 Eio 이벤트 루프(Domain)를 장시간 블로킹하여 시스템의 전체적인 응답 지연이나 타임아웃을 유발할 수 있습니다.

### 개선 효과
반복문 내부의 각 반복(iteration)마다 `Room_query.safe_yield ()`를 호출하여 제어권을 다른 파이버에 양보하도록 수정했습니다.
이를 통해 디렉토리 정리(GC)나 전체 에이전트 목록 조회 등 파일 시스템을 순회하는 작업이 진행되는 동안에도 다른 HTTP/SSE 요청 등 Eio의 스케줄링 대상 작업들이 차단되지 않고 정상적으로 서비스될 수 있습니다.