### PR TITLE
fix(swarm): replace raw Unix.open_process_in with Process_eio in metric runner

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -55,7 +55,8 @@ let git_probe_from_root repo_root =
           Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
           ""
     in
-    match Unix.close_process_in ic with
+    (* Wrap close in try/with to prevent resource leak on close failure *)
+    match (try Unix.close_process_in ic with _ -> Unix.WEXITED 1) with
     | Unix.WEXITED 0 -> trim_to_option output
     | _ -> None
   in

--- a/lib/swarm/swarm_goal_loop.ml
+++ b/lib/swarm/swarm_goal_loop.ml
@@ -88,10 +88,15 @@ let make_cancel_token () = { cancelled = false }
 (* ================================================================ *)
 
 let measure_metric metric_fn =
+  match Autoresearch_metric.validate_metric_fn metric_fn with
+  | Error e -> Error e
+  | Ok metric_fn ->
   try
-    let ic = Unix.open_process_in metric_fn in
-    let output = In_channel.input_all ic |> String.trim in
-    let status = Unix.close_process_in ic in
+    let status, raw_output =
+      Process_eio.run_argv_with_status ~timeout_sec:60.0
+        ["sh"; "-c"; metric_fn]
+    in
+    let output = String.trim raw_output in
     match status with
     | Unix.WEXITED 0 ->
         (match Float.of_string_opt output with


### PR DESCRIPTION
## Summary
- `swarm_goal_loop.ml`: Replace blocking `Unix.open_process_in` with Eio-aware `Process_eio.run_argv_with_status` (60s timeout, no resource leak). Add `validate_metric_fn` shell metacharacter validation (reusing existing `autoresearch_metric.ml` logic).
- `build_identity.ml`: Wrap `Unix.close_process_in` in `try/with` to prevent resource leak on close failure.

Closes part of #3064 (metric runner safety). TUI catch-all cleanup is a separate PR.

## Verification
- `dune build` passes
- Behavioral: metric_fn execution now has 60s timeout and input validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)