### PR TITLE
fix: replace catch-all exception handlers with specific patterns (#2987)

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -292,7 +292,7 @@ let create_eio_readonly ~sw ~env (cfg : config) : (t, error) result =
          call Pool.use concurrently (e.g. dashboard room-truth parallel
          fetch).  Use half the main pool size, minimum 3. *)
       let main_pool_max = match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-        | Some s -> (try max 1 (min (int_of_string s) 50) with _ -> 5)
+        | Some s -> (match int_of_string_opt s with Some n -> max 1 (min n 50) | None -> 5)
         | None -> 5
       in
       let max_pool = max 3 (main_pool_max / 2) in

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -96,7 +96,7 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
       let json = Yojson.Safe.from_string body in
       let reply = Yojson.Safe.Util.(json |> member "reply" |> to_string) in
       Ok reply
-    with _ ->
+    with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
       (* If not JSON, use the body as-is *)
       Ok body)
   else
@@ -167,7 +167,7 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
               else None
             ) msgs in
             String.concat "\n" sys_msgs
-          with _ -> ""
+          with Yojson.Safe.Util.Type_error _ | Failure _ -> ""
         in
         match route_cascade ~message:user_message ~system_prompt
                 ~max_tokens ~temperature with


### PR DESCRIPTION
## Summary

서버 코드에서 `with _ ->` (catch-all) 예외 핸들러 3곳을 특정 예외 패턴으로 교체.

## Why

`with _ ->`는 `Out_of_memory`, `Stack_overflow` 같은 치명적 시스템 예외까지 무시한다. 파싱 실패만 잡아야 할 곳에서 모든 예외를 삼키면 디버깅이 불가능해진다.

## Changes (2 files, 3 lines)

| File | Before | After |
|------|--------|-------|
| `server_openai_compat.ml:99` | `with _ ->` | `with Yojson.Json_error _ \| Type_error _ ->` |
| `server_openai_compat.ml:170` | `with _ -> ""` | `with Type_error _ \| Failure _ -> ""` |
| `backend_pg.ml:295` | `try int_of_string s with _ -> 5` | `int_of_string_opt s \|> match` |

Partial fix for #2987.

## Test plan

- [x] `dune clean && dune build` 성공
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)