### PR TITLE
chore: bump OAS agent-sdk pin to e64ca05

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.89.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="01754dcbcd25ae5c4f02941629917c40dd651754"
+readonly OAS_AGENT_SDK_SHA="e64ca059544347d56c0e0a09e03f489215079aeb"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.89.1"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#01754dcbcd25ae5c4f02941629917c40dd651754}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#e64ca059544347d56c0e0a09e03f489215079aeb}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
- OAS upstream main이 `e64ca05`로 진행하여 pinned SHA `01754dc`와 drift 발생
- Health check (OAS pin ratchet)이 모든 open PR에서 실패 중
- `oas-agent-sdk-pin.sh` + `opam-pin-external-deps.sh` SHA 동기화

## Impact
이 PR merge 후 모든 open PR의 Health check가 unblock됨.

## Test plan
- [ ] Health check (OAS pin ratchet) 통과
- [ ] Build and Test 통과 (새 OAS 버전 호환)