### PR TITLE
fix(pg): parallelize schema init and harden keeper filesystem fallback

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -536,7 +536,9 @@ let keeper_meta_path config name =
   Filename.concat (keeper_dir config) (name ^ ".json")
 
 let session_base_dir (config : Room.config) =
-  Filename.concat (Room.masc_root_dir config) "perpetual"
+  let d = Filename.concat (Room.masc_root_dir config) "perpetual" in
+  mkdir_p d;
+  d
 
 let keeper_agent_name name =
   Printf.sprintf "keeper-%s-agent" name

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -16,7 +16,9 @@ let keeper_dir_ (config : Room.config) =
   d
 
 let session_base_dir_ (config : Room.config) =
-  Filename.concat (Room.masc_root_dir config) "perpetual"
+  let d = Filename.concat (Room.masc_root_dir config) "perpetual" in
+  mkdir_p_ d;
+  d
 
 let env_present name =
   match Sys.getenv_opt name with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -252,6 +252,38 @@ let init_memory_pg_schema () =
   | None ->
       Log.MemoryPg.info "No PG pool available; long_term_backend will use JSONL fallback"
 
+(** Run independent PG schema inits in parallel via Eio fibers.
+    Each init only needs the shared PG pool (created in create_server_state).
+    Parallel execution reduces worst-case 3x RTT to 1x RTT. *)
+let init_pg_schemas_parallel () =
+  let errors = Atomic.make [] in
+  let record_error label exn =
+    let msg = Printf.sprintf "%s: %s" label (Printexc.to_string exn) in
+    let rec loop () =
+      let old = Atomic.get errors in
+      if not (Atomic.compare_and_set errors old (msg :: old)) then loop ()
+    in
+    loop ()
+  in
+  Eio.Fiber.all [
+    (fun () ->
+      try init_task_backend ()
+      with Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> record_error "task_backend" exn);
+    (fun () ->
+      try inject_shared_pg_pool ()
+      with Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> record_error "shared_pg_pool" exn);
+    (fun () ->
+      try init_memory_pg_schema ()
+      with Eio.Cancel.Cancelled _ as e -> raise e
+         | exn -> record_error "memory_pg_schema" exn);
+  ];
+  let errs = Atomic.get errors in
+  if errs <> [] then
+    Log.Server.warn "PG schema init completed with errors: %s"
+      (String.concat "; " errs)
+
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
   Governance_pipeline.install ~config:state.room_config ~governance_level;
   Tool_permissions.install ~get_agent_name:(fun () -> None)
@@ -789,9 +821,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       bootstrap_server_state_blocking state;
       install_tooling ~governance_level state;
-      init_task_backend ();
-      inject_shared_pg_pool ();
-      init_memory_pg_schema ();
+      init_pg_schemas_parallel ();
       state
     in
     let run_lazy_task (task_name, task_fn) =
@@ -830,7 +860,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     in
     try
       let pg_init_timeout =
-        Safe_ops.get_env_float_logged "MASC_PG_INIT_TIMEOUT_SEC" ~default:10.0
+        Safe_ops.get_env_float_logged "MASC_PG_INIT_TIMEOUT_SEC" ~default:30.0
       in
       Server_startup_state.mark_blocking ~backend_mode:initial_backend_mode;
       let state =


### PR DESCRIPTION
## Summary

- PG schema init(task, memory, shared pool)를 `Eio.Fiber.all`로 병렬 실행 — worst-case 3x RTT → 1x RTT
- `MASC_PG_INIT_TIMEOUT_SEC` 기본값 10s → 30s (안전망)
- `session_base_dir`에 `mkdir_p` 추가 — PG fallback 후 keeper_msg `Sys_error` 방지

## Root Cause

- **#3009**: 4개 PG 스키마(masc_kv, board, task, memory) 순차 초기화가 Supabase ap-south-1 RTT 기준 10초 초과
- **#3019**: `session_base_dir`가 `.masc/perpetual/` 디렉토리를 생성하지 않음 (`keeper_dir`은 `mkdir_p` 호출하는 반면)

## Changes

| File | Change |
|------|--------|
| `lib/server/server_runtime_bootstrap.ml` | `init_pg_schemas_parallel()` 추가, 순차 호출 교체, timeout 30s |
| `lib/keeper/keeper_types_profile.ml` | `session_base_dir`에 `mkdir_p` 추가 |
| `lib/keeper/keeper_types_resident.ml` | `session_base_dir_`에 `mkdir_p_` 추가 |

## Test plan

- [x] `test_server_runtime_bootstrap` 7/7 통과
- [x] `dune build` 성공
- [ ] CI quick suite 확인

Closes #3009
Closes #3019

🤖 Generated with [Claude Code](https://claude.com/claude-code)