### PR TITLE
fix(dashboard): guard transport-health against missing summary/agent_health

### DIFF
--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -354,6 +354,9 @@ export function TransportHealthPanel() {
   }
 
   if (!data) return null
+  if (!data.summary || !data.agent_health) {
+    return html`<div class="p-6 text-center text-text-muted text-sm">Transport data incomplete. <button class="underline" onClick=${() => void refreshTransportHealth()}>retry</button></div>`
+  }
 
   const sseStatus = queuePressureTone(data.summary.queue_pressure)
   const grpcStatus = grpcTone(data)


### PR DESCRIPTION
## Summary

- Overview 페이지에서 `Cannot read properties of undefined (reading 'queue_pressure')` 크래시 수정
- `data.summary`와 `data.agent_health`가 undefined일 때 retry 프롬프트 표시
- transport health API가 불완전한 응답을 반환할 때 graceful degradation

## Test plan

- [x] TypeScript + Vite 빌드 통과
- [ ] MASC 서버 미실행 상태에서 dashboard overview 접속 시 크래시 없이 retry 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)