### PR TITLE
feat: reactive push — wake all keepers on any broadcast

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -319,17 +319,16 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   Oas_sse_bridge.start ~sw ~clock ~bus:event_bus;
   (* Inject Event_bus into keeper resident runtime for telemetry publishing *)
   Keeper_keepalive.set_bus event_bus;
-  (* Wire broadcast → keeper wakeup: when a broadcast mentions a keeper,
-     interrupt its sleep so it processes the mention immediately. *)
+  (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
+     can react to new tasks, mentions, or room activity immediately. *)
   Room_eio.on_broadcast_mention := (fun mention ->
     match mention with
     | Some target ->
         Keeper_keepalive.wakeup_keeper target;
         Log.Keeper.info "broadcast mention → wakeup keeper %s" target
     | None ->
-        (* No specific mention — no targeted wakeup needed.
-           Keepers will see it on next heartbeat via board events. *)
-        ());
+        Keeper_keepalive.wakeup_all_keepers ();
+        Log.Keeper.info "broadcast → wakeup all keepers (reactive push)");
   (* Orchestrator needs synchronous registration for shutdown hook *)
   (try
     let cancel_orchestrator =


### PR DESCRIPTION
## Summary
- 모든 broadcast에서 keeper 즉시 wakeup (기존: @mention만)
- task created/claimed/completed 시 keeper가 다음 heartbeat까지 기다리지 않음
- `interruptible_sleep`의 `wakeup` ref를 활용하므로 추가 스레드/fiber 없음

## How it works
room_task.ml의 모든 task 이벤트(add, claim, transition)는 broadcast를 발생시킴.
broadcast → `on_broadcast_mention(None)` → `wakeup_all_keepers()` → keeper 즉시 깨어남.

## Test plan
- [ ] `dune build` 성공
- [ ] broadcast 시 keeper 로그에 "reactive push" 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)