### PR TITLE
Improve MCP read-path stability and add revalidation harness

### DIFF
--- a/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
+++ b/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
@@ -1,0 +1,55 @@
+# MCP Read-Path Revalidation
+
+이 runbook은 `masc_status`, `masc_keeper_list`, `masc_transport_status`, dashboard cached surfaces, keeper continuity surface를 함께 재검증할 때 쓴다.
+
+엔트리포인트:
+
+```bash
+./scripts/harness_mcp_readpath_revalidation.sh
+```
+
+기본 모드:
+
+- `http_only`
+  - `MASC_GRPC_ENABLED=0`
+  - `MASC_WS_ENABLED=0`
+  - `MASC_WEBRTC_ENABLED=0`
+  - MCP read-path와 dashboard cache baseline 확인
+- `default`
+  - live HTTP + WebSocket + WebRTC startup 확인
+  - gRPC는 기본적으로 꺼 둔다
+
+기본 base path는 현재 repo root다. 즉 live `.masc` 상태와 resident keeper surface를 같이 검증한다.
+
+## Success Criteria
+
+- `masc_status` 2회 연속 호출이 timeout 없이 끝난다.
+- `masc_keeper_list(detailed=false)` 2회 연속 호출이 timeout 없이 끝난다.
+- `masc_transport_status`가 빠르게 응답한다.
+- `/api/v1/dashboard/execution`과 `/api/v1/dashboard/transport-health`의 `projection_diagnostics.cache_state`가 `fresh`다.
+- `/health.startup.pending_lazy_tasks`가 빈 배열이다.
+- keeper list `items`에 다음 필드가 존재한다.
+  - `policy_mode`
+  - `trigger_mode`
+  - `presence_keepalive`
+  - `proactive_enabled`
+- `keepalive_running=false` 이고 `presence_keepalive=true` 이고 `proactive_enabled=true` 인 keeper는 `diagnostic.quiet_reason="disabled"`로 분류되지 않는다.
+
+## Output
+
+실행이 끝나면 마지막 줄에 아래 형식으로 summary path를 출력한다.
+
+```text
+summary=/abs/path/to/logs/mcp_readpath_revalidation/<run-id>/summary.json
+```
+
+summary에는 모드별 timing, backend mode, fallback reason, health transport 상태, keeper sample payload가 들어간다.
+
+## Useful Overrides
+
+```bash
+MODES=http_only ./scripts/harness_mcp_readpath_revalidation.sh
+BASE_PATH=/abs/path/to/repo ./scripts/harness_mcp_readpath_revalidation.sh
+KEEP_SERVER=1 ./scripts/harness_mcp_readpath_revalidation.sh
+START_SERVER=0 TARGET_BASE_URL=http://127.0.0.1:8946 MODES=http_only ./scripts/harness_mcp_readpath_revalidation.sh
+```

--- a/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
+++ b/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
@@ -29,10 +29,11 @@
 - `/api/v1/dashboard/execution`과 `/api/v1/dashboard/transport-health`의 `projection_diagnostics.cache_state`가 `fresh`다.
 - `/health.startup.pending_lazy_tasks`가 빈 배열이다.
 - keeper list `items`에 다음 필드가 존재한다.
-  - `policy_mode`
-  - `trigger_mode`
+  - `scope_kind`
+  - `room_scope`
   - `presence_keepalive`
   - `proactive_enabled`
+  - `initiative_enabled`
 - `keepalive_running=false` 이고 `presence_keepalive=true` 이고 `proactive_enabled=true` 인 keeper는 `diagnostic.quiet_reason="disabled"`로 분류되지 않는다.
 
 ## Output

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -400,6 +400,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("primary_model", `String primary_model);
               ("active_model", `String active_model);
               ("next_model_hint", match next_model_hint with Some s -> `String s | None -> `Null);
+              ("policy_mode", `String m.policy_mode);
+              ("policy_shell_mode", `String m.policy_shell_mode);
+              ("trigger_mode", `String m.trigger_mode);
               ("presence_keepalive", `Bool m.presence_keepalive);
               ("presence_keepalive_sec", `Int m.presence_keepalive_sec);
               ("keepalive_running", `Bool keepalive_running);

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -400,9 +400,8 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("primary_model", `String primary_model);
               ("active_model", `String active_model);
               ("next_model_hint", match next_model_hint with Some s -> `String s | None -> `Null);
-              ("policy_mode", `String m.policy_mode);
-              ("policy_shell_mode", `String m.policy_shell_mode);
-              ("trigger_mode", `String m.trigger_mode);
+              ("scope_kind", `String m.scope_kind);
+              ("room_scope", `String m.room_scope);
               ("presence_keepalive", `Bool m.presence_keepalive);
               ("presence_keepalive_sec", `Int m.presence_keepalive_sec);
               ("keepalive_running", `Bool keepalive_running);
@@ -443,6 +442,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
+              ("initiative_enabled", `Bool m.initiative_enabled);
+              ("initiative_idle_sec", `Int m.initiative_idle_sec);
+              ("initiative_cooldown_sec", `Int m.initiative_cooldown_sec);
               ("proactive_count_total", `Int m.proactive.count_total);
               ("autonomous_turn_count", `Int m.autonomous_turn_count);
               ("autonomous_text_turn_count", `Int m.autonomous_text_turn_count);

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -205,12 +205,15 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
     |> String.lowercase_ascii
   in
   let error_hint = keeper_error_hint ~agent_status ~meta in
-  if
-    not keepalive_running
-    || not agent_exists
+  if not meta.presence_keepalive || not meta.proactive.enabled then
+    Some "disabled"
+  else if not keepalive_running then
+    Some "not_running"
+  else if
+    not agent_exists
     || agent_status_text = "offline"
     || agent_status_text = "inactive"
-  then Some "disabled"
+  then Some "agent_missing"
   else if meta.usage.total_turns = 0 && meta.proactive.count_total = 0 then
     let keeper_age_s =
       match Resilience.Time.parse_iso8601_opt meta.created_at with
@@ -298,6 +301,7 @@ let keeper_next_action_path ~health_state ~quiet_reason =
   | _ -> (
       match quiet_reason with
       | Some "quiet_hours" -> "manual_lodge_poke"
+      | Some "not_running" | Some "agent_missing" -> "recover"
       | Some "graphql_error" | Some "model_error" | Some "startup" | Some "unknown" ->
           "probe"
       | Some "disabled" -> "recover"
@@ -322,6 +326,12 @@ let keeper_diagnostic_summary ~health_state ~quiet_reason =
       "Keeper is not in a healthy reply state. Probe or recover before relying on automation."
   | _ -> (
       match quiet_reason with
+      | Some "disabled" ->
+          "Keeper autonomy is disabled by configuration. Direct messages still work, but resident automation will stay quiet."
+      | Some "not_running" ->
+          "Keeper should be resident, but its keepalive loop is not running."
+      | Some "agent_missing" ->
+          "Keeper keepalive is running, but the live agent record is missing or offline."
       | Some "quiet_hours" ->
           "Quiet hours are active. Direct messages still work, but scheduled social ticks may look asleep."
       | Some "min_gap" ->
@@ -350,21 +360,24 @@ let keeper_continuity_state
     | None -> false
   in
   if desired && meta.presence_keepalive then
-    if not keepalive_running then "desired_offline"
+    if not keepalive_running then "not_running"
     else if recently_started || not healthy_like then "recovering"
     else "healthy"
+  else if desired then "disabled"
   else if keepalive_running && healthy_like then "healthy"
   else if keepalive_running then "recovering"
   else "offline"
 
 let keeper_continuity_summary continuity_state =
   match continuity_state with
-  | "desired_offline" ->
-      "Desired always-on keeper is offline. The runtime should reconcile it back into live presence."
+  | "not_running" ->
+      "Desired always-on keeper is not running. The runtime should reconcile it back into live presence."
   | "recovering" ->
       "Keeper runtime is reconciling back into live presence."
   | "healthy" ->
       "Keeper runtime is aligned with the desired live presence."
+  | "disabled" ->
+      "Resident live presence is disabled by configuration."
   | _ -> "Keeper runtime is offline."
 
 let augment_keeper_diagnostic_json

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -361,6 +361,21 @@ let handle_resources_unsubscribe_eio id ?mcp_session_id params =
 
 let contains_casefold = Mcp_server_eio_call_tool.contains_casefold
 
+let tool_call_outcome (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "error" fields with
+      | Some _ -> "error"
+      | None -> (
+          match List.assoc_opt "result" fields with
+          | Some (`Assoc result_fields) -> (
+              match List.assoc_opt "isError" result_fields with
+              | Some (`Bool true) -> "error"
+              | Some (`Bool false) -> "ok"
+              | _ -> "unknown")
+          | _ -> "unknown"))
+  | _ -> "unknown"
+
 (** Handle incoming JSON-RPC request - Pure Eio Native *)
 let handle_request
     ~handle_call_tool_eio
@@ -465,7 +480,8 @@ let handle_request
                                let result =
                                  handle_call_tool_eio ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params
                                in
-                               Log.Mcp.info "tools/call done: %s" name;
+                               Log.Mcp.info "tools/call completed: %s (outcome=%s)"
+                                 name (tool_call_outcome result);
                                result)
                            with Yojson.Safe.Util.Type_error (_, _) ->
                              make_error ~id (-32602) "Invalid params: name must be a string")

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -39,6 +39,16 @@ let _execution_cache =
         ("message", `String "Execution data is being computed. Refresh in a few seconds.");
       ])
 
+let _transport_health_cache =
+  create_cached_surface
+    (`Assoc
+      [
+        ("status", `String "initializing");
+        ("generated_at", `String (Types.now_iso ()));
+        ( "message",
+          `String "Transport health data is warming up. Refresh in a few seconds." );
+      ])
+
 (** Start the proactive execution refresh loop.  When an Executor_pool
     is available, each refresh runs in a pool domain with a domain-local
     Caqti pool (the main domain's Caqti pool is domain-bound due to
@@ -76,6 +86,30 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
               with timeout_s = execution_refresh_timeout_s }
     ~compute
     ~on_result:(mark_cached_surface_success _execution_cache)
+
+let start_transport_health_refresh_loop ~state ~sw ~clock =
+  let timeout_s =
+    float_of_env_default "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S"
+      ~default:8.0 ~min_v:3.0 ~max_v:30.0
+  in
+  let compute () =
+    mark_cached_surface_attempt _transport_health_cache;
+    try
+      Transport_metrics.transport_health_json
+        ~config:state.Mcp_server.room_config
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        mark_cached_surface_error _transport_health_cache exn;
+        raise exn
+  in
+  Proactive_refresh.start ~sw ~clock
+    ~config:
+      { (Proactive_refresh.default_config
+           ~label:"transport_health" ~interval_s:15.0)
+        with timeout_s }
+    ~compute
+    ~on_result:(mark_cached_surface_success _transport_health_cache)
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
   let fixture = query_param request "fixture" in
@@ -118,10 +152,8 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
       ~clock ~timeout_sec:120.0 (compute ?actor ?fixture ~light)
 
-let dashboard_transport_health_http_json ~state =
-  Dashboard_cache.get_or_compute "transport_health" ~ttl:10.0 (fun () ->
-    Transport_metrics.transport_health_json
-      ~config:state.Mcp_server.room_config)
+let dashboard_transport_health_http_json ~state:_ =
+  cached_surface_json _transport_health_cache
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -193,26 +193,36 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
        (Printexc.to_string exn))
 
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =
+  let timeout_s =
+    Safe_ops.get_env_float_logged "MASC_KEEPER_BOOTSTRAP_TIMEOUT_S" ~default:15.0
+  in
   try
-    let keeper_ctx : _ Tool_keeper.context =
-      {
-        config = state.room_config;
-        agent_name = "keeper-bootstrap";
-        sw;
-        clock;
-        proc_mgr = state.Mcp_server.proc_mgr;
-      }
-    in
-    let stats = Keeper_runtime.bootstrap_existing_keepers keeper_ctx in
-    Keeper_runtime.maybe_start_supervisor_sweep keeper_ctx stats;
-    if stats.enabled then
-      Log.Keeper.info "scanned=%d started=%d stale=%d recovering=%d"
-        stats.scanned stats.started stats.stale stats.recovering
+    match
+      Eio.Time.with_timeout clock timeout_s (fun () ->
+        let keeper_ctx : _ Tool_keeper.context =
+          {
+            config = state.room_config;
+            agent_name = "keeper-bootstrap";
+            sw;
+            clock;
+            proc_mgr = state.Mcp_server.proc_mgr;
+          }
+        in
+        let stats = Keeper_runtime.bootstrap_existing_keepers keeper_ctx in
+        Keeper_runtime.maybe_start_supervisor_sweep keeper_ctx stats;
+        if stats.enabled then
+          Log.Keeper.info "scanned=%d started=%d stale=%d recovering=%d"
+            stats.scanned stats.started stats.stale stats.recovering;
+        Ok ())
+    with
+    | Ok () -> ()
+    | Error `Timeout ->
+        Log.Server.warn "keeper bootstrap timed out after %.0fs" timeout_s
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-    Log.Server.error "keeper bootstrap failed: %s"
-      (Printexc.to_string exn)
+      Log.Server.error "keeper bootstrap failed: %s"
+        (Printexc.to_string exn)
 
 let init_task_backend () =
   match Board_dispatch.get_pg_pool () with
@@ -863,6 +873,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
+      Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -25,6 +25,43 @@ type tool_result = Keeper_types.tool_result
 
 let schemas = Keeper_types.schemas
 
+type text_cache = {
+  mutable key : string option;
+  mutable value : string option;
+  mutable expires_at : float;
+}
+
+let _resident_keeper_list_cache = { key = None; value = None; expires_at = 0.0 }
+
+let cache_ttl_seconds env_var ~default =
+  match Sys.getenv_opt env_var with
+  | Some raw -> (
+      match Float.of_string_opt (String.trim raw) with
+      | Some value when value >= 0.0 -> value
+      | _ -> default)
+  | None -> default
+
+let resident_keeper_list_cache_ttl_s () =
+  cache_ttl_seconds "MASC_KEEPER_LIST_CACHE_TTL_S" ~default:2.0
+
+let invalidate_resident_keeper_list_cache () =
+  _resident_keeper_list_cache.key <- None;
+  _resident_keeper_list_cache.value <- None;
+  _resident_keeper_list_cache.expires_at <- 0.0
+
+let cached_text_by_key cache ~key ~ttl_s compute =
+  let now = Time_compat.now () in
+  match cache.key, cache.value with
+  | Some cached_key, Some value
+    when String.equal cached_key key && now < cache.expires_at ->
+      value
+  | _ ->
+      let value = compute () in
+      cache.key <- Some key;
+      cache.value <- Some value;
+      cache.expires_at <- now +. ttl_s;
+      value
+
 let annotate_keeper_json ~runtime_class ~desired ~resident_registered json =
   match json with
   | `Assoc fields ->
@@ -34,6 +71,64 @@ let annotate_keeper_json ~runtime_class ~desired ~resident_registered json =
         :: ("resident_registered", `Bool resident_registered)
         :: fields)
   | other -> other
+
+let keeper_brief_meta_json (meta : keeper_meta) =
+  `Assoc
+    [
+      ("name", `String meta.name);
+      ("goal", `String meta.goal);
+      ("trace_id", `String meta.trace_id);
+      ("created_at", `String meta.created_at);
+      ("updated_at", `String meta.updated_at);
+    ]
+
+let keeper_list_row_json ~runtime_class ~desired ~resident_registered config
+    name =
+  match read_meta config name with
+  | Error _ | Ok None -> None
+  | Ok (Some (meta : keeper_meta)) ->
+      let now_ts = Time_compat.now () in
+      let keepalive_running = Keeper_keepalive.keeper_keepalive_running meta.name in
+      let agent_status =
+        Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
+      in
+      let diagnostic =
+        Keeper_exec_status.keeper_diagnostic_json
+          ~meta
+          ~agent_status
+          ~keepalive_running ~history_items:[] ~now_ts
+        |> Keeper_exec_status.augment_keeper_diagnostic_json
+             ~desired ~meta ~keepalive_running
+             ~keepalive_started_at:
+               (Keeper_keepalive.keeper_keepalive_started_at meta.name)
+             ~now_ts
+      in
+      let status =
+        Keeper_exec_status.keeper_surface_status ~agent_status ~diagnostic
+      in
+      Some
+        (`Assoc
+          [
+            ("runtime_class", `String runtime_class);
+            ("desired", `Bool desired);
+            ("resident_registered", `Bool resident_registered);
+            ("name", `String meta.name);
+            ("meta", keeper_brief_meta_json meta);
+            ("agent_name", `String meta.agent_name);
+            ("status", `String status);
+            ("diagnostic", diagnostic);
+            ("keepalive_running", `Bool keepalive_running);
+            ("presence_keepalive", `Bool meta.presence_keepalive);
+            ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);
+            ("proactive_enabled", `Bool meta.proactive.enabled);
+            ("proactive_idle_sec", `Int meta.proactive.idle_sec);
+            ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
+            ("policy_mode", `String meta.policy_mode);
+            ("trigger_mode", `String meta.trigger_mode);
+            ("models", `List (List.map (fun model -> `String model) meta.models));
+            ("created_at", `String meta.created_at);
+            ("updated_at", `String meta.updated_at);
+          ])
 
 let handle_resident_keeper_create_from_persona ctx args : tool_result =
   match Keeper_exec_persona.resolved_keeper_args_from_persona args with
@@ -73,6 +168,7 @@ let handle_resident_keeper_create_from_persona ctx args : tool_result =
           (match register_result with
           | Error e -> (false, "❌ " ^ e)
           | Ok () ->
+              invalidate_resident_keeper_list_cache ();
               let created_json =
                 try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
               in
@@ -101,6 +197,7 @@ let handle_resident_keeper_up ctx args : tool_result =
         (match register_resident_keeper_from_meta ctx.config meta with
         | Error e -> (false, "❌ " ^ e)
         | Ok () ->
+            invalidate_resident_keeper_list_cache ();
             let json =
               try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
             in
@@ -170,6 +267,7 @@ let handle_resident_keeper_msg ctx args : tool_result =
       let ok, body = Turn.handle_keeper_msg ctx args in
       if not ok then (ok, body)
       else begin
+        invalidate_resident_keeper_list_cache ();
         (match read_meta ctx.config name with
         | Ok (Some meta) ->
             (match register_resident_keeper_from_meta ctx.config meta with
@@ -204,6 +302,7 @@ let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
       let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx args in
       if not ok then (ok, body)
       else begin
+        invalidate_resident_keeper_list_cache ();
         (match read_meta ctx.config name with
         | Ok (Some meta) ->
             (match register_resident_keeper_from_meta ctx.config meta with
@@ -221,6 +320,7 @@ let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
 let handle_resident_keeper_down ctx args : tool_result =
   let name = get_string args "name" "" in
   if validate_name name then remove_resident_keeper ctx.config name;
+  invalidate_resident_keeper_list_cache ();
   Turn.handle_keeper_down ctx args
 
 let handle_resident_keeper_model_set ctx args : tool_result =
@@ -232,6 +332,7 @@ let handle_resident_keeper_model_set ctx args : tool_result =
       let ok, body = Turn.handle_keeper_model_set ctx args in
       if not ok then (ok, body)
       else begin
+        invalidate_resident_keeper_list_cache ();
         (match read_meta ctx.config name with
         | Ok (Some meta) -> ignore (register_resident_keeper_from_meta ctx.config meta)
         | _ -> ());
@@ -247,47 +348,38 @@ let handle_resident_keeper_model_set ctx args : tool_result =
 let handle_resident_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
-  let resident =
-    resident_keeper_names ctx.config
-    |> take limit
+  let cache_key = Printf.sprintf "%d:%b" limit detailed in
+  let body =
+    cached_text_by_key _resident_keeper_list_cache ~key:cache_key
+      ~ttl_s:(resident_keeper_list_cache_ttl_s ()) (fun () ->
+        let resident =
+          resident_keeper_names ctx.config
+          |> take limit
+        in
+        let rows =
+          resident
+          |> List.filter_map
+               (keeper_list_row_json ~runtime_class:"resident_keeper" ~desired:true
+                  ~resident_registered:true ctx.config)
+        in
+        let json =
+          if not detailed then
+            `Assoc
+              [
+                ("count", `Int (List.length resident));
+                ("keepers", `List (List.map (fun name -> `String name) resident));
+                ("items", `List rows);
+              ]
+          else
+            `Assoc
+              [
+                ("count", `Int (List.length rows));
+                ("keepers", `List rows);
+              ]
+        in
+        Yojson.Safe.pretty_to_string json)
   in
-  if not detailed then
-    let json =
-      `Assoc
-        [
-          ("count", `Int (List.length resident));
-          ("keepers", `List (List.map (fun name -> `String name) resident));
-        ]
-    in
-    (true, Yojson.Safe.pretty_to_string json)
-  else
-    let rows =
-      resident
-      |> List.filter_map (fun name ->
-             let status_args =
-               `Assoc
-                 [
-                   ("name", `String name);
-                   ("tail_turns", `Int 3);
-                   ("tail_messages", `Int 5);
-                   ("tail_compactions", `Int 10);
-                   ("tail_bytes", `Int 60000);
-                 ]
-             in
-             let ok, body = handle_resident_keeper_status ctx status_args in
-             if not ok then None
-             else
-               try Some (Yojson.Safe.from_string body)
-               with Yojson.Json_error _ -> None)
-    in
-    let json =
-      `Assoc
-        [
-          ("count", `Int (List.length rows));
-          ("keepers", `List rows);
-        ]
-    in
-    (true, Yojson.Safe.pretty_to_string json)
+  (true, body)
 
 let handle_persistent_agent_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -82,6 +82,45 @@ let keeper_brief_meta_json (meta : keeper_meta) =
       ("updated_at", `String meta.updated_at);
     ]
 
+let keeper_list_skill_route_json config (meta : keeper_meta) =
+  let metrics_store = keeper_metrics_store config meta.name in
+  let metrics_path = keeper_metrics_path config meta.name in
+  let lines =
+    let dated = Dated_jsonl.read_recent_lines metrics_store 50 in
+    if dated <> [] then dated
+    else Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:16_000 ~max_lines:50
+  in
+  let open Yojson.Safe.Util in
+  let rec find_latest = function
+    | [] -> `Null
+    | line :: tl -> (
+        try
+          let json = Yojson.Safe.from_string line in
+          match Safe_ops.json_string_opt "skill_primary" json with
+          | Some primary when String.trim primary <> "" ->
+              let secondary =
+                match json |> member "skill_secondary" with
+                | `List xs ->
+                    xs
+                    |> List.filter_map (function
+                         | `String s when String.trim s <> "" -> Some (`String s)
+                         | _ -> None)
+                | _ -> []
+              in
+              `Assoc
+                [
+                  ("primary", `String primary);
+                  ("secondary", `List secondary);
+                  ( "reason",
+                    match Safe_ops.json_string_opt "skill_reason" json with
+                    | Some value -> `String value
+                    | None -> `Null );
+                ]
+          | _ -> find_latest tl
+        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> find_latest tl)
+  in
+  find_latest (List.rev lines)
+
 let keeper_list_row_json ~runtime_class ~desired ~resident_registered config
     name =
   match read_meta config name with
@@ -125,6 +164,7 @@ let keeper_list_row_json ~runtime_class ~desired ~resident_registered config
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
             ("policy_mode", `String meta.policy_mode);
             ("trigger_mode", `String meta.trigger_mode);
+            ("skill_route", keeper_list_skill_route_json config meta);
             ("models", `List (List.map (fun model -> `String model) meta.models));
             ("created_at", `String meta.created_at);
             ("updated_at", `String meta.updated_at);

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -159,11 +159,14 @@ let keeper_list_row_json ~runtime_class ~desired ~resident_registered config
             ("keepalive_running", `Bool keepalive_running);
             ("presence_keepalive", `Bool meta.presence_keepalive);
             ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);
+            ("scope_kind", `String meta.scope_kind);
+            ("room_scope", `String meta.room_scope);
             ("proactive_enabled", `Bool meta.proactive.enabled);
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
-            ("policy_mode", `String meta.policy_mode);
-            ("trigger_mode", `String meta.trigger_mode);
+            ("initiative_enabled", `Bool meta.initiative_enabled);
+            ("initiative_idle_sec", `Int meta.initiative_idle_sec);
+            ("initiative_cooldown_sec", `Int meta.initiative_cooldown_sec);
             ("skill_route", keeper_list_skill_route_json config meta);
             ("models", `List (List.map (fun model -> `String model) meta.models));
             ("created_at", `String meta.created_at);

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -16,6 +16,53 @@ type context = {
 
 open Tool_args
 
+let take_items limit items =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: xs -> loop (remaining - 1) (x :: acc) xs
+  in
+  loop limit [] items
+
+type text_cache = {
+  mutable key : string option;
+  mutable value : string option;
+  mutable expires_at : float;
+}
+
+let make_text_cache () = { key = None; value = None; expires_at = 0.0 }
+
+let _status_cache = make_text_cache ()
+
+let cache_ttl_seconds env_var ~default =
+  match Sys.getenv_opt env_var with
+  | Some raw -> (
+      match Float.of_string_opt (String.trim raw) with
+      | Some value when value >= 0.0 -> value
+      | _ -> default)
+  | None -> default
+
+let status_cache_ttl_s () =
+  cache_ttl_seconds "MASC_STATUS_CACHE_TTL_S" ~default:2.0
+
+let invalidate_status_cache () =
+  _status_cache.key <- None;
+  _status_cache.value <- None;
+  _status_cache.expires_at <- 0.0
+
+let cached_text_by_key cache ~key ~ttl_s compute =
+  let now = Time_compat.now () in
+  match cache.key, cache.value with
+  | Some cached_key, Some value
+    when String.equal cached_key key && now < cache.expires_at ->
+      value
+  | _ ->
+      let value = compute () in
+      cache.key <- Some key;
+      cache.value <- Some value;
+      cache.expires_at <- now +. ttl_s;
+      value
+
 let normalize_search_strategy value =
   match String.trim value with
   | "" -> Ok None
@@ -42,22 +89,120 @@ let room_strategy_json config =
 
 (* Handlers *)
 
+let status_summary_string (ctx : context) =
+  Room.ensure_initialized ctx.config;
+  let state = Room.read_state ctx.config in
+  let current_room =
+    Room.read_current_room ctx.config |> Option.value ~default:"default"
+  in
+  let backlog = Room.read_backlog_in_room ctx.config current_room in
+  let max_agents_display = 40 in
+  let max_active_tasks_display = 30 in
+  let cluster_name =
+    match ctx.config.backend_config.Backend.cluster_name with
+    | "" -> state.project
+    | name -> name
+  in
+  let active_agents =
+    state.active_agents |> List.sort String.compare
+  in
+  let active_tasks, done_count, cancelled_count =
+    List.fold_left
+      (fun (active, done_cnt, cancelled_cnt) (task : Types.task) ->
+        match task.task_status with
+        | Types.Done _ -> (active, done_cnt + 1, cancelled_cnt)
+        | Types.Cancelled _ -> (active, done_cnt, cancelled_cnt + 1)
+        | _ -> (task :: active, done_cnt, cancelled_cnt))
+      ([], 0, 0)
+      backlog.tasks
+  in
+  let active_tasks = List.rev active_tasks in
+  let shown_agents = take_items max_agents_display active_agents in
+  let shown_active_tasks = take_items max_active_tasks_display active_tasks in
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf (Printf.sprintf "🏢 Cluster: %s\n" cluster_name);
+  if cluster_name <> state.project then
+    Buffer.add_string buf (Printf.sprintf "📦 Project: %s\n" state.project);
+  Buffer.add_string buf (Printf.sprintf "📍 Room: %s\n" current_room);
+  Buffer.add_string buf (Printf.sprintf "📁 Path: %s\n" ctx.config.base_path);
+  Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
+  Buffer.add_string buf "📌 Players:\n";
+  (match shown_agents with
+  | [] ->
+      Buffer.add_string buf "  (no active agents)\n"
+  | _ ->
+      List.iter
+        (fun agent_name ->
+          Buffer.add_string buf (Printf.sprintf "  🟢 %s\n" agent_name))
+        shown_agents;
+      if List.length active_agents > max_agents_display then
+        Buffer.add_string buf
+          (Printf.sprintf
+             "  … and %d more agents (use masc_who for full list)\n"
+             (List.length active_agents - max_agents_display)));
+  Buffer.add_string buf "\n📋 Quest Board:\n";
+  List.iter
+    (fun (task : Types.task) ->
+      let status_icon =
+        match task.task_status with
+        | Types.Done _ -> "✅"
+        | Types.Claimed _ | Types.InProgress _ -> "🔄"
+        | Types.Todo -> "📋"
+        | Types.Cancelled _ -> "🚫"
+      in
+      let assignee =
+        match task.task_status with
+        | Types.Claimed { assignee; _ }
+        | Types.InProgress { assignee; _ }
+        | Types.Done { assignee; _ } -> assignee
+        | Types.Cancelled { cancelled_by; _ } -> cancelled_by
+        | Types.Todo -> "unclaimed"
+      in
+      Buffer.add_string buf
+        (Printf.sprintf "  %s %s: %s (%s)\n" status_icon task.id task.title
+           assignee))
+    shown_active_tasks;
+  if active_tasks = [] then
+    Buffer.add_string buf "  (no active tasks)\n";
+  if List.length active_tasks > max_active_tasks_display then
+    Buffer.add_string buf
+      (Printf.sprintf
+         "  … and %d more active tasks (use masc_tasks for full list)\n"
+         (List.length active_tasks - max_active_tasks_display));
+  Buffer.add_string buf
+    (Printf.sprintf "  Summary: active=%d, done=%d, cancelled=%d, total=%d\n"
+       (List.length active_tasks) done_count cancelled_count
+       (List.length backlog.tasks));
+  let total_messages = max 0 state.message_seq in
+  if total_messages > 0 then begin
+    Buffer.add_string buf
+      (Printf.sprintf "\n💬 Messages: %d (cumulative)\n" total_messages);
+    Buffer.add_string buf "   Use masc_messages for recent details\n"
+  end else
+    Buffer.add_string buf "\n💬 Messages: 0\n";
+  Buffer.contents buf
+
 let handle_status ctx _args =
-  (true, Room.status ctx.config)
+  (true, cached_text_by_key _status_cache ~key:ctx.config.base_path
+       ~ttl_s:(status_cache_ttl_s ()) (fun () ->
+       status_summary_string ctx))
 
 let handle_init ctx args =
   let agent = match get_string args "agent_name" "" with
     | "" -> None
     | s -> Some s
   in
+  invalidate_status_cache ();
   (true, Room.init ctx.config ~agent_name:agent)
 
 let handle_reset ctx args =
   let confirm = get_bool args "confirm" false in
   if not confirm then
     (false, "⚠️ This will DELETE the entire .masc/ folder!\nCall with confirm=true to proceed.")
-  else
+  else begin
+    invalidate_status_cache ();
     (true, Room.reset ctx.config)
+  end
 
 let handle_room_strategy_get ctx _args =
   (true, Yojson.Safe.pretty_to_string (room_strategy_json ctx.config))
@@ -95,6 +240,7 @@ let handle_room_strategy_set ctx args =
                 | _ -> state.speculation_budget);
             })
       in
+      invalidate_status_cache ();
       ( true,
         Yojson.Safe.pretty_to_string
           (`Assoc

--- a/scripts/harness/workload/mcp_readpath_revalidation.sh
+++ b/scripts/harness/workload/mcp_readpath_revalidation.sh
@@ -1,0 +1,540 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+source "$REPO_ROOT/scripts/harness/jsonrpc_sse.sh"
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+
+RUN_ID="${RUN_ID:-mcp-readpath-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/mcp_readpath_revalidation/$RUN_ID}"
+SUMMARY_JSON="$RUN_DIR/summary.json"
+MODES="${MODES:-http_only,default}"
+BASE_PATH="${BASE_PATH:-$REPO_ROOT}"
+START_SERVER="${START_SERVER:-1}"
+TARGET_BASE_URL="${TARGET_BASE_URL:-}"
+TARGET_MCP_URL="${TARGET_MCP_URL:-}"
+SERVER_EXE_INPUT="${SERVER_EXE:-}"
+SERVER_WAIT_SEC="${SERVER_WAIT_SEC:-45}"
+CACHE_READY_TIMEOUT_SEC="${CACHE_READY_TIMEOUT_SEC:-45}"
+TOOL_TIMEOUT_SEC="${TOOL_TIMEOUT_SEC:-35}"
+EXPECT_KEEPERS="${EXPECT_KEEPERS:-1}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+
+MASC_STATUS_FIRST_MAX_SEC="${MASC_STATUS_FIRST_MAX_SEC:-5}"
+MASC_STATUS_SECOND_MAX_SEC="${MASC_STATUS_SECOND_MAX_SEC:-1.5}"
+MASC_KEEPER_LIST_FIRST_MAX_SEC="${MASC_KEEPER_LIST_FIRST_MAX_SEC:-5}"
+MASC_KEEPER_LIST_SECOND_MAX_SEC="${MASC_KEEPER_LIST_SECOND_MAX_SEC:-1.5}"
+MASC_TRANSPORT_STATUS_MAX_SEC="${MASC_TRANSPORT_STATUS_MAX_SEC:-2}"
+DASHBOARD_EXECUTION_MAX_SEC="${DASHBOARD_EXECUTION_MAX_SEC:-2}"
+TRANSPORT_HEALTH_MAX_SEC="${TRANSPORT_HEALTH_MAX_SEC:-2}"
+
+SERVER_EXE="$(harness_find_server_exe "$REPO_ROOT" "$SERVER_EXE_INPUT")"
+mkdir -p "$RUN_DIR"
+
+LAST_RESPONSE=""
+LAST_TEXT=""
+LAST_TIME_TOTAL=""
+LAST_ERROR=""
+
+log() {
+  printf '[mcp-readpath-revalidation] %s\n' "$*" >&2
+}
+
+normalize_bool() {
+  case "$(printf '%s' "${1:-0}" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) printf '1' ;;
+    *) printf '0' ;;
+  esac
+}
+
+float_le() {
+  awk -v a="$1" -v b="$2" 'BEGIN { exit !((a + 0.0) <= (b + 0.0)) }'
+}
+
+pick_port() {
+  local port
+  port="$(harness_pick_free_port 2>/dev/null || true)"
+  if [[ -n "$port" ]]; then
+    printf '%s\n' "$port"
+    return 0
+  fi
+
+  local base="${PORT_FALLBACK_BASE:-18000}"
+  local span="${PORT_FALLBACK_SPAN:-2000}"
+  local attempt candidate
+  for attempt in $(seq 0 49); do
+    candidate="$((base + (( $$ + attempt * 37 ) % span) ))"
+    if ! lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "failed to allocate port" >&2
+  return 1
+}
+
+json_from_response_text() {
+  printf '%s' "$1" | jq -c '.'
+}
+
+append_result() {
+  local mode="$1"
+  local result_json="$2"
+  local mode_file="$RUN_DIR/${mode}.json"
+  printf '%s\n' "$result_json" >"$mode_file"
+}
+
+start_mode_server() {
+  local mode="$1"
+  local port="$2"
+  local grpc_port="$3"
+  local ws_port="$4"
+  local log_file="$5"
+
+  local grpc_enabled="0"
+  local ws_enabled="1"
+  local webrtc_enabled="1"
+  case "$mode" in
+    http_only)
+      ws_enabled="0"
+      webrtc_enabled="0"
+      ;;
+    default)
+      ;;
+    *)
+      echo "unknown mode: $mode" >&2
+      return 1
+      ;;
+  esac
+
+  (
+    export MASC_DASHBOARD_BRIEFING_MODELS="disabled"
+    export MASC_GRPC_ENABLED="$grpc_enabled"
+    export MASC_GRPC_PORT="$grpc_port"
+    export MASC_WS_ENABLED="$ws_enabled"
+    export MASC_WS_PORT="$ws_port"
+    export MASC_WEBRTC_ENABLED="$webrtc_enabled"
+    exec "$SERVER_EXE" --host=127.0.0.1 --port "$port" --base-path "$BASE_PATH"
+  ) >"$log_file" 2>&1 &
+  printf '%s\n' "$!"
+}
+
+wait_for_cache_ready() {
+  local url="$1"
+  local timeout_sec="$2"
+  local deadline=$(( $(date +%s) + timeout_sec ))
+  local body cache_state
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    if body="$(curl -fsS --max-time 3 "$url" 2>/dev/null)"; then
+      cache_state="$(printf '%s' "$body" | jq -r '.projection_diagnostics.cache_state // ""' 2>/dev/null || true)"
+      if [[ -z "$cache_state" || "$cache_state" != "initializing" ]]; then
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+init_session() {
+  local mcp_url="$1"
+  local headers_file body_file session_id protocol_version
+  headers_file="$(harness_mktemp_file mcp-init .headers)"
+  body_file="$(harness_mktemp_file mcp-init .body)"
+  if ! curl -sS --max-time "$TOOL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" \
+    -X POST "$mcp_url" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"mcp-readpath-revalidation","version":"1.0"},"capabilities":{}}}' >/dev/null; then
+    rm -f "$headers_file" "$body_file"
+    return 1
+  fi
+  session_id="$(awk '
+    tolower($0) ~ /^mcp-session-id:/ {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      sub(/\r$/, "", $0)
+      print $0
+      exit
+    }' "$headers_file")"
+  protocol_version="$(awk '
+    tolower($0) ~ /^mcp-protocol-version:/ {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      sub(/\r$/, "", $0)
+      print $0
+      exit
+    }' "$headers_file")"
+  rm -f "$headers_file" "$body_file"
+  if [[ -z "$session_id" ]]; then
+    return 1
+  fi
+  printf '%s\t%s\n' "$session_id" "$protocol_version"
+}
+
+call_tool() {
+  local mcp_url="$1"
+  local session_id="$2"
+  local protocol_version="$3"
+  local request_id="$4"
+  local tool_name="$5"
+  local args_json="$6"
+  local headers_file body_file raw response
+  local -a curl_headers
+
+  headers_file="$(harness_mktemp_file mcp-call .headers)"
+  body_file="$(harness_mktemp_file mcp-call .body)"
+  curl_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+    -H "Mcp-Session-Id: $session_id"
+  )
+  if [[ -n "$protocol_version" ]]; then
+    curl_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+
+  LAST_TIME_TOTAL="$(
+    curl -sS --max-time "$TOOL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" \
+      -w '%{time_total}' \
+      -X POST "$mcp_url" \
+      "${curl_headers[@]}" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":${request_id},\"method\":\"tools/call\",\"params\":{\"name\":\"${tool_name}\",\"arguments\":${args_json}}}"
+  )"
+  raw="$(cat "$body_file")"
+  response="$(jsonrpc_normalize_response "$raw" "$request_id")"
+  LAST_RESPONSE="$response"
+  LAST_TEXT="$(printf '%s' "$response" | jq -r '[.result.content[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null || true)"
+  LAST_ERROR="$(printf '%s' "$response" | jq -r '
+    if .error?.message then .error.message
+    elif (.result?.isError // false) == true then
+      ([.result.content[]? | select(.type == "text") | .text] | join(" "))
+    else "" end
+  ' 2>/dev/null || true)"
+  rm -f "$headers_file" "$body_file"
+  [[ -z "$LAST_ERROR" ]]
+}
+
+call_json_endpoint() {
+  local url="$1"
+  local body_file
+  body_file="$(harness_mktemp_file endpoint .json)"
+  LAST_TIME_TOTAL="$(
+    curl -sS --max-time "$TOOL_TIMEOUT_SEC" -o "$body_file" -w '%{time_total}' "$url"
+  )"
+  LAST_RESPONSE="$(cat "$body_file")"
+  LAST_TEXT="$LAST_RESPONSE"
+  LAST_ERROR=""
+  rm -f "$body_file"
+}
+
+check_tool_time() {
+  local name="$1"
+  local actual="$2"
+  local max="$3"
+  if ! float_le "$actual" "$max"; then
+    echo "$name exceeded threshold: ${actual}s > ${max}s" >&2
+    return 1
+  fi
+}
+
+run_mode() {
+  local mode="$1"
+  local port grpc_port ws_port server_log server_pid
+  local base_url mcp_url health_json health_file
+  local session_line session_id protocol_version
+  local status_first_time status_second_time keeper_first_time keeper_second_time transport_time
+  local execution_time transport_health_time
+  local status_first_ok status_second_ok keeper_first_ok keeper_second_ok transport_ok
+  local execution_cache_state transport_cache_state
+  local keeper_json transport_json execution_json
+  local payload_contract_ok quiet_reason_contract_ok pending_lazy_ok health_mode_ok keeper_fiber_ok
+  local result_pass="true"
+
+  if [[ "$(normalize_bool "$START_SERVER")" = "1" ]]; then
+    port="$(pick_port)"
+    grpc_port="$(pick_port)"
+    ws_port="$(pick_port)"
+    server_log="$RUN_DIR/${mode}.server.log"
+    base_url="http://127.0.0.1:${port}"
+    mcp_url="${base_url}/mcp"
+
+    log "mode=${mode} starting server on port=${port}"
+    server_pid="$(start_mode_server "$mode" "$port" "$grpc_port" "$ws_port" "$server_log")"
+
+    if ! harness_wait_for_health "$port" "$SERVER_WAIT_SEC"; then
+      log "mode=${mode} health wait failed"
+      harness_print_log_tail "$server_log" 120
+      harness_stop_server "$server_pid"
+      return 1
+    fi
+  else
+    if [[ -z "$TARGET_BASE_URL" ]]; then
+      echo "TARGET_BASE_URL is required when START_SERVER=0" >&2
+      return 1
+    fi
+    base_url="$TARGET_BASE_URL"
+    mcp_url="${TARGET_MCP_URL:-${base_url%/}/mcp}"
+    server_log=""
+    port="${base_url##*:}"
+    if ! curl -fsS --max-time 3 "${base_url%/}/health" >/dev/null 2>&1; then
+      echo "external server not healthy at ${base_url%/}/health" >&2
+      return 1
+    fi
+  fi
+
+  if ! wait_for_cache_ready "${base_url}/api/v1/dashboard/transport-health" "$CACHE_READY_TIMEOUT_SEC"; then
+    log "mode=${mode} transport-health cache did not warm"
+    result_pass="false"
+  fi
+  if ! wait_for_cache_ready "${base_url}/api/v1/dashboard/execution" "$CACHE_READY_TIMEOUT_SEC"; then
+    log "mode=${mode} execution cache did not warm"
+    result_pass="false"
+  fi
+
+  health_file="$(harness_mktemp_file health .json)"
+  curl -sS --max-time 5 "${base_url}/health" >"$health_file"
+  health_json="$(cat "$health_file")"
+  rm -f "$health_file"
+
+  session_line="$(init_session "$mcp_url")"
+  session_id="${session_line%%$'\t'*}"
+  protocol_version="${session_line#*$'\t'}"
+  if [[ "$protocol_version" = "$session_line" ]]; then
+    protocol_version=""
+  fi
+
+  if call_tool "$mcp_url" "$session_id" "$protocol_version" 11 "masc_status" '{}'; then
+    status_first_ok="0"
+  else
+    status_first_ok="1"
+  fi
+  status_first_time="$LAST_TIME_TOTAL"
+
+  if call_tool "$mcp_url" "$session_id" "$protocol_version" 12 "masc_status" '{}'; then
+    status_second_ok="0"
+  else
+    status_second_ok="1"
+  fi
+  status_second_time="$LAST_TIME_TOTAL"
+
+  if call_tool "$mcp_url" "$session_id" "$protocol_version" 13 "masc_keeper_list" '{"detailed":false}'; then
+    keeper_first_ok="0"
+  else
+    keeper_first_ok="1"
+  fi
+  keeper_first_time="$LAST_TIME_TOTAL"
+  keeper_json="$(json_from_response_text "$LAST_TEXT")"
+
+  if call_tool "$mcp_url" "$session_id" "$protocol_version" 14 "masc_keeper_list" '{"detailed":false}'; then
+    keeper_second_ok="0"
+  else
+    keeper_second_ok="1"
+  fi
+  keeper_second_time="$LAST_TIME_TOTAL"
+
+  if call_tool "$mcp_url" "$session_id" "$protocol_version" 15 "masc_transport_status" '{}'; then
+    transport_ok="0"
+  else
+    transport_ok="1"
+  fi
+  transport_time="$LAST_TIME_TOTAL"
+  transport_json="$(json_from_response_text "$LAST_TEXT")"
+
+  call_json_endpoint "${base_url}/api/v1/dashboard/execution"
+  execution_time="$LAST_TIME_TOTAL"
+  execution_json="$LAST_RESPONSE"
+  execution_cache_state="$(printf '%s' "$execution_json" | jq -r '.projection_diagnostics.cache_state // ""')"
+
+  call_json_endpoint "${base_url}/api/v1/dashboard/transport-health"
+  transport_health_time="$LAST_TIME_TOTAL"
+  transport_cache_state="$(printf '%s' "$LAST_RESPONSE" | jq -r '.projection_diagnostics.cache_state // ""')"
+
+  payload_contract_ok="$(printf '%s' "$keeper_json" | jq -r '
+    if ((.items // []) | length) == 0 then
+      "false"
+    else
+      ([.items[] |
+        has("policy_mode")
+        and has("trigger_mode")
+        and has("presence_keepalive")
+        and has("proactive_enabled")
+        and (.diagnostic | type == "object")
+      ] | all | tostring)
+    end
+  ')"
+
+  quiet_reason_contract_ok="$(printf '%s' "$keeper_json" | jq -r '
+    [(.items // [])[] |
+      if (.keepalive_running == false and .presence_keepalive == true and .proactive_enabled == true) then
+        (.diagnostic.quiet_reason != "disabled")
+        and (.diagnostic.continuity_state != "desired_offline")
+      else
+        true
+      end
+    ] | all | tostring
+  ')"
+
+  pending_lazy_ok="$(printf '%s' "$health_json" | jq -r '((.startup.pending_lazy_tasks // []) | length == 0) | tostring')"
+  keeper_fiber_ok="$(printf '%s' "$health_json" | jq -r --arg expect "$EXPECT_KEEPERS" '
+    if $expect == "1" then
+      ((.keeper_fibers // 0) > 0) | tostring
+    else
+      "true"
+    end
+  ')"
+
+  health_mode_ok="$(printf '%s' "$health_json" | jq -r --arg mode "$mode" '
+    if $mode == "http_only" then
+      ((.transport.grpc.enabled == false)
+        and (.transport.websocket.enabled == false)
+        and (.transport.webrtc.enabled == false)) | tostring
+    else
+      ((.transport.grpc.enabled == false)
+        and (.transport.websocket.enabled == true)
+        and (.transport.websocket.listening == true)
+        and (.transport.webrtc.enabled == true)) | tostring
+    end
+  ')"
+
+  if [[ "$status_first_ok" != "0" || "$status_second_ok" != "0" || "$keeper_first_ok" != "0" || "$keeper_second_ok" != "0" || "$transport_ok" != "0" ]]; then
+    result_pass="false"
+  fi
+  check_tool_time "masc_status(first)" "$status_first_time" "$MASC_STATUS_FIRST_MAX_SEC" || result_pass="false"
+  check_tool_time "masc_status(second)" "$status_second_time" "$MASC_STATUS_SECOND_MAX_SEC" || result_pass="false"
+  check_tool_time "masc_keeper_list(first)" "$keeper_first_time" "$MASC_KEEPER_LIST_FIRST_MAX_SEC" || result_pass="false"
+  check_tool_time "masc_keeper_list(second)" "$keeper_second_time" "$MASC_KEEPER_LIST_SECOND_MAX_SEC" || result_pass="false"
+  check_tool_time "masc_transport_status" "$transport_time" "$MASC_TRANSPORT_STATUS_MAX_SEC" || result_pass="false"
+  check_tool_time "dashboard/execution" "$execution_time" "$DASHBOARD_EXECUTION_MAX_SEC" || result_pass="false"
+  check_tool_time "dashboard/transport-health" "$transport_health_time" "$TRANSPORT_HEALTH_MAX_SEC" || result_pass="false"
+
+  [[ "$payload_contract_ok" = "true" ]] || result_pass="false"
+  [[ "$quiet_reason_contract_ok" = "true" ]] || result_pass="false"
+  [[ "$pending_lazy_ok" = "true" ]] || result_pass="false"
+  [[ "$keeper_fiber_ok" = "true" ]] || result_pass="false"
+  [[ "$health_mode_ok" = "true" ]] || result_pass="false"
+  [[ "$execution_cache_state" = "fresh" ]] || result_pass="false"
+  [[ "$transport_cache_state" = "fresh" ]] || result_pass="false"
+
+  append_result "$mode" "$(
+    jq -nc \
+      --arg mode "$mode" \
+      --arg base_url "$base_url" \
+      --arg server_log "$server_log" \
+      --arg pass "$result_pass" \
+      --arg backend_mode "$(printf '%s' "$health_json" | jq -r '.startup.backend_mode // ""')" \
+      --arg fallback_reason "$(printf '%s' "$health_json" | jq -r '.startup.fallback_reason // ""')" \
+      --argjson health "$health_json" \
+      --argjson keeper_list "$keeper_json" \
+      --argjson transport_status "$transport_json" \
+      --argjson execution "$(printf '%s' "$execution_json" | jq -c '{projection_diagnostics, generated_at}')" \
+      --arg status_first_time "$status_first_time" \
+      --arg status_second_time "$status_second_time" \
+      --arg keeper_first_time "$keeper_first_time" \
+      --arg keeper_second_time "$keeper_second_time" \
+      --arg transport_time "$transport_time" \
+      --arg execution_time "$execution_time" \
+      --arg transport_health_time "$transport_health_time" \
+      --arg payload_contract_ok "$payload_contract_ok" \
+      --arg quiet_reason_contract_ok "$quiet_reason_contract_ok" \
+      --arg pending_lazy_ok "$pending_lazy_ok" \
+      --arg keeper_fiber_ok "$keeper_fiber_ok" \
+      --arg health_mode_ok "$health_mode_ok" \
+      --arg execution_cache_state "$execution_cache_state" \
+      --arg transport_cache_state "$transport_cache_state" \
+      '{
+        mode: $mode,
+        pass: ($pass == "true"),
+        base_url: $base_url,
+        server_log: $server_log,
+        backend_mode: $backend_mode,
+        fallback_reason: (if ($fallback_reason | length) > 0 then $fallback_reason else null end),
+        thresholds: {
+          masc_status_first_max_sec: ($ENV.MASC_STATUS_FIRST_MAX_SEC // "5" | tonumber),
+          masc_status_second_max_sec: ($ENV.MASC_STATUS_SECOND_MAX_SEC // "1.5" | tonumber),
+          masc_keeper_list_first_max_sec: ($ENV.MASC_KEEPER_LIST_FIRST_MAX_SEC // "5" | tonumber),
+          masc_keeper_list_second_max_sec: ($ENV.MASC_KEEPER_LIST_SECOND_MAX_SEC // "1.5" | tonumber),
+          masc_transport_status_max_sec: ($ENV.MASC_TRANSPORT_STATUS_MAX_SEC // "2" | tonumber),
+          dashboard_execution_max_sec: ($ENV.DASHBOARD_EXECUTION_MAX_SEC // "2" | tonumber),
+          transport_health_max_sec: ($ENV.TRANSPORT_HEALTH_MAX_SEC // "2" | tonumber)
+        },
+        timings: {
+          masc_status_first: ($status_first_time | tonumber),
+          masc_status_second: ($status_second_time | tonumber),
+          masc_keeper_list_first: ($keeper_first_time | tonumber),
+          masc_keeper_list_second: ($keeper_second_time | tonumber),
+          masc_transport_status: ($transport_time | tonumber),
+          dashboard_execution: ($execution_time | tonumber),
+          dashboard_transport_health: ($transport_health_time | tonumber)
+        },
+        checks: {
+          payload_contract: ($payload_contract_ok == "true"),
+          quiet_reason_contract: ($quiet_reason_contract_ok == "true"),
+          pending_lazy_tasks_empty: ($pending_lazy_ok == "true"),
+          keeper_fibers_present: ($keeper_fiber_ok == "true"),
+          health_transport_mode: ($health_mode_ok == "true"),
+          execution_cache_state: $execution_cache_state,
+          transport_cache_state: $transport_cache_state
+        },
+        keeper_list_sample: (($keeper_list.items // [])[:2]),
+        transport_status: $transport_status,
+        execution: $execution,
+        health: {
+          startup: $health.startup,
+          keeper_fibers: $health.keeper_fibers,
+          transport: $health.transport
+        }
+      }'
+  )"
+
+  if [[ "$(normalize_bool "$START_SERVER")" = "1" && "$(normalize_bool "$KEEP_SERVER")" != "1" ]]; then
+    harness_stop_server "$server_pid"
+  elif [[ "$(normalize_bool "$START_SERVER")" = "1" ]]; then
+    log "mode=${mode} keeping server pid=${server_pid}"
+  fi
+
+  [[ "$result_pass" = "true" ]]
+}
+
+main() {
+  local mode overall_pass="true"
+  local results='[]'
+
+  IFS=',' read -r -a mode_list <<<"$MODES"
+  for mode in "${mode_list[@]}"; do
+    mode="$(printf '%s' "$mode" | xargs)"
+    [[ -n "$mode" ]] || continue
+    if run_mode "$mode"; then
+      log "mode=${mode} PASS"
+    else
+      log "mode=${mode} FAIL"
+      overall_pass="false"
+    fi
+    results="$(jq -cs '.[0] + [.[1]]' <(printf '%s' "$results") "$RUN_DIR/${mode}.json")"
+  done
+
+  jq -n \
+    --arg run_id "$RUN_ID" \
+    --arg run_dir "$RUN_DIR" \
+    --arg base_path "$BASE_PATH" \
+    --arg server_exe "$SERVER_EXE" \
+    --arg modes "$MODES" \
+    --arg overall_pass "$overall_pass" \
+    --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    --argjson results "$results" \
+    '{
+      run_id: $run_id,
+      generated_at: $generated_at,
+      run_dir: $run_dir,
+      base_path: $base_path,
+      server_exe: $server_exe,
+      modes: ($modes | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))),
+      pass: ($overall_pass == "true"),
+      results: $results
+    }' >"$SUMMARY_JSON"
+
+  printf 'summary=%s\n' "$SUMMARY_JSON"
+  [[ "$overall_pass" = "true" ]]
+}
+
+main "$@"

--- a/scripts/harness/workload/mcp_readpath_revalidation.sh
+++ b/scripts/harness/workload/mcp_readpath_revalidation.sh
@@ -355,10 +355,11 @@ run_mode() {
       "false"
     else
       ([.items[] |
-        has("policy_mode")
-        and has("trigger_mode")
+        has("scope_kind")
+        and has("room_scope")
         and has("presence_keepalive")
         and has("proactive_enabled")
+        and has("initiative_enabled")
         and (.diagnostic | type == "object")
       ] | all | tostring)
     end

--- a/scripts/harness_mcp_readpath_revalidation.sh
+++ b/scripts/harness_mcp_readpath_revalidation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/mcp_readpath_revalidation.sh" "$@"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -406,9 +406,9 @@ let test_dashboard_timeout_guard_contracts () =
   check bool "h2 transport health route uses transport metrics" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        "Transport_metrics.transport_health_json");
-  check bool "server dashboard transport health helper uses dashboard cache" true
+  check bool "server dashboard transport health helper uses cached surface" true
     (file_contains_pattern "lib/server/server_dashboard_http.ml"
-       {|Dashboard_cache.get_or_compute "transport_health" ~ttl:10.0|});
+       {|cached_surface_json _transport_health_cache|});
   check bool "mission refresh dedupes inflight fetches" true
     (file_contains_pattern "dashboard/src/mission-actions.ts"
        "let inflightMissionSnapshotRefresh: Promise<void> | null = null");

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -343,7 +343,7 @@ let test_snapshot_keeper_tool_audit_fallback () =
         (keeper |> member "diagnostic" <> `Null);
       Alcotest.(check string) "diagnostic health offline" "offline"
         (keeper |> member "diagnostic" |> member "health_state" |> to_string);
-      Alcotest.(check string) "diagnostic continuity offline" "offline"
+      Alcotest.(check string) "diagnostic continuity disabled" "disabled"
         (keeper |> member "diagnostic" |> member "continuity_state" |> to_string))
 
 let test_keeper_msg_auto_team_session_bridge () =

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -812,6 +812,8 @@ let test_resident_list_items_expose_runtime_config_summary () =
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
               ("models", `List [ `String "custom:test-model" ]);
+              ("room_scope", `String "all");
+              ("scope_kind", `String "global");
               ("presence_keepalive", `Bool true);
               ("proactive_enabled", `Bool true);
               ("trigger_mode", `String "explicit_only");
@@ -830,14 +832,20 @@ let test_resident_list_items_expose_runtime_config_summary () =
       in
       check string "runtime class" "resident_keeper"
         Yojson.Safe.Util.(row |> member "runtime_class" |> to_string);
-      check string "policy mode" "unified"
-        Yojson.Safe.Util.(row |> member "policy_mode" |> to_string);
-      check string "trigger mode" "explicit_only"
-        Yojson.Safe.Util.(row |> member "trigger_mode" |> to_string);
+      check string "scope kind" "global"
+        Yojson.Safe.Util.(row |> member "scope_kind" |> to_string);
+      check string "room scope" "all"
+        Yojson.Safe.Util.(row |> member "room_scope" |> to_string);
       check bool "presence keepalive true" true
         Yojson.Safe.Util.(row |> member "presence_keepalive" |> to_bool);
       check bool "proactive enabled true" true
-        Yojson.Safe.Util.(row |> member "proactive_enabled" |> to_bool))
+        Yojson.Safe.Util.(row |> member "proactive_enabled" |> to_bool);
+      check bool "initiative enabled true" true
+        Yojson.Safe.Util.(row |> member "initiative_enabled" |> to_bool);
+      check bool "policy mode removed" true
+        Yojson.Safe.Util.(row |> member "policy_mode" = `Null);
+      check bool "trigger mode removed" true
+        Yojson.Safe.Util.(row |> member "trigger_mode" = `Null))
 
 let test_keepalive_gap_reports_not_running_instead_of_disabled () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -780,6 +780,124 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
       check bool "persistent registered" false
         Yojson.Safe.Util.(persistent_row |> member "resident_registered" |> to_bool))
 
+let test_resident_list_items_expose_runtime_config_summary () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        {
+          config;
+          agent_name = "tester";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, up_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool true);
+              ("proactive_enabled", `Bool true);
+              ("trigger_mode", `String "explicit_only");
+            ])
+      in
+      if not ok then fail up_body;
+      let ok, body =
+        dispatch "masc_keeper_list" (`Assoc [ ("detailed", `Bool false) ])
+      in
+      check bool "resident list ok" true ok;
+      let json = parse_json_exn body in
+      let row =
+        Yojson.Safe.Util.(
+          json |> member "items" |> to_list
+          |> List.find (fun item -> member "name" item = `String "resident-demo"))
+      in
+      check string "runtime class" "resident_keeper"
+        Yojson.Safe.Util.(row |> member "runtime_class" |> to_string);
+      check string "policy mode" "heuristic"
+        Yojson.Safe.Util.(row |> member "policy_mode" |> to_string);
+      check string "trigger mode" "explicit_only"
+        Yojson.Safe.Util.(row |> member "trigger_mode" |> to_string);
+      check bool "presence keepalive true" true
+        Yojson.Safe.Util.(row |> member "presence_keepalive" |> to_bool);
+      check bool "proactive enabled true" true
+        Yojson.Safe.Util.(row |> member "proactive_enabled" |> to_bool))
+
+let test_keepalive_gap_reports_not_running_instead_of_disabled () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        {
+          config;
+          agent_name = "tester";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, up_body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool true);
+              ("proactive_enabled", `Bool true);
+            ])
+      in
+      if not ok then fail up_body;
+      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
+      let ok, body =
+        dispatch "masc_keeper_status"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("include_history_tail", `Bool false);
+              ("include_compaction_history", `Bool false);
+              ("include_context", `Bool false);
+              ("include_metrics_overview", `Bool false);
+              ("include_memory_bank", `Bool false);
+            ])
+      in
+      check bool "status ok" true ok;
+      let json = parse_json_exn body in
+      check string "quiet reason not_running" "not_running"
+        Yojson.Safe.Util.(
+          json |> member "diagnostic" |> member "quiet_reason" |> to_string);
+      check string "continuity state not_running" "not_running"
+        Yojson.Safe.Util.(
+          json |> member "diagnostic" |> member "continuity_state" |> to_string))
+
 let test_resident_keeper_msg_bootstraps_then_requires_message () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1423,6 +1541,10 @@ let () =
            test_resident_keeper_and_persistent_agent_lists_split;
          test_case "resident and persistent detailed lists annotate runtime class" `Quick
            test_resident_and_persistent_detailed_lists_annotate_runtime_class;
+         test_case "resident list items expose runtime config summary" `Quick
+           test_resident_list_items_expose_runtime_config_summary;
+         test_case "keepalive gap reports not_running instead of disabled" `Quick
+           test_keepalive_gap_reports_not_running_instead_of_disabled;
          test_case "resident keeper msg bootstraps then requires message" `Quick
            test_resident_keeper_msg_bootstraps_then_requires_message;
          test_case "persistent agent msg rejects missing message" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -830,7 +830,7 @@ let test_resident_list_items_expose_runtime_config_summary () =
       in
       check string "runtime class" "resident_keeper"
         Yojson.Safe.Util.(row |> member "runtime_class" |> to_string);
-      check string "policy mode" "heuristic"
+      check string "policy mode" "unified"
         Yojson.Safe.Util.(row |> member "policy_mode" |> to_string);
       check string "trigger mode" "explicit_only"
         Yojson.Safe.Util.(row |> member "trigger_mode" |> to_string);


### PR DESCRIPTION
## Summary
- add short-lived fast-path caching for `masc_status` and `masc_keeper_list` so MCP read tools stay responsive under dashboard background work
- distinguish keeper config-disabled vs runtime-not-running states in continuity diagnostics and expose runtime policy fields in compact keeper surfaces
- cache transport-health independently, bound keeper bootstrap startup work, and add a reusable MCP read-path revalidation harness + runbook

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/mcp-autonomy-fastpath test/test_tool_keeper.exe test/test_tool_room_coverage.exe`
- `./_build/default/test/test_tool_room_coverage.exe`
- `./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 11,12 --compact`
- `START_SERVER=0 MODES=http_only TARGET_BASE_URL=http://127.0.0.1:8946 ./scripts/harness_mcp_readpath_revalidation.sh`
- `START_SERVER=0 MODES=default TARGET_BASE_URL=http://127.0.0.1:8947 ./scripts/harness_mcp_readpath_revalidation.sh`