### PR TITLE
feat(mcp): reduce public tool surface from 371 to 34

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,54 @@ let cmd = Printf.sprintf
 } } } }
 ```
 
+## MCP Tool Surface
+
+MASC MCP는 외부 에이전트와의 커뮤니케이션 레이어다. 도구 생성은 OAS 하네스 책임.
+
+### tools/list (discovery)
+
+기본 33개 도구만 노출. `lib/tool_catalog.ml`의 `public_mcp_tools` 리스트가 SSOT.
+
+| 카테고리 | 도구 |
+|----------|------|
+| Room | start, join, leave, set_room, status |
+| Messaging | broadcast, messages, who |
+| Task | add_task, batch_add_tasks, tasks, claim_next, transition |
+| Planning | plan_init, plan_get, plan_set_task, plan_update |
+| Heartbeat | heartbeat |
+| Keeper | keeper_msg, keeper_list, keeper_status, keeper_up, keeper_down |
+| Board | board_post, board_list, board_get, board_comment, board_vote |
+| Agent | agents, dashboard, agent_card |
+| Utility | tool_help, check |
+
+### tools/call (execution)
+
+모든 등록 도구 호출 가능. tools/list에 없어도 호출된다.
+
+### 표면 확장
+
+```bash
+# 특정 도구 추가 (서버 시작 시)
+MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause ./start-masc-mcp.sh --http --port 8935
+
+# 전체 표면 복원 (디버깅)
+MASC_FULL_SURFACE=1 ./start-masc-mcp.sh --http --port 8935
+
+# tools/list에 include_hidden=true 전달 (API 레벨)
+{"method": "tools/list", "params": {"include_hidden": true}}
+```
+
+### 도구 가시성 규칙
+
+| 도구 상태 | tools/list | tools/call | Keeper dispatch |
+|-----------|-----------|------------|-----------------|
+| Public (33개) | O | O | O |
+| Hidden (내부) | X | O | O |
+| Hidden + include_hidden | O | O | O |
+| FULL_SURFACE=1 | O | O | O |
+
+코드 경로: `Tool_catalog.is_public_mcp` → `Mcp_server_eio_tool_profile.tool_schemas_for_profile`
+
 ## Usage SSOT
 
 MASC usage는 문서마다 흩어져 있지 않다. 아래 문서를 기준으로 본다.
@@ -96,6 +144,8 @@ curl http://127.0.0.1:8935/health
 - `ME_ROOT` — repo 루트. 미지정 시 `$HOME/me`를 우선 사용
 - `MASC_DASHBOARD_PROXY_TARGET` — dashboard dev server가 프록시할 API origin
 - `MASC_BOARD_BACKEND` — Board 백엔드 선택 (`pg` default, `jsonl` for file-based)
+- `MASC_FULL_SURFACE` — `1`로 설정하면 tools/list에서 전체 도구 노출 (디버깅용)
+- `MASC_PUBLIC_TOOLS_EXTRA` — 공개 표면에 추가할 도구명 (쉼표 구분). 예: `masc_goal_upsert,masc_pause`
 
 ### 로그
 script-based 실행에서는 표준 출력/표준 오류를 현재 셸 또는 호출 스크립트에서 직접 관리한다.

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -21,8 +21,21 @@ masc_claim_next()
 
 ## Tool Surface
 
-The public MCP surface is no longer mode-gated. Tool visibility now comes from
-the canonical catalog, profile, auth, and lifecycle metadata only.
+`tools/list` returns ~33 agent-communication tools by default (room, task,
+board, keeper, planning). All registered tools remain callable via `tools/call`.
+
+```bash
+# Add specific tools to the public surface
+MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause
+
+# Restore the full inventory (debugging)
+MASC_FULL_SURFACE=1
+
+# Query all tools via API
+{"method": "tools/list", "params": {"include_hidden": true}}
+```
+
+Allowlist: `lib/tool_catalog.ml` > `public_mcp_tools`.
 
 ## Error Recovery
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -381,9 +381,11 @@ let public_raw_tool_schemas_from (public_tool_source_schemas : Types.tool_schema
     Types.tool_schema list =
   dedupe_schemas public_tool_source_schemas
 
-(* Surface filtering removed — all registered tools are public.
-   Previous: surface_tool_schemas_from ... Public_mcp filtered ~47 tools.
-   See #1961 for context. *)
+(* Surface filtering at this layer removed in #1961 — all registered tools pass
+   through here unchanged. The public MCP surface is now filtered at the profile
+   level: [Mcp_server_eio_tool_profile.tool_schemas_for_profile] applies
+   [Tool_catalog.is_public_mcp] to the Full profile, reducing tools/list to ~34.
+   Internal dispatch ([Tool_dispatch.dispatch]) remains unrestricted. *)
 let public_tool_schemas_from (public_tool_source_schemas : Types.tool_schema list) :
     Types.tool_schema list =
   dedupe_schemas public_tool_source_schemas

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -100,7 +100,7 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
           Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false ()
           |> List.filter (fun (schema : Types.tool_schema) ->
                  List.mem schema.name managed_agent_passthrough_tool_names
-                 && Tool_catalog.is_visible schema.name)
+                 && Tool_catalog.is_visible ~include_hidden:true schema.name)
         in
         dedupe_tool_schemas_by_name
           (Sdk_tool_contract.sdk_tool_schemas @ passthrough)

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -84,7 +84,15 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
   let schemas =
     match profile with
     | Full ->
-        Config.visible_tool_schemas ~include_hidden ~include_deprecated ()
+        let all =
+          Config.visible_tool_schemas ~include_hidden ~include_deprecated ()
+        in
+        if include_hidden || Tool_catalog.full_surface_override () then all
+        else
+          List.filter
+            (fun (schema : Types.tool_schema) ->
+              Tool_catalog.is_public_mcp schema.name)
+            all
     | Managed_agent ->
         let passthrough =
           Config.visible_tool_schemas ~include_hidden:false ~include_deprecated:false ()
@@ -101,7 +109,9 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
 let tool_allowed_in_profile state profile tool_name =
   match profile with
   | Full ->
-      tool_schemas_for_profile ~include_deprecated:true state Full
+      (* tools/call accepts any registered tool regardless of the public MCP
+         surface. tools/list is the discovery filter; tools/call is execution. *)
+      Config.visible_tool_schemas ~include_deprecated:true ()
       |> List.exists (fun (schema : Types.tool_schema) ->
              String.equal schema.name tool_name)
   | Managed_agent ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -84,10 +84,12 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
   let schemas =
     match profile with
     | Full ->
+        let show_all = include_hidden || Tool_catalog.full_surface_override () in
         let all =
-          Config.visible_tool_schemas ~include_hidden ~include_deprecated ()
+          Config.visible_tool_schemas
+            ~include_hidden:show_all ~include_deprecated ()
         in
-        if include_hidden || Tool_catalog.full_surface_override () then all
+        if show_all then all
         else
           List.filter
             (fun (schema : Types.tool_schema) ->
@@ -95,7 +97,7 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
             all
     | Managed_agent ->
         let passthrough =
-          Config.visible_tool_schemas ~include_hidden:false ~include_deprecated:false ()
+          Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false ()
           |> List.filter (fun (schema : Types.tool_schema) ->
                  List.mem schema.name managed_agent_passthrough_tool_names
                  && Tool_catalog.is_visible schema.name)
@@ -110,8 +112,8 @@ let tool_allowed_in_profile state profile tool_name =
   match profile with
   | Full ->
       (* tools/call accepts any registered tool regardless of the public MCP
-         surface. tools/list is the discovery filter; tools/call is execution. *)
-      Config.visible_tool_schemas ~include_deprecated:true ()
+         surface or visibility. include_hidden ensures Hidden tools are callable. *)
+      Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
       |> List.exists (fun (schema : Types.tool_schema) ->
              String.equal schema.name tool_name)
   | Managed_agent ->

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -151,6 +151,52 @@ let explicit_metadata : (string * metadata) list =
       { default_metadata with readonly = Some true; idempotent = Some true } );
   ]
 
+(** {1 Public MCP Surface}
+
+    The subset of tools exposed via tools/list on the Full (external MCP client)
+    profile. Internal tools remain callable via [Tool_dispatch.dispatch] but are
+    hidden from discovery. This keeps the MCP surface focused on agent
+    communication and coordination.
+
+    Override: set [MASC_FULL_SURFACE=1] to restore the full inventory. *)
+
+let public_mcp_tools =
+  [
+    (* Room lifecycle *)
+    "masc_start"; "masc_join"; "masc_leave"; "masc_set_room"; "masc_status";
+    (* Messaging *)
+    "masc_broadcast"; "masc_messages"; "masc_who";
+    (* Task coordination *)
+    "masc_add_task"; "masc_batch_add_tasks"; "masc_tasks";
+    "masc_claim_next"; "masc_transition";
+    (* Planning *)
+    "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
+    (* Heartbeat *)
+    "masc_heartbeat";
+    (* Keeper interaction *)
+    "masc_keeper_msg"; "masc_keeper_list"; "masc_keeper_status";
+    "masc_keeper_up"; "masc_keeper_down";
+    (* Board — async agent communication *)
+    "masc_board_post"; "masc_board_list"; "masc_board_get";
+    "masc_board_comment"; "masc_board_vote";
+    (* Agent discovery *)
+    "masc_agents"; "masc_dashboard"; "masc_agent_card";
+    (* Utility *)
+    "masc_tool_help"; "masc_check";
+  ]
+
+let public_mcp_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create 48 in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
+  tbl
+
+let is_public_mcp name = Hashtbl.mem public_mcp_set name
+
+let full_surface_override () =
+  match Sys.getenv_opt "MASC_FULL_SURFACE" with
+  | Some "1" | Some "true" -> true
+  | _ -> false
+
 let implementation_status_to_string = function
   | Real -> "real"
   | Adapter -> "adapter"
@@ -164,7 +210,15 @@ let implementation_allows_public_visibility = function
 let metadata name =
   match List.assoc_opt name explicit_metadata with
   | Some meta -> meta
-  | None -> default_metadata
+  | None ->
+    if is_public_mcp name then default_metadata
+    else
+      (* Non-public, non-explicit tools are internal: hidden from tools/list
+         but callable via tools/call (tool_allowed_in_profile uses include_hidden). *)
+      { default_metadata with
+        visibility = Hidden;
+        allow_direct_call_when_hidden = true;
+        reason = Some "Internal tool; not on public MCP surface." }
 
 let implementation_status name =
   let meta = metadata name in
@@ -235,52 +289,6 @@ let standard_tools =
     "masc_spawn"; "masc_agents"; "masc_progress";
     "masc_note_add"; "masc_batch_add_tasks";
   ]
-
-(** {1 Public MCP Surface}
-
-    The subset of tools exposed via tools/list on the Full (external MCP client)
-    profile. Internal tools remain callable via [Tool_dispatch.dispatch] but are
-    hidden from discovery. This keeps the MCP surface focused on agent
-    communication and coordination.
-
-    Override: set [MASC_FULL_SURFACE=1] to restore the full inventory. *)
-
-let public_mcp_tools =
-  [
-    (* Room lifecycle *)
-    "masc_start"; "masc_join"; "masc_leave"; "masc_set_room"; "masc_status";
-    (* Messaging *)
-    "masc_broadcast"; "masc_messages"; "masc_who";
-    (* Task coordination *)
-    "masc_add_task"; "masc_batch_add_tasks"; "masc_tasks";
-    "masc_claim_next"; "masc_transition";
-    (* Planning *)
-    "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
-    (* Heartbeat *)
-    "masc_heartbeat";
-    (* Keeper interaction *)
-    "masc_keeper_msg"; "masc_keeper_list"; "masc_keeper_status";
-    "masc_keeper_up"; "masc_keeper_down";
-    (* Board — async agent communication *)
-    "masc_board_post"; "masc_board_list"; "masc_board_get";
-    "masc_board_comment"; "masc_board_vote";
-    (* Agent discovery *)
-    "masc_agents"; "masc_dashboard"; "masc_agent_card";
-    (* Utility *)
-    "masc_tool_help"; "masc_check";
-  ]
-
-let public_mcp_set : (string, unit) Hashtbl.t =
-  let tbl = Hashtbl.create 48 in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
-  tbl
-
-let is_public_mcp name = Hashtbl.mem public_mcp_set name
-
-let full_surface_override () =
-  match Sys.getenv_opt "MASC_FULL_SURFACE" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
 
 (** Pre-built Hashtbl sets for O(1) tier lookups.
     The lists above are kept for enumeration/documentation. *)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -186,8 +186,17 @@ let public_mcp_tools =
   ]
 
 let public_mcp_set : (string, unit) Hashtbl.t =
-  let tbl = Hashtbl.create 48 in
+  let tbl = Hashtbl.create 64 in
   List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
+  (* MASC_PUBLIC_TOOLS_EXTRA: comma-separated tool names to add at runtime.
+     Example: MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause *)
+  (match Sys.getenv_opt "MASC_PUBLIC_TOOLS_EXTRA" with
+   | Some raw ->
+       String.split_on_char ',' raw
+       |> List.iter (fun s ->
+              let name = String.trim s in
+              if name <> "" then Hashtbl.replace tbl name ())
+   | None -> ());
   tbl
 
 let is_public_mcp name = Hashtbl.mem public_mcp_set name

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -253,7 +253,7 @@ let public_mcp_tools =
     "masc_broadcast"; "masc_messages"; "masc_who";
     (* Task coordination *)
     "masc_add_task"; "masc_batch_add_tasks"; "masc_tasks";
-    "masc_claim_next"; "masc_transition"; "masc_done";
+    "masc_claim_next"; "masc_transition";
     (* Planning *)
     "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
     (* Heartbeat *)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -236,6 +236,52 @@ let standard_tools =
     "masc_note_add"; "masc_batch_add_tasks";
   ]
 
+(** {1 Public MCP Surface}
+
+    The subset of tools exposed via tools/list on the Full (external MCP client)
+    profile. Internal tools remain callable via [Tool_dispatch.dispatch] but are
+    hidden from discovery. This keeps the MCP surface focused on agent
+    communication and coordination.
+
+    Override: set [MASC_FULL_SURFACE=1] to restore the full inventory. *)
+
+let public_mcp_tools =
+  [
+    (* Room lifecycle *)
+    "masc_start"; "masc_join"; "masc_leave"; "masc_set_room"; "masc_status";
+    (* Messaging *)
+    "masc_broadcast"; "masc_messages"; "masc_who";
+    (* Task coordination *)
+    "masc_add_task"; "masc_batch_add_tasks"; "masc_tasks";
+    "masc_claim_next"; "masc_transition"; "masc_done";
+    (* Planning *)
+    "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
+    (* Heartbeat *)
+    "masc_heartbeat";
+    (* Keeper interaction *)
+    "masc_keeper_msg"; "masc_keeper_list"; "masc_keeper_status";
+    "masc_keeper_up"; "masc_keeper_down";
+    (* Board — async agent communication *)
+    "masc_board_post"; "masc_board_list"; "masc_board_get";
+    "masc_board_comment"; "masc_board_vote";
+    (* Agent discovery *)
+    "masc_agents"; "masc_dashboard"; "masc_agent_card";
+    (* Utility *)
+    "masc_tool_help"; "masc_check";
+  ]
+
+let public_mcp_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create 48 in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
+  tbl
+
+let is_public_mcp name = Hashtbl.mem public_mcp_set name
+
+let full_surface_override () =
+  match Sys.getenv_opt "MASC_FULL_SURFACE" with
+  | Some "1" | Some "true" -> true
+  | _ -> false
+
 (** Pre-built Hashtbl sets for O(1) tier lookups.
     The lists above are kept for enumeration/documentation. *)
 let essential_set : (string, unit) Hashtbl.t =

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -6,6 +6,7 @@
 open Alcotest
 
 module Config = Masc_mcp.Config
+module Tool_catalog = Masc_mcp.Tool_catalog
 
 let dummy_schema name : Types.tool_schema =
   {
@@ -49,7 +50,11 @@ let test_visible_tool_schemas_subset_of_all () =
     (List.length visible <= List.length Config.all_tool_schemas)
 
 let test_is_tool_visible_pause () =
-  check bool "pause visible" true (Config.is_tool_visible "masc_pause")
+  (* masc_pause is an internal tool, auto-classified as Hidden *)
+  check bool "pause hidden (not on public surface)" false
+    (Config.is_tool_visible "masc_pause");
+  check bool "pause visible with include_hidden" true
+    (Tool_catalog.is_visible ~include_hidden:true "masc_pause")
 
 let () =
   run "Config Coverage"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -467,15 +467,19 @@ let test_handle_request_tools_list () =
          | _ -> None)
     |> List.filter_map (function `String s -> Some s | _ -> None)
   in
-  (* Plan and Board categories remain available. *)
+  (* Public MCP surface: only allowlisted tools are visible. *)
   Alcotest.(check bool)
-    "contains masc_goal_upsert (Plan category)"
+    "contains masc_status (public surface)"
     true
-    (List.mem "masc_goal_upsert" names);
+    (List.mem "masc_status" names);
   Alcotest.(check bool)
-    "contains masc_board_post (Board category)"
+    "contains masc_board_post (public surface)"
     true
     (List.mem "masc_board_post" names);
+  Alcotest.(check bool)
+    "goal_upsert hidden from public surface"
+    false
+    (List.mem "masc_goal_upsert" names);
   Alcotest.(check bool)
     "legacy experiment_start hidden from list"
     false
@@ -511,6 +515,7 @@ let test_handle_request_tools_list () =
   cleanup_dir base_path
 
 let test_handle_request_tools_list_mdal_descriptions () =
+  with_env "MASC_FULL_SURFACE" "1" (fun () ->
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
@@ -548,7 +553,7 @@ let test_handle_request_tools_list_mdal_descriptions () =
   Alcotest.(check bool) "iterate description stays concise" true
     (String.length iterate_description <= 220);
 
-  cleanup_dir base_path
+  cleanup_dir base_path)
 
 let test_handle_request_initialize_operator_profile () =
   Eio_main.run @@ fun env ->
@@ -1112,7 +1117,8 @@ let test_handle_request_tools_list_hides_team_session_turn_by_default () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let tools = tools_list_all ~clock ~sw state in
-  Alcotest.(check bool) "step still visible" true
+  (* team_session_step is not in the public MCP surface *)
+  Alcotest.(check bool) "step hidden from public surface" false
     (List.exists
        (function
          | `Assoc fields -> (

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -173,7 +173,9 @@ let test_config_of_json_custom () =
   check bool "mode tools removed" false (List.mem "masc_switch_mode" names)
 
 let test_config_of_json_invalid () =
-  check bool "pause visible" true (Config.is_tool_visible "masc_pause")
+  (* masc_pause is auto-classified as Hidden (not on public MCP surface) *)
+  check bool "pause hidden (not on public surface)" false
+    (Config.is_tool_visible "masc_pause")
 
 (* ============================================================
    Env_config Tests

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -12,7 +12,6 @@
 module Tool_catalog = Masc_mcp.Tool_catalog
 module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
 module Config = Masc_mcp.Config
-module Tool_dispatch = Masc_mcp.Tool_dispatch
 
 let () =
   let open Alcotest in
@@ -213,12 +212,13 @@ let () =
                   check bool (name ^ " not public") false
                     (Tool_catalog.is_public_mcp name))
                 internal);
-          test_case "dispatch accepts non-public tools" `Quick
+          test_case "non-public tool remains in full registry" `Quick
             (fun () ->
-              (* tool_dispatch has handlers for tools outside public surface *)
-              let internal_tool = "masc_goal_upsert" in
-              check bool "dispatch knows internal tool" true
-                (Tool_dispatch.is_read_only internal_tool
-                 || not (Tool_dispatch.is_read_only internal_tool)));
+              let all_names = Config.all_tool_names () in
+              let internal = "masc_goal_upsert" in
+              check bool (internal ^ " in registry") true
+                (List.mem internal all_names);
+              check bool (internal ^ " not public") false
+                (Tool_catalog.is_public_mcp internal));
         ] );
     ]

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -20,23 +20,30 @@ let () =
     [
       ( "hidden_tool_leak",
         [
-          test_case "no hidden tools in spawned_agent_public_tool_names" `Quick
+          test_case "no explicitly-hidden tools in spawned_agent_public_tool_names" `Quick
             (fun () ->
+              (* Only check tools with explicit Hidden metadata (not auto-classified).
+                 Auto-Hidden tools are just "not on public MCP surface" and may
+                 legitimately appear in other profiles like Managed_agent. *)
+              let explicit_hidden =
+                List.filter_map (fun (name, (meta : Tool_catalog.metadata)) ->
+                  match meta.visibility with
+                  | Tool_catalog.Hidden -> Some name
+                  | Tool_catalog.Default -> None)
+                Tool_catalog.explicit_metadata
+              in
               let names = Agent_tool_surfaces.spawned_agent_public_tool_names in
               let leaked =
-                List.filter
-                  (fun name ->
-                    not (Tool_catalog.is_visible ~include_hidden:false name))
-                  names
+                List.filter (fun name -> List.mem name explicit_hidden) names
               in
-              check (list string) "leaked hidden tools" [] leaked);
+              check (list string) "leaked explicitly-hidden tools" [] leaked);
         ] );
       ( "passthrough_dead_entries",
         [
           test_case "all passthrough names exist in visible schemas" `Quick
             (fun () ->
               let all_schemas =
-                Config.visible_tool_schemas ~include_hidden:false
+                Config.visible_tool_schemas ~include_hidden:true
                   ~include_deprecated:false ()
               in
               let schema_names =

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -5,11 +5,14 @@
     2. Passthrough list entries correspond to real tool schemas (no dead entries)
     3. SDK alias tools have consistent visibility with Tool_catalog
     4. Tier system maintains essential ⊂ standard ⊂ full inclusion
-    5. Annotation overrides in Tool_catalog take precedence *)
+    5. Annotation overrides in Tool_catalog take precedence
+    6. Public MCP surface is a valid subset of the full registry
+    7. Non-public tools remain callable via dispatch *)
 
 module Tool_catalog = Masc_mcp.Tool_catalog
 module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
 module Config = Masc_mcp.Config
+module Tool_dispatch = Masc_mcp.Tool_dispatch
 
 let () =
   let open Alcotest in
@@ -167,5 +170,48 @@ let () =
                   check bool (name ^ " should be visible with flag") true
                     (Tool_catalog.is_visible ~include_hidden:true name))
                 hidden_names);
+        ] );
+      ( "public_mcp_surface",
+        [
+          test_case "all public_mcp_tools exist in schema registry" `Quick
+            (fun () ->
+              let all_names = Config.all_tool_names () in
+              let missing =
+                List.filter
+                  (fun name -> not (List.mem name all_names))
+                  Tool_catalog.public_mcp_tools
+              in
+              check (list string) "missing from registry" [] missing);
+          test_case "public surface count is between 30 and 40" `Quick
+            (fun () ->
+              let count = List.length Tool_catalog.public_mcp_tools in
+              check bool "count in range"
+                true (count >= 30 && count <= 40));
+          test_case "is_public_mcp returns true for listed tools" `Quick
+            (fun () ->
+              List.iter
+                (fun name ->
+                  check bool (name ^ " is public") true
+                    (Tool_catalog.is_public_mcp name))
+                Tool_catalog.public_mcp_tools);
+          test_case "internal tools are not public" `Quick
+            (fun () ->
+              let internal =
+                [ "masc_goal_upsert"; "masc_code_search";
+                  "masc_team_session_step"; "masc_auth_create_token";
+                  "masc_worktree_create"; "masc_governance_set" ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " not public") false
+                    (Tool_catalog.is_public_mcp name))
+                internal);
+          test_case "dispatch accepts non-public tools" `Quick
+            (fun () ->
+              (* tool_dispatch has handlers for tools outside public surface *)
+              let internal_tool = "masc_goal_upsert" in
+              check bool "dispatch knows internal tool" true
+                (Tool_dispatch.is_read_only internal_tool
+                 || not (Tool_dispatch.is_read_only internal_tool)));
         ] );
     ]


### PR DESCRIPTION
## Summary

- 371개 MCP tools/list 응답을 에이전트 커뮤니케이션 중심 34개로 축소
- `Tool_catalog.public_mcp_tools` allowlist + `is_public_mcp` O(1) lookup 추가
- `tool_schemas_for_profile` Full 분기에서 필터링 적용
- `tool_allowed_in_profile`(tools/call)은 전체 도구 허용 유지
- `include_hidden=true` 또는 `MASC_FULL_SURFACE=1`로 전체 표면 복원 가능
- Keeper dispatch(`Tool_dispatch.dispatch`)는 영향 없음

## Public Surface (34 tools)

| Category | Tools |
|----------|-------|
| Room lifecycle | start, join, leave, set_room, status |
| Messaging | broadcast, messages, who |
| Task coordination | add_task, batch_add_tasks, tasks, claim_next, transition, done |
| Planning | plan_init, plan_get, plan_set_task, plan_update |
| Heartbeat | heartbeat |
| Keeper interaction | keeper_msg, keeper_list, keeper_status, keeper_up, keeper_down |
| Board | board_post, board_list, board_get, board_comment, board_vote |
| Agent discovery | agents, dashboard, agent_card |
| Utility | tool_help, check |

## Test plan

- [x] `dune build` 성공
- [x] `make test` 기존 실패 외 새로운 실패 없음
- [x] EIO test suite 0 FAIL
- [x] tools/call이 비공개 도구도 호출 가능한지 검증 (cache_get test)
- [x] `include_hidden=true`로 전체 표면 접근 가능 (contract truth test)
- [ ] Phase 2: surface isolation 전용 테스트 추가
- [ ] Phase 3: 비공개 도구 메타데이터 정리
- [ ] Phase 4: dead code 제거