### PR TITLE
refactor(dashboard): centralize magic numbers into config/constants.ts

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -58,11 +58,20 @@ function jsonHeaders(): Record<string, string> {
   }
 }
 
-// Backend dashboard timeout is 30s. Frontend must wait longer.
-export const DEFAULT_GET_TIMEOUT_MS = 35_000
-export const DEFAULT_POST_TIMEOUT_MS = 30_000
-export const DEFAULT_MCP_TIMEOUT_MS = 60_000
-export const ROOM_TRUTH_GET_TIMEOUT_MS = 30_000
+import {
+  DEFAULT_GET_TIMEOUT_MS,
+  DEFAULT_POST_TIMEOUT_MS,
+  KEEPER_MESSAGE_TIMEOUT_MS,
+  SOCIAL_SWEEP_TIMEOUT_MS,
+} from '../config/constants'
+
+// Re-export so existing consumers keep working
+export {
+  DEFAULT_GET_TIMEOUT_MS,
+  DEFAULT_POST_TIMEOUT_MS,
+  DEFAULT_MCP_TIMEOUT_MS,
+  ROOM_TRUTH_GET_TIMEOUT_MS,
+} from '../config/constants'
 const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
 
 class ApiRequestError extends Error {
@@ -286,9 +295,9 @@ function operatorActionTimeoutMs(body: OperatorActionRequest): number {
   switch (body.action_type) {
     case 'keeper_message':
     case 'keeper_recover':
-      return 90_000
+      return KEEPER_MESSAGE_TIMEOUT_MS
     case 'social_sweep':
-      return 45_000
+      return SOCIAL_SWEEP_TIMEOUT_MS
     default:
       return DEFAULT_POST_TIMEOUT_MS
   }

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -1,0 +1,29 @@
+// Centralized dashboard constants.
+// Change a value here to adjust behavior across the entire dashboard.
+
+// --- HTTP timeouts (milliseconds) ---
+// Backend dashboard timeout is 30s; frontend must wait slightly longer.
+export const DEFAULT_GET_TIMEOUT_MS = 35_000
+export const DEFAULT_POST_TIMEOUT_MS = 30_000
+export const DEFAULT_MCP_TIMEOUT_MS = 60_000
+export const ROOM_TRUTH_GET_TIMEOUT_MS = 30_000
+export const KEEPER_MESSAGE_TIMEOUT_MS = 90_000
+export const SOCIAL_SWEEP_TIMEOUT_MS = 45_000
+
+// --- SSE reconnection ---
+export const RECONNECT_BASE_MS = 1_000
+export const RECONNECT_MAX_MS = 15_000
+
+// --- Refresh & debounce (milliseconds) ---
+export const SHELL_TTL_MS = 5_000
+export const EXECUTION_TTL_MS = 30_000
+export const HEARTBEAT_STALE_MS = 120_000
+
+// --- Buffer & cache sizes ---
+export const MAX_JOURNAL_ENTRIES = 200
+export const OAS_AGENT_EVENT_BUFFER = 50
+export const OAS_KEEPER_SNAPSHOT_MAX = 20
+
+// --- Text truncation (characters) ---
+export const TRIM_TEXT_DEFAULT = 120
+export const TRUNCATE_DEFAULT = 260

--- a/dashboard/src/lib/truncate.ts
+++ b/dashboard/src/lib/truncate.ts
@@ -1,14 +1,16 @@
 // Unified text truncation utilities.
 
+import { TRIM_TEXT_DEFAULT, TRUNCATE_DEFAULT } from '../config/constants'
+
 /** Truncate text, collapsing whitespace. Returns null for empty input. Uses ellipsis. */
-export function trimText(value: string | null | undefined, max = 120): string | null {
+export function trimText(value: string | null | undefined, max = TRIM_TEXT_DEFAULT): string | null {
   const text = (value ?? '').replace(/\s+/g, ' ').trim()
   if (!text) return null
   return text.length > max ? `${text.slice(0, max - 1)}…` : text
 }
 
 /** Simple truncate — returns original if short enough, otherwise slices with ellipsis. */
-export function truncate(value: string, limit = 260): string {
+export function truncate(value: string, limit = TRUNCATE_DEFAULT): string {
   if (value.length <= limit) return value
   return `${value.slice(0, limit - 1)}…`
 }

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -16,9 +16,13 @@ import {
 } from './journal-entry'
 import type { OasKeeperSnapshot } from './types/oas'
 
+import {
+  RECONNECT_BASE_MS,
+  RECONNECT_MAX_MS,
+  MAX_JOURNAL_ENTRIES,
+} from './config/constants'
+
 const SSE_SESSION_KEY = 'masc_dashboard_sse_session_id'
-const RECONNECT_BASE_MS = 1000
-const RECONNECT_MAX_MS = 15000
 
 // --- Signals ---
 
@@ -47,7 +51,7 @@ function getOrCreateSessionId(): string {
 
 // --- Journal ---
 
-const MAX_JOURNAL = 200
+const MAX_JOURNAL = MAX_JOURNAL_ENTRIES
 
 function addJournalEntry(
   agent: string,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -114,8 +114,13 @@ export const goalsLoading = signal(false)
 
 import type { OasAgentEvent, OasKeeperSnapshot } from './types/oas'
 
-const OAS_AGENT_EVENT_BUFFER = 50
-const OAS_KEEPER_SNAPSHOT_MAX = 20
+import {
+  OAS_AGENT_EVENT_BUFFER,
+  OAS_KEEPER_SNAPSHOT_MAX,
+  HEARTBEAT_STALE_MS,
+  SHELL_TTL_MS,
+  EXECUTION_TTL_MS,
+} from './config/constants'
 
 export const oasAgentEvents = signal<OasAgentEvent[]>([])
 export const oasKeeperSnapshots = signal<Map<string, OasKeeperSnapshot>>(new Map())
@@ -269,8 +274,7 @@ export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>>
   return map
 })
 
-// Heartbeat staleness threshold (120 seconds)
-const HEARTBEAT_STALE_MS = 120_000
+// Heartbeat staleness threshold — value from config/constants.ts
 
 export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
   const now = Date.now()
@@ -291,8 +295,7 @@ interface RefreshOptions {
   force?: boolean
 }
 
-const SHELL_TTL_MS = 5_000
-const EXECUTION_TTL_MS = 30_000
+// TTL values from config/constants.ts
 
 let inflightDashboardRefresh: Promise<void> | null = null
 let inflightShellRefresh: Promise<void> | null = null


### PR DESCRIPTION
## Summary
- 대시보드 전체 15개 메뉴를 브라우저로 순회하여 가짜/하드코딩 데이터 감사 수행 — 프론트엔드에 가짜 데이터 0건 확인
- 파일마다 흩어진 16개 마법 숫자(타임아웃, 버퍼 크기, 텍스트 절삭 길이, SSE 재연결 딜레이, TTL)를 `config/constants.ts`로 중앙화
- 기존 `api/core.ts`의 re-export를 유지하여 하위 소비자 코드 변경 없음

## Changes
| 파일 | 변경 |
|------|------|
| `src/config/constants.ts` | 신규 - 16개 상수 중앙 정의 |
| `src/api/core.ts` | 6개 타임아웃 constants에서 import, re-export 유지 |
| `src/sse.ts` | 3개 상수 (reconnect, journal) constants에서 import |
| `src/store.ts` | 5개 상수 (buffer, heartbeat, TTL) constants에서 import |
| `src/lib/truncate.ts` | 2개 기본값 constants에서 import |

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm test` 62/62 통과
- [x] `npm run build` 성공
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)