### PR TITLE
fix(pg): increase domain-local readonly pool size to prevent concurrent usage error

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -290,7 +290,16 @@ let create_eio_readonly ~sw ~env (cfg : config) : (t, error) result =
   | None -> Error (ConnectionFailed "PostgreSQL URL not configured")
   | Some url ->
       let uri = Uri.of_string url in
-      let pool_config = Caqti_pool_config.create ~max_size:1 () in
+      (* Domain-local pools need >1 connection to avoid "Invalid concurrent
+         usage" when multiple Eio fibers within the same executor domain
+         call Pool.use concurrently (e.g. dashboard room-truth parallel
+         fetch).  Use half the main pool size, minimum 3. *)
+      let main_pool_max = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
+        | Some s -> (try max 1 (min (int_of_string s) 50) with _ -> 5)
+        | None -> 5
+      in
+      let max_pool = max 3 (main_pool_max / 2) in
+      let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
       match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
       | Error err -> Error (caqti_error_to_masc err)
       | Ok pool ->


### PR DESCRIPTION
## Summary
- `create_eio_readonly`의 PG pool `max_size:1` → `max(3, MASC_PG_POOL_SIZE/2)`로 변경
- Dashboard Executor_pool 내 여러 Eio fiber가 동시에 `Pool.use`를 호출할 때 Caqti의 "Invalid concurrent usage of PostgreSQL connection detected" 에러 방지

## Problem
- Domain-local readonly pool이 `max_size:1`로 생성됨
- Dashboard proactive refresh / room-truth parallel fetch에서 concurrent fiber가 같은 pool의 단일 connection을 사용하려 할 때 Caqti connection-level `in_use` flag에 걸림
- 오염된 connection이 pool에 반환되지 않아 cascade로 전체 서버의 PG 호출이 block
- 모든 tool call (masc_check, masc_keeper_list 등)이 30초 timeout으로 실패

## Root Cause
```
caqti-driver-postgresql/caqti_driver_postgresql.ml:
  let using_db f =
    if !in_use then
      failwith "Invalid concurrent usage of PostgreSQL connection detected.";
```

## Fix
`max_size:1` → `max 3 (MASC_PG_POOL_SIZE / 2)` — domain-local pool도 concurrent fiber를 처리할 수 있는 최소 connection 수 보장.

## Test plan
- [ ] PG backend (`MASC_STORAGE_TYPE=postgres`)로 서버 시작 후 tool call 정상 응답 확인
- [ ] Dashboard refresh loop에서 "concurrent usage" 에러 미발생 확인
- [ ] `dune build` 성공