### PR TITLE
fix(concurrency): protect 6 HIGH-risk global refs with Eio.Mutex/Atomic

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -39,49 +39,61 @@ type keeper_board_signal = {
 (** Current backend state. Single ref avoids contradictory initialized/backend pairs. *)
 let backend_state : backend_state ref = ref Uninitialized
 
+let board_mu = Eio.Mutex.create ()
+let with_board_rw f =
+  try Eio.Mutex.use_rw ~protect:true board_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_board_ro f =
+  try Eio.Mutex.use_ro board_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option ref = ref None
 
 let set_keeper_board_signal_hook hook =
-  keeper_board_signal_hook := Some hook
+  with_board_rw (fun () -> keeper_board_signal_hook := Some hook)
 
 let emit_keeper_board_signal signal =
-  match !keeper_board_signal_hook with
+  let hook_opt = with_board_ro (fun () -> !keeper_board_signal_hook) in
+  match hook_opt with
   | Some hook -> hook signal
   | None -> ()
 
 let is_initialized () =
-  match !backend_state with
-  | Active _ -> true
-  | Uninitialized -> false
+  with_board_ro (fun () ->
+    match !backend_state with
+    | Active _ -> true
+    | Uninitialized -> false)
 
 (** Initialize PostgreSQL backend. Call during server startup when PG pool is available. *)
 let init_pg pool =
-  if is_initialized () then begin
-    Log.BoardLog.warn "already initialized, ignoring init_pg";
-    Ok ()
-  end else
-  match Board_pg.create pool with
-  | Ok t ->
-      backend_state := Active (Postgres t);
-      Log.BoardLog.info "PostgreSQL backend initialized";
+  with_board_rw (fun () ->
+    if match !backend_state with Active _ -> true | Uninitialized -> false then begin
+      Log.BoardLog.warn "already initialized, ignoring init_pg";
       Ok ()
-  | Error e ->
-      Log.BoardLog.warn "PG init failed, falling back to JSONL: %s"
-        (Board.show_board_error e);
-      Error e
+    end else
+    match Board_pg.create pool with
+    | Ok t ->
+        backend_state := Active (Postgres t);
+        Log.BoardLog.info "PostgreSQL backend initialized";
+        Ok ()
+    | Error e ->
+        Log.BoardLog.warn "PG init failed, falling back to JSONL: %s"
+          (Board.show_board_error e);
+        Error e)
 
 (** Initialize JSONL backend. Default fallback. *)
 let init_jsonl () =
-  if is_initialized () then
-    Log.BoardLog.warn "already initialized, ignoring init_jsonl"
-  else begin
-    backend_state := Active (Jsonl (Board.global ()));
-    Log.BoardLog.info "JSONL backend initialized"
-  end
+  with_board_rw (fun () ->
+    if match !backend_state with Active _ -> true | Uninitialized -> false then
+      Log.BoardLog.warn "already initialized, ignoring init_jsonl"
+    else begin
+      backend_state := Active (Jsonl (Board.global ()));
+      Log.BoardLog.info "JSONL backend initialized"
+    end)
 
 (** Reset for testing. Clears backend state so init can be called again. *)
 let reset_for_test () =
-  backend_state := Uninitialized
+  with_board_rw (fun () -> backend_state := Uninitialized)
 
 (** Check MASC_BOARD_BACKEND env var. Returns true if JSONL is explicitly forced. *)
 let jsonl_forced () =
@@ -93,20 +105,23 @@ let jsonl_forced () =
     Normal path: Board is initialized by room_utils_backend_setup during server startup.
     Auto-init: JSONL fallback when startup init was skipped (tests, standalone tools). *)
 let backend () =
-  match !backend_state with
-  | Active backend -> backend
-  | Uninitialized ->
-      Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
-      init_jsonl ();
-      (match !backend_state with
-       | Active backend -> backend
-       | Uninitialized -> failwith "[Board_dispatch] auto-init failed to activate backend")
+  with_board_rw (fun () ->
+    match !backend_state with
+    | Active backend -> backend
+    | Uninitialized ->
+        Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
+        backend_state := Active (Jsonl (Board.global ()));
+        Log.BoardLog.info "JSONL backend initialized";
+        (match !backend_state with
+         | Active backend -> backend
+         | Uninitialized -> failwith "[Board_dispatch] auto-init failed to activate backend"))
 
 (** Get PostgreSQL pool if PG backend is active (for Board_listener) *)
 let get_pg_pool () =
-  match !backend_state with
-  | Active (Postgres t) -> Some (Board_pg.get_pool t)
-  | _ -> None
+  with_board_ro (fun () ->
+    match !backend_state with
+    | Active (Postgres t) -> Some (Board_pg.get_pool t)
+    | _ -> None)
 
 (** {1 In-memory sort for JSONL mode} *)
 
@@ -330,9 +345,10 @@ let search ~query ~limit =
 
 (** Flush dirty state (JSONL only, PG commits immediately) *)
 let flush () =
-  match !backend_state with
-  | Active (Jsonl store) -> Board.flush_dirty store
-  | _ -> ()
+  with_board_ro (fun () ->
+    match !backend_state with
+    | Active (Jsonl store) -> Board.flush_dirty store
+    | _ -> ())
 
 (** Sweep expired posts and comments *)
 let sweep () =
@@ -358,7 +374,8 @@ let post_to_yojson_with_karma (p : Board.post) ~author_karma =
 
 (** Backend name for diagnostics *)
 let backend_name () =
-  match !backend_state with
-  | Active (Jsonl _) -> "jsonl"
-  | Active (Postgres _) -> "postgresql"
-  | Uninitialized -> "uninitialized"
+  with_board_ro (fun () ->
+    match !backend_state with
+    | Active (Jsonl _) -> "jsonl"
+    | Active (Postgres _) -> "postgresql"
+    | Uninitialized -> "uninitialized")

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -65,20 +65,24 @@ let ensure_synapses_dir config =
 
 (** Lock contention metrics *)
 let lock_acquisitions = Atomic.make 0
-let lock_total_wait_ms = ref 0.0
-let lock_max_wait_ms = ref 0.0
+let lock_total_wait_ms = Atomic.make 0.0
+let lock_max_wait_ms = Atomic.make 0.0
+
+let rec cas_float atomic f =
+  let old = Atomic.get atomic in
+  if not (Atomic.compare_and_set atomic old (f old)) then cas_float atomic f
 
 (** Get lock statistics *)
 let get_lock_stats () =
   let avg_wait = if (Atomic.get lock_acquisitions) = 0 then 0.0
-    else !lock_total_wait_ms /. float_of_int (Atomic.get lock_acquisitions) in
-  ((Atomic.get lock_acquisitions), avg_wait, !lock_max_wait_ms)
+    else Atomic.get lock_total_wait_ms /. float_of_int (Atomic.get lock_acquisitions) in
+  ((Atomic.get lock_acquisitions), avg_wait, Atomic.get lock_max_wait_ms)
 
 (** Reset lock statistics *)
 let reset_lock_stats () =
   Atomic.set lock_acquisitions 0;
-  lock_total_wait_ms := 0.0;
-  lock_max_wait_ms := 0.0
+  Atomic.set lock_total_wait_ms 0.0;
+  Atomic.set lock_max_wait_ms 0.0
 
 (** Transactional lock for graph operations - synchronous *)
 let with_graph_lock config f =
@@ -90,8 +94,8 @@ let with_graph_lock config f =
   Unix.lockf fd Unix.F_LOCK 0;
   let wait_ms = (Time_compat.now () -. start_time) *. 1000.0 in
   Atomic.incr lock_acquisitions;
-  lock_total_wait_ms := !lock_total_wait_ms +. wait_ms;
-  if wait_ms > !lock_max_wait_ms then lock_max_wait_ms := wait_ms;
+  cas_float lock_total_wait_ms (fun v -> v +. wait_ms);
+  cas_float lock_max_wait_ms (fun v -> Float.max v wait_ms);
   (* Log if wait was significant *)
   let warn_threshold = Level2_config.Lock.warn_threshold_ms () in
   if wait_ms > warn_threshold then

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -89,19 +89,29 @@ let keeper_passthrough_masc_tool_names =
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []
 
+let masc_schemas_mu = Eio.Mutex.create ()
+let with_schemas_rw f =
+  try Eio.Mutex.use_rw ~protect:true masc_schemas_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_schemas_ro f =
+  try Eio.Mutex.use_ro masc_schemas_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 let inject_masc_schemas (schemas : Types.tool_schema list) =
-  masc_schemas_ref :=
-    List.filter (fun (s : Types.tool_schema) ->
-      String.starts_with ~prefix:"masc_" s.name
-      && List.mem s.name keeper_passthrough_masc_tool_names)
-      schemas
+  with_schemas_rw (fun () ->
+    masc_schemas_ref :=
+      List.filter (fun (s : Types.tool_schema) ->
+        String.starts_with ~prefix:"masc_" s.name
+        && List.mem s.name keeper_passthrough_masc_tool_names)
+        schemas)
 
 let keeper_masc_tool_names (_meta : keeper_meta) : string list =
-  !masc_schemas_ref
-  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+  with_schemas_ro (fun () ->
+    !masc_schemas_ref
+    |> List.map (fun (schema : Types.tool_schema) -> schema.name))
 
 let keeper_masc_tool_schemas (_meta : keeper_meta) : Types.tool_schema list =
-  !masc_schemas_ref
+  with_schemas_ro (fun () -> !masc_schemas_ref)
 
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -155,6 +155,14 @@ let fixed_rhythm base_s =
 let orchestrator_pulse : Pulse.t option ref = ref None
 let zombie_pulse : Pulse.t option ref = ref None
 
+let pulse_mu = Eio.Mutex.create ()
+let with_pulse_rw f =
+  try Eio.Mutex.use_rw ~protect:true pulse_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_pulse_ro f =
+  try Eio.Mutex.use_ro pulse_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 (** Build the orchestrator check consumer.
     Checks if orchestration is needed and spawns coordinator if so. *)
 let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config ()
@@ -233,7 +241,7 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   Log.Orchestrator.debug "zero-zombie cleanup enabled (interval: %.0fs)" neo4j_interval;
   let zombie_consumer = make_zero_zombie_consumer ~room_config in
   let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Perpetual ~consumers:[zombie_consumer] in
-  zombie_pulse := Some zp;
+  with_pulse_rw (fun () -> zombie_pulse := Some zp);
   Eio.Fiber.fork ~sw (fun () -> Pulse.run ~sw zp);
 
   (* Orchestrator check: respects enabled flag via should_act *)
@@ -245,10 +253,12 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
 
   let orch_consumer = make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config () in
   let op = Pulse.create ~clock ~rhythm:(fixed_rhythm config.check_interval_s) ~lifecycle:Perpetual ~consumers:[orch_consumer] in
-  orchestrator_pulse := Some op;
+  with_pulse_rw (fun () -> orchestrator_pulse := Some op);
   Eio.Fiber.fork ~sw (fun () -> Pulse.run ~sw op);
 
   (* Return cancel function — shuts down both Pulse engines *)
   fun () ->
-    (match !orchestrator_pulse with Some p -> Pulse.shutdown p | None -> ());
-    (match !zombie_pulse with Some p -> Pulse.shutdown p | None -> ())
+    with_pulse_ro (fun () ->
+      (match !orchestrator_pulse with Some p -> Pulse.shutdown p | None -> ()));
+    with_pulse_ro (fun () ->
+      (match !zombie_pulse with Some p -> Pulse.shutdown p | None -> ()))

--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -20,49 +20,62 @@ type backend_state =
 (** Current backend state. Single ref avoids contradictory initialized/backend pairs. *)
 let backend_state : backend_state ref = ref Uninitialized
 
+let task_mu = Eio.Mutex.create ()
+let with_task_rw f =
+  try Eio.Mutex.use_rw ~protect:true task_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_task_ro f =
+  try Eio.Mutex.use_ro task_mu (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
 let is_initialized () =
-  match !backend_state with
-  | Active _ -> true
-  | Uninitialized -> false
+  with_task_ro (fun () ->
+    match !backend_state with
+    | Active _ -> true
+    | Uninitialized -> false)
 
 (** Initialize PostgreSQL backend if URL is available *)
 let init_pg pool =
-  if is_initialized () then begin
-    Log.Task.warn "WARNING: already initialized, ignoring init_pg";
-    Ok ()
-  end else
-  match Task_pg.create pool with
-  | Ok t ->
-      backend_state := Active (Postgres t);
-      Log.Task.info "PostgreSQL backend initialized.";
+  with_task_rw (fun () ->
+    if match !backend_state with Active _ -> true | Uninitialized -> false then begin
+      Log.Task.warn "WARNING: already initialized, ignoring init_pg";
       Ok ()
-  | Error e ->
-      Log.Task.error "PG init failed, falling back to JSONL: %s"
-        (show_masc_error e);
-      Error e
+    end else
+    match Task_pg.create pool with
+    | Ok t ->
+        backend_state := Active (Postgres t);
+        Log.Task.info "PostgreSQL backend initialized.";
+        Ok ()
+    | Error e ->
+        Log.Task.error "PG init failed, falling back to JSONL: %s"
+          (show_masc_error e);
+        Error e)
 
 (** Initialize JSONL backend. Default fallback. *)
 let init_jsonl () =
-  if is_initialized () then
-    Log.Task.warn "WARNING: already initialized, ignoring init_jsonl"
-  else begin
-    backend_state := Active Jsonl;
-    Log.Task.info "JSONL backend initialized (using Room.* functions)."
-  end
+  with_task_rw (fun () ->
+    if match !backend_state with Active _ -> true | Uninitialized -> false then
+      Log.Task.warn "WARNING: already initialized, ignoring init_jsonl"
+    else begin
+      backend_state := Active Jsonl;
+      Log.Task.info "JSONL backend initialized (using Room.* functions)."
+    end)
 
 (** Reset for testing *)
 let reset_for_test () =
-  backend_state := Uninitialized
+  with_task_rw (fun () -> backend_state := Uninitialized)
 
 (** Get current backend, auto-init JSONL if not set *)
 let backend () =
-  match !backend_state with
-  | Active backend -> backend
-  | Uninitialized ->
-      init_jsonl ();
-      match !backend_state with
-      | Active backend -> backend
-      | Uninitialized -> Jsonl
+  with_task_rw (fun () ->
+    match !backend_state with
+    | Active backend -> backend
+    | Uninitialized ->
+        backend_state := Active Jsonl;
+        Log.Task.info "JSONL backend initialized (using Room.* functions).";
+        (match !backend_state with
+         | Active backend -> backend
+         | Uninitialized -> Jsonl))
 
 (** Check if PostgreSQL backend is active *)
 let is_postgres () =
@@ -72,9 +85,10 @@ let is_postgres () =
 
 (** Get PostgreSQL pool if available *)
 let get_pg_pool () =
-  match !backend_state with
-  | Active (Postgres t) -> Some (Task_pg.get_pool t)
-  | _ -> None
+  with_task_ro (fun () ->
+    match !backend_state with
+    | Active (Postgres t) -> Some (Task_pg.get_pool t)
+    | _ -> None)
 
 (** {1 Dispatch Functions} *)
 


### PR DESCRIPTION
## Summary

Addresses #2990 (HIGH risk subset — 6 of 78 remaining unprotected refs).

Previous PRs already fixed: sse_hot_sessions (#3052), eio_context (#3060), Domain.spawn (#3056), chain refs (#3062).

### Changes (5 files)

| File | Variable | Protection | Risk |
|------|----------|------------|------|
| `orchestrator.ml` | `orchestrator_pulse`, `zombie_pulse` | Eio.Mutex | Shutdown vs fiber race |
| `keeper_exec_tools.ml` | `masc_schemas_ref` | Eio.Mutex | Init vs dispatch race |
| `board_dispatch.ml` | `backend_state`, `signal_hook` | Eio.Mutex | Init vs access race |
| `task_dispatch.ml` | `backend_state` | Eio.Mutex | Same pattern as board |
| `hebbian_eio.ml` | `lock_total_wait_ms`, `lock_max_wait_ms` | Atomic.t | Lock-free counters |

### Pattern used

```ocaml
let mu = Eio.Mutex.create ()
let with_lock_rw f =
  try Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
```

Effect.Unhandled fallback ensures tests work outside Eio context.

### Remaining #2990 scope
- 5 MEDIUM risk refs (validate init ordering)
- 62 LOW risk refs (init-only, safe)

## Test plan

- [x] `dune build lib/ bin/` — compiles clean
- [x] Pre-existing test build failure (OAS optional param) on main — unrelated
- [ ] CI: Build and Test