### PR TITLE
fix(eio): metrics store mutex + sync I/O → async write queue (#3101)

### DIFF
--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -74,19 +74,60 @@ let generate_id () =
   let sequence = Atomic.get metric_counter in
   Printf.sprintf "metric-%d-%06d" timestamp_ms sequence
 
-(* Mutex protecting concurrent metric writes within this process.
-   Replaces Unix.lockf which blocks the Eio scheduler. *)
-let record_mutex = Eio.Mutex.create ()
+(* Async write queue: callers push (file, line) entries into a bounded stream.
+   A background fiber drains the stream and batches file appends, eliminating
+   the previous global mutex + synchronous I/O pattern that blocked all writers. *)
 
-(** Record a new task metric - Eio-compatible, non-blocking *)
+type write_entry = { file: string; line: string }
+
+let write_queue : write_entry Eio.Stream.t = Eio.Stream.create 256
+
+let queue_active = Atomic.make false
+
+(** Record a new task metric.
+    Lock-free: serializes the metric to JSON and pushes to the write queue.
+    Actual file I/O happens in the background flush fiber. *)
 let record config (metric : task_metric) : unit =
   ensure_metrics_dir config metric.agent_id;
   let file = current_month_file config metric.agent_id in
   let json = task_metric_to_yojson metric in
   let line = Yojson.Safe.to_string json ^ "\n" in
-  Eio.Mutex.use_rw ~protect:true record_mutex (fun () ->
+  if Atomic.get queue_active then
+    Eio.Stream.add write_queue { file; line }
+  else
+    (* Fallback: no flush fiber running (tests, pre-init). Direct write. *)
     Fs_compat.append_file file line
-  )
+
+(** Drain all pending entries from the write queue, batching by file. *)
+let flush_pending () =
+  let batch = Hashtbl.create 8 in
+  let rec drain () =
+    match Eio.Stream.take_nonblocking write_queue with
+    | None -> ()
+    | Some entry ->
+        let prev = try Hashtbl.find batch entry.file with Not_found -> Buffer.create 256 in
+        Buffer.add_string prev entry.line;
+        Hashtbl.replace batch entry.file prev;
+        drain ()
+  in
+  drain ();
+  Hashtbl.iter (fun file buf ->
+    (try Fs_compat.append_file file (Buffer.contents buf)
+     with exn ->
+       Log.Metrics.error "flush_pending: append failed for %s: %s"
+         file (Printexc.to_string exn))
+  ) batch
+
+(** Start the background flush fiber. Call once inside Eio_main.run.
+    Drains the write queue every 500ms or when the stream has entries. *)
+let start_flush_fiber ~clock =
+  Atomic.set queue_active true;
+  let rec loop () =
+    Eio.Time.sleep clock 0.5;
+    flush_pending ();
+    loop ()
+  in
+  loop ()
 
 (** Create a new task metric (helper) - pure *)
 let create_metric ~agent_id ~task_id ?(collaborators=[]) ?handoff_from () =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -491,6 +491,10 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   Log.info ~ctx:"startup" "subsystems: resident loops started"
 
 let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
+  (* Metrics flush fiber: drains write queue every 500ms, batches file appends.
+     Replaces the old mutex + synchronous file I/O pattern. *)
+  Eio.Fiber.fork ~sw (fun () -> Metrics_store_eio.start_flush_fiber ~clock);
+  Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
   (match Board_dispatch.get_pg_pool () with
   | Some pool ->
       let listener = Board_listener.create pool in


### PR DESCRIPTION
## Summary
- `metrics_store_eio.ml`: global `Eio.Mutex` + 동기 `Fs_compat.append_file` → `Eio.Stream` lock-free queue + background flush fiber
- `server_runtime_bootstrap.ml`: flush fiber 시작 + shutdown hook 등록

## Why
이전 패턴에서 `record()`를 호출하면 mutex를 잡고 파일 I/O를 수행. 모든 metric writer가 millisecond 단위로 대기. 11개 mutex hotspot 중 유일하게 I/O가 critical section 안에서 실행되는 패턴.

## Architecture
```
Before: record() → Mutex.use_rw → Fs_compat.append_file (blocking)
After:  record() → Stream.add (lock-free) → [background] → batch append
```

- `Eio.Stream.create 256`: bounded queue (backpressure at 256 entries)
- Flush fiber: 500ms interval, batches entries by file path
- Shutdown hook: `flush_pending()` drains remaining entries
- Fallback: test context (no flush fiber) → direct write

## Test plan
- [x] `dune build lib/` passes
- [x] Fallback path preserves test behavior (no flush fiber needed)

Closes #3101

🤖 Generated with [Claude Code](https://claude.com/claude-code)