### PR TITLE
fix(dashboard): simplify ops intervene surface

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -34,14 +34,20 @@ export function currentDashboardActor(): string {
   )
 }
 
-function authHeaders(): Record<string, string> {
+type HeaderOptions = {
+  includeActor?: boolean
+}
+
+function authHeaders(options: HeaderOptions = {}): Record<string, string> {
   const params = getQueryParams()
   const headers: Record<string, string> = {}
   const token = params.get('token')
   const storedAgent = readStoredAgentName()
   const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
   if (token) headers['Authorization'] = `Bearer ${token}`
-  if (agent) headers['X-MASC-Agent'] = encodeURIComponent(agent)
+  if (options.includeActor !== false && agent) {
+    headers['X-MASC-Agent'] = encodeURIComponent(agent)
+  }
   return headers
 }
 
@@ -127,12 +133,13 @@ export function defaultBoardVoter(): string {
 
 export type GetOptions = {
   timeoutMs?: number
+  includeActorHeader?: boolean
 }
 
 export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
   const res = await fetchWithTimeout(
     path,
-    { headers: authHeaders() },
+    { headers: authHeaders({ includeActor: opts.includeActorHeader }) },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
   )
   if (!res.ok) {
@@ -304,7 +311,7 @@ export function confirmOperatorAction(
 }
 
 export function fetchOperatorSnapshot(): Promise<OperatorSnapshot> {
-  return get('/api/v1/operator')
+  return get('/api/v1/operator', { includeActorHeader: false })
 }
 
 export function fetchOperatorDigest(options: {
@@ -317,5 +324,7 @@ export function fetchOperatorDigest(options: {
   if (options.targetId) params.set('target_id', options.targetId)
   if (options.includeWorkers != null) params.set('include_workers', options.includeWorkers ? 'true' : 'false')
   const query = params.toString()
-  return get(`/api/v1/operator/digest${query ? `?${query}` : ''}`)
+  return get(`/api/v1/operator/digest${query ? `?${query}` : ''}`, {
+    includeActorHeader: false,
+  })
 }

--- a/dashboard/src/components/ops/helpers.test.ts
+++ b/dashboard/src/components/ops/helpers.test.ts
@@ -26,4 +26,31 @@ describe('ops helper state exports', () => {
   it('re-exports the canonical actor persistence function', () => {
     expect(helpers.persistActorName).toBe(opsState.persistActorName)
   })
+
+  it('filters pending confirmations by global, mine, and actor scopes', () => {
+    const items = [
+      { confirm_token: 'a', actor: 'dashboard-a' },
+      { confirm_token: 'b', actor: 'dashboard-b' },
+      { confirm_token: 'c', actor: 'dashboard-a' },
+    ]
+
+    expect(
+      helpers.filterPendingConfirmations(items, 'dashboard-a', { kind: 'all' }).map(item => item.confirm_token),
+    ).toEqual(['a', 'b', 'c'])
+    expect(
+      helpers.filterPendingConfirmations(items, 'dashboard-a', { kind: 'mine' }).map(item => item.confirm_token),
+    ).toEqual(['a', 'c'])
+    expect(
+      helpers.filterPendingConfirmations(items, 'dashboard-a', { kind: 'actor', actor: 'dashboard-b' }).map(item => item.confirm_token),
+    ).toEqual(['b'])
+  })
+
+  it('only allows the owning actor to confirm a pending action', () => {
+    expect(
+      helpers.canManagePendingConfirmation({ confirm_token: 'a', actor: 'dashboard-a' }, 'dashboard-a'),
+    ).toBe(true)
+    expect(
+      helpers.canManagePendingConfirmation({ confirm_token: 'b', actor: 'dashboard-b' }, 'dashboard-a'),
+    ).toBe(false)
+  })
 })

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -6,6 +6,7 @@ import type {
   OperatorAttentionItem,
   OperatorGuidanceSummary,
   OperatorKeeperSnapshot,
+  PendingConfirmation,
   OperatorRecommendedAction,
   OperatorResidentJudgeRuntime,
   OperatorSessionSnapshot,
@@ -283,6 +284,33 @@ export function targetTypeLabel(value?: string | null): string {
 
 export function deliveryModeLabel(confirmRequired?: boolean): string {
   return confirmRequired ? '확인 후 실행' : '즉시 실행'
+}
+
+export type PendingQueueFilter =
+  | { kind: 'all' }
+  | { kind: 'mine' }
+  | { kind: 'actor'; actor: string }
+
+export function filterPendingConfirmations(
+  items: PendingConfirmation[],
+  currentActor: string,
+  filter: PendingQueueFilter,
+): PendingConfirmation[] {
+  switch (filter.kind) {
+    case 'all':
+      return items
+    case 'mine':
+      return items.filter(item => (item.actor ?? '').trim() === currentActor)
+    case 'actor':
+      return items.filter(item => (item.actor ?? '').trim() === filter.actor)
+  }
+}
+
+export function canManagePendingConfirmation(
+  item: PendingConfirmation,
+  currentActor: string,
+): boolean {
+  return (item.actor ?? '').trim() === currentActor
 }
 
 export function sessionActionLabel(value: typeof teamTurnKind.value): string {

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -27,15 +27,17 @@ import {
   attentionTone,
   hydratedWorkflowId,
   hydrateOpsWorkflow,
+  isSessionTerminal,
   isKeeperAttention,
   keeperPrioritySummary,
   isSessionAttention,
   keeperPriorityTone,
   normalizeStatus,
-  persistActorName,
   selectedSessionId,
   sessionPriorityTone,
+  submitPause,
   submitResume,
+  submitTeamStop,
   workflowTargetReady,
   type OpsPriorityCardData,
   type OpsPriorityTone,
@@ -53,11 +55,9 @@ export function Ops() {
   const sessions = snapshot?.sessions ?? []
   const keepers = snapshot?.keepers ?? []
   const pendingState = selectPendingConfirmState(snapshot)
-  const visiblePendingCount = pendingState.visible_count
   const totalPendingCount = pendingState.total_count
-  const hiddenPendingCount = pendingState.hidden_count
-  const pendingActorFilter = pendingState.actor_filter
   const selectedSession = sessions.find(session => session.session_id === selectedSessionId.value) ?? sessions[0] ?? null
+  const currentActor = actorName.value.trim() || 'dashboard'
   const roomAttention = roomDigest?.attention_items ?? []
   const sessionAttention = roomAttention.filter(isSessionAttention)
   const keeperAttention = roomAttention.filter(isKeeperAttention)
@@ -106,12 +106,10 @@ export function Ops() {
     {
       key: 'confirm',
       label: '확인 대기',
-      value: hiddenPendingCount > 0 ? `${visiblePendingCount}/${totalPendingCount}` : visiblePendingCount,
-      detail: visiblePendingCount > 0
-        ? '미리보기만 된 개입이 아직 사람 확인을 기다리고 있습니다'
-        : hiddenPendingCount > 0 && pendingActorFilter
-          ? `현재 개입 ID(${pendingActorFilter}) 기준으로는 비어 있고, 다른 개입 ID 대기 ${hiddenPendingCount}건이 있습니다`
-          : '지금 막혀 있는 확인 대기는 없습니다',
+      value: totalPendingCount,
+      detail: totalPendingCount > 0
+        ? '전역 승인 대기열에 사람 확인이 필요한 개입이 남아 있습니다'
+        : '지금 막혀 있는 확인 대기는 없습니다',
       tone: totalPendingCount > 0 ? 'warn' : 'ok',
     },
     {
@@ -155,15 +153,12 @@ export function Ops() {
   return html`
     <section class="flex flex-col gap-4">
       <div class="${CARD_STANDARD} flex justify-end items-center gap-4 flex-wrap">
-        <div class="flex items-end gap-3 flex-wrap max-[880px]:w-full">
-          <label class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium" for="ops-actor">개입 ID</label>
-          <input
-            id="ops-actor"
-            class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none ops-actor-input min-w-[180px]"
-            type="text"
-            value=${actorName.value}
-            onInput=${(event: Event) => persistActorName((event.target as HTMLInputElement).value)}
-          />
+        <div class="flex items-center gap-3 flex-wrap max-[880px]:w-full">
+          <div class="grid gap-0.5">
+            <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.06em] font-medium">실행 actor</span>
+            <strong class="text-[13px] text-[var(--text-strong)]">${currentActor}</strong>
+            <span class="text-[12px] text-[var(--text-muted)]">변경은 아래 고급 room 제어에서 합니다.</span>
+          </div>
           <button type="button"
             class="px-3 py-1.5 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] hover:bg-[var(--white-8)] transition-colors cursor-pointer text-[var(--text-body)]"
             onClick=${() => {
@@ -201,21 +196,6 @@ export function Ops() {
 
       ${(() => {
         const actions: Array<{ label: string; desc: string; tone: OpsPriorityTone; onClick: () => void }> = []
-        if (visiblePendingCount > 0 || hiddenPendingCount > 0) {
-          actions.push({
-            label: hiddenPendingCount > 0
-              ? `확인 대기 ${visiblePendingCount}/${totalPendingCount}건 확인`
-              : `확인 대기 ${visiblePendingCount}건 처리`,
-            desc: hiddenPendingCount > 0 && pendingActorFilter
-              ? `현재 개입 ID(${pendingActorFilter}) 기준으로 보이는 대기열을 먼저 확인합니다`
-              : '승인 또는 거부가 필요한 개입이 대기 중입니다',
-            tone: visiblePendingCount > 0 ? 'bad' : 'warn',
-            onClick: () => {
-              const el = document.querySelector('.ops-pending-section')
-              el?.scrollIntoView({ behavior: 'smooth' })
-            },
-          })
-        }
         if (room.paused) {
           actions.push({
             label: '방 재개',
@@ -223,19 +203,20 @@ export function Ops() {
             tone: 'warn',
             onClick: () => void submitResume(),
           })
-        }
-        if (flaggedKeepers.length > 0) {
-          const badKeepers = flaggedKeepers.filter(k => keeperPriorityTone(k) === 'bad')
+        } else {
           actions.push({
-            label: badKeepers.length > 0 ? `오프라인 키퍼 ${badKeepers.length}개` : `점검이 필요한 키퍼 ${flaggedKeepers.length}개`,
-            desc: badKeepers.length > 0
-              ? '메시지를 보내거나 상태를 확인하세요'
-              : `${leadingFlaggedKeeper?.name ?? '일부 키퍼'} · ${leadingFlaggedKeeper ? keeperPrioritySummary(leadingFlaggedKeeper) : '점검 필요'}`,
-            tone: badKeepers.length > 0 ? 'bad' : 'warn',
-            onClick: () => {
-              const el = document.querySelector('.ops-keeper-section')
-              el?.scrollIntoView({ behavior: 'smooth' })
-            },
+            label: '방 일시정지',
+            desc: '자동 spawn과 room automation을 잠시 멈춥니다',
+            tone: 'warn',
+            onClick: () => void submitPause(),
+          })
+        }
+        if (selectedSession && !isSessionTerminal(selectedSession)) {
+          actions.push({
+            label: '선택 세션 중지',
+            desc: `${selectedSession.session_id} · 실행 중인 세션을 즉시 멈춥니다`,
+            tone: 'bad',
+            onClick: () => void submitTeamStop(),
           })
         }
         if (actions.length === 0) return null
@@ -243,7 +224,7 @@ export function Ops() {
           <section class="${CARD_STANDARD}">
             <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">지금 할 수 있는 것</h3>
             <div class="flex flex-col gap-2">
-              ${actions.slice(0, 3).map(action => html`
+              ${actions.map(action => html`
                 <button type="button" class="ops-action-guide-item rounded-lg ${action.tone}" onClick=${action.onClick}>
                   <strong class="font-semibold">${action.label}</strong>
                   <span>${action.desc}</span>

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -2,24 +2,24 @@
 
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
-import { showToast } from '../common/toast'
+import { ActionButton } from '../common/button'
 import { openKeeperDetail } from '../keeper-detail'
 import { findKeeper } from '../execution/shared'
 import {
+  operatorActionBusy,
   operatorActionLog,
   operatorSnapshot,
 } from '../../operator-store'
-import type { Keeper, OperatorActionDescriptor, OperatorKeeperSnapshot } from '../../types'
+import type { Keeper, OperatorKeeperSnapshot } from '../../types'
 import {
   actionTypeLabel,
   displayStatus,
-  executeAction,
+  keeperMessage,
   keeperPrioritySummary,
   keeperPriorityTone,
   relativeAge,
   selectedKeeperName,
-  selectedSessionId,
-  targetTypeLabel,
+  submitKeeperMessage,
   logEntryBorderClass,
 } from './helpers'
 
@@ -43,8 +43,8 @@ export function OpsKeeperColumn() {
   const snapshot = operatorSnapshot.value
   const keepers = snapshot?.keepers ?? []
   const persistentAgents = snapshot?.persistent_agents ?? []
-  const availableActions = snapshot?.available_actions ?? []
   const selectedKeeper = keepers.find(keeper => keeper.name === selectedKeeperName.value) ?? keepers[0] ?? null
+  const busy = operatorActionBusy.value
 
   return html`
     <div class="flex flex-col gap-4 min-w-0">
@@ -121,51 +121,56 @@ export function OpsKeeperColumn() {
       </section>
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0">
-        <div class="flex items-center justify-between pb-2 border-b border-[var(--card-border)]">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">액션</h3>
-          <span class="text-[12px] text-[var(--text-muted)]">${availableActions.length}개</span>
+        <div class="pb-2 border-b border-[var(--card-border)] mb-1">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">선택한 Keeper 상태</h3>
         </div>
-        ${availableActions.length
-          ? html`<div class="flex flex-col gap-2">
-              ${['room', 'keeper', 'team_session'].map(targetType => {
-                const group = availableActions.filter((a: OperatorActionDescriptor) => a.target_type === targetType)
-                if (group.length === 0) return null
-                return html`
-                  <div key=${targetType}>
-                    <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-wider mb-1">${targetTypeLabel(targetType)}</div>
-                    <div class="flex flex-wrap gap-1">
-                      ${group.map((action: OperatorActionDescriptor) => html`
-                        <button type="button" key=${action.action_type}
-                          type="button"
-                          title=${action.description ?? ''}
-                          onClick=${() => {
-                            const targetId =
-                              action.target_type === 'keeper' ? selectedKeeperName.value
-                              : action.target_type === 'team_session' ? selectedSessionId.value
-                              : undefined
-                            if ((action.target_type === 'keeper' || action.target_type === 'team_session') && !targetId) {
-                              const what = action.target_type === 'keeper' ? 'keeper' : '세션'
-                              showToast(`먼저 ${what}를 선택하세요`, 'warning')
-                              return
-                            }
-                            void executeAction({
-                              action_type: action.action_type as Parameters<typeof executeAction>[0]['action_type'],
-                              target_type: action.target_type as 'room' | 'team_session' | 'keeper',
-                              target_id: targetId,
-                              payload: {},
-                              successMessage: `${actionTypeLabel(action.action_type)} 실행 완료`,
-                            })
-                          }}
-                          class="text-[12px] px-2 py-0.5 rounded cursor-pointer hover:brightness-125 transition-all ${action.confirm_required ? 'bg-[var(--warn-12)] border border-[var(--warn-28)] text-[var(--warn)]' : 'bg-[var(--accent-8)] border border-[var(--accent-12)] text-[var(--accent)]'}">
-                          ${actionTypeLabel(action.action_type)}
-                        </button>
-                      `)}
-                    </div>
-                  </div>
-                `
-              })}
-            </div>`
-          : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">액션 없음</div>`}
+        <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">목록에서는 상태를 보고, 직접 메시지는 아래 고급 패널에서만 보냅니다.</p>
+        ${selectedKeeper ? html`
+          <article class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-2">
+            <div class="flex justify-between items-center gap-3 max-[880px]:flex-col max-[880px]:items-start">
+              <strong>${selectedKeeper.name}</strong>
+              <span class="inline-flex items-center gap-1.5 text-[11px]">
+                <span class="w-2 h-2 rounded-full ${selectedKeeper.status === 'offline' ? 'bg-[var(--text-muted)]' : selectedKeeper.status === 'active' || selectedKeeper.status === 'running' ? 'bg-[var(--ok)]' : 'bg-[var(--warn)]'}"></span>
+                ${displayStatus(selectedKeeper.status)}
+              </span>
+            </div>
+            <div class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
+              ${keeperPrioritySummary(selectedKeeper)}
+            </div>
+            <div class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex gap-2">
+              <span>${selectedKeeper.last_model_used ?? selectedKeeper.model ?? 'model 확인 필요'}</span>
+              <span>${typeof selectedKeeper.context_ratio === 'number' ? `${Math.round(selectedKeeper.context_ratio * 100)}% ctx` : typeof selectedKeeper.context_tokens === 'number' ? `${Math.round(selectedKeeper.context_tokens / 1000)}k tok` : 'ctx 확인 필요'}</span>
+              <span>${relativeAge(selectedKeeper.last_turn_ago_s)}</span>
+            </div>
+          </article>
+        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">먼저 keeper를 하나 고르세요.</div>`}
+
+        <details class="ops-control-disclosure mt-0.5 border border-[var(--white-8)] rounded-xl bg-[var(--white-2)]">
+          <summary class="ops-control-summary list-none cursor-pointer grid gap-1 p-3 px-3.5">
+            <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 keeper 개입</span>
+            <strong>${selectedKeeper ? `${selectedKeeper.name}에게 직접 메시지` : 'keeper를 선택하면 메시지 입력이 열립니다.'}</strong>
+            <span>상세 진단은 keeper 상세 보기에서, 직접 개입은 이 패널에서 진행합니다.</span>
+          </summary>
+
+          <div class="grid gap-3 px-3.5 pb-3.5 border-t border-[var(--white-8)]">
+            <textarea
+              class="control-textarea"
+              rows=${3}
+              placeholder="keeper에게 보낼 메시지"
+              value=${keeperMessage.value}
+              onInput=${(event: Event) => { keeperMessage.value = (event.target as HTMLTextAreaElement).value }}
+              disabled=${busy || !selectedKeeper}
+            ></textarea>
+            <div class="control-row items-stretch">
+              <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitKeeperMessage() }} disabled=${busy || !selectedKeeper || !keeperMessage.value.trim()}>
+                메시지 보내기
+              <//>
+              <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">
+                현재 선택한 keeper에만 적용됩니다.
+              </span>
+            </div>
+          </div>
+        </details>
       </section>
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -1,6 +1,7 @@
 // Ops — Room column: broadcast, pause/resume, task inject, recommended actions, pending confirmations, room feed
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import { useRef } from 'preact/hooks'
@@ -13,9 +14,12 @@ import {
 } from '../../operator-store'
 import {
   actionTypeLabel,
+  actorName,
+  canManagePendingConfirmation,
   broadcastMessage,
   confirmPending,
   deliveryModeLabel,
+  filterPendingConfirmations,
   guidanceFreshnessLabel,
   guidanceLayerLabel,
   guidanceLayerTone,
@@ -34,8 +38,12 @@ import {
   taskTitle,
   formatMessageContent,
   logEntryBorderClass,
+  persistActorName,
+  type PendingQueueFilter,
 } from './helpers'
 import { selectPendingConfirmState } from '../../pending-confirm'
+
+const pendingQueueFilter = signal<PendingQueueFilter>({ kind: 'all' })
 
 export function OpsRoomColumn() {
   const roomControlDisclosureRef = useRef<HTMLDetailsElement | null>(null)
@@ -44,10 +52,6 @@ export function OpsRoomColumn() {
   const room = snapshot?.room ?? {}
   const pendingState = selectPendingConfirmState(snapshot)
   const pendingConfirms = pendingState.items
-  const confirmRequiredActions = pendingState.confirm_required_actions
-  const actorFilter = pendingState.actor_filter
-  const hiddenCount = pendingState.hidden_count
-  const hiddenActors = pendingState.hidden_actors
   const recentMessages = snapshot?.recent_messages ?? []
   const recommendedActions = roomDigest?.recommended_actions ?? []
   const activeRecommendedActions =
@@ -58,6 +62,23 @@ export function OpsRoomColumn() {
   const residentRuntime = roomDigest?.resident_judge_runtime ?? snapshot?.resident_judge_runtime
   const guidanceLayer = roomDigest?.active_guidance_layer ?? 'fallback'
   const roomFeed = recentMessages.slice(0, 5)
+  const currentActor = actorName.value.trim() || 'dashboard'
+  const actorOptions = pendingConfirms
+    .map(item => item.actor?.trim() ?? '')
+    .filter(Boolean)
+    .filter((value, index, source) => source.indexOf(value) === index)
+    .sort((a, b) => a.localeCompare(b))
+  const pendingFilter = pendingQueueFilter.value
+  const effectivePendingFilter =
+    pendingFilter.kind === 'actor'
+    && !actorOptions.includes(pendingFilter.actor)
+      ? ({ kind: 'all' } as PendingQueueFilter)
+      : pendingFilter
+  const filteredPendingConfirms =
+    filterPendingConfirmations(pendingConfirms, currentActor, effectivePendingFilter)
+  const confirmActionLabels = pendingState.confirm_required_actions
+    .map(item => actionTypeLabel(item.action_type))
+    .filter((label, index, source) => source.indexOf(label) === index)
   const openRoomControlDisclosure = () => {
     const disclosure = roomControlDisclosureRef.current
     if (disclosure) {
@@ -119,51 +140,81 @@ export function OpsRoomColumn() {
           <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">승인 대기</h3>
         </div>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
-          ${actorFilter
-            ? `현재 actor ${actorFilter} 기준 queue를 읽습니다. 승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.`
-            : '승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.'}
+          전역 승인 대기를 기본으로 보여줍니다. 현재 실행 actor는 <strong>${currentActor}</strong>이고, 다른 actor가 만든 항목은 여기서 읽기 전용입니다.
         </p>
-        ${confirmRequiredActions.length > 0 ? html`
-          <div class="flex flex-col gap-2">
-            ${confirmRequiredActions.map(item => html`
-              <article key=${`${item.action_type}:${item.target_type}`} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] min-w-0 flex-shrink-0">
-                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
-                  <strong>${actionTypeLabel(item.action_type)}</strong>
-                  <span>${targetTypeLabel(item.target_type)}</span>
-                  <span>${deliveryModeLabel(item.confirm_required)}</span>
-                </div>
-                <div class="mt-1.5 whitespace-pre-wrap break-words max-h-[200px] overflow-auto">${item.description ?? '설명 확인 필요'}</div>
-              </article>
-            `)}
+        ${confirmActionLabels.length > 0 ? html`
+          <div class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
+            확인 후 실행 액션: ${confirmActionLabels.join(', ')}
           </div>
         ` : null}
         ${pendingConfirms.length > 0 ? html`
+          <div class="flex flex-wrap gap-2">
+            <${ActionButton}
+              variant=${effectivePendingFilter.kind === 'all' ? 'primary' : 'ghost'}
+              size="lg"
+              onClick=${() => { pendingQueueFilter.value = { kind: 'all' } }}
+              disabled=${operatorActionBusy.value}
+            >
+              전체 ${pendingConfirms.length}
+            <//>
+            <${ActionButton}
+              variant=${effectivePendingFilter.kind === 'mine' ? 'primary' : 'ghost'}
+              size="lg"
+              onClick=${() => { pendingQueueFilter.value = { kind: 'mine' } }}
+              disabled=${operatorActionBusy.value}
+            >
+              내 것 ${pendingConfirms.filter(item => canManagePendingConfirmation(item, currentActor)).length}
+            <//>
+            ${actorOptions
+              .filter(actor => actor !== currentActor)
+              .map(actor => html`
+                <${ActionButton}
+                  key=${actor}
+                  variant=${effectivePendingFilter.kind === 'actor' && effectivePendingFilter.actor === actor ? 'primary' : 'ghost'}
+                  size="lg"
+                  onClick=${() => { pendingQueueFilter.value = { kind: 'actor', actor } }}
+                  disabled=${operatorActionBusy.value}
+                >
+                  ${actor}
+                <//>
+              `)}
+          </div>
+        ` : null}
+        ${filteredPendingConfirms.length > 0 ? html`
           <div class="flex flex-col gap-3 max-h-[400px] overflow-y-auto min-w-0 text-[var(--fs-sm)] text-[var(--text-muted)]">
-            ${pendingConfirms.map(item => html`
+            ${filteredPendingConfirms.map(item => {
+              const canManage = canManagePendingConfirmation(item, currentActor)
+              return html`
               <article key=${item.confirm_token} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)] min-w-0 flex-shrink-0">
                 <div class="flex flex-wrap gap-2 text-[var(--text-muted)] text-[var(--fs-xs)]">
                   <strong>${actionTypeLabel(item.action_type)}</strong>
                   <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
                   <span>${item.delegated_tool ?? '위임 도구 확인 필요'}</span>
+                  <span>owner ${item.actor ?? 'unknown'}</span>
                 </div>
                 ${item.preview ? html`<pre class="mt-2 py-[10px] px-3 rounded-xl bg-[rgba(8,15,29,0.82)] border border-solid border-[var(--white-8)] text-[#b9d6ff] text-[11px] leading-[1.45] overflow-x-auto whitespace-pre-wrap break-words max-h-[180px]">${prettyJson(item.preview)}</pre>` : null}
+                <div class="mt-2 text-[12px] leading-[1.45] text-[var(--text-muted)]">
+                  ${canManage
+                    ? '현재 실행 actor가 이 승인 대기를 처리할 수 있습니다.'
+                    : '다른 actor가 만든 승인 대기라서 여기서는 읽기만 가능합니다.'}
+                </div>
                 <div class="flex justify-between items-center gap-3 mt-3 max-[880px]:flex-col max-[880px]:items-start">
-                  <${ActionButton} variant="primary" size="lg" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
+                  <${ActionButton} variant="primary" size="lg" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value || !canManage}>
                     실행
                   <//>
-                  <${ActionButton} variant="ghost" size="lg" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
+                  <${ActionButton} variant="ghost" size="lg" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value || !canManage}>
                     거부
                   <//>
                   <span class="text-[var(--text-muted)] text-[var(--fs-xs)] font-mono break-all">${item.confirm_token}</span>
                 </div>
               </article>
-            `)}
+            `})}
           </div>
         ` : html`
           <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">
-            ${hiddenCount > 0 && actorFilter
-              ? `현재 선택한 actor(${actorFilter}) 기준 승인 대기는 0건입니다. 다른 actor 대기 ${hiddenCount}건${hiddenActors.length > 0 ? ` · ${hiddenActors.join(', ')}` : ''}`
-              : '지금 승인 대기는 없습니다. 위 목록의 preview-confirm 액션을 먼저 만들어야 여기에 쌓입니다.'}
+            ${pendingConfirms.length > 0
+              ? '선택한 필터에는 승인 대기가 없습니다. 전체 목록으로 돌아가서 다시 확인하세요.'
+              : '지금 승인 대기는 없습니다.'}
           </div>
         `}
       </section>
@@ -204,11 +255,21 @@ export function OpsRoomColumn() {
         >
           <summary class="ops-control-summary list-none cursor-pointer grid gap-1 p-3 px-3.5">
             <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 room 제어</span>
-            <strong>${room.paused ? '지금은 room이 멈춰 있어 재개 동선이 열려 있습니다.' : '방송 · 일시정지/재개 · 작업 주입'}</strong>
-            <span>${room.paused ? '운영 점검 후 재개하거나 공지를 보내세요.' : 'room 전체에 영향 주는 액션만 이 안에 넣었습니다.'}</span>
+            <strong>${room.paused ? '지금은 room이 멈춰 있어 재개 동선이 열려 있습니다.' : '실행 actor 설정, 방송, room 쓰기 액션'}</strong>
+            <span>${room.paused ? '운영 점검 후 재개하거나 공지를 보내세요.' : '기본 화면은 읽기 중심이고, 실제 room 변경은 이 안에서만 합니다.'}</span>
           </summary>
 
           <div class="grid gap-3 px-3.5 pb-3.5 border-t border-[var(--white-8)]">
+            <label class="control-label" for="ops-actor">실행 actor</label>
+            <input
+              id="ops-actor"
+              class="control-input"
+              type="text"
+              value=${actorName.value}
+              onInput=${(event: Event) => { persistActorName((event.target as HTMLInputElement).value) }}
+              disabled=${operatorActionBusy.value}
+            />
+
             <label class="control-label" for="ops-broadcast">Room 방송</label>
             <div class="control-row">
               <input

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -247,26 +247,13 @@ export function OpsSessionColumn() {
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel">
         <div class="pb-2 border-b border-[var(--card-border)] mb-1">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">선택한 Session 액션</h3>
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">선택한 Session 상태</h3>
         </div>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
           ${selectedSessionActionable
-            ? '선택한 live 세션에만 메모, 작업, 체크포인트, 중지 요청을 보냅니다.'
+            ? '기본은 읽기만 하고, 실제 세션 개입은 아래 고급 패널에서만 합니다.'
             : '종료된 세션은 여기서 읽기만 하고, 실제 개입은 위 live 세션을 다시 골라서 진행합니다.'}
         </p>
-        ${availableSessionActions.length > 0 ? html`
-          <div class="flex flex-col gap-2">
-            ${availableSessionActions.map(action => html`
-              <article key=${action.action_type} class="p-3 rounded-xl bg-[var(--white-3)] border border-[var(--white-8)]">
-                <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
-                  <strong>${actionTypeLabel(action.action_type)}</strong>
-                  <span>${deliveryModeLabel(action.confirm_required)}</span>
-                </div>
-                <div class="mt-1.5 whitespace-pre-wrap break-words">${action.description ?? '설명 확인 필요'}</div>
-              </article>
-            `)}
-          </div>
-        ` : null}
 
         ${selectedSession ? html`
           <div class="flex flex-col gap-2">
@@ -315,118 +302,135 @@ export function OpsSessionColumn() {
           <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션은 이미 종료돼서 새 노트, 작업, 중지를 보내지 않습니다. 위의 live 세션을 선택하세요.</div>
         ` : null}
 
-        ${linkedAutoresearch?.loop_id ? html`
-          <label class="control-label" for="ops-autoresearch-hypothesis">Autoresearch 제어</label>
-          <div class="control-row items-stretch">
-            <${ActionButton} variant="ghost" size="lg" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
-              상태 새로고침
-            <//>
-            <${ActionButton} variant="primary" size="lg" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
-              1 cycle 실행
-            <//>
-            <${ActionButton} variant="ghost" size="lg" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
-              loop 중지
-            <//>
+        <details class="ops-control-disclosure mt-0.5 border border-[var(--white-8)] rounded-xl bg-[var(--white-2)]">
+          <summary class="ops-control-summary list-none cursor-pointer grid gap-1 p-3 px-3.5">
+            <span class="text-[#9fe6b5] text-[var(--fs-2xs)] tracking-[0.08em] uppercase">고급 세션 개입</span>
+            <strong>${selectedSessionActionable ? '노트, 방송, 작업 주입, worker 교체, 중지' : '읽기 전용 세션은 여기서도 실행되지 않습니다.'}</strong>
+            <span>${selectedSessionActionable ? '선택한 live 세션에만 적용합니다.' : '실제 개입은 위 live 세션을 다시 선택한 뒤 진행하세요.'}</span>
+          </summary>
+
+          <div class="grid gap-3 px-3.5 pb-3.5 border-t border-[var(--white-8)]">
+            ${availableSessionActions.length > 0 ? html`
+              <div class="text-[12px] text-[var(--text-muted)] leading-[1.45]">
+                지원 액션:
+                ${availableSessionActions.map(action => `${actionTypeLabel(action.action_type)} (${deliveryModeLabel(action.confirm_required)})`).join(', ')}
+              </div>
+            ` : null}
+
+            ${linkedAutoresearch?.loop_id ? html`
+              <label class="control-label" for="ops-autoresearch-hypothesis">Autoresearch 제어</label>
+              <div class="control-row items-stretch">
+                <${ActionButton} variant="ghost" size="lg" onClick=${() => { void refreshAutoresearch() }} disabled=${busy}>
+                  상태 새로고침
+                <//>
+                <${ActionButton} variant="primary" size="lg" onClick=${() => { void cycleAutoresearch() }} disabled=${busy}>
+                  1 cycle 실행
+                <//>
+                <${ActionButton} variant="ghost" size="lg" onClick=${() => { void stopAutoresearch() }} disabled=${busy}>
+                  loop 중지
+                <//>
+              </div>
+              <textarea
+                id="ops-autoresearch-hypothesis"
+                class="control-textarea"
+                rows=${2}
+                placeholder="다음 cycle에 넣을 hypothesis"
+                value=${autoresearchHypothesis.value}
+                onInput=${(event: Event) => { autoresearchHypothesis.value = (event.target as HTMLTextAreaElement).value }}
+                disabled=${busy}
+              ></textarea>
+              <div class="control-row items-stretch">
+                <${ActionButton} variant="primary" size="lg" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
+                  hypothesis 주입
+                <//>
+                <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
+              </div>
+              ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${autoresearchError.value}</div>` : null}
+            ` : null}
+
+            <label class="control-label" for="ops-turn-kind">세션 액션</label>
+            <div class="control-row items-stretch">
+              <select
+                id="ops-turn-kind"
+                class="control-input min-w-[92px]"
+                value=${teamTurnKind.value}
+                onChange=${(event: Event) => { teamTurnKind.value = (event.target as HTMLSelectElement).value as typeof teamTurnKind.value }}
+                disabled=${busy || !selectedSessionActionable}
+              >
+                <option value="note">노트</option>
+                <option value="broadcast">방송</option>
+                <option value="task">작업</option>
+                <option value="worker_spawn_batch">worker 교체</option>
+              </select>
+              <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
+                적용
+              <//>
+            </div>
+            <div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">현재 선택: ${sessionActionLabel(teamTurnKind.value)}</div>
+
+            <textarea
+              class="control-textarea"
+              rows=${3}
+              placeholder="세션에 남길 메시지"
+              value=${teamMessage.value}
+              onInput=${(event: Event) => { teamMessage.value = (event.target as HTMLTextAreaElement).value }}
+              disabled=${busy || !selectedSessionActionable}
+            ></textarea>
+
+            ${teamTurnKind.value === 'task' ? html`
+              <input
+                class="control-input"
+                type="text"
+                placeholder="주입할 작업 제목"
+                value=${teamTaskTitle.value}
+                onInput=${(event: Event) => { teamTaskTitle.value = (event.target as HTMLInputElement).value }}
+                disabled=${busy || !selectedSessionActionable}
+              />
+              <textarea
+                class="control-textarea"
+                rows=${2}
+                placeholder="주입할 작업 설명"
+                value=${teamTaskDescription.value}
+                onInput=${(event: Event) => { teamTaskDescription.value = (event.target as HTMLTextAreaElement).value }}
+                disabled=${busy || !selectedSessionActionable}
+              ></textarea>
+              <select
+                class="control-input min-w-[92px]"
+                value=${teamTaskPriority.value}
+                onChange=${(event: Event) => { teamTaskPriority.value = (event.target as HTMLSelectElement).value }}
+                disabled=${busy || !selectedSessionActionable}
+              >
+                <option value="1">P1</option>
+                <option value="2">P2</option>
+                <option value="3">P3</option>
+                <option value="4">P4</option>
+                <option value="5">P5</option>
+              </select>
+            ` : teamTurnKind.value === 'worker_spawn_batch' ? html`
+              <textarea
+                class="control-textarea"
+                rows=${6}
+                placeholder='spawn_batch JSON, 예: [{"spawn_agent":"llama","spawn_prompt":"...", "spawn_role":"replacement"}]'
+                value=${teamSpawnBatchJson.value}
+                onInput=${(event: Event) => { teamSpawnBatchJson.value = (event.target as HTMLTextAreaElement).value }}
+                disabled=${busy || !selectedSessionActionable}
+              ></textarea>
+            ` : null}
+
+            <div class="control-row items-stretch">
+              <input
+                class="control-input"
+                type="text"
+                value=${teamStopReason.value}
+                onInput=${(event: Event) => { teamStopReason.value = (event.target as HTMLInputElement).value }}
+                disabled=${busy || !selectedSessionActionable}
+              />
+              <${ActionButton} variant="ghost" size="lg" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
+                세션 중지
+              <//>
+            </div>
           </div>
-          <textarea
-            id="ops-autoresearch-hypothesis"
-            class="control-textarea"
-            rows=${2}
-            placeholder="다음 cycle에 넣을 hypothesis"
-            value=${autoresearchHypothesis.value}
-            onInput=${(event: Event) => { autoresearchHypothesis.value = (event.target as HTMLTextAreaElement).value }}
-            disabled=${busy}
-          ></textarea>
-          <div class="control-row items-stretch">
-            <${ActionButton} variant="primary" size="lg" onClick=${() => { void injectHypothesis() }} disabled=${busy || !autoresearchHypothesis.value.trim()}>
-              hypothesis 주입
-            <//>
-            <span class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">canonical control은 MCP tool이고, 이 화면은 그 상태를 읽고 이어서 제어합니다.</span>
-          </div>
-          ${autoresearchError.value ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${autoresearchError.value}</div>` : null}
-        ` : null}
-
-        <label class="control-label" for="ops-turn-kind">세션 액션</label>
-        <div class="control-row items-stretch">
-          <select
-            id="ops-turn-kind"
-            class="control-input min-w-[92px]"
-            value=${teamTurnKind.value}
-            onChange=${(event: Event) => { teamTurnKind.value = (event.target as HTMLSelectElement).value as typeof teamTurnKind.value }}
-            disabled=${busy || !selectedSessionActionable}
-          >
-            <option value="note">노트</option>
-            <option value="broadcast">방송</option>
-            <option value="task">작업</option>
-            <option value="worker_spawn_batch">worker 교체</option>
-          </select>
-          <${ActionButton} variant="primary" size="lg" onClick=${() => { void submitTeamTurn() }} disabled=${busy || !selectedSessionActionable}>
-            적용
-          <//>
-        </div>
-        <div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">현재 선택: ${sessionActionLabel(teamTurnKind.value)}</div>
-
-        <textarea
-          class="control-textarea"
-          rows=${3}
-          placeholder="세션에 남길 메시지"
-          value=${teamMessage.value}
-          onInput=${(event: Event) => { teamMessage.value = (event.target as HTMLTextAreaElement).value }}
-          disabled=${busy || !selectedSessionActionable}
-        ></textarea>
-
-        ${teamTurnKind.value === 'task' ? html`
-          <input
-            class="control-input"
-            type="text"
-            placeholder="주입할 작업 제목"
-            value=${teamTaskTitle.value}
-            onInput=${(event: Event) => { teamTaskTitle.value = (event.target as HTMLInputElement).value }}
-            disabled=${busy || !selectedSessionActionable}
-          />
-          <textarea
-            class="control-textarea"
-            rows=${2}
-            placeholder="주입할 작업 설명"
-            value=${teamTaskDescription.value}
-            onInput=${(event: Event) => { teamTaskDescription.value = (event.target as HTMLTextAreaElement).value }}
-            disabled=${busy || !selectedSessionActionable}
-          ></textarea>
-          <select
-            class="control-input min-w-[92px]"
-            value=${teamTaskPriority.value}
-            onChange=${(event: Event) => { teamTaskPriority.value = (event.target as HTMLSelectElement).value }}
-            disabled=${busy || !selectedSessionActionable}
-          >
-            <option value="1">P1</option>
-            <option value="2">P2</option>
-            <option value="3">P3</option>
-            <option value="4">P4</option>
-            <option value="5">P5</option>
-          </select>
-        ` : teamTurnKind.value === 'worker_spawn_batch' ? html`
-          <textarea
-            class="control-textarea"
-            rows=${6}
-            placeholder='spawn_batch JSON, 예: [{"spawn_agent":"llama","spawn_prompt":"...", "spawn_role":"replacement"}]'
-            value=${teamSpawnBatchJson.value}
-            onInput=${(event: Event) => { teamSpawnBatchJson.value = (event.target as HTMLTextAreaElement).value }}
-            disabled=${busy || !selectedSessionActionable}
-          ></textarea>
-        ` : null}
-
-        <div class="control-row items-stretch">
-          <input
-            class="control-input"
-            type="text"
-            value=${teamStopReason.value}
-            onInput=${(event: Event) => { teamStopReason.value = (event.target as HTMLInputElement).value }}
-            disabled=${busy || !selectedSessionActionable}
-          />
-          <${ActionButton} variant="ghost" size="lg" onClick=${() => { void submitTeamStop() }} disabled=${busy || !selectedSessionActionable}>
-            세션 중지
-          <//>
-        </div>
+        </details>
       </section>
     </div>
   `

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -89,6 +89,10 @@ type available_action = {
   confirm_required : bool;
 }
 
+let make_available_action ~action_type ~target_type ~description =
+  { action_type; target_type; description;
+    confirm_required = Operator_approval.confirm_required action_type }
+
 let preview_of_pending_confirm (entry : pending_confirm) =
   `Assoc
     [
@@ -245,84 +249,44 @@ let pending_confirms_json ?actor config =
 
 let available_actions : available_action list =
   [
-    {
-      action_type = "broadcast";
-      target_type = "room";
-      description = "Use this when you need a room-wide operator broadcast.";
-      confirm_required = false;
-    };
-    {
-      action_type = "room_pause";
-      target_type = "room";
-      description = "Use this when you need to pause room automation or spawning.";
-      confirm_required = true;
-    };
-    {
-      action_type = "room_resume";
-      target_type = "room";
-      description = "Resume a paused MASC room, allowing the orchestrator to spawn agents again. Use when the pause reason is resolved (review done, incident cleared).";
-      confirm_required = false;
-    };
-    {
-      action_type = "social_sweep";
-      target_type = "room";
-      description = "Use this when you need to run one immediate public-square social sweep and inspect which keepers acted, passed, or were system-skipped.";
-      confirm_required = false;
-    };
-    {
-      action_type = "task_inject";
-      target_type = "room";
-      description = "Use this when you need to inject a new backlog task into the room through a preview-confirm path.";
-      confirm_required = true;
-    };
-    {
-      action_type = "team_note";
-      target_type = "team_session";
-      description = "Use this when you need to append a non-broadcast operator note to a team session.";
-      confirm_required = false;
-    };
-    {
-      action_type = "team_broadcast";
-      target_type = "team_session";
-      description = "Use this when you need a broadcast-style orchestration turn in a team session.";
-      confirm_required = false;
-    };
-    {
-      action_type = "team_task_inject";
-      target_type = "team_session";
-      description = "Use this when you need to inject a new task into a running team session.";
-      confirm_required = true;
-    };
-    {
-      action_type = "team_worker_spawn_batch";
-      target_type = "team_session";
-      description = "Use this when you need to spawn or replace one or more team-session workers through a preview-confirm path.";
-      confirm_required = true;
-    };
-    {
-      action_type = "team_stop";
-      target_type = "team_session";
-      description = "Use this when you need to stop a running team session.";
-      confirm_required = true;
-    };
-    {
-      action_type = "keeper_message";
-      target_type = "keeper";
-      description = "Use this when you need to send a direct operator message to a keeper.";
-      confirm_required = false;
-    };
-    {
-      action_type = "keeper_probe";
-      target_type = "keeper";
-      description = "Use this when you need an immediate keeper diagnostic snapshot with health, silence reason, and next suggested action.";
-      confirm_required = false;
-    };
-    {
-      action_type = "keeper_recover";
-      target_type = "keeper";
-      description = "Use this when a keeper is stale, degraded, or offline and you need a safe down/up recovery with before-and-after diagnostics.";
-      confirm_required = false;
-    };
+    make_available_action ~action_type:"broadcast" ~target_type:"room"
+      ~description:"Use this when you need a room-wide operator broadcast.";
+    make_available_action ~action_type:"room_pause" ~target_type:"room"
+      ~description:"Use this when you need to pause room automation or spawning.";
+    make_available_action ~action_type:"room_resume" ~target_type:"room"
+      ~description:
+        "Resume a paused MASC room, allowing the orchestrator to spawn agents again. Use when the pause reason is resolved (review done, incident cleared).";
+    make_available_action ~action_type:"social_sweep" ~target_type:"room"
+      ~description:
+        "Use this when you need to run one immediate public-square social sweep and inspect which keepers acted, passed, or were system-skipped.";
+    make_available_action ~action_type:"task_inject" ~target_type:"room"
+      ~description:
+        "Use this when you need to inject a new backlog task into the room immediately.";
+    make_available_action ~action_type:"team_note" ~target_type:"team_session"
+      ~description:
+        "Use this when you need to append a non-broadcast operator note to a team session.";
+    make_available_action ~action_type:"team_broadcast"
+      ~target_type:"team_session"
+      ~description:
+        "Use this when you need a broadcast-style orchestration turn in a team session.";
+    make_available_action ~action_type:"team_task_inject"
+      ~target_type:"team_session"
+      ~description:
+        "Use this when you need to inject a new task into a running team session.";
+    make_available_action ~action_type:"team_worker_spawn_batch"
+      ~target_type:"team_session"
+      ~description:
+        "Use this when you need to spawn or replace one or more team-session workers.";
+    make_available_action ~action_type:"team_stop" ~target_type:"team_session"
+      ~description:"Use this when you need to stop a running team session.";
+    make_available_action ~action_type:"keeper_message" ~target_type:"keeper"
+      ~description:"Use this when you need to send a direct operator message to a keeper.";
+    make_available_action ~action_type:"keeper_probe" ~target_type:"keeper"
+      ~description:
+        "Use this when you need an immediate keeper diagnostic snapshot with health, silence reason, and next suggested action.";
+    make_available_action ~action_type:"keeper_recover" ~target_type:"keeper"
+      ~description:
+        "Use this when a keeper is stale, degraded, or offline and you need a safe down/up recovery with before-and-after diagnostics.";
   ]
 
 let available_action_to_yojson (entry : available_action) =

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -67,7 +67,21 @@ let test_snapshot_exposes_keeper_and_social_actions () =
           Alcotest.(check string) "worker spawn batch target_type" "team_session"
             Yojson.Safe.Util.(worker_spawn_batch |> member "target_type" |> to_string);
           Alcotest.(check bool) "worker spawn batch confirm true" true
-            Yojson.Safe.Util.(worker_spawn_batch |> member "confirm_required" |> to_bool))
+            Yojson.Safe.Util.(worker_spawn_batch |> member "confirm_required" |> to_bool);
+          let task_inject =
+            match find_action "task_inject" with
+            | Some row -> row
+            | None -> Alcotest.fail "expected task_inject in available_actions"
+          in
+          Alcotest.(check bool) "task inject confirm false" false
+            Yojson.Safe.Util.(task_inject |> member "confirm_required" |> to_bool);
+          let team_stop =
+            match find_action "team_stop" with
+            | Some row -> row
+            | None -> Alcotest.fail "expected team_stop in available_actions"
+          in
+          Alcotest.(check bool) "team stop confirm true" true
+            Yojson.Safe.Util.(team_stop |> member "confirm_required" |> to_bool))
 
 let test_keeper_status_exposes_summary_and_recoverable () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -105,6 +105,16 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
         (List.exists
            (fun row ->
              Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "room_pause")
+           confirm_required_actions);
+      Alcotest.(check bool) "team stop listed" true
+        (List.exists
+           (fun row ->
+             Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "team_stop")
+           confirm_required_actions);
+      Alcotest.(check bool) "task inject not listed" false
+        (List.exists
+           (fun row ->
+             Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "task_inject")
            confirm_required_actions))
 
 let test_snapshot_caps_session_recent_events () =


### PR DESCRIPTION
## Summary
- switch operator reads to a global observer view while keeping actor-owned writes and confirms
- align available action metadata with the shared approval policy so confirm-required labels match real behavior
- simplify the intervene UI into read-first room/session/keeper views with advanced mutation controls folded away

## Validation
- npm test -- src/components/ops/helpers.test.ts
- npm run build
- dune exec --root . --build-dir /tmp/masc-codex-ops-observer-build ./test/test_operator_control.exe