### PR TITLE
fix(voice): remove dangling preview_url for unregistered TTS route (#3122)

### DIFF
--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -401,7 +401,6 @@ let public_json config =
             ("default_voice", `String config.tts.default_voice);
             ("available_voices", `List (List.map (fun voice -> `String voice) (available_voices config)));
             ("available_models", `List [ `String config.tts.default_model ]);
-            ("preview_url", `String "/api/v1/voice/tts");
             ("agent_voices", agent_voices_json config);
             ("active_endpoint", active_endpoint_json config.tts.endpoints);
           ] );


### PR DESCRIPTION
## Summary

\`voice_config.ml\`이 \`preview_url: "/api/v1/voice/tts"\`를 광고하지만 해당 경로를 처리하는 route가 없음 (이전 \`trpg_tts_proxy\`가 제거됨). 클라이언트가 이 URL로 요청하면 404.

\`preview_url\` 필드를 제거하여 존재하지 않는 엔드포인트를 광고하지 않도록 수정.

## Test plan

- [ ] CI Build and Test

Addresses #3122 (sub-issue 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)