### PR TITLE
refactor(keeper): consolidate board Hashtbls into Keeper_registry (#2904 Phase F)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -9,25 +9,10 @@ open Keeper_types
 open Keeper_memory
 open Keeper_execution
 
-(* ── Board / agent tracking (independent of keeper lifecycle) ── *)
+(* ── Board-reactive policy constants ── *)
 
-(** Per-keeper last known agent count for detecting roster changes. *)
-let last_agent_counts : (string, int) Hashtbl.t = Hashtbl.create 8
-let board_reactive_wakeups : (string, float) Hashtbl.t = Hashtbl.create 32
 let board_reactive_debounce_sec = 60.0
 let board_reactive_threshold = 4
-
-(** Dedicated mutex for [board_reactive_wakeups] and [last_agent_counts].
-    These are independent of keeper lifecycle tracked in [Keeper_registry]. *)
-let board_mu = Eio.Mutex.create ()
-
-let with_board_mu_ro f =
-  try Eio.Mutex.use_ro board_mu f
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-
-let with_board_mu_rw f =
-  try Eio.Mutex.use_rw ~protect:true board_mu f
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 (* OAS Event_bus ref — set via bootstrap *)
 let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
@@ -39,22 +24,6 @@ let get_bus () = !bus_ref
     pings over the gRPC bidirectional stream. *)
 let grpc_client_ref : Masc_grpc_client.t option ref = ref None
 let set_grpc_client c = grpc_client_ref := Some c
-
-let remove_board_reactive_wakeups keeper_name =
-  let prefix = keeper_name ^ ":" in
-  let to_remove =
-    Hashtbl.fold
-      (fun key _ acc ->
-        if String.starts_with ~prefix key then key :: acc else acc)
-      board_reactive_wakeups []
-  in
-  List.iter (Hashtbl.remove board_reactive_wakeups) to_remove
-
-(** Clean up board/agent tracking state for a keeper. *)
-let cleanup_keeper_tracking name =
-  with_board_mu_rw (fun () ->
-      Hashtbl.remove last_agent_counts name;
-      remove_board_reactive_wakeups name)
 
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~2 s instead of waiting for the full 30-300 s interval. *)
@@ -85,15 +54,9 @@ let wakeup_keeper name =
 let wakeup_all_keepers () =
   Keeper_registry.wakeup_all ()
 
-let board_reactive_wakeup_allowed ~keeper_name ~post_id =
-  let key = keeper_name ^ ":" ^ post_id in
-  let now_ts = Time_compat.now () in
-  with_board_mu_rw (fun () ->
-      match Hashtbl.find_opt board_reactive_wakeups key with
-      | Some last_ts when now_ts -. last_ts < board_reactive_debounce_sec -> false
-      | _ ->
-          Hashtbl.replace board_reactive_wakeups key now_ts;
-          true)
+let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
+  Keeper_registry.board_wakeup_allowed ~base_path keeper_name
+    ~post_id ~debounce_sec:board_reactive_debounce_sec
 
 let wakeup_relevant_keeper_for_board_signal
     ~(config : Room.config)
@@ -124,6 +87,7 @@ let wakeup_relevant_keeper_for_board_signal
   in
   let wake_meta (meta : keeper_meta) reason =
     if board_reactive_wakeup_allowed
+         ~base_path:config.base_path
          ~keeper_name:meta.name
          ~post_id:signal.post_id
     then (
@@ -391,16 +355,15 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
               in
               let agent_count_changed =
                 let last_count =
-                  with_board_mu_ro (fun () ->
-                      Hashtbl.find_opt last_agent_counts meta_current.name
-                      |> Option.value ~default:0)
+                  Keeper_registry.get_last_agent_count
+                    ~base_path:ctx.config.base_path meta_current.name
                 in
                 let changed =
                   last_count > 0 && current_agent_count <> last_count
                 in
-                with_board_mu_rw (fun () ->
-                    Hashtbl.replace last_agent_counts
-                      meta_current.name current_agent_count);
+                Keeper_registry.set_last_agent_count
+                  ~base_path:ctx.config.base_path
+                  meta_current.name current_agent_count;
                 changed
               in
               let pending_board_events, board_new_post_count, board_mention_count =
@@ -620,6 +583,6 @@ let stop_keepalive name =
        | Some close_fn -> (try close_fn () with _ -> ())
        | None -> ());
       Keeper_registry.set_state ~base_path:entry.base_path name
-        Keeper_registry.Stopped
-  ) entries;
-  cleanup_keeper_tracking name
+        Keeper_registry.Stopped;
+      Keeper_registry.cleanup_tracking ~base_path:entry.base_path name
+  ) entries

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -11,9 +11,6 @@ val get_bus : unit -> Agent_sdk.Event_bus.t option
     send heartbeat pings over the gRPC bidirectional stream. *)
 val set_grpc_client : Masc_grpc_client.t -> unit
 
-(** Clean up board-reactive wakeup and agent-count tracking for a keeper. *)
-val cleanup_keeper_tracking : string -> unit
-
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper. *)
 val wakeup_keeper : string -> unit

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -29,6 +29,8 @@ type registry_entry = {
   mutable last_restart_ts : float;
   mutable crash_log : (float * string) list;
   mutable last_error : string option;
+  mutable last_agent_count : int;
+  board_wakeups : (string, float) Hashtbl.t;
 }
 
 let state_to_string = function
@@ -70,6 +72,8 @@ let register ~base_path name meta =
       last_restart_ts = 0.0;
       crash_log = [];
       last_error = None;
+      last_agent_count = 0;
+      board_wakeups = Hashtbl.create 8;
     } in
     Hashtbl.replace registry (registry_key ~base_path name) entry;
     entry)
@@ -200,6 +204,44 @@ let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts
         entry.restart_count <- restart_count;
         entry.last_restart_ts <- last_restart_ts;
         entry.crash_log <- crash_log
+    | None -> ())
+
+let get_last_agent_count ~base_path name =
+  with_lock_ro (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry -> entry.last_agent_count
+    | None -> 0)
+
+let set_last_agent_count ~base_path name count =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry -> entry.last_agent_count <- count
+    | None -> ())
+
+let board_wakeup_allowed ~base_path name ~post_id ~debounce_sec =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | None -> true
+    | Some entry ->
+        let now_ts = Time_compat.now () in
+        match Hashtbl.find_opt entry.board_wakeups post_id with
+        | Some last_ts when now_ts -. last_ts < debounce_sec -> false
+        | _ ->
+            Hashtbl.replace entry.board_wakeups post_id now_ts;
+            true)
+
+let clear_board_wakeups ~base_path name =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry -> Hashtbl.reset entry.board_wakeups
+    | None -> ())
+
+let cleanup_tracking ~base_path name =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry ->
+        entry.last_agent_count <- 0;
+        Hashtbl.reset entry.board_wakeups
     | None -> ())
 
 let clear () =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -31,6 +31,8 @@ type registry_entry = {
   mutable last_restart_ts : float;
   mutable crash_log : (float * string) list;
   mutable last_error : string option;
+  mutable last_agent_count : int;
+  board_wakeups : (string, float) Hashtbl.t;
 }
 
 val state_to_string : keeper_state -> string
@@ -98,6 +100,23 @@ val restore_supervisor_state :
   base_path:string -> string ->
   restart_count:int -> last_restart_ts:float ->
   crash_log:(float * string) list -> unit
+
+(** Last known agent count for roster-change detection. Returns 0 if not found. *)
+val get_last_agent_count : base_path:string -> string -> int
+
+(** Update last agent count for a keeper. No-op if not found. *)
+val set_last_agent_count : base_path:string -> string -> int -> unit
+
+(** Check if a board-reactive wakeup is allowed (debounce).
+    Records timestamp if allowed. Returns true for unregistered keepers. *)
+val board_wakeup_allowed :
+  base_path:string -> string -> post_id:string -> debounce_sec:float -> bool
+
+(** Clear all board wakeup timestamps for a keeper. No-op if not found. *)
+val clear_board_wakeups : base_path:string -> string -> unit
+
+(** Reset tracking state (agent count + board wakeups) for a keeper. *)
+val cleanup_tracking : base_path:string -> string -> unit
 
 (** Clear the registry. For testing only. *)
 val clear : unit -> unit

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -48,7 +48,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
         Eio.Promise.resolve reg.done_r `Stopped;
         publish_lifecycle "stopped" meta.name "normal exit")
       ~finally:(fun () ->
-        Keeper_keepalive.cleanup_keeper_tracking meta.name;
+        Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path meta.name;
         match Eio.Promise.peek reg.done_p with
         | Some _ -> ()  (* Already resolved in the normal path *)
         | None ->

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -230,6 +230,44 @@ let test_spawn_slots () =
   R.clear ();
   check bool "slots available" true (R.spawn_slots_available ())
 
+(* ── Board tracking tests ─────────────────────────────── *)
+
+let test_last_agent_count_default () =
+  R.clear ();
+  check int "0 for unknown" 0 (R.get_last_agent_count ~base_path:bp "none")
+
+let test_last_agent_count_set_get () =
+  R.clear ();
+  ignore (R.register ~base_path:bp "ac1" (make_meta "ac1"));
+  R.set_last_agent_count ~base_path:bp "ac1" 42;
+  check int "set then get" 42 (R.get_last_agent_count ~base_path:bp "ac1")
+
+let test_board_wakeup_debounce () =
+  R.clear ();
+  ignore (R.register ~base_path:bp "bw1" (make_meta "bw1"));
+  let first = R.board_wakeup_allowed ~base_path:bp "bw1" ~post_id:"p1" ~debounce_sec:60.0 in
+  let second = R.board_wakeup_allowed ~base_path:bp "bw1" ~post_id:"p1" ~debounce_sec:60.0 in
+  check bool "first allowed" true first;
+  check bool "second blocked" false second
+
+let test_board_wakeup_different_post () =
+  R.clear ();
+  ignore (R.register ~base_path:bp "bw2" (make_meta "bw2"));
+  let first = R.board_wakeup_allowed ~base_path:bp "bw2" ~post_id:"p1" ~debounce_sec:60.0 in
+  let second = R.board_wakeup_allowed ~base_path:bp "bw2" ~post_id:"p2" ~debounce_sec:60.0 in
+  check bool "p1 allowed" true first;
+  check bool "p2 allowed" true second
+
+let test_cleanup_tracking () =
+  R.clear ();
+  ignore (R.register ~base_path:bp "ct1" (make_meta "ct1"));
+  R.set_last_agent_count ~base_path:bp "ct1" 10;
+  ignore (R.board_wakeup_allowed ~base_path:bp "ct1" ~post_id:"x" ~debounce_sec:60.0);
+  R.cleanup_tracking ~base_path:bp "ct1";
+  check int "agent count reset" 0 (R.get_last_agent_count ~base_path:bp "ct1");
+  let allowed = R.board_wakeup_allowed ~base_path:bp "ct1" ~post_id:"x" ~debounce_sec:60.0 in
+  check bool "wakeup allowed after cleanup" true allowed
+
 let () =
   run "Keeper_registry"
     [
@@ -260,5 +298,13 @@ let () =
           eio_test "fiber_health crashed" test_fiber_health_crashed;
           eio_test "shared refs" test_shared_refs;
           eio_test "spawn slots" test_spawn_slots;
+        ] );
+      ( "board_tracking",
+        [
+          eio_test "last_agent_count default 0" test_last_agent_count_default;
+          eio_test "last_agent_count set/get" test_last_agent_count_set_get;
+          eio_test "board wakeup debounce" test_board_wakeup_debounce;
+          eio_test "board wakeup different post" test_board_wakeup_different_post;
+          eio_test "cleanup_tracking resets" test_cleanup_tracking;
         ] );
     ]


### PR DESCRIPTION
## Summary

- `last_agent_counts` Hashtbl → `registry_entry.last_agent_count` mutable field
- `board_reactive_wakeups` Hashtbl → `registry_entry.board_wakeups` per-entry Hashtbl (key = post_id only)
- `board_mu` Eio.Mutex 제거 — Keeper_registry의 단일 mutex로 통합
- `remove_board_reactive_wakeups`의 암묵적 mutex 보호 버그 구조적으로 해소
- `cleanup_keeper_tracking` → `Keeper_registry.cleanup_tracking`으로 이동

## Changes

| File | Action |
|------|--------|
| `keeper_registry.ml/mli` | 2 fields + 5 API functions 추가 |
| `keeper_keepalive.ml` | board_mu, 2 Hashtbl, 관련 함수 제거 + call site 리와이어 |
| `keeper_keepalive.mli` | `cleanup_keeper_tracking` 제거 |
| `keeper_resident_supervisor.ml` | cleanup 호출 변경 |
| `test_keeper_registry.ml` | board_tracking 테스트 5개 추가 |

## Stats

6 files changed, +121 / -54

## Test plan

- [x] 27 registry tests pass (22 기존 + 5 신규 board_tracking)
- [x] 9 supervisor tests pass
- [ ] CI Build and Test
- [ ] Cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)