### PR TITLE
Expose keeper prompt and telemetry in dashboard

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -139,14 +139,52 @@ function ModelList({ models }: { models: string[] }) {
   `
 }
 
-function LongText({ text }: { text: string }) {
+function LongText({ text, truncateAt = 200 }: { text: string; truncateAt?: number | null }) {
   if (!text || text.trim() === '') return html`<span class="text-[11px] text-text-muted italic">--</span>`
-  const truncated = text.length > 200 ? text.slice(0, 200) + '...' : text
+  const truncated =
+    truncateAt !== null && truncateAt >= 0 && text.length > truncateAt
+      ? text.slice(0, truncateAt) + '...'
+      : text
   return html`<div class="text-[12px] text-text-body whitespace-pre-wrap max-h-[140px] overflow-y-auto custom-scrollbar border border-card-border bg-card/40 backdrop-blur-md p-3 rounded-xl mt-1.5 leading-relaxed shadow-inner hover:bg-card/60 transition-colors">${truncated}</div>`
 }
 
 function formatMaybeNumber(value: number | null, suffix = ''): string {
   return value === null ? '--' : `${value}${suffix}`
+}
+
+function formatMaybeFloat(value: number | null, digits = 1, suffix = ''): string {
+  return value === null ? '--' : `${value.toFixed(digits)}${suffix}`
+}
+
+function PromptSourceBadge({ source }: { source: string }) {
+  const tone =
+    source === 'override'
+      ? 'bg-amber-500/10 text-amber-300 border-amber-400/20'
+      : source === 'file'
+        ? 'bg-emerald-500/10 text-emerald-300 border-emerald-400/20'
+        : 'bg-white/5 text-text-dim border-white/10'
+  return html`<span class="text-[10px] font-bold px-2 py-0.5 rounded-md border ${tone} shadow-sm">${source.toUpperCase()}</span>`
+}
+
+function PromptBlock({
+  title,
+  block,
+}: {
+  title: string
+  block: { key: string; source: string; text: string }
+}) {
+  return html`
+    <div class="mt-2">
+      <div class="flex items-center justify-between gap-2 mb-1">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">${title}</div>
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] text-text-dim">${block.key}</span>
+          <${PromptSourceBadge} source=${block.source} />
+        </div>
+      </div>
+      <${LongText} text=${block.text} truncateAt=${null} />
+    </div>
+  `
 }
 
 const SOUL_PROFILES = ['balanced', 'safety', 'delivery', 'research', 'relationship', 'minimal'] as const
@@ -316,6 +354,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Instructions</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">System prompt blocks</div>
+    <${PromptBlock} title="Constitution" block=${c.prompt.system_prompt_blocks.constitution} />
+    <${PromptBlock} title="World" block=${c.prompt.system_prompt_blocks.world} />
+    <${PromptBlock} title="Capabilities" block=${c.prompt.system_prompt_blocks.capabilities} />
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">Effective system prompt</div>
+    <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
   `
 
   return html`
@@ -452,8 +496,17 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${SectionHeader} title="Metrics" />
       <${ConfigRow} label="Generation" value=${String(c.metrics.generation)} />
       <${ConfigRow} label="Total turns" value=${String(c.metrics.total_turns)} />
+      <${ConfigRow} label="Total input tokens" value=${formatTokens(c.metrics.total_input_tokens)} />
+      <${ConfigRow} label="Total output tokens" value=${formatTokens(c.metrics.total_output_tokens)} />
       <${ConfigRow} label="Total tokens" value=${formatTokens(c.metrics.total_tokens)} />
       <${ConfigRow} label="Total cost" value=${'$' + c.metrics.total_cost_usd.toFixed(4)} />
+      <${ConfigRow} label="Last model" value=${c.metrics.last_model_used || '--'} />
+      <${ConfigRow} label="Last input tokens" value=${formatTokens(c.metrics.last_input_tokens)} />
+      <${ConfigRow} label="Last output tokens" value=${formatTokens(c.metrics.last_output_tokens)} />
+      <${ConfigRow} label="Last total tokens" value=${formatTokens(c.metrics.last_total_tokens)} />
+      <${ConfigRow} label="Last latency" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
+      <${ConfigRow} label="Last throughput" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
+      <${ConfigRow} label="Last output throughput" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
       <${ConfigRow} label="Compactions" value=${String(c.metrics.compaction_count)} />
 
       ${'' /* --- Sources (read-only) --- */}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -427,6 +427,24 @@ export interface KeeperConfigPrompt {
   needs: string
   desires: string
   instructions: string
+  system_prompt_blocks: {
+    constitution: {
+      key: string
+      source: string
+      text: string
+    }
+    world: {
+      key: string
+      source: string
+      text: string
+    }
+    capabilities: {
+      key: string
+      source: string
+      text: string
+    }
+  }
+  effective_system_prompt: string
 }
 
 export interface KeeperConfigExecution {
@@ -525,8 +543,17 @@ export interface KeeperConfigSources {
 export interface KeeperConfigMetrics {
   generation: number
   total_turns: number
+  total_input_tokens: number
+  total_output_tokens: number
   total_tokens: number
   total_cost_usd: number
+  last_model_used: string
+  last_input_tokens: number
+  last_output_tokens: number
+  last_total_tokens: number
+  last_latency_ms: number
+  last_total_tokens_per_sec: number | null
+  last_output_tokens_per_sec: number | null
   compaction_count: number
 }
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,6 +10,18 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
+let prompt_block_json key =
+  `Assoc
+    [
+      ("key", `String key);
+      ("source", `String (Prompt_registry.prompt_source key));
+      ("text", `String (Prompt_registry.get_prompt key));
+    ]
+
+let tokens_per_sec_json ~tokens ~latency_ms =
+  if tokens <= 0 || latency_ms <= 0 then `Null
+  else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
+
 let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Safe.t =
   let include_goals = bool_of_env "MASC_DASHBOARD_INCLUDE_GOALS" in
   let history_fragment_filter_enabled =
@@ -502,6 +514,12 @@ let keeper_config_json (config : Room.config) (name : string)
        `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
   | Ok (Some (m : Keeper_types.keeper_meta)) ->
       let active_model = Keeper_exec_status.active_model_of_meta m in
+      let effective_system_prompt =
+        Keeper_prompt.build_keeper_system_prompt
+          ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
+          ~long_goal:m.long_goal ~soul_profile:m.soul_profile ~will:m.will
+          ~needs:m.needs ~desires:m.desires ~instructions:m.instructions ()
+      in
       let prompt =
         `Assoc [
           ("goal", `String m.goal);
@@ -513,6 +531,14 @@ let keeper_config_json (config : Room.config) (name : string)
           ("needs", `String m.needs);
           ("desires", `String m.desires);
           ("instructions", `String m.instructions);
+          ( "system_prompt_blocks",
+            `Assoc
+              [
+                ("constitution", prompt_block_json "keeper.constitution");
+                ("world", prompt_block_json "keeper.world");
+                ("capabilities", prompt_block_json "keeper.capabilities");
+              ] );
+          ("effective_system_prompt", `String effective_system_prompt);
         ]
       in
       let execution =
@@ -555,8 +581,21 @@ let keeper_config_json (config : Room.config) (name : string)
         `Assoc [
           ("generation", `Int m.generation);
           ("total_turns", `Int m.usage.total_turns);
+          ("total_input_tokens", `Int m.usage.total_input_tokens);
+          ("total_output_tokens", `Int m.usage.total_output_tokens);
           ("total_tokens", `Int m.usage.total_tokens);
           ("total_cost_usd", `Float m.usage.total_cost_usd);
+          ("last_model_used", `String m.usage.last_model_used);
+          ("last_input_tokens", `Int m.usage.last_input_tokens);
+          ("last_output_tokens", `Int m.usage.last_output_tokens);
+          ("last_total_tokens", `Int m.usage.last_total_tokens);
+          ("last_latency_ms", `Int m.usage.last_latency_ms);
+          ( "last_total_tokens_per_sec",
+            tokens_per_sec_json ~tokens:m.usage.last_total_tokens
+              ~latency_ms:m.usage.last_latency_ms );
+          ( "last_output_tokens_per_sec",
+            tokens_per_sec_json ~tokens:m.usage.last_output_tokens
+              ~latency_ms:m.usage.last_latency_ms );
           ("compaction_count", `Int m.compaction.count);
         ]
       in

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -217,6 +217,19 @@ initiative_post_ttl_hours = 24
           room_scope = "current";
           trigger_mode = "explicit_only";
           proactive = { meta.proactive with enabled = false };
+          usage =
+            {
+              meta.usage with
+              total_input_tokens = 1200;
+              total_output_tokens = 800;
+              total_tokens = 2000;
+              total_cost_usd = 0.042;
+              last_model_used = "glm:glm-4.7";
+              last_input_tokens = 120;
+              last_output_tokens = 80;
+              last_total_tokens = 200;
+              last_latency_ms = 4000;
+            };
           paused = true;
           updated_at = Types.now_iso ();
         }
@@ -257,6 +270,26 @@ initiative_post_ttl_hours = 24
         (json |> member "initiative" |> member "status" |> to_string);
       Alcotest.(check bool) "initiative configured in source" true
         (json |> member "initiative" |> member "configured_in_source" |> to_bool);
+      Alcotest.(check int) "total input tokens surfaced" 1200
+        (json |> member "metrics" |> member "total_input_tokens" |> to_int);
+      Alcotest.(check int) "last latency surfaced" 4000
+        (json |> member "metrics" |> member "last_latency_ms" |> to_int);
+      Alcotest.(check (option (float 0.001))) "last total tokens per sec surfaced"
+        (Some 50.0)
+        (json |> member "metrics" |> member "last_total_tokens_per_sec" |> to_float_option);
+      Alcotest.(check (option (float 0.001))) "last output tokens per sec surfaced"
+        (Some 20.0)
+        (json |> member "metrics" |> member "last_output_tokens_per_sec" |> to_float_option);
+      Alcotest.(check string) "prompt block source surfaced" "default"
+        (json |> member "prompt" |> member "system_prompt_blocks"
+         |> member "world" |> member "source" |> to_string);
+      let effective_system_prompt =
+        json |> member "prompt" |> member "effective_system_prompt" |> to_string
+      in
+      Alcotest.(check bool) "effective system prompt includes goal" true
+        (contains_substring effective_system_prompt ("Goal: " ^ mutated.goal));
+      Alcotest.(check bool) "effective system prompt includes world block" true
+        (contains_substring effective_system_prompt "<world>");
       let ok, _ =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
           ~args:(`Assoc [ ("name", `String keeper_name) ])


### PR DESCRIPTION
## Summary
- expose keeper config telemetry fields for input/output tokens, last latency, and derived tok/s
- expose keeper system prompt blocks plus effective system prompt in the dashboard config payload
- render the new prompt and telemetry sections in the keeper config panel and cover them with operator control tests

## Testing
- env DUNE_BUILD_DIR=.b dune exec --root . test/test_operator_control.exe
- ./node_modules/.bin/tsc --noEmit --pretty false