### PR TITLE
fix(dashboard): separate tool-host failures from system logs

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -54,6 +54,7 @@ export interface LogEntry {
   legacy_classified: boolean
   module: string
   message: string
+  details?: Record<string, unknown> | null
 }
 
 export interface LogsResponse {
@@ -76,6 +77,25 @@ export function fetchLogs(opts?: {
   }
   const qs = params.toString()
   return get(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
+}
+
+export interface ToolHostFailureReport {
+  agent_name?: string
+  client_name?: string
+  tool_name: string
+  transport?: string
+  phase?: string
+  message: string
+  request_id?: string
+  session_id?: string
+  trace_id?: string
+  timeout_ms?: number
+}
+
+export function reportToolHostFailure(
+  report: ToolHostFailureReport,
+): Promise<{ ok: boolean }> {
+  return post('/api/v1/dashboard/logs/tool-host-failures', report, undefined, 3000)
 }
 
 export interface AgentActivityEntry {

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { fetchWithTimeout, reportToolHostFailure } = vi.hoisted(() => ({
+  fetchWithTimeout: vi.fn(),
+  reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('./core', () => ({
+  fetchWithTimeout,
+  DEFAULT_MCP_TIMEOUT_MS: 30000,
+}))
+
+vi.mock('./dashboard', () => ({
+  reportToolHostFailure,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe('callMcpTool', () => {
+  it('reports tool-host failures after the MCP session is established', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-1' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockRejectedValueOnce(new Error('POST /mcp: timeout after 30000ms'))
+
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(
+      callMcpTool('masc_keeper_msg', { name: 'sangsu', message: 'ping' }),
+    ).rejects.toThrow('POST /mcp: timeout after 30000ms')
+
+    expect(reportToolHostFailure).toHaveBeenCalledTimes(1)
+    expect(reportToolHostFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_name: 'masc-dashboard',
+        tool_name: 'masc_keeper_msg',
+        transport: 'mcp_http',
+        phase: 'tools/call',
+        session_id: 'sess-1',
+        timeout_ms: 30000,
+      }),
+    )
+  })
+})

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -1,11 +1,47 @@
 // MASC Dashboard — MCP-over-HTTP client with session lifecycle
 
 import { fetchWithTimeout, DEFAULT_MCP_TIMEOUT_MS } from './core'
+import { reportToolHostFailure } from './dashboard'
 
 // --- MCP Session Management ---
 
 let mcpSessionId: string | null = null
 let initPromise: Promise<void> | null = null
+
+async function bestEffortReportToolHostFailure(payload: {
+  toolName: string
+  message: string
+  phase: string
+  requestId?: string
+  timeoutMs?: number
+}) {
+  try {
+    await reportToolHostFailure({
+      client_name: 'masc-dashboard',
+      tool_name: payload.toolName,
+      transport: 'mcp_http',
+      phase: payload.phase,
+      message: payload.message,
+      request_id: payload.requestId,
+      session_id: mcpSessionId ?? undefined,
+      timeout_ms: payload.timeoutMs,
+    })
+  } catch {
+    // Best-effort only. The original MCP error should surface unchanged.
+  }
+}
+
+function shouldReportToolHostFailure(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return (
+    normalized.includes('timeout after')
+    || normalized.includes('timed out awaiting tools/call')
+    || normalized.includes('failed to fetch')
+    || normalized.includes('networkerror')
+    || normalized.includes('load failed')
+    || normalized.includes('error decoding response body')
+  )
+}
 
 function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
   const headers: Record<string, string> = {
@@ -113,18 +149,35 @@ function extractMcpText(res: McpCallResponse): string {
 }
 
 export async function callMcpTool(toolName: string, args: Record<string, unknown>): Promise<string> {
-  await ensureSession()
-  const text = await mcpPost({
-    jsonrpc: '2.0',
-    method: 'tools/call',
-    params: {
-      name: toolName,
-      arguments: args,
-    },
-    id: Math.floor(Date.now() % 1000000),
-  })
-  const parsed = parseMcpHttpResponse(text)
-  return extractMcpText(parsed)
+  const requestId = String(Math.floor(Date.now() % 1000000))
+  let phase = mcpSessionId ? 'tools/call' : 'initialize'
+  try {
+    await ensureSession()
+    phase = 'tools/call'
+    const text = await mcpPost({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: toolName,
+        arguments: args,
+      },
+      id: Number.parseInt(requestId, 10),
+    })
+    const parsed = parseMcpHttpResponse(text)
+    return extractMcpText(parsed)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (shouldReportToolHostFailure(message)) {
+      await bestEffortReportToolHostFailure({
+        toolName,
+        message,
+        phase,
+        requestId: phase === 'tools/call' ? requestId : undefined,
+        timeoutMs: phase === 'initialize' ? 10000 : DEFAULT_MCP_TIMEOUT_MS,
+      })
+    }
+    throw err
+  }
 }
 
 function parseMcpJsonText(text: string): Record<string, unknown> {

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -13,6 +13,7 @@ function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
     legacy_classified: false,
     module: 'Dashboard',
     message: `entry-${seq}`,
+    details: null,
     ...overrides,
   }
 }

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -31,6 +31,7 @@ const SOURCE_LABELS: Record<string, string> = {
   structured: 'structured',
   legacy_stderr: 'legacy stderr',
   legacy_traceln: 'legacy traceln',
+  client_tool_host: 'client tool-host',
   sse: 'sse',
 }
 
@@ -66,8 +67,24 @@ function sourceLabel(source: string): string {
   return SOURCE_LABELS[source] ?? (source || 'structured')
 }
 
+function entryDetails(entry: LogEntry): Record<string, unknown> | null {
+  const details = entry.details
+  if (!details || typeof details !== 'object' || Array.isArray(details)) return null
+  return details
+}
+
+function detailLabel(details: Record<string, unknown> | null, key: string): string | null {
+  if (!details) return null
+  const value = details[key]
+  if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return null
+}
+
 function sourceTone(source: string): string {
   switch (source) {
+    case 'client_tool_host':
+      return 'text-[#dff3ff] bg-[rgba(71,184,255,0.12)] border-[rgba(71,184,255,0.22)]'
     case 'legacy_stderr':
       return 'text-[#ffb4b4] bg-[rgba(224,80,80,0.12)] border-[rgba(224,80,80,0.18)]'
     case 'legacy_traceln':
@@ -117,6 +134,12 @@ function renderLogRow(entry: LogEntry) {
   const level = normalizedLevel(entry)
   const rawLevelChanged = entry.raw_level && entry.raw_level !== level
   const source = entry.source || 'structured'
+  const details = entryDetails(entry)
+  const clientName = detailLabel(details, 'client_name')
+  const toolName = detailLabel(details, 'tool_name')
+  const phase = detailLabel(details, 'phase')
+  const requestId = detailLabel(details, 'request_id')
+  const sessionId = detailLabel(details, 'session_id')
   const sourceClass = sourceTone(source)
   const backgroundClass =
     level === 'ERROR'
@@ -148,6 +171,21 @@ function renderLogRow(entry: LogEntry) {
           : null}
         ${rawLevelChanged
           ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${entry.raw_level}</span>`
+          : null}
+        ${clientName
+          ? html`<span class="rounded-full border border-[rgba(71,184,255,0.16)] px-2 py-0.5 text-[10px] text-[#dff3ff]">${clientName}</span>`
+          : null}
+        ${toolName
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${toolName}</span>`
+          : null}
+        ${phase
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`
+          : null}
+        ${requestId
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">req ${requestId}</span>`
+          : null}
+        ${sessionId
+          ? html`<span class="rounded-full border border-[rgba(255,255,255,0.08)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">session ${sessionId}</span>`
           : null}
       </div>
       <div

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -281,6 +281,25 @@ let log_tool_call config ~agent_id ~tool_name ~success ~error_msg ?cost_estimate
   let outcome = if success then Success else Failure (Option.value error_msg ~default:"unknown") in
   log_action config ~agent_id ~action:(ToolCall tool_name) ?cost_estimate ?token_count ~outcome ()
 
+let log_client_tool_host_failure config ~agent_id ~client_name ~tool_name
+    ~transport ~message ?phase ?request_id ?session_id ?trace_id ?timeout_ms () =
+  let details =
+    `Assoc
+      (List.filter_map
+         Fun.id
+         [
+           Some ("client_name", `String client_name);
+           Some ("tool_name", `String tool_name);
+           Some ("transport", `String transport);
+           Option.map (fun value -> ("phase", `String value)) phase;
+           Option.map (fun value -> ("request_id", `String value)) request_id;
+           Option.map (fun value -> ("session_id", `String value)) session_id;
+           Option.map (fun value -> ("timeout_ms", `Int value)) timeout_ms;
+         ])
+  in
+  log_action config ~agent_id ~action:(Custom "client_tool_host_failure")
+    ~details ?trace_id ~outcome:(Failure message) ()
+
 let log_auth_attempt config ~agent_id ~success ~method_name ?cost_estimate ?token_count () =
   let action = if success then AuthSuccess else AuthFailure in
   log_action config ~agent_id ~action

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -1,0 +1,116 @@
+type report = {
+  agent_name : string;
+  client_name : string;
+  tool_name : string;
+  transport : string;
+  phase : string option;
+  message : string;
+  request_id : string option;
+  session_id : string option;
+  trace_id : string option;
+  timeout_ms : int option;
+}
+
+let trim_to_option value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let stringish_member_opt json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `String value -> trim_to_option value
+  | `Int value -> Some (string_of_int value)
+  | `Intlit value -> trim_to_option value
+  | `Float value -> Some (Printf.sprintf "%.0f" value)
+  | `Null -> None
+  | _ -> None
+
+let required_member json key =
+  match stringish_member_opt json key with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing required field: %s" key)
+
+let parse_timeout_ms json =
+  let open Yojson.Safe.Util in
+  match json |> member "timeout_ms" with
+  | `Null -> None
+  | `Int value -> Some (max 1 value)
+  | `Intlit value -> (
+      try Some (max 1 (int_of_string value)) with Failure _ -> None)
+  | _ -> None
+
+let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
+    (report, string) result =
+  match json with
+  | `Assoc _ -> (
+      match required_member json "tool_name", required_member json "message" with
+      | Ok tool_name, Ok message ->
+          let client_name =
+            match stringish_member_opt json "client_name" with
+            | Some value -> value
+            | None ->
+                Option.value
+                  ~default:"tool-host"
+                  (Option.bind fallback_agent trim_to_option)
+          in
+          let explicit_agent =
+            Option.bind (stringish_member_opt json "agent_name") trim_to_option
+          in
+          let fallback_agent = Option.bind fallback_agent trim_to_option in
+          let agent_name =
+            match explicit_agent with
+            | Some value -> value
+            | None -> Option.value ~default:client_name fallback_agent
+          in
+          let transport =
+            Option.value ~default:"mcp_http"
+              (stringish_member_opt json "transport")
+          in
+          Ok
+            {
+              agent_name;
+              client_name;
+              tool_name;
+              transport;
+              phase = stringish_member_opt json "phase";
+              message;
+              request_id = stringish_member_opt json "request_id";
+              session_id = stringish_member_opt json "session_id";
+              trace_id = stringish_member_opt json "trace_id";
+              timeout_ms = parse_timeout_ms json;
+            }
+      | Error msg, _ | _, Error msg -> Error msg)
+  | _ -> Error "request body must be a JSON object"
+
+let details_json (report : report) =
+  `Assoc
+    (List.filter_map
+       Fun.id
+       [
+         Some ("client_name", `String report.client_name);
+         Some ("tool_name", `String report.tool_name);
+         Some ("transport", `String report.transport);
+         Option.map (fun value -> ("phase", `String value)) report.phase;
+         Option.map (fun value -> ("request_id", `String value)) report.request_id;
+         Option.map (fun value -> ("session_id", `String value)) report.session_id;
+         Option.map (fun value -> ("trace_id", `String value)) report.trace_id;
+         Option.map (fun value -> ("timeout_ms", `Int value)) report.timeout_ms;
+       ])
+
+let ring_message (report : report) =
+  let phase =
+    match report.phase with
+    | Some value -> Printf.sprintf "%s " value
+    | None -> ""
+  in
+  Printf.sprintf "%s %s%s failed: %s" report.client_name phase report.tool_name
+    report.message
+
+let record config (report : report) =
+  let details = details_json report in
+  Log.client_tool_host_error ~details (ring_message report);
+  Audit_log.log_client_tool_host_failure config ~agent_id:report.agent_name
+    ~client_name:report.client_name ~tool_name:report.tool_name
+    ~transport:report.transport ~message:report.message ?phase:report.phase
+    ?request_id:report.request_id ?session_id:report.session_id
+    ?trace_id:report.trace_id ?timeout_ms:report.timeout_ms ()

--- a/lib/dune
+++ b/lib/dune
@@ -54,6 +54,7 @@
    dashboard_agent_relations
    dashboard_attention
    dashboard_cache
+   dashboard_tool_host_events
    dashboard_collaboration_evidence
    dashboard_governance
    dashboard_governance_judge

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -12,6 +12,7 @@ type source =
   | Structured
   | Legacy_stderr
   | Legacy_traceln
+  | Client_tool_host
 
 (** Current log level (Atomic for thread safety in OCaml 5) *)
 let current_level = Atomic.make 1 (* Info = 1 *)
@@ -43,6 +44,7 @@ let source_to_string = function
   | Structured -> "structured"
   | Legacy_stderr -> "legacy_stderr"
   | Legacy_traceln -> "legacy_traceln"
+  | Client_tool_host -> "client_tool_host"
 
 let has_prefix ~prefix value =
   let prefix_len = String.length prefix in
@@ -118,6 +120,7 @@ module Ring = struct
     legacy_classified : bool;
     module_name : string;
     message : string;
+    details : Yojson.Safe.t;
   }
 
   let capacity = 5000
@@ -132,6 +135,7 @@ module Ring = struct
       legacy_classified = false;
       module_name = "";
       message = "";
+      details = `Null;
     }
   let total = Atomic.make 0 (* total entries ever written *)
 
@@ -139,6 +143,7 @@ module Ring = struct
       ?raw_level
       ?(source = Structured)
       ?(legacy_classified = false)
+      ?(details = `Null)
       ~normalized_level
       ~module_name
       ~message
@@ -158,6 +163,7 @@ module Ring = struct
         legacy_classified;
         module_name;
         message;
+        details;
       }
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
@@ -206,6 +212,7 @@ module Ring = struct
       ("legacy_classified", `Bool e.legacy_classified);
       ("module", `String e.module_name);
       ("message", `String e.message);
+      ("details", e.details);
     ]
 
   let to_json entries =
@@ -256,6 +263,11 @@ let legacy_stderr ?level ?module_name message =
 
 let legacy_traceln ?level ?module_name message =
   emit_legacy_raw ?level ?module_name ~source:Legacy_traceln message
+
+let client_tool_host_error ?(module_name = "ToolHost") ?(details = `Null) message =
+  Printf.eprintf "%s\n%!" message;
+  Ring.push ~raw_level:"ERROR" ~normalized_level:"ERROR" ~source:Client_tool_host
+    ~module_name ~message ~details ()
 
 (** Module-specific loggers.
     Each module checks MASC_LOG_{NAME}_LEVEL env var for per-module override,

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -57,6 +57,7 @@ module Ring : sig
     legacy_classified : bool;
     module_name : string;
     message : string;
+    details : Yojson.Safe.t;
   }
 
   val recent :
@@ -70,6 +71,10 @@ module Ring : sig
 
   val to_json : entry list -> Yojson.Safe.t
 end
+
+val client_tool_host_error :
+  ?module_name:string -> ?details:Yojson.Safe.t -> string -> unit
+(** Mirror a client/tool-host failure into the dashboard log ring with its own source. *)
 
 (** Functor for creating module-specific loggers.
     [M.name] controls the env-var key MASC_LOG_{NAME}_LEVEL

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -98,6 +98,29 @@ let add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.post "/api/v1/dashboard/logs/tool-host-failures" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           let fallback_agent = agent_from_request request in
+           let report_result =
+             try
+               let json = Yojson.Safe.from_string body_str in
+               Dashboard_tool_host_events.report_of_yojson ?fallback_agent json
+             with Yojson.Json_error err ->
+               Error ("invalid json: " ^ err)
+           in
+           match report_result with
+           | Ok report ->
+               Dashboard_tool_host_events.record state.Mcp_server.room_config
+                 report;
+               Http.Response.json ~compress:true ~request:req {|{"ok":true}|}
+                 reqd
+           | Error message ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
+                 reqd)
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_room_truth_http_json ~state ~sw ~clock req in

--- a/test/dune
+++ b/test/dune
@@ -26,6 +26,7 @@
         test_subscriptions test_session test_progress test_mitosis test_spawn
         test_validation test_response test_voice_stream
         test_dashboard
+        test_dashboard_tool_host_events
         test_multi_room test_worktree_detection test_bounded test_mention test_hat
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier test_mdal
@@ -51,6 +52,7 @@
           test_subscriptions test_session test_progress test_mitosis test_spawn
           test_validation test_response test_voice_stream
           test_dashboard
+          test_dashboard_tool_host_events
           test_multi_room test_worktree_detection test_bounded test_mention test_hat
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier test_mdal

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -1,0 +1,119 @@
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_dashboard_tool_host_events_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let test_report_of_yojson_defaults () =
+  let json =
+    `Assoc
+      [
+        ("tool_name", `String "masc_keeper_msg");
+        ("message", `String "timed out awaiting tools/call after 120s");
+      ]
+  in
+  match Dashboard_tool_host_events.report_of_yojson ~fallback_agent:"codex" json with
+  | Error err -> fail err
+  | Ok report ->
+      check string "agent defaulted from fallback" "codex" report.agent_name;
+      check string "client defaulted from fallback" "codex" report.client_name;
+      check string "transport default" "mcp_http" report.transport;
+      check (option string) "phase missing" None report.phase
+
+let test_report_of_yojson_accepts_stringish_ids () =
+  let json =
+    `Assoc
+      [
+        ("client_name", `String "codex");
+        ("tool_name", `String "masc_keeper_msg");
+        ("message", `String "timed out awaiting tools/call after 120s");
+        ("request_id", `Int 42);
+        ("session_id", `String "sess-1");
+        ("trace_id", `String "trace-1");
+        ("timeout_ms", `Int 120000);
+        ("phase", `String "tools/call");
+      ]
+  in
+  match Dashboard_tool_host_events.report_of_yojson json with
+  | Error err -> fail err
+  | Ok report ->
+      check (option string) "request_id" (Some "42") report.request_id;
+      check (option int) "timeout_ms" (Some 120000) report.timeout_ms;
+      check (option string) "trace_id" (Some "trace-1") report.trace_id
+
+let test_record_writes_audit_and_ring () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun _env ->
+      let config = Room.default_config base_dir in
+      let report =
+        {
+          Dashboard_tool_host_events.agent_name = "codex";
+          client_name = "codex";
+          tool_name = "masc_keeper_msg";
+          transport = "mcp_http";
+          phase = Some "tools/call";
+          message = "timed out awaiting tools/call after 120s";
+          request_id = Some "99";
+          session_id = Some "sess-99";
+          trace_id = Some "trace-99";
+          timeout_ms = Some 120000;
+        }
+      in
+      Dashboard_tool_host_events.record config report;
+      let entries = Audit_log.read_entries ~n:20 config in
+      let matching =
+        List.find_opt
+          (fun (entry : Audit_log.audit_entry) ->
+            match entry.action with
+            | Audit_log.Custom "client_tool_host_failure" -> true
+            | _ -> false)
+          entries
+      in
+      let entry =
+        match matching with
+        | Some entry -> entry
+        | None -> fail "expected client_tool_host_failure audit entry"
+      in
+      (match entry.outcome with
+      | Audit_log.Failure reason ->
+          check string "failure reason" report.message reason
+      | Audit_log.Success -> fail "expected failure outcome");
+      let latest =
+        match Log.Ring.recent ~limit:1 () with
+        | row :: _ -> row
+        | [] -> fail "expected ring entry"
+      in
+      check string "ring source" "client_tool_host" latest.source;
+      check string "ring module" "ToolHost" latest.module_name;
+      check bool "ring details object" true
+        (match latest.details with `Assoc _ -> true | _ -> false))
+
+let () =
+  run "Dashboard_tool_host_events"
+    [
+      ( "dashboard_tool_host_events",
+        [
+          test_case "report defaults" `Quick test_report_of_yojson_defaults;
+          test_case "report stringish ids" `Quick
+            test_report_of_yojson_accepts_stringish_ids;
+          test_case "record writes audit and ring" `Quick
+            test_record_writes_audit_and_ring;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add a dedicated `client_tool_host` dashboard log source for host-side tool failures
- accept best-effort tool-host failure reports at `/api/v1/dashboard/logs/tool-host-failures`, mirror them into the dashboard ring, and persist them to the audit log
- report dashboard MCP timeout/network failures through that path and render correlation badges (client/tool/phase/request/session) in the log viewer

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-2841-log-sources test/test_dashboard_tool_host_events.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-2841-log-sources/_build/default/test/test_dashboard_tool_host_events.exe`

## Notes
- I could not run dashboard `tsc`/`vitest` locally in this worktree because `dashboard` dependencies are not installed (`tsc` and `vitest` were not found on PATH).

Closes #2841
