### PR TITLE
refactor(io): replace blocking Unix I/O in mention_inbox (#3099)

### DIFF
--- a/lib/mention_inbox.ml
+++ b/lib/mention_inbox.ml
@@ -71,13 +71,7 @@ let inbox_path (config : Room.config) : string =
 let append_mention (config : Room.config) (record : mention_record) : unit =
   let path = inbox_path config in
   let json = mention_record_to_json record in
-  let line = Yojson.Safe.to_string json ^ "\n" in
-  let fd =
-    Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND] 0o644
-  in
-  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
-      let _ = Unix.write_substring fd line 0 (String.length line) in
-      ())
+  Fs_compat.append_jsonl path json
 
 let load_all_mentions (config : Room.config) : mention_record list =
   let path = inbox_path config in
@@ -130,9 +124,4 @@ let mark_read (config : Room.config) ~(mention_id : string) : unit =
     |> String.concat "\n"
   in
   let content = if content = "" then "" else content ^ "\n" in
-  let fd =
-    Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o644
-  in
-  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
-      let _ = Unix.write_substring fd content 0 (String.length content) in
-      ())
+  Fs_compat.save_file path content


### PR DESCRIPTION
## Summary

`mention_inbox.ml`의 2개 blocking `Unix.openfile` 호출을 `Fs_compat` 래퍼로 교체:

- `append_mention`: `Unix.openfile O_APPEND` + `Unix.write_substring` → `Fs_compat.append_jsonl`
- `mark_read`: `Unix.openfile O_TRUNC` + `Unix.write_substring` → `Fs_compat.save_file`

`Fs_compat`는 Eio filesystem이 사용 가능하면 Eio path를 사용하고, 아니면 blocking fallback을 사용하는 dual-mode 래퍼.

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI Build and Test

Addresses #3099 (partially)

🤖 Generated with [Claude Code](https://claude.com/claude-code)