### PR TITLE
chore(deps): pin agent_sdk >= 0.90.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.89.1))
+  (agent_sdk (>= 0.90.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.89.1"}
+  "agent_sdk" {>= "0.90.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary

Pin OAS dependency to >= 0.90.0 for slot-aware admission control.

MASC keepers calling `complete_cascade` against local llama-server now auto-throttle to match discovered slot count, preventing the 8-keeper timeout issue.

Depends on: jeong-sik/oas#392 (merged), jeong-sik/oas#394 (version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)