### PR TITLE
test: remove ripgrep dependency from golden path harness

### DIFF
--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -57,7 +57,7 @@ else
 fi
 # Extract task_id from response
 task_text="$(printf "%s" "$r2" | extract_text)"
-task_id="$(printf "%s\n" "$task_text" | rg -o 'task-[0-9]+(-[0-9]+)?' | head -n1 || true)"
+task_id="$(printf "%s\n" "$task_text" | grep -oE 'task-[0-9]+(-[0-9]+)?' | head -n1 || true)"
 if [ -z "$task_id" ]; then
   step_fail "could not extract task_id from add_task response"
   echo "$r2"


### PR DESCRIPTION
## Summary
- replace `rg` task id extraction in `golden_path_1_contract.sh` with `grep -oE`
- keep the harness contract compatible with GitHub runners that do not have ripgrep installed
- scope the change to the CI regression surfaced by Contract Harness

## Verification
- `bash -n scripts/harness/contract/golden_path_1_contract.sh`
- `bash -n scripts/harness/contract/run_all.sh`
- `scripts/harness/contract/run_all.sh`