### PR TITLE
refactor(io): replace 12 blocking open_in/open_out with Fs_compat

### DIFF
--- a/lib/bridge/dune
+++ b/lib/bridge/dune
@@ -3,5 +3,5 @@
 (library
  (name event_bridge)
  (public_name masc_mcp.bridge)
- (libraries yojson masc_log)
+ (libraries yojson masc_log fs_compat)
  (modules event_bus))

--- a/lib/bridge/event_bus.ml
+++ b/lib/bridge/event_bus.ml
@@ -36,7 +36,5 @@ let to_json = function
 let broadcast event =
   let json = to_json event in
   let log_path = "logs/game_events.jsonl" in
-  let oc = open_out_gen [Open_append; Open_creat] 0o666 log_path in
-  output_string oc (json ^ "\n");
-  close_out oc;
+  Fs_compat.append_file log_path (json ^ "\n");
   Log.debug ~ctx:"event_bus" "Event Broadcasted: %s" json

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -16,13 +16,7 @@ let now_ms () = Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
 (** Read a file to string. Returns "" on error. *)
 let read_file_safe path =
-  try
-    let ic = open_in path in
-    let n = in_channel_length ic in
-    let s = Bytes.create n in
-    really_input ic s 0 n;
-    close_in ic;
-    Bytes.to_string s
+  try Fs_compat.load_file path
   with exn -> Log.Transport.warn "read_file_safe failed for %s: %s" path (Printexc.to_string exn); ""
 
 (** Safe filename: replace non-alphanumeric chars with underscores. *)
@@ -262,9 +256,8 @@ let handle_heartbeat
                   tm.tm_hour tm.tm_min tm.tm_sec
               in
               let updated = { agent with Types.last_seen = iso_now } in
-              let oc = open_out agent_file in
-              output_string oc (Yojson.Safe.to_string (Types.agent_to_yojson updated));
-              close_out oc
+              Fs_compat.save_file agent_file
+                (Yojson.Safe.to_string (Types.agent_to_yojson updated))
             | Error e ->
                 Log.Transport.warn "gRPC heartbeat: invalid agent JSON for %s: %s"
                   ping.agent_name e
@@ -337,29 +330,26 @@ let handle_subscribe
       "backlog.jsonl"
   in
   if Sys.file_exists backlog_file then begin
-    let ic = open_in backlog_file in
+    let content = Fs_compat.load_file backlog_file in
+    let lines = String.split_on_char '\n' content in
     let seq = ref 1L in
-    (try
-      while true do
-        let line = input_line ic in
-        if String.length line > 0 then begin
-          let msg_seq = !seq in
-          if Int64.compare msg_seq req.since_seq > 0 then begin
-            let event = T.Event.{
-              seq = msg_seq;
-              event_type = "message";
-              source_agent = "";
-              timestamp_ms = now_ms ();
-              payload_json = line;
-            } in
-            Grpc_eio.Stream.add stream (T.Event.to_bytes event);
-            incr events_count
-          end;
-          seq := Int64.add !seq 1L
-        end
-      done
-    with End_of_file -> ());
-    close_in_noerr ic
+    List.iter (fun line ->
+      if String.length line > 0 then begin
+        let msg_seq = !seq in
+        if Int64.compare msg_seq req.since_seq > 0 then begin
+          let event = T.Event.{
+            seq = msg_seq;
+            event_type = "message";
+            source_agent = "";
+            timestamp_ms = now_ms ();
+            payload_json = line;
+          } in
+          Grpc_eio.Stream.add stream (T.Event.to_bytes event);
+          incr events_count
+        end;
+        seq := Int64.add !seq 1L
+      end
+    ) lines
   end;
   (* Record delivered events from backlog replay *)
   Transport_metrics.inc_grpc_events_delivered ~delta:!events_count ();

--- a/lib/repo_synthesis_benchmark.ml
+++ b/lib/repo_synthesis_benchmark.ml
@@ -136,10 +136,7 @@ let default_question_set_path ~repo_root =
 let write_json_file path json =
   Fs_compat.mkdir_p (Filename.dirname path);
   let tmp = path ^ ".tmp" in
-  let oc = open_out_bin tmp in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> Yojson.Safe.pretty_to_channel oc json);
+  Fs_compat.save_file tmp (Yojson.Safe.pretty_to_string json);
   Unix.rename tmp path
 
 let read_json_file_opt path =

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -267,17 +267,14 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
       if not (Sys.file_exists target) then false
       else if has_search_replace then begin
         (* Search-replace mode: read file, substitute old_text → new_text *)
-        let ic = open_in target in
-        let content = In_channel.input_all ic in
-        close_in ic;
+        let content = Fs_compat.load_file target in
         if String.length content > 0 &&
            (try ignore (Re.Str.search_forward (Re.Str.regexp_string hypothesis.old_text) content 0); true
             with Not_found -> false)
         then begin
           let replaced = Re.Str.global_replace
             (Re.Str.regexp_string hypothesis.old_text) hypothesis.new_text content in
-          let oc = open_out target in
-          output_string oc replaced; close_out oc;
+          Fs_compat.save_file target replaced;
           true
         end else begin
           Log.Server.warn "research: old_text not found in %s" hypothesis.target_file;
@@ -291,8 +288,7 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
         if is_diff then begin
           (* Unified diff — write to temp file, git apply *)
           let patch_file = Printf.sprintf "%s/.research_patch.diff" worktree_path in
-          let oc = open_out patch_file in
-          output_string oc patch; close_out oc;
+          Fs_compat.save_file patch_file patch;
           let status, _ = Process_eio.run_argv_with_status ~timeout_sec:10.0
             [ "git"; "-C"; worktree_path; "apply"; "--check"; patch_file ] in
           let ok = match status with Unix.WEXITED 0 -> true | _ -> false in
@@ -304,14 +300,12 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
           end else begin
             (try Sys.remove patch_file with Sys_error _ -> ());
             (* Fallback: treat as full file replacement *)
-            let oc = open_out target in
-            output_string oc patch; close_out oc;
+            Fs_compat.save_file target patch;
             true
           end
         end else begin
           (* Full file content replacement *)
-          let oc = open_out target in
-          output_string oc patch; close_out oc;
+          Fs_compat.save_file target patch;
           true
         end
     with exn ->

--- a/lib/research/tool_research.ml
+++ b/lib/research/tool_research.ml
@@ -85,9 +85,7 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
   | "masc_research_status" ->
     let results_file = Printf.sprintf "%s/research_results.tsv" ctx.base_path in
     if Sys.file_exists results_file then begin
-      let ic = open_in results_file in
-      let content = In_channel.input_all ic in
-      close_in ic;
+      let content = Fs_compat.load_file results_file in
       Some (true, content)
     end else
       Some (true, "No research results found. Run masc_research_start first.")

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -16,15 +16,11 @@ open Printf
     Returns [None] on any file error. *)
 let read_file_truncated path ~max_chars =
   try
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      let len = min (in_channel_length ic) max_chars in
-      let buf = Bytes.create len in
-      really_input ic buf 0 len;
-      let content = Bytes.to_string buf in
-      if in_channel_length ic > max_chars
-      then Some (content ^ "\n... (truncated)")
-      else Some content)
+    let content = Fs_compat.load_file path in
+    if String.length content > max_chars then
+      Some (String.sub content 0 max_chars ^ "\n... (truncated)")
+    else
+      Some content
   with Sys_error _ -> None
 
 (** Build the isolated review prompt. Only file contents and the question


### PR DESCRIPTION
## Summary

Closes #2995 (partial — Tier 1: legacy file I/O).

Issue #2995 reports 3 categories of blocking I/O. Scoped to actionable Tier 1:

| Tier | Category | Count | Status |
|------|----------|-------|--------|
| **1** | `open_in`/`open_out` → `Fs_compat` | 12 sites | **This PR** |
| 2 | `Printf.printf` startup banners | 6 sites | Cold path, intentional UX |
| 3 | `Unix.openfile`/`Unix.lockf` file locking | 17 sites | Eio has no flock API — needs design |

### Changes (7 files, -27 lines net)

**`Fs_compat`** provides Eio-native I/O when `Eio.Stdenv.fs` is set (server runtime), with automatic fallback to blocking Unix I/O in non-Eio contexts (tests, CLI tools).

| File | Sites | Pattern |
|------|-------|---------|
| `research_loop.ml` | 5 | search-replace, patch write, file replace |
| `masc_grpc_service.ml` | 3 | read_file_safe, agent heartbeat, backlog replay |
| `tool_deep_review.ml` | 1 | truncated read → `load_file` + `String.sub` |
| `tool_research.ml` | 1 | results file load |
| `event_bus.ml` | 1 | event log append |
| `repo_synthesis_benchmark.ml` | 1 | atomic JSON write (save_file + rename) |

### Why Fs_compat instead of direct Eio.Path

Library code doesn't thread `env` — Fs_compat uses a global ref set at startup (`Fs_compat.set_fs`). This follows the OCaml Eio community's recommended gradual migration pattern for large codebases.

## Test plan

- [x] `dune build --root .` — compiles clean
- [x] `test_tool_unified` — 5 tests passed
- [ ] CI: Build and Test