### PR TITLE
chore: bump OAS pin to 1481466a

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.88.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="45f7ce387f354fc9baa6971dcd92346267346dde"
+readonly OAS_AGENT_SDK_SHA="1481466ac75e3a1925f7a0161cf0f69865527a3a"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.88.0"


### PR DESCRIPTION
OAS upstream moved. Bump pin to unblock all PR Health checks.