### PR TITLE
fix(keeper): use Eio_guard for registry mutex to prevent test deadlock

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -46,13 +46,11 @@ let mu = Eio.Mutex.create ()
 let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
 
-let with_lock_rw f =
-  try Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_lock_rw f = Eio_guard.with_mutex mu f
 
 let with_lock_ro f =
-  try Eio.Mutex.use_ro mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+  if not (Eio_guard.is_ready ()) then f ()
+  else Eio.Mutex.use_ro mu (fun () -> f ())
 
 let max_crash_log_entries = 5
 


### PR DESCRIPTION
## Summary
Replace try/catch-based mutex fallback in `Keeper_registry` with `Eio_guard.with_mutex` (write) and `Eio_guard.is_ready()` guard (read).

**Root cause**: Old fallback caught `Stdlib.Effect.Unhandled` and `Eio.Mutex.Poisoned` but missed `Sys_error("Mutex.lock: Resource deadlock avoided")` — the POSIX EDEADLK error that occurs when `build_keeper_briefs` reaches the no-heartbeat fallback path in unit test context.

Fixes #3085

## Verification
- All 4 dashboard mission tests pass (including keeper brief tests)
- `dune build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)