### PR TITLE
refactor(governance): migrate to ppx_deriving_yojson (#2964 batch 1)

### DIFF
--- a/lib/mcp_server_eio_governance.ml
+++ b/lib/mcp_server_eio_governance.ml
@@ -10,7 +10,7 @@ type governance_config = {
   level: string;
   audit_enabled: bool;
   anomaly_detection: bool;
-}
+} [@@deriving yojson { strict = false }]
 
 let governance_defaults level =
   let level_lc = String.lowercase_ascii level in
@@ -57,42 +57,29 @@ let load_governance (config : Room.config) : governance_config =
 
 let save_governance (config : Room.config) (g : governance_config) =
   ensure_masc_dir config;
-  let json = `Assoc [
-    ("level", `String g.level);
-    ("audit_enabled", `Bool g.audit_enabled);
-    ("anomaly_detection", `Bool g.anomaly_detection);
-    ("updated_at", `String (Types.now_iso ()));
-  ] in
+  let json = match governance_config_to_yojson g with
+    | `Assoc fields ->
+        `Assoc (fields @ [("updated_at", `String (Types.now_iso ()))])
+    | other -> other
+  in
   Room_utils.write_json config (governance_path config) json
 
 (** {1 MCP Sessions} *)
 
 type mcp_session_record = {
   id: string;
-  agent_name: string option;
+  agent_name: string option; [@default None]
   created_at: float;
   last_seen: float;
-}
+} [@@deriving yojson { strict = false }]
 
 let mcp_sessions_path (config : Room.config) =
   Filename.concat (Room_utils.masc_dir config) "mcp-sessions.json"
 
-let mcp_session_to_json (s : mcp_session_record) : Yojson.Safe.t =
-  `Assoc [
-    ("id", `String s.id);
-    ("agent_name", match s.agent_name with Some a -> `String a | None -> `Null);
-    ("created_at", `Float s.created_at);
-    ("last_seen", `Float s.last_seen);
-  ]
+let mcp_session_to_json = mcp_session_record_to_yojson
 
 let mcp_session_of_json (json : Yojson.Safe.t) : mcp_session_record option =
-  try
-    let id = match Json_util.get_string json "id" with Some v -> v | None -> raise Not_found in
-    let agent_name = Json_util.get_string json "agent_name" in
-    let created_at = match Json_util.get_float json "created_at" with Some v -> v | None -> raise Not_found in
-    let last_seen = match Json_util.get_float json "last_seen" with Some v -> v | None -> raise Not_found in
-    Some { id; agent_name; created_at; last_seen }
-  with Not_found | Yojson.Safe.Util.Type_error _ -> None
+  mcp_session_record_of_yojson json |> Result.to_option
 
 let load_mcp_sessions (config : Room.config) : mcp_session_record list =
   let path = mcp_sessions_path config in

--- a/test/dune
+++ b/test/dune
@@ -728,6 +728,12 @@
  (modules test_task_sandbox)
  (libraries masc_mcp masc_process alcotest eio eio_main unix yojson str mirage-crypto-rng mirage-crypto-rng.unix))
 
+; ppx_deriving_yojson roundtrip tests (#2964 migration)
+(test
+ (name test_governance_yojson_roundtrip)
+ (modules test_governance_yojson_roundtrip)
+ (libraries masc_mcp alcotest yojson))
+
 ; Error logging coverage tests (PR #466 silent failure fixes)
 (test
  (name test_error_logging_coverage)

--- a/test/test_governance_yojson_roundtrip.ml
+++ b/test/test_governance_yojson_roundtrip.ml
@@ -1,0 +1,164 @@
+(** Roundtrip tests for ppx_deriving_yojson migration of governance types.
+
+    Verifies that the ppx-generated serializers produce output compatible
+    with the previous manual JSON construction, and that deserialization
+    handles both complete and partial input correctly. *)
+
+open Masc_mcp
+
+let () =
+  let open Alcotest in
+  run "governance_yojson_roundtrip"
+    [
+      ( "mcp_session_record",
+        [
+          test_case "roundtrip with agent_name" `Quick (fun () ->
+              let s : Mcp_server_eio_governance.mcp_session_record =
+                {
+                  id = "sess-001";
+                  agent_name = Some "claude";
+                  created_at = 1711234567.0;
+                  last_seen = 1711234890.0;
+                }
+              in
+              let json =
+                Mcp_server_eio_governance.mcp_session_to_json s
+              in
+              let s' =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              check (option pass) "roundtrip succeeds" (Some ()) (Option.map (fun _ -> ()) s');
+              let s' = Option.get s' in
+              check string "id" s.id s'.id;
+              check (option string) "agent_name" s.agent_name s'.agent_name;
+              check (float 0.001) "created_at" s.created_at s'.created_at;
+              check (float 0.001) "last_seen" s.last_seen s'.last_seen);
+          test_case "roundtrip without agent_name" `Quick (fun () ->
+              let s : Mcp_server_eio_governance.mcp_session_record =
+                {
+                  id = "sess-002";
+                  agent_name = None;
+                  created_at = 1711234567.0;
+                  last_seen = 1711234890.0;
+                }
+              in
+              let json =
+                Mcp_server_eio_governance.mcp_session_to_json s
+              in
+              let s' =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              let s' = Option.get s' in
+              check (option string) "agent_name is None" None s'.agent_name);
+          test_case "backward compat: parse old-format JSON" `Quick (fun () ->
+              (* JSON matching the structure the manual serializer produced *)
+              let json =
+                `Assoc
+                  [
+                    ("id", `String "legacy-sess");
+                    ("agent_name", `Null);
+                    ("created_at", `Float 1000.0);
+                    ("last_seen", `Float 2000.0);
+                  ]
+              in
+              let s =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              let s = Option.get s in
+              check string "id" "legacy-sess" s.id;
+              check (option string) "agent_name" None s.agent_name);
+          test_case "backward compat: integer timestamps" `Quick (fun () ->
+              (* JSON with Int instead of Float for timestamps *)
+              let json =
+                `Assoc
+                  [
+                    ("id", `String "int-ts-sess");
+                    ("agent_name", `String "gemini");
+                    ("created_at", `Int 1711234567);
+                    ("last_seen", `Int 1711234890);
+                  ]
+              in
+              let s =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              let s = Option.get s in
+              check (float 0.001) "created_at from int" 1711234567.0 s.created_at;
+              check (float 0.001) "last_seen from int" 1711234890.0 s.last_seen);
+          test_case "missing agent_name key" `Quick (fun () ->
+              (* JSON without agent_name key at all *)
+              let json =
+                `Assoc
+                  [
+                    ("id", `String "no-agent");
+                    ("created_at", `Float 1000.0);
+                    ("last_seen", `Float 2000.0);
+                  ]
+              in
+              let s =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              let s = Option.get s in
+              check (option string) "agent_name defaults to None" None s.agent_name);
+          test_case "extra keys ignored" `Quick (fun () ->
+              let json =
+                `Assoc
+                  [
+                    ("id", `String "extra-keys");
+                    ("agent_name", `String "codex");
+                    ("created_at", `Float 1000.0);
+                    ("last_seen", `Float 2000.0);
+                    ("extra_field", `String "should be ignored");
+                  ]
+              in
+              let s =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              check (option pass) "extra keys ignored" (Some ()) (Option.map (fun _ -> ()) s));
+          test_case "invalid JSON returns None" `Quick (fun () ->
+              let json = `String "not-a-record" in
+              let s =
+                Mcp_server_eio_governance.mcp_session_of_json json
+              in
+              check (option pass) "invalid returns None" None (Option.map (fun _ -> ()) s));
+        ] );
+      ( "governance_config",
+        [
+          test_case "save roundtrip via to_yojson" `Quick (fun () ->
+              let g : Mcp_server_eio_governance.governance_config =
+                {
+                  level = "production";
+                  audit_enabled = true;
+                  anomaly_detection = false;
+                }
+              in
+              let json =
+                Mcp_server_eio_governance.governance_config_to_yojson g
+              in
+              match
+                Mcp_server_eio_governance.governance_config_of_yojson json
+              with
+              | Ok g' ->
+                  Alcotest.(check string) "level" g.level g'.level;
+                  Alcotest.(check bool) "audit" g.audit_enabled g'.audit_enabled;
+                  Alcotest.(check bool) "anomaly" g.anomaly_detection g'.anomaly_detection
+              | Error msg -> Alcotest.failf "governance roundtrip failed: %s" msg);
+          test_case "extra keys in governance JSON" `Quick (fun () ->
+              let json =
+                `Assoc
+                  [
+                    ("level", `String "development");
+                    ("audit_enabled", `Bool false);
+                    ("anomaly_detection", `Bool false);
+                    ("updated_at", `String "2026-03-25T00:00:00Z");
+                  ]
+              in
+              match
+                Mcp_server_eio_governance.governance_config_of_yojson json
+              with
+              | Ok g ->
+                  Alcotest.(check string) "level" "development" g.level;
+                  Alcotest.(check bool) "audit" false g.audit_enabled
+              | Error msg ->
+                  Alcotest.failf "should ignore extra keys: %s" msg);
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- `mcp_session_record`: 수동 `Yojson.Safe.Util` 파싱을 `[@@deriving yojson]`으로 완전 대체 (-13줄 보일러플레이트)
- `governance_config`: `save_governance`는 ppx 활용, `load_governance`는 레벨 의존 기본값 로직 보존
- 9개 roundtrip 테스트 추가 (backward compat, integer timestamps, missing/extra keys, invalid input)

## Context

Issue #2964 — 63개 파일에 걸친 수동 JSON 파싱 마이그레이션의 첫 배치.
이 PR은 마이그레이션 패턴을 확립하고 가장 깔끔한 변환 대상부터 시작합니다.

## Design decisions

- `governance_config`의 `load_governance`는 의도적으로 수동 파싱 유지: production 레벨일 때 `audit_enabled` 기본값이 `true`가 되는 비즈니스 로직이 있어 단순 `[@default false]`로 대체 불가
- `[@default None]` 사용 (not `[@yojson.option]`): 기존 JSON이 `"agent_name": null`을 emit하므로 호환성 유지
- `{ strict = false }`: governance.json에 `updated_at` 같은 추가 키가 있으므로 unknown key 무시

## Test plan

- [x] 9개 roundtrip 테스트 통과
- [x] 전체 테스트 스위트 통과 (operator_control 32/33 pass + 1 skip, 기존 동일)
- [x] `dune build` 성공
- [ ] CI checks green

Ref: #2964

Generated with [Claude Code](https://claude.com/claude-code)