### PR TITLE
Harden system logging observability fan-out

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -22,8 +22,10 @@ type action =
   | Join
   | Leave
   | ClaimTask
+  | StartTask
   | DoneTask
   | CancelTask
+  | ReleaseTask
   | Broadcast
   | Suspend
   | ToolCall of string
@@ -53,8 +55,10 @@ let action_to_string = function
   | Join -> "join"
   | Leave -> "leave"
   | ClaimTask -> "claim_task"
+  | StartTask -> "start_task"
   | DoneTask -> "done_task"
   | CancelTask -> "cancel_task"
+  | ReleaseTask -> "release_task"
   | Broadcast -> "broadcast"
   | Suspend -> "suspend"
   | ToolCall name -> "tool_call:" ^ name
@@ -70,8 +74,10 @@ let string_to_action = function
   | "join" -> Join
   | "leave" -> Leave
   | "claim_task" -> ClaimTask
+  | "start_task" -> StartTask
   | "done_task" -> DoneTask
   | "cancel_task" -> CancelTask
+  | "release_task" -> ReleaseTask
   | "broadcast" -> Broadcast
   | "suspend" -> Suspend
   | "auth_success" -> AuthSuccess
@@ -163,8 +169,10 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
 
 (** {1 File Operations} *)
 
+type config = Room_utils.config
+
 (** Legacy single-file path (for fallback reads). *)
-let legacy_audit_path (config : Room.config) =
+let legacy_audit_path (config : config) =
   let masc_dir = Room_utils.masc_dir config in
   Filename.concat masc_dir "audit.jsonl"
 
@@ -172,7 +180,7 @@ let legacy_audit_path (config : Room.config) =
     Cached per base_dir so all callers share the same Eio.Mutex. *)
 let audit_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
-let get_audit_store (config : Room.config) : Dated_jsonl.t =
+let get_audit_store (config : config) : Dated_jsonl.t =
   let base = Filename.concat (Room_utils.masc_dir config) "audit" in
   match Hashtbl.find_opt audit_store_cache base with
   | Some store -> store
@@ -183,7 +191,7 @@ let get_audit_store (config : Room.config) : Dated_jsonl.t =
 
 (** Read recent audit entries.
     Tries date-split store first; falls back to legacy single file. *)
-let read_entries ?(n = 10_000) (config : Room.config) : audit_entry list =
+let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
   let entries = Dated_jsonl.read_recent store n in
   if entries <> [] then
@@ -201,14 +209,14 @@ let read_entries ?(n = 10_000) (config : Room.config) : audit_entry list =
           with Yojson.Json_error _ -> None)
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
-let append_entry (config : Room.config) (entry : audit_entry) =
+let append_entry (config : config) (entry : audit_entry) =
   let store = get_audit_store config in
   Dated_jsonl.append store (entry_to_json entry)
 
 (** {1 Logging API} *)
 
 let log_action
-    (config : Room.config)
+    (config : config)
     ~agent_id
     ~action
     ?(room_id : string option)
@@ -327,7 +335,7 @@ let log_governance_decision config ~agent_id ~trace_id ~decision ~action_type ~c
 
 (** Prune audit entries older than [days] days.
     Date-split storage makes rotation unnecessary. *)
-let prune_old (config : Room.config) ~days =
+let prune_old (config : config) ~days =
   let store = get_audit_store config in
   let deleted = Dated_jsonl.prune store ~days in
   if deleted > 0 then
@@ -342,7 +350,7 @@ type stats = {
   newest_timestamp: float option;
 }
 
-let get_stats (config : Room.config) =
+let get_stats (config : config) =
   let store = get_audit_store config in
   (* Read a large window to compute stats *)
   let entries = Dated_jsonl.read_recent store 100_000 in

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -106,11 +106,17 @@ let ring_message (report : report) =
   Printf.sprintf "%s %s%s failed: %s" report.client_name phase report.tool_name
     report.message
 
-let record config (report : report) =
+let record ?fs config (report : report) =
   let details = details_json report in
   Log.client_tool_host_error ~details (ring_message report);
   Audit_log.log_client_tool_host_failure config ~agent_id:report.agent_name
     ~client_name:report.client_name ~tool_name:report.tool_name
     ~transport:report.transport ~message:report.message ?phase:report.phase
     ?request_id:report.request_id ?session_id:report.session_id
-    ?trace_id:report.trace_id ?timeout_ms:report.timeout_ms ()
+    ?trace_id:report.trace_id ?timeout_ms:report.timeout_ms ();
+  if Option.is_some fs then
+    Telemetry_eio.track_error ?fs config ~code:"client_tool_host_failure"
+      ~message:report.message
+      ~context:
+        (Printf.sprintf "client=%s tool=%s transport=%s"
+           report.client_name report.tool_name report.transport)

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -370,6 +370,20 @@ let log level ?(ctx : string option) fmt =
     end
   ) fmt
 
+let emit level ?(module_name = "") ?(details = `Null) message =
+  if should_log level then begin
+    let level_str = level_to_string level in
+    let prefix =
+      if module_name = "" then
+        Printf.sprintf "[%s] [%s]" (timestamp ()) level_str
+      else
+        Printf.sprintf "[%s] [%s] [%s]" (timestamp ()) level_str module_name
+    in
+    Printf.eprintf "%s %s\n%!" prefix message;
+    Ring.push ~raw_level:level_str ~normalized_level:level_str ~module_name
+      ~message ~details ()
+  end
+
 (** Convenience functions *)
 let debug ?ctx fmt = log Debug ?ctx fmt
 let info ?ctx fmt = log Info ?ctx fmt

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -34,6 +34,9 @@ val timestamp : unit -> string
 val log : level -> ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 (** Log a message at the given level with optional context. *)
 
+val emit : level -> ?module_name:string -> ?details:Yojson.Safe.t -> string -> unit
+(** Log a preformatted structured message with optional JSON details. *)
+
 val debug : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 val info : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 val warn : ?ctx:string -> ('a, unit, string, unit) format4 -> 'a

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -258,6 +258,19 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let error_msg = if success then None else Some (Printf.sprintf "timeout=%d|duration_ms=%d" (if !timeout_hit then 1 else 0) duration_ms) in
   Audit_log.log_tool_call state.Mcp_server.room_config
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg ();
+  if not success then
+    Log.emit Log.Error ~module_name:"MCP"
+      ~details:
+        (`Assoc
+          [
+            ("event_family", `String "tool_call_failure");
+            ("tool_name", `String name);
+            ("agent_name", `String agent_name);
+            ("duration_ms", `Int duration_ms);
+            ("timeout_hit", `Bool !timeout_hit);
+            ("attempts", `Int attempts);
+          ])
+      (Printf.sprintf "tool call failed: %s" name);
 
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -314,16 +314,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn -> log_mcp_exn ~label:"session register (nickname) failed" exn);
-        (* Prometheus + Telemetry: track auto-join *)
-        Prometheus.inc_gauge "masc_active_agents" ();
-        (match state.Mcp_server.fs with
-         | Some fs ->
-             (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                Log.Telemetry.debug "track_agent_joined (auto): %s" (Printexc.to_string exn))
-         | None -> ());
         nickname
       end
     end else

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -51,6 +51,109 @@ include Room_gc
 (* Wire Room_hooks callbacks                    *)
 (* ============================================ *)
 
+let telemetry_enabled () =
+  match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
+  | Some "false" | Some "0" -> false
+  | _ -> true
+
+let merge_detail_fields fields details =
+  match details with
+  | `Assoc extra -> `Assoc (fields @ extra)
+  | `Null -> `Assoc fields
+  | other -> `Assoc (fields @ [ ("payload", other) ])
+
+let task_action_of_transition = function
+  | "claim" -> Audit_log.ClaimTask
+  | "start" -> Audit_log.StartTask
+  | "done" -> Audit_log.DoneTask
+  | "cancel" -> Audit_log.CancelTask
+  | "release" -> Audit_log.ReleaseTask
+  | other -> Audit_log.Custom ("task_" ^ other)
+
+let observe_agent_lifecycle config ~agent_id ~room_id ~event_kind ~details =
+  let details =
+    merge_detail_fields
+      [
+        ("event_family", `String "agent_lifecycle");
+        ("event_kind", `String event_kind);
+        ("agent_id", `String agent_id);
+        ("room_id", `String room_id);
+      ]
+      details
+  in
+  let level =
+    match event_kind with
+    | "leave" -> Log.Info
+    | _ -> Log.Info
+  in
+  let message =
+    match event_kind with
+    | "rejoin" -> Printf.sprintf "agent rejoined: %s (%s)" agent_id room_id
+    | "leave" -> Printf.sprintf "agent left: %s (%s)" agent_id room_id
+    | _ -> Printf.sprintf "agent joined: %s (%s)" agent_id room_id
+  in
+  Log.emit level ~module_name:"Room" ~details message;
+  (match event_kind with
+   | "leave" -> Prometheus.dec_gauge "masc_active_agents" ()
+   | "join" | "rejoin" -> Prometheus.inc_gauge "masc_active_agents" ()
+   | _ -> ());
+  let audit_details =
+    match event_kind with
+    | "rejoin" -> merge_detail_fields [ ("rejoin", `Bool true) ] details
+    | _ -> details
+  in
+  let action =
+    match event_kind with
+    | "leave" -> Audit_log.Leave
+    | _ -> Audit_log.Join
+  in
+  Audit_log.log_action config ~agent_id ~action ~room_id
+    ~details:audit_details ~outcome:Audit_log.Success ();
+  if telemetry_enabled () then
+    match event_kind with
+    | "leave" -> Telemetry_eio.track_agent_left config ~agent_id ~reason:"leave"
+    | "rejoin" ->
+        Telemetry_eio.track_agent_joined config ~agent_id ()
+    | _ -> Telemetry_eio.track_agent_joined config ~agent_id ()
+
+let observe_task_transition_event config ~agent_name ~room_id ~task_id
+    ~transition ~details =
+  let details =
+    merge_detail_fields
+      [
+        ("event_family", `String "task_transition");
+        ("transition", `String transition);
+        ("task_id", `String task_id);
+        ("agent_id", `String agent_name);
+        ("room_id", `String room_id);
+      ]
+      details
+  in
+  let level =
+    match transition with
+    | "cancel" -> Log.Warn
+    | _ -> Log.Info
+  in
+  let message =
+    Printf.sprintf "task %s %s by %s (%s)" task_id transition agent_name
+      room_id
+  in
+  Log.emit level ~module_name:"Task" ~details message;
+  Audit_log.log_action config ~agent_id:agent_name
+    ~action:(task_action_of_transition transition) ~room_id
+    ~details ~outcome:Audit_log.Success ();
+  if telemetry_enabled () then
+    match transition with
+    | "start" ->
+        Telemetry_eio.track_task_started config ~task_id ~agent_id:agent_name
+    | "done" | "cancel" ->
+        let duration_ms =
+          Safe_ops.json_int ~default:0 "duration_ms" details
+        in
+        Telemetry_eio.track_task_completed config ~task_id ~duration_ms
+          ~success:(String.equal transition "done")
+    | _ -> ()
+
 (* force_release_task — zombie cleanup needs task management logic *)
 let () = Room_hooks.force_release_task_fn :=
   (fun config ~agent_name ~task_id () ->
@@ -82,6 +185,15 @@ let () = Room_hooks.relation_on_leave_fn := Relation_materializer.on_agent_leave
 
 (* Relation materializer — task done *)
 let () = Room_hooks.relation_on_task_done_fn := Relation_materializer.on_task_done
+
+let () = Room_hooks.observe_agent_lifecycle_fn :=
+  (fun config ~agent_id ~room_id ~event_kind ~details ->
+    observe_agent_lifecycle config ~agent_id ~room_id ~event_kind ~details)
+
+let () = Room_hooks.observe_task_transition_fn :=
+  (fun config ~agent_name ~room_id ~task_id ~transition ~details ->
+    observe_task_transition_event config ~agent_name ~room_id ~task_id
+      ~transition ~details)
 
 (* Board artifact cleanup — wraps Board_dispatch for GC *)
 let () = Room_hooks.cleanup_board_artifacts_fn := (fun () ->

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -84,6 +84,34 @@ let relation_on_task_done_fn
   : (assignee:string -> active_agents:string list -> unit) ref
   = ref (fun ~assignee:_ ~active_agents:_ -> ())
 
+(** Shared observability hook for join/rejoin/leave events.
+    Upper layers can mirror state transitions to audit, telemetry, and logs
+    without introducing circular dependencies into room sub-modules. *)
+let observe_agent_lifecycle_fn
+  : (Room_utils_backend_setup.config ->
+     agent_id:string ->
+     room_id:string ->
+     event_kind:string ->
+     details:Yojson.Safe.t ->
+     unit) ref
+  = ref
+      (fun _config ~agent_id:_ ~room_id:_ ~event_kind:_ ~details:_ -> ())
+
+(** Shared observability hook for task transitions.
+    Used by room task modules so every successful state transition is logged
+    consistently regardless of which tool or transport triggered it. *)
+let observe_task_transition_fn
+  : (Room_utils_backend_setup.config ->
+     agent_name:string ->
+     room_id:string ->
+     task_id:string ->
+     transition:string ->
+     details:Yojson.Safe.t ->
+     unit) ref
+  = ref
+      (fun _config ~agent_name:_ ~room_id:_ ~task_id:_ ~transition:_
+           ~details:_ -> ())
+
 (** Board artifact cleanup — wraps Board_dispatch.list_posts + delete_post.
     Returns number of deleted posts. *)
 let cleanup_board_artifacts_fn

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -7,6 +7,11 @@ open Types
 open Room_utils [@@warning "-33"]
 open Room_state [@@warning "-33"]
 
+let room_id_of_config (config : Room_utils_backend_setup.config) =
+  match config.scope with
+  | Default -> "default"
+  | Named id -> id
+
 (** Join room - with auto-generated nickname and metadata *)
 let join config ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
@@ -98,7 +103,16 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
                    ~content:(Printf.sprintf "👋 %s rejoined the room" nickname) in
          log_event config (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
-           nickname agent_type new_session_id (now_iso ()))
+           nickname agent_type new_session_id (now_iso ()));
+         !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+           ~room_id:(room_id_of_config config) ~event_kind:"rejoin"
+           ~details:
+             (`Assoc
+               [
+                 ("agent_type", `String agent_type);
+                 ("session_id", `String new_session_id);
+                 ("rejoin", `Bool true);
+               ]);
        end
      | Error e ->
          Log.Room.warn "agent rejoin: invalid agent JSON for %s: %s" nickname e);
@@ -155,6 +169,16 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     session_id
     (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
     (now_iso ()));
+  !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+    ~room_id:(room_id_of_config config) ~event_kind:"join"
+    ~details:
+      (`Assoc
+        [
+          ("agent_type", `String agent_type);
+          ("session_id", `String session_id);
+          ( "capabilities",
+            `List (List.map (fun s -> `String s) capabilities) );
+        ]);
 
   Printf.sprintf "✅ %s joined\n  Nickname: %s\n  Type: %s\n  Session: %s"
     nickname nickname agent_type session_id
@@ -216,7 +240,10 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
                 ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname room_id) in
       log_event scoped (Printf.sprintf
         "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
-        room_id nickname (now_iso ()))
+        room_id nickname (now_iso ()));
+      !Room_hooks.observe_agent_lifecycle_fn scoped ~agent_id:nickname ~room_id
+        ~event_kind:"rejoin"
+        ~details:(`Assoc [ ("rejoin", `Bool true) ]);
     end;
     Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname room_id
   end else begin
@@ -260,6 +287,16 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       session_id
       (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
       (now_iso ()));
+    !Room_hooks.observe_agent_lifecycle_fn scoped ~agent_id:nickname ~room_id
+      ~event_kind:"join"
+      ~details:
+        (`Assoc
+          [
+            ("agent_type", `String agent_type);
+            ("session_id", `String session_id);
+            ( "capabilities",
+              `List (List.map (fun s -> `String s) capabilities) );
+          ]);
     Printf.sprintf "✅ %s joined room %s" nickname room_id
   end
 
@@ -322,6 +359,9 @@ let leave config ~agent_name =
     log_event config (Printf.sprintf
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
+    !Room_hooks.observe_agent_lifecycle_fn config ~agent_id:actual_name
+      ~room_id:(room_id_of_config config) ~event_kind:"leave"
+      ~details:`Null;
 
     (* Record co-presence relationships via hook (async, non-blocking) *)
     (try !Room_hooks.relation_on_leave_fn

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -25,6 +25,45 @@ let emit_task_activity config ~agent_name ~task_id ~kind ~payload =
       Log.Misc.warn "task activity emit failed (%s %s): %s" kind task_id
         (Printexc.to_string exn)
 
+let task_status_to_string = function
+  | Types.Todo -> "todo"
+  | Types.Claimed _ -> "claimed"
+  | Types.InProgress _ -> "in_progress"
+  | Types.Done _ -> "done"
+  | Types.Cancelled _ -> "cancelled"
+
+let task_started_at_unix status =
+  let default_time = Time_compat.now () in
+  match status with
+  | Types.Claimed { claimed_at; _ } ->
+      Types.parse_iso8601 ~default_time claimed_at
+  | Types.InProgress { started_at; _ } ->
+      Types.parse_iso8601 ~default_time started_at
+  | _ -> default_time
+
+let task_transition_details ~from_status ~to_status ?notes ?reason ?duration_ms
+    ?(forced = false) () =
+  let optional_field name = function
+    | Some value -> [ (name, value) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("from_status", `String (task_status_to_string from_status));
+       ("to_status", `String (task_status_to_string to_status));
+       ("forced", `Bool forced);
+     ]
+    @ optional_field "notes"
+        (Option.map (fun value -> `String value) notes)
+    @ optional_field "reason"
+        (Option.map (fun value -> `String value) reason)
+    @ optional_field "duration_ms"
+        (Option.map (fun value -> `Int value) duration_ms))
+
+let observe_task_transition config ~agent_name ~task_id ~transition ~details =
+  !Room_hooks.observe_task_transition_fn config ~agent_name
+    ~room_id:(activity_room_id config) ~task_id ~transition ~details
+
 (** Add task — file-locked to prevent task ID collision under concurrency *)
 let add_task config ~title ~priority ~description =
   ensure_initialized config;
@@ -210,6 +249,14 @@ let claim_task config ~agent_name ~task_id =
             log_event config (Printf.sprintf
               "{\"type\":\"task_claim\",\"agent\":\"%s\",\"task\":\"%s\",\"ts\":\"%s\"}"
               agent_name task_id (now_iso ()));
+            observe_task_transition config ~agent_name ~task_id
+              ~transition:"claim"
+              ~details:
+                (task_transition_details ~from_status:Types.Todo
+                   ~to_status:
+                     (Types.Claimed
+                        { assignee = agent_name; claimed_at = now_iso () })
+                   ());
             Printf.sprintf "✅ %s claimed %s" agent_name task_id
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -294,6 +341,17 @@ let claim_task_r config ~agent_name ~task_id
                   emit_task_activity config ~agent_name ~task_id ~kind:"task.claimed"
                     ~payload:(`Assoc [ ("task_id", `String task_id) ]);
                   log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_claim"); ("agent", `String agent_name); ("task", `String task_id); ("ts", `String (now_iso ()))]));
+                  observe_task_transition config ~agent_name ~task_id
+                    ~transition:"claim"
+                    ~details:
+                      (task_transition_details ~from_status:Types.Todo
+                         ~to_status:
+                           (Types.Claimed
+                              {
+                                assignee = agent_name;
+                                claimed_at = now_iso ();
+                              })
+                         ());
                   Ok (Printf.sprintf "✅ %s claimed %s" agent_name task_id)
           end)
       with
@@ -325,14 +383,8 @@ let transition_task_r config ~agent_name ~task_id ~action
                  | None -> Error (Types.TaskNotFound task_id)
                  | Some task ->
                      let now = now_iso () in
+                     let now_ts = Time_compat.now () in
                      let action = String.lowercase_ascii action in
-                     let status_to_string = function
-                       | Types.Todo -> "todo"
-                       | Types.Claimed _ -> "claimed"
-                       | Types.InProgress _ -> "in_progress"
-                       | Types.Done _ -> "done"
-                       | Types.Cancelled _ -> "cancelled"
-                     in
                      let transition =
                        match action, task.task_status with
                        | "claim", Types.Todo ->
@@ -365,7 +417,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                        | _ ->
                            Error (Types.TaskInvalidState
                              (Printf.sprintf "Invalid transition: %s -> %s (%s)"
-                               (status_to_string task.task_status) action task_id))
+                               (task_status_to_string task.task_status) action task_id))
                      in
                      (match transition with
                       | Error e -> Error e
@@ -400,8 +452,8 @@ let transition_task_r config ~agent_name ~task_id ~action
                           log_event config (Printf.sprintf
                             "{\"type\":\"task_transition\",\"agent\":\"%s\",\"task\":\"%s\",\"action\":\"%s\",\"from\":\"%s\",\"to\":\"%s\",\"ts\":\"%s\"}"
                             agent_name task_id action
-                            (status_to_string task.task_status)
-                            (status_to_string new_status)
+                            (task_status_to_string task.task_status)
+                            (task_status_to_string new_status)
                             now);
                           (match action with
                            | "claim" ->
@@ -435,9 +487,28 @@ let transition_task_r config ~agent_name ~task_id ~action
                                  ~kind:"task.released"
                                  ~payload:(`Assoc [ ("task_id", `String task_id) ])
                            | _ -> ());
+                          let duration_ms =
+                            match action with
+                            | "done" | "cancel" ->
+                                Some
+                                  (max 0
+                                     (int_of_float
+                                        ((now_ts
+                                         -. task_started_at_unix task.task_status)
+                                        *. 1000.0)))
+                            | _ -> None
+                          in
+                          observe_task_transition config ~agent_name ~task_id
+                            ~transition:action
+                            ~details:
+                              (task_transition_details
+                                 ~from_status:task.task_status ~to_status:new_status
+                                 ?notes:(if notes = "" then None else Some notes)
+                                 ?reason:(if reason = "" then None else Some reason)
+                                 ?duration_ms ~forced:force ());
                           Ok (Printf.sprintf "✅ %s %s → %s" task_id
-                                (status_to_string task.task_status)
-                                (status_to_string new_status))
+                                (task_status_to_string task.task_status)
+                                (task_status_to_string new_status))
                      ))
           with
       | Eio.Cancel.Cancelled _ as e -> raise e
@@ -516,6 +587,25 @@ let complete_task config ~agent_name ~task_id ~notes =
               agent_name task_id
               (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes)
               (now_iso ()));
+            observe_task_transition config ~agent_name ~task_id
+              ~transition:"done"
+              ~details:
+                (task_transition_details ~from_status:task.task_status
+                   ~to_status:
+                     (Types.Done
+                        {
+                          assignee = agent_name;
+                          completed_at = now_iso ();
+                          notes = if notes = "" then None else Some notes;
+                        })
+                   ?notes:(if notes = "" then None else Some notes)
+                   ~duration_ms:
+                     (max 0
+                        (int_of_float
+                           ((Time_compat.now ()
+                            -. task_started_at_unix task.task_status)
+                           *. 1000.0)))
+                   ());
             (* Record task collaboration via hook (async, non-blocking) *)
             (try
                let active = (Room_state.read_state config).active_agents in
@@ -596,6 +686,25 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                       ("notes", if notes = "" then `Null else `String notes);
                     ]);
               log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_done"); ("agent", `String agent_name); ("task", `String task_id); ("notes", if notes = "" then `Null else `String notes); ("ts", `String (now_iso ()))]));
+              observe_task_transition config ~agent_name ~task_id
+                ~transition:"done"
+                ~details:
+                  (task_transition_details ~from_status:task.task_status
+                     ~to_status:
+                       (Types.Done
+                          {
+                            assignee = agent_name;
+                            completed_at = now_iso ();
+                            notes = if notes = "" then None else Some notes;
+                          })
+                     ?notes:(if notes = "" then None else Some notes)
+                     ~duration_ms:
+                       (max 0
+                          (int_of_float
+                             ((Time_compat.now ()
+                              -. task_started_at_unix task.task_status)
+                             *. 1000.0)))
+                     ());
               (* Agent Economy: earn credits via hook *)
               !Room_hooks.agent_economy_earn_fn
                 ~base_path:config.base_path ~agent_name
@@ -664,6 +773,25 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                       ("reason", if reason = "" then `Null else `String reason);
                     ]);
               log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_cancelled"); ("agent", `String agent_name); ("task", `String task_id); ("reason", if reason = "" then `Null else `String reason); ("ts", `String (now_iso ()))]));
+              observe_task_transition config ~agent_name ~task_id
+                ~transition:"cancel"
+                ~details:
+                  (task_transition_details ~from_status:task.task_status
+                     ~to_status:
+                       (Types.Cancelled
+                          {
+                            cancelled_by = agent_name;
+                            cancelled_at = now_iso ();
+                            reason = if reason = "" then None else Some reason;
+                          })
+                     ?reason:(if reason = "" then None else Some reason)
+                     ~duration_ms:
+                       (max 0
+                          (int_of_float
+                             ((Time_compat.now ()
+                              -. task_started_at_unix task.task_status)
+                             *. 1000.0)))
+                     ());
               Ok (Printf.sprintf "🚫 %s cancelled %s" agent_name task_id)
             end
       with

--- a/lib/room/room_task_schedule.ml
+++ b/lib/room/room_task_schedule.ml
@@ -36,6 +36,17 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
             String.equal assignee agent_name
         | Todo | Done _ | Cancelled _ -> false
       ) backlog.tasks in
+      let observe_auto_release () =
+        match previous_claim with
+        | Some prev ->
+            Room_task.observe_task_transition config ~agent_name ~task_id:prev.id
+              ~transition:"release"
+              ~details:
+                (Room_task.task_transition_details ~from_status:prev.task_status
+                   ~to_status:Types.Todo
+                   ~reason:"auto_release_before_claim_next" ())
+        | None -> ()
+      in
       let released_task_id, working_tasks = match previous_claim with
         | None -> None, backlog.tasks
         | Some prev ->
@@ -146,7 +157,8 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
                  last_updated = now_iso ();
                  version = backlog.version + 1;
                } in
-               write_backlog config new_backlog
+               write_backlog config new_backlog;
+               observe_auto_release ()
            | None -> ());
           clear_agent_state_after_release ();
           Claim_next_no_unclaimed
@@ -158,7 +170,8 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
                  last_updated = now_iso ();
                  version = backlog.version + 1;
                } in
-               write_backlog config new_backlog
+               write_backlog config new_backlog;
+               observe_auto_release ()
            | None -> ());
           clear_agent_state_after_release ();
           Claim_next_no_eligible { excluded_count = List.length exclude_task_ids }
@@ -204,7 +217,8 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
            | Some rid ->
                Room_task.emit_task_activity config ~agent_name ~task_id:rid
                  ~kind:"task.released"
-                 ~payload:(`Assoc [ ("task_id", `String rid) ])
+                 ~payload:(`Assoc [ ("task_id", `String rid) ]);
+               observe_auto_release ()
            | None -> ());
           Room_task.emit_task_activity config ~agent_name ~task_id:task.id
             ~kind:"task.claimed"
@@ -219,6 +233,14 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(stale_threshold_day
           log_event config (Printf.sprintf
             "{\"type\":\"task_claim_next\",\"agent\":\"%s\",\"task\":\"%s\",\"priority\":%d,\"ts\":\"%s\"}"
             agent_name task.id task.priority (now_iso ()));
+          Room_task.observe_task_transition config ~agent_name ~task_id:task.id
+            ~transition:"claim"
+            ~details:
+              (Room_task.task_transition_details ~from_status:Types.Todo
+                 ~to_status:
+                   (Types.Claimed
+                      { assignee = agent_name; claimed_at = now_iso () })
+                 ());
 
           let message = match released_task_id with
             | Some rid ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -92,6 +92,19 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
   in
   Audit_log.log_tool_call state.Mcp_server.room_config
     ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
+  if not success then
+    Log.emit Log.Error ~module_name:"Keeper"
+      ~details:
+        (`Assoc
+          [
+            ("event_family", `String "tool_call_failure");
+            ("tool_name", `String "masc_keeper_msg");
+            ("agent_name", `String agent_name);
+            ("duration_ms", `Int duration_ms);
+            ("timeout_hit", `Bool !timeout_hit);
+            ("streaming", `Bool false);
+          ])
+      "keeper tool call failed: masc_keeper_msg";
   let telemetry_enabled =
     match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
     | Some "false" | Some "0" -> false
@@ -293,6 +306,19 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
   in
   Audit_log.log_tool_call state.Mcp_server.room_config ~agent_id:agent_name
     ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
+  if not success then
+    Log.emit Log.Error ~module_name:"Keeper"
+      ~details:
+        (`Assoc
+          [
+            ("event_family", `String "tool_call_failure");
+            ("tool_name", `String "masc_keeper_msg");
+            ("agent_name", `String agent_name);
+            ("duration_ms", `Int duration_ms);
+            ("timeout_hit", `Bool !timeout_hit);
+            ("streaming", `Bool true);
+          ])
+      "keeper tool call failed: masc_keeper_msg";
   let telemetry_enabled =
     match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
     | Some "false" | Some "0" -> false

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -111,7 +111,8 @@ let add_routes ~sw ~clock router =
            in
            match report_result with
            | Ok report ->
-               Dashboard_tool_host_events.record state.Mcp_server.room_config
+               Dashboard_tool_host_events.record ?fs:state.Mcp_server.fs
+                 state.Mcp_server.room_config
                  report;
                Http.Response.json ~compress:true ~request:req {|{"ok":true}|}
                  reqd

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -126,13 +126,13 @@ let event_to_json event =
 
 (** Track an event - appends to date-split telemetry store.
     Thread-safe via Dated_jsonl internal mutex. *)
-let track ~fs:_ config event : unit =
+let track ?fs:_ config event : unit =
   let store = get_telemetry_store config in
   Dated_jsonl.append store (event_to_json event)
 
 (** Read all events.
     Tries date-split store first; falls back to legacy single file. *)
-let read_all_events ~fs:_ config : event_record list =
+let read_all_events ?fs:_ config : event_record list =
   let store = get_telemetry_store config in
   let jsons = Dated_jsonl.read_recent store 100_000 in
   if jsons <> [] then
@@ -149,11 +149,7 @@ let summarize_tool_usage ?fs config : tool_usage_summary =
   in
   let stats_by_tool = Hashtbl.create 32 in
   let total_calls = ref 0 in
-  let records =
-    match fs with
-    | Some fs -> read_all_events ~fs config
-    | None -> read_all_events_from_path telemetry_path
-  in
+  let records = read_all_events ?fs config in
   List.iter (fun (record : event_record) ->
     match record.event with
     | Tool_called { tool_name; success; _ } ->
@@ -180,11 +176,7 @@ type agent_activity = {
 }
 
 let summarize_agent_activity ?fs config ~since : agent_activity list =
-  let records =
-    match fs with
-    | Some fs -> read_all_events ~fs config
-    | None -> read_all_events_from_path (telemetry_file config)
-  in
+  let records = read_all_events ?fs config in
   let by_agent : (string, agent_activity) Hashtbl.t = Hashtbl.create 16 in
   List.iter (fun (record : event_record) ->
     if record.timestamp >= since then
@@ -233,8 +225,8 @@ let tool_usage_fields summary tool_name =
 
 (** Read events since a timestamp.
     With date-split storage, reads recent entries and filters by timestamp. *)
-let read_events_since ~fs config ~since : event_record list =
-  let all = read_all_events ~fs config in
+let read_events_since ?fs config ~since : event_record list =
+  let all = read_all_events ?fs config in
   List.filter (fun r -> r.timestamp >= since) all
 
 (** Metrics calculation functions (pure) *)
@@ -310,10 +302,10 @@ let calculate_error_rate events =
   else float_of_int errors /. float_of_int total
 
 (** Get aggregated metrics for last 24 hours *)
-let get_metrics ~fs config : metrics =
+let get_metrics ?fs config : metrics =
   let now = Time_compat.now () in
   let since_24h = now -. 86400.0 in
-  let events = read_events_since ~fs config ~since:since_24h in
+  let events = read_events_since ?fs config ~since:since_24h in
   {
     active_agents = count_active_agents events;
     tasks_in_progress = count_tasks_in_progress events;
@@ -324,26 +316,26 @@ let get_metrics ~fs config : metrics =
   }
 
 (** Convenience tracking functions *)
-let track_agent_joined ~fs config ~agent_id ?(capabilities=[]) () =
-  track ~fs config (Agent_joined { agent_id; capabilities })
+let track_agent_joined ?fs config ~agent_id ?(capabilities=[]) () =
+  track ?fs config (Agent_joined { agent_id; capabilities })
 
-let track_agent_left ~fs config ~agent_id ~reason =
-  track ~fs config (Agent_left { agent_id; reason })
+let track_agent_left ?fs config ~agent_id ~reason =
+  track ?fs config (Agent_left { agent_id; reason })
 
-let track_task_started ~fs config ~task_id ~agent_id =
-  track ~fs config (Task_started { task_id; agent_id })
+let track_task_started ?fs config ~task_id ~agent_id =
+  track ?fs config (Task_started { task_id; agent_id })
 
-let track_task_completed ~fs config ~task_id ~duration_ms ~success =
-  track ~fs config (Task_completed { task_id; duration_ms; success })
+let track_task_completed ?fs config ~task_id ~duration_ms ~success =
+  track ?fs config (Task_completed { task_id; duration_ms; success })
 
-let track_handoff ~fs config ~from_agent ~to_agent ~reason =
-  track ~fs config (Handoff_triggered { from_agent; to_agent; reason })
+let track_handoff ?fs config ~from_agent ~to_agent ~reason =
+  track ?fs config (Handoff_triggered { from_agent; to_agent; reason })
 
-let track_error ~fs config ~code ~message ~context =
-  track ~fs config (Error_occurred { code; message; context })
+let track_error ?fs config ~code ~message ~context =
+  track ?fs config (Error_occurred { code; message; context })
 
-let track_tool_called ~fs config ~tool_name ~success ~duration_ms ?agent_id () =
-  track ~fs config (Tool_called { tool_name; success; duration_ms; agent_id })
+let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id () =
+  track ?fs config (Tool_called { tool_name; success; duration_ms; agent_id })
 
 (** Prune telemetry entries older than [max_age_days] days.
     Replaces the old rotate function; date-split makes rewriting unnecessary. *)

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -12,11 +12,27 @@ type audit_event = {
   event_type: string;
   success: bool;
   detail: string option;
+  details: Yojson.Safe.t option;
 }
 
-(* Audit log path *)
-let audit_log_path (config : Room.config) =
-  Filename.concat (Room_utils.masc_dir config) "audit.jsonl"
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.sub value 0 prefix_len = prefix
+
+let normalize_event_type value =
+  if has_prefix ~prefix:"tool_call:" value then
+    "tool_call"
+  else
+    value
+
+let details_option = function
+  | `Null -> None
+  | json -> Some json
+
+let detail_string_of_details = function
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
 
 (* Convert audit event to JSON *)
 let audit_event_to_json (e : audit_event) : Yojson.Safe.t =
@@ -26,60 +42,35 @@ let audit_event_to_json (e : audit_event) : Yojson.Safe.t =
     ("event_type", `String e.event_type);
     ("success", `Bool e.success);
     ("detail", match e.detail with Some d -> `String d | None -> `Null);
+    ("details", match e.details with Some json -> json | None -> `Null);
   ]
 
-(* Read audit events since given timestamp.
-   Supports both legacy simple format ("agent"/"event_type"/"success")
-   and canonical Audit_log rich format ("agent_id"/"action"/"outcome"). *)
+(* Read audit events since given timestamp from the canonical date-split audit store. *)
 let read_audit_events (config : Room.config) ~since : audit_event list =
-  let path = audit_log_path config in
-  if not (Sys.file_exists path) then []
-  else
-    let content = In_channel.with_open_text path In_channel.input_all in
-    let lines = String.split_on_char '\n' content |> List.filter (fun s -> String.trim s <> "") in
-    List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        let module U = Yojson.Safe.Util in
-        let timestamp =
-          match U.member "timestamp" json with
-          | `Float f -> f
-          | `Int i -> float_of_int i
-          | `String s -> (try float_of_string s with Failure _ -> 0.0)
-          | _ -> 0.0
-        in
-        if timestamp < since then None
-        else
-          (* Try rich format first (agent_id/action/outcome), fall back to legacy *)
-          let agent =
-            match U.to_string_option (U.member "agent_id" json) with
-            | Some a -> a
-            | None -> json |> U.member "agent" |> U.to_string
-          in
-          let event_type =
-            match U.to_string_option (U.member "action" json) with
-            | Some a -> a
-            | None -> json |> U.member "event_type" |> U.to_string
-          in
-          let success =
-            match U.member "outcome" json with
-            | `Assoc _ as outcome ->
-                let status = U.to_string_option (U.member "status" outcome) in
-                (match status with Some "success" -> true | _ -> false)
-            | `String "success" -> true
-            | _ ->
-                (match U.to_bool_option (U.member "success" json) with
-                 | Some b -> b
-                 | None -> false)
-          in
-          let detail =
-            match U.to_string_option (U.member "detail" json) with
-            | Some _ as d -> d
-            | None -> U.to_string_option (U.member "details" json)
-          in
-          Some { timestamp; agent; event_type; success; detail }
-      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Not_found -> None
-    ) lines
+  Audit_log.read_entries config
+  |> List.filter (fun (entry : Audit_log.audit_entry) -> entry.timestamp >= since)
+  |> List.map (fun (entry : Audit_log.audit_entry) ->
+         let details = details_option entry.details in
+         let detail =
+           match detail_string_of_details entry.details with
+           | Some value -> Some value
+           | None ->
+               (match entry.outcome with
+                | Audit_log.Failure reason -> Some reason
+                | Audit_log.Success -> None)
+         in
+         {
+           timestamp = entry.timestamp;
+           agent = entry.agent_id;
+           event_type =
+             normalize_event_type (Audit_log.action_to_string entry.action);
+           success =
+             (match entry.outcome with
+              | Audit_log.Success -> true
+              | Audit_log.Failure _ -> false);
+           detail;
+           details;
+         })
 
 (* Handle masc_audit_query *)
 let handle_audit_query ctx args =
@@ -97,7 +88,7 @@ let handle_audit_query ctx args =
         | None -> true)
     |> List.filter (fun e ->
         if event_type = "all" then true
-        else e.event_type = event_type)
+        else e.event_type = normalize_event_type event_type)
     (* Sort newest-first so limit returns the most recent events *)
     |> List.sort (fun a b -> Float.compare b.timestamp a.timestamp)
   in
@@ -146,7 +137,10 @@ let handle_audit_stats ctx args =
   let stats_for agent_id =
     let agent_events = List.filter (fun e -> e.agent = agent_id) events in
     let count_type t =
-      List.fold_left (fun acc e -> if e.event_type = t then acc + 1 else acc) 0 agent_events
+      let normalized = normalize_event_type t in
+      List.fold_left
+        (fun acc e -> if e.event_type = normalized then acc + 1 else acc)
+        0 agent_events
     in
     let auth_success = count_type "auth_success" in
     let auth_failure = count_type "auth_failure" in
@@ -380,6 +374,13 @@ Pair with masc_audit_stats for aggregate trust metrics, masc_auth_list for crede
             `String "auth_failure";
             `String "anomaly_detected";
             `String "security_violation";
+            `String "join";
+            `String "leave";
+            `String "claim_task";
+            `String "start_task";
+            `String "done_task";
+            `String "cancel_task";
+            `String "release_task";
             `String "tool_call";
             `String "all"
           ]);

--- a/lib/tool_audit.mli
+++ b/lib/tool_audit.mli
@@ -11,6 +11,7 @@ type audit_event = {
   event_type: string;
   success: bool;
   detail: string option;
+  details: Yojson.Safe.t option;
 }
 
 (** {1 Governance Report Types} *)
@@ -60,4 +61,3 @@ val report_to_json : governance_report -> Yojson.Safe.t
 
 (** Tool schemas for MCP tools/list *)
 val schemas : Types.tool_schema list
-

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -284,17 +284,6 @@ let handle_join (ctx : context) : result option =
   ] in
   let _pushed = Session.push_notification_to_active_agents registry ~event:join_event in
   Mcp_server.sse_broadcast state join_event;
-  Audit_log.log_join config ~agent_id:nickname
-    ~room_id:(Filename.basename config.base_path) ();
-  Prometheus.inc_gauge "masc_active_agents" ();
-  (match state.Mcp_server.fs with
-   | Some fs ->
-       (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-          Log.Telemetry.debug "track_agent_joined (join): %s" (Printexc.to_string exn))
-   | None -> ());
   Some (true, final_result)
 
 (** masc_leave — leave a MASC room *)
@@ -318,15 +307,4 @@ let handle_leave (ctx : context) : result option =
     let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" session_id in
     Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
   end;
-  Audit_log.log_leave config ~agent_id:agent_name
-    ~room_id:(Filename.basename config.base_path) ();
-  Prometheus.dec_gauge "masc_active_agents" ();
-  (match state.Mcp_server.fs with
-   | Some fs ->
-       (try Telemetry_eio.track_agent_left ~fs config ~agent_id:agent_name ~reason:"leave"
-        with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | exn ->
-          Log.Telemetry.debug "track_agent_left: %s" (Printexc.to_string exn))
-   | None -> ());
   Some (true, result)

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -108,6 +108,23 @@ let handle_suspend ctx args =
       ~agent_id:target_agent
       ~opened:true
       ~reason:("Suspended by " ^ caller) ();
+    let details =
+      `Assoc
+        [
+          ("event_family", `String "agent_suspension");
+          ("caller_agent", `String caller);
+          ("target_agent", `String target_agent);
+          ("reason", `String reason);
+          ("duration_hours", `Float duration_hours);
+          ("rooms_affected", `Int rooms_affected);
+          ("is_self_suspend", `Bool is_self);
+        ]
+    in
+    Log.emit Log.Warn ~module_name:"Session" ~details
+      (Printf.sprintf "agent suspended: %s by %s" target_agent caller);
+    Telemetry_eio.track_error ctx.config ~code:"agent_suspended"
+      ~message:(Printf.sprintf "%s suspended by %s" target_agent caller)
+      ~context:"tool_suspend";
 
     Log.Session.warn "[Suspend] Agent '%s' suspended by '%s': %s (%.1fh, %d rooms)"
       target_agent caller reason duration_hours rooms_affected;

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -88,11 +88,7 @@ let handle_claim ctx args =
          ("task_id", `String task_id);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ]);
-       (* Audit: log claim event *)
-       Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name
-         ~room_id:(Filename.basename ctx.config.base_path)
-         ~task_id ()
+       ])
    | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
   result_to_response result
 
@@ -240,11 +236,7 @@ let handle_cancel_task ctx args =
          ("agent_name", `String ctx.agent_name);
          ("reason", `String reason);
          ("timestamp", `Float (Time_compat.now ()));
-       ]);
-       (* Audit: log cancel event *)
-       Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name
-         ~room_id:(Filename.basename ctx.config.base_path)
-         ~task_id ~reason ()
+       ])
    | Error err ->
        Log.Task.error "metrics record failed: %s" (Types.masc_error_to_string err));
   result_to_response result
@@ -365,18 +357,7 @@ let handle_transition ctx args =
          ("action", `String action);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ]);
-       (* Audit: log transition event by action type *)
-       let room_id = Filename.basename ctx.config.base_path in
-       (match action_lc with
-        | "claim" ->
-            Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
-        | "done" ->
-            Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
-        | "cancel" ->
-            Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id
-              ~reason:(if reason = "" then "cancelled" else reason) ()
-        | _ -> ())
+       ])
    | Error err ->
        Log.Task.error "task transition failed: %s" (Types.masc_error_to_string err));
   (* Record metrics *)

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -55,7 +55,7 @@ let test_report_of_yojson_accepts_stringish_ids () =
       check (option int) "timeout_ms" (Some 120000) report.timeout_ms;
       check (option string) "trace_id" (Some "trace-1") report.trace_id
 
-let test_record_writes_audit_and_ring () =
+let test_record_writes_audit_ring_and_telemetry () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -76,7 +76,7 @@ let test_record_writes_audit_and_ring () =
           timeout_ms = Some 120000;
         }
       in
-      Dashboard_tool_host_events.record config report;
+      Dashboard_tool_host_events.record ~fs:() config report;
       let entries = Audit_log.read_entries ~n:20 config in
       let matching =
         List.find_opt
@@ -103,7 +103,19 @@ let test_record_writes_audit_and_ring () =
       check string "ring source" "client_tool_host" latest.source;
       check string "ring module" "ToolHost" latest.module_name;
       check bool "ring details object" true
-        (match latest.details with `Assoc _ -> true | _ -> false))
+        (match latest.details with `Assoc _ -> true | _ -> false);
+      let telemetry_events = Telemetry_eio.read_all_events config in
+      let has_client_error =
+        List.exists
+          (fun (entry : Telemetry_eio.event_record) ->
+            match entry.event with
+            | Telemetry_eio.Error_occurred { code; context; _ } ->
+                String.equal code "client_tool_host_failure"
+                && String.contains context '='
+            | _ -> false)
+          telemetry_events
+      in
+      check bool "telemetry error recorded" true has_client_error)
 
 let () =
   run "Dashboard_tool_host_events"
@@ -113,7 +125,7 @@ let () =
           test_case "report defaults" `Quick test_report_of_yojson_defaults;
           test_case "report stringish ids" `Quick
             test_report_of_yojson_accepts_stringish_ids;
-          test_case "record writes audit and ring" `Quick
-            test_record_writes_audit_and_ring;
+          test_case "record writes audit ring and telemetry" `Quick
+            test_record_writes_audit_ring_and_telemetry;
         ] );
     ]

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -384,6 +384,7 @@ let test_audit_event_to_json_full () =
     event_type = "tool_call";
     success = true;
     detail = Some "masc_status";
+    details = Some (`Assoc [("tool_name", `String "masc_status")]);
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
@@ -400,6 +401,7 @@ let test_audit_event_to_json_no_detail () =
     event_type = "join";
     success = false;
     detail = None;
+    details = None;
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -64,6 +64,49 @@ let with_test_env f =
     Unix.rmdir tmp_dir;
     raise e
 
+let latest_ring_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.seq
+  | [] -> 0
+
+let detail_string details key =
+  match details with
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let detail_matches details expected =
+  List.for_all
+    (fun (key, value) ->
+      match detail_string details key with
+      | Some actual -> String.equal actual value
+      | None -> false)
+    expected
+
+let find_agent_name_by_prefix config prefix =
+  match
+    List.find_opt
+      (fun (agent : Types.agent) -> String.starts_with ~prefix agent.name)
+      (Room.get_agents_raw config)
+  with
+  | Some agent -> agent.name
+  | None -> Alcotest.failf "agent with prefix %s not found" prefix
+
+let audit_has_entry entries ~agent_id ~action_pred ~details =
+  List.exists
+    (fun (entry : Audit_log.audit_entry) ->
+      String.equal entry.agent_id agent_id
+      && action_pred entry.action
+      && detail_matches entry.details details)
+    entries
+
+let ring_has_entry entries ~details =
+  List.exists
+    (fun (entry : Log.Ring.entry) -> detail_matches entry.details details)
+    entries
+
 (* ============================================================ *)
 (* Batch Operations Tests                                        *)
 (* ============================================================ *)
@@ -373,6 +416,279 @@ let test_transition_version_mismatch () =
     | Error Types.TaskInvalidState _ -> ()
     | _ -> Alcotest.fail "Expected TaskInvalidState for version mismatch"
   )
+
+(* ============================================================ *)
+(* Observability Tests                                           *)
+(* ============================================================ *)
+
+let test_join_leave_emit_observability () =
+  with_test_env (fun config ->
+    let before_seq = latest_ring_seq () in
+    let join_result =
+      Room.join config ~agent_name:"gemini" ~capabilities:[ "review" ] ()
+    in
+    Alcotest.(check bool) "join succeeds" true (contains_check join_result);
+    let gemini = find_agent_name_by_prefix config "gemini" in
+    let leave_result = Room.leave config ~agent_name:gemini in
+    Alcotest.(check bool) "leave succeeds" true (contains_check leave_result);
+
+    let audit_entries = Audit_log.read_entries ~n:50 config in
+    Alcotest.(check bool) "audit join recorded" true
+      (audit_has_entry audit_entries ~agent_id:gemini
+         ~action_pred:(function Audit_log.Join -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "agent_lifecycle");
+             ("event_kind", "join");
+             ("room_id", "default");
+           ]);
+    Alcotest.(check bool) "audit leave recorded" true
+      (audit_has_entry audit_entries ~agent_id:gemini
+         ~action_pred:(function Audit_log.Leave -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "agent_lifecycle");
+             ("event_kind", "leave");
+             ("room_id", "default");
+           ]);
+
+    let telemetry_events = Telemetry_eio.read_all_events config in
+    let has_joined =
+      List.exists
+        (fun (entry : Telemetry_eio.event_record) ->
+          match entry.event with
+          | Telemetry_eio.Agent_joined { agent_id; _ } ->
+              String.equal agent_id gemini
+          | _ -> false)
+        telemetry_events
+    in
+    let has_left =
+      List.exists
+        (fun (entry : Telemetry_eio.event_record) ->
+          match entry.event with
+          | Telemetry_eio.Agent_left { agent_id; reason } ->
+              String.equal agent_id gemini && String.equal reason "leave"
+          | _ -> false)
+        telemetry_events
+    in
+    Alcotest.(check bool) "telemetry join recorded" true has_joined;
+    Alcotest.(check bool) "telemetry leave recorded" true has_left;
+
+    let ring_entries =
+      Log.Ring.recent ~limit:50 ~module_filter:"Room" ~since_seq:before_seq ()
+    in
+    Alcotest.(check bool) "ring join recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "agent_lifecycle");
+             ("event_kind", "join");
+             ("agent_id", gemini);
+           ]);
+    Alcotest.(check bool) "ring leave recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "agent_lifecycle");
+             ("event_kind", "leave");
+             ("agent_id", gemini);
+           ]))
+
+let test_task_transitions_emit_observability () =
+  with_test_env (fun config ->
+    let before_seq = latest_ring_seq () in
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ = Room.add_task config ~title:"Observed Task" ~priority:1 ~description:"" in
+
+    (match Room.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+    | Ok _ -> ()
+    | Error err ->
+        Alcotest.failf "claim_task_r failed: %s"
+          (Types.show_masc_error err));
+    (match
+       Room.transition_task_r config ~agent_name:claude ~task_id:"task-001"
+         ~action:"start" ()
+     with
+    | Ok _ -> ()
+    | Error err ->
+        Alcotest.failf "transition_task_r start failed: %s"
+          (Types.show_masc_error err));
+    (match
+       Room.complete_task_r config ~agent_name:claude ~task_id:"task-001"
+         ~notes:"done" with
+    | Ok _ -> ()
+    | Error err ->
+        Alcotest.failf "complete_task_r failed: %s"
+          (Types.show_masc_error err));
+
+    let audit_entries = Audit_log.read_entries ~n:50 config in
+    Alcotest.(check bool) "audit claim recorded" true
+      (audit_has_entry audit_entries ~agent_id:claude
+         ~action_pred:(function Audit_log.ClaimTask -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "claim");
+             ("task_id", "task-001");
+           ]);
+    Alcotest.(check bool) "audit start recorded" true
+      (audit_has_entry audit_entries ~agent_id:claude
+         ~action_pred:(function Audit_log.StartTask -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "start");
+             ("task_id", "task-001");
+           ]);
+    Alcotest.(check bool) "audit done recorded" true
+      (audit_has_entry audit_entries ~agent_id:claude
+         ~action_pred:(function Audit_log.DoneTask -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "done");
+             ("task_id", "task-001");
+           ]);
+
+    let telemetry_events = Telemetry_eio.read_all_events config in
+    let has_started =
+      List.exists
+        (fun (entry : Telemetry_eio.event_record) ->
+          match entry.event with
+          | Telemetry_eio.Task_started { task_id; agent_id } ->
+              String.equal task_id "task-001" && String.equal agent_id claude
+          | _ -> false)
+        telemetry_events
+    in
+    let has_completed =
+      List.exists
+        (fun (entry : Telemetry_eio.event_record) ->
+          match entry.event with
+          | Telemetry_eio.Task_completed { task_id; success; _ } ->
+              String.equal task_id "task-001" && success
+          | _ -> false)
+        telemetry_events
+    in
+    Alcotest.(check bool) "telemetry start recorded" true has_started;
+    Alcotest.(check bool) "telemetry completion recorded" true has_completed;
+
+    let ring_entries =
+      Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
+    in
+    Alcotest.(check bool) "ring claim recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "claim");
+             ("task_id", "task-001");
+           ]);
+    Alcotest.(check bool) "ring start recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "start");
+             ("task_id", "task-001");
+           ]);
+    Alcotest.(check bool) "ring done recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "done");
+             ("task_id", "task-001");
+           ]))
+
+let test_complete_task_legacy_emits_observability () =
+  with_test_env (fun config ->
+    let before_seq = latest_ring_seq () in
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ = Room.add_task config ~title:"Legacy Task" ~priority:1 ~description:"" in
+    let claim_result = Room.claim_task config ~agent_name:claude ~task_id:"task-001" in
+    Alcotest.(check bool) "legacy claim succeeds" true
+      (contains_check claim_result);
+    let done_result =
+      Room.complete_task config ~agent_name:claude ~task_id:"task-001"
+        ~notes:"legacy path"
+    in
+    Alcotest.(check bool) "legacy complete succeeds" true
+      (contains_check done_result);
+
+    let audit_entries = Audit_log.read_entries ~n:50 config in
+    Alcotest.(check bool) "legacy audit done recorded" true
+      (audit_has_entry audit_entries ~agent_id:claude
+         ~action_pred:(function Audit_log.DoneTask -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "done");
+             ("task_id", "task-001");
+           ]);
+
+    let telemetry_events = Telemetry_eio.read_all_events config in
+    let has_completed =
+      List.exists
+        (fun (entry : Telemetry_eio.event_record) ->
+          match entry.event with
+          | Telemetry_eio.Task_completed { task_id; success; _ } ->
+              String.equal task_id "task-001" && success
+          | _ -> false)
+        telemetry_events
+    in
+    Alcotest.(check bool) "legacy telemetry completion recorded" true
+      has_completed;
+
+    let ring_entries =
+      Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
+    in
+    Alcotest.(check bool) "legacy ring done recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "done");
+             ("task_id", "task-001");
+           ]))
+
+let test_claim_next_auto_release_emits_release_observability () =
+  with_test_env (fun config ->
+    let before_seq = latest_ring_seq () in
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ = Room.add_task config ~title:"First" ~priority:1 ~description:"" in
+    let _ = Room.add_task config ~title:"Second" ~priority:2 ~description:"" in
+
+    (match Room.claim_next_r config ~agent_name:claude () with
+    | Room.Claim_next_claimed _ -> ()
+    | _ -> Alcotest.fail "expected first claim_next_r to succeed");
+    (match Room.claim_next_r config ~agent_name:claude () with
+    | Room.Claim_next_claimed { released_task_id = Some released; task_id; _ } ->
+        Alcotest.(check string) "released task id" "task-001" released;
+        Alcotest.(check string) "new task id" "task-002" task_id
+    | _ -> Alcotest.fail "expected auto-release on second claim_next_r");
+
+    let audit_entries = Audit_log.read_entries ~n:50 config in
+    Alcotest.(check bool) "audit release recorded" true
+      (audit_has_entry audit_entries ~agent_id:claude
+         ~action_pred:(function Audit_log.ReleaseTask -> true | _ -> false)
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "release");
+             ("task_id", "task-001");
+           ]);
+
+    let ring_entries =
+      Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
+    in
+    Alcotest.(check bool) "ring release recorded" true
+      (ring_has_entry ring_entries
+         ~details:
+           [
+             ("event_family", "task_transition");
+             ("transition", "release");
+             ("task_id", "task-001");
+           ]))
 
 (* ============================================================ *)
 (* Pause/Resume Tests                                            *)
@@ -694,6 +1010,18 @@ let () =
       Alcotest.test_case "release" `Quick test_transition_release;
       Alcotest.test_case "invalid" `Quick test_transition_invalid;
       Alcotest.test_case "version mismatch" `Quick test_transition_version_mismatch;
+    ];
+
+    (* === Observability === *)
+    "observability", [
+      Alcotest.test_case "join leave fan-out" `Quick
+        test_join_leave_emit_observability;
+      Alcotest.test_case "task transitions fan-out" `Quick
+        test_task_transitions_emit_observability;
+      Alcotest.test_case "legacy complete fan-out" `Quick
+        test_complete_task_legacy_emits_observability;
+      Alcotest.test_case "claim_next auto-release fan-out" `Quick
+        test_claim_next_auto_release_emits_release_observability;
     ];
 
     (* === Pause/Resume === *)

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -10,6 +10,24 @@
 open Alcotest
 
 module Telemetry_eio = Masc_mcp.Telemetry_eio
+module Room = Masc_mcp.Room
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_telemetry_eio_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
 
 (* ============================================================
    event Type Tests
@@ -334,6 +352,25 @@ let test_calculate_error_rate_some_errors () =
   let rate = Telemetry_eio.calculate_error_rate events in
   check bool "positive" true (rate > 0.0)
 
+let test_summarize_tool_usage_reads_date_split_store_without_fs () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun _env ->
+      let config = Room.default_config base_dir in
+      Telemetry_eio.track_tool_called config ~tool_name:"masc_status"
+        ~success:true ~duration_ms:42 ~agent_id:"codex" ();
+      let summary = Telemetry_eio.summarize_tool_usage config in
+      check int "total calls" 1 summary.total_calls;
+      let stats =
+        match Hashtbl.find_opt summary.stats_by_tool "masc_status" with
+        | Some stats -> stats
+        | None -> fail "missing stats for masc_status"
+      in
+      check int "usage count" 1 stats.count;
+      check bool "telemetry available" true summary.telemetry_available)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -393,5 +430,9 @@ let () =
       test_case "empty" `Quick test_calculate_error_rate_empty;
       test_case "no errors" `Quick test_calculate_error_rate_no_errors;
       test_case "some errors" `Quick test_calculate_error_rate_some_errors;
+    ];
+    "store_reads", [
+      test_case "summarize_tool_usage reads date-split store" `Quick
+        test_summarize_tool_usage_reads_date_split_store_without_fs;
     ];
   ]

--- a/test/test_tool_audit_coverage.ml
+++ b/test/test_tool_audit_coverage.ml
@@ -8,6 +8,7 @@ module Tool_args = Masc_mcp.Tool_args
 
 module Tool_audit = Masc_mcp.Tool_audit
 module Room = Masc_mcp.Room
+module Audit_log = Masc_mcp.Audit_log
 
 let test_counter = ref 0
 
@@ -30,6 +31,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));
@@ -112,6 +114,7 @@ let test_event_to_json_with_detail () =
     event_type = "tool_call";
     success = true;
     detail = Some "test detail";
+    details = Some (`Assoc [("tool_name", `String "masc_status")]);
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
@@ -129,11 +132,14 @@ let test_event_to_json_no_detail () =
     event_type = "auth_success";
     success = true;
     detail = None;
+    details = None;
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
   Alcotest.(check bool) "detail is null" true
-    (json |> member "detail" = `Null)
+    (json |> member "detail" = `Null);
+  Alcotest.(check bool) "details is null" true
+    (json |> member "details" = `Null)
 
 (* ============================================================
    read_audit_events tests
@@ -141,10 +147,71 @@ let test_event_to_json_no_detail () =
 
 let test_read_audit_events_empty () =
   let ctx, base_dir = make_ctx () in
-  let events = Tool_audit.read_audit_events ctx.config ~since:0.0 in
-  Alcotest.(check (list unit)) "empty events" []
-    (List.map (fun _ -> ()) events);
-  cleanup_dir base_dir
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun _env ->
+      let events =
+        Tool_audit.read_audit_events ctx.config
+          ~since:(Unix.gettimeofday () +. 0.001)
+      in
+      Alcotest.(check (list unit)) "no later events" []
+        (List.map (fun _ -> ()) events))
+
+let test_read_audit_events_reads_canonical_store_and_normalizes_tool_call () =
+  let ctx, base_dir = make_ctx () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun _env ->
+      Audit_log.log_action ctx.config ~agent_id:"test-agent"
+        ~action:(Audit_log.ToolCall "masc_status")
+        ~room_id:"default"
+        ~details:(`Assoc [("tool_name", `String "masc_status")])
+        ~outcome:Audit_log.Success ();
+      let events = Tool_audit.read_audit_events ctx.config ~since:0.0 in
+      let tool_calls =
+        List.filter
+          (fun (event : Tool_audit.audit_event) ->
+            String.equal event.event_type "tool_call")
+          events
+      in
+      match tool_calls with
+      | [event] ->
+          Alcotest.(check string) "normalized event type" "tool_call"
+            event.event_type;
+          Alcotest.(check (option string)) "detail remains empty" None event.detail;
+          Alcotest.(check bool) "details preserved" true
+            (match event.details with Some (`Assoc _) -> true | _ -> false)
+      | _ -> Alcotest.fail "expected one normalized tool_call event")
+
+let test_audit_stats_counts_tool_call_prefixes () =
+  let ctx, base_dir = make_ctx () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun _env ->
+      Audit_log.log_action ctx.config ~agent_id:"test-agent"
+        ~action:(Audit_log.ToolCall "masc_status")
+        ~room_id:"default" ~details:`Null ~outcome:Audit_log.Success ();
+      let (ok, msg) = Tool_audit.handle_audit_stats ctx (`Assoc []) in
+      Alcotest.(check bool) "stats succeeds" true ok;
+      let json = Yojson.Safe.from_string msg in
+      let open Yojson.Safe.Util in
+      let agents = json |> member "agents" |> to_list in
+      let matching =
+        List.find_opt
+          (fun agent_json ->
+            match agent_json |> member "agent_id" with
+            | `String "test-agent" -> true
+            | _ -> false)
+          agents
+      in
+      match matching with
+      | Some agent_json ->
+          Alcotest.(check int) "tool call counted" 1
+            (agent_json |> member "tool_calls" |> to_int)
+      | None -> Alcotest.fail "expected stats for test-agent")
 
 (* ============================================================
    Helper function tests
@@ -198,8 +265,6 @@ let test_get_float_missing () =
 (* ============================================================
    Audit trail (trace_id linking) tests
    ============================================================ *)
-
-module Audit_log = Masc_mcp.Audit_log
 
 let test_audit_entry_trace_id_in_json () =
   let entry : Audit_log.audit_entry = {
@@ -319,6 +384,8 @@ let () =
     ("audit_stats", [
       Alcotest.test_case "empty stats" `Quick test_audit_stats_empty;
       Alcotest.test_case "with agent filter" `Quick test_audit_stats_with_agent;
+      Alcotest.test_case "counts tool_call prefixes" `Quick
+        test_audit_stats_counts_tool_call_prefixes;
     ]);
     ("audit_event_to_json", [
       Alcotest.test_case "with detail" `Quick test_event_to_json_with_detail;
@@ -326,6 +393,8 @@ let () =
     ]);
     ("read_audit_events", [
       Alcotest.test_case "empty log" `Quick test_read_audit_events_empty;
+      Alcotest.test_case "canonical store + normalization" `Quick
+        test_read_audit_events_reads_canonical_store_and_normalizes_tool_call;
     ]);
     ("helpers", [
       Alcotest.test_case "get_string present" `Quick test_get_string_present;


### PR DESCRIPTION
## Summary
- centralize join/leave/task transition observability fan-out in Room hooks
- add structured system log details and fill missing audit/telemetry collection paths
- fix audit and telemetry readers for canonical/date-split stores and add regressions

## Testing
- ./_build/default/test/test_room_coverage.exe
- ./_build/default/test/test_tool_audit_coverage.exe
- ./_build/default/test/test_dashboard_tool_host_events.exe
- ./_build/default/test/test_telemetry_eio_coverage.exe
- dune build --root . @check --display short