### PR TITLE
fix(runtime): unblock health and transport startup

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -461,6 +461,7 @@ let start
     ~(tool_dispatcher : string -> string -> (string, string) result)
   : unit =
   if not (is_enabled ()) then begin
+    Transport_metrics.set_grpc_runtime_listening false;
     Log.Server.info "gRPC transport disabled (set MASC_GRPC_ENABLED=0 to disable)";
   end
   else begin
@@ -475,13 +476,18 @@ let start
         Log.Server.info "  health: %s/Check" health_service_name;
         Log.Server.info
           "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
-        Grpc_eio.Server.serve ~sw ~env server
+        Transport_metrics.set_grpc_runtime_listening true;
+        Fun.protect
+          ~finally:(fun () -> Transport_metrics.set_grpc_runtime_listening false)
+          (fun () -> Grpc_eio.Server.serve ~sw ~env server)
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | Unix.Unix_error (Unix.EADDRINUSE, _, _) ->
+        Transport_metrics.set_grpc_runtime_listening false;
         Log.Server.error
           "gRPC coordination transport unavailable on 127.0.0.1:%d: port already in use"
           port
       | exn ->
+        Transport_metrics.set_grpc_runtime_listening false;
         Log.Server.error "gRPC server failed: %s" (Printexc.to_string exn)))
   end

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -42,6 +42,7 @@ let state_to_string = function
 
 let registry : (string, registry_entry) Hashtbl.t = Hashtbl.create 16
 let mu = Eio.Mutex.create ()
+let running_count_atomic = Atomic.make 0
 
 let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
@@ -54,6 +55,11 @@ let max_crash_log_entries = 5
 let register ~base_path name meta =
   with_lock_rw (fun () ->
     let done_p, done_r = Eio.Promise.create () in
+    let key = registry_key ~base_path name in
+    (match Hashtbl.find_opt registry key with
+     | Some entry when entry.state = Running ->
+         Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
+     | _ -> ());
     let entry = {
       base_path;
       name;
@@ -74,11 +80,18 @@ let register ~base_path name meta =
       board_cursor_ts = 0.0;
       tool_usage = Hashtbl.create 16;
     } in
-    Hashtbl.replace registry (registry_key ~base_path name) entry;
+    Hashtbl.replace registry key entry;
+    Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1);
     entry)
 
 let unregister ~base_path name =
-  with_lock_rw (fun () -> Hashtbl.remove registry (registry_key ~base_path name))
+  with_lock_rw (fun () ->
+    let key = registry_key ~base_path name in
+    (match Hashtbl.find_opt registry key with
+     | Some entry when entry.state = Running ->
+         Atomic.set running_count_atomic (max 0 (Atomic.get running_count_atomic - 1))
+     | _ -> ());
+    Hashtbl.remove registry key)
 
 let get ~base_path name =
   with_lock_ro (fun () -> Hashtbl.find_opt registry (registry_key ~base_path name))
@@ -106,7 +119,17 @@ let update_meta ~base_path name meta =
 let set_state ~base_path name state =
   with_lock_rw (fun () ->
     match Hashtbl.find_opt registry (registry_key ~base_path name) with
-    | Some entry -> entry.state <- state
+    | Some entry ->
+        if entry.state <> state then begin
+          (match (entry.state, state) with
+           | Running, (Paused | Stopped) ->
+               Atomic.set running_count_atomic
+                 (max 0 (Atomic.get running_count_atomic - 1))
+           | (Paused | Stopped), Running ->
+               Atomic.set running_count_atomic (Atomic.get running_count_atomic + 1)
+           | _ -> ());
+          entry.state <- state
+        end
     | None -> ())
 
 let record_restart ~base_path name =
@@ -129,13 +152,15 @@ let is_running ~base_path name =
   | _ -> false
 
 let count_running ?base_path () =
-  with_lock_ro (fun () ->
-    Hashtbl.fold
-      (fun _k v acc ->
-        match base_path with
-        | Some expected when not (String.equal expected v.base_path) -> acc
-        | _ -> if v.state = Running then acc + 1 else acc)
-      registry 0)
+  match base_path with
+  | None -> Atomic.get running_count_atomic
+  | Some expected ->
+      with_lock_ro (fun () ->
+        Hashtbl.fold
+          (fun _k v acc ->
+            if String.equal expected v.base_path && v.state = Running then acc + 1
+            else acc)
+          registry 0)
 
 let record_crash ~base_path name ts msg =
   with_lock_rw (fun () ->
@@ -246,7 +271,9 @@ let cleanup_tracking ~base_path name =
     | None -> ())
 
 let clear () =
-  with_lock_rw (fun () -> Hashtbl.clear registry)
+  with_lock_rw (fun () ->
+    Hashtbl.clear registry;
+    Atomic.set running_count_atomic 0)
 
 (* ── Board cursor ────────────────────────────────────────────── *)
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -77,7 +77,7 @@ let websocket_discovery_json request =
   let (host, _) = advertised_host_port request in
   let configured = Server_ws_standalone.is_enabled () in
   let port = Server_ws_standalone.configured_port () in
-  let listening = configured && Mitosis_spawn.port_listening port in
+  let listening = Transport_metrics.ws_listening () in
   let base_fields =
     [
       ("enabled", `Bool configured);
@@ -105,9 +105,7 @@ let transport_json request =
   let base_url = Printf.sprintf "http://%s:%d" host port in
   let grpc_enabled = Masc_grpc_server.is_enabled () in
   let grpc_port = Masc_grpc_server.configured_port () in
-  let grpc_listening =
-    grpc_enabled && Mitosis_spawn.port_listening grpc_port
-  in
+  let grpc_listening = Transport_metrics.grpc_listening () in
   let webrtc_enabled = Server_webrtc_transport.is_enabled () in
   `Assoc
     [

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -931,11 +931,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
-      (* Pre-warm shell cache so the first /dashboard load is instant.
-         shell is the only room-truth component without a proactive refresh loop. *)
-      Server_dashboard_http.warm_shell_cache state;
-      start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state;
-      start_lazy_startup state;
+      (* Start auxiliary transports before optional warmups and resident loops.
+         Otherwise HTTP can report ready while gRPC/WS startup is still stuck
+         behind heavier startup work. *)
       (* gRPC coordination transport (opt-in via MASC_GRPC_ENABLED=1) *)
       let tool_dispatcher tool_name args_json =
         let arguments =
@@ -987,7 +985,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                   peer_id (Printexc.to_string exn)));
         Server_webrtc_transport.set_connection_starter
           (fun peer_id ->
-            Server_webrtc_transport.start_webrtc_connection ~sw ~env peer_id))
+            Server_webrtc_transport.start_webrtc_connection ~sw ~env peer_id));
+      (* Pre-warm shell cache so the first /dashboard load is instant.
+         shell is the only room-truth component without a proactive refresh loop. *)
+      Server_dashboard_http.warm_shell_cache state;
+      start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state;
+      start_lazy_startup state
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -104,46 +104,51 @@ let start
     ~(env : Eio_unix.Stdenv.base)
     ~(on_message : string -> string -> unit)
   : unit =
-  if not (is_enabled ()) then
+  if not (is_enabled ()) then begin
+    Transport_metrics.set_ws_runtime_listening false;
     Log.Server.info "WebSocket transport disabled (MASC_WS_ENABLED=0)"
-  else begin
+  end else begin
     let port = configured_port () in
     let net = Eio.Stdenv.net env in
     let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
     let socket =
       Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:128 addr
     in
+    Transport_metrics.set_ws_runtime_listening true;
     let connection_handler =
       Ws_eio.Server.create_connection_handler ~sw
         (make_websocket_handler ~on_message)
     in
     Eio.Fiber.fork ~sw (fun () ->
-      Log.Server.info "WebSocket server starting on port %d" port;
-      let rec accept_loop backoff_s =
-        try
-          let flow, client_addr = Eio.Net.accept ~sw socket in
-          Eio.Fiber.fork ~sw (fun () ->
-            try connection_handler client_addr flow
+      Fun.protect
+        ~finally:(fun () -> Transport_metrics.set_ws_runtime_listening false)
+        (fun () ->
+          Log.Server.info "WebSocket server starting on port %d" port;
+          let rec accept_loop backoff_s =
+            try
+              let flow, client_addr = Eio.Net.accept ~sw socket in
+              Eio.Fiber.fork ~sw (fun () ->
+                try connection_handler client_addr flow
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  Log.Server.warn "WS standalone handler error: %s"
+                    (Printexc.to_string exn));
+              accept_loop 0.05
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
-              Log.Server.warn "WS standalone handler error: %s"
-                (Printexc.to_string exn));
-          accept_loop 0.05
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Server.error "WS standalone accept error: %s"
-            (Printexc.to_string exn);
-          (* Backoff to avoid tight error loops *)
-          (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s
-           with Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                  Log.Server.warn
-                    "WS standalone backoff sleep failed on port %d (backoff=%.2fs): %s"
-                    port backoff_s (Printexc.to_string exn));
-          let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
-          accept_loop next_backoff
-      in
-      accept_loop 0.05)
+              Log.Server.error "WS standalone accept error: %s"
+                (Printexc.to_string exn);
+              (* Backoff to avoid tight error loops *)
+              (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s
+               with Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                      Log.Server.warn
+                        "WS standalone backoff sleep failed on port %d (backoff=%.2fs): %s"
+                        port backoff_s (Printexc.to_string exn));
+              let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
+              accept_loop next_backoff
+          in
+          accept_loop 0.05))
   end

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -92,6 +92,15 @@ let set_ws_sessions count =
 
 (** {1 Environment-derived Transport Config} *)
 
+let grpc_runtime_listening : bool Atomic.t = Atomic.make false
+let ws_runtime_listening : bool Atomic.t = Atomic.make false
+
+let set_grpc_runtime_listening listening =
+  Atomic.set grpc_runtime_listening listening
+
+let set_ws_runtime_listening listening =
+  Atomic.set ws_runtime_listening listening
+
 let grpc_enabled () =
   match Sys.getenv_opt "MASC_GRPC_ENABLED" with
   | Some raw -> (
@@ -109,7 +118,7 @@ let grpc_port () =
   | None -> 8936
 
 let grpc_listening () =
-  grpc_enabled () && Mitosis_spawn.port_listening (grpc_port ())
+  grpc_enabled () && Atomic.get grpc_runtime_listening
 
 (** {1 Agent Health Metrics} *)
 
@@ -132,7 +141,9 @@ let init () =
   register_sse_metrics ();
   register_grpc_metrics ();
   register_ws_metrics ();
-  register_agent_metrics ()
+  register_agent_metrics ();
+  set_grpc_runtime_listening false;
+  set_ws_runtime_listening false
 
 (** {1 Transport Health JSON Snapshot} *)
 
@@ -193,7 +204,7 @@ let ws_port () =
   | None -> 8937
 
 let ws_listening () =
-  ws_enabled () && Mitosis_spawn.port_listening (ws_port ())
+  ws_enabled () && Atomic.get ws_runtime_listening
 
 let hot_session_json (session : hot_queue_session) =
   `Assoc

--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -50,10 +50,26 @@ needs_rebuild() {
 
 if needs_rebuild; then
   echo "[dashboard] Sources changed, rebuilding SPA..." >&2
-  (cd "$DASHBOARD_DIR" && npm install --prefer-offline --no-audit 2>&1 | tail -1 >&2 && npm run build 2>&1 | tail -3 >&2) || {
+  log_file="$(mktemp /tmp/masc-dashboard-build.XXXXXX.log)"
+  if [ -d "$DASHBOARD_DIR/node_modules" ]; then
+    if (cd "$DASHBOARD_DIR" && npm run build >"$log_file" 2>&1); then
+      tail -n 3 "$log_file" >&2 || true
+      rm -f "$log_file"
+      touch "$STAMP"
+      echo "[dashboard] Build complete." >&2
+      exit 0
+    fi
+    echo "[dashboard] Existing deps build failed, retrying after npm install..." >&2
+  fi
+
+  if ! (cd "$DASHBOARD_DIR" && npm install --prefer-offline --no-audit >"$log_file" 2>&1 && npm run build >>"$log_file" 2>&1); then
+    tail -n 20 "$log_file" >&2 || true
+    rm -f "$log_file"
     echo "[dashboard] Build failed (non-fatal)." >&2
     exit 0
-  }
+  fi
+  tail -n 6 "$log_file" >&2 || true
+  rm -f "$log_file"
   touch "$STAMP"
   echo "[dashboard] Build complete." >&2
 else

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -64,18 +64,37 @@ release_build_lock() {
 
 build_dashboard_spa() {
     local dashboard_dir="$SCRIPT_DIR/dashboard"
+    local log_file=""
 
     if [ ! -f "$dashboard_dir/package.json" ]; then
         return 0
     fi
 
     echo "[dashboard] Building SPA before server start..." >&2
-    if command -v npm >/dev/null 2>&1; then
-        (cd "$dashboard_dir" && npm install --prefer-offline --no-audit 2>&1 | tail -1 >&2 && npm run build 2>&1 | tail -3 >&2) || \
-            echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
-    else
+    if ! command -v npm >/dev/null 2>&1; then
         echo "[dashboard] npm not found, skipping dashboard build." >&2
+        return 0
     fi
+
+    log_file="$(mktemp /tmp/masc-dashboard-build.XXXXXX.log)"
+    if [ -d "$dashboard_dir/node_modules" ]; then
+        if (cd "$dashboard_dir" && npm run build >"$log_file" 2>&1); then
+            tail -n 3 "$log_file" >&2 || true
+            rm -f "$log_file"
+            return 0
+        fi
+        echo "[dashboard] Existing deps build failed, retrying after npm install..." >&2
+    fi
+
+    if (cd "$dashboard_dir" && npm install --prefer-offline --no-audit >"$log_file" 2>&1 && npm run build >>"$log_file" 2>&1); then
+        tail -n 6 "$log_file" >&2 || true
+        rm -f "$log_file"
+        return 0
+    fi
+
+    tail -n 20 "$log_file" >&2 || true
+    rm -f "$log_file"
+    echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
 }
 
 resolve_repo_env_root() {

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -25,6 +25,10 @@ let contains_substring haystack needle =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let write_executable path content =
+  write_file path content;
+  Unix.chmod path 0o755
+
 let rec mkdir_p path =
   if path = "" || path = "." || path = "/" then
     ()
@@ -75,8 +79,7 @@ let run_shell ?(env = []) ~cwd cmd =
   (code, stdout, stderr)
 
 let copy_script src dst =
-  write_file dst (read_file src);
-  Unix.chmod dst 0o755
+  write_executable dst (read_file src)
 
 let write_fake_eio_exe exe_path ~marker =
   mkdir_p (Filename.dirname exe_path);

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -134,6 +134,13 @@ let test_grpc_events_delivered () =
     "masc_grpc_events_delivered_total" () in
   check (float 0.01) "grpc events delta" 5.0 (after -. before)
 
+let test_grpc_runtime_listening_cache () =
+  TM.init ();
+  TM.set_grpc_runtime_listening true;
+  check bool "grpc listening uses runtime cache" true (TM.grpc_listening ());
+  TM.set_grpc_runtime_listening false;
+  check bool "grpc listening resets" false (TM.grpc_listening ())
+
 let test_ws_sessions () =
   TM.init ();
   TM.set_ws_sessions 4;
@@ -154,6 +161,13 @@ let test_ws_enabled_normalized_env_matches_runtime () =
       (TM.ws_enabled ());
     check bool "runtime server normalizes false env" false
       (Masc_mcp.Server_ws_standalone.is_enabled ()))
+
+let test_ws_runtime_listening_cache () =
+  TM.init ();
+  TM.set_ws_runtime_listening true;
+  check bool "ws listening uses runtime cache" true (TM.ws_listening ());
+  TM.set_ws_runtime_listening false;
+  check bool "ws listening resets" false (TM.ws_listening ())
 
 (* ============================================================
    Agent Health Metrics
@@ -250,6 +264,7 @@ let () =
       test_case "observe_grpc_heartbeat_latency" `Quick test_grpc_heartbeat_latency;
       test_case "set_grpc_subscribers" `Quick test_grpc_subscribers;
       test_case "inc_grpc_events_delivered" `Quick test_grpc_events_delivered;
+      test_case "runtime listening cache" `Quick test_grpc_runtime_listening_cache;
     ]);
     ("websocket", [
       test_case "set_ws_sessions" `Quick test_ws_sessions;
@@ -257,6 +272,8 @@ let () =
         test_ws_enabled_blank_env_matches_runtime;
       test_case "normalized env matches runtime" `Quick
         test_ws_enabled_normalized_env_matches_runtime;
+      test_case "runtime listening cache" `Quick
+        test_ws_runtime_listening_cache;
     ]);
     ("agent_health", [
       test_case "set_agent_heartbeat_age" `Quick test_agent_heartbeat_age;


### PR DESCRIPTION
## Summary
- replace transport health live probes with runtime listening caches and a fast keeper running count
- start gRPC and standalone WS before dashboard warmups/resident loops so HTTP ready does not hide delayed transport startup
- make dashboard build reuse existing node_modules before falling back to npm install

## Verification
- ./_build/default/test/test_transport_metrics.exe
- ./_build/default/test/test_keeper_registry.exe
- ./_build/default/test/test_start_masc_mcp_script.exe
- MCP_URL=http://127.0.0.1:8975/mcp scripts/harness/contract/streamable_http_contract.sh
- manual smoke: /health after 127s uptime stayed 200 with grpc/ws listening=true; grpc health returned SERVING