### PR TITLE
chore(ci): bump OAS pin to b94be7b

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="ea09ff04cc76c6778754f92deb2046de64d90428"
+readonly OAS_AGENT_SDK_SHA="b94be7bcf7b9698dcb7e8fa2e1b1d30287e17beb"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"


### PR DESCRIPTION
## Summary
Update pinned OAS SHA to match upstream main. Fixes Health ratchet failure blocking all PR CI.

Fixes #3087

## Verification
- `./scripts/check-oas-pin.sh` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)