### PR TITLE
fix(test): clear stale caches between dashboard mission tests

### DIFF
--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -459,8 +459,13 @@ let test_dashboard_mission_http_full_contract () =
       let config = Room_utils.default_config dir in
       let session_id = "ts-mission-http-fixture-001" in
       seed_room config session_id;
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      (* Clear stale cache entries from prior tests to avoid cross-test pollution.
+         Both dashboard-level and operator snapshot caches must be invalidated. *)
+      Lib.Dashboard_cache.invalidate_all ();
+      Lib.Operator_control.invalidate_snapshot_cache ();
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_mission_http_json


### PR DESCRIPTION
## Summary
Fix pre-existing CI failure in `test_dashboard_mission.ml` that blocked all PR merges.

**Root cause**: `Operator_control._snapshot_cache` (global `ref` with 30s TTL) retained test 1's session data (`ts-mission-fixture-001`) when test 2 ran. Test 2 expected `ts-mission-http-fixture-001` but got the stale cached result.

**Fix**:
- Call `Dashboard_cache.invalidate_all()` + `Operator_control.invalidate_snapshot_cache()` before the HTTP contract test
- Move `create_state` inside `Eio_main.run` and call `Eio_guard.enable()` for correct Eio-aware cache behavior

Fixes #3080

## Verification
- All 3 dashboard mission tests pass locally (3/3, 6.1s)
- `dune build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)