### PR TITLE
fix: structured logging for silent error paths (round 2)

### DIFF
--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -62,7 +62,32 @@ Tests break when:
 dune build --root .  # catches compilation errors in tests
 ```
 
-## 5. Version String Drift (2 occurrences)
+## 5. Silent Error Patterns — When to Log
+
+`| Error _ ->` 사용 시 side-effect 실패 삼킴에 주의.
+
+**로그 필수 (`warn`) — state를 바꾸려다 실패:**
+```ocaml
+| Error e -> Log.BoardLog.warn "notification failed: %s" e
+```
+SSE/notification 발행, 파일 쓰기, 외부 API 호출, audit/economy 기록.
+
+**로그 선택 (`debug`) — 읽다가 실패:**
+```ocaml
+| Error e -> Log.Reputation.debug "task file unreadable: %s" e
+```
+디렉토리 스캔 중 개별 파일, config 파싱, runtime context 미가용.
+
+**로그 불필요 (idiomatic OCaml):**
+```ocaml
+List.filter_map (function Ok t -> Some t | Error _ -> None)
+(try int_of_string s with _ -> default)
+(try Sys.remove tmp with _ -> ())
+```
+
+**PR 체크:** `rg '\| Error _ -> \(\)' lib/` 로 새 `| Error _ -> ()` 확인.
+
+## 6. Version String Drift (2 occurrences)
 
 `dune-project` version and `sdk_version.ml` (or equivalent) must match.
 CI checks this — but fix it before pushing.
@@ -73,7 +98,7 @@ grep '(version' dune-project | head -1
 grep 'let version' lib/sdk_version.ml
 ```
 
-## 6. Prompt Changes Need Checkpoint Reset
+## 7. Prompt Changes Need Checkpoint Reset
 
 Keeper system prompts are cached in checkpoints. After changing prompts:
 - Existing keepers continue using the old prompt from checkpoint

--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -194,7 +194,7 @@ let load_balances_from_ledger base_path =
     let path = ledger_path base_path in
     if Sys.file_exists path then begin
       match Safe_ops.read_file_safe path with
-      | Error _ -> ()
+      | Error e -> Log.Misc.warn "economy ledger read failed for %s: %s" path e
       | Ok content ->
         String.split_on_char '\n' content
         |> List.iter (fun line ->

--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -113,7 +113,7 @@ let count_tasks_from_room (config : Room.config) ~(agent_name : string)
         if Filename.check_suffix fname ".json" then begin
           let path = Filename.concat tasks_dir fname in
           match Safe_ops.read_json_file_safe path with
-          | Error _ -> ()
+          | Error e -> Log.Reputation.debug "task file read failed %s: %s" fname e
           | Ok json ->
             let status = Safe_ops.json_string ~default:"" "status" json in
             let assignee = Safe_ops.json_string ~default:"" "assignee" json in

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -239,7 +239,7 @@ let add_comment ~post_id ~author ~content ?parent_id
                     content;
                     hearth = post.hearth;
                   }
-            | Error _ -> ());
+            | Error e -> Log.BoardLog.warn "board signal skipped: get_post failed for %s: %s" post_id (Board_types.show_board_error e));
            ok
        | Error _ as err -> err)
   | Postgres t ->
@@ -256,7 +256,7 @@ let add_comment ~post_id ~author ~content ?parent_id
                     content;
                     hearth = post.hearth;
                   }
-            | Error _ -> ());
+            | Error e -> Log.BoardLog.warn "board signal skipped: pg get_post failed for %s: %s" post_id (Board_types.show_board_error e));
            ok
        | Error _ as err -> err)
 

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -340,7 +340,7 @@ let load_neo4j_identity_cache () =
       {|{"query":"{ agents(first: 50) { edges { node { name emoji koreanName model traits interests activityLevel primaryValue } } } }"}|}
     in
     match Graphql_client.request ~timeout_sec:10.0 body with
-    | Error _ -> ()
+    | Error e -> Log.Dashboard.warn "neo4j identity cache load failed: %s" e
     | Ok output -> (
         try
           let json = Yojson.Safe.from_string output in

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -490,7 +490,7 @@ let of_json (json : Yojson.Safe.t) : (int, string) result =
       | Ok entry ->
           register entry;
           incr count
-      | Error _ -> ()  (* Skip invalid entries *)
+      | Error e -> Log.Misc.debug "prompt entry parse skipped: %s" e
     ) entries;
     Ok !count
   with e ->

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -328,7 +328,7 @@ let wait_for_message registry ~agent_name ~timeout =
       | Some msg ->
           Some msg
       | None ->
-          (match Process_eio.get_clock () with Ok clk -> Eio.Time.sleep clk check_interval | Error _ -> ());
+          (match Process_eio.get_clock () with Ok clk -> Eio.Time.sleep clk check_interval | Error e -> Log.Session.debug "clock unavailable in wait_loop: %s" e);
           wait_loop ()
     end
   in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -93,7 +93,7 @@ let handle_claim ctx args =
        Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name
          ~room_id:(Filename.basename ctx.config.base_path)
          ~task_id ()
-   | Error _ -> ());
+   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
   result_to_response result
 
 let handle_claim_next ctx _args =

--- a/lib/voice/voice_bridge_eio_core.ml
+++ b/lib/voice/voice_bridge_eio_core.ml
@@ -160,7 +160,7 @@ let local_playback_argv ?path_value ~audio_file () =
 
 let start_local_playback ~sw ~agent_id ~audio_file =
   match load_voice_config () with
-  | Error _ -> ()
+  | Error e -> Log.Misc.warn "voice config load failed, skipping playback for %s: %s" agent_id e
   | Ok config ->
       if not (Voice_config.local_playback_enabled_for_agent config agent_id) then
         ()


### PR DESCRIPTION
## Summary
- PR #2934의 후속. 남아 있던 side-effect 실패 삼킴 패턴 8건 처리
- state-changing 실패 → `warn`, read-path/iteration → `debug` 레벨 분류

## Changes (8 files)

| File | Log Level | 내용 |
|------|-----------|------|
| `board_dispatch.ml` | warn | Board SSE 알림용 get_post 실패 |
| `dashboard_execution_helpers.ml` | warn | GraphQL agent identity 캐시 로드 실패 |
| `agent_economy.ml` | warn | Economy ledger 파일 읽기 실패 |
| `voice_bridge_eio_core.ml` | warn | Voice config 로드 실패 |
| `tool_task.ml` | debug | Task claim 실패 (이미 response로 전달) |
| `agent_reputation.ml` | debug | Task JSON 스캔 중 파일 읽기 실패 |
| `prompt_registry.ml` | debug | Prompt entry 파싱 실패 |
| `session.ml` | debug | Clock 미가용 시 wait loop |

## Test plan
- [x] `dune build` pass
- [x] `dune runtest` 32 tests pass
- [ ] CI Build and Test
- [ ] CI Lint
- [ ] CI Contract Harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)