### PR TITLE
revert(types): remove unused tool_visibility field

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -134,7 +134,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
         "Get the current MASC room status including active agents and task backlog.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
     {
       Types.name = "masc_tasks";
@@ -152,7 +151,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
                   ("include_cancelled", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_claim_next";
@@ -166,7 +164,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
               `Assoc [ ("agent_name", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "agent_name" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_transition";
@@ -194,7 +191,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
                   `String "action";
                 ] );
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_add_task";
@@ -212,7 +208,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "title" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_broadcast";
@@ -230,7 +225,6 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "agent_name"; `String "message" ]);
           ];
-      visibility = Public;
     };
   ]
 
@@ -242,7 +236,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
         "Update the worker heartbeat timestamp so long-running local tasks are not reaped as zombies.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
     {
       Types.name = "masc_team_session_status";
@@ -256,7 +249,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
               `Assoc [ ("session_id", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_team_session_step";
@@ -279,7 +271,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "session_id"; `String "turn_kind" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_memento_mori";
@@ -300,7 +291,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "context_ratio" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "lodge_research";
@@ -317,7 +307,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "topic" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "lodge_profile";
@@ -330,7 +319,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
               `Assoc [ ("agent_name", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "agent_name" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "lodge_search";
@@ -347,7 +335,6 @@ let local_worker_internal_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "query" ]);
           ];
-      visibility = Public;
     };
   ]
 
@@ -372,7 +359,6 @@ let local_worker_code_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "query" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_code_symbols";
@@ -386,7 +372,6 @@ let local_worker_code_schemas : Types.tool_schema list =
               `Assoc [ ("path", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "path" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_code_read";
@@ -405,7 +390,6 @@ let local_worker_code_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "path" ]);
           ];
-      visibility = Public;
     };
   ]
 
@@ -427,7 +411,6 @@ let local_worker_worktree_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "agent_name"; `String "task_id" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_worktree_remove";
@@ -444,14 +427,12 @@ let local_worker_worktree_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "agent_name"; `String "task_id" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_worktree_list";
       description = "List all active worktrees in the project with agent and task mappings. Use when checking for stale worktrees or seeing who is working in parallel.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
   ]
 
@@ -472,7 +453,6 @@ let local_worker_run_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "task_id"; `String "agent_name" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_run_plan";
@@ -489,7 +469,6 @@ let local_worker_run_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "task_id"; `String "plan" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_run_log";
@@ -506,7 +485,6 @@ let local_worker_run_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "task_id"; `String "note" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_run_deliverable";
@@ -523,7 +501,6 @@ let local_worker_run_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "task_id"; `String "deliverable" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_run_get";
@@ -536,14 +513,12 @@ let local_worker_run_schemas : Types.tool_schema list =
               `Assoc [ ("task_id", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "task_id" ]);
           ];
-      visibility = Public;
     };
     {
       Types.name = "masc_run_list";
       description = "List all task runs with their current status (init, active, completed). Use when surveying execution state across tasks or finding abandoned runs to resume.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
   ]
 
@@ -583,7 +558,6 @@ let local_worker_spawn_schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "agent_name"; `String "prompt" ]);
           ];
-      visibility = Public;
     };
   ]
 

--- a/lib/capability_registry.ml
+++ b/lib/capability_registry.ml
@@ -147,7 +147,6 @@ let projection_to_schema (projection : projection) : Types.tool_schema =
     Types.name = projection.tool_name;
     description = projection.description;
     input_schema = projection.input_schema;
-    visibility = Public;
   }
 
 let make_seed ?capability_id ?(risk_class = Safe)

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -198,7 +198,6 @@ let model_tool_defs_of_json = function
                      Types.name = tool_name;
                      description;
                      input_schema = parameters;
-                     visibility = Public;
                    })
   | Some _ -> []
 

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -15,7 +15,6 @@ let resident_schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -83,7 +82,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "persona_name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -239,7 +237,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -295,7 +292,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -408,7 +404,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"; `String "message"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -433,7 +428,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"; `String "model"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -463,7 +457,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"; `String "policy_mode"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -495,7 +488,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"; `String "action_id"; `String "verdict"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -519,7 +511,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -539,7 +530,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -559,7 +549,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -583,7 +572,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -602,7 +590,6 @@ let resident_schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* --- Phase 4: Keeper Autonomy MCP Tools --- *)
@@ -628,7 +615,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -653,7 +639,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -673,7 +658,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -693,7 +677,6 @@ let resident_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -741,7 +724,6 @@ let housekeep_schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_housekeep_delete";
@@ -760,7 +742,6 @@ let housekeep_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "path"; `String "reason"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_housekeep_prune";
@@ -779,7 +760,6 @@ let housekeep_schemas : tool_schema list = [
       ]);
       ("required", `List [`String "store"]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/procedure_tool_materializer.ml
+++ b/lib/procedure_tool_materializer.ml
@@ -145,7 +145,6 @@ let make_schema ~tool_name ~description : Types.tool_schema =
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   }
 
 (* ================================================================ *)

--- a/lib/research/tool_research.ml
+++ b/lib/research/tool_research.ml
@@ -29,7 +29,6 @@ and keeps changes that pass all tests. Results logged to research_results.tsv.";
       ]);
       ("required", `List []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_research_status";
@@ -39,7 +38,6 @@ Returns the contents of research_results.tsv with experiment outcomes.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -537,6 +537,5 @@ let sdk_tool_schemas : Types.tool_schema list =
         Types.name = binding.sdk_name;
         description = binding.description;
         input_schema = binding.input_schema;
-        visibility = Public;
       })
     sdk_bindings

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -360,7 +360,6 @@ let schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "agent_name" ]);
           ];
-    visibility = Public;
     };
   ]
 

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -398,7 +398,6 @@ Pair with masc_audit_stats for aggregate trust metrics, masc_auth_list for crede
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_audit_stats *)
@@ -421,7 +420,6 @@ Pair with masc_audit_query for detailed event logs, masc_agent_fitness for perfo
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_governance_report *)
@@ -443,7 +441,6 @@ Pair with masc_governance_set to configure audit policies, or masc_governance_st
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_audit_trail *)
@@ -479,7 +476,6 @@ Pair with masc_operator_confirm to see the original pending_confirm, or masc_gov
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -52,7 +52,6 @@ The MODEL receives the full file, generates a modified version, and writes it ba
       ]);
       ("required", `List [`String "goal"; `String "metric_fn"; `String "target_file"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -102,7 +101,6 @@ and persists cross-links so team-session status/stop can surface the linked loop
       ]);
       ("required", `List [`String "goal"; `String "metric_fn"; `String "target_file"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -118,7 +116,6 @@ Returns: loop_id, cycle count, baseline, best score, keep/discard counts, recent
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -138,7 +135,6 @@ The loop will finish its current cycle and save final state.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -160,7 +156,6 @@ Useful for directing the research based on human insight.";
       ]);
       ("required", `List [`String "hypothesis"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -182,7 +177,6 @@ Call this repeatedly to drive the autonomous loop.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -233,7 +227,6 @@ Use after synthesizing insights from multiple experiment cycles.";
       ]);
       ("required", `List [`String "goal"; `String "hypothesis"; `String "evidence"; `String "conclusion"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -254,6 +247,5 @@ Returns findings from all loops matching the query, most recent first.";
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -473,7 +473,6 @@ let tool_post_create : Types.tool_schema = {
     ]);
     ("required", `List [`String "content"]);
   ];
-  visibility = Public;
 }
 
 let tool_post_list : Types.tool_schema = {
@@ -493,7 +492,6 @@ let tool_post_list : Types.tool_schema = {
       ("since", `Assoc [("type", `String "number"); ("description", `String "Unix timestamp. Posts with activity after this time show a 🔔 indicator")]);
     ]);
   ];
-  visibility = Public;
 }
 
 let tool_post_get : Types.tool_schema = {
@@ -506,7 +504,6 @@ let tool_post_get : Types.tool_schema = {
     ]);
     ("required", `List [`String "post_id"]);
   ];
-  visibility = Public;
 }
 
 let tool_comment_add : Types.tool_schema = {
@@ -523,7 +520,6 @@ let tool_comment_add : Types.tool_schema = {
     ]);
     ("required", `List [`String "post_id"; `String "content"]);
   ];
-  visibility = Public;
 }
 
 let tool_vote : Types.tool_schema = {
@@ -538,7 +534,6 @@ let tool_vote : Types.tool_schema = {
     ]);
     ("required", `List [`String "post_id"]);
   ];
-  visibility = Public;
 }
 
 let tool_stats : Types.tool_schema = {
@@ -548,7 +543,6 @@ let tool_stats : Types.tool_schema = {
     ("type", `String "object");
     ("properties", `Assoc []);
   ];
-  visibility = Public;
 }
 
 let tool_search : Types.tool_schema = {
@@ -562,7 +556,6 @@ let tool_search : Types.tool_schema = {
     ]);
     ("required", `List [`String "query"]);
   ];
-  visibility = Public;
 }
 
 let tool_comment_vote : Types.tool_schema = {
@@ -577,7 +570,6 @@ let tool_comment_vote : Types.tool_schema = {
     ]);
     ("required", `List [`String "comment_id"]);
   ];
-  visibility = Public;
 }
 
 let tool_profile : Types.tool_schema = {
@@ -590,7 +582,6 @@ let tool_profile : Types.tool_schema = {
     ]);
     ("required", `List [`String "agent"]);
   ];
-  visibility = Public;
 }
 
 let tool_hearth_list : Types.tool_schema = {
@@ -600,7 +591,6 @@ let tool_hearth_list : Types.tool_schema = {
     ("type", `String "object");
     ("properties", `Assoc []);
   ];
-  visibility = Public;
 }
 
 (** {1 Migration Tool} *)
@@ -642,7 +632,6 @@ let tool_migrate : Types.tool_schema = {
     ("type", `String "object");
     ("properties", `Assoc []);
   ];
-  visibility = Public;
 }
 
 (** All board tools *)

--- a/lib/tool_cache.ml
+++ b/lib/tool_cache.ml
@@ -127,7 +127,6 @@ Retrieve with masc_cache_get. Browse entries with masc_cache_list.";
       ]);
       ("required", `List [`String "key"; `String "value"]);
     ];
-    visibility = Public;
   };
 
   (* masc_cache_get *)
@@ -146,7 +145,6 @@ If miss, check masc_cache_list to verify the key exists or re-populate with masc
       ]);
       ("required", `List [`String "key"]);
     ];
-    visibility = Public;
   };
 
   (* masc_cache_delete *)
@@ -163,7 +161,6 @@ If miss, check masc_cache_list to verify the key exists or re-populate with masc
       ]);
       ("required", `List [`String "key"]);
     ];
-    visibility = Public;
   };
 
   (* masc_cache_list *)
@@ -179,7 +176,6 @@ If miss, check masc_cache_list to verify the key exists or re-populate with masc
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_cache_clear *)
@@ -190,7 +186,6 @@ If miss, check masc_cache_list to verify the key exists or re-populate with masc
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_cache_stats *)
@@ -201,7 +196,6 @@ If miss, check masc_cache_list to verify the key exists or re-populate with masc
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -331,7 +331,6 @@ Pair with masc_code_symbols for file-level symbol outlines or masc_code_read for
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
 
   (* masc_code_symbols *)
@@ -350,7 +349,6 @@ Pair with masc_code_read to then read specific line ranges of interest.";
       ]);
       ("required", `List [`String "path"]);
     ];
-    visibility = Public;
   };
 
   (* masc_code_read *)
@@ -379,7 +377,6 @@ After masc_code_symbols identifies the relevant line numbers.";
       ]);
       ("required", `List [`String "path"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_code_swarm.ml
+++ b/lib/tool_code_swarm.ml
@@ -135,7 +135,6 @@ let schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "pattern" ]);
           ];
-    visibility = Public;
     };
     {
       name = "masc_code_swarm_verify";
@@ -170,7 +169,6 @@ let schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "plan_id" ]);
           ];
-    visibility = Public;
     };
     {
       name = "masc_code_swarm_merge";
@@ -235,6 +233,5 @@ let schemas : Types.tool_schema list =
                 ] );
             ("required", `List [ `String "plan_id" ]);
           ];
-    visibility = Public;
     };
   ]

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -363,7 +363,6 @@ Pair with masc_worktree_create to set up an isolated workspace first.";
       ]);
       ("required", `List [`String "path"; `String "content"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -394,7 +393,6 @@ The old_string must match exactly once unless replace_all is true.";
       ]);
       ("required", `List [`String "path"; `String "old_string"; `String "new_string"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -411,7 +409,6 @@ Cannot delete directories. Use when removing generated or obsolete files.";
       ]);
       ("required", `List [`String "path"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -438,7 +435,6 @@ Output truncated to 10KB. Timeout default 30s, max 120s.";
       ]);
       ("required", `List [`String "command"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -464,7 +460,6 @@ Restricted to .worktrees/ working directory. Force push and push to main/master 
       ]);
       ("required", `List [`String "action"; `String "cwd"]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_command_plane_schemas_01.ml
+++ b/lib/tool_command_plane_schemas_01.ml
@@ -21,7 +21,6 @@ Pair with masc_operation_start to run operations on defined units.";
             ("policy", `Assoc [ ("type", `String "object") ]);
             ("budget", `Assoc [ ("type", `String "object") ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_unit_list";
@@ -30,7 +29,6 @@ Pair with masc_operation_start to run operations on defined units.";
 Use when inspecting the organizational hierarchy or verifying unit definitions. \
 Pair with masc_observe_topology for a richer view with health and operation counts.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_unit_reparent";
@@ -44,7 +42,6 @@ Pair with masc_unit_list to verify the new topology after reparenting.";
             ("unit_id", string_prop "Managed unit id.");
             ("parent_unit_id", string_prop "New parent unit id. Omit only for company roots.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_unit_reassign";
@@ -59,7 +56,6 @@ Pair with masc_observe_topology to verify roster changes took effect.";
             ("leader_id", string_prop "New leader agent id.");
             ("roster", string_array_prop "Replacement roster.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_intent_create";
@@ -80,7 +76,6 @@ Pair with masc_operation_start to attach operations under this intent.";
             ("current_focus", `Assoc [ ("type", `String "object") ]);
             ("checkpoint_ref", string_prop "Optional checkpoint reference.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_intent_status";
@@ -93,7 +88,6 @@ Pair with masc_intent_update to change focus or state, or masc_intent_forecast f
           [
             ("intent_id", string_prop "Intent id to filter.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_intent_update";
@@ -115,7 +109,6 @@ After masc_intent_status to review current state; pair with masc_intent_forecast
             ("current_focus", `Assoc [ ("type", `String "object") ]);
             ("checkpoint_ref", string_prop "Optional checkpoint reference.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_intent_forecast";
@@ -129,7 +122,6 @@ After masc_intent_status; pair with masc_operation_start to act on the forecast.
             ("intent_id", string_prop "Managed intent id.");
             ("limit", integer_prop ~default:3 "Maximum candidate next states.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_start";
@@ -162,7 +154,6 @@ After masc_unit_define; follow with masc_dispatch_tick to materialize detachment
             ("chain_input", `Assoc [ ("type", `String "object"); ("description", `String "Optional JSON input forwarded to chain.run input.") ]);
             ("chain_checkpoint_enabled", boolean_prop ~default:true "Enable native checkpoint capture for chain.run.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_status";
@@ -173,7 +164,6 @@ After masc_operation_start; pair with masc_observe_operations for a combined vie
       input_schema =
         object_schema
           [ ("operation_id", string_prop "Operation id to filter."); ];
-      visibility = Public;
     };
     {
       name = "masc_operation_checkpoint";
@@ -188,7 +178,6 @@ Pair with masc_operation_resume to restart from the saved checkpoint.";
             ("checkpoint_ref", string_prop "Checkpoint reference or durable resume pointer.");
             ("note", string_prop "Optional checkpoint note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_pause";
@@ -201,7 +190,6 @@ Pair with masc_operation_resume to continue or masc_operation_stop to cancel.";
             ("operation_id", string_prop "Managed operation id.");
             ("note", string_prop "Optional pause note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_resume";
@@ -214,7 +202,6 @@ After masc_operation_pause; pair with masc_dispatch_tick to re-materialize detac
             ("operation_id", string_prop "Managed operation id.");
             ("note", string_prop "Optional resume note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_stop";
@@ -227,7 +214,6 @@ Pair with masc_operation_status to verify the cancellation took effect.";
             ("operation_id", string_prop "Managed operation id.");
             ("note", string_prop "Optional stop reason.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_operation_finalize";
@@ -240,7 +226,6 @@ After the operation's detachments report completion; pair with masc_observe_trac
             ("operation_id", string_prop "Managed operation id.");
             ("note", string_prop "Optional completion note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_chain_snapshot";
@@ -249,7 +234,6 @@ After the operation's detachments report completion; pair with masc_observe_trac
 Use when reviewing chain-backed operation execution or debugging chain runs. \
 Pair with masc_chain_run_get to fetch details of a specific run.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_chain_run_get";
@@ -262,7 +246,6 @@ After masc_chain_snapshot identifies the run_id.";
           [
             ("run_id", string_prop "Native chain run id from a chain-backed operation.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_plan";
@@ -276,7 +259,6 @@ Before masc_dispatch_assign to act on the recommendation.";
             ("operation_id", string_prop "Optional operation id to route.");
             ("assigned_unit_id", string_prop "Optional current unit id when planning a new operation.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_assign";
@@ -291,7 +273,6 @@ After masc_dispatch_plan; follow with masc_dispatch_tick to materialize.";
             ("target_unit_id", string_prop "Target unit id.");
             ("note", string_prop "Optional assignment note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_rebalance";
@@ -306,7 +287,6 @@ After masc_observe_capacity identifies overloaded units.";
             ("target_unit_id", string_prop "Target unit id.");
             ("note", string_prop "Optional rebalance note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_escalate";
@@ -321,7 +301,6 @@ Pair with masc_policy_approve if the escalation requires approval.";
             ("target_unit_id", string_prop "Optional explicit target unit id.");
             ("note", string_prop "Optional escalation note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_recall";
@@ -335,7 +314,6 @@ Pair with masc_operation_resume to re-activate when ready.";
             ("operation_id", string_prop "Managed operation id.");
             ("note", string_prop "Optional recall note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_dispatch_tick";
@@ -349,7 +327,6 @@ After masc_operation_start or masc_dispatch_assign; run repeatedly until stable.
             ("operation_id", string_prop "Optional operation filter.");
             ("detachment_id", string_prop "Optional detachment filter.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_detachment_list";
@@ -363,7 +340,6 @@ After masc_dispatch_tick; pair with masc_detachment_status for per-detachment de
             ("operation_id", string_prop "Optional operation or trace filter.");
             ("detachment_id", string_prop "Optional detachment id filter.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_detachment_status";
@@ -376,7 +352,6 @@ After masc_detachment_list identifies the detachment_id.";
           [
             ("detachment_id", string_prop "Managed detachment id.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_policy_status";
@@ -385,7 +360,6 @@ After masc_detachment_list identifies the detachment_id.";
 Use when checking pending approvals or reviewing policy state before strict actions. \
 Pair with masc_policy_approve or masc_policy_deny to process pending decisions.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_policy_approve";
@@ -399,7 +373,6 @@ After masc_policy_status shows pending decisions.";
             ("decision_id", string_prop "Managed decision id.");
             ("reason", string_prop "Optional approval note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_policy_deny";
@@ -413,7 +386,6 @@ After masc_policy_status shows pending decisions.";
             ("decision_id", string_prop "Managed decision id.");
             ("reason", string_prop "Optional denial note.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_policy_update";
@@ -428,7 +400,6 @@ Pair with masc_policy_status to review the updated configuration.";
             ("policy", `Assoc [ ("type", `String "object") ]);
             ("budget", `Assoc [ ("type", `String "object") ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_policy_freeze_unit";
@@ -442,7 +413,6 @@ Pair with masc_observe_capacity to check unit workload before/after freezing.";
             ("unit_id", string_prop "Managed unit id.");
             ("enabled", boolean_prop ~default:true "Set true to freeze, false to unfreeze.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_policy_kill_switch";
@@ -456,7 +426,6 @@ Pair with masc_policy_status to verify the kill-switch state.";
             ("unit_id", string_prop "Managed unit id.");
             ("enabled", boolean_prop ~default:true "Set true to enable, false to clear.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_observe_topology";
@@ -465,6 +434,5 @@ Pair with masc_policy_status to verify the kill-switch state.";
 Use when getting a birds-eye view of the organizational structure and its operational load. \
 Pair with masc_observe_capacity for per-unit budget utilization details.";
       input_schema = object_schema [];
-      visibility = Public;
     };
 ]

--- a/lib/tool_command_plane_schemas_02.ml
+++ b/lib/tool_command_plane_schemas_02.ml
@@ -9,7 +9,6 @@ let schemas : tool_schema list = [
 Use when you need a combined operations + detachments snapshot for quick assessment. \
 Pair with masc_observe_alerts for derived alerts on problematic units.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_observe_swarm";
@@ -23,7 +22,6 @@ Pair with masc_observe_alerts for a full picture.";
             ("run_id", string_prop "Swarm-live run id.");
             ("operation_id", string_prop "Optional managed operation id.");
           ];
-      visibility = Public;
     };
     {
       name = "masc_observe_alerts";
@@ -32,7 +30,6 @@ Pair with masc_observe_alerts for a full picture.";
 Use when scanning for problems across the command plane that need attention. \
 Pair with masc_dispatch_escalate or masc_dispatch_rebalance to address issues.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_observe_capacity";
@@ -41,7 +38,6 @@ Pair with masc_dispatch_escalate or masc_dispatch_rebalance to address issues.";
 Use when checking which units have available capacity or are overloaded. \
 Pair with masc_dispatch_rebalance to redistribute work from overloaded units.";
       input_schema = object_schema [];
-      visibility = Public;
     };
     {
       name = "masc_observe_traces";
@@ -55,6 +51,5 @@ Pair with masc_operation_status for the operation's current state.";
             ("operation_id", string_prop "Operation id.");
             ("limit", integer_prop ~default:25 "Maximum events to return.");
           ];
-      visibility = Public;
     };
 ]

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -69,7 +69,6 @@ Each message has 'role' (system/user/assistant/tool) and 'content' (string).");
       ]);
       ("required", `List [`String "messages"; `String "strategy"]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_cost.ml
+++ b/lib/tool_cost.ml
@@ -71,7 +71,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"; `String "cost_usd"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_cost_report";
@@ -94,7 +93,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_council_internal_schemas.ml
+++ b/lib/tool_council_internal_schemas.ml
@@ -49,7 +49,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "title"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_case_brief_submit";
@@ -78,7 +77,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "case_id"; `String "summary"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_cases";
@@ -96,7 +94,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_case_status";
@@ -111,7 +108,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "case_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_ruling_status";
@@ -126,7 +122,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "case_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_execution_orders";
@@ -145,7 +140,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_governance_status";
@@ -154,7 +148,6 @@ let schemas : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_route";
@@ -175,7 +168,6 @@ Pair with masc_dispatch_assign to actually assign work to the selected agents.";
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_execute";
@@ -197,7 +189,6 @@ Call masc_execute_dry_run first to preview. Pair with masc_execution_orders for 
       ]);
       ("required", `List [`String "topic"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_execute_dry_run";
@@ -218,7 +209,6 @@ Pair with masc_execute to run the action after confirming the dry-run output.";
       ]);
       ("required", `List [`String "topic"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_governance_feed";
@@ -237,7 +227,6 @@ Pair with masc_execute to run the action after confirming the dry-run output.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_runtime_params";
@@ -246,7 +235,6 @@ Pair with masc_execute to run the action after confirming the dry-run output.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_set_param";
@@ -268,6 +256,5 @@ Pair with masc_execute to run the action after confirming the dry-run output.";
       ]);
       ("required", `List [`String "param_key"; `String "value"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_encryption.ml
+++ b/lib/tool_encryption.ml
@@ -99,7 +99,6 @@ let schemas : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_encryption_enable";
@@ -114,7 +113,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_encryption_disable";
@@ -123,7 +121,6 @@ let schemas : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_generate_key *)
@@ -142,7 +139,6 @@ Store the key securely. Pair with masc_encryption_enable to apply.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -60,7 +60,6 @@ let schemas : tool_schema list =
                   ("parent_goal_id", `Assoc [ ("type", `String "string") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_goal_list";
@@ -93,7 +92,6 @@ let schemas : tool_schema list =
                       ] );
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_goal_snapshot";
@@ -104,7 +102,6 @@ let schemas : tool_schema list =
             ("type", `String "object");
             ("properties", `Assoc [ ("mode", `Assoc [ ("type", `String "string") ]) ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_goal_refresh";
@@ -133,7 +130,6 @@ let schemas : tool_schema list =
                   ("force", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_goal_dispatch";
@@ -166,7 +162,6 @@ let schemas : tool_schema list =
                   ("goal_ids", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_goal_review";
@@ -202,7 +197,6 @@ let schemas : tool_schema list =
                 ] );
             ("required", `List [ `String "goal_id"; `String "outcome" ]);
           ];
-      visibility = Public;
     };
   ]
 

--- a/lib/tool_handover.ml
+++ b/lib/tool_handover.ml
@@ -119,7 +119,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"; `String "handover_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_handover_claim_and_spawn";
@@ -146,7 +145,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "handover_id"; `String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_handover_create *)
@@ -223,7 +221,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"; `String "reason"; `String "goal"]);
     ];
-    visibility = Public;
   };
 
   (* masc_handover_list *)
@@ -242,7 +239,6 @@ After finding a handover, call masc_handover_get for details, then masc_handover
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_handover_get *)
@@ -261,7 +257,6 @@ Pair with masc_handover_list to browse available handovers first.";
       ]);
       ("required", `List [`String "handover_id"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_hat.ml
+++ b/lib/tool_hat.ml
@@ -45,7 +45,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_hat_wear *)
@@ -73,7 +72,6 @@ Pair with masc_hat_status to see all agents' current hats.";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -140,7 +140,6 @@ Prefer masc_heartbeat_start for automatic pings. Pair with masc_cleanup_zombies 
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_heartbeat_start *)
@@ -169,7 +168,6 @@ Smart mode skips beats when busy. Stop with masc_heartbeat_stop before masc_leav
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_heartbeat_stop *)
@@ -188,7 +186,6 @@ Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
       ]);
       ("required", `List [`String "heartbeat_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_heartbeat_list *)
@@ -201,7 +198,6 @@ Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead age
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_improve_loop_schemas.ml
+++ b/lib/tool_improve_loop_schemas.ml
@@ -22,7 +22,6 @@ let schemas : tool_schema list =
                   ("dry_run", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_improve_loop_status";
@@ -30,7 +29,6 @@ let schemas : tool_schema list =
         "Read the persisted state of the masc-mcp self-improvement loop, including current candidate, pause reason, last success/failure, and recent queue summary.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
     {
       name = "masc_improve_loop_pause";
@@ -43,7 +41,6 @@ let schemas : tool_schema list =
             ( "properties",
               `Assoc [ ("reason", `Assoc [ ("type", `String "string") ]) ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_improve_loop_resume";
@@ -56,7 +53,6 @@ let schemas : tool_schema list =
             ( "properties",
               `Assoc [ ("dry_run", `Assoc [ ("type", `String "boolean") ]) ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_improve_loop_tick";
@@ -74,6 +70,5 @@ let schemas : tool_schema list =
                   ("review_ok", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-      visibility = Public;
     };
   ]

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -328,7 +328,6 @@ Pair with masc_library_read to fetch a specific document or masc_library_search 
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_library_read *)
@@ -347,7 +346,6 @@ After masc_library_list or masc_library_search to find the topic name.";
       ]);
       ("required", `List [`String "topic"]);
     ];
-    visibility = Public;
   };
 
   (* masc_library_add *)
@@ -384,7 +382,6 @@ Follow up with masc_library_promote to move candidates to the main library after
       ]);
       ("required", `List [`String "title"; `String "source"; `String "confidence"; `String "content"]);
     ];
-    visibility = Public;
   };
 
   (* masc_library_promote *)
@@ -407,7 +404,6 @@ After masc_library_add placed the document in candidates/.";
       ]);
       ("required", `List [`String "topic"; `String "confidence"]);
     ];
-    visibility = Public;
   };
 
   (* masc_library_search *)
@@ -426,7 +422,6 @@ Pair with masc_library_read to fetch matching documents in full.";
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -147,7 +147,6 @@ let schemas : tool_schema list =
             ("type", `String "object");
             ("properties", `Assoc []);
           ];
-      visibility = Public;
     };
     {
       name = "masc_local_runtime_status";
@@ -163,7 +162,6 @@ let schemas : tool_schema list =
                   ("include_models", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_runtime_verify";
@@ -182,7 +180,6 @@ let schemas : tool_schema list =
                   ("expected_ctx", `Assoc [ ("type", `String "integer") ]);
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_local_runtime_bench";
@@ -204,6 +201,5 @@ let schemas : tool_schema list =
                   ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
                 ] );
           ];
-      visibility = Public;
     };
   ]

--- a/lib/tool_mdal_schemas.ml
+++ b/lib/tool_mdal_schemas.ml
@@ -80,7 +80,6 @@ MDAL itself does not read or score this path.");
       ]);
       ("required", `List [`String "profile"]);
     ];
-    visibility = Public;
   };
 
   {
@@ -97,7 +96,6 @@ Pair with masc_mdal_iterate to continue or masc_mdal_stop to end.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -114,7 +112,6 @@ After masc_mdal_start; check masc_mdal_status to see if the goal was met.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   {
@@ -135,7 +132,6 @@ After masc_mdal_iterate; pair with masc_mdal_status to review final metrics.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_mdal_swarm_start";
@@ -183,7 +179,6 @@ Pair with masc_mdal_status per worker to check individual progress.";
       ]);
       ("required", `List [`String "swarm_id"; `String "title"; `String "workers"; `String "aggregate_goal_expr"]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_mitosis_schemas.ml
+++ b/lib/tool_mitosis_schemas.ml
@@ -13,7 +13,6 @@ let schemas : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_all *)
@@ -26,7 +25,6 @@ Pair with masc_mitosis_divide to assist an agent approaching threshold.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_pool *)
@@ -39,7 +37,6 @@ Pair with masc_mitosis_divide for manual division, or masc_memento_mori for auto
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_divide *)
@@ -62,7 +59,6 @@ Pair with masc_mitosis_prepare to extract DNA first, or use masc_memento_mori fo
       ]);
       ("required", `List [`String "summary"]);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_check *)
@@ -80,7 +76,6 @@ After should_prepare: call masc_mitosis_prepare. After should_handoff: call masc
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_record *)
@@ -102,7 +97,6 @@ Pair with masc_mitosis_check to see if the counters have triggered a threshold."
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_prepare *)
@@ -121,7 +115,6 @@ Actual handoff happens at 80% via masc_mitosis_divide or masc_memento_mori.";
       ]);
       ("required", `List [`String "full_context"]);
     ];
-    visibility = Public;
   };
 
   (* masc_mitosis_handoff *)
@@ -210,7 +203,6 @@ Pair with masc_memento_mori for the all-in-one convenience wrapper.";
       ]);
       ("required", `List [`String "context_ratio"]);
     ];
-    visibility = Public;
   };
 
   (* masc_metrics_compare *)
@@ -233,7 +225,6 @@ Returns verdict: improved/degraded/neutral. Pair with masc_metrics_record to col
       ]);
       ("required", `List [`String "gen_a"; `String "gen_b"]);
     ];
-    visibility = Public;
   };
 
   (* masc_metrics_record *)
@@ -272,6 +263,5 @@ Pair with masc_metrics_compare to evaluate generational improvement.";
       ]);
       ("required", `List [`String "task_id"; `String "completed"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_model_catalog.ml
+++ b/lib/tool_model_catalog.ml
@@ -144,6 +144,5 @@ let schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_notifications.ml
+++ b/lib/tool_notifications.ml
@@ -22,7 +22,6 @@ Costs nothing to call frequently.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_check_notifications";
@@ -39,7 +38,6 @@ Use masc_consume_notifications to actually remove them after processing.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_consume_notifications";
@@ -55,7 +53,6 @@ Use masc_check_notifications first if you want to preview before consuming.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -59,7 +59,6 @@ let snapshot_schema ~remote =
                 ("include_keepers", `Assoc [ ("type", `String "boolean") ]);
               ] );
         ];
-    visibility = Public;
   }
 
 let digest_target_type_enums = [ `String "room"; `String "team_session" ]
@@ -96,7 +95,6 @@ let digest_schema ~remote =
                 ("include_workers", `Assoc [ ("type", `String "boolean") ]);
               ] );
         ];
-    visibility = Public;
   }
 
 let action_schema ~remote =
@@ -135,7 +133,6 @@ let action_schema ~remote =
               ] );
             ("required", `List [ `String "action_type"; `String "payload" ]);
         ];
-    visibility = Public;
   }
 
 let confirm_schema =
@@ -161,7 +158,6 @@ let confirm_schema =
               ] );
           ("required", `List [ `String "confirm_token" ]);
         ];
-    visibility = Public;
   }
 
 let judgment_write_schema =
@@ -207,7 +203,6 @@ let judgment_write_schema =
               ] );
           ("required", `List [ `String "surface"; `String "target_type"; `String "summary" ]);
         ];
-    visibility = Public;
   }
 
 let judgment_latest_schema =
@@ -239,7 +234,6 @@ let judgment_latest_schema =
               ] );
           ("required", `List [ `String "surface"; `String "target_type" ]);
         ];
-    visibility = Public;
   }
 
 let json_string_of_result = function

--- a/lib/tool_rate_limit.ml
+++ b/lib/tool_rate_limit.ml
@@ -64,7 +64,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_rate_limit_config";
@@ -90,7 +89,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -172,7 +172,6 @@ let schemas : Types.tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_relay_checkpoint *)
@@ -209,7 +208,6 @@ Pair with masc_relay_now to trigger handoff, or masc_relay_status to check if re
       ]);
       ("required", `List [`String "summary"]);
     ];
-    visibility = Public;
   };
 
   (* masc_relay_now *)
@@ -242,7 +240,6 @@ Call masc_relay_checkpoint first to save state. The successor continues where yo
       ]);
       ("required", `List [`String "summary"]);
     ];
-    visibility = Public;
   };
 
   (* masc_relay_smart_check *)
@@ -274,7 +271,6 @@ Returns relay recommendation before you commit. Pair with masc_relay_now if rela
       ]);
       ("required", `List [`String "task_hint"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -110,7 +110,6 @@ After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_
       ]);
       ("required", `List [`String "task_id"; `String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_run_plan *)
@@ -131,7 +130,6 @@ After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_
       ]);
       ("required", `List [`String "task_id"; `String "plan"]);
     ];
-    visibility = Public;
   };
 
   (* masc_run_log *)
@@ -152,7 +150,6 @@ After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_
       ]);
       ("required", `List [`String "task_id"; `String "note"]);
     ];
-    visibility = Public;
   };
 
   (* masc_run_deliverable *)
@@ -175,7 +172,6 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
       ]);
       ("required", `List [`String "task_id"; `String "deliverable"]);
     ];
-    visibility = Public;
   };
 
   (* masc_run_get *)
@@ -192,7 +188,6 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_run_list *)
@@ -203,7 +198,6 @@ After recording, the run shows as completed in masc_run_list and masc_run_get.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_schemas_a2a.ml
+++ b/lib/tool_schemas_a2a.ml
@@ -21,7 +21,6 @@ Pair with masc_a2a_delegate to send work, or masc_a2a_query_skill for skill deta
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_a2a_query_skill";
@@ -42,7 +41,6 @@ Call masc_a2a_discover first to find available agents and skill IDs.";
       ]);
       ("required", `List [`String "agent_name"; `String "skill_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_a2a_delegate";
@@ -86,7 +84,6 @@ Call masc_a2a_discover first to find capable agents. Pair with masc_a2a_subscrib
       ]);
       ("required", `List [`String "target_agent"; `String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_a2a_subscribe";
@@ -111,7 +108,6 @@ Pair with masc_poll_events to read buffered events, and masc_a2a_unsubscribe to 
       ]);
       ("required", `List [`String "events"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_a2a_unsubscribe";
@@ -130,7 +126,6 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
       ]);
       ("required", `List [`String "subscription_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_poll_events";
@@ -152,7 +147,6 @@ Workflow: masc_a2a_subscribe -> do work -> masc_poll_events periodically -> masc
       ]);
       ("required", `List [`String "subscription_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_heartbeat_result";
@@ -214,6 +208,5 @@ Reports tool usage and decision metadata. Pair with masc_heartbeat_start to init
             `String "decision_confidence";
           ]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_agent.ml
+++ b/lib/tool_schemas_agent.ml
@@ -16,7 +16,6 @@ Prefer masc_heartbeat_start for automatic pings. Pair with masc_cleanup_zombies 
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_cleanup_zombies";
@@ -27,7 +26,6 @@ Pair with masc_gc for full room maintenance including old tasks and messages.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_heartbeat_start";
@@ -54,7 +52,6 @@ Smart mode skips beats when busy. Stop with masc_heartbeat_stop before masc_leav
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_heartbeat_stop";
@@ -71,7 +68,6 @@ Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
       ]);
       ("required", `List [`String "heartbeat_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_heartbeat_list";
@@ -82,7 +78,6 @@ Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead age
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_gc";
@@ -99,7 +94,6 @@ Pair with masc_archive_view to inspect what was archived or masc_cleanup_zombies
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_agents";
@@ -110,7 +104,6 @@ Pair with masc_cleanup_zombies to remove stale agents or masc_find_by_capability
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_agent_update";
@@ -131,7 +124,6 @@ Only modifies the calling agent's own record. Pair with masc_agents to verify th
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_agent_card";
@@ -148,7 +140,6 @@ Action 'get' returns current card; 'refresh' rebuilds it from live bindings. Pai
         ]);
       ]);
     ];
-    visibility = Public;
   };
   (* masc_heartbeat_result removed: canonical definition in tool_schemas_a2a.ml *)
   {
@@ -170,7 +161,6 @@ Pair with masc_select_agent for automated assignment or masc_agents for raw stat
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_select_agent";
@@ -199,7 +189,6 @@ Pair with masc_agent_fitness to review scores or masc_transition(action='claim')
       ]);
       ("required", `List [`String "available_agents"]);
     ];
-    visibility = Public;
   };
   (* masc_register_capabilities *)
   {
@@ -222,7 +211,6 @@ Pair with masc_find_by_capability to search others or masc_who to see the full r
       ]);
       ("required", `List [`String "agent_name"; `String "capabilities"]);
     ];
-    visibility = Public;
   };
 
   (* masc_find_by_capability *)
@@ -241,7 +229,6 @@ Pair with masc_broadcast to @mention the found agent or masc_portal_open for dir
       ]);
       ("required", `List [`String "capability"]);
     ];
-    visibility = Public;
   };
 
   (* masc_collaboration_graph *)
@@ -261,7 +248,6 @@ Pair with masc_consolidate_learning to prune weak connections, masc_select_agent
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_consolidate_learning *)
@@ -280,7 +266,6 @@ Pair with masc_collaboration_graph to review the graph before and after consolid
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_get_metrics *)
@@ -304,7 +289,6 @@ Pair with masc_agent_fitness for computed scores, masc_audit_stats for security-
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_agent_relations — proxy to Neo4j/GraphQL for relationship data *)
@@ -324,7 +308,6 @@ Pair with masc_agents for room-level status or masc_collaboration_graph for Hebb
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_schemas_auth.ml
+++ b/lib/tool_schemas_auth.ml
@@ -16,7 +16,6 @@ After enabling, create tokens with masc_auth_create_token; check state with masc
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_disable";
@@ -27,7 +26,6 @@ Pair with masc_auth_status to confirm auth is off.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_status";
@@ -38,7 +36,6 @@ Pair with masc_auth_enable or masc_auth_disable to change settings.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_create_token";
@@ -60,7 +57,6 @@ After masc_auth_enable; the token should be passed in subsequent requests.";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_refresh";
@@ -81,7 +77,6 @@ After masc_auth_create_token issued the original token.";
       ]);
       ("required", `List [`String "agent_name"; `String "token"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_revoke";
@@ -98,7 +93,6 @@ Pair with masc_auth_create_token to issue a replacement if needed.";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_auth_list";
@@ -109,6 +103,5 @@ Pair with masc_auth_revoke to remove stale credentials.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_control.ml
+++ b/lib/tool_schemas_control.ml
@@ -16,7 +16,6 @@ let schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_resume";
@@ -25,7 +24,6 @@ let schemas : tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_pause_status";
@@ -34,6 +32,5 @@ let schemas : tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_fire_task.ml
+++ b/lib/tool_schemas_fire_task.ml
@@ -36,6 +36,5 @@ Recommended for file-modifying tasks. Default: false.");
       ]);
       ("required", `List [`String "goal"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_inline_convo.ml
+++ b/lib/tool_schemas_inline_convo.ml
@@ -34,7 +34,6 @@ Follow up with masc_convo_reply to add turns; end with masc_convo_conclude.";
       ]);
       ("required", `List [`String "topic"; `String "initiator"]);
     ];
-    visibility = Public;
   };
 
   (* masc_convo_reply *)
@@ -74,7 +73,6 @@ After masc_convo_start creates a thread; before masc_convo_conclude closes it.";
       ]);
       ("required", `List [`String "thread_id"; `String "speaker"; `String "content"]);
     ];
-    visibility = Public;
   };
 
   (* masc_convo_conclude *)
@@ -101,7 +99,6 @@ After masc_convo_reply turns are complete; pair with masc_convo_get to review th
       ]);
       ("required", `List [`String "thread_id"; `String "concluder"; `String "conclusion"]);
     ];
-    visibility = Public;
   };
 
   (* masc_convo_get *)
@@ -120,7 +117,6 @@ Pair with masc_convo_list to find thread IDs.";
       ]);
       ("required", `List [`String "thread_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_convo_list *)
@@ -133,6 +129,5 @@ Pair with masc_convo_get to read a specific thread.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_inline_episodes.ml
+++ b/lib/tool_schemas_inline_episodes.ml
@@ -20,7 +20,6 @@ Returns flushed/failed/pending counts. Pair with masc_episode_list to verify sto
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_episode_list *)
@@ -46,7 +45,6 @@ Pair with masc_episode_flush to ensure episodes are persisted before querying.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_self_introspect *)
@@ -59,7 +57,6 @@ Pair with masc_mitosis_check for threshold-based action, or masc_recall_search f
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_recall_search *)
@@ -82,6 +79,5 @@ Returns matched memories sorted by relevance. Pair with masc_episode_list for st
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas_inline_infra.ml
@@ -26,7 +26,6 @@ Pair with masc_subscription to receive session-scoped event notifications.";
       ]);
       ("required", `List [`String "action"]);
     ];
-    visibility = Public;
   };
 
   (* masc_cancellation *)
@@ -54,7 +53,6 @@ Pair with masc_progress to track operation progress alongside cancellation state
       ]);
       ("required", `List [`String "action"]);
     ];
-    visibility = Public;
   };
 
   (* masc_subscription *)
@@ -91,7 +89,6 @@ After subscribing, poll with action=poll. Clean up with action=unsubscribe befor
       ]);
       ("required", `List [`String "action"]);
     ];
-    visibility = Public;
   };
 
   (* masc_progress *)
@@ -127,7 +124,6 @@ Pair with masc_cancellation to support cooperative abort during tracked operatio
       ]);
       ("required", `List [`String "action"; `String "task_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_governance_set *)
@@ -162,7 +158,6 @@ Pair with masc_governance_report to verify policy effects and masc_governance_st
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_spawn *)
@@ -198,7 +193,6 @@ For llama, provide model explicitly. Pair with masc_add_task to create the task 
       ]);
       ("required", `List [`String "agent_name"; `String "prompt"]);
     ];
-    visibility = Public;
   };
 
   (* masc_memento_mori *)
@@ -234,6 +228,5 @@ Pair with masc_mitosis_status to see cell state, or masc_mitosis_handoff for asy
       ]);
       ("required", `List [`String "context_ratio"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_inline_room.ml
+++ b/lib/tool_schemas_inline_room.ml
@@ -17,7 +17,6 @@ let schemas : tool_schema list = [
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_set_room";
@@ -32,7 +31,6 @@ let schemas : tool_schema list = [
       ]);
       ("required", `List [`String "path"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_join";
@@ -52,7 +50,6 @@ let schemas : tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_leave";
@@ -71,7 +68,6 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_lock";
@@ -90,7 +86,6 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
       ]);
       ("required", `List [`String "agent_name"; `String "file"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_unlock";
@@ -109,7 +104,6 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
       ]);
       ("required", `List [`String "agent_name"; `String "file"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_broadcast";
@@ -134,7 +128,6 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
       ]);
       ("required", `List [`String "agent_name"; `String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_messages";
@@ -158,7 +151,6 @@ Tip: Search for '@your-name' in results to find mentions.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_listen";
@@ -178,7 +170,6 @@ Tip: Search for '@your-name' in results to find mentions.";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_who";
@@ -191,7 +182,6 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_interrupt";
@@ -222,7 +212,6 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"; `String "step"; `String "action"; `String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_approve";
@@ -237,7 +226,6 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_reject";
@@ -256,7 +244,6 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_pending_interrupts";
@@ -265,7 +252,6 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_branch";
@@ -292,6 +278,5 @@ Tip: Use capabilities to find the right agent for @mentions.";
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"; `String "source_step"; `String "branch_name"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_inline_verify.ml
+++ b/lib/tool_schemas_inline_verify.ml
@@ -14,7 +14,6 @@ let schemas : tool_schema list = [
       ]);
       ("required", `List [`String "verification_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_bounded_run *)
@@ -83,7 +82,6 @@ Pair with masc_team_session_start for supervised sessions or masc_mdal_start for
       ]);
       ("required", `List [`String "agents"; `String "prompt"; `String "goal"]);
     ];
-    visibility = Public;
   };
 
   (* masc_verify_request *)
@@ -117,7 +115,6 @@ Follow up with masc_verify_submit to provide a verdict or masc_verify_auto for a
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_verify_submit *)
@@ -149,7 +146,6 @@ After masc_verify_request creates the verification; pair with masc_verify_status
       ]);
       ("required", `List [`String "verification_id"; `String "verdict"]);
     ];
-    visibility = Public;
   };
 
   (* masc_verify_pending *)
@@ -162,7 +158,6 @@ Follow up with masc_verify_submit to provide a verdict for each pending request.
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_verify_auto *)
@@ -181,6 +176,5 @@ After masc_verify_request creates the request; alternative to manual masc_verify
       ]);
       ("required", `List [`String "verification_id"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_misc.ml
+++ b/lib/tool_schemas_misc.ml
@@ -22,7 +22,6 @@ Pair with masc_agents for agent details, masc_run_list for task details.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_verify_handoff";
@@ -48,7 +47,6 @@ Pair with masc_handover_get for the original context, masc_handover_claim for th
       ]);
       ("required", `List [`String "original"; `String "received"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_gc";
@@ -65,7 +63,6 @@ Pair with masc_archive_view to inspect what was archived or masc_cleanup_zombies
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_cleanup_zombies";
@@ -76,7 +73,6 @@ Pair with masc_gc for full room maintenance including old tasks and messages.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_stats";
@@ -93,7 +89,6 @@ Pair with masc_tool_help for details on specific tools. Data resets on server re
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_help";
@@ -110,7 +105,6 @@ Pair with masc_tool_stats to discover which tools exist.";
       ]);
       ("required", `List [`String "tool_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_admin_snapshot";
@@ -132,7 +126,6 @@ Pair with masc_tool_admin_update to apply changes based on the snapshot.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_admin_update";
@@ -193,7 +186,6 @@ After masc_tool_admin_snapshot to review current state before making changes.";
       ]);
       ("required", `List [`String "section"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_keeper_tool_catalog";
@@ -225,6 +217,5 @@ Pair with masc_tool_admin_snapshot for a broader admin view including auth and c
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_plan.ml
+++ b/lib/tool_schemas_plan.ml
@@ -16,7 +16,6 @@ After masc_claim_next or masc_add_task; follow up with masc_plan_update to write
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_plan_update";
@@ -37,7 +36,6 @@ After masc_plan_init creates the structure; pair with masc_plan_get to review.";
       ]);
       ("required", `List [`String "task_id"; `String "content"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_plan_get";
@@ -54,7 +52,6 @@ After masc_plan_init; omit task_id if masc_plan_set_task was called.";
       ]);
       ("required", `List []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_plan_set_task";
@@ -71,7 +68,6 @@ After masc_claim_next; auto-cleared on masc_leave.";
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_plan_get_task";
@@ -83,7 +79,6 @@ Set via masc_plan_set_task. Auto-cleared on masc_leave.";
       ("properties", `Assoc []);
       ("required", `List []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_plan_clear_task";
@@ -95,7 +90,6 @@ Use masc_transition to change task status separately. Auto-called on masc_leave.
       ("properties", `Assoc []);
       ("required", `List []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_note_add";
@@ -114,7 +108,6 @@ Use masc_transition to change task status separately. Auto-called on masc_leave.
       ]);
       ("required", `List [`String "task_id"; `String "note"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_deliver";
@@ -137,7 +130,6 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
       ]);
       ("required", `List [`String "task_id"; `String "content"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_error_add";
@@ -164,7 +156,6 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
       ]);
       ("required", `List [`String "task_id"; `String "error_type"; `String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_error_resolve";
@@ -183,6 +174,5 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
       ]);
       ("required", `List [`String "task_id"; `String "error_index"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_portal.ml
+++ b/lib/tool_schemas_portal.ml
@@ -24,7 +24,6 @@ Follow up with masc_portal_send to send messages; close with masc_portal_close."
       ]);
       ("required", `List [`String "agent_name"; `String "target_agent"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_portal_send";
@@ -51,7 +50,6 @@ After masc_portal_open establishes the channel; check responses via portal statu
       ]);
       ("required", `List [`String "agent_name"; `String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_portal_close";
@@ -68,7 +66,6 @@ Auto-closes on masc_leave. Pair with masc_portal_open to re-establish if needed.
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_portal_status";
@@ -83,6 +80,5 @@ Auto-closes on masc_leave. Pair with masc_portal_open to re-establish if needed.
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_room_core.ml
+++ b/lib/tool_schemas_room_core.ml
@@ -17,7 +17,6 @@ Call after masc_join to orient yourself. Pair with masc_tasks for detailed backl
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_reset";
@@ -35,7 +34,6 @@ Requires confirm=true to execute. Example: masc_reset({confirm: true})";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_workflow_guide";
@@ -46,7 +44,6 @@ Pair with masc_check to assert specific prerequisites before acting.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_check";
@@ -70,7 +67,6 @@ Pair with masc_workflow_guide for next-step recommendations.";
       ]);
       ("required", `List [`String "assertions"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_init";
@@ -86,6 +82,5 @@ After init, call masc_join to register your presence, then masc_add_task or masc
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_room_extra.ml
+++ b/lib/tool_schemas_room_extra.ml
@@ -18,7 +18,6 @@ Use this only when you explicitly need named-room compatibility behavior.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_room_create";
@@ -39,7 +38,6 @@ Use this only when you explicitly need named-room compatibility behavior.";
       ]);
       ("required", `List [`String "name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_room_enter";
@@ -61,7 +59,6 @@ Use this only when you explicitly need named-room compatibility behavior.";
       ]);
       ("required", `List [`String "room_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_room_strategy_get";
@@ -72,7 +69,6 @@ Pair with masc_room_strategy_set to update the strategy.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_room_strategy_set";
@@ -97,6 +93,5 @@ Call masc_room_strategy_get first to see current settings.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_schemas_worktree.ml
+++ b/lib/tool_schemas_worktree.ml
@@ -25,7 +25,6 @@ After work, create a PR with `gh pr create` and call masc_worktree_remove.";
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_worktree_remove";
@@ -46,7 +45,6 @@ After completing work in a worktree created by masc_worktree_create.";
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_worktree_list";
@@ -57,6 +55,5 @@ Pair with masc_worktree_remove to clean up stale entries.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -24,7 +24,6 @@ let base_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   (* Context status *)
   {
@@ -34,7 +33,6 @@ let base_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   (* Memory *)
   {
@@ -48,7 +46,6 @@ let base_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -63,7 +60,6 @@ let board_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "post_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_board_post";
@@ -77,7 +73,6 @@ let board_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "content"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_board_list";
@@ -90,7 +85,6 @@ let board_tools : Types.tool_schema list = [
         ("sort_by", `Assoc [("type", `String "string"); ("description", `String "Sort: recent (newest), hot (score+recency), updated (most active)")]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_board_comment";
@@ -103,7 +97,6 @@ let board_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "post_id"; `String "content"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_board_vote";
@@ -116,7 +109,6 @@ let board_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "post_id"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -140,7 +132,6 @@ let filesystem_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "path"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -159,7 +150,6 @@ let shell_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "op"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -175,7 +165,6 @@ let coding_keeper_bridge_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "cmd"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_github";
@@ -188,7 +177,6 @@ let coding_keeper_bridge_tools : Types.tool_schema list = [
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -218,7 +206,6 @@ let voice_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_voice_agent";
@@ -227,7 +214,6 @@ let voice_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_voice_sessions";
@@ -236,7 +222,6 @@ let voice_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_voice_session_start";
@@ -247,7 +232,6 @@ let voice_tools : Types.tool_schema list = [
         ("session_name", `Assoc [("type", `String "string"); ("description", `String "Optional session name")]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_voice_session_end";
@@ -256,7 +240,6 @@ let voice_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]
 
@@ -270,7 +253,6 @@ let weather_tools : Types.tool_schema list = [
         ("location", `Assoc [("type", `String "string")]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -285,7 +267,6 @@ let library_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "query"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_library_read";
@@ -297,7 +278,6 @@ let library_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "topic"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -312,7 +292,6 @@ let taskboard_tools : Types.tool_schema list = [
         ("include_done", `Assoc [("type", `String "boolean"); ("description", `String "Include completed tasks (default: false)")]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_tasks_audit";
@@ -321,7 +300,6 @@ let taskboard_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_task_force_release";
@@ -334,7 +312,6 @@ let taskboard_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_task_force_done";
@@ -347,7 +324,6 @@ let taskboard_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_broadcast";
@@ -359,7 +335,6 @@ let taskboard_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "message"]);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_task_claim";
@@ -368,7 +343,6 @@ let taskboard_tools : Types.tool_schema list = [
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "keeper_task_done";
@@ -381,7 +355,6 @@ let taskboard_tools : Types.tool_schema list = [
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
 ]
 
@@ -599,7 +572,6 @@ Shards: base (core), board, filesystem, shell, governance, weather, voice, taskb
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_revoke";
@@ -619,7 +591,6 @@ Cannot revoke 'base' shard (always present).";
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tool_list";
@@ -628,7 +599,6 @@ Cannot revoke 'base' shard (always present).";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_social.ml
+++ b/lib/tool_social.ml
@@ -242,7 +242,6 @@ Pair with masc_comment_add for discussion and masc_vote for prioritization.";
       ]);
       ("required", `List [`String "content"]);
     ];
-    visibility = Public;
   };
 
   (* masc_post_list *)
@@ -264,7 +263,6 @@ Pair with masc_post_get to read a specific post with its threaded comments.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 
   (* masc_post_get *)
@@ -283,7 +281,6 @@ Pair with masc_post_list to find the post_id, then masc_comment_add to reply.";
       ]);
       ("required", `List [`String "post_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_comment_add *)
@@ -314,7 +311,6 @@ Pair with masc_post_get to read existing comments before replying.";
       ]);
       ("required", `List [`String "post_id"; `String "content"]);
     ];
-    visibility = Public;
   };
 
   (* masc_comment_list *)
@@ -333,7 +329,6 @@ Pair with masc_post_get for the threaded view, or masc_comment_add to contribute
       ]);
       ("required", `List [`String "post_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_vote *)
@@ -366,7 +361,6 @@ Pair with masc_post_list to find posts worth voting on.";
       ]);
       ("required", `List [`String "target_id"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -177,7 +177,6 @@ Requires admin privileges or room owner status.";
       ]);
       ("required", `List [`String "target_agent"; `String "reason"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_circuit_status";
@@ -194,7 +193,6 @@ Open state includes remaining cooldown time.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
 ]
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -522,7 +522,6 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
       ]);
       ("required", `List [`String "title"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_batch_add_tasks";
@@ -559,7 +558,6 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
       ]);
       ("required", `List [`String "tasks"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_task_history";
@@ -579,7 +577,6 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
       ]);
       ("required", `List [`String "task_id"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_tasks";
@@ -607,7 +604,6 @@ Tip: Look for status='todo' tasks to claim.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_archive_view";
@@ -621,7 +617,6 @@ Tip: Look for status='todo' tasks to claim.";
         ]);
       ]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_claim_next";
@@ -636,7 +631,6 @@ Tip: Look for status='todo' tasks to claim.";
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_update_priority";
@@ -657,7 +651,6 @@ Tip: Look for status='todo' tasks to claim.";
       ]);
       ("required", `List [`String "task_id"; `String "priority"]);
     ];
-    visibility = Public;
   };
 
   (* masc_transition *)
@@ -696,7 +689,6 @@ After masc_add_task or masc_claim_next; pair with masc_deliver before action='do
       ]);
       ("required", `List [`String "agent_name"; `String "task_id"; `String "action"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_team_session_schemas.ml
+++ b/lib/tool_team_session_schemas.ml
@@ -189,7 +189,6 @@ Pair with masc_team_session_step to record turns and masc_team_session_finalize 
                 ] );
             ("required", `List [ `String "goal" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_status";
@@ -205,7 +204,6 @@ After masc_team_session_start; pair with masc_team_session_events for detailed t
             );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_step";
@@ -506,7 +504,6 @@ After masc_team_session_start; the primary write path for all session activity."
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_finalize";
@@ -535,7 +532,6 @@ Alternative to calling masc_team_session_stop then masc_team_session_report sepa
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_stop";
@@ -556,7 +552,6 @@ After masc_team_session_step turns are complete; follow with masc_team_session_p
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_report";
@@ -575,7 +570,6 @@ After masc_team_session_stop; pair with masc_team_session_prove for verifiable p
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_list";
@@ -599,7 +593,6 @@ Pair with masc_team_session_compare to diff two sessions.";
                       ] );
                 ] );
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_compare";
@@ -619,7 +612,6 @@ After masc_team_session_list identifies the two session IDs.";
                 ] );
             ("required", `List [ `String "base_session_id"; `String "target_session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_events";
@@ -646,7 +638,6 @@ After masc_team_session_start; the most-called session tool for progress monitor
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_prove";
@@ -673,7 +664,6 @@ After masc_team_session_stop or masc_team_session_report.";
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_team_session_verify_trace";
@@ -693,6 +683,5 @@ After masc_team_session_prove; the final verification step in the proof chain.";
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];
-      visibility = Public;
     };
   ]

--- a/lib/tool_tempo.ml
+++ b/lib/tool_tempo.ml
@@ -63,7 +63,6 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_tempo_get *)
@@ -76,7 +75,6 @@ Pair with masc_tempo_set to change interval or masc_tempo_adjust for auto-tuning
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_tempo_set *)
@@ -99,7 +97,6 @@ Check current value with masc_tempo_get first. Use masc_tempo_reset to return to
       ]);
       ("required", `List [`String "interval_seconds"]);
     ];
-    visibility = Public;
   };
 
   (* masc_tempo_adjust *)
@@ -112,7 +109,6 @@ Pair with masc_tempo_get to see the resulting interval after adjustment.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
   (* masc_tempo *)
@@ -141,7 +137,6 @@ For finer control, use masc_tempo_set (exact interval) or masc_tempo_adjust (aut
       ]);
       ("required", `List [`String "action"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -41,7 +41,6 @@ let schemas : tool_schema list =
                 ] );
             ("required", `List [ `String "agent_id"; `String "message" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_voice_session_start";
@@ -59,7 +58,6 @@ let schemas : tool_schema list =
                 ] );
             ("required", `List [ `String "agent_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_voice_session_end";
@@ -73,14 +71,12 @@ let schemas : tool_schema list =
                 [ ("agent_id", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "agent_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_voice_sessions";
       description = "List active voice sessions. Use to check existing sessions before starting a new one or debugging.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
     {
       name = "masc_voice_agent";
@@ -94,14 +90,12 @@ let schemas : tool_schema list =
                 [ ("agent_id", `Assoc [ ("type", `String "string") ]) ] );
             ("required", `List [ `String "agent_id" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_voice_transcript";
       description = "Get the current transcript (STT output). Requires STT service integration and an active voice session.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-      visibility = Public;
     };
     {
       name = "masc_voice_conference_start";
@@ -124,7 +118,6 @@ let schemas : tool_schema list =
                 ] );
             ("required", `List [ `String "agent_ids" ]);
           ];
-      visibility = Public;
     };
     {
       name = "masc_voice_conference_end";
@@ -146,7 +139,6 @@ let schemas : tool_schema list =
                 ] );
             ("required", `List [ `String "agent_ids" ]);
           ];
-      visibility = Public;
     };
   ]
 

--- a/lib/tool_vote.ml
+++ b/lib/tool_vote.ml
@@ -134,7 +134,6 @@ Pair with masc_vote_cast to collect votes and masc_vote_status to check the resu
       ]);
       ("required", `List [`String "proposer"; `String "topic"; `String "options"]);
     ];
-    visibility = Public;
   };
 
   (* masc_vote_cast *)
@@ -161,7 +160,6 @@ After masc_vote_create; check masc_vote_status to see if quorum is reached.";
       ]);
       ("required", `List [`String "agent_name"; `String "vote_id"; `String "choice"]);
     ];
-    visibility = Public;
   };
 
   (* masc_vote_status *)
@@ -180,7 +178,6 @@ After masc_vote_create or masc_vote_cast; pair with masc_votes to list all votes
       ]);
       ("required", `List [`String "vote_id"]);
     ];
-    visibility = Public;
   };
 
   (* masc_votes *)
@@ -193,7 +190,6 @@ Pair with masc_vote_cast to participate or masc_vote_create to start a new vote.
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/tool_walph.ml
+++ b/lib/tool_walph.ml
@@ -79,7 +79,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_walph_control *)
@@ -101,7 +100,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "command"; `String "agent_name"]);
     ];
-    visibility = Public;
   };
 
   (* masc_walph_natural *)
@@ -122,7 +120,6 @@ let schemas : Types.tool_schema list = [
       ]);
       ("required", `List [`String "message"; `String "agent_name"]);
     ];
-    visibility = Public;
   };
 
 ]

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -720,23 +720,11 @@ let tool_result_to_yojson r =
   | Some d -> `Assoc (base @ [("data", d)])
   | None -> `Assoc base
 
-(** Tool visibility controls which MCP surface a tool appears on.
-    - [Public]: Visible to TUI clients (Claude Code, Codex, Gemini) and agents.
-    - [Agent_only]: Internal agent use only; filtered from MCP tools/list.
-    - [Admin]: Requires explicit admin capability at runtime.
-    - [Hidden]: Deprecated or inactive; only visible with include_hidden=true. *)
-type tool_visibility =
-  | Public
-  | Agent_only
-  | Admin
-  | Hidden
-
 (** Tool schema for MCP *)
 type tool_schema = {
   name: string;
   description: string;
   input_schema: Yojson.Safe.t;
-  visibility: tool_visibility;
 }
 
 (** Structured result for claim_next scheduling (avoids brittle string parsing).

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -18,7 +18,6 @@ let dummy_schema name : Types.tool_schema =
           ("type", `String "object");
           ("properties", `Assoc []);
         ];
-    visibility = Public;
   }
 
 let test_dedupe_schemas () =

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -20,10 +20,10 @@ let make_meta ?(policy_mode = "learned_offline_v1") () =
 let test_inject_filters_allowlist () =
   let schemas : Types.tool_schema list =
     [
-      { name = "masc_status"; description = ""; input_schema = `Assoc []; visibility = Public };
-      { name = "masc_broadcast"; description = ""; input_schema = `Assoc []; visibility = Public };
-      { name = "masc_messages"; description = ""; input_schema = `Assoc []; visibility = Public };
-      { name = "keeper_time_now"; description = ""; input_schema = `Assoc []; visibility = Public };
+      { name = "masc_status"; description = ""; input_schema = `Assoc [] };
+      { name = "masc_broadcast"; description = ""; input_schema = `Assoc [] };
+      { name = "masc_messages"; description = ""; input_schema = `Assoc [] };
+      { name = "keeper_time_now"; description = ""; input_schema = `Assoc [] };
     ]
   in
   KET.inject_masc_schemas schemas;

--- a/test/test_tool_budget.ml
+++ b/test/test_tool_budget.ml
@@ -4,7 +4,7 @@ module Tool_budget = Masc_mcp.Tool_budget
 module Tool_catalog = Masc_mcp.Tool_catalog
 
 let mk_schema name desc : Types.tool_schema =
-  { name; description = desc; input_schema = `Assoc []; visibility = Public }
+  { name; description = desc; input_schema = `Assoc [] }
 
 (* Helper: always returns 0 usage *)
 let no_usage _ = 0

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -6,8 +6,7 @@ module Types = Types
 (** Helper: create a minimal tool_schema for registration. *)
 let make_schema name =
   { Types.name; description = "test tool " ^ name;
-    input_schema = `Assoc [("type", `String "object")];
-    visibility = Public }
+    input_schema = `Assoc [("type", `String "object")] }
 
 (** Helper: a handler that returns (true, "ok:<name>"). *)
 let echo_handler ~name ~args:_ = Some (true, "ok:" ^ name)


### PR DESCRIPTION
## Summary

- PR #2810에서 추가한 `tool_visibility` 타입과 `visibility` 필드 제거
- PR #2802의 `Tool_catalog.public_mcp_tools` allowlist가 동일 문제를 더 간결하게 해결
- `visibility` 필드는 dead code (필터링에 미사용, 보일러플레이트만 증가)

## Changes

- `lib/types/types_core.ml`: `tool_visibility` type + `visibility` field 제거
- 63개 tool 모듈: `visibility = Public;` 라인 삭제
- 4개 test 파일: 스키마 생성 코드 업데이트

66 files changed, 6 insertions(+), 423 deletions(-)

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)