### PR TITLE
fix(keeper): re-sync proactive_enabled from persona on bootstrap

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -29,7 +29,30 @@ let maybe_promote_live_persistent_keeper config name =
 
 let ensure_resident_meta config (spec : resident_keeper_spec) =
   match read_meta config spec.persistent_name with
-  | Ok (Some meta) -> Ok meta
+  | Ok (Some meta) ->
+    (* Re-sync proactive_enabled from persona defaults on bootstrap.
+       Persisted meta may have stale values from a previous session;
+       persona config is the source of truth for declarative settings. *)
+    let defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
+    let target_proactive =
+      match defaults.proactive_enabled with
+      | Some v -> v
+      | None -> Keeper_config.default_proactive_enabled
+    in
+    if meta.proactive.enabled <> target_proactive then begin
+      Log.Keeper.info "ensure_resident_meta: re-syncing proactive.enabled %b -> %b for %s"
+        meta.proactive.enabled target_proactive meta.name;
+      let updated = { meta with
+        proactive = { meta.proactive with enabled = target_proactive };
+        updated_at = now_iso ();
+      } in
+      match write_meta config updated with
+      | Ok () -> Ok updated
+      | Error e ->
+        Log.Keeper.warn "ensure_resident_meta: write_meta re-sync failed: %s" e;
+        Ok meta
+    end
+    else Ok meta
   | Ok None ->
     (* No persistent meta on disk. Try legacy seed_meta for backward compat,
        otherwise require manual keeper_up (which loads fresh from template). *)


### PR DESCRIPTION
## Summary
- `ensure_resident_meta`가 디스크에서 meta 로드 시 persona defaults를 재동기화하지 않던 버그 수정
- persona `profile.json`의 `proactive_enabled: true` 설정이 런타임 캐시의 stale `false` 값에 의해 무시되던 문제
- bootstrap 시 persona defaults (TOML > profile.json > hardcoded default) 우선순위 체인으로 재동기화

Closes #3108

## Changes
- `lib/keeper/keeper_runtime.ml`: `ensure_resident_meta`에서 `Ok (Some meta)` 경로에 persona defaults 재동기화 로직 추가 (+24/-1)

## Test plan
- [ ] `dune build --root .` 통과
- [ ] `make test` 통과
- [ ] keeper bootstrap 후 `masc_keeper_list`에서 persona 설정과 일치하는 `proactive_enabled` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)