### PR TITLE
feat(dashboard): semantic weight + click interaction for activity graph

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -1,13 +1,15 @@
 // Activity graph visualization — Canvas 2D force-directed graph
 // Fetches from /api/v1/activity/graph, renders nodes as circles and edges as lines
+// Supports hover (tooltip), click (detail panel), and semantic weight sizing.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { layoutGraph } from './activity-graph-layout'
-import type { ActivityGraphResponse } from '../types'
+import type { ActivityGraphResponse, ActivityGraphNode, ActivityGraphEdge } from '../types'
 
 const hoveredNodeId = signal<string | null>(null)
+export const selectedNodeId = signal<string | null>(null)
 
 // Node color by kind
 function nodeColor(kind: string, status: string): string {
@@ -23,25 +25,100 @@ function nodeColor(kind: string, status: string): string {
   }
 }
 
-// Edge color by kind
+// Edge color by actual backend edge kind
 function edgeColor(kind: string, active: boolean): string {
-  if (!active) return 'rgba(100, 116, 139, 0.2)'
+  if (!active) return 'rgba(100, 116, 139, 0.15)'
   switch (kind) {
-    case 'mention': return 'rgba(34, 211, 238, 0.4)'
-    case 'assigned': return 'rgba(74, 222, 128, 0.4)'
-    case 'voted': return 'rgba(167, 139, 250, 0.4)'
-    case 'commented': return 'rgba(244, 114, 182, 0.4)'
-    case 'collaborated': return 'rgba(251, 191, 36, 0.4)'
-    default: return 'rgba(148, 163, 184, 0.3)'
+    case 'works_on': return 'rgba(251, 191, 36, 0.5)'
+    case 'creates': return 'rgba(74, 222, 128, 0.4)'
+    case 'broadcasts': return 'rgba(34, 211, 238, 0.35)'
+    case 'mentions': return 'rgba(34, 211, 238, 0.55)'
+    case 'hands_off_to': return 'rgba(167, 139, 250, 0.5)'
+    case 'posts': return 'rgba(244, 114, 182, 0.4)'
+    case 'comments_on': return 'rgba(244, 114, 182, 0.3)'
+    case 'votes_on': return 'rgba(167, 139, 250, 0.35)'
+    case 'opens': return 'rgba(167, 139, 250, 0.4)'
+    case 'governs': return 'rgba(251, 146, 60, 0.4)'
+    case 'operates_on': return 'rgba(74, 222, 128, 0.45)'
+    case 'participates_in': return 'rgba(251, 191, 36, 0.35)'
+    case 'belongs_to': return 'rgba(148, 163, 184, 0.12)'
+    default: return 'rgba(148, 163, 184, 0.25)'
   }
 }
 
-function nodeRadius(weight: number): number {
-  return Math.max(6, Math.min(24, 6 + Math.log1p(weight) * 3))
+function nodeRadius(node: ActivityGraphNode): number {
+  const w = node.semantic_weight ?? node.weight
+  return Math.max(6, Math.min(24, 6 + Math.log1p(w) * 3))
+}
+
+function kindLabel(kind: string): string {
+  switch (kind) {
+    case 'agent': return '에이전트'
+    case 'task': return '작업'
+    case 'decision': return '결정'
+    case 'operation': return '작전'
+    case 'debate': return '토론'
+    case 'post': return '게시글'
+    case 'room': return '룸'
+    default: return kind
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'active': return '활성'
+    case 'offline': return '오프라인'
+    case 'retired': return '은퇴'
+    case 'spawned': return '생성됨'
+    case 'compacting': return '컴팩팅'
+    case 'handoff': return '핸드오프'
+    case 'todo': return '대기'
+    case 'claimed': return '점유됨'
+    case 'in_progress': return '진행 중'
+    case 'done': return '완료'
+    case 'cancelled': return '취소됨'
+    default: return status
+  }
+}
+
+function edgeKindLabel(kind: string): string {
+  switch (kind) {
+    case 'works_on': return '작업 중'
+    case 'creates': return '생성'
+    case 'broadcasts': return '브로드캐스트'
+    case 'mentions': return '멘션'
+    case 'hands_off_to': return '핸드오프'
+    case 'posts': return '게시'
+    case 'comments_on': return '댓글'
+    case 'votes_on': return '투표'
+    case 'belongs_to': return '소속'
+    case 'opens': return '열기'
+    case 'governs': return '거버넌스'
+    case 'operates_on': return '운영'
+    case 'participates_in': return '참여'
+    default: return kind
+  }
 }
 
 interface GraphViewProps {
   data: ActivityGraphResponse
+}
+
+function hitTest(
+  nodes: ActivityGraphNode[],
+  positions: Map<string, { x: number; y: number }>,
+  mx: number,
+  my: number,
+): string | null {
+  for (const node of nodes) {
+    const pos = positions.get(node.id)
+    if (!pos) continue
+    const r = nodeRadius(node)
+    const dx = mx - pos.x
+    const dy = my - pos.y
+    if (dx * dx + dy * dy <= (r + 4) * (r + 4)) return node.id
+  }
+  return null
 }
 
 export function GraphView({ data }: GraphViewProps) {
@@ -68,7 +145,7 @@ export function GraphView({ data }: GraphViewProps) {
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
     const layout = layoutGraph(
-      data.nodes.map(n => ({ id: n.id, weight: n.weight })),
+      data.nodes.map(n => ({ id: n.id, weight: n.semantic_weight ?? n.weight })),
       data.edges.map(e => ({ source: e.source, target: e.target, weight: e.weight })),
       width,
       height,
@@ -77,6 +154,7 @@ export function GraphView({ data }: GraphViewProps) {
 
     const positions = layout.positions
     const hovered = hoveredNodeId.value
+    const selected = selectedNodeId.value
 
     // Background
     ctx.fillStyle = '#0f1117'
@@ -88,15 +166,16 @@ export function GraphView({ data }: GraphViewProps) {
       const tp = positions.get(edge.target)
       if (!sp || !tp) continue
 
-      const isHighlighted = hovered === edge.source || hovered === edge.target
-      const lineWidth = isHighlighted
+      const isConnected = selected === edge.source || selected === edge.target
+        || hovered === edge.source || hovered === edge.target
+      const lineWidth = isConnected
         ? Math.max(1, Math.min(4, 1 + edge.weight * 0.5))
         : Math.max(0.5, Math.min(2, 0.5 + edge.weight * 0.3))
 
       ctx.beginPath()
       ctx.moveTo(sp.x, sp.y)
       ctx.lineTo(tp.x, tp.y)
-      ctx.strokeStyle = isHighlighted
+      ctx.strokeStyle = isConnected
         ? edgeColor(edge.kind, edge.active).replace(/[\d.]+\)$/, '0.7)')
         : edgeColor(edge.kind, edge.active)
       ctx.lineWidth = lineWidth
@@ -108,12 +187,18 @@ export function GraphView({ data }: GraphViewProps) {
       const pos = positions.get(node.id)
       if (!pos) continue
 
-      const r = nodeRadius(node.weight)
+      const r = nodeRadius(node)
       const isHovered = hovered === node.id
+      const isSelected = selected === node.id
       const color = nodeColor(node.kind, node.status)
 
-      // Glow for hovered
-      if (isHovered) {
+      // Glow for selected (distinct from hover)
+      if (isSelected) {
+        ctx.beginPath()
+        ctx.arc(pos.x, pos.y, r + 8, 0, Math.PI * 2)
+        ctx.fillStyle = 'rgba(251, 191, 36, 0.15)'
+        ctx.fill()
+      } else if (isHovered) {
         ctx.beginPath()
         ctx.arc(pos.x, pos.y, r + 6, 0, Math.PI * 2)
         ctx.fillStyle = color.replace(')', ', 0.2)').replace('rgb', 'rgba')
@@ -125,64 +210,122 @@ export function GraphView({ data }: GraphViewProps) {
       ctx.fillStyle = color
       ctx.fill()
 
-      // Border
-      ctx.strokeStyle = isHovered ? '#fff' : 'rgba(255,255,255,0.15)'
-      ctx.lineWidth = isHovered ? 2 : 1
+      // Border — selected gets gold, hovered gets white
+      ctx.strokeStyle = isSelected ? '#fbbf24' : isHovered ? '#fff' : 'rgba(255,255,255,0.15)'
+      ctx.lineWidth = isSelected ? 2.5 : isHovered ? 2 : 1
       ctx.stroke()
 
-      // Label for larger or hovered nodes
-      if (r >= 10 || isHovered) {
-        ctx.fillStyle = '#e2e8f0'
-        ctx.font = `${isHovered ? 11 : 9}px system-ui, sans-serif`
+      // Label for larger, hovered, or selected nodes
+      if (r >= 10 || isHovered || isSelected) {
+        ctx.fillStyle = isSelected ? '#fbbf24' : '#e2e8f0'
+        ctx.font = `${isHovered || isSelected ? 11 : 9}px system-ui, sans-serif`
         ctx.textAlign = 'center'
         ctx.fillText(node.label, pos.x, pos.y + r + 12)
       }
     }
 
-    // Mouse interaction for hover
+    // Mouse interaction
     function handleMouse(event: MouseEvent) {
       const canvasEl = canvasRef.current
       if (!canvasEl) return
       const canvasRect = canvasEl.getBoundingClientRect()
       const mx = event.clientX - canvasRect.left
       const my = event.clientY - canvasRect.top
+      const found = hitTest(data.nodes, positions, mx, my)
+      if (hoveredNodeId.value !== found) hoveredNodeId.value = found
+      canvasEl.style.cursor = found ? 'pointer' : 'crosshair'
+    }
 
-      let found: string | null = null
-      for (const node of data.nodes) {
-        const pos = positions.get(node.id)
-        if (!pos) continue
-        const r = nodeRadius(node.weight)
-        const dx = mx - pos.x
-        const dy = my - pos.y
-        if (dx * dx + dy * dy <= (r + 4) * (r + 4)) {
-          found = node.id
-          break
-        }
-      }
-      if (hoveredNodeId.value !== found) {
-        hoveredNodeId.value = found
-      }
+    function handleClick(event: MouseEvent) {
+      const canvasEl = canvasRef.current
+      if (!canvasEl) return
+      const canvasRect = canvasEl.getBoundingClientRect()
+      const mx = event.clientX - canvasRect.left
+      const my = event.clientY - canvasRect.top
+      const found = hitTest(data.nodes, positions, mx, my)
+      selectedNodeId.value = found
     }
 
     canvas.addEventListener('mousemove', handleMouse)
-    return () => canvas.removeEventListener('mousemove', handleMouse)
-  }, [data, hoveredNodeId.value])
+    canvas.addEventListener('click', handleClick)
+    return () => {
+      canvas.removeEventListener('mousemove', handleMouse)
+      canvas.removeEventListener('click', handleClick)
+    }
+  }, [data, hoveredNodeId.value, selectedNodeId.value])
 
   const hoveredNode = hoveredNodeId.value
     ? data.nodes.find(n => n.id === hoveredNodeId.value)
     : null
 
+  const selectedNode = selectedNodeId.value
+    ? data.nodes.find(n => n.id === selectedNodeId.value)
+    : null
+
+  // Edges connected to selected node
+  const connectedEdges: Array<{ edge: ActivityGraphEdge; otherLabel: string }> = []
+  if (selectedNode) {
+    for (const edge of data.edges) {
+      if (edge.source === selectedNode.id || edge.target === selectedNode.id) {
+        const otherId = edge.source === selectedNode.id ? edge.target : edge.source
+        const otherNode = data.nodes.find(n => n.id === otherId)
+        if (edge.kind !== 'belongs_to') {
+          connectedEdges.push({ edge, otherLabel: otherNode?.label ?? otherId })
+        }
+      }
+    }
+  }
+
   return html`
     <div ref=${containerRef} class="relative w-full overflow-hidden bg-[#0f1117] my-3 rounded-xl">
       <canvas ref=${canvasRef} class="block w-full cursor-crosshair" />
-      ${hoveredNode ? html`
+      ${hoveredNode && !selectedNode ? html`
         <div class="absolute bottom-3 left-3 flex items-center gap-3 py-2 px-3.5 rounded-[10px] bg-[rgba(15,23,42,0.92)] border border-[var(--slate-gray-20)] text-[13px] text-[var(--text-slate-light)] pointer-events-none">
           <strong class="text-base text-[var(--text-near-white)]">${hoveredNode.label}</strong>
-          <span class="py-0.5 px-[7px] bg-[var(--slate-gray-15)] text-[11px] text-[var(--text-slate)] rounded-md">${hoveredNode.kind === 'agent' ? '에이전트' : hoveredNode.kind === 'task' ? '작업' : hoveredNode.kind === 'decision' ? '결정' : hoveredNode.kind === 'operation' ? '작전' : hoveredNode.kind}</span>
-          <span>활동 지수 ${hoveredNode.weight}</span>
-          <span class="${hoveredNode.status === 'active' ? 'text-[var(--ok)]' : hoveredNode.status === 'offline' ? 'text-[var(--text-muted)]' : ''}">${hoveredNode.status === 'active' ? '활성' : hoveredNode.status === 'offline' ? '오프라인' : hoveredNode.status === 'retired' ? '은퇴' : hoveredNode.status}</span>
+          <span class="py-0.5 px-[7px] bg-[var(--slate-gray-15)] text-[11px] text-[var(--text-slate)] rounded-md">${kindLabel(hoveredNode.kind)}</span>
+          <span>중요도 ${(hoveredNode.semantic_weight ?? hoveredNode.weight).toFixed(1)}</span>
+          <span class="${hoveredNode.status === 'active' ? 'text-[var(--ok)]' : hoveredNode.status === 'offline' ? 'text-[var(--text-muted)]' : ''}">${statusLabel(hoveredNode.status)}</span>
         </div>
       ` : null}
     </div>
+
+    ${selectedNode ? html`
+      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">
+        <div class="flex items-center gap-3 mb-3">
+          <strong class="text-lg text-[var(--text-near-white)]">${selectedNode.label}</strong>
+          <span class="py-0.5 px-2 bg-[var(--slate-gray-15)] text-[11px] text-[var(--text-slate)] rounded-md">${kindLabel(selectedNode.kind)}</span>
+          <span class="py-0.5 px-2 rounded-md text-[11px] ${selectedNode.status === 'active' || selectedNode.status === 'done' ? 'text-[var(--ok)] bg-[var(--ok-10)]' : selectedNode.status === 'offline' || selectedNode.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--text-slate-light)] bg-[var(--slate-gray-10)]'}">${statusLabel(selectedNode.status)}</span>
+          <button type="button" class="ml-auto text-[var(--text-muted)] hover:text-[var(--text-slate-light)] text-sm cursor-pointer bg-transparent border-none" onClick=${() => { selectedNodeId.value = null }}>닫기</button>
+        </div>
+        <div class="grid grid-cols-3 gap-3 mb-3">
+          <div class="text-center">
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">중요도</div>
+            <div class="text-xl font-bold text-[var(--text-near-white)] tabular-nums">${(selectedNode.semantic_weight ?? selectedNode.weight).toFixed(1)}</div>
+          </div>
+          <div class="text-center">
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">빈도</div>
+            <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${selectedNode.weight}</div>
+          </div>
+          <div class="text-center">
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em]">연결</div>
+            <div class="text-xl font-bold text-[var(--text-slate-light)] tabular-nums">${connectedEdges.length}</div>
+          </div>
+        </div>
+        ${connectedEdges.length > 0 ? html`
+          <div class="border-t border-[var(--slate-gray-10)] pt-3">
+            <div class="text-[10px] text-[var(--text-muted)] uppercase tracking-[0.08em] mb-2">연결된 관계</div>
+            <div class="flex flex-col gap-1.5 max-h-[160px] overflow-y-auto">
+              ${connectedEdges.slice(0, 20).map(({ edge, otherLabel }) => html`
+                <div class="flex items-center gap-2 text-[13px] py-1 px-2 rounded-lg bg-[rgba(15,23,42,0.4)]" key=${edge.id ?? `${edge.source}-${edge.kind}-${edge.target}`}>
+                  <span class="text-[var(--text-slate-light)]">${otherLabel}</span>
+                  <span class="text-[11px] text-[var(--text-muted)]">${edgeKindLabel(edge.kind)}</span>
+                  ${edge.active ? html`<span class="w-1.5 h-1.5 rounded-full bg-[var(--ok)]"></span>` : null}
+                </div>
+              `)}
+            </div>
+          </div>
+        ` : null}
+      </div>
+    ` : null}
   `
 }

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -148,32 +148,40 @@ function ActivityFeed({ events }: { events: ActivityGraphTimelineEvent[] }) {
   `
 }
 
+function nodeScore(node: ActivityGraphNode): number {
+  return node.semantic_weight ?? node.weight
+}
+
 function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
   const agentNodes = nodes
     .filter(n => n.kind === 'agent')
-    .sort((a, b) => b.weight - a.weight)
+    .sort((a, b) => nodeScore(b) - nodeScore(a))
     .slice(0, 15)
 
   if (agentNodes.length === 0) {
     return html`<${EmptyState} message="활동 집계에 포함된 에이전트가 없습니다." compact />`
   }
 
-  const maxWeight = agentNodes[0]?.weight ?? 1
+  const maxScore = nodeScore(agentNodes[0]!) || 1
 
   return html`
     <div class="flex flex-col gap-1.5">
       ${agentNodes.map((node, i) => {
-        const pct = maxWeight > 0 ? (node.weight / maxWeight) * 100 : 0
+        const score = nodeScore(node)
+        const pct = maxScore > 0 ? (score / maxScore) * 100 : 0
         return html`
           <div class="flex items-center gap-[10px] py-2 px-3 rounded-[10px] bg-[rgba(15,23,42,0.5)] border border-solid border-[var(--slate-gray-8)]" key=${node.id}>
             <span class="w-[22px] text-center text-sm font-bold text-text-slate">${i + 1}</span>
             <div class="flex-1 flex flex-col gap-1 min-w-0">
-              <span class="text-base font-semibold text-[var(--text-near-white)] whitespace-nowrap overflow-hidden text-ellipsis">${node.label}</span>
+              <div class="flex items-center gap-2">
+                <span class="text-base font-semibold text-[var(--text-near-white)] whitespace-nowrap overflow-hidden text-ellipsis">${node.label}</span>
+                <span class="text-[11px] text-[var(--text-muted)]">${node.weight}회</span>
+              </div>
               <div class="h-1 rounded-sm bg-[var(--slate-gray-10)] overflow-hidden">
                 <div class="h-full rounded-sm bg-[var(--cyan)] transition-[width] duration-300 ease-in-out" style="width:${pct}%"></div>
               </div>
             </div>
-            <span class="text-sm font-semibold text-text-slate-light min-w-[32px] text-right">${node.weight}</span>
+            <span class="text-sm font-semibold text-text-slate-light min-w-[32px] text-right">${score.toFixed(1)}</span>
             <span class="text-[11px] py-0.5 px-[7px] rounded-md ${node.status === 'offline' || node.status === 'retired' ? 'text-[var(--text-slate)] bg-[var(--slate-gray-10)]' : 'text-[var(--ok)] bg-[var(--ok-10)]'}">${node.status}</span>
           </div>
         `
@@ -257,7 +265,7 @@ export function ActivityGraphSurface() {
       <${Card} title="활동 그래프" class="section mb-4" testId="activity_graph.graph">
         <div class="mb-4">
           <h2 class="monitor-headline">실행 이벤트 관계 그래프</h2>
-          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 최근 실행 이벤트 기준으로 시각화합니다. 노드 크기는 활동 빈도를 반영합니다.</p>
+          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. 노드 크기는 의미적 중요도를 반영합니다 (완료=5x, 생성=3x, 루틴=0.5x). 노드를 클릭하면 상세 정보를 확인할 수 있습니다.</p>
         </div>
         <${StatsRow} data=${data} />
         <${GraphView} data=${data} />
@@ -272,7 +280,7 @@ export function ActivityGraphSurface() {
         <${Card} title="활동 주체 순위" class="section mb-4" testId="activity_graph.leaderboard">
           <div class="mb-4">
             <h2 class="monitor-headline">활동 주체 순위</h2>
-            <p class="monitor-subheadline">그래프 이벤트 빈도(weight)를 기준으로 정렬한 최근 활동 주체 순위입니다.</p>
+            <p class="monitor-subheadline">의미적 중요도 기준 정렬입니다. 작업 완료, 의사결정, 핸드오프가 단순 입퇴장보다 높게 평가됩니다.</p>
           </div>
           <${NodeLeaderboard} nodes=${data.nodes} />
         <//>

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -239,11 +239,15 @@ export interface ActivityGraphNode {
   label: string
   type: string
   weight: number
+  semantic_weight?: number
   kind: string
   status: string
+  last_event_at?: string
+  meta?: Record<string, unknown>
 }
 
 export interface ActivityGraphEdge {
+  id?: string
   source: string
   target: string
   type: string

--- a/lib/activity_graph.ml
+++ b/lib/activity_graph.ml
@@ -21,6 +21,7 @@ type graph_node = {
   label : string;
   status : string;
   weight : int;
+  semantic_weight : float;
   last_event_at : string;
   meta : Yojson.Safe.t;
 }
@@ -104,6 +105,7 @@ let graph_node_to_yojson (value : graph_node) =
       ("label", `String value.label);
       ("status", `String value.status);
       ("weight", `Int value.weight);
+      ("semantic_weight", `Float value.semantic_weight);
       ("last_event_at", `String value.last_event_at);
       ("meta", value.meta);
     ]
@@ -373,6 +375,7 @@ type node_acc = {
   mutable label : string;
   mutable status : string;
   mutable weight : int;
+  mutable semantic_weight : float;
   mutable last_event_at : string;
   mutable meta : Yojson.Safe.t;
 }
@@ -399,12 +402,34 @@ let is_generic_status = function
   | "" | "active" | "observed" -> true
   | _ -> false
 
+(* Semantic weight multiplier by event kind.
+   Completion events score high; routine lifecycle events score low. *)
+let semantic_multiplier = function
+  | "task.done" | "decision.resolved" | "operation.finalized" -> 5.0
+  | "task.created" | "task.claimed" | "decision.opened" -> 3.0
+  | "agent.handoff" | "agent.spawned" -> 3.0
+  | "board.posted" | "board.voted" -> 2.0
+  | "task.started" | "task.released" | "task.cancelled" -> 1.5
+  | "message.broadcast" | "message.mentioned" -> 1.0
+  | "team.turn" | "team.turn_failed" -> 1.0
+  | "board.commented" | "decision.voted" -> 1.0
+  | "operation.started" | "operation.resumed" -> 1.0
+  | "policy.approved" | "policy.denied" -> 2.0
+  | "agent.joined" | "agent.left" -> 0.5
+  | "agent.retired" | "agent.compacted" -> 0.5
+  | "keeper.compaction" | "keeper.guardrail" -> 0.5
+  | "keeper.autonomy_started" | "keeper.autonomy_completed" -> 1.5
+  | "operation.paused" | "operation.stopped" -> 0.5
+  | _ -> 1.0
+
 let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
     ~(kind : string) ~(label : string)
-    ~(status : string) ~(ts_iso : string) ~(meta : Yojson.Safe.t) =
+    ~(status : string) ~(ts_iso : string) ~(meta : Yojson.Safe.t)
+    ~(sw_delta : float) =
   match Hashtbl.find_opt nodes id with
   | Some node ->
       node.weight <- node.weight + 1;
+      node.semantic_weight <- node.semantic_weight +. sw_delta;
       node.last_event_at <- ts_iso;
       if node.label = id || node.label = "" then node.label <- label;
       if status <> ""
@@ -420,12 +445,13 @@ let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
           label;
           status;
           weight = 1;
+          semantic_weight = sw_delta;
           last_event_at = ts_iso;
           meta;
         }
 
 let ensure_entity_node (nodes : (string, node_acc) Hashtbl.t) value
-    ~fallback_status ~ts_iso ~meta =
+    ~fallback_status ~ts_iso ~meta ~sw_delta =
   let node_id = entity_node_id value in
   let label =
     match payload_string "label" meta with
@@ -433,7 +459,7 @@ let ensure_entity_node (nodes : (string, node_acc) Hashtbl.t) value
     | None -> value.id
   in
   ensure_node nodes ~id:node_id ~kind:value.kind ~label ~status:fallback_status
-    ~ts_iso ~meta;
+    ~ts_iso ~meta ~sw_delta;
   node_id
 
 let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
@@ -459,15 +485,16 @@ let ensure_edge (edges : (string, edge_acc) Hashtbl.t) ~source ~target ~kind
         }
 
 let reduce_event ~nodes ~edges (value : event) =
+  let sw = semantic_multiplier value.kind in
   let room_node_id = "room:" ^ value.room_id in
   ensure_node nodes ~id:room_node_id ~kind:"room" ~label:value.room_id
-    ~status:"room" ~ts_iso:value.ts_iso ~meta:default_meta;
+    ~status:"room" ~ts_iso:value.ts_iso ~meta:default_meta ~sw_delta:sw;
   let actor_id =
     match value.actor with
     | Some actor ->
         let id =
           ensure_entity_node nodes actor ~fallback_status:"active"
-            ~ts_iso:value.ts_iso ~meta:value.payload
+            ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
         ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
@@ -479,7 +506,7 @@ let reduce_event ~nodes ~edges (value : event) =
     | Some subject ->
         let id =
           ensure_entity_node nodes subject ~fallback_status:"observed"
-            ~ts_iso:value.ts_iso ~meta:value.payload
+            ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
         ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
           ~active:true ~ts_iso:value.ts_iso ~meta:default_meta;
@@ -677,6 +704,7 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
             label = node.label;
             status = node.status;
             weight = node.weight;
+            semantic_weight = node.semantic_weight;
             last_event_at = node.last_event_at;
             meta = node.meta;
           }

--- a/lib/activity_graph.mli
+++ b/lib/activity_graph.mli
@@ -29,6 +29,7 @@ type graph_node = {
   label : string;
   status : string;
   weight : int;
+  semantic_weight : float;
   last_event_at : string;
   meta : Yojson.Safe.t;
 }


### PR DESCRIPTION
## Summary
- 활동 그래프 노드 크기를 단순 빈도(weight)에서 **의미적 중요도(semantic_weight)**로 전환
  - 완료 이벤트(task.done, decision.resolved) = 5x
  - 생성/점유 이벤트 = 3x
  - 루틴 이벤트(agent.joined/left) = 0.5x
- **클릭 인터랙션** 추가: 노드 클릭 시 디테일 패널 (중요도/빈도/연결 수 + 연결된 관계 목록)
- Edge 색상을 실제 백엔드 12종 edge kind에 맞게 교정
- 리더보드를 semantic weight 기반으로 정렬

## Changed files
| File | Change |
|------|--------|
| `lib/activity_graph.ml` | `semantic_weight` 필드 + `semantic_multiplier` 함수 |
| `lib/activity_graph.mli` | 인터페이스에 `semantic_weight` 추가 |
| `dashboard/src/types/sse.ts` | `semantic_weight`, `id` 등 타입 확장 |
| `dashboard/src/components/activity-graph-view.ts` | 클릭 선택, 디테일 패널, semantic radius |
| `dashboard/src/components/activity-graph.ts` | 리더보드 semantic 정렬 |

## Test plan
- [x] OCaml 빌드 통과 (`dune build --root .`)
- [x] 기존 activity graph 테스트 4/4 통과
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] Vite 프로덕션 빌드 통과
- [ ] 브라우저에서 `/dashboard` 활동 그래프 시각적 확인
- [ ] 노드 클릭 → 디테일 패널 동작 확인
- [ ] semantic weight로 노드 크기 차이 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)