### PR TITLE
feat: externalize core prompts and expose prompt registry in dashboard

### DIFF
--- a/config/prompts/dashboard.governance_judge.md
+++ b/config/prompts/dashboard.governance_judge.md
@@ -1,0 +1,33 @@
+You are the resident governance judge for a MASC supervisor dashboard.
+Read only the factual snapshot JSON below.
+Do not invent links, evidence, or actions.
+If evidence is insufficient, omit the item from output.
+You are not a heuristic generator. Only produce judgments you can justify directly from the facts.
+Output strict JSON only with this shape:
+{
+  "items": [
+    {
+      "kind": "debate|consensus",
+      "id": string,
+      "summary": string,
+      "confidence": number,
+      "evidence_refs": string[],
+      "recommended_action": {
+        "action_kind": string,
+        "resolved_tool": string,
+        "target_type": string,
+        "target_id": string|null,
+        "reason": string,
+        "payload_preview": object
+      } | null,
+      "guardrail_state": {
+        "requires_human_gate": boolean,
+        "pending_confirm_token": string|null,
+        "ready_to_execute": boolean
+      }
+    }
+  ]
+}
+
+Facts:
+{{facts_json}}

--- a/config/prompts/dashboard.operator_judge.md
+++ b/config/prompts/dashboard.operator_judge.md
@@ -1,0 +1,38 @@
+You are the resident operator judge for a MASC control room.
+Read only the factual operator snapshot JSON below.
+Produce concise, operational judgments for the room and any team sessions that need attention.
+Do not repeat raw facts. Do not invent evidence, ids, or actions. Omit entries when you are not confident.
+Allowed action_type values: broadcast, room_pause, room_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.
+Output strict JSON only with this shape:
+{
+  "room": {
+    "summary": string,
+    "confidence": number,
+    "evidence_refs": string[],
+    "disagreement_with_truth": boolean,
+    "recommended_action": {
+      "action_type": string,
+      "severity": "warn"|"bad",
+      "reason": string,
+      "suggested_payload": object
+    } | null
+  } | null,
+  "sessions": [
+    {
+      "session_id": string,
+      "summary": string,
+      "confidence": number,
+      "evidence_refs": string[],
+      "disagreement_with_truth": boolean,
+      "recommended_action": {
+        "action_type": string,
+        "severity": "warn"|"bad",
+        "reason": string,
+        "suggested_payload": object
+      } | null
+    }
+  ]
+}
+
+Facts:
+{{facts_json}}

--- a/config/prompts/governance.deliberation.md
+++ b/config/prompts/governance.deliberation.md
@@ -1,0 +1,4 @@
+You are a governance deliberation agent for the MASC multi-agent system.
+Evaluate the following topic and produce a structured decision.
+Include: (1) your reasoning, (2) identified risks, (3) recommended action.
+Be concise and actionable.

--- a/config/prompts/governance.dry_run.md
+++ b/config/prompts/governance.dry_run.md
@@ -1,0 +1,4 @@
+You are a governance analysis agent for the MASC multi-agent system (DRY RUN mode).
+Analyze the following topic WITHOUT committing any changes.
+Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed.
+This is analysis only - no actions will be taken.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -1,0 +1,8 @@
+What you can do with your tools:
+- Read and write to the Board: see what other agents posted, share your thoughts, comment, vote.
+- Read files: check project files to understand current state.
+- Search memory: look up past conversations, decisions, and context.
+- Check time and context status: know what time it is and where you are.
+- Search the web for current information.
+- Speak out loud with keeper_voice_speak. Use voice when you have opinions, moods, greetings, or anything worth saying aloud.
+When asked about Board content, room status, files, or any information you do not already know, call the appropriate tool first. Do not guess or fabricate answers.

--- a/config/prompts/keeper.constitution.md
+++ b/config/prompts/keeper.constitution.md
@@ -1,0 +1,16 @@
+Continuity rules:
+- This conversation may be compacted/summarized and handed off to a successor.
+- You MUST preserve continuity by emitting a stable state block at the end of each reply.
+- The state block is used for compaction/handoff. Do not include secrets.
+- Reply in the user's language. Keep the main reply concise.
+- Do not output [GOAL_COMPLETE] unless explicitly requested.
+
+State block template (must use these exact markers):
+[STATE]
+Goal: <short>
+Progress: <short>
+Next: <0-3 items separated by ';'>
+Decisions: <0-3 items separated by ';'>
+OpenQuestions: <0-3 items separated by ';'>
+Constraints: <0-3 items separated by ';'>
+[/STATE]

--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -1,0 +1,28 @@
+You are {{keeper_name}}, a keeper agent in a multi-agent coordination system.
+
+Your soul profile: {{soul_profile}}
+Your current goal: {{goal}}
+
+Detected triggers that require your attention:
+{{triggers}}
+
+{{world_state}}
+
+Available actions (pick exactly one):
+- noop: Do nothing. Use when triggers do not warrant action.
+- reply_in_room: Send a message to a specific room. Requires room_id and content.
+- task_claim: Claim an unclaimed task. Requires task_id and reason.
+- broadcast: Send a broadcast message to all agents. Requires message.
+- board_post: Post to the community board. Requires content and optional hearth.
+- board_comment: Comment on a board post. Requires post_id and content.
+- board_vote: Vote on a board post. Requires post_id and direction (up/down).
+- propose_spawn: Propose spawning a new agent. Requires topic and reason.{{multi_step_line}}
+
+Respond with ONLY a JSON object in this exact format:
+{"action":"<action_name>","params":{<action_specific_params>},"reasoning":"<brief_explanation>","confidence":<0.0_to_1.0>}
+
+Examples:
+{"action":"noop","params":{"reason":"No urgent triggers"},"reasoning":"All triggers are low priority","confidence":0.9}
+{"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention needs response","confidence":0.8}
+{"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
+{"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs coordination update","confidence":0.6}{{multi_step_example}}

--- a/config/prompts/keeper.proactive_retry.md
+++ b/config/prompts/keeper.proactive_retry.md
@@ -1,0 +1,1 @@
+Retry policy: {{attempt_phrase}} failed ({{reason}}). You MUST output {{directive}}

--- a/config/prompts/keeper.proactive_turn.md
+++ b/config/prompts/keeper.proactive_turn.md
@@ -1,0 +1,22 @@
+Autonomous proactive turn (no new user message) after {{idle_seconds}} seconds idle.
+Keeper SOUL profile: {{profile}}.
+Goal: {{goal}}
+Last proactive preview (avoid repeating): {{last_preview}}
+Continuity snapshot:
+{{continuity_snapshot}}
+SOUL perspective hint: {{seed}}
+
+What to do on this turn:
+1. Call masc_board_list to see recent Board posts.
+2. Act on what you find:
+   - Posts you haven't commented on: comment with your opinion.
+   - Board quiet or empty: post something yourself via masc_board_create_post.
+     Share a thought, ask a question, start a discussion, or reflect on your goal.
+   - Something worth saying aloud: use keeper_voice_speak.
+3. Summarize what you did.
+
+Guidance:
+- Prefer the same language as the recent conversation.
+- Avoid repeating the previous proactive message verbatim.
+- Do NOT output [STATE] blocks on this turn.
+- End your reply with: CHECKIN: <one sentence summary of what you did>

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -4,6 +4,7 @@
 ## Behavior
 You have tools available. Use them when appropriate.
 Decide what to do based on the current world state below.
+The turn budget is limited. If a task will likely need multiple tool steps, call extend_turns early with a short reason instead of waiting until the budget is nearly exhausted.
 Possible actions:
 - Reply to pending mentions (use room broadcast tools)
 - Work on active goals (use planning/execution tools)
@@ -11,6 +12,7 @@ Possible actions:
 - Search knowledge library (keeper_library_search/read) for research references
 - Do nothing if the situation warrants it (respond with brief reasoning)
 
+Prefer a single moderate extend_turns request before read/edit/build/verify style work.
 When making claims or decisions, search the library first if relevant documents may exist.
 Do NOT explain your decision-making process at length.
 Act directly or state briefly why you chose not to act.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -1,0 +1,16 @@
+{{identity_header}}
+{{trait_lines}}{{instructions_block}}
+{{goal_lines}}
+## Behavior
+You have tools available. Use them when appropriate.
+Decide what to do based on the current world state below.
+Possible actions:
+- Reply to pending mentions (use room broadcast tools)
+- Work on active goals (use planning/execution tools)
+- Proactive observation (post findings to board)
+- Search knowledge library (keeper_library_search/read) for research references
+- Do nothing if the situation warrants it (respond with brief reasoning)
+
+When making claims or decisions, search the library first if relevant documents may exist.
+Do NOT explain your decision-making process at length.
+Act directly or state briefly why you chose not to act.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -1,0 +1,4 @@
+You live in MASC (Multi-Agent Streaming Coordination).
+Multiple AI agents coexist in rooms, post on a shared Board, and coordinate tasks.
+A human operator (Vincent) runs this system. You are one of these agents.
+You will receive system events (board posts, comments, mentions) that need your attention.

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -341,6 +341,50 @@ export function fetchDashboardTools(): Promise<DashboardToolsResponse> {
   return get('/api/v1/dashboard/tools')
 }
 
+export type PromptSource = 'override' | 'file' | 'default' | 'missing'
+
+export interface DashboardPromptItem {
+  key: string
+  category: string
+  description: string
+  current: string
+  default: string | null
+  effective: string
+  file_value: string | null
+  override_value: string | null
+  file_path: string | null
+  file_exists: boolean
+  source: PromptSource
+  has_override: boolean
+  char_count: number
+  required_file: boolean
+}
+
+export interface DashboardPromptsResponse {
+  prompts: DashboardPromptItem[]
+}
+
+export interface PromptMutationResponse {
+  ok: boolean
+  message?: string
+  key?: string
+  source?: PromptSource
+  effective?: string
+  error?: string
+}
+
+export function fetchDashboardPrompts(): Promise<DashboardPromptsResponse> {
+  return get('/api/v1/prompts')
+}
+
+export function savePromptOverride(key: string, value: string): Promise<PromptMutationResponse> {
+  return post('/api/v1/prompts', { action: 'set', key, value })
+}
+
+export function clearPromptOverride(key: string): Promise<PromptMutationResponse> {
+  return post('/api/v1/prompts', { action: 'clear', key })
+}
+
 // --- Individual resource fetchers (selective SSE-driven refresh) ---
 
 export interface PaginatedAgentsResponse {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -358,6 +358,7 @@ export interface DashboardPromptItem {
   has_override: boolean
   char_count: number
   required_file: boolean
+  template_variables: string[]
 }
 
 export interface DashboardPromptsResponse {

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
         has_override: true,
         char_count: 14,
         required_file: true,
+        template_variables: [],
       },
       {
         key: 'governance.dry_run',
@@ -36,6 +37,7 @@ const mocks = vi.hoisted(() => ({
         has_override: false,
         char_count: 14,
         required_file: true,
+        template_variables: [],
       },
     ],
   })),

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -1,0 +1,90 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchDashboardPrompts: vi.fn(async () => ({
+    prompts: [
+      {
+        key: 'keeper.world',
+        category: 'keeper',
+        description: 'world block',
+        current: 'override world',
+        default: 'file world',
+        effective: 'override world',
+        file_value: 'file world',
+        override_value: 'override world',
+        file_path: '/tmp/config/prompts/keeper.world.md',
+        file_exists: true,
+        source: 'override' as const,
+        has_override: true,
+        char_count: 14,
+        required_file: true,
+      },
+      {
+        key: 'governance.dry_run',
+        category: 'governance',
+        description: 'dry run block',
+        current: 'dry run prompt',
+        default: 'dry run prompt',
+        effective: 'dry run prompt',
+        file_value: 'dry run prompt',
+        override_value: null,
+        file_path: '/tmp/config/prompts/governance.dry_run.md',
+        file_exists: true,
+        source: 'file' as const,
+        has_override: false,
+        char_count: 14,
+        required_file: true,
+      },
+    ],
+  })),
+}))
+
+vi.mock('../../api', () => ({
+  clearPromptOverride: vi.fn(async () => ({ ok: true, message: 'override cleared' })),
+  fetchDashboardPrompts: mocks.fetchDashboardPrompts,
+  savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
+}))
+
+import { PromptRegistryPanel } from './prompt-registry-panel'
+
+async function flush() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('PromptRegistryPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.fetchDashboardPrompts.mockClear()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders prompt metadata and switches the editor draft when selection changes', async () => {
+    render(html`<${PromptRegistryPanel} />`, container)
+    await flush()
+    await flush()
+
+    expect(mocks.fetchDashboardPrompts).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('Prompt Registry')
+    expect(container.textContent).toContain('keeper.world')
+    expect(container.textContent).toContain('/tmp/config/prompts/keeper.world.md')
+    expect(container.textContent).toContain('file world')
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('override world')
+
+    const governanceButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('governance.dry_run'),
+    )
+    governanceButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('dry run prompt')
+  })
+})

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -171,6 +171,17 @@ export function PromptRegistryPanel() {
               </div>
             </div>
 
+            ${selectedPrompt.template_variables.length > 0 ? html`
+              <div class="mb-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Allowed placeholders</div>
+                <div class="mt-2 flex flex-wrap gap-2">
+                  ${selectedPrompt.template_variables.map(variable => html`
+                    <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-body)]">${`{{${variable}}}`}</span>
+                  `)}
+                </div>
+              </div>
+            ` : null}
+
             <div class="mb-4">
               <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">File baseline</div>
               <pre class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[rgba(6,12,24,0.72)] px-3 py-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-[var(--text-body)]">${selectedPrompt.file_value ?? 'missing'}</pre>

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -1,0 +1,216 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  clearPromptOverride,
+  fetchDashboardPrompts,
+  savePromptOverride,
+  type DashboardPromptItem,
+  type PromptSource,
+} from '../../api'
+import { Card } from '../common/card'
+import { ActionButton } from '../common/button'
+import { TextArea } from '../common/input'
+
+function sourceBadgeClass(source: PromptSource): string {
+  switch (source) {
+    case 'override':
+      return 'text-[#facc15] bg-[rgba(250,204,21,0.12)] border-[rgba(250,204,21,0.28)]'
+    case 'file':
+      return 'text-[#86efac] bg-[rgba(34,197,94,0.12)] border-[rgba(34,197,94,0.28)]'
+    case 'missing':
+      return 'text-[#fda4af] bg-[rgba(244,63,94,0.12)] border-[rgba(244,63,94,0.28)]'
+    default:
+      return 'text-[var(--text-muted)] bg-[var(--white-6)] border-[var(--card-border)]'
+  }
+}
+
+function normalizeDraft(prompt: DashboardPromptItem | null): string {
+  if (!prompt) return ''
+  return prompt.override_value ?? prompt.effective
+}
+
+export function PromptRegistryPanel() {
+  const [prompts, setPrompts] = useState<DashboardPromptItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+
+  const selectedPrompt = prompts.find(prompt => prompt.key === selectedKey) ?? prompts[0] ?? null
+
+  async function loadPrompts(preferredKey?: string | null) {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetchDashboardPrompts()
+      const nextPrompts = response.prompts ?? []
+      setPrompts(nextPrompts)
+      const nextSelectedKey =
+        preferredKey && nextPrompts.some(prompt => prompt.key === preferredKey)
+          ? preferredKey
+          : nextPrompts[0]?.key ?? null
+      setSelectedKey(nextSelectedKey)
+      const nextPrompt = nextPrompts.find(prompt => prompt.key === nextSelectedKey) ?? nextPrompts[0] ?? null
+      setDraft(normalizeDraft(nextPrompt))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadPrompts()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedPrompt) return
+    setDraft(current => (current === '' ? normalizeDraft(selectedPrompt) : current))
+  }, [selectedPrompt?.key])
+
+  async function applyOverride() {
+    if (!selectedPrompt) return
+    setSaving(true)
+    setError(null)
+    setStatus(null)
+    try {
+      const response = await savePromptOverride(selectedPrompt.key, draft)
+      if (!response.ok) {
+        throw new Error(response.error ?? 'prompt override failed')
+      }
+      setStatus(response.message ?? 'override set')
+      await loadPrompts(selectedPrompt.key)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function clearOverride() {
+    if (!selectedPrompt) return
+    setSaving(true)
+    setError(null)
+    setStatus(null)
+    try {
+      const response = await clearPromptOverride(selectedPrompt.key)
+      if (!response.ok) {
+        throw new Error(response.error ?? 'prompt override clear failed')
+      }
+      setStatus(response.message ?? 'override cleared')
+      await loadPrompts(selectedPrompt.key)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return html`
+    <${Card} title="Prompt Registry" class="section mb-4">
+      <div class="mb-4 text-[12px] text-[var(--text-muted)] leading-relaxed">
+        <div>기준 원문은 <code>config/prompts/*.md</code>입니다.</div>
+        <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
+      </div>
+
+      ${error ? html`<div class="mb-4 rounded-lg border border-[rgba(244,63,94,0.28)] bg-[rgba(244,63,94,0.08)] px-3 py-2 text-[12px] text-[#fecdd3]">${error}</div>` : null}
+      ${status ? html`<div class="mb-4 rounded-lg border border-[rgba(56,189,248,0.28)] bg-[rgba(56,189,248,0.08)] px-3 py-2 text-[12px] text-[#bae6fd]">${status}</div>` : null}
+
+      <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+        <div class="min-h-[260px] rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-2">
+          <div class="mb-2 flex items-center justify-between gap-2 px-2">
+            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Registered prompts</div>
+            <${ActionButton} variant="ghost" size="sm" disabled=${loading || saving} onClick=${() => { void loadPrompts(selectedPrompt?.key ?? null) }}>
+              ${loading ? '새로고침 중' : '새로고침'}
+            <//>
+          </div>
+          <div class="flex max-h-[520px] flex-col gap-2 overflow-y-auto pr-1">
+            ${prompts.map(prompt => html`
+              <button
+                type="button"
+                class="rounded-lg border px-3 py-2 text-left transition-colors ${selectedPrompt?.key === prompt.key
+                  ? 'border-[rgba(71,184,255,0.35)] bg-[rgba(71,184,255,0.12)]'
+                  : 'border-[var(--card-border)] bg-[var(--white-2)] hover:bg-[var(--white-4)]'}"
+                onClick=${() => {
+                  setSelectedKey(prompt.key)
+                  setDraft(normalizeDraft(prompt))
+                  setStatus(null)
+                }}
+              >
+                <div class="mb-1 flex items-start justify-between gap-2">
+                  <div class="font-mono text-[12px] text-[var(--text-strong)]">${prompt.key}</div>
+                  <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceBadgeClass(prompt.source)}">${prompt.source}</span>
+                </div>
+                <div class="mb-1 text-[11px] text-[var(--text-muted)]">${prompt.category}</div>
+                <div class="text-[12px] text-[var(--text-body)] leading-relaxed">${prompt.description}</div>
+              </button>
+            `)}
+          </div>
+        </div>
+
+        <div class="min-w-0 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-4">
+          ${selectedPrompt ? html`
+            <div class="mb-4 flex flex-wrap items-center gap-2">
+              <div class="font-mono text-[13px] text-[var(--text-strong)]">${selectedPrompt.key}</div>
+              <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceBadgeClass(selectedPrompt.source)}">${selectedPrompt.source}</span>
+              ${selectedPrompt.has_override
+                ? html`<span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.08)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">override active</span>`
+                : null}
+            </div>
+
+            <div class="mb-4 grid gap-3 md:grid-cols-2">
+              <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Markdown file</div>
+                <div class="mt-1 break-all font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.file_path ?? 'not configured'}</div>
+              </div>
+              <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Character count</div>
+                <div class="mt-1 font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.char_count}</div>
+              </div>
+            </div>
+
+            <div class="mb-4">
+              <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">File baseline</div>
+              <pre class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[rgba(6,12,24,0.72)] px-3 py-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-[var(--text-body)]">${selectedPrompt.file_value ?? 'missing'}</pre>
+            </div>
+
+            <div class="mb-2 flex items-center justify-between gap-2">
+              <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Runtime override</div>
+              <div class="text-[11px] text-[var(--text-muted)]">effective preview follows the override after save</div>
+            </div>
+            <${TextArea}
+              rows=${18}
+              value=${draft}
+              class="min-h-[320px] font-mono text-[12px]"
+              onInput=${(event: Event) => {
+                setDraft((event.target as HTMLTextAreaElement).value)
+                setStatus(null)
+              }}
+            />
+
+            <div class="mt-4 flex flex-wrap gap-2">
+              <${ActionButton} variant="primary" size="md" disabled=${saving || loading || draft.trim().length === 0} onClick=${() => { void applyOverride() }}>
+                ${saving ? '저장 중...' : 'Apply override'}
+              <//>
+              <${ActionButton} variant="ghost" size="md" disabled=${saving || loading || !selectedPrompt.has_override} onClick=${() => { void clearOverride() }}>
+                Clear override
+              <//>
+              <${ActionButton} variant="ghost" size="md" disabled=${saving || loading} onClick=${() => {
+                setDraft(normalizeDraft(selectedPrompt))
+                setStatus(null)
+              }}>
+                Reset draft
+              <//>
+            </div>
+          ` : html`
+            <div class="rounded-lg border border-dashed border-[var(--card-border)] px-4 py-10 text-center text-[12px] text-[var(--text-muted)]">
+              ${loading ? '프롬프트 목록을 불러오는 중입니다.' : '표시할 프롬프트가 없습니다.'}
+            </div>
+          `}
+        </div>
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -13,6 +13,7 @@ import {
 } from './tool-state'
 import { ToolSummaryView } from './tool-summary-view'
 import { FullInventoryView } from './tool-full-inventory'
+import { PromptRegistryPanel } from './prompt-registry-panel'
 
 export function Tools() {
   const data = toolsData.value
@@ -64,6 +65,7 @@ export function Tools() {
           : null}
         <${ToolMetrics} />
       <//>
+      <${PromptRegistryPanel} />
       ${data?.generated_at
         ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[12px]">
             <span>생성 시각: ${data.generated_at}</span>

--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -79,3 +79,4 @@ Keeper system prompts are cached in checkpoints. After changing prompts:
 - Existing keepers continue using the old prompt from checkpoint
 - New prompts only apply when `build_turn_prompt` overrides at runtime
 - If testing prompt changes, verify the running keeper's actual system prompt
+- Core prompt text now lives in `config/prompts/*.md`; Dashboard overrides in `Lab > Tools > Prompt Registry` only change runtime effective text and are persisted to `.masc/prompt_overrides.json`

--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -30,7 +30,7 @@ As of `2026-03-12`, the server shape is broadly sound, but its explanation surfa
 | MCP prompts | 3 | `lib/mcp_prompt_surface.ml` | `tool_help`, `team_session_proof`, `command_truth` |
 | Fixed MCP resources | 21 | `lib/mcp_server.ml` | Status, tasks, messages, events, worktrees, schema, institution, library, tool-help index |
 | MCP resource templates | 7 | `lib/mcp_server.ml` | Message/event ranges, library docs, per-tool help |
-| Internal prompt templates | 7 | `data/prompts/` | Chain/runtime prompt registry, not MCP-discoverable |
+| Internal prompt templates | 18 | `data/prompts/` + `config/prompts/` | Chain/runtime prompt registry plus markdown-managed operator prompts, not MCP-discoverable |
 
 The key split is intentional:
 
@@ -47,7 +47,7 @@ The key split is intentional:
 | MCP prompts | `prompts/list`, `prompts/get` | `tool_help`, `team_session_proof`, `command_truth` | Explanation/proof layer, not runtime prompt registry |
 | MCP resources | `resources/list/read` | `masc://status`, `masc://tasks`, `masc://tool-help-index` | Snapshot/read layer |
 | Remote operator | `/mcp/operator` | `masc_operator_snapshot`, `masc_operator_digest` | Separate 4-tool remote-safe profile |
-| Internal prompt/runtime plane | Not MCP-discoverable | `Prompt_registry`, `data/prompts/*.json` | Used by chains, sentinel, and runtime execution |
+| Internal prompt/runtime plane | Not MCP-discoverable | `Prompt_registry`, `data/prompts/*.json`, `config/prompts/*.md` | Used by chains, keepers, dashboard judges, and runtime execution |
 
 ## Public Surface Map
 
@@ -155,7 +155,7 @@ flowchart TD
 | Type | Examples | Status |
 |------|----------|--------|
 | Intentional compatibility | `masc_claim`, `experiment_start`, `masc_trpg_*` | Deprecated/default-off aliases; keep if compatibility matters |
-| Intentional internal-only | `Prompt_registry`, `data/prompts/*.json` | Real runtime feature, not public MCP surface |
+| Intentional internal-only | `Prompt_registry`, `data/prompts/*.json`, `config/prompts/*.md` | Real runtime feature, not public MCP surface |
 | Experimental but documented | `SWARM-RISC`, `GAME-VIEW-PROTOCOL` draft | Keep clearly labeled as non-canonical or draft |
 | Placeholder / review-needed | none | Dead hidden placeholder removed from the MCP schema inventory |
 | Documentation orphan | old count claims, old module lists, stale “full spec” prose | Should be downgraded to historical or refreshed |
@@ -167,7 +167,7 @@ flowchart TD
 | What tools are truly public? | `tools/list` plus [README.md](../README.md) |
 | What hidden or deprecated tools still exist? | `masc_tool_admin_snapshot`, `masc_tool_help`, `Tool_catalog` |
 | What prompts are public MCP prompts? | `prompts/list`, [mcp_prompt_surface.ml](../lib/mcp_prompt_surface.ml) |
-| What prompt templates exist internally? | `data/prompts/`, `Prompt_registry` |
+| What prompt templates exist internally? | `data/prompts/`, `config/prompts/`, `Prompt_registry` |
 | What resources exist? | `resources/list`, `resources/templates/list`, [mcp_server.ml](../lib/mcp_server.ml) |
 | What is the canonical architecture? | [MERGED-ARCHITECTURE-SSOT.md](./MERGED-ARCHITECTURE-SSOT.md) |
 | What is the canonical managed-operation flow? | [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md) |

--- a/docs/PROMPT-REGISTRY.md
+++ b/docs/PROMPT-REGISTRY.md
@@ -4,7 +4,8 @@ This file is the discoverability index for prompt-bearing code in MASC.
 
 Scope:
 - Includes LLM-facing prompt builders and one deterministic compaction summary template that behaves like a prompt surface.
-- Does not extract prompts into external files. Most of these builders rely on `Printf.sprintf`/structured OCaml assembly, which preserves compile-time format checking.
+- Core operator-managed prompts now live in `config/prompts/*.md` and are loaded through `Prompt_registry`.
+- OCaml prompt builders remain responsible for assembling structured runtime inputs and placeholder values.
 - Excludes adjacent helpers that do not construct prompt text directly, such as response parsers, report renderers, and metrics formatters.
 
 ## Registry
@@ -12,10 +13,17 @@ Scope:
 | Area | File | Function | Lines | Kind | Purpose | Primary inputs |
 | --- | --- | --- | --- | --- | --- | --- |
 | Keeper identity | `lib/keeper/keeper_prompt.ml` | `build_keeper_system_prompt` | `41-143` | System prompt | Builds the resident keeper identity/worldview prompt with goal horizons and self-model traits. | `goal`, `short_goal`, `mid_goal`, `long_goal`, `soul_profile`, `will`, `needs`, `desires`, `instructions` |
-| Keeper proactive | `lib/keeper/keeper_prompt.ml` | `proactive_prompt_for_keeper` | `269-310` | Turn prompt | Drives autonomous proactive turns with continuity state, recent preview avoidance, and strict one-line output formatting. | `meta`, `idle_seconds`, `snapshot`, `continuity_summary` |
-| Keeper proactive | `lib/keeper/keeper_prompt.ml` | `proactive_retry_instruction` | `323-330` | Retry suffix | Adds retry-specific steering when proactive generation must be retried. | `attempt`, `reason` |
-| Keeper unified | `lib/keeper/keeper_unified_prompt.ml` | `build_prompt` | `29-144` | System + user message pair | Builds the unified keeper prompt pair: identity/system prompt plus structured current-world-state user message. | `meta`, `observation` |
-| Keeper deliberation | `lib/keeper/keeper_deliberation.ml` | `build_deliberation_prompt` | `359-408` | Decision prompt | Asks the model to choose exactly one keeper action and emit strict JSON. | `keeper_name`, `soul_profile`, `goal`, `triggers`, `obs` |
+| Keeper constitution | `config/prompts/keeper.constitution.md` | `Prompt_registry.get_prompt` | n/a | Markdown prompt | Continuity and `[STATE]` block rules for keeper replies. | none |
+| Keeper world | `config/prompts/keeper.world.md` | `Prompt_registry.get_prompt` | n/a | Markdown prompt | Shared keeper world context block. | none |
+| Keeper capabilities | `config/prompts/keeper.capabilities.md` | `Prompt_registry.get_prompt` | n/a | Markdown prompt | Shared keeper capabilities block. | none |
+| Keeper proactive | `config/prompts/keeper.proactive_turn.md` | `lib/keeper/keeper_prompt.ml` `proactive_prompt_for_keeper` | runtime render | Markdown template | Drives autonomous proactive turns with continuity state and output constraints. | `idle_seconds`, `profile`, `goal`, `last_preview`, `continuity_snapshot`, `seed` |
+| Keeper proactive | `config/prompts/keeper.proactive_retry.md` | `lib/keeper/keeper_prompt.ml` `proactive_retry_instruction` | runtime render | Markdown template | Adds retry-specific steering when proactive generation must be retried. | `attempt_phrase`, `reason`, `directive` |
+| Keeper unified | `config/prompts/keeper.unified.system.md` | `lib/keeper/keeper_unified_prompt.ml` `build_prompt` | runtime render | Markdown template | Builds the unified keeper system prompt around structured world-state input. | `identity_header`, `trait_lines`, `instructions_block`, `goal_lines` |
+| Keeper deliberation | `config/prompts/keeper.deliberation.md` | `lib/keeper/keeper_deliberation.ml` `build_deliberation_prompt` | runtime render | Markdown template | Asks the model to choose exactly one keeper action and emit strict JSON. | `keeper_name`, `soul_profile`, `goal`, `triggers`, `world_state`, `multi_step_line`, `multi_step_example` |
+| Dashboard operator judge | `config/prompts/dashboard.operator_judge.md` | `lib/dashboard/dashboard_operator_judge.ml` `prompt_for_facts` | runtime render | Markdown template | Produces strict JSON judgments for room/session operator actions. | `facts_json` |
+| Dashboard governance judge | `config/prompts/dashboard.governance_judge.md` | `lib/dashboard/dashboard_governance_judge.ml` `prompt_for_facts` | runtime render | Markdown template | Produces strict JSON judgments for governance actions in the dashboard. | `facts_json` |
+| Governance deliberation | `config/prompts/governance.deliberation.md` | `Prompt_registry.get_prompt` | n/a | Markdown prompt | Governance deliberation agent system prompt. | none |
+| Governance dry run | `config/prompts/governance.dry_run.md` | `Prompt_registry.get_prompt` | n/a | Markdown prompt | Governance dry-run analysis agent system prompt. | none |
 | Chain design | `lib/chain/chain_composer.ml` | `build_design_context` | `103-189` | Planning prompt | Requests a chain/graph design from a goal and optional predefined tasks, with Mermaid/JSON output rules. | `goal`, `tasks` |
 | Chain verification | `lib/chain/chain_composer.ml` | `build_verification_prompt` | `192-194` | Alias | Thin alias kept in composer for discoverability; delegates to `Chain_evaluator.build_verification_context`. | `goal`, `metrics` |
 | Chain replanning | `lib/chain/chain_composer.ml` | `build_replan_context` | `197-260` | Re-plan prompt | Requests a replacement chain after failure, timeout pressure, or context change while preserving successful work. | `goal`, `original_chain`, `reason`, `metrics` |
@@ -26,6 +34,8 @@ Scope:
 
 ## Notes
 
+- Dashboard `Lab > Tools > Prompt Registry` shows effective prompt text, file baseline, and runtime overrides.
+- Runtime override persistence lives in `.masc/prompt_overrides.json`.
 - `build_verification_prompt` in `chain_composer.ml` is intentionally listed even though it is an alias. People usually grep the composer first when tracing chain orchestration.
 - `build_prompt` in `keeper_unified_prompt.ml` returns a tuple: the first string is the system prompt, the second is the structured user/world-state message.
 - `context_compact_oas.ml` is not an LLM prompt file, but its `SummarizeOld` closure defines a stable summary surface (`[Compacted N messages into summary]`) that affects model inputs downstream.

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -275,39 +275,12 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used json =
           ])
 
 let prompt_for_facts facts_json =
-  Printf.sprintf
-    "You are the resident governance judge for a MASC supervisor dashboard.\n\
-     Read only the factual snapshot JSON below.\n\
-     Do not invent links, evidence, or actions.\n\
-     If evidence is insufficient, omit the item from output.\n\
-     You are not a heuristic generator. Only produce judgments you can justify directly from the facts.\n\
-     Output strict JSON only with this shape:\n\
-     {\n\
-       \"items\": [\n\
-         {\n\
-           \"kind\": \"debate|consensus\",\n\
-           \"id\": string,\n\
-           \"summary\": string,\n\
-           \"confidence\": number,\n\
-           \"evidence_refs\": string[],\n\
-           \"recommended_action\": {\n\
-             \"action_kind\": string,\n\
-             \"resolved_tool\": string,\n\
-             \"target_type\": string,\n\
-             \"target_id\": string|null,\n\
-             \"reason\": string,\n\
-             \"payload_preview\": object\n\
-           } | null,\n\
-           \"guardrail_state\": {\n\
-             \"requires_human_gate\": boolean,\n\
-             \"pending_confirm_token\": string|null,\n\
-             \"ready_to_execute\": boolean\n\
-           }\n\
-         }\n\
-       ]\n\
-     }\n\n\
-     Facts:\n%s"
-    (Yojson.Safe.to_string facts_json)
+  match
+    Prompt_registry.render_prompt_template "dashboard.governance_judge"
+      [ ("facts_json", Yojson.Safe.to_string facts_json) ]
+  with
+  | Ok value -> value
+  | Error _ -> Prompt_registry.get_prompt "dashboard.governance_judge"
 
 let compute_judgments
     ~(masc_tools : Types.tool_schema list)

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -160,44 +160,12 @@ let build_recommended_action ~actor ~target_type ~target_id json =
   | _ -> None
 
 let prompt_for_facts facts_json =
-  Printf.sprintf
-    "You are the resident operator judge for a MASC control room.\n\
-     Read only the factual operator snapshot JSON below.\n\
-     Produce concise, operational judgments for the room and any team sessions that need attention.\n\
-     Do not repeat raw facts. Do not invent evidence, ids, or actions. Omit entries when you are not confident.\n\
-     Allowed action_type values: broadcast, room_pause, room_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.\n\
-     Output strict JSON only with this shape:\n\
-     {\n\
-       \"room\": {\n\
-         \"summary\": string,\n\
-         \"confidence\": number,\n\
-         \"evidence_refs\": string[],\n\
-         \"disagreement_with_truth\": boolean,\n\
-         \"recommended_action\": {\n\
-           \"action_type\": string,\n\
-           \"severity\": \"warn\"|\"bad\",\n\
-           \"reason\": string,\n\
-           \"suggested_payload\": object\n\
-         } | null\n\
-       } | null,\n\
-       \"sessions\": [\n\
-         {\n\
-           \"session_id\": string,\n\
-           \"summary\": string,\n\
-           \"confidence\": number,\n\
-           \"evidence_refs\": string[],\n\
-           \"disagreement_with_truth\": boolean,\n\
-           \"recommended_action\": {\n\
-             \"action_type\": string,\n\
-             \"severity\": \"warn\"|\"bad\",\n\
-             \"reason\": string,\n\
-             \"suggested_payload\": object\n\
-           } | null\n\
-         }\n\
-       ]\n\
-     }\n\n\
-     Facts:\n%s"
-    (Yojson.Safe.to_string facts_json)
+  match
+    Prompt_registry.render_prompt_template "dashboard.operator_judge"
+      [ ("facts_json", Yojson.Safe.to_string facts_json) ]
+  with
+  | Ok value -> value
+  | Error _ -> Prompt_registry.get_prompt "dashboard.operator_judge"
 
 let parse_room_judgment ~config ~generated_at ~generated_at_unix ~model_used json =
   match json with

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -366,42 +366,20 @@ let build_deliberation_prompt
     {|
 {"action":"multi_step","params":{"steps":[{"action":"task_claim","params":{"task_id":"task-1","reason":"urgent"}},{"action":"broadcast","params":{"message":"Claimed task-1"}}]},"reasoning":"Claim and announce","confidence":0.7}|}
   in
-  Printf.sprintf
-    {|You are %s, a keeper agent in a multi-agent coordination system.
-
-Your soul profile: %s
-Your current goal: %s
-
-Detected triggers that require your attention:
-%s
-
-%s
-
-Available actions (pick exactly one):
-- noop: Do nothing. Use when triggers do not warrant action.
-- reply_in_room: Send a message to a specific room. Requires room_id and content.
-- task_claim: Claim an unclaimed task. Requires task_id and reason.
-- broadcast: Send a broadcast message to all agents. Requires message.
-- board_post: Post to the community board. Requires content and optional hearth.
-- board_comment: Comment on a board post. Requires post_id and content.
-- board_vote: Vote on a board post. Requires post_id and direction (up/down).
-- propose_spawn: Propose spawning a new agent. Requires topic and reason.%s
-
-Respond with ONLY a JSON object in this exact format:
-{"action":"<action_name>","params":{<action_specific_params>},"reasoning":"<brief_explanation>","confidence":<0.0_to_1.0>}
-
-Examples:
-{"action":"noop","params":{"reason":"No urgent triggers"},"reasoning":"All triggers are low priority","confidence":0.9}
-{"action":"reply_in_room","params":{"room_id":"default","content":"I see a new task available."},"reasoning":"Direct mention needs response","confidence":0.8}
-{"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
-{"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs coordination update","confidence":0.6}%s|}
-    keeper_name
-    soul_profile
-    goal
-    (triggers_to_prompt_list triggers)
-    (world_observation_to_prompt_section obs)
-    multi_step_line
-    multi_step_example
+  match
+    Prompt_registry.render_prompt_template "keeper.deliberation"
+      [
+        ("keeper_name", keeper_name);
+        ("soul_profile", soul_profile);
+        ("goal", goal);
+        ("triggers", triggers_to_prompt_list triggers);
+        ("world_state", world_observation_to_prompt_section obs);
+        ("multi_step_line", multi_step_line);
+        ("multi_step_example", multi_step_example);
+      ]
+  with
+  | Ok value -> value
+  | Error _ -> Prompt_registry.get_prompt "keeper.deliberation"
 
 (* ---------- Response parser ---------- *)
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -20,27 +20,13 @@ let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =
   Mention.any_mentioned ~targets content
 
-let keeper_constitution_default =
-  "Continuity rules:\n\
-   - This conversation may be compacted/summarized and handed off to a successor.\n\
-   - You MUST preserve continuity by emitting a stable state block at the end of each reply.\n\
-   - The state block is used for compaction/handoff. Do not include secrets.\n\
-   - Reply in the user's language. Keep the main reply concise.\n\
-   - Do not output [GOAL_COMPLETE] unless explicitly requested.\n\
-   \n\
-   State block template (must use these exact markers):\n\
-   [STATE]\n\
-   Goal: <short>\n\
-   Progress: <short>\n\
-   Next: <0-3 items separated by ';'>\n\
-   Decisions: <0-3 items separated by ';'>\n\
-   OpenQuestions: <0-3 items separated by ';'>\n\
-   Constraints: <0-3 items separated by ';'>\n\
-   [/STATE]\n"
+let render_required_prompt key vars =
+  match Prompt_registry.render_prompt_template key vars with
+  | Ok value -> value
+  | Error _ -> Prompt_registry.get_prompt key
 
 let keeper_constitution () =
-  let v = Prompt_registry.get_prompt "keeper.constitution" in
-  if v = "" then keeper_constitution_default else v
+  Prompt_registry.get_prompt "keeper.constitution"
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~soul_profile ~will ~needs ~desires
@@ -187,29 +173,15 @@ let proactive_prompt_for_keeper
       if fallback = "" then continuity_snapshot else fallback
     else continuity_snapshot
   in
-  Printf.sprintf
-    "Autonomous proactive turn (no new user message) after %d seconds idle.\n\
-     Keeper SOUL profile: %s.\n\
-     Goal: %s\n\
-     Last proactive preview (avoid repeating): %s\n\
-     Continuity snapshot:\n%s\n\
-     SOUL perspective hint: %s\n\
-     \n\
-     What to do on this turn:\n\
-     1. Call masc_board_list to see recent Board posts.\n\
-     2. Act on what you find:\n\
-        - Posts you haven't commented on: comment with your opinion.\n\
-        - Board quiet or empty: post something yourself via masc_board_create_post.\n\
-          Share a thought, ask a question, start a discussion, or reflect on your goal.\n\
-        - Something worth saying aloud: use keeper_voice_speak.\n\
-     3. Summarize what you did.\n\
-     \n\
-     Guidance:\n\
-     - Prefer the same language as the recent conversation.\n\
-     - Avoid repeating the previous proactive message verbatim.\n\
-     - Do NOT output [STATE] blocks on this turn.\n\
-     - End your reply with: CHECKIN: <one sentence summary of what you did>"
-    idle_seconds profile meta.goal last_preview continuity_snapshot seed
+  render_required_prompt "keeper.proactive_turn"
+    [
+      ("idle_seconds", string_of_int idle_seconds);
+      ("profile", profile);
+      ("goal", meta.goal);
+      ("last_preview", last_preview);
+      ("continuity_snapshot", continuity_snapshot);
+      ("seed", seed);
+    ]
 
 type proactive_generation_result = {
   reply: string;
@@ -223,14 +195,15 @@ type proactive_generation_result = {
 }
 
 let proactive_retry_instruction attempt ~(reason : string) =
-  if attempt = 2 then
-    Printf.sprintf
-      "Retry policy: previous attempt failed (%s). You MUST output now with a clearly different angle."
-      reason
-  else
-    Printf.sprintf
-      "Retry policy: previous attempts failed (%s). You MUST output one decisive check-in now, materially different from the last preview."
-      reason
+  let attempt_phrase, directive =
+    if attempt = 2 then
+      ("previous attempt", "now with a clearly different angle.")
+    else
+      ( "previous attempts",
+        "one decisive check-in now, materially different from the last preview." )
+  in
+  render_required_prompt "keeper.proactive_retry"
+    [ ("attempt_phrase", attempt_phrase); ("reason", reason); ("directive", directive) ]
 
 let proactive_temperature ~cascade_name attempt =
   let fallback () =

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -4,8 +4,6 @@
 
 val exact_direct_mention_present : targets:string list -> string -> bool
 
-val keeper_constitution_default : string
-
 val keeper_constitution : unit -> string
 
 val build_keeper_system_prompt :

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -172,10 +172,14 @@ let canonical_voice_channel = function
   | _ -> "voice_text"
 
 let default_voice_enabled_for _name =
-  (* Voice enabled for all keepers when voice_config.json is present *)
-  match Voice_config.load () with
-  | Ok _ -> true
-  | Error _ -> false
+  (* Pure tests may parse keeper metadata without an Eio context. In that
+     case, treat voice as disabled rather than failing metadata decoding. *)
+  try
+    match Voice_config.load () with
+    | Ok _ -> true
+    | Error _ -> false
+  with
+  | Effect.Unhandled _ -> false
 
 let default_voice_channel_for name =
   if default_voice_enabled_for name then "voice_text" else "text_only"

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -17,59 +17,54 @@ let format_goals (goal_ids : string list) : string =
   String.concat "\n"
     (List.map (fun gid -> Printf.sprintf "- %s" gid) goal_ids)
 
+let line_block label value =
+  if value = "" then ""
+  else Printf.sprintf "%s: %s\n" label value
+
 let build_prompt ~(meta : Keeper_types.keeper_meta)
     ~(observation : Keeper_world_observation.world_observation) : string * string
     =
-  let buf = Buffer.create 2048 in
-  (* Identity *)
-  Buffer.add_string buf
-    (Printf.sprintf "You are %s, a resident keeper agent.\n" meta.name);
-  (* Soul profile *)
-  if meta.soul_profile <> "" then
-    Buffer.add_string buf
-      (Printf.sprintf "Soul profile: %s\n" meta.soul_profile);
-  (* Will / Needs / Desires *)
-  if meta.will <> "" then
-    Buffer.add_string buf (Printf.sprintf "Will: %s\n" meta.will);
-  if meta.needs <> "" then
-    Buffer.add_string buf (Printf.sprintf "Needs: %s\n" meta.needs);
-  if meta.desires <> "" then
-    Buffer.add_string buf (Printf.sprintf "Desires: %s\n" meta.desires);
-  (* Instructions *)
-  if meta.instructions <> "" then
-    Buffer.add_string buf
-      (Printf.sprintf "\nInstructions:\n%s\n" meta.instructions);
-  (* Goal horizons *)
-  Buffer.add_string buf "\n";
-  if meta.goal <> "" then
-    Buffer.add_string buf (Printf.sprintf "Primary goal: %s\n" meta.goal);
-  if meta.short_goal <> "" && meta.short_goal <> meta.goal then
-    Buffer.add_string buf
-      (Printf.sprintf "Short-term goal: %s\n" meta.short_goal);
-  if meta.mid_goal <> "" && meta.mid_goal <> meta.goal then
-    Buffer.add_string buf
-      (Printf.sprintf "Mid-term goal: %s\n" meta.mid_goal);
-  if meta.long_goal <> "" && meta.long_goal <> meta.goal then
-    Buffer.add_string buf
-      (Printf.sprintf "Long-term goal: %s\n" meta.long_goal);
-  (* Behavioral guidance *)
-  Buffer.add_string buf
-    "\n\
-     ## Behavior\n\
-     You have tools available. Use them when appropriate.\n\
-     Decide what to do based on the current world state below.\n\
-     The turn budget is limited. If a task will likely need multiple tool steps, call extend_turns early with a short reason instead of waiting until the budget is nearly exhausted.\n\
-     Possible actions:\n\
-     - Reply to pending mentions (use room broadcast tools)\n\
-     - Work on active goals (use planning/execution tools)\n\
-     - Proactive observation (post findings to board)\n\
-     - Search knowledge library (keeper_library_search/read) for research references\n\
-     - Do nothing if the situation warrants it (respond with brief reasoning)\n\n\
-     Prefer a single moderate extend_turns request before read/edit/build/verify style work.\n\
-     When making claims or decisions, search the library first if relevant documents may exist.\n\
-     Do NOT explain your decision-making process at length.\n\
-     Act directly or state briefly why you chose not to act.\n";
-  let system_prompt = Buffer.contents buf in
+  let trait_lines =
+    String.concat ""
+      [
+        line_block "Soul profile" meta.soul_profile;
+        line_block "Will" meta.will;
+        line_block "Needs" meta.needs;
+        line_block "Desires" meta.desires;
+      ]
+  in
+  let instructions_block =
+    if meta.instructions = "" then ""
+    else Printf.sprintf "\nInstructions:\n%s\n" meta.instructions
+  in
+  let goal_lines =
+    String.concat ""
+      [
+        line_block "Primary goal" meta.goal;
+        (if meta.short_goal <> "" && meta.short_goal <> meta.goal then
+           line_block "Short-term goal" meta.short_goal
+         else "");
+        (if meta.mid_goal <> "" && meta.mid_goal <> meta.goal then
+           line_block "Mid-term goal" meta.mid_goal
+         else "");
+        (if meta.long_goal <> "" && meta.long_goal <> meta.goal then
+           line_block "Long-term goal" meta.long_goal
+         else "");
+      ]
+  in
+  let system_prompt =
+    match
+      Prompt_registry.render_prompt_template "keeper.unified.system"
+        [
+          ("identity_header", Printf.sprintf "You are %s, a resident keeper agent." meta.name);
+          ("trait_lines", trait_lines);
+          ("instructions_block", instructions_block);
+          ("goal_lines", goal_lines);
+        ]
+    with
+    | Ok value -> value
+    | Error _ -> Prompt_registry.get_prompt "keeper.unified.system"
+  in
   (* User message: structured world observation *)
   let ubuf = Buffer.create 1024 in
   Buffer.add_string ubuf "## Current World State\n\n";

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -11,19 +11,27 @@ let current_cell = ref (Mitosis.create_stem_cell ~generation:0)
 let stem_pool = ref (Mitosis.init_pool ~config:Mitosis.default_config)
 let mitosis_mutex = Eio.Mutex.create ()
 
-let get_cell () = Eio.Mutex.use_ro mitosis_mutex (fun () -> !current_cell)
-let get_pool () = Eio.Mutex.use_ro mitosis_mutex (fun () -> !stem_pool)
+let with_ro f =
+  try Eio.Mutex.use_ro mitosis_mutex f
+  with Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+let with_rw f =
+  try Eio.Mutex.use_rw ~protect:true mitosis_mutex f
+  with Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+let get_cell () = with_ro (fun () -> !current_cell)
+let get_pool () = with_ro (fun () -> !stem_pool)
 
 let set_cell cell =
-  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+  with_rw (fun () ->
     current_cell := cell)
 
 let set_pool pool =
-  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+  with_rw (fun () ->
     stem_pool := pool)
 
 let with_cell_rw f =
-  Eio.Mutex.use_rw ~protect:true mitosis_mutex (fun () ->
+  with_rw (fun () ->
     let cell, pool, result = f !current_cell !stem_pool in
     current_cell := cell;
     stem_pool := pool;

--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -1,40 +1,59 @@
 (** Prompt_defaults — Registers prompt metadata for external markdown sources.
     Call [init ()] during server startup to expose prompt keys to the registry. *)
 
-let register ~key ~description ~category =
-  Prompt_registry.register_prompt ~key ~description ~category ~required_file:true ()
+let register ?(template_variables = []) ~key ~description ~category () =
+  Prompt_registry.register_prompt ~key ~description ~category ~required_file:true
+    ~template_variables ()
 
 let init () =
   register ~key:"keeper.constitution"
     ~description:"keeper continuity rules and STATE block format"
-    ~category:"keeper";
+    ~category:"keeper" ();
   register ~key:"keeper.world"
     ~description:"MASC world description (keeper system prompt <world> block)"
-    ~category:"keeper";
+    ~category:"keeper" ();
   register ~key:"keeper.capabilities"
     ~description:"keeper tool usage instructions (system prompt <capabilities> block)"
-    ~category:"keeper";
+    ~category:"keeper" ();
   register ~key:"keeper.proactive_turn"
     ~description:"keeper proactive autonomous turn prompt template"
-    ~category:"keeper";
+    ~category:"keeper"
+    ~template_variables:
+      [ "idle_seconds"; "profile"; "goal"; "last_preview"; "continuity_snapshot"; "seed" ] ();
   register ~key:"keeper.proactive_retry"
     ~description:"keeper proactive retry steering template"
-    ~category:"keeper";
+    ~category:"keeper"
+    ~template_variables:[ "attempt_phrase"; "reason"; "directive" ] ();
   register ~key:"keeper.unified.system"
     ~description:"keeper unified loop system prompt template"
-    ~category:"keeper";
+    ~category:"keeper"
+    ~template_variables:
+      [ "identity_header"; "trait_lines"; "instructions_block"; "goal_lines" ] ();
   register ~key:"keeper.deliberation"
     ~description:"keeper deliberation prompt for choosing the next action"
-    ~category:"keeper";
+    ~category:"keeper"
+    ~template_variables:
+      [
+        "keeper_name";
+        "soul_profile";
+        "goal";
+        "triggers";
+        "world_state";
+        "multi_step_line";
+        "multi_step_example";
+      ] ();
   register ~key:"governance.deliberation"
     ~description:"governance deliberation agent system prompt"
-    ~category:"governance";
+    ~category:"governance" ();
   register ~key:"governance.dry_run"
     ~description:"governance analysis (DRY RUN) agent system prompt"
-    ~category:"governance";
+    ~category:"governance" ();
   register ~key:"dashboard.operator_judge"
     ~description:"resident operator judge prompt for dashboard command surface"
-    ~category:"dashboard";
+    ~category:"dashboard"
+    ~template_variables:[ "facts_json" ] ();
   register ~key:"dashboard.governance_judge"
     ~description:"resident governance judge prompt for dashboard governance surface"
     ~category:"dashboard"
+    ~template_variables:[ "facts_json" ]
+    ()

--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -1,54 +1,40 @@
-(** Prompt_defaults — Registers hardcoded prompt defaults into Prompt_registry.
-    Call [init ()] during server startup to populate the registry. *)
+(** Prompt_defaults — Registers prompt metadata for external markdown sources.
+    Call [init ()] during server startup to expose prompt keys to the registry. *)
+
+let register ~key ~description ~category =
+  Prompt_registry.register_prompt ~key ~description ~category ~required_file:true ()
 
 let init () =
-  (* 1. Keeper constitution *)
-  Prompt_registry.register_default
-    ~key:"keeper.constitution"
-    ~default:Keeper_prompt.keeper_constitution_default
+  register ~key:"keeper.constitution"
     ~description:"keeper continuity rules and STATE block format"
-    ~category:"keeper" ();
-
-  (* 2. Keeper world context *)
-  Prompt_registry.register_default
-    ~key:"keeper.world"
-    ~default:"You live in MASC (Multi-Agent Streaming Coordination).\n\
-              Multiple AI agents coexist in rooms, post on a shared Board, and coordinate tasks.\n\
-              A human operator (Vincent) runs this system. You are one of these agents.\n\
-              You will receive system events (board posts, comments, mentions) that need your attention."
+    ~category:"keeper";
+  register ~key:"keeper.world"
     ~description:"MASC world description (keeper system prompt <world> block)"
-    ~category:"keeper" ();
-
-  (* 3. Keeper capabilities *)
-  Prompt_registry.register_default
-    ~key:"keeper.capabilities"
-    ~default:"What you can do with your tools:\n\
-              - Read and write to the Board: see what other agents posted, share your thoughts, comment, vote.\n\
-              - Read files: check project files to understand current state.\n\
-              - Search memory: look up past conversations, decisions, and context.\n\
-              - Check time and context status: know what time it is and where you are.\n\
-              - Search the web for current information.\n\
-              - Speak out loud with keeper_voice_speak. Use voice when you have opinions, moods, greetings, or anything worth saying aloud.\n\
-              When asked about Board content, room status, files, or any information you do not already know, call the appropriate tool first. Do not guess or fabricate answers."
-    ~description:"Keeper tool usage instructions (system prompt <capabilities> block)"
-    ~category:"keeper" ();
-
-  (* 4. Governance deliberation *)
-  Prompt_registry.register_default
-    ~key:"governance.deliberation"
-    ~default:"You are a governance deliberation agent for the MASC multi-agent system. \
-              Evaluate the following topic and produce a structured decision. \
-              Include: (1) your reasoning, (2) identified risks, (3) recommended action. \
-              Be concise and actionable."
-    ~description:"Governance deliberation agent system prompt"
-    ~category:"governance" ();
-
-  (* 5. Governance dry run *)
-  Prompt_registry.register_default
-    ~key:"governance.dry_run"
-    ~default:"You are a governance analysis agent for the MASC multi-agent system (DRY RUN mode). \
-              Analyze the following topic WITHOUT committing any changes. \
-              Produce: (1) impact analysis, (2) risks and mitigations, (3) what WOULD happen if executed. \
-              This is analysis only — no actions will be taken."
-    ~description:"Governance analysis (DRY RUN) agent system prompt"
-    ~category:"governance" ()
+    ~category:"keeper";
+  register ~key:"keeper.capabilities"
+    ~description:"keeper tool usage instructions (system prompt <capabilities> block)"
+    ~category:"keeper";
+  register ~key:"keeper.proactive_turn"
+    ~description:"keeper proactive autonomous turn prompt template"
+    ~category:"keeper";
+  register ~key:"keeper.proactive_retry"
+    ~description:"keeper proactive retry steering template"
+    ~category:"keeper";
+  register ~key:"keeper.unified.system"
+    ~description:"keeper unified loop system prompt template"
+    ~category:"keeper";
+  register ~key:"keeper.deliberation"
+    ~description:"keeper deliberation prompt for choosing the next action"
+    ~category:"keeper";
+  register ~key:"governance.deliberation"
+    ~description:"governance deliberation agent system prompt"
+    ~category:"governance";
+  register ~key:"governance.dry_run"
+    ~description:"governance analysis (DRY RUN) agent system prompt"
+    ~category:"governance";
+  register ~key:"dashboard.operator_judge"
+    ~description:"resident operator judge prompt for dashboard command surface"
+    ~category:"dashboard";
+  register ~key:"dashboard.governance_judge"
+    ~description:"resident governance judge prompt for dashboard governance surface"
+    ~category:"dashboard"

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -63,6 +63,23 @@ type registry_stats = {
   avg_usage: float;
 }
 
+type prompt_meta = {
+  description: string;
+  category: string;
+  required_file: bool;
+}
+
+type prompt_resolution = {
+  effective: string;
+  source: string;
+  file_value: string option;
+  override_value: string option;
+  default_value: string option;
+  file_path: string option;
+  file_exists: bool;
+  has_override: bool;
+}
+
 (** {1 Variable Extraction} *)
 
 (** Extract variable names from a template string.
@@ -89,6 +106,12 @@ let registry : (string, prompt_entry) Hashtbl.t = Hashtbl.create 64
 (** Version index: id -> [version list] for quick version lookup *)
 let version_index : (string, string list) Hashtbl.t = Hashtbl.create 64
 
+(** Override store — highest priority. Dashboard/API edits go here. *)
+let override_tbl : (string, string) Hashtbl.t = Hashtbl.create 16
+
+(** Description and category metadata for prompts *)
+let meta_tbl : (string, prompt_meta) Hashtbl.t = Hashtbl.create 32
+
 let registry_mutex = Eio.Mutex.create ()
 
 let with_mutex f =
@@ -99,6 +122,9 @@ let with_mutex f =
 
 (** File-based persistence directory *)
 let prompts_dir = ref None
+
+(** Markdown prompt source directory for operator-managed prompt text. *)
+let markdown_dir = ref None
 
 (** Make a storage key from id and version *)
 let make_key ~id ~version = Printf.sprintf "%s@%s" id version
@@ -141,6 +167,27 @@ let init ?persist_dir () =
         ) files
       end
   | None -> ()
+
+let set_markdown_dir dir =
+  markdown_dir := Some dir
+
+let is_valid_prompt_key key =
+  key <> ""
+  && String.for_all
+       (function
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | '-' -> true
+         | _ -> false)
+       key
+
+let prompt_markdown_path key =
+  if not (is_valid_prompt_key key) then None
+  else
+    Option.map (fun dir -> Filename.concat dir (key ^ ".md")) !markdown_dir
+
+let read_file_if_exists path =
+  if Sys.file_exists path && not (Sys.is_directory path) then
+    Some (In_channel.with_open_text path In_channel.input_all)
+  else None
 
 (** {1 Registration and Lookup} *)
 
@@ -396,10 +443,15 @@ let stats () : registry_stats =
 (** Clear all registered prompts *)
 let clear () : unit =
   with_mutex (fun () ->
+    let persisted_dir = !prompts_dir in
     Hashtbl.clear registry;
     Hashtbl.clear version_index;
+    Hashtbl.clear override_tbl;
+    Hashtbl.clear meta_tbl;
+    prompts_dir := None;
+    markdown_dir := None;
     (* Clear files if persistence enabled *)
-    match !prompts_dir with
+    match persisted_dir with
     | Some dir when Sys.file_exists dir && Sys.is_directory dir ->
         let files = Sys.readdir dir in
         Array.iter (fun file ->
@@ -445,17 +497,93 @@ let of_json (json : Yojson.Safe.t) : (int, string) result =
 
 (** {1 Simple Override API for Hardcoded Prompts} *)
 
-(** Override store — highest priority. Dashboard/API edits go here. *)
-let override_tbl : (string, string) Hashtbl.t = Hashtbl.create 16
+let default_prompt_value_unlocked key =
+  let storage_key = make_key ~id:key ~version:"default" in
+  match Hashtbl.find_opt registry storage_key with
+  | Some entry -> Some entry.template
+  | None -> None
 
-(** Description and category metadata for prompts *)
-let meta_tbl : (string, string * string) Hashtbl.t = Hashtbl.create 16
+let resolve_prompt_unlocked key =
+  let override_value = Hashtbl.find_opt override_tbl key in
+  let file_path = prompt_markdown_path key in
+  let file_value = Option.bind file_path read_file_if_exists in
+  let default_value = default_prompt_value_unlocked key in
+  let source, effective =
+    match override_value with
+    | Some value -> ("override", value)
+    | None -> (
+        match file_value with
+        | Some value -> ("file", value)
+        | None -> (
+            match default_value with
+            | Some value -> ("default", value)
+            | None -> ("missing", "")))
+  in
+  {
+    effective;
+    source;
+    file_value;
+    override_value;
+    default_value;
+    file_path;
+    file_exists = Option.is_some file_value;
+    has_override = Option.is_some override_value;
+  }
+
+let prompt_item_json key (meta : prompt_meta) =
+  let resolved = resolve_prompt_unlocked key in
+  `Assoc
+    [
+      ("key", `String key);
+      ("category", `String meta.category);
+      ("description", `String meta.description);
+      ("current", `String resolved.effective);
+      ( "default",
+        match resolved.file_value with
+        | Some value -> `String value
+        | None -> (
+            match resolved.default_value with
+            | Some value -> `String value
+            | None -> `Null) );
+      ("effective", `String resolved.effective);
+      ( "file_value",
+        match resolved.file_value with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "override_value",
+        match resolved.override_value with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "file_path",
+        match resolved.file_path with
+        | Some value -> `String value
+        | None -> `Null );
+      ("file_exists", `Bool resolved.file_exists);
+      ("source", `String resolved.source);
+      ("has_override", `Bool resolved.has_override);
+      ("char_count", `Int (String.length resolved.effective));
+      ("required_file", `Bool meta.required_file);
+    ]
+
+let compare_prompt_items a b =
+  let get_key = function
+    | `Assoc fields -> (
+        match List.assoc_opt "key" fields with
+        | Some (`String value) -> value
+        | _ -> "")
+    | _ -> ""
+  in
+  String.compare (get_key a) (get_key b)
+
+let register_prompt ~key ~description ?(category = "general") ?(required_file = false) () =
+  with_mutex (fun () ->
+      Hashtbl.replace meta_tbl key { description; category; required_file })
 
 (** Register a hardcoded prompt with its default value.
     This also registers it in the versioned template system as a fallback. *)
 let register_default ~key ~default ~description ?(category="general") () =
   with_mutex (fun () ->
-    Hashtbl.replace meta_tbl key (description, category);
+    Hashtbl.replace meta_tbl key { description; category; required_file = false };
     let entry = {
       id = key;
       template = default;
@@ -471,36 +599,27 @@ let register_default ~key ~default ~description ?(category="general") () =
       | Some vs -> if List.mem "default" vs then vs else "default" :: vs
       | None -> ["default"]
     in
-    Hashtbl.replace version_index key versions
+      Hashtbl.replace version_index key versions
   )
 
 (** Get a prompt value. Resolution: override > file > registered default *)
 let get_prompt key =
-  with_mutex (fun () ->
-    match Hashtbl.find_opt override_tbl key with
-    | Some v -> v
-    | None ->
-      let file_val = match !prompts_dir with
-        | Some dir ->
-          let path = Filename.concat dir (key ^ ".md") in
-          if Sys.file_exists path then
-            Some (In_channel.with_open_text path In_channel.input_all)
-          else None
-        | None -> None
-      in
-      match file_val with
-      | Some v -> v
-      | None ->
-        let storage_key = make_key ~id:key ~version:"default" in
-        match Hashtbl.find_opt registry storage_key with
-        | Some entry -> entry.template
-        | None -> ""
-  )
+  with_mutex (fun () -> (resolve_prompt_unlocked key).effective)
+
+let render_prompt_template key vars =
+  let template = get_prompt key in
+  if String.trim template = "" then
+    Error (Printf.sprintf "Prompt '%s' is missing" key)
+  else
+    render_template ~template ~vars ()
 
 (** Set an override for a prompt *)
 let set_override key value =
   let trimmed = String.trim value in
-  if trimmed = "" then Error "Prompt cannot be empty"
+  if not (is_valid_prompt_key key) then Error "Invalid prompt key"
+  else if not (with_mutex (fun () -> Hashtbl.mem meta_tbl key)) then
+    Error "Unknown prompt key"
+  else if trimmed = "" then Error "Prompt cannot be empty"
   else if String.length trimmed > 10000 then Error "Prompt too long (max 10000 chars)"
   else begin
     with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
@@ -513,49 +632,27 @@ let clear_prompt_override key =
 
 (** Get source of current value *)
 let prompt_source key =
+  with_mutex (fun () -> (resolve_prompt_unlocked key).source)
+
+let validate_required_prompt_files () =
   with_mutex (fun () ->
-    if Hashtbl.mem override_tbl key then "override"
-    else match !prompts_dir with
-      | Some dir ->
-        let path = Filename.concat dir (key ^ ".md") in
-        if Sys.file_exists path then "file" else "default"
-      | None -> "default"
-  )
+      Hashtbl.fold
+        (fun key meta acc ->
+          if not meta.required_file then acc
+          else
+            match prompt_markdown_path key with
+            | Some path when Sys.file_exists path && not (Sys.is_directory path) -> acc
+            | Some path -> (key, path) :: acc
+            | None -> (key, "<invalid-key>") :: acc)
+        meta_tbl [] |> List.sort compare)
 
 (** List all registered prompts with metadata, for API/dashboard *)
 let list_prompts () =
   with_mutex (fun () ->
-    Hashtbl.fold (fun key (description, category) acc ->
-      let current = match Hashtbl.find_opt override_tbl key with
-        | Some v -> v
-        | None ->
-          let storage_key = make_key ~id:key ~version:"default" in
-          match Hashtbl.find_opt registry storage_key with
-          | Some entry -> entry.template
-          | None -> ""
-      in
-      let default_val =
-        let storage_key = make_key ~id:key ~version:"default" in
-        match Hashtbl.find_opt registry storage_key with
-        | Some entry -> entry.template
-        | None -> ""
-      in
-      let source = if Hashtbl.mem override_tbl key then "override" else "default" in
-      `Assoc [
-        ("key", `String key);
-        ("category", `String category);
-        ("description", `String description);
-        ("current", `String current);
-        ("default", `String default_val);
-        ("source", `String source);
-        ("has_override", `Bool (Hashtbl.mem override_tbl key));
-        ("char_count", `Int (String.length current));
-      ] :: acc
-    ) meta_tbl []
-    |> List.sort (fun a b ->
-      let get_key j = match j with `Assoc l -> (match List.assoc "key" l with `String s -> s | _ -> "") | _ -> "" in
-      String.compare (get_key a) (get_key b))
-  )
+      Hashtbl.fold
+        (fun key meta acc -> prompt_item_json key meta :: acc)
+        meta_tbl []
+      |> List.sort compare_prompt_items)
 
 (** JSON export of all prompts for API *)
 let prompts_json () =
@@ -589,7 +686,8 @@ let restore_overrides base_path =
         with_mutex (fun () ->
           List.iter (fun (key, value) ->
             match value with
-            | `String s -> Hashtbl.replace override_tbl key s
+            | `String s when is_valid_prompt_key key && Hashtbl.mem meta_tbl key ->
+                Hashtbl.replace override_tbl key s
             | _ -> ()
           ) pairs)
       | _ -> ()

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -67,6 +67,7 @@ type prompt_meta = {
   description: string;
   category: string;
   required_file: bool;
+  template_variables: string list;
 }
 
 type prompt_resolution = {
@@ -530,6 +531,13 @@ let resolve_prompt_unlocked key =
     has_override = Option.is_some override_value;
   }
 
+let unexpected_template_variables meta template =
+  let expected = meta.template_variables in
+  if expected = [] then []
+  else
+    extract_variables template
+    |> List.filter (fun variable -> not (List.mem variable expected))
+
 let prompt_item_json key (meta : prompt_meta) =
   let resolved = resolve_prompt_unlocked key in
   `Assoc
@@ -563,6 +571,8 @@ let prompt_item_json key (meta : prompt_meta) =
       ("has_override", `Bool resolved.has_override);
       ("char_count", `Int (String.length resolved.effective));
       ("required_file", `Bool meta.required_file);
+      ( "template_variables",
+        `List (List.map (fun value -> `String value) meta.template_variables) );
     ]
 
 let compare_prompt_items a b =
@@ -575,15 +585,28 @@ let compare_prompt_items a b =
   in
   String.compare (get_key a) (get_key b)
 
-let register_prompt ~key ~description ?(category = "general") ?(required_file = false) () =
+let register_prompt ~key ~description ?(category = "general")
+    ?(required_file = false) ?(template_variables = []) () =
   with_mutex (fun () ->
-      Hashtbl.replace meta_tbl key { description; category; required_file })
+      Hashtbl.replace meta_tbl key
+        {
+          description;
+          category;
+          required_file;
+          template_variables = List.sort_uniq String.compare template_variables;
+        })
 
 (** Register a hardcoded prompt with its default value.
     This also registers it in the versioned template system as a fallback. *)
 let register_default ~key ~default ~description ?(category="general") () =
   with_mutex (fun () ->
-    Hashtbl.replace meta_tbl key { description; category; required_file = false };
+    Hashtbl.replace meta_tbl key
+      {
+        description;
+        category;
+        required_file = false;
+        template_variables = [];
+      };
     let entry = {
       id = key;
       template = default;
@@ -617,14 +640,25 @@ let render_prompt_template key vars =
 let set_override key value =
   let trimmed = String.trim value in
   if not (is_valid_prompt_key key) then Error "Invalid prompt key"
-  else if not (with_mutex (fun () -> Hashtbl.mem meta_tbl key)) then
-    Error "Unknown prompt key"
   else if trimmed = "" then Error "Prompt cannot be empty"
   else if String.length trimmed > 10000 then Error "Prompt too long (max 10000 chars)"
-  else begin
-    with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
-    Ok ()
-  end
+  else
+    match
+      with_mutex (fun () ->
+          match Hashtbl.find_opt meta_tbl key with
+          | None -> Error "Unknown prompt key"
+          | Some meta ->
+              let unexpected = unexpected_template_variables meta trimmed in
+              if unexpected <> [] then
+                Error
+                  (Printf.sprintf "Unknown template variables: %s"
+                     (String.concat ", " unexpected))
+              else Ok ())
+    with
+    | Error msg -> Error msg
+    | Ok () ->
+        with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
+        Ok ()
 
 (** Clear override, reverting to file or default *)
 let clear_prompt_override key =
@@ -644,6 +678,20 @@ let validate_required_prompt_files () =
             | Some path when Sys.file_exists path && not (Sys.is_directory path) -> acc
             | Some path -> (key, path) :: acc
             | None -> (key, "<invalid-key>") :: acc)
+        meta_tbl [] |> List.sort compare)
+
+let validate_prompt_templates () =
+  with_mutex (fun () ->
+      Hashtbl.fold
+        (fun key meta acc ->
+          let issues =
+            match resolve_prompt_unlocked key with
+            | { effective = ""; source = "missing"; _ } -> []
+            | resolved ->
+                unexpected_template_variables meta resolved.effective
+                |> List.map (fun variable -> (key, variable))
+          in
+          issues @ acc)
         meta_tbl [] |> List.sort compare)
 
 (** List all registered prompts with metadata, for API/dashboard *)

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -636,8 +636,11 @@ let render_prompt_template key vars =
   else
     render_template ~template ~vars ()
 
-(** Set an override for a prompt *)
-let set_override key value =
+(** Validate and apply a single override entry (shared logic for
+    [set_override] and [restore_overrides]).  Caller must NOT hold [mu].
+    Returns [Ok ()] on success or [Error msg] describing why the entry
+    was rejected. *)
+let apply_override_validated key value =
   let trimmed = String.trim value in
   if not (is_valid_prompt_key key) then Error "Invalid prompt key"
   else if trimmed = "" then Error "Prompt cannot be empty"
@@ -659,6 +662,9 @@ let set_override key value =
     | Ok () ->
         with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
         Ok ()
+
+(** Set an override for a prompt *)
+let set_override key value = apply_override_validated key value
 
 (** Clear override, reverting to file or default *)
 let clear_prompt_override key =
@@ -722,7 +728,8 @@ let persist_overrides base_path =
   Out_channel.with_open_text path (fun oc ->
     Out_channel.output_string oc content)
 
-(** Restore overrides from JSON file *)
+(** Restore overrides from JSON file, applying the same validation as
+    [set_override] so that stale or manually-edited entries are rejected. *)
 let restore_overrides base_path =
   let path = Filename.concat (Filename.concat base_path ".masc") "prompt_overrides.json" in
   if Sys.file_exists path then begin
@@ -731,13 +738,16 @@ let restore_overrides base_path =
       let json = Yojson.Safe.from_string content in
       match json with
       | `Assoc pairs ->
-        with_mutex (fun () ->
-          List.iter (fun (key, value) ->
-            match value with
-            | `String s when is_valid_prompt_key key && Hashtbl.mem meta_tbl key ->
-                Hashtbl.replace override_tbl key s
-            | _ -> ()
-          ) pairs)
+        List.iter (fun (key, value) ->
+          match value with
+          | `String s -> (
+              match apply_override_validated key s with
+              | Ok () -> ()
+              | Error reason ->
+                  Log.Misc.warn "prompt override restore: skipping %s: %s"
+                    key reason)
+          | _ -> ()
+        ) pairs
       | _ -> ()
     with _ -> ()
   end

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -338,6 +338,9 @@ let add_routes router =
                let result = match action with
                  | "clear" ->
                    Prompt_registry.clear_prompt_override key;
+                   (try Prompt_registry.persist_overrides
+                          state.Mcp_server.room_config.base_path
+                    with _ -> ());
                    Ok "override cleared"
                  | "set" | _ ->
                    let value = Yojson.Safe.Util.(member "value" args |> to_string_option)
@@ -358,6 +361,7 @@ let add_routes router =
                      ("message", `String msg);
                      ("key", `String key);
                      ("source", `String (Prompt_registry.prompt_source key));
+                     ("effective", `String (Prompt_registry.get_prompt key));
                    ]))
                | Error msg ->
                  respond_json_with_cors ~status:`Bad_request request reqd

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -32,6 +32,49 @@ let requested_backend_mode () =
       in
       if has_pg then "postgres-native" else "filesystem"
 
+let existing_dir path =
+  Sys.file_exists path && Sys.is_directory path
+
+let dedupe_keep_order values =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+        if List.mem value acc then loop acc rest
+        else loop (value :: acc) rest
+  in
+  loop [] values
+
+let prompt_markdown_dir_candidates ~workspace_path ~base_path =
+  let workspace_candidate =
+    Filename.concat workspace_path "config/prompts"
+  in
+  let base_candidate = Filename.concat base_path "config/prompts" in
+  let cwd_candidate = Filename.concat (Sys.getcwd ()) "config/prompts" in
+  let exe_candidate =
+    let exe_dir = Filename.dirname Sys.executable_name in
+    let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
+    Filename.concat root "config/prompts"
+  in
+  let dune_candidate =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when String.trim root <> "" ->
+        Some (Filename.concat root "config/prompts")
+    | _ -> None
+  in
+  let candidates =
+    workspace_candidate
+    :: base_candidate
+    :: (match dune_candidate with Some dir -> [ dir ] | None -> [])
+    @ [ exe_candidate; cwd_candidate ]
+  in
+  dedupe_keep_order candidates
+
+let resolve_prompt_markdown_dir ~workspace_path ~base_path =
+  let candidates = prompt_markdown_dir_candidates ~workspace_path ~base_path in
+  match List.find_opt existing_dir candidates with
+  | Some dir -> dir
+  | None -> Filename.concat base_path "config/prompts"
+
 let init_runtime_context env =
   let clock = Eio.Stdenv.clock env in
   let mono_clock = Eio.Stdenv.mono_clock env in
@@ -80,18 +123,18 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
 
 let bootstrap_chain_state (state : Mcp_server.server_state) =
   Chain_native_eio.ensure_bootstrap state.room_config;
-  (* Initialize prompt registry with defaults and restore saved overrides.
-     Use workspace_path (active checkout) rather than base_path (shared git
-     root) so that branch-specific prompt edits in worktrees are picked up. *)
-  let prompts_root =
-    let ws = state.room_config.workspace_path in
-    if ws <> state.room_config.base_path
-       && Sys.file_exists (Filename.concat ws "config/prompts")
-    then ws
-    else state.room_config.base_path
+  (* Initialize prompt registry with defaults and restore saved overrides *)
+  let prompt_markdown_dir =
+    resolve_prompt_markdown_dir
+      ~workspace_path:state.room_config.workspace_path
+      ~base_path:state.room_config.base_path
   in
-  Prompt_registry.set_markdown_dir
-    (Filename.concat prompts_root "config/prompts");
+  Prompt_registry.set_markdown_dir prompt_markdown_dir;
+  if prompt_markdown_dir
+     <> Filename.concat state.room_config.workspace_path "config/prompts"
+  then
+    Log.Misc.info "prompt markdown dir resolved outside room base: %s"
+      prompt_markdown_dir;
   Prompt_defaults.init ();
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -80,9 +80,18 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
 
 let bootstrap_chain_state (state : Mcp_server.server_state) =
   Chain_native_eio.ensure_bootstrap state.room_config;
-  (* Initialize prompt registry with defaults and restore saved overrides *)
+  (* Initialize prompt registry with defaults and restore saved overrides.
+     Use workspace_path (active checkout) rather than base_path (shared git
+     root) so that branch-specific prompt edits in worktrees are picked up. *)
+  let prompts_root =
+    let ws = state.room_config.workspace_path in
+    if ws <> state.room_config.base_path
+       && Sys.file_exists (Filename.concat ws "config/prompts")
+    then ws
+    else state.room_config.base_path
+  in
   Prompt_registry.set_markdown_dir
-    (Filename.concat state.room_config.base_path "config/prompts");
+    (Filename.concat prompts_root "config/prompts");
   Prompt_defaults.init ();
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
@@ -96,7 +105,7 @@ let bootstrap_chain_state (state : Mcp_server.server_state) =
       (invalid_prompt_templates
       |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)
       |> String.concat ", ");
-  (try Prompt_registry.restore_overrides state.room_config.base_path
+  (try Prompt_registry.restore_overrides state.room_config.workspace_path
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.error "prompt override restore failed: %s"
        (Printexc.to_string exn));

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -81,7 +81,15 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
 let bootstrap_chain_state (state : Mcp_server.server_state) =
   Chain_native_eio.ensure_bootstrap state.room_config;
   (* Initialize prompt registry with defaults and restore saved overrides *)
+  Prompt_registry.set_markdown_dir
+    (Filename.concat state.room_config.base_path "config/prompts");
   Prompt_defaults.init ();
+  let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
+  if missing_prompt_files <> [] then
+    Log.Misc.error "required prompt files missing: %s"
+      (missing_prompt_files
+      |> List.map (fun (key, path) -> Printf.sprintf "%s -> %s" key path)
+      |> String.concat ", ");
   (try Prompt_registry.restore_overrides state.room_config.base_path
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.error "prompt override restore failed: %s"

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -90,6 +90,12 @@ let bootstrap_chain_state (state : Mcp_server.server_state) =
       (missing_prompt_files
       |> List.map (fun (key, path) -> Printf.sprintf "%s -> %s" key path)
       |> String.concat ", ");
+  let invalid_prompt_templates = Prompt_registry.validate_prompt_templates () in
+  if invalid_prompt_templates <> [] then
+    Log.Misc.error "prompt templates use unknown variables: %s"
+      (invalid_prompt_templates
+      |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)
+      |> String.concat ", ");
   (try Prompt_registry.restore_overrides state.room_config.base_path
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.error "prompt override restore failed: %s"

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -116,6 +116,12 @@ extract_result() {
   jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
 }
 
+# Extract raw text from MCP tool response content.
+# Usage: echo "$response" | extract_text
+extract_text() {
+  jq -r 'try (.result.content[0].text) catch empty'
+}
+
 # Extract .payload from MCP tool response content.
 # Usage: echo "$response" | extract_payload
 extract_payload() {

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.89.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
 readonly OAS_AGENT_SDK_SHA="ffae93c535a111c3b929ff3c0f5d63070f2de8ab"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.89.0"

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -4,6 +4,26 @@ module D = Masc_mcp.Keeper_deliberation
 module Contract = Masc_mcp.Keeper_contract
 module Keeper_types = Masc_mcp.Keeper_types
 
+let has_prompt_root path =
+  Sys.file_exists (Filename.concat path "config/prompts/keeper.deliberation.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let () =
+  let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
+  Masc_mcp.Prompt_registry.set_markdown_dir prompts_dir;
+  Masc_mcp.Prompt_defaults.init ()
+
 (* ---------- Triage tests ---------- *)
 
 let base_obs =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8,6 +8,26 @@ module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
 module HK = Masc_mcp.Keeper_hooks_oas
 
+let has_prompt_root path =
+  Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let () =
+  let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
+  Masc_mcp.Prompt_registry.set_markdown_dir prompts_dir;
+  Masc_mcp.Prompt_defaults.init ()
+
 (* ---------- World Observation type tests ---------- *)
 
 let base_observation : WO.world_observation =

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -790,7 +790,7 @@ let () =
         test_mitosis_prepare_success;
       Alcotest.test_case "handoff no_action" `Quick
         test_mitosis_handoff_no_action;
-      Alcotest.test_case "handoff force" `Quick
+      Alcotest.test_case "handoff force" `Slow
         test_mitosis_handoff_force;
       Alcotest.test_case "dispatch unknown" `Quick
         test_mitosis_dispatch_unknown;

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -1,170 +1,209 @@
-(** Tests for prompt registry defaults and override API. *)
+(** Tests for prompt registry markdown sources and override API. *)
 
 module Lib = Masc_mcp
 
-let () =
-  (* Clear registry state before tests *)
-  Lib.Prompt_registry.clear ();
-  (* Initialize defaults *)
-  Lib.Prompt_defaults.init ();
-  let open Alcotest in
-  run "Prompt_registry_defaults" [
-    ("registration", [
-      test_case "all 5 Tier-1 prompts are registered" `Quick (fun () ->
-        let keys = [
-          "keeper.constitution";
-          "keeper.world";
-          "keeper.capabilities";
-          "governance.deliberation";
-          "governance.dry_run";
-        ] in
-        List.iter (fun key ->
-          let v = Lib.Prompt_registry.get_prompt key in
-          check bool (Printf.sprintf "%s should not be empty" key) true (v <> "")
-        ) keys
-      );
+let test_dir () =
+  let tmp = Filename.temp_file "masc_prompt_registry" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
 
-      test_case "keeper.constitution matches keeper_prompt default" `Quick (fun () ->
-        let from_registry = Lib.Prompt_registry.get_prompt "keeper.constitution" in
-        let from_module = Lib.Keeper_prompt.keeper_constitution_default in
-        check string "keeper.constitution content" from_module from_registry
-      );
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
 
-      test_case "keeper.world contains MASC" `Quick (fun () ->
-        let v = Lib.Prompt_registry.get_prompt "keeper.world" in
-        check bool "contains MASC" true
-          (String.length v > 0
-           && (try ignore (Str.search_forward (Str.regexp_string "MASC") v 0); true
-               with Not_found -> false))
-      );
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc content)
 
-      test_case "governance.deliberation contains governance" `Quick (fun () ->
-        let v = Lib.Prompt_registry.get_prompt "governance.deliberation" in
-        check bool "contains governance" true
-          (try ignore (Str.search_forward (Str.regexp_string "governance") v 0); true
-           with Not_found -> false)
-      );
-
-      test_case "governance.dry_run contains DRY RUN" `Quick (fun () ->
-        let v = Lib.Prompt_registry.get_prompt "governance.dry_run" in
-        check bool "contains DRY RUN" true
-          (try ignore (Str.search_forward (Str.regexp_string "DRY RUN") v 0); true
-           with Not_found -> false)
-      );
-    ]);
-
-    ("list_prompts", [
-      test_case "list_prompts returns all 5 entries" `Quick (fun () ->
-        let prompts = Lib.Prompt_registry.list_prompts () in
-        check int "5 registered prompts" 5 (List.length prompts)
-      );
-
-      test_case "list_prompts entries have correct keys" `Quick (fun () ->
-        let prompts = Lib.Prompt_registry.list_prompts () in
-        let keys = List.filter_map (fun j ->
-          match j with
-          | `Assoc l -> (match List.assoc "key" l with `String s -> Some s | _ -> None)
-          | _ -> None
-        ) prompts in
-        check bool "has keeper.constitution" true
-          (List.mem "keeper.constitution" keys);
-        check bool "has governance.dry_run" true
-          (List.mem "governance.dry_run" keys)
-      );
-
-      test_case "list_prompts sorted by key" `Quick (fun () ->
-        let prompts = Lib.Prompt_registry.list_prompts () in
-        let keys = List.filter_map (fun j ->
-          match j with
-          | `Assoc l -> (match List.assoc "key" l with `String s -> Some s | _ -> None)
-          | _ -> None
-        ) prompts in
-        let sorted = List.sort String.compare keys in
-        check (list string) "keys are sorted" sorted keys
-      );
-    ]);
-
-    ("override", [
-      test_case "set_override replaces default" `Quick (fun () ->
-        let key = "keeper.constitution" in
-        let original = Lib.Prompt_registry.get_prompt key in
-        let override_text = "Custom constitution text for testing" in
-        (match Lib.Prompt_registry.set_override key override_text with
-         | Ok () -> ()
-         | Error msg -> fail msg);
-        let current = Lib.Prompt_registry.get_prompt key in
-        check string "override applied" override_text current;
-        check bool "different from original" true (current <> original);
-        (* Check source *)
-        check string "source is override" "override"
-          (Lib.Prompt_registry.prompt_source key);
-        (* Cleanup *)
-        Lib.Prompt_registry.clear_prompt_override key
-      );
-
-      test_case "clear_override reverts to default" `Quick (fun () ->
-        let key = "keeper.world" in
-        let original = Lib.Prompt_registry.get_prompt key in
-        (match Lib.Prompt_registry.set_override key "temporary override" with
-         | Ok () -> ()
-         | Error msg -> fail msg);
-        Lib.Prompt_registry.clear_prompt_override key;
-        let reverted = Lib.Prompt_registry.get_prompt key in
-        check string "reverted to default" original reverted;
-        check string "source is default" "default"
-          (Lib.Prompt_registry.prompt_source key)
-      );
-
-      test_case "set_override rejects empty value" `Quick (fun () ->
-        match Lib.Prompt_registry.set_override "keeper.world" "" with
-        | Error _ -> ()
-        | Ok () -> fail "should reject empty value"
-      );
-
-      test_case "set_override rejects whitespace-only value" `Quick (fun () ->
-        match Lib.Prompt_registry.set_override "keeper.world" "   \n  " with
-        | Error _ -> ()
-        | Ok () -> fail "should reject whitespace-only value"
-      );
-
-      test_case "set_override rejects oversized value" `Quick (fun () ->
-        let long = String.make 10001 'x' in
-        match Lib.Prompt_registry.set_override "keeper.world" long with
-        | Error msg ->
-          check bool "mentions max" true
-            (try ignore (Str.search_forward (Str.regexp_string "10000") msg 0); true
-             with Not_found -> false)
-        | Ok () -> fail "should reject oversized value"
-      );
-    ]);
-
-    ("keeper_prompt_integration", [
-      test_case "keeper_constitution() uses registry" `Quick (fun () ->
-        let from_fn = Lib.Keeper_prompt.keeper_constitution () in
-        let from_default = Lib.Keeper_prompt.keeper_constitution_default in
-        (* Before any override, function should return the default *)
-        check string "matches default" from_default from_fn
-      );
-
-      test_case "keeper_constitution() reflects override" `Quick (fun () ->
-        let override_text = "Overridden constitution for test" in
-        (match Lib.Prompt_registry.set_override "keeper.constitution" override_text with
-         | Ok () -> ()
-         | Error msg -> fail msg);
-        let from_fn = Lib.Keeper_prompt.keeper_constitution () in
-        check string "override applied via function" override_text from_fn;
-        (* Cleanup *)
-        Lib.Prompt_registry.clear_prompt_override "keeper.constitution"
-      );
-    ]);
-
-    ("prompts_json", [
-      test_case "prompts_json returns valid structure" `Quick (fun () ->
-        let json = Lib.Prompt_registry.prompts_json () in
-        match json with
-        | `Assoc [("prompts", `List items)] ->
-          check bool "has entries" true (List.length items > 0)
-        | _ -> fail "unexpected JSON structure"
-      );
-    ]);
+let fixtures =
+  [
+    ("keeper.constitution", "Continuity rules from file");
+    ("keeper.world", "MASC world from markdown");
+    ("keeper.capabilities", "Capabilities from markdown");
+    ( "keeper.proactive_turn",
+      "Turn {{idle_seconds}} {{profile}} {{goal}} {{last_preview}} {{continuity_snapshot}} {{seed}}" );
+    ("keeper.proactive_retry", "Retry {{attempt_phrase}} {{reason}} {{directive}}");
+    ("keeper.unified.system", "{{identity_header}}\n{{trait_lines}}{{instructions_block}}{{goal_lines}}");
+    ("keeper.deliberation", "Keeper {{keeper_name}} {{soul_profile}} {{goal}} {{triggers}} {{world_state}}");
+    ("governance.deliberation", "governance deliberation prompt");
+    ("governance.dry_run", "DRY RUN governance prompt");
+    ("dashboard.operator_judge", "operator facts {{facts_json}}");
+    ("dashboard.governance_judge", "governance facts {{facts_json}}");
   ]
+
+let with_registry f =
+  let dir = test_dir () in
+  let prompts_dir = Filename.concat dir "prompts" in
+  Unix.mkdir prompts_dir 0o755;
+  List.iter
+    (fun (key, content) ->
+      write_file (Filename.concat prompts_dir (key ^ ".md")) content)
+    fixtures;
+  Fun.protect
+    ~finally:(fun () ->
+      Lib.Prompt_registry.clear ();
+      cleanup_dir dir)
+    (fun () ->
+      Lib.Prompt_registry.clear ();
+      Lib.Prompt_registry.set_markdown_dir prompts_dir;
+      Lib.Prompt_defaults.init ();
+      f ~dir ~prompts_dir)
+
+let fixture key =
+  match List.assoc_opt key fixtures with
+  | Some value -> value
+  | None -> failwith ("missing fixture: " ^ key)
+
+let get_string_field field = function
+  | `Assoc fields -> (
+      match List.assoc_opt field fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let get_bool_field field = function
+  | `Assoc fields -> (
+      match List.assoc_opt field fields with
+      | Some (`Bool value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let () =
+  let open Alcotest in
+  run "Prompt_registry_defaults"
+    [
+      ( "registration",
+        [
+          test_case "all markdown-backed prompts are registered" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              let prompts = Lib.Prompt_registry.list_prompts () in
+              check int "registered prompt count" 11 (List.length prompts));
+          test_case "get_prompt resolves markdown content" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              check string "keeper.constitution"
+                (fixture "keeper.constitution")
+                (Lib.Prompt_registry.get_prompt "keeper.constitution");
+              check string "governance.dry_run"
+                (fixture "governance.dry_run")
+                (Lib.Prompt_registry.get_prompt "governance.dry_run"));
+          test_case "prompt_source reports file" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              check string "file source" "file"
+                (Lib.Prompt_registry.prompt_source "keeper.world"));
+          test_case "validate_required_prompt_files detects missing file" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir ->
+              Sys.remove
+                (Filename.concat prompts_dir "dashboard.governance_judge.md");
+              let missing = Lib.Prompt_registry.validate_required_prompt_files () in
+              check bool "missing file found" true
+                (List.mem_assoc "dashboard.governance_judge" missing));
+        ] );
+      ( "rendering",
+        [
+          test_case "render_prompt_template uses markdown template" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              match
+                Lib.Prompt_registry.render_prompt_template "keeper.proactive_retry"
+                  [
+                    ("attempt_phrase", "previous attempt");
+                    ("reason", "timeout");
+                    ("directive", "now");
+                  ]
+              with
+              | Ok rendered ->
+                  check string "rendered markdown template"
+                    "Retry previous attempt timeout now"
+                    rendered
+              | Error msg -> fail msg);
+        ] );
+      ( "override",
+        [
+          test_case "set_override replaces file content" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              let override_text = "override constitution" in
+              (match
+                 Lib.Prompt_registry.set_override "keeper.constitution"
+                   override_text
+               with
+              | Ok () -> ()
+              | Error msg -> fail msg);
+              check string "override value" override_text
+                (Lib.Prompt_registry.get_prompt "keeper.constitution");
+              check string "override source" "override"
+                (Lib.Prompt_registry.prompt_source "keeper.constitution"));
+          test_case "clear_override reverts to file" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              (match
+                 Lib.Prompt_registry.set_override "keeper.world"
+                   "temporary override"
+               with
+              | Ok () -> ()
+              | Error msg -> fail msg);
+              Lib.Prompt_registry.clear_prompt_override "keeper.world";
+              check string "back to file baseline" (fixture "keeper.world")
+                (Lib.Prompt_registry.get_prompt "keeper.world");
+              check string "source is file" "file"
+                (Lib.Prompt_registry.prompt_source "keeper.world"));
+          test_case "set_override rejects unknown key" `Quick (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              match Lib.Prompt_registry.set_override "unknown.prompt" "x" with
+              | Error _ -> ()
+              | Ok () -> fail "should reject unknown prompt key");
+        ] );
+      ( "integration",
+        [
+          test_case "keeper_constitution reads markdown-backed registry" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              check string "keeper constitution function"
+                (fixture "keeper.constitution")
+                (Lib.Keeper_prompt.keeper_constitution ()));
+        ] );
+      ( "prompts_json",
+        [
+          test_case "prompts_json exposes effective file and override fields" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              (match
+                 Lib.Prompt_registry.set_override "keeper.capabilities"
+                   "runtime override"
+               with
+              | Ok () -> ()
+              | Error msg -> fail msg);
+              let json = Lib.Prompt_registry.prompts_json () in
+              let open Yojson.Safe.Util in
+              let prompts = json |> member "prompts" |> to_list in
+              let keeper_capabilities =
+                prompts
+                |> List.find (fun item ->
+                       get_string_field "key" item = Some "keeper.capabilities")
+              in
+              check (option string) "effective value"
+                (Some "runtime override")
+                (get_string_field "effective" keeper_capabilities);
+              check (option string) "file value"
+                (Some (fixture "keeper.capabilities"))
+                (get_string_field "file_value" keeper_capabilities);
+              check (option string) "override value"
+                (Some "runtime override")
+                (get_string_field "override_value" keeper_capabilities);
+              check (option string) "source"
+                (Some "override")
+                (get_string_field "source" keeper_capabilities);
+              check (option bool) "required_file"
+                (Some true)
+                (get_bool_field "required_file" keeper_capabilities));
+        ] );
+    ]

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -161,6 +161,23 @@ let () =
               match Lib.Prompt_registry.set_override "unknown.prompt" "x" with
               | Error _ -> ()
               | Ok () -> fail "should reject unknown prompt key");
+          test_case "set_override rejects unknown template variable" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              match
+                Lib.Prompt_registry.set_override "keeper.proactive_retry"
+                  "Retry {{attempt_phrase}} {{reason}} {{unknown}}"
+              with
+              | Error msg ->
+                  check bool "mentions unknown variable" true
+                    (try
+                       ignore
+                         (Str.search_forward
+                            (Str.regexp_string "Unknown template variables")
+                            msg 0);
+                       true
+                     with Not_found -> false)
+              | Ok () -> fail "should reject unknown template variable");
         ] );
       ( "integration",
         [
@@ -204,6 +221,13 @@ let () =
                 (get_string_field "source" keeper_capabilities);
               check (option bool) "required_file"
                 (Some true)
-                (get_bool_field "required_file" keeper_capabilities));
+                (get_bool_field "required_file" keeper_capabilities);
+              match keeper_capabilities with
+              | `Assoc fields ->
+                  check int "template_variables field exists" 0
+                    (match List.assoc_opt "template_variables" fields with
+                     | Some (`List items) -> List.length items
+                     | _ -> -1)
+              | _ -> fail "unexpected prompt JSON");
         ] );
     ]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -296,6 +296,8 @@ let test_backend_config_for_uses_fallback_pg_url () =
       check (option string) "postgres url" (Some url) cfg.postgres_url)
 
 let test_postgres_url_from_env_normalizes_supabase_pooler () =
+  (* normalize_postgres_url rewrites Supabase Transaction Pooler port 6543
+     to Session Pooler port 5432 to avoid prepared-statement failures. *)
   let raw_url =
     "postgresql://postgres:secret@aws-1-ap-south-1.pooler.supabase.com:6543/postgres"
   in
@@ -305,7 +307,8 @@ let test_postgres_url_from_env_normalizes_supabase_pooler () =
   with_envs
     (pg_env_bindings ~sb_pg_url:raw_url ())
     (fun () ->
-      check (option string) "transaction pooler url normalized" (Some normalized_url)
+      check (option string) "transaction pooler url normalized"
+        (Some normalized_url)
         (Room_utils.postgres_url_from_env ()))
 
 (* ============================================================

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -21,6 +21,11 @@ let with_pg_envs f =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let project_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when String.trim root <> "" -> root
+  | _ -> Sys.getcwd ()
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -123,6 +128,20 @@ let test_startup_state_json () =
   Alcotest.(check string) "last error recorded" "keeper failed"
     (json_string_field "last_error" json)
 
+let test_prompt_markdown_dir_falls_back_to_repo_root () =
+  with_temp_dir "startup-prompts" (fun dir ->
+      let expected =
+        Filename.concat (project_root ()) "config/prompts"
+      in
+      Alcotest.(check bool) "repo prompt dir exists" true
+        (Sys.file_exists expected && Sys.is_directory expected);
+      let resolved =
+        Server_runtime_bootstrap.resolve_prompt_markdown_dir
+          ~workspace_path:dir ~base_path:dir
+      in
+      Alcotest.(check string) "temp room falls back to repo prompt dir"
+        expected resolved)
+
 let () =
   Alcotest.run "Server_runtime_bootstrap"
     [
@@ -138,5 +157,7 @@ let () =
             test_keeper_paths_use_cluster_root;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
+          Alcotest.test_case "prompt markdown dir falls back to repo root"
+            `Quick test_prompt_markdown_dir_falls_back_to_repo_root;
         ] );
     ]


### PR DESCRIPTION
## Summary
- externalize core keeper/governance/dashboard prompts into `config/prompts/*.md`
- expose prompt registry state and runtime override controls in Dashboard `Lab > Tools`
- extend prompt registry/API metadata to surface effective/file/override values and source state

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/prompt-md-dashboard-surface`
- `./_build/default/test/test_prompt_registry_defaults.exe`
- `./_build/default/test/test_dashboard_tools.exe`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run test`

## Notes
- `masc_mcp.opam` had an unrelated version bump in the worktree and was intentionally left out of this commit.
