### PR TITLE
refactor(bench): route bench through OAS Provider_registry [2/4]

### DIFF
--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -1,6 +1,7 @@
 (** Tool_local_runtime_bench -- concurrency benchmark against runtime pool. *)
 
 include Tool_local_runtime_http
+module Oas_types = Agent_sdk.Types
 
 let pctl percentile values =
   match values with
@@ -109,6 +110,19 @@ let raw_completion ~model_id ~prompt ~max_tokens ~timeout_sec () =
   raw_completion_at ~server_url:Env_config.Llama.server_url ~model_id ~prompt
     ~max_tokens ~timeout_sec ()
 
+let error_message_of_http_error = function
+  | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.HttpError { code; body } -> (
+      try
+        let json = Yojson.Safe.from_string body in
+        match Yojson.Safe.Util.member "error" json with
+        | `Assoc fields -> (
+            match List.assoc_opt "message" fields with
+            | Some (`String msg) -> msg
+            | _ -> Printf.sprintf "HTTP %d" code)
+        | _ -> Printf.sprintf "HTTP %d" code
+      with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
+
 let per_runtime_breakdown_to_yojson counts =
   counts
   |> Hashtbl.to_seq_values
@@ -178,6 +192,118 @@ let finalize_runtime_breakdown json =
         ]
   | _ -> json
 
+let default_local_model_id () =
+  let _label, model_id = Oas_model_resolve.default_local_model_label_and_id () in
+  model_id
+
+let is_oas_managed_runtime_pool = function
+  | None -> true
+  | Some pool ->
+      let trimmed = String.trim pool in
+      trimmed = ""
+      || String.equal trimmed Local_runtime_pool.default_pool_label
+      || String.equal trimmed "default"
+
+let runtime_base_url_for_pool runtime_pool =
+  match runtime_pool with
+  | Some pool ->
+      let trimmed = String.trim pool in
+      if is_oas_managed_runtime_pool (Some trimmed) then
+        Llm_provider.Provider_registry.next_llama_endpoint ()
+      else if
+        String.starts_with ~prefix:"http://" trimmed
+        || String.starts_with ~prefix:"https://" trimmed
+      then
+        trimmed
+      else
+        let snapshots = Local_runtime_pool.snapshots () in
+        (match
+           List.find_opt
+             (fun (runtime : Local_runtime_pool.runtime_snapshot) ->
+               String.equal runtime.id trimmed)
+             snapshots
+         with
+         | Some runtime -> runtime.base_url
+         | None -> trimmed)
+  | None -> Llm_provider.Provider_registry.next_llama_endpoint ()
+
+let model_label_for_pool ~model_id runtime_pool =
+  match runtime_pool with
+  | Some pool ->
+      let trimmed = String.trim pool in
+      if is_oas_managed_runtime_pool (Some trimmed) then
+        Printf.sprintf "llama:%s" model_id
+      else
+        let base_url =
+          if
+            String.starts_with ~prefix:"http://" trimmed
+            || String.starts_with ~prefix:"https://" trimmed
+          then
+            trimmed
+          else
+            runtime_base_url_for_pool runtime_pool
+        in
+        Printf.sprintf "custom:%s@%s" model_id base_url
+  | None -> Printf.sprintf "llama:%s" model_id
+
+let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec ()
+    =
+  match Masc_eio_env.get_opt () with
+  | None ->
+      let base_url = runtime_base_url_for_pool runtime_pool in
+      ( raw_completion_at ~server_url:base_url ~model_id ~prompt ~max_tokens
+          ~timeout_sec (),
+        Local_runtime_pool.runtime_id_of_base_url base_url )
+  | Some env -> (
+      let started = Time_compat.now () in
+      let model_label = model_label_for_pool ~model_id runtime_pool in
+      match
+        Llm_provider.Cascade_config.parse_model_string ~max_tokens model_label
+      with
+      | None ->
+          ( { success = false; latency_ms = 0; error = Some ("invalid model label: " ^ model_label) },
+            "unknown" )
+      | Some provider_config ->
+          let runtime_id =
+            Local_runtime_pool.runtime_id_of_base_url provider_config.base_url
+          in
+          let messages =
+            [
+              {
+                Oas_types.role = Oas_types.User;
+                content = [ Oas_types.Text prompt ];
+                name = None;
+                tool_call_id = None;
+              };
+            ]
+          in
+          let run_completion () =
+            Llm_provider.Complete.complete ~sw:env.sw ~net:env.net
+              ~config:provider_config ~messages ()
+          in
+          let outcome =
+            match env.clock with
+            | Some clock -> (
+                try Ok (Eio.Time.with_timeout_exn clock (float_of_int timeout_sec) run_completion)
+                with Eio.Time.Timeout -> Error "timeout")
+            | None -> Ok (run_completion ())
+          in
+          let latency_ms =
+            int_of_float ((Time_compat.now () -. started) *. 1000.0)
+          in
+          let sample =
+            match outcome with
+            | Error message -> { success = false; latency_ms; error = Some message }
+            | Ok (Ok _response) -> { success = true; latency_ms; error = None }
+            | Ok (Error http_error) ->
+                {
+                  success = false;
+                  latency_ms;
+                  error = Some (error_message_of_http_error http_error);
+                }
+          in
+          (sample, runtime_id))
+
 let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     ~timeout_sec () =
   let total = parallelism * rounds in
@@ -188,25 +314,17 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     Eio.Fiber.all
       (List.init parallelism (fun fiber_idx ->
            fun () ->
-             match
-               Local_runtime_pool.acquire ?preferred_pool:runtime_pool
-                 ~model_name:model_id ()
-             with
-             | Error err ->
-                 results.(offset + fiber_idx) <-
-                   Some { success = false; latency_ms = 0; error = Some err }
-             | Ok assignment ->
-                 let sample =
-                   raw_completion_at ~server_url:assignment.base_url
-                     ~model_id:assignment.model_name ~prompt ~max_tokens
-                     ~timeout_sec ()
-                 in
-                 Local_runtime_pool.release assignment.lease
-                   ~success:sample.success ?error:sample.error
-                   ~latency_ms:sample.latency_ms ();
-                 update_runtime_breakdown runtime_breakdown
-                   ~runtime_id:assignment.runtime_id ~sample;
-                 results.(offset + fiber_idx) <- Some sample))
+             let resolved_model_id =
+               match model_id with
+               | Some model when String.trim model <> "" -> model
+               | _ -> default_local_model_id ()
+             in
+             let sample, runtime_id =
+               oas_completion_at ?runtime_pool ~model_id:resolved_model_id
+                 ~prompt ~max_tokens ~timeout_sec ()
+             in
+             update_runtime_breakdown runtime_breakdown ~runtime_id ~sample;
+             results.(offset + fiber_idx) <- Some sample))
   done;
   let samples = results |> Array.to_list |> List.filter_map (fun item -> item) in
   let success_count =
@@ -235,6 +353,7 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
     (`Assoc
       [
         ("server_url", `String Env_config.Llama.server_url);
+        ("source", `String "oas_complete");
         ("model_id", string_opt_to_json model_id);
         ("runtime_pool", string_opt_to_json runtime_pool);
         ("parallelism", `Int parallelism);

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -418,19 +418,40 @@ let prepare_spawn (env : _ step_env) (spec : spawn_spec) =
       in
       match model_name with
       | None -> Error "local worker model resolution failed"
-      | Some model_name -> (
-          match
-            Local_runtime_pool.acquire
-              ?preferred_pool:spec.runtime_pool
-              ~model_name:(Some model_name) ()
-          with
-          | Ok assignment ->
-              Ok
-                ( Local_runtime_pool.model_label_of_assignment
-                    assignment,
-                  Some assignment.lease,
-                  Some assignment.runtime_id )
-          | Error err -> Error err)
+      | Some model_name ->
+          let runtime_pool =
+            match spec.runtime_pool with
+            | Some pool ->
+                let trimmed = String.trim pool in
+                if trimmed = "" then None else Some trimmed
+            | None -> None
+          in
+          let use_oas_balancing =
+            match runtime_pool with
+            | None -> true
+            | Some pool ->
+                String.equal pool Local_runtime_pool.default_pool_label
+                || String.equal pool "default"
+          in
+          if use_oas_balancing then
+            let base_url = Llm_provider.Provider_registry.next_llama_endpoint () in
+            Ok
+              ( Printf.sprintf "custom:%s@%s" model_name base_url,
+                None,
+                Some (Local_runtime_pool.runtime_id_of_base_url base_url) )
+          else (
+            match
+              Local_runtime_pool.acquire
+                ?preferred_pool:spec.runtime_pool
+                ~model_name:(Some model_name) ()
+            with
+            | Ok assignment ->
+                Ok
+                  ( Printf.sprintf "custom:%s@%s" assignment.model_name
+                      assignment.base_url,
+                    Some assignment.lease,
+                    Some assignment.runtime_id )
+            | Error err -> Error err)
     else
       let label, _model_id = Oas_model_resolve.default_local_model_label_and_id () in
       Ok (label, None, None)

--- a/scripts/harness/workload/team_session_local64_smoke.sh
+++ b/scripts/harness/workload/team_session_local64_smoke.sh
@@ -409,7 +409,7 @@ fi
 echo "session_id=$SESSION_ID"
 
 echo "[3/8] inspect local llama runtime"
-runtime_raw="$(call_tool 91004 "masc_llama_runtime_status" '{"include_models":true}')"
+runtime_raw="$(call_tool 91004 "masc_local_runtime_status" '{"include_models":true}')"
 require_tool_success "$runtime_raw"
 require_result_condition "$runtime_raw" '.runtime_count >= 1 and .configured_capacity >= 1' "runtime status missing pool data"
 
@@ -484,7 +484,7 @@ fi
 require_json_condition "$digest_json" "$digest_expr" "operator digest did not expose local64 census/runtime visibility"
 
 echo "[8/8] benchmark runtime pool"
-bench_raw="$(call_tool 91008 "masc_llama_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
+bench_raw="$(call_tool 91008 "masc_local_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
 require_tool_success "$bench_raw"
 require_result_condition "$bench_raw" '.total_requests >= 1 and .per_runtime_breakdown != null' "runtime bench did not return breakdown"
 

--- a/scripts/harness_team_session_local64_smoke.sh
+++ b/scripts/harness_team_session_local64_smoke.sh
@@ -67,12 +67,12 @@ export MASC_LOCAL64_BASE_PATH="$BASE_PATH"
 need_pool_start="false"
 if [ "$POOL_SHARDS" -gt 1 ] || [ "$POOL_FORCE_START" = "true" ]; then
   need_pool_start="true"
-elif [ -n "${LLAMA_MODEL_PATH:-}" ] && [ -z "${MASC_LLAMA_RUNTIMES_JSON:-}" ]; then
+elif [ -n "${LLAMA_MODEL_PATH:-}" ] && [ -z "${LLM_ENDPOINTS:-}" ]; then
   need_pool_start="true"
 fi
 
 if [ "$need_pool_start" = "true" ]; then
-  export MASC_LLAMA_RUNTIMES_JSON="$("$ROOT_DIR/scripts/llama-runtime-pool.sh" start --target-shards "$POOL_SHARDS" --seed-port "$SEED_PORT")"
+  export LLM_ENDPOINTS="$("$ROOT_DIR/scripts/llama-runtime-pool.sh" start --target-shards "$POOL_SHARDS" --seed-port "$SEED_PORT")"
   POOL_STARTED="true"
 fi
 
@@ -86,8 +86,8 @@ if [ "$MCP_URL" = "http://127.0.0.1:${PORT}/mcp" ]; then
     PATH="$PATH" \
     HOME="$HOME" \
     TMPDIR="${TMPDIR:-/tmp}" \
+    LLM_ENDPOINTS="${LLM_ENDPOINTS:-}" \
     LLAMA_SERVER_URL="${LLAMA_SERVER_URL:-http://127.0.0.1:${SEED_PORT}}" \
-    MASC_LLAMA_RUNTIMES_JSON="${MASC_LLAMA_RUNTIMES_JSON:-}" \
     MASC_LLAMA_RUNTIME_COOLDOWN_SEC="${MASC_LLAMA_RUNTIME_COOLDOWN_SEC:-}" \
     MASC_LLAMA_RUNTIME_DEBUG="${MASC_LLAMA_RUNTIME_DEBUG:-}" \
     MASC_TEAM_SESSION_MODEL_35B="${MASC_TEAM_SESSION_MODEL_35B:-}" \

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -232,23 +232,25 @@ start_shard() {
   fi
 }
 
-print_env_json() {
+print_env_value() {
   resolve_seed_args
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))
-  local runtimes='[]'
+  local endpoints=()
   local port
   for port in $(seq "$SEED_PORT" "$max_port"); do
     if port_is_listening "$port"; then
-      runtimes="$(jq -cn \
-        --argjson existing "$runtimes" \
-        --arg id "$(runtime_id "$port")" \
-        --arg base_url "$(runtime_url "$port")" \
-        --arg model "$MODEL_ALIAS" \
-        --argjson max_concurrency "$PARALLEL" \
-        '$existing + [{id:$id,base_url:$base_url,model:$model,max_concurrency:$max_concurrency}]')"
+      endpoints+=("$(runtime_url "$port")")
     fi
   done
-  printf '%s\n' "$runtimes"
+  local joined=""
+  local endpoint
+  for endpoint in "${endpoints[@]}"; do
+    if [ -n "$joined" ]; then
+      joined+=","
+    fi
+    joined+="$endpoint"
+  done
+  printf '%s\n' "$joined"
 }
 
 start_pool() {
@@ -259,7 +261,7 @@ start_pool() {
   for port in $(seq "$SEED_PORT" "$max_port"); do
     start_shard "$port" || failures=$((failures + 1))
   done
-  print_env_json
+  print_env_value
   if [ "$failures" -gt 0 ]; then
     echo "warning: $failures shard(s) failed to start" >&2
   fi
@@ -277,7 +279,7 @@ status_pool() {
       printf 'down\n'
     fi
   done
-  print_env_json
+  print_env_value
 }
 
 stop_pool() {
@@ -335,7 +337,7 @@ case "$COMMAND" in
   start) start_pool ;;
   status) status_pool ;;
   stop) stop_pool ;;
-  print-env) print_env_json ;;
+  print-env) print_env_value ;;
   bench) bench_pool ;;
   *)
     usage


### PR DESCRIPTION
## Summary
- `is_oas_managed_runtime_pool()` 헬퍼: None/local64/default → OAS 관리 판정
- `runtime_base_url_for_pool()`: OAS 경로는 `next_llama_endpoint()`, 커스텀은 snapshot lookup
- per-runtime breakdown에 OAS 분산 결과 반영

## Stacked PR
2/4 — base: `refactor/oas-delegation-gate` (#2789)

## Test plan
- [ ] `dune build` 통과
- [ ] `masc_local_runtime_bench(runtime_pool="local64", parallelism=12)` 3-shard 분산 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)