### PR TITLE
fix(dashboard): translate hardcoded English strings to Korean

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -149,13 +149,13 @@ export async function refreshAgentDetail(): Promise<void> {
           return { taskId: task.id, text: text.trim() }
         } catch (err) {
           const message = err instanceof Error ? err.message : 'history load failed'
-          return { taskId: task.id, text: `Failed to load history: ${message}` }
+          return { taskId: task.id, text: `이력 로드 실패: ${message}` }
         }
       }),
     )
     taskHistories.value = historyRows
   } catch (err) {
-    detailError.value = err instanceof Error ? err.message : 'Failed to load agent detail'
+    detailError.value = err instanceof Error ? err.message : '에이전트 상세 정보 로드 실패'
   } finally {
     loading.value = false
   }
@@ -172,10 +172,10 @@ export async function submitMention(): Promise<void> {
   try {
     await sendBroadcast(sender, `@${target} ${text}`)
     mentionText.value = ''
-    showToast(`Mention sent to ${target}`, 'success')
+    showToast(`${target}에게 멘션 전송 완료`, 'success')
     void refreshAgentDetail()
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Failed to send mention'
+    const msg = err instanceof Error ? err.message : '멘션 전송 실패'
     showToast(msg, 'error')
   } finally {
     sendingMention.value = false

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -11,33 +11,33 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
   if (!worker) return null
 
   return html`
-    <${Card} title="Worker Status">
+    <${Card} title="워커 상태">
       <div class="flex flex-col gap-1.5">
         <div class="flex items-baseline gap-2 text-[13px]">
-          <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">State</span>
+          <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">상태</span>
           <${StatusBadge} status=${worker.state} />
         </div>
         ${worker.focus ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">Focus</span>
+            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">포커스</span>
             <span>${worker.focus}</span>
           </div>
         ` : null}
         ${worker.recent_output_preview ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">Output</span>
+            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">출력</span>
             <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">Session</span>
+            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">세션</span>
             <span class="font-mono" style="font-size: 11px">${worker.related_session_id}</span>
           </div>
         ` : null}
         ${worker.last_signal_at ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
-            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">Signal</span>
+            <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">시그널</span>
             <${TimeAgo} timestamp=${worker.last_signal_at} />
             ${worker.signal_truth ? html`<span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${worker.signal_truth}</span>` : null}
           </div>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -62,7 +62,7 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
       <div class="mb-3">
         <span class="text-[10px] font-medium py-1 px-2.5 border border-accent/20 bg-accent/10 text-accent whitespace-nowrap rounded-md shadow-sm group-hover:bg-accent/20 transition-colors">${row.taskId}</span>
       </div>
-      <pre class="m-0 whitespace-pre-wrap text-[12px] leading-relaxed text-text-body font-mono opacity-90">${row.text || 'No task history yet'}</pre>
+      <pre class="m-0 whitespace-pre-wrap text-[12px] leading-relaxed text-text-body font-mono opacity-90">${row.text || '작업 이력 없음'}</pre>
     </div>
   `
 }

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -140,7 +140,7 @@ async function loadProfile(name: string): Promise<void> {
       taskHistories.value = rows
     }
   } catch (err) {
-    profileError.value = err instanceof Error ? err.message : 'Failed to load profile'
+    profileError.value = err instanceof Error ? err.message : '프로필 로드 실패'
   } finally {
     loading.value = false
   }
@@ -416,7 +416,7 @@ export function AgentProfile({ name }: { name: string }) {
             <div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`
               <div class="border border-[var(--card-border)] rounded-[10px] bg-[var(--white-2)] p-2.5" key=${row.taskId}>
                 <div class="mb-2"><span class="text-[10px] py-0.5 px-2 border border-solid border-[rgba(71,184,255,0.36)] bg-[var(--accent-12)] text-[#9ad9ff] whitespace-nowrap rounded-full">${row.taskId}</span></div>
-                <pre class="m-0 whitespace-pre-wrap text-[13px] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || 'No history yet'}</pre>
+                <pre class="m-0 whitespace-pre-wrap text-[13px] leading-[1.5] text-[#cfe0ff] font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace]">${row.text || '이력 없음'}</pre>
               </div>
             `)}</div>
           <//>

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -403,8 +403,8 @@ export function ChatComposer({
       <div class="flex flex-wrap items-center justify-between gap-2">
         <div class="text-[11px] leading-[1.55] text-[var(--text-muted)]">
           ${streaming
-            ? 'Keeper reply stream is active. You can stop it if the run looks stuck.'
-            : 'Direct messages are kept in this lane. Internal keeper prompts stay hidden.'}
+            ? '키퍼 응답 스트림이 활성 상태입니다. 멈춘 것 같으면 중지할 수 있습니다.'
+            : '직접 메시지만 이 레인에 표시됩니다. 내부 키퍼 프롬프트는 숨겨집니다.'}
         </div>
         <div class="flex gap-2 items-center">
         <${ActionButton}

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -43,7 +43,7 @@ export function SwarmLivePanels() {
           <div class="card rounded-xl-title">스웜 라이브 런</div>
         </div>
         ${commandPlaneSwarmLoading.value
-          ? html`<${EmptyState} message="Loading swarm live state…" compact />`
+          ? html`<${EmptyState} message="스웜 라이브 상태 불러오는 중..." compact />`
           : commandPlaneSwarmError.value
             ? html`<${EmptyState} message=${commandPlaneSwarmError.value} compact />`
             : swarm

--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -147,6 +147,6 @@ export function buildAgentMotion(
   return {
     activeAssignedCount,
     lastActivityAt: options.lastSeen ?? null,
-    lastActivityText: fallbackText ?? 'Presence heartbeat',
+    lastActivityText: fallbackText ?? '프레즌스 하트비트',
   }
 }

--- a/dashboard/src/components/governance-strips.ts
+++ b/dashboard/src/components/governance-strips.ts
@@ -106,7 +106,7 @@ export function RuntimeParamsPanel() {
   if (params.length === 0 && !runtimeLoading.value) return null
 
   return html`
-    <${Card} title="Runtime Parameters" class="section mb-4">
+    <${Card} title="런타임 파라미터" class="section mb-4">
       ${runtimeLoading.value
         ? html`<${LoadingState}>파라미터 로딩 중...<//>`
         : html`

--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -33,6 +33,6 @@ describe('normalizeKeeperChatErrorValue', () => {
   })
 
   it('falls back to a stable generic message', () => {
-    expect(normalizeKeeperChatErrorValue({ code: 500 })).toBe('Stream error')
+    expect(normalizeKeeperChatErrorValue({ code: 500 })).toBe('스트림 오류')
   })
 })

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -168,7 +168,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
       <div class="px-4 py-4">
         <${ChatTranscript}
           entries=${transcriptEntries}
-          emptyText="Send a direct prompt to start the keeper conversation."
+          emptyText="직접 프롬프트를 보내 키퍼 대화를 시작하세요."
           showMetadata=${false}
         />
       </div>

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -60,7 +60,7 @@ export function normalizeKeeperChatErrorValue(value: unknown): string {
       ?? asString(nestedError?.error)
     if (message) return message
   }
-  return 'Stream error'
+  return '스트림 오류'
 }
 
 function cancelStream(): void {
@@ -107,7 +107,7 @@ async function sendChat(keeperName: string): Promise<void> {
     })
   } catch (err) {
     if (err instanceof DOMException && err.name === 'AbortError') return
-    const msg = err instanceof Error ? err.message : 'Chat failed'
+    const msg = err instanceof Error ? err.message : '채팅 실패'
     chatError.value = msg
     showToast(msg, 'error')
   } finally {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -74,7 +74,7 @@ export async function loadKeeperConfig(name: string): Promise<void> {
     const config = await fetchKeeperConfig(name)
     configState.value = { status: 'loaded', config }
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load config'
+    const message = err instanceof Error ? err.message : '설정 로드 실패'
     configState.value = { status: 'error', message }
   }
 }
@@ -450,12 +450,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Joined rooms</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 룸</div>
         <${ModelList} models=${c.coordination.joined_room_ids} />
       </div>
 
       ${'' /* --- Drift (read-only) --- */}
-      <${SectionHeader} title="Drift" />
+      <${SectionHeader} title="드리프트" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">State</span>
         <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
@@ -465,7 +465,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
 
       ${'' /* --- Initiative (read-only) --- */}
-      <${SectionHeader} title="Initiative" />
+      <${SectionHeader} title="이니셔티브" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">State</span>
         <${FeatureBadge} status=${c.initiative.status} value=${c.initiative.enabled} />
@@ -475,11 +475,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Cooldown" value=${formatMaybeNumber(c.initiative.cooldown_sec, 's')} />
       <${ConfigRow} label="Context mode" value=${c.initiative.context_mode || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Configured in defaults</span>
+        <span class="text-xs text-[var(--text-muted)]">기본값에 설정됨</span>
         <${BoolBadge} value=${c.initiative.configured_in_source} />
       </div>
       ${c.initiative.source_defaults ? html`
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-1">Source defaults</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-1">소스 기본값</div>
         <${ConfigRow} label="Enabled" value=${c.initiative.source_defaults.enabled === null ? '--' : String(c.initiative.source_defaults.enabled)} />
         <${ConfigRow} label="Scope" value=${c.initiative.source_defaults.scope || '--'} />
         <${ConfigRow} label="Idle trigger" value=${formatMaybeNumber(c.initiative.source_defaults.idle_sec, 's')} />
@@ -489,14 +489,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ` : null}
 
       ${'' /* --- Team Session (read-only) --- */}
-      <${SectionHeader} title="Auto Team Session" />
+      <${SectionHeader} title="자동 팀 세션" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">State</span>
         <${FeatureBadge} status=${c.auto_team_session.status} value=${c.auto_team_session.enabled} />
       </div>
 
       ${'' /* --- Handoff (read-only) --- */}
-      <${SectionHeader} title="Handoff" />
+      <${SectionHeader} title="핸드오프" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">Auto</span>
         <${BoolBadge} value=${c.handoff.auto} />
@@ -506,7 +506,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Last Call Performance (read-only) --- */}
       ${'' /* Totals (generation, turns, tokens, cost, compactions) are in KpiGrid */}
-      <${SectionHeader} title="Last Call Performance" />
+      <${SectionHeader} title="마지막 호출 성능" />
       <${ConfigRow} label="Total input tokens" value=${formatTokens(c.metrics.total_input_tokens)} />
       <${ConfigRow} label="Total output tokens" value=${formatTokens(c.metrics.total_output_tokens)} />
       <${ConfigRow} label="Last model" value=${c.metrics.last_model_used || '--'} />
@@ -518,14 +518,14 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="Last output throughput" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
 
       ${'' /* --- Sources (read-only) --- */}
-      <${SectionHeader} title="Sources" />
+      <${SectionHeader} title="소스" />
       <${ConfigRow} label="Default source" value=${c.sources.default_source_kind || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Live override</span>
+        <span class="text-xs text-[var(--text-muted)]">라이브 오버라이드</span>
         <${BoolBadge} value=${c.sources.has_live_override} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Resident spec exists</span>
+        <span class="text-xs text-[var(--text-muted)]">레지던트 스펙 존재</span>
         <${BoolBadge} value=${c.sources.resident_spec_exists} />
       </div>
       <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Live meta path</div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -460,9 +460,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">State</span>
         <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
       </div>
-      <${ConfigRow} label="Min turn gap" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
-      <${ConfigRow} label="Count total" value=${formatMaybeNumber(c.drift.count_total)} />
-      ${c.drift.last_reason ? html`<${ConfigRow} label="Last reason" value=${c.drift.last_reason} />` : null}
+      <${ConfigRow} label="최소 턴 간격" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
+      <${ConfigRow} label="총 횟수" value=${formatMaybeNumber(c.drift.count_total)} />
+      ${c.drift.last_reason ? html`<${ConfigRow} label="마지막 사유" value=${c.drift.last_reason} />` : null}
 
       ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="이니셔티브" />
@@ -470,10 +470,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">State</span>
         <${FeatureBadge} status=${c.initiative.status} value=${c.initiative.enabled} />
       </div>
-      <${ConfigRow} label="Scope" value=${c.initiative.scope || '--'} />
-      <${ConfigRow} label="Idle trigger" value=${formatMaybeNumber(c.initiative.idle_sec, 's')} />
-      <${ConfigRow} label="Cooldown" value=${formatMaybeNumber(c.initiative.cooldown_sec, 's')} />
-      <${ConfigRow} label="Context mode" value=${c.initiative.context_mode || '--'} />
+      <${ConfigRow} label="범위" value=${c.initiative.scope || '--'} />
+      <${ConfigRow} label="유휴 트리거" value=${formatMaybeNumber(c.initiative.idle_sec, 's')} />
+      <${ConfigRow} label="쿨다운" value=${formatMaybeNumber(c.initiative.cooldown_sec, 's')} />
+      <${ConfigRow} label="컨텍스트 모드" value=${c.initiative.context_mode || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">기본값에 설정됨</span>
         <${BoolBadge} value=${c.initiative.configured_in_source} />
@@ -501,25 +501,25 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">Auto</span>
         <${BoolBadge} value=${c.handoff.auto} />
       </div>
-      <${ConfigRow} label="Threshold" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="Cooldown" value=${c.handoff.cooldown_sec + 's'} />
+      <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="쿨다운" value=${c.handoff.cooldown_sec + 's'} />
 
       ${'' /* --- Last Call Performance (read-only) --- */}
       ${'' /* Totals (generation, turns, tokens, cost, compactions) are in KpiGrid */}
       <${SectionHeader} title="마지막 호출 성능" />
-      <${ConfigRow} label="Total input tokens" value=${formatTokens(c.metrics.total_input_tokens)} />
-      <${ConfigRow} label="Total output tokens" value=${formatTokens(c.metrics.total_output_tokens)} />
-      <${ConfigRow} label="Last model" value=${c.metrics.last_model_used || '--'} />
-      <${ConfigRow} label="Last input tokens" value=${formatTokens(c.metrics.last_input_tokens)} />
-      <${ConfigRow} label="Last output tokens" value=${formatTokens(c.metrics.last_output_tokens)} />
-      <${ConfigRow} label="Last total tokens" value=${formatTokens(c.metrics.last_total_tokens)} />
-      <${ConfigRow} label="Last latency" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
-      <${ConfigRow} label="Last throughput" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
-      <${ConfigRow} label="Last output throughput" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
+      <${ConfigRow} label="총 입력 토큰" value=${formatTokens(c.metrics.total_input_tokens)} />
+      <${ConfigRow} label="총 출력 토큰" value=${formatTokens(c.metrics.total_output_tokens)} />
+      <${ConfigRow} label="마지막 모델" value=${c.metrics.last_model_used || '--'} />
+      <${ConfigRow} label="마지막 입력 토큰" value=${formatTokens(c.metrics.last_input_tokens)} />
+      <${ConfigRow} label="마지막 출력 토큰" value=${formatTokens(c.metrics.last_output_tokens)} />
+      <${ConfigRow} label="마지막 총 토큰" value=${formatTokens(c.metrics.last_total_tokens)} />
+      <${ConfigRow} label="마지막 지연" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
+      <${ConfigRow} label="마지막 처리량" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
+      <${ConfigRow} label="마지막 출력 처리량" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
 
       ${'' /* --- Sources (read-only) --- */}
       <${SectionHeader} title="소스" />
-      <${ConfigRow} label="Default source" value=${c.sources.default_source_kind || '--'} />
+      <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">라이브 오버라이드</span>
         <${BoolBadge} value=${c.sources.has_live_override} />

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -372,14 +372,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${'' /* --- Execution (read-only) --- */}
       ${'' /* Active model is shown in the header badge — not duplicated here */}
       <${SectionHeader} title="Execution" />
-<<<<<<< HEAD
-      <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
-||||||| parent of 597f7a4b (docs(keeper): replace policy_mode docs with initiative system)
       <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
-      <${ConfigRow} label="Shell mode" value=${c.execution.policy_shell_mode || '--'} />
-=======
-      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
->>>>>>> 597f7a4b (docs(keeper): replace policy_mode docs with initiative system)
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">Verify</span>
         <${BoolBadge} value=${c.execution.verify} />

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -286,7 +286,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       editMode.value = false
       editDraft.value = null
     } catch (err) {
-      saveError.value = err instanceof Error ? err.message : 'Save failed'
+      saveError.value = err instanceof Error ? err.message : '저장 실패'
     } finally {
       saving.value = false
     }
@@ -320,22 +320,22 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
   // --- Prompt section (editable) ---
   const promptSection = isEditing ? html`
-    <${SectionHeader} title="Prompt (editing)" />
-    <${EditTextarea} field="goal" label="Goal" rows=${3} />
-    <${EditTextarea} field="short_goal" label="Short-term goal" rows=${2} />
-    <${EditTextarea} field="mid_goal" label="Mid-term goal" rows=${2} />
-    <${EditTextarea} field="long_goal" label="Long-term goal" rows=${2} />
-    <${EditSelect} field="soul_profile" label="Soul profile" options=${SOUL_PROFILES} />
-    <${EditTextarea} field="will" label="Will" rows=${2} />
-    <${EditTextarea} field="needs" label="Needs" rows=${2} />
-    <${EditTextarea} field="desires" label="Desires" rows=${2} />
-    <${EditTextarea} field="instructions" label="Instructions" rows=${4} />
+    <${SectionHeader} title="프롬프트 (편집)" />
+    <${EditTextarea} field="goal" label="목표" rows=${3} />
+    <${EditTextarea} field="short_goal" label="단기 목표" rows=${2} />
+    <${EditTextarea} field="mid_goal" label="중기 목표" rows=${2} />
+    <${EditTextarea} field="long_goal" label="장기 목표" rows=${2} />
+    <${EditSelect} field="soul_profile" label="소울 프로필" options=${SOUL_PROFILES} />
+    <${EditTextarea} field="will" label="의지" rows=${2} />
+    <${EditTextarea} field="needs" label="필요" rows=${2} />
+    <${EditTextarea} field="desires" label="욕구" rows=${2} />
+    <${EditTextarea} field="instructions" label="지시사항" rows=${4} />
   ` : html`
-    <${SectionHeader} title="Prompt" />
-    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">Goal</div>
+    <${SectionHeader} title="프롬프트" />
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-0.5">목표</div>
     <${LongText} text=${c.prompt.goal} />
     ${c.prompt.short_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Short-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">단기 목표</div>
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
@@ -371,8 +371,8 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       ${'' /* --- Execution (read-only) --- */}
       ${'' /* Active model is shown in the header badge — not duplicated here */}
-      <${SectionHeader} title="Execution" />
-      <${ConfigRow} label="Active model" value=${c.execution.active_model || '--'} />
+      <${SectionHeader} title="실행" />
+      <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">Verify</span>
         <${BoolBadge} value=${c.execution.verify} />
@@ -392,52 +392,52 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ` : null}
 
       ${'' /* --- Compaction (read-only) --- */}
-      <${SectionHeader} title="Compaction" />
-      <${ConfigRow} label="Profile" value=${c.compaction.profile || '--'} />
-      <${ConfigRow} label="Ratio gate" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="Message gate" value=${String(c.compaction.message_gate)} />
-      <${ConfigRow} label="Token gate" value=${formatTokens(c.compaction.token_gate)} />
-      <${ConfigRow} label="Cooldown" value=${c.compaction.cooldown_sec + 's'} />
+      <${SectionHeader} title="컴팩션" />
+      <${ConfigRow} label="프로필" value=${c.compaction.profile || '--'} />
+      <${ConfigRow} label="비율 게이트" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
+      <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
+      <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
 
       ${'' /* --- Proactive (read-only) --- */}
-      <${SectionHeader} title="Proactive" />
+      <${SectionHeader} title="프로액티브" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Enabled</span>
+        <span class="text-xs text-[var(--text-muted)]">활성</span>
         <${BoolBadge} value=${c.proactive.enabled} />
       </div>
-      <${ConfigRow} label="Idle trigger" value=${c.proactive.idle_sec + 's'} />
-      <${ConfigRow} label="Cooldown" value=${c.proactive.cooldown_sec + 's'} />
+      <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
+      <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
 
       ${'' /* --- Runtime (read-only) --- */}
-      <${SectionHeader} title="Runtime" />
+      <${SectionHeader} title="런타임" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Paused</span>
+        <span class="text-xs text-[var(--text-muted)]">일시정지</span>
         <${BoolBadge} value=${c.runtime.paused} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Desired</span>
+        <span class="text-xs text-[var(--text-muted)]">원하는 상태</span>
         <${BoolBadge} value=${c.runtime.desired} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Resident registered</span>
+        <span class="text-xs text-[var(--text-muted)]">레지던트 등록</span>
         <${BoolBadge} value=${c.runtime.resident_registered} />
       </div>
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Keepalive running</span>
+        <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
         <${BoolBadge} value=${c.runtime.keepalive_running} />
       </div>
-      <${ConfigRow} label="Fiber health" value=${c.runtime.fiber_health || '--'} />
+      <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Presence keepalive</span>
+        <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>
         <${BoolBadge} value=${c.runtime.presence_keepalive} />
       </div>
-      <${ConfigRow} label="Presence interval" value=${c.runtime.presence_keepalive_sec + 's'} />
+      <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
 
       ${'' /* --- Coordination (read-only) --- */}
-      <${SectionHeader} title="Coordination" />
-      <${ConfigRow} label="Room scope" value=${c.coordination.room_scope || '--'} />
-      <${ConfigRow} label="Scope kind" value=${c.coordination.scope_kind || '--'} />
-      <${ConfigRow} label="Trigger mode" value=${c.coordination.trigger_mode || '--'} />
+      <${SectionHeader} title="조율" />
+      <${ConfigRow} label="룸 범위" value=${c.coordination.room_scope || '--'} />
+      <${ConfigRow} label="범위 유형" value=${c.coordination.scope_kind || '--'} />
+      <${ConfigRow} label="트리거 모드" value=${c.coordination.trigger_mode || '--'} />
       <div class="mt-1.5">
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Mention targets</div>
         <${ModelList} models=${c.coordination.mention_targets} />

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -95,12 +95,12 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         <${KpiCard}
           label="Generation"
           value=${keeper.generation ?? '-'}
-          hint="Succession count"
+          hint="승계 횟수"
         />
         <${KpiCard}
           label="Turns"
           value=${keeper.turn_count ?? '-'}
-          hint="Total loop turns"
+          hint="총 루프 회차"
         />
         <${KpiCard}
           label="Context"

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -83,7 +83,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
 
   const ctxPct = keeper.context_ratio != null ? Math.round(keeper.context_ratio * 100) : null
   const ctxTone: KpiTone = ctxPct == null ? 'default' : ctxPct > 85 ? 'bad' : ctxPct > 70 ? 'warn' : ctxPct > 0 ? 'ok' : 'default'
-  const ctxHint = ctxPct != null && ctxPct > 80 ? 'Approaching limit' : undefined
+  const ctxHint = ctxPct != null && ctxPct > 80 ? '한계 접근 중' : undefined
 
   const actLevel = typeof keeper.activityLevel === 'number' ? keeper.activityLevel : null
   const actTone: KpiTone = actLevel == null ? 'default' : actLevel >= 4 ? 'ok' : actLevel >= 2 ? 'warn' : 'default'
@@ -112,7 +112,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         <${KpiCard}
           label="Activity"
           value=${keeper.activityLevel ?? '-'}
-          hint="Level 0-5"
+          hint="레벨 0-5"
           tone=${actTone}
         />
       </div>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -113,12 +113,12 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
   // Quality/rate metrics only — raw counts (handoffs, compactions, k2k, etc.)
   // are authoritative in KpiGrid to avoid duplication.
   const rows: Array<{ label: string; value: string | number }> = [
-    { label: 'Model fallback', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
-    { label: 'Proactive fallback', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
-    { label: 'Memory pass rate', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
-    { label: 'Preview similarity', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
-    { label: 'Memory avg score', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
-    { label: 'Fallback rate', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
+    { label: '모델 폴백', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
+    { label: '프로액티브 폴백', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
+    { label: '메모리 통과율', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
+    { label: '프리뷰 유사도', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
+    { label: '메모리 평균 점수', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
+    { label: '폴백 비율', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
   ]
 
   const visibleRows = rows.filter(row =>
@@ -178,63 +178,63 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-col gap-1.5">
-      <${SignalRow} label="Room" value=${roomName} />
-      <${SignalRow} label="Project" value=${project} />
-      ${clusterVisible ? html`<${SignalRow} label="Cluster" value=${clusterRaw} />` : null}
-      <${SignalRow} label="Current task" value=${currentTaskLabel} />
-      <${SignalRow} label="Skill route" value=${skillRouteLabel} />
-      <${SignalRow} label="Context source" value=${keeper.context_source ?? keeper.context?.source ?? '-'} />
+      <${SignalRow} label="룸" value=${roomName} />
+      <${SignalRow} label="프로젝트" value=${project} />
+      ${clusterVisible ? html`<${SignalRow} label="클러스터" value=${clusterRaw} />` : null}
+      <${SignalRow} label="현재 태스크" value=${currentTaskLabel} />
+      <${SignalRow} label="스킬 경로" value=${skillRouteLabel} />
+      <${SignalRow} label="컨텍스트 출처" value=${keeper.context_source ?? keeper.context?.source ?? '-'} />
 
       <div class="flex justify-end mt-1">
         <button type="button"
           class="py-1.5 px-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-colors cursor-pointer"
           onClick=${() => { openToolsInventory(openToolsQuery) }}
         >
-          Open tools panel
+          도구 패널 열기
         </button>
       </div>
 
       <${ToolSection}
-        title="Allowed tools"
-        description="Currently permitted tools for this keeper runtime."
+        title="허용된 도구"
+        description="이 키퍼 런타임에 현재 허용된 도구."
         tools=${allowedTools}
         fallback=${allowlistFallback}
       />
 
       <${ToolSection}
-        title="Observed tools"
-        description="Recent execution evidence from heartbeat or runtime telemetry."
+        title="관측된 도구"
+        description="하트비트 또는 런타임 텔레메트리의 최근 실행 근거."
         tools=${observedTools}
         fallback=${observedFallback}
       />
 
-      <${SignalRow} label="Tool calls" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
-      <${SignalRow} label="Evidence source" value=${auditSource ?? metadataFallback} />
+      <${SignalRow} label="도구 호출" value=${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback} />
+      <${SignalRow} label="근거 출처" value=${auditSource ?? metadataFallback} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Observed at</span>
+        <span class="text-xs text-[var(--text-muted)]">관측 시점</span>
         <span class="text-xs font-medium text-[var(--text-strong)]">${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</span>
       </div>
 
       <${ToolSection}
-        title="Keeper recent tools"
+        title="키퍼 최근 도구"
         tools=${recentTools}
         fallback=${linkedRecentFallback}
       />
 
       ${topTools.length > 0
-        ? html`<${ToolSection} title="Window top tools" tools=${topTools} fallback="" />`
+        ? html`<${ToolSection} title="윈도우 상위 도구" tools=${topTools} fallback="" />`
         : null}
 
       <${ToolSection}
-        title="Capabilities"
+        title="등록된 기능"
         tools=${capabilities}
-        fallback="No registered capabilities"
+        fallback="등록된 기능 없음"
       />
 
       <${ToolSection}
-        title="Available actions nearby"
+        title="사용 가능한 인근 액션"
         tools=${actions.map(action => actionDescriptorLabel(action.action_type))}
-        fallback="No operator action advertisements"
+        fallback="운영자 액션 광고 없음"
       />
     </div>
   `

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -65,9 +65,9 @@ async function runSocialSweep(): Promise<void> {
     })
     invalidateDashboardCache()
     await refreshDashboard({ force: true })
-    showToast('Social sweep finished', 'success')
+    showToast('소셜 스위프 완료', 'success')
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to run social sweep'
+    const message = err instanceof Error ? err.message : '소셜 스위프 실행 실패'
     showToast(message, 'error')
   }
 }
@@ -110,18 +110,18 @@ function KeeperStatusPill({ status }: { status: string }) {
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="border-t border-[var(--border-slate-12)] pt-5">
-      <h3 class="m-0 mb-3 text-[13px] font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">Direct Comms</h3>
+      <h3 class="m-0 mb-3 text-[13px] font-semibold text-[var(--text-strong)] uppercase tracking-[0.06em]">직접 통신</h3>
 
       <div class="flex flex-col gap-4">
         <div class="w-full">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
-            placeholder="Send a direct prompt to this keeper"
+            placeholder="이 키퍼에게 직접 프롬프트 전송"
           />
         </div>
 
         <details class="group">
-          <summary class="cursor-pointer py-2.5 px-4 text-xs text-[var(--text-muted)] tracking-wider uppercase list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors">Runtime diagnostics</summary>
+          <summary class="cursor-pointer py-2.5 px-4 text-xs text-[var(--text-muted)] tracking-wider uppercase list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors">런타임 진단</summary>
           <div class="flex flex-col gap-3 px-4 pb-4 pt-2">
             <${KeeperDiagnosticSummary} keeper=${keeper} />
             <${KeeperRuntimeActions}

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -105,10 +105,10 @@ describe('KeeperConversationPanel', () => {
     )
     await Promise.resolve()
 
-    expect(container.textContent).toContain('Direct Chat')
+    expect(container.textContent).toContain('직접 대화')
     expect(container.textContent).toContain('@sangsu')
-    expect(container.textContent).toContain('Show metadata')
-    expect(container.textContent).toContain('1 internal history entries are hidden')
+    expect(container.textContent).toContain('메타데이터 표시')
+    expect(container.textContent).toContain('1개의 내부 이력이 가독성을 위해 숨겨져 있습니다')
     expect(container.textContent).not.toContain('Conversation Lane')
     expect(container.textContent).not.toContain('Visible thread')
     expect(container.textContent).not.toContain('Hidden internal')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -151,7 +151,7 @@ export function KeeperDiagnosticSummary({
   }, [keeper?.name])
 
   if (!keeper) {
-    return html`<div class="text-xs text-[var(--text-muted)] leading-relaxed py-2">Select a keeper to inspect direct reply state.</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] leading-relaxed py-2">키퍼를 선택하여 직접 응답 상태를 확인하세요.</div>`
   }
 
   const detail = keeperStatusDetails.value[keeper.name]
@@ -172,18 +172,18 @@ export function KeeperDiagnosticSummary({
       <div class="text-xs text-[var(--text-body)] leading-relaxed">
         ${diagnostic?.continuity_summary
           ?? diagnostic?.summary
-          ?? 'Keeper diagnostic summary is not available yet. Probe or open the detail overlay to inspect current runtime state.'}
+          ?? '키퍼 진단 요약을 아직 사용할 수 없습니다. 프로브하거나 상세 오버레이를 열어 런타임 상태를 확인하세요.'}
       </div>
       <div class="text-xs text-[var(--text-body)] leading-relaxed mt-1">
-        Reply: ${diagnostic?.last_reply_status ?? 'unknown'}
+        응답: ${diagnostic?.last_reply_status ?? 'unknown'}
         ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}
-        ${diagnostic?.next_eligible_at_s ? html` -- next eligible ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
+        ${diagnostic?.next_eligible_at_s ? html` -- 다음 응답 가능 ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
       ${diagnostic?.last_error
         ? html`<div class="text-xs text-[#ffb4b4] leading-relaxed mt-1">${diagnostic.last_error}</div>`
         : null}
       ${showRawStatus
-        ? html`<pre class="mt-3 py-3 px-4 rounded-lg border border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[11px] leading-relaxed whitespace-pre-wrap break-words font-mono max-h-[240px] overflow-auto">${detail?.rawText ?? 'No keeper status loaded yet.'}</pre>`
+        ? html`<pre class="mt-3 py-3 px-4 rounded-lg border border-[var(--card-border)] bg-[rgba(2,10,24,0.82)] text-[#9ad8b6] text-[11px] leading-relaxed whitespace-pre-wrap break-words font-mono max-h-[240px] overflow-auto">${detail?.rawText ?? '키퍼 상태를 아직 불러오지 않았습니다.'}</pre>`
         : null}
     </div>
   `
@@ -244,7 +244,7 @@ export function KeeperConversationPanel({
       <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(9,15,28,0.96),rgba(5,10,20,0.94))] shadow-[0_24px_56px_rgba(0,0,0,0.28)]">
         <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
           <div class="min-w-[220px] flex-1">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Direct Chat</div>
+            <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
             <div class="mt-2 flex flex-wrap items-center gap-2">
               <div class="text-[15px] font-semibold text-[var(--text-strong)]">@${keeperName}</div>
               <span class=${`inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em] ${conversationStateClass(sending, hydrating)}`}>
@@ -261,7 +261,7 @@ export function KeeperConversationPanel({
               class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
               onClick=${() => { setShowMetadata(!showMetadata) }}
             >
-              ${showMetadata ? 'Hide metadata' : 'Show metadata'}
+              ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
             ${!historyExpanded && rawThread.length >= 10
               ? html`
@@ -271,7 +271,7 @@ export function KeeperConversationPanel({
                     disabled=${hydrating}
                     onClick=${() => { void expandHistory() }}
                   >
-                    ${hydrating ? 'Loading...' : `Load full history (${thread.length} direct shown)`}
+                    ${hydrating ? '불러오는 중...' : `전체 이력 불러오기 (직접 대화 ${thread.length}건 표시 중)`}
                   </button>
                 `
               : null}
@@ -281,7 +281,7 @@ export function KeeperConversationPanel({
         <div class="px-4 py-4">
           <${ChatTranscript}
             entries=${thread}
-            emptyText="No direct conversation yet. Internal keeper prompts and tool chatter are hidden."
+            emptyText="아직 직접 대화가 없습니다. 내부 키퍼 프롬프트와 도구 호출은 숨김 처리됩니다."
             showMetadata=${showMetadata}
             variant="messenger"
           />
@@ -290,7 +290,7 @@ export function KeeperConversationPanel({
         ${hiddenHistoryCount > 0
           ? html`
               <div class="mx-4 mb-4 rounded-[16px] border border-[rgba(245,158,11,0.16)] bg-[rgba(245,158,11,0.06)] px-3 py-2 text-[11px] leading-[1.55] text-[#f4d79e]">
-                ${hiddenHistoryCount} internal history entries are hidden from this transcript to keep the conversation readable.
+                이 대화에서 ${hiddenHistoryCount}개의 내부 이력이 가독성을 위해 숨겨져 있습니다.
               </div>
             `
           : null}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -199,7 +199,7 @@ export function LogViewer() {
             <input
               class="logs-module-input min-w-[220px] rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               type="text"
-              placeholder="module filter"
+              placeholder="모듈 필터"
               value=${moduleFilter.value}
               onInput=${(e: Event) => {
                 moduleFilter.value = (e.target as HTMLInputElement).value

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -87,7 +87,7 @@ export function OpsSessionColumn() {
       await effect()
       await refreshSelectedSession()
     } catch (err) {
-      autoresearchError.value = err instanceof Error ? err.message : 'Autoresearch action failed'
+      autoresearchError.value = err instanceof Error ? err.message : '오토리서치 액션 실패'
     } finally {
       autoresearchBusy.value = false
     }

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -26,9 +26,9 @@ export function SnapshotCard() {
     <section class="grid gap-2 rounded-lg border border-[rgba(255,255,255,0.06)] bg-[linear-gradient(180deg,rgba(255,255,255,0.045),rgba(255,255,255,0.02))] p-2.5">
       <div class="flex items-start justify-between gap-3">
         <div>
-          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">Room Pulse</div>
+          <div class="text-[10px] font-semibold uppercase tracking-[0.18em] text-[rgba(154,217,255,0.68)]">룸 펄스</div>
           <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
-            ${liveConnected ? 'Live control room' : 'Signal recovering'}
+            ${liveConnected ? '라이브 관제실' : '신호 복구 중'}
           </div>
         </div>
         <div class="flex items-center gap-1.5">

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -203,10 +203,10 @@ export function PromptRegistryPanel() {
 
             <div class="mt-4 flex flex-wrap gap-2">
               <${ActionButton} variant="primary" size="md" disabled=${saving || loading || draft.trim().length === 0} onClick=${() => { void applyOverride() }}>
-                ${saving ? '저장 중...' : 'Apply override'}
+                ${saving ? '저장 중...' : '오버라이드 적용'}
               <//>
               <${ActionButton} variant="ghost" size="md" disabled=${saving || loading || !selectedPrompt.has_override} onClick=${() => { void clearOverride() }}>
-                Clear override
+                오버라이드 제거
               <//>
               <${ActionButton} variant="ghost" size="md" disabled=${saving || loading} onClick=${() => {
                 setDraft(normalizeDraft(selectedPrompt))

--- a/dashboard/src/components/worktrees.ts
+++ b/dashboard/src/components/worktrees.ts
@@ -30,7 +30,7 @@ export function Worktrees() {
           setWorktrees([{ id: 'raw', branch: 'Unknown', path: resText }])
         }
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : 'Failed to load worktrees')
+        setError(err instanceof Error ? err.message : '워크트리 로드 실패')
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary
- 대시보드 UI에 남아있던 영어 하드코딩 문자열 ~60개를 한국어로 번역
- 14개 파일 수정: keeper-shared, keeper-detail, keeper-detail-runtime, keeper-detail-panels, keeper-config-panel, keeper-chat-panel, agent-detail, agent-detail-state, agent-profile, worktrees, resident-runtime-rail, chat/primitives, ops/ops-session-column
- 번역 대상: placeholder, 에러 메시지, 섹션 헤더, ConfigRow 라벨, 진단 문자열, 토스트 메시지

## Test plan
- [x] `vite build` 빌드 통과
- [x] `vitest run` 65 테스트 전부 통과
- [x] 테스트 assertion도 한국어로 업데이트 (keeper-shared.test.ts)
- [ ] 브라우저에서 각 페이지 한국어 표시 확인

Generated with [Claude Code](https://claude.com/claude-code)