### PR TITLE
fix: bump agent_sdk floor to 0.89.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.89.0))
+  (agent_sdk (>= 0.89.1))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.89.0"}
+  "agent_sdk" {>= "0.89.1"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- PR #2927 updated `oas-agent-sdk-pin.sh` to v0.89.1 but missed bumping the dependency floor in `dune-project` and `masc_mcp.opam` (0.89.0 → 0.89.1)
- This causes `check-oas-pin.sh` → `Verify OAS pin ratchet` Health check to fail on **every** CI run
- All 12 open PRs currently blocked by this Health failure

## Test plan
- [ ] CI Health check passes (OAS pin ratchet verification)

Generated with [Claude Code](https://claude.com/claude-code)