### PR TITLE
fix(ci): land post-3086 stability follow-ups

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -298,33 +298,42 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
           in
            try
              let started = Time_compat.now () in
+             let buf = Buffer.create 1024 in
              let wrapped_command =
                match workdir with
                | Some dir when String.trim dir <> "" ->
                    Printf.sprintf "cd %s && %s" (Filename.quote dir) command
                | _ -> command
              in
-             let status, output =
-               Process_eio.run_argv_with_status ~timeout_sec:timeout
-                 [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
-             in
              let result =
-               match status with
-               | Unix.WEXITED 0 ->
+               try
+                 let status, output =
+                   Eio.Time.with_timeout_exn clock timeout (fun () ->
+                     Eio.Switch.run @@ fun sw ->
+                     let proc = Eio.Process.spawn ~sw proc_mgr
+                       ~stdout:(Eio.Flow.buffer_sink buf)
+                       ["sh"; "-c"; wrapped_command ^ " 2>&1"] in
+                     let status = Eio.Process.await proc in
+                     (status, Buffer.contents buf))
+                 in
+                 match status with
+                 | `Exited 0 ->
                    Ok { Agent_sdk.Types.content = output }
-               | Unix.WEXITED code ->
+                 | `Exited code ->
                    Error { Agent_sdk.Types.message =
                      Printf.sprintf "Exit code %d:\n%s" code output;
                      recoverable = false }
-               | Unix.WSIGNALED sig_num ->
+                 | `Signaled sig_num ->
                    Error { Agent_sdk.Types.message =
-                     Printf.sprintf "Timeout after %.0fs: %s\n%s" timeout command
-                       output;
+                     Printf.sprintf "Killed by signal %d:\n%s" sig_num output;
                      recoverable = sig_num = Sys.sigterm }
-               | Unix.WSTOPPED sig_num ->
-                   Error { Agent_sdk.Types.message =
-                     Printf.sprintf "Stopped by signal %d:\n%s" sig_num output;
-                     recoverable = false }
+               with
+               | Eio.Time.Timeout ->
+                 let output = Buffer.contents buf in
+                 Error { Agent_sdk.Types.message =
+                   Printf.sprintf "Timeout after %.0fs: %s\n%s" timeout command
+                     output;
+                   recoverable = true }
              in
              let duration_ms =
                int_of_float ((Time_compat.now () -. started) *. 1000.0)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -295,42 +295,36 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
              Worker_tool_input.extract_float "timeout_s" input
              |> Option.value ~default:30.0
              |> Float.min 120.0
-           in
+          in
            try
              let started = Time_compat.now () in
+             let wrapped_command =
+               match workdir with
+               | Some dir when String.trim dir <> "" ->
+                   Printf.sprintf "cd %s && %s" (Filename.quote dir) command
+               | _ -> command
+             in
+             let status, output =
+               Process_eio.run_argv_with_status ~timeout_sec:timeout
+                 [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
+             in
              let result =
-               Eio.Fiber.first
-               (fun () ->
-                  Eio.Switch.run @@ fun sw ->
-                  let buf = Buffer.create 1024 in
-                  let wrapped_command =
-                    match workdir with
-                    | Some dir when String.trim dir <> "" ->
-                        Printf.sprintf "cd %s && %s" (Filename.quote dir) command
-                    | _ -> command
-                  in
-                  let proc = Eio.Process.spawn ~sw proc_mgr
-                    ~stdout:(Eio.Flow.buffer_sink buf)
-                    ~stderr:(Eio.Flow.buffer_sink buf)
-                    ["sh"; "-c"; wrapped_command] in
-                  let status = Eio.Process.await proc in
-                  let output = Buffer.contents buf in
-                  (match status with
-                   | `Exited 0 ->
-                     Ok { Agent_sdk.Types.content = output }
-                   | `Exited code ->
-                     Error { Agent_sdk.Types.message =
-                       Printf.sprintf "Exit code %d:\n%s" code output;
-                       recoverable = false }
-                   | `Signaled sig_num ->
-                     Error { Agent_sdk.Types.message =
-                       Printf.sprintf "Killed by signal %d:\n%s" sig_num output;
-                       recoverable = false }))
-               (fun () ->
-                  Eio.Time.sleep clock timeout;
-                  Error { Agent_sdk.Types.message =
-                    Printf.sprintf "Timeout after %.0fs: %s" timeout command;
-                    recoverable = true })
+               match status with
+               | Unix.WEXITED 0 ->
+                   Ok { Agent_sdk.Types.content = output }
+               | Unix.WEXITED code ->
+                   Error { Agent_sdk.Types.message =
+                     Printf.sprintf "Exit code %d:\n%s" code output;
+                     recoverable = false }
+               | Unix.WSIGNALED sig_num ->
+                   Error { Agent_sdk.Types.message =
+                     Printf.sprintf "Timeout after %.0fs: %s\n%s" timeout command
+                       output;
+                     recoverable = sig_num = Sys.sigterm }
+               | Unix.WSTOPPED sig_num ->
+                   Error { Agent_sdk.Types.message =
+                     Printf.sprintf "Stopped by signal %d:\n%s" sig_num output;
+                     recoverable = false }
              in
              let duration_ms =
                int_of_float ((Time_compat.now () -. started) *. 1000.0)

--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -137,7 +137,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl ~port ~path:"/health" () in
       match res.status with
-      | Some 200 -> true
+      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -231,7 +231,20 @@ let with_server f =
 
 let test_board_missing_post_returns_404 () =
   with_server @@ fun ~port ->
-  let res = run_curl ~port ~path:"/api/v1/board/post-not-exists-12345" () in
+  let rec get_until_ready retries_left =
+    let res = run_curl ~port ~path:"/api/v1/board/post-not-exists-12345" () in
+    match (res.status, retries_left) with
+    | Some 503, retries
+      when retries > 0
+           && contains_substr "Server is starting up, not ready yet" res.body ->
+        Unix.sleepf 0.5;
+        get_until_ready (retries - 1)
+    | None, retries when retries > 0 && res.curl_exit = 28 ->
+        Unix.sleepf 0.5;
+        get_until_ready (retries - 1)
+    | _ -> res
+  in
+  let res = get_until_ready 40 in
   (match res.status with
    | Some code -> check int "missing post returns 404" 404 code
    | None ->

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -215,7 +215,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl_get ~max_time_sec:1 ~port ~path:"/health" () in
       match res.status with
-      | Some 200 -> true
+      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -349,11 +349,16 @@ let rec call_until_ready ~port ~retries_left =
          && contains_substr "Server state not initialized" result.body ->
       Unix.sleepf 0.5;
       call_until_ready ~port ~retries_left:(retries - 1)
+  | Some 503, retries
+    when retries > 0
+         && contains_substr "Server is starting up, not ready yet" result.body ->
+      Unix.sleepf 0.5;
+      call_until_ready ~port ~retries_left:(retries - 1)
   | _ -> result
 
 let test_post_tools_call_streams_keepalive_before_result () =
   with_server @@ fun ~port ->
-  let result = call_until_ready ~port ~retries_left:10 in
+  let result = call_until_ready ~port ~retries_left:40 in
   require_http_ok "streaming tools/call" result;
   check int "curl exits cleanly" 0 result.curl_exit;
   check bool "prime event sent" true (contains_substr "retry: 3000" result.body);

--- a/test/test_openapi_api_e2e.ml
+++ b/test/test_openapi_api_e2e.ml
@@ -123,6 +123,17 @@ let find_free_port () =
           None)
 
 let wait_for_health ~port ~timeout_s =
+  let has_ready_flag body =
+    let needle = "\"state_ready\":true" in
+    let needle_len = String.length needle in
+    let body_len = String.length body in
+    let rec loop idx =
+      if idx + needle_len > body_len then false
+      else if String.sub body idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+  in
   let deadline = Unix.gettimeofday () +. timeout_s in
   let rec loop () =
     if Unix.gettimeofday () > deadline then
@@ -130,7 +141,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl ~port ~path:"/health" () in
       match res.status with
-      | Some 200 -> true
+      | Some 200 when has_ready_flag res.body -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -254,7 +254,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl_get ~port ~path:"/health" () in
       match res.status with
-      | Some 200 -> true
+      | Some 200 when contains_substr "\"state_ready\":true" res.body -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()
@@ -822,10 +822,20 @@ let test_mcp_requires_auth_when_bound_non_loopback () =
   @@ fun ~port ~supervisor_token:_ ~planner_token:_ ~implementer_a_token:_
             ~implementer_b_token:_ ~supervisor_nickname:_ ~planner_nickname:_
             ~implementer_a_nickname:_ ~implementer_b_nickname:_ ->
-  let result =
-    run_curl_json ~port ~path:"/mcp" ~session_id:"strict-remote"
-      ~payload:(tools_list_payload ~id:1) ()
+  let rec call_until_ready retries_left =
+    let result =
+      run_curl_json ~port ~path:"/mcp" ~session_id:"strict-remote"
+        ~payload:(tools_list_payload ~id:1) ()
+    in
+    match (result.status, retries_left) with
+    | Some 503, retries
+      when retries > 0
+           && contains_substr "Server is starting up, not ready yet" result.body ->
+        Unix.sleepf 0.5;
+        call_until_ready (retries - 1)
+    | _ -> result
   in
+  let result = call_until_ready 40 in
   Alcotest.(check (option int)) "returns unauthorized" (Some 401) result.status;
   check bool "strict auth message" true
     (contains_substr "requires room auth enabled with require_token=true"

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -170,6 +170,17 @@ let find_free_port () =
       | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) -> None)
 
 let wait_for_health ~port ~timeout_s =
+  let has_ready_flag body =
+    let needle = "\"state_ready\":true" in
+    let needle_len = String.length needle in
+    let body_len = String.length body in
+    let rec loop idx =
+      if idx + needle_len > body_len then false
+      else if String.sub body idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+  in
   let deadline = Unix.gettimeofday () +. timeout_s in
   let rec loop () =
     if Unix.gettimeofday () > deadline then
@@ -177,7 +188,7 @@ let wait_for_health ~port ~timeout_s =
     else
       let res = run_curl ~max_time:0.2 ~port ~path:"/health" () in
       match res.status with
-      | Some 200 -> true
+      | Some 200 when has_ready_flag res.body -> true
       | _ ->
           Unix.sleepf 0.1;
           loop ()

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 type http_result = {
   status: int option;
+  body: string;
   curl_exit: int;
   stderr: string;
 }
@@ -123,10 +124,11 @@ let run_curl ?(headers=[]) ?max_time ~port ~path () =
     | Unix.WSTOPPED code -> 256 + code
   in
   let header_raw = read_file header_file in
+  let body = read_file body_file in
   (try Sys.remove header_file with _ -> ());
   (try Sys.remove body_file with _ -> ());
   let (status, _headers) = parse_headers header_raw in
-  { status; curl_exit; stderr }
+  { status; body; curl_exit; stderr }
 
 let find_main_eio_exe () =
   let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in


### PR DESCRIPTION
## Summary

Land the CI/test stability follow-ups that were prepared after `#3086` had already merged:

- ratchet the OAS runtime pin to current upstream main
- harden startup-gated e2e probes to wait for `state_ready`
- capture SSE storm curl response bodies in the test helper
- restore `shell_exec` timeout handling on explicit Eio process/switch semantics while preserving timeout output and `SIGTERM` recoverability

## Why separate PR

`#3086` was already merged before these follow-up commits were ready, so the fixes need to land independently on top of current `main`.

## Local verification

- `env DUNE_BUILD_DIR=.ci_build_healthcheck2 opam exec -- dune build --root . @check --display short` passed on the repair stack before branch extraction
- fresh GitHub CI will validate this branch against current `main`

## Review

Cross-model review evidence will be added in-thread.