### PR TITLE
fix(test): add unit arg to compact calls after optional param (#3128)

### DIFF
--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -31,7 +31,7 @@ let test_merge_contiguous_still_merges_plain_user () =
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.MergeContiguous] in
+    ~strategies:[Compact.MergeContiguous] () in
   let user_msgs = List.filter (fun (m : Agent_sdk.Types.message) ->
     m.role = Agent_sdk.Types.User) result in
   check int "plain user messages merged" 1 (List.length user_msgs)
@@ -49,7 +49,7 @@ let test_compact_prune_tool_outputs () =
   ] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.PruneToolOutputs] in
+    ~strategies:[Compact.PruneToolOutputs] () in
   let tool_text = Agent_sdk.Types.text_of_message (List.nth result 1) in
   check bool "tool output was pruned" true
     (String.length tool_text < String.length long_output)
@@ -57,7 +57,7 @@ let test_compact_prune_tool_outputs () =
 let test_compact_empty_messages () =
   let result, tokens = Compact.compact
     ~system_prompt:"sys" ~messages:[]
-    ~strategies:[Compact.PruneToolOutputs; Compact.MergeContiguous] in
+    ~strategies:[Compact.PruneToolOutputs; Compact.MergeContiguous] () in
   check int "empty input = empty output" 0 (List.length result);
   check bool "tokens > 0 (system prompt)" true (tokens > 0)
 
@@ -65,7 +65,7 @@ let test_compact_single_message () =
   let msgs = [msg Agent_sdk.Types.User "hello"] in
   let result, _tokens = Compact.compact
     ~system_prompt:"sys" ~messages:msgs
-    ~strategies:[Compact.MergeContiguous; Compact.DropLowImportance] in
+    ~strategies:[Compact.MergeContiguous; Compact.DropLowImportance] () in
   check bool "single message survives" true (List.length result >= 1)
 
 let test_compact_drop_low_importance () =

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -74,7 +74,7 @@ let test_roundtrip_tool_msg () =
 let compact_ctx (ctx : Keeper_exec_context.working_context) strategies =
   let messages, token_count =
     Context_compact_oas.compact
-      ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies in
+      ~system_prompt:ctx.system_prompt ~messages:ctx.messages ~strategies () in
   { ctx with Keeper_exec_context.messages; token_count; importance_scores = [] }
 (* ================================================================ *)
 

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -108,7 +108,7 @@ let test_compact_syncs_oas_context () =
   let messages, token_count =
     Context_compact_oas.compact
       ~system_prompt:ctx.system_prompt ~messages:ctx.messages
-      ~strategies:[Context_compact_oas.MergeContiguous] in
+      ~strategies:[Context_compact_oas.MergeContiguous] () in
   let ctx = Keeper_exec_context.sync_oas_context
     { ctx with messages; token_count; importance_scores = [] } in
   let ratio =


### PR DESCRIPTION
## Summary

\`Context_compact_oas.compact\`에 \`?observation\` optional parameter가 추가된 후, 기존 3개 테스트 파일의 7개 호출에 trailing \`()\`이 누락되어 빌드 실패.

수정: 각 호출에 \`()\` 추가.

Closes #3128

🤖 Generated with [Claude Code](https://claude.com/claude-code)