### PR TITLE
fix(dashboard): translate final English strings to Korean (batch 5)

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -404,7 +404,7 @@ export function AgentProfile({ name }: { name: string }) {
           <${AgentLiveTimeline} name=${name} />
         <//>
 
-        <${Card} title="Room 활동" class="ff-card rounded-xl">
+        <${Card} title="룸 활동" class="ff-card rounded-xl">
           ${lines.length === 0
             ? html`<${EmptyState} message="관련 활동 없음" compact />`
             : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>

--- a/dashboard/src/components/common/mitosis-ring.ts
+++ b/dashboard/src/components/common/mitosis-ring.ts
@@ -13,7 +13,7 @@ export function MitosisRing({ ratio, size = 40, stroke = 4 }: { ratio?: number; 
   else if (ratio >= 0.5) colorClass = 'mitosis-warn'
 
   return html`
-    <div class="relative inline-flex items-center justify-center ml-auto mr-2.5" title="Mitosis Context Load: ${Math.round(ratio * 100)}%">
+    <div class="relative inline-flex items-center justify-center ml-auto mr-2.5" title="분열 컨텍스트 부하: ${Math.round(ratio * 100)}%">
       <svg class="mitosis-ring" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
         <circle class="mitosis-ring-bg" cx="${c}" cy="${c}" r="${r}" stroke-width="${stroke}" />
         <circle 

--- a/dashboard/src/components/goals/goal-components.ts
+++ b/dashboard/src/components/goals/goal-components.ts
@@ -50,7 +50,7 @@ export function GoalRow({ goal }: { goal: Goal }) {
           <span class="text-[15px] font-bold text-text-strong group-hover:text-accent transition-colors tracking-wide truncate">${goal.title}</span>
         </div>
         <div class="flex gap-3 flex-wrap items-center mt-2.5 text-[11px] font-medium text-text-muted/90">
-          <span class="text-amber-500 tracking-[1px] text-[13px] drop-shadow-sm" title="Priority ${goal.priority}">${priorityStars(goal.priority)}</span>
+          <span class="text-amber-500 tracking-[1px] text-[13px] drop-shadow-sm" title="우선순위 ${goal.priority}">${priorityStars(goal.priority)}</span>
           ${goal.metric ? html`<span class="flex items-center gap-1.5 px-2 py-0.5 bg-accent/10 text-accent rounded-md border border-accent/20"><span class="w-1.5 h-1.5 rounded-full bg-accent/60"></span>${goal.metric}${goal.target_value ? ` \u2192 ${goal.target_value}` : ''}</span>` : null}
           ${goal.due_date ? html`<span class="flex items-center gap-1.5 px-2 py-0.5 bg-bad/10 text-bad rounded-md border border-bad/20"><span>마감:</span><${TimeAgo} timestamp=${goal.due_date} /></span>` : null}
         </div>

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -111,7 +111,7 @@ let inflightTransportHealthRefresh: Promise<void> | null = null
 const PRACTICAL_CASES: PracticalCase[] = [
   {
     id: 'wallboard',
-    title: 'Wallboard / dashboard',
+    title: '월보드 / 대시보드',
     transport: 'SSE',
     endpoint: (data) => data.streamable_http.observer_stream,
     description: 'Observer SSE 읽기 전용 스트림.',
@@ -119,7 +119,7 @@ const PRACTICAL_CASES: PracticalCase[] = [
   },
   {
     id: 'agent-fanout',
-    title: 'Agent fanout / heartbeat',
+    title: '에이전트 팬아웃 / 하트비트',
     transport: 'gRPC',
     endpoint: (data) => `:${data.grpc.port}`,
     description: '양방향 스트림. heartbeat, backlog replay 지원.',
@@ -127,7 +127,7 @@ const PRACTICAL_CASES: PracticalCase[] = [
   },
   {
     id: 'duplex-ui',
-    title: 'Duplex UI / browser bridge',
+    title: '양방향 UI / 브라우저 브릿지',
     transport: 'WebSocket',
     endpoint: (_data) => '/ws',
     description: '양방향 소켓. operator UI 제어용.',
@@ -135,7 +135,7 @@ const PRACTICAL_CASES: PracticalCase[] = [
   },
   {
     id: 'p2p-fastlane',
-    title: 'P2P fast lane',
+    title: 'P2P 패스트 레인',
     transport: 'WebRTC',
     endpoint: (_data) => '/webrtc/offer -> /webrtc/answer',
     description: 'DataChannel P2P. signaling 후 직접 연결.',
@@ -143,7 +143,7 @@ const PRACTICAL_CASES: PracticalCase[] = [
   },
   {
     id: 'stateless-control',
-    title: 'Stateless scripting / queue trigger',
+    title: '스테이트리스 스크립팅 / 큐 트리거',
     transport: 'Streamable HTTP',
     endpoint: (data) => data.streamable_http.endpoint,
     description: 'Stateless POST. 세션 불필요.',


### PR DESCRIPTION
## Summary
- agent-profile: `Room 활동` → `룸 활동` (영한 혼용 수정)
- mitosis-ring: tooltip `Mitosis Context Load` → `분열 컨텍스트 부하`
- goal-components: tooltip `Priority` → `우선순위`
- transport-health: PRACTICAL_CASES 5개 타이틀 한국어 번역

## Test plan
- [x] `vite build` 통과
- [x] `vitest run` 65 테스트 전부 통과

Generated with [Claude Code](https://claude.com/claude-code)