### PR TITLE
fix(dashboard): deliver A2A events to observer SSE sessions

### DIFF
--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -196,7 +196,10 @@ export function connectSSE(): void {
 
   es.onmessage = (e: MessageEvent) => {
     try {
-      const event = JSON.parse(e.data as string) as SSEEvent
+      const raw = JSON.parse(e.data as string)
+      // Unwrap JSON-RPC notifications: extract params as the actual event.
+      // Server wraps events as {"jsonrpc":"2.0","method":"masc/event","params":{type,agent,...}}
+      const event: SSEEvent = (raw.jsonrpc && raw.params?.type) ? raw.params : raw
       eventCount.value++
       lastEvent.value = event
       handleEvent(event)

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -590,7 +590,7 @@ let notify_event ~(event_type : event_type) ~(agent : string) ~(data : Yojson.Sa
         ("method", `String "masc/event");
         ("params", event_params);
       ] in
-      Sse.broadcast_to Coordinators mcp_notification;
+      Sse.broadcast mcp_notification;
       Log.debug ~ctx:"a2a" "Event %s from %s buffered+SSE (sub: %s)"
         (show_event_type event_type) agent sub.id
     end


### PR DESCRIPTION
## Summary

대시보드 "최근 활동" 영역이 항상 "이벤트 대기 중"으로 표시되는 버그 수정.

- **서버**: `a2a_tools.ml`에서 이벤트를 `Coordinators`에만 broadcast → `All`로 변경. Observer(대시보드) 세션도 수신 가능
- **대시보드**: `sse.ts`에서 JSON-RPC notification 래퍼(`{"jsonrpc":"2.0","params":{...}}`)를 언래핑하여 flat event 추출

## Test plan

- [ ] 대시보드 열고 agent join/broadcast/task claim 시 "최근 활동"에 이벤트 표시 확인
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)