### PR TITLE
fix(runtime): guard against chat contract drift

### DIFF
--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -166,7 +166,7 @@ let schemas : tool_schema list =
     {
       name = "masc_runtime_verify";
       description =
-        "Strictly verify the active provider/runtime contract used for swarm and benchmark runs. Returns reachability, model match, slots, ctx, configured capacity, active slots, and blocker codes such as provider_unreachable, provider_model_mismatch, slot_count_insufficient, or ctx_mismatch.";
+        "Strictly verify the active provider/runtime contract used for swarm and benchmark runs. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and blocker codes such as provider_unreachable, provider_model_mismatch, slot_count_insufficient, ctx_mismatch, or chat_contract_incompatible.";
       input_schema =
         `Assoc
           [

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -49,6 +49,43 @@ let http_get_json_with_status ?(timeout_sec = 10) url =
       with Yojson.Json_error msg ->
         Error (Printf.sprintf "invalid json from %s: %s" url msg))
 
+let http_post_json_text_with_status ~timeout_sec ~url ~body_json =
+  let status, body =
+    Process_eio.run_argv_with_status
+      [
+        "curl";
+        "-sS";
+        "--http1.1";
+        "--max-time";
+        string_of_int (max 1 timeout_sec);
+        "-H";
+        "Content-Type: application/json";
+        "-d";
+        body_json;
+        "-w";
+        "\n%{http_code}";
+        url;
+      ]
+  in
+  match status with
+  | Unix.WEXITED 0 ->
+      let payload, http_status = split_http_body_and_status body in
+      Ok (http_status, payload)
+  | Unix.WEXITED code ->
+      Error (Printf.sprintf "curl exit code %d for %s" code url)
+  | Unix.WSIGNALED sig_num ->
+      Error (Printf.sprintf "curl signal %d for %s" sig_num url)
+  | Unix.WSTOPPED sig_num ->
+      Error (Printf.sprintf "curl stopped %d for %s" sig_num url)
+
+let http_post_json_with_status ~timeout_sec ~url ~body_json =
+  match http_post_json_text_with_status ~timeout_sec ~url ~body_json with
+  | Error _ as err -> err
+  | Ok (http_status, payload) -> (
+      try Ok (http_status, Yojson.Safe.from_string payload)
+      with Yojson.Json_error msg ->
+        Error (Printf.sprintf "invalid json from %s: %s" url msg))
+
 let int_member json key =
   let open Yojson.Safe.Util in
   match member key json with

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -174,9 +174,39 @@ let probe_chat_completion_compatible
 let provider_health_reachable ~status ~body:_ =
   status = Some 200
 
-let classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
-    ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
-    ~chat_completion_compatible
+let chat_contract_probe_body ~model_id =
+  Yojson.Safe.to_string
+    (`Assoc
+      [
+        ("model", `String model_id);
+        ("messages", `List [ `Assoc [ ("role", `String "user"); ("content", `String "ping") ] ]);
+        ("max_tokens", `Int 1);
+        ("temperature", `Float 0.0);
+      ])
+
+let chat_contract_reachable ~status ~body =
+  if status <> Some 200 then
+    false
+  else
+    match body with
+    | None -> false
+    | Some payload -> (
+        match Yojson.Safe.from_string payload with
+        | exception Yojson.Json_error _ -> false
+        | json -> (
+            match Yojson.Safe.Util.member "choices" json with
+            | `List _ -> true
+            | _ -> false))
+
+let chat_contract_status ~status ~body ~error =
+  match status with
+  | Some 200 when chat_contract_reachable ~status ~body -> "confirmed"
+  | Some _ -> "rejected"
+  | None -> if Option.is_some error then "unknown" else "unknown"
+
+let classify_runtime_blocker ~provider_reachable ~slot_reachable
+    ~chat_contract_status ~expected_model ~actual_model_id ~expected_slots
+    ~actual_slots_total ~expected_ctx ~actual_ctx ~chat_completion_compatible
     =
   if not provider_reachable || not slot_reachable then
     (Some "provider_unreachable", Some "llama runtime health or slots endpoint failed")
@@ -214,6 +244,9 @@ let classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
         (Printf.sprintf "expected ctx %s, got %s"
            (match expected_ctx with Some value -> string_of_int value | None -> "<none>")
            (match actual_ctx with Some value -> string_of_int value | None -> "<mixed-or-missing>")) )
+  else if String.equal chat_contract_status "rejected" then
+    ( Some "chat_contract_incompatible",
+      Some "runtime passed health/slots but failed /v1/chat/completions contract probe" )
   else
     (None, None)
 
@@ -312,7 +345,9 @@ let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_c
     | _ -> None
   in
   let runtime_blocker, detail =
-    classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
+    classify_runtime_blocker ~provider_reachable ~slot_reachable
+      ~chat_contract_status:(if chat_completion_compatible then "confirmed" else "rejected")
+      ~expected_model
       ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx
       ~actual_ctx ~chat_completion_compatible
   in
@@ -357,10 +392,10 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
   let configured_max_concurrent_models = Inference_utils.max_concurrent_models in
   let available_model_permits = Inference_utils.model_permits_available () in
   let runtime_rows, provider_reachable, slot_reachable, actual_slots_total,
-      active_slots_now, actual_ctxs, actual_models =
+      active_slots_now, actual_ctxs, actual_models, chat_contract_statuses =
     List.fold_left
       (fun
-        (rows, provider_ok, slot_ok, slots_acc, active_acc, ctxs, models)
+        (rows, provider_ok, slot_ok, slots_acc, active_acc, ctxs, models, chat_states)
         (runtime : Local_runtime_pool.runtime_snapshot)
       ->
         let base_url = String.trim runtime.base_url in
@@ -421,6 +456,27 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
           | Some model -> Some model
           | None -> runtime.model
         in
+        let probe_model =
+          match actual_model with
+          | Some model_id -> Some model_id
+          | None -> (
+              match expected_model with
+              | Some model_id when String.trim model_id <> "" -> Some (String.trim model_id)
+              | _ -> runtime.model)
+        in
+        let chat_status, chat_body, chat_err =
+          match probe_model with
+          | None -> (None, None, Some "chat contract probe skipped: no model id available")
+          | Some model_id ->
+              let url = base_url ^ "/v1/chat/completions" in
+              let body_json = chat_contract_probe_body ~model_id in
+              match http_post_json_text_with_status ~timeout_sec:15 ~url ~body_json with
+              | Ok (status_code, payload) -> (status_code, Some payload, None)
+              | Error err -> (None, None, Some err)
+        in
+        let chat_status_label =
+          chat_contract_status ~status:chat_status ~body:chat_body ~error:chat_err
+        in
         let current_active =
           slot_json |> Option.map active_slots_of_json |> Option.value ~default:0
         in
@@ -441,6 +497,10 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
               ("props_error", string_opt_to_json props_err);
               ("models_status_code", int_opt_to_json models_status);
               ("models_error", string_opt_to_json models_err);
+              ("chat_status_code", int_opt_to_json chat_status);
+              ("chat_contract_status", `String chat_status_label);
+              ("chat_contract_reachable", `Bool (chat_contract_reachable ~status:chat_status ~body:chat_body));
+              ("chat_error", string_opt_to_json chat_err);
               ("expected_model", string_opt_to_json expected_model);
               ("actual_model_id", string_opt_to_json actual_model);
               ("expected_slots", int_opt_to_json expected_slots);
@@ -456,8 +516,9 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
           slots_acc + Option.value ~default:0 actual_slots,
           active_acc + current_active,
           (match actual_ctx with Some value -> value :: ctxs | None -> ctxs),
-          (match actual_model with Some value -> value :: models | None -> models) ))
-      ([], true, true, 0, 0, [], []) runtimes
+          (match actual_model with Some value -> value :: models | None -> models),
+          chat_status_label :: chat_states ))
+      ([], true, true, 0, 0, [], [], []) runtimes
   in
   let actual_ctx =
     match List.sort_uniq compare actual_ctxs with [ value ] -> Some value | _ -> None
@@ -467,9 +528,19 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
     | [ value ] -> Some value
     | _ -> None
   in
+  let overall_chat_contract_status =
+    let states = List.sort_uniq String.compare chat_contract_statuses in
+    if List.mem "rejected" states then
+      "rejected"
+    else if List.mem "unknown" states then
+      "unknown"
+    else
+      "confirmed"
+  in
   let runtime_blocker, detail =
     classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
       ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
+      ~chat_contract_status:overall_chat_contract_status
       ~chat_completion_compatible:true
   in
   `Assoc
@@ -481,6 +552,8 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
       ("provider_reachable", `Bool provider_reachable);
       ("slot_reachable", `Bool slot_reachable);
       ("chat_completion_compatible", `Bool true);
+      ("chat_contract_status", `String overall_chat_contract_status);
+      ("chat_contract_reachable", `Bool (String.equal overall_chat_contract_status "confirmed"));
       ("expected_model", string_opt_to_json expected_model);
       ("actual_model_id", string_opt_to_json actual_model_id);
       ("expected_slots", int_opt_to_json expected_slots);

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -198,11 +198,12 @@ let chat_contract_reachable ~status ~body =
             | `List _ -> true
             | _ -> false))
 
-let chat_contract_status ~status ~body ~error =
+let chat_contract_status ~status ~body =
   match status with
   | Some 200 when chat_contract_reachable ~status ~body -> "confirmed"
-  | Some _ -> "rejected"
-  | None -> if Option.is_some error then "unknown" else "unknown"
+  | Some (400 | 404 | 405 | 415 | 422) -> "rejected"
+  | Some _ -> "unknown"
+  | None -> "unknown"
 
 let classify_runtime_blocker ~provider_reachable ~slot_reachable
     ~chat_contract_status ~expected_model ~actual_model_id ~expected_slots
@@ -382,6 +383,7 @@ let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_c
 let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
     ?expected_model () =
   let runtimes = runtime_snapshots_for_pool runtime_pool in
+  let has_runtimes = runtimes <> [] in
   let configured_capacity =
     runtimes
     |> List.fold_left
@@ -475,7 +477,7 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
               | Error err -> (None, None, Some err)
         in
         let chat_status_label =
-          chat_contract_status ~status:chat_status ~body:chat_body ~error:chat_err
+          chat_contract_status ~status:chat_status ~body:chat_body
         in
         let current_active =
           slot_json |> Option.map active_slots_of_json |> Option.value ~default:0
@@ -530,7 +532,9 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
   in
   let overall_chat_contract_status =
     let states = List.sort_uniq String.compare chat_contract_statuses in
-    if List.mem "rejected" states then
+    if not has_runtimes then
+      "unknown"
+    else if List.mem "rejected" states then
       "rejected"
     else if List.mem "unknown" states then
       "unknown"
@@ -538,7 +542,9 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
       "confirmed"
   in
   let runtime_blocker, detail =
-    classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
+    classify_runtime_blocker
+      ~provider_reachable:(provider_reachable && has_runtimes)
+      ~slot_reachable:(slot_reachable && has_runtimes) ~expected_model
       ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
       ~chat_contract_status:overall_chat_contract_status
       ~chat_completion_compatible:true
@@ -549,8 +555,8 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
       ("runtime_pool", string_opt_to_json runtime_pool);
       ("provider_base_url", `String Env_config.Llama.server_url);
       ("slot_url", `String Env_config.Llama.server_url);
-      ("provider_reachable", `Bool provider_reachable);
-      ("slot_reachable", `Bool slot_reachable);
+      ("provider_reachable", `Bool (provider_reachable && has_runtimes));
+      ("slot_reachable", `Bool (slot_reachable && has_runtimes));
       ("chat_completion_compatible", `Bool true);
       ("chat_contract_status", `String overall_chat_contract_status);
       ("chat_contract_reachable", `Bool (String.equal overall_chat_contract_status "confirmed"));

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 extract_text() {
-  jq -r 'if ._harness_error? then empty else try (.result.content[0].text) catch empty end'
+  mcp_extract_text
 }
 
 PASS=0

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 extract_text() {
-  mcp_extract_text
+  jq -r 'if ._harness_error? then empty else try (.result.content[0].text) catch empty end'
 }
 
 PASS=0

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -191,8 +191,10 @@ chat_contract_status() {
   body="${body%$'\n'*}"
   if [ "$status" = "200" ] && printf '%s' "$body" | jq -e '.choices | type == "array"' >/dev/null 2>&1; then
     printf 'confirmed'
-  else
+  elif [[ "$status" =~ ^(400|404|405|415|422)$ ]]; then
     printf 'rejected'
+  else
+    printf 'unknown'
   fi
 }
 

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -13,6 +13,11 @@ DEFAULT_CHAT_TEMPLATE="${LLAMA_POOL_CHAT_TEMPLATE:-chatml}"
 DEFAULT_CHAT_TEMPLATE_KWARGS="${LLAMA_POOL_CHAT_TEMPLATE_KWARGS:-{\"enable_thinking\":false}}"
 SEED_BINARY=""
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 1
+fi
+
 mkdir -p "$STATE_DIR"
 
 usage() {

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -165,6 +165,37 @@ port_is_listening() {
   lsof -iTCP:"$1" -sTCP:LISTEN -t >/dev/null 2>&1
 }
 
+chat_probe_payload() {
+  jq -cn --arg model "$1" \
+    '{model:$model,messages:[{role:"user",content:"ping"}],max_tokens:1,temperature:0}'
+}
+
+chat_contract_status() {
+  local port="$1"
+  local payload body status rc
+  payload="$(chat_probe_payload "$MODEL_ALIAS")"
+  if body="$(curl -sS --http1.1 --max-time 15 \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    -w '\n%{http_code}' \
+    "$(runtime_url "$port")/v1/chat/completions" 2>/dev/null)"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [ "${rc:-0}" -ne 0 ]; then
+    printf 'unknown'
+    return 0
+  fi
+  status="${body##*$'\n'}"
+  body="${body%$'\n'*}"
+  if [ "$status" = "200" ] && printf '%s' "$body" | jq -e '.choices | type == "array"' >/dev/null 2>&1; then
+    printf 'confirmed'
+  else
+    printf 'rejected'
+  fi
+}
+
 wait_for_runtime() {
   local port="$1"
   local deadline=$((SECONDS + 45))
@@ -236,10 +267,19 @@ print_env_value() {
   resolve_seed_args
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))
   local endpoints=()
-  local port
+  local port contract_status
   for port in $(seq "$SEED_PORT" "$max_port"); do
-    if port_is_listening "$port"; then
+    if ! port_is_listening "$port"; then
+      continue
+    fi
+    contract_status="$(chat_contract_status "$port")"
+    if [ "$contract_status" != "rejected" ]; then
       endpoints+=("$(runtime_url "$port")")
+      if [ "$contract_status" = "unknown" ]; then
+        echo "warning: including $(runtime_id "$port") in runtime pool with unconfirmed chat contract (probe timed out or transport failed)" >&2
+      fi
+    else
+      echo "warning: excluding $(runtime_id "$port") from runtime pool; /v1/chat/completions contract probe failed" >&2
     fi
   done
   local joined=""
@@ -269,12 +309,19 @@ start_pool() {
 
 status_pool() {
   resolve_seed_args
-  local port
+  local port contract_status
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))
   for port in $(seq "$SEED_PORT" "$max_port"); do
     printf '%s\t%s\t' "$(runtime_id "$port")" "$(runtime_url "$port")"
     if port_is_listening "$port"; then
-      printf 'up\n'
+      contract_status="$(chat_contract_status "$port")"
+      if [ "$contract_status" = "confirmed" ]; then
+        printf 'up-chat\n'
+      elif [ "$contract_status" = "unknown" ]; then
+        printf 'up-unknown\n'
+      else
+        printf 'up-nochat\n'
+      fi
     else
       printf 'down\n'
     fi

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -14,7 +14,7 @@ let test_provider_health_reachable_accepts_json_health () =
 let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =
   let blocker, detail =
     Masc_mcp.Tool_local_runtime.classify_runtime_blocker ~provider_reachable:true
-      ~slot_reachable:true
+      ~slot_reachable:true ~chat_contract_status:"confirmed"
       ~expected_model:(Some "qwen3.5-35b-a3b-ud-q8-xl")
       ~actual_model_id:(Some "qwen3.5-35b-a3b-ud-q8-xl")
       ~expected_slots:(Some 12) ~actual_slots_total:4
@@ -79,6 +79,23 @@ let test_runtime_verify_prefers_oas_discovery_cache () =
       check bool "passes expected contract" true
         (result |> member "pass" |> to_bool))
 
+let test_classify_runtime_blocker_flags_chat_contract_mismatch () =
+  let blocker, detail =
+    Masc_mcp.Tool_local_runtime.classify_runtime_blocker ~provider_reachable:true
+      ~slot_reachable:true ~chat_contract_status:"rejected"
+      ~expected_model:(Some "Qwen3.5-9B-Q4_K_M.gguf")
+      ~actual_model_id:(Some "Qwen3.5-9B-Q4_K_M.gguf")
+      ~expected_slots:(Some 4) ~actual_slots_total:4
+      ~expected_ctx:(Some 131072) ~actual_ctx:(Some 131072)
+      ~chat_completion_compatible:false
+  in
+  check (option string) "chat blocker" (Some "chat_contract_incompatible")
+    blocker;
+  check bool "detail mentions chat contract" true
+    (match detail with
+    | Some msg -> String.contains msg 'c'
+    | None -> false)
+
 let () =
   run "tool_local_runtime_verify"
     [
@@ -93,5 +110,7 @@ let () =
             test_classify_runtime_blocker_prefers_slot_count_when_health_ok;
           test_case "runtime verify prefers oas discovery cache" `Quick
             test_runtime_verify_prefers_oas_discovery_cache;
+          test_case "chat contract mismatch is reported" `Quick
+            test_classify_runtime_blocker_flags_chat_contract_mismatch;
         ] );
     ]

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -87,7 +87,7 @@ let test_classify_runtime_blocker_flags_chat_contract_mismatch () =
       ~actual_model_id:(Some "Qwen3.5-9B-Q4_K_M.gguf")
       ~expected_slots:(Some 4) ~actual_slots_total:4
       ~expected_ctx:(Some 131072) ~actual_ctx:(Some 131072)
-      ~chat_completion_compatible:false
+      ~chat_completion_compatible:true
   in
   check (option string) "chat blocker" (Some "chat_contract_incompatible")
     blocker;

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -96,6 +96,19 @@ let test_classify_runtime_blocker_flags_chat_contract_mismatch () =
     | Some msg -> String.contains msg 'c'
     | None -> false)
 
+let test_classify_runtime_blocker_allows_unknown_chat_status () =
+  let blocker, detail =
+    Masc_mcp.Tool_local_runtime.classify_runtime_blocker ~provider_reachable:true
+      ~slot_reachable:true ~chat_contract_status:"unknown"
+      ~expected_model:(Some "Qwen3.5-9B-Q4_K_M.gguf")
+      ~actual_model_id:(Some "Qwen3.5-9B-Q4_K_M.gguf")
+      ~expected_slots:(Some 4) ~actual_slots_total:4
+      ~expected_ctx:(Some 131072) ~actual_ctx:(Some 131072)
+      ~chat_completion_compatible:true
+  in
+  check (option string) "unknown chat is not blocker" None blocker;
+  check (option string) "unknown chat detail absent" None detail
+
 let () =
   run "tool_local_runtime_verify"
     [
@@ -112,5 +125,7 @@ let () =
             test_runtime_verify_prefers_oas_discovery_cache;
           test_case "chat contract mismatch is reported" `Quick
             test_classify_runtime_blocker_flags_chat_contract_mismatch;
+          test_case "unknown chat status is tolerated" `Quick
+            test_classify_runtime_blocker_allows_unknown_chat_status;
         ] );
     ]


### PR DESCRIPTION
## Summary

- add a chat-completions contract probe to local runtime verification so health-only green runtimes can still be flagged as incompatible
- classify runtime chat probe state as `confirmed`, `rejected`, or `unknown`, and only fail closed on explicit contract rejection
- gate `scripts/llama-runtime-pool.sh` env output on the same probe so drifted shards are excluded from the runtime pool

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/oas-chat-contract-guard lib/tool_local_runtime_http.ml lib/tool_local_runtime_verify.ml lib/tool_local_runtime.ml test/test_local_runtime_pool.exe`
- `./_build/default/test/test_local_runtime_pool.exe`
- `./_build/default/test/test_tool_local_runtime_verify.exe`
- `./scripts/llama-runtime-pool.sh status --target-shards 3 --seed-port 8085`
