### PR TITLE
refactor(backend): remove FileSystem Effect.Unhandled fallback (#3114)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -101,9 +101,10 @@ module FileSystem = struct
         let path_part = String.map (function ':' -> '/' | c -> c) safe_key in
         Ok Eio.Path.(t.fs / path_part)
 
+  (** Run a blocking file operation in a system thread.
+      FileSystem backend requires Eio context — no fallback. *)
   let run_blocking_file_op f =
-    try Eio_unix.run_in_systhread f
-    with Stdlib.Effect.Unhandled _ -> f ()
+    Eio_unix.run_in_systhread f
 
   let with_locked_rw_fd path_str f =
     run_blocking_file_op (fun () ->


### PR DESCRIPTION
## Summary
- `FileSystem.run_blocking_file_op`에서 `Effect.Unhandled` fallback 제거
- FileSystem은 항상 Eio context에서 실행 (with_eio_env 강제) → fallback 불필요
- fallback이 있으면 Eio context 없이 호출 시 blocking I/O가 Eio thread에서 무음으로 실행되는 위험
- Memory backend의 dual fallback (Effect.Unhandled + Poisoned)은 유지

## Changes
- `lib/backend/backend.ml`: `run_blocking_file_op` 1줄 변경 (try/with 제거)

## Test plan
- [x] `test_backend.exe` — 15/15 pass (167s, PG 포함)
- [x] `test_backend_coverage.exe` — 37/37 pass
- [x] `dune build lib/` passes

Closes #3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)