### PR TITLE
refactor(keeper): remove auto_team_session interception

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -4,7 +4,7 @@ open Keeper_types
 
 let string_list_to_json values =
   `List (List.map (fun value -> `String value) values)
-let auto_team_session_enabled (_meta : keeper_meta) = false
+(* auto_team_session removed — keeper decides autonomously via Agent.run() *)
 let linked_team_session config (meta : keeper_meta) =
   match meta.active_team_session_id with
   | Some session_id -> Team_session_store.load_session config session_id
@@ -27,7 +27,7 @@ let team_session_bridge_json config (meta : keeper_meta) =
   in
   `Assoc
     [
-      ("enabled", `Bool (auto_team_session_enabled meta));
+      ("enabled", `Bool false);
       ("active_session_id",
        match meta.active_team_session_id with
        | Some session_id -> `String session_id
@@ -113,8 +113,8 @@ let drift_surface_json () =
 let auto_team_session_surface_json () =
   `Assoc
     [
-      ("status", `String "wired");
-      ("enabled", `Bool true);
+      ("status", `String "removed");
+      ("enabled", `Bool false);
     ]
 
 let coordination_surface_json (meta : keeper_meta) =

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -474,10 +474,10 @@ let handle_keeper_status ctx args : tool_result =
            ]);
            ("initiative", initiative_surface_json defaults_snapshot.defaults);
            ("auto_team_session", auto_team_session_surface_json ());
-           ("auto_team_session_enabled", `Bool (auto_team_session_enabled m));
+           ("auto_team_session_enabled", `Bool false);
            ("initiative", initiative_surface_json defaults_snapshot.defaults);
            ("auto_team_session", auto_team_session_surface_json ());
-           ("auto_team_session_enabled", `Bool (auto_team_session_enabled m));
+           ("auto_team_session_enabled", `Bool false);
            ("active_team_session_id",
              match m.active_team_session_id with
              | Some session_id -> `String session_id

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -7,7 +7,7 @@
 
     Sub-modules:
     - Keeper_turn_up: start/reconfigure
-    - Keeper_turn_session: team-session integration
+    - Keeper_turn_session: team-session helpers (auto-interception removed)
     - Keeper_turn_setup: ensure_keeper_exists, apply_settings_update
     - Keeper_turn_lifecycle: model-set, shutdown *)
 
@@ -86,10 +86,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       (* start_keepalive is deferred AFTER run_turn completes.
          Starting it here causes the heartbeat fiber to immediately grab LLM
          slots, starving the synchronous run_turn call (Issue #2610). *)
-      match maybe_handle_auto_team_session ctx meta message with
-      | Error err -> (false, "❌ " ^ err)
-      | Ok (Some result, _) -> result
-      | Ok (None, meta) ->
       (* === Harness: trajectory accumulator + eval gate config === *)
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let trajectory_acc =

--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -272,30 +272,10 @@ let append_keeper_auto_team_session_note (ctx : _ context) (meta : keeper_meta)
     | Some refreshed -> Ok refreshed
     | None -> Error ("team session disappeared after note: " ^ session.session_id)
 
-let maybe_handle_auto_team_session (ctx : _ context) (meta : keeper_meta)
-    (message : string) :
+(* Auto team_session interception removed — keeper decides autonomously
+   via Agent.run() and tool calls. Stub kept for backward compatibility
+   until keeper_turn_session.ml is fully cleaned up. *)
+let maybe_handle_auto_team_session (_ctx : _ context) (meta : keeper_meta)
+    (_message : string) :
     ((tool_result option * keeper_meta), string) result =
-  if not (Keeper_status_bridge.auto_team_session_enabled meta) then
-    Ok (None, meta)
-  else
-    let linked_meta, running_session = running_session_for_keeper ctx.config meta in
-    match running_session with
-    | Some session -> (
-        match append_keeper_auto_team_session_note ctx linked_meta session message with
-        | Error err -> Error err
-        | Ok session' ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
-    | None -> (
-        match start_keeper_auto_team_session ctx linked_meta message with
-        | Error err -> Error err
-        | Ok (updated_meta, session, spawn_error) ->
-            let json =
-              keeper_auto_team_session_response_json
-                ~meta:updated_meta ~session ~created:true ~reused:false
-                ?spawn_error ()
-            in
-            Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))
+  Ok (None, meta)


### PR DESCRIPTION
## Summary
- `auto_team_session` bypass 코드 경로 제거 (-24줄)
- keeper가 Agent.run() LLM 턴을 실행하고 자율적으로 판단
- `auto_team_session_surface_json` → status "removed"

Follows #2902 (disabled). This PR removes the dead code path.

## Test plan
- [ ] `dune build` 성공
- [ ] keeper_msg로 메시지 보내면 team_session 대신 실제 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)