### PR TITLE
fix(keeper): restore room_scope All variant and fix CI test

### DIFF
--- a/lib/keeper/keeper_contract.ml
+++ b/lib/keeper/keeper_contract.ml
@@ -76,12 +76,12 @@ let scope_kind_to_string = function
   | Global -> "global"
 
 let room_scope_of_string = function
-  | "all" -> Current
+  | "all" -> All
   | _ -> Current
 
 let parse_room_scope = function
   | "current" -> Some Current
-  | "all" -> Some Current
+  | "all" -> Some All
   | _ -> None
 
 let room_scope_to_string = function

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -150,6 +150,7 @@ let resolve_allowed_models ~explicit_allowed_models ~seed_allowed_models ~models
     dedupe_keep_order models
 
 let canonical_room_scope = function
+  | "all" -> "all"
   | _ -> "current"
 
 let canonical_scope_kind = function

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -1,4 +1,22 @@
+let has_prompt_root path =
+  Sys.file_exists (Filename.concat path "config/prompts/keeper.world.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
 let () =
+  let root = repo_root () in
+  Masc_mcp.Prompt_registry.set_markdown_dir (Filename.concat root "config/prompts");
+  Masc_mcp.Prompt_defaults.init ();
   Alcotest.run "Operator_control"
     [
       ( "operator",

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -280,7 +280,7 @@ initiative_post_ttl_hours = 24
       Alcotest.(check (option (float 0.001))) "last output tokens per sec surfaced"
         (Some 20.0)
         (json |> member "metrics" |> member "last_output_tokens_per_sec" |> to_float_option);
-      Alcotest.(check string) "prompt block source surfaced" "default"
+      Alcotest.(check string) "prompt block source surfaced" "file"
         (json |> member "prompt" |> member "system_prompt_blocks"
          |> member "world" |> member "source" |> to_string);
       let effective_system_prompt =


### PR DESCRIPTION
## Summary

CI `test_operator_control` 실패 수정 (2건).

### 1. `canonical_room_scope`가 모든 입력을 `"current"`로 붕괴

```ocaml
(* before — All variant 사실상 dead code *)
let canonical_room_scope = function
  | _ -> "current"

(* after *)
let canonical_room_scope = function
  | "all" -> "all"
  | _ -> "current"
```

`room_scope_of_string`, `parse_room_scope`도 동일하게 수정.
이로 인해 `live_override_fields`가 room_scope 변경을 감지하지 못했음.

### 2. `test_operator_control`에 Prompt_registry 초기화 누락

prompt block source 테스트가 `"default"` 기대했지만, 실제로는 markdown 파일에서 로드하므로 `"file"`이 정확한 값. `set_markdown_dir` + `Prompt_defaults.init()` 추가.

## Test plan

- [x] `dune exec test/test_operator_control.exe` — 31 tests pass (로컬)
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)