### PR TITLE
fix(pg): reduce read-path contention

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -417,7 +417,8 @@ let acquire_lock t ~key ~ttl_seconds ~owner =
     let* acquired = C.find_opt acquire_lock_q (nkey, owner, ttl_seconds) in
     Ok (Option.is_some acquired)
   ) t.pool with
-  | Ok b -> Ok b
+  | Ok true -> Ok true
+  | Ok false -> Ok false
   | Error err -> Error (caqti_error_to_masc err)
 
 let release_lock t ~key ~owner =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -8,6 +8,13 @@
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 let wait_for_message_eio = Mcp_server_eio_helpers.wait_for_message_eio
 
+let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join =
+  if room_initialized && join_required && agent_name <> "unknown" then
+    try check_join ()
+    with Sys_error _ | Yojson.Json_error _ -> false
+  else
+    false
+
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
@@ -365,13 +372,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* Check if agent must join first — Fix 3: use cached value *)
   let room_initialized = !room_init_cached in
   let is_joined =
-    if room_initialized then
-      (* Some tools (e.g., masc_init) must run before initialization.
-         Guard the join check to avoid raising and crashing the server. *)
-      try Room.is_agent_joined config ~agent_name
-      with Sys_error _ | Yojson.Json_error _ -> false
-    else
-      false
+    resolve_join_state
+      ~room_initialized
+      ~join_required
+      ~agent_name
+      ~check_join:(fun () -> Room.is_agent_joined config ~agent_name)
   in
 
   (* Debug: log join check *)

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -59,6 +59,16 @@ let get_tasks_raw_in_room config room_id =
 let safe_yield () =
   try Eio.Fiber.yield () with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
 
+let take_first n xs =
+  if n <= 0 then []
+  else
+    let rec loop acc remaining = function
+      | [] -> List.rev acc
+      | _ when remaining <= 0 -> List.rev acc
+      | x :: rest -> loop (x :: acc) (remaining - 1) rest
+    in
+    loop [] n xs
+
 (** Get raw agent list (for orchestrator) *)
 let get_agents_raw config =
   ensure_initialized config;
@@ -157,14 +167,12 @@ let audit_orphan_tasks config : (Types.task * string) list =
     ) backlog.tasks
 
 let is_agent_active_at_path config path =
-  if not (path_exists config path) then false
-  else
-    try
-      let json = read_json config path in
-      match agent_of_yojson json with
-      | Ok agent -> agent.status <> Inactive
-      | Error _ -> false
-    with Sys_error _ | Yojson.Json_error _ -> false
+  match read_json_opt config path with
+  | None -> false
+  | Some json ->
+      (match agent_of_yojson json with
+       | Ok agent -> agent.status <> Inactive
+       | Error _ -> false)
 
 let is_agent_joined_in_room config ~room_id ~agent_name =
   if not (root_is_initialized config) then false
@@ -201,35 +209,80 @@ let extract_seq_from_filename name =
   | None -> 0
   | Some idx -> Safe_ops.int_of_string_with_default ~default:0 (String.sub name 0 idx)
 
+let message_name_from_key key =
+  match List.rev (String.split_on_char ':' key) with
+  | name :: _ -> name
+  | [] -> key
+
+let collect_recent_messages_from_pg config ~msgs_path ~since_seq ~limit =
+  match config.backend with
+  | PostgresNative backend -> (
+      match key_of_path config msgs_path with
+      | None -> None
+      | Some key_prefix -> (
+          match
+            Backend.PostgresNative.get_all_matching_recent backend
+              ~prefix:(key_prefix ^ ":")
+              ~suffix:".json"
+              ~updated_since:0.0
+              ~limit:(max 64 (limit * 8))
+          with
+          | Ok pairs ->
+              let messages =
+                pairs
+                |> List.filter_map (fun (key, value) ->
+                       let name = message_name_from_key key in
+                       if extract_seq_from_filename name <= since_seq then
+                         None
+                       else
+                         match
+                           Safe_ops.parse_json_safe
+                             ~context:"collect_recent_messages_from_pg" value
+                         with
+                         | Ok json -> (
+                             match message_of_yojson json with
+                             | Ok msg when msg.seq > since_seq -> Some msg
+                             | _ -> None)
+                         | Error _ -> None)
+                |> List.sort (fun a b -> compare b.seq a.seq)
+                |> take_first limit
+              in
+              Some messages
+          | Error _ -> None))
+  | Memory _ | FileSystem _ -> None
+
 (** Read most-recent messages without parsing the entire history directory. *)
 let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
-  let names =
-    Sys.readdir msgs_path
-    |> Array.to_list
-    |> List.filter is_valid_filename
-    |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
-  in
-  let rec loop remaining acc = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | name :: rest ->
-        safe_yield ();
-        if extract_seq_from_filename name <= since_seq then List.rev acc
-        else
-          let path = Filename.concat msgs_path name in
-          match read_json config path with
-          | json ->
-              (match message_of_yojson json with
-               | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
-               | _ -> loop remaining acc rest)
-          | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-          | exception e ->
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Room"
-                (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
-                   name (Printexc.to_string e));
-              loop remaining acc rest
-  in
-  loop limit [] names
+  match collect_recent_messages_from_pg config ~msgs_path ~since_seq ~limit with
+  | Some rows -> rows
+  | None ->
+      let names =
+        Sys.readdir msgs_path
+        |> Array.to_list
+        |> List.filter is_valid_filename
+        |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
+      in
+      let rec loop remaining acc = function
+        | _ when remaining <= 0 -> List.rev acc
+        | [] -> List.rev acc
+        | name :: rest ->
+            safe_yield ();
+            if extract_seq_from_filename name <= since_seq then List.rev acc
+            else
+              let path = Filename.concat msgs_path name in
+              match read_json config path with
+              | json ->
+                  (match message_of_yojson json with
+                   | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
+                   | _ -> loop remaining acc rest)
+              | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+              | exception e ->
+                  Log.legacy_traceln ~level:Log.Warn ~module_name:"Room"
+                    (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
+                       name (Printexc.to_string e));
+                  loop remaining acc rest
+      in
+      loop limit [] names
 
 (** Get raw message list (for dashboard) *)
 let get_messages_raw config ~since_seq ~limit =
@@ -314,26 +367,16 @@ let get_messages config ~since_seq ~limit =
   let buf = Buffer.create 256 in
   Buffer.add_string buf "💬 Recent Messages\n";
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
-
-  let msgs_path = messages_dir config in
-  if Sys.file_exists msgs_path then begin
-    let files = Sys.readdir msgs_path |> Array.to_list
-      |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a)) in
-    let count = ref 0 in
-    List.iter (fun name ->
-      if !count < limit then begin
-        let path = Filename.concat msgs_path name in
-        let json = read_json config path in
-        match message_of_yojson json with
-        | Ok msg when msg.seq > since_seq ->
-            let time_part = String.sub msg.timestamp 0 (min 16 (String.length msg.timestamp)) in
-            let time_str = String.map (function 'T' -> ' ' | c -> c) time_part in
-            Buffer.add_string buf (Printf.sprintf "[%s] %s: %s\n" time_str msg.from_agent msg.content);
-            incr count
-        | _ -> ()
-      end
-    ) files
-  end;
+  let messages = get_messages_raw config ~since_seq ~limit in
+  List.iter
+    (fun msg ->
+      let time_part =
+        String.sub msg.timestamp 0 (min 16 (String.length msg.timestamp))
+      in
+      let time_str = String.map (function 'T' -> ' ' | c -> c) time_part in
+      Buffer.add_string buf
+        (Printf.sprintf "[%s] %s: %s\n" time_str msg.from_agent msg.content))
+    messages;
 
   if Buffer.length buf = 73 then (* Only header *)
     Buffer.add_string buf "(no new messages)\n";

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -514,17 +514,17 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
     mark_cached_surface_attempt _operator_digest_cache;
     let started_at = Unix.gettimeofday () in
     try
-      let sessions =
-        if Room.is_initialized config then
-          dashboard_active_or_recent_sessions ~clock config
-        else
-          []
-      in
       let command_plane_summary, swarm_status =
         command_plane_summary_cache_parts ~allow_initializing:false ~state
       in
       run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config
         (fun ~config ~sw ->
+          let sessions =
+            if Room.is_initialized config then
+              dashboard_active_or_recent_sessions ~clock config
+            else
+              []
+          in
           let ctx : _ Operator_control.context =
             {
               config;
@@ -661,13 +661,9 @@ let operator_digest_http_json ~state ~sw ~clock request =
     let effective_target_type =
       Option.value ~default:"room" target_type
     in
-    let mode =
-      if String.equal effective_target_type "room" then Inline_shared
-      else Offloaded_readonly
-    in
     match Eio.Time.with_timeout clock 30.0 (fun () ->
       Ok
-        (run_dashboard_compute ~mode ~sw ~clock
+        (run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock
            ~config:state.Mcp_server.room_config
            (fun ~config ~sw ->
              let ctx : _ Operator_control.context =
@@ -686,9 +682,18 @@ let operator_digest_http_json ~state ~sw ~clock request =
                else
                  (None, None)
              in
+             let sessions =
+               if String.equal effective_target_type "room"
+                  && Room.is_initialized config
+               then
+                 Some (dashboard_active_or_recent_sessions ~clock config)
+               else
+                 None
+             in
              match
                Operator_control.digest_json ?actor ~target_type:effective_target_type
-                 ?target_id ?include_workers ?command_plane_summary ?swarm_status
+                 ?target_id ?include_workers ?sessions
+                 ?command_plane_summary ?swarm_status
                  ctx
              with
              | Ok json -> json

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -118,6 +118,48 @@ let int_field_exn label fields name =
   | Some (`Int value) -> value
   | _ -> Alcotest.failf "%s missing int field %s" label name
 
+let test_resolve_join_state_skips_read_only_lookup () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:false
+      ~agent_name:"codex"
+      ~check_join:(fun () ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "lookup skipped" false !called;
+  Alcotest.(check bool) "read-only defaults false" false joined
+
+let test_resolve_join_state_checks_join_required_tools () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"codex"
+      ~check_join:(fun () ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "lookup performed" true !called;
+  Alcotest.(check bool) "join result preserved" true joined
+
+let test_resolve_join_state_skips_unknown_agent () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"unknown"
+      ~check_join:(fun () ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "unknown agent skipped" false !called;
+  Alcotest.(check bool) "unknown agent treated unjoined" false joined
+
 let rec collect_tools ~clock ~sw ?profile ?cursor state acc =
   let response = tools_list_response ~clock ~sw ?profile ?cursor state in
   let tools = tools_from_response response in
@@ -2415,6 +2457,12 @@ let state_tests = [
   "create_state", `Quick, test_create_state;
   "type compatibility", `Quick, test_type_compatibility;
   "eio context delegation", `Quick, test_eio_context_delegation;
+  "resolve_join_state skips read-only lookup", `Quick,
+    test_resolve_join_state_skips_read_only_lookup;
+  "resolve_join_state checks join-required tools", `Quick,
+    test_resolve_join_state_checks_join_required_tools;
+  "resolve_join_state skips unknown agent", `Quick,
+    test_resolve_join_state_skips_unknown_agent;
 ]
 
 let protocol_tests = [


### PR DESCRIPTION
## Summary
- skip join-state lookup for non-join-required tool calls so read-only MCP tools stop hitting PG unnecessarily
- reduce room message and agent-active read path contention by using cheaper PG-backed reads and offloaded dashboard digest/session fetches
- keep the acquire-lock path on the single-statement expired-lock takeover query and add regression coverage for the join-state helper

## Verification
- dune build --root . @check
- dune exec --root . test/test_mcp_server_eio.exe

## Notes
- main was fast-forwarded to origin/main before rebasing this branch
- runtime probing still showed a separate intermittent `Invalid concurrent usage of PostgreSQL connection detected.` path around dashboard/operator warm-cache and room message refresh; that follow-up is not resolved in this PR