### PR TITLE
fix(dashboard): redirect root to dashboard

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -83,6 +83,18 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
     H2.Body.Writer.close writer
   in
 
+  let h2_respond_redirect ?(status = `Found) ?(extra_headers = []) h2_reqd location =
+    let headers =
+      H2.Headers.of_list ([
+        ("location", location);
+        ("content-length", "0");
+      ] @ extra_headers)
+    in
+    let response = H2.Response.create ~headers status in
+    let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
+    H2.Body.Writer.close writer
+  in
+
   (* Read H2 request body asynchronously *)
   let h2_read_body h2_reqd callback =
     let body = H2.Reqd.request_body h2_reqd in
@@ -226,7 +238,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           H2.Body.Writer.close writer
 
       | `GET, "/" ->
-          h2_respond_text h2_reqd "MASC MCP Server (HTTP/2)" ~extra_headers:cors
+          h2_respond_redirect h2_reqd "/dashboard" ~extra_headers:cors
 
       | `GET, "/favicon.ico" | `GET, "/favicon.svg" ->
           h2_respond_bytes

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -11,6 +11,17 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 
+let redirect_to_dashboard reqd =
+  let response =
+    Httpun.Response.create
+      ~headers:(Httpun.Headers.of_list [
+        ("location", "/dashboard");
+        ("content-length", "0");
+      ])
+      `Found
+  in
+  Httpun.Reqd.respond_with_string reqd response ""
+
 let is_dashboard_observer_stream request =
   match Server_utils.query_param request "sse_kind" with
   | Some raw ->
@@ -115,7 +126,7 @@ let add_routes ~port ~host router =
          in
          Http.Response.json json reqd
        ) request reqd)
-  |> Http.Router.get "/" (fun _req reqd -> Http.Response.text "MASC MCP Server" reqd)
+  |> Http.Router.get "/" (fun _req reqd -> redirect_to_dashboard reqd)
   |> Http.Router.get "/static/css/middleware.css"
        (serve_playground_asset "static/css/middleware.css")
   |> Http.Router.get "/static/js/middleware.js"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -170,6 +170,17 @@ let test_room_current_validation_contracts () =
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        "Room.ensure_room_bootstrap config room_id")
 
+let test_root_redirect_contracts () =
+  check bool "http root redirects to dashboard" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       {|Http.Router.get "/" (fun _req reqd -> redirect_to_dashboard reqd)|});
+  check bool "http redirect sets dashboard location" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
+       {|("location", "/dashboard")|});
+  check bool "h2 root redirects to dashboard" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|h2_respond_redirect h2_reqd "/dashboard" ~extra_headers:cors|})
+
 let test_dashboard_component_split_contracts () =
   check bool "proof view imports proof helpers" true
     (file_contains_pattern "dashboard/src/components/proof.ts"
@@ -373,6 +384,7 @@ let () =
            test_case "input validation contracts" `Quick test_input_validation_contracts;
            test_case "room current validation contracts" `Quick
              test_room_current_validation_contracts;
+           test_case "root redirect contracts" `Quick test_root_redirect_contracts;
            test_case "dashboard component split contracts" `Quick test_dashboard_component_split_contracts;
            test_case "activity surface contracts" `Quick test_activity_surface_contracts;
            test_case "local review script contracts" `Quick test_local_review_script_contracts;


### PR DESCRIPTION
## Summary
- redirect `GET /` to `/dashboard` for the HTTP router
- mirror the same redirect in the HTTP/2 gateway
- add a source guard so both root surfaces keep redirecting to the dashboard

## Verification
- `dune build --root . -j 4 test/test_ci_hardening_source.exe && ./_build/default/test/test_ci_hardening_source.exe`

## Notes
- `bin/main_eio.exe` rebuild in this fresh worktree was started but not waited through because the machine currently has multiple long-running `dune` jobs from other worktrees, so I kept the local verification focused on the route/source guard change.