### PR TITLE
fix(test): clear stale caches before dashboard mission HTTP test

### DIFF
--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -461,6 +461,8 @@ let test_dashboard_mission_http_full_contract () =
       seed_room config session_id;
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+      Lib.Dashboard_cache.invalidate_all ();
+      Lib.Operator_control.invalidate_snapshot_cache ();
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_mission_http_json


### PR DESCRIPTION
## Summary
- `Operator_control._snapshot_cache` (30s TTL global ref) leaks across sequential Alcotest runs
- Test 0 populates cache with `ts-mission-fixture-001`, test 1 reads stale data instead of `ts-mission-http-fixture-001`
- Fix: call `Dashboard_cache.invalidate_all()` + `Operator_control.invalidate_snapshot_cache()` before the HTTP test

## Test plan
- [x] `test_dashboard_mission.exe` — all 3 tests pass locally
- [ ] CI Build and Test green

Generated with [Claude Code](https://claude.com/claude-code)