### PR TITLE
test(operator): tighten keeper config prompt source provenance

### DIFF
--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -282,13 +282,14 @@ initiative_post_ttl_hours = 24
       Alcotest.(check (option (float 0.001))) "last output tokens per sec surfaced"
         (Some 20.0)
         (json |> member "metrics" |> member "last_output_tokens_per_sec" |> to_float_option);
-      (* Prompt source depends on test env: "default", "missing", or "file" *)
+      (* Prompt source depends on runtime bootstrap and any restored overrides;
+         accepted values come from Prompt_registry.resolve_prompt_unlocked. *)
       let prompt_source =
         json |> member "prompt" |> member "system_prompt_blocks"
         |> member "world" |> member "source" |> to_string
       in
       Alcotest.(check bool) "prompt block source surfaced" true
-        (String.length prompt_source > 0);
+        (List.mem prompt_source [ "override"; "file"; "default"; "missing" ]);
       let effective_system_prompt =
         json |> member "prompt" |> member "effective_system_prompt" |> to_string
       in


### PR DESCRIPTION
## Summary
- follow up the merged operator-control fix with a tighter keeper config provenance assertion
- accept the closed set of prompt source tags returned by `Prompt_registry.resolve_prompt_unlocked`
- keep the operator quick suite stable across file/default/override prompt bootstrap paths

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-unused-open-ci test/test_operator_control.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-unused-open-ci/_build/default/test/test_operator_control.exe test operator 26`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-turn-unused-open-ci/_build/default/test/test_operator_control.exe test operator --quick-tests`

## Issues
Refs #2888
