### PR TITLE
fix(pg,dashboard): raise session cap and return structured digest errors

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -479,7 +479,8 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
       | Ok json ->
           with_projection_diagnostics ~surface:"operator_digest" ~started_at
             ~extra:(operator_snapshot_extra sessions) json
-      | Error err -> failwith err
+      | Error err ->
+          `Assoc [("error", `String err); ("digest_error", `Bool true)]
     with exn ->
       mark_cached_surface_error _operator_digest_cache exn;
       raise exn
@@ -625,7 +626,8 @@ let operator_digest_http_json ~state ~sw ~clock request =
                  ctx
              with
              | Ok json -> json
-             | Error err -> failwith err))
+             | Error err ->
+                 `Assoc [("error", `String err); ("status", `String "validation_error")]))
     ) with
     | Ok json ->
         let extra =

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -349,7 +349,7 @@ let list_sessions ?(since_unix = 0.0) ?(limit = 0) config : Team_session_types.s
     | PostgresNative backend when since_unix > 0.0 || limit > 0 ->
         let row_limit =
           if limit > 0 then limit
-          else 1000
+          else 10000
         in
         ( true,
           Backend.PostgresNative.get_all_matching_recent backend


### PR DESCRIPTION
## Summary
- `team_session_store`: limit=0 시 1000→10000 상한으로 변경. silent truncation 방지. Closes #2778
- `server_dashboard_http_core`: digest_json Error에서 `failwith` 대신 structured JSON 반환. 500→400 수준 에러 표시. Closes #2777

## Test plan
- [x] `dune build` pass
- [ ] `/api/v1/operator/digest?target_type=team_session` (target_id 없이) → error JSON 반환 확인
- [ ] limit=0 세션 조회 시 1000건 이상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)