### PR TITLE
refactor: remove vendor/model hardcoding from MASC

### DIFF
--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -90,12 +90,13 @@ let resolve_provider_of_label (label : string) : Oas.Provider.config =
   match Llm_provider.Cascade_config.parse_model_string label with
   | Some pc -> Oas.Provider.config_of_provider_config pc
   | None ->
+    (* No vendor-specific fallback — use local llama via OAS round-robin *)
     Oas.Provider.config_of_provider_config
       (Llm_provider.Provider_config.make
-         ~kind:Llm_provider.Provider_config.Glm
+         ~kind:Llm_provider.Provider_config.OpenAI_compat
          ~model_id:"auto"
-         ~base_url:"https://open.bigmodel.cn/api/paas/v4"
-         ~request_path:"/chat/completions" ())
+         ~base_url:(Llm_provider.Provider_registry.next_llama_endpoint ())
+         ~request_path:"/v1/chat/completions" ())
 
 (* ================================================================ *)
 (* Internal: event publishing                                        *)

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -456,7 +456,8 @@ let model_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
           worker_class_text role_text spawn_prompt
       in
       (match
-        Oas_worker.run_named ~cascade_name:"routing_judge"
+        Oas_worker.run_named ~cascade_name:(match Sys.getenv_opt "MASC_ROUTING_CASCADE" with
+          | Some s when String.trim s <> "" -> String.trim s | _ -> "routing_judge")
           ~system_prompt:"You are a routing judge for a hybrid swarm. Output only JSON."
           ~goal:prompt ~max_turns:1
           ~temperature:0.0 ~max_tokens:220 ()

--- a/lib/tool_team_session_step_spawn.ml
+++ b/lib/tool_team_session_step_spawn.ml
@@ -95,8 +95,10 @@ let execute_spawn_pipeline
                            "You are agent '%s'. Execute the task and return a clear result."
                            prepared.spec.spawn_agent)
                          ~max_turns
-                         ~temperature:0.3
-                         ~max_tokens:4096
+                         ~temperature:(Safe_ops.get_env_float_logged
+                           "MASC_SPAWN_TEMPERATURE" ~default:0.3)
+                         ~max_tokens:(Safe_ops.get_env_int_logged
+                           "MASC_SPAWN_MAX_TOKENS" ~default:4096)
                          ()
                      in
                      let elapsed_ms =


### PR DESCRIPTION
## Summary
- GLM fallback URL (`open.bigmodel.cn`) 제거 → local llama round-robin
- `"routing_judge"` cascade → `MASC_ROUTING_CASCADE` env var
- spawn `temperature:0.3`/`max_tokens:4096` → `MASC_SPAWN_TEMPERATURE`/`MASC_SPAWN_MAX_TOKENS`
- OAS pin 갱신

Replaces #2847.

## Test plan
- [ ] `dune build` 성공
- [ ] `grep "open.bigmodel.cn" lib/` 결과 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)