### PR TITLE
chore: bump OAS agent-sdk pin to f2ed189

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.89.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e64ca059544347d56c0e0a09e03f489215079aeb"
+readonly OAS_AGENT_SDK_SHA="f2ed189eed67beb24e3efb296768dabfacdcf7dd"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.89.1"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#e64ca059544347d56c0e0a09e03f489215079aeb}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#f2ed189eed67beb24e3efb296768dabfacdcf7dd}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
OAS upstream advanced again (f2ed189). Pin bump to unblock Health checks.

Second drift since initial bump (#2975). Consider automating this or relaxing the ratchet.