### PR TITLE
feat(cost): model-aware token pricing for cost estimation

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -69,6 +69,20 @@ let inference_timeout =
     ~serialize:(fun v -> `Float v)
     ~deserialize:deserialize_float
 
+(* ── cost_policy surface ──────────────────────────────────────── *)
+
+(** Per-session cost ceiling in USD.
+    Default 0.50: based on observed keeper sessions averaging $0.02-0.15
+    (local llama + GLM fallback). 0.50 is ~3x worst-case observed session cost.
+    Governs Eval_gate.max_cost_usd pre-execution gating. *)
+let _cost_max_session_usd =
+  Runtime_params.register
+    ~key:"cost.max_session_usd"
+    ~default:(fun () -> 0.50)
+    ~validate:(validate_float_range ~min:0.01 ~max:50.0 "cost_max_session_usd")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+
 (* ── surface catalog ─────────────────────────────────────────── *)
 
 type surface = {
@@ -95,6 +109,12 @@ let surfaces =
           "inference.default_model";
           "inference.timeout_seconds";
         ];
+    };
+    {
+      id = "cost_policy";
+      description = "Per-session cost limits for keeper execution";
+      risk = "medium";
+      param_keys = [ "cost.max_session_usd" ];
     };
   ]
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -78,6 +78,7 @@ let run_turn
     ?max_tokens
     ?max_cost_usd
     ?on_event
+    ?(trajectory_acc : Trajectory.accumulator option)
     ()
   : (run_result, string) result =
   (* 0. Resolve inference parameters via Cascade_inference *)
@@ -160,6 +161,7 @@ let run_turn
   let tools = extend_turns_tool :: keeper_tools in
   let hooks = Keeper_hooks_oas.make_hooks
     ~config ~meta_ref ~session ~ctx_ref ~generation ?max_cost_usd
+    ?trajectory_acc
     () in
   let base_dir = Filename.concat config.base_path ".masc" in
   let memory =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -149,13 +149,8 @@ let make_hooks
         (* Emit per-turn cost event for task attribution *)
         (match trajectory_acc with
          | Some acc ->
-           (* Rough per-turn cost estimate based on token count.
-              Local llama models are effectively free; cloud models
-              average ~$0.003/1K input + $0.015/1K output tokens.
-              This estimate errs conservative (uses cloud pricing). *)
-           let cost_usd =
-             (Float.of_int input_tok *. 0.000003)
-             +. (Float.of_int output_tok *. 0.000015)
+           let cost_usd = Trajectory.estimate_turn_cost
+             ~model ~input_tokens:input_tok ~output_tokens:output_tok
            in
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:(!meta_ref).name ~task_id:acc.task_id

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -63,12 +63,46 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
           | _ -> ""))
   with Yojson.Safe.Util.Type_error _ -> ""
 
+(** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
+    Schema matches bin/masc_cost.ml with an additional "source" field to
+    distinguish automatic entries from manual CLI entries.
+
+    Called from [after_turn] hook when a trajectory accumulator is present. *)
+let emit_cost_event
+    ~(masc_root : string)
+    ~(agent_name : string)
+    ~(task_id : string option)
+    ~(model : string)
+    ~(input_tokens : int)
+    ~(output_tokens : int)
+    ~(cost_usd : float)
+    : unit =
+  let path = Filename.concat masc_root "costs.jsonl" in
+  let entry = `Assoc [
+    ("agent", `String agent_name);
+    ("task_id",
+      (match task_id with Some t -> `String t | None -> `Null));
+    ("model", `String model);
+    ("input_tokens", `Int input_tokens);
+    ("output_tokens", `Int output_tokens);
+    ("cost_usd", `Float cost_usd);
+    ("timestamp", `String (Types.now_iso ()));
+    ("source", `String "auto_trajectory");
+  ] in
+  let line = Yojson.Safe.to_string entry ^ "\n" in
+  (try Fs_compat.append_file path line
+   with Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.error "emit_cost_event: failed to write %s: %s"
+          path (Printexc.to_string exn))
+
 (** Build OAS hooks for a keeper agent.
 
     All keepers receive the full tool set unconditionally.
     Safety is enforced through eval_gate deny lists and these hooks:
     1. Cost budget — reject when accumulated cost exceeds limit
     2. Destructive pattern detection — reject dangerous bash/edit commands
+    3. Cost event emission — auto-emit per-turn cost to .masc/costs.jsonl
 
     @param config Room configuration
     @param meta_ref Mutable ref to keeper metadata
@@ -77,7 +111,8 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
     @param generation Current generation counter
     @param max_cost_usd Optional cost budget (rejects tool calls above limit)
     @param destructive_check Enable destructive pattern detection (default true)
-    @param on_tool_executed Optional callback after each tool execution *)
+    @param on_tool_executed Optional callback after each tool execution
+    @param trajectory_acc Optional trajectory accumulator for cost attribution *)
 let make_hooks
     ~(config : Room.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)
@@ -88,6 +123,7 @@ let make_hooks
     ?(destructive_check : bool = true)
     ?(on_tool_executed : string -> Yojson.Safe.t -> string -> unit =
         fun _ _ _ -> ())
+    ?(trajectory_acc : Trajectory.accumulator option)
     ()
   : Agent_sdk.Hooks.hooks =
   ignore config;
@@ -103,12 +139,29 @@ let make_hooks
       match event with
       | Agent_sdk.Hooks.AfterTurn { turn; response } ->
         let model = response.model in
-        let usage = match response.usage with
-          | Some u -> u.input_tokens + u.output_tokens
-          | None -> 0
+        let input_tok, output_tok = match response.usage with
+          | Some u -> (u.input_tokens, u.output_tokens)
+          | None -> (0, 0)
         in
+        let total_tok = input_tok + output_tok in
         Log.Keeper.info "keeper:%s turn=%d model=%s tokens=%d"
-          (!meta_ref).name turn model usage;
+          (!meta_ref).name turn model total_tok;
+        (* Emit per-turn cost event for task attribution *)
+        (match trajectory_acc with
+         | Some acc ->
+           (* Rough per-turn cost estimate based on token count.
+              Local llama models are effectively free; cloud models
+              average ~$0.003/1K input + $0.015/1K output tokens.
+              This estimate errs conservative (uses cloud pricing). *)
+           let cost_usd =
+             (Float.of_int input_tok *. 0.000003)
+             +. (Float.of_int output_tok *. 0.000015)
+           in
+           emit_cost_event ~masc_root:acc.masc_root
+             ~agent_name:(!meta_ref).name ~task_id:acc.task_id
+             ~model ~input_tokens:input_tok ~output_tokens:output_tok
+             ~cost_usd
+         | None -> ());
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -184,7 +184,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 ~user_message:message
                 ~cascade_name:"keeper_turn"
                 ~generation:meta.generation
-                ?on_event ()
+                ?on_event
+                ~trajectory_acc
+                ()
             with
             | Error e ->
               (try ignore (Trajectory.finalize trajectory_acc

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -216,6 +216,7 @@ let ensure_keeper_exists
       last_team_session_started_at = "";
       team_session_start_count_total = 0;
       paused = false;
+      current_task_id = None;
     } in
     let base_dir = session_base_dir ctx.config in
     mkdir_p base_dir;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -287,6 +287,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_team_session_started_at = "";
             team_session_start_count_total = 0;
             paused = false;
+            current_task_id = None;
          } in
          (try
             ignore

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -106,6 +106,10 @@ type keeper_meta = {
   initiative_idle_sec: int;
   initiative_cooldown_sec: int;
   paused: bool;
+  current_task_id: string option;
+  (** Currently claimed task ID for cost attribution.
+      Set when keeper claims a task; cleared on masc_done.
+      Propagated to trajectory accumulator for per-task cost tracking. *)
 }
 
 let now_iso () = Types.now_iso ()
@@ -202,6 +206,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("initiative_idle_sec", `Int m.initiative_idle_sec);
       ("initiative_cooldown_sec", `Int m.initiative_cooldown_sec);
       ("paused", `Bool m.paused);
+      ("current_task_id",
+        (match m.current_task_id with None -> `Null | Some s -> `String s));
     ]
 
 let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
@@ -426,6 +432,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let paused =
       Safe_ops.json_bool ~default:false "paused" json
     in
+    let current_task_id = Safe_ops.json_string_opt "current_task_id" json in
     if not (validate_name name) then
       Error "invalid keeper meta (bad name)"
     else if not (validate_name trace_id) then
@@ -525,6 +532,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           initiative_idle_sec;
           initiative_cooldown_sec;
           paused;
+          current_task_id;
         }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -62,11 +62,76 @@ type trajectory = {
 (* Cost estimation                                                  *)
 (* ================================================================ *)
 
+(** Per-token pricing by model category (USD per token).
+
+    Three tiers:
+    - Local: llama-server / Qwen / Ollama — zero marginal cost (electricity only)
+    - GLM:   ZAI GLM-4/5 — discounted Chinese cloud pricing
+    - Cloud:  Claude / GPT / Gemini — standard API pricing
+
+    Prices sourced from public pricing pages (2026-03 snapshot).
+    Updated manually; check pricing pages before adjusting.
+
+    Returns (input_price_per_token, output_price_per_token). *)
+(** Simple substring check — avoids Str dependency. *)
+let contains (haystack : string) (needle : string) : bool =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let found = ref false in
+    for i = 0 to hlen - nlen do
+      if not !found && String.sub haystack i nlen = needle then found := true
+    done;
+    !found
+
+let starts_with (s : string) (prefix : string) : bool =
+  let plen = String.length prefix in
+  String.length s >= plen && String.sub s 0 plen = prefix
+
+let model_token_pricing (model : string) : float * float =
+  let m = String.lowercase_ascii model in
+  (* Local models: free *)
+  if starts_with m "qwen" || starts_with m "llama" || starts_with m "ollama"
+     || m = "local" || m = "auto" || m = ""
+  then (0.0, 0.0)
+  (* GLM models: ~$0.001/1K input, $0.002/1K output *)
+  else if starts_with m "glm"
+  then (0.000001, 0.000002)
+  (* Claude Haiku: $0.25/1M input, $1.25/1M output *)
+  else if contains m "haiku"
+  then (0.00000025, 0.00000125)
+  (* Claude Sonnet: $3/1M input, $15/1M output *)
+  else if contains m "sonnet"
+  then (0.000003, 0.000015)
+  (* Claude Opus: $15/1M input, $75/1M output *)
+  else if contains m "opus"
+  then (0.000015, 0.000075)
+  (* GPT-4o: $2.50/1M input, $10/1M output *)
+  else if contains m "gpt-4o"
+  then (0.0000025, 0.00001)
+  (* Gemini: $1.25/1M input, $5/1M output (Gemini 2.0 Flash) *)
+  else if contains m "gemini"
+  then (0.00000125, 0.000005)
+  (* Unknown: use conservative cloud pricing (Sonnet-level) *)
+  else (0.000003, 0.000015)
+
+(** Estimate cost in USD for a single LLM turn.
+    Uses [model_token_pricing] to look up per-token rates. *)
+let estimate_turn_cost ~(model : string) ~(input_tokens : int)
+    ~(output_tokens : int) : float =
+  let (in_price, out_price) = model_token_pricing model in
+  (Float.of_int input_tokens *. in_price)
+  +. (Float.of_int output_tokens *. out_price)
+
 (** Rough per-call cost estimates for keeper tools.
-    Most are local/free; only MODEL-calling tools have cost. *)
+    These are fixed estimates for tool-level overhead (not LLM turn cost).
+    Most tools are local/free; only MODEL-calling tools have cost.
+
+    For LLM turn-level cost, use [estimate_turn_cost] instead. *)
 let tool_cost_estimate (tool_name : string) : float =
   match tool_name with
-  (* MODEL-intensive tools *)
+  (* MODEL-intensive tools — rough fixed overhead *)
   | "keeper_board_post" -> 0.002
   | "keeper_board_comment" -> 0.001
   | "keeper_bash" -> 0.0001

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -52,6 +52,10 @@ type trajectory = {
   total_turns : int;
   total_tool_calls : int;
   outcome : trajectory_outcome;
+  task_id : string option;
+  (** Claimed task ID for cost attribution.
+      Set when keeper claims a task via masc_claim; None if no task claimed.
+      Enables per-task cost aggregation from trajectory summaries. *)
 }
 
 (* ================================================================ *)
@@ -126,6 +130,8 @@ let trajectory_to_json (t : trajectory) : Yojson.Safe.t =
     ("total_turns", `Int t.total_turns);
     ("total_tool_calls", `Int t.total_tool_calls);
     ("outcome", outcome_to_json t.outcome);
+    ("task_id",
+      (match t.task_id with None -> `Null | Some s -> `String s));
     ("entries", `List (List.map entry_to_json t.entries));
   ]
 
@@ -167,6 +173,8 @@ let append_summary ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
     ("total_turns", `Int traj.total_turns);
     ("total_tool_calls", `Int traj.total_tool_calls);
     ("outcome", outcome_to_json traj.outcome);
+    ("task_id",
+      (match traj.task_id with None -> `Null | Some s -> `String s));
     ("started_at", `Float traj.started_at);
     ("ended_at", `Float traj.ended_at);
   ] in
@@ -187,6 +195,10 @@ type accumulator = {
   generation : int;
   started_at : float;
   masc_root : string;
+  mutable task_id : string option;
+  (** Claimed task ID for cost attribution.
+      Starts as None; set via [set_task_id] when keeper claims a task.
+      Propagated to trajectory record on [finalize]. *)
 }
 
 let create_accumulator ~masc_root ~keeper_name ~trace_id ~generation : accumulator =
@@ -199,7 +211,16 @@ let create_accumulator ~masc_root ~keeper_name ~trace_id ~generation : accumulat
     generation;
     started_at = Time_compat.now ();
     masc_root;
+    task_id = None;
   }
+
+(** Bind a claimed task to this trajectory for cost attribution. *)
+let set_task_id (acc : accumulator) (id : string) : unit =
+  acc.task_id <- Some id
+
+(** Clear task binding (e.g., after masc_done). *)
+let clear_task_id (acc : accumulator) : unit =
+  acc.task_id <- None
 
 let increment_turn (acc : accumulator) : unit =
   acc.turn <- acc.turn + 1
@@ -226,6 +247,7 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
     total_turns = acc.turn;
     total_tool_calls = acc.total_calls;
     outcome;
+    task_id = acc.task_id;
   } in
   (try append_summary ~masc_root:acc.masc_root ~keeper_name:acc.keeper_name
        ~trace_id:acc.trace_id traj

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -272,6 +272,60 @@ let test_task_id_null_when_none () =
     | _ -> Alcotest.fail "Expected task_id to be null when not set")
 
 (* ================================================================ *)
+(* Test: model-aware pricing                                         *)
+(* ================================================================ *)
+
+let test_local_model_free () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"qwen3.5-35b-a3b" ~input_tokens:1000 ~output_tokens:500 in
+  Alcotest.(check (float 0.0001)) "local model free" 0.0 cost
+
+let test_llama_model_free () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"llama-3.2-1b" ~input_tokens:1000 ~output_tokens:500 in
+  Alcotest.(check (float 0.0001)) "llama free" 0.0 cost
+
+let test_auto_model_free () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"auto" ~input_tokens:1000 ~output_tokens:500 in
+  Alcotest.(check (float 0.0001)) "auto free" 0.0 cost
+
+let test_empty_model_free () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"" ~input_tokens:1000 ~output_tokens:500 in
+  Alcotest.(check (float 0.0001)) "empty free" 0.0 cost
+
+let test_glm_model_cheap () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"glm-4-flash" ~input_tokens:1000 ~output_tokens:1000 in
+  (* 1000 * 0.000001 + 1000 * 0.000002 = 0.003 *)
+  Alcotest.(check (float 0.0001)) "glm cheap" 0.003 cost
+
+let test_sonnet_model_priced () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"claude-sonnet-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
+  (* 1000 * 0.000003 + 1000 * 0.000015 = 0.018 *)
+  Alcotest.(check (float 0.0001)) "sonnet priced" 0.018 cost
+
+let test_opus_model_expensive () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"claude-opus-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
+  (* 1000 * 0.000015 + 1000 * 0.000075 = 0.090 *)
+  Alcotest.(check (float 0.001)) "opus expensive" 0.090 cost
+
+let test_haiku_model_cheap () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"claude-haiku-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
+  (* 1000 * 0.00000025 + 1000 * 0.00000125 = 0.0015 *)
+  Alcotest.(check (float 0.0001)) "haiku cheap" 0.0015 cost
+
+let test_unknown_model_conservative () =
+  let cost = Trajectory.estimate_turn_cost
+    ~model:"future-model-v99" ~input_tokens:1000 ~output_tokens:1000 in
+  (* Uses Sonnet pricing as conservative default *)
+  Alcotest.(check (float 0.0001)) "unknown conservative" 0.018 cost
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -309,5 +363,16 @@ let () =
       Alcotest.test_case "finalize propagates" `Quick test_finalize_propagates_task_id;
       Alcotest.test_case "json with task_id" `Quick test_task_id_in_trajectory_json;
       Alcotest.test_case "json null when none" `Quick test_task_id_null_when_none;
+    ]);
+    ("model_pricing", [
+      Alcotest.test_case "local qwen free" `Quick test_local_model_free;
+      Alcotest.test_case "llama free" `Quick test_llama_model_free;
+      Alcotest.test_case "auto free" `Quick test_auto_model_free;
+      Alcotest.test_case "empty free" `Quick test_empty_model_free;
+      Alcotest.test_case "glm cheap" `Quick test_glm_model_cheap;
+      Alcotest.test_case "sonnet priced" `Quick test_sonnet_model_priced;
+      Alcotest.test_case "opus expensive" `Quick test_opus_model_expensive;
+      Alcotest.test_case "haiku cheap" `Quick test_haiku_model_cheap;
+      Alcotest.test_case "unknown conservative" `Quick test_unknown_model_conservative;
     ]);
   ]

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -204,6 +204,74 @@ let test_calls_in_current_turn () =
     Alcotest.(check int) "calls in turn 1" 2 count)
 
 (* ================================================================ *)
+(* Test: task_id binding and propagation                             *)
+(* ================================================================ *)
+
+let test_task_id_default_none () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-001" ~generation:0 in
+    Alcotest.(check (option string)) "task_id default" None acc.Trajectory.task_id)
+
+let test_set_task_id () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-002" ~generation:0 in
+    Trajectory.set_task_id acc "task-042";
+    Alcotest.(check (option string)) "task_id set"
+      (Some "task-042") acc.Trajectory.task_id)
+
+let test_clear_task_id () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-003" ~generation:0 in
+    Trajectory.set_task_id acc "task-042";
+    Trajectory.clear_task_id acc;
+    Alcotest.(check (option string)) "task_id cleared" None acc.Trajectory.task_id)
+
+let test_finalize_propagates_task_id () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-004" ~generation:0 in
+    Trajectory.set_task_id acc "task-099";
+    Trajectory.increment_turn acc;
+    let traj = Trajectory.finalize acc Trajectory.Completed in
+    Alcotest.(check (option string)) "task_id propagated"
+      (Some "task-099") traj.Trajectory.task_id)
+
+let test_task_id_in_trajectory_json () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-005" ~generation:0 in
+    Trajectory.set_task_id acc "task-json-test";
+    let traj = Trajectory.finalize acc Trajectory.Completed in
+    let json = Trajectory.trajectory_to_json traj in
+    let open Yojson.Safe.Util in
+    let task_id_val = json |> member "task_id" in
+    match task_id_val with
+    | `String s ->
+      Alcotest.(check string) "task_id in json" "task-json-test" s
+    | _ -> Alcotest.fail "Expected task_id to be a string in trajectory JSON")
+
+let test_task_id_null_when_none () =
+  with_tmpdir (fun dir ->
+    let acc = Trajectory.create_accumulator
+      ~masc_root:dir ~keeper_name:"test-keeper"
+      ~trace_id:"trace-tid-006" ~generation:0 in
+    let traj = Trajectory.finalize acc Trajectory.Completed in
+    let json = Trajectory.trajectory_to_json traj in
+    let open Yojson.Safe.Util in
+    let task_id_val = json |> member "task_id" in
+    match task_id_val with
+    | `Null -> ()
+    | _ -> Alcotest.fail "Expected task_id to be null when not set")
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -233,5 +301,13 @@ let () =
     ]);
     ("outcome", [
       Alcotest.test_case "outcome_to_string" `Quick test_outcome_to_string;
+    ]);
+    ("task_id", [
+      Alcotest.test_case "default none" `Quick test_task_id_default_none;
+      Alcotest.test_case "set_task_id" `Quick test_set_task_id;
+      Alcotest.test_case "clear_task_id" `Quick test_clear_task_id;
+      Alcotest.test_case "finalize propagates" `Quick test_finalize_propagates_task_id;
+      Alcotest.test_case "json with task_id" `Quick test_task_id_in_trajectory_json;
+      Alcotest.test_case "json null when none" `Quick test_task_id_null_when_none;
     ]);
   ]


### PR DESCRIPTION
## Summary

Replace hardcoded cloud pricing in cost estimation with model-aware pricing table.

**Before**: All models priced at Sonnet-level ($0.003/$0.015 per 1K tokens) — local llama sessions appear to cost money when they're free.

**After**: `Trajectory.estimate_turn_cost ~model ~input_tokens ~output_tokens` looks up per-model pricing:

| Tier | Models | Input (per 1M) | Output (per 1M) |
|------|--------|----------------|-----------------|
| Local | qwen, llama, ollama, auto | $0.00 | $0.00 |
| GLM | glm-4/5 | $1.00 | $2.00 |
| Haiku | claude-haiku-* | $0.25 | $1.25 |
| Sonnet | claude-sonnet-* | $3.00 | $15.00 |
| Opus | claude-opus-* | $15.00 | $75.00 |
| GPT-4o | gpt-4o-* | $2.50 | $10.00 |
| Gemini | gemini-* | $1.25 | $5.00 |
| Unknown | (fallback) | $3.00 | $15.00 |

## Changes (3 files, +134/-9)

| File | Change |
|------|--------|
| `lib/trajectory.ml` | `model_token_pricing` + `estimate_turn_cost` functions |
| `lib/keeper/keeper_hooks_oas.ml` | Use `estimate_turn_cost` instead of inline math |
| `test/test_trajectory.ml` | 9 new pricing tests (28 total) |

## Builds on

PR #3003 (C-2 task cost accounting pipeline)

## Test plan

- [x] `dune build --root .` compiles
- [x] 28/28 trajectory tests pass
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)