### PR TITLE
fix(pg): support Supabase Transaction Pooler via Pg_infix oneshot queries

### DIFF
--- a/lib/backend/backend_eio_pg.ml
+++ b/lib/backend/backend_eio_pg.ml
@@ -33,7 +33,7 @@ let strip_namespace namespace key =
   else key
 
 (* Caqti 2.x query definitions *)
-open Caqti_request.Infix
+open Pg_infix
 
 let get_q =
   (Caqti_type.string ->? Caqti_type.string)

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -42,7 +42,7 @@ let strip_namespace namespace key =
 
 (* Caqti 2.x query definitions using Infix operators
    Syntax: (param_type ->? row_type) "SQL" for static queries *)
-open Caqti_request.Infix
+open Pg_infix
 
 let get_q =
   (Caqti_type.string ->? Caqti_type.string)

--- a/lib/backend/dune
+++ b/lib/backend/dune
@@ -4,6 +4,7 @@
  (public_name masc_mcp.masc_backend)
  (wrapped false)
  (modules
+  pg_infix
   compression_dict
   backend_core
   backend

--- a/lib/backend/pg_infix.ml
+++ b/lib/backend/pg_infix.ml
@@ -1,0 +1,48 @@
+(** Pg_infix — Caqti_request.Infix wrapper for Transaction Pooler compatibility.
+
+    Supabase Transaction Pooler (port 6543) does not support prepared statements
+    because connections are shared across sessions. When Transaction Pooler is
+    detected, all requests use [~oneshot:true] (Direct policy) to avoid
+    prepared statement errors.
+
+    Session Pooler (port 5432) and direct connections work normally with
+    the default Static prepared statement policy. *)
+
+let use_oneshot =
+  lazy
+    (let env_url name =
+       match Sys.getenv_opt name with
+       | Some v when String.trim v <> "" -> Some (String.trim v)
+       | _ -> None
+     in
+     let url =
+       match env_url "MASC_POSTGRES_URL" with
+       | Some _ as u -> u
+       | None -> (
+           match env_url "DATABASE_URL" with
+           | Some _ as u -> u
+           | None -> (
+               match env_url "SUPABASE_DB_URL" with
+               | Some _ as u -> u
+               | None -> env_url "SB_PG_URL"))
+     in
+     match url with
+     | None -> false
+     | Some url -> (
+         match Uri.port (Uri.of_string url) with
+         | Some 6543 -> true
+         | _ -> false))
+
+let oneshot () = Lazy.force use_oneshot
+
+let ( ->. ) a b ?(oneshot = oneshot ()) s =
+  Caqti_request.Infix.( ->. ) a b ~oneshot s
+
+let ( ->? ) a b ?(oneshot = oneshot ()) s =
+  Caqti_request.Infix.( ->? ) a b ~oneshot s
+
+let ( ->* ) a b ?(oneshot = oneshot ()) s =
+  Caqti_request.Infix.( ->* ) a b ~oneshot s
+
+let ( ->! ) a b ?(oneshot = oneshot ()) s =
+  Caqti_request.Infix.( ->! ) a b ~oneshot s

--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -26,7 +26,7 @@ let caqti_err e = IoError (Caqti_error.show e)
 
 (** {1 Schema DDL} *)
 
-open Caqti_request.Infix
+open Pg_infix
 
 let create_tasks_table_q =
   (Caqti_type.unit ->. Caqti_type.unit)

--- a/lib/board/board_listener.ml
+++ b/lib/board/board_listener.ml
@@ -11,7 +11,7 @@
     - Table polling: Reliable delivery (messages persist until consumed)
 *)
 
-open Caqti_request.Infix
+open Pg_infix
 
 (** Board listener channel (matches board_pg.ml) *)
 let channel = "masc_board"

--- a/lib/board/board_pg.ml
+++ b/lib/board/board_pg.ml
@@ -25,7 +25,7 @@ let caqti_err e = Io_error (Caqti_error.show e)
 
 (** {1 Schema DDL} *)
 
-open Caqti_request.Infix
+open Pg_infix
 
 let create_posts_table_q =
   (Caqti_type.unit ->. Caqti_type.unit)

--- a/lib/board/board_pg_queries.ml
+++ b/lib/board/board_pg_queries.ml
@@ -2,7 +2,7 @@
 
 open Board_core [@@warning "-33"]
 open Board [@@warning "-33"]
-open Caqti_request.Infix
+open Pg_infix
 
 let ttl_where = "(expires_at = 0 OR expires_at > extract(epoch from now()))"
 

--- a/lib/memory/memory_pg.ml
+++ b/lib/memory/memory_pg.ml
@@ -14,7 +14,7 @@ type pool = (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t
 
 (** {1 Schema DDL} *)
 
-open Caqti_request.Infix
+open Pg_infix
 
 let create_table_q =
   (Caqti_type.unit ->. Caqti_type.unit)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -156,13 +156,13 @@ let env_opt name =
 
 let normalize_postgres_url url =
   let uri = Uri.of_string url in
-  match Uri.host uri, Uri.port uri with
+  (match Uri.host uri, Uri.port uri with
   | Some host, Some 6543 when String.ends_with ~suffix:".pooler.supabase.com" host ->
-      let normalized = Uri.to_string (Uri.with_port uri (Some 5432)) in
       Log.Backend.info
-        "Supabase transaction pooler detected in PostgreSQL URL; using session pooler port 5432 for prepared-statement compatibility";
-      normalized
-  | _ -> url
+        "Supabase Transaction Pooler detected (port 6543 on %s); Pg_infix will use oneshot queries to avoid prepared-statement errors"
+        host
+  | _ -> ());
+  url
 
 let postgres_url_from_env () =
   let raw_url =

--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -195,7 +195,7 @@ let test_evict_expired_batch () =
 let test_maybe_evict_expired_triggers_when_ratio_high () =
   with_temp_masc_dir (fun config ->
     (* Reset last_batch_eviction to allow immediate trigger *)
-    Cache_eio.last_batch_eviction := 0.0;
+    Atomic.set Cache_eio.last_batch_eviction 0.0;
 
     (* Create 8 expired + 2 valid = 80% expired ratio > 50% threshold *)
     for i = 1 to 8 do
@@ -223,7 +223,7 @@ let test_maybe_evict_expired_triggers_when_ratio_high () =
 let test_maybe_evict_expired_throttled () =
   with_temp_masc_dir (fun config ->
     (* Set last_batch_eviction to now (prevents re-run within interval) *)
-    Cache_eio.last_batch_eviction := Unix.gettimeofday ();
+    Atomic.set Cache_eio.last_batch_eviction (Unix.gettimeofday ());
 
     (* Create expired entries *)
     let _ = Cache_eio.set config ~key:"exp-1" ~value:"v1" ~ttl_seconds:(-1) () in


### PR DESCRIPTION
## Summary
- `Pg_infix` 모듈: Caqti Infix 연산자를 래핑하여 Transaction Pooler(6543) 감지 시 `~oneshot:true` 자동 적용
- 7개 PG 파일에서 `open Caqti_request.Infix` → `open Pg_infix`
- `normalize_postgres_url`의 6543→5432 강제 전환 제거 (포트 유지, 로그만 출력)
- `test_cache_eio.ml` Atomic.t vs ref 불일치 수정 (기존 main 문제)
- Closes #2518

## Test plan
- [x] `dune build` pass
- [ ] Transaction Pooler(6543)에서 prepared statement 에러 미발생 확인
- [ ] Session Pooler(5432)에서 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)