### PR TITLE
refactor(backend): encapsulate compression behind _compress/_decompress

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -144,6 +144,9 @@ module FileSystem = struct
                 raise exn)
     | None -> ()
 
+  let _compress = Compression.compress_with_header
+  let _decompress = Compression.decompress_auto
+
   (** Get value by key (auto-decompresses ZSTD if detected) *)
   let get t key =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
@@ -153,7 +156,7 @@ module FileSystem = struct
           try
             let content = Eio.Path.load path in
             (* Compact Protocol v4: Auto-decompress if ZSTD header present *)
-            let decompressed = Compression.decompress_auto content in
+            let decompressed = _decompress content in
             Ok decompressed
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
@@ -172,7 +175,7 @@ module FileSystem = struct
           try
             _ensure_parent_dir ~log_errors:true path;
             (* Compact Protocol v4: Compress before saving (if beneficial) *)
-            let compressed = Compression.compress_with_header value in
+            let compressed = _compress value in
             (* Write file *)
             Eio.Path.save ~create:(`Or_truncate 0o644) path compressed;
             Ok ()
@@ -271,7 +274,7 @@ module FileSystem = struct
   (** Set if not exists (atomic, auto-compresses) *)
   let set_if_not_exists t key value =
     (* Compact Protocol v4: Compress before saving *)
-    let compressed = Compression.compress_with_header value in
+    let compressed = _compress value in
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
       match key_to_path t key with
       | Error e -> Error e
@@ -509,11 +512,11 @@ module FileSystem = struct
               if n = 0 then None
               else
                 let raw = Bytes.sub_string buf 0 n in
-                Some (Compression.decompress_auto raw)
+                Some (_decompress raw)
             end
           in
           let new_content = f current in
-          let compressed = Compression.compress_with_header new_content in
+          let compressed = _compress new_content in
           let _ = Unix.lseek fd 0 Unix.SEEK_SET in
           let _ = Unix.ftruncate fd 0 in
           let _ = Unix.write_substring fd compressed 0 (String.length compressed) in

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -9,6 +9,9 @@
 
 module Compression = Backend_compression
 
+let _compress = Compression.compress_with_header
+let _decompress = Compression.decompress_auto
+
 (** {1 Types} *)
 
 include Backend_types
@@ -292,13 +295,13 @@ let get t key =
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find_opt get_q nkey
   ) t.pool with
-  | Ok (Some v) -> Ok (Compression.decompress_auto v)
+  | Ok (Some v) -> Ok (_decompress v)
   | Ok None -> Error (NotFound key)
   | Error err -> Error (caqti_error_to_masc err)
 
 let set t key value =
   let nkey = namespaced_key t.namespace key in
-  let compressed = Compression.compress_with_header value in
+  let compressed = _compress value in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.exec set_q (nkey, compressed)
@@ -348,7 +351,7 @@ let get_all t ~prefix =
   ) t.pool with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
-        (strip_namespace t.namespace k, Compression.decompress_auto v)
+        (strip_namespace t.namespace k, _decompress v)
       ) pairs)
   | Error err -> Error (caqti_error_to_masc err)
 
@@ -364,13 +367,13 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     ) t.pool with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
-          (strip_namespace t.namespace k, Compression.decompress_auto v)
+          (strip_namespace t.namespace k, _decompress v)
         ) pairs)
     | Error err -> Error (caqti_error_to_masc err)
 
 let set_if_not_exists t key value =
   let nkey = namespaced_key t.namespace key in
-  let compressed = Compression.compress_with_header value in
+  let compressed = _compress value in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     let* existing = C.find_opt exists_q nkey in
@@ -385,11 +388,11 @@ let set_if_not_exists t key value =
 
 let compare_and_swap t ~key ~expected ~value =
   let nkey = namespaced_key t.namespace key in
-  let compressed_new = Compression.compress_with_header value in
+  let compressed_new = _compress value in
   (* CAS compares stored payload bytes directly. This preserves the public
      raw-value contract because Backend_compression is deterministic for the
      current simplified zstd path (fixed level, no external dictionary). *)
-  let compressed_expected = Compression.compress_with_header expected in
+  let compressed_expected = _compress expected in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     let* row = C.find_opt compare_and_swap_q (nkey, compressed_expected, compressed_new) in
@@ -428,7 +431,7 @@ let extend_lock t ~key ~owner ~ttl_seconds =
 
 (* Pub/Sub using table as queue + NOTIFY for real-time *)
 let publish t ~channel ~message =
-  let compressed = Compression.compress_with_header message in
+  let compressed = _compress message in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     (* Insert into table for reliability (persistent queue) *)
@@ -453,7 +456,7 @@ let subscribe t ~channel ~callback =
     C.find_opt subscribe_q channel
   ) t.pool with
   | Ok (Some msg) ->
-      let decompressed = Compression.decompress_auto msg in
+      let decompressed = _decompress msg in
       callback decompressed;
       Ok ()
   | Ok None -> Ok ()


### PR DESCRIPTION
## Summary
- backend.ml (5곳) + backend_pg.ml (9곳) 총 14개 `Compression.*` 직접 호출을 `_compress`/`_decompress` alias로 중앙화
- 압축 전략 변경 시 모듈당 1곳만 수정하면 됨
- 순수 기계적 리팩터링, 동작 변경 없음

Closes #3111

## Changes
- `lib/backend/backend.ml`: FileSystem module에 `_compress`/`_decompress` alias 추가, 5곳 교체
- `lib/backend/backend_pg.ml`: module 상단에 alias 추가, 9곳 교체

## Test plan
- [x] `dune build --root .` 통과
- [ ] CI checks 통과
- [ ] 기존 backend 테스트 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)