### PR TITLE
Fix dashboard prefix scans and relax keeper turn budget

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -172,21 +172,61 @@ module FileSystemBackend : BACKEND = struct
     | Error _ -> false
     | Ok path -> Sys.file_exists path
 
+  let starts_with ~prefix value =
+    let prefix_len = String.length prefix in
+    String.length value >= prefix_len
+    && String.sub value 0 prefix_len = prefix
+
+  let normalize_prefix_for_scan prefix =
+    let len = String.length prefix in
+    if len > 0 && prefix.[len - 1] = ':' then
+      String.sub prefix 0 (len - 1)
+    else
+      prefix
+
+  let key_of_path t path =
+    let base = t.base_path ^ Filename.dir_sep in
+    if path = t.base_path then
+      Some ""
+    else if starts_with ~prefix:base path then
+      let rel =
+        String.sub path (String.length base) (String.length path - String.length base)
+      in
+      Some (String.map (function '/' -> ':' | c -> c) rel)
+    else
+      None
+
+  let rec collect_keys_under t ~requested_prefix path acc =
+    if Sys.is_directory path then
+      Sys.readdir path
+      |> Array.fold_left
+           (fun acc name ->
+             collect_keys_under t ~requested_prefix
+               (Filename.concat path name) acc)
+           acc
+    else
+      match key_of_path t path with
+      | Some key when requested_prefix = "" || starts_with ~prefix:requested_prefix key ->
+          key :: acc
+      | _ -> acc
+
   let list_keys t ~prefix =
-    match safe_key_to_path t prefix with
+    let scan_prefix = normalize_prefix_for_scan prefix in
+    let scan_root_result =
+      if scan_prefix = "" then
+        Ok t.base_path
+      else
+        safe_key_to_path t scan_prefix
+    in
+    match scan_root_result with
     | Error e -> Error e
-    | Ok prefix_path ->
-        let dir = Filename.dirname prefix_path in
-        if Sys.file_exists dir && Sys.is_directory dir then begin
-          let files = Sys.readdir dir |> Array.to_list in
-          let prefix_base = Filename.basename prefix_path in
-          let matching = List.filter (fun f ->
-            String.length f >= String.length prefix_base &&
-            String.sub f 0 (String.length prefix_base) = prefix_base
-          ) files in
-          Ok (List.map (fun f -> prefix ^ String.sub f (String.length prefix_base) (String.length f - String.length prefix_base)) matching)
-        end else
+    | Ok scan_root ->
+        if not (Sys.file_exists scan_root) then
           Ok []
+        else
+          Ok
+            (collect_keys_under t ~requested_prefix:prefix scan_root []
+             |> List.sort_uniq String.compare)
 
   let get_all t ~prefix =
     match list_keys t ~prefix with

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -184,9 +184,17 @@ module FileSystemBackend : BACKEND = struct
     else
       prefix
 
+  let strip_trailing_sep s =
+    let len = String.length s in
+    if len > 0 && s.[len - 1] = Filename.dir_sep.[0] then
+      String.sub s 0 (len - 1)
+    else
+      s
+
   let key_of_path t path =
-    let base = t.base_path ^ Filename.dir_sep in
-    if path = t.base_path then
+    let normalized = strip_trailing_sep t.base_path in
+    let base = normalized ^ Filename.dir_sep in
+    if path = normalized || path = t.base_path then
       Some ""
     else if starts_with ~prefix:base path then
       let rel =

--- a/lib/backend/backend_eio.ml
+++ b/lib/backend/backend_eio.ml
@@ -201,13 +201,14 @@ module FileSystem = struct
                collect_keys_under ~requested_prefix ~logical_prefix:child_prefix
                  Eio.Path.(path / name) acc)
              acc
-    | _ ->
+    | `Regular_file ->
         if requested_prefix = ""
            || starts_with ~prefix:requested_prefix logical_prefix
         then
           logical_prefix :: acc
         else
           acc
+    | _ -> acc
 
   let list_keys t ~prefix =
     let scan_prefix = normalize_prefix_for_scan prefix in

--- a/lib/backend/backend_eio.ml
+++ b/lib/backend/backend_eio.ml
@@ -177,19 +177,55 @@ module FileSystem = struct
     )
 
   (** List keys with prefix *)
+  let starts_with ~prefix value =
+    let prefix_len = String.length prefix in
+    String.length value >= prefix_len
+    && String.sub value 0 prefix_len = prefix
+
+  let normalize_prefix_for_scan prefix =
+    let len = String.length prefix in
+    if len > 0 && prefix.[len - 1] = ':' then
+      String.sub prefix 0 (len - 1)
+    else
+      prefix
+
+  let rec collect_keys_under ~requested_prefix ~logical_prefix path acc =
+    match Eio.Path.kind ~follow:true path with
+    | `Directory ->
+        Eio.Path.read_dir path
+        |> List.fold_left
+             (fun acc name ->
+               let child_prefix =
+                 if logical_prefix = "" then name else logical_prefix ^ ":" ^ name
+               in
+               collect_keys_under ~requested_prefix ~logical_prefix:child_prefix
+                 Eio.Path.(path / name) acc)
+             acc
+    | _ ->
+        if requested_prefix = ""
+           || starts_with ~prefix:requested_prefix logical_prefix
+        then
+          logical_prefix :: acc
+        else
+          acc
+
   let list_keys t ~prefix =
-    match key_to_path t prefix with
+    let scan_prefix = normalize_prefix_for_scan prefix in
+    let scan_root =
+      if scan_prefix = "" then
+        Ok (scan_prefix, t.fs)
+      else
+        match key_to_path t scan_prefix with
+        | Ok path -> Ok (scan_prefix, path)
+        | Error e -> Error e
+    in
+    match scan_root with
     | Error e -> Error e
-    | Ok dir_path ->
+    | Ok (logical_prefix, dir_path) ->
         try
-          let entries = Eio.Path.read_dir dir_path in
-          let keys = List.filter_map (fun name ->
-            let key = if prefix = "" then name else prefix ^ ":" ^ name in
-            match validate_key key with
-            | Ok k -> Some k
-            | Error _ -> None
-          ) entries in
-          Ok keys
+          Ok
+            (collect_keys_under ~requested_prefix:prefix ~logical_prefix dir_path []
+             |> List.sort_uniq String.compare)
         with
         | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
             Ok []  (* Directory doesn't exist = no keys *)

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -550,14 +550,15 @@ let keeper_unified_max_tokens () : int =
     ~max_v:16000
 
 (** Max agent turns (tool loops) for unified keeper turns.
-    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 12.
-    A productive keeper workflow (read -> edit -> build -> verify) needs 4-6 tool calls.
+    Env: [MASC_KEEPER_UNIFIED_MAX_TURNS]. Default: 20.
+    A productive keeper workflow (read -> inspect -> edit -> build -> verify)
+    can consume 8-12 turns once retries and board/reporting steps are included.
     Previous default (1000) caused 787s+ latency per turn.
-    At 10, multi-step turns were still hitting the ceiling after a single tool failure;
-    12 leaves one extra recovery step without reopening the old runaway latencies. *)
+    At 10, multi-step workflows still truncate too often before [extend_turns]
+    is used. *)
 let keeper_unified_max_turns () : int =
   int_of_env_default
     "MASC_KEEPER_UNIFIED_MAX_TURNS"
-    ~default:12
+    ~default:20
     ~min_v:1
     ~max_v:50

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -58,12 +58,14 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
      ## Behavior\n\
      You have tools available. Use them when appropriate.\n\
      Decide what to do based on the current world state below.\n\
+     The turn budget is limited. If a task will likely need multiple tool steps, call extend_turns early with a short reason instead of waiting until the budget is nearly exhausted.\n\
      Possible actions:\n\
      - Reply to pending mentions (use room broadcast tools)\n\
      - Work on active goals (use planning/execution tools)\n\
      - Proactive observation (post findings to board)\n\
      - Search knowledge library (keeper_library_search/read) for research references\n\
      - Do nothing if the situation warrants it (respond with brief reasoning)\n\n\
+     Prefer a single moderate extend_turns request before read/edit/build/verify style work.\n\
      When making claims or decisions, search the library first if relevant documents may exist.\n\
      Do NOT explain your decision-making process at length.\n\
      Act directly or state briefly why you chose not to act.\n";

--- a/lib/team_session/team_session_engine_helpers.ml
+++ b/lib/team_session/team_session_engine_helpers.ml
@@ -85,12 +85,14 @@ type worker_run_event_snapshot = {
   in_flight_actors : string list;
 }
 
-let worker_run_event_snapshot (config : Room.config)
+let worker_run_event_snapshot ?events (config : Room.config)
     (session : Team_session_types.session) =
   let requested = Hashtbl.create 16 in
   let completed = Hashtbl.create 16 in
   let events =
-    Team_session_store.read_events ~max_events:2000 config session.session_id
+    match events with
+    | Some rows -> rows
+    | None -> Team_session_store.read_events ~max_events:2000 config session.session_id
   in
   List.iter
     (fun json ->
@@ -165,10 +167,12 @@ let bootstrap_present_agent_names (config : Room.config)
     |> Team_session_types.dedup_strings
     |> List.sort String.compare
 
-let session_seen_and_live_agent_names (config : Room.config)
+let session_seen_and_live_agent_names ?events (config : Room.config)
     (session : Team_session_types.session) ~now =
   let events =
-    Team_session_store.read_events ~max_events:2000 config session.session_id
+    match events with
+    | Some rows -> rows
+    | None -> Team_session_store.read_events ~max_events:2000 config session.session_id
   in
   let seen_agents, live_agents =
     List.fold_left
@@ -184,7 +188,7 @@ let session_seen_and_live_agent_names (config : Room.config)
       ([], []) events
   in
   let bootstrap_agents = bootstrap_present_agent_names config session ~now in
-  let worker_runs = worker_run_event_snapshot config session in
+  let worker_runs = worker_run_event_snapshot ~events config session in
   ( (seen_agents @ bootstrap_agents)
     |> Team_session_types.dedup_strings
     |> List.sort String.compare,
@@ -192,8 +196,8 @@ let session_seen_and_live_agent_names (config : Room.config)
     |> Team_session_types.dedup_strings
     |> List.sort String.compare )
 
-let session_active_agent_names config session ~now =
-  session_seen_and_live_agent_names config session ~now |> snd
+let session_active_agent_names ?events config session ~now =
+  session_seen_and_live_agent_names ?events config session ~now |> snd
 
 let bootstrap_grace_seconds (session : Team_session_types.session) =
   float_of_int (session.checkpoint_interval_sec * max 1 session.min_agents)
@@ -263,9 +267,11 @@ let controller_tree_json_of_session (session : Team_session_types.session) =
           ("lanes", `List lanes);
         ]
 
-let controller_intervention_counts (config : Room.config) session_id =
+let controller_intervention_counts ?events (config : Room.config) session_id =
   let counts = Hashtbl.create 8 in
-  Team_session_store.read_events ~max_events:2000 config session_id
+  (match events with
+  | Some rows -> rows
+  | None -> Team_session_store.read_events ~max_events:2000 config session_id)
   |> List.iter (fun json ->
          match Yojson.Safe.Util.member "event_type" json with
          | `String
@@ -320,8 +326,12 @@ let context_pressure_by_lane_json (session : Team_session_types.session) =
   |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   |> fun fields -> `Assoc fields
 
-let lane_health_json (config : Room.config) (session : Team_session_types.session) =
-  let events = Team_session_store.read_events ~max_events:2000 config session.session_id in
+let lane_health_json ?events (config : Room.config) (session : Team_session_types.session) =
+  let events =
+    match events with
+    | Some rows -> rows
+    | None -> Team_session_store.read_events ~max_events:2000 config session.session_id
+  in
   let failed_runtime_actors =
     events
     |> List.filter_map (fun json ->
@@ -561,4 +571,3 @@ let cascade_metrics_json (session : Team_session_types.session) =
       ("success_rate", `Float success_rate);
       ("fallback_task_created", `Int (max 0 session.fallback_task_created));
     ]
-

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -17,7 +17,7 @@ let generate_and_mark_report ~(config : Room.config)
         ~event_type:"report_generation_failed"
         ~detail:(`Assoc [ ("error", `String e); ("ts_iso", `String (now_iso ())) ])
 
-let summary_json_of_session (config : Room.config)
+let summary_json_of_session ?events (config : Room.config)
     (session : Team_session_types.session) =
   let now = Time_compat.now () in
   let end_time = Option.value session.stopped_at ~default:now in
@@ -31,7 +31,7 @@ let summary_json_of_session (config : Room.config)
   in
   let deltas, done_total = done_delta_metrics config session in
   let seen_agents, active_agents =
-    session_seen_and_live_agent_names config session ~now
+    session_seen_and_live_agent_names ?events config session ~now
   in
   let planned_runtime_actors = Team_session_types.planned_worker_actor_names session in
   let planned_participants = Team_session_types.planned_participant_names session in
@@ -110,10 +110,10 @@ let summary_json_of_session (config : Room.config)
       ( "routing_reason_summary",
         `List (List.map (fun reason -> `String reason) routing_reason_summary) );
       ("controller_tree", controller_tree_json_of_session session);
-      ("lane_health", lane_health_json config session);
+      ("lane_health", lane_health_json ?events config session);
       ("confidence_heatmap", confidence_heatmap_json session);
       ("context_pressure_by_lane", context_pressure_by_lane_json session);
-      ("intervention_counters", controller_intervention_counts config session.session_id);
+      ("intervention_counters", controller_intervention_counts ?events config session.session_id);
       ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ( "last_checkpoint_at",
         Option.fold ~none:`Null ~some:(fun v -> `Float v)
@@ -178,11 +178,16 @@ let worker_run_status_json (json : Yojson.Safe.t) =
       ("ts_iso", member "ts_iso" json);
     ]
 
-let status_sections (config : Room.config) (session : Team_session_types.session) =
-  let summary = summary_json_of_session config session in
+let status_sections ?events (config : Room.config) (session : Team_session_types.session) =
+  let events =
+    match events with
+    | Some rows -> rows
+    | None -> Team_session_store.read_events ~max_events:2000 config session.session_id
+  in
+  let summary = summary_json_of_session ~events config session in
   let active_agents =
     let now = Time_compat.now () in
-    session_active_agent_names config session ~now
+    session_active_agent_names ~events config session ~now
   in
   let team_health = team_health_json session active_agents in
   let communication_metrics = communication_metrics_json session in
@@ -191,8 +196,9 @@ let status_sections (config : Room.config) (session : Team_session_types.session
   (summary, team_health, communication_metrics, orchestration_state, cascade_metrics)
 
 let session_status_json (config : Room.config) (session : Team_session_types.session) =
+  let events = Team_session_store.read_events ~max_events:2000 config session.session_id in
   let worker_run_summary =
-    let snapshot = worker_run_event_snapshot config session in
+    let snapshot = worker_run_event_snapshot ~events config session in
     let recent_runs =
       recent_worker_run_meta_jsons config session.session_id
       |> List.fold_left
@@ -232,7 +238,7 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
   in
   let summary, team_health, communication_metrics, orchestration_state,
       cascade_metrics =
-    status_sections config session
+    status_sections ~events config session
   in
   let linked_autoresearch = `Null in
   `Assoc

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -209,31 +209,91 @@ let append_event config session_id ~(event_type : string) ~(detail : Yojson.Safe
   with_file_lock config path (fun () -> append_text_file path line);
   emit_activity_event config ~session_id ~event_type ~detail
 
+let take_last n lst =
+  if n <= 0 then []
+  else
+    let total = List.length lst in
+    if total <= n then lst
+    else lst |> List.filteri (fun i _ -> i >= total - n)
+
+let parse_event_lines lines =
+  List.filter_map
+    (fun line ->
+      let trimmed = String.trim line in
+      if trimmed = "" then None
+      else
+        match Safe_ops.parse_json_safe ~context:"team_session.events" trimmed with
+        | Ok json -> Some json
+        | Error _ -> None)
+    lines
+
+let read_tail_lines path ~max_bytes ~max_lines =
+  if max_lines <= 0 || max_bytes <= 0 || not (Fs_compat.file_exists path) then
+    []
+  else
+    try
+      let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
+      Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+          let stats = Unix.fstat fd in
+          let file_size = stats.Unix.st_size in
+          if file_size <= 0 then []
+          else
+            let bytes_to_read = min file_size max_bytes in
+            let start_pos = max 0 (file_size - bytes_to_read) in
+            ignore (Unix.lseek fd start_pos Unix.SEEK_SET);
+            let buf = Bytes.create bytes_to_read in
+            let rec read_loop offset remaining =
+              if remaining <= 0 then offset
+              else
+                match Unix.read fd buf offset remaining with
+                | 0 -> offset
+                | n -> read_loop (offset + n) (remaining - n)
+            in
+            let read_len = read_loop 0 bytes_to_read in
+            if read_len <= 0 then []
+            else
+              let chunk = Bytes.sub_string buf 0 read_len in
+              let normalized =
+                if start_pos = 0 then chunk
+                else
+                  match String.index_opt chunk '\n' with
+                  | Some idx ->
+                      String.sub chunk (idx + 1) (String.length chunk - idx - 1)
+                  | None -> ""
+              in
+              normalized
+              |> String.split_on_char '\n'
+              |> List.filter (fun line -> String.trim line <> "")
+              |> take_last max_lines)
+    with
+    | Unix.Unix_error _ | Sys_error _ -> []
+
 let read_events ?max_events config session_id : Yojson.Safe.t list =
   let path = events_jsonl_path config session_id in
   if not (path_exists config path) then
     []
   else
-    (* Read-only: no lock needed. Append-only JSONL is safe for concurrent reads. *)
-    let content = Fs_compat.load_file path in
-    let all_lines = String.split_on_char '\n' content in
-    let parsed =
-      List.filter_map (fun line ->
-        let trimmed = String.trim line in
-        if trimmed = "" then None
-        else
-          match Safe_ops.parse_json_safe ~context:"team_session.events" trimmed with
-          | Ok json -> Some json
-          | Error _ -> None
-      ) all_lines
-    in
     match max_events with
     | Some n when n > 0 ->
-        let total = List.length parsed in
-        if total <= n then parsed
+        let tail_lines =
+          read_tail_lines path
+            ~max_bytes:(max 262_144 (n * 4096))
+            ~max_lines:(n * 3)
+        in
+        let tail_parsed = parse_event_lines tail_lines in
+        if List.length tail_parsed >= n then
+          take_last n tail_parsed
         else
-          parsed |> List.filteri (fun i _ -> i >= total - n)
-    | _ -> parsed
+          (* Fallback for unusually large JSON lines or sparse parseable rows. *)
+          let content = Fs_compat.load_file path in
+          let all_lines = String.split_on_char '\n' content in
+          parse_event_lines all_lines |> take_last n
+    | _ ->
+        let content = Fs_compat.load_file path in
+        let all_lines = String.split_on_char '\n' content in
+        parse_event_lines all_lines
 
 let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoint) =
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -220,6 +220,38 @@ let test_filesystem_backend_basic () =
       | Ok _ -> ()
       | Error e -> fail (Backend.show_error e))
 
+let test_filesystem_backend_recursive_prefix_get_all () =
+  let cfg = { Backend.default_config with base_path = "/tmp/masc-test-fs-prefix" } in
+  match Backend.FileSystemBackend.create cfg with
+  | Error _ -> fail "Failed to create"
+  | Ok backend ->
+      let writes =
+        [
+          ("team-sessions:ts-1:session.json", "s1");
+          ("team-sessions:ts-1:events.jsonl", "e1");
+          ("team-sessions:ts-2:session.json", "s2");
+          ("mitosis:node-1", "m1");
+        ]
+      in
+      List.iter
+        (fun (key, value) ->
+          match Backend.FileSystemBackend.set backend ~key ~value with
+          | Ok () -> ()
+          | Error e -> fail (Backend.show_error e))
+        writes;
+      (match Backend.FileSystemBackend.list_keys backend ~prefix:"team-sessions:" with
+      | Ok keys ->
+          check int "recursive session keys" 3 (List.length keys);
+          check bool "session key present" true
+            (List.mem "team-sessions:ts-1:session.json" keys)
+      | Error e -> fail (Backend.show_error e));
+      (match Backend.FileSystemBackend.get_all backend ~prefix:"team-sessions:" with
+      | Ok pairs ->
+          check int "recursive session rows" 3 (List.length pairs);
+          check bool "events row present" true
+            (List.mem ("team-sessions:ts-1:events.jsonl", "e1") pairs)
+      | Error e -> fail (Backend.show_error e))
+
 (* Test: error messages *)
 let test_error_messages () =
   check bool "ConnectionFailed" true
@@ -395,6 +427,8 @@ let () =
     "filesystem", [
       test_case "create" `Quick test_filesystem_backend_create;
       test_case "basic ops" `Quick test_filesystem_backend_basic;
+      test_case "recursive prefix get_all" `Quick
+        test_filesystem_backend_recursive_prefix_get_all;
       test_case "atomic set_if_not_exists" `Quick test_filesystem_atomic_set;
       test_case "locking" `Quick test_filesystem_locking;
     ];

--- a/test/test_backend_eio.ml
+++ b/test/test_backend_eio.ml
@@ -129,6 +129,29 @@ let test_nested_keys () =
   | Ok v -> Alcotest.(check string) "nested value matches" value v
   | Error _ -> Alcotest.fail "get nested key failed"
 
+let test_recursive_prefix_get_all () =
+  with_eio_env @@ fun backend ->
+  let writes =
+    [
+      ("team-sessions:ts-1:session.json", "s1");
+      ("team-sessions:ts-1:events.jsonl", "e1");
+      ("team-sessions:ts-2:session.json", "s2");
+      ("mitosis:node-1", "m1");
+    ]
+  in
+  List.iter
+    (fun (key, value) ->
+      match Backend_eio.FileSystem.set backend key value with
+      | Ok () -> ()
+      | Error _ -> Alcotest.fail "set for recursive prefix test failed")
+    writes;
+  match Backend_eio.FileSystem.list_keys backend ~prefix:"team-sessions:" with
+  | Ok keys ->
+      Alcotest.(check int) "recursive keys" 3 (List.length keys);
+      Alcotest.(check bool) "session key present" true
+        (List.mem "team-sessions:ts-2:session.json" keys)
+  | Error _ -> Alcotest.fail "recursive list_keys failed"
+
 (** Test set_if_not_exists *)
 let test_set_if_not_exists () =
   with_eio_env @@ fun backend ->
@@ -251,6 +274,8 @@ let () =
     "validation", [
       Alcotest.test_case "key validation" `Quick test_key_validation;
       Alcotest.test_case "nested keys" `Quick test_nested_keys;
+      Alcotest.test_case "recursive prefix get_all" `Quick
+        test_recursive_prefix_get_all;
     ];
     "atomic", [
       Alcotest.test_case "set_if_not_exists" `Quick test_set_if_not_exists;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -89,6 +89,25 @@ let test_prompt_contains_goal () =
        with Not_found -> false
      in has_goal)
 
+let test_prompt_mentions_extend_turns_guidance () =
+  let sys, _user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
+  check bool "mentions extend_turns" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward (Str.regexp_string "extend_turns") sys 0);
+         true
+       with Not_found -> false
+     in found);
+  check bool "mentions early extension guidance" true
+    (let found =
+       try
+         ignore
+           (Str.search_forward (Str.regexp_string "call extend_turns early") sys 0);
+         true
+       with Not_found -> false
+     in found)
+
 let test_prompt_omits_empty_sections () =
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:base_observation in
   check bool "no mention section" true
@@ -255,7 +274,7 @@ let test_unified_turn_runtime_defaults () =
       (KC.keeper_unified_temperature ());
     check int "unified max_tokens default" 2048
       (KC.keeper_unified_max_tokens ());
-    check int "unified max_turns default" 12
+    check int "unified max_turns default" 20
       (KC.keeper_unified_max_turns ()))))
 
 (* ---------- Metrics observation tests ---------- *)
@@ -425,6 +444,8 @@ let () =
         [
           test_case "contains identity" `Quick test_prompt_contains_identity;
           test_case "contains goal" `Quick test_prompt_contains_goal;
+          test_case "mentions extend_turns guidance" `Quick
+            test_prompt_mentions_extend_turns_guidance;
           test_case "omits empty sections" `Quick test_prompt_omits_empty_sections;
           test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
           test_case "includes goals" `Quick test_prompt_includes_goals_section;

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -238,11 +238,11 @@ let test_list_sessions_records_fallback_diagnostics () =
            ~updated_at_iso:"2026-03-24T10:00:00Z");
       ignore (Team_session_store.list_sessions ~since_unix:1.0 ~limit:1 config);
       let diagnostics = Team_session_store.session_list_diagnostics_json () in
-      Alcotest.(check string) "fallback source" "filesystem"
+      Alcotest.(check string) "fallback source" "backend_get_all"
         Yojson.Safe.Util.(diagnostics |> member "source" |> to_string);
       Alcotest.(check bool) "pg recent not attempted" false
         Yojson.Safe.Util.(diagnostics |> member "pg_recent_attempted" |> to_bool);
-      Alcotest.(check string) "fallback reason" "filesystem_scan"
+      Alcotest.(check string) "fallback reason" "pg_recent_unavailable"
         Yojson.Safe.Util.(diagnostics |> member "fallback_reason" |> to_string);
       Alcotest.(check bool) "last error mentions pg recent" true
         (String.length Yojson.Safe.Util.(diagnostics |> member "last_error" |> to_string) > 0);


### PR DESCRIPTION
## Summary
- fix filesystem backend recursive prefix scans for descendant keys such as `team-sessions:` and `mitosis:`
- reduce dashboard/operator session status overhead by tail-reading and reusing `events.jsonl`
- raise unified keeper default max turns from `10` to `20` and teach the prompt to call `extend_turns` early for multi-step work

## Testing
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-backend-prefix-scan test/test_backend.exe test/test_backend_eio.exe test/test_tool_team_session.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_backend.exe`
- `./_build/default/test/test_tool_team_session.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_backend_eio.exe` -> local `postgres backend` case failed in current env; the new `recursive prefix get_all` validation case passed before that failure

## Review Evidence
- direct `sb glm-text` review attempts on 2026-03-24 degraded into truncated reasoning-only output and one overload response; no actionable high/critical finding was produced
- `sb glm-cascade --simple` fallback failed locally with `Mcp-Session-Id header required` and fallback-chain failure
- local llama fallback at `http://127.0.0.1:8085` was attempted but did not return in a reasonable time window
