### PR TITLE
perf(backend): parallel PG schema init — 5 RTT to 2 RTT

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -235,20 +235,36 @@ let create ~sw ~env ~url ~cluster_name ~node_id =
       Error (caqti_error_to_masc err)
   | Ok pool ->
       Log.Backend.info "[EioPG] pool created, initializing schema...";
-      (* Initialize schema including pubsub tables and indexes *)
-      let init_result = Caqti_eio.Pool.use (fun conn ->
-        let module C = (val conn : Caqti_eio.CONNECTION) in
-        let* () = C.exec create_schema_q () in
-        let* () = C.exec create_pubsub_table_q () in
-        let* () = C.exec create_index_q () in
-        let* () = C.exec create_pubsub_index_q () in
-        let* () = C.exec create_pubsub_created_at_index_q () in
-        Ok ()
-      ) pool in
+      (* Parallel DDL init: 2-phase to respect table→index dependency.
+         Each fiber gets its own connection from pool; all DDL uses IF NOT EXISTS. *)
+      let exec_ddl q =
+        match Caqti_eio.Pool.use (fun conn ->
+          let module C = (val conn : Caqti_eio.CONNECTION) in
+          C.exec q ()
+        ) pool with
+        | Ok () -> ()
+        | Error e -> raise (Failure (Caqti_error.show e))
+      in
+      let init_result =
+        try
+          (* Phase 1: create tables in parallel (independent) *)
+          let (_: unit * unit) = Eio.Fiber.pair
+            (fun () -> exec_ddl create_schema_q)
+            (fun () -> exec_ddl create_pubsub_table_q)
+          in
+          (* Phase 2: create indexes in parallel (tables now exist) *)
+          Eio.Fiber.all [
+            (fun () -> exec_ddl create_index_q);
+            (fun () -> exec_ddl create_pubsub_index_q);
+            (fun () -> exec_ddl create_pubsub_created_at_index_q);
+          ];
+          Ok ()
+        with Failure msg -> Error (IOError msg)
+      in
       (match init_result with
        | Error err ->
-           Log.Backend.error "[EioPG] schema init failed: %s" (Caqti_error.show err);
-           Error (caqti_error_to_masc err)
+           Log.Backend.error "[EioPG] schema init failed: %s" (show_error err);
+           Error err
        | Ok () ->
            Log.Backend.info "[EioPG] connected and schema ready";
            at_exit (fun () ->


### PR DESCRIPTION
## Summary
- PG 스키마 초기화가 5개 DDL을 단일 커넥션에서 순차 실행 (5 RTT)
- 2-phase 병렬 init으로 변경: Phase 1 (2 테이블 병렬) → Phase 2 (3 인덱스 병렬)
- 각 fiber가 pool에서 별도 커넥션 획득. 모든 DDL은 IF NOT EXISTS로 멱등성 보장
- Supabase 기준 startup latency ~100-300ms → ~40-120ms 예상

Closes #3113

## Changes
- `lib/backend/backend_pg.ml`: `Eio.Fiber.pair`/`Eio.Fiber.all`로 2-phase 병렬 DDL init

## Test plan
- [ ] `dune build --root .` 통과
- [ ] `make test` 통과
- [ ] 서버 시작 시 "[EioPG] connected and schema ready" 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)