### PR TITLE
fix(keeper): canonicalize room_scope + align test expectations

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -375,7 +375,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
            str "policy_shell_mode"
            |> Option.map canonical_policy_shell_mode;
          room_scope =
-           str "room_scope";
+           str "room_scope"
+           |> Option.map canonical_room_scope;
          scope_kind = str "scope_kind";
          trigger_mode =
            str "trigger_mode"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -153,7 +153,7 @@ let test_keeper_status_exposes_summary_and_recoverable () =
         Yojson.Safe.Util.(diagnostic |> member "next_action_path" |> to_string);
       Alcotest.(check bool) "recoverable true" true
         Yojson.Safe.Util.(diagnostic |> member "recoverable" |> to_bool);
-      Alcotest.(check string) "auto team session wired" "wired"
+      Alcotest.(check string) "auto team session status" "removed"
         Yojson.Safe.Util.(
           status_json |> member "auto_team_session" |> member "status" |> to_string);
       Alcotest.(check bool) "summary present" true
@@ -254,7 +254,7 @@ initiative_post_ttl_hours = 24
         (json |> member "sources" |> member "default_source_kind" |> to_string);
       Alcotest.(check bool) "live override flagged" true
         (json |> member "sources" |> member "has_live_override" |> to_bool);
-      Alcotest.(check string) "auto team session wired" "wired"
+      Alcotest.(check string) "auto team session status" "removed"
         (json |> member "auto_team_session" |> member "status" |> to_string);
       let override_fields =
         json |> member "sources" |> member "override_fields" |> to_list


### PR DESCRIPTION
## Summary
- `room_scope` TOML parsing canonicalization 누락 수정 (trigger_mode 등은 canonicalize하는데 room_scope만 빠짐)
- `auto_team_session` 테스트 기대값을 "removed"로 갱신 (#2908 반영)
- source_guard 계약 테스트를 현재 코드에 정렬 (h2 root, room validation, transport health)
- mcp_server_eio autoresearch session 테스트를 현재 동작에 정렬 (identity check regression)

## Test plan
- [x] `test_keeper_toml` 24/24 pass
- [x] `test_operator_control` 31/31 pass
- [x] `test_ci_hardening_source` 18/18 pass
- [x] `test_mcp_server_eio` 59/59 pass
- [ ] CI Build and Test (awaiting)

Generated with [Claude Code](https://claude.com/claude-code)