### PR TITLE
fix: bump OAS pin + fix priority test regression

### DIFF
--- a/test/test_fire_task.ml
+++ b/test/test_fire_task.ml
@@ -139,14 +139,15 @@ let test_task_priority_defaults () =
       ~title:"Default priority task"
       ~priority:3
       ~description:"Fire-and-forget task" in
-    (* Verify task exists and priority is reflected in status *)
+    (* Verify task exists in status output *)
     let status = Room.status config in
     check bool "task title in status" true
       (try ignore (Str.search_forward (Str.regexp_string "Default priority task") status 0); true
        with Not_found -> false);
-    check bool "priority value in status" true
-      (try ignore (Str.search_forward (Str.regexp_string "3") status 0); true
-       with Not_found -> false)
+    (* Verify priority is persisted in backlog (status output does not include priority) *)
+    let backlog = Room.read_backlog config in
+    check bool "task has correct priority" true
+      (List.exists (fun (t : Types_core.task) -> t.title = "Default priority task" && t.priority = 3) backlog.tasks)
   )
 
 (* ============================================================


### PR DESCRIPTION
## Summary
- Bump OAS pin to `ffae93c5` (unblock Health checks on all PRs)
- Fix `test_task_priority_defaults` regression from #2805: verify priority via `read_backlog` instead of status text

## Test plan
- [ ] Health pass (OAS pin matches upstream)
- [ ] Build and Test pass (priority test fixed)

Supersedes #2844 and #2851.