### PR TITLE
refactor(keeper): remove legacy keepalives and supervised_registry Hashtbls

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1,30 +1,38 @@
-(** Keeper_keepalive — keepalive registry and resident heartbeat fiber.
+(** Keeper_keepalive — resident heartbeat fiber and board-reactive wakeup.
 
-    When [MASC_AGENT_TRANSPORT=grpc], a secondary fiber sends heartbeat
-    pings over a gRPC bidirectional stream in parallel with the
-    existing file-based heartbeat loop. *)
+    Per-keeper lifecycle (start, stop, wakeup) is managed through
+    [Keeper_registry] (SSOT).  This module provides the heartbeat loop
+    body, board-reactive wakeup filtering, and optional gRPC heartbeat
+    fiber. *)
 
 open Keeper_types
 open Keeper_memory
 open Keeper_execution
 
-type keepalive_entry = {
-  stop : bool ref;
-  wakeup : bool ref;
-    (** When set, [interruptible_sleep] exits early so the keeper
-        processes a pending mention or board event immediately. *)
-  started_at : float;
-  grpc_close : (unit -> unit) option;
-    (** Close the gRPC heartbeat stream when stopping. *)
-}
+(* ── Board / agent tracking (independent of keeper lifecycle) ── *)
 
-(** Per-keeper last known agent count for detecting changes. *)
+(** Per-keeper last known agent count for detecting roster changes. *)
 let last_agent_counts : (string, int) Hashtbl.t = Hashtbl.create 8
-let keepalive_registry_mu = Eio.Mutex.create ()
+let board_reactive_wakeups : (string, float) Hashtbl.t = Hashtbl.create 32
+let board_reactive_debounce_sec = 60.0
+let board_reactive_threshold = 4
+
+(** Dedicated mutex for [board_reactive_wakeups] and [last_agent_counts].
+    These are independent of keeper lifecycle tracked in [Keeper_registry]. *)
+let board_mu = Eio.Mutex.create ()
+
+let with_board_mu_ro f =
+  try Eio.Mutex.use_ro board_mu f
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+let with_board_mu_rw f =
+  try Eio.Mutex.use_rw ~protect:true board_mu f
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 (* OAS Event_bus ref — set via bootstrap *)
 let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
 let set_bus bus = bus_ref := Some bus
+let get_bus () = !bus_ref
 
 (** Optional gRPC client — set at server bootstrap when
     [MASC_AGENT_TRANSPORT=grpc]. When set, heartbeat also sends
@@ -32,17 +40,7 @@ let set_bus bus = bus_ref := Some bus
 let grpc_client_ref : Masc_grpc_client.t option ref = ref None
 let set_grpc_client c = grpc_client_ref := Some c
 
-let keepalives : (string, keepalive_entry) Hashtbl.t = Hashtbl.create 8
-let board_reactive_wakeups : (string, float) Hashtbl.t = Hashtbl.create 32
-let board_reactive_debounce_sec = 60.0
-let board_reactive_threshold = 4
-
-let with_keepalive_registry_ro f = Eio.Mutex.use_ro keepalive_registry_mu f
-
-let with_keepalive_registry_rw f =
-  Eio.Mutex.use_rw ~protect:true keepalive_registry_mu f
-
-let remove_board_reactive_wakeups_unlocked keeper_name =
+let remove_board_reactive_wakeups keeper_name =
   let prefix = keeper_name ^ ":" in
   let to_remove =
     Hashtbl.fold
@@ -52,37 +50,11 @@ let remove_board_reactive_wakeups_unlocked keeper_name =
   in
   List.iter (Hashtbl.remove board_reactive_wakeups) to_remove
 
-let running_keepers () =
-  with_keepalive_registry_ro (fun () -> Hashtbl.length keepalives)
-
-let keeper_keepalive_running name =
-  with_keepalive_registry_ro (fun () -> Hashtbl.mem keepalives name)
-
-let keeper_keepalive_started_at name =
-  with_keepalive_registry_ro (fun () ->
-      Hashtbl.find_opt keepalives name |> Option.map (fun entry -> entry.started_at))
-
-let keeper_spawn_slots_available () =
-  let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
-  max_keepers <= 0
-  || with_keepalive_registry_ro (fun () -> Hashtbl.length keepalives < max_keepers)
-
-let register_keepalive name entry =
-  with_keepalive_registry_rw (fun () -> Hashtbl.replace keepalives name entry)
-
-let unregister_keepalive name =
-  with_keepalive_registry_rw (fun () ->
-      Hashtbl.remove keepalives name;
+(** Clean up board/agent tracking state for a keeper. *)
+let cleanup_keeper_tracking name =
+  with_board_mu_rw (fun () ->
       Hashtbl.remove last_agent_counts name;
-      remove_board_reactive_wakeups_unlocked name)
-
-let sync_registry_running ~base_path (meta : keeper_meta) =
-  match Keeper_registry.get ~base_path meta.name with
-  | Some _ ->
-      Keeper_registry.update_meta ~base_path meta.name meta;
-      Keeper_registry.set_state ~base_path meta.name Keeper_registry.Running
-  | None ->
-      ignore (Keeper_registry.register ~base_path meta.name meta)
+      remove_board_reactive_wakeups name)
 
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~2 s instead of waiting for the full 30-300 s interval. *)
@@ -103,21 +75,20 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
     its sleep and run the next heartbeat cycle. Used by broadcast notification
     when a @mention targets a running keeper. *)
 let wakeup_keeper name =
-  with_keepalive_registry_ro (fun () ->
-      match Hashtbl.find_opt keepalives name with
-      | Some entry -> entry.wakeup := true
-      | None -> ())
+  Keeper_registry.all ()
+  |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
+         if String.equal entry.name name && entry.state = Keeper_registry.Running
+         then Keeper_registry.wakeup ~base_path:entry.base_path name)
 
 (** Wake up all running keepers — used when a broadcast mentions @@all
     or when a system-wide event requires immediate attention. *)
 let wakeup_all_keepers () =
-  with_keepalive_registry_ro (fun () ->
-      Hashtbl.iter (fun _name entry -> entry.wakeup := true) keepalives)
+  Keeper_registry.wakeup_all ()
 
 let board_reactive_wakeup_allowed ~keeper_name ~post_id =
   let key = keeper_name ^ ":" ^ post_id in
   let now_ts = Time_compat.now () in
-  with_keepalive_registry_rw (fun () ->
+  with_board_mu_rw (fun () ->
       match Hashtbl.find_opt board_reactive_wakeups key with
       | Some last_ts when now_ts -. last_ts < board_reactive_debounce_sec -> false
       | _ ->
@@ -128,8 +99,9 @@ let wakeup_relevant_keeper_for_board_signal
     ~(config : Room.config)
     (signal : Board_dispatch.keeper_board_signal) =
   let running_names =
-    with_keepalive_registry_ro (fun () ->
-        Hashtbl.fold (fun name _ acc -> name :: acc) keepalives [])
+    Keeper_registry.all ()
+    |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
+           if e.state = Keeper_registry.Running then Some e.name else None)
   in
   let candidates =
     running_names
@@ -419,14 +391,14 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               in
               let agent_count_changed =
                 let last_count =
-                  with_keepalive_registry_ro (fun () ->
+                  with_board_mu_ro (fun () ->
                       Hashtbl.find_opt last_agent_counts meta_current.name
                       |> Option.value ~default:0)
                 in
                 let changed =
                   last_count > 0 && current_agent_count <> last_count
                 in
-                with_keepalive_registry_rw (fun () ->
+                with_board_mu_rw (fun () ->
                     Hashtbl.replace last_agent_counts
                       meta_current.name current_agent_count);
                 changed
@@ -584,17 +556,13 @@ let run_grpc_heartbeat_fiber ~sw ~stop
 let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
     (m : keeper_meta) : unit =
   if not m.presence_keepalive then ()
-  else
-    let can_start =
-      let max_keepers = Env_config.KeeperBootstrap.max_active_keepers in
-      with_keepalive_registry_ro (fun () ->
-          (not (Hashtbl.mem keepalives m.name))
-          && (max_keepers <= 0 || Hashtbl.length keepalives < max_keepers))
-    in
-    if not can_start then ()
+  else if Keeper_registry.is_running ~base_path:ctx.config.base_path m.name then ()
+  else if not (Keeper_registry.spawn_slots_available ()) then ()
   else (
-    let stop = ref false in
-    let wakeup = ref false in
+    (* Register in Keeper_registry first — single source of truth. *)
+    let reg = Keeper_registry.register ~base_path:ctx.config.base_path m.name m in
+    let stop = reg.fiber_stop in
+    let wakeup = reg.fiber_wakeup in
     (* Start optional gRPC heartbeat fiber *)
     let grpc_close =
       match Masc_grpc_transport.from_env (), !grpc_client_ref with
@@ -615,9 +583,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
         None
       | _ -> None
     in
-    with_keepalive_registry_rw (fun () ->
-        Hashtbl.replace keepalives m.name
-          { stop; wakeup; started_at = Time_compat.now (); grpc_close });
+    (match grpc_close with
+     | Some _ ->
+         Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name
+           grpc_close
+     | None -> ());
     let live_meta =
       try
         (if not (Room_utils.is_initialized ctx.config) then
@@ -634,30 +604,22 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
           (Printexc.to_string exn);
         m
     in
-    sync_registry_running ~base_path:ctx.config.base_path live_meta;
+    Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
         run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup))
 
 let stop_keepalive name =
-  match
-    with_keepalive_registry_rw (fun () ->
-        match Hashtbl.find_opt keepalives name with
-        | None -> None
-        | Some entry ->
-            Hashtbl.remove keepalives name;
-            Hashtbl.remove last_agent_counts name;
-            remove_board_reactive_wakeups_unlocked name;
-            Some entry)
-  with
-  | None -> ()
-  | Some entry ->
-      Keeper_registry.all ()
-      |> List.iter (fun (registry_entry : Keeper_registry.registry_entry) ->
-             if String.equal registry_entry.name name then
-               Keeper_registry.set_state ~base_path:registry_entry.base_path name
-                 Keeper_registry.Stopped);
-      entry.stop := true;
-      (match entry.grpc_close with
-       (* cleanup: best-effort gRPC close, ignore transport errors *)
-       | Some close_fn -> (try close_fn () with exn -> ignore exn)
-       | None -> ())
+  let entries =
+    Keeper_registry.all ()
+    |> List.filter (fun (e : Keeper_registry.registry_entry) ->
+           String.equal e.name name)
+  in
+  List.iter (fun (entry : Keeper_registry.registry_entry) ->
+      entry.fiber_stop := true;
+      (match !(entry.grpc_close) with
+       | Some close_fn -> (try close_fn () with _ -> ())
+       | None -> ());
+      Keeper_registry.set_state ~base_path:entry.base_path name
+        Keeper_registry.Stopped
+  ) entries;
+  cleanup_keeper_tracking name

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -1,31 +1,18 @@
 open Keeper_types
 
-type keepalive_entry = {
-  stop : bool ref;
-  wakeup : bool ref;
-  started_at : float;
-  grpc_close : (unit -> unit) option;
-}
-
 (** Inject the shared Event_bus for keeper snapshot publishing. *)
 val set_bus : Agent_sdk.Event_bus.t -> unit
+
+(** Retrieve the shared Event_bus, if set. *)
+val get_bus : unit -> Agent_sdk.Event_bus.t option
 
 (** Inject a gRPC client for heartbeat streaming.
     When set and [MASC_AGENT_TRANSPORT=grpc], keepalive will also
     send heartbeat pings over the gRPC bidirectional stream. *)
 val set_grpc_client : Masc_grpc_client.t -> unit
 
-val running_keepers : unit -> int
-val keeper_keepalive_running : string -> bool
-val keeper_keepalive_started_at : string -> float option
-val keeper_spawn_slots_available : unit -> bool
-
-(** Register a keepalive entry in the internal registry.
-    Used by Keeper_resident_supervisor for backward-compatible registration. *)
-val register_keepalive : string -> keepalive_entry -> unit
-
-(** Remove a keepalive entry from the internal registry. *)
-val unregister_keepalive : string -> unit
+(** Clean up board-reactive wakeup and agent-count tracking for a keeper. *)
+val cleanup_keeper_tracking : string -> unit
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -192,5 +192,15 @@ let crash_log_of ~base_path name =
   | Some entry -> entry.crash_log
   | None -> []
 
+let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts
+    ~crash_log =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry ->
+        entry.restart_count <- restart_count;
+        entry.last_restart_ts <- last_restart_ts;
+        entry.crash_log <- crash_log
+    | None -> ())
+
 let clear () =
   with_lock_rw (fun () -> Hashtbl.clear registry)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -93,5 +93,11 @@ val fiber_health_of : base_path:string -> string -> fiber_health
 (** Recent crash entries (up to 5) for a keeper. *)
 val crash_log_of : base_path:string -> string -> (float * string) list
 
+(** Restore supervisor state on a freshly registered entry (used by restart). *)
+val restore_supervisor_state :
+  base_path:string -> string ->
+  restart_count:int -> last_restart_ts:float ->
+  crash_log:(float * string) list -> unit
+
 (** Clear the registry. For testing only. *)
 val clear : unit -> unit

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -1,48 +1,17 @@
 (** Keeper_resident_supervisor — resident keepalive fiber supervision.
 
     Supervises the MASC-owned background keepalive fibers that maintain
-    keeper presence and heartbeat snapshots. This is not the OAS [Agent.run]
-    lifecycle; it sits outside the turn loop and only manages resident
-    liveness/restart policy for keepalive work.
+    keeper presence and heartbeat snapshots. Uses [Keeper_registry] as
+    the single source of truth for keeper state. The Promise-based
+    liveness tracking ([done_p]/[done_r]) lives in registry entries.
+
+    This is not the OAS [Agent.run] lifecycle; it sits outside the turn
+    loop and only manages resident liveness/restart policy.
 
     @since 2.102.0 *)
 
 open Keeper_types
 open Keeper_execution
-
-(* ── Internal Types ──────────────────────────────────────── *)
-
-type supervised_entry = {
-  name : string;
-  stop : bool ref;
-  wakeup : bool ref;
-  started_at : float; [@warning "-69"]
-  done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t;
-  done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u;
-  restart_count : int ref;
-  last_restart_ts : float ref;
-  crash_log : (float * string) list ref;
-}
-
-(* ── Public query type ───────────────────────────────────── *)
-
-type supervised_state = {
-  name : string;
-  fiber_health : fiber_health;
-  restart_count : int;
-  last_restart_ts : float;
-  crash_log : (float * string) list;
-}
-
-(* ── Registries ──────────────────────────────────────────── *)
-
-let supervised_registry : (string, supervised_entry) Hashtbl.t =
-  Hashtbl.create 8
-
-let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
-
-let init ~bus =
-  bus_ref := Some bus
 
 (* ── Pure helpers ────────────────────────────────────────── *)
 
@@ -59,94 +28,51 @@ let keep_last_n n item lst =
 (* ── Event publishing ────────────────────────────────────── *)
 
 let publish_lifecycle event_name keeper_name detail =
-  match !bus_ref with
+  match Keeper_keepalive.get_bus () with
   | Some bus ->
       Oas_events.publish_keeper_resident_lifecycle bus ~event:event_name
         ~keeper_name ~detail
   | None -> ()
 
-(* ── Fiber health queries ────────────────────────────────── *)
-
-let fiber_health_of name =
-  match Hashtbl.find_opt supervised_registry name with
-  | None -> Fiber_unknown
-  | Some entry ->
-      match Eio.Promise.peek entry.done_p with
-      | None -> Fiber_alive
-      | Some `Stopped -> Fiber_unknown  (* cleaned up by sweep *)
-      | Some (`Crashed _) ->
-          if !(entry.restart_count) >= Env_config.KeeperResidentSupervisor.max_restarts
-          then Fiber_dead
-          else Fiber_zombie
-
-let supervised_state_of name =
-  match Hashtbl.find_opt supervised_registry name with
-  | None -> None
-  | Some entry ->
-      Some {
-        name = entry.name;
-        fiber_health = fiber_health_of name;
-        restart_count = !(entry.restart_count);
-        last_restart_ts = !(entry.last_restart_ts);
-        crash_log = !(entry.crash_log);
-      }
-
-let crash_log_of name =
-  match Hashtbl.find_opt supervised_registry name with
-  | None -> []
-  | Some entry -> !(entry.crash_log)
-
-let supervised_count () = Hashtbl.length supervised_registry
-
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
-let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta) entry =
+let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
+    (reg : Keeper_registry.registry_entry) =
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     Fun.protect
       (fun () ->
         Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
-          ctx meta entry.stop ~wakeup:entry.wakeup;
+          ctx meta reg.fiber_stop ~wakeup:reg.fiber_wakeup;
         Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
           Keeper_registry.Stopped;
-        Eio.Promise.resolve entry.done_r `Stopped;
+        Eio.Promise.resolve reg.done_r `Stopped;
         publish_lifecycle "stopped" meta.name "normal exit")
       ~finally:(fun () ->
-        Keeper_keepalive.unregister_keepalive meta.name;
-        match Eio.Promise.peek entry.done_p with
+        Keeper_keepalive.cleanup_keeper_tracking meta.name;
+        match Eio.Promise.peek reg.done_p with
         | Some _ -> ()  (* Already resolved in the normal path *)
         | None ->
             let msg = "fiber terminated without resolution" in
-            entry.crash_log :=
-              keep_last_n 5 (Time_compat.now (), msg) !(entry.crash_log);
-            Keeper_registry.record_error ~base_path:ctx.config.base_path meta.name msg;
+            Keeper_registry.record_crash ~base_path:ctx.config.base_path
+              meta.name (Time_compat.now ()) msg;
+            Keeper_registry.record_error ~base_path:ctx.config.base_path
+              meta.name msg;
             Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
               Keeper_registry.Stopped;
-            Eio.Promise.resolve entry.done_r (`Crashed msg);
+            Eio.Promise.resolve reg.done_r (`Crashed msg);
             publish_lifecycle "crashed" meta.name msg))
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (meta : keeper_meta) =
   if not meta.presence_keepalive then ()
-  else if Hashtbl.mem supervised_registry meta.name then ()
+  else if Keeper_registry.is_running ~base_path:ctx.config.base_path meta.name
+  then ()
   else if not (Keeper_registry.spawn_slots_available ()) then ()
   else begin
-    let stop = ref false in
-    let now = Time_compat.now () in
-    let done_p, done_r = Eio.Promise.create () in
-    let wakeup_ref = ref false in
-    let entry = {
-      name = meta.name;
-      stop; wakeup = wakeup_ref; started_at = now;
-      done_p; done_r;
-      restart_count = ref 0;
-      last_restart_ts = ref 0.0;
-      crash_log = ref [];
-    } in
-    Hashtbl.replace supervised_registry meta.name entry;
-    (* Register in the shared keepalive registry *)
-    let wakeup = ref false in
-    Keeper_keepalive.register_keepalive meta.name
-      { Keeper_keepalive.stop; wakeup; started_at = now; grpc_close = None };
+    (* Register in Keeper_registry — single source of truth. *)
+    let reg =
+      Keeper_registry.register ~base_path:ctx.config.base_path meta.name meta
+    in
     (* Room initialization *)
     (try
        if not (Room_utils.is_initialized ctx.config) then
@@ -164,18 +90,10 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
           (Printexc.to_string exn);
         meta
     in
-    (match Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name with
-     | Some _ ->
-         Keeper_registry.update_meta ~base_path:ctx.config.base_path live_meta.name
-           live_meta;
-         Keeper_registry.set_state ~base_path:ctx.config.base_path live_meta.name
-           Keeper_registry.Running
-     | None ->
-         ignore
-           (Keeper_registry.register ~base_path:ctx.config.base_path live_meta.name
-              live_meta));
+    Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name
+      live_meta;
     publish_lifecycle "started" meta.name "supervised";
-    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta entry
+    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg
   end
 
 (* ── Sweep and recover ───────────────────────────────────── *)
@@ -183,56 +101,54 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Env_config.KeeperResidentSupervisor.max_restarts in
+  let base_path = ctx.config.base_path in
+  let entries = Keeper_registry.all ~base_path () in
   let to_restart = ref [] in
-  let to_remove = ref [] in
-  Hashtbl.iter (fun name entry ->
+  let to_unregister = ref [] in
+  List.iter (fun (entry : Keeper_registry.registry_entry) ->
     match Eio.Promise.peek entry.done_p with
     | None -> ()  (* Alive — skip *)
     | Some `Stopped ->
-        to_remove := name :: !to_remove
+        to_unregister := entry :: !to_unregister
     | Some (`Crashed msg) ->
-        if !(entry.restart_count) >= max_restarts then begin
-          to_remove := name :: !to_remove;
-          publish_lifecycle "dead" name
+        if entry.restart_count >= max_restarts then begin
+          to_unregister := entry :: !to_unregister;
+          publish_lifecycle "dead" entry.name
             (Printf.sprintf "restart budget exhausted (%d), last: %s"
                max_restarts msg);
           Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
-            name max_restarts
+            entry.name max_restarts
         end else begin
-          let delay = backoff_delay !(entry.restart_count) in
-          if now -. !(entry.last_restart_ts) >= delay then
-            to_restart := (name, entry, msg) :: !to_restart
+          let delay = backoff_delay entry.restart_count in
+          if now -. entry.last_restart_ts >= delay then
+            to_restart := (entry, msg) :: !to_restart
         end
-  ) supervised_registry;
+  ) entries;
   (* Clean up stopped/dead entries *)
-  List.iter (fun name -> Hashtbl.remove supervised_registry name) !to_remove;
+  List.iter (fun (entry : Keeper_registry.registry_entry) ->
+    Keeper_registry.unregister ~base_path entry.name
+  ) !to_unregister;
   (* Restart zombies *)
-  List.iter (fun (name, (old_entry : supervised_entry), crash_msg) ->
-    match read_meta ctx.config name with
+  List.iter (fun ((old_entry : Keeper_registry.registry_entry), crash_msg) ->
+    match read_meta ctx.config old_entry.name with
     | Ok (Some meta) ->
-        let attempt = !(old_entry.restart_count) + 1 in
-        let done_p, done_r = Eio.Promise.create () in
-        let new_wakeup = ref false in
-        let new_entry = {
-          name;
-          stop = ref false;
-          wakeup = new_wakeup;
-          started_at = now;
-          done_p; done_r;
-          restart_count = ref attempt;
-          last_restart_ts = ref now;
-          crash_log = ref (keep_last_n 5 (now, crash_msg) !(old_entry.crash_log));
-        } in
-        Hashtbl.replace supervised_registry name new_entry;
-        Keeper_keepalive.register_keepalive name
-          { Keeper_keepalive.stop = new_entry.stop; wakeup = new_wakeup;
-            started_at = now; grpc_close = None };
-        launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta new_entry;
-        publish_lifecycle "restarted" name
+        let attempt = old_entry.restart_count + 1 in
+        let old_crash_log = old_entry.crash_log in
+        (* Re-register — fresh refs for the new fiber *)
+        let reg =
+          Keeper_registry.register ~base_path old_entry.name meta
+        in
+        (* Carry over supervisor history from previous entry *)
+        Keeper_registry.restore_supervisor_state ~base_path old_entry.name
+          ~restart_count:attempt ~last_restart_ts:now
+          ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
+        launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg;
+        publish_lifecycle "restarted" old_entry.name
           (Printf.sprintf "attempt %d" attempt);
         Log.Keeper.info "%s: restarted (attempt %d, backoff %.0fs)"
-          name attempt (backoff_delay (attempt - 1))
+          old_entry.name attempt (backoff_delay (attempt - 1))
     | _ ->
-        Log.Keeper.error "%s: cannot read meta for restart, removing" name;
-        Hashtbl.remove supervised_registry name
+        Log.Keeper.error "%s: cannot read meta for restart, removing"
+          old_entry.name;
+        Keeper_registry.unregister ~base_path old_entry.name
   ) !to_restart

--- a/lib/keeper/keeper_resident_supervisor.mli
+++ b/lib/keeper/keeper_resident_supervisor.mli
@@ -1,63 +1,32 @@
 (** Keeper_resident_supervisor — resident keepalive fiber supervision.
 
-    Wraps the MASC-owned keeper heartbeat fibers with Eio.Promise-based
-    liveness tracking. Detects zombie fibers (registry entry with terminated
-    fiber) and performs automatic restart with exponential backoff.
+    Wraps the MASC-owned keeper heartbeat fibers with Promise-based
+    liveness tracking via [Keeper_registry]. Detects zombie fibers
+    (resolved Promise) and performs automatic restart with exponential
+    backoff.
 
-    This does not supervise the OAS [Agent.run] lifecycle. OAS turn hooks,
-    validators, and periodic callbacks remain inside the agent execution path;
-    this module only supervises the outer resident keepalive runtime.
+    This does not supervise the OAS [Agent.run] lifecycle.
 
     @since 2.102.0 *)
 
 open Keeper_types
-
-(** {1 Supervised State} *)
-
-type supervised_state = {
-  name : string;
-  fiber_health : fiber_health;
-  restart_count : int;
-  last_restart_ts : float;
-  crash_log : (float * string) list;   (** Most recent 5 entries *)
-}
-
-(** {1 Initialization} *)
-
-val init : bus:Agent_sdk.Event_bus.t -> unit
-(** Connect the shared runtime Event_bus. Call once during bootstrap. *)
 
 (** {1 Supervised Execution} *)
 
 val supervise_keepalive :
   proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
 (** Start a keeper heartbeat loop inside a supervised fiber.
-    Registers in both the keepalive registry
-    and the supervisor registry (Promise-based liveness tracking).
+    Registers in [Keeper_registry] (SSOT) and launches the fiber.
     On fiber termination, resolves the Promise and publishes
     resident-lifecycle events via Event_bus. *)
 
 (** {1 Sweep and Recovery} *)
 
 val sweep_and_recover : 'a context -> unit
-(** Scan all supervised keepers. Detect zombies (resolved Promise),
-    restart with exponential backoff if within budget, mark dead otherwise.
-    Called periodically by the keeper supervisor loop. *)
-
-(** {1 Queries} *)
-
-val fiber_health_of : string -> fiber_health
-(** Fiber-level health of a keeper by name.
-    Returns Fiber_unknown if the keeper is not in the supervised registry. *)
-
-val supervised_state_of : string -> supervised_state option
-(** Full supervised state snapshot for a keeper, or None if not supervised. *)
-
-val crash_log_of : string -> (float * string) list
-(** Recent crash entries (up to 5) for a supervised keeper. *)
-
-val supervised_count : unit -> int
-(** Number of keepers currently in the supervised registry. *)
+(** Scan all supervised keepers in [Keeper_registry]. Detect zombies
+    (resolved Promise), restart with exponential backoff if within
+    budget, mark dead otherwise. Called periodically by the keeper
+    supervisor loop. *)
 
 (** {1 Pure Helpers (exposed for testing)} *)
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -2,7 +2,6 @@
     Runtime-only mutable state stays behind keeper runtime/execution modules. *)
 
 open Keeper_types
-open Keeper_keepalive
 open Keeper_exec_status
 
 let maybe_promote_live_persistent_keeper config name =
@@ -81,7 +80,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     let remaining_slots =
       ref
         (if max_keepers > 0 then
-           max 0 (max_keepers - running_keepers ())
+           max 0 (max_keepers - Keeper_registry.count_running ())
          else
            max_int)
     in
@@ -103,7 +102,9 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 && (m.usage.last_turn_ts <= 0.0
                     || now_ts -. m.usage.last_turn_ts >= stale_turn_sec)
               in
-              let already_running = keeper_keepalive_running m.name in
+              let already_running =
+                Keeper_registry.is_running ~base_path:ctx.config.base_path m.name
+              in
               let started_here =
                 if already_running then false
                 else if max_keepers > 0 && !remaining_slots <= 0 then false
@@ -170,7 +171,7 @@ let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
   Hashtbl.create 4
 
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
-  if stats.started > 0 || Keeper_resident_supervisor.supervised_count () > 0
+  if stats.started > 0 || Keeper_registry.count_running () > 0
   then start_supervisor_sweep ctx
 
 let start_existing_keepalives ctx =

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -137,15 +137,12 @@ let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_default
 let runtime_registry_entry (config : Room_utils.config) name =
   Keeper_registry.get ~base_path:config.base_path name
 
-let runtime_keepalive_running config (meta : keeper_meta) =
-  match runtime_registry_entry config meta.name with
-  | Some entry -> entry.state = Keeper_registry.Running
-  | None -> Keeper_keepalive.keeper_keepalive_running meta.name
+let runtime_keepalive_running (config : Room_utils.config) (meta : keeper_meta) =
+  Keeper_registry.is_running ~base_path:config.base_path meta.name
 
-let runtime_keepalive_started_at config (meta : keeper_meta) =
-  match runtime_registry_entry config meta.name with
-  | Some entry -> Some entry.started_at
-  | None -> Keeper_keepalive.keeper_keepalive_started_at meta.name
+let runtime_keepalive_started_at (config : Room_utils.config)
+    (meta : keeper_meta) =
+  Keeper_registry.started_at ~base_path:config.base_path meta.name
 
 let runtime_surface_json config (meta : keeper_meta) =
   let resident_spec =
@@ -160,7 +157,9 @@ let runtime_surface_json config (meta : keeper_meta) =
   in
   let keepalive_running = runtime_keepalive_running config meta in
   let fiber_health =
-    match Keeper_resident_supervisor.fiber_health_of meta.name with
+    match
+      Keeper_registry.fiber_health_of ~base_path:config.base_path meta.name
+    with
     | Fiber_unknown when keepalive_running -> Fiber_alive
     | health -> health
   in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -75,7 +75,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         p.presence_keepalive_sec_opt
     in
     let max_active_keepers = Env_config.KeeperBootstrap.max_active_keepers in
-    let active_keepers = running_keepers () in
+    let active_keepers = Keeper_registry.count_running () in
     if presence_keepalive && max_active_keepers > 0 && active_keepers >= max_active_keepers then
       (false,
         Printf.sprintf

--- a/test/test_keeper_resident_supervisor.ml
+++ b/test/test_keeper_resident_supervisor.ml
@@ -1,8 +1,10 @@
 (** Test suite for Keeper_resident_supervisor — fiber liveness tracking and recovery.
-    Pure tests for backoff/helpers + Eio tests for Promise-based tracking. *)
+    Pure tests for backoff/helpers. Fiber health queries now delegate to
+    Keeper_registry (tested in test_keeper_registry.ml). *)
 
 open Alcotest
 module Sup = Masc_mcp.Keeper_resident_supervisor
+module Reg = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
 
 (* ── Pure tests: backoff_delay ──────────────────────────── *)
@@ -46,24 +48,22 @@ let test_keep_last_n_over_limit () =
   (* oldest item "d" should be dropped *)
   check bool "old item dropped" false (List.mem "d" result)
 
-(* ── Eio tests: fiber_health_of ─────────────────────────── *)
+(* ── Registry-based tests (replacing removed supervisor Hashtbl queries) *)
 
 let test_fiber_health_unknown () =
-  (* Querying a name not in registry *)
-  let health = Sup.fiber_health_of "nonexistent-keeper" in
+  Reg.clear ();
+  let health = Reg.fiber_health_of ~base_path:"/tmp" "nonexistent-keeper" in
   check bool "unknown for unregistered"
     true (health = KT.Fiber_unknown)
 
-let test_supervised_count_initially_zero () =
-  check int "no supervised keepers initially" 0 (Sup.supervised_count ())
-
-let test_supervised_state_of_none () =
-  check bool "no state for unregistered"
-    true (Sup.supervised_state_of "nonexistent" = None)
+let test_registry_count_initially_zero () =
+  Reg.clear ();
+  check int "no keepers initially" 0 (Reg.count_running ())
 
 let test_crash_log_empty_for_unknown () =
+  Reg.clear ();
   check int "empty crash log" 0
-    (List.length (Sup.crash_log_of "nonexistent"))
+    (List.length (Reg.crash_log_of ~base_path:"/tmp" "nonexistent"))
 
 (* ── Test runner ────────────────────────────────────────── *)
 
@@ -81,8 +81,7 @@ let () =
     ];
     "fiber_health", [
       test_case "unknown for unregistered" `Quick test_fiber_health_unknown;
-      test_case "supervised count zero" `Quick test_supervised_count_initially_zero;
-      test_case "state_of returns None" `Quick test_supervised_state_of_none;
+      test_case "registry count zero" `Quick test_registry_count_initially_zero;
       test_case "crash_log empty" `Quick test_crash_log_empty_for_unknown;
     ];
   ]


### PR DESCRIPTION
## Summary
- Remove `keepalives` Hashtbl from `keeper_keepalive.ml` and `supervised_registry` Hashtbl from `keeper_resident_supervisor.ml`
- All keeper lifecycle operations now go through `Keeper_registry` (SSOT) exclusively
- Net: -334/+183 lines across 10 files

## Context
Phase E of #2904 (keeper state SSOT unification). Phase B+C+D landed in #3002 which extended `Keeper_registry` with supervisor fields. This PR completes the migration by removing the redundant Hashtbls.

## Changes
- **keeper_keepalive.ml**: Remove `keepalive_entry` type, `keepalives` Hashtbl, `keepalive_registry_mu`, 9 deprecated functions. Redirect `start_keepalive`/`stop_keepalive`/`wakeup_*` to registry. Add `board_mu` for independent board-reactive tracking.
- **keeper_resident_supervisor.ml**: Remove `supervised_entry`/`supervised_state` types, `supervised_registry` Hashtbl, duplicate `bus_ref`, 5 deprecated query functions. Use `Keeper_registry` for fiber launch, sweep, and restart.
- **keeper_registry.ml/mli**: Add `restore_supervisor_state` for carrying over crash history on restart.
- **keeper_status_bridge.ml**: Remove fallback to deprecated keepalive functions, redirect `fiber_health_of` to registry.
- **keeper_runtime.ml**: Remove `open Keeper_keepalive`, use `Keeper_registry.is_running`/`count_running`.

## Test plan
- [x] 22 keeper_registry tests pass
- [x] 9 keeper_resident_supervisor tests pass (updated to use registry)
- [x] `dune build` compiles clean
- [x] Pre-existing flaky tests (mcp streaming, operator auth) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)