### PR TITLE
fix(log): surface silent failures and unify logging

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -219,7 +219,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    Log.Server.warn "[main] keeper bootstrap failed (continuing without keepers): %s" (Printexc.to_string exn)
+    Log.Server.error "[main] keeper bootstrap failed (continuing without keepers): %s" (Printexc.to_string exn)
 
 (** CLI options *)
 let port =

--- a/lib/chain/chain_telemetry.ml
+++ b/lib/chain/chain_telemetry.ml
@@ -436,7 +436,7 @@ let string_of_event = function
 
 (** Create a console logging handler *)
 let console_handler ?(prefix="[CHAIN]") event =
-  Printf.printf "%s %s\n%!" prefix (string_of_event event)
+  Log.Telemetry.info "%s %s" prefix (string_of_event event)
 
 (** Subscribe console logger *)
 let enable_console_logging ?(prefix="[CHAIN]") () =

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -23,7 +23,7 @@ let read_file_safe path =
     really_input ic s 0 n;
     close_in ic;
     Bytes.to_string s
-  with _ -> ""
+  with exn -> Log.Transport.warn "read_file_safe failed for %s: %s" path (Printexc.to_string exn); ""
 
 (** Safe filename: replace non-alphanumeric chars with underscores. *)
 let safe_filename name =
@@ -75,7 +75,7 @@ let handle_join (room_config : Room_utils_backend_setup.config) (bytes : string)
                     Option.value ~default:"" agent.current_task;
                 } : T.agent_info)
               | _ -> None
-            with _ -> None)
+            with exn -> Log.Transport.debug "agent parse skip: %s" (Printexc.to_string exn); None)
         else []
       in
       T.JoinResponse.{
@@ -181,7 +181,7 @@ let handle_get_status (room_config : Room_utils_backend_setup.config) (_bytes : 
             assigned_to = json |> member "assigned_to" |> to_string_option |> Option.value ~default:"";
             priority = (try json |> member "priority" |> to_int with _ -> 0);
           } : T.task_info)
-        with _ -> None)
+        with exn -> Log.Transport.debug "task parse skip: %s" (Printexc.to_string exn); None)
     else []
   in
   T.StatusResponse.(to_bytes {
@@ -264,7 +264,7 @@ let handle_heartbeat
               close_out oc
             | Error _ -> ()
           end
-        with _ -> ());
+        with exn -> Log.Transport.error "gRPC heartbeat update failed: %s" (Printexc.to_string exn));
         (* Count active agents and pending tasks *)
         let masc_dir = Filename.concat room_config.base_path ".masc" in
         let agents_dir = Filename.concat masc_dir "agents" in

--- a/lib/mitosis.ml
+++ b/lib/mitosis.ml
@@ -218,7 +218,7 @@ let bounded_handoff_dna ~config ~parent_cell ~full_context =
 let extract_delta ~config ~full_context ~since_len =
   let current_len = String.length full_context in
   if current_len < config.min_context_for_delta then begin
-    Printf.printf "[MITOSIS/DELTA] Short session (%d < %d chars), skipping delta\n%!"
+    Log.Mitosis_log.debug "short session (%d < %d chars), skipping delta"
       current_len config.min_context_for_delta;
     ""
   end
@@ -228,7 +228,7 @@ let extract_delta ~config ~full_context ~since_len =
     let raw_delta = safe_sub full_context since_len (current_len - since_len) in
     let compressed = compress_to_dna ~ratio:config.dna_compression_ratio ~context:raw_delta in
     if String.length compressed < config.min_delta_len then begin
-      Printf.printf "[MITOSIS/DELTA] Delta too short (%d < %d chars), treating as noise\n%!"
+      Log.Mitosis_log.debug "delta too short (%d < %d chars), treating as noise"
         (String.length compressed) config.min_delta_len;
       ""
     end
@@ -295,7 +295,7 @@ let perform_mitosis ~config ~pool ~parent ~full_context =
     | ReadyForHandoff prepared_dna ->
         let delta = extract_delta ~config ~full_context ~since_len:parent.prepare_context_len in
         let merged = merge_dna_with_delta ~prepared_dna ~delta in
-        Printf.printf "[MITOSIS/DELTA] Merged DNA: prepared=%d chars + delta=%d chars\n%!"
+        Log.Mitosis_log.info "merged DNA: prepared=%d chars + delta=%d chars"
           (String.length prepared_dna) (String.length delta);
         merged
     | Idle -> bounded_handoff_dna ~config ~parent_cell:parent ~full_context
@@ -332,7 +332,7 @@ let execute_mitosis ~config ~pool ~parent ~full_context ~spawn_fn =
   let prompt = build_mitosis_prompt ~child ~dna in
   let spawn_result = spawn_fn ~prompt in
   let _ = complete_apoptosis dying_parent in
-  Printf.printf "[MITOSIS] Cell %s (gen %d) -> Cell %s (gen %d)\n%!"
+  Log.Mitosis_log.info "cell %s (gen %d) -> cell %s (gen %d)"
     parent.id parent.generation child.id child.generation;
   (spawn_result, child, new_pool, dna)
 let record_activity ~cell ~task_done ~tool_called =
@@ -351,7 +351,7 @@ type mitosis_check_result =
 
 let auto_mitosis_check_2phase ~config ~pool ~cell ~context_ratio ~full_context ~spawn_fn =
   if should_handoff ~config ~cell ~context_ratio then begin
-    Printf.printf "[MITOSIS/HANDOFF] Threshold %.0f%% reached for cell %s (gen %d), executing handoff...\n%!"
+    Log.Mitosis_log.info "threshold %.0f%% reached for cell %s (gen %d), executing handoff"
       (config.handoff_threshold *. 100.0) cell.id cell.generation;
     let (spawn_result, child, new_pool, dna) =
       execute_mitosis ~config ~pool ~parent:cell ~full_context ~spawn_fn in
@@ -366,7 +366,7 @@ let auto_mitosis_check_2phase ~config ~pool ~cell ~context_ratio ~full_context ~
 
 let auto_mitosis_check ~config ~pool ~cell ~context_ratio ~full_context ~spawn_fn =
   if should_divide ~config ~cell ~context_ratio then begin
-    Printf.printf "[MITOSIS/AUTO] Trigger met for cell %s (gen %d), dividing...\n%!"
+    Log.Mitosis_log.info "auto trigger met for cell %s (gen %d), dividing"
       cell.id cell.generation;
     Some (execute_mitosis ~config ~pool ~parent:cell ~full_context ~spawn_fn)
   end

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -186,22 +186,19 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
-            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
-                 timeout_sec label);
+            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+              timeout_sec label;
             ""
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-                (Printf.sprintf
-                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                   label (Printexc.to_string exn));
+              Log.Misc.warn
+                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                label (Printexc.to_string exn);
               run_unix_argv_fallback ?env argv
             ) else (
-              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
-                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
-                   (Printexc.to_string exn));
+              Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                (Printexc.to_string exn);
               "")
 
 let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (argv : string list) : string =
@@ -223,22 +220,19 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
               Buffer.contents buf)
         with
         | Eio.Time.Timeout ->
-            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
-                 timeout_sec label);
+            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+              timeout_sec label;
             ""
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-                (Printf.sprintf
-                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                   label (Printexc.to_string exn));
+              Log.Misc.warn
+                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                label (Printexc.to_string exn);
               run_unix_argv_with_stdin_fallback ?env ~stdin_content argv
             ) else (
-              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
-                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
-                   (Printexc.to_string exn));
+              Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                (Printexc.to_string exn);
               "")
 
 let run_argv_with_stdin_and_status
@@ -273,23 +267,20 @@ let run_argv_with_stdin_and_status
                   (unix_status, Buffer.contents buf)))
         with
         | Eio.Time.Timeout ->
-            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
-                 timeout_sec label);
+            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+              timeout_sec label;
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-                (Printf.sprintf
-                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                   label (Printexc.to_string exn));
+              Log.Misc.warn
+                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                label (Printexc.to_string exn);
               run_unix_argv_with_stdin_and_status_fallback ?env ~stdin_content
                 argv
             ) else (
-              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
-                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
-                   (Printexc.to_string exn));
+              Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                (Printexc.to_string exn);
               (Unix.WEXITED 1, ""))
 
 let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.process_status * string =
@@ -318,20 +309,17 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.
                   (unix_status, Buffer.contents buf)))
         with
         | Eio.Time.Timeout ->
-            Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-              (Printf.sprintf "[Process_eio] Timeout after %.0fs: %s"
-                 timeout_sec label);
+            Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
+              timeout_sec label;
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Process_eio"
-                (Printf.sprintf
-                   "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
-                   label (Printexc.to_string exn));
+              Log.Misc.warn
+                "[Process_eio] argv bind error, retrying via Unix fallback: %s — %s"
+                label (Printexc.to_string exn);
               run_unix_argv_with_status_fallback ?env argv
             ) else (
-              Log.legacy_traceln ~level:Log.Error ~module_name:"Process_eio"
-                (Printf.sprintf "[Process_eio] argv error: %s — %s" label
-                   (Printexc.to_string exn));
+              Log.Misc.error "[Process_eio] argv error: %s — %s" label
+                (Printexc.to_string exn);
               (Unix.WEXITED 1, ""))

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -89,7 +89,8 @@ let cleanup_zombies
                   in
                   Resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
               zombie_entries := (agent.name, path) :: !zombie_entries
-          | _ -> ()
+          | Ok _ -> () (* not a zombie, skip *)
+          | Error err -> Log.Gc.warn "skipping agent %s: parse error: %s" name err
         end
       )
     ) scan_paths;
@@ -109,8 +110,8 @@ let cleanup_zombies
           | Ok agent ->
               let updated = { agent with status = Inactive; last_seen = now_iso () } in
               write_json config path (agent_to_yojson updated)
-          | Error _ -> ()
-        with Sys_error _ -> ());
+          | Error err -> Log.Gc.warn "gc status update parse error for %s: %s" name err
+        with Sys_error msg -> Log.Gc.warn "gc status update I/O error for %s: %s" name msg);
         let _stopped = Heartbeat.stop_by_agent ~agent_name:name in
         ()
       ) !zombie_entries;

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -1045,15 +1045,21 @@ let handle_ag_ui_events ~deps request reqd =
               let rec loop () =
                 if not !(info.stop) then (
                   (try Eio.Time.sleep clock sse_ping_interval_s
-                   with Eio.Cancel.Cancelled _ as exn -> raise exn | _ -> ());
+                   with Eio.Cancel.Cancelled _ as exn -> raise exn
+                      | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
                   (try
                      if info.closed then
                        stop_sse_session info.session_id
                      else if not !(info.stop) then
                        ignore (send_raw info ": ping\n\n")
                    with Eio.Cancel.Cancelled _ as exn -> raise exn
-                      | _ -> stop_sse_session info.session_id);
+                      | exn ->
+                          Log.Server.warn "SSE ping send failed for session %s: %s" info.session_id (Printexc.to_string exn);
+                          stop_sse_session info.session_id);
                   loop ())
               in
-              try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn | _ -> ())
+              try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn
+                | exn ->
+                    Log.Server.error "SSE ping loop exited for session %s: %s" info.session_id (Printexc.to_string exn);
+                    stop_sse_session info.session_id)
       | _ -> ())

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -264,7 +264,7 @@ let load_stats () =
         | None ->
             Log.Thompson.error "Failed to parse stats line"
       ) entries;
-      Printf.printf "[thompson_sampling] Loaded stats for %d agents\n%!"
+      Log.Metrics.debug "thompson sampling loaded stats for %d agents"
         (Hashtbl.length stats_table)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -282,7 +282,7 @@ let save_stats () =
       ) stats_table ""
     in
     Fs_compat.save_file path content;
-    Printf.printf "[thompson_sampling] Saved stats for %d agents\n%!"
+    Log.Metrics.debug "thompson sampling saved stats for %d agents"
       (Hashtbl.length stats_table)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -429,7 +429,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
       if List.mem name !selected_names then None
       else if not (is_trigger_eligible ~agent_name:name Thompson) then begin
         (* Unhealthy agents excluded from Thompson selection *)
-        Printf.printf "[thompson_sampling] Skipping %s (unhealthy) from Thompson pool\n%!" name;
+        Log.Metrics.info "thompson sampling skipping %s (unhealthy)" name;
         None
       end
       else begin


### PR DESCRIPTION
## Summary

- room_gc/gRPC/SSE transport의 silent exception swallowing 패턴에 구조화된 로그 추가
- mitosis/chain_telemetry/thompson_sampling의 Printf.printf를 Log 모듈로 전환
- process_eio의 12개 legacy_traceln을 structured Log.Misc로 마이그레이션
- keeper bootstrap warn→error 승격 (degraded state)

## 변경 카테고리

| 카테고리 | 위험도 | 파일 수 | 수정 규모 |
|----------|--------|---------|----------|
| Silent failure surfacing | HIGH | 3 | ~25줄 |
| Printf → Log module | MEDIUM | 3 | ~30줄 |
| Legacy → Structured | LOW-MED | 2 | ~15줄 |

## Test plan

- [x] `dune build --root .` 성공
- [x] `make test` — pre-existing operator test 실패 확인 (본 PR 무관)
- [ ] `MASC_LOG_LEVEL=DEBUG` 서버 기동 후 신규 로그 출력 확인
- [ ] Dashboard /api/v1/logs ring buffer에 GC/Transport/Mitosis 로그 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)