### PR TITLE
fix(cost): remove hardcoded pricing from MASC hooks

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -146,21 +146,15 @@ let make_hooks
         let total_tok = input_tok + output_tok in
         Log.Keeper.info "keeper:%s turn=%d model=%s tokens=%d"
           (!meta_ref).name turn model total_tok;
-        (* Emit per-turn cost event for task attribution *)
+        (* Emit per-turn cost event for task attribution.
+           cost_usd is 0.0 until OAS cascade provides actual cost
+           (see oas#393). Token counts are the primary data for now. *)
         (match trajectory_acc with
          | Some acc ->
-           (* Rough per-turn cost estimate based on token count.
-              Local llama models are effectively free; cloud models
-              average ~$0.003/1K input + $0.015/1K output tokens.
-              This estimate errs conservative (uses cloud pricing). *)
-           let cost_usd =
-             (Float.of_int input_tok *. 0.000003)
-             +. (Float.of_int output_tok *. 0.000015)
-           in
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:(!meta_ref).name ~task_id:acc.task_id
              ~model ~input_tokens:input_tok ~output_tokens:output_tok
-             ~cost_usd
+             ~cost_usd:0.0
          | None -> ());
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);


### PR DESCRIPTION
## Summary

MASC에서 hardcoded token pricing 제거. pricing은 inference provider(OAS cascade)의 관심사.

**Before**: `keeper_hooks_oas.ml`에서 모든 모델에 cloud pricing 적용 ($0.003/1K input + $0.015/1K output)
→ local llama 세션도 비용이 발생하는 것처럼 기록됨

**After**: `cost_usd: 0.0` placeholder. OAS cascade가 실측 cost를 제공할 때까지 토큰 수만 기록.

## Context

- PR #3022 (model-aware pricing) 닫음 — MASC가 모델별 단가 테이블을 가지면 안 됨
- `masc-model-agnostic` 원칙: cascade가 추상화, 모델명 MASC 레벨 노출 금지
- OAS 쪽 이슈: oas#393 (cascade 응답에 cost_usd 포함)
- MASC 쪽 이슈: #3029

## Changes (1 file, +4/-10)

| File | Change |
|------|--------|
| `lib/keeper/keeper_hooks_oas.ml` | Remove inline pricing math, use `cost_usd:0.0` |

## Test plan

- [x] `dune build --root .` compiles
- [x] 19/19 trajectory tests pass
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)