### PR TITLE
chore: bump OAS pin to 999385d1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="b51e424c8b574a225c7112b539b5f8dc8aa54740"
+readonly OAS_AGENT_SDK_SHA="999385d16730bf0d13505f5cd7e7ee971caee53d"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"


### PR DESCRIPTION
## Summary
- OAS upstream main moved to `999385d1`, causing Health check failures on all open PRs
- Bumps the pin to unblock CI

## Test plan
- [ ] Health check passes (OAS pin ratchet)
- [ ] Build and Test passes