### PR TITLE
refactor: add Result_syntax shared module (#3156 step 4.0)

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -188,7 +188,7 @@ let cleanup_pubsub_limit_q =
      DELETE FROM masc_pubsub WHERE id IN (SELECT id FROM ranked WHERE rn > $1) RETURNING 1\
    ) SELECT COUNT(*)::int FROM deleted"
 
-let (let*) = Result.bind
+open Result_syntax
 
 (** Read MASC_PG_POOL_SIZE from env, clamped to [1, 50]. Default: 10. *)
 let configured_pool_size () =

--- a/lib/backend/task_pg.ml
+++ b/lib/backend/task_pg.ml
@@ -12,7 +12,7 @@
 
 open Types
 
-let (let*) = Result.bind
+open Result_syntax
 
 type t = {
   pool: (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t;

--- a/lib/board/board_pg.ml
+++ b/lib/board/board_pg.ml
@@ -11,7 +11,7 @@
 
 open Board
 
-let (let*) = Result.bind
+open Result_syntax
 
 type t = {
   pool: (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t;

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard)
+ (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax)
  (libraries yojson unix str eio time_compat fs_compat masc_log))

--- a/lib/core/result_syntax.ml
+++ b/lib/core/result_syntax.ml
@@ -1,0 +1,9 @@
+(** Result_syntax — shared Result monad binding operators.
+
+    Eliminates the need for per-file Result.bind definitions
+    that were duplicated across 21+ files.
+    Usage: [open Result_syntax] at the top of any module that
+    uses [let*] for Result chaining. *)
+
+let ( let* ) = Result.bind
+let ( let+ ) r f = Result.map f r

--- a/lib/memory/memory_pg.ml
+++ b/lib/memory/memory_pg.ml
@@ -8,7 +8,7 @@
 
     @since 2.130.0 *)
 
-let (let*) = Result.bind
+open Result_syntax
 
 type pool = (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t
 


### PR DESCRIPTION
## Summary
- `lib/core/result_syntax.ml` 생성: `let ( let* ) = Result.bind` + `let ( let+ )`
- 4개 파일의 로컬 정의를 `open Result_syntax`로 교체
- 나머지 17개 파일은 포맷 차이로 follow-up pass 필요

## Why
21개 파일에서 동일한 `let (let*) = Result.bind` 정의가 중복. 공유 모듈로 통합하면 일관성 + DRY.

## Test plan
- [x] `dune build lib/` passes

Partially addresses #3156 (step 4.0: foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)