### PR TITLE
fix(autoresearch): restore field-presence guards for partial state rejection

### DIFF
--- a/lib/autoresearch_storage.ml
+++ b/lib/autoresearch_storage.ml
@@ -120,7 +120,11 @@ let load_state ~base_path loop_id =
                path;
              None
          | `Assoc _
-           when not (has_required_string_field "loop_id") ->
+           when not (has_required_string_field "loop_id")
+                || Yojson.Safe.Util.member "goal" json = `Null
+                || Yojson.Safe.Util.member "metric_fn" json = `Null
+                || Yojson.Safe.Util.member "model_model" json = `Null
+                || Yojson.Safe.Util.member "target_file" json = `Null ->
              Log.Autoresearch.error
                "invalid autoresearch state schema for %s: missing required string fields"
                path;

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -157,13 +157,19 @@ let load_degraded_persisted_summary ~(base_path : string) loop_id =
   match Safe_ops.read_json_file_safe path with
   | Error _ -> None
   | Ok (`Assoc fields as json) ->
-      if List.mem_assoc "llm_model" fields && not (List.mem_assoc "model_model" fields) then
-        None
-      else
-        (try Some (Autoresearch_serde.state_of_yojson json)
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | _ -> None)
+      if List.mem_assoc "llm_model" fields && not (List.mem_assoc "model_model" fields)
+      then None
+      else if
+        not (List.mem_assoc "goal" fields)
+        || not (List.mem_assoc "metric_fn" fields)
+        || not (List.mem_assoc "model_model" fields)
+        || not (List.mem_assoc "target_file" fields)
+      then None
+      else (
+        try Some (Autoresearch_serde.state_of_yojson json)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> None)
   | Ok json ->
       (try Some (Autoresearch_serde.state_of_yojson json)
        with


### PR DESCRIPTION
## Summary
- `load_state`와 `load_degraded_persisted_summary`에 필드 존재 검증(goal, metric_fn, model_model, target_file) 복원
- 구조적으로 불완전한 state.json을 reject하여 dashboard loopjson 테스트 안정화

## Context
PR #2809가 `state_of_yojson`의 기본값을 완화했는데, storage/dashboard 레이어에서 필드 존재 검증이 빠지면서 loopjson 테스트가 CI에서 간헐 실패.
#2854에서 cherry-pick 분리 (transport 커밋 제외).

Supersedes #2854.

## Test plan
- [x] `test_dashboard_autoresearch` 5/5 pass (loopjson 전부 green)
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)