### PR TITLE
chore: bump OAS pin to 45f7ce38

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="999385d16730bf0d13505f5cd7e7ee971caee53d"
+readonly OAS_AGENT_SDK_SHA="45f7ce387f354fc9baa6971dcd92346267346dde"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"


### PR DESCRIPTION
## Summary
- OAS upstream main moved again (999385d1 → 45f7ce38)
- All open PRs have Health fail due to pin drift

## Test plan
- [ ] Health check passes