### PR TITLE
fix(cp): replace blocking stdlib I/O with Eio-native pread in JSONL tail reader

### DIFF
--- a/lib/command_plane/cp_io.ml
+++ b/lib/command_plane/cp_io.ml
@@ -246,11 +246,18 @@ let read_recent_events config ~limit =
   if not (Room_utils.path_exists config (events_path config)) then
     []
   else
-    read_jsonl_tail_lines (events_path config) ~max_lines:limit
-    |> List.filter_map (fun line ->
-           match Safe_ops.parse_json_safe ~context:"command_plane_v2.events" line with
-           | Ok json -> event_of_json json
-           | Error _ -> None)
+    (* Over-read to compensate for blank/malformed lines lost during filtering *)
+    let over_read = max limit (limit * 2) in
+    let all =
+      read_jsonl_tail_lines (events_path config) ~max_lines:over_read
+      |> List.filter_map (fun line ->
+             match Safe_ops.parse_json_safe ~context:"command_plane_v2.events" line with
+             | Ok json -> event_of_json json
+             | Error _ -> None)
+    in
+    let n = List.length all in
+    if n <= limit then all
+    else List.filteri (fun i _ -> i >= n - limit) all
 
 let append_event config (event : event_record) =
   ensure_dirs config;

--- a/lib/command_plane/cp_io.ml
+++ b/lib/command_plane/cp_io.ml
@@ -127,52 +127,104 @@ let write_intents config intents =
         ("intents", `List (List.map intent_to_json intents));
       ])
 
+(** Combine byte chunks into a single string, split into non-empty lines,
+    and return the last [max_lines]. Shared by both Eio and stdlib paths. *)
+let take_last_lines (chunks : Bytes.t list) max_lines =
+  let total_bytes =
+    List.fold_left (fun acc chunk -> acc + Bytes.length chunk) 0 chunks
+  in
+  let combined = Bytes.create total_bytes in
+  let _ =
+    List.fold_left
+      (fun offset chunk ->
+        let len = Bytes.length chunk in
+        Bytes.blit chunk 0 combined offset len;
+        offset + len)
+      0 chunks
+  in
+  let all_lines =
+    Bytes.to_string combined
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  let total = List.length all_lines in
+  if total <= max_lines then all_lines
+  else List.filteri (fun i _ -> i >= total - max_lines) all_lines
+
+(** Read tail chunks backwards from a file opened via Eio.
+    Uses [pread_exact] which does not block the Eio scheduler. *)
+let read_tail_chunks_eio (file : _ Eio.File.ro) ~file_len ~max_lines =
+  let chunk_size = 8192 in
+  let target_newlines = max_lines * 3 in
+  let chunks = ref [] in
+  let total_newlines = ref 0 in
+  let pos = ref file_len in
+  while !pos > 0 && !total_newlines <= target_newlines do
+    let read_start = max 0 (!pos - chunk_size) in
+    let read_len = !pos - read_start in
+    let buf = Cstruct.create read_len in
+    Eio.File.pread_exact file
+      ~file_offset:(Optint.Int63.of_int read_start) [buf];
+    let bytes = Cstruct.to_bytes buf in
+    chunks := bytes :: !chunks;
+    for i = 0 to read_len - 1 do
+      if Bytes.get bytes i = '\n' then incr total_newlines
+    done;
+    pos := read_start
+  done;
+  !chunks
+
+(** Read tail chunks backwards from a file opened via stdlib.
+    Falls back to blocking I/O for non-Eio contexts (tests). *)
+let read_tail_chunks_stdlib ic ~file_len ~max_lines =
+  let chunk_size = 8192 in
+  let target_newlines = max_lines * 3 in
+  let chunks = ref [] in
+  let total_newlines = ref 0 in
+  let pos = ref file_len in
+  while !pos > 0 && !total_newlines <= target_newlines do
+    let read_start = max 0 (!pos - chunk_size) in
+    let read_len = !pos - read_start in
+    seek_in ic read_start;
+    let chunk = Bytes.create read_len in
+    really_input ic chunk 0 read_len;
+    chunks := chunk :: !chunks;
+    for i = 0 to read_len - 1 do
+      if Bytes.get chunk i = '\n' then incr total_newlines
+    done;
+    pos := read_start
+  done;
+  !chunks
+
 let read_jsonl_tail_lines path ~max_lines =
   if max_lines <= 0 || not (Fs_compat.file_exists path) then
     []
   else
-    let ic = open_in_bin path in
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      let file_len = in_channel_length ic in
-      if file_len = 0 then []
-      else
-        let chunk_size = 8192 in
-        let target_newlines = max_lines * 3 in
-        let chunks = ref [] in
-        let total_newlines = ref 0 in
-        let pos = ref file_len in
-        while !pos > 0 && !total_newlines <= target_newlines do
-          let read_start = max 0 (!pos - chunk_size) in
-          let read_len = !pos - read_start in
-          seek_in ic read_start;
-          let chunk = Bytes.create read_len in
-          really_input ic chunk 0 read_len;
-          chunks := chunk :: !chunks;
-          for i = 0 to read_len - 1 do
-            if Bytes.get chunk i = '\n' then incr total_newlines
-          done;
-          pos := read_start
-        done;
-        let total_bytes =
-          List.fold_left (fun acc chunk -> acc + Bytes.length chunk) 0 !chunks
+    match Fs_compat.get_fs_opt () with
+    | Some fs ->
+      (* Eio-native path: non-blocking pread_exact *)
+      let eio_path = Eio.Path.(fs / path) in
+      Eio.Path.with_open_in eio_path (fun file ->
+        let file_len =
+          Optint.Int63.to_int (Eio.File.size file)
         in
-        let combined = Bytes.create total_bytes in
-        let _ =
-          List.fold_left
-            (fun offset chunk ->
-              let len = Bytes.length chunk in
-              Bytes.blit chunk 0 combined offset len;
-              offset + len)
-            0 !chunks
-        in
-        let all_lines =
-          Bytes.to_string combined
-          |> String.split_on_char '\n'
-          |> List.filter (fun line -> String.trim line <> "")
-        in
-        let total = List.length all_lines in
-        if total <= max_lines then all_lines
-        else List.filteri (fun i _ -> i >= total - max_lines) all_lines)
+        if file_len = 0 then []
+        else
+          let chunks =
+            read_tail_chunks_eio file ~file_len ~max_lines
+          in
+          take_last_lines chunks max_lines)
+    | None ->
+      (* Stdlib fallback for non-Eio contexts *)
+      let ic = open_in_bin path in
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+        let file_len = in_channel_length ic in
+        if file_len = 0 then []
+        else
+          let chunks =
+            read_tail_chunks_stdlib ic ~file_len ~max_lines
+          in
+          take_last_lines chunks max_lines)
 
 let read_events config =
   ensure_dirs config;

--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -570,7 +570,10 @@ let recent_operator_trace_events config ?trace_id limit =
     []
   else
     (match trace_id with
-     | None -> read_jsonl_tail_lines (operator_action_log_path config) ~max_lines:limit
+     | None ->
+         (* Over-read to compensate for blank/malformed lines lost during filtering *)
+         read_jsonl_tail_lines (operator_action_log_path config)
+           ~max_lines:(max limit (limit * 2))
      | Some _ ->
          Fs_compat.load_file (operator_action_log_path config)
          |> String.split_on_char '\n')

--- a/test/dune
+++ b/test/dune
@@ -451,6 +451,11 @@
  (modules test_cp_section_cache)
  (libraries masc_mcp alcotest yojson unix))
 
+(test
+ (name test_cp_jsonl_tail)
+ (modules test_cp_jsonl_tail)
+ (libraries masc_mcp masc_mcp.fs_compat alcotest yojson unix eio eio_main))
+
 (executable
  (name test_cp_search_fabric_benchmark)
  (modules test_cp_search_fabric_benchmark)

--- a/test/test_cp_jsonl_tail.ml
+++ b/test/test_cp_jsonl_tail.ml
@@ -1,0 +1,220 @@
+(** Tests for read_jsonl_tail_lines edge cases (issue #2922).
+    Covers: empty files, fewer-than-limit lines, chunk-boundary splits,
+    and both Eio-native and stdlib fallback paths. *)
+
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_cp_jsonl_tail_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc content)
+
+(* --- stdlib fallback tests (no Eio fs set) --- *)
+
+let test_empty_file () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "empty.jsonl" in
+    write_file path "";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+    Alcotest.(check int) "empty file returns 0 lines" 0 (List.length result))
+
+let test_nonexistent_file () =
+  let result = Cp_io.read_jsonl_tail_lines "/tmp/no_such_file_ever.jsonl" ~max_lines:10 in
+  Alcotest.(check int) "nonexistent returns 0 lines" 0 (List.length result)
+
+let test_zero_max_lines () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "data.jsonl" in
+    write_file path "{\"a\":1}\n{\"b\":2}\n";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:0 in
+    Alcotest.(check int) "max_lines=0 returns 0" 0 (List.length result))
+
+let test_fewer_than_limit () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "few.jsonl" in
+    write_file path "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+    Alcotest.(check int) "3 lines when asking for 10" 3 (List.length result);
+    Alcotest.(check string) "first line" "{\"a\":1}" (List.nth result 0);
+    Alcotest.(check string) "last line" "{\"c\":3}" (List.nth result 2))
+
+let test_exact_limit () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "exact.jsonl" in
+    write_file path "{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:3 in
+    Alcotest.(check int) "exactly 3 lines" 3 (List.length result))
+
+let test_more_than_limit () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "many.jsonl" in
+    let lines =
+      List.init 20 (fun i -> Printf.sprintf "{\"i\":%d}" i)
+    in
+    write_file path (String.concat "\n" lines ^ "\n");
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:5 in
+    Alcotest.(check int) "returns 5 lines" 5 (List.length result);
+    Alcotest.(check string) "first returned is line 15" "{\"i\":15}" (List.nth result 0);
+    Alcotest.(check string) "last returned is line 19" "{\"i\":19}" (List.nth result 4))
+
+let test_chunk_boundary () =
+  (* Create a file larger than 8192 bytes (chunk_size) to exercise
+     multi-chunk backward reading and chunk-boundary line splits. *)
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "big.jsonl" in
+    (* Each line ~80 chars, 200 lines = ~16KB > 8192 chunk_size *)
+    let lines =
+      List.init 200 (fun i ->
+        Printf.sprintf "{\"idx\":%d,\"pad\":\"%s\"}" i (String.make 60 'x'))
+    in
+    write_file path (String.concat "\n" lines ^ "\n");
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+    Alcotest.(check int) "returns 10 lines" 10 (List.length result);
+    (* last line should be idx=199 *)
+    let last = List.nth result 9 in
+    let idx_ok =
+      try
+        match Yojson.Safe.from_string last with
+        | `Assoc fields ->
+          (match List.assoc_opt "idx" fields with
+           | Some (`Int 199) -> true
+           | _ -> false)
+        | _ -> false
+      with _ -> false
+    in
+    Alcotest.(check bool) "last line contains idx 199" true idx_ok)
+
+let test_single_line_no_trailing_newline () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "single.jsonl" in
+    write_file path "{\"only\":true}";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:5 in
+    Alcotest.(check int) "single line without newline" 1 (List.length result);
+    Alcotest.(check string) "content" "{\"only\":true}" (List.nth result 0))
+
+let test_blank_lines_filtered () =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let path = Filename.concat dir "blanks.jsonl" in
+    write_file path "{\"a\":1}\n\n\n{\"b\":2}\n   \n{\"c\":3}\n";
+    let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+    Alcotest.(check int) "blank lines filtered" 3 (List.length result))
+
+(* --- Eio-native path tests --- *)
+
+let test_eio_empty_file () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
+  Fun.protect ~finally:(fun () -> Fs_compat.clear_fs ()) (fun () ->
+    let dir = temp_dir () in
+    Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+      let path = Filename.concat dir "empty.jsonl" in
+      write_file path "";
+      let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+      Alcotest.(check int) "eio: empty file" 0 (List.length result)))
+
+let test_eio_fewer_than_limit () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
+  Fun.protect ~finally:(fun () -> Fs_compat.clear_fs ()) (fun () ->
+    let dir = temp_dir () in
+    Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+      let path = Filename.concat dir "few.jsonl" in
+      write_file path "{\"a\":1}\n{\"b\":2}\n";
+      let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+      Alcotest.(check int) "eio: 2 lines" 2 (List.length result)))
+
+let test_eio_chunk_boundary () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
+  Fun.protect ~finally:(fun () -> Fs_compat.clear_fs ()) (fun () ->
+    let dir = temp_dir () in
+    Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+      let path = Filename.concat dir "big.jsonl" in
+      let lines =
+        List.init 200 (fun i ->
+          Printf.sprintf "{\"idx\":%d,\"pad\":\"%s\"}" i (String.make 60 'x'))
+      in
+      write_file path (String.concat "\n" lines ^ "\n");
+      let result = Cp_io.read_jsonl_tail_lines path ~max_lines:10 in
+      Alcotest.(check int) "eio: returns 10 lines" 10 (List.length result);
+      let last = List.nth result 9 in
+      let idx_ok =
+        try
+          match Yojson.Safe.from_string last with
+          | `Assoc fields ->
+            (match List.assoc_opt "idx" fields with
+             | Some (`Int 199) -> true
+             | _ -> false)
+          | _ -> false
+        with _ -> false
+      in
+      Alcotest.(check bool) "eio: last line is idx 199" true idx_ok))
+
+let test_eio_more_than_limit () =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
+  Fun.protect ~finally:(fun () -> Fs_compat.clear_fs ()) (fun () ->
+    let dir = temp_dir () in
+    Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+      let path = Filename.concat dir "many.jsonl" in
+      let lines =
+        List.init 20 (fun i -> Printf.sprintf "{\"i\":%d}" i)
+      in
+      write_file path (String.concat "\n" lines ^ "\n");
+      let result = Cp_io.read_jsonl_tail_lines path ~max_lines:5 in
+      Alcotest.(check int) "eio: returns 5" 5 (List.length result);
+      Alcotest.(check string) "eio: first is 15" "{\"i\":15}" (List.nth result 0);
+      Alcotest.(check string) "eio: last is 19" "{\"i\":19}" (List.nth result 4)))
+
+let () =
+  Alcotest.run "Cp_jsonl_tail"
+    [
+      ( "stdlib_fallback",
+        [
+          Alcotest.test_case "empty file" `Quick test_empty_file;
+          Alcotest.test_case "nonexistent file" `Quick test_nonexistent_file;
+          Alcotest.test_case "zero max_lines" `Quick test_zero_max_lines;
+          Alcotest.test_case "fewer than limit" `Quick test_fewer_than_limit;
+          Alcotest.test_case "exact limit" `Quick test_exact_limit;
+          Alcotest.test_case "more than limit" `Quick test_more_than_limit;
+          Alcotest.test_case "chunk boundary" `Quick test_chunk_boundary;
+          Alcotest.test_case "single line no newline" `Quick test_single_line_no_trailing_newline;
+          Alcotest.test_case "blank lines filtered" `Quick test_blank_lines_filtered;
+        ] );
+      ( "eio_native",
+        [
+          Alcotest.test_case "eio empty file" `Quick test_eio_empty_file;
+          Alcotest.test_case "eio fewer than limit" `Quick test_eio_fewer_than_limit;
+          Alcotest.test_case "eio chunk boundary" `Quick test_eio_chunk_boundary;
+          Alcotest.test_case "eio more than limit" `Quick test_eio_more_than_limit;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- `read_jsonl_tail_lines`가 `open_in_bin`/`seek_in`/`really_input`(blocking stdlib I/O)를 사용하여 Eio 스케줄러를 stall시키는 문제 수정
- `Fs_compat.get_fs_opt()` 분기: Eio fs 있으면 `Eio.File.pread_exact`(non-blocking), 없으면 기존 stdlib 폴백
- 공유 헬퍼 `take_last_lines`, `read_tail_chunks_eio`, `read_tail_chunks_stdlib`로 중복 제거
- 13개 Alcotest 케이스 추가 (stdlib 9개 + Eio 4개): empty, nonexistent, zero limit, fewer-than-limit, exact, more-than-limit, chunk-boundary, single-line-no-newline, blank-lines
- **추가**: `read_recent_events`와 `recent_operator_trace_events`의 tail-read 호출에 over-read factor(×2) 적용 — blank/malformed 줄 필터링 후에도 `limit`개 반환 보장

## Test plan

- [x] `dune exec test/test_cp_jsonl_tail.exe` — 13/13 pass
- [x] `make test` — operator test failure는 main에도 존재하는 기존 이슈 (unrelated)
- [ ] CI green 확인

Closes #2922
Closes #2945

🤖 Generated with [Claude Code](https://claude.com/claude-code)