### PR TITLE
fix(eio): wrap blocking process I/O in Eio_unix.run_in_systhread (#2965 Phase 4)

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -37,24 +37,30 @@ let executable_dir () =
   in
   Filename.dirname path
 
+(** Probe git commit via subprocess.
+    Offloaded to system thread to avoid blocking Eio scheduler. *)
 let git_probe_from_root repo_root =
-  let cmd =
-    Printf.sprintf "git -C %s rev-parse --short HEAD 2>/dev/null"
-      (Filename.quote repo_root)
+  let f () =
+    let cmd =
+      Printf.sprintf "git -C %s rev-parse --short HEAD 2>/dev/null"
+        (Filename.quote repo_root)
+    in
+    let ic = Unix.open_process_in cmd in
+    let output =
+      try In_channel.input_all ic with
+      | Sys_error msg ->
+          Log.Identity.warn "git_probe_from_root read failed: %s" msg;
+          ""
+      | exn ->
+          Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
+          ""
+    in
+    match Unix.close_process_in ic with
+    | Unix.WEXITED 0 -> trim_to_option output
+    | _ -> None
   in
-  let ic = Unix.open_process_in cmd in
-  let output =
-    try In_channel.input_all ic with
-    | Sys_error msg ->
-        Log.Identity.warn "git_probe_from_root read failed: %s" msg;
-        ""
-    | exn ->
-        Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
-        ""
-  in
-  match Unix.close_process_in ic with
-  | Unix.WEXITED 0 -> trim_to_option output
-  | _ -> None
+  try Eio_unix.run_in_systhread f
+  with Stdlib.Effect.Unhandled _ -> f ()
 
 let probe_git_commit () =
   [ Sys.getcwd (); executable_dir () ]

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -148,20 +148,26 @@ type process_result = {
   stderr : string;
 }
 
+(** Run subprocess and capture stdout/stderr.
+    Offloaded to system thread to avoid blocking Eio scheduler. *)
 let run_process ~prog ~argv ~env =
-  let ic, oc, ec =
-    Unix.open_process_args_full prog (Array.of_list argv) env
+  let f () =
+    let ic, oc, ec =
+      Unix.open_process_args_full prog (Array.of_list argv) env
+    in
+    close_out_noerr oc;
+    let stdout = read_all ic in
+    let stderr = read_all ec in
+    let exit_code =
+      match Unix.close_process_full (ic, oc, ec) with
+      | Unix.WEXITED code -> code
+      | Unix.WSIGNALED code -> 128 + code
+      | Unix.WSTOPPED code -> 256 + code
+    in
+    { exit_code; stdout; stderr }
   in
-  close_out_noerr oc;
-  let stdout = read_all ic in
-  let stderr = read_all ec in
-  let exit_code =
-    match Unix.close_process_full (ic, oc, ec) with
-    | Unix.WEXITED code -> code
-    | Unix.WSIGNALED code -> 128 + code
-    | Unix.WSTOPPED code -> 256 + code
-  in
-  { exit_code; stdout; stderr }
+  try Eio_unix.run_in_systhread f
+  with Stdlib.Effect.Unhandled _ -> f ()
 
 let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
   let start = Unix.gettimeofday () in

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -1,19 +1,27 @@
+(** Run git subprocess and capture stdout lines.
+    Offloaded to a system thread via Eio_unix.run_in_systhread to avoid
+    blocking the Eio scheduler. Falls back to direct execution when
+    called without Eio context (tests, signal handlers). *)
 let run_git_capture_lines ~workdir args =
-  try
-    let ic =
-      Unix.open_process_args_in "git"
-        (Array.of_list ("git" :: "-C" :: workdir :: args))
-    in
-    let rec loop acc =
-      match input_line ic with
-      | line -> loop (line :: acc)
-      | exception End_of_file -> List.rev acc
-    in
-    let lines = loop [] in
-    match Unix.close_process_in ic with
-    | Unix.WEXITED 0 -> Some lines
-    | _ -> None
-  with Sys_error _ | Unix.Unix_error _ -> None
+  let f () =
+    try
+      let ic =
+        Unix.open_process_args_in "git"
+          (Array.of_list ("git" :: "-C" :: workdir :: args))
+      in
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      let lines = loop [] in
+      match Unix.close_process_in ic with
+      | Unix.WEXITED 0 -> Some lines
+      | _ -> None
+    with Sys_error _ | Unix.Unix_error _ -> None
+  in
+  try Eio_unix.run_in_systhread f
+  with Stdlib.Effect.Unhandled _ -> f ()
 
 let repo_root_for ~base_path =
   match run_git_capture_lines ~workdir:base_path [ "rev-parse"; "--show-toplevel" ] with


### PR DESCRIPTION
## Summary
- `worktree_live_context.ml`: git subprocess → `Eio_unix.run_in_systhread` (hot path)
- `build_identity.ml`: git probe → `Eio_unix.run_in_systhread` (init-time)
- `tool_command_plane_support.ml`: command plane subprocess → `Eio_unix.run_in_systhread`

Blocking `Unix.open_process_*` calls stall the Eio scheduler. `run_in_systhread` offloads them to a worker thread so other fibers continue.

All use `Effect.Unhandled` fallback for non-Eio contexts.

## Context
Phase 4 of #2965. Addresses blocking subprocess I/O in Eio context.

## Test plan
- [ ] `dune build` compiles
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)