### PR TITLE
refactor(backend): encapsulate compression behind encode/decode (#3111)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -16,9 +16,13 @@
     - Automatically decompresses on load (ZSTD/ZSTDD header detection)
 *)
 
-(** {1 Compression} *)
+(** {1 Compression (internal)} *)
 
-module Compression = Backend_compression
+(** Encode value for storage (transparent zstd compression). *)
+let encode = Backend_compression.compress_with_header
+
+(** Decode stored value (auto-detects zstd header). *)
+let decode = Backend_compression.decompress_auto
 
 (** {1 Types} *)
 
@@ -153,7 +157,7 @@ module FileSystem = struct
           try
             let content = Eio.Path.load path in
             (* Compact Protocol v4: Auto-decompress if ZSTD header present *)
-            let decompressed = Compression.decompress_auto content in
+            let decompressed = decode content in
             Ok decompressed
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
@@ -172,7 +176,7 @@ module FileSystem = struct
           try
             _ensure_parent_dir ~log_errors:true path;
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
-            let compressed = Compression.compress_with_header value in
+            let compressed = encode value in
             (* Write file *)
             Eio.Path.save ~create:(`Or_truncate 0o644) path compressed;
             Ok ()
@@ -271,7 +275,7 @@ module FileSystem = struct
   (** Set if not exists (atomic, auto-compresses) *)
   let set_if_not_exists t key value =
     (* Compact Protocol v4: Compress before saving *)
-    let compressed = Compression.compress_with_header value in
+    let compressed = encode value in
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
       match key_to_path t key with
       | Error e -> Error e
@@ -509,11 +513,11 @@ module FileSystem = struct
               if n = 0 then None
               else
                 let raw = Bytes.sub_string buf 0 n in
-                Some (Compression.decompress_auto raw)
+                Some (decode raw)
             end
           in
           let new_content = f current in
-          let compressed = Compression.compress_with_header new_content in
+          let compressed = encode new_content in
           let _ = Unix.lseek fd 0 Unix.SEEK_SET in
           let _ = Unix.ftruncate fd 0 in
           let _ = Unix.write_substring fd compressed 0 (String.length compressed) in

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -7,7 +7,10 @@
     Backend.Postgres delegates to this module.
 *)
 
-module Compression = Backend_compression
+(** {1 Compression (internal)} *)
+
+let encode = Backend_compression.compress_with_header
+let decode = Backend_compression.decompress_auto
 
 (** {1 Types} *)
 
@@ -292,13 +295,13 @@ let get t key =
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find_opt get_q nkey
   ) t.pool with
-  | Ok (Some v) -> Ok (Compression.decompress_auto v)
+  | Ok (Some v) -> Ok (decode v)
   | Ok None -> Error (NotFound key)
   | Error err -> Error (caqti_error_to_masc err)
 
 let set t key value =
   let nkey = namespaced_key t.namespace key in
-  let compressed = Compression.compress_with_header value in
+  let compressed = encode value in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.exec set_q (nkey, compressed)
@@ -348,7 +351,7 @@ let get_all t ~prefix =
   ) t.pool with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
-        (strip_namespace t.namespace k, Compression.decompress_auto v)
+        (strip_namespace t.namespace k, decode v)
       ) pairs)
   | Error err -> Error (caqti_error_to_masc err)
 
@@ -364,13 +367,13 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     ) t.pool with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
-          (strip_namespace t.namespace k, Compression.decompress_auto v)
+          (strip_namespace t.namespace k, decode v)
         ) pairs)
     | Error err -> Error (caqti_error_to_masc err)
 
 let set_if_not_exists t key value =
   let nkey = namespaced_key t.namespace key in
-  let compressed = Compression.compress_with_header value in
+  let compressed = encode value in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     let* existing = C.find_opt exists_q nkey in
@@ -385,11 +388,11 @@ let set_if_not_exists t key value =
 
 let compare_and_swap t ~key ~expected ~value =
   let nkey = namespaced_key t.namespace key in
-  let compressed_new = Compression.compress_with_header value in
+  let compressed_new = encode value in
   (* CAS compares stored payload bytes directly. This preserves the public
      raw-value contract because Backend_compression is deterministic for the
      current simplified zstd path (fixed level, no external dictionary). *)
-  let compressed_expected = Compression.compress_with_header expected in
+  let compressed_expected = encode expected in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     let* row = C.find_opt compare_and_swap_q (nkey, compressed_expected, compressed_new) in
@@ -428,7 +431,7 @@ let extend_lock t ~key ~owner ~ttl_seconds =
 
 (* Pub/Sub using table as queue + NOTIFY for real-time *)
 let publish t ~channel ~message =
-  let compressed = Compression.compress_with_header message in
+  let compressed = encode message in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     (* Insert into table for reliability (persistent queue) *)
@@ -453,7 +456,7 @@ let subscribe t ~channel ~callback =
     C.find_opt subscribe_q channel
   ) t.pool with
   | Ok (Some msg) ->
-      let decompressed = Compression.decompress_auto msg in
+      let decompressed = decode msg in
       callback decompressed;
       Ok ()
   | Ok None -> Ok ()

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -91,7 +91,7 @@ let test_pubsub_max_messages_env () =
 
 let test_compression_small_data () =
   let data = "hello" in
-  let (compressed, used_dict, did_compress) = Backend.Compression.compress data in
+  let (compressed, used_dict, did_compress) = Backend_compression.compress data in
   (* Small data should not be compressed *)
   check bool "small data not compressed" false did_compress;
   check string "small data unchanged" data compressed;
@@ -100,19 +100,19 @@ let test_compression_small_data () =
 let test_compression_large_data () =
   (* Create data larger than min_size (32 bytes) *)
   let data = String.make 100 'a' in
-  let (compressed, _used_dict, did_compress) = Backend.Compression.compress data in
+  let (compressed, _used_dict, did_compress) = Backend_compression.compress data in
   check bool "large data compressed" true did_compress;
   check bool "compressed smaller" true (String.length compressed < String.length data)
 
 let test_compression_roundtrip () =
   let data = String.make 200 'x' ^ String.make 200 'y' in
-  let encoded = Backend.Compression.compress_with_header data in
-  let decoded = Backend.Compression.decompress_auto encoded in
+  let encoded = Backend_compression.compress_with_header data in
+  let decoded = Backend_compression.decompress_auto encoded in
   check string "roundtrip matches" data decoded
 
 let test_compression_uncompressed_passthrough () =
   let data = "short" in
-  let result = Backend.Compression.decompress_auto data in
+  let result = Backend_compression.decompress_auto data in
   check string "uncompressed passthrough" data result
 
 let test_compression_encode_header () =
@@ -120,10 +120,10 @@ let test_compression_encode_header () =
   let orig_size = 1000 in
   let compressed = "compressed_data" in
 
-  let with_dict = Backend.Compression.encode_with_header ~used_dict:true orig_size compressed in
+  let with_dict = Backend_compression.encode_with_header ~used_dict:true orig_size compressed in
   check bool "dict header starts with ZSTDD" true (String.sub with_dict 0 5 = "ZSTDD");
 
-  let without_dict = Backend.Compression.encode_with_header ~used_dict:false orig_size compressed in
+  let without_dict = Backend_compression.encode_with_header ~used_dict:false orig_size compressed in
   check bool "std header starts with ZSTD" true (String.sub without_dict 0 4 = "ZSTD")
 
 let test_compression_decode_header () =
@@ -132,16 +132,16 @@ let test_compression_decode_header () =
   let data = "test_compressed" in
 
   (* With dictionary *)
-  let encoded_dict = Backend.Compression.encode_with_header ~used_dict:true orig data in
-  (match Backend.Compression.decode_header encoded_dict with
+  let encoded_dict = Backend_compression.encode_with_header ~used_dict:true orig data in
+  (match Backend_compression.decode_header encoded_dict with
   | Some (size, _, used_dict) ->
       check int "decoded size" orig size;
       check bool "decoded used_dict" true used_dict
   | None -> fail "decode_header failed for dict");
 
   (* Without dictionary *)
-  let encoded_std = Backend.Compression.encode_with_header ~used_dict:false orig data in
-  match Backend.Compression.decode_header encoded_std with
+  let encoded_std = Backend_compression.encode_with_header ~used_dict:false orig data in
+  match Backend_compression.decode_header encoded_std with
   | Some (size, _, used_dict) ->
       check int "decoded size std" orig size;
       check bool "decoded used_dict std" false used_dict
@@ -149,10 +149,10 @@ let test_compression_decode_header () =
 
 let test_compression_invalid_header () =
   (* Test with data that doesn't have a valid header *)
-  let result = Backend.Compression.decode_header "short" in
+  let result = Backend_compression.decode_header "short" in
   check bool "short data returns None" true (Option.is_none result);
 
-  let result2 = Backend.Compression.decode_header "INVALID_HEADER_DATA" in
+  let result2 = Backend_compression.decode_header "INVALID_HEADER_DATA" in
   check bool "invalid header returns None" true (Option.is_none result2)
 
 (* ============================================================ *)

--- a/test/test_compression.ml
+++ b/test/test_compression.ml
@@ -12,7 +12,7 @@
 
 (* ===== Backend Compression Tests ===== *)
 
-module BackendCompression = Backend.Compression
+module BackendCompression = Backend_compression
 
 let test_backend_compress_skip_small () =
   let small = "tiny" in  (* <32 bytes, below min_dict_size *)


### PR DESCRIPTION
## Summary
- `module Compression = Backend_compression` alias 제거
- 14개 `Compression.compress_with_header`/`decompress_auto` 호출을 모듈-로컬 `encode`/`decode` 함수로 교체
- backend.ml (5개 site) + backend_pg.ml (9개 site)
- 압축 포맷 변경 시 2곳만 수정하면 됨 (이전: 14곳)

## Test plan
- [x] `test_backend.exe` — 15/15 pass (169s, PG 포함)
- [x] `dune build lib/` passes
- [x] 외부에서 `Backend.Compression` 참조 없음 확인

Closes #3111

🤖 Generated with [Claude Code](https://claude.com/claude-code)