### PR TITLE
fix(sync): add Eio.Mutex to runtime mutable state (#2965 Phase 3)

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -188,8 +188,14 @@ let balance_cache : (string * string, float) Hashtbl.t = Hashtbl.create 32
 (* Track whether we have loaded from disk for a given base_path *)
 let loaded_paths : (string, bool) Hashtbl.t = Hashtbl.create 4
 
+(* Mutex protecting balance_cache and loaded_paths. *)
+let economy_mu = Eio.Mutex.create ()
+let with_economy_rw f =
+  try Eio.Mutex.use_rw ~protect:true economy_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 let load_balances_from_ledger base_path =
-  if Hashtbl.mem loaded_paths base_path then ()
+  if with_economy_rw (fun () -> Hashtbl.mem loaded_paths base_path) then ()
   else begin
     let path = ledger_path base_path in
     if Sys.file_exists path then begin
@@ -204,19 +210,21 @@ let load_balances_from_ledger base_path =
               let json = Yojson.Safe.from_string trimmed in
               match transaction_of_json json with
               | Some txn ->
-                Hashtbl.replace balance_cache (base_path, txn.agent_name) txn.balance_after
+                with_economy_rw (fun () ->
+                  Hashtbl.replace balance_cache (base_path, txn.agent_name) txn.balance_after)
               | None -> ()
             with Yojson.Json_error msg ->
               Log.Misc.warn "agent_economy: skipping malformed ledger entry: %s" msg)
     end;
-    Hashtbl.replace loaded_paths base_path true
+    with_economy_rw (fun () -> Hashtbl.replace loaded_paths base_path true)
   end
 
 let get_balance ~base_path ~agent_name =
   load_balances_from_ledger base_path;
-  match Hashtbl.find_opt balance_cache (base_path, agent_name) with
-  | Some b -> b
-  | None -> initial_balance ()
+  with_economy_rw (fun () ->
+    match Hashtbl.find_opt balance_cache (base_path, agent_name) with
+    | Some b -> b
+    | None -> initial_balance ())
 
 (** {1 Reputation Integration} *)
 

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -34,17 +34,24 @@ let judgments_path base_path =
 (** Date-split store: [.masc/governance/judgments/YYYY-MM/DD.jsonl].
     Cached per base_dir so all callers share the same Eio.Mutex. *)
 let judgments_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+let states : (string, state) Hashtbl.t = Hashtbl.create 4
+
+(** Mutex for outer [states] and [judgments_store_cache] Hashtbls.
+    Inner per-state mutex protects per-keeper operations. *)
+let outer_mu = Eio.Mutex.create ()
+let with_outer_rw f =
+  try Eio.Mutex.use_rw ~protect:true outer_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 let get_judgments_store base_path : Dated_jsonl.t =
-  let dir = Filename.concat (governance_dir base_path) "judgments" in
-  match Hashtbl.find_opt judgments_store_cache dir with
-  | Some store -> store
-  | None ->
-    let store = Dated_jsonl.create ~base_dir:dir () in
-    Hashtbl.replace judgments_store_cache dir store;
-    store
-
-let states : (string, state) Hashtbl.t = Hashtbl.create 4
+  with_outer_rw (fun () ->
+    let dir = Filename.concat (governance_dir base_path) "judgments" in
+    match Hashtbl.find_opt judgments_store_cache dir with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      Hashtbl.replace judgments_store_cache dir store;
+      store)
 
 let with_lock (st : state) f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
@@ -77,26 +84,27 @@ let enabled () =
 let keeper_name = "operator-judge"
 
 let get_state base_path =
-  match Hashtbl.find_opt states base_path with
-  | Some st -> st
-  | None ->
-      let st =
-        {
-          mutex = Eio.Mutex.create ();
-          started = false;
-          refreshing = false;
-          judge_online = false;
-          generated_at_unix = None;
-          expires_at_unix = None;
-          generated_at = None;
-          expires_at = None;
-          model_used = None;
-          last_error = None;
+  with_outer_rw (fun () ->
+    match Hashtbl.find_opt states base_path with
+    | Some st -> st
+    | None ->
+        let st =
+          {
+            mutex = Eio.Mutex.create ();
+            started = false;
+            refreshing = false;
+            judge_online = false;
+            generated_at_unix = None;
+            expires_at_unix = None;
+            generated_at = None;
+            expires_at = None;
+            model_used = None;
+            last_error = None;
           judgments = Hashtbl.create 32;
         }
       in
       Hashtbl.add states base_path st;
-      st
+      st)
 
 let key_of kind id = kind ^ ":" ^ id
 

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -26,27 +26,34 @@ let keeper_name = "operator-judge"
 
 let states : (string, state) Hashtbl.t = Hashtbl.create 4
 
+(** Mutex for outer [states] Hashtbl. Inner per-state mutex for per-keeper ops. *)
+let outer_mu = Eio.Mutex.create ()
+let with_outer_rw f =
+  try Eio.Mutex.use_rw ~protect:true outer_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 let with_lock st f =
   Eio.Mutex.use_rw ~protect:true st.mutex f
 
 let get_state base_path =
-  match Hashtbl.find_opt states base_path with
-  | Some st -> st
-  | None ->
-      let st =
-        {
-          mutex = Eio.Mutex.create ();
-          started = false;
-          refreshing = false;
-          judge_online = false;
-          generated_at = None;
-          expires_at = None;
-          model_used = None;
-          last_error = None;
-        }
-      in
-      Hashtbl.add states base_path st;
-      st
+  with_outer_rw (fun () ->
+    match Hashtbl.find_opt states base_path with
+    | Some st -> st
+    | None ->
+        let st =
+          {
+            mutex = Eio.Mutex.create ();
+            started = false;
+            refreshing = false;
+            judge_online = false;
+            generated_at = None;
+            expires_at = None;
+            model_used = None;
+            last_error = None;
+          }
+        in
+        Hashtbl.add states base_path st;
+        st)
 
 let enabled () =
   match Sys.getenv_opt "MASC_OPERATOR_JUDGE_ENABLED" with

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -55,9 +55,18 @@ let pending_votes : (string, int * int) Hashtbl.t = Hashtbl.create 16
 (** Base path for stats storage (cluster root, e.g. ~/me) *)
 let base_path_ref : string option ref = ref None
 
+(** Mutex protecting stats_table, pending_votes, and base_path_ref. *)
+let ts_mu = Eio.Mutex.create ()
+let with_ts_rw f =
+  try Eio.Mutex.use_rw ~protect:true ts_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_ts_ro f =
+  try Eio.Mutex.use_ro ts_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 (** Set base path for stats storage. Call during server init. *)
 let set_base_path path =
-  base_path_ref := Some path
+  with_ts_rw (fun () -> base_path_ref := Some path)
 
 (** Stats file path — uses cluster base_path, not execution directory *)
 let stats_path () =
@@ -188,21 +197,24 @@ let make_default_stats name =
   }
 
 let get_stats name =
-  match Hashtbl.find_opt stats_table name with
-  | Some s -> s
-  | None ->
-      let s = make_default_stats name in
-      Hashtbl.add stats_table name s;
-      s
+  with_ts_rw (fun () ->
+    match Hashtbl.find_opt stats_table name with
+    | Some s -> s
+    | None ->
+        let s = make_default_stats name in
+        Hashtbl.add stats_table name s;
+        s)
 
 let get_all_stats () =
-  Hashtbl.fold (fun _ v acc -> v :: acc) stats_table []
+  with_ts_ro (fun () ->
+    Hashtbl.fold (fun _ v acc -> v :: acc) stats_table [])
 
 let init_agent name =
-  if not (Hashtbl.mem stats_table name) then begin
-    let s = make_default_stats name in
-    Hashtbl.add stats_table name s
-  end
+  with_ts_rw (fun () ->
+    if not (Hashtbl.mem stats_table name) then begin
+      let s = make_default_stats name in
+      Hashtbl.add stats_table name s
+    end)
 
 (** {1 JSON Serialization} *)
 
@@ -293,13 +305,14 @@ let save_stats () =
 (** {1 Feedback Updates} *)
 
 let record_vote ~agent_name ~direction =
-  let (up, down) = Hashtbl.find_opt pending_votes agent_name
-    |> Option.value ~default:(0, 0) in
-  let (up', down') = match direction with
-    | `Up -> (up + 1, down)
-    | `Down -> (up, down + 1)
-  in
-  Hashtbl.replace pending_votes agent_name (up', down')
+  with_ts_rw (fun () ->
+    let (up, down) = Hashtbl.find_opt pending_votes agent_name
+      |> Option.value ~default:(0, 0) in
+    let (up', down') = match direction with
+      | `Up -> (up + 1, down)
+      | `Down -> (up, down + 1)
+    in
+    Hashtbl.replace pending_votes agent_name (up', down'))
 
 let flush_pending_votes () =
   let decay = Env_config.LodgeSelection.vote_decay_factor in


### PR DESCRIPTION
## Summary
- `thompson_sampling.ml`: stats_table + pending_votes + base_path_ref → `ts_mu`
- `agent_economy.ml`: balance_cache + loaded_paths → `economy_mu` (I/O-safe wrapping)
- `dashboard_governance_judge.ml`: outer `states` + `judgments_store_cache` → `outer_mu`
- `dashboard_operator_judge.ml`: outer `states` → `outer_mu`

All use `Effect.Unhandled _ | Eio.Mutex.Poisoned _` fallback.

Skipped (already protected): prompt_registry.ml (registry_mutex), chain_run_store.ml (mutex).

## Context
Phase 3 of #2965. Protects runtime hot-path mutable state accessed from concurrent Eio fibers.

## Test plan
- [ ] `dune build` compiles
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)