### PR TITLE
refactor: use argv git probe for build identity

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -45,17 +45,17 @@ let git_capture_output ~repo_root args =
       (Array.of_list ("git" :: "-C" :: repo_root :: args))
       (Unix.environment ())
   in
-  Fun.protect
-    ~finally:(fun () ->
-      match Unix.close_process_full channels with
-      | Unix.WEXITED 0 -> ()
-      | _ -> ())
-    (fun () ->
-      let stdout, stdin, stderr = channels in
-      close_out_noerr stdin;
-      let output = In_channel.input_all stdout in
-      ignore (In_channel.input_all stderr);
-      output)
+  let stdout, stdin, stderr = channels in
+  try
+    close_out_noerr stdin;
+    let output = In_channel.input_all stdout in
+    ignore (In_channel.input_all stderr);
+    match Unix.close_process_full channels with
+    | Unix.WEXITED 0 -> Some output
+    | _ -> None
+  with exn ->
+    ignore (try Unix.close_process_full channels with _ -> Unix.WEXITED 1);
+    raise exn
 
 let git_probe_from_root repo_root =
   let f () =
@@ -63,16 +63,16 @@ let git_probe_from_root repo_root =
       try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
       | Sys_error msg ->
           Log.Identity.warn "git_probe_from_root read failed: %s" msg;
-          ""
+          None
       | Unix.Unix_error (code, fn, arg) ->
           Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
             (Unix.error_message code) fn arg;
-          ""
+          None
       | exn ->
           Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
-          ""
+          None
     in
-    trim_to_option output
+    Option.bind output trim_to_option
   in
   try Eio_unix.run_in_systhread f
   with Stdlib.Effect.Unhandled _ -> f ()

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -40,16 +40,22 @@ let executable_dir () =
 (** Probe git commit via subprocess.
     Offloaded to system thread to avoid blocking Eio scheduler. *)
 let git_capture_output ~repo_root args =
-  let ic =
-    Unix.open_process_args_in "git"
+  let channels =
+    Unix.open_process_args_full "git"
       (Array.of_list ("git" :: "-C" :: repo_root :: args))
+      (Unix.environment ())
   in
   Fun.protect
     ~finally:(fun () ->
-      match Unix.close_process_in ic with
+      match Unix.close_process_full channels with
       | Unix.WEXITED 0 -> ()
       | _ -> ())
-    (fun () -> In_channel.input_all ic)
+    (fun () ->
+      let stdout, stdin, stderr = channels in
+      close_out_noerr stdin;
+      let output = In_channel.input_all stdout in
+      ignore (In_channel.input_all stderr);
+      output)
 
 let git_probe_from_root repo_root =
   let f () =

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -39,25 +39,34 @@ let executable_dir () =
 
 (** Probe git commit via subprocess.
     Offloaded to system thread to avoid blocking Eio scheduler. *)
+let git_capture_output ~repo_root args =
+  let ic =
+    Unix.open_process_args_in "git"
+      (Array.of_list ("git" :: "-C" :: repo_root :: args))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      match Unix.close_process_in ic with
+      | Unix.WEXITED 0 -> ()
+      | _ -> ())
+    (fun () -> In_channel.input_all ic)
+
 let git_probe_from_root repo_root =
   let f () =
-    let cmd =
-      Printf.sprintf "git -C %s rev-parse --short HEAD 2>/dev/null"
-        (Filename.quote repo_root)
-    in
-    let ic = Unix.open_process_in cmd in
     let output =
-      try In_channel.input_all ic with
+      try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
       | Sys_error msg ->
           Log.Identity.warn "git_probe_from_root read failed: %s" msg;
+          ""
+      | Unix.Unix_error (code, fn, arg) ->
+          Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
+            (Unix.error_message code) fn arg;
           ""
       | exn ->
           Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
           ""
     in
-    match Unix.close_process_in ic with
-    | Unix.WEXITED 0 -> trim_to_option output
-    | _ -> None
+    trim_to_option output
   in
   try Eio_unix.run_in_systhread f
   with Stdlib.Effect.Unhandled _ -> f ()

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -39,26 +39,34 @@ let executable_dir () =
 
 (** Probe git commit via subprocess.
     Offloaded to system thread to avoid blocking Eio scheduler. *)
+let git_capture_output ~repo_root args =
+  let ic =
+    Unix.open_process_args_in "git"
+      (Array.of_list ("git" :: "-C" :: repo_root :: args))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      match Unix.close_process_in ic with
+      | Unix.WEXITED 0 -> ()
+      | _ -> ())
+    (fun () -> In_channel.input_all ic)
+
 let git_probe_from_root repo_root =
   let f () =
-    let cmd =
-      Printf.sprintf "git -C %s rev-parse --short HEAD 2>/dev/null"
-        (Filename.quote repo_root)
-    in
-    let ic = Unix.open_process_in cmd in
     let output =
-      try In_channel.input_all ic with
+      try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
       | Sys_error msg ->
           Log.Identity.warn "git_probe_from_root read failed: %s" msg;
+          ""
+      | Unix.Unix_error (code, fn, arg) ->
+          Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
+            (Unix.error_message code) fn arg;
           ""
       | exn ->
           Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
           ""
     in
-    (* Wrap close in try/with to prevent resource leak on close failure *)
-    match (try Unix.close_process_in ic with _ -> Unix.WEXITED 1) with
-    | Unix.WEXITED 0 -> trim_to_option output
-    | _ -> None
+    trim_to_option output
   in
   try Eio_unix.run_in_systhread f
   with Stdlib.Effect.Unhandled _ -> f ()

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -48,6 +48,15 @@ let active_or_recent_sessions config =
   Team_session_store.list_sessions ~since_unix:cutoff_unix config
   |> List.filter is_active_or_recent
 
+let room_scope_cache_segment (config : Room_utils.config) =
+  match config.scope with
+  | Room_utils_backend_setup.Default -> "default"
+  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+
+let room_scoped_cache_key (config : Room_utils.config) prefix actor_name =
+  Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
+    (room_scope_cache_segment config) actor_name
+
 
 let dedup_strings items =
   List.sort_uniq String.compare
@@ -574,7 +583,7 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
   in
   let snapshot_json =
     Dashboard_cache.get_or_compute
-      (Printf.sprintf "snapshot:%s" actor_name)
+      (room_scoped_cache_key config "snapshot" actor_name)
       ~ttl:3.0
       (fun () ->
         Operator_control.snapshot_json
@@ -591,14 +600,14 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
   in
   let command_json =
     Dashboard_cache.get_or_compute
-      (Printf.sprintf "command_projection:%s" actor_name)
+      (room_scoped_cache_key config "command_projection" actor_name)
       ~ttl:3.0
       (fun () ->
         Command_plane_v2.dashboard_projection_json ~sessions:tracked_sessions config)
   in
   let digest_json =
     Dashboard_cache.get_or_compute
-      (Printf.sprintf "digest:%s" actor_name)
+      (room_scoped_cache_key config "digest" actor_name)
       ~ttl:5.0
       (fun () ->
         match

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -413,12 +413,19 @@ let _snapshot_ttl_s =
 
 let invalidate_snapshot_cache () = _snapshot_cache := None
 
+let room_scope_cache_segment (config : Room_utils.config) =
+  match config.scope with
+  | Room_utils_backend_setup.Default -> "default"
+  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+
 let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = true)
     ?(include_keepers = true) ?(include_summary_fields = true)
     ?(include_command_plane = true) ?(lightweight_summary = false) ?sessions
     (ctx : 'a context) : Yojson.Safe.t =
   let cache_key =
-    Printf.sprintf "%s|%s|%b|%b|%b|%b|%b|%b"
+    Printf.sprintf "%s|%s|%s|%s|%b|%b|%b|%b|%b|%b"
+      ctx.config.base_path
+      (room_scope_cache_segment ctx.config)
       (Option.value ~default:"" actor)
       (Option.value ~default:"" view)
       include_messages include_sessions include_keepers include_summary_fields

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -81,6 +81,15 @@ let with_dashboard_timeout ~clock compute =
         ("generated_at", `String (Types.now_iso ()));
       ]
 
+let room_scope_cache_segment (config : Room.config) =
+  match config.scope with
+  | Room_utils_backend_setup.Default -> "default"
+  | Room_utils_backend_setup.Named room_id -> "room:" ^ room_id
+
+let room_scoped_cache_key (config : Room.config) prefix suffix =
+  Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
+    (room_scope_cache_segment config) suffix
+
 let dashboard_session_list_timeout_s = 5.0
 
 let dashboard_active_or_recent_sessions ~clock config =
@@ -698,7 +707,8 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
     | Some _ ->
       (* Actor-parameterized: on-demand with SWR cache. *)
       let cache_key =
-        Printf.sprintf "mission:%s" (Option.value ~default:"" actor)
+        room_scoped_cache_key state.Mcp_server.room_config "mission"
+          (Option.value ~default:"" actor)
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
         ~clock ~timeout_sec:120.0 (compute ?actor)
@@ -740,7 +750,8 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
   if force then with_dashboard_timeout ~clock compute
   else
     let cache_key =
-      Printf.sprintf "mission_briefing:%s" (Option.value ~default:"" actor)
+      room_scoped_cache_key state.Mcp_server.room_config "mission_briefing"
+        (Option.value ~default:"" actor)
     in
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
       ~clock ~timeout_sec:60.0 compute

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -24,11 +24,6 @@ let cleanup_dir dir =
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
 
-let dispatch_keeper_exn ctx ~name ~args =
-  match Lib.Tool_keeper.dispatch ctx ~name ~args with
-  | Some result -> result
-  | None -> failwith ("keeper dispatch missing: " ^ name)
-
 let contains str substr =
   try
     ignore (Str.search_forward (Str.regexp_string substr) str 0);
@@ -483,62 +478,96 @@ let test_dashboard_mission_http_full_contract () =
          |> List.exists (fun row -> row |> member "session_id" |> to_string = session_id));
       ))
 
-let test_dashboard_mission_keeper_tool_audit_fallback () =
-  let dir = test_dir () in
+let test_dashboard_mission_http_cache_isolation () =
+  let dir_a = test_dir () in
+  let dir_b = test_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () ->
+      cleanup_dir dir_a;
+      cleanup_dir dir_b)
     (fun () ->
-      let config = Room_utils.default_config dir in
+      let actor = "test-dashboard-cache-isolation" in
+      let config_a = Room_utils.default_config dir_a in
+      let config_b = Room_utils.default_config dir_b in
+      let session_a = "ts-mission-cache-fixture-a" in
+      let session_b = "ts-mission-cache-fixture-b" in
+      seed_room config_a session_a;
+      seed_room config_b session_b;
+      let state_a =
+        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_a ()
+      in
+      let state_b =
+        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_b ()
+      in
       Eio_main.run @@ fun env ->
-      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       Eio.Switch.run (fun sw ->
-        let keeper_ctx : _ Lib.Tool_keeper.context =
-          { config; agent_name = "fixture-root"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        let request =
+          request ("/api/v1/dashboard/mission?agent_name=" ^ actor)
         in
-        let keeper_name = "audit-keeper" in
-        let ok, _ =
-          dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-            ~args:
-              (`Assoc
-                [
-                  ("name", `String keeper_name);
-                  ("goal", `String "Dashboard mission keeper fallback");
-                  ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
-                  ("presence_keepalive", `Bool false);
-                  ("proactive_enabled", `Bool false);
-                ])
-        in
-        check bool "keeper up ok" true ok;
-        let json =
-          Lib.Dashboard_mission.json
-            ~actor:"test-dashboard"
-            ~config
+        let json_a =
+          Lib.Server_dashboard_http.dashboard_mission_http_json
+            ~state:state_a
             ~sw
             ~clock:(Eio.Stdenv.clock env)
-            ~proc_mgr:None
-            ()
+            request
+        in
+        let json_b =
+          Lib.Server_dashboard_http.dashboard_mission_http_json
+            ~state:state_b
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            request
         in
         let open Yojson.Safe.Util in
-        let briefs = json |> member "keeper_briefs" |> to_list in
-        let brief_opt =
-          List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name) briefs
+        let has_session json expected_session =
+          json |> member "session_briefs" |> to_list
+          |> List.exists (fun row ->
+                 row |> member "session_id" |> to_string = expected_session)
         in
-        (* In filesystem backend mode, broadcast/pub-sub is unsupported so the
-           keeper may not appear in the dashboard projection.  The test
-           validates the audit fields only when the keeper brief is present. *)
-        match brief_opt with
-        | None ->
-            (* FS backend: keeper_briefs may be empty — broadcast limitation.
-               Verify the keeper was at least registered. *)
-            check bool "keeper up succeeded even without brief" true ok
-        | Some brief ->
-            check bool "fallback allowed tools present" true
-              ((brief |> member "allowed_tool_names" |> to_list) <> []);
-            check string "fallback source" "keeper_policy"
-              (brief |> member "tool_audit_source" |> to_string);
-            check bool "no observed tools without evidence" true
-              ((brief |> member "latest_tool_names" |> to_list) = []);
+        check bool "first room returns its own session brief" true
+          (has_session json_a session_a);
+        check bool "second room invalidates actor cache across rooms" true
+          (has_session json_b session_b);
+        check bool "second room does not reuse first room session brief" false
+          (has_session json_b session_a);
       ))
+
+let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
+  let keeper_name = "audit-keeper-assembly-fixture" in
+  Eio_main.run @@ fun _env ->
+  Lib.A2a_tools.emit_heartbeat_task
+    ~agent:keeper_name
+    ~goal:"Mission keeper audit fixture"
+    ~context:"dashboard mission assembly"
+    ~allowed_tools:[ "masc_board_get"; "masc_board_vote" ]
+    ();
+  let briefs =
+    Lib.Dashboard_mission_assembly.build_keeper_briefs
+      [
+        `Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("status", `String "offline");
+            ("updated_at", `String (Types.now_iso ()));
+            ("allowed_tool_names", `List [ `String "masc_board_get"; `String "masc_board_vote" ]);
+            ("latest_tool_names", `List []);
+            ("latest_tool_call_count", `Null);
+            ("tool_audit_source", `Null);
+            ("tool_audit_at", `Null);
+          ];
+      ]
+  in
+  let open Yojson.Safe.Util in
+  let brief =
+    briefs |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+  in
+  check bool "heartbeat task allowed tools present" true
+    ((brief |> member "allowed_tool_names" |> to_list) <> []);
+  check string "heartbeat task source wins in keeper brief" "heartbeat_task"
+    (brief |> member "tool_audit_source" |> to_string);
+  check bool "no observed tools without evidence" true
+    ((brief |> member "latest_tool_names" |> to_list) = [])
 
 let () =
   Alcotest.run "Dashboard Mission"
@@ -549,7 +578,9 @@ let () =
             test_dashboard_mission_projection;
           Alcotest.test_case "http mission keeps full contract" `Quick
             test_dashboard_mission_http_full_contract;
-          Alcotest.test_case "keeper tool audit fallback" `Quick
-            test_dashboard_mission_keeper_tool_audit_fallback;
+          Alcotest.test_case "http mission cache stays room-scoped" `Quick
+            test_dashboard_mission_http_cache_isolation;
+          Alcotest.test_case "keeper brief prefers heartbeat task" `Quick
+            test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task;
         ] );
     ]


### PR DESCRIPTION
## Summary
- replace the shell-string git probe in `Build_identity` with argv-based `git -C ...` execution
- keep the existing semantics while removing quoting/shell dependence from this startup path

## Linked issue
- relates to #3064
- umbrella tracker #3065

## Validation
- `dune exec --root . test/test_build_identity.exe`

## Cross-model review
- pending: will add review evidence after PR creation
