### PR TITLE
refactor(cost): remove MASC-side pricing, record-only (#3029)

### DIFF
--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -62,67 +62,9 @@ type trajectory = {
 (* Cost estimation                                                  *)
 (* ================================================================ *)
 
-(** Per-token pricing by model category (USD per token).
-
-    Three tiers:
-    - Local: llama-server / Qwen / Ollama — zero marginal cost (electricity only)
-    - GLM:   ZAI GLM-4/5 — discounted Chinese cloud pricing
-    - Cloud:  Claude / GPT / Gemini — standard API pricing
-
-    Prices sourced from public pricing pages (2026-03 snapshot).
-    Updated manually; check pricing pages before adjusting.
-
-    Returns (input_price_per_token, output_price_per_token). *)
-(** Simple substring check — avoids Str dependency. *)
-let contains (haystack : string) (needle : string) : bool =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let found = ref false in
-    for i = 0 to hlen - nlen do
-      if not !found && String.sub haystack i nlen = needle then found := true
-    done;
-    !found
-
-let starts_with (s : string) (prefix : string) : bool =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
-
-let model_token_pricing (model : string) : float * float =
-  let m = String.lowercase_ascii model in
-  (* Local models: free *)
-  if starts_with m "qwen" || starts_with m "llama" || starts_with m "ollama"
-     || m = "local" || m = "auto" || m = ""
-  then (0.0, 0.0)
-  (* GLM models: ~$0.001/1K input, $0.002/1K output *)
-  else if starts_with m "glm"
-  then (0.000001, 0.000002)
-  (* Claude Haiku: $0.25/1M input, $1.25/1M output *)
-  else if contains m "haiku"
-  then (0.00000025, 0.00000125)
-  (* Claude Sonnet: $3/1M input, $15/1M output *)
-  else if contains m "sonnet"
-  then (0.000003, 0.000015)
-  (* Claude Opus: $15/1M input, $75/1M output *)
-  else if contains m "opus"
-  then (0.000015, 0.000075)
-  (* GPT-4o: $2.50/1M input, $10/1M output *)
-  else if contains m "gpt-4o"
-  then (0.0000025, 0.00001)
-  (* Gemini: $1.25/1M input, $5/1M output (Gemini 2.0 Flash) *)
-  else if contains m "gemini"
-  then (0.00000125, 0.000005)
-  (* Unknown: use conservative cloud pricing (Sonnet-level) *)
-  else (0.000003, 0.000015)
-
-(** Estimate cost in USD for a single LLM turn.
-    Uses [model_token_pricing] to look up per-token rates. *)
-let estimate_turn_cost ~(model : string) ~(input_tokens : int)
-    ~(output_tokens : int) : float =
-  let (in_price, out_price) = model_token_pricing model in
-  (Float.of_int input_tokens *. in_price)
-  +. (Float.of_int output_tokens *. out_price)
+(* model_token_pricing and estimate_turn_cost removed (#3029).
+   Pricing belongs to OAS cascade, not MASC.
+   MASC records cost_usd from OAS responses via emit_cost_event. *)
 
 (** Rough per-call cost estimates for keeper tools.
     Most are local/free; only MODEL-calling tools have cost. *)

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -271,54 +271,8 @@ let test_task_id_null_when_none () =
     | `Null -> ()
     | _ -> Alcotest.fail "Expected task_id to be null when not set")
 
-(* ================================================================ *)
-(* Test: model-aware pricing                                         *)
-(* ================================================================ *)
-
-let test_local_model_free () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"qwen3.5-35b-a3b" ~input_tokens:1000 ~output_tokens:500 in
-  Alcotest.(check (float 0.0001)) "local model free" 0.0 cost
-
-let test_llama_model_free () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"llama-3.2-1b" ~input_tokens:1000 ~output_tokens:500 in
-  Alcotest.(check (float 0.0001)) "llama free" 0.0 cost
-
-let test_auto_model_free () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"auto" ~input_tokens:1000 ~output_tokens:500 in
-  Alcotest.(check (float 0.0001)) "auto free" 0.0 cost
-
-let test_empty_model_free () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"" ~input_tokens:1000 ~output_tokens:500 in
-  Alcotest.(check (float 0.0001)) "empty free" 0.0 cost
-
-let test_glm_model_cheap () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"glm-4-flash" ~input_tokens:1000 ~output_tokens:1000 in
-  Alcotest.(check (float 0.0001)) "glm cheap" 0.003 cost
-
-let test_sonnet_model_priced () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"claude-sonnet-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
-  Alcotest.(check (float 0.0001)) "sonnet priced" 0.018 cost
-
-let test_opus_model_expensive () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"claude-opus-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
-  Alcotest.(check (float 0.001)) "opus expensive" 0.090 cost
-
-let test_haiku_model_cheap () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"claude-haiku-4-20260514" ~input_tokens:1000 ~output_tokens:1000 in
-  Alcotest.(check (float 0.0001)) "haiku cheap" 0.0015 cost
-
-let test_unknown_model_conservative () =
-  let cost = Trajectory.estimate_turn_cost
-    ~model:"future-model-v99" ~input_tokens:1000 ~output_tokens:1000 in
-  Alcotest.(check (float 0.0001)) "unknown conservative" 0.018 cost
+(* model_pricing tests removed — model_token_pricing / estimate_turn_cost
+   deleted from Trajectory (#3029). Pricing belongs to OAS cascade. *)
 
 (* ================================================================ *)
 (* Runner                                                            *)
@@ -358,16 +312,5 @@ let () =
       Alcotest.test_case "finalize propagates" `Quick test_finalize_propagates_task_id;
       Alcotest.test_case "json with task_id" `Quick test_task_id_in_trajectory_json;
       Alcotest.test_case "json null when none" `Quick test_task_id_null_when_none;
-    ]);
-    ("model_pricing", [
-      Alcotest.test_case "local qwen free" `Quick test_local_model_free;
-      Alcotest.test_case "llama free" `Quick test_llama_model_free;
-      Alcotest.test_case "auto free" `Quick test_auto_model_free;
-      Alcotest.test_case "empty free" `Quick test_empty_model_free;
-      Alcotest.test_case "glm cheap" `Quick test_glm_model_cheap;
-      Alcotest.test_case "sonnet priced" `Quick test_sonnet_model_priced;
-      Alcotest.test_case "opus expensive" `Quick test_opus_model_expensive;
-      Alcotest.test_case "haiku cheap" `Quick test_haiku_model_cheap;
-      Alcotest.test_case "unknown conservative" `Quick test_unknown_model_conservative;
     ]);
   ]


### PR DESCRIPTION
## Summary
- `trajectory.ml`에서 `model_token_pricing`, `estimate_turn_cost` 및 관련 유틸리티 제거 (-120줄)
- MASC는 cost를 계산하지 않고 OAS cascade에서 받아서 기록만 함
- `emit_cost_event`는 유지 (현재 0.0 placeholder, OAS 연동 시 실제 값 수신)
- `tool_cost_estimate`는 유지 (eval_gate에서 사용 중)

## 원칙
- `masc-model-agnostic`: MASC에서 모델명 패턴 매칭 금지
- pricing은 inference를 실행하는 쪽(OAS cascade)이 소유

## 후속 작업
- OAS cascade 응답에 `cost_usd` 필드 추가 (별도 이슈)
- `keeper_hooks_oas.ml`의 `after_turn` hook에서 실제 cost 전달

## Test plan
- [x] `test_trajectory` 19 tests 전부 통과 (model_pricing 9개 제거)
- [x] `dune build` 전체 빌드 성공
- [ ] CI green 확인

Generated with [Claude Code](https://claude.com/claude-code)