### PR TITLE
perf: optimize server runtime for 12+ concurrent keepers

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -232,12 +232,12 @@ let create_eio ~sw ~env (cfg : config) : (t, error) result =
   | None -> Error (ConnectionFailed "PostgreSQL URL not configured (set MASC_POSTGRES_URL)")
   | Some url ->
       let uri = Uri.of_string url in
-      (* Pool sizing: Supabase session pooler shares pool_size across all
-         clients. Keep low to avoid MaxClientsInSessionMode on restarts.
-         Rule: (CPU cores * 2) is overkill for a single app; 3 suffices. *)
+      (* Pool sizing: default 5, tunable via MASC_PG_POOL_SIZE (1-50).
+         12+ concurrent keepers need ~12 connections.
+         Supabase Pro supports 500+ max_connections. *)
       let max_pool = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-        | Some s -> (try min (int_of_string s) 5 with _ -> 3)
-        | None -> 3
+        | Some s -> (try max 1 (min (int_of_string s) 50) with _ -> 5)
+        | None -> 5
       in
       let pool_config = Caqti_pool_config.create
           ~max_size:max_pool

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -48,7 +48,8 @@ let register_keepalive name entry =
   Hashtbl.replace keepalives name entry
 
 let unregister_keepalive name =
-  Hashtbl.remove keepalives name
+  Hashtbl.remove keepalives name;
+  Hashtbl.remove last_agent_counts name
 
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~2 s instead of waiting for the full 30-300 s interval. *)
@@ -98,20 +99,20 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               | Ok (Some latest) -> latest
               | _ -> m
             in
-            (try
-               let synced = ensure_keeper_room_presence ctx.config meta_current in
-               (match write_meta ctx.config synced with
-                | Ok () -> ()
-                | Error e -> Log.Keeper.warn "write_meta failed (heartbeat): %s" e)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               Log.Keeper.error "room heartbeat failed: %s"
-                 (Printexc.to_string exn));
             let meta_current =
-              match read_meta ctx.config m.name with
-              | Ok (Some latest) -> latest
-              | _ -> meta_current
+              try
+                let synced = ensure_keeper_room_presence ctx.config meta_current in
+                (match write_meta ctx.config synced with
+                 | Ok () -> synced  (* use written value directly, no second read_meta *)
+                 | Error e ->
+                   Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
+                   synced)
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Keeper.error "room heartbeat failed: %s"
+                  (Printexc.to_string exn);
+                meta_current
             in
             let now_ts = Time_compat.now () in
             if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -25,8 +25,8 @@ type t = {
 
 (** {1 Configuration} *)
 
-let default_rate = 20.0  (* Higher default for multi-agent coordination *)
-let default_burst = 50
+let default_rate = 60.0  (* 12+ concurrent keepers need higher throughput *)
+let default_burst = 150
 
 let rate_from_env () =
   Sys.getenv_opt "MASC_RATE_LIMIT"

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -185,6 +185,15 @@ let make_health_json ?(listener = "http/1.1") request =
         shared_pool_injected = shared;
       });
     ("subsystems", Subsystem_health.to_yojson ());
+    ("gc", let s = Gc.stat () in `Assoc [
+      ("minor_collections", `Int s.minor_collections);
+      ("major_collections", `Int s.major_collections);
+      ("compactions", `Int s.compactions);
+      ("heap_words", `Int s.heap_words);
+      ("live_words", `Int s.live_words);
+      ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
+    ]);
+    ("keeper_fibers", `Int (Keeper_keepalive.running_keepers ()));
   ]
 
 (** Health check handler *)

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -5,6 +5,11 @@
 
 set -e
 
+# OCaml GC tuning for multi-keeper concurrency.
+# s=4194304: minor heap 4MB (default 256KB), reduces minor GC frequency ~16x.
+# o=80: major heap overhead 80% (default 120), reduces compaction frequency.
+export OCAMLRUNPARAM="${OCAMLRUNPARAM:-s=4194304,o=80}"
+
 # Optional: load OPAM environment if available (must never be fatal for MCP startup)
 if command -v opam >/dev/null 2>&1; then
     eval "$(opam env 2>/dev/null)" >/dev/null 2>/dev/null || true

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -14,10 +14,10 @@ module Rate_limit = Masc_mcp.Rate_limit
    ============================================================ *)
 
 let test_default_rate () =
-  check (float 0.001) "default rate" 20.0 Rate_limit.default_rate
+  check (float 0.001) "default rate" 60.0 Rate_limit.default_rate
 
 let test_default_burst () =
-  check int "default burst" 50 Rate_limit.default_burst
+  check int "default burst" 150 Rate_limit.default_burst
 
 (* ============================================================
    Create Tests
@@ -25,8 +25,8 @@ let test_default_burst () =
 
 let test_create_default () =
   let limiter = Rate_limit.create () in
-  check (float 0.001) "rate" 20.0 limiter.rate;
-  check int "burst" 50 limiter.burst
+  check (float 0.001) "rate" 60.0 limiter.rate;
+  check int "burst" 150 limiter.burst
 
 let test_create_custom_rate () =
   let limiter = Rate_limit.create ~rate:100.0 () in


### PR DESCRIPTION
## Summary
- GC tuning: `OCAMLRUNPARAM` (minor heap 4MB, overhead 80%) — minor GC frequency ~16x reduction
- PG pool: hard-cap 5→50, default 3→5 — 12 keeper 동시 접근 병목 해소
- Rate limit: 20/50→60/150 req/s/burst — per-keeper 처리량 3x
- Heartbeat I/O: 이중 `read_meta` 제거, file I/O 50% 감소
- Hashtbl cleanup: keeper 제거 시 stale 엔트리 정리
- Health endpoint: GC stats + keeper fiber count 노출

## Context
5 keeper 동시 시 45분 후 crash(PR#2344), 6 keeper on 4 LLM slots에서 35→4.3 tok/s 급감 이력.
12+ keeper 안정 운영 목표.

## Key Changes
| File | Change |
|------|--------|
| `start-masc-mcp.sh` | `OCAMLRUNPARAM` 환경변수 추가 |
| `lib/backend/backend_pg.ml` | pool hard-cap `min s 5` → `min s 50`, default 3→5 |
| `lib/rate_limit.ml` | default rate 20→60, burst 50→150 |
| `lib/keeper/keeper_keepalive.ml` | 이중 read_meta 제거 + Hashtbl cleanup |
| `lib/server/server_routes_http_runtime.ml` | GC/keeper metrics in /health |

## Test plan
- [x] `dune build` 성공
- [x] rate_limit 테스트 24/24 통과
- [ ] 12 keeper 동시 부팅 → 1시간 안정 운영
- [ ] `/health` endpoint에서 GC metrics 확인
- [ ] `MASC_PG_POOL_SIZE=12` 설정 후 pool 크기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)