### PR TITLE
fix(ci): resolve test hangs, PG timeout diagnostics, and shutdown exceptions

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -265,7 +265,8 @@ let base_path =
   Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
 
 (** Graceful shutdown exception *)
-exception Shutdown
+(* Shutdown exception removed: graceful shutdown returns normally from
+   await_shutdown_signal, letting Eio.Fiber.first cancel run_server. *)
 
 let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
 
@@ -367,19 +368,26 @@ let run_cmd host port base_path =
             Eio.Time.sleep clock 0.2;
             Masc_mcp.Shutdown_hooks.run_all ();
             (try Board_dispatch.flush ()
-             with _ ->
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ ->
                Log.Server.warn
                  "[Shutdown] Board flush skipped (not initialized)");
-            close_all_sse_connections ();
-            Eio.Time.sleep clock 0.2;
-            raise Shutdown
+            (* Return normally — Eio.Fiber.first will cancel run_server
+               cleanly via Eio.Cancel.Cancelled, avoiding "Multiple
+               exceptions" from raising Shutdown + Cancelled together. *)
+            ()
       in
       Eio.Fiber.first
         (fun () -> run_server ~sw ~env ~host ~port ~base_path)
-        await_shutdown_signal
+        await_shutdown_signal;
+      (* Server stopped; close SSE connections after server is down. *)
+      (try close_all_sse_connections ()
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | _ -> ());
+      Log.Server.info "MASC MCP: Shutdown complete."
     with
-    | Shutdown ->
-        Log.Server.info "MASC MCP: Shutdown complete."
     | Eio.Cancel.Cancelled _ ->
         Log.Server.info "MASC MCP: Shutdown complete."
     | Unix.Unix_error (Unix.EADDRINUSE, _, _) when attempt < max_bind_retries ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -846,12 +846,30 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       |> String.lowercase_ascii
     in
     let init_state_blocking () =
-      let state =
-        create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
+      let pg_pool_timeout =
+        Safe_ops.get_env_float_logged "MASC_PG_POOL_TIMEOUT_SEC" ~default:15.0
       in
+      let t0 = Eio.Time.now clock in
+      let state =
+        (try
+           Eio.Time.with_timeout_exn clock pg_pool_timeout (fun () ->
+             create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr
+               ~fs)
+         with Eio.Time.Timeout ->
+           Log.Server.error
+             "PG pool creation timed out after %.0fs (inner limit); \
+              outer timeout will trigger JSONL fallback"
+             pg_pool_timeout;
+           raise Eio.Time.Timeout)
+      in
+      let t1 = Eio.Time.now clock in
+      Log.Server.info "State created (PG pool) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
+      let t2 = Eio.Time.now clock in
+      Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       install_tooling ~governance_level state;
       init_pg_schemas_parallel ();
+      Log.Server.info "Tooling + schemas in %.1fs" (Eio.Time.now clock -. t2);
       state
     in
     let run_lazy_task (task_name, task_fn) =

--- a/test/dune
+++ b/test/dune
@@ -200,7 +200,7 @@
 (test
  (name test_ci_hardening_source)
  (modules test_ci_hardening_source)
- (libraries alcotest unix))
+ (libraries alcotest unix str))
 
 (test
  (name test_local_review_script)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -16,13 +16,11 @@ let file_contains_pattern file_rel pattern =
       ~finally:(fun () -> close_in_noerr ic)
       (fun () ->
         let content = In_channel.input_all ic in
-        let rec loop idx =
-          let remaining = String.length content - idx in
-          let plen = String.length pattern in
-          remaining >= plen
-          && (String.sub content idx plen = pattern || loop (idx + 1))
-        in
-        if String.length pattern = 0 then true else loop 0)
+        if String.length pattern = 0 then true
+        else
+          let re = Str.regexp_string pattern in
+          (try ignore (Str.search_forward re content 0); true
+           with Not_found -> false))
 
 let test_ci_sync_and_asset_contracts () =
   check bool "pr sync script added" true

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -4,6 +4,9 @@ module Lib = Masc_mcp
 
 open Alcotest
 
+(* Force filesystem backend so tests run without PG/Eio context. *)
+let () = Unix.putenv "MASC_STORAGE_TYPE" "filesystem"
+
 let test_dir () =
   let tmp = Filename.temp_file "masc_dashboard_mission" "" in
   Sys.remove tmp;
@@ -313,8 +316,13 @@ let test_dashboard_mission_projection () =
         ~context:"fixture context"
         ~allowed_tools:[ "masc_board_comment" ]
         ();
-      Sys.remove
-        (Filename.concat (Room_utils.agents_dir config) "llama-local-delta.json");
+      (* Simulate delta departing: remove agent file if it exists (Memory
+         backend does not write files), then ensure agent dir exists so
+         Dashboard_mission sees delta as departed. *)
+      let delta_path =
+        Filename.concat (Room_utils.agents_dir config) "llama-local-delta.json"
+      in
+      if Sys.file_exists delta_path then Sys.remove delta_path;
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Dashboard_mission.json


### PR DESCRIPTION
## Summary
- **test_ci_hardening_source hang**: `String.sub` O(n*m) → `Str.search_forward` (0.032s, was hanging)
- **PG cold-start**: inner `MASC_PG_POOL_TIMEOUT_SEC` (15s) + per-phase timing logs for diagnostics
- **test_dashboard_mission crash**: `Sys.remove` guard for Memory backend + force filesystem storage type
- **Shutdown "Multiple exceptions"**: return normally from shutdown signal handler instead of raising exception

## Context
Blockers identified from `.masc/TODO.md` and recent CI failures. Dependency chain: PG timeout → dashboard test init → test hang reports.

## Pre-existing issues (not addressed)
- `test_dashboard_mission` 3 assertion failures: attention kind mismatch under Memory backend (needs mission projection logic investigation)
- `test_oas_adapters/integration/coverage` build errors: `compact` function signature change (pre-existing on main)

## Test plan
- [x] `dune exec test/test_ci_hardening_source.exe` — 20 tests pass in 0.032s
- [x] `dune exec test/test_dashboard_room_truth.exe` — 4 tests pass in 0.034s
- [x] `dune exec test/test_dashboard_mission.exe` — no crash (3 pre-existing assertion failures remain)
- [x] `dune build bin/main_eio.exe` — builds clean
- [ ] Manual: `^C` shutdown → verify no "Multiple exceptions" in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)