### PR TITLE
chore: bump OAS pin to v0.89.1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.89.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.89.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ffae93c535a111c3b929ff3c0f5d63070f2de8ab"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.89.0"
+readonly OAS_AGENT_SDK_SHA="c029ac7aef670745b24f58ae720c7005e76ef9c9"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.89.1"


### PR DESCRIPTION
Pin script + min version update. v0.89.1: cascade inference API, 21 tests, simplify.