### PR TITLE
fix(dashboard): add system logging to silent error paths

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -90,7 +90,8 @@ export async function submitGovernancePetition(title: string): Promise<Governanc
       ruling: rulingRaw,
       execution_order: null,
     })
-  } catch {
+  } catch (err) {
+    console.warn('[governance] petition response parse failed', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -109,8 +110,8 @@ export async function submitGovernanceCaseBrief(
     const raw = JSON.parse(text) as Record<string, unknown>
     const existing = normalizeGovernanceCaseBundle(raw)
     if (existing) return existing
-  } catch {
-    // Fall through to a full status fetch.
+  } catch (err) {
+    console.debug('[governance] fast status update failed, falling back to full fetch', err instanceof Error ? err.message : err)
   }
   return fetchGovernanceCaseStatus(caseId)
 }
@@ -119,7 +120,8 @@ export async function fetchGovernanceCaseStatus(caseId: string): Promise<Governa
   const text = await callMcpTool('masc_case_status', { case_id: caseId })
   try {
     return normalizeGovernanceCaseBundle(JSON.parse(text) as Record<string, unknown>)
-  } catch {
+  } catch (err) {
+    console.warn('[governance] case status parse failed', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -134,7 +136,8 @@ export async function decideGovernanceExecutionOrder(
   })
   try {
     return normalizeGovernanceExecutionOrder(JSON.parse(text) as Record<string, unknown>)
-  } catch {
+  } catch (err) {
+    console.warn('[governance] execution order parse failed', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -273,7 +276,8 @@ export async function fetchGoals(): Promise<import('../types').Goal[]> {
     }
     if (Array.isArray(res)) return res
     return (res as Record<string, unknown>).goals as import('../types').Goal[] ?? []
-  } catch {
+  } catch (err) {
+    console.warn('[goals] fetch/parse error', err instanceof Error ? err.message : err)
     return []
   }
 }
@@ -286,7 +290,8 @@ export async function fetchActivityGraph(since?: string): Promise<import('../typ
     const resp = await fetchWithTimeout(`/api/v1/activity/graph${params}`, {}, 10000)
     if (!resp.ok) return null
     return (await resp.json()) as import('../types').ActivityGraphResponse
-  } catch {
+  } catch (err) {
+    console.debug('[activity] graph fetch failed', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -297,7 +302,8 @@ export async function fetchSwimlane(since?: string): Promise<import('../types').
     const resp = await fetchWithTimeout(`/api/v1/activity/swimlane${params}`, {}, 10000)
     if (!resp.ok) return null
     return (await resp.json()) as import('../types').SwimlaneResponse
-  } catch {
+  } catch (err) {
+    console.debug('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)
     return null
   }
 }

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -141,7 +141,8 @@ function parseSseEvent(frame: string): KeeperChatStreamEvent | null {
   if (dataLines.length === 0) return null
   try {
     return JSON.parse(dataLines.join('\n')) as KeeperChatStreamEvent
-  } catch {
+  } catch (err) {
+    console.debug('[keeper-stream] SSE frame parse failed', dataLines.join('\n').slice(0, 120), err instanceof Error ? err.message : err)
     return null
   }
 }

--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -350,8 +350,8 @@ export function relevantPitfalls(ids: string[]): CommandPlaneHelpPitfall[] {
 export async function fire(action: () => Promise<void>) {
   try {
     await action()
-  } catch {
-    // Error state is already captured in the store.
+  } catch (err) {
+    console.debug('[command] action error (state captured in store)', err instanceof Error ? err.message : err)
   }
 }
 

--- a/dashboard/src/components/governance-store.ts
+++ b/dashboard/src/components/governance-store.ts
@@ -139,8 +139,8 @@ export async function loadRuntimeParams() {
     const data = await fetchRuntimeParams()
     runtimeParams.value = data.parameters ?? []
     runtimeSurfaces.value = data.surfaces ?? []
-  } catch {
-    // silent -- params panel is optional
+  } catch (err) {
+    console.debug('[governance] runtime params load failed (optional)', err instanceof Error ? err.message : err)
   } finally {
     runtimeLoading.value = false
   }

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -201,7 +201,8 @@ async function submitComment(postId: string) {
     showToast('댓글을 등록했습니다', 'success')
     await loadPostDetail(postId)
     refreshBoard()
-  } catch {
+  } catch (err) {
+    console.warn('[board] comment submit failed', err instanceof Error ? err.message : err)
     showToast('댓글 등록에 실패했습니다', 'error')
   } finally {
     commentSubmitting.value = false
@@ -220,7 +221,8 @@ async function submitNewPost() {
     showNewPostForm.value = false
     showToast('글을 등록했습니다', 'success')
     refreshBoard()
-  } catch {
+  } catch (err) {
+    console.warn('[board] post submit failed', err instanceof Error ? err.message : err)
     showToast('글 등록에 실패했습니다', 'error')
   } finally {
     newPostSubmitting.value = false
@@ -378,7 +380,8 @@ function PostCard({ post }: { post: BoardPost }) {
     try {
       await votePost(post.id, dir)
       refreshBoard()
-    } catch {
+    } catch (err) {
+      console.warn(`[board] vote failed (post=${post.id}, dir=${dir})`, err instanceof Error ? err.message : err)
       showToast('투표에 실패했습니다', 'error')
     }
   }
@@ -391,7 +394,8 @@ function PostCard({ post }: { post: BoardPost }) {
       await deleteBoardPost(post.id)
       showToast('게시글을 삭제했습니다', 'success')
       refreshBoard()
-    } catch {
+    } catch (err) {
+      console.warn('[board] post delete failed', err instanceof Error ? err.message : err)
       showToast('게시글 삭제에 실패했습니다', 'error')
     } finally {
       deletingPostId.value = null
@@ -549,7 +553,8 @@ function PostDetail({ post }: { post: BoardPost }) {
     try {
       await votePost(post.id, dir)
       refreshBoard()
-    } catch {
+    } catch (err) {
+      console.warn(`[board] vote failed (post=${post.id}, dir=${dir})`, err instanceof Error ? err.message : err)
       showToast('투표에 실패했습니다', 'error')
     }
   }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -75,6 +75,7 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
     return detail
   } catch (err) {
     const message = err instanceof Error ? err.message : `Failed to inspect ${keeperName}`
+    console.warn(`[keeper] hydration failed for ${keeperName}:`, message)
     setRecordValue(keeperActionErrors, keeperName, message)
     return null
   } finally {
@@ -102,8 +103,8 @@ export async function loadFullKeeperHistory(name: string): Promise<void> {
     try { parsed = JSON.parse(text) } catch { parsed = null }
     const detail = normalizeStatusDetail(keeperName, text, parsed)
     setStatusDetail(keeperName, detail)
-  } catch {
-    // ignore — best effort
+  } catch (err) {
+    console.warn(`[keeper] full history load failed for ${keeperName}`, err instanceof Error ? err.message : err)
   } finally {
     setRecordValue(keeperHydrating, keeperName, false)
   }
@@ -227,8 +228,8 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
         })
         await refreshDashboardState()
         return
-      } catch {
-        // Fall through to the shared error path below.
+      } catch (fallbackErr) {
+        console.warn(`[keeper] stream fallback also failed for ${keeperName}`, fallbackErr instanceof Error ? fallbackErr.message : fallbackErr)
       }
     }
 
@@ -289,6 +290,7 @@ export async function probeKeeperRuntime(name: string, actor: string): Promise<K
     return diagnostic
   } catch (err) {
     const message = err instanceof Error ? err.message : `Failed to probe ${keeperName}`
+    console.warn(`[keeper] probe failed for ${keeperName}:`, message)
     setRecordValue(keeperActionErrors, keeperName, message)
     throw err
   } finally {
@@ -326,6 +328,7 @@ export async function recoverKeeperRuntime(name: string, actor: string): Promise
     return after
   } catch (err) {
     const message = err instanceof Error ? err.message : `Failed to recover ${keeperName}`
+    console.warn(`[keeper] recovery failed for ${keeperName}:`, message)
     setRecordValue(keeperActionErrors, keeperName, message)
     throw err
   } finally {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -19,6 +19,7 @@ export function abortKeeperThreadMessage(name: string): void {
   if (!keeperName) return
   const controller = getStreamController(keeperName)
   const entryId = activeStreamEntryId(keeperName)
+  console.debug(`[keeper-stream] aborting stream for ${keeperName}${entryId ? ` (entry=${entryId})` : ''}`)
   if (controller) controller.abort()
   if (entryId) {
     finalizeAssistantEntry(keeperName, entryId, {

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -175,6 +175,7 @@ export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void
         isRecord(raw)
         && asString((raw as Record<string, unknown>).status) === 'initializing'
       if (isInitializing) {
+        console.debug('[room-truth] server initializing, scheduling warm-up retry')
         roomTruthInitializing.value = true
         scheduleWarmRetry(1)
         return
@@ -183,7 +184,9 @@ export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void
       roomTruth.value = normalizeRoomTruth(raw)
       lastRoomTruthRefreshAt = Date.now()
     } catch (err) {
-      roomTruthError.value = err instanceof Error ? err.message : 'Failed to load room truth'
+      const detail = err instanceof Error ? err.message : 'Failed to load room truth'
+      console.warn('[room-truth] fetch failed:', detail)
+      roomTruthError.value = detail
     } finally {
       roomTruthLoading.value = false
       inflightRoomTruthRefresh = null
@@ -194,6 +197,7 @@ export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void
 }
 
 function scheduleWarmRetry(attempt: number): void {
+  console.debug(`[room-truth] warm-up retry ${attempt}/${WARM_MAX_RETRIES}`)
   if (attempt > WARM_MAX_RETRIES) {
     roomTruthInitializing.value = false
     roomTruthError.value = 'Server warm-up timed out. Try refreshing.'

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -177,7 +177,8 @@ async function refreshActiveRoute(): Promise<void> {
   try {
     const { refreshForRoute } = await import('./tab-refresh')
     refreshForRoute(route.value)
-  } catch {
+  } catch (err) {
+    console.debug('[SSE] tab-refresh unavailable, using fallback refreshes', err instanceof Error ? err.message : '')
     _refreshCommandPlaneFn?.()
     _refreshOperatorFn?.()
     _refreshMissionFn?.()
@@ -209,11 +210,15 @@ async function hydrateAfterReconnect(): Promise<void> {
   try {
     await refreshRoomTruth({ force: true })
     await refreshActiveRoute()
-  } catch {
-    // First attempt failed (server may still be warming up) — retry once.
+  } catch (err) {
+    console.warn('[SSE] reconnect hydration failed, retrying in 3s', err instanceof Error ? err.message : err)
     setTimeout(() => {
-      void refreshRoomTruth({ force: true })
-      void refreshActiveRoute()
+      void refreshRoomTruth({ force: true }).catch(retryErr =>
+        console.warn('[SSE] reconnect room-truth retry failed', retryErr instanceof Error ? retryErr.message : retryErr),
+      )
+      void refreshActiveRoute().catch(retryErr =>
+        console.warn('[SSE] reconnect route retry failed', retryErr instanceof Error ? retryErr.message : retryErr),
+      )
     }, 3000)
   }
 }
@@ -303,8 +308,12 @@ export function startPeriodicRefresh(): void {
     if (!connected.value) {
       invalidateDashboardCache()
     }
-    void refreshRoomTruth()
-    void refreshActiveRoute()
+    void refreshRoomTruth().catch(err =>
+      console.warn('[periodic] room-truth refresh failed', err instanceof Error ? err.message : err),
+    )
+    void refreshActiveRoute().catch(err =>
+      console.warn('[periodic] route refresh failed', err instanceof Error ? err.message : err),
+    )
   }, PERIODIC_REFRESH_MS)
 }
 

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -156,6 +156,7 @@ function scheduleReconnect(): void {
   reconnectAttempts++
   const exp = Math.min(reconnectAttempts, 5)
   const delay = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * Math.pow(2, exp))
+  console.debug(`[SSE] reconnect #${reconnectAttempts} in ${delay}ms`)
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null
     connectSSE()
@@ -170,6 +171,7 @@ export function connectSSE(): void {
   }
 
   const sseUrl = buildDashboardSseUrl(getOrCreateSessionId())
+  console.debug('[SSE] connecting', sseUrl)
   const es = new EventSource(sseUrl)
   source = es
 
@@ -180,6 +182,9 @@ export function connectSSE(): void {
     connected.value = true
     if (wasDisconnected) {
       reconnectCount.value++
+      console.debug(`[SSE] reconnected (count=${reconnectCount.value})`)
+    } else {
+      console.debug('[SSE] connected')
     }
   }
 
@@ -188,6 +193,7 @@ export function connectSSE(): void {
     if (connected.value) {
       lastDisconnectedAt.value = Date.now()
     }
+    console.warn('[SSE] connection error, scheduling reconnect')
     connected.value = false
     es.close()
     source = null


### PR DESCRIPTION
## Summary
- SSE 연결 생명주기(connect/disconnect/reconnect)에 `console.debug` 로깅 추가
- 7개 silent `catch {}` 블록에 `console.warn`/`console.debug` 추가 (governance, goals, activity)
- Dangling `void` promise에 `.catch()` 핸들러 추가 (periodic refresh, reconnect hydration)
- Keeper hydration/probe/recover 실패 시 `console.warn` 추가
- Room truth warm-up 재시도 과정 `console.debug` 추가

## Changes by file
| File | Logging added |
|------|--------------|
| `sse.ts` | connect, reconnect (#N in Nms), error |
| `sse-store.ts` | hydration failure, periodic refresh, route refresh fallback |
| `api/actions.ts` | 7 silent catch blocks (governance x4, goals, activity x2) |
| `room-truth-store.ts` | warm-up retry progress, fetch failure detail |
| `keeper-actions.ts` | hydration, history load, stream fallback, probe, recover |

## Level convention
- `console.debug`: 정상 흐름 (연결 성공, warm-up 재시도, 의도된 fallback)
- `console.warn`: 실패 경로 (파싱 실패, 네트워크 에러, hydration 실패)
- 기존 `[Dashboard]`, `[Board]` prefix 패턴 유지

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `vite build` 성공
- [ ] DevTools console에서 SSE 연결/단절 시 로그 확인
- [ ] 서버 중단 시 reconnect backoff 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)