### PR TITLE
fix(keeper): disable auto team_session interception

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -4,7 +4,7 @@ open Keeper_types
 
 let string_list_to_json values =
   `List (List.map (fun value -> `String value) values)
-let auto_team_session_enabled (_meta : keeper_meta) = true
+let auto_team_session_enabled (_meta : keeper_meta) = false
 let linked_team_session config (meta : keeper_meta) =
   match meta.active_team_session_id with
   | Some session_id -> Team_session_store.load_session config session_id


### PR DESCRIPTION
## Summary
- `auto_team_session_enabled`가 `true`로 하드코딩되어 모든 keeper_msg가 team_session 생성으로 가로채짐
- keeper의 Agent.run() LLM 턴이 실행되지 않음 — 대화 불가
- `false`로 변경하여 keeper가 자율적으로 판단

## Root cause
`keeper_status_bridge.ml:7` — `let auto_team_session_enabled (_meta : keeper_meta) = true`

## Test plan
- [ ] keeper_msg로 "야" 보내면 team_session 대신 실제 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)