### PR TITLE
chore: bump OAS pin to b51e424c

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7319cf6d09d971079d1b9018d8c485f294feed5f"
+readonly OAS_AGENT_SDK_SHA="b51e424c8b574a225c7112b539b5f8dc8aa54740"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"


### PR DESCRIPTION
OAS upstream에 새 커밋이 추가되어 pin ratchet CI가 실패. 최신 SHA로 갱신.