### PR TITLE
fix: harden production stubs — explicit errors, drop dead goal parsing

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -589,6 +589,7 @@ let handle_tool_admin_update ctx args =
                   [
                     ("field", `String "tool_allowlist");
                     ("status", `String "advisory_only");
+                    ("enforcement", `String "none");
                     ("reason",
                      `String
                        "Stored in CPv2 policy but not yet enforced by runtime tool dispatch.");
@@ -600,6 +601,7 @@ let handle_tool_admin_update ctx args =
                   [
                     ("field", `String "model_allowlist");
                     ("status", `String "advisory_only");
+                    ("enforcement", `String "none");
                     ("reason",
                      `String
                        "Stored in CPv2 policy but not yet enforced by runtime model selection.");

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -43,20 +43,13 @@ let handle_relay_checkpoint _ctx args =
   let todos = get_string_list args "todos" in
   let pdca_state = get_string_opt args "pdca_state" in
   let relevant_files = get_string_list args "relevant_files" in
-  (* Goal fields are parsed for validation but not yet persisted in checkpoint.
-     They will be wired into checkpoint storage when Goal Store integration
-     is added to the relay module (tracked in Phase 2 roadmap). *)
-  let _active_goal_ids = get_string_list args "active_goal_ids" in
-  let _goal_blockers = get_string_list args "goal_blockers" in
-  let _goal_progress = match Yojson.Safe.Util.member "goal_progress" args with
-    | `List items -> List.filter_map (fun item ->
-        match item with
-        | `List [`String gid; `Float pct] -> Some (gid, pct)
-        | `List [`String gid; `Int n] -> Some (gid, float_of_int n)
-        | _ -> None
-      ) items
-    | _ -> []
-  in
+  (* Goal fields (active_goal_ids, goal_blockers, goal_progress) are accepted
+     by the schema but not persisted — silently discarding them would hide
+     caller intent.  Log when they are present so operators can detect drift. *)
+  (let goal_ids = get_string_list args "active_goal_ids" in
+   if goal_ids <> [] then
+     Log.Misc.info "[RELAY] active_goal_ids provided but not persisted (goal store not integrated): %s"
+       (String.concat "," goal_ids));
   let cell = Mcp_server.get_cell () in
   let messages = get_int args "messages" cell.Mitosis.task_count in
   let tool_calls = get_int args "tool_calls" cell.Mitosis.tool_call_count in

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -223,13 +223,12 @@ let handle_voice_agent _ctx args : result =
   else
     json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
 
-(* Category C: STT stub — returns not_available until service is integrated *)
+(* STT: not implemented — returns explicit error so callers do not mistake for success *)
 let handle_voice_transcript (_ctx : 'a context) _args : result =
-  (* Transcript requires an external STT service — not yet integrated locally *)
   (false, Yojson.Safe.to_string
     (`Assoc
-      [ ("status", `String "not_available");
-        ("message", `String "transcript requires STT service integration") ]))
+      [ ("error", `String "not_implemented");
+        ("message", `String "masc_voice_transcript requires an external STT service that is not integrated. This tool is not functional.") ]))
 
 (* Category B: conference = batch start of local sessions for multiple agents.
    Each agent_id gets its own Voice_session_manager session; the "conference"


### PR DESCRIPTION
## Summary
First cleanup batch for #3100 — production stub/fake hardening.

- `tool_voice.ml`: STT transcript returns `"error": "not_implemented"` instead of misleading `"status": "not_available"`. Callers now get explicit failure.
- `tool_relay.ml`: Remove 14 lines of dead goal-field parsing that accepted `active_goal_ids`, `goal_blockers`, `goal_progress` and silently discarded them. Log when goal_ids are provided but not persisted.
- `tool_misc.ml`: Add `"enforcement": "none"` to advisory policy fields so operators see that `tool_allowlist`/`model_allowlist` are stored but not enforced.

Closes part of #3100

## Audit inventory (captured for issue)
| File | Finding | Action |
|------|---------|--------|
| tool_voice.ml:226 | STT stub silent fallback | HARDENED |
| tool_relay.ml:46-59 | Goal fields parsed then discarded | DELETED + logged |
| tool_misc.ml:590-607 | Policy advisory without enforcement flag | HARDENED |
| room_hooks.ml callback refs | No-op defaults | LOW risk (wired at startup) |
| board_core.ml deferred_flush | No-op ref | LOW risk (wired by votes module) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)