### PR TITLE
feat(validation): add tool input schema pre-dispatch validation (C-4)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -392,6 +392,7 @@
    tool_catalog
    tool_result
    tool_dispatch
+   tool_input_validation
    tool_tag_init
    tool_permissions
    sse_room_filter

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -166,7 +166,11 @@ let () =
   (* Inject masc_* schemas into keeper bridge for profile-based filtering.
      Must happen after all schemas are assembled. *)
   Keeper_exec_tools.inject_masc_schemas Tools.all_schemas_extended;
-  Log.Mcp.info "Tag registry initialized: %d tools registered" (tag_registry_count ())
+  Log.Mcp.info "Tag registry initialized: %d tools registered" (tag_registry_count ());
+  (* C-4: Register input schema validation pre-hook.
+     Validates tool arguments against their declared input_schema
+     before dispatch — catches missing required fields and type mismatches. *)
+  Tool_input_validation.register_pre_hook ()
 
 (** {1 execute_tool_eio -- included from Mcp_server_eio_execute} *)
 

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -167,15 +167,23 @@ type module_tag =
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
 let tag_registry_initialized = ref false
 
+(** Schema registry — maps tool name → input_schema JSON.
+    Populated alongside tag_registry during server initialization.
+    Used by Tool_input_validation pre-hook to validate arguments
+    before dispatch (C-4 precondition validation). *)
+let schema_registry : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 512
+
 let register_module_tag ~(schemas : Types.tool_schema list) ~tag =
   List.iter (fun (s : Types.tool_schema) ->
-    Hashtbl.replace tag_registry s.name tag) schemas
+    Hashtbl.replace tag_registry s.name tag;
+    Hashtbl.replace schema_registry s.name s.input_schema) schemas
 
 (** Register a single tool name with a tag (for modules without schema exports). *)
 let register_name_tag ~tool_name ~tag =
   Hashtbl.replace tag_registry tool_name tag
 
 let lookup_tag name = Hashtbl.find_opt tag_registry name
+let lookup_schema name = Hashtbl.find_opt schema_registry name
 
 let tag_registry_count () = Hashtbl.length tag_registry
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -105,6 +105,10 @@ val register_name_tag : tool_name:string -> tag:module_tag -> unit
 val lookup_tag : string -> module_tag option
 (** Look up the module tag for a tool name. *)
 
+val lookup_schema : string -> Yojson.Safe.t option
+(** Look up the input_schema JSON for a tool name.
+    Used by Tool_input_validation pre-hook for argument validation. *)
+
 val tag_registry_count : unit -> int
 (** Number of entries in the tag registry. *)
 

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -1,0 +1,160 @@
+(** Tool_input_validation — Pre-dispatch JSON Schema validation for MCP tools.
+
+    Validates tool call arguments against their declared input_schema before
+    the tool handler executes. Catches missing required fields and basic type
+    mismatches that would otherwise cause silent failures (default "" substitution)
+    or runtime exceptions deep in handler code.
+
+    Scope (intentionally limited):
+    - Required field presence check
+    - Top-level property type validation (string, integer, number, boolean, array, object)
+    - Does NOT validate: nested schemas, enums, patterns, min/max bounds
+
+    Registered as a Tool_dispatch pre-hook at server startup.
+    When validation fails, the tool call is rejected with a descriptive error
+    before any side effects occur.
+
+    @since 2.150.0 — C-4 ecosystem audit *)
+
+(* ================================================================ *)
+(* JSON Schema type checking                                         *)
+(* ================================================================ *)
+
+(** Check if a JSON value matches the declared type string.
+    Follows JSON Schema draft-07 type keywords. *)
+let value_matches_type (value : Yojson.Safe.t) (type_str : string) : bool =
+  match type_str with
+  | "string" -> (match value with `String _ -> true | _ -> false)
+  | "integer" -> (match value with `Int _ -> true | `Intlit _ -> true | _ -> false)
+  | "number" ->
+    (match value with
+     | `Float _ | `Int _ | `Intlit _ -> true
+     | _ -> false)
+  | "boolean" -> (match value with `Bool _ -> true | _ -> false)
+  | "array" -> (match value with `List _ -> true | _ -> false)
+  | "object" -> (match value with `Assoc _ -> true | _ -> false)
+  | "null" -> (match value with `Null -> true | _ -> false)
+  | _ -> true  (* Unknown type keyword — permissive, don't block *)
+
+(** Human-readable type name for a JSON value. *)
+let type_name_of (value : Yojson.Safe.t) : string =
+  match value with
+  | `String _ -> "string"
+  | `Int _ | `Intlit _ -> "integer"
+  | `Float _ -> "number"
+  | `Bool _ -> "boolean"
+  | `List _ -> "array"
+  | `Assoc _ -> "object"
+  | `Null -> "null"
+
+(* ================================================================ *)
+(* Validation engine                                                 *)
+(* ================================================================ *)
+
+(** Validate tool arguments against a JSON Schema input_schema.
+
+    Returns Ok () on success, Error message on first validation failure.
+    Checks are ordered: required fields first, then type checks.
+
+    @param tool_name Used only for error messages
+    @param schema The input_schema from tool_schema (JSON Schema object)
+    @param args The actual arguments passed to the tool call *)
+let validate ~(tool_name : string) ~(schema : Yojson.Safe.t)
+    ~(args : Yojson.Safe.t) : (unit, string) result =
+  let open Yojson.Safe.Util in
+  (* Only validate object-type schemas *)
+  let schema_type =
+    try schema |> member "type" |> to_string
+    with Type_error _ -> "object"
+  in
+  if schema_type <> "object" then Ok ()
+  else
+    (* Extract properties and required list from schema *)
+    let properties =
+      try
+        match schema |> member "properties" with
+        | `Assoc props -> props
+        | _ -> []
+      with Type_error _ -> []
+    in
+    let required =
+      try
+        match schema |> member "required" with
+        | `List items ->
+          List.filter_map (function `String s -> Some s | _ -> None) items
+        | _ -> []
+      with Type_error _ -> []
+    in
+    let arg_fields =
+      match args with
+      | `Assoc fields -> fields
+      | `Null -> []  (* Allow null as empty args — common for no-arg tools *)
+      | _ -> []      (* Non-object args: will fail required check if any exist *)
+    in
+    (* 1. Check required fields *)
+    let missing =
+      List.filter (fun key ->
+        not (List.mem_assoc key arg_fields)
+      ) required
+    in
+    if missing <> [] then
+      Error (Printf.sprintf "%s: missing required field(s): %s"
+        tool_name (String.concat ", " missing))
+    else
+      (* 2. Type-check provided fields against property schemas *)
+      let type_errors =
+        List.filter_map (fun (key, value) ->
+          match List.assoc_opt key properties with
+          | None -> None  (* Extra fields allowed — open schema *)
+          | Some prop_schema ->
+            let expected_type =
+              try
+                match prop_schema |> member "type" with
+                | `String t -> Some t
+                | _ -> None
+              with Type_error _ -> None
+            in
+            (match expected_type with
+             | None -> None  (* No type declared — skip *)
+             | Some t ->
+               if value_matches_type value t then None
+               else
+                 Some (Printf.sprintf "'%s' expected %s, got %s"
+                   key t (type_name_of value)))
+        ) arg_fields
+      in
+      if type_errors <> [] then
+        Error (Printf.sprintf "%s: type mismatch: %s"
+          tool_name (String.concat "; " type_errors))
+      else
+        Ok ()
+
+(* ================================================================ *)
+(* Pre-hook registration                                             *)
+(* ================================================================ *)
+
+(** Register input validation as a Tool_dispatch pre-hook.
+    Must be called after all tool schemas are registered (server init).
+
+    When validation fails, returns a Tool_result error that short-circuits
+    tool execution — the handler never runs and no side effects occur.
+
+    Tools without a registered schema are allowed through (permissive). *)
+let register_pre_hook () =
+  Tool_dispatch.register_pre_hook (fun ~name ~args ->
+    match Tool_dispatch.lookup_schema name with
+    | None -> None  (* No schema registered — allow *)
+    | Some schema ->
+      match validate ~tool_name:name ~schema ~args with
+      | Ok () -> None  (* Validation passed — proceed to handler *)
+      | Error msg ->
+        Log.info "tool_input_validation rejected %s: %s" name msg;
+        Some { Tool_result.
+          success = false;
+          data = `Assoc [
+            ("error", `String msg);
+            ("validation", `String "input_schema_precondition");
+          ];
+          tool_name = name;
+          duration_ms = 0.0;
+        })

--- a/test/dune
+++ b/test/dune
@@ -45,6 +45,7 @@
         test_keeper_toml
         test_keeper_bash_safety
         test_worktree_live_context
+        test_tool_input_validation
 )
  (modules test_room test_types test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
@@ -71,6 +72,7 @@
           test_keeper_toml
           test_keeper_bash_safety
           test_worktree_live_context
+          test_tool_input_validation
   )
  (libraries masc_mcp agent_sdk alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1,0 +1,177 @@
+(** Unit tests for Tool_input_validation — pre-dispatch schema validation. *)
+
+open Masc_mcp
+
+(** Simple substring check — avoids Astring dependency. *)
+let string_contains haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let found = ref false in
+    for i = 0 to hlen - nlen do
+      if not !found && String.sub haystack i nlen = needle then found := true
+    done;
+    !found
+
+(* ================================================================ *)
+(* Helper: build a simple tool schema                                *)
+(* ================================================================ *)
+
+(** Build a JSON Schema object with given properties and required list. *)
+let make_schema ?(required = []) (props : (string * string) list) : Yojson.Safe.t =
+  let prop_entries =
+    List.map (fun (name, type_str) ->
+      (name, `Assoc [("type", `String type_str)])
+    ) props
+  in
+  `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc prop_entries);
+    ("required", `List (List.map (fun s -> `String s) required));
+  ]
+
+(* ================================================================ *)
+(* Test: required field validation                                   *)
+(* ================================================================ *)
+
+let test_required_present () =
+  let schema = make_schema ~required:["name"] [("name", "string")] in
+  let args = `Assoc [("name", `String "alice")] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" msg)
+
+let test_required_missing () =
+  let schema = make_schema ~required:["name"; "room"] [("name", "string"); ("room", "string")] in
+  let args = `Assoc [("name", `String "alice")] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Error msg ->
+    Alcotest.(check bool) "mentions room" true (String.length msg > 0 && string_contains msg "room")
+  | Ok () -> Alcotest.fail "Expected Error for missing required field"
+
+let test_required_missing_multiple () =
+  let schema = make_schema ~required:["a"; "b"; "c"] [("a", "string"); ("b", "string"); ("c", "string")] in
+  let args = `Assoc [("a", `String "ok")] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Error msg ->
+    Alcotest.(check bool) "mentions b" true (string_contains msg "b");
+    Alcotest.(check bool) "mentions c" true (string_contains msg "c")
+  | Ok () -> Alcotest.fail "Expected Error for missing multiple fields"
+
+let test_no_required_fields () =
+  let schema = make_schema [("name", "string")] in
+  let args = `Assoc [] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail (Printf.sprintf "Expected Ok, got Error: %s" msg)
+
+(* ================================================================ *)
+(* Test: type validation                                             *)
+(* ================================================================ *)
+
+let test_type_string_ok () =
+  let schema = make_schema [("name", "string")] in
+  let args = `Assoc [("name", `String "alice")] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+let test_type_string_wrong () =
+  let schema = make_schema [("name", "string")] in
+  let args = `Assoc [("name", `Int 42)] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Error msg ->
+    Alcotest.(check bool) "mentions type mismatch" true
+      (string_contains msg "expected string")
+  | Ok () -> Alcotest.fail "Expected type error"
+
+let test_type_integer_ok () =
+  let schema = make_schema [("count", "integer")] in
+  let args = `Assoc [("count", `Int 5)] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+let test_type_boolean_wrong () =
+  let schema = make_schema [("flag", "boolean")] in
+  let args = `Assoc [("flag", `String "true")] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Error msg ->
+    Alcotest.(check bool) "mentions boolean" true
+      (string_contains msg "expected boolean")
+  | Ok () -> Alcotest.fail "Expected type error"
+
+let test_type_array_ok () =
+  let schema = make_schema [("items", "array")] in
+  let args = `Assoc [("items", `List [`String "a"; `String "b"])] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+let test_number_accepts_int () =
+  let schema = make_schema [("value", "number")] in
+  let args = `Assoc [("value", `Int 42)] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+(* ================================================================ *)
+(* Test: edge cases                                                  *)
+(* ================================================================ *)
+
+let test_null_args_no_required () =
+  let schema = make_schema [("optional", "string")] in
+  let args = `Null in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+let test_null_args_with_required () =
+  let schema = make_schema ~required:["name"] [("name", "string")] in
+  let args = `Null in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Error _ -> ()
+  | Ok () -> Alcotest.fail "Expected error for null args with required fields"
+
+let test_extra_fields_allowed () =
+  let schema = make_schema ~required:["name"] [("name", "string")] in
+  let args = `Assoc [("name", `String "alice"); ("extra", `Int 42)] in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+let test_non_object_schema_skipped () =
+  let schema = `Assoc [("type", `String "string")] in
+  let args = `String "anything" in
+  match Tool_input_validation.validate ~tool_name:"test" ~schema ~args with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+
+(* ================================================================ *)
+(* Runner                                                            *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "Tool_input_validation" [
+    ("required", [
+      Alcotest.test_case "present" `Quick test_required_present;
+      Alcotest.test_case "missing" `Quick test_required_missing;
+      Alcotest.test_case "missing multiple" `Quick test_required_missing_multiple;
+      Alcotest.test_case "no required fields" `Quick test_no_required_fields;
+    ]);
+    ("type_check", [
+      Alcotest.test_case "string ok" `Quick test_type_string_ok;
+      Alcotest.test_case "string wrong" `Quick test_type_string_wrong;
+      Alcotest.test_case "integer ok" `Quick test_type_integer_ok;
+      Alcotest.test_case "boolean wrong" `Quick test_type_boolean_wrong;
+      Alcotest.test_case "array ok" `Quick test_type_array_ok;
+      Alcotest.test_case "number accepts int" `Quick test_number_accepts_int;
+    ]);
+    ("edge_cases", [
+      Alcotest.test_case "null args no required" `Quick test_null_args_no_required;
+      Alcotest.test_case "null args with required" `Quick test_null_args_with_required;
+      Alcotest.test_case "extra fields allowed" `Quick test_extra_fields_allowed;
+      Alcotest.test_case "non-object schema skipped" `Quick test_non_object_schema_skipped;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

- Add pre-dispatch JSON Schema validation for MCP tool calls (C-4 ecosystem audit)
- Validates required fields + basic type checks before tool handlers execute
- Catches silent failures where missing fields defaulted to `""` via `Safe_ops`

## How It Works

Tool schemas are already defined in `tool_schemas_*.ml` but were never validated at runtime. This PR:

1. **Schema registry** (`tool_dispatch.ml`): Populates `schema_registry` alongside existing `tag_registry` during server init
2. **Validator** (`tool_input_validation.ml`): Checks required fields + JSON Schema types (string, integer, number, boolean, array, object)
3. **Pre-hook** (`mcp_server_eio.ml`): Registered after tag registry init — rejects invalid calls before any side effects

## Scope (intentionally limited)

- Required field presence
- Top-level property type matching
- Does NOT validate: nested schemas, enums, patterns, min/max bounds
- Tools without schemas pass through (permissive)

## Files Changed (7 files, +358/-2)

| File | Change |
|------|--------|
| `lib/tool_input_validation.ml` | New: validator + pre-hook registration |
| `lib/tool_dispatch.ml` | schema_registry + lookup_schema |
| `lib/tool_dispatch.mli` | Export lookup_schema |
| `lib/mcp_server_eio.ml` | Register pre-hook at startup |
| `lib/dune` | Add tool_input_validation module |
| `test/test_tool_input_validation.ml` | 14 tests |
| `test/dune` | Register test |

## Test plan

- [x] `dune build --root .` compiles (0 errors)
- [x] `dune exec test/test_tool_input_validation.exe` — 14/14 pass
- [ ] `make test` — full suite
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)