### PR TITLE
refactor(pool): convert runtime pool to census/metrics role [3/4]

### DIFF
--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -95,8 +95,13 @@ let empty_pool = {
 }
 
 let pool : pool_state ref = ref empty_pool
+let pool_mu = Mutex.create ()
 
-let reset () = pool := empty_pool
+let with_pool_lock f =
+  Mutex.lock pool_mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock pool_mu) f
+
+let reset () = with_pool_lock (fun () -> pool := empty_pool)
 
 let parse_int_opt raw =
   try Some (int_of_string (String.trim raw)) with Failure _ -> None
@@ -118,6 +123,71 @@ let runtime_id_of_base_url base_url =
   | None ->
       let digest = Digest.string base_url |> Digest.to_hex in
       sprintf "local-%s" (String.sub digest 0 8)
+
+let model_of_discovery_status (status : Discovery_cache.endpoint_info) =
+  match status.models with
+  | model :: _ -> trim_opt (Some model.id)
+  | [] -> (
+      match status.props with
+      | Some props -> trim_opt (Some props.model)
+      | None -> trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL"))
+
+let max_concurrency_of_discovery_status (status : Discovery_cache.endpoint_info) =
+  match status.slots with
+  | Some slots when slots.total > 0 -> slots.total
+  | _ ->
+      int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
+        ~default:default_parallel_hint
+
+let runtime_of_discovery_status (status : Discovery_cache.endpoint_info) =
+  let base_url = String.trim status.url in
+  let unavailable =
+    if status.healthy then None else Some (wall_now () +. cooldown_seconds ())
+  in
+  {
+    id = runtime_id_of_base_url base_url;
+    base_url;
+    model = model_of_discovery_status status;
+    max_concurrency = max_concurrency_of_discovery_status status;
+    active_slots = 0;
+    queue_depth = 0;
+    latency_ema_ms = None;
+    failure_streak = if status.healthy then 0 else 1;
+    cooldown_until = unavailable;
+    last_error =
+      if status.healthy then None else Some "oas discovery marked endpoint unhealthy";
+    total_started = 0;
+    total_success = 0;
+    total_failure = 0;
+  }
+
+let runtime_of_endpoint_url base_url =
+  let base_url = String.trim base_url in
+  {
+    id = runtime_id_of_base_url base_url;
+    base_url;
+    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    max_concurrency =
+      int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
+        ~default:default_parallel_hint;
+    active_slots = 0;
+    queue_depth = 0;
+    latency_ema_ms = None;
+    failure_streak = 0;
+    cooldown_until = None;
+    last_error = None;
+    total_started = 0;
+    total_success = 0;
+    total_failure = 0;
+  }
+
+let safe_discovery_statuses () =
+  try Discovery_cache.get_cached_or_refresh ()
+  with
+  | Stdlib.Effect.Unhandled _ -> []
+  | exn ->
+      debug_log "discovery_cache unavailable: %s" (Printexc.to_string exn);
+      []
 
 let runtime_to_snapshot (runtime : runtime) =
   {
@@ -227,8 +297,7 @@ let parse_llm_endpoints raw =
 let current_fingerprint () =
   String.concat "||"
     [
-      Option.value ~default:"" (Sys.getenv_opt "MASC_LLAMA_RUNTIMES_JSON");
-      Option.value ~default:"" (Sys.getenv_opt "LLM_ENDPOINTS");
+      String.concat "," (Llm_provider.Discovery.endpoints_from_env ());
       Env_config.Llama.server_url;
       Option.value ~default:"" (Sys.getenv_opt "LLAMA_SWARM_MODEL");
       Option.value ~default:""
@@ -239,59 +308,53 @@ let current_fingerprint () =
     ]
 
 let load_runtimes_from_env () =
-  match trim_opt (Sys.getenv_opt "MASC_LLAMA_RUNTIMES_JSON") with
-  | None -> (
-      match trim_opt (Sys.getenv_opt "LLM_ENDPOINTS") with
-      | Some raw ->
-          let runtimes = parse_llm_endpoints raw in
-          if runtimes = [] then
-            ([ default_runtime () ], [ "LLM_ENDPOINTS produced no usable runtimes" ])
-          else (runtimes, [])
-      | None -> ([ default_runtime () ], []))
-  | Some raw -> (
-      try
-        match Yojson.Safe.from_string raw with
-        | `List items ->
-            let parsed, errors =
-              List.fold_left
-                (fun (acc, errs) item ->
-                  match normalize_runtime_json item with
-                  | Ok runtime -> (runtime :: acc, errs)
-                  | Error err -> (acc, err :: errs))
-                ([], []) items
-            in
-            let runtimes = List.rev parsed in
-            if runtimes = [] then
-              ([ default_runtime () ], "MASC_LLAMA_RUNTIMES_JSON produced no usable runtimes" :: errors)
-            else (runtimes, List.rev errors)
-        | _ ->
-            ([ default_runtime () ], [ "MASC_LLAMA_RUNTIMES_JSON must be a JSON array" ])
-      with Yojson.Json_error err ->
-        ([ default_runtime () ], [ "invalid MASC_LLAMA_RUNTIMES_JSON: " ^ err ]))
+  let discovered =
+    safe_discovery_statuses () |> List.map runtime_of_discovery_status
+  in
+  match discovered with
+  | _ :: _ -> (discovered, [])
+  | [] ->
+      let endpoints = Llm_provider.Discovery.endpoints_from_env () in
+      let runtimes = List.map runtime_of_endpoint_url endpoints in
+      if runtimes = [] then ([ default_runtime () ], []) else (runtimes, [])
 
 (* ensure_loaded: the only function that may yield (debug_log calls Eio.traceln).
    Yield happens AFTER the ref swap, so callers reading !pool after this
    function returns see a consistent snapshot. *)
 let ensure_loaded () =
-  let state = !pool in
   let fingerprint = current_fingerprint () in
-  if not (String.equal fingerprint state.fingerprint) then begin
+  let needs_reload =
+    with_pool_lock (fun () -> not (String.equal fingerprint (!pool).fingerprint))
+  in
+  if needs_reload then begin
     let loaded, errors = load_runtimes_from_env () in
     let refreshed = List.map refresh_runtime_metrics loaded in
-    pool := { state with runtimes = refreshed; fingerprint; parse_errors = errors };
-    debug_log "reload runtimes count=%d errors=%d" (List.length loaded) (List.length errors)
+    let reloaded =
+      with_pool_lock (fun () ->
+        let state = !pool in
+        if not (String.equal fingerprint state.fingerprint) then begin
+          pool := { state with runtimes = refreshed; fingerprint; parse_errors = errors };
+          true
+        end else
+          false)
+    in
+    if reloaded then
+      debug_log "reload runtimes count=%d errors=%d" (List.length loaded)
+        (List.length errors)
   end else begin
-    let refreshed = List.map refresh_runtime_metrics state.runtimes in
-    pool := { state with runtimes = refreshed }
+    with_pool_lock (fun () ->
+      let state = !pool in
+      let refreshed = List.map refresh_runtime_metrics state.runtimes in
+      pool := { state with runtimes = refreshed })
   end
 
 let parse_errors () =
   ensure_loaded ();
-  (!pool).parse_errors
+  with_pool_lock (fun () -> (!pool).parse_errors)
 
 let snapshots () =
   ensure_loaded ();
-  List.map runtime_to_snapshot (!pool).runtimes
+  with_pool_lock (fun () -> List.map runtime_to_snapshot (!pool).runtimes)
 
 let configured_capacity () =
   snapshots ()
@@ -314,17 +377,18 @@ let allocated_slots () =
        (fun acc (runtime : runtime_snapshot) -> acc + runtime.active_slots)
        0
 
-let measured_ceiling () = (!pool).measured_ceiling
+let measured_ceiling () = with_pool_lock (fun () -> (!pool).measured_ceiling)
 
 let record_measured_ceiling value =
-  let state = !pool in
-  let bounded = max 0 value in
-  let new_ceiling =
-    match state.measured_ceiling with
-    | Some current -> Some (max current bounded)
-    | None -> Some bounded
-  in
-  pool := { state with measured_ceiling = new_ceiling }
+  with_pool_lock (fun () ->
+    let state = !pool in
+    let bounded = max 0 value in
+    let new_ceiling =
+      match state.measured_ceiling with
+      | Some current -> Some (max current bounded)
+      | None -> Some bounded
+    in
+    pool := { state with measured_ceiling = new_ceiling })
 
 let model_name_for_runtime (runtime : runtime) requested_model =
   match trim_opt requested_model with
@@ -442,85 +506,107 @@ let select_runtime ?preferred_pool ?model_name () =
    After that, reading !pool and swapping pool := are yield-free. *)
 let acquire ?preferred_pool ~model_name () =
   ensure_loaded ();
-  (* --- yield-free critical section --- *)
-  let state : pool_state = !pool in
-  let* runtime = select_runtime_from state.runtimes ?preferred_pool ?model_name () in
-  let* model_name = model_name_for_runtime runtime model_name in
-  let updated = { runtime with
-    active_slots = runtime.active_slots + 1;
-    queue_depth = max 0 (runtime.active_slots + 1 - runtime.max_concurrency);
-    total_started = runtime.total_started + 1;
-  } in
-  let new_runtimes : runtime list =
-    List.map
-      (fun (r : runtime) ->
-        if String.equal r.id runtime.id then updated else r)
-      (state.runtimes : runtime list)
-  in
-  pool := { state with runtimes = new_runtimes };
-  (* --- end critical section --- *)
-  Ok
-    {
-      runtime_id = runtime.id;
-      base_url = runtime.base_url;
-      model_name;
-      max_concurrency = runtime.max_concurrency;
-      lease = { runtime_id = runtime.id };
-    }
+  with_pool_lock (fun () ->
+    let state : pool_state = !pool in
+    let* runtime =
+      select_runtime_from state.runtimes ?preferred_pool ?model_name ()
+    in
+    let* model_name = model_name_for_runtime runtime model_name in
+    let updated =
+      {
+        runtime with
+        active_slots = runtime.active_slots + 1;
+        queue_depth = max 0 (runtime.active_slots + 1 - runtime.max_concurrency);
+        total_started = runtime.total_started + 1;
+      }
+    in
+    let new_runtimes : runtime list =
+      List.map
+        (fun (r : runtime) ->
+          if String.equal r.id runtime.id then updated else r)
+        (state.runtimes : runtime list)
+    in
+    pool := { state with runtimes = new_runtimes };
+    Ok
+      {
+        runtime_id = runtime.id;
+        base_url = runtime.base_url;
+        model_name;
+        max_concurrency = runtime.max_concurrency;
+        lease = { runtime_id = runtime.id };
+      })
 
 (* release: ensure_loaded may yield. After that, ref read+swap is yield-free.
    debug_log (may yield) is placed AFTER the ref swap. *)
 let release (lease : lease) ~success ?error ?latency_ms () =
   ensure_loaded ();
-  (* --- yield-free critical section --- *)
-  let state : pool_state = !pool in
-  match
-    List.find_opt
-      (fun (runtime : runtime) -> String.equal runtime.id lease.runtime_id)
-      state.runtimes
-  with
-  | None -> ()
-  | Some runtime ->
-      let before_failure_streak = runtime.failure_streak in
-      let active_slots = max 0 (runtime.active_slots - 1) in
-      let latency_ema_ms =
-        match latency_ms with
-        | Some latency ->
-            let latency = float_of_int (max 0 latency) in
-            Some
-              (match runtime.latency_ema_ms with
-               | None -> latency
-               | Some previous -> (previous *. 0.8) +. (latency *. 0.2))
-        | None -> runtime.latency_ema_ms
-      in
-      let failure_streak, cooldown_until, last_error, total_success, total_failure =
-        if success then
-          (0, None, None, runtime.total_success + 1, runtime.total_failure)
-        else
-          let streak = runtime.failure_streak + 1 in
-          let cooldown =
-            if streak >= 3 then Some (wall_now () +. cooldown_seconds ())
-            else runtime.cooldown_until
+  let release_summary =
+    with_pool_lock (fun () ->
+      let state : pool_state = !pool in
+      match
+        List.find_opt
+          (fun (runtime : runtime) -> String.equal runtime.id lease.runtime_id)
+          state.runtimes
+      with
+      | None -> None
+      | Some runtime ->
+          let before_failure_streak = runtime.failure_streak in
+          let active_slots = max 0 (runtime.active_slots - 1) in
+          let latency_ema_ms =
+            match latency_ms with
+            | Some latency ->
+                let latency = float_of_int (max 0 latency) in
+                Some
+                  (match runtime.latency_ema_ms with
+                   | None -> latency
+                   | Some previous -> (previous *. 0.8) +. (latency *. 0.2))
+            | None -> runtime.latency_ema_ms
           in
-          (streak, cooldown, trim_opt error, runtime.total_success, runtime.total_failure + 1)
-      in
-      let queue_depth = max 0 (active_slots - runtime.max_concurrency) in
-      let updated = { runtime with
-        active_slots; queue_depth; latency_ema_ms;
-        failure_streak; cooldown_until; last_error;
-        total_success; total_failure;
-      } in
-      let new_runtimes : runtime list =
-        List.map
-          (fun (r : runtime) ->
-            if String.equal r.id runtime.id then updated else r)
-          (state.runtimes : runtime list)
-      in
-      pool := { state with runtimes = new_runtimes };
-      (* --- end critical section --- *)
+          let failure_streak, cooldown_until, last_error, total_success,
+              total_failure =
+            if success then
+              (0, None, None, runtime.total_success + 1, runtime.total_failure)
+            else
+              let streak = runtime.failure_streak + 1 in
+              let cooldown =
+                if streak >= 3 then Some (wall_now () +. cooldown_seconds ())
+                else runtime.cooldown_until
+              in
+              ( streak,
+                cooldown,
+                trim_opt error,
+                runtime.total_success,
+                runtime.total_failure + 1 )
+          in
+          let queue_depth = max 0 (active_slots - runtime.max_concurrency) in
+          let updated =
+            {
+              runtime with
+              active_slots;
+              queue_depth;
+              latency_ema_ms;
+              failure_streak;
+              cooldown_until;
+              last_error;
+              total_success;
+              total_failure;
+            }
+          in
+          let new_runtimes : runtime list =
+            List.map
+              (fun (r : runtime) ->
+                if String.equal r.id runtime.id then updated else r)
+              (state.runtimes : runtime list)
+          in
+          pool := { state with runtimes = new_runtimes };
+          Some (runtime.id, before_failure_streak, updated))
+  in
+  match release_summary with
+  | None -> ()
+  | Some (runtime_id, before_failure_streak, updated) ->
       debug_log
         "release runtime=%s success=%b before_streak=%d after_streak=%d cooldown=%s total_success=%d total_failure=%d error=%s"
-        runtime.id success before_failure_streak updated.failure_streak
+        runtime_id success before_failure_streak updated.failure_streak
         (match updated.cooldown_until with
          | Some value -> Printf.sprintf "%.3f" value
          | None -> "null")

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -1,6 +1,7 @@
 (** Tool_local_runtime_verify -- runtime contract verification. *)
 
 include Tool_local_runtime_http
+module Oas_types = Agent_sdk.Types
 
 let runtime_snapshots_for_pool runtime_pool =
   let snapshots = Local_runtime_pool.snapshots () in
@@ -15,6 +16,32 @@ let runtime_snapshots_for_pool runtime_pool =
           snapshots
       in
       if filtered = [] then snapshots else filtered
+
+let safe_discovery_endpoints () =
+  try Some (Discovery_cache.get_cached_or_refresh ())
+  with
+  | Stdlib.Effect.Unhandled _ -> None
+  | _ -> None
+
+let discovery_endpoints_for_pool runtime_pool =
+  match safe_discovery_endpoints () with
+  | None -> None
+  | Some [] -> None
+  | Some endpoints ->
+      let matches_pool (endpoint : Discovery_cache.endpoint_info) =
+        match Option.bind runtime_pool trim_to_option with
+        | None -> true
+        | Some pool
+          when String.equal pool Local_runtime_pool.default_pool_label
+               || String.equal pool "default" ->
+            true
+        | Some pool ->
+            String.equal pool endpoint.url
+            || String.equal pool
+                 (Local_runtime_pool.runtime_id_of_base_url endpoint.url)
+      in
+      let filtered = List.filter matches_pool endpoints in
+      Some (if filtered = [] then endpoints else filtered)
 
 let active_slots_of_json json =
   let open Yojson.Safe.Util in
@@ -45,14 +72,117 @@ let active_slots_of_json json =
   in
   List.fold_left (fun acc slot -> if is_active slot then acc + 1 else acc) 0 slots
 
+let slot_count_of_json json =
+  let open Yojson.Safe.Util in
+  let slots =
+    match json with
+    | `List items -> items
+    | `Assoc _ -> (
+        match member "slots" json with
+        | `List items -> items
+        | _ -> (
+            match member "data" json with
+            | `List items -> items
+            | _ -> (
+                match member "items" json with `List items -> items | _ -> [])))
+    | _ -> []
+  in
+  List.length slots
+
+let endpoint_model_id (endpoint : Discovery_cache.endpoint_info) =
+  match endpoint.models with
+  | model :: _ -> trim_to_option model.id
+  | [] -> (
+      match endpoint.props with
+      | Some props -> trim_to_option props.model
+      | None -> None)
+
+let endpoint_total_slots (endpoint : Discovery_cache.endpoint_info) =
+  match endpoint.slots with
+  | Some slots when slots.total > 0 -> Some slots.total
+  | _ -> (
+      match endpoint.props with
+      | Some props when props.total_slots > 0 -> Some props.total_slots
+      | _ -> None)
+
+let endpoint_ctx_size (endpoint : Discovery_cache.endpoint_info) =
+  match endpoint.props with
+  | Some props when props.ctx_size > 0 -> Some props.ctx_size
+  | _ -> None
+
+let endpoint_busy_slots (endpoint : Discovery_cache.endpoint_info) =
+  match endpoint.slots with Some slots -> slots.busy | None -> 0
+
+let first_endpoint_url endpoints =
+  match endpoints with
+  | (endpoint : Discovery_cache.endpoint_info) :: _ -> Some endpoint.url
+  | [] -> None
+
+let error_message_of_http_error = function
+  | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.HttpError { code; body } -> (
+      try
+        let json = Yojson.Safe.from_string body in
+        match Yojson.Safe.Util.member "error" json with
+        | `Assoc fields -> (
+            match List.assoc_opt "message" fields with
+            | Some (`String msg) -> msg
+            | _ -> Printf.sprintf "HTTP %d" code)
+        | _ -> Printf.sprintf "HTTP %d" code
+      with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
+
+let probe_chat_completion_compatible
+    ?(timeout_sec = 5)
+    (endpoint : Discovery_cache.endpoint_info) =
+  match Masc_eio_env.get_opt (), endpoint_model_id endpoint with
+  | None, _ -> (None, None)
+  | _, None -> (None, Some "missing model id")
+  | Some env, Some model_id ->
+      let provider_config =
+        Llm_provider.Provider_config.make
+          ~kind:Llm_provider.Provider_config.OpenAI_compat
+          ~model_id ~base_url:endpoint.url ~request_path:"/v1/chat/completions"
+          ~max_tokens:1 ~temperature:0.0 ()
+      in
+      let messages =
+        [
+          {
+            Oas_types.role = Oas_types.User;
+            content = [ Oas_types.Text "hi" ];
+            name = None;
+            tool_call_id = None;
+          };
+        ]
+      in
+      let run_completion () =
+        Llm_provider.Complete.complete ~sw:env.sw ~net:env.net
+          ~config:provider_config ~messages ()
+      in
+      let outcome =
+        match env.clock with
+        | Some clock -> (
+            try Ok (Eio.Time.with_timeout_exn clock (float_of_int timeout_sec) run_completion)
+            with Eio.Time.Timeout -> Error "timeout")
+        | None -> Ok (run_completion ())
+      in
+      match outcome with
+      | Error message -> (Some false, Some message)
+      | Ok (Ok _response) -> (Some true, None)
+      | Ok (Error http_error) ->
+          (Some false, Some (error_message_of_http_error http_error))
+
 let provider_health_reachable ~status ~body:_ =
   status = Some 200
 
 let classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
     ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
+    ~chat_completion_compatible
     =
   if not provider_reachable || not slot_reachable then
     (Some "provider_unreachable", Some "llama runtime health or slots endpoint failed")
+  else if not chat_completion_compatible then
+    ( Some "provider_protocol_incompatible",
+      Some "one or more endpoints failed the OAS chat-completions probe" )
   else if
     match expected_model, actual_model_id with
     | Some expected, Some actual -> not (String.equal expected actual)
@@ -87,7 +217,135 @@ let classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
   else
     (None, None)
 
-let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () =
+let runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_ctx
+    ?expected_model endpoints () =
+  let configured_capacity =
+    endpoints
+    |> List.fold_left
+         (fun acc (endpoint : Discovery_cache.endpoint_info) ->
+           acc + Option.value ~default:0 (endpoint_total_slots endpoint))
+         0
+  in
+  let configured_max_concurrent_models = Inference_utils.max_concurrent_models in
+  let available_model_permits = Inference_utils.model_permits_available () in
+  let runtime_rows, provider_reachable, slot_reachable, actual_slots_total,
+      active_slots_now, actual_ctxs, actual_models, chat_completion_compatible =
+    List.fold_left
+      (fun
+        ( rows,
+          provider_ok,
+          slot_ok,
+          slots_acc,
+          active_acc,
+          ctxs,
+          models,
+          chat_ok )
+        (endpoint : Discovery_cache.endpoint_info)
+      ->
+        let provider_ok_row = endpoint.healthy in
+        let actual_slots = endpoint_total_slots endpoint in
+        let slot_ok_row = Option.is_some actual_slots in
+        let actual_ctx = endpoint_ctx_size endpoint in
+        let actual_model = endpoint_model_id endpoint in
+        let current_active = endpoint_busy_slots endpoint in
+        let chat_probe_ok, chat_probe_error =
+          probe_chat_completion_compatible endpoint
+        in
+        let row =
+          `Assoc
+            [
+              ( "runtime_id",
+                `String
+                  (Local_runtime_pool.runtime_id_of_base_url endpoint.url) );
+              ("base_url", `String endpoint.url);
+              ("provider_base_url", `String endpoint.url);
+              ("slot_url", `String endpoint.url);
+              ("provider_reachable", `Bool provider_ok_row);
+              ( "provider_status_code",
+                int_opt_to_json
+                  (if provider_ok_row then Some 200 else None) );
+              ( "provider_error",
+                string_opt_to_json
+                  (if provider_ok_row then None
+                   else Some "oas discovery marked endpoint unhealthy") );
+              ("slot_reachable", `Bool slot_ok_row);
+              ("slot_status_code", int_opt_to_json (if slot_ok_row then Some 200 else None));
+              ("slot_error", `Null);
+              ( "props_status_code",
+                int_opt_to_json
+                  (if Option.is_some endpoint.props then Some 200 else None) );
+              ("props_error", `Null);
+              ( "models_status_code",
+                int_opt_to_json
+                  (if endpoint.models <> [] then Some 200 else None) );
+              ("models_error", `Null);
+              ("expected_model", string_opt_to_json expected_model);
+              ("actual_model_id", string_opt_to_json actual_model);
+              ("expected_slots", int_opt_to_json expected_slots);
+              ("actual_slots", int_opt_to_json actual_slots);
+              ("expected_ctx", int_opt_to_json expected_ctx);
+              ("actual_ctx", int_opt_to_json actual_ctx);
+              ("active_slots_now", `Int current_active);
+              ( "chat_completion_compatible",
+                match chat_probe_ok with
+                | Some value -> `Bool value
+                | None -> `Null );
+              ("chat_completion_error", string_opt_to_json chat_probe_error);
+            ]
+        in
+        ( row :: rows,
+          provider_ok && provider_ok_row,
+          slot_ok && slot_ok_row,
+          slots_acc + Option.value ~default:0 actual_slots,
+          active_acc + current_active,
+          (match actual_ctx with Some value -> value :: ctxs | None -> ctxs),
+          (match actual_model with Some value -> value :: models | None -> models),
+          (match chat_probe_ok with Some false -> false | _ -> chat_ok) ))
+      ([], true, true, 0, 0, [], [], true) endpoints
+  in
+  let actual_ctx =
+    match List.sort_uniq compare actual_ctxs with [ value ] -> Some value | _ -> None
+  in
+  let actual_model_id =
+    match List.sort_uniq String.compare actual_models with
+    | [ value ] -> Some value
+    | _ -> None
+  in
+  let runtime_blocker, detail =
+    classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
+      ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx
+      ~actual_ctx ~chat_completion_compatible
+  in
+  `Assoc
+    [
+      ("checked_at", `String (Types.now_iso ()));
+      ("runtime_pool", string_opt_to_json runtime_pool);
+      ("source", `String "oas_discovery");
+      ("cache_age_seconds", `Float (Discovery_cache.cache_age_seconds ()));
+      ("provider_base_url", string_opt_to_json (first_endpoint_url endpoints));
+      ("slot_url", string_opt_to_json (first_endpoint_url endpoints));
+      ("provider_reachable", `Bool provider_reachable);
+      ("slot_reachable", `Bool slot_reachable);
+      ("chat_completion_compatible", `Bool chat_completion_compatible);
+      ("expected_model", string_opt_to_json expected_model);
+      ("actual_model_id", string_opt_to_json actual_model_id);
+      ("expected_slots", int_opt_to_json expected_slots);
+      ("actual_slots", `Int actual_slots_total);
+      ("expected_ctx", int_opt_to_json expected_ctx);
+      ("actual_ctx", int_opt_to_json actual_ctx);
+      ("active_slots_now", `Int active_slots_now);
+      ("peak_hot_slots", `Int active_slots_now);
+      ("configured_capacity", `Int configured_capacity);
+      ("configured_max_concurrent_models", `Int configured_max_concurrent_models);
+      ("available_model_permits", `Int available_model_permits);
+      ("runtime_blocker", string_opt_to_json runtime_blocker);
+      ("detail", string_opt_to_json detail);
+      ("pass", `Bool (runtime_blocker = None));
+      ("runtimes", `List (List.rev runtime_rows));
+    ]
+
+let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
+    ?expected_model () =
   let runtimes = runtime_snapshots_for_pool runtime_pool in
   let configured_capacity =
     runtimes
@@ -130,13 +388,21 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
           | Ok (status_code, payload) -> (status_code, Some payload, None)
           | Error err -> (None, None, Some err)
         in
-        let provider_ok' =
-          provider_ok
-          && provider_health_reachable ~status:provider_status ~body:provider_body
+        let provider_ok_row =
+          provider_health_reachable ~status:provider_status ~body:provider_body
         in
-        let slot_ok' = slot_ok && slot_status = Some 200 in
+        let provider_ok' = provider_ok && provider_ok_row in
+        let slot_ok_row = slot_status = Some 200 in
+        let slot_ok' = slot_ok && slot_ok_row in
         let actual_slots =
-          Option.bind props_json (fun json -> int_member json "total_slots")
+          match Option.bind props_json (fun json -> int_member json "total_slots") with
+          | Some total -> Some total
+          | None ->
+              (match slot_json with
+               | Some json ->
+                   let total = slot_count_of_json json in
+                   if total > 0 then Some total else None
+               | None -> None)
         in
         let actual_ctx =
           Option.bind props_json (fun json ->
@@ -145,11 +411,15 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
               | _ -> None)
         in
         let actual_model =
-          Option.bind models_json (fun json ->
-              match Yojson.Safe.Util.member "data" json with
-              | `List ((`Assoc _ as first) :: _) -> string_member first "id"
-              | `List _ -> None
-              | _ -> None)
+          match
+            Option.bind models_json (fun json ->
+                match Yojson.Safe.Util.member "data" json with
+                | `List ((`Assoc _ as first) :: _) -> string_member first "id"
+                | `List _ -> None
+                | _ -> None)
+          with
+          | Some model -> Some model
+          | None -> runtime.model
         in
         let current_active =
           slot_json |> Option.map active_slots_of_json |> Option.value ~default:0
@@ -161,10 +431,10 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
               ("base_url", `String base_url);
               ("provider_base_url", `String base_url);
               ("slot_url", `String base_url);
-              ("provider_reachable", `Bool provider_ok');
+              ("provider_reachable", `Bool provider_ok_row);
               ("provider_status_code", int_opt_to_json provider_status);
               ("provider_error", string_opt_to_json provider_err);
-              ("slot_reachable", `Bool (slot_status = Some 200));
+              ("slot_reachable", `Bool slot_ok_row);
               ("slot_status_code", int_opt_to_json slot_status);
               ("slot_error", string_opt_to_json slot_err);
               ("props_status_code", int_opt_to_json props_status);
@@ -200,6 +470,7 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
   let runtime_blocker, detail =
     classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
       ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
+      ~chat_completion_compatible:true
   in
   `Assoc
     [
@@ -209,6 +480,7 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
       ("slot_url", `String Env_config.Llama.server_url);
       ("provider_reachable", `Bool provider_reachable);
       ("slot_reachable", `Bool slot_reachable);
+      ("chat_completion_compatible", `Bool true);
       ("expected_model", string_opt_to_json expected_model);
       ("actual_model_id", string_opt_to_json actual_model_id);
       ("expected_slots", int_opt_to_json expected_slots);
@@ -225,3 +497,12 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
       ("pass", `Bool (runtime_blocker = None));
       ("runtimes", `List (List.rev runtime_rows));
     ]
+
+let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () =
+  match discovery_endpoints_for_pool runtime_pool with
+  | Some endpoints ->
+      runtime_verify_json_from_discovery ?runtime_pool ?expected_slots ?expected_ctx
+        ?expected_model endpoints ()
+  | None ->
+      runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
+        ?expected_model ()

--- a/test/dune
+++ b/test/dune
@@ -224,7 +224,7 @@
 (test
  (name test_tool_local_runtime_verify)
  (modules test_tool_local_runtime_verify)
- (libraries masc_mcp alcotest yojson))
+ (libraries masc_mcp alcotest yojson eio eio_main))
 
 ; Voice tool wrapper tests
 (test

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -12,24 +12,45 @@ let with_env name value f =
       | None -> Unix.putenv name "")
     f
 
+let make_runtime ?model ?(max_concurrency = 2) id base_url =
+  {
+    Local_runtime_pool.id;
+    base_url;
+    model;
+    max_concurrency;
+    active_slots = 0;
+    queue_depth = 0;
+    latency_ema_ms = None;
+    failure_streak = 0;
+    cooldown_until = None;
+    last_error = None;
+    total_started = 0;
+    total_success = 0;
+    total_failure = 0;
+  }
+
+let install_pool runtimes =
+  Local_runtime_pool.pool :=
+    {
+      Local_runtime_pool.empty_pool with
+      runtimes;
+      fingerprint = Local_runtime_pool.current_fingerprint ();
+    }
+
 let test_parse_runtime_env () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"local-a","base_url":"http://127.0.0.1:8085","model":"qwen-a","max_concurrency":12},
-      {"id":"local-b","base_url":"http://127.0.0.1:8086","model":"qwen-a","max_concurrency":10}
-    ]|}
-  in
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  with_env "LLM_ENDPOINTS"
+    (Some "http://127.0.0.1:8085,http://127.0.0.1:8086")
+  @@ fun () ->
   let snapshots = Local_runtime_pool.snapshots () in
   Alcotest.(check int) "runtime count" 2 (List.length snapshots);
-  Alcotest.(check int) "configured capacity" 22
+  Alcotest.(check int) "configured capacity" 24
     (Local_runtime_pool.configured_capacity ());
   let runtime_ids =
     snapshots |> List.map (fun (runtime : Local_runtime_pool.runtime_snapshot) -> runtime.id)
   in
-  Alcotest.(check bool) "contains local-a" true (List.mem "local-a" runtime_ids);
-  Alcotest.(check bool) "contains local-b" true (List.mem "local-b" runtime_ids)
+  Alcotest.(check bool) "contains local-8085" true (List.mem "local-8085" runtime_ids);
+  Alcotest.(check bool) "contains local-8086" true (List.mem "local-8086" runtime_ids)
 
 let test_parse_llm_endpoints_env () =
   Local_runtime_pool.reset ();
@@ -52,13 +73,12 @@ let test_parse_llm_endpoints_env () =
 
 let test_acquire_and_release () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"local-a","base_url":"http://127.0.0.1:8085","max_concurrency":2},
-      {"id":"local-b","base_url":"http://127.0.0.1:8086","model":"qwen-b","max_concurrency":2}
-    ]|}
-  in
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  install_pool
+    [
+      make_runtime "local-a" "http://127.0.0.1:8085" ~max_concurrency:2;
+      make_runtime "local-b" "http://127.0.0.1:8086" ~model:"qwen-b"
+        ~max_concurrency:2;
+    ];
   let assignment =
     match
       Local_runtime_pool.acquire ~preferred_pool:"local-a"
@@ -82,14 +102,14 @@ let test_acquire_and_release () =
 
 let test_acquire_prefers_exact_model_match () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"generic","base_url":"http://127.0.0.1:8185","max_concurrency":2},
-      {"id":"lead","base_url":"http://127.0.0.1:8186","model":"qwen35-lead","max_concurrency":2},
-      {"id":"worker","base_url":"http://127.0.0.1:8187","model":"qwen9-worker","max_concurrency":2}
-    ]|}
-  in
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  install_pool
+    [
+      make_runtime "generic" "http://127.0.0.1:8185" ~max_concurrency:2;
+      make_runtime "lead" "http://127.0.0.1:8186" ~model:"qwen35-lead"
+        ~max_concurrency:2;
+      make_runtime "worker" "http://127.0.0.1:8187" ~model:"qwen9-worker"
+        ~max_concurrency:2;
+    ];
   let assignment =
     match Local_runtime_pool.acquire ~model_name:(Some "qwen9-worker") () with
     | Ok assignment -> assignment
@@ -102,13 +122,13 @@ let test_acquire_prefers_exact_model_match () =
 
 let test_acquire_rejects_mismatched_preferred_model_pool () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"lead","base_url":"http://127.0.0.1:8285","model":"qwen35-lead","max_concurrency":2},
-      {"id":"worker","base_url":"http://127.0.0.1:8286","model":"qwen9-worker","max_concurrency":2}
-    ]|}
-  in
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  install_pool
+    [
+      make_runtime "lead" "http://127.0.0.1:8285" ~model:"qwen35-lead"
+        ~max_concurrency:2;
+      make_runtime "worker" "http://127.0.0.1:8286" ~model:"qwen9-worker"
+        ~max_concurrency:2;
+    ];
   match
     Local_runtime_pool.acquire ~preferred_pool:"lead"
       ~model_name:(Some "qwen9-worker") ()
@@ -128,12 +148,8 @@ let test_select_runtime_from_empty_returns_error () =
 
 let test_acquire_requires_explicit_or_runtime_model () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"local-no-model","base_url":"http://127.0.0.1:7085","max_concurrency":1}
-    ]|}
-  in
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  install_pool
+    [ make_runtime "local-no-model" "http://127.0.0.1:7085" ~max_concurrency:1 ];
   match Local_runtime_pool.acquire ~preferred_pool:"local-no-model" ~model_name:None () with
   | Ok _ -> Alcotest.fail "runtime without model should reject implicit acquire"
   | Error message ->
@@ -150,13 +166,9 @@ let test_record_measured_ceiling () =
 
 let test_failure_cooldown_from_env () =
   Local_runtime_pool.reset ();
-  let json =
-    {|[
-      {"id":"local-c","base_url":"http://127.0.0.1:9085","model":"qwen-c","max_concurrency":1}
-    ]|}
-  in
   with_env "MASC_LLAMA_RUNTIME_COOLDOWN_SEC" (Some "120") @@ fun () ->
-  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  install_pool
+    [ make_runtime "local-c" "http://127.0.0.1:9085" ~model:"qwen-c" ~max_concurrency:1 ];
   let fail_once () =
     let assignment =
       match Local_runtime_pool.acquire ~preferred_pool:"local-c" ~model_name:None () with

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -27,6 +27,57 @@ let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =
     | Some msg -> String.contains msg '1' && String.contains msg '4'
     | None -> false)
 
+let make_endpoint ~url ~model_id ~ctx_size ~total_slots ~busy =
+  let module D = Llm_provider.Discovery in
+  {
+    D.url;
+    healthy = true;
+    models = [ { D.id = model_id; owned_by = "llamacpp" } ];
+    props = Some { D.total_slots; ctx_size; model = "" };
+    slots = Some { D.total = total_slots; busy; idle = total_slots - busy };
+    capabilities = Llm_provider.Capabilities.openai_chat_extended_capabilities;
+  }
+
+let test_runtime_verify_prefers_oas_discovery_cache () =
+  Eio_main.run @@ fun _env ->
+  let previous_endpoints = !(Masc_mcp.Discovery_cache.cached_endpoints) in
+  let previous_updated_at = !(Masc_mcp.Discovery_cache.cache_updated_at) in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Discovery_cache.cached_endpoints := previous_endpoints;
+      Masc_mcp.Discovery_cache.cache_updated_at := previous_updated_at)
+    (fun () ->
+      Masc_mcp.Discovery_cache.cached_endpoints :=
+        [
+          make_endpoint ~url:"http://127.0.0.1:8085"
+            ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
+            ~total_slots:4 ~busy:0;
+          make_endpoint ~url:"http://127.0.0.1:8086"
+            ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
+            ~total_slots:4 ~busy:1;
+          make_endpoint ~url:"http://127.0.0.1:8087"
+            ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
+            ~total_slots:4 ~busy:1;
+        ];
+      Masc_mcp.Discovery_cache.cache_updated_at := Time_compat.now ();
+      let result =
+        Masc_mcp.Tool_local_runtime.runtime_verify_json
+          ~expected_slots:12 ~expected_ctx:262144
+          ~expected_model:"qwen3.5-35b-a3b-ud-q4-xl" ()
+      in
+      let open Yojson.Safe.Util in
+      check string "source" "oas_discovery"
+        (result |> member "source" |> to_string);
+      check bool "provider reachable" true
+        (result |> member "provider_reachable" |> to_bool);
+      check bool "slot reachable" true
+        (result |> member "slot_reachable" |> to_bool);
+      check int "actual slots" 12 (result |> member "actual_slots" |> to_int);
+      check int "active slots now" 2
+        (result |> member "active_slots_now" |> to_int);
+      check bool "passes expected contract" true
+        (result |> member "pass" |> to_bool))
+
 let () =
   run "tool_local_runtime_verify"
     [
@@ -39,5 +90,7 @@ let () =
         [
           test_case "slot shortage beats provider_unreachable" `Quick
             test_classify_runtime_blocker_prefers_slot_count_when_health_ok;
+          test_case "runtime verify prefers oas discovery cache" `Quick
+            test_runtime_verify_prefers_oas_discovery_cache;
         ] );
     ]

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -19,6 +19,7 @@ let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =
       ~actual_model_id:(Some "qwen3.5-35b-a3b-ud-q8-xl")
       ~expected_slots:(Some 12) ~actual_slots_total:4
       ~expected_ctx:(Some 262144) ~actual_ctx:(Some 262144)
+      ~chat_completion_compatible:true
   in
   check (option string) "slot blocker" (Some "slot_count_insufficient")
     blocker;


### PR DESCRIPTION
## Summary
- OAS가 provider 선택을 소유하므로, MASC runtime pool은 census/metrics 역할로 전환
- `acquire()`: explicit pool pinning(디버그)에서만 사용
- OAS Discovery 기반 fingerprint 및 runtime 로딩

Replaces closed #2792.

## Test plan
- [ ] `dune build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)