### PR TITLE
refactor(keeper): wire Keeper_registry as SSOT for keeper state (#2904)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -256,7 +256,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | _ -> 0
           in
           let keepalive_running =
-            Keeper_keepalive.keeper_keepalive_running m.name
+            Keeper_registry.is_running m.name
           in
 
           let context =
@@ -640,7 +640,7 @@ let keeper_config_json (config : Room.config) (name : string)
         let diagnostic_for_stage =
           Keeper_exec_status.keeper_diagnostic_json
             ~meta:m ~agent_status
-            ~keepalive_running:(Keeper_keepalive.keeper_keepalive_running m.name)
+            ~keepalive_running:(Keeper_registry.is_running m.name)
             ~history_items:[] ~now_ts
         in
         let surface =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -199,7 +199,9 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               try
                 let synced = ensure_keeper_room_presence ctx.config meta_current in
                 (match write_meta ctx.config synced with
-                 | Ok () -> synced  (* use written value directly, no second read_meta *)
+                 | Ok () ->
+                   Keeper_registry.update_meta synced.name synced;
+                   synced
                  | Error e ->
                    Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
                    synced)
@@ -610,6 +612,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     with_keepalive_registry_rw (fun () ->
         Hashtbl.replace keepalives m.name
           { stop; wakeup; started_at = Time_compat.now (); grpc_close });
+    ignore (Keeper_registry.register m.name m : Keeper_registry.registry_entry);
     (try
        if not (Room_utils.is_initialized ctx.config) then
          let (_init_msg : string) = Room.init ctx.config ~agent_name:None in ()
@@ -644,6 +647,8 @@ let stop_keepalive name =
   with
   | None -> ()
   | Some entry ->
+      Keeper_registry.set_state name Keeper_registry.Stopped;
+      Keeper_registry.unregister name;
       entry.stop := true;
       (match entry.grpc_close with
        (* cleanup: best-effort gRPC close, ignore transport errors *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -102,5 +102,10 @@ let count_running () =
       (fun _k v acc -> if v.state = Running then acc + 1 else acc)
       registry 0)
 
+let started_at name =
+  match get name with
+  | Some e -> Some e.started_at
+  | None -> None
+
 let clear () =
   with_lock (fun () -> Hashtbl.clear registry)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -54,6 +54,9 @@ val record_restart : string -> unit
 (** Record an error for a keeper. *)
 val record_error : string -> string -> unit
 
+(** Return the started_at timestamp for a keeper, or None if not registered. *)
+val started_at : string -> float option
+
 (** Check if a keeper is in Running state. *)
 val is_running : string -> bool
 

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -116,6 +116,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta) entry
             let msg = "fiber terminated without resolution" in
             entry.crash_log :=
               keep_last_n 5 (Time_compat.now (), msg) !(entry.crash_log);
+            Keeper_registry.record_error meta.name msg;
             Eio.Promise.resolve entry.done_r (`Crashed msg);
             publish_lifecycle "crashed" meta.name msg))
 
@@ -138,6 +139,7 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
       crash_log = ref [];
     } in
     Hashtbl.replace supervised_registry meta.name entry;
+    ignore (Keeper_registry.register meta.name meta : Keeper_registry.registry_entry);
     (* Register in the shared keepalive registry *)
     let wakeup = ref false in
     Keeper_keepalive.register_keepalive meta.name
@@ -187,7 +189,9 @@ let sweep_and_recover (ctx : _ context) =
         end
   ) supervised_registry;
   (* Clean up stopped/dead entries *)
-  List.iter (fun name -> Hashtbl.remove supervised_registry name) !to_remove;
+  List.iter (fun name ->
+      Hashtbl.remove supervised_registry name;
+      Keeper_registry.unregister name) !to_remove;
   (* Restart zombies *)
   List.iter (fun (name, (old_entry : supervised_entry), crash_msg) ->
     match read_meta ctx.config name with
@@ -206,6 +210,8 @@ let sweep_and_recover (ctx : _ context) =
           crash_log = ref (keep_last_n 5 (now, crash_msg) !(old_entry.crash_log));
         } in
         Hashtbl.replace supervised_registry name new_entry;
+        ignore (Keeper_registry.register name meta : Keeper_registry.registry_entry);
+        Keeper_registry.record_restart name;
         Keeper_keepalive.register_keepalive name
           { Keeper_keepalive.stop = new_entry.stop; wakeup = new_wakeup;
             started_at = now; grpc_close = None };

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -2,7 +2,6 @@
     Runtime-only mutable state stays behind keeper runtime/execution modules. *)
 
 open Keeper_types
-open Keeper_keepalive
 open Keeper_exec_status
 
 let maybe_promote_live_persistent_keeper config name =
@@ -81,7 +80,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     let remaining_slots =
       ref
         (if max_keepers > 0 then
-           max 0 (max_keepers - running_keepers ())
+           max 0 (max_keepers - Keeper_registry.count_running ())
          else
            max_int)
     in
@@ -103,7 +102,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 && (m.usage.last_turn_ts <= 0.0
                     || now_ts -. m.usage.last_turn_ts >= stale_turn_sec)
               in
-              let already_running = keeper_keepalive_running m.name in
+              let already_running = Keeper_registry.is_running m.name in
               let started_here =
                 if already_running then false
                 else if max_keepers > 0 && !remaining_slots <= 0 then false

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -5,7 +5,6 @@ open Tool_args
 open Keeper_types
 open Keeper_memory
 open Keeper_alerting
-open Keeper_keepalive
 open Keeper_execution
 open Keeper_exec_status
 open Keeper_exec_status_metrics
@@ -183,7 +182,7 @@ let handle_keeper_list ctx args : tool_result =
               ("will", if String.trim m.will = "" then `Null else `String m.will);
               ("needs", if String.trim m.needs = "" then `Null else `String m.needs);
               ("desires", if String.trim m.desires = "" then `Null else `String m.desires);
-              ("keepalive_running", `Bool (keeper_keepalive_running m.name));
+              ("keepalive_running", `Bool (Keeper_registry.is_running m.name));
               ("active_model", `String active_model);
               ("next_model_hint", match next_model_hint with Some s -> `String s | None -> `Null);
               ("keeper_age_s", `Float keeper_age_s);

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -150,7 +150,7 @@ let runtime_surface_json config (meta : keeper_meta) =
       ("paused", `Bool meta.paused);
       ("desired", `Bool desired);
       ("resident_registered", `Bool (Option.is_some resident_spec));
-      ("keepalive_running", `Bool (Keeper_keepalive.keeper_keepalive_running meta.name));
+      ("keepalive_running", `Bool (Keeper_registry.is_running meta.name));
       ( "fiber_health",
         `String
           (Keeper_exec_status.string_of_fiber_health

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -71,7 +71,7 @@ let handle_keeper_status ctx args : tool_result =
                  ("message_count", `Int (List.length c.messages));
                ]
          in
-         let keepalive_running = keeper_keepalive_running m.name in
+         let keepalive_running = Keeper_registry.is_running m.name in
          let agent_status = parse_agent_status ctx.config ~agent_name:m.agent_name in
          let now_ts = Time_compat.now () in
          let created_ts =

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -176,7 +176,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = true) config =
               Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
             in
             let keepalive_running =
-              Keeper_keepalive.keeper_keepalive_running meta.name
+              Keeper_registry.is_running meta.name
             in
             let agent_exists =
               match agent_json |> U.member "exists" with
@@ -185,7 +185,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = true) config =
             in
             let now_ts = Time_compat.now () in
             let keepalive_started_at =
-              Keeper_keepalive.keeper_keepalive_started_at meta.name
+              Keeper_registry.started_at meta.name
             in
             let diagnostic =
               Keeper_exec_status.keeper_diagnostic_json ~meta

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -202,7 +202,7 @@ let make_health_json ?(listener = "http/1.1") request =
       ("live_words", `Int s.live_words);
       ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
     ]);
-    ("keeper_fibers", `Int (Keeper_keepalive.running_keepers ()));
+    ("keeper_fibers", `Int (Keeper_registry.count_running ()));
   ]
 
 (** Health check handler *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -127,7 +127,7 @@ let keeper_list_row_json ~runtime_class ~desired ~resident_registered config
   | Error _ | Ok None -> None
   | Ok (Some (meta : keeper_meta)) ->
       let now_ts = Time_compat.now () in
-      let keepalive_running = Keeper_keepalive.keeper_keepalive_running meta.name in
+      let keepalive_running = Keeper_registry.is_running meta.name in
       let agent_status =
         Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
       in

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -115,6 +115,16 @@ let test_register_replaces () =
   | Some e ->
     check int "restart count reset" 0 e.restart_count
 
+let test_started_at () =
+  R.clear ();
+  check (option (float 0.01)) "none before register" None (R.started_at "s1");
+  let _entry = R.register "s1" (make_meta "s1") in
+  (match R.started_at "s1" with
+   | None -> fail "expected started_at after register"
+   | Some ts -> check bool "positive timestamp" true (ts > 0.0));
+  R.unregister "s1";
+  check (option (float 0.01)) "none after unregister" None (R.started_at "s1")
+
 let () =
   run "Keeper_registry"
     [
@@ -131,5 +141,6 @@ let () =
           test_case "get_exn not found" `Quick test_get_exn_not_found;
           test_case "noop on missing keys" `Quick test_noop_on_missing;
           test_case "register replaces existing" `Quick test_register_replaces;
+          test_case "started_at" `Quick test_started_at;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Phase 2 of #2904 (keeper state SSOT 통합)
- `Keeper_registry`를 keeper 생명주기(start/stop/heartbeat/supervise/sweep)에 연결
- 7곳의 `keeper_keepalive_running` → `Keeper_registry.is_running` 교체
- 2곳의 `running_keepers` → `Keeper_registry.count_running` 교체
- `started_at` accessor 추가 (12개 registry 테스트 통과)
- 내부 Hashtbl(keepalive/supervisor)은 파이버 제어용으로 유지, Registry가 외부 API

## Changes (13 files, +43/-15)

| Area | File | Change |
|------|------|--------|
| Registry | `keeper_registry.ml/.mli` | `started_at` accessor 추가 |
| Lifecycle | `keeper_keepalive.ml` | register on start, unregister on stop, update_meta in heartbeat |
| Supervisor | `keeper_resident_supervisor.ml` | register on supervise, unregister on sweep, record_restart/record_error |
| Consumers | 7 files | `keeper_keepalive_running` → `Keeper_registry.is_running` |
| Test | `test_keeper_registry.ml` | `started_at` 테스트 추가 |

## Test plan

- [x] `dune build` 성공
- [x] `dune test` 전체 통과
- [x] `test_keeper_registry.exe` 12개 테스트 통과 (started_at 포함)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)