### PR TITLE
chore: bump OAS pin to v0.89.1 (auto model_id fix)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.89.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.89.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="c029ac7aef670745b24f58ae720c7005e76ef9c9"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.89.0"
+readonly OAS_AGENT_SDK_SHA="01754dcbcd25ae5c4f02941629917c40dd651754"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.89.1"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#a9a1b9b002078981d01d890fb49919183e970e40}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#01754dcbcd25ae5c4f02941629917c40dd651754}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
- OAS pin을 v0.89.1로 업데이트 (01754dc)
- OAS v0.89.1에서 `"auto"` model_id를 cloud provider별 기본 모델로 해석하도록 수정됨
- keeper unified turn에서 `"glm:auto"` → `"glm-4.7"` (또는 `ZAI_DEFAULT_MODEL` env var)로 해석
- ZhipuAI "模型不存在" 에러 해소

## Related
- OAS PR: jeong-sik/oas#388

## Test plan
- [ ] MASC 서버 재시작 후 keeper unified turn 에러 미발생 확인
- [ ] Dashboard render timeout이 별도 이슈인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)