### PR TITLE
fix(prompt): bootstrap keeper prompt registry outside server startup

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -513,6 +513,9 @@ let keeper_config_json (config : Room.config) (name : string)
       (`Not_found,
        `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
   | Ok (Some (m : Keeper_types.keeper_meta)) ->
+      ignore
+        (Prompt_defaults.bootstrap_runtime ~workspace_path:config.workspace_path
+           ~base_path:config.base_path);
       let active_model = Keeper_exec_status.active_model_of_meta m in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt

--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -5,6 +5,49 @@ let register ?(template_variables = []) ~key ~description ~category () =
   Prompt_registry.register_prompt ~key ~description ~category ~required_file:true
     ~template_variables ()
 
+let existing_dir path =
+  Sys.file_exists path && Sys.is_directory path
+
+let dedupe_keep_order values =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+        if List.mem value acc then loop acc rest
+        else loop (value :: acc) rest
+  in
+  loop [] values
+
+let prompt_markdown_dir_candidates ~workspace_path ~base_path =
+  let workspace_candidate = Filename.concat workspace_path "config/prompts" in
+  let base_candidate = Filename.concat base_path "config/prompts" in
+  let cwd_candidate = Filename.concat (Sys.getcwd ()) "config/prompts" in
+  let exe_candidate =
+    let exe_dir = Filename.dirname Sys.executable_name in
+    let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
+    Filename.concat root "config/prompts"
+  in
+  let dune_candidate =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when String.trim root <> "" ->
+        Some (Filename.concat root "config/prompts")
+    | _ -> None
+  in
+  let candidates =
+    workspace_candidate
+    :: base_candidate
+    :: (match dune_candidate with Some dir -> [ dir ] | None -> [])
+    @ [ exe_candidate; cwd_candidate ]
+  in
+  dedupe_keep_order candidates
+
+let resolve_prompt_markdown_dir ~workspace_path ~base_path =
+  let candidates = prompt_markdown_dir_candidates ~workspace_path ~base_path in
+  match List.find_opt existing_dir candidates with
+  | Some dir -> dir
+  | None -> Filename.concat base_path "config/prompts"
+
+let bootstrapped_signature : (string * string) option ref = ref None
+
 let init () =
   register ~key:"keeper.constitution"
     ~description:"keeper continuity rules and STATE block format"
@@ -57,3 +100,20 @@ let init () =
     ~category:"dashboard"
     ~template_variables:[ "facts_json" ]
     ()
+
+let bootstrap_runtime ~workspace_path ~base_path =
+  let prompt_markdown_dir =
+    resolve_prompt_markdown_dir ~workspace_path ~base_path
+  in
+  let signature = (workspace_path, prompt_markdown_dir) in
+  if !bootstrapped_signature <> Some signature then (
+    Prompt_registry.set_markdown_dir prompt_markdown_dir;
+    init ();
+    (try Prompt_registry.restore_overrides workspace_path
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         Log.Misc.error "prompt override restore failed: %s"
+           (Printexc.to_string exn));
+    bootstrapped_signature := Some signature);
+  prompt_markdown_dir

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -32,49 +32,6 @@ let requested_backend_mode () =
       in
       if has_pg then "postgres-native" else "filesystem"
 
-let existing_dir path =
-  Sys.file_exists path && Sys.is_directory path
-
-let dedupe_keep_order values =
-  let rec loop acc = function
-    | [] -> List.rev acc
-    | value :: rest ->
-        if List.mem value acc then loop acc rest
-        else loop (value :: acc) rest
-  in
-  loop [] values
-
-let prompt_markdown_dir_candidates ~workspace_path ~base_path =
-  let workspace_candidate =
-    Filename.concat workspace_path "config/prompts"
-  in
-  let base_candidate = Filename.concat base_path "config/prompts" in
-  let cwd_candidate = Filename.concat (Sys.getcwd ()) "config/prompts" in
-  let exe_candidate =
-    let exe_dir = Filename.dirname Sys.executable_name in
-    let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
-    Filename.concat root "config/prompts"
-  in
-  let dune_candidate =
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root when String.trim root <> "" ->
-        Some (Filename.concat root "config/prompts")
-    | _ -> None
-  in
-  let candidates =
-    workspace_candidate
-    :: base_candidate
-    :: (match dune_candidate with Some dir -> [ dir ] | None -> [])
-    @ [ exe_candidate; cwd_candidate ]
-  in
-  dedupe_keep_order candidates
-
-let resolve_prompt_markdown_dir ~workspace_path ~base_path =
-  let candidates = prompt_markdown_dir_candidates ~workspace_path ~base_path in
-  match List.find_opt existing_dir candidates with
-  | Some dir -> dir
-  | None -> Filename.concat base_path "config/prompts"
-
 let init_runtime_context env =
   let clock = Eio.Stdenv.clock env in
   let mono_clock = Eio.Stdenv.mono_clock env in
@@ -125,17 +82,15 @@ let bootstrap_chain_state (state : Mcp_server.server_state) =
   Chain_native_eio.ensure_bootstrap state.room_config;
   (* Initialize prompt registry with defaults and restore saved overrides *)
   let prompt_markdown_dir =
-    resolve_prompt_markdown_dir
+    Prompt_defaults.bootstrap_runtime
       ~workspace_path:state.room_config.workspace_path
       ~base_path:state.room_config.base_path
   in
-  Prompt_registry.set_markdown_dir prompt_markdown_dir;
   if prompt_markdown_dir
      <> Filename.concat state.room_config.workspace_path "config/prompts"
   then
     Log.Misc.info "prompt markdown dir resolved outside room base: %s"
       prompt_markdown_dir;
-  Prompt_defaults.init ();
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
     Log.Misc.error "required prompt files missing: %s"
@@ -148,10 +103,6 @@ let bootstrap_chain_state (state : Mcp_server.server_state) =
       (invalid_prompt_templates
       |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)
       |> String.concat ", ");
-  (try Prompt_registry.restore_overrides state.room_config.workspace_path
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Misc.error "prompt override restore failed: %s"
-       (Printexc.to_string exn));
   (try Tool_command_plane.backfill_chain_overlays state.room_config
    with
    | Eio.Cancel.Cancelled _ as e -> raise e

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -164,14 +164,11 @@ let test_keeper_config_exposes_live_runtime_and_sources () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let cwd = Sys.getcwd () in
-  let prompts_dir = Filename.concat cwd "config/prompts" in
   Fun.protect
     ~finally:(fun () ->
       Unix.chdir cwd;
       cleanup_dir base_dir)
     (fun () ->
-      Masc_mcp.Prompt_registry.set_markdown_dir prompts_dir;
-      Masc_mcp.Prompt_defaults.init ();
       Unix.chdir base_dir;
       let keepers_dir = Filename.concat (Filename.concat base_dir "config") "keepers" in
       Fs_compat.mkdir_p keepers_dir;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -164,11 +164,14 @@ let test_keeper_config_exposes_live_runtime_and_sources () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let cwd = Sys.getcwd () in
+  let prompts_dir = Filename.concat cwd "config/prompts" in
   Fun.protect
     ~finally:(fun () ->
       Unix.chdir cwd;
       cleanup_dir base_dir)
     (fun () ->
+      Masc_mcp.Prompt_registry.set_markdown_dir prompts_dir;
+      Masc_mcp.Prompt_defaults.init ();
       Unix.chdir base_dir;
       let keepers_dir = Filename.concat (Filename.concat base_dir "config") "keepers" in
       Fs_compat.mkdir_p keepers_dir;
@@ -282,13 +285,9 @@ initiative_post_ttl_hours = 24
       Alcotest.(check (option (float 0.001))) "last output tokens per sec surfaced"
         (Some 20.0)
         (json |> member "metrics" |> member "last_output_tokens_per_sec" |> to_float_option);
-      (* Prompt registry is empty in test env; source is "missing" not "default" *)
-      let prompt_source =
-        json |> member "prompt" |> member "system_prompt_blocks"
-        |> member "world" |> member "source" |> to_string
-      in
-      Alcotest.(check bool) "prompt block source surfaced" true
-        (prompt_source = "default" || prompt_source = "missing");
+      Alcotest.(check string) "prompt block source surfaced" "file"
+        (json |> member "prompt" |> member "system_prompt_blocks"
+         |> member "world" |> member "source" |> to_string);
       let effective_system_prompt =
         json |> member "prompt" |> member "effective_system_prompt" |> to_string
       in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -245,7 +245,7 @@ let test_prompt_markdown_dir_falls_back_to_repo_root () =
       Alcotest.(check bool) "repo prompt dir exists" true
         (Sys.file_exists expected && Sys.is_directory expected);
       let resolved =
-        Server_runtime_bootstrap.resolve_prompt_markdown_dir
+        Prompt_defaults.resolve_prompt_markdown_dir
           ~workspace_path:dir ~base_path:dir
       in
       Alcotest.(check string) "temp room falls back to repo prompt dir"


### PR DESCRIPTION
## Summary
- move prompt registry bootstrap into a shared runtime helper
- reuse that helper from server startup and direct keeper config rendering
- keep the keeper config provenance test aligned with real runtime prompt source (`file`)

## Root cause
`Dashboard_http_keeper.keeper_config_json` depended on server startup side effects.
Server startup initialized prompt markdown discovery and prompt defaults, but direct library calls did not. That meant the same keeper config endpoint logic could report `system_prompt_blocks.*.source` as `missing` outside the server boot path.

## Fix
- added `Prompt_defaults.bootstrap_runtime ~workspace_path ~base_path`
- switched `server_runtime_bootstrap` to use the shared helper instead of open-coded prompt setup
- made `Dashboard_http_keeper.keeper_config_json` call the same helper before reading prompt provenance
- removed test-only prompt bootstrap from `test_operator_control_keeper.ml`
- kept the expectation aligned with runtime behavior: prompt source is `file` when `config/prompts/*.md` is present

## Verification
- `env -u DUNE_RPC ALCOTEST_QUICK_TESTS=1 dune exec --root . ./test/test_operator_control.exe -- test operator 25`
- `env -u DUNE_RPC ALCOTEST_QUICK_TESTS=1 dune exec --root . ./test/test_operator_control.exe`
- `env -u DUNE_RPC dune build --root . bin/main_eio.exe`

## Notes
- latest `main` still reproduced `test_operator_control` case 25 before this fix
- follow-up investigation context: #2888
