### PR TITLE
fix: align monitoring activity surface styling

### DIFF
--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -12,28 +12,35 @@ export function Live() {
   const isConnected = connected.value
 
   return html`
-    <div class="grid gap-4">
-      <div class="live-header">
-        <h2 class="m-0 text-[1.25rem] font-semibold">라이브 모니터</h2>
-        <div class="flex gap-3 items-center text-[13px] text-[var(--white-50)]">
-          <span class="live-stat">
+    <div class="flex flex-col gap-5">
+      <section class="rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] px-5 py-4 shadow-[0_12px_30px_rgba(0,0,0,0.16)]">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div class="flex flex-col gap-2">
+            <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
+            <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+          </div>
+          <div class="flex flex-wrap gap-2 items-center text-[13px] text-[var(--text-muted)]">
+            <span class="inline-flex items-center gap-2 rounded-full border border-[var(--border-slate-12)] bg-[var(--white-3)] px-3 py-1.5">
             <span class="live-stat-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
             ${isConnected ? '연결됨' : '오프라인'}
-          </span>
-          <span class="live-stat">에이전트 ${agents.value.length}</span>
-          <span class="live-stat">이벤트 ${eventCount.value}</span>
+            </span>
+            <span class="inline-flex items-center rounded-full border border-[var(--border-slate-12)] bg-[var(--white-3)] px-3 py-1.5">에이전트 ${agents.value.length}</span>
+            <span class="inline-flex items-center rounded-full border border-[var(--border-slate-12)] bg-[var(--white-3)] px-3 py-1.5">이벤트 ${eventCount.value}</span>
+          </div>
         </div>
-      </div>
+      </section>
 
-      <${PulseStrip} />
+      <section class="rounded-[24px] border border-[var(--border-slate-12)] bg-[var(--white-3)] p-4">
+        <${PulseStrip} />
+      </section>
 
-      <div class="live-panels">
-        <div class="live-panel-main">
+      <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
+        <section class="live-panel-main min-h-[420px] xl:min-h-[520px] rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] p-4 shadow-[0_10px_24px_rgba(0,0,0,0.14)]">
           <${ActivityStream} />
-        </div>
-        <div class="live-panel-side">
+        </section>
+        <section class="live-panel-side min-h-[420px] xl:min-h-[520px] rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] p-4 shadow-[0_10px_24px_rgba(0,0,0,0.14)]">
           <${FocusSidebar} />
-        </div>
+        </section>
       </div>
     </div>
   `

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -23,13 +23,13 @@ function FilterBar() {
   const active = liveFilters.value
 
   return html`
-    <div class="flex gap-1.5">
+    <div class="flex flex-wrap gap-1.5">
       ${FILTER_OPTIONS.map(opt => html`
         <button type="button"
           key=${opt.kind}
-          class="px-2 py-0.5 text-[11px] rounded-md border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
-            ? 'border-[rgba(200,168,78,0.5)] bg-[rgba(200,168,78,0.12)] text-[#e8d48b]'
-            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'}"
+          class="px-3 py-1.5 text-[11px] rounded-full border cursor-pointer transition-all duration-150 ${active.has(opt.kind)
+            ? 'border-[var(--border-slate-22)] bg-[var(--accent-soft)] text-[var(--text-strong)]'
+            : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:border-[var(--border-slate-22)] hover:text-[var(--text-body)]'}"
           onClick=${() => toggleLiveFilter(opt.kind)}
         >
           ${opt.label}
@@ -44,32 +44,32 @@ export function ActivityStream() {
 
   return html`
     <div class="grid gap-3 grid-rows-[auto_auto_1fr] min-h-0">
-      <div class="activity-stream-head">
-        <h3 class="m-0 text-[0.95rem] font-semibold">활동 스트림</h3>
-        <span class="text-xs text-[rgba(255,255,255,0.4)]">${entries.length} events</span>
+      <div class="activity-stream-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
+        <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">활동 스트림</h3>
+        <span class="text-xs text-[var(--text-muted)]">${entries.length} events</span>
       </div>
       <${FilterBar} />
-      <div class="activity-stream-list">
+      <div class="activity-stream-list grid gap-2 content-start">
         ${entries.length === 0
           ? html`<div class="py-6 text-center text-[13px]">
               ${!connected.value
                 ? html`<div class="text-[#e05050]">SSE 연결이 끊겨있습니다. 서버 상태를 확인하세요.</div>`
                 : liveFilters.value.size > 0
-                  ? html`<div class="text-[var(--white-25)]">선택한 필터에 맞는 이벤트가 없습니다. 필터를 해제해 보세요.</div>`
-                  : html`<div class="text-[var(--white-25)]">아직 수신된 이벤트가 없습니다. 에이전트가 활동하면 여기에 표시됩니다.</div>`
+                  ? html`<div class="text-[var(--text-muted)]">선택한 필터에 맞는 이벤트가 없습니다. 필터를 해제해 보세요.</div>`
+                  : html`<div class="text-[var(--text-muted)]">아직 수신된 이벤트가 없습니다. 에이전트가 활동하면 여기에 표시됩니다.</div>`
               }
             </div>`
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}
-              class="activity-item rounded-lg ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
+              class="activity-item rounded-2xl border border-[var(--border-slate-12)] border-l-2 bg-[var(--white-2)] px-3.5 py-3 ${eventKindColor(entry)} ${i === 0 ? 'activity-item-new' : ''}"
             >
-              <div class="activity-item-head">
-                <span class="activity-kind-chip rounded ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
-                <span class="text-[0.75rem] text-[var(--white-60)] font-medium">${entry.agent}</span>
-                <span class="text-[0.7rem] text-[var(--white-30)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
+              <div class="activity-item-head flex items-center gap-2">
+                <span class="activity-kind-chip rounded-md px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.04em] ${eventKindColor(entry)}">${eventKindLabel(entry)}</span>
+                <span class="text-[0.75rem] text-[var(--text-body)] font-medium">${entry.agent}</span>
+                <span class="text-[0.7rem] text-[var(--text-muted)] ml-auto">${formatTimeAgo(entry.timestamp)}</span>
               </div>
-              <div class="text-[13px] text-[var(--white-70)] leading-[1.4] break-words">${entry.text}</div>
+              <div class="text-[13px] text-[var(--text-body)] leading-[1.5] break-words">${entry.text}</div>
             </div>
           `)}
       </div>

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -27,21 +27,21 @@ export function FocusSidebar() {
 
   return html`
     <div class="grid gap-3 grid-rows-[auto_1fr] min-h-0">
-      <div class="focus-sidebar-head">
-        <h3 class="m-0 text-[0.95rem] font-semibold">에이전트</h3>
-        <span class="text-xs text-[rgba(255,255,255,0.4)]">${list.length}명 활성</span>
+      <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
+        <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">에이전트</h3>
+        <span class="text-xs text-[var(--text-muted)]">${list.length}명 활성</span>
       </div>
       <div class="grid gap-1.5 content-start overflow-y-auto max-h-[560px] pr-1">
         ${list.length === 0
-          ? html`<div class="py-6 text-center text-[var(--white-25)] text-[13px]">활성 에이전트 없음</div>`
+          ? html`<div class="py-6 text-center text-[var(--text-muted)] text-[13px]">활성 에이전트 없음</div>`
           : list.map(agent => html`
             <div
               key=${agent.name}
-              class="focus-agent-card transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
+              class="focus-agent-card rounded-2xl border border-[var(--border-slate-12)] bg-[var(--white-3)] p-3.5 transition-colors duration-200 ${selected === agent.name ? 'focus-agent-selected' : ''}"
               onClick=${() => openAgentDetail(agent.name)}
             >
               <div class="focus-agent-header">
-                <span class="text-[0.85rem] font-medium flex items-center gap-1">
+                <span class="text-[0.85rem] font-medium text-[var(--text-strong)] flex items-center gap-1">
                   ${agent.emoji ? html`<span class="text-[0.95rem]">${agent.emoji}</span>` : null}
                   ${agent.koreanName ?? agent.name}
                 </span>
@@ -51,12 +51,12 @@ export function FocusSidebar() {
                 </span>
               </div>
               ${agent.currentTask
-                ? html`<div class="text-[0.75rem] text-[var(--white-55)] py-[3px] px-2 bg-[var(--white-3)] border border-[var(--white-5)] whitespace-nowrap overflow-hidden text-ellipsis rounded-md">${agent.currentTask}</div>`
+                ? html`<div class="text-[0.75rem] text-[var(--text-body)] py-[3px] px-2 bg-[var(--white-2)] border border-[var(--border-slate-12)] whitespace-nowrap overflow-hidden text-ellipsis rounded-md">${agent.currentTask}</div>`
                 : null}
               <div class="flex items-center gap-2 mt-1">
                 ${agent.lastActivityText
-                  ? html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
-                  : html`<span class="text-[11px] text-[var(--white-40)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic text-[rgba(255,255,255,0.25)]">최근 활동 없음</span>`}
+                  ? html`<span class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0">${agent.lastActivityText}</span>`
+                  : html`<span class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex-1 min-w-0 italic">최근 활동 없음</span>`}
                 ${agent.lastActivityAt
                   ? html`<${TimeAgo} timestamp=${agent.lastActivityAt} />`
                   : null}


### PR DESCRIPTION
## Summary
- bring the monitoring activity surface onto the same card and spacing system as sessions and agents
- replace the old gold activity filter buttons with the shared blue/slate accent treatment used elsewhere in monitoring
- give the live stream and focus sidebar explicit card shells so the activity page no longer reads like raw text blocks

## Verification
- npm run typecheck
- npm run build
- checked `#monitoring?section=activity` through a local Vite dev preview proxied to http://127.0.0.1:8935

## Review note
- visual-only change for the monitoring activity surface