### PR TITLE
fix(pg): increase PG init timeout from 10s to 30s

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -830,7 +830,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     in
     try
       let pg_init_timeout =
-        Safe_ops.get_env_float_logged "MASC_PG_INIT_TIMEOUT_SEC" ~default:10.0
+        Safe_ops.get_env_float_logged "MASC_PG_INIT_TIMEOUT_SEC" ~default:30.0
       in
       Server_startup_state.mark_blocking ~backend_mode:initial_backend_mode;
       let state =


### PR DESCRIPTION
## Summary
- **Fixes** #3009: PG init timeout causes unnecessary filesystem fallback on startup
- Default `MASC_PG_INIT_TIMEOUT_SEC` raised from 10s to 30s
- Sequential schema init (masc_kv, board, task, memory) on Supabase ap-south-1 takes ~6-12s per connection

## Test plan
- [x] Build passes
- [ ] CI green
- [ ] Manual verification: server starts with PG backend on Supabase without fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)