### PR TITLE
style(dashboard): tighten dashboard spacing rhythm

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -67,7 +67,7 @@ export function App() {
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
-      <header class="shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.5)] px-4 py-2.5 backdrop-blur-2xl z-10 relative">
+      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.44)] px-3 py-2 backdrop-blur-xl lg:px-4 lg:py-2.5">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
         <div class="mx-auto flex w-full max-w-[1680px] items-center justify-between gap-4 max-[860px]:flex-col max-[860px]:items-stretch">
           <div class="min-w-0">
@@ -102,13 +102,13 @@ export function App() {
         </div>
       </header>
 
-      <div class="flex flex-1 gap-3 overflow-hidden p-3 max-[1100px]:flex-col max-[1100px]:p-2">
+      <div class="flex flex-1 gap-2.5 overflow-hidden p-2.5 max-[1100px]:flex-col max-[1100px]:gap-2 max-[1100px]:p-2">
         <aside class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 
-        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(10,15,26,0.7)] backdrop-blur-xl max-[1100px]:min-h-0">
-          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-4 lg:p-5">
+        <main class="min-w-0 flex-1 overflow-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(10,15,26,0.68)] backdrop-blur-lg max-[1100px]:min-h-0">
+          <div class="mx-auto h-full max-w-[1600px] overflow-y-auto p-3 lg:p-4">
             <${DashboardMain} />
           </div>
         </main>

--- a/dashboard/src/components/common/card.ts
+++ b/dashboard/src/components/common/card.ts
@@ -9,7 +9,7 @@ import { SectionHeader } from './section-header'
 export const CARD_BASE = 'card'
 export const CARD_STANDARD = `${CARD_BASE}`
 export const CARD_LIGHT = `${CARD_BASE} !bg-transparent !backdrop-blur-none`
-export const CARD_COMPACT = `${CARD_BASE} !p-4`
+export const CARD_COMPACT = `${CARD_BASE} !p-3.5 !shadow-[0_1px_2px_rgba(0,0,0,0.14)]`
 
 type CardVariant = 'standard' | 'light' | 'compact'
 
@@ -73,19 +73,20 @@ interface ClickableCardProps {
 interface CardProps {
   title?: ComponentChildren
   class?: string
+  variant?: CardVariant
   testId?: string
   children: ComponentChildren
 }
 
-export function Card({ title, class: cx, testId, children }: CardProps) {
+export function Card({ title, class: cx, variant = 'standard', testId, children }: CardProps) {
   if (title) {
     return html`
-      <${SectionCard} label=${title} class=${cx ?? ''} variant="standard">
+      <${SectionCard} label=${title} class=${cx ?? ''} variant=${variant}>
         ${children}
       <//>
     `
   }
-  return html`<${SurfaceCard} class=${cx} testId=${testId}>${children}<//>`
+  return html`<${SurfaceCard} variant=${variant} class=${cx} testId=${testId}>${children}<//>`
 }
 
 export function ClickableCard({

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -17,11 +17,11 @@ interface FilterChipsProps<T extends string> {
 
 export function FilterChips<T extends string>({ chips, active, onChange }: FilterChipsProps<T>) {
   return html`
-    <div class="flex gap-1.5 flex-wrap">
+    <div class="flex flex-wrap gap-1.5">
       ${chips.map(chip => html`
         <button type="button"
           key=${chip.key}
-          class="px-2.5 py-1 text-[length:var(--fs-xs)] rounded-xl border cursor-pointer transition-all duration-150 ${active.value === chip.key
+          class="rounded-lg border px-2 py-1 text-[length:var(--fs-xs)] cursor-pointer transition-all duration-150 ${active.value === chip.key
             ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
             : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'}"
           onClick=${() => { active.value = chip.key; onChange?.(chip.key) }}

--- a/dashboard/src/components/common/stat-tile.ts
+++ b/dashboard/src/components/common/stat-tile.ts
@@ -26,7 +26,7 @@ const LABEL_STYLES = {
 
 export function StatTile({ label, value, hint, variant = 'default' }: StatTileProps) {
   return html`
-    <div class="flex flex-col items-center px-4 py-3 rounded-lg border ${VARIANT_STYLES[variant]}">
+    <div class="flex flex-col items-center rounded-lg border px-3.5 py-2.5 ${VARIANT_STYLES[variant]}">
       <span class="text-base font-bold tabular-nums leading-tight">${value}</span>
       <span class="text-[length:var(--fs-2xs)] tracking-wider uppercase ${LABEL_STYLES[variant]}">${label}</span>
       ${hint ? html`<span class="text-[length:var(--fs-2xs)] text-[var(--text-dim)] mt-0.5">${hint}</span>` : null}

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -19,7 +19,7 @@ export function Operations() {
   const section = currentSection()
 
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4">
       <div class="transition-opacity duration-300">
         ${section === 'governance'
           ? html`<${Governance} />`

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -91,7 +91,7 @@ export function BuildIdentityBadge() {
       </button>
       ${buildIdentityOpen.value
         ? html`
-            <div class="absolute top-[calc(100%+10px)] right-0 min-w-[300px] py-3 px-3.5 border border-solid border-[var(--card-border)] rounded-lg bg-[rgba(6,14,28,0.97)] shadow-lg grid gap-2">
+            <div class="absolute top-[calc(100%+8px)] right-0 min-w-[280px] rounded-lg border border-solid border-[var(--card-border)] bg-[rgba(6,14,28,0.96)] px-3 py-2.5 shadow-[0_10px_24px_rgba(0,0,0,0.22)] grid gap-1.5">
               <div class="flex justify-between gap-3 text-xs text-[color:var(--text-muted)]">
                 <span>릴리즈</span>
                 <strong class="text-[color:var(--text-strong)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
@@ -127,7 +127,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
 
   return html`
     <nav class="flex flex-col h-full">
-      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-3 pt-3 pb-1.5">
+      <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2.5 pt-2.5 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
             <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">Navigation</div>
@@ -143,8 +143,8 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         </button>
       </div>
 
-      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1.5' : 'px-3'} py-2">
-        <div class="flex flex-col gap-2.5">
+      <div class="flex-1 overflow-y-auto ${collapsed ? 'px-1.5' : 'px-2.5'} py-1.5">
+        <div class="flex flex-col gap-2">
           ${DASHBOARD_SURFACES.map(surface => {
             const isSurfaceActive = surface.id === currentTab
             const sections = sectionItemsForTab(surface.id)
@@ -152,7 +152,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
             if (collapsed) {
               return html`
                 <button type="button"
-                  class="flex items-center justify-center w-full rounded-xl p-2.5 cursor-pointer transition-all duration-200 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.18)] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.06)] border border-transparent'}"
+                  class="flex items-center justify-center w-full rounded-xl p-2 cursor-pointer transition-all duration-200 ${isSurfaceActive ? 'bg-[rgba(71,184,255,0.16)] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border border-[rgba(71,184,255,0.18)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                   title=${surface.label}
                 >
@@ -162,29 +162,29 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
             }
 
             return html`
-              <div class="flex flex-col gap-1.5">
+              <div class="flex flex-col gap-1">
                 <button type="button"
-                  class="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-2 text-left cursor-pointer transition-all duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.15),rgba(71,184,255,0.05))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.2)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)] border border-transparent'}"
+                  class="flex items-center gap-2.5 w-full rounded-lg px-2.5 py-1.5 text-left cursor-pointer transition-all duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[#d9f2ff] shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border border-[rgba(71,184,255,0.18)]' : 'bg-transparent text-[var(--text-strong)] hover:bg-[rgba(255,255,255,0.05)] border border-transparent'}"
                   onClick=${() => navigate(surface.defaultTab, surface.defaultParams)}
                 >
                   <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.03)] text-[14px]">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff] drop-shadow-[0_0_8px_rgba(71,184,255,0.4)]' : ''}">${surface.label}</div>
+                    <div class="text-[14px] font-medium truncate leading-none ${isSurfaceActive ? 'text-[#9ad9ff]' : ''}">${surface.label}</div>
                   </div>
                 </button>
 
                 ${sections.length > 0 ? html`
-                  <div class="flex flex-col gap-0.5 pl-11 pr-1 border-l border-[rgba(255,255,255,0.05)] ml-7">
+                  <div class="ml-7 flex flex-col gap-0.5 border-l border-[rgba(255,255,255,0.05)] pl-10 pr-1">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id
                       return html`
                         <button type="button"
-                          class="w-full rounded-lg px-3 py-2 text-left cursor-pointer text-[13px] transition-all duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.15)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] border border-[rgba(71,184,255,0.15)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)] border border-transparent'}"
+                          class="w-full rounded-lg px-2.5 py-1.5 text-left cursor-pointer text-[13px] transition-all duration-200 ${isSectionActive ? 'bg-[rgba(71,184,255,0.14)] text-[#cfeaff] font-medium shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] border border-[rgba(71,184,255,0.14)]' : 'text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.05)] hover:text-[var(--text-body)] border border-transparent'}"
                           onClick=${() => navigate(surface.id, item.params)}
                         >
-                          <div class="truncate ${isSectionActive ? 'drop-shadow-[0_0_8px_rgba(71,184,255,0.3)]' : ''}">${item.label}</div>
+                          <div class="truncate">${item.label}</div>
                         </button>
                       `
                     })}
@@ -197,7 +197,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       </div>
 
       ${!collapsed ? html`
-        <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] p-4 bg-[rgba(0,0,0,0.1)]">
+        <div class="shrink-0 border-t border-[rgba(255,255,255,0.08)] bg-[rgba(0,0,0,0.08)] p-3.5">
           <${SnapshotCard} />
         </div>
       ` : null}
@@ -252,12 +252,12 @@ function SurfaceLead() {
   const currentSection = currentSectionForRoute(route.value)
 
   return html`
-    <div class="mb-8 flex flex-wrap items-end justify-between gap-4">
+    <div class="mb-5 flex flex-wrap items-end justify-between gap-3">
       <div class="min-w-0">
-        <h2 class="text-[32px] font-bold tracking-tight text-[var(--text-strong)] flex items-center gap-3 drop-shadow-md">
+        <h2 class="flex items-center gap-2.5 text-[28px] font-bold tracking-tight text-[var(--text-strong)]">
           ${currentSection?.label ?? currentView?.label ?? '홈'}
         </h2>
-        <p class="mt-2 max-w-[700px] text-[14px] leading-relaxed text-[rgba(255,255,255,0.5)]">
+        <p class="mt-1.5 max-w-[680px] text-[13px] leading-relaxed text-[rgba(255,255,255,0.54)]">
           ${currentSection?.description ?? currentView?.description ?? '지금 필요한 신호를 가장 안정적으로 읽을 수 있는 기본 화면입니다.'}
         </p>
       </div>
@@ -282,7 +282,7 @@ export function DashboardMain() {
 
   return html`
     ${roomTruthInitializing.value ? html`
-      <div class="text-center py-[6px] px-4 bg-[rgba(230,167,0,0.12)] border-b border-solid border-b-[rgba(230,167,0,0.3)] text-[#e6a700] text-[0.8rem] shrink-0 rounded-xl mb-4">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
+      <div class="mb-3 shrink-0 rounded-xl border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-3.5 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
     <${SurfaceLead} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -34,27 +34,27 @@ export function Planning() {
   const mdalState = mdalSnapshotState.value
 
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-5">
 
       <!-- Task-based stats grid -->
-      <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-4">
-        <div class="flex flex-col gap-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+      <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
+        <div class="flex flex-col gap-1.5 rounded-xl border border-card-border bg-card/32 p-4 shadow-sm">
           <span class="text-[11px] text-text-muted tracking-widest uppercase font-semibold">전체 태스크</span>
           <span class="text-[32px] font-bold text-text-strong leading-none tabular-nums">${totalTasks}</span>
         </div>
-        <div class="flex flex-col gap-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+        <div class="flex flex-col gap-1.5 rounded-xl border border-card-border bg-card/32 p-4 shadow-sm">
           <span class="text-[11px] text-text-muted tracking-widest uppercase font-semibold">할 일</span>
           <span class="text-[32px] font-bold leading-none tabular-nums text-[#e0e0e0]">${todo.length}</span>
         </div>
-        <div class="flex flex-col gap-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+        <div class="flex flex-col gap-1.5 rounded-xl border border-card-border bg-card/32 p-4 shadow-sm">
           <span class="text-[11px] text-text-muted tracking-widest uppercase font-semibold">진행 중</span>
           <span class="text-[32px] font-bold leading-none tabular-nums text-warn">${inProgress.length}</span>
         </div>
-        <div class="flex flex-col gap-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+        <div class="flex flex-col gap-1.5 rounded-xl border border-card-border bg-card/32 p-4 shadow-sm">
           <span class="text-[11px] text-text-muted tracking-widest uppercase font-semibold">완료</span>
           <span class="text-[32px] font-bold leading-none tabular-nums text-ok">${done.length}</span>
         </div>
-        <div class="flex flex-col gap-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+        <div class="flex flex-col gap-1.5 rounded-xl border border-card-border bg-card/32 p-4 shadow-sm">
           <span class="text-[11px] text-text-muted tracking-widest uppercase font-semibold">높은 우선순위</span>
           <span class="text-[32px] font-bold leading-none tabular-nums ${highPriority > 0 ? 'text-bad' : 'text-text-muted/50'}">${highPriority}</span>
         </div>
@@ -78,12 +78,12 @@ export function Planning() {
       <${TaskBacklog} />
 
       <!-- Goals in collapsible details -->
-      <details class="overview-section-collapsible group bg-card/20 backdrop-blur-sm rounded-2xl border border-card-border/50 overflow-hidden" open=${hasGoals}>
-        <summary class="px-5 py-4 cursor-pointer flex items-center bg-card/40 hover:bg-card/60 transition-colors border-b border-transparent group-open:border-card-border/50 text-[14px] font-bold text-text-strong">
+      <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/50 bg-card/18" open=${hasGoals}>
+        <summary class="flex items-center border-b border-transparent bg-card/28 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-card/44 group-open:border-card-border/40">
           목표 파이프라인
           <span class="inline-flex items-center rounded-lg px-2.5 py-1 text-[10px] uppercase tracking-wider ml-auto bg-accent/10 text-accent border border-accent/20 shadow-sm font-semibold">${goals.value.length}</span>
         </summary>
-        <div class="p-5">
+        <div class="p-4">
           ${hasGoals ? html`
             <${GoalsSummary} />
             <${FilterBar} />
@@ -92,7 +92,7 @@ export function Planning() {
               : filteredGoals.value.length === 0
                 ? html`<${EmptyState} message="현재 필터에 맞는 목표가 없습니다" compact />`
                 : html`
-                    <div class="mt-4 flex flex-col gap-6">
+                    <div class="mt-3 flex flex-col gap-5">
                       <${HorizonGroup} horizon="short" items=${grouped.short ?? []} />
                       <${HorizonGroup} horizon="mid" items=${grouped.mid ?? []} />
                       <${HorizonGroup} horizon="long" items=${grouped.long ?? []} />
@@ -105,16 +105,16 @@ export function Planning() {
       </details>
 
       <!-- MDAL Loops in collapsible details -->
-      <details class="overview-section-collapsible group bg-card/20 backdrop-blur-sm rounded-2xl border border-card-border/50 overflow-hidden" open=${hasLoops}>
-        <summary class="px-5 py-4 cursor-pointer flex items-center bg-card/40 hover:bg-card/60 transition-colors border-b border-transparent group-open:border-card-border/50 text-[14px] font-bold text-text-strong">
+      <details class="overview-section-collapsible group overflow-hidden rounded-xl border border-card-border/50 bg-card/18" open=${hasLoops}>
+        <summary class="flex items-center border-b border-transparent bg-card/28 px-4 py-3.5 cursor-pointer text-[14px] font-bold text-text-strong transition-colors hover:bg-card/44 group-open:border-card-border/40">
           MDAL 루프
           <span class="inline-flex items-center rounded-lg px-2.5 py-1 text-[10px] uppercase tracking-wider ml-auto bg-accent/10 text-accent border border-accent/20 shadow-sm font-semibold">${loops.length}</span>
         </summary>
-        <div class="p-5">
+        <div class="p-4">
           ${mdalLoading.value && loops.length === 0
             ? html`<${LoadingState}>MDAL 루프 불러오는 중...<//>`
             : loops.length === 0 && (mdalState === 'error' || lastMdalError.value)
-              ? html`<div class="p-4 border border-bad/30 bg-bad/10 rounded-xl shadow-sm text-[13px] text-bad font-medium text-center">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
+              ? html`<div class="rounded-xl border border-bad/30 bg-bad/10 p-3.5 text-center text-[13px] font-medium text-bad shadow-sm">MDAL 스냅샷을 불러오지 못했습니다${lastMdalError.value ? `: ${lastMdalError.value}` : ''}. 백엔드 상태를 확인하세요.</div>`
               : loops.length === 0
                 ? html`<${EmptyState} message="가동 중인 루프가 없습니다. masc_mdal_start로 시작할 수 있습니다." />`
                 : html`

--- a/dashboard/src/components/governance-panels.ts
+++ b/dashboard/src/components/governance-panels.ts
@@ -43,8 +43,8 @@ export function GuardrailPane({
   const ruling = detail?.ruling
   const order = detail?.execution_order
   return html`
-    <div class="flex flex-col gap-6">
-      <${Card} title="판정 / 집행" class="section mb-2">
+    <div class="flex flex-col gap-4">
+      <${Card} title="판정 / 집행" class="section" variant="compact">
         ${!item || !detail
           ? html`<${EmptyState} message="사건을 고르면 판정과 집행 경로가 보입니다." compact />`
           : html`
@@ -59,29 +59,29 @@ export function GuardrailPane({
                   ${ruling?.generated_at ? html`<span class="px-2 py-0.5 rounded-md bg-white/5 border border-white/10"><${TimeAgo} timestamp=${ruling.generated_at} /></span>` : null}
                 </div>
                 ${ruling?.summary
-                  ? html`<div class="mt-2 mb-4 border border-accent/20 rounded-xl bg-accent/10 text-text-strong p-4 leading-relaxed text-[13px] shadow-sm">${ruling.summary}</div>`
-                  : html`<div class="mt-2 text-text-muted text-[13px] italic bg-card/40 p-4 rounded-xl border border-card-border/50 text-center">아직 판정이 생성되지 않았습니다.</div>`}
-                <div class="flex gap-2 flex-wrap mb-2">
-                  ${item.provenance ? html`<span class="inline-flex items-center px-2 py-1 rounded-lg text-[10px] font-medium border border-white/10 bg-white/5 text-text-muted shadow-sm">${item.provenance}</span>` : null}
-                  ${item.risk_class ? html`<span class="inline-flex items-center px-2 py-1 rounded-lg text-[10px] font-medium border border-bad/20 bg-bad/10 text-bad shadow-sm">${item.risk_class}</span>` : null}
-                  ${item.subject_type ? html`<span class="inline-flex items-center px-2 py-1 rounded-lg text-[10px] font-medium border border-white/10 bg-white/5 text-text-dim shadow-sm">${item.subject_type}</span>` : null}
+                  ? html`<div class="mb-3.5 mt-1.5 rounded-xl border border-accent/20 bg-accent/10 p-3.5 text-[13px] leading-relaxed text-text-strong shadow-sm">${ruling.summary}</div>`
+                  : html`<div class="mt-1.5 rounded-xl border border-card-border/50 bg-card/34 p-3.5 text-center text-[13px] italic text-text-muted">아직 판정이 생성되지 않았습니다.</div>`}
+                <div class="mb-1.5 flex flex-wrap gap-1.5">
+                  ${item.provenance ? html`<span class="inline-flex items-center rounded-lg border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-medium text-text-muted">${item.provenance}</span>` : null}
+                  ${item.risk_class ? html`<span class="inline-flex items-center rounded-lg border border-bad/20 bg-bad/10 px-2 py-0.5 text-[10px] font-medium text-bad">${item.risk_class}</span>` : null}
+                  ${item.subject_type ? html`<span class="inline-flex items-center rounded-lg border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-medium text-text-dim">${item.subject_type}</span>` : null}
                 </div>
               </div>
               
-              <div class="mt-4 pt-4 border-t border-card-border/50">
+              <div class="mt-3.5 border-t border-card-border/50 pt-3.5">
                 <${ActionRequestCard} order=${order} />
               </div>
               
               ${order?.status === 'needs_human_gate'
                 ? html`
-                    <div class="flex flex-col gap-3 mt-5 p-5 border border-warn/30 bg-warn/10 rounded-xl shadow-inner">
+                    <div class="mt-4 flex flex-col gap-3 rounded-xl border border-warn/30 bg-warn/10 p-4 shadow-inner">
                       <h4 class="text-[12px] font-bold text-warn uppercase tracking-wider">⚠️ 관리자 승인 대기</h4>
                       <div class="text-text-strong text-[13px] leading-relaxed">이 집행 명령은 고위험 작업으로 분류되어 승인이 필요합니다.</div>
-                      <div class="flex gap-3 mt-2">
-                        <button type="button" class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-ok/30 bg-ok/20 text-ok hover:bg-ok/30" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
+                      <div class="mt-1.5 flex gap-2.5">
+                        <button type="button" class="rounded-xl border border-ok/30 bg-ok/20 px-4 py-2 text-[13px] font-semibold text-ok transition-all duration-200 hover:bg-ok/30 disabled:opacity-50 shadow-sm shadow-black/15" onClick=${() => respondToExecutionOrder('confirm')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '명령 승인'}
                         </button>
-                        <button type="button" class="px-5 py-2.5 rounded-xl text-[13px] font-semibold transition-all duration-200 shadow-sm shadow-black/20 disabled:opacity-50 border border-bad/30 bg-bad/20 text-bad hover:bg-bad/30" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
+                        <button type="button" class="rounded-xl border border-bad/30 bg-bad/20 px-4 py-2 text-[13px] font-semibold text-bad transition-all duration-200 hover:bg-bad/30 disabled:opacity-50 shadow-sm shadow-black/15" onClick=${() => respondToExecutionOrder('deny')} disabled=${governanceActing.value}>
                           ${governanceActing.value ? '처리 중...' : '집행 거부'}
                         </button>
                       </div>
@@ -91,15 +91,15 @@ export function GuardrailPane({
             `}
       <//>
       
-      <${Card} title="심의 의견 제출" class="section mb-4">
+      <${Card} title="심의 의견 제출" class="section" variant="compact">
         ${!item
           ? html`<${EmptyState} message="사건을 선택한 뒤 의견을 추가하세요." compact />`
           : html`
               <div class="flex flex-col gap-4">
-                <div class="flex flex-wrap gap-2 p-1.5 bg-card/40 backdrop-blur-md rounded-xl border border-card-border/50 w-fit">
+                <div class="flex w-fit flex-wrap gap-1.5 rounded-xl border border-card-border/50 bg-card/32 p-1">
                   ${(['support', 'oppose', 'neutral'] as const).map(stance => html`
                     <button type="button"
-                      class="px-4 py-2 rounded-lg text-[12px] font-bold transition-all duration-200 border cursor-pointer
+                      class="rounded-lg border px-3 py-1.5 text-[12px] font-bold cursor-pointer transition-all duration-200
                         ${governanceBriefStance.value === stance
                           ? 'bg-accent/20 text-accent border-accent/30 shadow-sm'
                           : 'bg-transparent text-text-muted border-transparent hover:bg-white/5 hover:text-text-body'
@@ -147,7 +147,7 @@ export function ActionRequestCard({ order }: { order: GovernanceExecutionOrder |
       </div>
       ${request.target_type ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">대상 ${request.target_type}${request.target_id ? `:${request.target_id}` : ''}</div>` : null}
       ${request.reason ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">${request.reason}</div>` : null}
-      ${request.payload_preview ? html`<pre class="whitespace-pre-wrap border border-[var(--card-border)] rounded-[9px] bg-[rgba(0,0,0,0.28)] text-[#d3e3ff] p-3 text-[13px] leading-[1.5] font-mono mt-0 text-[11px] max-h-[180px] overflow-auto">${serializePreview(request.payload_preview)}</pre>` : null}
+      ${request.payload_preview ? html`<pre class="mt-0 max-h-[180px] overflow-auto whitespace-pre-wrap rounded-[9px] border border-[var(--card-border)] bg-[rgba(0,0,0,0.26)] p-2.5 text-[11px] leading-[1.5] text-[#d3e3ff] font-mono">${serializePreview(request.payload_preview)}</pre>` : null}
       ${order.execution_ref ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">결과 참조 ${order.execution_ref}</div>` : null}
       ${order.result_summary ? html`<div class="text-[#c8daf7] text-[13px] leading-[1.45]">${order.result_summary}</div>` : null}
     </div>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -46,7 +46,7 @@ function GovernanceSummaryStrip() {
 
   return html`
     ${isStale ? html`
-      <div class="mb-4 p-4 rounded-xl border border-warn/30 bg-warn/10 text-[13px] text-warn font-medium shadow-sm flex items-center gap-3">
+      <div class="mb-3.5 flex items-center gap-3 rounded-xl border border-warn/30 bg-warn/10 p-3.5 text-[13px] font-medium text-warn shadow-sm">
         <span class="text-lg">⚠️</span>
         <div>
           모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
@@ -55,14 +55,14 @@ function GovernanceSummaryStrip() {
         </div>
       </div>
     ` : null}
-    <div class="flex items-center justify-between mb-3 px-1">
+    <div class="mb-2.5 flex items-center justify-between px-0.5">
       <div class="flex items-center gap-3">
         <h2 class="text-lg font-bold text-text-strong tracking-wide">Governance</h2>
-        <span class="text-[11px] font-medium px-2.5 py-1 bg-white/5 rounded-md text-text-muted border border-white/5 shadow-inner">진행 중 ${itemCount}건 / 활동 ${activityCount}건</span>
+        <span class="rounded-md border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-muted">진행 중 ${itemCount}건 / 활동 ${activityCount}건</span>
       </div>
       ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}
     </div>
-    <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-4 mb-6">
+    <div class="mb-5 grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
       <${KpiCard} label="열린 케이스" value=${summary?.cases_open ?? itemCount} />
       <${KpiCard} label="판정 대기" value=${summary?.pending_ruling ?? 0} />
       <${KpiCard} label="자동집행 준비" value=${summary?.ready_auto_execute ?? 0} />
@@ -74,12 +74,12 @@ function GovernanceSummaryStrip() {
 
 function GovernanceToolbar() {
   return html`
-    <div class="mb-6">
-      <${Card} title="청원 콘솔">
-        <div class="flex flex-col gap-4 mt-2">
+    <div class="mb-5">
+      <${Card} title="청원 콘솔" variant="compact">
+        <div class="mt-1.5 flex flex-col gap-3.5">
           <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-3 items-center">
             <input
-              class="w-full py-2.5 px-4 rounded-xl bg-card/60 backdrop-blur-md border border-card-border text-text-strong text-[13px] font-sans placeholder:text-text-dim focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner"
+              class="w-full rounded-xl border border-card-border bg-card/48 px-3.5 py-2 text-[13px] font-sans text-text-strong placeholder:text-text-dim transition-all duration-200 focus:border-accent/50 focus:outline-none focus:ring-1 focus:ring-accent/50"
               type="text"
               placeholder="청원 제목을 입력하세요..."
               value=${governanceTopicInput.value}
@@ -92,10 +92,10 @@ function GovernanceToolbar() {
               disabled=${governanceStarting.value}
             />
             <button type="button"
-              class="px-5 py-2.5 rounded-xl text-[13px] font-semibold border transition-all duration-200 cursor-pointer shadow-sm
+              class="rounded-xl border px-4 py-2 text-[13px] font-semibold cursor-pointer transition-all duration-200
                 ${governanceStarting.value || governanceTopicInput.value.trim() === ''
                   ? 'bg-card/40 text-text-muted border-card-border opacity-50 cursor-not-allowed'
-                  : 'bg-accent/10 text-accent border-accent/20 hover:bg-accent/20 hover:shadow-md'
+                  : 'bg-accent/10 text-accent border-accent/20 hover:bg-accent/18'
                 }"
               onClick=${submitPetition}
               disabled=${governanceStarting.value || governanceTopicInput.value.trim() === ''}
@@ -103,7 +103,7 @@ function GovernanceToolbar() {
               ${governanceStarting.value ? '접수 중...' : '청원 접수'}
             </button>
             <button type="button"
-              class="px-4 py-2.5 rounded-xl text-[13px] font-semibold border border-transparent bg-white/5 text-text-muted hover:bg-white/10 hover:text-text-strong transition-all duration-200 cursor-pointer shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              class="rounded-xl border border-transparent bg-white/5 px-3.5 py-2 text-[13px] font-semibold text-text-muted transition-all duration-200 cursor-pointer hover:bg-white/10 hover:text-text-strong disabled:cursor-not-allowed disabled:opacity-50"
             onClick=${refreshGovernance}
             disabled=${governanceLoading.value}
           >
@@ -121,7 +121,7 @@ function GovernanceToolbar() {
           active=${governanceFilter}
           onChange=${() => { void refreshGovernance() }}
         />
-        ${governanceError.value ? html`<div class="mt-2 p-2.5 rounded-lg border border-[rgba(239,68,68,0.35)] bg-[var(--bad-8)] text-[#f7b6b6] text-[12px]">${governanceError.value}</div>` : null}
+        ${governanceError.value ? html`<div class="mt-2 rounded-lg border border-[rgba(239,68,68,0.35)] bg-[var(--bad-8)] p-2.5 text-[12px] text-[#f7b6b6]">${governanceError.value}</div>` : null}
       </div>
     <//>
   `
@@ -130,7 +130,7 @@ function GovernanceToolbar() {
 function DecisionInbox() {
   const items = filteredItemsByFilter(governanceFilter.value, governanceData.value?.items ?? [])
   return html`
-    <${Card} title="사건 수신함" class="section mb-6">
+    <${Card} title="사건 수신함" class="section mb-5" variant="compact">
       <div class="flex flex-col gap-3 governance-inbox">
         ${items.length === 0
           ? html`<${EmptyState} message="이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요." />`
@@ -138,39 +138,39 @@ function DecisionInbox() {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`
                 <button type="button"
-                  class="w-full text-left flex gap-4 p-5 rounded-2xl border cursor-pointer transition-all duration-200 shadow-sm shadow-black/10 group hover:-translate-y-0.5 hover:shadow-md
+                  class="group flex w-full gap-3 rounded-xl border p-4 text-left cursor-pointer transition-all duration-200 shadow-sm shadow-black/8 hover:-translate-y-0.5 hover:shadow-md
                     ${selected
-                      ? 'border-accent/40 bg-accent/10 shadow-[0_0_15px_rgba(71,184,255,0.15)]'
-                      : 'border-card-border bg-card/40 backdrop-blur-md hover:border-accent/30 hover:bg-card/60'
+                      ? 'border-accent/40 bg-accent/10 shadow-[0_0_12px_rgba(71,184,255,0.12)]'
+                      : 'border-card-border bg-card/34 hover:border-accent/30 hover:bg-card/52'
                     }"
                   onClick=${() => selectDecision(item)}
                 >
                   <div class="min-w-0 flex-1">
-                    <div class="flex items-center gap-3 min-w-0 mb-2">
-                      <span class="inline-flex items-center px-2.5 py-1 rounded-lg text-[10px] font-bold bg-accent/10 text-accent border border-accent/20 shadow-sm">${kindLabel(item.kind)}</span>
+                    <div class="mb-1.5 flex min-w-0 items-center gap-2.5">
+                      <span class="inline-flex items-center rounded-lg border border-accent/20 bg-accent/10 px-2 py-0.5 text-[10px] font-bold text-accent">${kindLabel(item.kind)}</span>
                       <span class="text-[15px] font-bold text-text-strong break-words group-hover:text-accent transition-colors leading-tight tracking-wide">${item.topic}</span>
                     </div>
-                    <div class="mt-2 flex flex-wrap gap-3 text-[12px] text-text-muted/90 font-medium">
+                    <div class="mt-1.5 flex flex-wrap gap-2.5 text-[12px] text-text-muted/90 font-medium">
                       <span class="leading-relaxed opacity-90">${item.truth_summary || '사실 요약이 아직 없습니다'}</span>
                       ${item.last_activity_at
                         ? html`<span class="text-text-dim flex items-center gap-1.5"><span class="w-1 h-1 rounded-full bg-text-dim/50"></span><${TimeAgo} timestamp=${item.last_activity_at} /></span>`
                         : null}
                     </div>
-                    <div class="flex gap-2 flex-wrap mt-3.5">
-                      ${item.origin ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium border border-white/10 bg-white/5 text-text-muted shadow-sm">${item.origin}</span>` : null}
-                      ${item.risk_class ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium border border-bad/20 bg-bad/10 text-bad shadow-sm">${item.risk_class}</span>` : null}
-                      ${item.provenance ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-medium border border-white/10 bg-white/5 text-text-muted shadow-sm">${item.provenance}</span>` : null}
+                    <div class="mt-3 flex flex-wrap gap-1.5">
+                      ${item.origin ? html`<span class="inline-flex items-center rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-medium text-text-muted">${item.origin}</span>` : null}
+                      ${item.risk_class ? html`<span class="inline-flex items-center rounded-md border border-bad/20 bg-bad/10 px-2 py-0.5 text-[10px] font-medium text-bad">${item.risk_class}</span>` : null}
+                      ${item.provenance ? html`<span class="inline-flex items-center rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-medium text-text-muted">${item.provenance}</span>` : null}
                       ${item.status === 'needs_human_gate'
-                        ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold border border-warn/30 bg-warn/20 text-warn shadow-sm animate-pulse">승인 대기</span>`
+                        ? html`<span class="inline-flex items-center rounded-md border border-warn/30 bg-warn/20 px-2 py-0.5 text-[10px] font-bold text-warn animate-pulse">승인 대기</span>`
                         : null}
                       ${item.status === 'executed'
-                        ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold border border-ok/30 bg-ok/10 text-ok shadow-sm">집행 완료</span>`
+                        ? html`<span class="inline-flex items-center rounded-md border border-ok/30 bg-ok/10 px-2 py-0.5 text-[10px] font-bold text-ok">집행 완료</span>`
                         : null}
                     </div>
                   </div>
                   <div class="flex flex-col items-end justify-between flex-shrink-0 pt-0.5">
-                    <span class="inline-flex items-center px-3 py-1 rounded-full text-[11px] font-bold border shadow-sm ${governanceToneClass(item.status)}">${caseStatusLabel(item.status)}</span>
-                    <span class="text-[11px] font-medium text-text-dim px-2 py-1 bg-white/5 rounded-md border border-white/5 mt-auto">의견 ${item.brief_count ?? 0}</span>
+                    <span class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-bold ${governanceToneClass(item.status)}">${caseStatusLabel(item.status)}</span>
+                    <span class="mt-auto rounded-md border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-dim">의견 ${item.brief_count ?? 0}</span>
                   </div>
                 </button>
               `
@@ -186,7 +186,7 @@ export function Governance() {
   }, [])
 
   return html`
-    <div class="flex flex-col gap-1">
+    <div class="flex flex-col gap-0.5">
       <${GovernanceSummaryStrip} />
       <${GovernanceToolbar} />
       <div class="governance-layout">

--- a/dashboard/src/components/lab-unified.ts
+++ b/dashboard/src/components/lab-unified.ts
@@ -6,7 +6,7 @@ import { Lab } from './lab'
 
 export function LabSurface() {
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4">
       <div class="transition-opacity duration-300">
         <${Lab} />
       </div>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -70,7 +70,7 @@ function HomeSectionHeader({
   onLink?: () => void
 }) {
   return html`
-    <div class="flex items-center justify-between mb-3">
+    <div class="mb-2.5 flex items-center justify-between">
       <div class="flex items-center gap-2">
         <span class="text-xs font-semibold text-[var(--text-strong)] uppercase tracking-wider">${label}</span>
         ${count != null ? html`<${CountBadge}>${count}<//>` : null}
@@ -90,25 +90,25 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
 
   return html`
     <div
-      class="p-5 rounded-2xl border bg-card/60 backdrop-blur-md cursor-pointer transition-all duration-200 shadow-sm shadow-black/10 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/50' : 'border-card-border hover:border-accent/40'}"
+      class="rounded-xl border bg-card/55 p-4 cursor-pointer transition-all duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
       key=${s.session_id}
       onClick=${() => navigate('status', { section: 'sessions', session_id: s.session_id })}
     >
-      <div class="flex items-start gap-3 mb-3">
+      <div class="mb-2.5 flex items-start gap-3">
         <span class="w-2.5 h-2.5 rounded-full shrink-0 mt-1 shadow-[0_0_8px_rgba(0,0,0,0.5)] ${statusDotColor(s.status)}"></span>
         <div class="min-w-0 flex-1">
           <div class="text-[14px] font-bold text-text-strong leading-snug truncate group-hover:text-accent transition-colors">${primary}</div>
           ${secondary ? html`<div class="text-[12px] text-text-muted mt-1 truncate">${secondary}</div>` : null}
         </div>
       </div>
-      <div class="flex items-center gap-4 text-[11px] text-text-muted/90 pl-6 font-medium">
+      <div class="flex items-center gap-3 text-[11px] text-text-muted/90 pl-5 font-medium">
         ${creator ? html`<span>${systemSession ? '시스템' : creator}</span>` : null}
         ${s.status ? html`<span>${statusLabel(s.status)}</span>` : null}
         ${s.elapsed_sec ? html`<span>${formatDuration(s.elapsed_sec)}</span>` : null}
         ${s.member_names?.length ? html`<span>${s.member_names.length}명</span>` : null}
       </div>
       ${hasBlocker ? html`
-        <div class="text-[11px] font-medium text-bad-light mt-4 pl-6 truncate bg-bad/10 py-1.5 px-3 rounded-lg border border-bad/20">${s.blocker_summary}</div>
+        <div class="mt-3 truncate rounded-lg border border-bad/20 bg-bad/10 px-3 py-1.5 pl-5 text-[11px] font-medium text-bad-light">${s.blocker_summary}</div>
       ` : null}
     </div>
   `
@@ -139,7 +139,7 @@ function HotSessions() {
         onLink=${() => navigate('status', { section: 'sessions' })}
       />
       ${userSessions.length > 0
-        ? html`<div class="grid grid-cols-2 max-[960px]:grid-cols-1 gap-3">${userSessions.map(renderSessionCard)}</div>`
+        ? html`<div class="grid grid-cols-2 gap-3 max-[960px]:grid-cols-1">${userSessions.map(renderSessionCard)}</div>`
         : html`<div class="text-xs text-[var(--text-muted)] py-6 text-center">활성 세션 없음</div>`}
     </div>
   `
@@ -166,10 +166,10 @@ function AgentPulse() {
         linkLabel="전체 보기 ->"
         onLink=${() => navigate('status', { section: 'agents' })}
       />
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
         ${agents.map((a: ObservatoryAgent) => html`
           <div
-            class="flex items-start gap-4 p-5 rounded-2xl border border-card-border bg-card/60 backdrop-blur-md cursor-pointer transition-all duration-200 shadow-sm shadow-black/10 hover:shadow-md hover:bg-card hover:-translate-y-0.5 hover:border-accent/40 group"
+            class="flex items-start gap-3 p-4 rounded-xl border border-card-border bg-card/55 cursor-pointer transition-all duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 hover:border-accent/32 group"
             key=${a.name}
             onClick=${() => navigate('status', { section: 'agents', agent: a.name })}
           >
@@ -182,7 +182,7 @@ function AgentPulse() {
               ${a.koreanName && a.koreanName !== a.name ? html`
                 <span class="text-[11px] text-text-dim font-mono leading-none tracking-wide">${a.name}</span>
               ` : null}
-              <span class="text-[12px] text-text-muted/90 leading-relaxed font-medium mt-0.5" style="display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden">
+              <span class="mt-0.5 text-[12px] font-medium leading-relaxed text-text-muted/90" style="display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden">
                 ${a.focus ?? a.currentTask ?? a.status}
               </span>
             </div>
@@ -200,23 +200,23 @@ export function Overview() {
   const roomHealth = snap?.summary?.room_health ?? null
 
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-5">
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
       <${AttentionSpotlight} snap=${snap} />
 
-      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
         <${HotSessions} />
       </div>
 
-      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
         <${AgentPulse} />
       </div>
 
-      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
         <${TransportHealthPanel} />
       </div>
 
-      <div class="p-6 rounded-xl border border-card-border/50 bg-card/30 backdrop-blur-xl shadow-lg shadow-black/10">
+      <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
         <${HomeSectionHeader} label="최근 활동" />
         <${NarrativeTimeline} entries=${journal} maxItems=${8} />
       </div>

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -19,7 +19,7 @@ export function Status() {
   const section = currentSection()
 
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4">
       <div class="transition-opacity duration-300">
         ${section === 'agents'
           ? html`<${AgentsUnified} />`

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -21,7 +21,7 @@ export function Work() {
     : 'board'
 
   return html`
-    <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4">
       <div class="transition-opacity duration-300">
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -43,7 +43,7 @@ export function Worktrees() {
   }
 
   if (error) {
-    return html`<div class="text-bad p-4 border border-bad/30 rounded-xl bg-bad/10 shadow-sm shadow-bad/5">${error}</div>`
+    return html`<div class="rounded-xl border border-bad/30 bg-bad/10 p-3.5 text-bad shadow-sm shadow-bad/5">${error}</div>`
   }
 
   if (!worktrees || worktrees.length === 0) {
@@ -55,43 +55,43 @@ export function Worktrees() {
   // Check if it's the raw text fallback
   if (worktrees.length === 1 && worktrees[0]?.id === 'raw') {
     return html`
-      <div class="bg-card/40 backdrop-blur-md border border-card-border rounded-2xl p-5 shadow-sm shadow-black/10">
+      <div class="rounded-xl border border-card-border bg-card/34 p-4 shadow-sm shadow-black/8">
         <pre class="font-mono text-sm text-text-body whitespace-pre-wrap">${worktrees[0]?.path}</pre>
       </div>
     `
   }
 
   return html`
-    <div class="grid gap-5">
+    <div class="grid gap-4">
       <div class="flex items-center justify-end">
-        <span class="text-xs font-medium px-2.5 py-1 bg-white/10 rounded-full text-text-muted border border-white/5">${worktrees.length}개</span>
+        <span class="rounded-full border border-white/5 bg-white/10 px-2.5 py-0.5 text-xs font-medium text-text-muted">${worktrees.length}개</span>
       </div>
       
-      <div class="grid gap-4 grid-cols-1 lg:grid-cols-2">
+      <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
         ${worktrees.map(wt => html`
-          <div key=${wt.id || wt.branch} class="flex flex-col gap-3 p-5 rounded-2xl border border-card-border bg-card/60 backdrop-blur-md hover:border-accent/40 hover:-translate-y-0.5 hover:shadow-md transition-all duration-200 shadow-sm shadow-black/10 group">
+          <div key=${wt.id || wt.branch} class="group flex flex-col gap-2.5 rounded-xl border border-card-border bg-card/55 p-4 shadow-sm shadow-black/8 transition-all duration-200 hover:-translate-y-0.5 hover:border-accent/32 hover:shadow-md">
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3">
-                <div class="size-7 rounded-lg bg-accent/10 flex items-center justify-center border border-accent/20">
+                <div class="flex size-6.5 items-center justify-center rounded-lg border border-accent/20 bg-accent/10">
                   <span class="text-[14px]">🌿</span>
                 </div>
                 <span class="font-semibold text-[14px] text-text-strong truncate group-hover:text-accent transition-colors" title=${wt.branch}>${wt.branch}</span>
               </div>
-              ${wt.agent ? html`<span class="text-[10px] font-medium px-2.5 py-1 rounded-md bg-accent/10 text-accent border border-accent/20 shadow-sm">${wt.agent}</span>` : null}
+              ${wt.agent ? html`<span class="rounded-md border border-accent/20 bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-accent">${wt.agent}</span>` : null}
             </div>
             
-            <div class="text-[11px] text-text-muted/90 flex items-center gap-2 font-mono mt-1 bg-bg-0/50 p-2 rounded-lg border border-white/5">
+            <div class="mt-0.5 flex items-center gap-2 rounded-lg border border-white/5 bg-bg-0/45 px-2.5 py-1.5 font-mono text-[11px] text-text-muted/90">
               <span>📁</span> <span class="truncate" title=${wt.path}>${wt.path}</span>
             </div>
             
             ${wt.task_id ? html`
-              <div class="text-[11px] font-medium text-text-muted flex items-center gap-2 mt-1 px-1">
+              <div class="mt-0.5 flex items-center gap-2 px-0.5 text-[11px] font-medium text-text-muted">
                 <span>📋</span> <span>${wt.task_id}</span>
               </div>
             ` : null}
             
             ${wt.created_at ? html`
-              <div class="text-[10px] text-text-dim mt-2 pt-3 border-t border-card-border/50 flex justify-between">
+              <div class="mt-1.5 flex justify-between border-t border-card-border/50 pt-2.5 text-[10px] text-text-dim">
                 <span>생성됨</span>
                 <span>${new Date(wt.created_at).toLocaleString()}</span>
               </div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -268,16 +268,16 @@ a:hover {
   background: var(--card);
   border: 1px solid var(--card-border);
   border-radius: 12px;
-  padding: 16px;
+  padding: 14px;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.18),
-    0 4px 12px rgba(0, 0, 0, 0.10);
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 3px 10px rgba(0, 0, 0, 0.08);
   transition: border-color 0.15s, box-shadow 0.15s;
   &:hover { border-color: var(--border-slate-22); }
 }
 
 @utility card-title-row {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 @utility card-title {
@@ -286,7 +286,7 @@ a:hover {
   color: var(--text-strong);
   letter-spacing: -0.01em;
   line-height: 1.3;
-  padding-bottom: 8px;
+  padding-bottom: 6px;
   border-bottom: 1px solid var(--border-slate-12);
 }
 
@@ -315,9 +315,9 @@ a:hover {
   color: var(--text-strong);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding-bottom: 8px;
+  padding-bottom: 6px;
   border-bottom: 1px solid var(--border-slate-12);
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 /* ── Status Badge base ─────────────────────────────────────── */

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -106,6 +106,12 @@ extract_text() {
 }
 
 # Extract .result from MCP tool response content.
+# Usage: echo "$response" | extract_text
+extract_text() {
+  jq -r 'if ._harness_error? then empty else try (.result.content[0].text) catch empty end'
+}
+
+# Extract .result from MCP tool response content.
 # Usage: echo "$response" | extract_result
 extract_result() {
   jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'


### PR DESCRIPTION
## Summary
- tighten the dashboard shell gutters and section lead spacing
- reduce repeated card padding and dial back neutral blur/shadow treatments
- compact overview, planning, governance, and worktrees surfaces without changing routes or data flow

## Verification
- npm run typecheck
- npm test
- npm run build