### PR TITLE
fix(dashboard,pg): address Codex review findings from #2754

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -625,7 +625,13 @@ let operator_digest_http_json ~state ~sw ~clock request =
                  ctx
              with
              | Ok json -> json
-             | Error err -> failwith err))
+             | Error err ->
+                 `Assoc
+                   [
+                     ("error", `String "validation_error");
+                     ("message", `String err);
+                     ("generated_at", `String (Types.now_iso ()));
+                   ]))
     ) with
     | Ok json ->
         let extra =

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -347,9 +347,12 @@ let list_sessions ?(since_unix = 0.0) ?(limit = 0) config : Team_session_types.s
   let pg_recent_attempted, pg_recent_result =
     match config.backend with
     | PostgresNative backend when since_unix > 0.0 || limit > 0 ->
+        (* Safety cap: PG backend returns Ok [] when limit<=0, so we need a
+           positive value. 10_000 is high enough to avoid silent truncation
+           in practice while preventing unbounded queries. See #2778. *)
         let row_limit =
           if limit > 0 then limit
-          else 1000
+          else 10_000
         in
         ( true,
           Backend.PostgresNative.get_all_matching_recent backend


### PR DESCRIPTION
## Summary

- **P1 (#2777)**: `digest_json` validation error가 `failwith`로 exception 탈출 → HTTP 500. inline `validation_error` JSON 응답으로 변경하여 structured error 반환.
- **P2 (#2778)**: PG fast path의 `limit=0`(unlimited) 시 silent 1000-row cap → 10,000으로 상향. `backend_pg.ml`이 `limit<=0`에서 `Ok []`을 반환하므로 양수 cap은 필수. 기존 1000은 대규모 환경에서 truncation 위험.

Closes #2777
Closes #2778

## Test plan

- [x] `dune build @check` 통과
- [x] `test_operator_control.exe` 30 tests 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)