### PR TITLE
refactor: fix OAS bridge error handling and ignored results (#2960)

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -102,7 +102,9 @@ let institution_as_json (config : Room_utils.config) : Yojson.Safe.t option =
 let seed_institution ~(memory : Agent_sdk.Memory.t) ~(config : Room_utils.config) : bool =
   match institution_as_json config with
   | Some json ->
-    ignore (Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "institution" json);
+    (match Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "institution" json with
+     | Ok () -> ()
+     | Error msg -> Logs.warn (fun m -> m "Failed to store institution memory: %s" msg));
     true
   | None -> false
 
@@ -119,7 +121,9 @@ let seed_procedures ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) ~(limi
       ("procedures", `List (List.map Procedural_memory.to_json procs));
       ("count", `Int (List.length procs));
     ] in
-    ignore (Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "procedures" json);
+    (match Agent_sdk.Memory.store memory ~tier:Agent_sdk.Memory.Long_term "procedures" json with
+    | Ok () -> ()
+    | Error msg -> Logs.warn (fun m -> m "Failed to store procedures memory: %s" msg));
     List.length procs
   end
 
@@ -281,7 +285,8 @@ let seed_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string)
   let episodes = Institution_eio.load_recent_episodes_jsonl ~limit in
   List.iter
     (fun episode ->
-      ignore (Agent_sdk.Memory.store_episode memory (oas_episode_of_institution episode)))
+      (try Agent_sdk.Memory.store_episode memory (oas_episode_of_institution episode)
+       with exn -> Logs.warn (fun m -> m "Failed to store episode memory: %s" (Printexc.to_string exn))))
     episodes;
   List.length episodes
 
@@ -341,7 +346,8 @@ let seed_procedures_as_oas ~(memory : Agent_sdk.Memory.t)
     ~(agent_name : string) ~(limit : int) : int =
   let procs = Procedural_memory.top_procedures ~agent_name ~limit in
   List.iter (fun p ->
-    ignore (Agent_sdk.Memory.store_procedure memory (oas_procedure_of_masc p))
+    (try Agent_sdk.Memory.store_procedure memory (oas_procedure_of_masc p)
+     with exn -> Logs.warn (fun m -> m "Failed to store procedure memory: %s" (Printexc.to_string exn)))
   ) procs;
   List.length procs
 

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -456,14 +456,16 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
                   `Error (Printexc.to_string exn)
             in
             let status_of = function
-              | `Verdict Verifier_oas.Pass -> "pass"
-              | `Verdict (Verifier_oas.Warn _) -> "warn"
-              | `Verdict (Verifier_oas.Fail _) -> "fail"
+              | `Verdict (Ok Verifier_oas.Pass) -> "pass"
+              | `Verdict (Ok (Verifier_oas.Warn _)) -> "warn"
+              | `Verdict (Ok (Verifier_oas.Fail _)) -> "fail"
+              | `Verdict (Error _) -> "warn"
               | `Timeout -> "warn"
               | `Error _ -> "warn"
             in
             let verdict_text_of = function
-              | `Verdict v -> Verifier_oas.verdict_to_string v
+              | `Verdict (Ok v) -> Verifier_oas.verdict_to_string v
+              | `Verdict (Error e) -> Printf.sprintf "WARN: %s" e
               | `Timeout -> "WARN: verifier_timeout"
               | `Error _ -> "WARN: verifier_error"
             in

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -148,9 +148,9 @@ One line only.|}
 (* Core: verify                                                     *)
 (* ================================================================ *)
 
-let verify (req : verification_request) : verdict =
+let verify (req : verification_request) : (verdict, string) result =
   if should_skip ~action_description:req.action_description then
-    Pass
+    Ok Pass
   else
     let prompt = build_prompt req in
     match
@@ -163,10 +163,9 @@ let verify (req : verification_request) : verdict =
         ()
     with
     | Ok result ->
-      parse_verdict (Oas_response.text_of_response result.response)
+      Ok (parse_verdict (Oas_response.text_of_response result.response))
     | Error message ->
-      Log.Verifier.warn "OAS run failed: %s (defaulting to WARN)" message;
-      Warn ("verifier_unavailable: " ^ message)
+      Error message
 
 (* ================================================================ *)
 (* Verdict -> Hook Decision (OAS bridge)                            *)
@@ -219,15 +218,22 @@ let make_pre_tool_hook
       else
         let input_str =
           try Yojson.Safe.to_string input
-          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "{}" in
+          with Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+                 Log.Verifier.warn "Failed to serialize input: %s" (Printexc.to_string exn);
+                 "{}" in
         let req : verification_request = {
           action_description;
           action_result = input_str;
           goal;
           context_summary;
         } in
-        let verdict = verify req in
-        verdict_to_hook_decision verdict
+        begin match verify req with
+        | Ok verdict -> verdict_to_hook_decision verdict
+        | Error msg ->
+            Log.Verifier.warn "OAS run failed: %s (defaulting to Continue)" msg;
+            Agent_sdk.Hooks.Continue
+        end
     | _ -> Agent_sdk.Hooks.Continue
 
 (** Install the verifier hook into an existing OAS hooks record.

--- a/lib/worker_verification.ml
+++ b/lib/worker_verification.ml
@@ -42,7 +42,7 @@ let verify_worker_result
     } in
     let verdict = Verifier_oas.verify req in
     match verdict with
-    | Verifier_oas.Pass ->
+    | Ok Verifier_oas.Pass ->
       let verified = Oas.Verified_output.verify unverified
         ~verifier:"verifier_oas"
         ~confidence:0.9
@@ -50,7 +50,7 @@ let verify_worker_result
       (match verified with
        | Some v -> Verified { run_result; verified_output = v }
        | None -> Unverified { run_result; reason = "verification threshold not met" })
-    | Verifier_oas.Warn reason ->
+    | Ok (Verifier_oas.Warn reason) ->
       let verified = Oas.Verified_output.verify unverified
         ~verifier:"verifier_oas"
         ~confidence:0.6
@@ -58,8 +58,10 @@ let verify_worker_result
       (match verified with
        | Some v -> Verified { run_result; verified_output = v }
        | None -> Unverified { run_result; reason })
-    | Verifier_oas.Fail reason ->
+    | Ok (Verifier_oas.Fail reason) ->
       Unverified { run_result; reason }
+    | Error reason ->
+      Unverified { run_result; reason = Printf.sprintf "verifier_error: %s" reason }
 
 let text_of_outcome = function
   | Verified vr -> Oas.Verified_output.text vr.verified_output

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -226,7 +226,7 @@ let test_verify_skips_readonly () =
     context_summary = "test context";
   } in
   Alcotest.(check bool) "read-only skips to Pass" true
-    (Verifier_oas.verify req = Pass)
+    (Verifier_oas.verify req = Ok Pass)
 
 (* ================================================================ *)
 (* Roundtrip: keeper_default_gate_config -> guardrails               *)


### PR DESCRIPTION
Resolves #2960

### Changes
- `verifier_oas.ml` 내부 `verify`의 반환값을 `Result.t`로 변경하여 에러 무시 안티패턴 제거
- `memory_oas_bridge.ml`의 `Agent_sdk.Memory.store` 호출 시 `ignore`하던 로직을 `Result` 패턴 매칭으로 로깅하도록 교체
- 반환 타입이 `unit`인 일부 저장 호출은 `try ... with exn` 구조로 명시적 실패 방어
- 사이드 이펙트(의존하는 워커 및 테스트 파일) 타입 교정 완료