### PR TITLE
fix: align monitoring agents surface styling

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -277,22 +277,22 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   ]
 
   return html`
-    <div class="agent-page mx-auto flex max-w-[1200px] flex-col gap-5 px-4 py-5 sm:px-6 lg:px-0">
-      <section class="rounded-[28px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-5 shadow-[0_18px_50px_rgba(0,0,0,0.18)]">
+    <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
+      <section class="rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(17,26,46,0.94),rgba(11,18,32,0.92))] p-5 shadow-[0_12px_30px_rgba(0,0,0,0.16)]">
         <div class="flex flex-col gap-5">
           <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div class="flex min-w-0 flex-col gap-3">
               <div class="flex flex-wrap items-center gap-3">
-                <h2 class="m-0 text-[20px] font-semibold text-[var(--ff-gold-bright)] tracking-[0.5px] [text-shadow:0_1px_4px_rgba(212,169,75,0.2)]">${pageTitle}</h2>
-                <span class="inline-flex items-center rounded-full border border-[rgba(200,168,78,0.22)] bg-[rgba(200,168,78,0.12)] px-2.5 py-1 text-[11px] font-medium text-[#e8d48b]">${resultCountLabel}</span>
+                <h2 class="m-0 text-[20px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">${pageTitle}</h2>
+                <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[var(--accent-soft)] px-2.5 py-1 text-[11px] font-medium text-[#cfeaff]">${resultCountLabel}</span>
               </div>
-              <p class="m-0 max-w-[720px] text-[13px] leading-[1.6] text-[var(--white-30)]">${pageDescription}</p>
+              <p class="m-0 max-w-[720px] text-[13px] leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
             </div>
 
             <label class="flex w-full max-w-[320px] flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
               <span>에이전트 이름으로 찾기</span>
               <${TextInput}
-                class="rounded-2xl border-[var(--white-10)] bg-[var(--bg-1)] px-4 py-3 text-[14px] text-[var(--white-90)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] placeholder:text-[var(--white-25)] focus:border-[var(--ff-gold)] focus:shadow-[0_0_0_2px_var(--ff-gold-dim)]"
+                class="rounded-2xl bg-[rgba(8,16,32,0.6)] px-4 py-3 text-[14px] text-[var(--text-strong)] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]"
                 name="agent_search"
                 ariaLabel="에이전트 이름 검색"
                 autoComplete="off"
@@ -303,7 +303,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             </label>
           </div>
 
-          <div class="rounded-2xl border border-[var(--white-6)] bg-[var(--white-2)] p-3.5 md:p-4">
+          <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
                 <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">연결 상태</div>
@@ -314,12 +314,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 value=${filter}
                 onChange=${(key: StatusFilter) => setFilter(key)}
                 size="md"
+                tone="accent"
               />
             </div>
           </div>
           <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             ${legendCards.map(card => html`
-              <div class="rounded-2xl border border-[var(--card-border)] bg-[var(--bg-1)] px-4 py-4 shadow-[0_8px_24px_rgba(0,0,0,0.14)]">
+              <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] px-4 py-4 shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
                 <div class="text-[11px] font-semibold text-[var(--text-strong)]">${card.title}</div>
                 <p class="m-0 mt-2 text-[12px] leading-[1.55] text-[var(--text-muted)]">${card.body}</p>
               </div>
@@ -341,7 +342,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="group flex min-h-[308px] w-full flex-col gap-4 rounded-[24px] border border-[var(--card-border)] bg-[var(--bg-1)] p-5 text-left shadow-[0_16px_40px_rgba(0,0,0,0.16)] transition-all duration-200 cursor-pointer hover:border-[var(--accent-soft)] hover:bg-[var(--bg-0)] hover:-translate-y-0.5"
+              class="group flex min-h-[308px] w-full flex-col gap-4 rounded-[22px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(17,26,46,0.92),rgba(11,18,32,0.92))] p-5 text-left shadow-[0_10px_24px_rgba(0,0,0,0.14)] transition-all duration-200 cursor-pointer hover:border-[rgba(71,184,255,0.3)] hover:bg-[linear-gradient(180deg,rgba(20,30,52,0.96),rgba(12,19,35,0.94))] hover:-translate-y-0.5"
               key=${agent.name}
               aria-label=${`${agent.name} 상세 보기`}
               onClick=${() => openAgentDetail(agent.name)}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -90,9 +90,10 @@ export function AgentsUnified() {
           navigate('status', key === 'all' ? { section: 'agents' } : { section: 'agents', view: key })
         }}
         size="md"
-        class="w-fit rounded-xl bg-[var(--white-3)] p-1"
+        tone="accent"
+        class="w-fit rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] p-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
       />
-      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-muted)]">
+      <div class="rounded-2xl border border-[var(--white-8)] bg-[linear-gradient(180deg,rgba(71,184,255,0.08),rgba(255,255,255,0.02))] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-body)]">
         <strong class="mr-2 text-[var(--text-strong)]">${currentViewMeta.label}</strong>
         <span>${currentViewMeta.description} ${currentViewSummary}</span>
       </div>

--- a/dashboard/src/components/common/filter-chips.ts
+++ b/dashboard/src/components/common/filter-chips.ts
@@ -19,6 +19,7 @@ interface FilterChipsProps<T extends string> {
   onChange?: (key: T) => void
   class?: string
   size?: 'sm' | 'md'
+  tone?: 'gold' | 'accent'
 }
 
 export function FilterChips<T extends string>({
@@ -28,11 +29,18 @@ export function FilterChips<T extends string>({
   onChange,
   class: cx,
   size = 'sm',
+  tone = 'gold',
 }: FilterChipsProps<T>) {
   const activeKey = active?.value ?? value
   const chipClass = size === 'md'
     ? 'inline-flex min-h-9 items-center gap-1.5 rounded-2xl border px-3 py-2 text-[11px] font-medium'
     : 'inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[length:var(--fs-xs)]'
+  const activeToneClass = tone === 'accent'
+    ? 'border-[rgba(71,184,255,0.45)] bg-[var(--accent-soft)] text-[#d9f2ff]'
+    : 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
+  const idleToneClass = tone === 'accent'
+    ? 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(71,184,255,0.35)] hover:text-[var(--text-body)]'
+    : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'
 
   return html`
     <div class="flex flex-wrap gap-1.5 ${cx ?? ''}">
@@ -42,8 +50,8 @@ export function FilterChips<T extends string>({
           title=${chip.title}
           aria-pressed=${activeKey === chip.key}
           class="${chipClass} cursor-pointer transition-all duration-150 ${activeKey === chip.key
-            ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
-            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[rgba(200,168,78,0.4)]'}"
+            ? activeToneClass
+            : idleToneClass}"
           onClick=${() => {
             if (active) active.value = chip.key
             onChange?.(chip.key)


### PR DESCRIPTION
## Summary
- align the monitoring agents surface with the dashboard shell tone by removing the gold-heavy hero treatment
- add an optional accent tone to FilterChips so the agents surface can use the same blue active state as adjacent monitoring views
- widen the agent roster layout to match the rest of the monitoring surface and soften card shadows/backgrounds

## Verification
- npm run typecheck
- npm run build
- checked the agents surface via local Vite dev preview proxied to http://127.0.0.1:8935

## Review note
- visual-only change for monitoring/agents and its local chip treatment