### PR TITLE
refactor(keeper): consolidate remaining Hashtbls into SSOT registry

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -372,6 +372,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                 (try
                    let events, new_count, mention_count =
                      Keeper_world_observation.collect_board_events
+                       ~base_path:ctx.config.base_path
                        ~meta:meta_current
                        ~continuity_summary:meta_current.continuity_summary
                    in

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -31,6 +31,8 @@ type registry_entry = {
   mutable last_error : string option;
   mutable last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
+  mutable board_cursor_ts : float;
+  tool_usage : (string, tool_call_entry) Hashtbl.t;
 }
 
 let state_to_string = function
@@ -74,6 +76,8 @@ let register ~base_path name meta =
       last_error = None;
       last_agent_count = 0;
       board_wakeups = Hashtbl.create 8;
+      board_cursor_ts = 0.0;
+      tool_usage = Hashtbl.create 16;
     } in
     Hashtbl.replace registry (registry_key ~base_path name) entry;
     entry)
@@ -241,8 +245,70 @@ let cleanup_tracking ~base_path name =
     match Hashtbl.find_opt registry (registry_key ~base_path name) with
     | Some entry ->
         entry.last_agent_count <- 0;
-        Hashtbl.reset entry.board_wakeups
+        Hashtbl.reset entry.board_wakeups;
+        entry.board_cursor_ts <- 0.0;
+        Hashtbl.reset entry.tool_usage
     | None -> ())
 
 let clear () =
   with_lock_rw (fun () -> Hashtbl.clear registry)
+
+(* ── Board cursor ────────────────────────────────────────────── *)
+
+let get_board_cursor_ts ~base_path name =
+  with_lock_ro (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry -> entry.board_cursor_ts
+    | None -> 0.0)
+
+let set_board_cursor_ts ~base_path name ts =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | Some entry -> entry.board_cursor_ts <- ts
+    | None -> ())
+
+(* ── Tool usage tracking ─────────────────────────────────────── *)
+
+let record_tool_use ~base_path name ~tool_name ~success =
+  with_lock_rw (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | None -> ()
+    | Some entry ->
+      let e =
+        match Hashtbl.find_opt entry.tool_usage tool_name with
+        | Some e -> e
+        | None ->
+          let e = { count = 0; successes = 0; failures = 0;
+                    last_used_at = 0.0 } in
+          Hashtbl.replace entry.tool_usage tool_name e; e
+      in
+      e.count <- e.count + 1;
+      (if success then e.successes <- e.successes + 1
+       else e.failures <- e.failures + 1);
+      e.last_used_at <- Time_compat.now ())
+
+let tool_usage_of ~base_path name =
+  with_lock_ro (fun () ->
+    match Hashtbl.find_opt registry (registry_key ~base_path name) with
+    | None -> []
+    | Some entry ->
+      Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
+      |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count))
+
+(** Look up a keeper by name across all base_paths (O(n) scan). *)
+let find_by_name name =
+  with_lock_ro (fun () ->
+    Hashtbl.fold
+      (fun _k v acc ->
+        match acc with
+        | Some _ -> acc
+        | None -> if String.equal v.name name then Some v else None)
+      registry None)
+
+let tool_usage_of_by_name name =
+  with_lock_ro (fun () ->
+    match find_by_name name with
+    | None -> []
+    | Some entry ->
+      Hashtbl.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
+      |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count))

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -33,6 +33,8 @@ type registry_entry = {
   mutable last_error : string option;
   mutable last_agent_count : int;
   board_wakeups : (string, float) Hashtbl.t;
+  mutable board_cursor_ts : float;
+  tool_usage : (string, Keeper_types.tool_call_entry) Hashtbl.t;
 }
 
 val state_to_string : keeper_state -> string
@@ -120,3 +122,24 @@ val cleanup_tracking : base_path:string -> string -> unit
 
 (** Clear the registry. For testing only. *)
 val clear : unit -> unit
+
+(** Get board event cursor timestamp. Returns 0.0 if not found. *)
+val get_board_cursor_ts : base_path:string -> string -> float
+
+(** Update board event cursor timestamp. No-op if not found. *)
+val set_board_cursor_ts : base_path:string -> string -> float -> unit
+
+(** Record a tool call for a keeper. No-op if not found. *)
+val record_tool_use :
+  base_path:string -> string -> tool_name:string -> success:bool -> unit
+
+(** Get tool usage sorted by call count descending. *)
+val tool_usage_of : base_path:string -> string ->
+  (string * Keeper_types.tool_call_entry) list
+
+(** Look up a keeper by name across all base_paths (O(n) scan). *)
+val find_by_name : string -> registry_entry option
+
+(** Get tool usage by keeper name (scans all base_paths). *)
+val tool_usage_of_by_name : string ->
+  (string * Keeper_types.tool_call_entry) list

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -143,11 +143,21 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     Called once from start_existing_keepalives after bootstrap. *)
 let supervisor_sweeps : (string, Pulse.t) Hashtbl.t =
   Hashtbl.create 4
+let supervisor_sweeps_mu = Eio.Mutex.create ()
+
+let with_sweeps_ro f =
+  try Eio.Mutex.use_ro supervisor_sweeps_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+let with_sweeps_rw f =
+  try Eio.Mutex.use_rw ~protect:true supervisor_sweeps_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 let supervisor_sweep_running base_path =
-  match Hashtbl.find_opt supervisor_sweeps base_path with
-  | Some pulse -> Pulse.is_alive pulse
-  | None -> false
+  with_sweeps_ro (fun () ->
+    match Hashtbl.find_opt supervisor_sweeps base_path with
+    | Some pulse -> Pulse.is_alive pulse
+    | None -> false)
 
 let start_supervisor_sweep ctx =
   let base_path = ctx.config.base_path in
@@ -174,7 +184,8 @@ let start_supervisor_sweep ctx =
       ~lifecycle:Perpetual
       ~consumers:[consumer]
     in
-    Hashtbl.replace supervisor_sweeps base_path p;
+    with_sweeps_rw (fun () ->
+      Hashtbl.replace supervisor_sweeps base_path p);
     Pulse.run ~sw:ctx.sw p;
     Log.Keeper.info "resident supervisor sweep started (interval %.0fs)"
       Env_config.KeeperResidentSupervisor.sweep_interval_sec
@@ -182,6 +193,11 @@ let start_supervisor_sweep ctx =
 
 let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
   Hashtbl.create 4
+let bootstrap_done_mu = Eio.Mutex.create ()
+
+let with_bootstrap_rw f =
+  try Eio.Mutex.use_rw ~protect:true bootstrap_done_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
   if stats.started > 0 || Keeper_registry.count_running () > 0
@@ -189,9 +205,17 @@ let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
 
 let start_existing_keepalives ctx =
   let base_path = ctx.config.base_path in
-  if Hashtbl.mem existing_keepalive_bootstrap_done base_path then ()
+  (* Atomic check-and-set: eliminates TOCTOU race on the gate. *)
+  let should_run =
+    with_bootstrap_rw (fun () ->
+      if Hashtbl.mem existing_keepalive_bootstrap_done base_path then false
+      else begin
+        Hashtbl.replace existing_keepalive_bootstrap_done base_path ();
+        true
+      end)
+  in
+  if not should_run then ()
   else begin
-    Hashtbl.replace existing_keepalive_bootstrap_done base_path ();
     try
       let stats = bootstrap_existing_keepers ctx in
       if keeper_debug then
@@ -201,7 +225,8 @@ let start_existing_keepalives ctx =
       maybe_start_supervisor_sweep ctx stats
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       (* Retry bootstrap on next keeper tool call if this attempt failed. *)
-      Hashtbl.remove existing_keepalive_bootstrap_done base_path;
+      with_bootstrap_rw (fun () ->
+        Hashtbl.remove existing_keepalive_bootstrap_done base_path);
       raise exn
   end
 

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -11,41 +11,20 @@
 
 (* ── Per-keeper tool usage tracking ──────────────────────────── *)
 
-type tool_call_entry = {
+(** Re-export from Keeper_types so dashboard code using
+    [e.Keeper_tools_oas.count] keeps compiling. *)
+type tool_call_entry = Keeper_types.tool_call_entry = {
   mutable count : int;
   mutable successes : int;
   mutable failures : int;
   mutable last_used_at : float;
 }
 
-(** Per-keeper tool usage: keeper_name → (tool_name → entry). *)
-let usage_by_keeper : (string, (string, tool_call_entry) Hashtbl.t) Hashtbl.t =
-  Hashtbl.create 8
-
-let record_tool_use ~keeper_name ~tool_name ~success =
-  let keeper_tbl = match Hashtbl.find_opt usage_by_keeper keeper_name with
-    | Some t -> t
-    | None ->
-      let t = Hashtbl.create 16 in
-      Hashtbl.replace usage_by_keeper keeper_name t; t
-  in
-  let entry = match Hashtbl.find_opt keeper_tbl tool_name with
-    | Some e -> e
-    | None ->
-      let e = { count = 0; successes = 0; failures = 0; last_used_at = 0.0 } in
-      Hashtbl.replace keeper_tbl tool_name e; e
-  in
-  entry.count <- entry.count + 1;
-  if success then entry.successes <- entry.successes + 1
-  else entry.failures <- entry.failures + 1;
-  entry.last_used_at <- Unix.gettimeofday ()
+(** Tool usage now lives in Keeper_registry (per-entry tool_usage Hashtbl).
+    These public functions preserve the existing API surface. *)
 
 let tool_usage_for_keeper keeper_name : (string * tool_call_entry) list =
-  match Hashtbl.find_opt usage_by_keeper keeper_name with
-  | None -> []
-  | Some tbl ->
-    Hashtbl.fold (fun name entry acc -> (name, entry) :: acc) tbl []
-    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+  Keeper_registry.tool_usage_of_by_name keeper_name
 
 let tool_usage_json keeper_name : Yojson.Safe.t =
   `List (List.map (fun (name, e) ->
@@ -164,7 +143,7 @@ let make_tools
                 let count = prior_fails + 1 in
                 with_failure_counts (fun () ->
                   Hashtbl.replace failure_counts key count);
-                record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:false;
+                Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 Log.Keeper.warn
                   "tool %s returned error result (%d/%d) for same args"
                   td.name count max_consecutive_failures;
@@ -172,7 +151,7 @@ let make_tools
               end else begin
                 with_failure_counts (fun () ->
                   Hashtbl.remove failure_counts key);
-                record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:true;
+                Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
                 (* PR#814 Gap 1: Capture git status delta after successful tool execution.
                    If the working tree changed, log it so the keeper is aware of
                    file-system side effects from its tool calls. *)
@@ -188,7 +167,7 @@ let make_tools
               let count = prior_fails + 1 in
               with_failure_counts (fun () ->
                 Hashtbl.replace failure_counts key count);
-              record_tool_use ~keeper_name:meta.name ~tool_name:td.name ~success:false;
+              Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
               let msg = Printf.sprintf "tool %s failed (%d/%d): %s"
                 td.name count max_consecutive_failures
                 (Printexc.to_string exn) in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -779,3 +779,13 @@ type fiber_health =
   | Fiber_zombie   (** Registry entry exists but fiber terminated *)
   | Fiber_dead     (** Restart budget exhausted, manual recovery needed *)
   | Fiber_unknown  (** Not in supervised registry *)
+
+(** Per-tool usage entry for keeper tool tracking.
+    Defined here so Keeper_registry can embed it without depending
+    on Keeper_tools_oas (avoids module init order issues). *)
+type tool_call_entry = {
+  mutable count : int;
+  mutable successes : int;
+  mutable failures : int;
+  mutable last_used_at : float;
+}

--- a/lib/keeper/keeper_types_resident.ml
+++ b/lib/keeper/keeper_types_resident.ml
@@ -79,15 +79,20 @@ let keeper_metrics_path config name =
 (** Date-split metrics store: [.masc/perpetual-keepers/<name>/metrics/YYYY-MM/DD.jsonl].
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 let metrics_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 8
+let metrics_store_mu = Eio.Mutex.create ()
 
 let keeper_metrics_store config name : Dated_jsonl.t =
   let dir = Filename.concat (keeper_dir_ config) (name ^ "/metrics") in
-  match Hashtbl.find_opt metrics_store_cache dir with
-  | Some store -> store
-  | None ->
-    let store = Dated_jsonl.create ~base_dir:dir () in
-    Hashtbl.replace metrics_store_cache dir store;
-    store
+  let lookup () =
+    match Hashtbl.find_opt metrics_store_cache dir with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:dir () in
+      Hashtbl.replace metrics_store_cache dir store;
+      store
+  in
+  try Eio.Mutex.use_rw ~protect:true metrics_store_mu lookup
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> lookup ()
 
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -216,38 +216,25 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
       let trimmed = String.trim meta.continuity_summary in
       if trimmed = "" then "No continuity snapshot available." else trimmed
 
-(** Per-keeper cursor for board event collection.
-    Tracks the last check timestamp so no posts are missed between heartbeats.
-    In-memory only — first run after restart uses a 300s bootstrap window. *)
-let board_cursors_mu = Eio.Mutex.create ()
-let board_cursors : (string, float) Hashtbl.t = Hashtbl.create 8
+(** Board event cursor bootstrap window (seconds). *)
 let bootstrap_window_sec = 300.0
 
-let reset_board_cursor name =
-  Eio.Mutex.use_rw ~protect:true board_cursors_mu (fun () ->
-      Hashtbl.remove board_cursors name)
-[@@warning "-32"]
 (** Collect recent board activity using cursor-based tracking.
+    Cursor state lives in Keeper_registry (board_cursor_ts field).
     Returns (event summaries, new post count, mention count). *)
-let collect_board_events ~(continuity_summary : string) ~(meta : keeper_meta) :
-    string list * int * int =
+let collect_board_events ~(base_path : string) ~(continuity_summary : string)
+    ~(meta : keeper_meta) : string list * int * int =
   try
     let since_ts =
-      Eio.Mutex.use_ro board_cursors_mu (fun () ->
-          match Hashtbl.find_opt board_cursors meta.name with
-          | Some ts -> ts
-          | None -> Time_compat.now () -. bootstrap_window_sec)
+      let ts = Keeper_registry.get_board_cursor_ts ~base_path meta.name in
+      if ts > 0.0 then ts
+      else Time_compat.now () -. bootstrap_window_sec
     in
-    (* Capture the watermark before fetch so posts created during the read
-       window are included on the next pass instead of being skipped. *)
     let cursor_watermark = Time_compat.now () in
     let posts =
       Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:20 ()
     in
-    (* Update the cursor only after a successful read to avoid losing events
-       when the board fetch fails mid-turn. *)
-    Eio.Mutex.use_rw ~protect:true board_cursors_mu (fun () ->
-        Hashtbl.replace board_cursors meta.name cursor_watermark);
+    Keeper_registry.set_board_cursor_ts ~base_path meta.name cursor_watermark;
     let recent =
       List.filter (fun (p : Board.post) -> p.updated_at >= since_ts) posts
       |> List.filter (fun (p : Board.post) ->
@@ -338,7 +325,7 @@ let observe ~(pending_board_events : string list option) ~(config : Room.config)
     | Some events -> events
     | None ->
         let events, _board_new_count, _board_mention_count =
-          collect_board_events ~meta ~continuity_summary
+          collect_board_events ~base_path:config.base_path ~meta ~continuity_summary
         in
         events
   in

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -62,6 +62,7 @@ type board_signal_match = {
     Used by both the world observation builder and the deliberation triage
     in keepalive to populate board-related triggers. *)
 val collect_board_events :
+  base_path:string ->
   continuity_summary:string ->
   meta:Keeper_types.keeper_meta ->
   string list * int * int

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -130,7 +130,8 @@ let test_observe_uses_precollected_board_events () =
       | Ok _ -> ()
       | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
       let events, _, _ =
-        WO.collect_board_events ~continuity_summary:"goal test-keeper"
+        WO.collect_board_events ~base_path:base_dir
+          ~continuity_summary:"goal test-keeper"
           ~meta:minimal_meta
       in
       let obs =


### PR DESCRIPTION
## Summary

- Per-keeper 상태(`board_cursors`, `usage_by_keeper`)를 `Keeper_registry`로 통합
- 무보호 Hashtbl 3개에 `Eio.Mutex` 추가 (data race 제거)
- `tool_call_entry` 타입을 `keeper_types.ml`로 이동 (모듈 초기화 안전성)

## Root Cause

Keeper 상태가 6개 모듈-레벨 Hashtbl에 분산. 이 중 3개(`supervisor_sweeps`, `bootstrap_done`, `metrics_store_cache`)는 Eio.Mutex 없이 동작하여 concurrent fiber 환경에서 data race 가능.

## Changes

| File | Action |
|------|--------|
| `keeper_registry.ml/.mli` | `board_cursor_ts`, `tool_usage` 필드 + 6 accessor 함수 |
| `keeper_world_observation.ml/.mli` | `board_cursors` Hashtbl+mutex 삭제, registry 경유 |
| `keeper_keepalive.ml` | `collect_board_events` 호출에 `~base_path` 추가 |
| `keeper_tools_oas.ml` | `usage_by_keeper` Hashtbl 삭제, registry 경유 |
| `keeper_types.ml` | `tool_call_entry` 타입 추가 |
| `keeper_runtime.ml` | `supervisor_sweeps`, `bootstrap_done`에 Eio.Mutex + atomic CAS |
| `keeper_types_resident.ml` | `metrics_store_cache`에 Eio.Mutex |
| `test/test_keeper_unified.ml` | `~base_path` 파라미터 추가 |

## Test plan

- [x] `dune build` 성공
- [x] `test_keeper_registry` 27/27 통과
- [x] `rg board_cursors lib/keeper/` — 잔존 0
- [x] `rg usage_by_keeper lib/keeper/` — 잔존 0
- [ ] CI full suite 확인

Closes #2904

🤖 Generated with [Claude Code](https://claude.com/claude-code)