### PR TITLE
Fix keeper read path and cache hydration

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -40,13 +40,13 @@ let parse_agent_status (config : Room.config) ~(agent_name : string) : Yojson.Sa
   let agent_file =
     Filename.concat (Room.agents_dir config) (Room.safe_filename agent_name ^ ".json")
   in
-  if not (Sys.file_exists agent_file) then
+  if not (Room.path_exists config agent_file) then
     `Assoc [ ("exists", `Bool false) ]
-  else
-    match Safe_ops.read_json_file_safe agent_file with
-    | Error _ ->
+  else (
+    match Room.read_json_opt config agent_file with
+    | None ->
         `Assoc [ ("exists", `Bool true); ("error", `String "failed_to_read") ]
-    | Ok json -> (
+    | Some json -> (
         match Types.agent_of_yojson json with
         | Error _ ->
             `Assoc [ ("exists", `Bool true); ("error", `String "failed_to_parse") ]
@@ -79,7 +79,7 @@ let parse_agent_status (config : Room.config) ~(agent_name : string) : Yojson.Sa
                 ("age_s", `Float age_s);
                 ("last_seen_ago_s", `Float last_seen_ago_s);
                 ("is_zombie", `Bool (Room.is_zombie_agent ~agent_name:agent.name agent.last_seen));
-              ])
+              ]))
 
 let json_string_opt key json =
   match Yojson.Safe.Util.member key json with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -571,6 +571,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
         m
     in
     Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
+    (match get_bus () with
+     | Some bus ->
+         Oas_events.publish_keeper_resident_lifecycle bus ~event:"started"
+           ~keeper_name:live_meta.name ~detail:"keepalive"
+     | None -> ());
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
         run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup))
 
@@ -587,5 +592,10 @@ let stop_keepalive name =
        | None -> ());
       Keeper_registry.set_state ~base_path:entry.base_path name
         Keeper_registry.Stopped;
-      Keeper_registry.cleanup_tracking ~base_path:entry.base_path name
+      Keeper_registry.cleanup_tracking ~base_path:entry.base_path name;
+      (match get_bus () with
+       | Some bus ->
+           Oas_events.publish_keeper_resident_lifecycle bus ~event:"stopped"
+             ~keeper_name:name ~detail:"manual stop"
+       | None -> ())
   ) entries

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -98,6 +98,24 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
 
 (* ── Sweep and recover ───────────────────────────────────── *)
 
+let reconcile_desired_resident_keepers (ctx : _ context) =
+  let base_path = ctx.config.base_path in
+  Keeper_types.list_resident_keepers ctx.config
+  |> List.iter (fun (spec : Keeper_types.resident_keeper_spec) ->
+       if not spec.desired then ()
+       else
+         match read_meta ctx.config spec.persistent_name with
+         | Ok (Some meta)
+           when not meta.paused
+                && meta.presence_keepalive
+                && not (Keeper_registry.is_running ~base_path meta.name) ->
+             supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
+             if Keeper_registry.is_running ~base_path meta.name then begin
+               publish_lifecycle "reconciled" meta.name "late resident registration";
+               Log.Keeper.info "%s: reconciled late resident keeper" meta.name
+             end
+         | _ -> ())
+
 let sweep_and_recover (ctx : _ context) =
   let now = Time_compat.now () in
   let max_restarts = Env_config.KeeperResidentSupervisor.max_restarts in
@@ -151,4 +169,5 @@ let sweep_and_recover (ctx : _ context) =
         Log.Keeper.error "%s: cannot read meta for restart, removing"
           old_entry.name;
         Keeper_registry.unregister ~base_path old_entry.name
-  ) !to_restart
+  ) !to_restart;
+  reconcile_desired_resident_keepers ctx

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -200,8 +200,7 @@ let with_bootstrap_rw f =
   with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
-  if stats.started > 0 || Keeper_registry.count_running () > 0
-  then start_supervisor_sweep ctx
+  if stats.enabled then start_supervisor_sweep ctx
 
 let start_existing_keepalives ctx =
   let base_path = ctx.config.base_path in

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -49,6 +49,141 @@ let _transport_health_cache =
           `String "Transport health data is warming up. Refresh in a few seconds." );
       ])
 
+let keepalive_running_of_lifecycle_event = function
+  | "started" | "restarted" | "reconciled" -> Some true
+  | "stopped" | "crashed" | "dead" -> Some false
+  | _ -> None
+
+let patch_keeper_diagnostic ~keepalive_running (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields ->
+      let fields =
+        upsert_assoc_field "keepalive_running" (`Bool keepalive_running) fields
+      in
+      let fields =
+        if keepalive_running then
+          let fields =
+            match List.assoc_opt "continuity_state" fields with
+            | Some (`String ("not_running" | "desired_offline" | "disabled")) ->
+                upsert_assoc_field "continuity_state" (`String "recovering") fields
+            | _ -> fields
+          in
+          match List.assoc_opt "quiet_reason" fields with
+          | Some (`String "not_running") ->
+              upsert_assoc_field "quiet_reason" `Null fields
+          | _ -> fields
+        else
+          fields
+          |> upsert_assoc_field "continuity_state" (`String "not_running")
+          |> upsert_assoc_field "quiet_reason" (`String "not_running")
+      in
+      `Assoc fields
+  | other -> other
+
+let patch_keeper_row ~keeper_name ~keepalive_running = function
+  | `Assoc fields as row -> (
+      match Yojson.Safe.Util.member "name" row with
+      | `String name when String.equal name keeper_name ->
+          let diagnostic =
+            match Yojson.Safe.Util.member "diagnostic" row with
+            | `Assoc _ as json ->
+                patch_keeper_diagnostic ~keepalive_running json
+            | `Null ->
+                `Assoc
+                  [
+                    ("keepalive_running", `Bool keepalive_running);
+                    ( "continuity_state",
+                      `String (if keepalive_running then "recovering" else "not_running") );
+                  ]
+            | other -> other
+          in
+          let row_fields : (string * Yojson.Safe.t) list = fields in
+          `Assoc
+            (row_fields
+            |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running)
+            |> upsert_assoc_field "diagnostic" diagnostic)
+      | _ -> row)
+  | other -> other
+
+let patch_keeper_rows ~keeper_name ~keepalive_running rows =
+  List.map (patch_keeper_row ~keeper_name ~keepalive_running) rows
+
+let running_keeper_names (config : Room.config) =
+  Keeper_types.resident_keeper_names config
+  |> List.filter_map (fun name ->
+         match Keeper_types.read_meta config name with
+         | Ok (Some meta)
+           when Keeper_status_bridge.runtime_keepalive_running config meta ->
+             Some name
+         | _ -> None)
+
+let patch_surface_json_for_running_keepers (config : Room.config) = function
+  | `Assoc fields as json ->
+      let running = running_keeper_names config in
+      if running = [] then json
+      else
+        let patch_rows rows =
+          List.fold_left
+            (fun acc keeper_name ->
+              patch_keeper_rows ~keeper_name ~keepalive_running:true acc)
+            rows running
+        in
+        (match List.assoc_opt "keepers" fields with
+         | Some (`List rows) ->
+             `Assoc
+               (upsert_assoc_field "keepers" (`List (patch_rows rows)) fields)
+         | Some (`Assoc keeper_fields) -> (
+             match List.assoc_opt "items" keeper_fields with
+             | Some (`List rows) ->
+                 let keeper_fields =
+                   upsert_assoc_field "items" (`List (patch_rows rows))
+                     keeper_fields
+                 in
+                 `Assoc
+                   (upsert_assoc_field "keepers" (`Assoc keeper_fields) fields)
+             | _ -> json)
+         | _ -> json)
+  | other -> other
+
+let patch_execution_cache_for_keeper ~keeper_name ~keepalive_running =
+  match _execution_cache.json with
+  | `Assoc fields -> (
+      match List.assoc_opt "keepers" fields with
+      | Some (`List rows) ->
+          _execution_cache.json <-
+            `Assoc
+              (upsert_assoc_field "keepers"
+                 (`List (patch_keeper_rows ~keeper_name ~keepalive_running rows))
+                 fields)
+      | _ -> ())
+  | _ -> ()
+
+let patch_operator_snapshot_cache_for_keeper ~keeper_name ~keepalive_running =
+  match _operator_snapshot_cache.json with
+  | `Assoc fields -> (
+      match List.assoc_opt "keepers" fields with
+      | Some (`Assoc keeper_fields) -> (
+          match List.assoc_opt "items" keeper_fields with
+          | Some (`List rows) ->
+              let keeper_fields =
+                upsert_assoc_field "items"
+                  (`List (patch_keeper_rows ~keeper_name ~keepalive_running rows))
+                  keeper_fields
+              in
+              _operator_snapshot_cache.json <-
+                `Assoc
+                  (upsert_assoc_field "keepers" (`Assoc keeper_fields) fields)
+          | _ -> ())
+      | _ -> ())
+  | _ -> ()
+
+let patch_keeper_dependent_caches ~keeper_name ~event =
+  match keepalive_running_of_lifecycle_event event with
+  | None -> ()
+  | Some keepalive_running ->
+      patch_execution_cache_for_keeper ~keeper_name ~keepalive_running;
+      patch_operator_snapshot_cache_for_keeper ~keeper_name ~keepalive_running
+
 (** Start the proactive execution refresh loop.  When an Executor_pool
     is available, each refresh runs in a pool domain with a domain-local
     Caqti pool (the main domain's Caqti pool is domain-bound due to
@@ -69,6 +204,7 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
       run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config:room_config
         (fun ~config ~sw ->
           Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
+          |> patch_surface_json_for_running_keepers config
           |> with_projection_diagnostics ~surface:"execution" ~started_at
                ~extra:
                  [
@@ -124,6 +260,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
         Dashboard_execution.json ?actor ?fixture ~light
           ~config ~sw ~clock
           ~proc_mgr:state.Mcp_server.proc_mgr ()
+        |> patch_surface_json_for_running_keepers config
         |> with_projection_diagnostics ~surface:"execution" ~started_at
              ~extra:
                [

--- a/lib/server/server_dashboard_http_cache.ml
+++ b/lib/server/server_dashboard_http_cache.ml
@@ -51,6 +51,15 @@ let mark_cached_surface_error surface exn =
   surface.last_error_at <- Some iso;
   surface.last_error_unix <- Some ts
 
+let invalidate_cached_surface surface =
+  surface.last_success_at <- None;
+  surface.last_success_unix <- None;
+  surface.last_attempt_at <- None;
+  surface.last_attempt_unix <- None;
+  surface.last_error <- None;
+  surface.last_error_at <- None;
+  surface.last_error_unix <- None
+
 let upsert_assoc_field key value fields =
   (key, value) :: List.remove_assoc key fields
 
@@ -150,4 +159,3 @@ let initialized_json_opt ?(allow_initializing = false) = function
       | Some (`String "initializing") when not allow_initializing -> None
       | _ -> Some json)
   | _ -> None
-

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -310,6 +310,36 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   in
   (* Event_bus → SSE bridge: relay masc:* events to dashboard *)
   Oas_sse_bridge.start ~sw ~clock ~bus:event_bus;
+  let keeper_lifecycle_sub =
+    Agent_sdk.Event_bus.subscribe event_bus
+      ~filter:(function
+        | Agent_sdk.Event_bus.Custom ("masc:keeper:resident_lifecycle", _) -> true
+        | _ -> false)
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    let rec loop () =
+      let events = Agent_sdk.Event_bus.drain keeper_lifecycle_sub in
+      List.iter
+        (function
+          | Agent_sdk.Event_bus.Custom ("masc:keeper:resident_lifecycle", payload) ->
+              (match
+                 ( Safe_ops.json_string_opt "event" payload,
+                   Safe_ops.json_string_opt "keeper_name" payload )
+               with
+              | Some event, Some keeper_name ->
+                  Server_dashboard_http.patch_keeper_dependent_caches
+                    ~keeper_name ~event
+              | _ -> ())
+          | _ -> ())
+        events;
+      if events <> [] then
+        Log.Dashboard.info
+          "patched keeper-dependent dashboard caches (%d lifecycle event(s))"
+          (List.length events);
+      Eio.Time.sleep clock 0.25;
+      loop ()
+    in
+    loop ());
   (* Inject Event_bus into keeper resident runtime for telemetry publishing *)
   Keeper_keepalive.set_bus event_bus;
   Board_dispatch.set_keeper_board_signal_hook (fun signal ->

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ea09ff04cc76c6778754f92deb2046de64d90428"
+readonly OAS_AGENT_SDK_SHA="b94be7bcf7b9698dcb7e8fa2e1b1d30287e17beb"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1473,6 +1473,55 @@ let test_session_dir_mkdir_p_creates_full_tree () =
       check bool "history file written" true
         (Sys.file_exists history_path))
 
+let test_parse_agent_status_reads_compressed_filesystem_backend () =
+  Eio_main.run @@ fun env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      with_env "MASC_STORAGE_TYPE" "filesystem" (fun () ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        Fun.protect
+          ~finally:(fun () -> Fs_compat.clear_fs ())
+          (fun () ->
+            let config = Masc_mcp.Room.default_config base_dir in
+            ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+            let agent_name = "keeper-sangsu-agent" in
+            let agent_file =
+              Filename.concat (Masc_mcp.Room.agents_dir config)
+                (Masc_mcp.Room.safe_filename agent_name ^ ".json")
+            in
+            let agent : Types.agent =
+              {
+                name = agent_name;
+                agent_type = "keeper";
+                status = Types.Active;
+                capabilities = [ "keeper"; "resident" ];
+                current_task = None;
+                joined_at = "2026-03-25T00:00:00Z";
+                last_seen = "2026-03-25T00:01:00Z";
+                meta = None;
+              }
+            in
+            Masc_mcp.Room.write_json config agent_file
+              (Types.agent_to_yojson agent);
+            let raw =
+              match Safe_ops.read_file_safe agent_file with
+              | Ok content -> content
+              | Error e -> fail e
+            in
+            check string "compressed header prefix" "ZSTD" (String.sub raw 0 4);
+            let status_json =
+              Masc_mcp.Keeper_exec_status.parse_agent_status config ~agent_name
+            in
+            check bool "exists" true (require_json_bool_field status_json "exists");
+            check string "agent name preserved" agent_name
+              Yojson.Safe.Util.(status_json |> member "name" |> to_string);
+            check string "status preserved" "active"
+              Yojson.Safe.Util.(status_json |> member "status" |> to_string);
+            check bool "no read error" true
+              Yojson.Safe.Util.(status_json |> member "error" = `Null))))
+
 let test_resident_bootstrap_marks_stale_explicit_keeper () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1605,6 +1654,8 @@ let () =
            test_write_meta_syncs_registered_resident_seed;
          test_case "keeper up persists allowed paths" `Quick
            test_keeper_up_persists_allowed_paths_to_status_policy;
+         test_case "parse_agent_status reads compressed filesystem backend" `Quick
+           test_parse_agent_status_reads_compressed_filesystem_backend;
          test_case "resident bootstrap marks stale explicit keeper" `Quick
            test_resident_bootstrap_marks_stale_explicit_keeper;
          test_case "session dir mkdir_p creates full tree from scratch (issue #3019)" `Quick


### PR DESCRIPTION
## Summary
- keep resident supervisor sweep running so late-registered resident keepers are reconciled after bootstrap
- read keeper agent status through backend-aware room helpers so compressed filesystem backend records parse correctly
- patch operator/execution dashboard keeper rows from lifecycle events and rehydrate execution payloads from live keepalive state

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3061-keeper-readpath-timeout bin/main_eio.exe test/test_tool_keeper.exe test/test_keeper_resident_supervisor.exe
- ./_build/default/test/test_tool_keeper.exe test --color=never 'read_file_tail_lines' 28
- ./_build/default/test/test_keeper_resident_supervisor.exe
- live check on patched binary: /api/v1/operator and /api/v1/dashboard/execution both showed sangsu/dm-keeper keepalive_running=true after autoboot

## Why this matters
Current filesystem backend stores agent records with backend compression headers. Keeper status parsing was bypassing the backend read path, so dashboard/operator surfaces misread live keepers as offline or not running.