### PR TITLE
fix(dashboard): translate remaining English UI strings to Korean (batch 5)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -333,7 +333,7 @@ export function ChatTranscript({
       ${entries.length === 0
         ? html`
             <div class="flex min-h-[220px] flex-col items-center justify-center rounded-[18px] border border-dashed border-[rgba(148,163,184,0.18)] bg-[rgba(255,255,255,0.03)] px-6 text-center">
-              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">No Direct Messages</div>
+              <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 메시지 없음</div>
               <div class="mt-3 max-w-[34rem] text-[13px] leading-[1.7] text-[var(--text-secondary)]">${emptyText}</div>
             </div>
           `
@@ -382,8 +382,8 @@ export function ChatComposer({
   return html`
     <div class="chat-composer flex flex-col gap-3">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">Message</div>
-        <div class="text-[11px] text-[var(--text-muted)]">Enter to send, Shift+Enter for newline</div>
+        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">메시지</div>
+        <div class="text-[11px] text-[var(--text-muted)]">Enter로 전송, Shift+Enter로 줄바꿈</div>
       </div>
       <textarea
         class="control-textarea min-h-[96px] rounded-[18px] border border-[rgba(148,163,184,0.16)] bg-[rgba(255,255,255,0.04)] px-3 py-3 text-[14px] leading-[1.6]"

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -58,7 +58,7 @@ function parseBlocks(src: string) {
       const inner = thinkLines.join('\n').trim()
       nodes.push(html`
         <details class="think-block rounded-lg">
-          <summary>Thinking...</summary>
+          <summary>생각 중...</summary>
           <div>${inlineToVdom(inner)}</div>
         </details>
       `)

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -130,7 +130,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
       <div class="flex items-center ${collapsed ? 'justify-center' : 'justify-between'} px-2.5 pt-2.5 pb-1">
         ${!collapsed ? html`
           <div class="px-1">
-            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">Navigation</div>
+            <div class="text-[10px] font-bold uppercase tracking-[0.2em] text-[rgba(154,217,255,0.5)]">내비게이션</div>
             <div class="mt-0.5 text-[13px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">MASC Core</div>
           </div>
         ` : null}

--- a/dashboard/src/components/goals/mdal-components.ts
+++ b/dashboard/src/components/goals/mdal-components.ts
@@ -28,12 +28,12 @@ export function LoopRow({ loop }: { loop: MdalLoop }) {
         </div>
 
         <div class="flex gap-3 flex-wrap text-[#b9c9ea] text-[13px]">
-          <span>Baseline ${formatMetric(loop.baseline_metric)}</span>
+          <span>기준값 ${formatMetric(loop.baseline_metric)}</span>
           <span>현재 ${formatMetric(loop.current_metric)}</span>
           <span class=${formatMetricDelta(loop).startsWith('+') ? 'text-[#9af3ba]' : 'text-[#fda4af]'}>
             Delta ${formatMetricDelta(loop)}
           </span>
-          <span>Elapsed ${formatElapsedCompact(loop.elapsed_seconds)}</span>
+          <span>경과 ${formatElapsedCompact(loop.elapsed_seconds)}</span>
         </div>
 
         <div class="text-[var(--text-body)] text-base leading-[1.5]">${loop.target || '명시된 목표가 없습니다'}</div>

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -57,7 +57,7 @@ function GovernanceSummaryStrip() {
     ` : null}
     <div class="mb-2.5 flex items-center justify-between px-0.5">
       <div class="flex items-center gap-3">
-        <h2 class="text-lg font-bold text-text-strong tracking-wide">Governance</h2>
+        <h2 class="text-lg font-bold text-text-strong tracking-wide">거버넌스</h2>
         <span class="rounded-md border border-white/5 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-text-muted">진행 중 ${itemCount}건 / 활동 ${activityCount}건</span>
       </div>
       ${data?.generated_at ? html`<span class="text-[11px] text-text-dim font-mono">${data.generated_at}</span>` : null}

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -152,15 +152,15 @@ export function KeeperChatPanel({ name }: { name: string }) {
     <div class="overflow-hidden rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(11,18,34,0.95),rgba(6,11,22,0.92))] shadow-[0_24px_56px_rgba(0,0,0,0.24)]">
       <div class="flex flex-wrap items-start justify-between gap-3 border-b border-[rgba(148,163,184,0.12)] px-4 py-4">
         <div class="min-w-[220px] flex-1">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">Direct Chat</div>
+          <div class="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">직접 대화</div>
           <div class="mt-2 text-[15px] font-semibold text-[var(--text-strong)]">@${name}</div>
           <div class="mt-1 text-[13px] leading-[1.65] text-[var(--text-secondary)]">
-            Live direct conversation with this keeper. Streaming responses stay in the same transcript lane.
+            이 키퍼와의 실시간 직접 대화입니다. 스트리밍 응답은 동일한 대화 레인에 표시됩니다.
           </div>
         </div>
         <div class="flex items-center gap-2">
           <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[rgba(71,184,255,0.08)] px-2.5 py-1 text-[11px] font-medium text-[#bfe8ff]">
-            ${entries.length} messages
+            ${entries.length}개 메시지
           </span>
         </div>
       </div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -245,7 +245,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   }
 
   if (state.status === 'loading') {
-    return html`<div class="py-3 text-xs text-[var(--text-muted)]">Loading config...</div>`
+    return html`<div class="py-3 text-xs text-[var(--text-muted)]">설정 로딩 중...</div>`
   }
 
   if (state.status === 'error') {
@@ -302,17 +302,17 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           class="${btnBase} bg-[#4ade80] text-[#000]"
           onClick=${saveConfig}
           disabled=${isSaving}
-        >${isSaving ? 'Saving...' : 'Save'}</button>
+        >${isSaving ? '저장 중...' : '저장'}</button>
         <button type="button"
           class="${btnBase} bg-[var(--white-10)] text-[var(--text-body)]"
           onClick=${cancelEdit}
           disabled=${isSaving}
-        >Cancel</button>
+        >취소</button>
       ` : html`
         <button type="button"
           class="${btnBase} bg-[var(--purple)] text-[#000]"
           onClick=${enterEditMode}
-        >Edit</button>
+        >편집</button>
       `}
       ${saveError.value ? html`<span class="text-xs text-[#ef4444]">${saveError.value}</span>` : null}
     </div>
@@ -339,19 +339,19 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${LongText} text=${c.prompt.short_goal} />
     ` : null}
     ${c.prompt.mid_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Mid-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">중기 목표</div>
       <${LongText} text=${c.prompt.mid_goal} />
     ` : null}
     ${c.prompt.long_goal ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Long-term goal</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">장기 목표</div>
       <${LongText} text=${c.prompt.long_goal} />
     ` : null}
     ${c.prompt.soul_profile ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Soul profile</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">소울 프로필</div>
       <${LongText} text=${c.prompt.soul_profile} />
     ` : null}
     ${c.prompt.instructions ? html`
-      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Instructions</div>
+      <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">지시사항</div>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
     <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-3 mb-0.5">시스템 프롬프트 블록</div>
@@ -374,11 +374,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${SectionHeader} title="실행" />
       <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Verify</span>
+        <span class="text-xs text-[var(--text-muted)]">검증</span>
         <${BoolBadge} value=${c.execution.verify} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Models</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
         <${ModelList} models=${c.execution.models} />
       </div>
       ${'' /* Show allowed_models only when it differs from models */}
@@ -386,7 +386,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         && JSON.stringify(c.execution.allowed_models.slice().sort()) !== JSON.stringify(c.execution.models.slice().sort())
         ? html`
         <div class="mt-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Allowed models</div>
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">허용 모델</div>
           <${ModelList} models=${c.execution.allowed_models} />
         </div>
       ` : null}
@@ -439,7 +439,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="범위 유형" value=${c.coordination.scope_kind || '--'} />
       <${ConfigRow} label="트리거 모드" value=${c.coordination.trigger_mode || '--'} />
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Mention targets</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
         <${ModelList} models=${c.coordination.mention_targets} />
       </div>
       <div class="mt-1.5">
@@ -450,7 +450,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${'' /* --- Drift (read-only) --- */}
       <${SectionHeader} title="드리프트" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <span class="text-xs text-[var(--text-muted)]">상태</span>
         <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
       </div>
       <${ConfigRow} label="최소 턴 간격" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
@@ -460,7 +460,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ${'' /* --- Initiative (read-only) --- */}
       <${SectionHeader} title="이니셔티브" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <span class="text-xs text-[var(--text-muted)]">상태</span>
         <${FeatureBadge} status=${c.initiative.status} value=${c.initiative.enabled} />
       </div>
       <${ConfigRow} label="범위" value=${c.initiative.scope || '--'} />
@@ -473,25 +473,25 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       </div>
       ${c.initiative.source_defaults ? html`
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-1">소스 기본값</div>
-        <${ConfigRow} label="Enabled" value=${c.initiative.source_defaults.enabled === null ? '--' : String(c.initiative.source_defaults.enabled)} />
-        <${ConfigRow} label="Scope" value=${c.initiative.source_defaults.scope || '--'} />
-        <${ConfigRow} label="Idle trigger" value=${formatMaybeNumber(c.initiative.source_defaults.idle_sec, 's')} />
-        <${ConfigRow} label="Cooldown" value=${formatMaybeNumber(c.initiative.source_defaults.cooldown_sec, 's')} />
-        <${ConfigRow} label="Context mode" value=${c.initiative.source_defaults.context_mode || '--'} />
-        <${ConfigRow} label="Post TTL" value=${formatMaybeNumber(c.initiative.source_defaults.post_ttl_hours, 'h')} />
+        <${ConfigRow} label="활성" value=${c.initiative.source_defaults.enabled === null ? '--' : String(c.initiative.source_defaults.enabled)} />
+        <${ConfigRow} label="범위" value=${c.initiative.source_defaults.scope || '--'} />
+        <${ConfigRow} label="유휴 트리거" value=${formatMaybeNumber(c.initiative.source_defaults.idle_sec, 's')} />
+        <${ConfigRow} label="쿨다운" value=${formatMaybeNumber(c.initiative.source_defaults.cooldown_sec, 's')} />
+        <${ConfigRow} label="컨텍스트 모드" value=${c.initiative.source_defaults.context_mode || '--'} />
+        <${ConfigRow} label="포스트 TTL" value=${formatMaybeNumber(c.initiative.source_defaults.post_ttl_hours, 'h')} />
       ` : null}
 
       ${'' /* --- Team Session (read-only) --- */}
       <${SectionHeader} title="자동 팀 세션" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">State</span>
+        <span class="text-xs text-[var(--text-muted)]">상태</span>
         <${FeatureBadge} status=${c.auto_team_session.status} value=${c.auto_team_session.enabled} />
       </div>
 
       ${'' /* --- Handoff (read-only) --- */}
       <${SectionHeader} title="핸드오프" />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">Auto</span>
+        <span class="text-xs text-[var(--text-muted)]">자동</span>
         <${BoolBadge} value=${c.handoff.auto} />
       </div>
       <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
@@ -534,7 +534,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ModelList} models=${c.sources.precedence} />
       </div>
       <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">Override fields</div>
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">오버라이드 필드</div>
         <${ModelList} models=${c.sources.override_fields} />
       </div>
 

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -240,7 +240,7 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
       <input
         class="w-full py-2 px-3 mb-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--ok-40)]"
         type="text"
-        placeholder="Search fields..."
+        placeholder="필드 검색..."
         value=${fieldSearch.value}
         onInput=${(e: Event) => { fieldSearch.value = (e.target as HTMLInputElement).value }}
       />
@@ -314,7 +314,7 @@ export function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 }
 
 export function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No equipment</div>`
+  if (items.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">장비 없음</div>`
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -330,7 +330,7 @@ export function EquipmentList({ items }: { items: string[] }) {
 
 export function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">No relationships</div>`
+  if (entries.length === 0) return html`<div class="py-2 px-3 text-xs text-[var(--text-muted)] italic">관계 없음</div>`
 
   return html`
     <div class="max-h-[220px] overflow-y-auto flex flex-col gap-1.5">

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -121,7 +121,7 @@ export function PromptRegistryPanel() {
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <div class="min-h-[260px] rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
-            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Registered prompts</div>
+            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">등록된 프롬프트</div>
             <${ActionButton} variant="ghost" size="sm" disabled=${loading || saving} onClick=${() => { void loadPrompts(selectedPrompt?.key ?? null) }}>
               ${loading ? '새로고침 중' : '새로고침'}
             <//>
@@ -156,24 +156,24 @@ export function PromptRegistryPanel() {
               <div class="font-mono text-[13px] text-[var(--text-strong)]">${selectedPrompt.key}</div>
               <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${sourceBadgeClass(selectedPrompt.source)}">${selectedPrompt.source}</span>
               ${selectedPrompt.has_override
-                ? html`<span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.08)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">override active</span>`
+                ? html`<span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.08)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">오버라이드 활성</span>`
                 : null}
             </div>
 
             <div class="mb-4 grid gap-3 md:grid-cols-2">
               <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Markdown file</div>
-                <div class="mt-1 break-all font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.file_path ?? 'not configured'}</div>
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">마크다운 파일</div>
+                <div class="mt-1 break-all font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.file_path ?? '미설정'}</div>
               </div>
               <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Character count</div>
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">문자 수</div>
                 <div class="mt-1 font-mono text-[12px] text-[var(--text-body)]">${selectedPrompt.char_count}</div>
               </div>
             </div>
 
             ${selectedPrompt.template_variables.length > 0 ? html`
               <div class="mb-4 rounded-lg border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-2">
-                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Allowed placeholders</div>
+                <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">허용된 플레이스홀더</div>
                 <div class="mt-2 flex flex-wrap gap-2">
                   ${selectedPrompt.template_variables.map(variable => html`
                     <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-body)]">${`{{${variable}}}`}</span>
@@ -183,13 +183,13 @@ export function PromptRegistryPanel() {
             ` : null}
 
             <div class="mb-4">
-              <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">File baseline</div>
-              <pre class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[rgba(6,12,24,0.72)] px-3 py-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-[var(--text-body)]">${selectedPrompt.file_value ?? 'missing'}</pre>
+              <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">파일 기준값</div>
+              <pre class="max-h-[220px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[rgba(6,12,24,0.72)] px-3 py-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-[var(--text-body)]">${selectedPrompt.file_value ?? '없음'}</pre>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
-              <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Runtime override</div>
-              <div class="text-[11px] text-[var(--text-muted)]">effective preview follows the override after save</div>
+              <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">런타임 오버라이드</div>
+              <div class="text-[11px] text-[var(--text-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
             </div>
             <${TextArea}
               rows=${18}
@@ -212,7 +212,7 @@ export function PromptRegistryPanel() {
                 setDraft(normalizeDraft(selectedPrompt))
                 setStatus(null)
               }}>
-                Reset draft
+                초안 초기화
               <//>
             </div>
           ` : html`

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -346,7 +346,7 @@ export function TransportHealthPanel() {
   const data = transportHealth.value
 
   if (loading.value && !data) {
-    return html`<div class="p-6 text-center text-text-muted text-sm">Transport health loading...</div>`
+    return html`<div class="p-6 text-center text-text-muted text-sm">트랜스포트 상태 로딩 중...</div>`
   }
 
   if (error.value && !data) {
@@ -431,7 +431,7 @@ export function TransportHealthPanel() {
         ? html`
             <div class="rounded-xl border border-card-border/70 bg-card/35 p-4">
               <div class="flex items-center justify-between gap-3 mb-3">
-                <span class="text-xs font-semibold text-text-strong uppercase tracking-wider">Hot Queues</span>
+                <span class="text-xs font-semibold text-text-strong uppercase tracking-wider">핫 큐</span>
                 <span class="text-[10px] text-text-muted">backpressure candidates</span>
               </div>
               <div class="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3">
@@ -452,7 +452,7 @@ export function TransportHealthPanel() {
 
       <div class="rounded-xl border border-card-border/70 bg-card/35 p-4">
         <div class="flex items-center justify-between gap-3 mb-3">
-          <span class="text-xs font-semibold text-text-strong uppercase tracking-wider">Practical Paths</span>
+          <span class="text-xs font-semibold text-text-strong uppercase tracking-wider">실용 경로</span>
           <span class="text-[10px] text-text-muted">${data.generated_at}</span>
         </div>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">


### PR DESCRIPTION
## Summary
- Translate 40+ remaining hardcoded English strings across 10 dashboard components
- Covers: keeper-config-panel, chat primitives, transport-health, governance, keeper-chat-panel, keeper-detail-panels, prompt-registry, dashboard-shell, markdown, mdal-components
- TypeScript type check passes, dashboard build succeeds

## Files changed (10)
- `keeper-config-panel.ts` — State, Verify, Models, goal labels, buttons
- `chat/primitives.ts` — No Direct Messages, Message, Enter to send
- `transport-health.ts` — loading, Hot Queues, Practical Paths
- `keeper-chat-panel.ts` — Direct Chat, description
- `governance.ts` — Governance heading
- `keeper-detail-panels.ts` — No equipment, No relationships, Search fields
- `tools/prompt-registry-panel.ts` — section headers, status text
- `dashboard-shell.ts` — Navigation
- `common/markdown.ts` — Thinking...
- `goals/mdal-components.ts` — Baseline, Elapsed

Generated with [Claude Code](https://claude.com/claude-code)