### PR TITLE
feat(dashboard): time filter + sparklines + swimlane timeline for activity graph

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -280,11 +280,22 @@ export async function fetchGoals(): Promise<import('../types').Goal[]> {
 
 // --- Activity Graph ---
 
-export async function fetchActivityGraph(): Promise<import('../types').ActivityGraphResponse | null> {
+export async function fetchActivityGraph(since?: string): Promise<import('../types').ActivityGraphResponse | null> {
   try {
-    const resp = await fetchWithTimeout('/api/v1/activity/graph', {}, 10000)
+    const params = since ? `?since=${since}` : ''
+    const resp = await fetchWithTimeout(`/api/v1/activity/graph${params}`, {}, 10000)
     if (!resp.ok) return null
     return (await resp.json()) as import('../types').ActivityGraphResponse
+  } catch {
+    return null
+  }
+}
+
+export async function fetchSwimlane(): Promise<import('../types').SwimlaneResponse | null> {
+  try {
+    const resp = await fetchWithTimeout('/api/v1/activity/swimlane', {}, 10000)
+    if (!resp.ok) return null
+    return (await resp.json()) as import('../types').SwimlaneResponse
   } catch {
     return null
   }

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -288,6 +288,20 @@ export function GraphView({ data }: GraphViewProps) {
         </div>
       ` : null}
     </div>
+    <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 px-1">
+      ${[
+        { label: '에이전트', color: '#22d3ee' },
+        { label: '작업', color: '#fbbf24' },
+        { label: '결정', color: '#a78bfa' },
+        { label: '작전', color: '#4ade80' },
+        { label: '게시글', color: '#f472b6' },
+      ].map(({ label, color }) => html`
+        <div class="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]" key=${label}>
+          <span class="w-2.5 h-2.5 rounded-full inline-block" style="background:${color}"></span>
+          ${label}
+        </div>
+      `)}
+    </div>
 
     ${selectedNode ? html`
       <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] p-4 mt-2">

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -119,7 +119,7 @@ function StatsRow({ data }: { data: ActivityGraphResponse }) {
   const s = data.stats
   const h = data.stats_history ?? []
   const evSeries = h.map(b => b.events)
-  const agSeries = h.map(b => b.agents_active)
+  const agSeries = h.map(b => b.active_agents)
   const tdSeries = h.map(b => b.tasks_done)
 
   function statCard(label: string, value: number, series: number[], color: string, highlight = false) {

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -7,25 +7,56 @@ import { Card } from './common/card'
 import { EmptyState, LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
 import { TimeAgo } from './common/time-ago'
+import { Sparkline } from './common/sparkline'
 import { GraphView } from './activity-graph-view'
+import { ActivitySwimlane } from './activity-swimlane'
+import { CollapsibleSection } from './common/collapsible'
 import { fetchActivityGraph } from '../api'
 import type { ActivityGraphResponse, ActivityGraphNode, ActivityGraphTimelineEvent } from '../types'
 
 const graphData = signal<ActivityGraphResponse | null>(null)
 const graphError = signal<string | null>(null)
 const graphLoading = signal(false)
+const selectedTimeRange = signal<string>('all')
+
+const TIME_RANGES: Array<{ value: string; label: string }> = [
+  { value: '1h', label: '1시간' },
+  { value: '6h', label: '6시간' },
+  { value: '24h', label: '24시간' },
+  { value: '7d', label: '7일' },
+  { value: 'all', label: '전체' },
+]
 
 async function loadGraph() {
   if (graphLoading.value) return
   graphLoading.value = true
   graphError.value = null
   try {
-    graphData.value = await fetchActivityGraph()
+    const since = selectedTimeRange.value !== 'all' ? selectedTimeRange.value : undefined
+    graphData.value = await fetchActivityGraph(since)
   } catch (err) {
     graphError.value = err instanceof Error ? err.message : String(err)
   } finally {
     graphLoading.value = false
   }
+}
+
+function TimeRangeSelector() {
+  const current = selectedTimeRange.value
+  return html`
+    <div class="flex gap-1.5 mb-3">
+      ${TIME_RANGES.map(({ value, label }) => html`
+        <button type="button" key=${value}
+          class="px-3 py-1 text-xs rounded-full border cursor-pointer transition-all duration-150 ${
+            current === value
+              ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
+              : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'
+          }"
+          onClick=${() => { selectedTimeRange.value = value; loadGraph() }}
+        >${label}</button>
+      `)}
+    </div>
+  `
 }
 
 function kindLabel(kind: string): string {
@@ -86,32 +117,29 @@ function eventSummary(event: ActivityGraphTimelineEvent): string {
 
 function StatsRow({ data }: { data: ActivityGraphResponse }) {
   const s = data.stats
+  const h = data.stats_history ?? []
+  const evSeries = h.map(b => b.events)
+  const agSeries = h.map(b => b.agents_active)
+  const tdSeries = h.map(b => b.tasks_done)
+
+  function statCard(label: string, value: number, series: number[], color: string, highlight = false) {
+    return html`
+      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
+        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">${label}</div>
+        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums ${highlight ? 'text-[var(--ok)]' : ''}">${value}</div>
+        ${series.length >= 2 ? html`<div class="mt-2"><${Sparkline} values=${series} color=${color} /></div>` : null}
+      </div>
+    `
+  }
+
   return html`
     <div class="stats-grid grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3 mb-4">
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">노드</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.node_count}</div>
-      </div>
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">엣지</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.edge_count}</div>
-      </div>
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">에이전트</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.agent_count}</div>
-      </div>
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">활성</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums text-[var(--ok)]">${s.active_agents}</div>
-      </div>
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">작업</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.task_count}</div>
-      </div>
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--card)] py-[15px] px-3.5">
-        <div class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">이벤트</div>
-        <div class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${s.event_count}</div>
-      </div>
+      ${statCard('노드', s.node_count ?? 0, evSeries, '#94a3b8')}
+      ${statCard('엣지', s.edge_count ?? 0, evSeries, '#64748b')}
+      ${statCard('에이전트', s.agent_count ?? 0, agSeries, '#22d3ee')}
+      ${statCard('활성', s.active_agents ?? 0, agSeries, '#4ade80', true)}
+      ${statCard('작업', s.task_count ?? 0, tdSeries, '#fbbf24')}
+      ${statCard('이벤트', s.event_count ?? 0, evSeries, '#a78bfa')}
     </div>
   `
 }
@@ -265,15 +293,21 @@ export function ActivityGraphSurface() {
       <${Card} title="활동 그래프" class="section mb-4" testId="activity_graph.graph">
         <div class="mb-4">
           <h2 class="monitor-headline">실행 이벤트 관계 그래프</h2>
-          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. 노드 크기는 의미적 중요도를 반영합니다 (완료=5x, 생성=3x, 루틴=0.5x). 노드를 클릭하면 상세 정보를 확인할 수 있습니다.</p>
+          <p class="monitor-subheadline">에이전트, 작업, 결정, 운영 이벤트 간의 연결을 시각화합니다. 노드 크기는 의미적 중요도를 반영합니다. 노드를 클릭하면 상세 정보를 확인할 수 있습니다.</p>
         </div>
+        <${TimeRangeSelector} />
         <${StatsRow} data=${data} />
         <${GraphView} data=${data} />
         <div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[13px]">
           <span>생성 시각: ${data.generated_at}</span>
           <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
+          ${selectedTimeRange.value !== 'all' ? html`<span>필터: ${TIME_RANGES.find(r => r.value === selectedTimeRange.value)?.label}</span>` : null}
           ${data.window.room_id ? html`<span>room: ${data.window.room_id}</span>` : null}
         </div>
+      <//>
+
+      <${CollapsibleSection} title="에이전트 타임라인" open=${true}>
+        <${ActivitySwimlane} />
       <//>
 
       <div class="grid grid-cols-[minmax(0,1.08fr)_minmax(0,0.96fr)_minmax(0,0.88fr)] gap-4">

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -1,0 +1,333 @@
+// Activity swimlane — Canvas 2D per-agent timeline visualization
+// Shows horizontal time spans per agent, color-coded by kind.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import { Card } from './common/card'
+import { EmptyState, LoadingState } from './common/feedback-state'
+import { fetchSwimlane } from '../api'
+import type { SwimlaneResponse, AgentSpan } from '../types'
+
+const swimlaneData = signal<SwimlaneResponse | null>(null)
+const swimlaneLoading = signal(false)
+const swimlaneError = signal<string | null>(null)
+
+const LANE_HEIGHT = 32
+const LANE_GAP = 4
+const LEFT_MARGIN = 80
+const RIGHT_PAD = 16
+const TOP_PAD = 24
+const BOTTOM_PAD = 28
+
+function spanColor(kind: string): string {
+  switch (kind) {
+    case 'task': return '#fbbf24'
+    case 'operation': return '#4ade80'
+    case 'autonomy': return '#22d3ee'
+    case 'presence': return 'rgba(148, 163, 184, 0.25)'
+    default: return '#94a3b8'
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 0) ms = 0
+  const totalMinutes = Math.floor(ms / 60_000)
+  const totalHours = Math.floor(totalMinutes / 60)
+  const totalDays = Math.floor(totalHours / 24)
+
+  if (totalDays >= 1) {
+    const remainHours = totalHours % 24
+    return remainHours > 0 ? `${totalDays}일 ${remainHours}시간` : `${totalDays}일`
+  }
+  if (totalHours >= 1) {
+    const remainMinutes = totalMinutes % 60
+    return remainMinutes > 0 ? `${totalHours}시간 ${remainMinutes}분` : `${totalHours}시간`
+  }
+  return `${totalMinutes}분`
+}
+
+async function loadSwimlane() {
+  if (swimlaneLoading.value) return
+  swimlaneLoading.value = true
+  swimlaneError.value = null
+  try {
+    swimlaneData.value = await fetchSwimlane()
+  } catch (err) {
+    swimlaneError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    swimlaneLoading.value = false
+  }
+}
+
+interface TooltipInfo {
+  x: number
+  y: number
+  span: AgentSpan
+}
+
+function drawSwimlane(
+  ctx: CanvasRenderingContext2D,
+  data: SwimlaneResponse,
+  canvasWidth: number,
+  canvasHeight: number,
+  tooltip: TooltipInfo | null,
+) {
+  const { agents, spans, time_range } = data
+  const drawWidth = canvasWidth - LEFT_MARGIN - RIGHT_PAD
+  const timeSpan = time_range.max_ms - time_range.min_ms || 1
+
+  // Background
+  ctx.fillStyle = '#0f1117'
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight)
+
+  // Time axis ticks
+  const tickCount = Math.min(6, Math.max(2, Math.floor(drawWidth / 100)))
+  ctx.font = '10px system-ui, sans-serif'
+  ctx.fillStyle = '#64748b'
+  ctx.textAlign = 'center'
+
+  for (let i = 0; i <= tickCount; i++) {
+    const frac = i / tickCount
+    const x = LEFT_MARGIN + frac * drawWidth
+    const timeMs = time_range.min_ms + frac * timeSpan
+    const date = new Date(timeMs)
+    const label = `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`
+
+    ctx.fillText(label, x, TOP_PAD - 6)
+
+    ctx.beginPath()
+    ctx.moveTo(x, TOP_PAD)
+    ctx.lineTo(x, canvasHeight - BOTTOM_PAD)
+    ctx.strokeStyle = 'rgba(100, 116, 139, 0.12)'
+    ctx.lineWidth = 1
+    ctx.stroke()
+  }
+
+  // Agent lanes
+  for (let i = 0; i < agents.length; i++) {
+    const agentName = agents[i]!
+    const y = TOP_PAD + i * (LANE_HEIGHT + LANE_GAP)
+
+    // Agent name
+    ctx.fillStyle = '#94a3b8'
+    ctx.font = '11px system-ui, sans-serif'
+    ctx.textAlign = 'right'
+    const displayName = agentName.length > 10 ? agentName.slice(0, 9) + '..' : agentName
+    ctx.fillText(displayName, LEFT_MARGIN - 8, y + LANE_HEIGHT / 2 + 4)
+
+    // Lane background
+    ctx.fillStyle = 'rgba(30, 41, 59, 0.3)'
+    ctx.fillRect(LEFT_MARGIN, y, drawWidth, LANE_HEIGHT)
+  }
+
+  // Draw spans
+  for (const span of spans) {
+    const agentIdx = agents.indexOf(span.agent)
+    if (agentIdx < 0) continue
+
+    const y = TOP_PAD + agentIdx * (LANE_HEIGHT + LANE_GAP)
+    const x1 = LEFT_MARGIN + ((span.start_ms - time_range.min_ms) / timeSpan) * drawWidth
+    const x2 = LEFT_MARGIN + ((span.end_ms - time_range.min_ms) / timeSpan) * drawWidth
+    const w = Math.max(x2 - x1, 3) // min 3px visibility
+    const color = spanColor(span.kind)
+
+    ctx.fillStyle = color
+    ctx.globalAlpha = span.kind === 'presence' ? 0.25 : 0.7
+    ctx.beginPath()
+    ctx.roundRect(x1, y + 4, w, LANE_HEIGHT - 8, 3)
+    ctx.fill()
+    ctx.globalAlpha = 1.0
+
+    // Label inside span if wide enough
+    if (w > 50 && span.label) {
+      ctx.fillStyle = '#0f172a'
+      ctx.font = '10px system-ui, sans-serif'
+      ctx.textAlign = 'left'
+      const text = span.label.length > 20 ? span.label.slice(0, 18) + '..' : span.label
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(x1, y, w, LANE_HEIGHT)
+      ctx.clip()
+      ctx.fillText(text, x1 + 4, y + LANE_HEIGHT / 2 + 3)
+      ctx.restore()
+    }
+  }
+
+  // Tooltip
+  if (tooltip) {
+    const { x, y, span } = tooltip
+    const duration = formatDuration(span.end_ms - span.start_ms)
+    const lines = [
+      span.label || span.kind,
+      `종류: ${span.kind}`,
+      `지속: ${duration}`,
+    ]
+    const lineHeight = 16
+    const padX = 10
+    const padTop = 8
+    const boxW = 180
+    const boxH = padTop * 2 + lines.length * lineHeight
+
+    const tx = Math.min(x + 12, canvasWidth - boxW - 8)
+    const ty = Math.max(y - boxH - 4, 4)
+
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.95)'
+    ctx.beginPath()
+    ctx.roundRect(tx, ty, boxW, boxH, 6)
+    ctx.fill()
+    ctx.strokeStyle = 'rgba(100, 116, 139, 0.3)'
+    ctx.lineWidth = 1
+    ctx.stroke()
+
+    ctx.fillStyle = '#e2e8f0'
+    ctx.font = '11px system-ui, sans-serif'
+    ctx.textAlign = 'left'
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i]!, tx + padX, ty + padTop + (i + 1) * lineHeight - 2)
+    }
+  }
+}
+
+function hitTestSpan(
+  data: SwimlaneResponse,
+  mx: number,
+  my: number,
+  canvasWidth: number,
+): AgentSpan | null {
+  const { agents, spans, time_range } = data
+  const drawWidth = canvasWidth - LEFT_MARGIN - RIGHT_PAD
+  const timeSpan = time_range.max_ms - time_range.min_ms || 1
+
+  for (const span of spans) {
+    const agentIdx = agents.indexOf(span.agent)
+    if (agentIdx < 0) continue
+
+    const y = TOP_PAD + agentIdx * (LANE_HEIGHT + LANE_GAP)
+    const x1 = LEFT_MARGIN + ((span.start_ms - time_range.min_ms) / timeSpan) * drawWidth
+    const x2 = LEFT_MARGIN + ((span.end_ms - time_range.min_ms) / timeSpan) * drawWidth
+    const w = Math.max(x2 - x1, 3)
+
+    if (mx >= x1 && mx <= x1 + w && my >= y + 4 && my <= y + LANE_HEIGHT - 4) {
+      return span
+    }
+  }
+  return null
+}
+
+export function ActivitySwimlane() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const tooltipRef = useRef<TooltipInfo | null>(null)
+
+  useEffect(() => { loadSwimlane() }, [])
+
+  const data = swimlaneData.value
+  const loading = swimlaneLoading.value
+  const error = swimlaneError.value
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const container = containerRef.current
+    if (!canvas || !container || !data || data.agents.length === 0) return
+
+    const rect = container.getBoundingClientRect()
+    const width = Math.max(rect.width, 400)
+    const agentCount = data.agents.length
+    const contentHeight = TOP_PAD + agentCount * (LANE_HEIGHT + LANE_GAP) + BOTTOM_PAD
+    const height = Math.max(120, Math.min(400, contentHeight))
+    const dpr = window.devicePixelRatio || 1
+
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+    drawSwimlane(ctx, data, width, height, tooltipRef.current)
+
+    function handleMouse(event: MouseEvent) {
+      const canvasEl = canvasRef.current
+      const containerEl = containerRef.current
+      if (!canvasEl || !containerEl || !data) return
+
+      const canvasRect = canvasEl.getBoundingClientRect()
+      const mx = event.clientX - canvasRect.left
+      const my = event.clientY - canvasRect.top
+
+      const containerRect = containerEl.getBoundingClientRect()
+      const cWidth = Math.max(containerRect.width, 400)
+
+      const span = hitTestSpan(data, mx, my, cWidth)
+      const prev = tooltipRef.current
+
+      if (span) {
+        tooltipRef.current = { x: mx, y: my, span }
+        canvasEl.style.cursor = 'pointer'
+      } else {
+        tooltipRef.current = null
+        canvasEl.style.cursor = 'default'
+      }
+
+      // Redraw if tooltip changed
+      const changed = (span !== null) !== (prev !== null) || (span && prev && span !== prev.span)
+      if (changed) {
+        const ctx2 = canvasEl.getContext('2d')
+        if (ctx2) {
+          const dpr2 = window.devicePixelRatio || 1
+          ctx2.setTransform(dpr2, 0, 0, dpr2, 0, 0)
+          drawSwimlane(ctx2, data, cWidth, canvasEl.height / dpr2, tooltipRef.current)
+        }
+      }
+    }
+
+    canvas.addEventListener('mousemove', handleMouse)
+    return () => {
+      canvas.removeEventListener('mousemove', handleMouse)
+    }
+  }, [data])
+
+  if (loading && !data) {
+    return html`
+      <${Card} title="활동 타임라인" testId="activity_swimlane">
+        <${LoadingState}>타임라인 불러오는 중...<//>
+      <//>
+    `
+  }
+
+  if (error && !data) {
+    return html`
+      <${Card} title="활동 타임라인" testId="activity_swimlane">
+        <${EmptyState}>타임라인을 불러올 수 없습니다: ${error}<//>
+      <//>
+    `
+  }
+
+  if (!data || data.agents.length === 0) {
+    return html`
+      <${Card} title="활동 타임라인" testId="activity_swimlane">
+        <${EmptyState}>표시할 에이전트 활동 타임라인이 없습니다.<//>
+      <//>
+    `
+  }
+
+  return html`
+    <${Card} title="활동 타임라인" testId="activity_swimlane">
+      <div class="mb-2">
+        <p class="text-[13px] text-[var(--text-muted)]">에이전트별 활동 구간을 시간축으로 보여줍니다.</p>
+      </div>
+      <div ref=${containerRef} class="relative w-full overflow-hidden bg-[#0f1117] rounded-xl">
+        <canvas ref=${canvasRef} class="block w-full" />
+      </div>
+      <div class="flex flex-wrap gap-3 mt-3 text-[11px] text-[var(--text-muted)]">
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[#fbbf24] inline-block"></span>작업</span>
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[#4ade80] inline-block"></span>운영</span>
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[#22d3ee] inline-block"></span>자율</span>
+        <span class="flex items-center gap-1.5"><span class="w-3 h-2 rounded-sm bg-[rgba(148,163,184,0.5)] inline-block"></span>접속</span>
+      </div>
+    <//>
+  `
+}

--- a/dashboard/src/components/common/sparkline.ts
+++ b/dashboard/src/components/common/sparkline.ts
@@ -1,0 +1,88 @@
+// Sparkline — inline Canvas 2D sparkline chart
+// Draws a filled area, polyline stroke, and a dot at the latest data point.
+
+import { html } from 'htm/preact'
+import { useEffect, useRef } from 'preact/hooks'
+
+interface SparklineProps {
+  values: number[]
+  width?: number
+  height?: number
+  color?: string
+}
+
+export function Sparkline({
+  values,
+  width = 120,
+  height = 28,
+  color = '#22d3ee',
+}: SparklineProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || values.length < 2) return
+
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+    const padY = 3
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const range = max - min || 1
+
+    function toX(i: number): number {
+      return (i / (values.length - 1)) * width
+    }
+
+    function toY(v: number): number {
+      return height - padY - ((v - min) / range) * (height - padY * 2)
+    }
+
+    // Filled area
+    ctx.beginPath()
+    ctx.moveTo(toX(0), height)
+    for (let i = 0; i < values.length; i++) {
+      ctx.lineTo(toX(i), toY(values[i]!))
+    }
+    ctx.lineTo(toX(values.length - 1), height)
+    ctx.closePath()
+
+    // Parse color for fill opacity
+    ctx.fillStyle = color.startsWith('#')
+      ? `${color}18`
+      : color.replace(/[\d.]+\)$/, '0.08)')
+    ctx.fill()
+
+    // Polyline stroke
+    ctx.beginPath()
+    ctx.moveTo(toX(0), toY(values[0]!))
+    for (let i = 1; i < values.length; i++) {
+      ctx.lineTo(toX(i), toY(values[i]!))
+    }
+    ctx.strokeStyle = color
+    ctx.lineWidth = 1.5
+    ctx.lineJoin = 'round'
+    ctx.lineCap = 'round'
+    ctx.stroke()
+
+    // Dot at latest data point
+    const lastIdx = values.length - 1
+    const lastVal = values[lastIdx]!
+    ctx.beginPath()
+    ctx.arc(toX(lastIdx), toY(lastVal), 2.5, 0, Math.PI * 2)
+    ctx.fillStyle = color
+    ctx.fill()
+  }, [values, width, height, color])
+
+  if (values.length < 2) return null
+
+  return html`<canvas ref=${canvasRef} class="block" />`
+}

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -280,4 +280,22 @@ export interface ActivityGraphResponse {
   timeline: ActivityGraphTimelineEvent[]
   generated_at: string
   window: { start: number; end: number; limit: number; room_id: string }
+  stats_history?: Array<{ bucket: number; events: number; agents_active: number; tasks_done: number }>
+}
+
+// --- Swimlane types ---
+
+export interface AgentSpan {
+  agent: string
+  start_ms: number
+  end_ms: number
+  kind: string
+  label: string
+  status: string
+}
+
+export interface SwimlaneResponse {
+  agents: string[]
+  spans: AgentSpan[]
+  time_range: { min_ms: number; max_ms: number }
 }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -237,7 +237,6 @@ export const LEGACY_TAB_REDIRECTS: Record<LegacyTabId, { tab: TabId; params?: Re
 export interface ActivityGraphNode {
   id: string
   label: string
-  type: string
   weight: number
   semantic_weight?: number
   kind: string
@@ -250,10 +249,11 @@ export interface ActivityGraphEdge {
   id?: string
   source: string
   target: string
-  type: string
-  weight: number
   kind: string
+  weight: number
   active: boolean
+  last_event_at?: string
+  meta?: Record<string, unknown>
 }
 
 export interface ActivityGraphTimelineEvent {
@@ -279,8 +279,8 @@ export interface ActivityGraphResponse {
   stats: ActivityGraphStats
   timeline: ActivityGraphTimelineEvent[]
   generated_at: string
-  window: { start: number; end: number; limit: number; room_id: string }
-  stats_history?: Array<{ bucket: number; events: number; agents_active: number; tasks_done: number }>
+  window: { limit: number; room_id: string | null; kinds: string[] }
+  stats_history?: Array<{ bucket: number; events: number; active_agents: number; tasks_done: number }>
 }
 
 // --- Swimlane types ---

--- a/lib/activity_graph.ml
+++ b/lib/activity_graph.ml
@@ -689,8 +689,12 @@ let reduce_event ~nodes ~edges (value : event) =
   | _ -> ())
 
 let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
-    ?(timeline_limit = 80) () =
+    ?(timeline_limit = 80) ?since_ms () =
   let events = list_events config ?room_id ~kinds ~after_seq:0 ~limit () in
+  let events = match since_ms with
+    | Some ms -> List.filter (fun e -> e.ts_ms >= ms) events
+    | None -> events
+  in
   let nodes = Hashtbl.create 64 in
   let edges = Hashtbl.create 96 in
   List.iter (reduce_event ~nodes ~edges) events;
@@ -762,6 +766,41 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
            | _ -> acc)
          0
   in
+  let stats_history =
+    let num_buckets = 12 in
+    match events with
+    | [] -> []
+    | _ ->
+        let min_ts = List.fold_left (fun m e -> min m e.ts_ms) max_int events in
+        let max_ts = List.fold_left (fun m e -> max m e.ts_ms) 0 events in
+        let range = max 1 (max_ts - min_ts) in
+        let bucket_width = max 1 (range / num_buckets) in
+        let buckets = Array.make num_buckets (0, (Hashtbl.create 4 : (string, bool) Hashtbl.t), 0) in
+        Array.iteri (fun i _ ->
+          buckets.(i) <- (0, Hashtbl.create 4, 0)
+        ) buckets;
+        List.iter (fun (e : event) ->
+          let idx = min (num_buckets - 1) ((e.ts_ms - min_ts) / bucket_width) in
+          let (count, agents_tbl, tasks_done) = buckets.(idx) in
+          let new_tasks_done = tasks_done + (if e.kind = "task.done" then 1 else 0) in
+          (match e.actor with
+           | Some actor -> Hashtbl.replace agents_tbl actor.id true
+           | None -> ());
+          buckets.(idx) <- (count + 1, agents_tbl, new_tasks_done)
+        ) events;
+        Array.to_list (Array.mapi (fun i (count, agents_tbl, tasks_done) ->
+          let bucket_start = min_ts + (i * bucket_width) in
+          let bucket_end = if i = num_buckets - 1 then max_ts else bucket_start + bucket_width in
+          `Assoc [
+            ("bucket", `Int i);
+            ("start_ms", `Int bucket_start);
+            ("end_ms", `Int bucket_end);
+            ("events", `Int count);
+            ("active_agents", `Int (Hashtbl.length agents_tbl));
+            ("tasks_done", `Int tasks_done);
+          ]
+        ) buckets)
+  in
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
@@ -787,7 +826,128 @@ let graph_json config ?room_id ?(kinds = []) ?(limit = 500)
             ("operation_count", `Int (count_kind "operation"));
             ("active_agents", `Int active_agents);
           ] );
+      ("stats_history", `List stats_history);
       ("nodes", `List nodes_json);
       ("edges", `List edges_json);
       ("timeline", `List (List.map event_to_yojson timeline));
     ]
+
+type agent_span = {
+  agent : string;
+  start_ms : int;
+  end_ms : int;
+  span_kind : string;
+  label : string;
+  span_status : string;
+}
+
+let agent_span_to_yojson (s : agent_span) =
+  `Assoc [
+    ("agent", `String s.agent);
+    ("start_ms", `Int s.start_ms);
+    ("end_ms", `Int s.end_ms);
+    ("kind", `String s.span_kind);
+    ("label", `String s.label);
+    ("status", `String s.span_status);
+  ]
+
+(* Span start events paired with their matching end events *)
+let span_start_kind = function
+  | "task.claimed" | "task.started" -> Some "task"
+  | "agent.joined" -> Some "presence"
+  | "operation.started" -> Some "operation"
+  | "keeper.autonomy_started" -> Some "autonomy"
+  | _ -> None
+
+let span_end_kind = function
+  | "task.done" | "task.released" | "task.cancelled" -> Some "task"
+  | "agent.left" | "agent.retired" -> Some "presence"
+  | "operation.finalized" | "operation.stopped" -> Some "operation"
+  | "keeper.autonomy_completed" -> Some "autonomy"
+  | _ -> None
+
+let span_end_status = function
+  | "task.done" -> "completed"
+  | "task.released" -> "released"
+  | "task.cancelled" -> "cancelled"
+  | "agent.left" -> "left"
+  | "agent.retired" -> "retired"
+  | "operation.finalized" -> "finalized"
+  | "operation.stopped" -> "stopped"
+  | "keeper.autonomy_completed" -> "completed"
+  | _ -> "ended"
+
+let agent_spans_json config ?room_id ?(limit = 500) () =
+  let events = list_events config ?room_id ~kinds:[] ~after_seq:0 ~limit () in
+  let now_ms = now_ts_ms () in
+  (* open_spans keyed by (agent_id, subject_id option) *)
+  let open_spans : (string * string option, int * string * string) Hashtbl.t =
+    Hashtbl.create 32
+  in
+  let closed_spans : agent_span list ref = ref [] in
+  let agents_set : (string, bool) Hashtbl.t = Hashtbl.create 16 in
+  List.iter (fun (e : event) ->
+    let agent_id = match e.actor with
+      | Some a -> Some a.id
+      | None -> None
+    in
+    let subject_id = match e.subject with
+      | Some s -> Some s.id
+      | None -> None
+    in
+    match agent_id with
+    | None -> ()
+    | Some aid ->
+        Hashtbl.replace agents_set aid true;
+        (match span_start_kind e.kind with
+         | Some sk ->
+             let label = match subject_id with
+               | Some sid -> sid
+               | None -> e.kind
+             in
+             Hashtbl.replace open_spans (aid, subject_id) (e.ts_ms, sk, label)
+         | None -> ());
+        (match span_end_kind e.kind with
+         | Some ek ->
+             let key = (aid, subject_id) in
+             (match Hashtbl.find_opt open_spans key with
+              | Some (start_ms, sk, label) when String.equal sk ek ->
+                  Hashtbl.remove open_spans key;
+                  closed_spans := {
+                    agent = aid;
+                    start_ms;
+                    end_ms = e.ts_ms;
+                    span_kind = sk;
+                    label;
+                    span_status = span_end_status e.kind;
+                  } :: !closed_spans
+              | _ -> ())
+         | None -> ())
+  ) events;
+  (* Close unpaired start events with now_ms *)
+  Hashtbl.iter (fun (aid, _subj) (start_ms, sk, label) ->
+    closed_spans := {
+      agent = aid;
+      start_ms;
+      end_ms = now_ms;
+      span_kind = sk;
+      label;
+      span_status = "open";
+    } :: !closed_spans
+  ) open_spans;
+  let all_spans = List.rev !closed_spans in
+  let agents = Hashtbl.fold (fun k _ acc -> k :: acc) agents_set []
+    |> List.sort String.compare
+  in
+  let min_ms = List.fold_left (fun m (s : agent_span) -> min m s.start_ms) max_int all_spans in
+  let max_ms = List.fold_left (fun m (s : agent_span) -> max m s.end_ms) 0 all_spans in
+  let time_range_min = if all_spans = [] then now_ms else min_ms in
+  let time_range_max = if all_spans = [] then now_ms else max_ms in
+  `Assoc [
+    ("agents", `List (List.map (fun a -> `String a) agents));
+    ("spans", `List (List.map agent_span_to_yojson all_spans));
+    ("time_range", `Assoc [
+      ("min_ms", `Int time_range_min);
+      ("max_ms", `Int time_range_max);
+    ]);
+  ]

--- a/lib/activity_graph.mli
+++ b/lib/activity_graph.mli
@@ -125,5 +125,26 @@ val graph_json :
   ?kinds:string list ->
   ?limit:int ->
   ?timeline_limit:int ->
+  ?since_ms:int ->
+  unit ->
+  Yojson.Safe.t
+
+(** {1 Agent spans (swimlane data)} *)
+
+type agent_span = {
+  agent : string;
+  start_ms : int;
+  end_ms : int;
+  span_kind : string;
+  label : string;
+  span_status : string;
+}
+
+val agent_span_to_yojson : agent_span -> Yojson.Safe.t
+
+val agent_spans_json :
+  Room_utils.config ->
+  ?room_id:string ->
+  ?limit:int ->
   unit ->
   Yojson.Safe.t

--- a/lib/server/server_activity_http.ml
+++ b/lib/server/server_activity_http.ml
@@ -59,6 +59,17 @@ let events_http_json ~deps ~state request =
   Activity_graph.json_response state.Mcp_server.room_config ?room_id ~kinds
     ~after_seq ~limit ()
 
+let parse_since_ms (raw : string) : int option =
+  let len = String.length raw in
+  if len < 2 then None
+  else
+    let suffix = raw.[len - 1] in
+    let num_str = String.sub raw 0 (len - 1) in
+    match (int_of_string_opt num_str, suffix) with
+    | Some n, 'h' -> Some (n * 3600 * 1000)
+    | Some n, 'd' -> Some (n * 24 * 3600 * 1000)
+    | _ -> None
+
 let graph_http_json ~deps ~state request =
   let room_id = room_filter deps request in
   let kinds = kind_filters deps request in
@@ -70,8 +81,18 @@ let graph_http_json ~deps ~state request =
     deps.int_query_param request "timeline_limit" ~default:80
     |> clamp ~min_v:10 ~max_v:200
   in
+  let since_ms =
+    match deps.query_param request "since" with
+    | Some raw ->
+        (match parse_since_ms raw with
+         | Some delta_ms ->
+             let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
+             Some (now_ms - delta_ms)
+         | None -> None)
+    | None -> None
+  in
   Activity_graph.graph_json state.Mcp_server.room_config ?room_id ~kinds ~limit
-    ~timeline_limit ()
+    ~timeline_limit ?since_ms ()
 
 let stream_headers ~deps origin =
   Httpun.Headers.of_list

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -48,6 +48,13 @@ let add_routes router =
          let json = activity_graph_http_json ~state req in
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/activity/swimlane" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let room_id = query_param req "room_id" in
+         let limit = int_query_param req "limit" ~default:500 |> clamp ~min_v:1 ~max_v:2000 in
+         let json = Activity_graph.agent_spans_json state.Mcp_server.room_config ?room_id ~limit () in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/governance/cases" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in


### PR DESCRIPTION
## Summary
#2838 후속 작업. 활동 그래프를 4단계에 걸쳐 추가 개선합니다.

### Phase 2: 시간 윈도우 필터
- `since` 쿼리 파라미터 (`1h`, `6h`, `24h`, `7d`) 지원
- pill 버튼으로 시간 범위 선택 UI

### Phase 3: KPI 스파크라인
- 12-bucket `stats_history` API 응답 추가
- Canvas 2D 스파크라인 컴포넌트 (`sparkline.ts`)
- 각 KPI 카드 아래에 추세선 렌더링

### Phase 4: 에이전트 스윔레인 타임라인
- 이벤트 쌍에서 스팬 추출 (task, presence, operation, autonomy)
- `GET /api/v1/activity/swimlane` 엔드포인트
- Canvas 2D 스윔레인 (`activity-swimlane.ts`) — 에이전트별 가로 타임라인, 호버 툴팁

### Phase 5: 그래프 범례
- 노드 종류별 색상 범례를 캔버스 아래에 표시

## Changed files
| File | Change |
|------|--------|
| `lib/activity_graph.ml` | since_ms, stats_history, agent_spans_json |
| `lib/activity_graph.mli` | 인터페이스 확장 |
| `lib/server/server_activity_http.ml` | since 파라미터 파싱 |
| `lib/server/server_routes_http_routes_activity.ml` | swimlane 라우트 |
| `dashboard/src/components/common/sparkline.ts` | 새 파일 |
| `dashboard/src/components/activity-swimlane.ts` | 새 파일 |
| `dashboard/src/components/activity-graph.ts` | 시간 필터, 스파크라인, 스윔레인 통합 |
| `dashboard/src/components/activity-graph-view.ts` | 범례 추가 |
| `dashboard/src/types/sse.ts` | AgentSpan, SwimlaneResponse, stats_history 타입 |
| `dashboard/src/api/actions.ts` | fetchSwimlane, since 파라미터 |

## Test plan
- [x] OCaml 빌드 통과
- [x] 기존 activity graph 테스트 4/4 통과
- [x] TypeScript 타입 체크 통과
- [x] Vite 프로덕션 빌드 통과
- [ ] 브라우저에서 시간 필터 전환 동작 확인
- [ ] 스파크라인 렌더링 확인
- [ ] 스윔레인 타임라인 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)