### PR TITLE
chore: extract Eio_guard.with_rw/with_ro to deduplicate mutex boilerplate

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -40,12 +40,8 @@ type keeper_board_signal = {
 let backend_state : backend_state ref = ref Uninitialized
 
 let board_mu = Eio.Mutex.create ()
-let with_board_rw f =
-  try Eio.Mutex.use_rw ~protect:true board_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-let with_board_ro f =
-  try Eio.Mutex.use_ro board_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_board_rw f = Eio_guard.with_rw board_mu f
+let with_board_ro f = Eio_guard.with_ro board_mu f
 
 let keeper_board_signal_hook : (keeper_board_signal -> unit) option ref = ref None
 

--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -19,3 +19,14 @@ let with_mutex mutex f =
     Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
   else
     f ()
+
+(** Read-write guard that falls back to direct execution when
+    Eio runtime is unavailable (e.g. unit tests). *)
+let with_rw mutex f =
+  try Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+(** Read-only guard with the same fallback. *)
+let with_ro mutex f =
+  try Eio.Mutex.use_ro mutex (fun () -> f ())
+  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -90,12 +90,8 @@ let keeper_passthrough_masc_tool_names =
 let masc_schemas_ref : Types.tool_schema list ref = ref []
 
 let masc_schemas_mu = Eio.Mutex.create ()
-let with_schemas_rw f =
-  try Eio.Mutex.use_rw ~protect:true masc_schemas_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-let with_schemas_ro f =
-  try Eio.Mutex.use_ro masc_schemas_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_schemas_rw f = Eio_guard.with_rw masc_schemas_mu f
+let with_schemas_ro f = Eio_guard.with_ro masc_schemas_mu f
 
 let inject_masc_schemas (schemas : Types.tool_schema list) =
   with_schemas_rw (fun () ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -156,12 +156,8 @@ let orchestrator_pulse : Pulse.t option ref = ref None
 let zombie_pulse : Pulse.t option ref = ref None
 
 let pulse_mu = Eio.Mutex.create ()
-let with_pulse_rw f =
-  try Eio.Mutex.use_rw ~protect:true pulse_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-let with_pulse_ro f =
-  try Eio.Mutex.use_ro pulse_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_pulse_rw f = Eio_guard.with_rw pulse_mu f
+let with_pulse_ro f = Eio_guard.with_ro pulse_mu f
 
 (** Build the orchestrator check consumer.
     Checks if orchestration is needed and spawns coordinator if so. *)

--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -21,12 +21,8 @@ type backend_state =
 let backend_state : backend_state ref = ref Uninitialized
 
 let task_mu = Eio.Mutex.create ()
-let with_task_rw f =
-  try Eio.Mutex.use_rw ~protect:true task_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
-let with_task_ro f =
-  try Eio.Mutex.use_ro task_mu (fun () -> f ())
-  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+let with_task_rw f = Eio_guard.with_rw task_mu f
+let with_task_ro f = Eio_guard.with_ro task_mu f
 
 let is_initialized () =
   with_task_ro (fun () ->


### PR DESCRIPTION
## Summary

/simplify review finding: PR #3109 introduced 4 identical mutex wrapper implementations. This PR extracts them into shared `Eio_guard.with_rw`/`with_ro` helpers.

### Before (repeated 4x, 6 lines each)
```ocaml
let with_X_rw f =
  try Eio.Mutex.use_rw ~protect:true X_mu (fun () -> f ())
  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
let with_X_ro f =
  try Eio.Mutex.use_ro X_mu (fun () -> f ())
  with Stdlib.Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
```

### After (1 line each)
```ocaml
let with_X_rw f = Eio_guard.with_rw X_mu f
let with_X_ro f = Eio_guard.with_ro X_mu f
```

Net: +11 lines in eio_guard.ml, -24 lines across 4 modules = **-5 lines net**, eliminates drift risk.

## Test plan
- [x] `dune build lib/ bin/` — compiles clean