### PR TITLE
fix: cap cascade_counters + document lab route redirect

### DIFF
--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -152,6 +152,8 @@ function parseSegments(
   const tabFromPath = segments[0]
   const tabFromQuery = params.tab
 
+  // Lab tab removed (#2898). Redirect legacy lab bookmarks (e.g. #lab?surface=trpg)
+  // to command tab. No valid lab section exists to fall back to.
   if ((tabFromPath === 'lab' || tabFromQuery === 'lab') && params.surface && !params.section) {
     const nextParams = { ...params, section: 'command' }
     return {

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -26,14 +26,19 @@ type cascade_counter = {
 
 let cascade_counters_mu = Eio.Mutex.create ()
 let cascade_counters : (string, cascade_counter) Hashtbl.t = Hashtbl.create 8
+let cascade_max_keys = 256
 
 let record_cascade ~cascade_name ~outcome =
   Eio.Mutex.use_rw ~protect:true cascade_counters_mu (fun () ->
     let c = match Hashtbl.find_opt cascade_counters cascade_name with
       | Some c -> c
       | None ->
-        let c = { calls = 0; successes = 0; failures = 0; rejected = 0 } in
-        Hashtbl.replace cascade_counters cascade_name c; c
+        if Hashtbl.length cascade_counters >= cascade_max_keys then
+          { calls = 0; successes = 0; failures = 0; rejected = 0 }
+        else begin
+          let c = { calls = 0; successes = 0; failures = 0; rejected = 0 } in
+          Hashtbl.replace cascade_counters cascade_name c; c
+        end
     in
     c.calls <- c.calls + 1;
     match outcome with


### PR DESCRIPTION
## Summary

Follow-up to Codex P2 review findings:

- **oas_worker.ml**: `cascade_counters` hashtable was unbounded — clients with unique cascade names could grow memory indefinitely. Added 256-key cap; excess names are tracked in a throwaway counter not stored in the table.
- **dashboard/src/router.ts**: Added comment explaining the lab→command redirect is intentional (lab tab fully removed in #2898).

## Test plan

- [ ] `dune build --root .` passes
- [ ] Cascade metrics still report for known cascade names
- [ ] Lab bookmark `#lab?surface=trpg` redirects to command tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)