### PR TITLE
ci(lint): add gRPC proto descriptor drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,12 @@ jobs:
         env:
           OCAMLPARAM: "_,warn-error=+a"
 
+      - name: Check gRPC proto descriptor drift
+        run: |
+          sudo apt-get install -y -qq protobuf-compiler
+          chmod +x scripts/gen-grpc-descriptors.sh
+          scripts/gen-grpc-descriptors.sh --check
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Lint job에 proto descriptor drift 검증 step 추가. `protoc` + `scripts/gen-grpc-descriptors.sh --check`로 `masc_coordination.proto` 소스와 OCaml 하드코딩 descriptor의 일치를 검증.

proto 변경 후 descriptor 업데이트를 잊으면 Lint job이 실패.

## 변경

- `.github/workflows/ci.yml` lint job에 step 추가:
  1. `apt-get install protobuf-compiler`
  2. `scripts/gen-grpc-descriptors.sh --check`

## Test plan

- [x] 로컬에서 `scripts/gen-grpc-descriptors.sh --check` → `OK`
- [ ] CI Lint job에서 step 실행 확인

Refs #2771

🤖 Generated with [Claude Code](https://claude.com/claude-code)