### PR TITLE
fix: replace catch-all handlers in TUI and metric runner (#3064)

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -235,7 +235,7 @@ let get_terminal_size () =
     let cols = read_tput "cols" in
     let rows = read_tput "lines" in
     (rows, cols)
-  with _ -> (24, 80)
+  with Failure _ | Unix.Unix_error _ | End_of_file -> (24, 80)
 
 (** Draw horizontal line *)
 let draw_hline width =
@@ -1009,11 +1009,11 @@ let load_keepers (base_path : string) : keeper list =
            let path = Filename.concat keepers_dir f in
            let json = Yojson.Safe.from_file path in
            let open Yojson.Safe.Util in
-           let str key default = try json |> member key |> to_string with _ -> default in
-           let int_ key default = try json |> member key |> to_int with _ -> default in
-           let float_ key default = try json |> member key |> to_number with _ -> default in
-           let bool_ key default = try json |> member key |> to_bool with _ -> default in
-           let str_list key = try json |> member key |> to_list |> List.map to_string with _ -> [] in
+           let str key default = try json |> member key |> to_string with Type_error _ -> default in
+           let int_ key default = try json |> member key |> to_int with Type_error _ -> default in
+           let float_ key default = try json |> member key |> to_number with Type_error _ -> default in
+           let bool_ key default = try json |> member key |> to_bool with Type_error _ -> default in
+           let str_list key = try json |> member key |> to_list |> List.map to_string with Type_error _ -> [] in
            Some {
              k_name = str "name" (Filename.chop_suffix f ".json");
              k_goal = str "goal" "";
@@ -1040,7 +1040,7 @@ let load_keepers (base_path : string) : keeper list =
              k_created_at = str "created_at" "";
              k_updated_at = str "updated_at" "";
            }
-         with _ -> None
+         with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Sys_error _ -> None
        )
     |> List.sort (fun a b -> String.compare a.k_name b.k_name)
   else []
@@ -1062,18 +1062,18 @@ let read_last_lines path n =
         if len <= n then all
         else
           List.filteri (fun i _ -> i >= len - n) all)
-  with _ -> []
+  with Sys_error _ -> []
 
 (** Parse a single metrics JSONL line into a log_entry *)
 let parse_log_entry (line : string) : log_entry option =
   try
     let json = Yojson.Safe.from_string line in
     let open Yojson.Safe.Util in
-    let str key default = try json |> member key |> to_string with _ -> default in
-    let int_ key default = try json |> member key |> to_int with _ -> default in
-    let float_ key default = try json |> member key |> to_number with _ -> default in
-    let bool_ key default = try json |> member key |> to_bool with _ -> default in
-    let str_list key = try json |> member key |> to_list |> List.map to_string with _ -> [] in
+    let str key default = try json |> member key |> to_string with Type_error _ -> default in
+    let int_ key default = try json |> member key |> to_int with Type_error _ -> default in
+    let float_ key default = try json |> member key |> to_number with Type_error _ -> default in
+    let bool_ key default = try json |> member key |> to_bool with Type_error _ -> default in
+    let str_list key = try json |> member key |> to_list |> List.map to_string with Type_error _ -> [] in
     Some {
       le_ts = str "ts" "";
       le_channel = str "channel" "unknown";
@@ -1082,8 +1082,8 @@ let parse_log_entry (line : string) : log_entry option =
       le_context_max = int_ "context_max" 0;
       le_message_count = int_ "message_count" 0;
       le_model_used = str "model_used" "";
-      le_input_tokens = (try json |> member "usage" |> member "input_tokens" |> to_int with _ -> 0);
-      le_output_tokens = (try json |> member "usage" |> member "output_tokens" |> to_int with _ -> 0);
+      le_input_tokens = (try json |> member "usage" |> member "input_tokens" |> to_int with Type_error _ -> 0);
+      le_output_tokens = (try json |> member "usage" |> member "output_tokens" |> to_int with Type_error _ -> 0);
       le_latency_ms = int_ "latency_ms" 0;
       le_cost_usd = float_ "cost_usd" 0.0;
       le_work_kind = str "work_kind" "";
@@ -1093,7 +1093,7 @@ let parse_log_entry (line : string) : log_entry option =
       le_repetition_risk = float_ "repetition_risk" 0.0;
       le_guardrail_stop = bool_ "guardrail_stop" false;
     }
-  with _ -> None
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
 
 (** Find the most recent metrics file for a keeper *)
 let find_metrics_files (base_path : string) (keeper_name : string) : string list =
@@ -1199,7 +1199,7 @@ let load_from_masc_dir (state : state) (base_path : string) =
              let current_task = json |> member "current_task" |> to_string_option in
              let last_seen = json |> member "last_seen" |> to_string in
              Some { name; status; current_task; last_seen }
-           with _ -> None
+           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Sys_error _ -> None
          )
     else []
   );
@@ -1222,7 +1222,7 @@ let load_from_masc_dir (state : state) (base_path : string) =
              let priority = json |> member "priority" |> to_int_option |> Option.value ~default:3 in
              let claimed_by = json |> member "claimed_by" |> to_string_option in
              Some { id; title; status; priority; claimed_by }
-           with _ -> None
+           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Sys_error _ -> None
          )
       |> List.sort (fun a b -> compare a.priority b.priority)
     else []
@@ -1304,17 +1304,17 @@ let send_keeper_message (state : state) (keeper_name : string) (message : string
             (try
               let json = Yojson.Safe.from_string data in
               let open Yojson.Safe.Util in
-              let typ = try json |> member "type" |> to_string with _ -> "" in
+              let typ = try json |> member "type" |> to_string with Type_error _ -> "" in
               if typ = "content_delta" || typ = "delta" then begin
-                let delta = try json |> member "delta" |> to_string with _ -> "" in
+                let delta = try json |> member "delta" |> to_string with Type_error _ -> "" in
                 Buffer.add_string result delta
               end else if typ = "content_complete" || typ = "complete" then begin
                 (* Check for full text in content field *)
-                let text = try json |> member "text" |> to_string with _ -> "" in
+                let text = try json |> member "text" |> to_string with Type_error _ -> "" in
                 if text <> "" && Buffer.length result = 0 then
                   Buffer.add_string result text
               end
-            with _ -> ())
+            with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ())
           end
         ) lines;
 
@@ -1333,20 +1333,20 @@ let send_keeper_message (state : state) (keeper_name : string) (message : string
                 incr idx
             done;
             if !found then !idx else 0
-          with _ -> 0 in
+          with Invalid_argument _ -> 0 in
           if body_start > 0 then begin
             let body_str = String.sub response body_start (String.length response - body_start) in
             (* Try parsing as JSON *)
             (try
               let json = Yojson.Safe.from_string (String.trim body_str) in
               let open Yojson.Safe.Util in
-              let text = try json |> member "result" |> member "text" |> to_string with _ -> "" in
+              let text = try json |> member "result" |> member "text" |> to_string with Type_error _ -> "" in
               if text <> "" then text
               else
-                let msg = try json |> member "error" |> member "message" |> to_string with _ -> "" in
+                let msg = try json |> member "error" |> member "message" |> to_string with Type_error _ -> "" in
                 if msg <> "" then "(error: " ^ msg ^ ")"
                 else "(no response parsed)"
-            with _ -> "(response parsing failed)")
+            with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> "(response parsing failed)")
           end else "(empty response)"
         end)
   with

--- a/lib/swarm/swarm_goal_loop.ml
+++ b/lib/swarm/swarm_goal_loop.ml
@@ -89,9 +89,12 @@ let make_cancel_token () = { cancelled = false }
 
 let measure_metric metric_fn =
   try
-    let ic = Unix.open_process_in metric_fn in
-    let output = In_channel.input_all ic |> String.trim in
-    let status = Unix.close_process_in ic in
+    let (status, output) =
+      Process_eio.run_argv_with_status
+        ~timeout_sec:30.0
+        ["sh"; "-c"; metric_fn]
+    in
+    let output = String.trim output in
     match status with
     | Unix.WEXITED 0 ->
         (match Float.of_string_opt output with


### PR DESCRIPTION
## Summary

- **bin/masc_tui.ml**: 24개 `with _ ->` catch-all 패턴을 구체적 예외 타입으로 교체
  - JSON 파싱 helpers: `Type_error _` (10개)
  - 외부 JSON 로딩: `Json_error _ | Type_error _ | Sys_error _` (4개)
  - 파일 I/O: `Sys_error _` (1개)
  - SSE 파싱: `Json_error _ | Type_error _` (3개)
  - 터미널 크기: `Failure _ | Unix.Unix_error _ | End_of_file` (1개)
  - 기타: `Invalid_argument _`, `Type_error _` (5개)

- **lib/swarm/swarm_goal_loop.ml**: `measure_metric`의 `Unix.open_process_in` (blocking, raw shell string)을 `Process_eio.run_argv_with_status` (non-blocking, 30s timeout)로 교체

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI Build and Test

Addresses #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)