### PR TITLE
chore(keeper): SSOT cleanup Phase 3-4 — thin seed_meta, remove dead model fields, docs

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -616,6 +616,45 @@ Keeper가 응답하지 않을 때, `diagnostic.quiet_reason`을 확인:
 
 ---
 
+## 8. 설정과 동기화
+
+### 8.1 설정 소스
+
+Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는 `docs/spec/14-configuration.md` Section 12 참조.
+
+| 소스 | 경로 | 역할 |
+|------|------|------|
+| Persona template | `config/personas/<name>/profile.json` | Blueprint (goal, instructions, soul_profile 등) |
+| TOML declaration | `config/keepers/<name>.toml` | Persona 없이 선언적 정의 |
+| Persistent meta | `.masc/keeper_<name>.json` | 런타임 상태 (turn 카운트, context ratio 등) |
+
+Resident-keeper (`.masc/resident-keepers/<name>.json`)는 등록 메타데이터(persona_name, desired, timestamps)만 저장한다.
+
+### 8.2 Template 변경 반영
+
+Persona template을 수정해도 실행 중인 keeper에 자동 반영되지 않는다. 반영 방법:
+
+```text
+masc_keeper_down(name: "sangsu")
+masc_keeper_up(name: "sangsu")
+```
+
+`keeper_down`이 persistent meta를 제거하고, `keeper_up`이 template에서 fresh로 재생성한다.
+
+### 8.3 base-path 주의사항
+
+`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다 (기본: repo root).
+
+worktree에서 서버를 실행하면 `.masc/`가 worktree 내부를 가리키므로 **main repo의 keeper 상태에 접근할 수 없다**. keeper가 보이지 않을 때 가장 흔한 원인이다.
+
+해결: repo root에서 서버를 실행하거나, `--base-path`를 main repo root로 명시 지정.
+
+### 8.4 모델 실행
+
+모델 선택은 `config/cascade.json`이 유일한 권위다. Keeper 설정에 모델 필드를 직접 지정하지 않는다. `cascade_name` (기본 `"keeper_unified"`)이 cascade를 지정하고 `Oas_model_resolve`가 실행 모델을 결정한다.
+
+---
+
 ## 부록: 관련 문서
 
 | 문서 | 용도 |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -98,6 +98,21 @@ Failed tool calls include recovery hints automatically. Common patterns:
 | "no unclaimed tasks" | `masc_add_task(title="...")` |
 | "task not found" | `masc_status` to see available tasks |
 
+## 7. Keeper Bootstrap
+
+Keeper를 시작하려면:
+
+```text
+masc_keeper_up(name: "sangsu")
+```
+
+전제조건:
+- `config/personas/<name>/profile.json`이 존재해야 한다 (또는 `config/keepers/<name>.toml`)
+- 서버가 **repo root**에서 실행되어야 `.masc/` 디렉토리에 접근 가능. worktree에서 실행하면 keeper 상태를 찾지 못한다. 필요 시 `--base-path`를 repo root로 지정.
+- `MASC_PERSONAS_DIR` 환경변수로 커스텀 persona 경로 지정 가능.
+
+상세: `docs/KEEPER-USER-MANUAL.md`
+
 ## References
 
 - `docs/COMMAND-PLANE-RUNBOOK.md` — CPv2 benchmark/swarm path

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -394,3 +394,60 @@ masc_set_param(key, value)
 | `hybrid` (기본값) | LLM 우선, 실패 시 keyword fallback. |
 
 점수 공식 (keyword mode): `total = trait_overlap * 0.4 + interest_overlap * 0.4 + capability_match * 0.2`.
+
+---
+
+## 12. Keeper 설정 소스와 우선순위
+
+### 12.1 설정 소스
+
+Keeper의 행동을 결정하는 설정은 3곳에서 공급된다.
+
+| 소스 | 경로 | 형식 | 역할 |
+|------|------|------|------|
+| Persona template | `config/personas/<name>/profile.json` | JSON | Blueprint. goal, instructions, soul_profile 등 정의 |
+| TOML declaration | `config/keepers/<name>.toml` | TOML | Persona 없이 선언적으로 keeper 정의 |
+| Persistent meta | `.masc/keeper_<name>.json` | JSON | 런타임 상태. turn 카운트, context ratio 등 포함 |
+
+**Resident-keeper** (`.masc/resident-keepers/<name>.json`)는 설정 소스가 아니라 등록/lifecycle 메타데이터다. `persona_name`, `desired`, voice 설정, 타임스탬프만 저장한다.
+
+### 12.2 설정 적용 우선순위
+
+**새 keeper 생성 시** (`keeper_up`, meta 없음):
+
+```
+inline args > TOML (config/keepers/) > persona template (config/personas/) > 하드코딩 기본값
+```
+
+**기존 keeper resume 시** (`keeper_up`, meta 존재):
+
+```
+inline args > stored keeper_meta > TOML/persona template (fallback) > 하드코딩 기본값
+```
+
+코드 경로: `keeper_turn_up_args.ml:parse()` → `load_keeper_profile_defaults()`가 TOML > persona 순서로 로드.
+
+### 12.3 Persona 디렉토리 탐색 순서
+
+`personas_root_opt()` (`keeper_types_profile.ml`):
+
+```
+$MASC_PERSONAS_DIR > $MASC_BASE_PATH/config/personas/ > $ME_ROOT/personas/ (legacy, 경고 로그)
+```
+
+### 12.4 Template 변경 반영
+
+Template 변경은 기존 keeper에 자동 전파되지 않는다. 반영 방법:
+
+1. `keeper_down <name>` — keeper 중지 + meta 파일 삭제
+2. `keeper_up <name>` — template에서 fresh로 재생성
+
+### 12.5 `--base-path`와 `.masc/` 의존성
+
+`--base-path` CLI 인자가 `.masc/` 디렉토리 위치를 결정한다. 기본값은 repo root.
+
+worktree에서 서버를 실행하면 `.masc/`가 worktree 내부를 가리키므로 main repo의 keeper 상태에 접근할 수 없다. keeper가 보이지 않는 가장 흔한 원인.
+
+### 12.6 모델 실행
+
+모델 선택은 `cascade.json`이 유일한 권위다. keeper_meta의 `cascade_name` (기본 `"keeper_unified"`)이 cascade를 지정하고, `Oas_model_resolve`가 실행 모델을 결정한다. keeper 설정에 모델 필드를 직접 지정하지 않는다.

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -73,12 +73,6 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let errors = ref [] in
   let name = Safe_ops.json_string ~default:"" "name" json in
   let goal = Safe_ops.json_string ~default:"" "goal" json |> String.trim in
-  (* Legacy model fields no longer validated; cascade_name is the authority. *)
-  let _models = Safe_ops.json_string_list "models" json in
-  let _allowed_models = Safe_ops.json_string_list "allowed_models" json in
-  let _active_model =
-    Safe_ops.json_string ~default:"" "active_model" json |> String.trim
-  in
   let _policy_voice_enabled =
     Safe_ops.json_bool ~default:false "policy_voice_enabled" json
   in

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -14,7 +14,7 @@ let handle_persona_list _ctx args : tool_result =
     if detailed then
       `List (List.map persona_summary_to_json personas)
     else
-      string_list_to_json (List.map (fun persona -> persona.persona_name) personas)
+      string_list_to_json (List.map (fun (persona : Keeper_types_profile.persona_summary) -> persona.persona_name) personas)
   in
   let json =
     `Assoc

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -30,9 +30,14 @@ let maybe_promote_live_persistent_keeper config name =
 let ensure_resident_meta config (spec : resident_keeper_spec) =
   match read_meta config spec.persistent_name with
   | Ok (Some meta) -> Ok meta
-  | Ok None -> (
-      match meta_of_json spec.seed_meta with
-      | Ok meta ->
+  | Ok None ->
+    (* No persistent meta on disk. Try legacy seed_meta for backward compat,
+       otherwise require manual keeper_up (which loads fresh from template). *)
+    (match spec.seed_meta with
+     | `Assoc (_ :: _) ->
+       (* Legacy resident-keeper with full seed_meta snapshot *)
+       (match meta_of_json spec.seed_meta with
+        | Ok meta ->
           let meta =
             { meta with
               name = spec.persistent_name;
@@ -41,9 +46,17 @@ let ensure_resident_meta config (spec : resident_keeper_spec) =
             }
           in
           (match write_meta config meta with
-          | Ok () -> Ok meta
-          | Error msg -> Error msg)
-      | Error msg -> Error msg)
+           | Ok () -> Ok meta
+           | Error msg -> Error msg)
+        | Error msg -> Error msg)
+     | _ ->
+       (* Thin format: persona_name only. Cannot auto-create meta;
+          user must run keeper_up to initialize from template. *)
+       Log.Keeper.warn
+         "ensure_resident_meta: no persistent meta for %s (persona=%s) — run keeper_up to initialize"
+         spec.persistent_name spec.persona_name;
+       Error (Printf.sprintf "no persistent meta for %s — run keeper_up to initialize"
+                spec.persistent_name))
   | Error msg -> Error msg
 
 type keeper_bootstrap_stats = {

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -100,14 +100,6 @@ let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_default
        (match defaults.instructions with
         | Some value -> value <> meta.instructions
         | None -> false)
-  |> add_if "execution.models"
-       (defaults.models <> [] && defaults.models <> meta.models)
-  |> add_if "execution.allowed_models"
-       (defaults.allowed_models <> [] && defaults.allowed_models <> meta.allowed_models)
-  |> add_if "execution.active_model"
-       (match defaults.active_model with
-        | Some value -> value <> meta.active_model
-        | None -> false)
   |> add_if "coordination.room_scope"
        (match defaults.room_scope with
         | Some value ->

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -136,8 +136,10 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       Option.value ~default:old.voice_agent_id p.voice_agent_id_opt;
     mention_targets;
     persona_profile_path =
-      if String.trim old.persona_profile_path <> "" then old.persona_profile_path
-      else Option.value ~default:"" p.profile_defaults.manifest_path;
+      (* Always resolve fresh to pick up path migrations (e.g. legacy ~/me/personas/ -> config/personas/) *)
+      (match Keeper_types_profile.persona_profile_path_opt p.name with
+       | Some path -> path
+       | None -> Option.value ~default:"" p.profile_defaults.manifest_path);
     presence_keepalive =
       Option.value
         ~default:

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -544,7 +544,8 @@ type resident_keeper_spec = {
   voice_enabled : bool;
   voice_channel : string;
   voice_agent_id : string;
-  seed_meta : Yojson.Safe.t;
+  persona_name : string;
+  seed_meta : Yojson.Safe.t;  (* legacy: kept for backward-compat reads only *)
   created_at : string;
   updated_at : string;
 }
@@ -566,7 +567,7 @@ let resident_keeper_to_json (spec : resident_keeper_spec) =
       ("voice_enabled", `Bool spec.voice_enabled);
       ("voice_channel", `String spec.voice_channel);
       ("voice_agent_id", `String spec.voice_agent_id);
-      ("seed_meta", spec.seed_meta);
+      ("persona_name", `String spec.persona_name);
       ("created_at", `String spec.created_at);
       ("updated_at", `String spec.updated_at);
     ]
@@ -604,6 +605,15 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
       | `Assoc _ as value -> value
       | _ -> `Assoc []
     in
+    let persona_name =
+      match json |> member "persona_name" |> to_string_option with
+      | Some pn -> pn
+      | None ->
+        (* Legacy: extract name from seed_meta or fall back to spec name *)
+        (match seed_meta with
+         | `Assoc _ -> Safe_ops.json_string ~default:name "name" seed_meta
+         | _ -> name)
+    in
     let created_at =
       json |> member "created_at" |> to_string_option
       |> Option.value ~default:(now_iso ())
@@ -620,6 +630,7 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
         voice_enabled;
         voice_channel;
         voice_agent_id;
+        persona_name;
         seed_meta;
         created_at;
         updated_at;
@@ -698,7 +709,8 @@ let register_resident_keeper_from_meta config (meta : keeper_meta) :
       voice_enabled = meta.voice_enabled;
       voice_channel = meta.voice_channel;
       voice_agent_id = meta.voice_agent_id;
-      seed_meta = meta_to_json meta;
+      persona_name = meta.name;
+      seed_meta = `Assoc [];
       created_at;
       updated_at = now_iso ();
     }

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -208,9 +208,6 @@ type keeper_profile_defaults = {
   needs : string option;
   desires : string option;
   instructions : string option;
-  models : string list;
-  allowed_models : string list;
-  active_model : string option;
   policy_voice_enabled : bool option;
   room_scope : string option;
   scope_kind : string option;
@@ -240,9 +237,6 @@ let empty_keeper_profile_defaults = {
   needs = None;
   desires = None;
   instructions = None;
-  models = [];
-  allowed_models = [];
-  active_model = None;
   policy_voice_enabled = None;
   room_scope = None;
   scope_kind = None;
@@ -333,9 +327,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
          needs = str "needs";
          desires = str "desires";
          instructions = str "instructions";
-         models = strs "models";
-         allowed_models = strs "allowed_models";
-         active_model = str "active_model";
          policy_voice_enabled = bool_ "policy_voice_enabled";
          room_scope =
            str "room_scope"
@@ -429,9 +420,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 needs = Safe_ops.json_string_opt "needs" keeper_json;
                 desires = Safe_ops.json_string_opt "desires" keeper_json;
                 instructions = Safe_ops.json_string_opt "instructions" keeper_json;
-                models = Safe_ops.json_string_list "models" keeper_json;
-                allowed_models = Safe_ops.json_string_list "allowed_models" keeper_json;
-                active_model = Safe_ops.json_string_opt "active_model" keeper_json;
                 policy_voice_enabled =
                   (match Yojson.Safe.Util.member "policy_voice_enabled" keeper_json with
                   | `Bool flag -> Some flag

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -382,13 +382,7 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
         Log.Keeper.info "autoboot: skipping %s (desired=false)" spec.name
       else
         try
-          (* Prefer persisted meta on disk; fall back to seed_meta from resident spec. *)
-          let meta =
-            match Keeper_types.read_meta config spec.name with
-            | Ok (Some m) -> Ok m
-            | Ok None -> Keeper_types.meta_of_json spec.seed_meta
-            | Error e -> Error e
-          in
+          let meta = Keeper_runtime.ensure_resident_meta config spec in
           match meta with
           | Error e ->
             Log.Keeper.error "autoboot: failed to load meta for %s: %s" spec.name e

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -267,10 +267,6 @@ let handle_resident_keeper_status ctx args : tool_result =
            (annotate_keeper_json ~runtime_class:"resident_keeper" ~desired:true
               ~resident_registered:true json))
 
-(* Legacy model injection removed: cascade_name is the authority.
-   Kept as a no-op to avoid changing call-site signatures. *)
-let inject_models_from_meta _config _name args = args
-
 let inject_goal_from_message args =
   match Safe_ops.json_string_opt "goal" args with
   | Some _ -> args
@@ -291,7 +287,6 @@ let handle_resident_keeper_msg ctx args : tool_result =
     | _ ->
         let args_enriched =
           args |> inject_goal_from_message
-               |> inject_models_from_meta ctx.config name
         in
         let ok, body = handle_resident_keeper_up ctx args_enriched in
         if ok then Ok () else Error body
@@ -326,7 +321,6 @@ let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
     | _ ->
         let args_enriched =
           args |> inject_goal_from_message
-               |> inject_models_from_meta ctx.config name
         in
         let ok, body = handle_resident_keeper_up ctx args_enriched in
         if ok then Ok () else Error body

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -148,7 +148,6 @@ let test_profile_minimal () =
   let input = {|
 [keeper]
 goal = "test goal"
-models = ["llama:test"]
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -157,8 +156,6 @@ models = ["llama:test"]
     | Error e -> fail e
     | Ok defaults ->
       check (option string) "goal" (Some "test goal") defaults.goal;
-      check int "models count" 1 (List.length defaults.models);
-      check string "model" "llama:test" (List.hd defaults.models);
       check (option string) "soul_profile" None defaults.soul_profile
 
 let test_profile_full () =
@@ -193,9 +190,6 @@ policy_voice_enabled = false
       check (option string) "goal" (Some "analyze logs") d.goal;
       check (option string) "soul_profile" (Some "research") d.soul_profile;
       check (option string) "will" (Some "detect issues") d.will;
-      check int "models" 1 (List.length d.models);
-      check int "allowed_models" 2 (List.length d.allowed_models);
-      check (option string) "active_model" (Some "llama:qwen3.5-35b-a3b-ud-q4-xl") d.active_model;
       check (option string) "room_scope" (Some "all") d.room_scope;
       check int "mention_targets" 2 (List.length d.mention_targets);
       check (option bool) "proactive" (Some true) d.proactive_enabled;

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1382,12 +1382,10 @@ let test_write_meta_syncs_registered_resident_seed () =
         Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string);
       check string "resident voice agent id sync" ""
         Yojson.Safe.Util.(resident_json |> member "voice_agent_id" |> to_string);
-      check bool "seed proactive sync" false
-        Yojson.Safe.Util.(
-          resident_json |> member "seed_meta" |> member "proactive_enabled" |> to_bool);
-      check bool "seed trigger mode removed" true
-        Yojson.Safe.Util.(
-          resident_json |> member "seed_meta" |> member "trigger_mode" = `Null))
+      check string "persona_name in resident spec" "buddy"
+        Yojson.Safe.Util.(resident_json |> member "persona_name" |> to_string);
+      check bool "seed_meta absent in thin format" true
+        (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null))
 
 let test_keeper_up_persists_allowed_paths_to_status_policy () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

Phase 3-4 of keeper configuration SSOT cleanup (#2996). Builds on Phase 1 (PR #3001, merged) and Phase 2 (PR #3012, merged).

### Phase 3: SSOT structure

- **Remove dead model fields from `keeper_profile_defaults`**: `models`, `allowed_models`, `active_model` were neutered in Phase 2 but type fields remained. Now fully removed from type, parsers, and drift checks.
- **Thin `seed_meta` in resident-keeper**: Replace the full 95+ field `keeper_meta` JSON snapshot with a lightweight `persona_name` reference. Backward-compatible: old JSON with full `seed_meta` still parses; new writes use thin format.
- **Fix `persona_profile_path`**: Always resolve fresh via `persona_profile_path_opt()` instead of using stale stored path. Fixes legacy `~/me/personas/` -> `config/personas/` path migration.
- **Consolidate autoboot fallback**: `server_runtime_bootstrap.ml` now delegates to `Keeper_runtime.ensure_resident_meta` instead of duplicating `seed_meta` logic.

### Phase 4: Documentation

- **`docs/spec/14-configuration.md`**: Add Section 12 covering keeper configuration sources, priority order, persona directory search, template change propagation, base-path pitfall.
- **`docs/KEEPER-USER-MANUAL.md`**: Add Section 8 (configuration, base-path warning, model execution via cascade).
- **`docs/QUICK-START.md`**: Add Section 7 (keeper bootstrap prerequisites).

## Test plan

- [x] `dune build` passes
- [x] `test_tool_keeper` — 29 tests pass
- [x] `test_keeper_toml` — 24 tests pass
- [x] `test_keeper_deliberation` — 71 tests pass
- [x] `test_keeper_masc_bridge` — 6 tests pass
- [x] `test_server_runtime_bootstrap` — 6 tests pass
- [ ] Manual: verify existing resident-keepers with full `seed_meta` still autoboot

Closes #2996

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
