### PR TITLE
fix(safety): replace silent catch-all handlers with specific exceptions

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -583,7 +583,9 @@ let stop_keepalive name =
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
       entry.fiber_stop := true;
       (match !(entry.grpc_close) with
-       | Some close_fn -> (try close_fn () with _ -> ())
+       | Some close_fn ->
+         (try close_fn ()
+          with Eio.Cancel.Cancelled _ as e -> raise e | _exn -> ())
        | None -> ());
       Keeper_registry.set_state ~base_path:entry.base_path name
         Keeper_registry.Stopped;

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -184,7 +184,7 @@ module Ring = struct
   let rotate_if_needed () =
     let today = date_string () in
     if today <> !file_current_date && !file_base_dir <> "" then begin
-      (match !file_channel with Some oc -> (try close_out oc with _ -> ()) | None -> ());
+      (match !file_channel with Some oc -> (try close_out oc with Sys_error _ -> ()) | None -> ());
       open_sink !file_base_dir
     end
 
@@ -195,7 +195,7 @@ module Ring = struct
         output_string oc (Yojson.Safe.to_string entry_json);
         output_char oc '\n';
         (* flush on warn/error for timely persistence *)
-        (try flush oc with _ -> ())
+        (try flush oc with Sys_error _ -> ())
     | None -> ()
 
   let entry_of_json json =
@@ -211,9 +211,9 @@ module Ring = struct
         legacy_classified = json |> member "legacy_classified" |> to_bool;
         module_name = json |> member "module" |> to_string;
         message = json |> member "message" |> to_string;
-        details = (try json |> member "details" with _ -> `Null);
+        details = (try json |> member "details" with Type_error _ -> `Null);
       }
-    with _ -> None
+    with Type_error _ -> None
 
   let load_from_file dir =
     ensure_dir dir;

--- a/lib/server/server_mcp_transport_http_sse.ml
+++ b/lib/server/server_mcp_transport_http_sse.ml
@@ -154,7 +154,10 @@ let send_raw info data =
       Sse.touch info.session_id;
       true
     with
-    | Eio.Cancel.Cancelled _ as e -> raise e
+    | Eio.Cancel.Cancelled _ as e ->
+      (try close_sse_conn info
+       with Eio.Cancel.Cancelled _ | Sys_error _ -> ());
+      raise e
     | exn ->
       Log.Misc.debug "SSE send_raw failed: %s" (Printexc.to_string exn);
       close_sse_conn info;

--- a/lib/server/server_mcp_transport_http_sse.ml
+++ b/lib/server/server_mcp_transport_http_sse.ml
@@ -153,6 +153,9 @@ let send_raw info data =
           Httpun.Body.Writer.flush info.writer (fun _ -> ()));
       Sse.touch info.session_id;
       true
-    with _exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Misc.debug "SSE send_raw failed: %s" (Printexc.to_string exn);
       close_sse_conn info;
       false


### PR DESCRIPTION
## Summary

Closes #2987 (partial — exception handling portion).

Issue #2987 reports 4 categories of unsafe patterns. After audit:

| Category | Reported | Actual | Status |
|----------|----------|--------|--------|
| `with _ ->` catch-all | 29건 | 9 silent (나머지는 `with exn ->` + 로깅) | **6건 수정** (3건은 이미 main에서 해결) |
| `List.nth`/`List.hd` unsafe | 26건 | 0건 unsafe (전부 `nth_opt`) | 수정 불필요 |
| `mutable` 남용 | 397건 | 아키텍처 레벨 | #2955에서 추적 |
| `String.length` 과용 | 1158건 | O(1), 실질적 문제 아님 | 수정 불필요 |

### Changes (3 files, 6 fixes)

**`lib/masc_log/log.ml`** (4건):
- `close_out`/`flush`: `with _ ->` → `with Sys_error _ ->`
- JSON `member`/parse: `with _ ->` → `with Type_error _ ->`

**`lib/keeper/keeper_keepalive.ml`** (1건):
- gRPC close: `Eio.Cancel.Cancelled` 전파 보존

**`lib/server/server_mcp_transport_http_sse.ml`** (1건):
- SSE write: `Eio.Cancel.Cancelled` 전파 + debug 로깅 추가

### Why this matters

`with _ ->` catches **everything** including `Out_of_memory`, `Stack_overflow`, and `Eio.Cancel.Cancelled`. The last one is particularly dangerous in Eio: swallowing cancellation prevents structured concurrency cleanup, causing fiber leaks.

## Test plan

- [x] `dune build --root .` — type-checks (wrong exception types = compile error)
- [x] `test_keeper_unified` — 28 tests passed
- [x] `test_keeper_registry` — 27 tests passed
- [x] `test_sse` — 3 tests passed