### PR TITLE
fix(session): enable PG recent path for all PostgresNative list_sessions calls

### DIFF
--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -408,10 +408,9 @@ let list_sessions ?(since_unix = 0.0) ?(limit = 0) config : Team_session_types.s
   in
   let pg_recent_attempted, pg_recent_result =
     match config.backend with
-    | PostgresNative backend when since_unix > 0.0 || limit > 0 ->
-        (* Safety cap: PG backend returns Ok [] when limit<=0, so we need a
-           positive value. 10_000 is high enough to avoid silent truncation
-           in practice while preventing unbounded queries. See #2778. *)
+    | PostgresNative backend ->
+        (* Always prefer PG when available. Safety cap prevents unbounded
+           queries when caller omits limit. See #2778, #2770. *)
         let row_limit =
           if limit > 0 then limit
           else 10_000


### PR DESCRIPTION
## Summary

`list_sessions`의 PG fast path가 `since_unix > 0 || limit > 0` guard로 제한되어, 기본 인자로 호출하는 dashboard/swarm 경로에서 file-system scan 폴백이 발생. 17-30초 timeout의 원인.

## 변경

```diff
-    | PostgresNative backend when since_unix > 0.0 || limit > 0 ->
+    | PostgresNative backend ->
```

- guard 제거 → PostgresNative이면 항상 PG 경로 사용
- 기존 `row_limit = 10_000` safety cap은 유지 (unbounded query 방지)

## 영향 받는 호출

| 호출 | 이전 | 이후 |
|------|------|------|
| `dashboard_proof.ml` (인자 없음) | file scan → 17s+ | PG query |
| `swarm_status_inputs.ml` (인자 없음) | file scan | PG query |
| `command_plane_orchestra.ml` (인자 없음) | file scan | PG query |
| `server_dashboard_http_core.ml` (since_unix 전달) | PG query | PG query (변경 없음) |

## Test plan

- [x] `test_swarm_persistence.exe` — 12/12 pass
- [x] `dune build` 성공
- [ ] CI 확인

Closes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)