### PR TITLE
perf(snapshot): parallelize I/O and eliminate redundant computation

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -430,10 +430,12 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
        json
    | _ ->
   let t0 = Time_compat.now () in
+  let timing_records = ref [] in
   let timed label f =
     let t_start = Time_compat.now () in
     let result = f () in
     let elapsed = Time_compat.now () -. t_start in
+    timing_records := (label, elapsed) :: !timing_records;
     if elapsed > 0.5 then
       Log.Dashboard.info "[snapshot_json] %s: %.0fms" label (elapsed *. 1000.0);
     result
@@ -543,39 +545,81 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
          ("authoritative_judgment_available", `Bool false);
          ("provenance_summary", operator_surface_contract_json);
          ("room", room_json config);
-         ( "sessions",
-           timed "sessions_json" (fun () ->
-           if initialized && include_sessions then sessions_json ~status_cache config tracked_sessions
-           else `Assoc [ ("count", `Int 0); ("items", `List []) ]) );
-         ( "keepers",
-           timed "keepers_json" (fun () ->
-           if initialized && include_keepers then
-             keepers_json ~keeper_names
-               ~include_recent_activity:(not lightweight_summary) config
-           else `Assoc [ ("count", `Int 0); ("items", `List []) ]) );
-         ( "persistent_agents",
-           timed "persistent_agents_json" (fun () ->
-           if initialized && include_keepers then persistent_agents_json ~keeper_names config
-           else `Assoc [ ("count", `Int 0); ("items", `List []) ]) );
-         ("command_plane", command_plane_json);
+       ]
+      @ (
+         (* Parallelize independent I/O: sessions, keepers, persistent_agents.
+            Eio.Fiber.all runs all thunks as fibers within the current switch,
+            completing when all finish. On failure, remaining fibers are cancelled. *)
+         let empty_section = `Assoc [ ("count", `Int 0); ("items", `List []) ] in
+         let sessions_ref = ref empty_section in
+         let keepers_ref = ref empty_section in
+         let persistent_ref = ref empty_section in
+         Eio.Fiber.all [
+           (fun () ->
+             sessions_ref :=
+               timed "sessions_json" (fun () ->
+                 if initialized && include_sessions then
+                   sessions_json ~status_cache config tracked_sessions
+                 else empty_section));
+           (fun () ->
+             keepers_ref :=
+               timed "keepers_json" (fun () ->
+                 if initialized && include_keepers then
+                   keepers_json ~keeper_names
+                     ~include_recent_activity:(not lightweight_summary) config
+                 else empty_section));
+           (fun () ->
+             persistent_ref :=
+               timed "persistent_agents_json" (fun () ->
+                 if initialized && include_keepers then
+                   persistent_agents_json ~keeper_names config
+                 else empty_section));
+         ];
+         [
+           ("sessions", !sessions_ref);
+           ("keepers", !keepers_ref);
+           ("persistent_agents", !persistent_ref);
+           ("command_plane", command_plane_json);
+         ]
+      )
+      @ [
          ("swarm_status", swarm_status_json);
-         ("role_census", aggregate_worker_class_counts tracked_sessions);
-         ("runtime_pools", aggregate_runtime_pool_counts tracked_sessions);
-         ("lane_census", aggregate_lane_counts tracked_sessions);
-         ("controller_census", aggregate_controller_counts tracked_sessions);
-         ("control_domains", aggregate_control_domain_counts tracked_sessions);
-         ("model_tiers", aggregate_tier_counts tracked_sessions);
-         ("task_profiles", aggregate_task_profile_counts tracked_sessions);
-         ("escalation_count", `Int (aggregate_escalation_count tracked_sessions));
+       ]
+      @ (let (role_census, runtime_pools, lane_census, controller_census,
+              control_domains, model_tiers, task_profiles, escalation_count) =
+           timed "aggregates" (fun () -> aggregate_all_worker_metrics tracked_sessions)
+         in
+         [
+           ("role_census", role_census);
+           ("runtime_pools", runtime_pools);
+           ("lane_census", lane_census);
+           ("controller_census", controller_census);
+           ("control_domains", control_domains);
+           ("model_tiers", model_tiers);
+           ("task_profiles", task_profiles);
+           ("escalation_count", `Int escalation_count);
+         ])
+      @ [
          ("local_runtime", aggregated_local_runtime_json tracked_sessions);
          ( "recent_messages",
            if initialized && include_messages && not lightweight_summary then
              recent_messages_json config
            else
              `List [] );
-         ("pending_confirms", pending_confirms_json ?actor config);
-         ("pending_confirm_envelope", pending_confirm_envelope_json ?actor config);
-         ("pending_confirm_summary", pending_confirm_summary_json ?actor config);
+       ]
+      @ (let confirm_scope = timed "pending_confirms" (fun () ->
+           pending_confirm_scope ?actor config) in
+         [
+           ("pending_confirms",
+             `List (List.map pending_confirm_to_yojson confirm_scope.visible_entries));
+           ("pending_confirm_envelope",
+             `Assoc [
+               ("items", `List (List.map pending_confirm_to_yojson confirm_scope.visible_entries));
+               ("summary", pending_confirm_summary_json_of_scope confirm_scope);
+             ]);
+           ("pending_confirm_summary", pending_confirm_summary_json_of_scope confirm_scope);
+         ])
+      @ [
          ("available_actions", available_actions_json);
          ( "recent_actions",
            if lightweight_summary then `List [] else recent_actions_json config );
@@ -583,9 +627,14 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
       @ summary_fields)
   in
   let elapsed_total = Time_compat.now () -. t0 in
-  if elapsed_total > 1.0 then
+  if elapsed_total > 1.0 then begin
     Log.Dashboard.info "[snapshot_json] total: %.0fms (sessions=%d keepers=%d)"
       (elapsed_total *. 1000.0)
       (List.length tracked_sessions) (List.length keeper_names);
+    List.iter (fun (label, dt) ->
+      if dt > 0.1 then
+        Log.Dashboard.info "[snapshot_json]   %s: %.0fms" label (dt *. 1000.0))
+      (List.rev !timing_records)
+  end;
   _snapshot_cache := Some (cache_key, result, now);
   result)

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -99,6 +99,10 @@ val aggregate_control_domain_counts : Team_session_types.session list -> Yojson.
 val aggregate_tier_counts : Team_session_types.session list -> Yojson.Safe.t
 val aggregate_task_profile_counts : Team_session_types.session list -> Yojson.Safe.t
 val aggregate_escalation_count : Team_session_types.session list -> int
+val aggregate_all_worker_metrics :
+  Team_session_types.session list ->
+  Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t *
+  Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t * int
 val aggregated_local_runtime_json : Team_session_types.session list -> Yojson.Safe.t
 
 val session_card_to_yojson : actor:string -> session_digest -> Yojson.Safe.t

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -336,6 +336,20 @@ let aggregate_task_profile_counts s   = aggregate_worker_counts s Team_session_t
 let aggregate_escalation_count s =
   all_planned_workers s |> Team_session_types.escalation_count
 
+(** Compute all 7 worker-count aggregates + escalation in a single pass
+    over [all_planned_workers], avoiding 8 separate list traversals. *)
+let aggregate_all_worker_metrics sessions =
+  let workers = all_planned_workers sessions in
+  let to_json count_fn = count_fn workers |> Team_session_types.counts_to_json in
+  ( to_json Team_session_types.worker_class_counts,
+    to_json Team_session_types.runtime_pool_counts,
+    to_json Team_session_types.lane_counts,
+    to_json Team_session_types.controller_level_counts,
+    to_json Team_session_types.control_domain_counts,
+    to_json Team_session_types.model_tier_counts,
+    to_json Team_session_types.task_profile_counts,
+    Team_session_types.escalation_count workers )
+
 let aggregated_local_runtime_json (sessions : Team_session_types.session list) =
   if
     List.exists

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -336,8 +336,9 @@ let aggregate_task_profile_counts s   = aggregate_worker_counts s Team_session_t
 let aggregate_escalation_count s =
   all_planned_workers s |> Team_session_types.escalation_count
 
-(** Compute all 7 worker-count aggregates + escalation in a single pass
-    over [all_planned_workers], avoiding 8 separate list traversals. *)
+(** Compute all 7 worker-count aggregates + escalation with a single
+    [all_planned_workers] concat_map, avoiding 8 separate list allocations.
+    Each count_fn still iterates [workers] independently. *)
 let aggregate_all_worker_metrics sessions =
   let workers = all_planned_workers sessions in
   let to_json count_fn = count_fn workers |> Team_session_types.counts_to_json in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -454,6 +454,25 @@ let _operator_refresh_interval_s =
     ~min_v:2.0
     ~max_v:600.0
 
+(* Shared session list cache between snapshot and digest refresh loops.
+   Both loops run as fibers in the same Eio domain (cooperative scheduling),
+   so no mutex needed for the mutable ref. TTL = 80% of refresh interval
+   to avoid serving stale data across interval boundaries. *)
+let _shared_sessions : Team_session_types.session list ref = ref []
+let _shared_sessions_at : float ref = ref 0.0
+
+let dashboard_active_or_recent_sessions_cached ~clock config =
+  let now = Time_compat.now () in
+  if now -. !_shared_sessions_at < _operator_refresh_interval_s *. 0.8
+     && !_shared_sessions <> [] then
+    !_shared_sessions
+  else begin
+    let sessions = dashboard_active_or_recent_sessions ~clock config in
+    _shared_sessions := sessions;
+    _shared_sessions_at := now;
+    sessions
+  end
+
 let operator_snapshot_extra sessions =
   [
     ("session_count", `Int (List.length sessions));
@@ -472,7 +491,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
         (fun ~config ~sw ->
           let sessions =
             if Room.is_initialized config then
-              dashboard_active_or_recent_sessions ~clock config
+              dashboard_active_or_recent_sessions_cached ~clock config
             else
               []
           in
@@ -521,7 +540,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
         (fun ~config ~sw ->
           let sessions =
             if Room.is_initialized config then
-              dashboard_active_or_recent_sessions ~clock config
+              dashboard_active_or_recent_sessions_cached ~clock config
             else
               []
           in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -458,20 +458,19 @@ let _operator_refresh_interval_s =
    Both loops run as fibers in the same Eio domain (cooperative scheduling),
    so no mutex needed for the mutable ref. TTL = 80% of refresh interval
    to avoid serving stale data across interval boundaries. *)
-let _shared_sessions : Team_session_types.session list ref = ref []
+let _shared_sessions : Team_session_types.session list option ref = ref None
 let _shared_sessions_at : float ref = ref 0.0
 
 let dashboard_active_or_recent_sessions_cached ~clock config =
   let now = Time_compat.now () in
-  if now -. !_shared_sessions_at < _operator_refresh_interval_s *. 0.8
-     && !_shared_sessions <> [] then
-    !_shared_sessions
-  else begin
+  match !_shared_sessions with
+  | Some cached when now -. !_shared_sessions_at < _operator_refresh_interval_s *. 0.8 ->
+      cached
+  | _ ->
     let sessions = dashboard_active_or_recent_sessions ~clock config in
-    _shared_sessions := sessions;
+    _shared_sessions := Some sessions;
     _shared_sessions_at := now;
     sessions
-  end
 
 let operator_snapshot_extra sessions =
   [


### PR DESCRIPTION
## Summary

Dashboard `snapshot_json` 계산 최적화. sessions=3일 때 137초 소요되던 snapshot이 병렬화 + 중복 제거로 개선.

### Changes

- **Eio.Fiber.all 병렬화**: `sessions_json`, `keepers_json`, `persistent_agents_json`을 병렬 실행. wall-clock = max(개별 시간)으로 수렴
- **Single-pass aggregates**: 8개 `aggregate_*` 함수가 각각 `all_planned_workers` 호출 → 1회 호출로 통합 (`aggregate_all_worker_metrics`)
- **Pending confirm dedup**: `pending_confirm_scope`를 1회 계산 후 3개 JSON 필드에 재사용 (3x file I/O → 1x)
- **Session list 공유**: snapshot/digest refresh 루프가 독립적으로 session scan → 캐시 ref 공유 (2x scan → 1x per interval)
- **타이밍 진단**: `snapshot_json > 1s`일 때 phase별 breakdown 로그 출력

### JSON Output

출력 구조 불변. 키 이름, 값 형태 모두 동일.

## Test plan

- [x] `test_operator_control` 32 tests 전부 통과
- [x] `dune build` 성공
- [ ] 실서버에서 `snapshot_json total` 로그 시간 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)