### PR TITLE
refactor(backend): extract FileSystem._ensure_parent_dir helper

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -129,6 +129,17 @@ module FileSystem = struct
 
   (** {2 Core Operations} *)
 
+  let _ensure_parent_dir path =
+    match Eio.Path.split path with
+    | Some (parent, _) ->
+        (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
+         with Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+              Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                (Printf.sprintf "[WARN] mkdirs failed: %s"
+                   (Printexc.to_string exn)))
+    | None -> ()
+
   (** Get value by key (auto-decompresses ZSTD if detected) *)
   let get t key =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
@@ -155,16 +166,7 @@ module FileSystem = struct
       | Error e -> Error e
       | Ok path ->
           try
-            (* Ensure parent directory exists *)
-            (match Eio.Path.split path with
-             | Some (parent, _) ->
-                 (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                  with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e ->
-                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                         (Printf.sprintf "[WARN] mkdirs failed: %s"
-                            (Printexc.to_string e)))
-             | None -> ());
+            _ensure_parent_dir path;
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
             let compressed = Compression.compress_with_header value in
             (* Write file *)
@@ -275,31 +277,16 @@ module FileSystem = struct
             match Eio.Path.kind ~follow:true path with
             | `Regular_file -> Error (AlreadyExists key)
             | _ ->
-                (* Ensure parent directory *)
-                (match Eio.Path.split path with
-                 | Some (parent, _) ->
-                     (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                      with Eio.Cancel.Cancelled _ as e -> raise e
-                   | e ->
-                       Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                         (Printf.sprintf "[WARN] mkdirs failed: %s"
-                            (Printexc.to_string e)))
-                 | None -> ());
+                _ensure_parent_dir path;
                 (* Write with exclusive create *)
                 Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
                 Ok true
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
               (* Parent doesn't exist, create it *)
-              (match key_to_path t key with
-               | Error e -> Error e
-               | Ok path ->
-                   (match Eio.Path.split path with
-                    | Some (parent, _) ->
-                        Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
-                    | None -> ());
-                   Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
-                   Ok true)
+              _ensure_parent_dir path;
+              Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
+              Ok true
           | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
               Error (AlreadyExists key)
           | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -129,15 +129,18 @@ module FileSystem = struct
 
   (** {2 Core Operations} *)
 
-  let _ensure_parent_dir path =
+  let _ensure_parent_dir ?(log_errors = false) path =
     match Eio.Path.split path with
     | Some (parent, _) ->
         (try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 parent
          with Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
-              Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-                (Printf.sprintf "[WARN] mkdirs failed: %s"
-                   (Printexc.to_string exn)))
+              if log_errors then
+                Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
+                  (Printf.sprintf "[WARN] mkdirs failed: %s"
+                     (Printexc.to_string exn))
+              else
+                raise exn)
     | None -> ()
 
   (** Get value by key (auto-decompresses ZSTD if detected) *)
@@ -166,7 +169,7 @@ module FileSystem = struct
       | Error e -> Error e
       | Ok path ->
           try
-            _ensure_parent_dir path;
+            _ensure_parent_dir ~log_errors:true path;
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
             let compressed = Compression.compress_with_header value in
             (* Write file *)
@@ -277,7 +280,7 @@ module FileSystem = struct
             match Eio.Path.kind ~follow:true path with
             | `Regular_file -> Error (AlreadyExists key)
             | _ ->
-                _ensure_parent_dir path;
+                _ensure_parent_dir ~log_errors:true path;
                 (* Write with exclusive create *)
                 Eio.Path.save ~create:(`Exclusive 0o644) path compressed;
                 Ok true


### PR DESCRIPTION
Closes #3115

## Summary
- extract `FileSystem._ensure_parent_dir` to remove duplicated parent-directory setup in `set` and `set_if_not_exists`
- preserve the existing log-and-continue behavior for the normal write path
- preserve exception propagation in the `Not_found` recovery path after GLM review feedback

## Verification
- `dune build --root .`
  - fails on current `main` due unrelated pre-existing errors:
    - `test/test_dashboard_http_core.ml`: `Backend.PostgresNative` unbound
    - `test/test_file_lock_eio.ml`: warning 33 (`unused open Masc_mcp`) treated as error
- `/opt/homebrew/bin/timeout 20s ./_build/default/test/test_backend.exe`
  - passed: `basic`, `validation`, `atomic`, `memory`, `health`, `unified`
  - failed only in `postgres` cases because the sandbox could not resolve the Supabase host (`aws-1-ap-south-1.pooler.supabase.com`)

## Cross-Model Review
- `GLM-5` via `sb glm-text` on 2026-03-26 01:37 KST found one material regression: the first refactor swallowed `mkdirs` failures in the `Not_found` recovery path
- patched in follow-up commit `4c4bb3051` to restore exception propagation there while keeping the helper extraction
- no unpatched high/critical reviewer finding remains on the branch
