### PR TITLE
fix(dashboard): translate remaining English UI strings to Korean (batch 6)

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -142,17 +142,17 @@ export function AgentDetailOverlay() {
             </div>
             <div class="mt-2 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
               ${agent?.current_task || missionBrief?.current_work
-                ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">Task: <span class="text-text-strong">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
+                ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">태스크: <span class="text-text-strong">${agent?.current_task ?? missionBrief?.current_work}</span></span>`
                 : null}
-              ${lastSeenAt ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">Last seen: <span class="text-text-strong"><${TimeAgo} timestamp=${lastSeenAt} /></span></span>` : null}
+              ${lastSeenAt ? html`<span class="bg-card/40 px-3 py-1.5 rounded-lg border border-card-border shadow-sm">마지막 확인: <span class="text-text-strong"><${TimeAgo} timestamp=${lastSeenAt} /></span></span>` : null}
             </div>
             ${keeper || continuitySummary || missionBrief?.related_session_id
               ? html`
                   <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
                     ${keeper
-                      ? html`<span class="flex items-center gap-1.5">Linked keeper: <strong class="text-text-strong">${keeper.name}</strong>${keeperIdentity ? html`<span class="text-text-dim text-xs">· ${keeperIdentity}</span>` : ''}</span>`
+                      ? html`<span class="flex items-center gap-1.5">연결된 키퍼: <strong class="text-text-strong">${keeper.name}</strong>${keeperIdentity ? html`<span class="text-text-dim text-xs">· ${keeperIdentity}</span>` : ''}</span>`
                       : null}
-                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">Session: <strong class="font-mono text-text-strong text-xs bg-white/5 px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
+                    ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-text-strong text-xs bg-white/5 px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
                     ${continuitySummary ? html`<span class="text-accent/90 bg-accent/10 px-2 py-0.5 rounded-md border border-accent/10">${continuitySummary}</span>` : null}
                   </div>
                 `

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -138,7 +138,7 @@ function statusColor(status: string): string {
 }
 
 function decisionLabel(decision: string): string {
-  return decision === 'keep' ? 'Keep' : 'Discard'
+  return decision === 'keep' ? '유지' : '삭제'
 }
 
 function formatElapsed(seconds: number): string {
@@ -249,7 +249,7 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
         </div>
         <div>
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1">Keep / Discard</div>
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1">유지 / 삭제</div>
           <div class="flex items-center gap-2">
             <span class="text-green-400 text-sm font-mono font-semibold">${loop.total_keeps}</span>
             <span class="text-[var(--text-muted)] text-xs">/</span>

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -335,7 +335,7 @@ export function ChainsSurface() {
     <div class="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-4">
       <section class="${CARD_STANDARD} min-h-[240px]">
         <div class="pb-2 border-b border-[var(--card-border)] mb-3">
-          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">Chains</h3>
+          <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider">체인</h3>
         </div>
         <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${chainStatusTone(summary?.connection.status)}">
           <div class="flex justify-between gap-3 items-start">

--- a/dashboard/src/components/command/swarm-live-panels.ts
+++ b/dashboard/src/components/command/swarm-live-panels.ts
@@ -113,21 +113,21 @@ export function SwarmLivePanels() {
         ${swarm?.provider
           ? html`
               <div class="cmd-card rounded-xl-grid">
-                <span>Provider</span><span>${swarm.provider.provider_base_url ?? 'n/a'}</span>
-                <span>Provider Reachable</span><span>${swarm.provider.provider_reachable == null ? 'n/a' : swarm.provider.provider_reachable ? 'yes' : 'no'}</span>
-                <span>Requested Model</span><span>${swarm.provider.provider_model_id ?? 'n/a'}</span>
-                <span>Actual Model</span><span>${swarm.provider.actual_model_id ?? 'n/a'}</span>
-                <span>Slot URL</span><span>${swarm.provider.slot_url ?? 'n/a'}</span>
-                <span>Expected Slots</span><span>${swarm.provider.expected_slots ?? 'n/a'}</span>
-                <span>Actual Slots</span><span>${swarm.provider.actual_slots ?? swarm.provider.total_slots ?? 0}</span>
-                <span>Expected Ctx</span><span>${swarm.provider.expected_ctx ?? 'n/a'}</span>
-                <span>Actual Ctx</span><span>${swarm.provider.actual_ctx ?? swarm.provider.ctx_per_slot ?? 0}</span>
-                <span>Active Now</span><span>${swarm.provider.active_slots_now ?? 0}</span>
-                <span>Peak Active</span><span>${swarm.provider.peak_active_slots ?? 0}</span>
-                <span>Sample Count</span><span>${swarm.provider.sample_count ?? 0}</span>
-                <span>Last Sample</span><span>${swarm.provider.last_sample_at ? relativeTime(swarm.provider.last_sample_at) : 'n/a'}</span>
+                <span>프로바이더</span><span>${swarm.provider.provider_base_url ?? 'n/a'}</span>
+                <span>프로바이더 도달 가능</span><span>${swarm.provider.provider_reachable == null ? 'n/a' : swarm.provider.provider_reachable ? 'yes' : 'no'}</span>
+                <span>요청 모델</span><span>${swarm.provider.provider_model_id ?? 'n/a'}</span>
+                <span>실제 모델</span><span>${swarm.provider.actual_model_id ?? 'n/a'}</span>
+                <span>슬롯 URL</span><span>${swarm.provider.slot_url ?? 'n/a'}</span>
+                <span>예상 슬롯</span><span>${swarm.provider.expected_slots ?? 'n/a'}</span>
+                <span>실제 슬롯</span><span>${swarm.provider.actual_slots ?? swarm.provider.total_slots ?? 0}</span>
+                <span>예상 컨텍스트</span><span>${swarm.provider.expected_ctx ?? 'n/a'}</span>
+                <span>실제 컨텍스트</span><span>${swarm.provider.actual_ctx ?? swarm.provider.ctx_per_slot ?? 0}</span>
+                <span>현재 활성</span><span>${swarm.provider.active_slots_now ?? 0}</span>
+                <span>최대 활성</span><span>${swarm.provider.peak_active_slots ?? 0}</span>
+                <span>샘플 수</span><span>${swarm.provider.sample_count ?? 0}</span>
+                <span>마지막 샘플</span><span>${swarm.provider.last_sample_at ? relativeTime(swarm.provider.last_sample_at) : 'n/a'}</span>
                 <span>런타임 막힘</span><span>${swarm.provider.runtime_blocker ?? 'none'}</span>
-                <span>Doctor Checked</span><span>${swarm.provider.checked_at ? relativeTime(swarm.provider.checked_at) : 'n/a'}</span>
+                <span>닥터 체크</span><span>${swarm.provider.checked_at ? relativeTime(swarm.provider.checked_at) : 'n/a'}</span>
               </div>
               ${swarm.provider.detail
                 ? html`<div class="cmd-card rounded-xl-sub">${swarm.provider.detail}</div>`

--- a/dashboard/src/components/command/swarm-storyboard.ts
+++ b/dashboard/src/components/command/swarm-storyboard.ts
@@ -64,7 +64,7 @@ export function SwarmLaneStrip({ lane }: { lane: CommandPlaneSwarmLane }) {
       </div>
       <div class="flex flex-col gap-1.5 mt-2 text-[0.82rem]">
         <div class="flex items-center gap-1.5 text-[var(--text-dim,var(--white-55))]">
-          <span class="shrink-0 w-14 text-[11px] uppercase tracking-[0.04em] opacity-60">Step</span>
+          <span class="shrink-0 w-14 text-[11px] uppercase tracking-[0.04em] opacity-60">단계</span>
           <span>${lane.current_step}</span>
         </div>
         ${totalWorkers > 0
@@ -233,7 +233,7 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
   return html`
     <article class="bg-[var(--white-4)] border border-[var(--white-8)] p-4 rounded-xl cmd-guide-card ${toneClass(tone)}">
       <div class="flex justify-between gap-3 items-start">
-        <strong>Run Resolution</strong>
+        <strong>실행 판정</strong>
         <${StatusChip} label=${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)} tone=${toneClass(tone)} />
       </div>
       <p>
@@ -242,10 +242,10 @@ export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResp
           : recommendation?.reason ?? '이 run에 대한 별도 resolution recommendation은 아직 없습니다.'}
       </p>
       <div class="cmd-card rounded-xl-grid">
-        <span>Run</span><span>${runId}</span>
-        <span>Provenance</span><span><${ProvenanceChip} item=${{ kind: recommendation?.provenance ?? 'recorded' }} /></span>
-        <span>Engine</span><span>${recommendation?.decision_engine ?? 'operator_record'}</span>
-        <span>Authoritative</span><span>${recommendation?.authoritative ? 'yes' : 'no'}</span>
+        <span>실행</span><span>${runId}</span>
+        <span>출처</span><span><${ProvenanceChip} item=${{ kind: recommendation?.provenance ?? 'recorded' }} /></span>
+        <span>엔진</span><span>${recommendation?.decision_engine ?? 'operator_record'}</span>
+        <span>권위적</span><span>${recommendation?.authoritative ? 'yes' : 'no'}</span>
       </div>
       ${recommendation?.evidence
         ? html`

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -45,7 +45,7 @@ export function ActivityStream() {
   return html`
     <div class="grid gap-3 grid-rows-[auto_auto_1fr] min-h-0">
       <div class="activity-stream-head">
-        <h3 class="m-0 text-[0.95rem] font-semibold">Activity Stream</h3>
+        <h3 class="m-0 text-[0.95rem] font-semibold">활동 스트림</h3>
         <span class="text-xs text-[rgba(255,255,255,0.4)]">${entries.length} events</span>
       </div>
       <${FilterBar} />

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -49,7 +49,7 @@ export function OpsKeeperColumn() {
   return html`
     <div class="flex flex-col gap-4 min-w-0">
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0 ops-lane-panel ops-keeper-section">
-        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">Keeper 목록</h3>
+        <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">키퍼 목록</h3>
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">keeper를 선택하면 아래에서 메시지를 보내거나 상세 정보를 볼 수 있습니다.</p>
 
         <div class="flex flex-col gap-2">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -227,7 +227,7 @@ export function OpsRoomColumn() {
 
         <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
-            <span>Room</span>
+            <span>룸</span>
             <strong>${room.current_room ?? room.room_id ?? 'default'}</strong>
           </div>
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
@@ -243,7 +243,7 @@ export function OpsRoomColumn() {
             <strong>${room.paused ? '일시정지' : '진행 중'}</strong>
           </div>
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1 ${runtimeJudgeTone(residentRuntime)}">
-            <span>Resident Judge</span>
+            <span>레지던트 판정기</span>
             <strong>${runtimeJudgeLabel(residentRuntime)}</strong>
           </div>
         </div>

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -266,10 +266,10 @@ export function OpsSessionColumn() {
             </div>
             ${selectedSession.linked_autoresearch ? html`
               <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
-                <span>Autoresearch: ${String(selectedSession.linked_autoresearch.status ?? 'unknown')}</span>
-                <span>Loop: ${String(selectedSession.linked_autoresearch.loop_id ?? 'n/a')}</span>
-                <span>Cycle: ${String(selectedSession.linked_autoresearch.current_cycle ?? 0)}</span>
-                <span>Best: ${String(selectedSession.linked_autoresearch.best_score ?? 'n/a')}</span>
+                <span>오토리서치: ${String(selectedSession.linked_autoresearch.status ?? 'unknown')}</span>
+                <span>루프: ${String(selectedSession.linked_autoresearch.loop_id ?? 'n/a')}</span>
+                <span>사이클: ${String(selectedSession.linked_autoresearch.current_cycle ?? 0)}</span>
+                <span>최고 점수: ${String(selectedSession.linked_autoresearch.best_score ?? 'n/a')}</span>
               </div>
               <div class="text-[var(--fs-xs)] text-[var(--text-muted)] mt-1 whitespace-nowrap overflow-hidden text-ellipsis">
                 <span>파일: ${selectedSession.linked_autoresearch.target_file ?? 'n/a'}</span>
@@ -280,13 +280,13 @@ export function OpsSessionColumn() {
                   : null}
               </div>
               ${selectedSession.linked_autoresearch.program_note
-                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Program note: ${selectedSession.linked_autoresearch.program_note}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">프로그램 노트: ${selectedSession.linked_autoresearch.program_note}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.queued_hypothesis
-                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Queued hypothesis: ${selectedSession.linked_autoresearch.queued_hypothesis}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">대기 가설: ${selectedSession.linked_autoresearch.queued_hypothesis}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.warnings && selectedSession.linked_autoresearch.warnings.length > 0
-                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">Warnings: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
+                ? html`<div class="-mt-0.5 text-[var(--text-muted)] text-[var(--fs-sm)] leading-[1.45]">경고: ${selectedSession.linked_autoresearch.warnings.join(', ')}</div>`
                 : null}
               ${selectedSession.linked_autoresearch.error
                 ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">${selectedSession.linked_autoresearch.error}</div>`

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -355,7 +355,7 @@ export function TransportHealthPanel() {
 
   if (!data) return null
   if (!data.summary || !data.agent_health) {
-    return html`<div class="p-6 text-center text-text-muted text-sm">Transport data incomplete. <button class="underline" onClick=${() => void refreshTransportHealth()}>retry</button></div>`
+    return html`<div class="p-6 text-center text-text-muted text-sm">트랜스포트 데이터 불완전. <button class="underline" onClick=${() => void refreshTransportHealth()}>재시도</button></div>`
   }
 
   const sseStatus = queuePressureTone(data.summary.queue_pressure)
@@ -370,7 +370,7 @@ export function TransportHealthPanel() {
       <div class="flex items-start justify-between gap-4">
         <div>
           <div class="flex items-center gap-2">
-            <span class="text-base text-text-strong">Transport</span>
+            <span class="text-base text-text-strong">트랜스포트</span>
             <span class="text-[10px] uppercase tracking-wider text-text-muted">${data.cluster.cluster && data.cluster.cluster !== 'unknown' && data.cluster.cluster !== 'default' ? `${data.cluster.cluster} / ` : ''}${data.cluster.room_id}</span>
           </div>
           <div class="mt-1 text-sm text-text-body">


### PR DESCRIPTION
## Summary
- Translate 40+ remaining English labels across 10 dashboard components
- Covers: agent-detail, transport-health, activity-stream, autoresearch, ops columns, swarm panels, storyboard, operations
- Vite build passes

## Files changed (10)
- `agent-detail.ts` — Task/Last seen/Linked keeper/Session labels
- `transport-health.ts` — Transport heading, retry, data incomplete
- `live/activity-stream.ts` — Activity Stream heading
- `autoresearch.ts` — Keep/Discard labels
- `ops/ops-session-column.ts` — Autoresearch/Loop/Cycle/Best labels
- `ops/ops-room-column.ts` — Room/Resident Judge
- `ops/ops-keeper-column.ts` — Keeper heading
- `command/swarm-live-panels.ts` — 15 provider/slot grid labels
- `command/swarm-storyboard.ts` — Step/Run/Provenance/Engine
- `command/operations.ts` — Chains heading

Generated with [Claude Code](https://claude.com/claude-code)