### PR TITLE
fix(keeper): ensure full session dir tree before file I/O

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -97,8 +97,13 @@ let run_turn
         (* Keep under Cloudflare tunnel 100s timeout: 2048 / 35 tok/s ~ 59s *)
         ~fallback:(fun () -> 2048)
   in
-  (* 1. Ensure session directory *)
-  Keeper_types.mkdir_p base_dir;
+  (* 1. Ensure session directory tree exists.
+     Both the base perpetual dir AND the trace-specific session dir must
+     exist before any file I/O (checkpoint load, history persist).
+     In filesystem fallback mode (PG unavailable), these directories may
+     not have been created by keeper_up if it only registered in-memory. *)
+  let session_dir = Filename.concat base_dir meta.trace_id in
+  Keeper_types.mkdir_p session_dir;
   (* 2. Load checkpoint *)
   let (session, ctx_opt) =
     Keeper_exec_context.load_context_from_checkpoint

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -166,6 +166,8 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    Oas_model_resolve.resolve_primary_max_context cascade_models
                  in
                  let base_dir = session_base_dir ctx.config in
+                 (* Ensure session directory tree for filesystem fallback (issue #3019) *)
+                 Fs_compat.mkdir_p (Filename.concat base_dir meta_current.trace_id);
                  let _session, ctx_opt =
                    load_context_from_checkpoint
                      ~trace_id:meta_current.trace_id

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -203,7 +203,8 @@ let ensure_keeper_exists
       current_task_id = None;
     } in
     let base_dir = session_base_dir ctx.config in
-    mkdir_p base_dir;
+    (* Ensure full session dir tree, not just base_dir (issue #3019) *)
+    mkdir_p (Filename.concat base_dir trace_id);
     let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
     (match ensure_api_keys_for_labels cascade_models with
      | Error e -> Error e

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -154,7 +154,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
        let primary_max_context = Oas_model_resolve.resolve_primary_max_context cascade_models in
        let trace_id = generate_trace_id () in
          let base_dir = session_base_dir ctx.config in
-         mkdir_p base_dir;
+         (* Ensure full session dir tree, not just base_dir (issue #3019) *)
+         mkdir_p (Filename.concat base_dir trace_id);
          let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
            let persona_extended =
              Keeper_types_profile.load_persona_extended p.name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -210,6 +210,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         Keeper_unified_prompt.build_prompt ~meta ~observation
       in
       let base_dir = session_base_dir config in
+      (* Ensure session dir tree for filesystem fallback (issue #3019) *)
+      Keeper_types.mkdir_p (Filename.concat base_dir meta.trace_id);
       (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
       let temperature =
         Cascade_inference.resolve_temperature

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1439,6 +1439,40 @@ let test_keeper_up_persists_allowed_paths_to_status_policy () =
       check (list string) "allowed_paths roundtrip" allowed_paths persisted)
 (* test_keeper_policy_set_accepts_explicit_event_v1: removed — keeper policy_mode system removed *)
 
+(* Issue #3019: session dir must be created from scratch in filesystem fallback.
+   When PG is unavailable and keeper_up only registers in-memory, the session
+   directory under .masc/perpetual/<trace_id> might not exist. The fix ensures
+   all callers create the full directory tree before file I/O. *)
+let test_session_dir_mkdir_p_creates_full_tree () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      (* Simulate the path that session_base_dir returns:
+         <base_path>/.masc/perpetual *)
+      let session_base = Filename.concat
+        (Filename.concat base_dir ".masc") "perpetual" in
+      let trace_id = "trace-test-3019" in
+      let session_dir = Filename.concat session_base trace_id in
+      (* Before fix: only base_dir was mkdir_p'd, not session_dir.
+         After fix: mkdir_p session_dir creates the full tree. *)
+      check bool "session dir absent before mkdir_p" false
+        (Sys.file_exists session_dir);
+      (* Use the same mkdir_p that Keeper_types exposes *)
+      Masc_mcp.Keeper_types.mkdir_p session_dir;
+      check bool "session dir exists after mkdir_p" true
+        (Sys.file_exists session_dir);
+      check bool "session dir is directory" true
+        (Sys.is_directory session_dir);
+      (* Simulate persist_message writing history.jsonl *)
+      let history_path = Filename.concat session_dir "history.jsonl" in
+      let oc = open_out history_path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc "{\"role\":\"user\",\"content\":\"hello\"}\n");
+      check bool "history file written" true
+        (Sys.file_exists history_path))
+
 let test_resident_bootstrap_marks_stale_explicit_keeper () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1573,5 +1607,7 @@ let () =
            test_keeper_up_persists_allowed_paths_to_status_policy;
          test_case "resident bootstrap marks stale explicit keeper" `Quick
            test_resident_bootstrap_marks_stale_explicit_keeper;
+         test_case "session dir mkdir_p creates full tree from scratch (issue #3019)" `Quick
+           test_session_dir_mkdir_p_creates_full_tree;
        ]);
   ]


### PR DESCRIPTION
## Summary
- **Fixes** #3019: `keeper_msg` fails with `Sys_error("No such file or directory")` after PG fallback to filesystem backend
- All keeper code paths now `mkdir_p` the full session directory (`base_dir/<trace_id>`), not just `base_dir`
- Covers 5 entry points: `run_turn`, keepalive, unified_turn, turn_setup, turn_up_create

## Root Cause
When PG backend is unavailable and MASC falls back to JSONL/filesystem mode, `keeper_up` registers the keeper in-memory but the session directory under `.masc/perpetual/<trace_id>/` may not be created before subsequent `keeper_msg` calls attempt file I/O (history persistence, checkpoint save).

## Test plan
- [x] New test: `session dir mkdir_p creates full tree from scratch` — verifies directory creation from empty state
- [x] All 30 keeper tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)