### PR TITLE
fix(backend): key validation and lock edge cases (#3057)

### DIFF
--- a/lib/backend/backend_eio.ml
+++ b/lib/backend/backend_eio.ml
@@ -72,7 +72,9 @@ module FileSystem = struct
       let rec check_segments = function
         | [] -> Ok key
         | seg :: rest ->
-            if seg = "." || seg = ".." then
+            if String.length seg = 0 then
+              Error (InvalidKey "Consecutive colons not allowed")
+            else if seg = "." || seg = ".." then
               Error (InvalidKey "Path traversal detected")
             else if String.length seg >= 2 && String.sub seg 0 2 = ".." then
               Error (InvalidKey "Path traversal detected")
@@ -341,6 +343,11 @@ module FileSystem = struct
         (match get t lock_key with
          | Ok json ->
              (match lock_info_of_json json with
+              | Some existing when existing.owner = owner ->
+                  (* Same owner reacquire: renew the lock *)
+                  (match set t lock_key (lock_info_to_json info) with
+                   | Ok () -> Ok true
+                   | Error e -> Error e)
               | Some existing when existing.expires_at < now ->
                   (* Expired, try to take over *)
                   (match set t lock_key (lock_info_to_json info) with
@@ -380,6 +387,7 @@ module FileSystem = struct
               | Ok () -> Ok true
               | Error e -> Error e)
          | _ -> Ok false)
+    | Error (NotFound _) -> Ok false
     | Error e -> Error e
 
   (** {2 Atomic Operations (Cross-Process Safe)} *)


### PR DESCRIPTION
## Summary

main 브랜치에서 지속 실패 중인 3개 테스트의 근본 원인을 수정.

## Root Causes & Fixes

### 1. `key_validation: consecutive colons`
- **원인**: `String.split_on_char ':' "test::key"` → `["test"; ""; "key"]`. 빈 세그먼트 `""`가 모든 검증을 통과
- **수정**: `validate_key`에 `String.length seg = 0` 체크 추가

### 2. `lock_edge_cases: extend nonexistent`
- **원인**: `extend_lock`이 존재하지 않는 키에 대해 `Error(NotFound)`를 반환. 테스트는 `Ok false` 기대
- **수정**: `Error (NotFound _) -> Ok false` 패턴 추가

### 3. `lock_edge_cases: reacquire same owner`
- **원인**: `acquire_lock`이 이미 소유한 락 재취득 시 소유자 체크 없이 `Ok false` 반환
- **수정**: `existing.owner = owner` 체크를 만료 체크보다 앞에 추가

## Impact

이 PR이 머지되면 모든 PR의 Build and Test가 정상 통과한다 (broken window 제거).

Fixes #3057.

## Test plan

- [x] `dune clean && dune build` 성공
- [ ] CI Build and Test의 3개 실패 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)