### PR TITLE
fix(pg): isolate readonly dashboard reads

### DIFF
--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -248,55 +248,61 @@ let collect_recent_messages_from_pg config ~msgs_path ~since_seq ~limit =
                 |> take_first limit
               in
               Some messages
-          | Error _ -> None))
+          | Error err ->
+              Log.Room.warn "collect_recent_messages_from_pg failed: %s"
+                (Backend.show_error err);
+              None))
   | Memory _ | FileSystem _ -> None
 
 (** Read most-recent messages without parsing the entire history directory. *)
 let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
-  match collect_recent_messages_from_pg config ~msgs_path ~since_seq ~limit with
-  | Some rows -> rows
-  | None ->
-      let names =
-        Sys.readdir msgs_path
-        |> Array.to_list
-        |> List.filter is_valid_filename
-        |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
-      in
-      let rec loop remaining acc = function
-        | _ when remaining <= 0 -> List.rev acc
-        | [] -> List.rev acc
-        | name :: rest ->
-            safe_yield ();
-            if extract_seq_from_filename name <= since_seq then List.rev acc
-            else
-              let path = Filename.concat msgs_path name in
-              match read_json config path with
-              | json ->
-                  (match message_of_yojson json with
-                   | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
-                   | _ -> loop remaining acc rest)
-              | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-              | exception e ->
-                  Log.legacy_traceln ~level:Log.Warn ~module_name:"Room"
-                    (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
-                       name (Printexc.to_string e));
-                  loop remaining acc rest
-      in
-      loop limit [] names
+  match config.backend with
+  | PostgresNative _ -> (
+      match collect_recent_messages_from_pg config ~msgs_path ~since_seq ~limit with
+      | Some rows -> rows
+      | None -> [])
+  | Memory _ | FileSystem _ ->
+      if not (Sys.file_exists msgs_path) then []
+      else
+        let names =
+          Sys.readdir msgs_path
+          |> Array.to_list
+          |> List.filter is_valid_filename
+          |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
+        in
+        let rec loop remaining acc = function
+          | _ when remaining <= 0 -> List.rev acc
+          | [] -> List.rev acc
+          | name :: rest ->
+              safe_yield ();
+              if extract_seq_from_filename name <= since_seq then List.rev acc
+              else
+                let path = Filename.concat msgs_path name in
+                match read_json config path with
+                | json ->
+                    (match message_of_yojson json with
+                     | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
+                     | _ -> loop remaining acc rest)
+                | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+                | exception e ->
+                    Log.legacy_traceln ~level:Log.Warn ~module_name:"Room"
+                      (Printf.sprintf "[WARN] Failed to read %s %s: %s" warn_label
+                         name (Printexc.to_string e));
+                    loop remaining acc rest
+        in
+        loop limit [] names
 
 (** Get raw message list (for dashboard) *)
 let get_messages_raw config ~since_seq ~limit =
   ensure_initialized config;
   let msgs_path = messages_dir_in_room config (current_room_id config) in
-  if not (Sys.file_exists msgs_path) then []
-  else collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"message"
+  collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"message"
 
 let get_messages_raw_in_room config ~room_id ~since_seq ~limit =
   if not (root_is_initialized config) then []
   else
     let msgs_path = messages_dir_in_room config room_id in
-    if not (Sys.file_exists msgs_path) then []
-    else collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"room message"
+    collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"room message"
 
 (** List tasks *)
 let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status config =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -137,9 +137,24 @@ let _executor_pool : Eio.Executor_pool.t option ref = ref None
 
 let set_executor_pool pool = _executor_pool := Some pool
 
+let isolated_readonly_dashboard_config ~sw ~clock ~(config : Room.config) =
+  match config.backend_config.Backend.backend_type with
+  | Backend.PostgresNative ->
+      let net = Eio_context.get_net () in
+      let mono_clock = Eio_context.get_mono_clock () in
+      Room_utils_backend_setup.with_domain_local_pg_backend
+        ~sw ~net ~clock ~mono_clock config
+  | Backend.Memory | Backend.FileSystem -> Some config
+
 let run_dashboard_compute ?(mode = Offloaded_readonly) ~sw ~clock
     ~(config : Room.config) compute =
   let fallback () = compute ~config ~sw in
+  let fallback_isolated_pg () =
+    match isolated_readonly_dashboard_config ~sw ~clock ~config with
+    | Some isolated -> compute ~config:isolated ~sw
+    | None ->
+        failwith "dashboard readonly backend unavailable"
+  in
   let run_in_pool pool_sw =
     match config.backend_config.Backend.backend_type with
     | Backend.PostgresNative ->
@@ -166,14 +181,21 @@ let run_dashboard_compute ?(mode = Offloaded_readonly) ~sw ~clock
            | `Fallback ->
                Log.Dashboard.warn
                  "dashboard offload fallback: domain-local backend unavailable";
-               fallback ()
+               (match config.backend_config.Backend.backend_type with
+                | Backend.PostgresNative -> fallback_isolated_pg ()
+                | Backend.Memory | Backend.FileSystem -> fallback ())
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
              Log.Dashboard.warn "dashboard offload failed, using inline compute: %s"
                (Printexc.to_string exn);
-             fallback ())
-    | None -> fallback ()
+             (match config.backend_config.Backend.backend_type with
+              | Backend.PostgresNative -> fallback_isolated_pg ()
+              | Backend.Memory | Backend.FileSystem -> fallback ()))
+    | None ->
+        (match config.backend_config.Backend.backend_type with
+         | Backend.PostgresNative -> fallback_isolated_pg ()
+         | Backend.Memory | Backend.FileSystem -> fallback ())
   in
   match mode with
   | Inline_shared -> fallback ()

--- a/test/dune
+++ b/test/dune
@@ -423,6 +423,11 @@
  (modules test_room_messages_raw)
  (libraries masc_mcp alcotest unix))
 
+(test
+ (name test_room_messages_pg)
+ (modules test_room_messages_pg)
+ (libraries masc_mcp alcotest eio eio_main unix))
+
 
 (test
  (name test_tool_goals)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -44,6 +44,28 @@ let with_test_env f =
       Eio.Switch.run @@ fun sw ->
       f ~env ~sw ~config)
 
+let with_pg_test_env f =
+  match Sys.getenv_opt "MASC_POSTGRES_URL" with
+  | None | Some "" -> ()
+  | Some url ->
+      let dir = test_dir () in
+      Fun.protect
+        ~finally:(fun () -> cleanup_dir dir)
+        (fun () ->
+          with_env "MASC_STORAGE_TYPE" "postgres" @@ fun () ->
+          with_env "MASC_POSTGRES_URL" url @@ fun () ->
+          with_env "DATABASE_URL" "" @@ fun () ->
+          with_env "SUPABASE_DB_URL" "" @@ fun () ->
+          with_env "SB_PG_URL" "" @@ fun () ->
+          Eio_main.run @@ fun env ->
+          Eio.Switch.run @@ fun sw ->
+          let config =
+            Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
+          in
+          match config.Room_utils.backend with
+          | Room_utils.PostgresNative _ -> f ~env ~sw ~config
+          | Room_utils.Memory _ | Room_utils.FileSystem _ -> ())
+
 let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
   with_test_env @@ fun ~env ~sw ~config ->
   let caller_domain = Domain.self () in
@@ -74,6 +96,27 @@ let test_run_dashboard_compute_with_pool_uses_executor_domain () =
   check bool "executor pool runs compute off the caller domain" true
     (result_domain <> caller_domain)
 
+let test_run_dashboard_compute_without_pool_uses_isolated_pg_backend () =
+  with_pg_test_env @@ fun ~env ~sw ~config ->
+  match config.Room_utils.backend with
+  | Room_utils.PostgresNative shared_backend ->
+      let reused_shared_pool =
+        Lib.Server_dashboard_http_core.run_dashboard_compute
+          ~sw
+          ~clock:(Eio.Stdenv.clock env)
+          ~config
+          (fun ~config ~sw:_ ->
+            match config.Room_utils.backend with
+            | Room_utils.PostgresNative readonly_backend ->
+                Backend.PostgresNative.get_pool shared_backend
+                == Backend.PostgresNative.get_pool readonly_backend
+            | Room_utils.Memory _ | Room_utils.FileSystem _ ->
+                Alcotest.fail "expected postgres backend during readonly compute")
+      in
+      check bool "no pool uses isolated postgres backend" false
+        reused_shared_pool
+  | Room_utils.Memory _ | Room_utils.FileSystem _ -> ()
+
 let () =
   run "dashboard_http_core"
     [
@@ -81,6 +124,8 @@ let () =
         [
           test_case "no pool stays on caller domain" `Quick
             test_run_dashboard_compute_without_pool_stays_in_current_domain;
+          test_case "pg no pool uses isolated backend" `Quick
+            test_run_dashboard_compute_without_pool_uses_isolated_pg_backend;
           test_case "pool uses executor domain" `Quick
             test_run_dashboard_compute_with_pool_uses_executor_domain;
         ] );

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -59,6 +59,8 @@ let with_pg_test_env f =
           with_env "SB_PG_URL" "" @@ fun () ->
           Eio_main.run @@ fun env ->
           Eio.Switch.run @@ fun sw ->
+          Eio_context.set_net (Eio.Stdenv.net env);
+          Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);
           let config =
             Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
           in

--- a/test/test_room_messages_pg.ml
+++ b/test/test_room_messages_pg.ml
@@ -42,6 +42,8 @@ let with_pg_test_env f =
           with_env "SB_PG_URL" "" @@ fun () ->
           Eio_main.run @@ fun env ->
           Eio.Switch.run @@ fun sw ->
+          Eio_context.set_net (Eio.Stdenv.net env);
+          Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);
           let config =
             Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
           in

--- a/test/test_room_messages_pg.ml
+++ b/test/test_room_messages_pg.ml
@@ -1,0 +1,75 @@
+open Masc_mcp
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_room_messages_pg" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
+let with_pg_test_env f =
+  match Sys.getenv_opt "MASC_POSTGRES_URL" with
+  | None | Some "" -> ()
+  | Some url ->
+      let dir = test_dir () in
+      Fun.protect
+        ~finally:(fun () -> cleanup_dir dir)
+        (fun () ->
+          with_env "MASC_STORAGE_TYPE" "postgres" @@ fun () ->
+          with_env "MASC_POSTGRES_URL" url @@ fun () ->
+          with_env "DATABASE_URL" "" @@ fun () ->
+          with_env "SUPABASE_DB_URL" "" @@ fun () ->
+          with_env "SB_PG_URL" "" @@ fun () ->
+          Eio_main.run @@ fun env ->
+          Eio.Switch.run @@ fun sw ->
+          let config =
+            Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
+          in
+          match config.Room_utils.backend with
+          | Room_utils.PostgresNative _ ->
+              let _ = Room.init config ~agent_name:(Some "claude") in
+              Fun.protect
+                ~finally:(fun () -> ignore (Room.reset config))
+                (fun () -> f ~env ~sw ~config)
+          | Room_utils.Memory _ | Room_utils.FileSystem _ -> ())
+
+let test_get_messages_raw_uses_postgres_backend () =
+  with_pg_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 1" in
+  let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 2" in
+  let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 3" in
+  let msgs = Room.get_messages_raw config ~since_seq:0 ~limit:2 in
+  let contents = List.map (fun (msg : Types.message) -> msg.content) msgs in
+  Alcotest.(check int) "limit respected" 2 (List.length msgs);
+  Alcotest.(check (list string)) "newest messages first from postgres"
+    [ "Message 3"; "Message 2" ] contents
+
+let () =
+  Alcotest.run "Room PG message regression"
+    [
+      ( "messages_pg",
+        [
+          Alcotest.test_case "get_messages_raw uses postgres backend" `Quick
+            test_get_messages_raw_uses_postgres_backend;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- isolate `Offloaded_readonly` dashboard compute from the shared PG pool even when no executor pool is available
- make room message reads authoritative on PostgreSQL when `PostgresNative` is active
- add PG regressions for readonly dashboard compute and PG-backed message retrieval

## Verification
- `dune build --root . ./test/test_dashboard_http_core.exe ./test/test_room_messages_pg.exe ./test/test_mcp_server_eio.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `./_build/default/test/test_room_messages_raw.exe`
- `./_build/default/test/test_room_messages_pg.exe`
- `./_build/default/test/test_mcp_server_eio.exe`

## Notes
- follow-up to merged PR #3036
- preserves filesystem behavior for non-PG backends while removing mixed PG/file message reads on PG-backed rooms