### PR TITLE
fix(keeper): collect board events once per heartbeat + observe pass-through

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -270,6 +270,19 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                  Log.Keeper.error "heartbeat snapshot write failed: %s"
                    (Printexc.to_string exn));
               last_snapshot_ts := now_ts);
+            (* Collect board events once per heartbeat, shared by triage and observe
+               to avoid double cursor advancement. *)
+            let board_events_result =
+              (try
+                 Some (Keeper_world_observation.collect_board_events
+                         ~meta:meta_current)
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Keeper.warn "keepalive: board count query failed: %s"
+                   (Printexc.to_string exn);
+                 None)
+            in
             (* Deliberation triage: run when initiative is enabled (default: all keepers).
                Initiative cooldown: skip triage if last proactive action was within cooldown_sec. *)
             let meta_after_triage =
@@ -333,20 +346,12 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                     meta_current.name current_agent_count;
                   changed
                 in
-                (* Board activity enrichment *)
+                (* Board activity from pre-collected result *)
                 let board_new_post_count, board_mention_count =
-                  (try
-                     let _events, new_count, mention_count =
-                       Keeper_world_observation.collect_board_events
-                         ~meta:meta_current
-                     in
-                     (new_count, mention_count)
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | exn ->
-                     Log.Keeper.warn "keepalive: board count query failed: %s"
-                       (Printexc.to_string exn);
-                     (0, 0))
+                  match board_events_result with
+                  | Some (_events, new_count, mention_count) ->
+                      (new_count, mention_count)
+                  | None -> (0, 0)
                 in
                 let obs =
                   { obs with
@@ -397,6 +402,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    let obs =
                      Keeper_world_observation.observe
                        ~config:ctx.config ~meta:meta_after_triage
+                       ?pre_collected_board_events:board_events_result ()
                    in
                    match
                      Keeper_unified_turn.run_unified_turn

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -227,7 +227,9 @@ let collect_board_events ~(meta : keeper_meta) : string list * int * int =
       (Printexc.to_string exn);
     ([], 0, 0)
 
-let observe ~(config : Room.config) ~(meta : keeper_meta) : world_observation =
+let observe ~(config : Room.config) ~(meta : keeper_meta)
+    ?(pre_collected_board_events : (string list * int * int) option)
+    () : world_observation =
   let pending_mentions = collect_pending_mentions ~config ~meta in
   let unclaimed_task_count, failed_task_count =
     read_backlog_counts ~config
@@ -245,7 +247,9 @@ let observe ~(config : Room.config) ~(meta : keeper_meta) : world_observation =
       ~agent_name:meta.name
   in
   let pending_board_events, _board_new_count, _board_mention_count =
-    collect_board_events ~meta
+    match pre_collected_board_events with
+    | Some result -> result
+    | None -> collect_board_events ~meta
   in
   {
     pending_mentions;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -60,4 +60,6 @@ val collect_board_events :
 
     @param config Room configuration for I/O operations
     @param meta Current keeper metadata *)
-val observe : config:Room.config -> meta:Keeper_types.keeper_meta -> world_observation
+val observe : config:Room.config -> meta:Keeper_types.keeper_meta ->
+  ?pre_collected_board_events:(string list * int * int) ->
+  unit -> world_observation


### PR DESCRIPTION
## Summary
Fixes review findings from #2961:

1. **Board events collected once** — `collect_board_events` advances cursor on each call. Previously called twice (triage + observe), second call always returned empty. Now collected before triage and passed to `observe` via `?pre_collected_board_events`.

2. **TODO for Eio.Mutex** — `keepalives`, `last_agent_counts`, `board_reactive_wakeups` Hashtbls need mutex protection (tracked in #2965).

## Files
- `lib/keeper/keeper_keepalive.ml` — hoist board collection, pass to observe
- `lib/keeper/keeper_world_observation.ml` — add `?pre_collected_board_events` arg
- `lib/keeper/keeper_world_observation.mli` — update signature

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)