### PR TITLE
fix(server): add startup watchdog and liveness/readiness probes

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -285,6 +285,8 @@ let with_admin_auth handler request reqd =
 (** Public read access - no auth required (dashboard, health) *)
 let is_public_read_path path =
   String.equal path "/health"
+  || String.equal path "/health/live"
+  || String.equal path "/health/ready"
   || String.equal path "/"
   || String.equal path "/dashboard"
   || String.equal path "/dashboard/"

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -157,6 +157,38 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           in
           h2_respond_json h2_reqd body ~extra_headers:cors
 
+      | `GET, "/health/live" ->
+          let body =
+            Yojson.Safe.to_string
+              (`Assoc [
+                 ("live", `Bool true);
+                 ("startup", Server_startup_state.to_yojson ());
+               ])
+          in
+          h2_respond_json h2_reqd body ~extra_headers:cors
+
+      | `GET, "/health/ready" ->
+          let current = Server_startup_state.(!state) in
+          let body, status =
+            if current.state_ready then
+              (Yojson.Safe.to_string
+                 (`Assoc [
+                    ("ready", `Bool true);
+                    ("phase", `String (Server_startup_state.phase_to_string current.phase));
+                    ("backend_mode", `String current.backend_mode);
+                  ]),
+               `OK)
+            else
+              (Yojson.Safe.to_string
+                 (`Assoc [
+                    ("ready", `Bool false);
+                    ("phase", `String (Server_startup_state.phase_to_string current.phase));
+                    ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
+                  ]),
+               `Service_unavailable)
+          in
+          h2_respond_json ~status h2_reqd body ~extra_headers:cors
+
       | `GET, "/ws" ->
           let body =
             Server_routes_http_runtime.websocket_discovery_json httpun_request

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -58,6 +58,8 @@ let webrtc_signaling_handler ~tool_name signaling_fn request reqd =
 let add_routes ~port ~host router =
   router
   |> Http.Router.get "/health" health_handler
+  |> Http.Router.get "/health/live" liveness_handler
+  |> Http.Router.get "/health/ready" readiness_handler
   |> Http.Router.get "/ws" websocket_discovery_handler
   |> Http.Router.get "/metrics" (fun request reqd ->
        with_read_auth (fun _state _req reqd ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -211,6 +211,45 @@ let health_handler request reqd =
     (Yojson.Safe.to_string (make_health_json request))
     reqd
 
+(** Liveness probe: responds 200 as soon as the HTTP accept loop is running.
+    Does not depend on server_state initialization.
+    Kubernetes/Railway liveness probe target. *)
+let liveness_handler _request reqd =
+  let startup = Server_startup_state.to_yojson () in
+  let body =
+    Yojson.Safe.to_string
+      (`Assoc
+         [
+           ("live", `Bool true);
+           ("startup", startup);
+         ])
+  in
+  Http.Response.json body reqd
+
+(** Readiness probe: responds 200 only when server_state is initialized. *)
+let readiness_handler _request reqd =
+  let current = Server_startup_state.(!state) in
+  if current.state_ready then
+    Http.Response.json
+      (Yojson.Safe.to_string
+         (`Assoc
+            [
+              ("ready", `Bool true);
+              ("phase", `String (Server_startup_state.phase_to_string current.phase));
+              ("backend_mode", `String current.backend_mode);
+            ]))
+      reqd
+  else
+    Http.Response.json ~status:`Service_unavailable
+      (Yojson.Safe.to_string
+         (`Assoc
+            [
+              ("ready", `Bool false);
+              ("phase", `String (Server_startup_state.phase_to_string current.phase));
+              ("elapsed_sec", `Float (Server_startup_state.elapsed_since_start ()));
+            ]))
+      reqd
+
 let board_post_detail_json ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error _ ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1010,6 +1010,23 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Log.Server.error "Background init failed (HTTP still serving): %s"
         (Printexc.to_string exn));
 
+  (* 2b. Startup watchdog: if init does not reach state_ready within timeout,
+     log and exit so external process managers can restart the server.
+     Prevents zombie-listener state where the socket is open but HTTP
+     requests hang because init is stuck. *)
+  Eio.Fiber.fork ~sw (fun () ->
+    let timeout_sec = Server_startup_state.watchdog_timeout_sec () in
+    Eio.Time.sleep clock timeout_sec;
+    let current = Server_startup_state.(!state) in
+    if not current.state_ready then (
+      let elapsed = Server_startup_state.elapsed_since_start () in
+      Log.Server.error
+        "[watchdog] Server init did not complete within %.0fs (elapsed=%.1fs, phase=%s, backend=%s). Exiting."
+        timeout_sec elapsed
+        (Server_startup_state.phase_to_string current.phase)
+        current.backend_mode;
+      exit 1));
+
   (* 3. Start serving -- /health responds before init completes *)
   match http_mode with
   | `H2_only ->

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -11,6 +11,7 @@ type t = {
   pending_lazy_tasks : string list;
   last_error : string option;
   fallback_reason : string option;
+  started_at : float;
 }
 
 let state =
@@ -22,6 +23,7 @@ let state =
       pending_lazy_tasks = [];
       last_error = None;
       fallback_reason = None;
+      started_at = Unix.gettimeofday ();
     }
 
 let phase_to_string = function
@@ -41,6 +43,7 @@ let reset ?(backend_mode = "unknown") () =
       pending_lazy_tasks = [];
       last_error = None;
       fallback_reason = None;
+      started_at = Unix.gettimeofday ();
     }
 
 let mark_blocking ~backend_mode =
@@ -53,6 +56,25 @@ let mark_blocking ~backend_mode =
         pending_lazy_tasks = [];
         last_error = None;
       })
+
+(** True when the HTTP accept loop can serve requests (always true after socket bind). *)
+let is_live () = true
+
+(** Seconds elapsed since startup began. *)
+let elapsed_since_start () =
+  Unix.gettimeofday () -. !state.started_at
+
+(** Default startup watchdog timeout in seconds. Override with MASC_STARTUP_WATCHDOG_SEC. *)
+let default_watchdog_timeout_sec = 120.0
+
+(** Read watchdog timeout from env, clamped to [30, 600]. *)
+let watchdog_timeout_sec () =
+  match Sys.getenv_opt "MASC_STARTUP_WATCHDOG_SEC" with
+  | Some s ->
+    (match float_of_string_opt s with
+     | Some v -> Float.max 30.0 (Float.min 600.0 v)
+     | None -> default_watchdog_timeout_sec)
+  | None -> default_watchdog_timeout_sec
 
 let mark_state_ready ~backend_mode =
   update (fun current ->
@@ -120,4 +142,6 @@ let to_yojson () =
         match current.fallback_reason with
         | Some reason -> `String reason
         | None -> `Null );
+      ("elapsed_sec", `Float (elapsed_since_start ()));
+      ("watchdog_timeout_sec", `Float (watchdog_timeout_sec ()));
     ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -237,6 +237,60 @@ let test_startup_state_json () =
   Alcotest.(check string) "last error recorded" "keeper failed"
     (json_string_field "last_error" json)
 
+let test_startup_state_liveness () =
+  Server_startup_state.reset ~backend_mode:"unknown" ();
+  Alcotest.(check bool) "is_live returns true even during init" true
+    (Server_startup_state.is_live ());
+  Alcotest.(check bool) "elapsed_since_start is non-negative" true
+    (Server_startup_state.elapsed_since_start () >= 0.0)
+
+let test_startup_state_readiness_before_init () =
+  Server_startup_state.reset ~backend_mode:"postgres-native" ();
+  let current = Server_startup_state.(!state) in
+  Alcotest.(check bool) "not ready before init" false current.state_ready;
+  Alcotest.(check string) "phase is blocking" "blocking"
+    (Server_startup_state.phase_to_string current.phase)
+
+let test_startup_state_readiness_after_init () =
+  Server_startup_state.reset ~backend_mode:"filesystem" ();
+  Server_startup_state.mark_state_ready ~backend_mode:"filesystem";
+  let current = Server_startup_state.(!state) in
+  Alcotest.(check bool) "ready after init" true current.state_ready;
+  Alcotest.(check string) "phase is ready" "ready"
+    (Server_startup_state.phase_to_string current.phase)
+
+let test_watchdog_timeout_env () =
+  with_env "MASC_STARTUP_WATCHDOG_SEC" (Some "90") (fun () ->
+      Alcotest.(check (float 0.1)) "reads env" 90.0
+        (Server_startup_state.watchdog_timeout_sec ()));
+  with_env "MASC_STARTUP_WATCHDOG_SEC" (Some "10") (fun () ->
+      Alcotest.(check (float 0.1)) "clamps to 30 min" 30.0
+        (Server_startup_state.watchdog_timeout_sec ()));
+  with_env "MASC_STARTUP_WATCHDOG_SEC" (Some "999") (fun () ->
+      Alcotest.(check (float 0.1)) "clamps to 600 max" 600.0
+        (Server_startup_state.watchdog_timeout_sec ()));
+  with_env "MASC_STARTUP_WATCHDOG_SEC" None (fun () ->
+      Alcotest.(check (float 0.1)) "default 120" 120.0
+        (Server_startup_state.watchdog_timeout_sec ()))
+
+let test_startup_state_json_includes_watchdog () =
+  Server_startup_state.reset ~backend_mode:"filesystem" ();
+  let json = Server_startup_state.to_yojson () in
+  let elapsed =
+    match Yojson.Safe.Util.member "elapsed_sec" json with
+    | `Float v -> v
+    | _ -> Alcotest.failf "elapsed_sec missing or not float"
+  in
+  Alcotest.(check bool) "elapsed_sec present and non-negative" true
+    (elapsed >= 0.0);
+  let watchdog =
+    match Yojson.Safe.Util.member "watchdog_timeout_sec" json with
+    | `Float v -> v
+    | _ -> Alcotest.failf "watchdog_timeout_sec missing or not float"
+  in
+  Alcotest.(check bool) "watchdog_timeout_sec is positive" true
+    (watchdog > 0.0)
+
 let test_prompt_markdown_dir_falls_back_to_repo_root () =
   with_temp_dir "startup-prompts" (fun dir ->
       let expected =
@@ -322,6 +376,16 @@ let () =
             test_keeper_paths_use_cluster_root;
           Alcotest.test_case "startup state json reports lazy failure" `Quick
             test_startup_state_json;
+          Alcotest.test_case "liveness probe is always true" `Quick
+            test_startup_state_liveness;
+          Alcotest.test_case "readiness false before init" `Quick
+            test_startup_state_readiness_before_init;
+          Alcotest.test_case "readiness true after init" `Quick
+            test_startup_state_readiness_after_init;
+          Alcotest.test_case "watchdog timeout env parsing" `Quick
+            test_watchdog_timeout_env;
+          Alcotest.test_case "startup json includes watchdog fields" `Quick
+            test_startup_state_json_includes_watchdog;
           Alcotest.test_case "prompt markdown dir falls back to repo root"
             `Quick test_prompt_markdown_dir_falls_back_to_repo_root;
           Alcotest.test_case "main_eio serves health before lazy startup"


### PR DESCRIPTION
## Summary

- `/health/live`: 서버 소켓이 열리면 즉시 200 응답. init 상태와 무관. Kubernetes/Railway liveness probe 대상.
- `/health/ready`: init 완료 후 200, 미완료 시 503. Readiness probe 대상.
- **Startup watchdog fiber**: `MASC_STARTUP_WATCHDOG_SEC` (기본 120s, 범위 30-600) 내에 init이 완료되지 않으면 `exit 1`. 좀비 리스너 방지.
- `/health` JSON에 `elapsed_sec`, `watchdog_timeout_sec` 필드 추가.

## 배경

PG 초기화 타임아웃 시 서버가 좀비 리스너 상태에 빠짐:
- 프로세스 alive, 포트 listen, TCP accept 가능 → 하지만 HTTP 응답 불가
- 외부에서 "정상"으로 오판하는 silent failure

## Test plan

- [x] 기존 테스트 전부 통과 (11 tests, 0 failures)
- [x] 새 테스트 5개: liveness/readiness/watchdog env/JSON fields
- [ ] CI green 확인

Closes #3107

🤖 Generated with [Claude Code](https://claude.com/claude-code)