### PR TITLE
revert(perf): remove OCAMLRUNPARAM GC tuning that caused 10GB+ RSS

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -5,10 +5,9 @@
 
 set -e
 
-# OCaml GC tuning for multi-keeper concurrency.
-# s=4194304: minor heap 4MB (default 256KB), reduces minor GC frequency ~16x.
-# o=80: major heap overhead 80% (default 120), reduces compaction frequency.
-export OCAMLRUNPARAM="${OCAMLRUNPARAM:-s=4194304,o=80}"
+# OCaml GC: use defaults. Large minor heap (s=4194304) caused 10GB+ RSS
+# because Eio fibers share the domain heap and 360 tools + 12 keepers
+# amplify allocation pressure. The default 256KB minor heap is sufficient.
 
 # Optional: load OPAM environment if available (must never be fatal for MCP startup)
 if command -v opam >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- #2782에서 추가된 `OCAMLRUNPARAM=s=4194304,o=80` 제거
- 4MB minor heap (기본 256KB의 16배) + 360 tools + 12 keeper fibers → 10GB+ RSS
- OCaml 기본값으로 복귀

## Test plan
- [ ] `./start-masc-mcp.sh` 실행 후 RSS 확인 (`ps -o rss -p $(pgrep main_eio)`)
- [ ] 기존 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)