### PR TITLE
chore(deps): bump OAS pin to v0.90.0

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.89.1"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="3e7da31d54c69fe0aea951ca5301eb59d85f24e5"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.89.1"
+readonly OAS_AGENT_SDK_SHA="ea09ff04cc76c6778754f92deb2046de64d90428"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#3e7da31d54c69fe0aea951ca5301eb59d85f24e5}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#ea09ff04cc76c6778754f92deb2046de64d90428}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary

- OAS agent_sdk pin ratcheted from `3e7da31` (v0.89.1) to `ea09ff0` (v0.90.0)
- New upstream feature: local LLM slot-aware admission control (#392)
- Fixes CI Health check "OAS main drift" failure

## Files

| File | Change |
|------|--------|
| `scripts/oas-agent-sdk-pin.sh` | SHA + base_tag + min_version |
| `scripts/opam-pin-external-deps.sh` | Hardcoded fallback SHA |

## Test plan

- [x] `scripts/check-oas-pin.sh` passes locally
- [ ] CI Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)