### PR TITLE
fix(keeper,dashboard): reduce repeated timeout churn

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -550,13 +550,14 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 10.
+    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 12.
     A productive keeper workflow (read -> edit -> build -> verify) needs 4-6 tool calls.
     Previous default (1000) caused 787s+ latency per turn.
-    At 5, simple tasks (read + post) work but multi-step workflows are truncated. *)
+    At 10, multi-step turns were still hitting the ceiling after a single tool failure;
+    12 leaves one extra recovery step without reopening the old runaway latencies. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:10
+    ~default:12
     ~min_v:1
     ~max_v:50

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -398,7 +398,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    with
                    | Error e ->
                        Log.Keeper.error "unified turn failed: %s" e;
-                       meta_after_triage
+                       (match read_meta ctx.config meta_after_triage.name with
+                        | Ok (Some latest) -> latest
+                        | _ -> meta_after_triage)
                    | Ok updated -> updated
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -77,6 +77,24 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       (if has_tool_calls then now_iso () else meta.last_autonomous_action_at);
   }
 
+let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
+    ~(reason : string) : keeper_meta =
+  let now_ts = Time_compat.now () in
+  let preview =
+    let trimmed = String.trim reason in
+    if trimmed = "" then "unified turn failed"
+    else short_preview trimmed
+  in
+  {
+    meta with
+    updated_at = now_iso ();
+    total_turns = meta.total_turns + 1;
+    last_turn_ts = now_ts;
+    last_latency_ms = latency_ms;
+    last_proactive_reason = "unified:error:" ^ String.trim reason;
+    last_proactive_preview = preview;
+  }
+
 let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int) : (keeper_meta, string) result =
@@ -126,7 +144,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ())
       in
       match run_result with
-      | Error e -> Error e
+      | Error e ->
+          let updated_meta =
+            update_metrics_from_failure meta ~latency_ms ~reason:e
+          in
+          (match write_meta config updated_meta with
+           | Ok () -> ()
+           | Error msg ->
+               Log.Keeper.error
+                 "write_meta failed after unified turn failure: %s" msg);
+          Error e
       | Ok result ->
           (* 6. Observe result and update metrics *)
           let updated_meta =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -27,6 +27,12 @@ val update_metrics_from_result :
   Keeper_agent_run.run_result ->
   Keeper_types.keeper_meta
 
+val update_metrics_from_failure :
+  Keeper_types.keeper_meta ->
+  latency_ms:int ->
+  reason:string ->
+  Keeper_types.keeper_meta
+
 val run_unified_turn :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -52,7 +52,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
     mark_cached_surface_attempt _execution_cache;
     let started_at = Unix.gettimeofday () in
     try
-      run_dashboard_compute ~mode:Inline_shared ~sw ~clock ~config:room_config
+      run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config:room_config
         (fun ~config ~sw ->
           Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
           |> with_projection_diagnostics ~surface:"execution" ~started_at

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -282,7 +282,7 @@ let test_dashboard_executor_pool_contracts () =
        "run_dashboard_compute ~mode ~sw ~clock");
   check bool "execution refresh loop uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http.ml"
-       "run_dashboard_compute ~mode:Inline_shared ~sw ~clock ~config:room_config");
+       "run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config:room_config");
   check bool "execution parameterized path uses dashboard compute helper" true
     (file_contains_pattern "lib/server/server_dashboard_http.ml"
        "run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock");

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -255,7 +255,7 @@ let test_unified_turn_runtime_defaults () =
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
       (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 10
+    check int "unified max_turns default" 12
       (KC.keeper_unified_max_turns ()))))
 
 (* ---------- Metrics observation tests ---------- *)
@@ -314,6 +314,39 @@ let test_metrics_noop_response () =
   check int "autonomous unchanged" minimal_meta.autonomous_action_count
     updated.autonomous_action_count;
   check int "total_turns +1" (minimal_meta.total_turns + 1) updated.total_turns
+
+let test_metrics_failure_response () =
+  let reason = "Agent run failed: Max turns exceeded (turn 10, limit 10)" in
+  let updated =
+    UT.update_metrics_from_failure minimal_meta ~latency_ms:250 ~reason
+  in
+  check int "total_turns +1" (minimal_meta.total_turns + 1) updated.total_turns;
+  check int "latency recorded" 250 updated.last_latency_ms;
+  check bool "last_turn_ts updated" true (updated.last_turn_ts > 0.0);
+  check int "proactive count unchanged" minimal_meta.proactive_count_total
+    updated.proactive_count_total;
+  check bool "failure reason tagged" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward
+              (Str.regexp_string "unified:error:")
+              updated.last_proactive_reason 0);
+         true
+       with Not_found -> false
+     in
+     found);
+  check bool "failure preview preserved" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward
+              (Str.regexp_string "Max turns exceeded")
+              updated.last_proactive_preview 0);
+         true
+       with Not_found -> false
+     in
+     found)
 
 let test_metrics_mixed_response () =
   let result =
@@ -414,6 +447,7 @@ let () =
           test_case "text response" `Quick test_metrics_text_response;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
+          test_case "failure response" `Quick test_metrics_failure_response;
           test_case "mixed response" `Quick test_metrics_mixed_response;
           test_case "normalize passthrough" `Quick
             test_normalize_response_text_passthrough;


### PR DESCRIPTION
## Summary
- persist keeper unified-turn failure diagnostics into keeper meta so repeated failures do not look like idle/no-op turns
- raise the default unified keeper turn budget from 10 to 12 to leave room for a single recovery step after a tool failure
- offload the background dashboard execution refresh to the readonly executor path instead of running it inline

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-dashboard-timeout --build-dir _build-keeper-turn-dashboard-timeout test/test_keeper_unified.exe test/test_ci_hardening_source.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-dashboard-timeout/_build-keeper-turn-dashboard-timeout/default/test/test_keeper_unified.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-dashboard-timeout/_build-keeper-turn-dashboard-timeout/default/test/test_ci_hardening_source.exe
