### PR TITLE
fix(dashboard): translate remaining English labels to Korean (batch 4)

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -354,12 +354,12 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Instructions</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">System prompt blocks</div>
-    <${PromptBlock} title="Constitution" block=${c.prompt.system_prompt_blocks.constitution} />
-    <${PromptBlock} title="World" block=${c.prompt.system_prompt_blocks.world} />
-    <${PromptBlock} title="Capabilities" block=${c.prompt.system_prompt_blocks.capabilities} />
+    <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
+    <${PromptBlock} title="헌법" block=${c.prompt.system_prompt_blocks.constitution} />
+    <${PromptBlock} title="세계관" block=${c.prompt.system_prompt_blocks.world} />
+    <${PromptBlock} title="능력" block=${c.prompt.system_prompt_blocks.capabilities} />
     <details class="mt-3">
-      <summary class="cursor-pointer py-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors">View compiled system prompt</summary>
+      <summary class="cursor-pointer py-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] list-none select-none rounded-lg hover:bg-[var(--white-3)] transition-colors">컴파일된 시스템 프롬프트 보기</summary>
       <${LongText} text=${c.prompt.effective_system_prompt} truncateAt=${null} />
     </details>
   `
@@ -521,16 +521,16 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-xs text-[var(--text-muted)]">레지던트 스펙 존재</span>
         <${BoolBadge} value=${c.sources.resident_spec_exists} />
       </div>
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Live meta path</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">라이브 메타 경로</div>
       <${LongText} text=${c.sources.live_meta_path} />
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Resident spec path</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">레지던트 스펙 경로</div>
       <${LongText} text=${c.sources.resident_spec_path} />
       ${c.sources.default_manifest_path ? html`
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Default manifest path</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">기본 매니페스트 경로</div>
         <${LongText} text=${c.sources.default_manifest_path} />
       ` : null}
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Precedence</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">우선순위</div>
         <${ModelList} models=${c.sources.precedence} />
       </div>
       <div class="mt-1.5">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -210,18 +210,18 @@ export function KeeperDetailOverlay() {
         ${'' /* ── Detail sections grid ── */}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 
-          <${SectionCard} title="Profile">
-            <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
-            <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
+          <${SectionCard} title="프로필">
+            <${TraitsList} traits=${keeper.traits ?? []} label="특성" />
+            <${TraitsList} traits=${keeper.interests ?? []} label="관심사" />
             ${keeper.primaryValue
               ? html`<div class="flex items-center gap-2 mt-3 text-xs text-[var(--text-muted)]">
-                  <span class="text-[var(--text-muted)]">Core value:</span>
+                  <span class="text-[var(--text-muted)]">핵심 가치:</span>
                   <span class="font-medium text-[var(--ok)]">${keeper.primaryValue}</span>
                 </div>`
               : null}
             ${keeper.skill_primary
               ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
-                  <span>Skill path:</span>
+                  <span>스킬 경로:</span>
                   <span class="font-medium text-[var(--cyan)]">${keeper.skill_primary}</span>
                 </div>`
               : null}
@@ -230,7 +230,7 @@ export function KeeperDetailOverlay() {
               : null}
             ${keeper.last_heartbeat
               ? html`<div class="flex items-center gap-2 mt-2 text-xs text-[var(--text-muted)]">
-                  <span>Last heartbeat:</span>
+                  <span>마지막 하트비트:</span>
                   <${TimeAgo} timestamp=${keeper.last_heartbeat} />
                 </div>`
               : null}
@@ -253,7 +253,7 @@ export function KeeperDetailOverlay() {
 
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`
-              <${SectionCard} title="Equipment (${keeper.inventory.length})">
+              <${SectionCard} title="장비 (${keeper.inventory.length})">
                 <${EquipmentList} items=${keeper.inventory} />
               <//>
             `
@@ -261,21 +261,21 @@ export function KeeperDetailOverlay() {
 
           ${keeper.relationships && Object.keys(keeper.relationships).length > 0
             ? html`
-              <${SectionCard} title="Relationships (${Object.keys(keeper.relationships).length})">
+              <${SectionCard} title="관계 (${Object.keys(keeper.relationships).length})">
                 <${RelationshipList} rels=${keeper.relationships} />
               <//>
             `
             : null}
 
-          <${SectionCard} title="Quality Signals">
+          <${SectionCard} title="품질 시그널">
             <${RuntimeSignals} keeper=${keeper} />
           <//>
 
-          <${SectionCard} title="Neighborhood & Tool Audit">
+          <${SectionCard} title="인근 환경 & 도구 감사">
             <${KeeperNeighborhood} keeper=${keeper} />
           <//>
 
-          <${SectionCard} title="Config">
+          <${SectionCard} title="설정">
             <${KeeperConfigPanel} keeperName=${keeper.name} />
           <//>
         </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -28,12 +28,12 @@ export function FocusSidebar() {
   return html`
     <div class="grid gap-3 grid-rows-[auto_1fr] min-h-0">
       <div class="focus-sidebar-head">
-        <h3 class="m-0 text-[0.95rem] font-semibold">Agents</h3>
-        <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length} active</span>
+        <h3 class="m-0 text-[0.95rem] font-semibold">에이전트</h3>
+        <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length}명 활성</span>
       </div>
       <div class="grid gap-1.5 content-start overflow-y-auto max-h-[560px] pr-1">
         ${list.length === 0
-          ? html`<div class="py-6 text-center text-[var(--white-25)] text-[13px]">No active agents</div>`
+          ? html`<div class="py-6 text-center text-[var(--white-25)] text-[13px]">활성 에이전트 없음</div>`
           : list.map(agent => html`
             <div
               key=${agent.name}
@@ -56,7 +56,7 @@ export function FocusSidebar() {
               <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText
                   ? html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
-                  : html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic text-[rgba(255,255,255,0.25)]">No recent activity</span>`}
+                  : html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic text-[rgba(255,255,255,0.25)]">최근 활동 없음</span>`}
                 ${agent.lastActivityAt
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -75,7 +75,7 @@ describe('PromptRegistryPanel', () => {
     await flush()
 
     expect(mocks.fetchDashboardPrompts).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Prompt Registry')
+    expect(container.textContent).toContain('프롬프트 레지스트리')
     expect(container.textContent).toContain('keeper.world')
     expect(container.textContent).toContain('/tmp/config/prompts/keeper.world.md')
     expect(container.textContent).toContain('file world')

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -109,7 +109,7 @@ export function PromptRegistryPanel() {
   }
 
   return html`
-    <${Card} title="Prompt Registry" class="section mb-4">
+    <${Card} title="프롬프트 레지스트리" class="section mb-4">
       <div class="mb-4 text-[12px] text-[var(--text-muted)] leading-relaxed">
         <div>기준 원문은 <code>config/prompts/*.md</code>입니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -399,31 +399,31 @@ export function TransportHealthPanel() {
         <//>
 
         <${SectionCard} title="WebSocket" status=${wsStatus} eyebrow=${transportEyebrow(data.websocket.configured, data.websocket.listening, data.websocket.port)}>
-          <${MetricRow} label="Listener" value=${data.websocket.listening ? 'live' : 'down'} />
-          <${MetricRow} label="Sessions" value=${data.websocket.sessions} />
-          <${MetricRow} label="Mode" value=${data.websocket.mode} />
-          <${MetricRow} label="Relay Source" value=${data.websocket.relay_source} />
+          <${MetricRow} label="리스너" value=${data.websocket.listening ? 'live' : 'down'} />
+          <${MetricRow} label="세션" value=${data.websocket.sessions} />
+          <${MetricRow} label="모드" value=${data.websocket.mode} />
+          <${MetricRow} label="릴레이 소스" value=${data.websocket.relay_source} />
         <//>
 
         <${SectionCard} title="WebRTC" status=${webrtcStatus} eyebrow=${data.webrtc.enabled ? `${data.webrtc.ice_server_count} ICE` : 'disabled'}>
-          <${MetricRow} label="Connected Channels" value=${data.webrtc.connected_channels} />
-          <${MetricRow} label="Active Peers" value=${data.webrtc.active_peers} />
-          <${MetricRow} label="Pending Offers" value=${data.webrtc.pending_offers} />
-          <${MetricRow} label="Live Connections" value=${data.webrtc.live_connections} />
+          <${MetricRow} label="연결된 채널" value=${data.webrtc.connected_channels} />
+          <${MetricRow} label="활성 피어" value=${data.webrtc.active_peers} />
+          <${MetricRow} label="대기 오퍼" value=${data.webrtc.pending_offers} />
+          <${MetricRow} label="라이브 연결" value=${data.webrtc.live_connections} />
         <//>
 
         <${SectionCard} title="HTTP" status=${h2Status} eyebrow=${data.http2.listener_mode}>
           <${MetricRow} label="POST" value=${data.streamable_http.endpoint} />
-          <${MetricRow} label="Observer Stream" value=${data.streamable_http.observer_stream} />
-          <${MetricRow} label="Operator Surface" value=${data.streamable_http.operator_endpoint} />
-          <${MetricRow} label="Legacy" value=${data.streamable_http.legacy_sse_endpoint} sub=${'deprecated'} />
+          <${MetricRow} label="옵저버 스트림" value=${data.streamable_http.observer_stream} />
+          <${MetricRow} label="오퍼레이터 표면" value=${data.streamable_http.operator_endpoint} />
+          <${MetricRow} label="레거시" value=${data.streamable_http.legacy_sse_endpoint} sub=${'deprecated'} />
         <//>
 
-        <${SectionCard} title="Agent Pool" status=${clusterStatus} eyebrow=${`${data.cluster.live_agents} live`}>
-          <${MetricRow} label="Managed Units" value=${data.cluster.managed_units} sub=${`${data.cluster.total_units} total`} />
-          <${MetricRow} label="Active Ops" value=${data.cluster.active_operations} />
-          <${MetricRow} label="Stale Units" value=${data.cluster.stale_units} />
-          <${MetricRow} label="Stale Agents" value=${data.agent_health.stale_total} />
+        <${SectionCard} title="에이전트 풀" status=${clusterStatus} eyebrow=${`${data.cluster.live_agents} live`}>
+          <${MetricRow} label="관리 유닛" value=${data.cluster.managed_units} sub=${`${data.cluster.total_units} 전체`} />
+          <${MetricRow} label="활성 작업" value=${data.cluster.active_operations} />
+          <${MetricRow} label="부실 유닛" value=${data.cluster.stale_units} />
+          <${MetricRow} label="부실 에이전트" value=${data.agent_health.stale_total} />
         <//>
       </div>
 


### PR DESCRIPTION
## Summary
- keeper-detail 섹션 카드 타이틀 (프로필, 장비, 관계, 품질 시그널, 설정) 번역
- keeper-config-panel 프롬프트 블록 (헌법, 세계관, 능력), 소스 경로 라벨 번역
- transport-health MetricRow 라벨 (WebSocket, WebRTC, HTTP, 에이전트 풀) 번역
- live/focus-sidebar 에이전트 패널 번역
- prompt-registry-panel 타이틀 번역

## Test plan
- [x] `vite build` 통과
- [x] `vitest run` 65 테스트 전부 통과

Generated with [Claude Code](https://claude.com/claude-code)