### PR TITLE
fix(keeper): add keeper_status_bridge.mli to fix phantom module (#2894)

### DIFF
--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -1,0 +1,44 @@
+(** Keeper status surface helpers — JSON projections for dashboard/operator.
+
+    These functions project keeper runtime state (meta, defaults, config)
+    into JSON structures consumed by the dashboard and operator control
+    endpoints.
+
+    Without this .mli, OCaml may generate an empty module interface when
+    types from other modules (keeper_meta, keeper_profile_defaults) escape
+    through return types. This caused phantom module issues in CI (#2894).
+
+    @since 2.130.0
+    @since 2.149.0 — .mli added to stabilize module interface *)
+
+open Keeper_types
+
+val string_list_to_json : string list -> Yojson.Safe.t
+
+val team_session_state_json :
+  Room_utils.config -> keeper_meta -> Yojson.Safe.t
+
+val team_session_bridge_json :
+  Room_utils.config -> keeper_meta -> Yojson.Safe.t
+
+val unsupported_feature_status : bool -> string
+
+val initiative_surface_json :
+  ?meta:keeper_meta -> keeper_profile_defaults -> Yojson.Safe.t
+
+val initiative_configured_in_source : keeper_profile_defaults -> bool
+
+val drift_surface_json : unit -> Yojson.Safe.t
+
+val auto_team_session_surface_json : unit -> Yojson.Safe.t
+
+val coordination_surface_json : keeper_meta -> Yojson.Safe.t
+
+val live_override_fields :
+  keeper_meta -> keeper_profile_defaults -> string list
+
+val runtime_surface_json :
+  Room_utils.config -> keeper_meta -> Yojson.Safe.t
+
+val source_provenance_json :
+  Room_utils.config -> keeper_meta -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

keeper_status_bridge.ml에 .mli가 없어서 CI에서 모듈 인터페이스가 비어지는 phantom module 문제 수정.

## Problem

OCaml이 .mli 없이 컴파일할 때, `keeper_meta`와 `keeper_profile_defaults` 타입이 return type을 통해 모듈 경계를 넘어 escape하면 전체 모듈의 exported values가 사라진다. 이로 인해:
- `initiative_surface_json`이 invisible → fallback 코드가 `"source_only"` 반환
- CI test `operator 26: keeper config exposes live runtime` 실패 (Expected `"wired"`, Got `"source_only"`)

## Fix

`keeper_status_bridge.mli` 작성 — 11개 public 함수를 명시적으로 export. 타입 경계가 안정화되어 모든 값이 정상 노출.

## Test

- [x] `test_operator_control.exe` 32 tests passed (locally)
- [x] `dune build --root .` 통과

Fixes #2894.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>