### PR TITLE
fix(pg): skip unresolved 1Password op:// templates in env vars

### DIFF
--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -149,9 +149,20 @@ let resolve_masc_base_path path =
 (* Environment helpers                          *)
 (* ============================================ *)
 
+let is_unresolved_template value =
+  let v = String.trim value in
+  (String.length v >= 2 && v.[0] = '{' && v.[1] = '{')
+  || (String.length v >= 5 && String.sub v 0 5 = "op://")
+
 let env_opt name =
   match Sys.getenv_opt name with
-  | Some value when String.trim value <> "" -> Some value
+  | Some value when String.trim value <> "" ->
+      if is_unresolved_template value then begin
+        Log.Backend.warn
+          "%s contains unresolved 1Password template; skipping" name;
+        None
+      end else
+        Some value
   | _ -> None
 
 let normalize_postgres_url url =


### PR DESCRIPTION
## Summary
- `env_opt`가 `{{ op://... }}` 미해석 1Password 템플릿을 감지하면 skip + warning 로그
- `~/.secrets.env`의 `SUPABASE_DB_URL` op:// 원문이 Caqti에 전달되어 "suitable driver for URI-scheme {{ op" 에러 발생하는 문제 해결
- 다음 env var(`SB_PG_URL` 등)로 정상 fallback

## Test plan
- [ ] `dune build` (CI)
- [ ] `SUPABASE_DB_URL="{{ op://test }}" ./start-masc-mcp.sh` → warning 로그 후 다른 URL 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)