### PR TITLE
fix(eio): use Eio_guard.with_mutex to prevent deadlock in unit tests (#3085)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -165,11 +165,11 @@ let next_heartbeat_snapshot_seq () =
   !heartbeat_snapshot_seq
 
 let latest_heartbeat_task agent =
-  Eio.Mutex.use_ro heartbeat_mutex (fun () ->
+  Eio_guard.with_mutex heartbeat_mutex (fun () ->
     Hashtbl.find_opt latest_heartbeat_tasks agent)
 
 let latest_heartbeat_result agent =
-  Eio.Mutex.use_ro heartbeat_mutex (fun () ->
+  Eio_guard.with_mutex heartbeat_mutex (fun () ->
     Hashtbl.find_opt latest_heartbeat_results agent)
 
 let remote_agent_card_paths =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -46,13 +46,8 @@ let mu = Eio.Mutex.create ()
 let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
 
-let with_lock_rw f =
-  try Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-
-let with_lock_ro f =
-  try Eio.Mutex.use_ro mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_lock_rw f = Eio_guard.with_mutex mu f
+let with_lock_ro f = Eio_guard.with_mutex mu f
 
 let max_crash_log_entries = 5
 


### PR DESCRIPTION
## Summary

- **a2a_tools.ml**: `latest_heartbeat_task`/`latest_heartbeat_result`가 raw `Eio.Mutex.use_ro`를 fallback 없이 사용하여 non-Eio test에서 `EDEADLK` 발생. `Eio_guard.with_mutex`로 교체.
- **keeper_registry.ml**: 수동 `try/catch` fallback 패턴을 `Eio_guard.with_mutex`로 통일.

## Root cause

`Eio_guard.enable()`가 이전 테스트의 `Eio_main.run`에서 호출된 후 flag가 reset되지 않아, 후속 non-Eio 테스트에서 `Eio.Mutex`가 실제 lock을 시도하고 EDEADLK 발생.

`Eio_guard.with_mutex`는 `is_ready()` flag를 확인하여 Eio가 비활성 상태면 lock을 건너뛴다.

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI Build and Test

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)