### PR TITLE
refactor: replace hardcoded temperature/max_tokens with Cascade_inference

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -105,7 +105,11 @@ let generate_code_change ~goal ~baseline ~history ~insights
   match
     Oas_worker.run_named ~cascade_name:"autoresearch"
       ~goal:prompt ~max_turns:1
-      ~temperature:0.7 ~max_tokens:4096 ()
+      ~temperature:(Cascade_inference.resolve_temperature
+        ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
+      ~max_tokens:(Cascade_inference.resolve_max_tokens
+        ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
+      ()
   with
   | Error e -> Result.error (Printf.sprintf "MODEL call failed: %s" e)
   | Ok result -> parse_model_code_response (Oas_response.text_of_response result.Oas_worker.response)

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -507,7 +507,12 @@ let execute_single_agent_run ~sw:_ ~provider ~model ~prompt =
           match
             Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
               ~system_prompt:(run_system_prompt provider)
-              ~max_turns:4 ~max_tokens:2048 ~temperature:0.2 ()
+              ~max_turns:4
+              ~max_tokens:(Cascade_inference.resolve_max_tokens
+                ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 2048))
+              ~temperature:(Cascade_inference.resolve_temperature
+                ~cascade_name:"provider_benchmark" ~fallback:(fun () -> 0.2))
+              ()
           with
           | Ok result ->
               Ok (response_text_of_api_response result.response)

--- a/lib/procedure_tool_materializer.ml
+++ b/lib/procedure_tool_materializer.ml
@@ -114,8 +114,10 @@ let make_handler (procedure : Procedural_memory.procedure) : Tool_dispatch.handl
         ~goal:query
         ~system_prompt
         ~max_turns:1
-        ~temperature:0.3
-        ~max_tokens:2048
+        ~temperature:(Cascade_inference.resolve_temperature
+          ~cascade_name:"materialized_procedure" ~fallback:(fun () -> 0.3))
+        ~max_tokens:(Cascade_inference.resolve_max_tokens
+          ~cascade_name:"materialized_procedure" ~fallback:(fun () -> 2048))
         ()
     with
     | Ok result ->

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -208,7 +208,8 @@ let generate_hypothesis ~sw ~net ~clock ~(config : Research_config.t)
       ~defaults:config.cascade_defaults
       ~messages
       ~system_prompt:config.system_prompt
-      ~temperature:0.7
+      ~temperature:(Cascade_inference.resolve_temperature
+        ~cascade_name:config.cascade_name ~fallback:(fun () -> 0.7))
       ~max_tokens:config.max_tokens
       ~timeout_sec:config.timeout_sec
       ()

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -299,7 +299,11 @@ let planned_worker_to_entry_with_state
       Oas_worker.run_named_with_masc_tools
         ~cascade_name ~goal:prompt ~system_prompt
         ~masc_tools ~dispatch:dispatch_with_defaults ~max_turns
-        ~temperature:0.3 ~max_tokens:4096 ?raw_trace ()
+        ~temperature:(Cascade_inference.resolve_temperature
+          ~cascade_name ~fallback:(fun () -> 0.3))
+        ~max_tokens:(Cascade_inference.resolve_max_tokens
+          ~cascade_name ~fallback:(fun () -> 4096))
+        ?raw_trace ()
     with
     | Ok result ->
         Hashtbl.replace success_by_agent name true;


### PR DESCRIPTION
## Summary
- 5개 call site에서 하드코딩된 temperature/max_tokens를 `Cascade_inference.resolve_*`로 교체
- cascade.json에서 오버라이드 가능, 기본값은 동일하게 유지
- MASC가 추론 파라미터를 직접 결정하지 않고 cascade config에 위임

## Changed files
- `procedure_tool_materializer.ml` (T=0.3, max=2048)
- `team_session_oas_bridge.ml` (T=0.3, max=4096)
- `dashboard_provider_runs.ml` (T=0.2, max=2048)
- `autoresearch_codegen.ml` (T=0.7, max=4096)
- `research_loop.ml` (T=0.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)