### PR TITLE
fix(calibration): harden reject prefix matching and error handling

### DIFF
--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -157,7 +157,7 @@ let record_human_label
 
 let string_field json key =
   try Yojson.Safe.Util.(json |> member key |> to_string)
-  with _ -> ""
+  with Yojson.Safe.Util.Type_error _ | Not_found -> ""
 
 (* ================================================================ *)
 (* Divergence analysis                                               *)
@@ -192,8 +192,9 @@ let find_divergences ?(since = "") ?(until = "") () : divergence list =
     | Some l_json ->
       let ev = string_field v_json "verdict" in
       let hv = string_field l_json "human_verdict" in
-      let ev_norm = if String.length ev >= 6 &&
-                       String.sub ev 0 6 = "reject" then "reject"
+      let ev_norm = if ev = "reject" ||
+                       (String.length ev >= 7 &&
+                        String.sub ev 0 7 = "reject:") then "reject"
                     else ev in
       if ev_norm <> hv then
         divergences := {
@@ -282,8 +283,9 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
     match Hashtbl.find_opt labeled_hashes hash with
     | None -> ()
     | Some hv ->
-      let ev_norm = if String.length ev >= 6 &&
-                       String.sub ev 0 6 = "reject" then "reject"
+      let ev_norm = if ev = "reject" ||
+                       (String.length ev >= 7 &&
+                        String.sub ev 0 7 = "reject:") then "reject"
                     else ev in
       if ev_norm = hv then incr agree
       else if ev_norm = "approve" && hv = "reject" then incr false_pos


### PR DESCRIPTION
## Summary

GLM-5 cross-model review findings for PR #3133 (eval_calibration):

- Fix reject normalization: match `"reject:"` (7 chars) or exact `"reject"` instead of loose 6-char prefix which could match `"rejects"`
- Narrow exception handler in `string_field`: catch `Type_error` and `Not_found` only, instead of blanket catch-all that hides structural JSONL errors

## Test plan

- [x] `test_eval_calibration`: 16/16 passing (includes divergence tests that exercise reject matching)

## Context

Follow-up to #3133 (A-2 Evaluator Calibration Loop). Addresses review feedback from GLM-5 cross-model evaluation.