### PR TITLE
feat(keeper): per-keeper tool usage tracking for Observed tools

### DIFF
--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -53,7 +53,18 @@ let keeper_tool_audit_json_fields keeper agent_name =
           Some "heartbeat_result",
           Some result.updated_at )
     | None, None ->
-        (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
+        (* Use per-keeper tool tracking as last-resort fallback *)
+        let tracked = Keeper_tools_oas.tool_usage_for_keeper agent_name in
+        if tracked <> [] then
+          let names = List.map fst tracked in
+          let total = List.fold_left (fun acc (_, e) -> acc + e.Keeper_tools_oas.count) 0 tracked in
+          let latest_at = List.fold_left (fun acc (_, e) ->
+            max acc e.Keeper_tools_oas.last_used_at) 0.0 tracked in
+          let at_str = if latest_at > 0.0
+            then Some (Dashboard_utils.iso_of_unix latest_at) else None in
+          (fallback_allowed, names, Some total, Some "keeper_dispatch", at_str)
+        else
+          (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
   in
   [
     ("allowed_tool_names", string_list_json allowed_tool_names);

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -9,6 +9,66 @@
 
     @since Phase 4 — Keeper → Agent.run() migration *)
 
+(* ── Per-keeper tool usage tracking ──────────────────────────── *)
+
+type tool_call_entry = {
+  mutable count : int;
+  mutable successes : int;
+  mutable failures : int;
+  mutable last_used_at : float;
+}
+
+(** Per-keeper tool usage: keeper_name → (tool_name → entry). *)
+let usage_by_keeper : (string, (string, tool_call_entry) Hashtbl.t) Hashtbl.t =
+  Hashtbl.create 8
+
+let record_tool_use ~keeper_name ~tool_name ~success =
+  let keeper_tbl = match Hashtbl.find_opt usage_by_keeper keeper_name with
+    | Some t -> t
+    | None ->
+      let t = Hashtbl.create 16 in
+      Hashtbl.replace usage_by_keeper keeper_name t; t
+  in
+  let entry = match Hashtbl.find_opt keeper_tbl tool_name with
+    | Some e -> e
+    | None ->
+      let e = { count = 0; successes = 0; failures = 0; last_used_at = 0.0 } in
+      Hashtbl.replace keeper_tbl tool_name e; e
+  in
+  entry.count <- entry.count + 1;
+  if success then entry.successes <- entry.successes + 1
+  else entry.failures <- entry.failures + 1;
+  entry.last_used_at <- Unix.gettimeofday ()
+
+let tool_usage_for_keeper keeper_name : (string * tool_call_entry) list =
+  match Hashtbl.find_opt usage_by_keeper keeper_name with
+  | None -> []
+  | Some tbl ->
+    Hashtbl.fold (fun name entry acc -> (name, entry) :: acc) tbl []
+    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+
+let tool_usage_json keeper_name : Yojson.Safe.t =
+  `List (List.map (fun (name, e) ->
+    `Assoc [
+      ("tool_name", `String name);
+      ("count", `Int e.count);
+      ("successes", `Int e.successes);
+      ("failures", `Int e.failures);
+      ("last_used_at", `Float e.last_used_at);
+    ]
+  ) (tool_usage_for_keeper keeper_name))
+
+let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
+  tool_usage_for_keeper keeper_name
+  |> List.sort (fun (_, a) (_, b) -> Float.compare b.last_used_at a.last_used_at)
+  |> (fun l -> let rec take n acc = function
+    | [] -> List.rev acc
+    | _ when n <= 0 -> List.rev acc
+    | (name, _) :: rest -> take (n - 1) (name :: acc) rest
+    in take limit [] l)
+
+(* ── end tracking ────────────────────────────────────────────── *)
+
 (** Build OAS Tool.t list from keeper's allowed tools.
 
     Each tool delegates to [execute_keeper_tool_call] with the current
@@ -104,6 +164,7 @@ let make_tools
                 let count = prior_fails + 1 in
                 with_failure_counts (fun () ->
                   Hashtbl.replace failure_counts key count);
+                record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:false;
                 Log.Keeper.warn
                   "tool %s returned error result (%d/%d) for same args"
                   td.name count max_consecutive_failures;
@@ -111,12 +172,14 @@ let make_tools
               end else begin
                 with_failure_counts (fun () ->
                   Hashtbl.remove failure_counts key);
+                record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:true;
                 (true, result)
               end
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               let count = prior_fails + 1 in
               with_failure_counts (fun () ->
                 Hashtbl.replace failure_counts key count);
+              record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:false;
               let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
                 td.name count max_consecutive_failures
                 (Printexc.to_string exn) in


### PR DESCRIPTION
## Summary
- keeper_tools_oas.ml에 per-keeper tool call 카운터 추가 (name, count, successes, failures, last_used_at)
- dashboard_mission_assembly.ml에서 heartbeat 없을 때 keeper dispatch 데이터를 fallback으로 사용
- "Observed tools" 필드가 "none_recent" 대신 실제 사용 도구 목록 표시

## How it works
1. `make_tools`의 tool execution wrapper에서 `record_tool_use` 호출 (성공/실패/예외 모두)
2. `usage_by_keeper` Hashtbl에 keeper_name → tool_name → entry 저장
3. dashboard가 keeper status를 조회할 때, heartbeat 데이터가 없으면 `tool_usage_for_keeper`에서 데이터 가져옴
4. Evidence source: `keeper_dispatch` (heartbeat와 구분)

## Exposed API
- `tool_usage_json : string -> Yojson.Safe.t` — keeper별 tool usage JSON
- `recent_tools_for_keeper : ?limit:int -> string -> string list` — 최근 사용 도구 이름
- `record_tool_use : keeper_name:string -> tool_name:string -> success:bool -> unit`

## Test plan
- [x] test_tool_keeper.exe 27/27 pass
- [x] test_keeper_agent_isolation.exe 12/12 pass
- [x] Library build pass
- [ ] keeper 실행 후 대시보드에서 Observed tools 실데이터 확인

Closes #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)