### PR TITLE
fix(dashboard): add governance section to tab-refresh plan

### DIFF
--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -31,6 +31,11 @@ describe('refreshPlanForRoute', () => {
       tab: 'command',
       params: { section: 'warroom' },
     })).toEqual(['roomTruth', 'commandCurrentSurface', 'commandChainSummary'])
+
+    expect(refreshPlanForRoute({
+      tab: 'command',
+      params: { section: 'governance' },
+    })).toEqual(['roomTruth', 'governance'])
   })
 
   it('refreshes the new workspace and lab sections only where store-backed data is needed', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -21,6 +21,11 @@ async function refreshAutoresearchLabSurface(): Promise<void> {
   await refreshAutoresearchSurface()
 }
 
+async function refreshGovernanceSurface(): Promise<void> {
+  const { refreshGovernance } = await import('./components/governance-store')
+  await refreshGovernance()
+}
+
 export type RefreshTask =
   | 'roomTruth'
   | 'missionSnapshot'
@@ -35,6 +40,7 @@ export type RefreshTask =
   | 'commandOrchestra'
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
+  | 'governance'
 
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
@@ -68,6 +74,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       }
       if (routeState.params.section === 'intervene') {
         return ['roomTruth', 'operatorSnapshot', 'operatorRoomDigest']
+      }
+      if (routeState.params.section === 'governance') {
+        return ['roomTruth', 'governance']
       }
       return []
     case 'workspace':
@@ -109,6 +118,7 @@ const REFRESHERS: Record<RefreshTask, () => void> = {
   commandOrchestra: () => { void refreshCommandPlaneOrchestra(undefined, undefined, { force: true }) },
   operatorSnapshot: () => { void refreshOperatorSnapshot({ force: true }) },
   operatorRoomDigest: () => { void refreshOperatorRoomDigest({ force: true }) },
+  governance: () => { void refreshGovernanceSurface() },
 }
 
 export function refreshForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): void {


### PR DESCRIPTION
## Summary
- `tab-refresh.ts`의 `refreshPlanForRoute`에 governance section 케이스가 누락되어 있었음
- command 탭에서 governance section 전환 시 데이터가 자동 새로고침되지 않는 문제 수정
- `governance` RefreshTask 추가 (lazy-load `refreshGovernance` from governance-store)

## Root Cause
`command` 탭의 switch 분기에서 `warroom`과 `intervene`만 처리하고 `governance`는 빈 배열(`[]`)로 fallthrough.

## Test plan
- [x] vitest `tab-refresh.test.ts` 4/4 pass (governance 케이스 포함)
- [x] TypeScript `tsc --noEmit` pass
- [ ] 대시보드에서 지휘통제 > 거버넌스 탭 전환 시 데이터 자동 로드 확인

Follow-up to #2869 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)