### PR TITLE
fix(dashboard): stabilize autoresearch refresh and a11y

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -74,6 +74,8 @@ export function App() {
             <div class="flex items-center gap-4">
               <button type="button"
                 class="hidden max-[768px]:flex size-10 items-center justify-center rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.05)] text-[var(--text-body)] cursor-pointer hover:bg-[rgba(255,255,255,0.1)]"
+                aria-expanded=${mobileMenuOpen.value}
+                aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 onClick=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
               >
                 ${mobileMenuOpen.value ? '\u2715' : '\u2630'}
@@ -103,7 +105,7 @@ export function App() {
       </header>
 
       <div class="flex flex-1 gap-2.5 overflow-hidden p-2.5 max-[1100px]:flex-col max-[1100px]:gap-2 max-[1100px]:p-2">
-        <aside class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+        <aside id="dashboard-side-rail" class="${sidebarCollapsed.value ? 'w-14' : 'w-[220px]'} shrink-0 overflow-y-auto overflow-x-hidden rounded-xl border border-[rgba(255,255,255,0.06)] bg-[rgba(15,22,36,0.6)] backdrop-blur-xl transition-[width] duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] max-[1100px]:w-full max-[1100px]:max-h-[300px] ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
           <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
         </aside>
 

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -197,6 +197,9 @@ export function AgentDetailOverlay() {
               <input
                 class="w-full px-4 py-2.5 rounded-xl border border-card-border bg-card/60 text-text-strong text-[13px] placeholder:text-text-dim focus:outline-none focus:border-accent/50 focus:ring-1 focus:ring-accent/50 transition-all duration-200 shadow-inner"
                 type="text"
+                name="agent_direct_mention"
+                aria-label="직접 멘션 메시지"
+                autocomplete="off"
                 placeholder="@멘션 메시지 입력..."
                 value=${mentionText.value}
                 onInput=${(e: Event) => { mentionText.value = (e.target as HTMLInputElement).value }}

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -188,6 +188,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <input
             type="text"
             class="py-1.5 px-3 border border-[var(--ff-border-subtle)] bg-[var(--ff-navy)] text-[var(--white-90)] text-base w-[200px] rounded transition-colors duration-200 focus:outline-none focus:border-[var(--ff-gold)] focus:shadow-[0_0_0_2px_var(--ff-gold-dim)] placeholder:text-[var(--white-25)]"
+            name="agent_search"
+            aria-label="에이전트 이름 검색"
+            autocomplete="off"
             placeholder="에이전트 이름으로 찾기"
             value=${search}
             onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
@@ -241,12 +244,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const lastActivityLabel = lastActivity != null ? `${formatDuration(lastActivity)} 전` : '활동 기록 없음'
 
           return html`
-            <div
-              class="group flex flex-col gap-4 p-5 bg-[var(--bg-1)] border border-[var(--card-border)] rounded-2xl hover:border-[var(--accent-soft)] hover:bg-[var(--bg-0)] transition-all duration-200 shadow-sm cursor-pointer"
+            <button type="button"
+              class="group flex w-full flex-col gap-4 p-5 bg-[var(--bg-1)] border border-[var(--card-border)] rounded-2xl hover:border-[var(--accent-soft)] hover:bg-[var(--bg-0)] transition-all duration-200 shadow-sm cursor-pointer text-left"
               key=${agent.name}
+              aria-label=${`${agent.name} 상세 보기`}
               onClick=${() => openAgentDetail(agent.name)}
-              role="button"
-              tabindex="0"
             >
               <div class="flex items-start gap-4">
                 <div class="shrink-0 relative">
@@ -307,7 +309,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   </div>
                 ` : null}
               </div>
-            </div>
+            </button>
           `
         })}
         ${filtered.length === 0 ? html`

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -26,6 +26,10 @@ const loopDetail = signal<AutoresearchLoopDetail | null>(null)
 const detailLoading = signal(false)
 const detailError = signal<string | null>(null)
 
+let loopsRequest: Promise<void> | null = null
+let pendingRefreshDetail = false
+let detailRequestSeq = 0
+
 const selectedLoop = computed<AutoresearchLoopSummary | null>(() => {
   const id = selectedLoopId.value
   if (!id || !loopsData.value) return null
@@ -54,25 +58,34 @@ async function syncSelectedLoopDetail(data: AutoresearchLoopsResponse): Promise<
 }
 
 async function loadLoops({ refreshDetail = false }: { refreshDetail?: boolean } = {}) {
-  if (loopsLoading.value) return
+  pendingRefreshDetail ||= refreshDetail
+  if (loopsRequest) return loopsRequest
+
   loopsLoading.value = true
   loopsError.value = null
-  try {
-    const data = await fetchAutoresearchLoops()
-    loopsData.value = data
-    if (refreshDetail) {
-      await syncSelectedLoopDetail(data)
-    } else if (!selectedLoopId.value && data.loops.length > 0) {
-      const first = data.loops[0]
-      if (first) {
-        selectedLoopId.value = first.loop_id
+  loopsRequest = (async () => {
+    try {
+      const data = await fetchAutoresearchLoops()
+      loopsData.value = data
+      if (pendingRefreshDetail) {
+        pendingRefreshDetail = false
+        await syncSelectedLoopDetail(data)
+      } else if (!selectedLoopId.value && data.loops.length > 0) {
+        const first = data.loops[0]
+        if (first) {
+          selectedLoopId.value = first.loop_id
+        }
       }
+    } catch (err) {
+      loopsError.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      pendingRefreshDetail = false
+      loopsLoading.value = false
+      loopsRequest = null
     }
-  } catch (err) {
-    loopsError.value = err instanceof Error ? err.message : String(err)
-  } finally {
-    loopsLoading.value = false
-  }
+  })()
+
+  return loopsRequest
 }
 
 export async function refreshAutoresearchSurface(): Promise<void> {
@@ -80,13 +93,19 @@ export async function refreshAutoresearchSurface(): Promise<void> {
 }
 
 async function loadDetail(loopId: string) {
+  const requestSeq = ++detailRequestSeq
   detailLoading.value = true
   detailError.value = null
   try {
-    loopDetail.value = await fetchAutoresearchLoopDetail(loopId)
+    const detail = await fetchAutoresearchLoopDetail(loopId)
+    if (requestSeq !== detailRequestSeq || selectedLoopId.value !== loopId) return
+    loopDetail.value = detail
   } catch (err) {
+    if (requestSeq !== detailRequestSeq || selectedLoopId.value !== loopId) return
+    loopDetail.value = null
     detailError.value = err instanceof Error ? err.message : String(err)
   } finally {
+    if (requestSeq !== detailRequestSeq) return
     detailLoading.value = false
   }
 }

--- a/dashboard/src/components/common/toast.ts
+++ b/dashboard/src/components/common/toast.ts
@@ -52,7 +52,7 @@ export function ToastContainer() {
   if (items.length === 0) return null
 
   return html`
-    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2">
+    <div class="fixed top-5 right-5 z-[var(--z-overlay-toast,3070)] flex flex-col gap-2" aria-live="polite" aria-atomic="true">
       ${items.map(t => html`
         <div
           key=${t.id}
@@ -62,6 +62,7 @@ export function ToastContainer() {
           <span class="flex-1 text-[12px] text-[var(--text-body)] leading-[1.4]">${t.message}</span>
           <button type="button"
             class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer text-[11px] p-0.5 transition-colors duration-150"
+            aria-label="알림 닫기"
             onClick=${(e: Event) => { e.stopPropagation(); dismissToast(t.id) }}
             title="닫기"
           >\u2715</button>

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -136,6 +136,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
         ` : null}
         <button type="button"
           class="flex size-7 items-center justify-center rounded-lg text-[var(--text-muted)] hover:bg-[rgba(255,255,255,0.08)] hover:text-white cursor-pointer transition-all duration-200"
+          aria-label=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           onClick=${onToggle}
           title=${collapsed ? '사이드바 펼치기' : '사이드바 접기'}
         >

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -81,6 +81,9 @@ function GovernanceToolbar() {
             <input
               class="w-full rounded-xl border border-card-border bg-card/48 px-3.5 py-2 text-[13px] font-sans text-text-strong placeholder:text-text-dim transition-all duration-200 focus:border-accent/50 focus:outline-none focus:ring-1 focus:ring-accent/50"
               type="text"
+              name="petition_topic"
+              aria-label="청원 제목"
+              autocomplete="off"
               placeholder="청원 제목을 입력하세요..."
               value=${governanceTopicInput.value}
               onInput=${(event: Event) => {

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -242,12 +242,17 @@ function NewPostForm() {
       <input
         class="w-full px-3 py-2 rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] text-[14px] font-medium focus:border-[rgba(71,184,255,0.5)] outline-none placeholder:text-[var(--text-muted)]"
         type="text"
+        name="board_post_title"
+        aria-label="새 글 제목"
+        autocomplete="off"
         placeholder="제목"
         value=${newPostTitle.value}
         onInput=${(e: Event) => { newPostTitle.value = (e.target as HTMLInputElement).value }}
       />
       <textarea
         class="w-full px-3 py-2 rounded-lg bg-[var(--white-4)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] min-h-[80px] resize-y focus:border-[rgba(71,184,255,0.5)] outline-none placeholder:text-[var(--text-muted)]"
+        name="board_post_content"
+        aria-label="새 글 내용"
         placeholder="내용을 입력하세요..."
         value=${newPostContent.value}
         onInput=${(e: Event) => { newPostContent.value = (e.target as HTMLTextAreaElement).value }}

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -125,6 +125,9 @@ export function FullInventoryView({
         <input
           class="w-full px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none max-w-[320px]"
           type="text"
+          name="tool_inventory_query"
+          aria-label="도구 인벤토리 검색"
+          autocomplete="off"
           placeholder="도구, 문서, 권한, 대체 도구 검색..."
           value=${searchQuery.value}
           onInput=${(e: Event) => {
@@ -133,6 +136,8 @@ export function FullInventoryView({
         />
         <select
           class="px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--card-border)] text-[var(--text-body)] text-[13px] focus:border-[var(--accent)]/50 outline-none"
+          name="tool_inventory_category"
+          aria-label="도구 카테고리 필터"
           value=${categoryFilter.value}
           onChange=${(e: Event) => {
             categoryFilter.value = (e.target as HTMLSelectElement).value
@@ -208,6 +213,7 @@ export function FullInventoryView({
     <button type="button"
       class=${`tool-back-to-top${showBackToTop.value ? ' visible' : ''}`}
       onClick=${scrollToTop}
+      aria-label="목록 맨 위로 이동"
       title="맨 위로"
     >
       <svg width="20" height="20" viewBox="0 0 20 20" fill="none">

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -123,7 +123,9 @@
 
 /* ── Kanban (pseudo-elements, priority variants, hover transform) ── */
 .kanban-card {
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition-property: transform, box-shadow, border-color;
+  transition-duration: 0.3s;
+  transition-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
 .kanban-card::before {
@@ -142,4 +144,3 @@
   border-color: var(--accent);
   box-shadow: 0 4px 12px rgba(0, 240, 255, 0.1);
 }
-

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -1292,7 +1292,8 @@ tbody tr:hover {
 /* roster-card: pseudo-elements (::before/::after) require raw CSS */
 
 @utility roster-filter-btn {
-  transition: all 0.15s;
+  transition-property: background-color, color, border-color;
+  transition-duration: 0.15s;
   &:hover { background: var(--ff-gold-dim); color: var(--ff-gold-bright); border-color: var(--color-ff-border); }
   &.active { background: var(--ff-gold-dim); color: var(--ff-gold-bright); border-color: var(--ff-gold); }
 }
@@ -1425,7 +1426,9 @@ tbody tr:hover {
   font-weight: 500;
   color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition-property: background-color, color;
+  transition-duration: 0.15s;
+  transition-timing-function: ease;
   border: none;
   background: transparent;
   white-space: nowrap;
@@ -1509,7 +1512,9 @@ tbody tr:hover {
 
 /* ── Kanban (pseudo-elements require raw CSS) ── */
 .kanban-card {
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition-property: transform, box-shadow, border-color;
+  transition-duration: 0.3s;
+  transition-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
 .kanban-card::before {
@@ -1571,7 +1576,8 @@ tbody tr:hover {
 /* ── Goals ────────────────────────────────────── */
 
 @utility goal-filter-btn {
-  transition: all 0.15s;
+  transition-property: background-color, color, border-color;
+  transition-duration: 0.15s;
   &:hover { background: var(--white-10); color: var(--text-near-white); }
   &.active { background: rgba(99,102,241,0.2); border-color: rgba(99,102,241,0.4); color: #818cf8; }
 }
@@ -1666,7 +1672,8 @@ button.monitor-row {
 
 /* ── Agents Unified Tab (chip toggle) ────────── */
 @utility agents-chip {
-  transition: all 0.15s;
+  transition-property: color, border-color;
+  transition-duration: 0.15s;
   &:hover { border-color: var(--accent); color: var(--text-strong); }
 }
 


### PR DESCRIPTION
## Summary
- stabilize autoresearch refresh so in-flight loop/detail requests do not race or overwrite the current selection
- tighten dashboard accessibility on interactive controls, form fields, toast announcements, and document locale
- narrow several `transition: all` rules to explicit properties

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

## Notes
- Vite still reports the pre-existing `tab-refresh` dynamic/static import chunking warning during build.
- Cross-model review evidence will be added on the PR thread.