### PR TITLE
refactor: extract gate config constants and default_execution_scope

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -24,6 +24,7 @@ let validate_name name =
   name <> "" && Str.string_match re name 0
 
 let default_soul_profile = "balanced"
+let default_execution_scope = "observe_only"
 let default_proactive_enabled = true
 let default_proactive_idle_sec = 900
 let default_proactive_cooldown_sec = 1800

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -149,7 +149,7 @@ let ensure_keeper_exists
       policy_mode;
       policy_voice_enabled;
       policy_shell_mode;
-      execution_scope = "observe_only";
+      execution_scope = default_execution_scope;
       allowed_paths;
       scope_kind;
       room_scope;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -234,7 +234,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            policy_mode;
            policy_voice_enabled;
            policy_shell_mode;
-           execution_scope = "observe_only";
+           execution_scope = default_execution_scope;
            allowed_paths;
            scope_kind;
            room_scope;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -255,7 +255,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       |> canonical_policy_shell_mode
     in
     let execution_scope =
-      Safe_ops.json_string ~default:"observe_only" "execution_scope" json
+      Safe_ops.json_string ~default:default_execution_scope "execution_scope" json
     in
     let allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let voice_enabled =

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -129,33 +129,34 @@ let oas_provider_of_label = Worker_container.oas_provider_of_label
     Observe_only: strict allowlist (read-only tools), low budget.
     Limited_code_change: moderate budget, deny destructive bash.
     Autonomous: permissive, higher budget. *)
+(* Destructive operations denied in all non-autonomous scopes. *)
+let destructive_denied_tools =
+  [ "shell_exec_dangerous"; "git_push_force"; "rm_rf" ]
+
+(* Code mutation tools additionally denied in observe_only scope. *)
+let code_mutation_denied_tools =
+  [ "keeper_bash";
+    "masc_code_write"; "masc_code_edit"; "masc_code_delete";
+    "masc_code_shell"; "masc_code_git" ]
+
+(* Local model (Qwen3.5 Q4) — no cloud cost, so generous turn budget. *)
+let local_model_gate =
+  { Eval_gate.default_config with
+    destructive_check_enabled = true;
+    max_tool_calls_per_turn = 30;
+    max_cost_usd = 1.00;
+  }
+
 let gate_config_of_execution_scope
     (scope : Team_session_types.execution_scope) : Eval_gate.gate_config =
   match scope with
   | Observe_only ->
-      (* No code modification, but coordination and read ops are unrestricted.
-         Local model (Qwen3.5 Q4) — no cloud cost, so generous turn budget. *)
-      { Eval_gate.default_config with
-        destructive_check_enabled = true;
-        denied_tools = [
-          "shell_exec_dangerous"; "git_push_force"; "rm_rf";
-          "keeper_bash";
-          "masc_code_write"; "masc_code_edit"; "masc_code_delete";
-          "masc_code_shell"; "masc_code_git";
-        ];
-        max_tool_calls_per_turn = 30;
-        max_cost_usd = 1.00;
+      { local_model_gate with
+        denied_tools = destructive_denied_tools @ code_mutation_denied_tools;
       }
   | Limited_code_change ->
-      (* Code modification allowed, destructive ops blocked.
-         Local model — generous budget. *)
-      { Eval_gate.default_config with
-        destructive_check_enabled = true;
-        denied_tools = [
-          "shell_exec_dangerous"; "git_push_force"; "rm_rf";
-        ];
-        max_tool_calls_per_turn = 30;
-        max_cost_usd = 1.00;
+      { local_model_gate with
+        denied_tools = destructive_denied_tools;
       }
   | Autonomous ->
       { Eval_gate.default_config with


### PR DESCRIPTION
## Summary
- `destructive_denied_tools`, `code_mutation_denied_tools`, `local_model_gate`를 모듈 상수로 추출 (DRY + 매 호출마다 리스트 재할당 제거)
- `default_execution_scope` 상수를 keeper_config.ml에 추가, 3곳의 매직 스트링 `"observe_only"` 대체

## Context
/simplify 리뷰 결과에서 발견된 3가지 이슈 수정:
1. Observe_only와 Limited_code_change의 gate config 중복
2. `"observe_only"` 매직 스트링 반복
3. denied_tools 리스트 매 호출 재할당

## Test plan
- [x] `dune build` 성공
- [x] `test_verifier_oas_bridge` 23/23 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)