### PR TITLE
fix(autoresearch): restore field-presence guards for partial state rejection

### DIFF
--- a/lib/autoresearch_storage.ml
+++ b/lib/autoresearch_storage.ml
@@ -120,7 +120,11 @@ let load_state ~base_path loop_id =
                path;
              None
          | `Assoc _
-           when not (has_required_string_field "loop_id") ->
+           when not (has_required_string_field "loop_id")
+                || Yojson.Safe.Util.member "goal" json = `Null
+                || Yojson.Safe.Util.member "metric_fn" json = `Null
+                || Yojson.Safe.Util.member "model_model" json = `Null
+                || Yojson.Safe.Util.member "target_file" json = `Null ->
              Log.Autoresearch.error
                "invalid autoresearch state schema for %s: missing required string fields"
                path;

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -157,13 +157,19 @@ let load_degraded_persisted_summary ~(base_path : string) loop_id =
   match Safe_ops.read_json_file_safe path with
   | Error _ -> None
   | Ok (`Assoc fields as json) ->
-      if List.mem_assoc "llm_model" fields && not (List.mem_assoc "model_model" fields) then
-        None
-      else
-        (try Some (Autoresearch_serde.state_of_yojson json)
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | _ -> None)
+      if List.mem_assoc "llm_model" fields && not (List.mem_assoc "model_model" fields)
+      then None
+      else if
+        not (List.mem_assoc "goal" fields)
+        || not (List.mem_assoc "metric_fn" fields)
+        || not (List.mem_assoc "model_model" fields)
+        || not (List.mem_assoc "target_file" fields)
+      then None
+      else (
+        try Some (Autoresearch_serde.state_of_yojson json)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> None)
   | Ok json ->
       (try Some (Autoresearch_serde.state_of_yojson json)
        with


### PR DESCRIPTION
## Summary
- Restores field-presence validation (goal, metric_fn, model_model, target_file) in `load_state` and `load_degraded_persisted_summary` to reject structurally incomplete state files
- The serde layer (`state_of_yojson`) keeps its relaxed defaults for tolerating degraded values, but the storage/dashboard layers now properly gate on field presence

## Context
PR #2809 relaxed `autoresearch_serde.state_of_yojson` to use optional defaults instead of `required_str` for goal/metric_fn/model_model/target_file. This was correct for tolerating degraded state values. However, the corresponding guard in `load_state` was reduced to only check `loop_id`, and the new `load_degraded_persisted_summary` fallback had no field-presence checks at all. This caused partial/garbage state files (e.g. only `{"loop_id":"x","status":"running"}`) to be accepted and appear in the dashboard loops list.

## Test plan
- [x] `test_dashboard_autoresearch` - all 5 tests pass (loops_json:0 "skips invalid persisted state" was failing, now passes)
- [x] `test_ci_hardening_source` - all 15 source_guard tests pass