### PR TITLE
chore: replace raw Printf.printf with structured logging in lib/

### DIFF
--- a/lib/agent_health.ml
+++ b/lib/agent_health.ml
@@ -65,7 +65,7 @@ let filter_healthy (agents : (string * 'a) list) : (string * 'a) list * (string 
         healthy := (name, data) :: !healthy
     | Unhealthy reason ->
         skipped := (name, reason) :: !skipped;
-        Printf.printf "[agent_health] Skipping %s: %s\n%!" name reason
+        Log.Misc.info "[agent_health] Skipping %s: %s" name reason
   ) agents;
   (List.rev !healthy, List.rev !skipped)
 

--- a/lib/bridge/event_bus.ml
+++ b/lib/bridge/event_bus.ml
@@ -39,4 +39,4 @@ let broadcast event =
   let oc = open_out_gen [Open_append; Open_creat] 0o666 log_path in
   output_string oc (json ^ "\n");
   close_out oc;
-  print_endline ("📡 Event Broadcasted: " ^ json)
+  Printf.eprintf "[event_bus] Event broadcasted: %s\n%!" json

--- a/lib/mitosis/mitosis_helpers.ml
+++ b/lib/mitosis/mitosis_helpers.ml
@@ -94,7 +94,7 @@ let queue_episode ~base_path ~session_id ~agent_name ~generation
   let file = Filename.concat dir (ep_id ^ ".json") in
   try
     Fs_compat.save_file file (Yojson.Safe.pretty_to_string json);
-    Printf.printf "[EPISODE/QUEUE] Queued episode %s (gen %d) → %s\n%!" ep_id generation file;
+    Log.Misc.info "[EPISODE/QUEUE] Queued episode %s (gen %d) -> %s" ep_id generation file;
     Some ep_id
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "episode queue failed: %s" (Printexc.to_string exn);

--- a/lib/mitosis_dna.ml
+++ b/lib/mitosis_dna.ml
@@ -179,7 +179,7 @@ let merge_dna_with_delta ~prepared_dna ~delta =
     let deduped_len = String.length deduped_delta in
     let original_len = String.length delta in
     if deduped_len < original_len then
-      Printf.printf "[MITOSIS/MERGE] Deduplication: %d -> %d chars (-%d%% overlap)\n%!"
+      Log.Misc.info "[MITOSIS/MERGE] Deduplication: %d -> %d chars (-%d%% overlap)"
         original_len deduped_len ((original_len - deduped_len) * 100 / original_len);
     if String.length (String.trim deduped_delta) = 0 then
       prepared_dna

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -292,7 +292,7 @@ let save_checkpoint ~summary ~task ~todos ~pdca ~files ~metrics =
     } in
     let cps = cp :: !checkpoints in
     checkpoints := List.filteri (fun i _ -> i < max_checkpoints) cps;
-    Printf.printf "[CHECKPOINT] Saved at %.1f%% context usage\n%!"
+    Log.Misc.info "[CHECKPOINT] Saved at %.1f%% context usage"
       (metrics.usage_ratio *. 100.0);
     cp)
 

--- a/lib/tool_inline_dispatch_episode.ml
+++ b/lib/tool_inline_dispatch_episode.ml
@@ -46,7 +46,7 @@ let handle_episode_flush ~config ~arguments ~(state : Mcp_server.server_state) ~
         Fs_compat.mkdir_p processed_dir;
         let new_path = Filename.concat processed_dir file in
         Sys.rename file_path new_path;
-        Printf.printf "[EPISODE/FLUSH] Processed episode %s -> %s\n%!" ep_id new_path;
+        Log.Misc.info "[EPISODE/FLUSH] Processed episode %s -> %s" ep_id new_path;
         incr flushed
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Log.Misc.error "Failed to flush %s: %s" file (Printexc.to_string exn);


### PR DESCRIPTION
## Summary
- Converts 6 `Printf.printf`/`print_endline` calls to `Log.Misc.info` (or `Printf.eprintf` for isolated `event_bridge` library)
- Partial progress on #2995 (item 3: unstructured logging and side effects)
- Startup banner messages intentionally preserved (stdout is appropriate there)

## Changed files
- `agent_health.ml` — skip message
- `event_bus.ml` — broadcast message (stdout -> stderr)
- `mitosis_helpers.ml` — episode queue message
- `mitosis_dna.ml` — deduplication stats
- `relay.ml` — checkpoint save message
- `tool_inline_dispatch_episode.ml` — flush message

## Test plan
- [x] Build passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)