### PR TITLE
fix(keeper): route runtime status through KeeperRegistry

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -30,7 +30,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
   let series_points = 120 in
   (* Prefer KeeperRegistry (in-memory SSOT) with file fallback for
      keepers not yet started in this server session. *)
-  let registry_entries = Keeper_registry.all () in
+  let registry_entries = Keeper_registry.all ~base_path:config.base_path () in
   let registry_names =
     List.map (fun (e : Keeper_registry.registry_entry) -> e.name) registry_entries
   in
@@ -255,8 +255,11 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | `List xs -> List.length xs
             | _ -> 0
           in
-          let keepalive_running =
-            Keeper_keepalive.keeper_keepalive_running m.name
+          let keepalive_running = runtime_keepalive_running config m in
+          let registry_state =
+            match Keeper_registry.get ~base_path:config.base_path m.name with
+            | Some entry -> Some (Keeper_registry.state_to_string entry.state)
+            | None -> None
           in
 
           let context =
@@ -339,8 +342,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      ~desired:true
                      ~meta:m
                      ~keepalive_running
-                     ~keepalive_started_at:
-                       (Keeper_keepalive.keeper_keepalive_started_at m.name)
+                     ~keepalive_started_at:(runtime_keepalive_started_at config m)
                      ~now_ts
               in
               let detail_fields =
@@ -365,6 +367,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("runtime_class", `String "resident_keeper");
               ("desired", `Bool true);
               ("resident_registered", `Bool true);
+              ("registry_state",
+                match registry_state with
+                | Some state -> `String state
+                | None -> `Null);
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));
@@ -640,7 +646,7 @@ let keeper_config_json (config : Room.config) (name : string)
         let diagnostic_for_stage =
           Keeper_exec_status.keeper_diagnostic_json
             ~meta:m ~agent_status
-            ~keepalive_running:(Keeper_keepalive.keeper_keepalive_running m.name)
+            ~keepalive_running:(runtime_keepalive_running config m)
             ~history_items:[] ~now_ts
         in
         let surface =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -76,6 +76,14 @@ let unregister_keepalive name =
       Hashtbl.remove last_agent_counts name;
       remove_board_reactive_wakeups_unlocked name)
 
+let sync_registry_running ~base_path (meta : keeper_meta) =
+  match Keeper_registry.get ~base_path meta.name with
+  | Some _ ->
+      Keeper_registry.update_meta ~base_path meta.name meta;
+      Keeper_registry.set_state ~base_path meta.name Keeper_registry.Running
+  | None ->
+      ignore (Keeper_registry.register ~base_path meta.name meta)
+
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~2 s instead of waiting for the full 30-300 s interval. *)
 let interruptible_sleep ~clock ~stop ~wakeup duration =
@@ -610,26 +618,25 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     with_keepalive_registry_rw (fun () ->
         Hashtbl.replace keepalives m.name
           { stop; wakeup; started_at = Time_compat.now (); grpc_close });
-    (try
-       if not (Room_utils.is_initialized ctx.config) then
-         let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ()
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.error "room init failed: %s"
-         (Printexc.to_string exn));
-    (try
-       let synced = ensure_keeper_room_presence ctx.config m in
-       (match write_meta ctx.config synced with
-        | Ok () -> ()
-        | Error e -> Log.Keeper.warn "write_meta failed (bootstrap): %s" e)
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.error "room presence bootstrap failed: %s"
-         (Printexc.to_string exn));
+    let live_meta =
+      try
+        (if not (Room_utils.is_initialized ctx.config) then
+           let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ());
+        let synced = ensure_keeper_room_presence ctx.config m in
+        (match write_meta ctx.config synced with
+         | Ok () -> ()
+         | Error e -> Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
+        synced
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.error "room presence bootstrap failed: %s"
+          (Printexc.to_string exn);
+        m
+    in
+    sync_registry_running ~base_path:ctx.config.base_path live_meta;
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
-        run_heartbeat_loop ~proactive_warmup_sec ctx m stop ~wakeup))
+        run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup))
 
 let stop_keepalive name =
   match
@@ -644,6 +651,11 @@ let stop_keepalive name =
   with
   | None -> ()
   | Some entry ->
+      Keeper_registry.all ()
+      |> List.iter (fun (registry_entry : Keeper_registry.registry_entry) ->
+             if String.equal registry_entry.name name then
+               Keeper_registry.set_state ~base_path:registry_entry.base_path name
+                 Keeper_registry.Stopped);
       entry.stop := true;
       (match entry.grpc_close with
        (* cleanup: best-effort gRPC close, ignore transport errors *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -15,6 +15,7 @@ type keeper_state =
   | Stopped
 
 type registry_entry = {
+  base_path : string;
   name : string;
   mutable meta : keeper_meta;
   mutable state : keeper_state;
@@ -33,6 +34,9 @@ let state_to_string = function
 let registry : (string, registry_entry) Hashtbl.t = Hashtbl.create 16
 let mu = Eio.Mutex.create ()
 
+let registry_key ~base_path name =
+  base_path ^ "\x1f" ^ name
+
 let with_lock_rw f =
   try Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
   with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
@@ -41,9 +45,10 @@ let with_lock_ro f =
   try Eio.Mutex.use_ro mu (fun () -> f ())
   with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
-let register name meta =
+let register ~base_path name meta =
   with_lock_rw (fun () ->
     let entry = {
+      base_path;
       name;
       meta;
       state = Running;
@@ -53,57 +58,65 @@ let register name meta =
       restart_count = 0;
       last_error = None;
     } in
-    Hashtbl.replace registry name entry;
+    Hashtbl.replace registry (registry_key ~base_path name) entry;
     entry)
 
-let unregister name =
-  with_lock_rw (fun () -> Hashtbl.remove registry name)
+let unregister ~base_path name =
+  with_lock_rw (fun () -> Hashtbl.remove registry (registry_key ~base_path name))
 
-let get name =
-  with_lock_ro (fun () -> Hashtbl.find_opt registry name)
+let get ~base_path name =
+  with_lock_ro (fun () -> Hashtbl.find_opt registry (registry_key ~base_path name))
 
-let get_exn name =
-  match get name with
+let get_exn ~base_path name =
+  match get ~base_path name with
   | Some e -> e
   | None -> raise Not_found
 
-let all () =
+let all ?base_path () =
   with_lock_ro (fun () ->
-    Hashtbl.fold (fun _k v acc -> v :: acc) registry [])
+    Hashtbl.fold
+      (fun _k v acc ->
+        match base_path with
+        | Some expected when not (String.equal expected v.base_path) -> acc
+        | _ -> v :: acc)
+      registry [])
 
-let update_meta name meta =
+let update_meta ~base_path name meta =
   with_lock_rw (fun () ->
-    match Hashtbl.find_opt registry name with
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
     | Some entry -> entry.meta <- meta
     | None -> ())
 
-let set_state name state =
+let set_state ~base_path name state =
   with_lock_rw (fun () ->
-    match Hashtbl.find_opt registry name with
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
     | Some entry -> entry.state <- state
     | None -> ())
 
-let record_restart name =
+let record_restart ~base_path name =
   with_lock_rw (fun () ->
-    match Hashtbl.find_opt registry name with
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
     | Some entry -> entry.restart_count <- entry.restart_count + 1
     | None -> ())
 
-let record_error name err =
+let record_error ~base_path name err =
   with_lock_rw (fun () ->
-    match Hashtbl.find_opt registry name with
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
     | Some entry -> entry.last_error <- Some err
     | None -> ())
 
-let is_running name =
-  match get name with
+let is_running ~base_path name =
+  match get ~base_path name with
   | Some { state = Running; _ } -> true
   | _ -> false
 
-let count_running () =
+let count_running ?base_path () =
   with_lock_ro (fun () ->
     Hashtbl.fold
-      (fun _k v acc -> if v.state = Running then acc + 1 else acc)
+      (fun _k v acc ->
+        match base_path with
+        | Some expected when not (String.equal expected v.base_path) -> acc
+        | _ -> if v.state = Running then acc + 1 else acc)
       registry 0)
 
 let clear () =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -15,6 +15,7 @@ type keeper_state =
   | Stopped
 
 type registry_entry = {
+  base_path : string;
   name : string;
   mutable meta : keeper_meta;
   mutable state : keeper_state;
@@ -28,37 +29,37 @@ type registry_entry = {
 val state_to_string : keeper_state -> string
 
 (** Register a keeper as running. Returns the new entry. *)
-val register : string -> keeper_meta -> registry_entry
+val register : base_path:string -> string -> keeper_meta -> registry_entry
 
 (** Unregister a keeper (removes from registry). *)
-val unregister : string -> unit
+val unregister : base_path:string -> string -> unit
 
 (** Look up a keeper by name. *)
-val get : string -> registry_entry option
+val get : base_path:string -> string -> registry_entry option
 
 (** Look up a keeper by name, raising [Not_found] if absent. *)
-val get_exn : string -> registry_entry
+val get_exn : base_path:string -> string -> registry_entry
 
 (** Return all registered keepers. *)
-val all : unit -> registry_entry list
+val all : ?base_path:string -> unit -> registry_entry list
 
 (** Update the meta for a registered keeper. No-op if not found. *)
-val update_meta : string -> keeper_meta -> unit
+val update_meta : base_path:string -> string -> keeper_meta -> unit
 
 (** Change keeper state. No-op if not found. *)
-val set_state : string -> keeper_state -> unit
+val set_state : base_path:string -> string -> keeper_state -> unit
 
 (** Record a restart for a keeper. Increments restart_count. *)
-val record_restart : string -> unit
+val record_restart : base_path:string -> string -> unit
 
 (** Record an error for a keeper. *)
-val record_error : string -> string -> unit
+val record_error : base_path:string -> string -> string -> unit
 
 (** Check if a keeper is in Running state. *)
-val is_running : string -> bool
+val is_running : base_path:string -> string -> bool
 
 (** Count keepers in Running state. *)
-val count_running : unit -> int
+val count_running : ?base_path:string -> unit -> int
 
 (** Clear the registry. For testing only. *)
 val clear : unit -> unit

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -106,6 +106,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta) entry
       (fun () ->
         Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
           ctx meta entry.stop ~wakeup:entry.wakeup;
+        Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
+          Keeper_registry.Stopped;
         Eio.Promise.resolve entry.done_r `Stopped;
         publish_lifecycle "stopped" meta.name "normal exit")
       ~finally:(fun () ->
@@ -116,6 +118,9 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta) entry
             let msg = "fiber terminated without resolution" in
             entry.crash_log :=
               keep_last_n 5 (Time_compat.now (), msg) !(entry.crash_log);
+            Keeper_registry.record_error ~base_path:ctx.config.base_path meta.name msg;
+            Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
+              Keeper_registry.Stopped;
             Eio.Promise.resolve entry.done_r (`Crashed msg);
             publish_lifecycle "crashed" meta.name msg))
 
@@ -149,15 +154,28 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Keeper.error "supervisor room init failed: %s"
          (Printexc.to_string exn));
-    (* Presence sync *)
-    (try
-       let synced = ensure_keeper_room_presence ctx.config meta in
-       ignore (write_meta ctx.config synced)
-     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-       Log.Keeper.error "supervisor presence sync failed: %s"
-         (Printexc.to_string exn));
+    let live_meta =
+      try
+        let synced = ensure_keeper_room_presence ctx.config meta in
+        ignore (write_meta ctx.config synced);
+        synced
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Log.Keeper.error "supervisor presence sync failed: %s"
+          (Printexc.to_string exn);
+        meta
+    in
+    (match Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name with
+     | Some _ ->
+         Keeper_registry.update_meta ~base_path:ctx.config.base_path live_meta.name
+           live_meta;
+         Keeper_registry.set_state ~base_path:ctx.config.base_path live_meta.name
+           Keeper_registry.Running
+     | None ->
+         ignore
+           (Keeper_registry.register ~base_path:ctx.config.base_path live_meta.name
+              live_meta));
     publish_lifecycle "started" meta.name "supervised";
-    launch_supervised_fiber ~proactive_warmup_sec ctx meta entry
+    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta entry
   end
 
 (* ── Sweep and recover ───────────────────────────────────── *)

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -5,7 +5,6 @@ open Tool_args
 open Keeper_types
 open Keeper_memory
 open Keeper_alerting
-open Keeper_keepalive
 open Keeper_execution
 open Keeper_exec_status
 open Keeper_exec_status_metrics
@@ -183,7 +182,7 @@ let handle_keeper_list ctx args : tool_result =
               ("will", if String.trim m.will = "" then `Null else `String m.will);
               ("needs", if String.trim m.needs = "" then `Null else `String m.needs);
               ("desires", if String.trim m.desires = "" then `Null else `String m.desires);
-              ("keepalive_running", `Bool (keeper_keepalive_running m.name));
+              ("keepalive_running", `Bool (runtime_keepalive_running ctx.config m));
               ("active_model", `String active_model);
               ("next_model_hint", match next_model_hint with Some s -> `String s | None -> `Null);
               ("keeper_age_s", `Float keeper_age_s);

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -134,6 +134,19 @@ let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_default
         | None -> false)
   |> List.rev
 
+let runtime_registry_entry (config : Room_utils.config) name =
+  Keeper_registry.get ~base_path:config.base_path name
+
+let runtime_keepalive_running config (meta : keeper_meta) =
+  match runtime_registry_entry config meta.name with
+  | Some entry -> entry.state = Keeper_registry.Running
+  | None -> Keeper_keepalive.keeper_keepalive_running meta.name
+
+let runtime_keepalive_started_at config (meta : keeper_meta) =
+  match runtime_registry_entry config meta.name with
+  | Some entry -> Some entry.started_at
+  | None -> Keeper_keepalive.keeper_keepalive_started_at meta.name
+
 let runtime_surface_json config (meta : keeper_meta) =
   let resident_spec =
     match read_resident_keeper config meta.name with
@@ -145,16 +158,29 @@ let runtime_surface_json config (meta : keeper_meta) =
     | Some spec -> spec.desired
     | None -> false
   in
+  let keepalive_running = runtime_keepalive_running config meta in
+  let fiber_health =
+    match Keeper_resident_supervisor.fiber_health_of meta.name with
+    | Fiber_unknown when keepalive_running -> Fiber_alive
+    | health -> health
+  in
+  let registry_state =
+    match runtime_registry_entry config meta.name with
+    | Some entry -> Some (Keeper_registry.state_to_string entry.state)
+    | None -> None
+  in
   `Assoc
     [
       ("paused", `Bool meta.paused);
       ("desired", `Bool desired);
       ("resident_registered", `Bool (Option.is_some resident_spec));
-      ("keepalive_running", `Bool (Keeper_keepalive.keeper_keepalive_running meta.name));
+      ("keepalive_running", `Bool keepalive_running);
+      ("registry_state",
+       match registry_state with
+       | Some state -> `String state
+       | None -> `Null);
       ( "fiber_health",
-        `String
-          (Keeper_exec_status.string_of_fiber_health
-             (Keeper_resident_supervisor.fiber_health_of meta.name)) );
+        `String (Keeper_exec_status.string_of_fiber_health fiber_health) );
       ("presence_keepalive", `Bool meta.presence_keepalive);
       ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);
     ]

--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -30,6 +30,12 @@ val coordination_surface_json : keeper_meta -> Yojson.Safe.t
 val live_override_fields :
   keeper_meta -> keeper_profile_defaults -> string list
 
+val runtime_keepalive_running :
+  Room_utils.config -> keeper_meta -> bool
+
+val runtime_keepalive_started_at :
+  Room_utils.config -> keeper_meta -> float option
+
 val runtime_surface_json :
   Room_utils.config -> keeper_meta -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -6,7 +6,6 @@ open Keeper_types
 open Keeper_memory
 open Keeper_alerting
 open Keeper_exec_tools
-open Keeper_keepalive
 open Keeper_execution
 open Keeper_exec_status
 open Keeper_exec_status_metrics
@@ -71,7 +70,7 @@ let handle_keeper_status ctx args : tool_result =
                  ("message_count", `Int (List.length c.messages));
                ]
          in
-         let keepalive_running = keeper_keepalive_running m.name in
+         let keepalive_running = runtime_keepalive_running ctx.config m in
          let agent_status = parse_agent_status ctx.config ~agent_name:m.agent_name in
          let now_ts = Time_compat.now () in
          let created_ts =
@@ -310,7 +309,7 @@ let handle_keeper_status ctx args : tool_result =
                 ~desired:(is_resident_keeper ctx.config m.name)
                 ~meta:m
                 ~keepalive_running
-                ~keepalive_started_at:(keeper_keepalive_started_at m.name)
+                ~keepalive_started_at:(runtime_keepalive_started_at ctx.config m)
                 ~now_ts
          in
          let compaction_history_tail =

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -97,8 +97,9 @@ let handle_keeper_down ctx args : tool_result =
         (Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
            ~target_type:"keeper" ~target_id:(Some name));
       (if remove_meta then
-         Safe_ops.remove_file_logged ~context:"keeper_down"
-           (keeper_meta_path ctx.config name)
+         ( Safe_ops.remove_file_logged ~context:"keeper_down"
+             (keeper_meta_path ctx.config name);
+           Keeper_registry.unregister ~base_path:ctx.config.base_path name )
        else
          let retained =
            {
@@ -109,7 +110,10 @@ let handle_keeper_down ctx args : tool_result =
              paused = true;
            }
          in
-         write_meta_logged ctx.config retained);
+         (write_meta_logged ctx.config retained;
+          Keeper_registry.update_meta ~base_path:ctx.config.base_path name retained;
+          Keeper_registry.set_state ~base_path:ctx.config.base_path name
+            Keeper_registry.Paused));
       if remove_session then (
         let rec rm_rf path =
           if Sys.file_exists path then begin

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -3,6 +3,8 @@ open Alcotest
 module R = Masc_mcp.Keeper_registry
 module Keeper_types = Masc_mcp.Keeper_types
 
+let bp = "/tmp/test"
+
 let make_meta name =
   let json = `Assoc [
     ("name", `String name);
@@ -18,99 +20,99 @@ let make_meta name =
 let test_register_and_get () =
   R.clear ();
   let meta = make_meta "k1" in
-  let entry = R.register "k1" meta in
+  let entry = R.register ~base_path:bp "k1" meta in
   check string "name" "k1" entry.name;
   check string "state" "running" (R.state_to_string entry.state);
-  match R.get "k1" with
+  match R.get ~base_path:bp "k1" with
   | None -> fail "expected entry for k1"
   | Some e -> check string "get name" "k1" e.name
 
 let test_unregister () =
   R.clear ();
-  let _entry = R.register "k2" (make_meta "k2") in
-  check bool "exists before" true (Option.is_some (R.get "k2"));
-  R.unregister "k2";
-  check bool "gone after" true (Option.is_none (R.get "k2"))
+  let _entry = R.register ~base_path:bp "k2" (make_meta "k2") in
+  check bool "exists before" true (Option.is_some (R.get ~base_path:bp "k2"));
+  R.unregister ~base_path:bp "k2";
+  check bool "gone after" true (Option.is_none (R.get ~base_path:bp "k2"))
 
 let test_all () =
   R.clear ();
-  let _e1 = R.register "a" (make_meta "a") in
-  let _e2 = R.register "b" (make_meta "b") in
-  let _e3 = R.register "c" (make_meta "c") in
+  let _e1 = R.register ~base_path:bp "a" (make_meta "a") in
+  let _e2 = R.register ~base_path:bp "b" (make_meta "b") in
+  let _e3 = R.register ~base_path:bp "c" (make_meta "c") in
   let all = R.all () in
   check int "count" 3 (List.length all)
 
 let test_update_meta () =
   R.clear ();
-  let _entry = R.register "k3" (make_meta "k3") in
+  let _entry = R.register ~base_path:bp "k3" (make_meta "k3") in
   let updated_meta = { (make_meta "k3") with goal = "updated goal" } in
-  R.update_meta "k3" updated_meta;
-  match R.get "k3" with
+  R.update_meta ~base_path:bp "k3" updated_meta;
+  match R.get ~base_path:bp "k3" with
   | None -> fail "expected k3"
   | Some e -> check string "goal updated" "updated goal" e.meta.goal
 
 let test_set_state () =
   R.clear ();
-  let _entry = R.register "k4" (make_meta "k4") in
-  check bool "running" true (R.is_running "k4");
-  R.set_state "k4" R.Paused;
-  check bool "not running after pause" false (R.is_running "k4");
-  match R.get "k4" with
+  let _entry = R.register ~base_path:bp "k4" (make_meta "k4") in
+  check bool "running" true (R.is_running ~base_path:bp "k4");
+  R.set_state ~base_path:bp "k4" R.Paused;
+  check bool "not running after pause" false (R.is_running ~base_path:bp "k4");
+  match R.get ~base_path:bp "k4" with
   | None -> fail "expected k4"
   | Some e -> check string "state" "paused" (R.state_to_string e.state)
 
 let test_count_running () =
   R.clear ();
-  let _e1 = R.register "r1" (make_meta "r1") in
-  let _e2 = R.register "r2" (make_meta "r2") in
-  let _e3 = R.register "r3" (make_meta "r3") in
+  let _e1 = R.register ~base_path:bp "r1" (make_meta "r1") in
+  let _e2 = R.register ~base_path:bp "r2" (make_meta "r2") in
+  let _e3 = R.register ~base_path:bp "r3" (make_meta "r3") in
   check int "3 running" 3 (R.count_running ());
-  R.set_state "r2" R.Paused;
+  R.set_state ~base_path:bp "r2" R.Paused;
   check int "2 running" 2 (R.count_running ());
-  R.unregister "r1";
+  R.unregister ~base_path:bp "r1";
   check int "1 running" 1 (R.count_running ())
 
 let test_record_restart () =
   R.clear ();
-  let _entry = R.register "k5" (make_meta "k5") in
-  R.record_restart "k5";
-  R.record_restart "k5";
-  match R.get "k5" with
+  let _entry = R.register ~base_path:bp "k5" (make_meta "k5") in
+  R.record_restart ~base_path:bp "k5";
+  R.record_restart ~base_path:bp "k5";
+  match R.get ~base_path:bp "k5" with
   | None -> fail "expected k5"
   | Some e -> check int "restart count" 2 e.restart_count
 
 let test_record_error () =
   R.clear ();
-  let _entry = R.register "k6" (make_meta "k6") in
+  let _entry = R.register ~base_path:bp "k6" (make_meta "k6") in
   check bool "no error initially" true
-    (Option.is_none (Option.bind (R.get "k6") (fun e -> e.last_error)));
-  R.record_error "k6" "something broke";
-  match R.get "k6" with
+    (Option.is_none (Option.bind (R.get ~base_path:bp "k6") (fun e -> e.last_error)));
+  R.record_error ~base_path:bp "k6" "something broke";
+  match R.get ~base_path:bp "k6" with
   | None -> fail "expected k6"
   | Some e ->
     check (option string) "error recorded" (Some "something broke") e.last_error
 
 let test_get_exn_not_found () =
   R.clear ();
-  match R.get_exn "nonexistent" with
+  match R.get_exn ~base_path:bp "nonexistent" with
   | _ -> fail "expected Not_found"
   | exception Not_found -> ()
 
 let test_noop_on_missing () =
   R.clear ();
-  R.update_meta "ghost" (make_meta "ghost");
-  R.set_state "ghost" R.Paused;
-  R.record_restart "ghost";
-  R.record_error "ghost" "err";
-  R.unregister "ghost";
+  R.update_meta ~base_path:bp "ghost" (make_meta "ghost");
+  R.set_state ~base_path:bp "ghost" R.Paused;
+  R.record_restart ~base_path:bp "ghost";
+  R.record_error ~base_path:bp "ghost" "err";
+  R.unregister ~base_path:bp "ghost";
   check bool "no crash on missing" true true
 
 let test_register_replaces () =
   R.clear ();
-  let _e1 = R.register "dup" (make_meta "dup") in
-  R.record_restart "dup";
-  let _e2 = R.register "dup" (make_meta "dup") in
-  match R.get "dup" with
+  let _e1 = R.register ~base_path:bp "dup" (make_meta "dup") in
+  R.record_restart ~base_path:bp "dup";
+  let _e2 = R.register ~base_path:bp "dup" (make_meta "dup") in
+  match R.get ~base_path:bp "dup" with
   | None -> fail "expected dup"
   | Some e ->
     check int "restart count reset" 0 e.restart_count

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -904,7 +904,21 @@ let test_keepalive_gap_reports_not_running_instead_of_disabled () =
           json |> member "diagnostic" |> member "quiet_reason" |> to_string);
       check string "continuity state not_running" "not_running"
         Yojson.Safe.Util.(
-          json |> member "diagnostic" |> member "continuity_state" |> to_string))
+          json |> member "diagnostic" |> member "continuity_state" |> to_string);
+      check string "runtime registry state stopped" "stopped"
+        Yojson.Safe.Util.(
+          json |> member "runtime" |> member "registry_state" |> to_string);
+      let ok, _ =
+        dispatch "masc_keeper_down" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "keeper down ok" true ok;
+      let entry =
+        match Masc_mcp.Keeper_registry.get ~base_path:config.base_path "resident-demo" with
+        | Some entry -> entry
+        | None -> fail "missing registry entry after keeper_down"
+      in
+      check string "registry state paused" "paused"
+        (Masc_mcp.Keeper_registry.state_to_string entry.state))
 
 let test_resident_keeper_msg_bootstraps_then_requires_message () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- scope `KeeperRegistry` entries by `config.base_path` and wire the live keeper lifecycle to update registry state on start, stop, crash, and keeper_down
- switch keeper runtime consumers to prefer registry-backed keepalive state and expose `runtime.registry_state` on status/config surfaces
- lock the running -> stopped -> paused transition with keeper lifecycle regression checks

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-2904-keeper-registry-runtime test/test_tool_keeper.exe test/test_operator_control.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-2904-keeper-registry-runtime/_build/default/test/test_tool_keeper.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-2904-keeper-registry-runtime/_build/default/test/test_operator_control.exe`

Refs #2904