### PR TITLE
refactor: add .mli for eio_guard + result_syntax (#3155 batch 1)

### DIFF
--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -1,0 +1,22 @@
+(** Eio_guard — Dual-mode mutex guard for pre/post Eio runtime.
+
+    Before {!enable} is called, all guard functions execute [f] directly
+    (single-threaded, no locking needed). After {!enable}, they acquire
+    the given [Eio.Mutex.t] before running [f].
+
+    Call {!enable} once inside [Eio_main.run]. *)
+
+val enable : unit -> unit
+(** Activate mutex guards. Call once after Eio runtime starts. *)
+
+val is_ready : unit -> bool
+(** [true] after {!enable} has been called. *)
+
+val with_mutex : Eio.Mutex.t -> (unit -> 'a) -> 'a
+(** Acquire read-write lock if Eio is ready, run [f] directly otherwise. *)
+
+val with_rw : Eio.Mutex.t -> (unit -> 'a) -> 'a
+(** Read-write guard with exception fallback (legacy). *)
+
+val with_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
+(** Read-only guard with exception fallback (legacy). *)

--- a/lib/core/result_syntax.mli
+++ b/lib/core/result_syntax.mli
@@ -1,0 +1,7 @@
+(** Result_syntax — shared Result monad binding operators.
+
+    Usage: [open Result_syntax] at the top of any module that
+    uses [let*] for Result chaining. *)
+
+val ( let* ) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+val ( let+ ) : ('a, 'e) result -> ('a -> 'b) -> ('b, 'e) result


### PR DESCRIPTION
## Summary
- `lib/core/eio_guard.mli`: public API 정의 (enable, is_ready, with_mutex, with_rw, with_ro). 내부 Atomic 상태 숨김.
- `lib/core/result_syntax.mli`: let* / let+ 연산자 타입 명시.

## Why
607개 .ml 중 21.7%만 .mli 보유. 서명 없는 모듈은 모든 내부 함수가 public으로 노출되어 의도치 않은 coupling 생성. #3155의 첫 batch.

## Test plan
- [x] `dune build lib/` passes

Partially addresses #3155

🤖 Generated with [Claude Code](https://claude.com/claude-code)