### PR TITLE
refactor(dashboard): eliminate keeper detail page duplication

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -358,8 +358,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
     <${PromptBlock} title="Constitution" block=${c.prompt.system_prompt_blocks.constitution} />
     <${PromptBlock} title="World" block=${c.prompt.system_prompt_blocks.world} />
     <${PromptBlock} title="Capabilities" block=${c.prompt.system_prompt_blocks.capabilities} />
-    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">Effective system prompt</div>
-    <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
+    <details class="mt-3">
+      <summary class="cursor-pointer py-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors">View compiled system prompt</summary>
+      <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
+    </details>
   `
 
   return html`
@@ -368,8 +370,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${toolbar}
 
       ${'' /* --- Execution (read-only) --- */}
+      ${'' /* Active model is shown in the header badge — not duplicated here */}
       <${SectionHeader} title="Execution" />
-      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
       <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">Verify</span>
@@ -379,7 +381,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Models</div>
         <${ModelList} models=${c.execution.models} />
       </div>
-      ${c.execution.allowed_models.length > 0 ? html`
+      ${'' /* Show allowed_models only when it differs from models */}
+      ${c.execution.allowed_models.length > 0
+        && JSON.stringify(c.execution.allowed_models.slice().sort()) !== JSON.stringify(c.execution.models.slice().sort())
+        ? html`
         <div class="mt-1.5">
           <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Allowed models</div>
           <${ModelList} models=${c.execution.allowed_models} />
@@ -492,14 +497,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Threshold" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
       <${ConfigRow} label="Cooldown" value=${c.handoff.cooldown_sec + 's'} />
 
-      ${'' /* --- Metrics (read-only) --- */}
-      <${SectionHeader} title="Metrics" />
-      <${ConfigRow} label="Generation" value=${String(c.metrics.generation)} />
-      <${ConfigRow} label="Total turns" value=${String(c.metrics.total_turns)} />
+      ${'' /* --- Last Call Performance (read-only) --- */}
+      ${'' /* Totals (generation, turns, tokens, cost, compactions) are in KpiGrid */}
+      <${SectionHeader} title="Last Call Performance" />
       <${ConfigRow} label="Total input tokens" value=${formatTokens(c.metrics.total_input_tokens)} />
       <${ConfigRow} label="Total output tokens" value=${formatTokens(c.metrics.total_output_tokens)} />
-      <${ConfigRow} label="Total tokens" value=${formatTokens(c.metrics.total_tokens)} />
-      <${ConfigRow} label="Total cost" value=${'$' + c.metrics.total_cost_usd.toFixed(4)} />
       <${ConfigRow} label="Last model" value=${c.metrics.last_model_used || '--'} />
       <${ConfigRow} label="Last input tokens" value=${formatTokens(c.metrics.last_input_tokens)} />
       <${ConfigRow} label="Last output tokens" value=${formatTokens(c.metrics.last_output_tokens)} />
@@ -507,7 +509,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Last latency" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
       <${ConfigRow} label="Last throughput" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
       <${ConfigRow} label="Last output throughput" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
-      <${ConfigRow} label="Compactions" value=${String(c.metrics.compaction_count)} />
 
       ${'' /* --- Sources (read-only) --- */}
       <${SectionHeader} title="Sources" />

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -121,6 +121,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         <${KpiCard}
           label="Tokens"
           value=${formatTokens(keeper.context_tokens)}
+          hint=${keeper.context_max ? `/ ${formatTokens(keeper.context_max)}` : undefined}
         />
         <${KpiCard}
           label="Handoffs"
@@ -183,11 +184,13 @@ export function ContextChart({ keeper }: { keeper: Keeper }) {
     </div>`
 }
 
-// ── Field Dictionary ─────────────────────────────────────
+// ── Raw Data (Debug) ─────────────────────────────────────
+// Collapsed-by-default debug dump of all keeper fields.
+// Primary display is handled by Header, KpiGrid, Profile, and Config sections.
 
 const fieldSearch = signal('')
 
-export function FieldDictionary({ keeper }: { keeper: Keeper }) {
+export function RawDataDebug({ keeper }: { keeper: Keeper }) {
   const filter = fieldSearch.value.toLowerCase()
 
   const fields: { title: string; key: string; value: string }[] = [

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -110,16 +110,12 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
   const mw = keeper.metrics_window
 
+  // Quality/rate metrics only — raw counts (handoffs, compactions, k2k, etc.)
+  // are authoritative in KpiGrid to avoid duplication.
   const rows: Array<{ label: string; value: string | number }> = [
     { label: 'Model fallback', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
     { label: 'Proactive fallback', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
     { label: 'Memory pass rate', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
-    { label: 'Handoffs', value: typeof mw?.handoff_count === 'number' ? mw.handoff_count : keeper.handoff_count_total ?? '-' },
-    { label: 'Compactions', value: typeof mw?.compaction_events === 'number' ? mw.compaction_events : keeper.compaction_count ?? '-' },
-    { label: 'Saved tokens', value: typeof mw?.compaction_saved_tokens === 'number' ? mw.compaction_saved_tokens : keeper.last_compaction_saved_tokens ?? '-' },
-    { label: 'K2K events', value: keeper.k2k_count ?? '-' },
-    { label: 'Conv tail', value: keeper.conversation_tail_count ?? '-' },
-    { label: 'Tool calls', value: typeof mw?.tool_call_count === 'number' ? mw.tool_call_count : '-' },
     { label: 'Preview similarity', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
     { label: 'Memory avg score', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
     { label: 'Fallback rate', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
@@ -186,6 +182,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
       <${SignalRow} label="Cluster" value=${cluster} />
       <${SignalRow} label="Current task" value=${currentTaskLabel} />
       <${SignalRow} label="Skill route" value=${skillRouteLabel} />
+      <${SignalRow} label="Context source" value=${keeper.context_source ?? keeper.context?.source ?? '-'} />
 
       <div class="flex justify-end mt-1">
         <button type="button"

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -18,8 +18,8 @@ import { showToast } from './common/toast'
 import {
   ContextChart,
   EquipmentList,
-  FieldDictionary,
   KpiGrid,
+  RawDataDebug,
   RelationshipList,
   TraitsList,
   TrpgStats,
@@ -210,10 +210,6 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Detail sections grid ── */}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-          <${SectionCard} title="Field Dictionary">
-            <${FieldDictionary} keeper=${keeper} />
-          <//>
-
           <${SectionCard} title="Profile">
             <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
             <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
@@ -237,6 +233,13 @@ export function KeeperDetailOverlay() {
                   <span>Last heartbeat:</span>
                   <${TimeAgo} timestamp=${keeper.last_heartbeat} />
                 </div>`
+              : null}
+            ${keeper.memory_recent_note
+              ? html`
+                <div class="mt-3 py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
+                  ${keeper.memory_recent_note}
+                </div>
+              `
               : null}
           <//>
 
@@ -264,7 +267,7 @@ export function KeeperDetailOverlay() {
             `
             : null}
 
-          <${SectionCard} title="Runtime Signals">
+          <${SectionCard} title="Quality Signals">
             <${RuntimeSignals} keeper=${keeper} />
           <//>
 
@@ -275,31 +278,19 @@ export function KeeperDetailOverlay() {
           <${SectionCard} title="Config">
             <${KeeperConfigPanel} keeperName=${keeper.name} />
           <//>
-
-          <${SectionCard} title="Memory & Context">
-            <div class="flex flex-col gap-2">
-              <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-                <span class="text-xs text-[var(--text-muted)]">Context source</span>
-                <span class="text-xs font-medium text-[var(--text-strong)]">${keeper.context_source ?? keeper.context?.source ?? '-'}</span>
-              </div>
-              <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-                <span class="text-xs text-[var(--text-muted)]">Context tokens</span>
-                <span class="text-xs font-medium text-[var(--text-strong)]">
-                  ${keeper.context_tokens ?? keeper.context?.context_tokens ?? '-'}
-                  /
-                  ${keeper.context_max ?? keeper.context?.context_max ?? '-'}
-                </span>
-              </div>
-              ${keeper.memory_recent_note
-                ? html`
-                  <div class="py-2 px-3 rounded-lg bg-[rgba(167,139,250,0.06)] border border-[rgba(167,139,250,0.12)] text-xs text-[var(--text-body)] leading-relaxed">
-                    ${keeper.memory_recent_note}
-                  </div>
-                `
-                : html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No recent memory note</div>`}
-            </div>
-          <//>
         </div>
+
+        ${'' /* ── Raw Data (Debug) — collapsed by default ── */}
+        <details class="mt-4">
+          <summary class="cursor-pointer py-3 px-4 text-[11px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] hover:bg-[var(--white-6)] transition-colors flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-[var(--text-dim)]"></span>
+            Raw Data (Debug)
+          </summary>
+          <div class="mt-2 p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md">
+            <${RawDataDebug} keeper=${keeper} />
+          </div>
+        </details>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Keeper 상세 페이지에서 17개 데이터 포인트가 최대 4곳에 반복 표시되던 문제 해결
- 각 데이터에 단일 authoritative section을 지정하여 중복 제거
- 정보 손실 없이 Progressive Disclosure 패턴 적용

## Changes

| 파일 | 변경 |
|------|------|
| `keeper-detail-runtime.ts` | RuntimeSignals에서 KpiGrid 중복 6행 제거, Neighborhood에 context_source 추가 |
| `keeper-detail-panels.ts` | FieldDictionary → RawDataDebug (collapsed debug), Tokens에 context_max hint |
| `keeper-config-panel.ts` | active_model 제거, allowed_models 조건부, Metrics→Last Call Performance, effective_system_prompt collapsed |
| `keeper-detail.ts` | FieldDict를 collapsed debug로 이동, Memory&Context 제거→분산, "Quality Signals" rename |

## Test plan

- [x] `npm run build` 성공 (tsc --noEmit + vite build)
- [x] 기존 테스트 17/18 pass (1건 기존 governance 타임아웃, 무관)
- [ ] keeper 상세 페이지에서 각 섹션 표시 확인
- [ ] Raw Data (Debug) 접힘/펼침 확인
- [ ] View compiled system prompt 접힘/펼침 확인
- [ ] Config edit mode 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)