### PR TITLE
chore: bump agent_sdk to >= 0.89.0 (Reflexion + Tool_index + Durable_event)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.88.0))
+  (agent_sdk (>= 0.89.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.88.0"}
+  "agent_sdk" {>= "0.89.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary

- Bump `agent_sdk` dependency from `>= 0.88.0` to `>= 0.89.0`
- Build verified: MASC compiles clean with OAS v0.89.0

## New OAS modules available

| Module | Purpose |
|--------|---------|
| `Reflexion` | Act-evaluate-reflect-retry loop (MAR pattern) |
| `Tool_index` | BM25 dynamic tool exposure (for 371-tool scale) |
| `Durable_event` | Event-sourced agent loop journal (crash recovery) |
| `Clear_tool_results` | Context compression strategy |
| `PreCompact` hook | Pre-compression lifecycle event |

## Next steps (separate PRs)

- Delete `cascade_inference.ml` after OAS PR #383 merges (exposes `resolve_inference_params`)
- Migrate `verifier_oas.ml` -> OAS guardrails/
- Migrate `governance_pipeline.ml` -> OAS guardrails/

## Test plan

- [x] `dune build --root .` clean (0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)