### PR TITLE
refactor: extract research into masc_research sub-library (#3096)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -546,10 +546,7 @@
    tool_autoresearch_repo_synthesis
    tool_autoresearch_cycle
    tool_autoresearch
-   ;; Code Research Loop — automated self-improvement via LLM
-   research_config
-   research_metric
-   research_loop
+   ;; Code Research Loop — tool_research adapter (core logic in masc_research library)
    tool_research
    ;; godsplit-phase1: type/schema sub-modules
    team_session_types_enums
@@ -807,6 +804,8 @@
    masc_backend
    ;; Process execution + file locking (extracted sub-library)
    masc_process
+   ;; Research loop — experimental, non-core (extracted sub-library)
+   masc_research
    ;; Room coordination (extracted sub-library)
    masc_room
    )

--- a/lib/research/dune
+++ b/lib/research/dune
@@ -1,0 +1,17 @@
+(include_subdirs no)
+(library
+ (name masc_research)
+ (public_name masc_mcp.masc_research)
+ (wrapped false)
+ (modules research_config research_metric research_loop)
+ (libraries
+   masc_log
+   masc_types
+   masc_process
+   fs_compat
+   agent_sdk.llm_provider
+   eio
+   unix
+   yojson
+   re
+   str))

--- a/lib/research/research_config.ml
+++ b/lib/research/research_config.ml
@@ -20,6 +20,7 @@ type t = {
   cascade_defaults : string list;  (** fallback model labels when no cascade config file *)
   timeout_sec : int;           (** per-request timeout (seconds) *)
   max_tokens : int;            (** max tokens per LLM response *)
+  temperature : float;         (** LLM sampling temperature *)
   system_prompt : string;
 }
 
@@ -42,6 +43,7 @@ let default ?(repo = default_repo_config ()) () : t =
     cascade_defaults = ["llama:auto"];
     timeout_sec = 120;
     max_tokens = 8192;
+    temperature = 0.7;
     system_prompt =
       "You are a code improvement researcher for an OCaml codebase (MASC MCP server). \
        Propose ONE focused, small change per experiment. Prioritize: \

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -208,8 +208,7 @@ let generate_hypothesis ~sw ~net ~clock ~(config : Research_config.t)
       ~defaults:config.cascade_defaults
       ~messages
       ~system_prompt:config.system_prompt
-      ~temperature:(Cascade_inference.resolve_temperature
-        ~cascade_name:config.cascade_name ~fallback:(fun () -> 0.7))
+      ~temperature:config.temperature
       ~max_tokens:config.max_tokens
       ~timeout_sec:config.timeout_sec
       ()

--- a/lib/tool_research.ml
+++ b/lib/tool_research.ml
@@ -68,9 +68,13 @@ let dispatch (ctx : context) ~name ~args : (bool * string) option =
       ~repo:(Research_config.default_repo_config ~path:repo_path ())
       ()
     in
+    let temperature = Cascade_inference.resolve_temperature
+      ~cascade_name ~fallback:(fun () -> 0.7)
+    in
     let config = { config with
       max_iterations;
       cascade_name;
+      temperature;
       results_file = Printf.sprintf "%s/research_results.tsv" repo_path;
     } in
     let results = Research_loop.run ~sw:ctx.sw ~net:ctx.net ~clock:ctx.clock ~config in


### PR DESCRIPTION
## Summary
- `lib/research/` 3개 모듈(research_config, research_metric, research_loop)을 별도 `masc_research` dune library로 추출
- `tool_research.ml`은 main lib에 adapter로 유지 (MCP dispatch 연결)
- `Cascade_inference` 순환 의존 해결: temperature를 `Research_config.t` 필드로 주입

## Module classification (audit 결과)
| Group | Classification | Extractable |
|-------|---------------|-------------|
| **research/** | Experimental | Extracted (this PR) |
| autoresearch_* | Experimental | Follow-up (#3096 scope 밖) |
| grpc/ | Production-Core | No (transport layer) |
| voice/ | Production (Optional) | Possible (follow-up) |
| council/ | Production-Core | Possible (follow-up) |

## Dependency direction
```
main lib (masc_mcp) --depends-on--> masc_research
masc_research does NOT depend on main lib (no circular dependency)
```

## Test plan
- [x] `dune build lib/` passes
- [x] No reverse dependency from production core to research

Closes #3096

🤖 Generated with [Claude Code](https://claude.com/claude-code)