### PR TITLE
fix(eio): protect shared mutable state with Atomic and Eio.Mutex

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -170,11 +170,10 @@ let latest_heartbeat_results : (string, heartbeat_result_snapshot) Hashtbl.t =
 
 let heartbeat_mutex = Eio.Mutex.create ()
 
-let heartbeat_snapshot_seq = ref 0
+let heartbeat_snapshot_seq = Atomic.make 0
 
 let next_heartbeat_snapshot_seq () =
-  heartbeat_snapshot_seq := !heartbeat_snapshot_seq + 1;
-  !heartbeat_snapshot_seq
+  Atomic.fetch_and_add heartbeat_snapshot_seq 1 + 1
 
 let latest_heartbeat_task agent =
   Eio.Mutex.use_ro heartbeat_mutex (fun () ->

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -91,8 +91,9 @@ let is_expired entry =
   | None -> false
   | Some exp -> Time_compat.now () > exp
 
-(** Timestamp of last batch eviction, used to throttle periodic checks. *)
-let last_batch_eviction = ref 0.0
+(** Timestamp of last batch eviction, used to throttle periodic checks.
+    Atomic to prevent eviction stampede under concurrent fiber access. *)
+let last_batch_eviction = Atomic.make 0.0
 
 (** Minimum interval between batch evictions (seconds). *)
 let batch_eviction_interval = 60.0
@@ -125,7 +126,11 @@ let evict_expired config =
     Returns number of evicted entries (0 if skipped). *)
 let maybe_evict_expired config =
   let now = Time_compat.now () in
-  if now -. !last_batch_eviction < batch_eviction_interval then 0
+  let old_val = Atomic.get last_batch_eviction in
+  if now -. old_val < batch_eviction_interval then 0
+  else if not (Atomic.compare_and_set last_batch_eviction old_val now) then
+    (* Another fiber already claimed this eviction window *)
+    0
   else begin
     let dir = cache_dir config in
     if not (Sys.file_exists dir) then 0
@@ -151,13 +156,10 @@ let maybe_evict_expired config =
               | _ -> acc
         ) 0 sample in
         let ratio = float_of_int expired_count /. float_of_int sample_size in
-        if ratio > 0.5 then begin
-          last_batch_eviction := now;
+        if ratio > 0.5 then
           evict_expired config
-        end else begin
-          last_batch_eviction := now;
+        else
           0
-        end
       end
   end
 

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -4,9 +4,30 @@
     Legacy handlers have been removed.
 *)
 
-(** Global state for Mitosis cell lifecycle *)
+(** Global state for Mitosis cell lifecycle.
+    Protected by [mitosis_mutex]. Use [get_cell]/[set_cell]/[with_cell_rw]
+    instead of direct ref access. *)
 let current_cell = ref (Mitosis.create_stem_cell ~generation:0)
 let stem_pool = ref (Mitosis.init_pool ~config:Mitosis.default_config)
+let mitosis_mutex = Eio.Mutex.create ()
+
+let get_cell () = Eio.Mutex.use_ro mitosis_mutex (fun () -> !current_cell)
+let get_pool () = Eio.Mutex.use_ro mitosis_mutex (fun () -> !stem_pool)
+
+let set_cell cell =
+  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+    current_cell := cell)
+
+let set_pool pool =
+  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+    stem_pool := pool)
+
+let with_cell_rw f =
+  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+    let cell, pool, result = f !current_cell !stem_pool in
+    current_cell := cell;
+    stem_pool := pool;
+    result)
 
 (** JSON-RPC request *)
 type jsonrpc_request = {

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -300,7 +300,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
       let summary = arg_get_string "summary" "" in
       let current_task = arg_get_string "current_task" "" in
       let target_agent = arg_get_string "target_agent" "claude" in
-      let cell = !(Mcp_server.current_cell) in
+      let cell = Mcp_server.get_cell () in
       let mitosis_config = Mitosis.default_config in
 
       let should_prepare_now = Mitosis.should_prepare ~config:mitosis_config ~cell ~context_ratio in
@@ -330,7 +330,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
           Some (false, "full_context required when context_ratio > 50%")
         else begin
           let prepared_cell = Mitosis.prepare_for_division ~config:mitosis_config ~cell ~full_context in
-          Mcp_server.current_cell := prepared_cell;
+          Mcp_server.set_cell prepared_cell;
           let response = `Assoc [
             ("status", `String "prepared");
             ("context_ratio", `Float context_ratio);
@@ -370,18 +370,19 @@ let dispatch (ctx : context) ~(name : string) : result option =
               ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds ()
           in
 
+          let pool = Mcp_server.get_pool () in
           let (spawn_result, new_cell, new_pool, _handoff_dna) =
             Mitosis.execute_mitosis
               ~config:mitosis_config
-              ~pool:!(Mcp_server.stem_pool)
+              ~pool
               ~parent:cell
               ~full_context:(Printf.sprintf "Summary: %s\n\nCurrent Task: %s\n\nContext:\n%s"
                   (if summary = "" then "Memento mori - context limit reached" else summary)
                   current_task full_context)
               ~spawn_fn
           in
-              Mcp_server.current_cell := new_cell;
-              Mcp_server.stem_pool := new_pool;
+              Mcp_server.set_cell new_cell;
+              Mcp_server.set_pool new_pool;
 
               let response = `Assoc [
                 ("status", `String "divided");

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -57,7 +57,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   ignore (arg_get_string, arg_get_int, arg_get_float, arg_get_bool, arg_get_string_list, arg_get_string_opt, arg_get_float_opt);
   match (name : string) with
   | "masc_self_introspect" ->
-      let cell = !(Mcp_server.current_cell) in
+      let cell = Mcp_server.get_cell () in
       let generation = cell.Mitosis.generation in
       let tool_calls = cell.Mitosis.tool_call_count in
       let task_count = cell.Mitosis.task_count in
@@ -126,7 +126,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       let summary = arg_get_string "summary" "" in
       let current_task = arg_get_string "current_task" "" in
       let target_agent = arg_get_string "target_agent" "claude" in
-      let cell = !(Mcp_server.current_cell) in
+      let cell = Mcp_server.get_cell () in
       let mitosis_config = Mitosis.default_config in
       let should_prepare_now = Mitosis.should_prepare ~config:mitosis_config ~cell ~context_ratio in
       let should_handoff_now = Mitosis.should_handoff ~config:mitosis_config ~cell ~context_ratio in
@@ -148,7 +148,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           Some (false, "full_context required when context_ratio > 50%")
         else begin
           let prepared_cell = Mitosis.prepare_for_division ~config:mitosis_config ~cell ~full_context in
-          Mcp_server.current_cell := prepared_cell;
+          Mcp_server.set_cell prepared_cell;
           let response = `Assoc [
             ("status", `String "prepared");
             ("context_ratio", `Float context_ratio);
@@ -176,15 +176,16 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
               let spawn_fn ~prompt =
                 Spawn.spawn ~agent_name:target_agent
                   ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds () in
+              let pool = Mcp_server.get_pool () in
               let (spawn_result, new_cell, new_pool, _handoff_dna) =
                 Mitosis.execute_mitosis ~config:mitosis_config
-                  ~pool:!(Mcp_server.stem_pool) ~parent:cell
+                  ~pool ~parent:cell
                   ~full_context:(Printf.sprintf "Summary: %s\n\nCurrent Task: %s\n\nContext:\n%s"
                       (if summary = "" then "Memento mori - context limit reached" else summary)
                       current_task full_context)
                   ~spawn_fn in
-              Mcp_server.current_cell := new_cell;
-              Mcp_server.stem_pool := new_pool;
+              Mcp_server.set_cell new_cell;
+              Mcp_server.set_pool new_pool;
               let response = `Assoc [
                 ("status", `String "divided");
                 ("context_ratio", `Float context_ratio);

--- a/lib/tool_mitosis_oas.ml
+++ b/lib/tool_mitosis_oas.ml
@@ -42,8 +42,8 @@ let get_string args key default =
 let get_float args key default =
   Tool_args.get_float args key default
 
-let current_cell () = !(Mcp_server.current_cell)
-let stem_pool () = !(Mcp_server.stem_pool)
+let current_cell () = Mcp_server.get_cell ()
+let stem_pool () = Mcp_server.get_pool ()
 
 (** Clamp context_ratio to valid range *)
 let validate_context_ratio ratio =
@@ -121,7 +121,7 @@ let handle_mitosis_record ctx args : result =
     | `Bool b -> b | _ -> false in
   let cell = current_cell () in
   let updated = Mitosis.record_activity ~cell ~task_done ~tool_called in
-  Mcp_server.current_cell := updated;
+  Mcp_server.set_cell updated;
   Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:updated ~config:Mitosis.default_config;
   json_ok (`Assoc [
     ("recorded", `Bool true);
@@ -143,7 +143,7 @@ let handle_mitosis_prepare ctx args : result =
   else begin
     let config = Mitosis.default_config in
     let prepared = Mitosis.prepare_for_division ~config ~cell ~full_context in
-    Mcp_server.current_cell := prepared;
+    Mcp_server.set_cell prepared;
     Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:prepared ~config;
     json_ok (`Assoc [
       ("prepared", `Bool true);
@@ -203,7 +203,7 @@ let handle_mitosis_divide ctx args : result =
   in
   (* Update MASC L3 state regardless of run outcome *)
   let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
-  Mcp_server.current_cell := new_cell;
+  Mcp_server.set_cell new_cell;
   Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:new_cell ~config;
   let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name:ctx.agent_name in
   match run_result with
@@ -252,7 +252,7 @@ let handle_mitosis_handoff ctx args : result =
     let full_context = summary in
     let dna = Mitosis.extract_dna ~config:config_m ~parent_cell:cell ~full_context in
     let prepared_cell = Mitosis.prepare_for_division ~config:config_m ~cell ~full_context in
-    Mcp_server.current_cell := prepared_cell;
+    Mcp_server.set_cell prepared_cell;
     (* Phase 2: Run successor agent *)
     let target = get_string args "target_agent" "claude" in
     let next_gen = prepared_cell.Mitosis.generation + 1 in
@@ -277,7 +277,7 @@ let handle_mitosis_handoff ctx args : result =
     in
     (* Update state regardless of run outcome *)
     let new_cell = Mitosis.create_stem_cell ~generation:next_gen in
-    Mcp_server.current_cell := new_cell;
+    Mcp_server.set_cell new_cell;
     Mitosis.write_status_with_backend ~room_config:ctx.config ~cell:new_cell ~config:config_m;
     let _flushed = Memory_oas_bridge.flush_all ~memory ~agent_name:ctx.agent_name in
     match run_result with

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -57,7 +57,7 @@ let handle_relay_checkpoint _ctx args =
       ) items
     | _ -> []
   in
-  let cell = !(Mcp_server.current_cell) in
+  let cell = Mcp_server.get_cell () in
   let messages = get_int args "messages" cell.Mitosis.task_count in
   let tool_calls = get_int args "tool_calls" cell.Mitosis.tool_call_count in
   let metrics = Relay.estimate_context ~messages ~tool_calls ~model:"claude" in


### PR DESCRIPTION
## Summary

- **cache_eio.ml**: `last_batch_eviction` ref → `Atomic.t` + CAS. 동시 fiber 접근 시 eviction stampede 방지
- **a2a_tools.ml**: `heartbeat_snapshot_seq` ref → `Atomic.t`. monotonic counter 보장
- **mcp_server.ml**: `current_cell`/`stem_pool` global ref에 `Eio.Mutex` + accessor 함수 추가. 4개 consumer 파일 업데이트

## Context

3-agent 병렬 전수 검사에서 발견된 shared mutable state 이슈 3건 수정.
PR #2767 (blocking I/O)과 독립적인 파일 세트.

## Changed files (7)

| File | Fix |
|------|-----|
| `lib/cache_eio.ml` | Atomic CAS for eviction throttle |
| `lib/a2a_tools.ml` | Atomic counter |
| `lib/mcp_server.ml` | Eio.Mutex + get/set/with_cell_rw |
| `lib/tool_mitosis_oas.ml` | Use Mcp_server.get_cell/set_cell |
| `lib/tool_inline_dispatch_extra.ml` | Use Mcp_server.get_cell/set_cell |
| `lib/tool_inline_dispatch.ml` | Use Mcp_server.get_cell/get_pool |
| `lib/tool_relay.ml` | Use Mcp_server.get_cell |

## Test plan

- [ ] `dune build --root . lib/` 빌드 성공 확인
- [ ] 기존 test suite 통과 (`make test`)
- [ ] 서버 시작 후 mitosis tool 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)