### PR TITLE
chore: bump v2.144.0 — Mode Removal + Transport Metrics + 4-Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 
 ## [Unreleased]
 
+## [2.144.0] - 2026-03-24
+
+### Added
+- **Transport observability metrics** — Prometheus text format metrics for SSE/gRPC/agent-health, transport health dashboard panel with 15s polling (#2750)
+- **Keeper tool bridge** — bridge 329 masc_* tools to keeper via dispatch registry (#2675)
+- **Keeper improve loop** — keeper-driven iterative improvement loop (#2722)
+- **Repeated-failure guardrail** — prevents keeper tool retry loops (#2694)
+- **Destructive pattern normalization** — harness capability matrix for tool safety (#2689)
+- **4-Protocol transport** — WebSocket enabled by default, runtime discovery and interop (#2630, #2634, #2668, #2683, #2768)
+
+### Changed
+- **Mode removal** — removed mode-based tool categorization; all keepers get all tools unconditionally, safety handled by eval_gate deny lists (#2762)
+- **Dashboard CSS cleanup** — migrated control-btn to ActionButton, removed dead CSS (-77 lines) (#2751)
+- **Dashboard compact UI** — reduced padding to cloud console density (#2664)
+- **OAS checkpoints canonical** — keeper checkpoints delegated to OAS (#2734)
+
+### Fixed
+- **Relay checkpoint cap** — capped in-memory checkpoint list at 500 entries to prevent unbounded memory growth (#2743)
+- **Eio safety** — protect shared mutable state with Atomic and Eio.Mutex, replace blocking Unix I/O with Eio-native operations (#2769, #2767)
+- **Dashboard stability** — stabilize cached PG paths, prevent Eio loop starvation (#2765, #2761, #2763)
+- **Governance** — classify transition risk from action args, restore medium risk for masc_transition (#2720, #2711)
+
 ## [2.138.0] - 2026-03-23
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.143.0)
+(version 2.144.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary

v2.143.0 이후 103 커밋 반영.

### 주요 변경
- **Mode 제거** — keeper 도구 카테고리화(coding/readonly/learned) 제거. 모든 keeper가 전체 도구 접근. eval_gate deny list로 안전 보장 (#2762)
- **Transport metrics 복구** — 유실된 PR #2412에서 Prometheus 메트릭 + 대시보드 패널 복구 (#2750)
- **4-Protocol transport** — WS/WebRTC/gRPC/SSE 기본 활성화 (#2630, #2634, #2668, #2683, #2768)
- **Keeper tool bridge** — 329개 masc_* 도구를 keeper에 연결 (#2675)
- **Relay checkpoint cap** — 무제한 증가하던 checkpoint 리스트 500개 상한 (메모리 누수 수정) (#2743)
- **Dashboard CSS 정리** — control-btn 제거, dead CSS -77줄 (#2751)
- **Eio 안전성** — Atomic/Eio.Mutex 보호, blocking I/O 제거 (#2769, #2767)

## Test plan
- [x] `dune build` 통과
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)