### PR TITLE
fix(keeper): remove hardcoded max_turns:10 and silent checkpoint errors

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -51,7 +51,9 @@ let prune ~(session_dir : string) ~(keep : int) : int =
     List.iter (fun filename ->
       let path = Filename.concat session_dir filename in
       (try Sys.remove path
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()))
+       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+         Log.Keeper.warn "checkpoint cleanup failed for %s: %s"
+           path (Printexc.to_string exn)))
       to_remove;
     List.length to_remove
 

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -597,7 +597,8 @@ let run_proactive_generation
           Oas_worker.run_named ~cascade_name:"keeper_turn"
             ~goal:prompt ~system_prompt:turn_system_prompt
             ~tools ~initial_messages:ctx_work.messages
-            ~max_turns:10 ~temperature ~max_tokens ()) in
+            ~max_turns:(Keeper_config.keeper_unified_max_turns ())
+            ~temperature ~max_tokens ()) in
       match agent_result with
       | Error _ -> None
       | Ok result ->


### PR DESCRIPTION
## Summary
- proactive generation `max_turns:10` → `Keeper_config.keeper_unified_max_turns()` (default 20, env var configurable)
- checkpoint cleanup `| _ -> ()` → `Log.Keeper.warn` with error details

## Root cause
- keeper_config.ml 주석에 "10이면 multi-step이 잘린다"고 되어 있는데 proactive만 10 하드코딩
- checkpoint 삭제 실패 시 silent swallow → 누적 감지 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)