### PR TITLE
fix(backend): narrow FileSystem.exists catch to Not_found only (#3112)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -159,7 +159,7 @@ module FileSystem = struct
           match Eio.Path.kind ~follow:true path with
           | `Regular_file -> true
           | _ -> false
-        with Eio.Io _ -> false
+        with Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> false
 
   (** Delete key *)
   let delete t key =


### PR DESCRIPTION
## Summary

**Commit 1**: `FileSystem.exists`가 `Eio.Io _` (모든 I/O 에러)를 catch하여 `false`로 반환 — permission denied, disk failure 등도 "파일 없음"으로 처리됨. `Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _)`만 catch하도록 축소.

**Commit 2**: `Memory.with_lock`의 12줄 수동 `Effect.Unhandled`/`Poisoned` fallback을 `Eio_guard.with_mutex` 1줄로 교체. Dead code `_poisoned_warned` Atomic 제거.

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI Build and Test

Closes #3112, Addresses #3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)