### PR TITLE
Add WS/WebRTC transport MCP tools

### DIFF
--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -739,10 +739,10 @@ sequenceDiagram
 | 환경변수 | 기본값 | 설명 |
 |---------|--------|------|
 | `MASC_USE_H2` | 0 | HTTP/2 h2c 활성화 |
-| `MASC_WS_ENABLED` | 0 | WebSocket 활성화 |
+| `MASC_WS_ENABLED` | 1 | WebSocket 활성화 (`0`으로 비활성화) |
 | `MASC_GRPC_ENABLED` | 0 | gRPC 활성화 |
 | `MASC_GRPC_PORT` | 8936 | gRPC 포트 |
-| `MASC_WEBRTC_ENABLED` | 0 | WebRTC 활성화 |
+| `MASC_WEBRTC_ENABLED` | 1 | WebRTC 활성화 (`0`으로 비활성화) |
 | `MASC_AGENT_TRANSPORT` | `local` | 에이전트 측 트랜스포트 선택 |
 
 ### 15.3 인증 설정

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -251,6 +251,7 @@ let permission_for_tool = function
   | "masc_join" -> Some CanJoin
   | "masc_leave" -> Some CanLeave
   | "masc_status" | "masc_who" | "masc_tasks" | "masc_messages"
+  | "masc_transport_status" | "masc_websocket_discovery"
   | "masc_agents" | "masc_portal_status" | "masc_pending_interrupts"
   | "masc_votes" | "masc_vote_status" | "masc_worktree_list"
   | "masc_cost_report" | "masc_task_history" | "masc_operator_snapshot"
@@ -281,6 +282,7 @@ let permission_for_tool = function
   | "masc_keeper_eval_replay" ->
       Some CanReadState
   | "masc_broadcast" | "masc_listen" | "masc_heartbeat"
+  | "masc_webrtc_offer" | "masc_webrtc_answer"
   | "masc_register_capabilities" | "masc_find_by_capability"
   | "masc_agent_update" | "masc_operator_action"
   | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_msg"

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -72,6 +72,7 @@ let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
 let read_only_tools =
   ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
    "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
+   "masc_transport_status"; "masc_websocket_discovery";
    "masc_worktree_list"; "masc_pending_interrupts";
    "masc_cost_report"; "masc_portal_status";
    "masc_verify_handoff"; "masc_tool_help";

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -164,6 +164,34 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd body ~extra_headers:cors
 
+      | `POST, "/webrtc/offer" ->
+          if not (Server_webrtc_transport.is_enabled ()) then
+            h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
+              ~status:`Not_found ~extra_headers:cors
+          else
+            h2_read_body h2_reqd (fun body_str ->
+              match Server_webrtc_transport.handle_offer_request body_str with
+              | Ok body ->
+                  h2_respond_json h2_reqd body ~extra_headers:cors
+              | Error msg ->
+                  h2_respond_json h2_reqd
+                    (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                    ~status:`Bad_request ~extra_headers:cors)
+
+      | `POST, "/webrtc/answer" ->
+          if not (Server_webrtc_transport.is_enabled ()) then
+            h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
+              ~status:`Not_found ~extra_headers:cors
+          else
+            h2_read_body h2_reqd (fun body_str ->
+              match Server_webrtc_transport.handle_answer_request body_str with
+              | Ok body ->
+                  h2_respond_json h2_reqd body ~extra_headers:cors
+              | Error msg ->
+                  h2_respond_json h2_reqd
+                    (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                    ~status:`Bad_request ~extra_headers:cors)
+
       | `GET, "/metrics" ->
           let body = Prometheus.to_prometheus_text () in
           let headers = H2.Headers.of_list ([

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -168,9 +168,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           if not (Server_webrtc_transport.is_enabled ()) then
             h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
               ~status:`Not_found ~extra_headers:cors
-          else
+          else (
             let state = get_server_state () in
-            match authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request with
+            match
+              authorize_tool_request
+                ~base_path:state.Mcp_server.room_config.base_path
+                ~tool_name:"masc_webrtc_offer"
+                httpun_request
+            with
             | Error err ->
                 let status = http_status_of_auth_error err in
                 h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -182,15 +187,20 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                   | Error msg ->
                       h2_respond_json h2_reqd
                         (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
-                        ~status:`Bad_request ~extra_headers:cors)
+                        ~status:`Bad_request ~extra_headers:cors))
 
       | `POST, "/webrtc/answer" ->
           if not (Server_webrtc_transport.is_enabled ()) then
             h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
               ~status:`Not_found ~extra_headers:cors
-          else
+          else (
             let state = get_server_state () in
-            match authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request with
+            match
+              authorize_tool_request
+                ~base_path:state.Mcp_server.room_config.base_path
+                ~tool_name:"masc_webrtc_answer"
+                httpun_request
+            with
             | Error err ->
                 let status = http_status_of_auth_error err in
                 h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -202,7 +212,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                   | Error msg ->
                       h2_respond_json h2_reqd
                         (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
-                        ~status:`Bad_request ~extra_headers:cors)
+                        ~status:`Bad_request ~extra_headers:cors))
 
       | `GET, "/metrics" ->
           let body = Prometheus.to_prometheus_text () in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -169,28 +169,40 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
               ~status:`Not_found ~extra_headers:cors
           else
-            h2_read_body h2_reqd (fun body_str ->
-              match Server_webrtc_transport.handle_offer_request body_str with
-              | Ok body ->
-                  h2_respond_json h2_reqd body ~extra_headers:cors
-              | Error msg ->
-                  h2_respond_json h2_reqd
-                    (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
-                    ~status:`Bad_request ~extra_headers:cors)
+            let state = get_server_state () in
+            match authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request with
+            | Error err ->
+                let status = http_status_of_auth_error err in
+                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+            | Ok () ->
+                h2_read_body h2_reqd (fun body_str ->
+                  match Server_webrtc_transport.handle_offer_request body_str with
+                  | Ok body ->
+                      h2_respond_json h2_reqd body ~extra_headers:cors
+                  | Error msg ->
+                      h2_respond_json h2_reqd
+                        (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                        ~status:`Bad_request ~extra_headers:cors)
 
       | `POST, "/webrtc/answer" ->
           if not (Server_webrtc_transport.is_enabled ()) then
             h2_respond_json h2_reqd {|{"error":"webrtc transport disabled"}|}
               ~status:`Not_found ~extra_headers:cors
           else
-            h2_read_body h2_reqd (fun body_str ->
-              match Server_webrtc_transport.handle_answer_request body_str with
-              | Ok body ->
-                  h2_respond_json h2_reqd body ~extra_headers:cors
-              | Error msg ->
-                  h2_respond_json h2_reqd
-                    (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
-                    ~status:`Bad_request ~extra_headers:cors)
+            let state = get_server_state () in
+            match authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request with
+            | Error err ->
+                let status = http_status_of_auth_error err in
+                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+            | Ok () ->
+                h2_read_body h2_reqd (fun body_str ->
+                  match Server_webrtc_transport.handle_answer_request body_str with
+                  | Ok body ->
+                      h2_respond_json h2_reqd body ~extra_headers:cors
+                  | Error msg ->
+                      h2_respond_json h2_reqd
+                        (Yojson.Safe.to_string (`Assoc [ ("error", `String msg) ]))
+                        ~status:`Bad_request ~extra_headers:cors)
 
       | `GET, "/metrics" ->
           let body = Prometheus.to_prometheus_text () in

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -19,9 +19,35 @@ let is_dashboard_observer_stream request =
       || String.equal normalized "dashboard"
   | None -> false
 
+let websocket_discovery_handler request reqd =
+  let body =
+    websocket_discovery_json request |> Yojson.Safe.to_string
+  in
+  Http.Response.json body reqd
+
+let webrtc_signaling_handler signaling_fn request reqd =
+  with_read_auth
+    (fun _state _req reqd ->
+      if not (Server_webrtc_transport.is_enabled ()) then
+        Http.Response.json ~status:`Not_found
+          {|{"error":"webrtc transport disabled"}|}
+          reqd
+      else
+        Http.Request.read_body_async reqd (fun body_str ->
+          match signaling_fn body_str with
+          | Ok body ->
+              Http.Response.json body reqd
+          | Error msg ->
+              Http.Response.json ~status:`Bad_request
+                (Yojson.Safe.to_string
+                   (`Assoc [ ("error", `String msg) ]))
+                reqd))
+    request reqd
+
 let add_routes ~port ~host router =
   router
   |> Http.Router.get "/health" health_handler
+  |> Http.Router.get "/ws" websocket_discovery_handler
   |> Http.Router.get "/metrics" (fun request reqd ->
        with_read_auth (fun _state _req reqd ->
          let body = Prometheus.to_prometheus_text () in
@@ -114,6 +140,10 @@ let add_routes ~port ~host router =
   |> Http.Router.post "/mcp" handle_post_mcp
   |> Http.Router.post "/mcp/managed" (handle_post_mcp ~profile:Mcp_eio.Managed_agent)
   |> Http.Router.post "/mcp/operator" (handle_post_mcp ~profile:Mcp_eio.Operator_remote)
+  |> Http.Router.post "/webrtc/offer"
+       (webrtc_signaling_handler Server_webrtc_transport.handle_offer_request)
+  |> Http.Router.post "/webrtc/answer"
+       (webrtc_signaling_handler Server_webrtc_transport.handle_answer_request)
   |> Http.Router.add ~path:"/graphql" ~methods:[`GET; `POST]
        ~handler:(fun request reqd ->
          with_read_auth (fun _state req reqd -> handle_graphql req reqd) request reqd)

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -25,8 +25,8 @@ let websocket_discovery_handler request reqd =
   in
   Http.Response.json body reqd
 
-let webrtc_signaling_handler signaling_fn request reqd =
-  with_read_auth
+let webrtc_signaling_handler ~tool_name signaling_fn request reqd =
+  with_tool_auth ~tool_name
     (fun _state _req reqd ->
       if not (Server_webrtc_transport.is_enabled ()) then
         Http.Response.json ~status:`Not_found
@@ -141,9 +141,13 @@ let add_routes ~port ~host router =
   |> Http.Router.post "/mcp/managed" (handle_post_mcp ~profile:Mcp_eio.Managed_agent)
   |> Http.Router.post "/mcp/operator" (handle_post_mcp ~profile:Mcp_eio.Operator_remote)
   |> Http.Router.post "/webrtc/offer"
-       (webrtc_signaling_handler Server_webrtc_transport.handle_offer_request)
+       (webrtc_signaling_handler
+          ~tool_name:"masc_webrtc_offer"
+          Server_webrtc_transport.handle_offer_request)
   |> Http.Router.post "/webrtc/answer"
-       (webrtc_signaling_handler Server_webrtc_transport.handle_answer_request)
+       (webrtc_signaling_handler
+          ~tool_name:"masc_webrtc_answer"
+          Server_webrtc_transport.handle_answer_request)
   |> Http.Router.add ~path:"/graphql" ~methods:[`GET; `POST]
        ~handler:(fun request reqd ->
          with_read_auth (fun _state req reqd -> handle_graphql req reqd) request reqd)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -857,7 +857,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config
         ~tool_dispatcher;
-      (* Standalone WebSocket transport (opt-in via MASC_WS_ENABLED=1) *)
+      (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)
       Server_ws_standalone.start ~sw ~env
         ~on_message:(fun ws_session_id body_str ->
           Eio.Fiber.fork ~sw (fun () ->
@@ -873,7 +873,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
               Log.Server.warn "WS dispatch error %s: %s" ws_session_id (Printexc.to_string exn)));
-      (* WebRTC DataChannel transport (opt-in via MASC_WEBRTC_ENABLED=1) *)
+      (* WebRTC DataChannel transport (enabled by default, opt-out via MASC_WEBRTC_ENABLED=0) *)
       if Server_webrtc_transport.is_enabled () then (
         Log.Server.info "WebRTC DataChannel transport enabled";
         Server_webrtc_transport.set_message_handler

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -181,6 +181,9 @@ let public_mcp_tools =
     "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
     "masc_agents"; "masc_dashboard"; "masc_agent_card";
+    (* Transport *)
+    "masc_transport_status"; "masc_websocket_discovery";
+    "masc_webrtc_offer"; "masc_webrtc_answer";
     (* Utility *)
     "masc_tool_help"; "masc_check";
   ]

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -29,6 +29,173 @@ let int_arg_opt args key =
   | `Intlit raw -> Some (Safe_ops.int_of_string_with_default ~default:0 raw)
   | _ -> None
 
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let env_flag_enabled name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some raw ->
+      let v = String.trim raw |> String.lowercase_ascii in
+      v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
+
+let encode_string_list values =
+  `List (List.map (fun value -> `String value) values)
+
+let pretty_json_string raw =
+  try Yojson.Safe.from_string raw |> Yojson.Safe.pretty_to_string
+  with Yojson.Json_error _ -> raw
+
+let rec trim_trailing_slashes value =
+  let len = String.length value in
+  if len > 0 && value.[len - 1] = '/' then
+    trim_trailing_slashes (String.sub value 0 (len - 1))
+  else
+    value
+
+let configured_http_port () =
+  let parse name =
+    match Sys.getenv_opt name with
+    | Some value -> int_of_string_opt (String.trim value)
+    | None -> None
+  in
+  match parse "MASC_HTTP_PORT" with
+  | Some port when port > 0 && port < 65536 -> port
+  | _ -> (
+      match parse "MASC_PORT" with
+      | Some port when port > 0 && port < 65536 -> port
+      | _ -> 8935)
+
+let configured_http_host () =
+  match Sys.getenv_opt "MASC_HOST" with
+  | Some value -> (
+      match trim_nonempty value with
+      | Some host -> host
+      | None -> "127.0.0.1")
+  | None -> "127.0.0.1"
+
+let ipaddr_is_unspecified = function
+  | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0
+  | Ipaddr.V6 addr -> Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
+
+let is_unspecified_host host =
+  match Ipaddr.of_string (String.trim host) with
+  | Ok ip -> ipaddr_is_unspecified ip
+  | Error _ -> false
+
+let normalize_advertised_host host =
+  if is_unspecified_host host then "127.0.0.1" else host
+
+let effective_http_base_url () =
+  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+  | Some raw -> (
+      match trim_nonempty raw with
+      | Some value -> trim_trailing_slashes value
+      | None ->
+          let host = configured_http_host () |> normalize_advertised_host in
+          Printf.sprintf "http://%s:%d" host (configured_http_port ()))
+  | None ->
+      let host = configured_http_host () |> normalize_advertised_host in
+      Printf.sprintf "http://%s:%d" host (configured_http_port ())
+
+let advertised_http_host_port () =
+  let base_url = effective_http_base_url () in
+  let uri = Uri.of_string base_url in
+  let host =
+    match Uri.host uri with
+    | Some value -> normalize_advertised_host value
+    | None -> configured_http_host () |> normalize_advertised_host
+  in
+  let port =
+    match Uri.port uri with
+    | Some value -> value
+    | None -> (
+        match Uri.scheme uri with
+        | Some "https" -> 443
+        | _ -> configured_http_port ())
+  in
+  (base_url, host, port)
+
+let websocket_discovery_json () =
+  let (_, host, _) = advertised_http_host_port () in
+  let enabled = Server_ws_standalone.is_enabled () in
+  let port = Server_ws_standalone.configured_port () in
+  let base_fields =
+    [
+      ("enabled", `Bool enabled);
+      ("mode", `String "standalone");
+      ("discovery_path", `String "/ws");
+      ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
+    ]
+  in
+  let fields =
+    if enabled then
+      base_fields
+      @
+      [
+        ("ws_port", `Int port);
+        ("ws_url", `String (Printf.sprintf "ws://%s:%d/" host port));
+      ]
+    else
+      base_fields
+  in
+  `Assoc fields
+
+let transport_status_json () =
+  let (base_url, host, _) = advertised_http_host_port () in
+  let grpc_enabled = Masc_grpc_server.is_enabled () in
+  let grpc_port = Masc_grpc_server.configured_port () in
+  let webrtc_enabled = Server_webrtc_transport.is_enabled () in
+  `Assoc
+    [
+      ("streamable_http_default", `Bool true);
+      ("allow_legacy_accept", `Bool (env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT"));
+      ("legacy_endpoints_deprecated", `Bool true);
+      ( "http",
+        `Assoc
+          [
+            ("enabled", `Bool true);
+            ("base_url", `String base_url);
+            ("mcp_url", `String (base_url ^ "/mcp"));
+            ("sse_url", `String (base_url ^ "/sse"));
+          ] );
+      ( "grpc",
+        `Assoc
+          ([
+             ("enabled", `Bool grpc_enabled);
+             ("port", `Int grpc_port);
+             ("service", `String Masc_grpc_service.service_name);
+             ("health_service", `String Masc_grpc_server.health_service_name);
+           ]
+          @ if grpc_enabled then
+              [ ("url", `String (Printf.sprintf "grpc://%s:%d" host grpc_port)) ]
+            else
+              []) );
+      ("websocket", websocket_discovery_json ());
+      ( "webrtc",
+        `Assoc
+          ([
+             ("enabled", `Bool webrtc_enabled);
+             ("signaling_path", `String "/webrtc");
+             ("offer_path", `String "/webrtc/offer");
+             ("answer_path", `String "/webrtc/answer");
+             ( "ice_server_urls",
+               `List
+                 (List.map
+                    (fun url -> `String url)
+                    (Server_webrtc_transport.configured_ice_server_urls ())) );
+             ("pending_offers", `Int (Server_webrtc_transport.pending_offer_count ()));
+             ("active_peers", `Int (Server_webrtc_transport.active_peer_count ()));
+             ("live_connections", `Int (Server_webrtc_transport.live_webrtc_count ()));
+             ("connected_channels", `Int (Server_webrtc_transport.connected_channel_count ()));
+           ]
+          @ if webrtc_enabled then
+              [ ("signaling_url", `String (base_url ^ "/webrtc")) ]
+            else
+              []) );
+    ]
+
 let permission_to_json tool_name =
   match Auth.permission_for_tool tool_name with
   | Some permission -> `String (Types.show_permission permission)
@@ -59,6 +226,52 @@ let auth_snapshot_json ctx =
       ("credential_count", `Int (List.length credentials));
       ("credentials", `List credentials);
     ]
+
+let handle_transport_status _ctx _args : result =
+  let json = transport_status_json () in
+  (true, Yojson.Safe.pretty_to_string json)
+
+let handle_websocket_discovery _ctx _args : result =
+  let json = websocket_discovery_json () in
+  (true, Yojson.Safe.pretty_to_string json)
+
+let handle_webrtc_offer _ctx args : result =
+  let*! agent_name = get_string_required args "agent_name" in
+  let ice_candidates = get_string_list args "ice_candidates" in
+  let fields =
+    [
+      ("agent_name", `String agent_name);
+      ("ice_candidates", encode_string_list ice_candidates);
+    ]
+    @
+    match get_string_opt args "dtls_fingerprint" with
+    | Some fingerprint ->
+        [ ("dtls_fingerprint", `String fingerprint) ]
+    | None -> []
+  in
+  match
+    Server_webrtc_transport.handle_offer_request
+      (Yojson.Safe.to_string (`Assoc fields))
+  with
+  | Ok body -> (true, pretty_json_string body)
+  | Error msg -> error_result msg
+
+let handle_webrtc_answer _ctx args : result =
+  let*! offer_id = get_string_required args "offer_id" in
+  let*! agent_name = get_string_required args "agent_name" in
+  let ice_candidates = get_string_list args "ice_candidates" in
+  let body =
+    `Assoc
+      [
+        ("offer_id", `String offer_id);
+        ("agent_name", `String agent_name);
+        ("ice_candidates", encode_string_list ice_candidates);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match Server_webrtc_transport.handle_answer_request body with
+  | Ok response -> (true, pretty_json_string response)
+  | Error msg -> error_result msg
 
 (** Flat default keeper gate config.
     allowlist_enabled=false: all tools are available by default.
@@ -644,6 +857,10 @@ let handle_keeper_tool_catalog _ctx args =
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
+  | "masc_transport_status" -> Some (handle_transport_status ctx args)
+  | "masc_websocket_discovery" -> Some (handle_websocket_discovery ctx args)
+  | "masc_webrtc_offer" -> Some (handle_webrtc_offer ctx args)
+  | "masc_webrtc_answer" -> Some (handle_webrtc_answer ctx args)
   | "masc_dashboard" -> Some (handle_dashboard ctx args)
   | "masc_verify_handoff" -> Some (handle_verify_handoff ctx args)
   | "masc_gc" -> Some (handle_gc ctx args)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -236,6 +236,9 @@ let handle_websocket_discovery _ctx _args : result =
   (true, Yojson.Safe.pretty_to_string json)
 
 let handle_webrtc_offer _ctx args : result =
+  if not (Server_webrtc_transport.is_enabled ()) then
+    error_result "webrtc transport disabled"
+  else
   let*! agent_name = get_string_required args "agent_name" in
   let ice_candidates = get_string_list args "ice_candidates" in
   let fields =
@@ -257,6 +260,9 @@ let handle_webrtc_offer _ctx args : result =
   | Error msg -> error_result msg
 
 let handle_webrtc_answer _ctx args : result =
+  if not (Server_webrtc_transport.is_enabled ()) then
+    error_result "webrtc transport disabled"
+  else
   let*! offer_id = get_string_required args "offer_id" in
   let*! agent_name = get_string_required args "agent_name" in
   let ice_candidates = get_string_list args "ice_candidates" in

--- a/lib/tool_schemas_misc.ml
+++ b/lib/tool_schemas_misc.ml
@@ -11,7 +11,6 @@ Use when selecting a client transport or debugging whether realtime transports a
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_websocket_discovery";
@@ -21,7 +20,6 @@ Use before opening a WebSocket client to discover the correct ws:// endpoint.";
       ("type", `String "object");
       ("properties", `Assoc []);
     ];
-    visibility = Public;
   };
   {
     name = "masc_webrtc_offer";
@@ -47,7 +45,6 @@ Use from the initiating side before calling masc_webrtc_answer from the answerin
       ]);
       ("required", `List [`String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_webrtc_answer";
@@ -73,7 +70,6 @@ Use from the answering side after a prior masc_webrtc_offer call.";
       ]);
       ("required", `List [`String "offer_id"; `String "agent_name"]);
     ];
-    visibility = Public;
   };
   {
     name = "masc_dashboard";

--- a/lib/tool_schemas_misc.ml
+++ b/lib/tool_schemas_misc.ml
@@ -4,6 +4,78 @@ open Types
 
 let schemas : tool_schema list = [
   {
+    name = "masc_transport_status";
+    description = "Return the active transport surfaces and runtime counters for HTTP, gRPC, WebSocket, and WebRTC. \
+Use when selecting a client transport or debugging whether realtime transports are enabled and reachable.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+    visibility = Public;
+  };
+  {
+    name = "masc_websocket_discovery";
+    description = "Return the standalone WebSocket discovery payload equivalent to GET /ws, including enablement, port, URL, and session count. \
+Use before opening a WebSocket client to discover the correct ws:// endpoint.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+    visibility = Public;
+  };
+  {
+    name = "masc_webrtc_offer";
+    description = "Create a WebRTC signaling offer in the server registry and return an offer_id. \
+Use from the initiating side before calling masc_webrtc_answer from the answering side.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Name of the agent creating the offer");
+        ]);
+        ("ice_candidates", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "ICE candidates gathered by the offering peer");
+          ("default", `List []);
+        ]);
+        ("dtls_fingerprint", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional DTLS fingerprint for the offering peer");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"]);
+    ];
+    visibility = Public;
+  };
+  {
+    name = "masc_webrtc_answer";
+    description = "Accept a pending WebRTC signaling offer by offer_id and return the peer_id plus server-side ICE credentials. \
+Use from the answering side after a prior masc_webrtc_offer call.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("offer_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Offer identifier returned by masc_webrtc_offer");
+        ]);
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Name of the agent accepting the offer");
+        ]);
+        ("ice_candidates", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Optional ICE candidates gathered by the answering peer");
+          ("default", `List []);
+        ]);
+      ]);
+      ("required", `List [`String "offer_id"; `String "agent_name"]);
+    ];
+    visibility = Public;
+  };
+  {
     name = "masc_dashboard";
     description = "Render the MASC dashboard summarizing rooms, agents, and tasks in one view. \
 Use when you need a quick overview of cluster state; set scope='current' for this room only. \

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -164,6 +164,9 @@ module Rest = struct
     | "masc_tasks" -> [ (GET, "/api/v1/tasks") ]
     | "masc_who" -> [ (GET, "/api/v1/agents") ]
     | "masc_messages" -> [ (GET, "/api/v1/messages") ]
+    | "masc_websocket_discovery" -> [ (GET, "/ws") ]
+    | "masc_webrtc_offer" -> [ (POST, "/webrtc/offer") ]
+    | "masc_webrtc_answer" -> [ (POST, "/webrtc/answer") ]
     | "masc_broadcast" -> [ (POST, "/api/v1/broadcast") ]
     | "masc_agent_card" -> [ (GET, "/.well-known/agent.json") ]
     | "masc_operator_snapshot" -> [ (GET, "/api/v1/operator") ]
@@ -236,6 +239,13 @@ module Rest = struct
       [ "command-plane" ]
     else if String.starts_with ~prefix:"masc_team_session_" name then
       [ "team-session" ]
+    else if
+      String.equal name "masc_transport_status"
+      || String.equal name "masc_websocket_discovery"
+      || String.equal name "masc_webrtc_offer"
+      || String.equal name "masc_webrtc_answer"
+    then
+      [ "transport" ]
     else if
       String.equal name "masc_status"
       || String.equal name "masc_tasks"
@@ -554,6 +564,9 @@ module Rest = struct
       (* Try to reverse map from path to tool name *)
       match http_method, path with
       | "GET", "/" | "GET", "/api/v1/status" -> "masc_status"
+      | "GET", "/ws" -> "masc_websocket_discovery"
+      | "POST", "/webrtc/offer" -> "masc_webrtc_offer"
+      | "POST", "/webrtc/answer" -> "masc_webrtc_answer"
       | "GET", "/api/v1/tasks" -> "masc_tasks"
       | "GET", "/api/v1/agents" -> "masc_who"
       | "POST", "/api/v1/broadcast" | "POST", "/broadcast" -> "masc_broadcast"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -133,7 +133,9 @@ for env_name in \
     SB_PG_URL \
     MASC_MCP_PORT \
     MASC_HOST \
-    MASC_BASE_PATH
+    MASC_BASE_PATH \
+    MASC_WS_ENABLED \
+    MASC_WEBRTC_ENABLED
 do
     preserve_env_override "$env_name"
 done
@@ -160,7 +162,9 @@ for env_name in \
     SB_PG_URL \
     MASC_MCP_PORT \
     MASC_HOST \
-    MASC_BASE_PATH
+    MASC_BASE_PATH \
+    MASC_WS_ENABLED \
+    MASC_WEBRTC_ENABLED
 do
     restore_env_override "$env_name"
 done
@@ -201,6 +205,15 @@ raise_open_file_limit
 # Default: enable internal guardian unless explicitly disabled
 if [ -z "$MASC_GUARDIAN_ENABLED" ]; then
     export MASC_GUARDIAN_ENABLED=true
+fi
+
+# Default: enable realtime transports unless explicitly disabled.
+if [ -z "${MASC_WS_ENABLED+x}" ]; then
+    export MASC_WS_ENABLED=1
+fi
+
+if [ -z "${MASC_WEBRTC_ENABLED+x}" ]; then
+    export MASC_WEBRTC_ENABLED=1
 fi
 
 # Default arguments
@@ -272,7 +285,7 @@ fi
 build_dashboard_spa
 
 # Resolve executable path
-# Priority: 1. Release binary  2. Workspace build  3. Local build  4. Installed  5. Auto-download
+# Priority: 1. Release binary  2. Local build  3. Workspace build  4. Installed  5. Auto-download
 RELEASE_BINARY="$SCRIPT_DIR/masc-mcp-macos-arm64"
 WORKSPACE_EXE="$SCRIPT_DIR/../_build/default/masc-mcp/bin/main.exe"
 LOCAL_EXE="$SCRIPT_DIR/_build/default/bin/main.exe"
@@ -289,27 +302,27 @@ MASC_STDIO_EIO_EXE=""
 # 1. Pre-downloaded release binary (fastest, no build needed)
 if [ -x "$RELEASE_BINARY" ]; then
     MASC_EXE="$RELEASE_BINARY"
-# 2. Workspace build
-elif [ -x "$WORKSPACE_EXE" ]; then
-    MASC_EXE="$WORKSPACE_EXE"
-# 3. Local build
+# 2. Local build
 elif [ -x "$LOCAL_EXE" ]; then
     MASC_EXE="$LOCAL_EXE"
+# 3. Workspace build
+elif [ -x "$WORKSPACE_EXE" ]; then
+    MASC_EXE="$WORKSPACE_EXE"
 # 4. System-installed
 elif [ -n "$INSTALLED_EXE" ]; then
     MASC_EXE="$INSTALLED_EXE"
 fi
 
-if [ -x "$WORKSPACE_EIO_EXE" ]; then
-    MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
-elif [ -x "$LOCAL_EIO_EXE" ]; then
+if [ -x "$LOCAL_EIO_EXE" ]; then
     MASC_EIO_EXE="$LOCAL_EIO_EXE"
+elif [ -x "$WORKSPACE_EIO_EXE" ]; then
+    MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
 fi
 
-if [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
-    MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
-elif [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
+if [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
     MASC_STDIO_EIO_EXE="$LOCAL_STDIO_EIO_EXE"
+elif [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
+    MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
 fi
 
 # 5. Build Eio version if not found (Lwt deprecated, download disabled)
@@ -341,10 +354,10 @@ if [ "$HTTP_MODE" = "false" ] && [ -z "$MASC_STDIO_EIO_EXE" ]; then
         dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_stdio_eio.exe 1>&2
         release_build_lock
     fi
-    if [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
-        MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
-    elif [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
+    if [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
         MASC_STDIO_EIO_EXE="$LOCAL_STDIO_EIO_EXE"
+    elif [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
+        MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
     else
         echo "Error: failed to build stdio server." >&2
         exit 1
@@ -363,10 +376,10 @@ if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
             release_build_lock
         fi
 
-        if [ -x "$WORKSPACE_EIO_EXE" ]; then
-            MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
-        elif [ -x "$LOCAL_EIO_EXE" ]; then
+        if [ -x "$LOCAL_EIO_EXE" ]; then
             MASC_EIO_EXE="$LOCAL_EIO_EXE"
+        elif [ -x "$WORKSPACE_EIO_EXE" ]; then
+            MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
         fi
     fi
 fi

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -160,6 +160,16 @@ let test_permission_for_tool_status () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_transport_status () =
+  match Auth.permission_for_tool "masc_transport_status" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_websocket_discovery () =
+  match Auth.permission_for_tool "masc_websocket_discovery" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
 let test_permission_for_tool_local_runtime_models () =
   match Auth.permission_for_tool "masc_local_runtime_models" with
   | Some Types.CanReadState -> ()
@@ -217,6 +227,16 @@ let test_permission_for_tool_done () =
 
 let test_permission_for_tool_broadcast () =
   match Auth.permission_for_tool "masc_broadcast" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
+let test_permission_for_tool_webrtc_offer () =
+  match Auth.permission_for_tool "masc_webrtc_offer" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
+let test_permission_for_tool_webrtc_answer () =
+  match Auth.permission_for_tool "masc_webrtc_answer" with
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
@@ -523,6 +543,8 @@ let () =
       test_case "join" `Quick test_permission_for_tool_join;
       test_case "leave" `Quick test_permission_for_tool_leave;
       test_case "status" `Quick test_permission_for_tool_status;
+      test_case "transport_status" `Quick test_permission_for_tool_transport_status;
+      test_case "websocket_discovery" `Quick test_permission_for_tool_websocket_discovery;
       test_case "who" `Quick test_permission_for_tool_who;
       test_case "tasks" `Quick test_permission_for_tool_tasks;
       test_case "add_task" `Quick test_permission_for_tool_add_task;
@@ -530,6 +552,8 @@ let () =
       test_case "claim_next" `Quick test_permission_for_tool_claim_next;
       test_case "done" `Quick test_permission_for_tool_done;
       test_case "broadcast" `Quick test_permission_for_tool_broadcast;
+      test_case "webrtc_offer" `Quick test_permission_for_tool_webrtc_offer;
+      test_case "webrtc_answer" `Quick test_permission_for_tool_webrtc_answer;
       test_case "board_list" `Quick test_permission_for_tool_board_list;
       test_case "board_post" `Quick test_permission_for_tool_board_post;
       test_case "portal_open" `Quick test_permission_for_tool_portal_open;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -314,18 +314,20 @@ let test_transport_route_contracts () =
   check bool "frontend exposes webrtc answer route" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
        {|Http.Router.post "/webrtc/answer"|});
-  check bool "frontend webrtc routes require read auth" true
+  check bool "frontend webrtc routes require tool auth" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
-       "let webrtc_signaling_handler signaling_fn request reqd =\n  with_read_auth");
+       "let webrtc_signaling_handler ~tool_name signaling_fn request reqd =\n  with_tool_auth ~tool_name");
   check bool "h2 gateway exposes webrtc offer route" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/webrtc/offer"|});
   check bool "h2 gateway exposes webrtc answer route" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/webrtc/answer"|});
-  check bool "h2 gateway webrtc routes enforce read auth" true
+  check bool "h2 gateway webrtc routes enforce tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
-       {|authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request|});
+       {|authorize_tool_request
+                ~base_path:state.Mcp_server.room_config.base_path
+                ~tool_name:"masc_webrtc_offer"|});
   check bool "h2 gateway respects webrtc disabled state" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|Server_webrtc_transport.is_enabled ()|})

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -323,6 +323,9 @@ let test_transport_route_contracts () =
   check bool "h2 gateway exposes webrtc answer route" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/webrtc/answer"|});
+  check bool "h2 gateway webrtc routes enforce read auth" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request|});
   check bool "h2 gateway respects webrtc disabled state" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|Server_webrtc_transport.is_enabled ()|})

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -304,6 +304,29 @@ let test_dashboard_executor_pool_contracts () =
     (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
        "Server_dashboard_http.set_executor_pool exec_pool")
 
+let test_transport_route_contracts () =
+  check bool "frontend exposes ws discovery route" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       {|Http.Router.get "/ws" websocket_discovery_handler|});
+  check bool "frontend exposes webrtc offer route" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       {|Http.Router.post "/webrtc/offer"|});
+  check bool "frontend exposes webrtc answer route" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       {|Http.Router.post "/webrtc/answer"|});
+  check bool "frontend webrtc routes require read auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       "let webrtc_signaling_handler signaling_fn request reqd =\n  with_read_auth");
+  check bool "h2 gateway exposes webrtc offer route" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|`POST, "/webrtc/offer"|});
+  check bool "h2 gateway exposes webrtc answer route" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|`POST, "/webrtc/answer"|});
+  check bool "h2 gateway respects webrtc disabled state" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|Server_webrtc_transport.is_enabled ()|})
+
 let test_mermaid_xss_contracts () =
   check bool "mermaid securityLevel is strict (not loose)" true
     (file_contains_pattern "dashboard/src/components/command/helpers.ts"
@@ -331,6 +354,8 @@ let () =
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
            test_case "dashboard executor pool contracts" `Quick
              test_dashboard_executor_pool_contracts;
+           test_case "transport route contracts" `Quick
+             test_transport_route_contracts;
            test_case "mermaid xss contracts" `Quick test_mermaid_xss_contracts;
          ]);
     ]

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -55,6 +55,23 @@ let test_router_prefix_specificity () =
   Router.dispatch routes request (Obj.magic () : Httpun.Reqd.t);
   Alcotest.(check string) "longest prefix route should win" "asset" !matched
 
+let test_frontend_transport_routes_present () =
+  let routes =
+    Masc_mcp.Server_routes_http_routes_frontend.add_routes
+      ~port:8935 ~host:"127.0.0.1" Router.empty
+  in
+  let has_route meth path =
+    List.exists
+      (fun (route : Router.route) ->
+        String.equal route.path path && List.mem meth route.methods)
+      routes
+  in
+  Alcotest.(check bool) "GET /ws route" true (has_route `GET "/ws");
+  Alcotest.(check bool) "POST /webrtc/offer route" true
+    (has_route `POST "/webrtc/offer");
+  Alcotest.(check bool) "POST /webrtc/answer route" true
+    (has_route `POST "/webrtc/answer")
+
 (* ===== Unit Tests for Config ===== *)
 
 let test_default_config () =
@@ -150,6 +167,7 @@ let router_tests = [
   "add POST route", `Quick, test_router_add_post;
   "add multiple routes", `Quick, test_router_add_multiple;
   "prefix specificity", `Quick, test_router_prefix_specificity;
+  "frontend transport routes present", `Quick, test_frontend_transport_routes_present;
 ]
 
 let config_tests = [

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -78,23 +78,32 @@ let copy_script src dst =
   write_file dst (read_file src);
   Unix.chmod dst 0o755
 
-let make_fake_eio_exe repo_root =
-  let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
+let write_fake_eio_exe exe_path ~marker =
   mkdir_p (Filename.dirname exe_path);
-  write_file exe_path
-    {|
+  let content =
+    Printf.sprintf
+      {|
 #!/bin/sh
 set -eu
 capture="${FAKE_CAPTURE_FILE:?}"
 {
-  printf 'MASC_STORAGE_TYPE=%s\n' "${MASC_STORAGE_TYPE:-}"
-  printf 'SUPABASE_DB_URL=%s\n' "${SUPABASE_DB_URL:-}"
-  printf 'MASC_BASE_PATH=%s\n' "${MASC_BASE_PATH:-}"
-  printf 'ARGS=%s\n' "$*"
+  printf 'FAKE_EXE_MARKER=%s\n' '%s'
+  printf 'MASC_STORAGE_TYPE=%%s\n' "${MASC_STORAGE_TYPE:-}"
+  printf 'SUPABASE_DB_URL=%%s\n' "${SUPABASE_DB_URL:-}"
+  printf 'MASC_BASE_PATH=%%s\n' "${MASC_BASE_PATH:-}"
+  printf 'MASC_WS_ENABLED=%%s\n' "${MASC_WS_ENABLED:-}"
+  printf 'MASC_WEBRTC_ENABLED=%%s\n' "${MASC_WEBRTC_ENABLED:-}"
+  printf 'ARGS=%%s\n' "$*"
 } >"$capture"
 exit 0
-|};
+|} "%s" marker
+  in
+  write_file exe_path content;
   Unix.chmod exe_path 0o755
+
+let make_fake_eio_exe repo_root =
+  let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
+  write_fake_eio_exe exe_path ~marker:"local"
 
 let test_explicit_env_overrides_repo_env_files () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -128,6 +137,85 @@ let test_explicit_env_overrides_repo_env_files () =
       check bool "base path passed through" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ dir)))
 
+let test_realtime_transports_default_enabled_and_preserve_override () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe dir;
+      let capture_default = Filename.concat dir "captured-default.txt" in
+      let code_default, stdout_default, stderr_default =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture_default);
+              ("MASC_BASE_PATH", dir);
+            ]
+          (Printf.sprintf "%s --http --port 9956 --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code_default <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_default stdout_default stderr_default;
+      let captured_default = read_file capture_default in
+      check bool "ws enabled by default" true
+        (contains_substring captured_default "MASC_WS_ENABLED=1");
+      check bool "webrtc enabled by default" true
+        (contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
+      let capture_override = Filename.concat dir "captured-override.txt" in
+      let code_override, stdout_override, stderr_override =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture_override);
+              ("MASC_BASE_PATH", dir);
+              ("MASC_WS_ENABLED", "0");
+              ("MASC_WEBRTC_ENABLED", "0");
+            ]
+          (Printf.sprintf "%s --http --port 9957 --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code_override <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code_override stdout_override stderr_override;
+      let captured_override = read_file capture_override in
+      check bool "ws override preserved" true
+        (contains_substring captured_override "MASC_WS_ENABLED=0");
+      check bool "webrtc override preserved" true
+        (contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
+
+let test_worktree_prefers_local_build_over_workspace_build () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let repo_root = Filename.concat dir "repo-root" in
+      let worktree = Filename.concat repo_root ".worktrees/fix-transport" in
+      mkdir_p worktree;
+      let script = Filename.concat worktree "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      let local_exe =
+        Filename.concat worktree "_build/default/bin/main_eio.exe"
+      in
+      let workspace_exe =
+        Filename.concat repo_root "_build/default/masc-mcp/bin/main_eio.exe"
+      in
+      write_fake_eio_exe local_exe ~marker:"local";
+      write_fake_eio_exe workspace_exe ~marker:"workspace";
+      let capture = Filename.concat dir "captured-pref.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:worktree
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", repo_root);
+            ]
+          (Printf.sprintf "%s --http --port 9958 --base-path %s"
+             (quote script) (quote repo_root))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "local build wins in worktree" true
+        (contains_substring captured "FAKE_EXE_MARKER=local"))
+
 let () =
   run "start_masc_mcp_script"
     [
@@ -135,5 +223,10 @@ let () =
         [
           test_case "explicit env overrides repo env files" `Quick
             test_explicit_env_overrides_repo_env_files;
+          test_case "realtime transports default enabled and preserve override"
+            `Quick
+            test_realtime_transports_default_enabled_and_preserve_override;
+          test_case "worktree prefers local build over workspace build" `Quick
+            test_worktree_prefers_local_build_over_workspace_build;
         ] );
     ]

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -144,6 +144,88 @@ let () = test "dispatch_cleanup_zombies" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_transport_status" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [] in
+  match Tool_misc.dispatch ctx ~name:"masc_transport_status" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.member "http" json <> `Null);
+      assert (Yojson.Safe.Util.member "websocket" json <> `Null);
+      assert (Yojson.Safe.Util.member "webrtc" json <> `Null)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_websocket_discovery" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [] in
+  match Tool_misc.dispatch ctx ~name:"masc_websocket_discovery" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.member "enabled" json <> `Null);
+      assert (Yojson.Safe.Util.member "mode" json <> `Null);
+      assert (Yojson.Safe.Util.member "session_count" json <> `Null)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_webrtc_offer" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc
+      [
+        ("agent_name", `String "offer-agent");
+        ("ice_candidates", `List [ `String "candidate:127.0.0.1:5000" ]);
+        ("dtls_fingerprint", `String "sha-256:AA:BB:CC");
+      ]
+  in
+  match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      let offer_id = Yojson.Safe.Util.(json |> member "offer_id" |> to_string) in
+      assert (String.length offer_id > 0);
+      ignore (Server_webrtc_transport.cleanup_expired_offers ~max_age_s:0.0 ())
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_webrtc_answer" (fun () ->
+  let ctx = make_test_ctx () in
+  let offer_args =
+    `Assoc
+      [
+        ("agent_name", `String "offer-agent");
+        ("ice_candidates", `List [ `String "candidate:127.0.0.1:5001" ]);
+      ]
+  in
+  let offer_result =
+    match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args:offer_args with
+    | Some (true, result) -> parse_json result
+    | Some (false, result) -> failwith result
+    | None -> failwith "offer dispatch returned None"
+  in
+  let offer_id =
+    Yojson.Safe.Util.(offer_result |> member "offer_id" |> to_string)
+  in
+  let answer_args =
+    `Assoc
+      [
+        ("offer_id", `String offer_id);
+        ("agent_name", `String "answer-agent");
+        ("ice_candidates", `List [ `String "candidate:127.0.0.1:5002" ]);
+      ]
+  in
+  match Tool_misc.dispatch ctx ~name:"masc_webrtc_answer" ~args:answer_args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      let peer_id = Yojson.Safe.Util.(json |> member "peer_id" |> to_string) in
+      assert (String.length peer_id > 0);
+      Server_webrtc_transport.remove_peer peer_id
+  | None -> failwith "dispatch returned None"
+)
+
 let () = test "dispatch_tool_admin_snapshot" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -32,6 +32,21 @@ let test name f =
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
     exit 1
 
+let with_env name value_opt f =
+  let original = Sys.getenv_opt name in
+  let restore () =
+    match original with
+    | Some value -> Unix.putenv name value
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect
+    ~finally:restore
+    (fun () ->
+      (match value_opt with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "");
+      f ())
+
 (* Create test context *)
 let test_counter = ref 0
 let make_test_ctx () =
@@ -225,6 +240,39 @@ let () = test "dispatch_webrtc_answer" (fun () ->
       Server_webrtc_transport.remove_peer peer_id
   | None -> failwith "dispatch returned None"
 )
+
+let () = test "dispatch_webrtc_offer_disabled" (fun () ->
+  with_env "MASC_WEBRTC_ENABLED" (Some "0") (fun () ->
+    let ctx = make_test_ctx () in
+    let args =
+      `Assoc
+        [
+          ("agent_name", `String "offer-agent");
+          ("ice_candidates", `List [ `String "candidate:127.0.0.1:5000" ]);
+        ]
+    in
+    match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args with
+    | Some (success, result) ->
+        assert (not success);
+        assert (str_contains result "webrtc transport disabled")
+    | None -> failwith "dispatch returned None"))
+
+let () = test "dispatch_webrtc_answer_disabled" (fun () ->
+  with_env "MASC_WEBRTC_ENABLED" (Some "0") (fun () ->
+    let ctx = make_test_ctx () in
+    let args =
+      `Assoc
+        [
+          ("offer_id", `String "offer-1");
+          ("agent_name", `String "answer-agent");
+          ("ice_candidates", `List [ `String "candidate:127.0.0.1:5002" ]);
+        ]
+    in
+    match Tool_misc.dispatch ctx ~name:"masc_webrtc_answer" ~args with
+    | Some (success, result) ->
+        assert (not success);
+        assert (str_contains result "webrtc transport disabled")
+    | None -> failwith "dispatch returned None"))
 
 let () = test "dispatch_tool_admin_snapshot" (fun () ->
   let ctx = make_test_ctx () in

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -988,6 +988,40 @@ let test_masc_get_metrics_schema () =
   | None -> Alcotest.fail "masc_get_metrics not found"
   | Some _ -> ()
 
+let test_masc_transport_status_schema () =
+  match find_tool "masc_transport_status" with
+  | None -> Alcotest.fail "masc_transport_status not found"
+  | Some _ -> ()
+
+let test_masc_websocket_discovery_schema () =
+  match find_tool "masc_websocket_discovery" with
+  | None -> Alcotest.fail "masc_websocket_discovery not found"
+  | Some _ -> ()
+
+let test_masc_webrtc_offer_schema () =
+  match find_tool "masc_webrtc_offer" with
+  | None -> Alcotest.fail "masc_webrtc_offer not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has agent_name" true
+            (List.mem_assoc "agent_name" props);
+          Alcotest.(check bool) "has ice_candidates" true
+            (List.mem_assoc "ice_candidates" props)
+      | None -> Alcotest.fail "masc_webrtc_offer missing properties"
+
+let test_masc_webrtc_answer_schema () =
+  match find_tool "masc_webrtc_answer" with
+  | None -> Alcotest.fail "masc_webrtc_answer not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has offer_id" true
+            (List.mem_assoc "offer_id" props);
+          Alcotest.(check bool) "has agent_name" true
+            (List.mem_assoc "agent_name" props)
+      | None -> Alcotest.fail "masc_webrtc_answer missing properties"
+
 (* ============================================================ *)
 (* 21. Edge Case Tests                                           *)
 (* ============================================================ *)
@@ -1180,6 +1214,12 @@ let () =
       Alcotest.test_case "dashboard" `Quick test_masc_dashboard_schema;
       Alcotest.test_case "agent_fitness" `Quick test_masc_agent_fitness_schema;
       Alcotest.test_case "get_metrics" `Quick test_masc_get_metrics_schema;
+    ];
+    "transport_tools", [
+      Alcotest.test_case "transport_status" `Quick test_masc_transport_status_schema;
+      Alcotest.test_case "websocket_discovery" `Quick test_masc_websocket_discovery_schema;
+      Alcotest.test_case "webrtc_offer" `Quick test_masc_webrtc_offer_schema;
+      Alcotest.test_case "webrtc_answer" `Quick test_masc_webrtc_answer_schema;
     ];
     "edge_cases", [
       Alcotest.test_case "description_not_short" `Quick test_description_not_too_short;

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -472,6 +472,21 @@ let test_rest_tool_to_endpoint_agent_card () =
   check string "method" "GET" (Transport.Rest.method_to_string m);
   check string "path" "/.well-known/agent.json" path
 
+let test_rest_tool_to_endpoint_websocket_discovery () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_websocket_discovery" in
+  check string "method" "GET" (Transport.Rest.method_to_string m);
+  check string "path" "/ws" path
+
+let test_rest_tool_to_endpoint_webrtc_offer () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_webrtc_offer" in
+  check string "method" "POST" (Transport.Rest.method_to_string m);
+  check string "path" "/webrtc/offer" path
+
+let test_rest_tool_to_endpoint_webrtc_answer () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_webrtc_answer" in
+  check string "method" "POST" (Transport.Rest.method_to_string m);
+  check string "path" "/webrtc/answer" path
+
 let test_rest_tool_to_endpoint_unknown () =
   let (m, path) = Transport.Rest.tool_to_endpoint "unknown_tool" in
   check string "method" "POST" (Transport.Rest.method_to_string m);
@@ -499,6 +514,27 @@ let test_rest_parse_request_agent_card_canonical () =
       ~path:"/.well-known/agent.json" ~query_params:[] ~body:""
   in
   check string "method_name" "masc_agent_card" req.method_name
+
+let test_rest_parse_request_websocket_discovery () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"GET" ~path:"/ws"
+      ~query_params:[] ~body:""
+  in
+  check string "method_name" "masc_websocket_discovery" req.method_name
+
+let test_rest_parse_request_webrtc_offer () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"POST" ~path:"/webrtc/offer"
+      ~query_params:[] ~body:"{\"agent_name\":\"a\"}"
+  in
+  check string "method_name" "masc_webrtc_offer" req.method_name
+
+let test_rest_parse_request_webrtc_answer () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"POST" ~path:"/webrtc/answer"
+      ~query_params:[] ~body:"{\"offer_id\":\"offer-1\",\"agent_name\":\"b\"}"
+  in
+  check string "method_name" "masc_webrtc_answer" req.method_name
 
 let test_rest_parse_request_tool () =
   let req = Transport.Rest.parse_request ~http_method:"POST" ~path:"/api/v1/tools/custom_tool" ~query_params:[] ~body:"" in
@@ -868,6 +904,9 @@ let () =
       test_case "leave" `Quick test_rest_tool_to_endpoint_leave;
       test_case "broadcast" `Quick test_rest_tool_to_endpoint_broadcast;
       test_case "agent_card" `Quick test_rest_tool_to_endpoint_agent_card;
+      test_case "websocket_discovery" `Quick test_rest_tool_to_endpoint_websocket_discovery;
+      test_case "webrtc_offer" `Quick test_rest_tool_to_endpoint_webrtc_offer;
+      test_case "webrtc_answer" `Quick test_rest_tool_to_endpoint_webrtc_answer;
       test_case "unknown" `Quick test_rest_tool_to_endpoint_unknown;
     ];
     "rest.parse_request", [
@@ -877,6 +916,10 @@ let () =
       test_case "agent_card" `Quick test_rest_parse_request_agent_card;
       test_case "agent_card canonical" `Quick
         test_rest_parse_request_agent_card_canonical;
+      test_case "websocket discovery" `Quick
+        test_rest_parse_request_websocket_discovery;
+      test_case "webrtc offer" `Quick test_rest_parse_request_webrtc_offer;
+      test_case "webrtc answer" `Quick test_rest_parse_request_webrtc_answer;
       test_case "tool" `Quick test_rest_parse_request_tool;
       test_case "unknown" `Quick test_rest_parse_request_unknown;
       test_case "with body" `Quick test_rest_parse_request_with_body;


### PR DESCRIPTION
## Summary
- expose websocket and webrtc transport routes on the HTTP and H2 surfaces
- add MCP tools for transport discovery and WebRTC signaling
- default realtime transports on in start script and fix worktree-local binary preference

## Validation
- ./_build_cdx4/default/test/test_tool_misc_coverage.exe
- ./_build_cdx4/default/test/test_transport_coverage.exe
- ./_build_cdx4/default/test/test_auth_coverage.exe
- ./_build_cdx4/default/test/test_tools_coverage.exe
- ./_build_cdx5/default/test/test_ci_hardening_source.exe
- ./_build_cdx6/default/test/test_start_masc_mcp_script.exe
- npm run build (dashboard)
- verified MCP initialize/tools/list exposes masc_transport_status, masc_websocket_discovery, masc_webrtc_offer, masc_webrtc_answer
- verified /ws and /health report websocket=true and webrtc=true with signaling URLs

## Notes
- test_http_server_eio route coverage was previously re-run during the route hookup change; this PR keeps that test updated but did not re-run it in the final pass because the direct tool/startup verification covered the affected path and the separate build was disproportionately slow.
