### PR TITLE
feat(keeper): ungate triage — initiative_enabled replaces dead policy_mode gate

### DIFF
--- a/config/keepers/example.toml
+++ b/config/keepers/example.toml
@@ -37,9 +37,7 @@ proactive_enabled = true
 presence_keepalive = true
 presence_keepalive_sec = 30
 
-# Policy (policy_mode defaults to "heuristic", rarely needs override)
 policy_action_budget = "board"
-policy_shell_mode = "readonly"
 
 # Initiative (autonomous posting)
 initiative_enabled = true

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -42,8 +42,6 @@ proactive_enabled = true
 presence_keepalive = true
 presence_keepalive_sec = 30
 
-policy_shell_mode = "coding"
-
 initiative_enabled = true
 initiative_scope = "board_only"
 initiative_idle_sec = 300

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -372,7 +372,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${'' /* --- Execution (read-only) --- */}
       ${'' /* Active model is shown in the header badge — not duplicated here */}
       <${SectionHeader} title="Execution" />
+<<<<<<< HEAD
       <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
+||||||| parent of 597f7a4b (docs(keeper): replace policy_mode docs with initiative system)
+      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
+      <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
+=======
+      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
+>>>>>>> 597f7a4b (docs(keeper): replace policy_mode docs with initiative system)
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">Verify</span>
         <${BoolBadge} value=${c.execution.verify} />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -451,8 +451,6 @@ export interface KeeperConfigExecution {
   models: string[]
   allowed_models: string[]
   active_model: string
-  policy_mode: string
-  policy_shell_mode: string
   verify: boolean
 }
 

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -1,9 +1,9 @@
 # Keeper Capability Matrix
 
-Tool availability for keepers is determined by two axes:
-**policy_mode** (who decides what tools) and **policy_shell_mode** (shell access level).
+All keepers receive the full tool surface unconditionally.
+`initiative_enabled` controls whether triage (trigger detection) runs on each heartbeat.
 
-Research profile (`soul_profile = "research"`) adds autoresearch/research tools regardless of other settings.
+Research profile (`soul_profile = "research"`) adds autoresearch/research tools.
 
 ## Tool Shards (keeper_model_tools: 26 tools total)
 
@@ -25,21 +25,23 @@ Notes:
 - `keeper_fs_edit` remains a legacy internal tool but is intentionally excluded from default keeper exposure.
 - Code mutation uses `masc_code_{write,edit,delete,shell,git}` in addition to the `coding` shard above.
 
-## Policy Mode × Shell Mode Matrix
+## Tool Surface
 
-| | `disabled` | `readonly` | `sandboxed` / default | `coding` |
-|---|---|---|---|---|
-| **Heuristic** (default) | base + board + fs + shell + library + taskboard + governance (26 tools) | same | same | default + coding shard + `masc_code_*` (38 tools) |
-| **Learned_offline_v1** | read + coordination + board + governance (23 tools) | + `keeper_shell_readonly` (24) | same as `disabled` | readonly set + coding shard + `masc_code_*` (36 tools) |
-| **Explicit_event_v1** | same as Heuristic | same | same | same |
-| **Model_deliberation** | same as Heuristic | same | same | same |
+All keepers receive: base + board + fs + shell + library + taskboard + governance + coding shards.
+Voice tools are added when `policy_voice_enabled = true`.
+`write_done = true` returns empty tool list (session terminated).
 
-Notes:
-- "read" = `keeper_read_tool_names` (7 tools: `keeper_read`, `keeper_fs_read`, `keeper_memory_search`, `keeper_library_search`, `keeper_library_read`, `keeper_time_now`, `keeper_context_status`)
-- "coordination" = `keeper_tasks_list`, `keeper_task_claim`, `keeper_task_done`, `keeper_broadcast`
-- Voice tools are added only when `policy_voice_enabled = true`
-- Coding mode is the preferred path for code writing, test execution, and GitHub issue/PR work because it exposes `masc_worktree_create` plus the worktree-restricted `masc_code_*` tools
-- `write_done = true` returns empty tool list (session terminated)
+## Initiative System
+
+| Parameter | Default | Effect |
+|-----------|---------|--------|
+| `initiative_enabled` | true | Master gate for triage (trigger detection) |
+| `initiative_idle_sec` | 0 (use proactive.idle_sec) | Override idle threshold for triage triggers |
+| `initiative_cooldown_sec` | 0 (no cooldown) | Minimum wait between triage-triggered actions |
+
+When initiative is enabled, 9 trigger types are evaluated on each heartbeat:
+DirectMention, NewUnclaimedTask, FailedTask, AgentJoinedOrLeft, GoalDeadline,
+BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 
 ## Keeper Workflows
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -594,7 +594,7 @@ let keeper_config_json (config : Room.config) (name : string)
       in
       let defaults_snapshot = Keeper_types.keeper_default_source_snapshot m.name in
       let drift = drift_surface_json () in
-      let initiative = initiative_surface_json defaults_snapshot.defaults in
+      let initiative = initiative_surface_json ~meta:m defaults_snapshot.defaults in
       let handoff =
         `Assoc [
           ("auto", `Bool m.auto_handoff);

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -571,8 +571,8 @@ let keeper_config_json (config : Room.config) (name : string)
           ("models", `List (List.map (fun s -> `String s) m.models));
           ("allowed_models", `List (List.map (fun s -> `String s) m.allowed_models));
           ("active_model", `String active_model);
-          ("policy_mode", `String m.policy_mode);
-          ("policy_shell_mode", `String m.policy_shell_mode);
+          ("policy_mode", `String "unified");
+          ("policy_shell_mode", `String "coding");
           ("verify", `Bool false);
         ]
       in

--- a/lib/keeper/keeper_contract.ml
+++ b/lib/keeper/keeper_contract.ml
@@ -1,5 +1,8 @@
-(** Keeper_contract — typed keeper runtime enums while preserving
-    current JSON and MCP string representations at the boundary. *)
+(** Keeper_contract — typed keeper policy/runtime enums while preserving
+    current JSON and MCP string representations at the boundary.
+
+    policy_mode was removed: all keepers use a unified mode.
+    Fields kept in JSON for backward compatibility. *)
 
 type policy_action_budget =
   | Conversation

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -82,14 +82,11 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let active_model =
     Safe_ops.json_string ~default:"" "active_model" json |> String.trim
   in
-  let _policy_mode = "heuristic" in
+  let _policy_mode = "unified" in
   let _policy_voice_enabled =
     Safe_ops.json_bool ~default:false "policy_voice_enabled" json
   in
-  let _policy_shell_mode =
-    Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
-    |> canonical_policy_shell_mode
-  in
+  let _policy_shell_mode = "coding" in
   let _initiative_enabled =
     Safe_ops.json_bool ~default:false "initiative_enabled" json
   in
@@ -203,7 +200,10 @@ let resolved_keeper_args_from_persona args :
                      | model :: _ -> model
                      | [] -> "")
             in
-            let policy_mode = "heuristic" in
+            let policy_mode =
+              ignore (first_some (get_string_opt args "policy_mode") defaults.policy_mode);
+              "unified"
+            in
             let policy_voice_enabled =
               first_some
                 (get_bool_opt args "policy_voice_enabled")
@@ -211,11 +211,10 @@ let resolved_keeper_args_from_persona args :
               |> Option.value ~default:false
             in
             let policy_shell_mode =
-              first_some
+              ignore (first_some
                 (get_string_opt args "policy_shell_mode")
-                defaults.policy_shell_mode
-              |> Option.value ~default:"disabled"
-              |> canonical_policy_shell_mode
+                defaults.policy_shell_mode);
+              "coding"
             in
             let room_scope =
               get_string_opt args "room_scope"

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -103,9 +103,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               try
                 let synced = ensure_keeper_room_presence ctx.config meta_current in
                 (match write_meta ctx.config synced with
-                 | Ok () ->
-                   Keeper_registry.update_meta synced.name synced;
-                   synced
+                 | Ok () -> synced  (* use written value directly, no second read_meta *)
                  | Error e ->
                    Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
                    synced)
@@ -272,7 +270,111 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  Log.Keeper.error "heartbeat snapshot write failed: %s"
                    (Printexc.to_string exn));
               last_snapshot_ts := now_ts);
-            let meta_after_triage = meta_current in
+            (* Deliberation triage: run when initiative is enabled (default: all keepers) *)
+            let meta_after_triage =
+              if meta_current.initiative_enabled then (
+                let obs =
+                  Keeper_deliberation.empty_world_observation
+                    ~keeper_name:meta_current.name
+                in
+                (* L2 enrichment: read room state for richer world observation *)
+                let unclaimed_count, failed_count =
+                  (try
+                     let backlog = Room.read_backlog ctx.config in
+                     let unclaimed =
+                       List.length
+                         (List.filter
+                            (fun (t : Types.task) ->
+                              t.task_status = Types.Todo)
+                            backlog.tasks)
+                     in
+                     let failed =
+                       List.length
+                         (List.filter
+                            (fun (t : Types.task) ->
+                              match t.task_status with
+                              | Types.Cancelled _ -> true
+                              | _ -> false)
+                            backlog.tasks)
+                     in
+                     (unclaimed, failed)
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                     Log.Keeper.warn "keepalive: task count query failed: %s" (Printexc.to_string exn);
+                     (0, 0))
+                in
+                let current_agent_count =
+                  (try
+                     List.length (Room.get_agents_raw ctx.config)
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                     Log.Keeper.warn "keepalive: agent count query failed: %s" (Printexc.to_string exn);
+                     0)
+                in
+                let agent_count_changed =
+                  let last_count =
+                    Hashtbl.find_opt last_agent_counts meta_current.name
+                    |> Option.value ~default:0
+                  in
+                  let changed =
+                    last_count > 0 && current_agent_count <> last_count
+                  in
+                  Hashtbl.replace last_agent_counts
+                    meta_current.name current_agent_count;
+                  changed
+                in
+                (* Board activity enrichment *)
+                let board_new_post_count, board_mention_count =
+                  (try
+                     let _events, new_count, mention_count =
+                       Keeper_world_observation.collect_board_events
+                         ~meta:meta_current
+                     in
+                     (new_count, mention_count)
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                     Log.Keeper.warn "keepalive: board count query failed: %s"
+                       (Printexc.to_string exn);
+                     (0, 0))
+                in
+                let obs =
+                  { obs with
+                    active_goal_count = List.length meta_current.active_goal_ids;
+                    idle_seconds =
+                      (let activity_ts =
+                         max meta_current.usage.last_turn_ts
+                           meta_current.proactive.last_ts
+                       in
+                       if activity_ts <= 0.0 then 0
+                       else int_of_float (max 0.0 (now_ts -. activity_ts)));
+                    idle_gate = meta_current.proactive.idle_sec;
+                    unclaimed_task_count = unclaimed_count;
+                    failed_task_count = failed_count;
+                    active_agent_count = current_agent_count;
+                    agent_count_changed;
+                    board_new_post_count;
+                    board_mention_count;
+                  }
+                in
+                let triage_result = Keeper_deliberation.triage obs in
+                let triggers_str =
+                  match triage_result with
+                  | Keeper_deliberation.Skip reason -> "skip:" ^ reason
+                  | Keeper_deliberation.Triggered triggers ->
+                      String.concat ","
+                        (List.map
+                           Keeper_deliberation.deliberation_trigger_to_string
+                           triggers)
+                in
+                if Keeper_types.keeper_debug then
+                  Log.KeeperExec.info "%s triage: %s"
+                    meta_current.name triggers_str;
+                { meta_current with last_triage_triggers = triggers_str })
+              else meta_current
+            in
             let proactive_warmup_elapsed =
               proactive_warmup_sec <= 0
               || now_ts -. keepalive_started_ts
@@ -395,11 +497,6 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     in
     Hashtbl.replace keepalives m.name
       { stop; wakeup; started_at = Time_compat.now (); grpc_close };
-    (* Register in KeeperRegistry SSOT (additive during migration) *)
-    let reg_entry = Keeper_registry.register m.name m in
-    reg_entry.fiber_stop := false;
-    reg_entry.fiber_wakeup := false;
-    ignore reg_entry;
     (try
        if not (Room_utils.is_initialized ctx.config) then
          let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ()
@@ -422,16 +519,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
         run_heartbeat_loop ~proactive_warmup_sec ctx m stop ~wakeup))
 
 let stop_keepalive name =
-  Keeper_registry.unregister name;
   match Hashtbl.find_opt keepalives name with
   | None -> ()
   | Some entry ->
       entry.stop := true;
       (match entry.grpc_close with
-       | Some close_fn ->
-           (try close_fn ()
-            with exn ->
-              Log.Keeper.debug "keepalive grpc close failed for %s: %s"
-                name (Printexc.to_string exn))
+       | Some close_fn -> (try close_fn () with _ -> ())
        | None -> ());
       Hashtbl.remove keepalives name

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -270,9 +270,17 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  Log.Keeper.error "heartbeat snapshot write failed: %s"
                    (Printexc.to_string exn));
               last_snapshot_ts := now_ts);
-            (* Deliberation triage: run when initiative is enabled (default: all keepers) *)
+            (* Deliberation triage: run when initiative is enabled (default: all keepers).
+               Initiative cooldown: skip triage if last proactive action was within cooldown_sec. *)
             let meta_after_triage =
-              if meta_current.initiative_enabled then (
+              let cooldown_sec = meta_current.initiative_cooldown_sec in
+              let cooldown_elapsed =
+                cooldown_sec <= 0
+                || (let last_action_ts = meta_current.proactive.last_ts in
+                    last_action_ts <= 0.0
+                    || now_ts -. last_action_ts >= float_of_int cooldown_sec)
+              in
+              if meta_current.initiative_enabled && cooldown_elapsed then (
                 let obs =
                   Keeper_deliberation.empty_world_observation
                     ~keeper_name:meta_current.name
@@ -350,7 +358,10 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                        in
                        if activity_ts <= 0.0 then 0
                        else int_of_float (max 0.0 (now_ts -. activity_ts)));
-                    idle_gate = meta_current.proactive.idle_sec;
+                    idle_gate =
+                      (if meta_current.initiative_idle_sec > 0
+                       then meta_current.initiative_idle_sec
+                       else meta_current.proactive.idle_sec);
                     unclaimed_task_count = unclaimed_count;
                     failed_task_count = failed_count;
                     active_agent_count = current_agent_count;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -53,10 +53,6 @@ let resident_schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
         ]);
         ("active_model", `Assoc [("type", `String "string")]);
-        ("policy_mode", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"]);
-        ]);
         ("room_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "current"; `String "all"]);
@@ -143,11 +139,6 @@ let resident_schemas : tool_schema list = [
         ("active_model", `Assoc [
           ("type", `String "string");
           ("description", `String "Current persisted model label. Prefer 'default' for adapter-managed selection; explicit-only keepers may still pin a concrete provider:model label.");
-        ]);
-        ("policy_mode", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"; `String "explicit_event_v1"]);
-          ("description", `String "Behavior selection mode persisted on the keeper. explicit_event_v1 disables heuristic routing and uses explicit lifecycle/timer events only.");
         ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -221,7 +221,6 @@ let handle_keeper_list ctx args : tool_result =
               ("continuity_compaction_cooldown_sec", `Int m.compaction.cooldown_sec);
               ("continuity_reflection_hold_s", `Float continuity_reflection_hold_s);
               ("last_continuity_update_ts", `Float m.last_continuity_update_ts);
-              ("policy_mode", `String m.policy_mode);
               ("active_team_session_id",
                 match m.active_team_session_id with
                 | Some session_id -> `String session_id

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -187,14 +187,6 @@ let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_default
        (match defaults.active_model with
         | Some value -> value <> meta.active_model
         | None -> false)
-  |> add_if "execution.policy_mode"
-       (match defaults.policy_mode with
-        | Some value -> value <> meta.policy_mode
-        | None -> false)
-  |> add_if "execution.policy_shell_mode"
-       (match defaults.policy_shell_mode with
-        | Some value -> value <> meta.policy_shell_mode
-        | None -> false)
   |> add_if "coordination.room_scope"
        (match defaults.room_scope with
         | Some value ->

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -102,11 +102,15 @@ let initiative_surface_json ?(meta : keeper_meta option) (defaults : keeper_prof
         match defaults.initiative_scope with
         | Some v -> `String v | None -> `Null);
       ("idle_sec",
-        match defaults.initiative_idle_sec with
-        | Some v -> `Int v | None -> `Null);
+        match meta with
+        | Some m when m.initiative_idle_sec > 0 -> `Int m.initiative_idle_sec
+        | _ -> (match defaults.initiative_idle_sec with
+                | Some v -> `Int v | None -> `Null));
       ("cooldown_sec",
-        match defaults.initiative_cooldown_sec with
-        | Some v -> `Int v | None -> `Null);
+        match meta with
+        | Some m when m.initiative_cooldown_sec > 0 -> `Int m.initiative_cooldown_sec
+        | _ -> (match defaults.initiative_cooldown_sec with
+                | Some v -> `Int v | None -> `Null));
       ("context_mode",
         match defaults.initiative_context_mode with
         | Some v -> `String v | None -> `Null);

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -86,16 +86,30 @@ let initiative_source_defaults_json (defaults : keeper_profile_defaults) :
 let initiative_configured_in_source (defaults : keeper_profile_defaults) =
   initiative_source_defaults_json defaults <> `Null
 
-let initiative_surface_json (defaults : keeper_profile_defaults) =
+let initiative_surface_json ?(meta : keeper_meta option) (defaults : keeper_profile_defaults) =
   let configured_in_source = initiative_configured_in_source defaults in
+  let runtime_enabled = match meta with
+    | Some m -> `Bool m.initiative_enabled
+    | None -> (match defaults.initiative_enabled with
+               | Some v -> `Bool v
+               | None -> `Bool true)
+  in
   `Assoc
     [
-      ("status", `String (unsupported_feature_status configured_in_source));
-      ("enabled", `Null);
-      ("scope", `Null);
-      ("idle_sec", `Null);
-      ("cooldown_sec", `Null);
-      ("context_mode", `Null);
+      ("status", `String "wired");
+      ("enabled", runtime_enabled);
+      ("scope",
+        match defaults.initiative_scope with
+        | Some v -> `String v | None -> `Null);
+      ("idle_sec",
+        match defaults.initiative_idle_sec with
+        | Some v -> `Int v | None -> `Null);
+      ("cooldown_sec",
+        match defaults.initiative_cooldown_sec with
+        | Some v -> `Int v | None -> `Null);
+      ("context_mode",
+        match defaults.initiative_context_mode with
+        | Some v -> `String v | None -> `Null);
       ("configured_in_source", `Bool configured_in_source);
       ("source_defaults", initiative_source_defaults_json defaults);
     ]

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -472,10 +472,7 @@ let handle_keeper_status ctx args : tool_result =
             ("available_internal_tools", string_list_to_json all_internal_tools);
             ("blocked_internal_tools", string_list_to_json blocked_internal_tools);
            ]);
-           ("initiative", initiative_surface_json defaults_snapshot.defaults);
-           ("auto_team_session", auto_team_session_surface_json ());
-           ("auto_team_session_enabled", `Bool false);
-           ("initiative", initiative_surface_json defaults_snapshot.defaults);
+           ("initiative", initiative_surface_json ~meta:m defaults_snapshot.defaults);
            ("auto_team_session", auto_team_session_surface_json ());
            ("auto_team_session_enabled", `Bool false);
            ("active_team_session_id",

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -464,9 +464,9 @@ let handle_keeper_status ctx args : tool_result =
            ]);
            ("drift", drift_surface_json ());
            ("policy", `Assoc [
-             ("mode", `String m.policy_mode);
+             ("mode", `String "unified");
              ("voice_enabled", `Bool m.policy_voice_enabled);
-             ("shell_mode", `String m.policy_shell_mode);
+             ("shell_mode", `String "coding");
              ("allowed_paths", string_list_to_json m.allowed_paths);
            ("allowed_tools", string_list_to_json allowed_tools);
             ("available_internal_tools", string_list_to_json all_internal_tools);

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -219,6 +219,8 @@ let ensure_keeper_exists
       autonomous_action_count = 0;
       last_triage_triggers = "";
       initiative_enabled = true;
+      initiative_idle_sec = 0;
+      initiative_cooldown_sec = 0;
       active_team_session_id = None;
       last_team_session_started_at = "";
       team_session_start_count_total = 0;

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -99,12 +99,13 @@ let ensure_keeper_exists
               | model :: _ -> model
               | [] -> "")
     in
-    let policy_mode = "heuristic" in
+    (* Mode categorization removed: always use fixed values. *)
+    let policy_mode = "unified" in
     let policy_voice_enabled =
       profile_defaults.policy_voice_enabled
       |> Option.value ~default:false
     in
-    let policy_shell_mode = canonical_policy_shell_mode "coding" in
+    let policy_shell_mode = "coding" in
     let allowed_paths = [] in
     let room_scope =
       profile_defaults.room_scope |> Option.value ~default:"current"

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -218,6 +218,7 @@ let ensure_keeper_exists
       last_autonomous_action_at = "";
       autonomous_action_count = 0;
       last_triage_triggers = "";
+      initiative_enabled = true;
       active_team_session_id = None;
       last_team_session_started_at = "";
       team_session_start_count_total = 0;

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -18,9 +18,7 @@ type parsed_args = {
   models_in : string list;
   allowed_models_in : string list;
   active_model_opt : string option;
-  policy_mode_opt : string option;
   policy_voice_enabled_opt : bool option;
-  policy_shell_mode_opt : string option;
   allowed_paths_opt : string list option;
   room_scope_opt : string option;
   scope_kind_opt : string option;
@@ -68,9 +66,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let models_in = get_string_list args "models" in
     let allowed_models_in = get_string_list args "allowed_models" in
     let active_model_opt = get_string_opt args "active_model" in
-    let policy_mode_opt = get_string_opt args "policy_mode" in
     let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
-    let policy_shell_mode_opt = get_string_opt args "policy_shell_mode" in
     let allowed_paths_opt =
       let raw = get_string_list args "allowed_paths" in
       if raw = [] then None else Some raw
@@ -140,9 +136,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       models_in;
       allowed_models_in;
       active_model_opt;
-      policy_mode_opt;
       policy_voice_enabled_opt;
-      policy_shell_mode_opt;
       allowed_paths_opt;
       room_scope_opt;
       scope_kind_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -296,6 +296,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_triage_triggers = "";
             initiative_enabled =
               Option.value ~default:true p.profile_defaults.initiative_enabled;
+            initiative_idle_sec =
+              Option.value ~default:0 p.profile_defaults.initiative_idle_sec;
+            initiative_cooldown_sec =
+              Option.value ~default:0 p.profile_defaults.initiative_cooldown_sec;
             active_team_session_id = None;
             last_team_session_started_at = "";
             team_session_start_count_total = 0;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -59,15 +59,15 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            | model :: _ -> model
             | [] -> "")
   in
-  let policy_mode = "heuristic" in
+  (* Mode categorization removed: always use fixed values. *)
+  let policy_mode = "unified" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
-      (if not (default_voice_enabled_for p.name && Option.is_none p.policy_mode_opt)
-       then p.profile_defaults.policy_voice_enabled else None)
+      p.profile_defaults.policy_voice_enabled
     |> Option.value ~default:false
   in
-  let policy_shell_mode = canonical_policy_shell_mode "coding" in
+  let policy_shell_mode = "coding" in
   let allowed_paths =
     Option.value ~default:[] p.allowed_paths_opt
   in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -294,6 +294,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_autonomous_action_at = "";
             autonomous_action_count = 0;
             last_triage_triggers = "";
+            initiative_enabled =
+              Option.value ~default:true p.profile_defaults.initiative_enabled;
             active_team_session_id = None;
             last_team_session_started_at = "";
             team_session_start_count_total = 0;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -57,14 +57,15 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
             | model :: _ -> model
             | [] -> "")
   in
-  let policy_mode = "heuristic" in
+  (* Mode categorization removed: always use fixed values. *)
+  let policy_mode = "unified" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
       (first_some (Some old.policy_voice_enabled) p.profile_defaults.policy_voice_enabled)
     |> Option.value ~default:false
   in
-  let policy_shell_mode = canonical_policy_shell_mode "coding" in
+  let policy_shell_mode = "coding" in
   let allowed_paths =
     Option.value ~default:old.allowed_paths p.allowed_paths_opt
   in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -128,9 +128,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("models", `List (List.map (fun s -> `String s) m.models));
       ("allowed_models", `List (List.map (fun s -> `String s) m.allowed_models));
       ("active_model", `String m.active_model);
-      ("policy_mode", `String m.policy_mode);
+      ("policy_mode", `String "unified");
       ("policy_voice_enabled", `Bool m.policy_voice_enabled);
-      ("policy_shell_mode", `String m.policy_shell_mode);
+      ("policy_shell_mode", `String "coding");
       ("execution_scope", `String m.execution_scope);
       ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
       ("scope_kind", `String m.scope_kind);
@@ -249,13 +249,16 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       dedupe_keep_order base
     in
     let active_model = Safe_ops.json_string ~default:"" "active_model" json in
-    let policy_mode = "heuristic" in
+    let policy_mode =
+      ignore (Safe_ops.json_string ~default:"heuristic" "policy_mode" json);
+      "unified"
+    in
     let policy_voice_enabled =
       Safe_ops.json_bool ~default:(default_voice_enabled_for name) "policy_voice_enabled" json
     in
     let policy_shell_mode =
-      Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
-      |> canonical_policy_shell_mode
+      ignore (Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json);
+      "coding"
     in
     let execution_scope =
       Safe_ops.json_string ~default:default_execution_scope "execution_scope" json

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -99,6 +99,7 @@ type keeper_meta = {
   last_autonomous_action_at: string;
   autonomous_action_count: int;
   last_triage_triggers: string;
+  initiative_enabled: bool;
   paused: bool;
 }
 
@@ -189,6 +190,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("last_autonomous_action_at", `String m.last_autonomous_action_at);
       ("autonomous_action_count", `Int m.autonomous_action_count);
       ("last_triage_triggers", `String m.last_triage_triggers);
+      ("initiative_enabled", `Bool m.initiative_enabled);
       ("paused", `Bool m.paused);
     ]
 
@@ -393,6 +395,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let last_triage_triggers =
       Safe_ops.json_string ~default:"" "last_triage_triggers" json
     in
+    let initiative_enabled =
+      Safe_ops.json_bool ~default:true "initiative_enabled" json
+    in
     let paused =
       Safe_ops.json_bool ~default:false "paused" json
     in
@@ -488,6 +493,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           last_autonomous_action_at;
           autonomous_action_count;
           last_triage_triggers;
+          initiative_enabled;
           paused;
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -100,6 +100,8 @@ type keeper_meta = {
   autonomous_action_count: int;
   last_triage_triggers: string;
   initiative_enabled: bool;
+  initiative_idle_sec: int;
+  initiative_cooldown_sec: int;
   paused: bool;
 }
 
@@ -191,6 +193,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("autonomous_action_count", `Int m.autonomous_action_count);
       ("last_triage_triggers", `String m.last_triage_triggers);
       ("initiative_enabled", `Bool m.initiative_enabled);
+      ("initiative_idle_sec", `Int m.initiative_idle_sec);
+      ("initiative_cooldown_sec", `Int m.initiative_cooldown_sec);
       ("paused", `Bool m.paused);
     ]
 
@@ -398,6 +402,12 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let initiative_enabled =
       Safe_ops.json_bool ~default:true "initiative_enabled" json
     in
+    let initiative_idle_sec =
+      Safe_ops.json_int ~default:0 "initiative_idle_sec" json
+    in
+    let initiative_cooldown_sec =
+      Safe_ops.json_int ~default:0 "initiative_cooldown_sec" json
+    in
     let paused =
       Safe_ops.json_bool ~default:false "paused" json
     in
@@ -494,6 +504,8 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           autonomous_action_count;
           last_triage_triggers;
           initiative_enabled;
+          initiative_idle_sec;
+          initiative_cooldown_sec;
           paused;
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -181,11 +181,6 @@ let default_voice_channel_for name =
 let default_voice_agent_id_for name =
   if default_voice_enabled_for name then name else ""
 
-(** Mode categorization removed. Always returns "coding" (full access) regardless
-    of input. Field kept for JSON backward compatibility. *)
-let canonical_policy_shell_mode = function
-  | _ -> "coding"
-
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)
 
@@ -362,11 +357,13 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
          models = strs "models";
          allowed_models = strs "allowed_models";
          active_model = str "active_model";
-         policy_mode = Some "heuristic";
+         policy_mode =
+           str "policy_mode"
+           |> Option.map (fun _ -> "unified");
          policy_voice_enabled = bool_ "policy_voice_enabled";
          policy_shell_mode =
            str "policy_shell_mode"
-           |> Option.map canonical_policy_shell_mode;
+           |> Option.map (fun _ -> "coding");
          room_scope =
            str "room_scope"
            |> Option.map canonical_room_scope;
@@ -472,14 +469,15 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 allowed_models = Safe_ops.json_string_list "allowed_models" keeper_json;
                 active_model = Safe_ops.json_string_opt "active_model" keeper_json;
                 policy_mode =
-                  Some "heuristic";
+                  Safe_ops.json_string_opt "policy_mode" keeper_json
+                  |> Option.map (fun _ -> "unified");
                 policy_voice_enabled =
                   (match Yojson.Safe.Util.member "policy_voice_enabled" keeper_json with
                   | `Bool flag -> Some flag
                   | _ -> None);
                 policy_shell_mode =
                   Safe_ops.json_string_opt "policy_shell_mode" keeper_json
-                  |> Option.map canonical_policy_shell_mode;
+                  |> Option.map (fun _ -> "coding");
                 room_scope = Safe_ops.json_string_opt "room_scope" keeper_json;
                 scope_kind = Safe_ops.json_string_opt "scope_kind" keeper_json;
                 trigger_mode =

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -135,11 +135,20 @@ let build_prompt ~(meta : Keeper_types.keeper_meta)
        Buffer.add_string ubuf summary;
        Buffer.add_string ubuf "\n"
    | _ -> ());
-  (* Triage triggers *)
+  (* Triage triggers — when present, signal urgency to the model *)
   let tt = String.trim observation.triage_triggers in
   if tt <> "" && not (String.length tt >= 5 && String.sub tt 0 5 = "skip:")
   then (
-    Buffer.add_string ubuf
-      (Printf.sprintf "\n### Triage Triggers\n%s\n" tt));
+    let trigger_list =
+      String.split_on_char ',' tt
+      |> List.map String.trim
+      |> List.filter (fun s -> s <> "")
+    in
+    Buffer.add_string ubuf "\n### Action Triggers (triage)\n";
+    Buffer.add_string ubuf "The following conditions require your attention:\n";
+    List.iter (fun t ->
+      Buffer.add_string ubuf (Printf.sprintf "- %s\n" t)
+    ) trigger_list;
+    Buffer.add_string ubuf "Prioritize responding to these before passive observation.\n");
   let user_message = Buffer.contents ubuf in
   (system_prompt, user_message)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -310,6 +310,54 @@ let keeper_tool_policy_json () =
       ("destructive_check_enabled", `Bool gate.destructive_check_enabled);
     ]
 
+let keeper_policy_row ctx ~runtime_class (meta : Keeper_types.keeper_meta) =
+  let status_json =
+    Keeper_exec_status.parse_agent_status ctx.config ~agent_name:meta.agent_name
+  in
+  let status =
+    match U.member "status" status_json with
+    | `String value -> value
+    | _ -> "unknown"
+  in
+  let policy_json =
+    match keeper_tool_policy_json () with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  `Assoc
+    ([
+       ("name", `String meta.name);
+       ("runtime_class", `String runtime_class);
+       ("agent_name", `String meta.agent_name);
+       ("status", `String status);
+       ("policy_mode", `String "unified");
+       ("action_budget", `String "conversation");
+       ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
+       ("allowed_models", `List (List.map (fun model -> `String model) meta.allowed_models));
+       ("updated_at", `String meta.updated_at);
+     ]
+    @ policy_json)
+
+let keeper_policies_json ctx =
+  let resident_rows =
+    Keeper_types.resident_keeper_names ctx.config
+    |> List.filter_map (fun name ->
+           match Keeper_types.read_meta ctx.config name with
+           | Ok (Some meta) -> Some (keeper_policy_row ctx ~runtime_class:"resident_keeper" meta)
+           | Ok None | Error _ -> None)
+  in
+  let persistent_rows =
+    Keeper_types.persistent_agent_names ctx.config
+    |> List.filter_map (fun name ->
+           match Keeper_types.read_meta ctx.config name with
+           | Ok (Some meta) -> Some (keeper_policy_row ctx ~runtime_class:"persistent_agent" meta)
+           | Ok None | Error _ -> None)
+  in
+  `Assoc
+    [
+      ("resident_keepers", `List resident_rows);
+      ("persistent_agents", `List persistent_rows);
+    ]
 
 let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
   (* Build reverse index: tool_name -> surface string list.
@@ -439,12 +487,69 @@ let handle_tool_admin_snapshot ctx args =
               ("policy_status", Command_plane_v2.policy_status_json ctx.config);
               ("enforcement_summary", enforcement_summary_json ());
             ] );
+        ("keeper_policies", keeper_policies_json ctx);
         ( "tool_inventory",
           tool_inventory_json ctx ~include_hidden ~include_deprecated );
       ]
   in
   (true, Yojson.Safe.pretty_to_string payload)
 
+let apply_keeper_policy_update config ~runtime_class args =
+  let name = get_string args "name" "" |> String.trim in
+  let action_budget_opt = get_string_opt args "action_budget" |> Option.map String.trim in
+  let membership_ok =
+    match runtime_class with
+    | "resident_keeper" -> List.mem name (Keeper_types.resident_keeper_names config)
+    | "persistent_agent" -> List.mem name (Keeper_types.persistent_agent_names config)
+    | _ -> false
+  in
+  if not (Keeper_types.validate_name name) then
+    Error "invalid keeper name"
+  else if not membership_ok then
+    Error
+      (Printf.sprintf "%s not found in %s set" name runtime_class)
+  else
+    match Keeper_types.read_meta config name with
+    | Error err -> Error err
+    | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
+    | Ok (Some meta) ->
+        let action_budget =
+          match action_budget_opt with
+          | None -> Ok Keeper_contract.Conversation
+          | Some raw -> (
+              match Keeper_contract.parse_policy_action_budget raw with
+              | Some budget -> Ok budget
+              | None -> Error (Printf.sprintf "invalid action_budget: %s" raw))
+        in
+        (match action_budget with
+        | Error err -> Error err
+        | Ok action_budget ->
+                let updated =
+                  {
+                    meta with
+                    policy_mode = "unified";
+                    updated_at = Types.now_iso ();
+                  }
+                in
+                (match Keeper_types.write_meta config updated with
+                | Error err -> Error err
+                | Ok () ->
+                    let policy_json =
+                      match keeper_tool_policy_json () with
+                      | `Assoc fields -> fields
+                      | _ -> []
+                    in
+                    Ok
+                      (`Assoc
+                        ([
+                           ("status", `String "ok");
+                           ("runtime_class", `String runtime_class);
+                           ("name", `String updated.name);
+                           ("policy_mode", `String "unified");
+                           ("action_budget", `String (Keeper_contract.policy_action_budget_to_string action_budget));
+                         ]
+                        @ policy_json)))
+        )
 
 let handle_tool_admin_update ctx args =
   let section =
@@ -551,8 +656,18 @@ let handle_tool_admin_update ctx args =
               ]
           in
           (true, Yojson.Safe.pretty_to_string payload))
+  | "keeper_policy" ->
+      (match apply_keeper_policy_update ctx.config ~runtime_class:"resident_keeper" args with
+      | Ok json ->
+          (true, Yojson.Safe.pretty_to_string (`Assoc [ ("status", `String "ok"); ("section", `String "keeper_policy"); ("result", json) ]))
+      | Error err -> (false, "❌ " ^ err))
+  | "persistent_agent_policy" ->
+      (match apply_keeper_policy_update ctx.config ~runtime_class:"persistent_agent" args with
+      | Ok json ->
+          (true, Yojson.Safe.pretty_to_string (`Assoc [ ("status", `String "ok"); ("section", `String "persistent_agent_policy"); ("result", json) ]))
+      | Error err -> (false, "❌ " ^ err))
   | _ ->
-      (false, "❌ section must be one of: auth | unit_policy")
+      (false, "❌ section must be one of: auth | unit_policy | keeper_policy | persistent_agent_policy")
 
 (* Handlers *)
 

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -189,7 +189,7 @@ let coding_workspace_tools : Types.tool_schema list =
     (Tool_schemas_worktree.schemas @ Tool_code.schemas)
 
 (** Coding tools — shell/github bridges plus worktree-first code workflow.
-    NOT in default shards. Only granted when policy_shell_mode = "coding". *)
+    Always granted (policy_shell_mode is always "coding"). *)
 let coding_tools : Types.tool_schema list =
   coding_keeper_bridge_tools @ coding_workspace_tools
 

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -101,11 +101,11 @@ val shard_autoresearch : shard
 
 val coding_tools : Types.tool_schema list
 (** Coding shard tools (keeper_github/keeper_bash + worktree/code inspection).
-    Not in default shards — only granted when policy_shell_mode = "coding". *)
+    Always granted (policy_shell_mode is always "coding"). *)
 
 val shard_coding : shard
-(** Coding shard: github/shell bridge + worktree/code inspection
-    (requires policy_shell_mode=coding). *)
+(** Coding shard: github/shell bridge + worktree/code inspection.
+    Always granted. *)
 
 val keeper_model_tools : Types.tool_schema list
 (** Default tool set from default shards — excludes coding tools. *)

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -797,6 +797,37 @@ let test_initiative_enabled_roundtrip_false () =
     check bool "roundtrip preserves false" false ie
   | Error e -> fail ("parse failed: " ^ e)
 
+let test_initiative_idle_sec_overrides_idle_gate () =
+  (* When initiative_idle_sec > 0, triage uses it instead of proactive.idle_sec.
+     We verify this by creating an obs with idle_seconds > initiative_idle_sec but
+     < default idle_gate — triggers should fire because initiative_idle_sec is the gate. *)
+  let obs = { base_obs with
+    active_goal_count = 1;
+    idle_seconds = 120;  (* above initiative_idle_sec=60 *)
+    idle_gate = 60;      (* initiative_idle_sec override *)
+  } in
+  match D.triage obs with
+  | D.Skip _ -> fail "should trigger IdleTimeout with custom idle_gate=60"
+  | D.Triggered triggers ->
+    check bool "has idle_timeout" true
+      (List.exists (fun t -> t = D.IdleTimeout) triggers)
+
+let test_initiative_cooldown_sec_roundtrip () =
+  let json_str = {|{"name":"test","initiative_enabled":true,"initiative_idle_sec":120,"initiative_cooldown_sec":30,"policy_mode":"heuristic","policy_shell_mode":"coding","trace_id":"t4","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json = Yojson.Safe.from_string json_str in
+  match Keeper_types.meta_of_json json with
+  | Ok m ->
+    check int "initiative_idle_sec" 120 m.initiative_idle_sec;
+    check int "initiative_cooldown_sec" 30 m.initiative_cooldown_sec;
+    let re_json = Keeper_types.meta_to_json m in
+    let idle = Yojson.Safe.Util.member "initiative_idle_sec" re_json
+               |> Yojson.Safe.Util.to_int in
+    let cool = Yojson.Safe.Util.member "initiative_cooldown_sec" re_json
+               |> Yojson.Safe.Util.to_int in
+    check int "roundtrip idle_sec" 120 idle;
+    check int "roundtrip cooldown_sec" 30 cool
+  | Error e -> fail ("parse failed: " ^ e)
+
 let test_initiative_enabled_missing_defaults_true () =
   (* When JSON omits initiative_enabled, defaults to true (backward compat) *)
   let json_str = {|{"name":"test","policy_mode":"heuristic","policy_shell_mode":"coding","trace_id":"t3","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
@@ -974,5 +1005,9 @@ let () =
             test_initiative_enabled_roundtrip_false;
           test_case "missing field defaults to true" `Quick
             test_initiative_enabled_missing_defaults_true;
+          test_case "idle_sec overrides triage idle_gate" `Quick
+            test_initiative_idle_sec_overrides_idle_gate;
+          test_case "cooldown_sec JSON roundtrip" `Quick
+            test_initiative_cooldown_sec_roundtrip;
         ] );
     ]

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -774,6 +774,37 @@ let test_prompt_always_includes_multi_step () =
     (try ignore (Str.search_forward (Str.regexp_string "multi_step") prompt 0); true
      with Not_found -> false)
 
+(* ---------- initiative_enabled tests ---------- *)
+
+let test_initiative_enabled_default_true () =
+  (* When JSON has initiative_enabled = true, roundtrip preserves it *)
+  let json_str = {|{"name":"test","initiative_enabled":true,"policy_mode":"heuristic","policy_shell_mode":"coding","trace_id":"t1","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json = Yojson.Safe.from_string json_str in
+  match Keeper_types.meta_of_json json with
+  | Ok m -> check bool "initiative_enabled default" true m.initiative_enabled
+  | Error e -> fail ("parse failed: " ^ e)
+
+let test_initiative_enabled_roundtrip_false () =
+  (* When JSON has initiative_enabled = false, roundtrip preserves it *)
+  let json_str = {|{"name":"test","initiative_enabled":false,"policy_mode":"heuristic","policy_shell_mode":"coding","trace_id":"t2","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json = Yojson.Safe.from_string json_str in
+  match Keeper_types.meta_of_json json with
+  | Ok m ->
+    check bool "initiative_enabled false" false m.initiative_enabled;
+    let re_json = Keeper_types.meta_to_json m in
+    let ie = Yojson.Safe.Util.member "initiative_enabled" re_json
+             |> Yojson.Safe.Util.to_bool in
+    check bool "roundtrip preserves false" false ie
+  | Error e -> fail ("parse failed: " ^ e)
+
+let test_initiative_enabled_missing_defaults_true () =
+  (* When JSON omits initiative_enabled, defaults to true (backward compat) *)
+  let json_str = {|{"name":"test","policy_mode":"heuristic","policy_shell_mode":"coding","trace_id":"t3","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json = Yojson.Safe.from_string json_str in
+  match Keeper_types.meta_of_json json with
+  | Ok m -> check bool "missing initiative_enabled defaults to true" true m.initiative_enabled
+  | Error e -> fail ("parse failed: " ^ e)
+
 let () =
   run "Keeper_deliberation"
     [
@@ -934,5 +965,14 @@ let () =
             test_daily_budget_from_env_default;
           test_case "daily budget from env custom" `Quick
             test_daily_budget_from_env_custom;
+        ] );
+      ( "initiative_enabled",
+        [
+          test_case "meta JSON default is true" `Quick
+            test_initiative_enabled_default_true;
+          test_case "meta JSON roundtrip false" `Quick
+            test_initiative_enabled_roundtrip_false;
+          test_case "missing field defaults to true" `Quick
+            test_initiative_enabled_missing_defaults_true;
         ] );
     ]

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -1,7 +1,6 @@
 open Alcotest
 
 module D = Masc_mcp.Keeper_deliberation
-module Contract = Masc_mcp.Keeper_contract
 module Keeper_types = Masc_mcp.Keeper_types
 
 let has_prompt_root path =
@@ -248,8 +247,6 @@ let test_deliberation_meta_defaults () =
   check (float 0.001) "default ts" 0.0 dm.last_deliberation_ts;
   check string "default triggers" "" dm.last_triage_triggers
 
-(* Policy mode tests removed: type system purged (always "heuristic") *)
-
 (* ---------- Keeper meta deliberation fields ---------- *)
 
 let test_keeper_meta_deliberation_fields_roundtrip () =
@@ -274,7 +271,7 @@ let test_keeper_meta_deliberation_fields_roundtrip () =
   match Keeper_types.meta_of_json json with
   | Error err -> fail ("meta parse failed: " ^ err)
   | Ok meta ->
-      check string "policy mode" "heuristic" meta.policy_mode;
+      check string "policy mode" "unified" meta.policy_mode;
       check string "triage triggers" "direct_mention"
         meta.last_triage_triggers
 

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -16,10 +16,9 @@ open Masc_mcp
 
 (** Build a keeper_meta via JSON round-trip, overriding key policy fields. *)
 let make_meta
-    ?(policy_shell_mode = "disabled")
+    ?(policy_shell_mode = "coding")
     ?(policy_voice_enabled = false)
     ?(soul_profile = "default")
-    ?(policy_mode = "learned_offline_v1")
     ?(name = "test-keeper")
     () : Keeper_types.keeper_meta =
   let json = `Assoc [
@@ -29,7 +28,6 @@ let make_meta
     ("policy_shell_mode", `String policy_shell_mode);
     ("policy_voice_enabled", `Bool policy_voice_enabled);
     ("soul_profile", `String soul_profile);
-    ("policy_mode", `String policy_mode);
   ] in
   match Keeper_types.meta_of_json json with
   | Ok meta -> meta
@@ -189,8 +187,7 @@ let test_write_done_kills_all () =
 
 let test_all_keepers_get_full_toolset () =
   (* Any keeper (regardless of mode/shell/profile) gets all tools *)
-  let meta = make_meta ~policy_shell_mode:"disabled"
-    ~policy_mode:"learned_offline_v1" () in
+  let meta = make_meta () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has keeper_fs_read" true (List.mem "keeper_fs_read" tools);
   check bool "has keeper_read" true (List.mem "keeper_read" tools);
@@ -225,7 +222,7 @@ let test_all_keepers_have_research_tools () =
   check bool "has research tools" true has_any_research
 
 let test_heuristic_mode_tools () =
-  let meta = make_meta ~policy_mode:"heuristic" () in
+  let meta = make_meta () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "heuristic returns nonempty tools" true (List.length tools > 0)
 
@@ -244,8 +241,7 @@ let test_all_keepers_have_shell_and_coding () =
   check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 
 let test_all_modes_produce_same_tools () =
-  (* Mode removal: canonical_policy_shell_mode always returns "coding",
-     canonical_policy_mode always returns "heuristic" *)
+  (* policy_mode and policy_shell_mode are always "unified" and "coding" respectively *)
   let meta_a = make_meta ~policy_shell_mode:"sandboxed" () in
   let meta_b = make_meta ~policy_shell_mode:"coding" () in
   let tools_a = Keeper_exec_tools.keeper_allowed_tool_names meta_a in

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -205,7 +205,8 @@ policy_voice_enabled = false
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "keepalive" (Some true) d.presence_keepalive;
       check (option int) "keepalive_sec" (Some 30) d.presence_keepalive_sec;
-      check (option string) "policy_mode" (Some "heuristic") d.policy_mode;
+      (* policy_mode always canonicalized to "unified" *)
+      check (option string) "policy_mode" (Some "unified") d.policy_mode;
       (* Mode removal: canonical_policy_shell_mode always returns "coding" *)
       check (option string) "policy_shell_mode" (Some "coding") d.policy_shell_mode;
       check (option bool) "policy_voice" (Some false) d.policy_voice_enabled

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -217,7 +217,7 @@ let test_prompt_includes_triage_triggers () =
   let _sys, user = UP.build_prompt ~meta:minimal_meta ~observation:obs in
   check bool "has triage section" true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Triage Triggers") user 0); true
+       try ignore (Str.search_forward (Str.regexp_string "Action Triggers (triage)") user 0); true
        with Not_found -> false
      in found)
 

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -268,7 +268,7 @@ initiative_post_ttl_hours = 24
         (List.mem "coordination.room_scope" override_fields);
       Alcotest.(check bool) "override field proactive" true
         (List.mem "proactive.enabled" override_fields);
-      Alcotest.(check string) "initiative source-only" "source_only"
+      Alcotest.(check string) "initiative wired" "wired"
         (json |> member "initiative" |> member "status" |> to_string);
       Alcotest.(check bool) "initiative configured in source" true
         (json |> member "initiative" |> member "configured_in_source" |> to_bool);

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -265,8 +265,6 @@ let test_keeper_model_set_persists_active_model () =
 
 let make_keeper_exec_meta
     ?(name = "sangsu")
-    ?(policy_mode = "heuristic")
-    ?(policy_shell_mode = "disabled")
     ?(allowed_paths = [])
     () =
   let json =
@@ -275,8 +273,6 @@ let make_keeper_exec_meta
         ("name", `String name);
         ("agent_name", `String name);
         ("trace_id", `String ("trace-" ^ name));
-        ("policy_mode", `String policy_mode);
-        ("policy_shell_mode", `String policy_shell_mode);
         ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
       ]
   in
@@ -335,33 +331,12 @@ let write_jsonl_lines path lines =
 
 let test_keeper_shell_tool_policy_gates () =
   Eio_main.run @@ fun _env ->
-  let heuristic = make_keeper_exec_meta () in
-  let learned_disabled =
-    make_keeper_exec_meta ~name:"learned-disabled"
-      ~policy_mode:"learned_offline_v1" ()
-  in
-  let learned_readonly =
-    make_keeper_exec_meta ~name:"learned-readonly"
-      ~policy_mode:"learned_offline_v1"
-      ~policy_shell_mode:"readonly" ()
-  in
-  let explicit_event =
-    make_keeper_exec_meta ~name:"explicit-event"
-      ~policy_mode:"explicit_event_v1" ()
-  in
-  let deliberation =
-    make_keeper_exec_meta ~name:"deliberation"
-      ~policy_mode:"model_deliberation" ()
-  in
-  check_keeper_shell_tool_presence "heuristic" heuristic
+  (* policy_mode removed: all keepers use unified mode with full tools *)
+  let unified = make_keeper_exec_meta () in
+  let other = make_keeper_exec_meta ~name:"other-keeper" () in
+  check_keeper_shell_tool_presence "unified" unified
     ~expect_bash:true ~expect_shell_readonly:true;
-  check_keeper_shell_tool_presence "learned disabled" learned_disabled
-    ~expect_bash:true ~expect_shell_readonly:true;
-  check_keeper_shell_tool_presence "learned readonly" learned_readonly
-    ~expect_bash:true ~expect_shell_readonly:true;
-  check_keeper_shell_tool_presence "explicit event" explicit_event
-    ~expect_bash:true ~expect_shell_readonly:true;
-  check_keeper_shell_tool_presence "model deliberation" deliberation
+  check_keeper_shell_tool_presence "other" other
     ~expect_bash:true ~expect_shell_readonly:true
 
 let test_keeper_shell_readonly_enforces_allowed_paths () =
@@ -376,8 +351,7 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
       write_file (Filename.concat base_dir allowed_rel) "keeper-ok\n";
       write_file (Filename.concat base_dir blocked_rel) "should-not-read\n";
       let meta =
-        make_keeper_exec_meta ~policy_mode:"learned_offline_v1"
-          ~policy_shell_mode:"readonly"
+        make_keeper_exec_meta
           ~allowed_paths:[ "allowed" ] ()
       in
       let ctx_work =
@@ -417,26 +391,9 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
 
 let test_keeper_fs_read_policy_gates () =
   Eio_main.run @@ fun _env ->
-  let heuristic = make_keeper_exec_meta () in
-  let learned_offline =
-    make_keeper_exec_meta ~name:"fs-read-learned"
-      ~policy_mode:"learned_offline_v1" ()
-  in
-  let explicit_event =
-    make_keeper_exec_meta ~name:"fs-read-explicit"
-      ~policy_mode:"explicit_event_v1" ()
-  in
-  let deliberation =
-    make_keeper_exec_meta ~name:"fs-read-deliberation"
-      ~policy_mode:"model_deliberation" ()
-  in
-  check_keeper_exec_tool_presence "heuristic fs_read" heuristic
-    ~tool_name:"keeper_fs_read" ~expect_allowed:true;
-  check_keeper_exec_tool_presence "learned fs_read" learned_offline
-    ~tool_name:"keeper_fs_read" ~expect_allowed:true;
-  check_keeper_exec_tool_presence "explicit event fs_read" explicit_event
-    ~tool_name:"keeper_fs_read" ~expect_allowed:true;
-  check_keeper_exec_tool_presence "model deliberation fs_read" deliberation
+  (* policy_mode removed: all keepers get fs_read *)
+  let unified = make_keeper_exec_meta () in
+  check_keeper_exec_tool_presence "unified fs_read" unified
     ~tool_name:"keeper_fs_read" ~expect_allowed:true
 
 let test_keeper_fs_read_enforces_allowed_paths_and_truncation () =
@@ -523,10 +480,7 @@ let test_keeper_bash_requires_cmd_and_runs () =
         ~cwd_default:(Eio.Stdenv.fs env)
         ~proc_mgr:(Eio.Stdenv.process_mgr env)
         ~clock:(Eio.Stdenv.clock env);
-      let meta =
-        make_keeper_exec_meta ~policy_mode:"learned_offline_v1"
-          ~policy_shell_mode:"coding" ()
-      in
+      let meta = make_keeper_exec_meta () in
       let ctx_work =
         Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
           ~max_tokens:4000
@@ -581,41 +535,10 @@ let test_keeper_bash_requires_cmd_and_runs () =
 
 let test_keeper_fs_edit_policy_gates () =
   Eio_main.run @@ fun _env ->
-  let heuristic_disabled = make_keeper_exec_meta () in
-  let heuristic_coding =
-    make_keeper_exec_meta ~name:"fs-edit-heuristic"
-      ~policy_shell_mode:"coding" ()
-  in
-  let learned_disabled =
-    make_keeper_exec_meta ~name:"fs-edit-learned-disabled"
-      ~policy_mode:"learned_offline_v1" ()
-  in
-  let learned_coding =
-    make_keeper_exec_meta ~name:"fs-edit-learned-coding"
-      ~policy_mode:"learned_offline_v1"
-      ~policy_shell_mode:"coding" ()
-  in
-  let explicit_event_coding =
-    make_keeper_exec_meta ~name:"fs-edit-explicit"
-      ~policy_mode:"explicit_event_v1"
-      ~policy_shell_mode:"coding" ()
-  in
-  let deliberation_coding =
-    make_keeper_exec_meta ~name:"fs-edit-deliberation"
-      ~policy_mode:"model_deliberation"
-      ~policy_shell_mode:"coding" ()
-  in
-  check_keeper_exec_tool_presence "heuristic fs_edit default" heuristic_disabled
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
-  check_keeper_exec_tool_presence "heuristic fs_edit coding" heuristic_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
-  check_keeper_exec_tool_presence "learned fs_edit disabled" learned_disabled
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
-  check_keeper_exec_tool_presence "learned fs_edit coding" learned_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
-  check_keeper_exec_tool_presence "explicit event fs_edit coding" explicit_event_coding
-    ~tool_name:"keeper_fs_edit" ~expect_allowed:false;
-  check_keeper_exec_tool_presence "model deliberation fs_edit coding" deliberation_coding
+  (* policy_mode removed: all keepers use unified mode.
+     fs_edit is not in allowed tools by default *)
+  let unified = make_keeper_exec_meta () in
+  check_keeper_exec_tool_presence "unified fs_edit" unified
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false
 
 let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
@@ -634,8 +557,7 @@ let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
       let allowed_path = Filename.concat root_dir allowed_rel in
       let blocked_path = Filename.concat root_dir blocked_rel in
       let meta =
-        make_keeper_exec_meta ~policy_shell_mode:"coding"
-          ~allowed_paths:[ "allowed" ] ()
+        make_keeper_exec_meta ~allowed_paths:[ "allowed" ] ()
       in
       let ctx_work =
         Masc_mcp.Keeper_exec_context.create ~system_prompt:"test"
@@ -1187,9 +1109,8 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
          Test checks whichever mode is active. *)
       let voice_enabled =
         Yojson.Safe.Util.(json |> member "voice_enabled" |> to_bool) in
-      (* canonical_policy_mode maps all modes to "heuristic" since mode
-         categorization was removed — policy_mode is always heuristic *)
-      check string "policy mode" "heuristic"
+      (* policy_mode system removed — always "unified" *)
+      check string "policy mode" "unified"
         Yojson.Safe.Util.(json |> member "policy_mode" |> to_string);
       if voice_enabled then begin
         check string "voice channel" "voice_text"
@@ -1448,7 +1369,7 @@ let test_resident_bootstrap_marks_stale_explicit_keeper () =
       let stale_meta =
         {
           meta with
-          policy_mode = "explicit_event_v1";
+          policy_mode = "unified";
           presence_keepalive = true;
           proactive = { meta.proactive with enabled = false };
           usage = { meta.usage with last_turn_ts = 0.0 };

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -687,8 +687,6 @@ let test_masc_keeper_up_schema () =
   | Some schema ->
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
-          Alcotest.(check bool) "has policy_mode" true
-            (List.mem_assoc "policy_mode" props);
           Alcotest.(check bool) "has scope_kind" true
             (List.mem_assoc "scope_kind" props);
           Alcotest.(check bool) "has presence_keepalive" true


### PR DESCRIPTION
## Summary
Replaces #2903 (stale merge state).

- Replace `policy_mode` gate with `initiative_enabled` (default: true for all keepers)
- Add `initiative_idle_sec`, `initiative_cooldown_sec` for fine-grained control
- Remove dead `policy_mode`/`policy_shell_mode` type system
- Wire urgency prompt for triggered triage results

## Test plan
- [x] CI ALL GREEN on previous push
- [ ] CI green on this PR