### PR TITLE
[Eio] Phase 6: replace blocking F_LOCK with non-blocking F_TLOCK (#3099)

### DIFF
--- a/lib/council/dune
+++ b/lib/council/dune
@@ -3,5 +3,5 @@
  (name council)
  (public_name masc_mcp.council)
  (modules router debate consensus balance executor conversation governance_v2 governance_v2_types governance_v2_serde loop_guard thread_persist council)
- (libraries str yojson base64 unix eio cohttp cohttp-eio uuidm time_compat masc_log fs_compat)
+ (libraries str yojson base64 unix eio eio.unix cohttp cohttp-eio uuidm time_compat masc_log fs_compat)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -274,17 +274,39 @@ let is_terminal_case_status = function
   | Executed | Blocked | Closed -> true
   | Pending_ruling | Ready_auto_execute | Needs_human_gate -> false
 
+let run_blocking_lock_op f =
+  try Eio_unix.run_in_systhread f
+  with Stdlib.Effect.Unhandled _ -> f ()
+
 let submit_petition base_path ~title ~origin ~subject_type ~risk_class
     ~requested_action ~source_refs ~created_by =
   ensure_dirs base_path;
-  (* File lock to prevent race condition between list_cases and write *)
+  (* File lock to prevent race condition between list_cases and write.
+     Uses F_TLOCK (non-blocking) in systhread to avoid blocking Eio scheduler. *)
   let lock_path = Filename.concat (cases_dir base_path) "_submit.lock" in
-  let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
+  let fd = run_blocking_lock_op (fun () ->
+    let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
+    let rec acquire attempts =
+      if attempts <= 0 then begin
+        Unix.close fd;
+        raise (Failure "governance_v2: submit lock timeout after 200 attempts")
+      end
+      else
+        try Unix.lockf fd Unix.F_TLOCK 0; fd
+        with
+        | Unix.Unix_error (Unix.EAGAIN, _, _)
+        | Unix.Unix_error (Unix.EACCES, _, _) ->
+            Unix.sleepf 0.01;
+            acquire (attempts - 1)
+    in
+    try acquire 200
+    with exn -> Unix.close fd; raise exn
+  ) in
   Fun.protect ~finally:(fun () ->
-    (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
-    Unix.close fd
-  ) (fun () ->
-    Unix.lockf fd Unix.F_LOCK 0;
+      run_blocking_lock_op (fun () ->
+        (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
+        Unix.close fd))
+  (fun () ->
     (* Include task_id from source_refs in dedup key for stronger matching *)
     let task_id_suffix =
       List.find_opt (fun s ->

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -84,26 +84,52 @@ let reset_lock_stats () =
   Atomic.set lock_total_wait_ms 0.0;
   Atomic.set lock_max_wait_ms 0.0
 
-(** Transactional lock for graph operations - synchronous *)
+(** Run a blocking op in systhread when Eio context is available *)
+let run_blocking_op f =
+  try Eio_unix.run_in_systhread f
+  with Stdlib.Effect.Unhandled _ -> f ()
+
+(** Transactional lock for graph operations.
+    Uses F_TLOCK (non-blocking) from a systhread so the Eio scheduler stays
+    free.  The body [f] runs in the main Eio context (not in the systhread)
+    so it can use Eio.Path / Fs_compat safely. *)
 let with_graph_lock config f =
   ensure_synapses_dir config;
   let lock_file = synapses_lock_file config in
-  let fd = Unix.openfile lock_file [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
-  (* Track lock acquisition time *)
   let start_time = Time_compat.now () in
-  Unix.lockf fd Unix.F_LOCK 0;
+  (* Acquire lock in systhread (non-blocking F_TLOCK + retry) *)
+  let fd = run_blocking_op (fun () ->
+    let fd = Unix.openfile lock_file [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
+    let rec acquire attempts =
+      if attempts <= 0 then begin
+        Unix.close fd;
+        raise (Failure "hebbian_eio: graph lock timeout after 200 attempts")
+      end
+      else
+        try Unix.lockf fd Unix.F_TLOCK 0; fd
+        with
+        | Unix.Unix_error (Unix.EAGAIN, _, _)
+        | Unix.Unix_error (Unix.EACCES, _, _) ->
+            Unix.sleepf 0.01;
+            acquire (attempts - 1)
+    in
+    try acquire 200
+    with exn -> Unix.close fd; raise exn
+  ) in
+  (* Record lock metrics *)
   let wait_ms = (Time_compat.now () -. start_time) *. 1000.0 in
   Atomic.incr lock_acquisitions;
   cas_float lock_total_wait_ms (fun v -> v +. wait_ms);
   cas_float lock_max_wait_ms (fun v -> Float.max v wait_ms);
-  (* Log if wait was significant *)
   let warn_threshold = Level2_config.Lock.warn_threshold_ms () in
   if wait_ms > warn_threshold then
     Log.Misc.warn "Lock contention detected: %.1fms wait (threshold: %.0fms)" wait_ms warn_threshold;
+  (* Run body in Eio context, release lock in systhread *)
   Common.protect ~module_name:"hebbian_eio" ~finally_label:"finalizer"
     ~finally:(fun () ->
-      Unix.lockf fd Unix.F_ULOCK 0;
-      Unix.close fd)
+      run_blocking_op (fun () ->
+        (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
+        Unix.close fd))
     f
 
 (** Synapse to JSON *)


### PR DESCRIPTION
## Summary
- `hebbian_eio.ml` `with_graph_lock`: `F_LOCK` (blocking) -> `F_TLOCK` + systhread retry
- `governance_v2.ml` `submit_petition`: `F_LOCK` (blocking) -> `F_TLOCK` + systhread retry
- council/dune: `eio.unix` dependency 추가

## Why
`Unix.lockf F_LOCK`은 lock을 얻을 때까지 무한 대기하며, Eio scheduler 전체를 block한다. keeper가 synaptic graph를 업데이트하거나 petition을 제출할 때 다른 모든 fiber가 멈추는 문제.

## Pattern
`file_lock_eio.ml`과 `backend.ml`에서 이미 검증된 패턴 적용:
1. Lock acquire/release만 `Eio_unix.run_in_systhread`에서 실행
2. `F_TLOCK` (non-blocking) + 200회 retry (2초 timeout)
3. Body `f()`는 main Eio context에서 실행 (Fs_compat 호출 가능)

## Audit findings (추가 수정 불필요)
- `backend.ml`: 이미 `run_blocking_file_op` + `F_TLOCK` 사용 (safe)
- `mention_inbox.ml`: 이미 `Fs_compat` 마이그레이션 완료 (safe)
- `file_lock_eio.ml`: 이미 올바른 패턴 (참조 구현)

## Test plan
- [x] `test_hebbian_eio.exe` — 9/9 pass (lock stats: 0.14ms avg)
- [x] `test_governance_pipeline.exe` — 57/57 pass
- [x] `test_governance_yojson_roundtrip.exe` — 9/9 pass
- [x] `dune build lib/` passes

Closes #3099

🤖 Generated with [Claude Code](https://claude.com/claude-code)