### PR TITLE
[Tech Debt] Remove walph_loop legacy stub (zero production callers) (#3100)

### DIFF
--- a/lib/room/room_walph_eio.ml
+++ b/lib/room/room_walph_eio.ml
@@ -227,43 +227,6 @@ let walph_control config ~from_agent ~command ~args ?(target_agent=None) () =
   let _ = Room_state.broadcast config ~from_agent:"walph" ~content:response in
   response
 
-(** {1 Legacy Loop Stub} *)
-
-(** Walph loop execution has been removed.
-    Keep a stub for transitional direct callers so they get a clear, non-mutating response. *)
-let walph_loop config ~clock:_ ~agent_name
-    ?(preset="drain") ?(max_iterations=10) ?target
-    ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
-    ?(default_model="explicit-model-required")
-    ~model_dispatch:_ () =
-  Room_utils_ops.ensure_initialized config;
-  let _ = get_walph_state_exn config ~agent_name in
-  let details =
-    [
-      ("preset", `String preset);
-      ("max_iterations", `Int max_iterations);
-      ( "target",
-        match target with
-        | Some value -> `String value
-        | None -> `Null );
-      ("max_consecutive_errors", `Int max_consecutive_errors);
-      ("error_backoff_sec", `Int error_backoff_sec);
-      ("default_model", `String default_model);
-      ("ts", `String (Types.now_iso ()));
-    ]
-  in
-  Room_utils_ops.log_event config
-    (Yojson.Safe.to_string
-       (`Assoc
-         (("type", `String "walph_loop_removed_call")
-          :: ("agent", `String agent_name)
-          :: details)));
-  let result =
-    "🚫 Walph loop has been removed. Use Team Session + Supervisor for supervised swarm execution."
-  in
-  let _ = Room_state.broadcast config ~from_agent:"walph" ~content:result in
-  result
-
 (** {1 Swarm Walph - Multi-Agent Coordination} *)
 
 (** Swarm status summary for all active Walph instances in a room *)

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -277,27 +277,6 @@ let test_eio_status_json_fields () =
   ignore (json |> member "started_at");
   ignore (json |> member "last_stop_reason")
 
-(** Test: walph_loop is removed and leaves state idle *)
-let test_eio_loop_removed () =
-  with_test_config "error_cutoff" @@ fun env _fs config ->
-  let state = Room_walph_eio.get_walph_state_exn config ~agent_name:"error-agent" in
-  let result =
-    Room_walph_eio.walph_loop config
-      ~clock:(Eio.Stdenv.clock env)
-      ~agent_name:"error-agent"
-      ~preset:"coverage"
-      ~max_iterations:10
-      ~max_consecutive_errors:2
-      ~error_backoff_sec:0
-      ~model_dispatch:(fun ~tool_name:_ ~model:_ ~prompt:_ ~timeout_sec:_ ~max_chars:_ () -> "")
-      ()
-  in
-  check bool "removed message" true
-    (contains result "Walph loop has been removed");
-  check bool "state remains idle" false state.running;
-  check int "iterations unchanged" 0 state.iterations;
-  check int "errors unchanged" 0 state.errors
-
 let test_eio_default_dispatch_uses_shared_cascade () =
   (* Verify old direct MODEL dispatch paths remain absent from Room. *)
   check bool "legacy direct dispatch removed" false
@@ -320,7 +299,6 @@ let eio_tests = [
   "multi-agent with review preset", `Quick, test_eio_multi_agent_with_review;
   "list walph states", `Quick, test_eio_list_walph_states;
   "status json fields", `Quick, test_eio_status_json_fields;
-  "loop removed", `Quick, test_eio_loop_removed;
   "default dispatch uses shared cascade", `Quick,
   test_eio_default_dispatch_uses_shared_cascade;
 ]


### PR DESCRIPTION
## Summary
- Production stub audit 완료 (606 .ml 파일): 위험한 hidden stub 없음
- `walph_loop` transitional stub 제거 — production caller 0개 확인
- 관련 test case 정리 (11개 테스트 전부 통과)
- Inventory를 #3100 이슈 코멘트에 기록

## Changes
- `lib/room/room_walph_eio.ml`: `walph_loop` 함수 + section header 제거 (37줄)
- `test/test_walph_eio.ml`: `test_eio_loop_removed` 테스트 + 등록 제거 (22줄)

## Not changed (intentional stubs, keep)
- `tool_voice.ml`: STT explicit error response (prevents silent failure)
- `room_hooks.ml`: DI callback defaults (overwritten at startup)
- `backend_pg.ml`: `close` no-op (Caqti manages pool)

## Test plan
- [x] `dune build lib/` passes
- [x] `test_walph_eio.exe` — 11 tests pass
- [x] `test_tools_coverage.ml` walph_loop removal assertion unchanged

Closes #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)