### PR TITLE
fix(build): auto-build dashboard SPA on make build + fix TS types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,17 @@
 # Default target — OCaml + dashboard
 all: build-all
 
-# Build OCaml only
+# Build OCaml + dashboard (dashboard rebuilds only when sources changed)
 build:
 	dune build --root .
+	@scripts/build-dashboard-if-needed.sh
 
-# Build dashboard SPA (Vite)
+# Build dashboard SPA (Vite) — force rebuild
 dashboard:
 	cd dashboard && npm ci && npm run build
 
-# Build everything (OCaml + dashboard)
-build-all: build dashboard
+# Build everything (alias for build)
+build-all: build
 
 # Run tests (alias for test-unit)
 test:

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -446,6 +446,9 @@ export interface OperatorKeeperSnapshot {
   context_tokens?: number
   keepalive_running?: boolean
   autonomous_action_count?: number
+  autonomous_turn_count?: number
+  autonomous_text_turn_count?: number
+  autonomous_tool_turn_count?: number
   last_model_used?: string
   active_model?: string
   diagnostic?: Record<string, unknown>

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# build-dashboard-if-needed.sh — Rebuild dashboard SPA only when sources changed.
+# Called by `make build`. Compares source mtime against build output.
+# Skips when: no package.json, npm missing, or sources unchanged.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DASHBOARD_DIR="$REPO_ROOT/dashboard"
+OUTPUT_DIR="$REPO_ROOT/assets/dashboard"
+STAMP="$OUTPUT_DIR/.build-stamp"
+
+# No dashboard source — nothing to do
+if [ ! -f "$DASHBOARD_DIR/package.json" ]; then
+  exit 0
+fi
+
+# No npm — skip silently
+if ! command -v npm >/dev/null 2>&1; then
+  echo "[dashboard] npm not found, skipping." >&2
+  exit 0
+fi
+
+# Check if rebuild is needed: any source file newer than stamp
+needs_rebuild() {
+  # No stamp or no output → must build
+  [ ! -f "$STAMP" ] && return 0
+  [ ! -f "$OUTPUT_DIR/index.html" ] && return 0
+
+  # Any .ts/.tsx/.css/.html source newer than stamp → rebuild
+  if find "$DASHBOARD_DIR/src" \
+       -newer "$STAMP" \( -name '*.ts' -o -name '*.tsx' -o -name '*.css' -o -name '*.html' \) \
+       2>/dev/null | head -1 | grep -q .; then
+    return 0
+  fi
+
+  # Root index.html newer than stamp → rebuild
+  if [ "$DASHBOARD_DIR/index.html" -nt "$STAMP" ]; then
+    return 0
+  fi
+
+  # package.json changed → rebuild (deps may have changed)
+  if [ "$DASHBOARD_DIR/package.json" -nt "$STAMP" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+if needs_rebuild; then
+  echo "[dashboard] Sources changed, rebuilding SPA..." >&2
+  (cd "$DASHBOARD_DIR" && npm install --prefer-offline --no-audit 2>&1 | tail -1 >&2 && npm run build 2>&1 | tail -3 >&2) || {
+    echo "[dashboard] Build failed (non-fatal)." >&2
+    exit 0
+  }
+  touch "$STAMP"
+  echo "[dashboard] Build complete." >&2
+else
+  echo "[dashboard] Up to date, skipping." >&2
+fi


### PR DESCRIPTION
## Summary
- `make build` now auto-builds dashboard SPA when sources changed (mtime stamp comparison)
- Dashboard rebuild skipped when up to date (~0s overhead)
- Build failure is non-fatal (server shows fallback page)
- Fix missing `autonomous_turn_count` / `autonomous_text_turn_count` / `autonomous_tool_turn_count` fields in `OperatorKeeperSnapshot` type (was causing `tsc` build failure)

## Files
- `scripts/build-dashboard-if-needed.sh` (new) — conditional build script
- `Makefile` — `build` target includes dashboard
- `dashboard/src/types/dashboard-mission.ts` — add 3 missing fields

## Test plan
- [ ] `make build` runs dune + dashboard build
- [ ] Second `make build` shows "[dashboard] Up to date, skipping."
- [ ] `touch dashboard/src/app.ts && make build` triggers rebuild
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)