### PR TITLE
fix(test): wrap remaining tests in Eio context (#3178, batch 1)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -261,7 +261,7 @@
 (test
  (name test_tool_improve_loop)
  (modules test_tool_improve_loop)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 ; Board TTL + metadata classification tests
 (test
  (name test_board_ttl)
@@ -336,7 +336,7 @@
 (test
  (name test_cache_eio)
  (modules test_cache_eio)
- (libraries masc_mcp alcotest str yojson))
+ (libraries masc_mcp alcotest str yojson eio eio_main))
 
 (test
  (name test_chain_native_eio_bootstrap)
@@ -421,7 +421,7 @@
 (test
  (name test_room_messages_raw)
  (modules test_room_messages_raw)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest unix eio eio_main))
 
 (test
  (name test_room_messages_pg)
@@ -458,7 +458,7 @@
 (test
  (name test_cp_section_cache)
  (modules test_cp_section_cache)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 (test
  (name test_cp_jsonl_tail)
@@ -468,7 +468,7 @@
 (executable
  (name test_cp_search_fabric_benchmark)
  (modules test_cp_search_fabric_benchmark)
- (libraries masc_mcp yojson unix))
+ (libraries masc_mcp yojson unix eio eio_main))
 
 (executable
  (name test_repo_synthesis_benchmark)
@@ -483,7 +483,7 @@
 (test
  (name test_swarm_persistence)
  (modules test_swarm_persistence)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 (test
  (name test_tool_team_session)
@@ -527,11 +527,11 @@
 (test
  (name test_keeper_tools_oas)
  (modules test_keeper_tools_oas)
- (libraries masc_mcp agent_sdk alcotest unix))
+ (libraries masc_mcp agent_sdk alcotest unix eio eio_main))
 (test
  (name test_keeper_tool_exposure)
  (modules test_keeper_tool_exposure)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest unix eio eio_main))
 (test
  (name test_keeper_task_dispatch)
  (modules test_keeper_task_dispatch)
@@ -804,7 +804,7 @@
 (test
  (name test_operator_mcp_e2e)
  (modules test_operator_mcp_e2e)
- (libraries masc_mcp alcotest yojson unix mirage-crypto-rng mirage-crypto-rng.unix)
+ (libraries masc_mcp alcotest yojson unix eio eio_main mirage-crypto-rng mirage-crypto-rng.unix)
  (deps ../bin/main_eio.exe))
 
 ; Agent Registry Eio tests

--- a/test/dune
+++ b/test/dune
@@ -356,12 +356,12 @@
 (test
  (name test_hebbian_eio)
  (modules test_hebbian_eio)
- (libraries masc_mcp alcotest str yojson))
+ (libraries masc_mcp alcotest str yojson eio eio_main))
 
 (test
  (name test_planning_eio)
  (modules test_planning_eio)
- (libraries masc_mcp alcotest str yojson))
+ (libraries masc_mcp alcotest str yojson eio eio_main))
 
 ; Thompson Sampling module tests (Thompson Sampling + Health Gate)
 (test
@@ -432,7 +432,7 @@
 (test
  (name test_tool_goals)
  (modules test_tool_goals)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 (test
  (name test_command_plane_v2)
@@ -535,7 +535,7 @@
 (test
  (name test_keeper_task_dispatch)
  (modules test_keeper_task_dispatch)
- (libraries masc_mcp agent_sdk alcotest re unix))
+ (libraries masc_mcp agent_sdk alcotest re unix eio eio_main))
 (test
  (name test_autoresearch_knowledge)
  (modules test_autoresearch_knowledge)
@@ -670,7 +670,7 @@
 (test
  (name test_task_dispatch)
  (modules test_task_dispatch)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest unix eio eio_main))
 
 ; Board PostgreSQL backend tests (skipped when MASC_POSTGRES_URL is absent)
 (test
@@ -682,7 +682,7 @@
 (test
  (name test_drift_guard_core)
  (modules test_drift_guard_core)
- (libraries masc_mcp alcotest unix yojson))
+ (libraries masc_mcp alcotest unix yojson eio eio_main))
 
 (test
  (name test_verify_handoff_tool)
@@ -905,7 +905,7 @@
 (test
  (name test_tool_goals_coverage)
  (modules test_tool_goals_coverage)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 ; Proof criteria pure-function unit tests (no server required)
 (test

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -57,7 +57,8 @@ let test_emit_and_list_events () =
       check int "task filter" 1 (List.length task_only))
 
 let test_filtered_client_receives_matching_events () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_config (fun config ->
       let received = ref [] in
       let push frame = received := frame :: !received in
@@ -83,7 +84,8 @@ let test_filtered_client_receives_matching_events () =
       check int "only matching frame delivered" 1 (List.length !received))
 
 let test_graph_json_summarizes_relationships () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_config (fun config ->
       ignore
         (Lib.Activity_graph.emit config ~room_id:"default" ~kind:"agent.joined"
@@ -119,7 +121,8 @@ let test_graph_json_summarizes_relationships () =
         (List.length (json |> member "timeline" |> to_list)))
 
 let test_graph_json_tracks_runtime_activity_kinds () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   with_config (fun config ->
       ignore
         (Lib.Activity_graph.emit config ~room_id:"default"
@@ -190,7 +193,8 @@ let test_graph_json_tracks_runtime_activity_kinds () =
         (has_edge "votes_on"))
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Activity Graph"
     [
       ( "core",

--- a/test/test_agent_health.ml
+++ b/test/test_agent_health.ml
@@ -9,7 +9,8 @@ open Alcotest
 
 (* Test: fresh agent is healthy *)
 let test_fresh_agent_healthy () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-health-fresh-" ^ string_of_int (Random.int 100000) in
   let status = Agent_health.check_health ~agent_name:name in
   match status with
@@ -19,20 +20,23 @@ let test_fresh_agent_healthy () =
 
 (* Test: is_healthy returns true for fresh agent *)
 let test_is_healthy_fresh () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-healthy-" ^ string_of_int (Random.int 100000) in
   check bool "fresh agent is healthy" true (Agent_health.is_healthy ~agent_name:name)
 
 (* Test: recording success keeps agent healthy *)
 let test_record_success_stays_healthy () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-success-" ^ string_of_int (Random.int 100000) in
   Agent_health.record_success ~agent_name:name;
   check bool "still healthy after success" true (Agent_health.is_healthy ~agent_name:name)
 
 (* Test: repeated failures make agent unhealthy *)
 let test_failures_make_unhealthy () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-fail-" ^ string_of_int (Random.int 100000) in
   (* Default threshold is 3 failures in 60s *)
   Agent_health.record_failure ~agent_name:name ~reason:"test-error-1";
@@ -43,7 +47,8 @@ let test_failures_make_unhealthy () =
 
 (* Test: check_health returns Unhealthy with reason after breaker opens *)
 let test_unhealthy_has_reason () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-reason-" ^ string_of_int (Random.int 100000) in
   Agent_health.record_failure ~agent_name:name ~reason:"boom-1";
   Agent_health.record_failure ~agent_name:name ~reason:"boom-2";
@@ -55,7 +60,8 @@ let test_unhealthy_has_reason () =
 
 (* Test: filter_healthy separates healthy from unhealthy *)
 let test_filter_healthy () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let healthy_name = "test-filter-ok-" ^ string_of_int (Random.int 100000) in
   let sick_name = "test-filter-sick-" ^ string_of_int (Random.int 100000) in
   (* Make one agent unhealthy *)
@@ -71,7 +77,8 @@ let test_filter_healthy () =
 
 (* Test: get_summary returns correct structure *)
 let test_get_summary () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-summary-" ^ string_of_int (Random.int 100000) in
   let s = Agent_health.get_summary ~agent_name:name in
   check string "agent_name matches" name s.agent_name;
@@ -80,7 +87,8 @@ let test_get_summary () =
 
 (* Test: get_summary shows failures after recording *)
 let test_get_summary_with_failures () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-sumfail-" ^ string_of_int (Random.int 100000) in
   Agent_health.record_failure ~agent_name:name ~reason:"oops1";
   Agent_health.record_failure ~agent_name:name ~reason:"oops2";
@@ -96,7 +104,8 @@ let test_status_to_string () =
 
 (* Test: summary_to_json produces valid JSON *)
 let test_summary_to_json () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-json-" ^ string_of_int (Random.int 100000) in
   let s = Agent_health.get_summary ~agent_name:name in
   let json = Agent_health.summary_to_json s in
@@ -112,7 +121,8 @@ let test_summary_to_json () =
 
 (* Test: success after failures resets health (if not yet opened) *)
 let test_success_resets_partial_failures () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let name = "test-reset-" ^ string_of_int (Random.int 100000) in
   Agent_health.record_failure ~agent_name:name ~reason:"err1";
   Agent_health.record_failure ~agent_name:name ~reason:"err2";

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -151,7 +151,8 @@ module RegistryTests = struct
   (* Note: These tests require Eio runtime, run with test_integration *)
   
   let test_register_and_find () =
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
     let identity = Agent_identity.from_agent_name "test-agent" in
     let _ = Agent_identity.Registry.register reg identity in
@@ -163,7 +164,8 @@ module RegistryTests = struct
     check bool "found by name" true (Option.is_some found_by_name)
 
   let test_unregister () =
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
     let identity = Agent_identity.from_agent_name "test-agent" in
     let registered = Agent_identity.Registry.register reg identity in
@@ -173,7 +175,8 @@ module RegistryTests = struct
     check int "count after unregister" 0 (Agent_identity.Registry.count reg)
 
   let test_touch () =
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
     (* Create identity with old timestamp *)
     let old_time = Unix.gettimeofday () -. 10.0 in
@@ -193,7 +196,8 @@ module RegistryTests = struct
     | None -> fail "identity not found after touch"
 
   let test_list_active () =
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let reg = Agent_identity.Registry.create () in
     let id1 = Agent_identity.from_agent_name "active-agent" in
     let id2 = Agent_identity.({

--- a/test/test_agent_registry_eio.ml
+++ b/test/test_agent_registry_eio.ml
@@ -6,12 +6,14 @@ open Masc_mcp
 (* All tests must run within Eio context due to Eio.Mutex usage *)
 
 let test_init () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   check bool "total count >= 0" true (Agent_registry_eio.total_count () >= 0)
 
 let test_get_or_create_new () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `String "test-new-agent");
@@ -23,7 +25,8 @@ let test_get_or_create_new () =
   check (option string) "room_id" (Some "test-room") identity.room_id
 
 let test_get_or_create_existing () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [("_agent_name", `String "existing-agent")] in
   let id1 = Agent_registry_eio.get_or_create_identity params in
@@ -32,7 +35,8 @@ let test_get_or_create_existing () =
   check string "same agent_name" id1.agent_name id2.agent_name
 
 let test_mcp_session_persistence () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let mcp_sid = Printf.sprintf "test-mcp-session-%d" (Random.int 10000) in
   let params = `Assoc [("_agent_name", `String "session-agent")] in
@@ -46,7 +50,8 @@ let test_mcp_session_persistence () =
   check string "same session_key" id1.session_key id2.session_key
 
 let test_get_by_name () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let name = Printf.sprintf "lookup-agent-%d" (Random.int 10000) in
   let params = `Assoc [("_agent_name", `String name)] in
@@ -57,7 +62,8 @@ let test_get_by_name () =
   | None -> fail "agent not found by name"
 
 let test_active_count () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let initial = Agent_registry_eio.active_count () in
   
@@ -70,7 +76,8 @@ let test_active_count () =
   check bool "count increased" true (after >= initial)
 
 let test_list_active () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let name = Printf.sprintf "active-list-agent-%d" (Random.int 10000) in
   let _ = Agent_registry_eio.get_or_create_identity 
@@ -80,14 +87,16 @@ let test_list_active () =
   check bool "has active agents" true (List.length active > 0)
 
 let test_cleanup_stale () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   (* This should not fail even with nothing to clean *)
   let cleaned = Agent_registry_eio.cleanup_stale_sessions () in
   check bool "cleanup returned count" true (cleaned >= 0)
 
 let test_concurrent_access () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   (* Simulate concurrent access *)

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -173,7 +173,8 @@ let test_set_if_not_exists () =
 
 (** Test Memory backend basic operations *)
 let test_memory_backend () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let backend = Backend.Memory.create () in
 
   (* Set value *)

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -271,7 +271,8 @@ let test_eio_atomic_update () =
 (* ============================================================ *)
 
 let test_eio_memory_list_keys () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let backend = Backend.Memory.create () in
   let _ = Backend.Memory.set backend "prefix:a" "1" in
   let _ = Backend.Memory.set backend "prefix:b" "2" in
@@ -282,7 +283,8 @@ let test_eio_memory_list_keys () =
   | Error _ -> fail "list_keys failed"
 
 let test_eio_memory_clear () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let backend = Backend.Memory.create () in
   let _ = Backend.Memory.set backend "key1" "1" in
   let _ = Backend.Memory.set backend "key2" "2" in
@@ -293,7 +295,8 @@ let test_eio_memory_clear () =
   check bool "cleared2" false (Backend.Memory.exists backend "key2")
 
 let test_eio_memory_delete_not_found () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let backend = Backend.Memory.create () in
   match Backend.Memory.delete backend "nonexistent" with
   | Error (Backend.NotFound _) -> ()
@@ -304,7 +307,8 @@ let test_eio_memory_delete_not_found () =
 (* ============================================================ *)
 
 let test_eio_unified_memory () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let mem = Backend.Memory.create () in
   let backend = Backend.Mem mem in
 
@@ -329,7 +333,8 @@ let test_eio_unified_memory () =
   check bool "unified not exists" false (Backend.exists backend "key")
 
 let test_eio_unified_set_if_not_exists () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let mem = Backend.Memory.create () in
   let backend = Backend.Mem mem in
 
@@ -344,7 +349,8 @@ let test_eio_unified_set_if_not_exists () =
   | _ -> fail "second set_if_not_exists should fail"
 
 let test_eio_unified_list_keys () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let mem = Backend.Memory.create () in
   let backend = Backend.Mem mem in
 
@@ -356,7 +362,8 @@ let test_eio_unified_list_keys () =
   | Error _ -> fail "list_keys failed"
 
 let test_eio_unified_lock_memory () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let mem = Backend.Memory.create () in
   let backend = Backend.Mem mem in
 
@@ -456,7 +463,8 @@ let test_eio_fs_list_keys_empty () =
 (* ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Backend Coverage" [
     "validate_ttl", [
       test_case "zero TTL" `Quick test_validate_ttl_zero;

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -12,7 +12,8 @@ let test_base_path =
 
 (** Wrap test body in Eio runtime with isolated JSONL backend *)
 let with_eio f () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Unix.putenv "MASC_BASE_PATH" test_base_path;
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -17,7 +17,8 @@ let () =
   test_default_ttl ();
 
   (* Eio-dependent tests *)
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
 
   (* Test 2: Create permanent post (default) *)
   let test_permanent_post () =

--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -19,7 +19,8 @@ let with_temp_masc_dir f =
       (Printf.sprintf "masc-cache-eio-%d-%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.)))
   in
   Unix.mkdir base 0o755;
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
   try

--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -19,6 +19,7 @@ let with_temp_masc_dir f =
       (Printf.sprintf "masc-cache-eio-%d-%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.)))
   in
   Unix.mkdir base 0o755;
+  Eio_main.run @@ fun _env ->
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
   try

--- a/test/test_chain_native_eio_bootstrap.ml
+++ b/test/test_chain_native_eio_bootstrap.ml
@@ -35,7 +35,8 @@ let test_ensure_bootstrap_omits_legacy_sentinel_prompts () =
         | None -> Sys.getcwd ()
       in
       Unix.putenv "MASC_CHAIN_SOURCE_BASE_PATH" source_root;
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       Lib.Chain_native_eio.ensure_bootstrap config;

--- a/test/test_cp_search_fabric_benchmark.ml
+++ b/test/test_cp_search_fabric_benchmark.ml
@@ -169,7 +169,8 @@ let run_scenario ~strategy =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base_dir in
       setup_units config;
       let started_at = Unix.gettimeofday () in
@@ -289,7 +290,8 @@ let run_coding_scenario ?(strategy = "best_first_v1") ?(speculation = false) () 
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base_dir in
       setup_coding_units config;
       if speculation then

--- a/test/test_cp_search_fabric_benchmark.ml
+++ b/test/test_cp_search_fabric_benchmark.ml
@@ -169,6 +169,7 @@ let run_scenario ~strategy =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base_dir in
       setup_units config;
       let started_at = Unix.gettimeofday () in
@@ -288,6 +289,7 @@ let run_coding_scenario ?(strategy = "best_first_v1") ?(speculation = false) () 
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base_dir in
       setup_coding_units config;
       if speculation then

--- a/test/test_cp_section_cache.ml
+++ b/test/test_cp_section_cache.ml
@@ -40,7 +40,8 @@ let reset_section_cache () =
 let test_basic_snapshot () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -55,7 +56,8 @@ let test_basic_snapshot () =
 let test_cache_hit_no_change () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -71,7 +73,8 @@ let test_cache_hit_no_change () =
 let test_partial_invalidation () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -98,7 +101,8 @@ let test_partial_invalidation () =
 let test_explicit_sessions_bypass () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_cp_section_cache.ml
+++ b/test/test_cp_section_cache.ml
@@ -40,6 +40,7 @@ let reset_section_cache () =
 let test_basic_snapshot () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Eio_main.run @@ fun _env ->
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -54,6 +55,7 @@ let test_basic_snapshot () =
 let test_cache_hit_no_change () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Eio_main.run @@ fun _env ->
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -69,6 +71,7 @@ let test_cache_hit_no_change () =
 let test_partial_invalidation () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Eio_main.run @@ fun _env ->
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
@@ -95,6 +98,7 @@ let test_partial_invalidation () =
 let test_explicit_sessions_bypass () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  Eio_main.run @@ fun _env ->
   reset_section_cache ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -66,7 +66,8 @@ let test_parse_timestamp_invalid () =
 (* ===== generate Tests ===== *)
 
 let test_generate_compact () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -79,7 +80,8 @@ let test_generate_compact () =
   cleanup_dir dir
 
 let test_generate_full () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -94,7 +96,8 @@ let test_generate_full () =
 (* ===== Section Tests ===== *)
 
 let test_agents_section_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -104,7 +107,8 @@ let test_agents_section_empty () =
   cleanup_dir dir
 
 let test_tasks_section_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -114,7 +118,8 @@ let test_tasks_section_empty () =
   cleanup_dir dir
 
 let test_messages_section_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -124,7 +129,8 @@ let test_messages_section_empty () =
   cleanup_dir dir
 
 let test_worktrees_section_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -66,6 +66,7 @@ let test_parse_timestamp_invalid () =
 (* ===== generate Tests ===== *)
 
 let test_generate_compact () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -78,6 +79,7 @@ let test_generate_compact () =
   cleanup_dir dir
 
 let test_generate_full () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -92,6 +94,7 @@ let test_generate_full () =
 (* ===== Section Tests ===== *)
 
 let test_agents_section_empty () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -101,6 +104,7 @@ let test_agents_section_empty () =
   cleanup_dir dir
 
 let test_tasks_section_empty () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -110,6 +114,7 @@ let test_tasks_section_empty () =
   cleanup_dir dir
 
 let test_messages_section_empty () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;
@@ -119,6 +124,7 @@ let test_messages_section_empty () =
   cleanup_dir dir
 
 let test_worktrees_section_empty () =
+  Eio_main.run @@ fun _env ->
   let dir = test_dir () in
   let config = Room_utils.default_config dir in
   setup_room config;

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -52,7 +52,8 @@ let with_clean_loops f =
     f
 
 let with_eio_test f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   f ()
 
 let legacy_state_json ?(loop_id = "legacy-loop") ?(model = "glm:legacy") () =

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -162,7 +162,8 @@ let test_dashboard_shell_current_room_status () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:None);
       Lib.Room.write_current_room config "focus-room";
@@ -197,7 +198,8 @@ let test_dashboard_shell_counts_resident_keepers () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:None);
       ignore

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -26,7 +26,8 @@ let test_empty_governance_structure () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json =
@@ -78,7 +79,8 @@ let test_governance_dir_created_before_read () =
       check bool ".masc/governance/judgments exists" true
         (Sys.file_exists judgments && Sys.is_directory judgments);
       (* read_recent on empty dir returns [] — dashboard_json should still work *)
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json =

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -588,7 +588,8 @@ let test_dashboard_mission_http_cache_isolation () =
 
 let test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task () =
   let keeper_name = "audit-keeper-assembly-fixture" in
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Lib.A2a_tools.emit_heartbeat_task
     ~agent:keeper_name
     ~goal:"Mission keeper audit fixture"

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -245,7 +245,8 @@ let test_dashboard_proof_projection () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-fixture-001" in
@@ -273,7 +274,8 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-worker-runs" in
@@ -303,7 +305,8 @@ let test_timeline_json_orders_command_plane_events_by_timestamp () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-fixture-ordered" in
@@ -339,7 +342,8 @@ let test_dashboard_proof_prefers_actual_activity_over_stronger_persisted_verdict
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-persisted-verdict" in
@@ -392,7 +396,8 @@ let test_dashboard_proof_marks_mentioned_only_actor_as_unanswered () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-mentioned-only" in
@@ -443,7 +448,8 @@ let test_dashboard_proof_ignores_unknown_mentions_outside_session () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-ignore-unknown-mentions" in
@@ -486,7 +492,8 @@ let test_dashboard_proof_uses_historical_verdict_when_live_is_empty () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-historical-only" in

--- a/test/test_dashboard_tool_host_events.ml
+++ b/test/test_dashboard_tool_host_events.ml
@@ -60,7 +60,8 @@ let test_record_writes_audit_ring_and_telemetry () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base_dir in
       let report =
         {

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -26,7 +26,8 @@ let test_dashboard_tools_projection () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json = Lib.Server_dashboard_http.dashboard_tools_http_json config in

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -19,7 +19,8 @@ let make_json i =
 (* ── append creates YYYY-MM/DD.jsonl ──────────────────── *)
 
 let test_append_creates_dated_file () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_append" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   Dated_jsonl.append store (make_json 1);
@@ -42,7 +43,8 @@ let test_append_creates_dated_file () =
 (* ── read_recent returns newest N in chronological order ─ *)
 
 let test_read_recent () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_recent" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   for i = 1 to 5 do
@@ -57,7 +59,8 @@ let test_read_recent () =
   check (list int) "newest 3 chronological" [3; 4; 5] values
 
 let test_read_recent_zero () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_zero" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   Dated_jsonl.append store (make_json 1);
@@ -65,7 +68,8 @@ let test_read_recent_zero () =
   check int "returns 0" 0 (List.length result)
 
 let test_read_recent_more_than_exists () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_overflow" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   Dated_jsonl.append store (make_json 1);
@@ -76,7 +80,8 @@ let test_read_recent_more_than_exists () =
 (* ── read_recent_lines returns raw strings ─────────────── *)
 
 let test_read_recent_lines () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_lines" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   for i = 1 to 4 do
@@ -94,7 +99,8 @@ let test_read_recent_lines () =
 (* ── read_range filters by date ────────────────────────── *)
 
 let test_read_range () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_range" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   Dated_jsonl.append store (make_json 1);
@@ -110,7 +116,8 @@ let test_read_range () =
   check int "empty for future" 0 (List.length result2)
 
 let test_read_range_malformed () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_badrange" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   let result = Dated_jsonl.read_range store ~since:"bad" ~until:"dates" in
@@ -119,7 +126,8 @@ let test_read_range_malformed () =
 (* ── prune removes old files ───────────────────────────── *)
 
 let test_prune () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_prune" in
   (* Create a fake old month dir with a day file *)
   let old_month = Filename.concat dir "2020-01" in
@@ -139,7 +147,8 @@ let test_prune () =
   check bool "today survives prune" true (List.length result > 0)
 
 let test_prune_zero_days () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_prune0" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   let deleted = Dated_jsonl.prune store ~days:0 in
@@ -148,7 +157,8 @@ let test_prune_zero_days () =
 (* ── concurrent append safety ──────────────────────────── *)
 
 let test_concurrent_append () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_concurrent" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   let n = 50 in
@@ -164,7 +174,8 @@ let test_concurrent_append () =
 (* ── empty store ───────────────────────────────────────── *)
 
 let test_empty_store () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "dated_jsonl_empty" in
   let store = Dated_jsonl.create ~base_dir:dir () in
   let result = Dated_jsonl.read_recent store 10 in

--- a/test/test_dispatch_chain_evidence.ml
+++ b/test/test_dispatch_chain_evidence.ml
@@ -77,7 +77,8 @@ let () =
 
 (* Test Tool_rate_limit dispatch *)
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_test_room () in
   let registry = Session.create () in
   let ctx : Tool_rate_limit.context = { config; agent_name = "evidence-agent"; registry } in

--- a/test/test_drift_guard_core.ml
+++ b/test/test_drift_guard_core.ml
@@ -13,6 +13,7 @@ let rec rm_rf path =
       Sys.remove path
 
 let with_temp_masc_dir f =
+  Eio_main.run @@ fun _env ->
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-drift-guard-%d-%d" (Unix.getpid ())

--- a/test/test_drift_guard_core.ml
+++ b/test/test_drift_guard_core.ml
@@ -13,7 +13,8 @@ let rec rm_rf path =
       Sys.remove path
 
 let with_temp_masc_dir f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-drift-guard-%d-%d" (Unix.getpid ())

--- a/test/test_eio_mutex_concurrency.ml
+++ b/test/test_eio_mutex_concurrency.ml
@@ -130,7 +130,8 @@ let test_session_concurrent_create_find () =
 (** {1 Test Runner} *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Eio.Mutex Migration Concurrency" [
     "Rate Limit", [
       test_case "concurrent same key" `Quick test_rate_limit_concurrent;

--- a/test/test_error_logging_coverage.ml
+++ b/test/test_error_logging_coverage.ml
@@ -88,7 +88,8 @@ let rec rm_rf path =
 let with_test_room f =
   let dir = make_test_dir () in
   Unix.mkdir dir 0o755;
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config dir in
   let _ = Room.init config ~agent_name:(Some "test-agent") in
   Fun.protect

--- a/test/test_error_logging_coverage.ml
+++ b/test/test_error_logging_coverage.ml
@@ -88,6 +88,7 @@ let rec rm_rf path =
 let with_test_room f =
   let dir = make_test_dir () in
   Unix.mkdir dir 0o755;
+  Eio_main.run @@ fun _env ->
   let config = Room.default_config dir in
   let _ = Room.init config ~agent_name:(Some "test-agent") in
   Fun.protect

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -64,7 +64,8 @@ let test_notes_hash_length () =
 (* ================================================================ *)
 
 let test_record_verdict_writes () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
@@ -79,7 +80,8 @@ let test_record_verdict_writes () =
   Cal.reset_store_for_testing ()
 
 let test_record_verdict_reject () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
@@ -93,7 +95,8 @@ let test_record_verdict_reject () =
   Cal.reset_store_for_testing ()
 
 let test_record_verdict_hash_matches () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
@@ -113,7 +116,8 @@ let test_record_verdict_hash_matches () =
 (* ================================================================ *)
 
 let test_record_human_label () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   Cal.record_human_label
@@ -133,7 +137,8 @@ let test_record_human_label () =
 (* ================================================================ *)
 
 let test_find_divergences_false_positive () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FP task" ~notes:"looks ok but not" () in
@@ -151,7 +156,8 @@ let test_find_divergences_false_positive () =
   Cal.reset_store_for_testing ()
 
 let test_find_divergences_false_negative () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FN task" ~notes:"actually good work" () in
@@ -168,7 +174,8 @@ let test_find_divergences_false_negative () =
   Cal.reset_store_for_testing ()
 
 let test_find_divergences_agreement () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"OK task" ~notes:"done correctly" () in
@@ -183,7 +190,8 @@ let test_find_divergences_agreement () =
   Cal.reset_store_for_testing ()
 
 let test_find_divergences_no_labels () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
@@ -198,7 +206,8 @@ let test_find_divergences_no_labels () =
 (* ================================================================ *)
 
 let test_select_examples_max () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   (* Create 3 false positives *)
@@ -218,7 +227,8 @@ let test_select_examples_max () =
   Cal.reset_store_for_testing ()
 
 let test_select_examples_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   let examples = Cal.select_examples ~max_examples:5 in
@@ -246,7 +256,8 @@ let test_format_few_shot_block_nonempty () =
 (* ================================================================ *)
 
 let test_calibration_stats () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir () in
   Cal.set_store_for_testing ~base_dir:dir;
   (* 2 approvals, 1 rejection *)

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -34,7 +34,8 @@ let test_with_lock_without_eio () =
 
 let test_with_lock_inside_eio () =
   with_temp_path @@ fun path ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let calls = ref 0 in
   let result =
     File_lock_eio.with_lock path (fun () ->

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -341,7 +341,8 @@ let setup () =
   Tool_dispatch.clear_hooks ()
 
 let test_hook_development_allows () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete"
@@ -355,7 +356,8 @@ let test_hook_development_allows () =
   cleanup_tmpdir tmpdir
 
 let test_hook_production_blocks_critical () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete2"
@@ -375,7 +377,8 @@ let test_hook_production_blocks_critical () =
   cleanup_tmpdir tmpdir
 
 let test_hook_production_allows_low () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
@@ -386,7 +389,8 @@ let test_hook_production_allows_low () =
   cleanup_tmpdir tmpdir
 
 let test_hook_enterprise_blocks_high () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
@@ -401,7 +405,8 @@ let test_hook_enterprise_blocks_high () =
   cleanup_tmpdir tmpdir
 
 let test_hook_paranoid_blocks_medium () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
@@ -418,7 +423,8 @@ let test_hook_paranoid_blocks_medium () =
 (* ── Response structure tests ───────────────────────────────── *)
 
 let test_blocked_response_structure () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in
@@ -440,7 +446,8 @@ let test_blocked_response_structure () =
   cleanup_tmpdir tmpdir
 
 let test_blocked_response_structure_claim_next () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmpdir = make_tmpdir () in
   let config = Room.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"paranoid" in

--- a/test/test_graphql_api.ml
+++ b/test/test_graphql_api.ml
@@ -29,7 +29,8 @@ let graphql_query config query =
   Yojson.Safe.from_string response.body
 
 let test_status_query () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   let config = Room_utils.default_config base_path in
   let _ = Room.init config ~agent_name:None in
@@ -42,7 +43,8 @@ let test_status_query () =
   cleanup_dir base_path
 
 let test_tasks_connection () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   let config = Room_utils.default_config base_path in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_graphql_api.ml
+++ b/test/test_graphql_api.ml
@@ -29,6 +29,7 @@ let graphql_query config query =
   Yojson.Safe.from_string response.body
 
 let test_status_query () =
+  Eio_main.run @@ fun _env ->
   let base_path = temp_dir () in
   let config = Room_utils.default_config base_path in
   let _ = Room.init config ~agent_name:None in
@@ -41,6 +42,7 @@ let test_status_query () =
   cleanup_dir base_path
 
 let test_tasks_connection () =
+  Eio_main.run @@ fun _env ->
   let base_path = temp_dir () in
   let config = Room_utils.default_config base_path in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -256,7 +256,8 @@ let test_grpc_server_registers_health_service () =
       | Some value -> Unix.putenv "MASC_STORAGE_TYPE" value
       | None -> Unix.putenv "MASC_STORAGE_TYPE" "")
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       with_temp_dir "masc-grpc-health" (fun dir ->
           let room_config = Room_utils.default_config dir in
           let server =

--- a/test/test_heartbeat_qw.ml
+++ b/test/test_heartbeat_qw.ml
@@ -3,7 +3,8 @@
 
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   (* Clear state before each test group *)
   let reset () =
     List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))

--- a/test/test_hebbian_eio.ml
+++ b/test/test_hebbian_eio.ml
@@ -17,7 +17,8 @@ let rec rm_rf path =
       Sys.remove path
 
 let with_temp_masc_dir f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-hebbian-eio-%d-%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.)))

--- a/test/test_hebbian_eio.ml
+++ b/test/test_hebbian_eio.ml
@@ -17,6 +17,7 @@ let rec rm_rf path =
       Sys.remove path
 
 let with_temp_masc_dir f =
+  Eio_main.run @@ fun _env ->
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-hebbian-eio-%d-%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.)))

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -50,7 +50,8 @@ let test_classify_mcp_accept () =
   ()
 
 let test_protocol_continuity_allows_missing_header () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-missing-header" in
   let headers = Httpun.Headers.of_list [] in
@@ -65,7 +66,8 @@ let test_protocol_continuity_allows_missing_header () =
           failf "expected missing protocol header to use session continuity, got %s" msg)
 
 let test_protocol_version_for_session_falls_back_to_negotiated_version () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-negotiated-version" in
   let headers = Httpun.Headers.of_list [] in
@@ -78,7 +80,8 @@ let test_protocol_version_for_session_falls_back_to_negotiated_version () =
         (Session.get_protocol_version_for_session ~session_id request))
 
 let test_protocol_continuity_rejects_mismatch () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-mismatch" in
   let headers =
@@ -166,7 +169,8 @@ let test_initialize_never_uses_sse () =
        Masc_mcp.Mcp_protocol.Http_negotiation.Streamable)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "http_negotiation"
     [
       ("accepts_sse_header", [test_case "parses Accept" `Quick test_accepts_sse_header]);

--- a/test/test_identity_e2e.ml
+++ b/test/test_identity_e2e.ml
@@ -8,7 +8,8 @@ open Masc_mcp
 
 (** Test identity extraction from MCP-like params *)
 let test_identity_from_mcp_params () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   let params = `Assoc [
@@ -29,7 +30,8 @@ let test_identity_from_mcp_params () =
 
 (** Test MCP session persistence *)
 let test_mcp_session_persistence () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   let mcp_session = "mcp-session-e2e-test" in
@@ -50,7 +52,8 @@ let test_mcp_session_persistence () =
 
 (** Test room context updates *)
 let test_room_context_updates () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   let mcp_session = "mcp-room-test" in
@@ -67,7 +70,8 @@ let test_room_context_updates () =
 
 (** Test multi-agent isolation *)
 let test_multi_agent_isolation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   (* Create 3 different agents *)
@@ -108,7 +112,8 @@ let test_display_string () =
 
 (** Test cleanup of stale sessions *)
 let test_stale_cleanup () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   
   (* Create active agent *)

--- a/test/test_identity_edge_cases.ml
+++ b/test/test_identity_edge_cases.ml
@@ -5,7 +5,8 @@ open Masc_mcp
 
 (* Empty/null params *)
 let test_empty_params () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let identity = Agent_registry_eio.get_or_create_identity (`Assoc []) in
   check bool "has agent_name" true (String.length identity.agent_name > 0);
@@ -14,7 +15,8 @@ let test_empty_params () =
 
 (* Null values in params *)
 let test_null_values () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `Null);
@@ -25,7 +27,8 @@ let test_null_values () =
 
 (* Very long agent name *)
 let test_long_agent_name () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let long_name = String.make 1000 'a' in
   let params = `Assoc [("_agent_name", `String long_name)] in
@@ -34,7 +37,8 @@ let test_long_agent_name () =
 
 (* Special characters in names *)
 let test_special_chars () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let special_name = "agent-🤖-τεστ-テスト" in
   let params = `Assoc [("_agent_name", `String special_name)] in
@@ -43,7 +47,8 @@ let test_special_chars () =
 
 (* Unknown channel *)
 let test_unknown_channel () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `String "test");
@@ -56,7 +61,8 @@ let test_unknown_channel () =
 
 (* Empty capabilities list *)
 let test_empty_capabilities () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `String "test");
@@ -67,7 +73,8 @@ let test_empty_capabilities () =
 
 (* Invalid capabilities format *)
 let test_invalid_capabilities () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   let params = `Assoc [
     ("_agent_name", `String "test");
@@ -78,7 +85,8 @@ let test_invalid_capabilities () =
 
 (* Rapid session creation *)
 let test_rapid_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
   for i = 1 to 100 do
     let params = `Assoc [("_agent_name", `String (Printf.sprintf "rapid-%d" i))] in

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -19,7 +19,8 @@ let make_meta name =
 
 (** Wrap each test body in Eio_main.run for Eio.Mutex support. *)
 let eio_test name fn =
-  test_case name `Quick (fun () -> Eio_main.run @@ fun _env -> fn ())
+  test_case name `Quick (fun () -> Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env); fn ())
 
 (* ── Basic registry operations ─────────────────────────── *)
 

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -16,6 +16,7 @@ let make_ctx_work () =
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
    Force filesystem backend by unsetting PG env vars. *)
 let with_room f =
+  Eio_main.run @@ fun _env ->
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_task_%d" (Random.int 1_000_000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -16,7 +16,8 @@ let make_ctx_work () =
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
    Force filesystem backend by unsetting PG env vars. *)
 let with_room f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "test_keeper_task_%d" (Random.int 1_000_000)) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -238,6 +238,7 @@ let cleanup_path_test_dir dir =
 let test_path_relative_within_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"lib/foo.ml" in
@@ -246,6 +247,7 @@ let test_path_relative_within_root () =
 let test_path_absolute_outside_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"/etc/passwd" in
@@ -266,6 +268,7 @@ let test_path_traversal_attack () =
   (try Unix.mkdir deep 0o755
    with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir base) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config deep in
     (* ../../../../etc/passwd should escape any reasonable root *)
     let result = Keeper_alerting_path.resolve_keeper_target_path
@@ -275,6 +278,7 @@ let test_path_traversal_attack () =
 let test_path_allowed_paths_filter () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     (* lib is allowed, src is not *)
     let ok_result = Keeper_alerting_path.resolve_keeper_target_path
@@ -292,6 +296,7 @@ let test_path_allowed_paths_filter () =
 let test_path_empty_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"" in
@@ -300,6 +305,7 @@ let test_path_empty_rejected () =
 let test_path_whitespace_only_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"   " in
@@ -308,6 +314,7 @@ let test_path_whitespace_only_rejected () =
 let test_path_empty_allowed_permits_all_within_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun _env ->
     let config = Room.default_config dir in
     (* Empty allowed_paths = permit all within root *)
     let r1 = Keeper_alerting_path.resolve_keeper_target_path

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -238,7 +238,8 @@ let cleanup_path_test_dir dir =
 let test_path_relative_within_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"lib/foo.ml" in
@@ -247,7 +248,8 @@ let test_path_relative_within_root () =
 let test_path_absolute_outside_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"/etc/passwd" in
@@ -268,7 +270,8 @@ let test_path_traversal_attack () =
   (try Unix.mkdir deep 0o755
    with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir base) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config deep in
     (* ../../../../etc/passwd should escape any reasonable root *)
     let result = Keeper_alerting_path.resolve_keeper_target_path
@@ -278,7 +281,8 @@ let test_path_traversal_attack () =
 let test_path_allowed_paths_filter () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     (* lib is allowed, src is not *)
     let ok_result = Keeper_alerting_path.resolve_keeper_target_path
@@ -296,7 +300,8 @@ let test_path_allowed_paths_filter () =
 let test_path_empty_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"" in
@@ -305,7 +310,8 @@ let test_path_empty_rejected () =
 let test_path_whitespace_only_rejected () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_target_path
       ~config ~allowed_paths:[] ~raw_path:"   " in
@@ -314,7 +320,8 @@ let test_path_whitespace_only_rejected () =
 let test_path_empty_allowed_permits_all_within_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
-    Eio_main.run @@ fun _env ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     (* Empty allowed_paths = permit all within root *)
     let r1 = Keeper_alerting_path.resolve_keeper_target_path

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -26,7 +26,8 @@ let test_make_tools_returns_nonempty () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       check bool "tools nonempty" true (List.length tools > 0))
@@ -43,7 +44,8 @@ let test_tools_have_valid_schemas () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       List.iter (fun (tool : Agent_sdk.Tool.t) ->
@@ -65,7 +67,8 @@ let test_tool_count_matches_allowed () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
@@ -103,7 +106,8 @@ let test_error_json_is_returned_as_tool_error () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -130,7 +134,8 @@ let test_repeated_error_results_are_blocked () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -162,7 +167,8 @@ let test_failure_count_resets_after_success () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -205,7 +211,8 @@ let test_failure_tracking_is_independent_per_args () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -26,6 +26,7 @@ let test_make_tools_returns_nonempty () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       check bool "tools nonempty" true (List.length tools > 0))
@@ -42,6 +43,7 @@ let test_tools_have_valid_schemas () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       List.iter (fun (tool : Agent_sdk.Tool.t) ->
@@ -63,6 +65,7 @@ let test_tool_count_matches_allowed () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
@@ -100,6 +103,7 @@ let test_error_json_is_returned_as_tool_error () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -126,6 +130,7 @@ let test_repeated_error_results_are_blocked () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -157,6 +162,7 @@ let test_failure_count_resets_after_success () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in
@@ -199,6 +205,7 @@ let test_failure_tracking_is_independent_per_args () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config dir in
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_ref in
       let tool = find_tool "keeper_fs_read" tools in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -116,7 +116,8 @@ let test_observe_uses_precollected_board_events () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Unix.putenv "MASC_BASE_PATH" base_dir;
       Masc_mcp.Board.reset_global_for_test ();
       Masc_mcp.Board_dispatch.reset_for_test ();

--- a/test/test_mcp_full_cycle.ml
+++ b/test/test_mcp_full_cycle.ml
@@ -34,7 +34,8 @@ let test_identity_extraction () =
 
 (** Test: Agent identity persists in registry *)
 let test_identity_registry_persistence () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   (* First call - register agent *)
@@ -51,7 +52,8 @@ let test_identity_registry_persistence () =
 
 (** Test: Multi-agent scenario - identities don't collide *)
 let test_multi_agent_isolation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   let agents = ["agent-a"; "agent-b"; "agent-c"] in
@@ -73,7 +75,8 @@ let test_multi_agent_isolation () =
 
 (** Test: Room context preserved in identity *)
 let test_room_context () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   let id = Agent_identity.from_agent_name "room-agent" in
@@ -89,7 +92,8 @@ let test_room_context () =
 
 (** Test: Capability filtering *)
 let test_capability_filtering () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   let params_with_caps = `Assoc [
@@ -105,7 +109,8 @@ let test_capability_filtering () =
 
 (** Test: Stale agent cleanup *)
 let test_stale_agent_cleanup () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   (* Active agent *)
@@ -127,7 +132,8 @@ let test_stale_agent_cleanup () =
 
 (** Test: Concurrent registration safety *)
 let test_concurrent_registration () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   (* Spawn multiple fibers registering agents *)
@@ -146,7 +152,8 @@ let test_concurrent_registration () =
 
 (** Test: Session key stability across updates *)
 let test_session_key_stability () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let reg = Agent_identity.Registry.create () in
   
   let id = Agent_identity.from_agent_name "stable-agent" in

--- a/test/test_mdal_store.ml
+++ b/test/test_mdal_store.ml
@@ -70,7 +70,8 @@ let dummy_state () : Mdal.loop_state =
   }
 
 let test_round_trip () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -94,7 +95,8 @@ let test_round_trip () =
   cleanup_dir base_dir
 
 let test_latest_pointer_and_listing () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));

--- a/test/test_metrics_store_eio.ml
+++ b/test/test_metrics_store_eio.ml
@@ -185,7 +185,8 @@ let test_generate_id () =
   print_endline "✓ test_generate_id passed"
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   print_endline "\n=== Metrics_store_eio Tests ===\n";
   test_create_metric ();
   test_complete_metric ();

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -22,7 +22,8 @@ let cleanup_dir dir =
   rm dir
 
 let with_config f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -22,6 +22,7 @@ let cleanup_dir dir =
   rm dir
 
 let with_config f =
+  Eio_main.run @@ fun _env ->
   let dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)

--- a/test/test_notifications.ml
+++ b/test/test_notifications.ml
@@ -43,7 +43,8 @@ let extract_json body = Yojson.Safe.from_string body
 
 (* Run a test function inside Eio runtime *)
 let with_eio f () =
-  Eio_main.run @@ fun _env -> f ()
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env); f ()
 
 (* ── Tests ───────────────────────────────────── *)
 

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -8,7 +8,8 @@ open Masc_mcp
 (* ================================================================ *)
 
 let test_event_bus_broadcast () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_broadcast bus ~agent_name:"test-agent" ~content:"hello";
@@ -21,7 +22,8 @@ let test_event_bus_broadcast () =
   | _ -> Alcotest.fail "expected Custom masc:broadcast event"
 
 let test_event_bus_heartbeat () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_heartbeat bus ~agent_name:"perpetual" ~turn:5 ~context_pct:0.42;
@@ -34,7 +36,8 @@ let test_event_bus_heartbeat () =
   | _ -> Alcotest.fail "expected Custom masc:heartbeat event"
 
 let test_event_bus_task_transition () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let bus = Event_bus.create () in
   let sub = Event_bus.subscribe bus in
   Oas_events.publish_task_transition bus ~agent_name:"worker"

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -415,6 +415,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let base_path = Filename.temp_file "operator-mcp-base-" "" in
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config base_path in
   ignore (Masc_mcp.Room.init config ~agent_name:(Some "supervisor-root"));
   let supervisor_nickname =

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -415,7 +415,8 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
   let base_path = Filename.temp_file "operator-mcp-base-" "" in
   (try Sys.remove base_path with _ -> ());
   Unix.mkdir base_path 0o755;
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config base_path in
   ignore (Masc_mcp.Room.init config ~agent_name:(Some "supervisor-root"));
   let supervisor_nickname =

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -185,6 +185,7 @@ let make_test_dir () =
   tmp_dir
 
 let with_initialized_room f =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = make_test_dir () in
   let config = Room.default_config tmp_dir in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -185,7 +185,8 @@ let make_test_dir () =
   tmp_dir
 
 let with_initialized_room f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = make_test_dir () in
   let config = Room.default_config tmp_dir in
   let _ = Room.init config ~agent_name:None in

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -80,6 +80,7 @@ let test_error_entry_serialization () =
 (* ===== File Operations Tests ===== *)
 
 let test_init () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   match Planning_eio.init config ~task_id:"init-test" with
   | Ok ctx ->
@@ -95,6 +96,7 @@ let test_init () =
       fail (Printf.sprintf "Init failed: %s" e)
 
 let test_load () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"load-test" with
@@ -108,6 +110,7 @@ let test_load () =
       fail (Printf.sprintf "Load failed: %s" e)
 
 let test_load_nonexistent () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   match Planning_eio.load config ~task_id:"nonexistent-task" with
   | Ok _ ->
@@ -117,6 +120,7 @@ let test_load_nonexistent () =
       ()
 
 let test_update_plan () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"update-plan-test" with
@@ -139,6 +143,7 @@ let test_update_plan () =
       fail (Printf.sprintf "Update plan failed: %s" e)
 
 let test_add_note () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"add-note-test" with
@@ -159,6 +164,7 @@ let test_add_note () =
       fail (Printf.sprintf "Add note 2 failed: %s" e)
 
 let test_set_deliverable () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"deliverable-test" with
@@ -173,6 +179,7 @@ let test_set_deliverable () =
       fail (Printf.sprintf "Set deliverable failed: %s" e)
 
 let test_set_deliverable_auto_init () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Do NOT call init -- set_deliverable should auto-init *)
   let content = "# Auto-init Deliverable\n\nDelivered without prior plan_init." in
@@ -190,6 +197,7 @@ let test_set_deliverable_auto_init () =
 (* ===== Error Tracking Tests ===== *)
 
 let test_add_error () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"error-test" with
@@ -209,6 +217,7 @@ let test_add_error () =
       fail (Printf.sprintf "Add error failed: %s" e)
 
 let test_resolve_error () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize and add error *)
   (match Planning_eio.init config ~task_id:"resolve-test" with
@@ -228,6 +237,7 @@ let test_resolve_error () =
       fail (Printf.sprintf "Resolve error failed: %s" e)
 
 let test_resolve_invalid_index () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initialize and add error *)
   (match Planning_eio.init config ~task_id:"invalid-resolve-test" with
@@ -244,6 +254,7 @@ let test_resolve_invalid_index () =
 (* ===== Session Context Tests ===== *)
 
 let test_session_context () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* Initially no current task *)
   check (option string) "no current task" None (Planning_eio.get_current_task config);
@@ -255,6 +266,7 @@ let test_session_context () =
   check (option string) "current task cleared" None (Planning_eio.get_current_task config)
 
 let test_resolve_task_id () =
+  Eio_main.run @@ fun _env ->
   let config = make_config () in
   (* With explicit task_id *)
   (match Planning_eio.resolve_task_id config ~task_id:"explicit-task" with

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -80,7 +80,8 @@ let test_error_entry_serialization () =
 (* ===== File Operations Tests ===== *)
 
 let test_init () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   match Planning_eio.init config ~task_id:"init-test" with
   | Ok ctx ->
@@ -96,7 +97,8 @@ let test_init () =
       fail (Printf.sprintf "Init failed: %s" e)
 
 let test_load () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"load-test" with
@@ -110,7 +112,8 @@ let test_load () =
       fail (Printf.sprintf "Load failed: %s" e)
 
 let test_load_nonexistent () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   match Planning_eio.load config ~task_id:"nonexistent-task" with
   | Ok _ ->
@@ -120,7 +123,8 @@ let test_load_nonexistent () =
       ()
 
 let test_update_plan () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"update-plan-test" with
@@ -143,7 +147,8 @@ let test_update_plan () =
       fail (Printf.sprintf "Update plan failed: %s" e)
 
 let test_add_note () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"add-note-test" with
@@ -164,7 +169,8 @@ let test_add_note () =
       fail (Printf.sprintf "Add note 2 failed: %s" e)
 
 let test_set_deliverable () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"deliverable-test" with
@@ -179,7 +185,8 @@ let test_set_deliverable () =
       fail (Printf.sprintf "Set deliverable failed: %s" e)
 
 let test_set_deliverable_auto_init () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Do NOT call init -- set_deliverable should auto-init *)
   let content = "# Auto-init Deliverable\n\nDelivered without prior plan_init." in
@@ -197,7 +204,8 @@ let test_set_deliverable_auto_init () =
 (* ===== Error Tracking Tests ===== *)
 
 let test_add_error () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize first *)
   (match Planning_eio.init config ~task_id:"error-test" with
@@ -217,7 +225,8 @@ let test_add_error () =
       fail (Printf.sprintf "Add error failed: %s" e)
 
 let test_resolve_error () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize and add error *)
   (match Planning_eio.init config ~task_id:"resolve-test" with
@@ -237,7 +246,8 @@ let test_resolve_error () =
       fail (Printf.sprintf "Resolve error failed: %s" e)
 
 let test_resolve_invalid_index () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initialize and add error *)
   (match Planning_eio.init config ~task_id:"invalid-resolve-test" with
@@ -254,7 +264,8 @@ let test_resolve_invalid_index () =
 (* ===== Session Context Tests ===== *)
 
 let test_session_context () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* Initially no current task *)
   check (option string) "no current task" None (Planning_eio.get_current_task config);
@@ -266,7 +277,8 @@ let test_session_context () =
   check (option string) "current task cleared" None (Planning_eio.get_current_task config)
 
 let test_resolve_task_id () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = make_config () in
   (* With explicit task_id *)
   (match Planning_eio.resolve_task_id config ~task_id:"explicit-task" with

--- a/test/test_progress.ml
+++ b/test/test_progress.ml
@@ -186,7 +186,8 @@ let test_validate_progress_negative () =
   check bool "error mentions range" true (String.length msg > 0)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "progress"
     [
       ("notify", [

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -325,7 +325,8 @@ let test_small_value () =
    ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Prometheus Coverage" [
     "type_to_string", [
       test_case "counter" `Quick test_type_to_string_counter;

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -483,7 +483,8 @@ let () = test "backoff delay capped at max_delay_s" (fun () ->
 (* ── Test: circuit_breaker wrap ────────────────────────────── *)
 
 let () = test "circuit_breaker wrap records success/failure" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let cb = Circuit_breaker.create
     ~failure_threshold:2 ~failure_window:60.0 ~cooldown:1.0 () in
   (* Success path *)
@@ -504,7 +505,8 @@ let () = test "circuit_breaker wrap records success/failure" (fun () ->
 (* ── Test: circuit_breaker wrap_exn ────────────────────────── *)
 
 let () = test "circuit_breaker wrap_exn catches exceptions" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let cb = Circuit_breaker.create
     ~failure_threshold:3 ~failure_window:60.0 ~cooldown:1.0 () in
   let r = Circuit_breaker.wrap_exn cb ~agent_id:"exc-test" (fun () ->

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -172,7 +172,8 @@ let test_too_many_requests_body () =
    ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Rate Limit Coverage" [
     "constants", [
       test_case "default_rate" `Quick test_default_rate;

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -852,7 +852,8 @@ let test_estimate_context_claude_sonnet () =
    ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Relay Coverage" [
     "relay_config.defaults", [
       test_case "threshold" `Quick test_default_config_threshold;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -22,6 +22,7 @@ let contains_warning result = String.sub result 0 3 = "\xE2\x9A\xA0"  (* ⚠ *)
 let contains_portal result = String.sub result 0 4 = "\xF0\x9F\x8C\x80"  (* 🌀 *)
 
 let test_init_creates_folder () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -43,6 +44,7 @@ let test_init_creates_folder () =
   Unix.rmdir tmp_dir
 
 let test_join_creates_agent () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -66,6 +68,7 @@ let test_join_creates_agent () =
   Unix.rmdir tmp_dir
 
 let test_add_and_claim_task () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -90,6 +93,7 @@ let test_add_and_claim_task () =
   Unix.rmdir tmp_dir
 
 let test_add_task_uses_archive_max_id () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -115,6 +119,7 @@ let test_add_task_uses_archive_max_id () =
   Unix.rmdir tmp_dir
 
 let test_broadcast_message () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -135,6 +140,7 @@ let test_broadcast_message () =
   Unix.rmdir tmp_dir
 
 let test_worktree_list_no_git () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -155,6 +161,7 @@ let test_worktree_list_no_git () =
   Unix.rmdir tmp_dir
 
 let test_worktree_create_no_git () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -171,6 +178,7 @@ let test_worktree_create_no_git () =
   Unix.rmdir tmp_dir
 
 let test_event_log () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -199,6 +207,7 @@ let contains_error result = String.sub result 0 3 = "\xE2\x9D\x8C"  (* ❌ *)
    Eio context + Fs_compat.set_fs are set up in the top-level runner,
    so Room.default_config gets FileSystem backend. *)
 let with_test_env f =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -214,6 +223,7 @@ let with_test_env f =
     raise e
 
 let with_memory_test_env f =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_mem_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -488,6 +498,7 @@ let test_operations_preserve_state () =
 (* --- Event Log Verification --- *)
 
 let test_event_log_on_join () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -507,6 +518,7 @@ let test_event_log_on_join () =
   Unix.rmdir tmp_dir
 
 let test_event_log_on_claim_done () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -917,6 +929,7 @@ let test_unicode_task_title () =
 (* ============================================================ *)
 
 let test_reset_clears_all_state () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -935,6 +948,7 @@ let test_reset_clears_all_state () =
   Unix.rmdir tmp_dir
 
 let test_reinit_after_reset () =
+  Eio_main.run @@ fun _env ->
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -1440,9 +1454,7 @@ let test_heartbeat_concurrent_start_stop () =
   Alcotest.(check int) "list empty after cleanup" 0 (List.length (Heartbeat.list ()))
 
 let () =
-  Eio_main.run @@ fun env ->
   Eio_guard.enable ();
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Random.init 42;
   Alcotest.run "Room" [
     (* === Happy Path Tests === *)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -22,7 +22,8 @@ let contains_warning result = String.sub result 0 3 = "\xE2\x9A\xA0"  (* ⚠ *)
 let contains_portal result = String.sub result 0 4 = "\xF0\x9F\x8C\x80"  (* 🌀 *)
 
 let test_init_creates_folder () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -44,7 +45,8 @@ let test_init_creates_folder () =
   Unix.rmdir tmp_dir
 
 let test_join_creates_agent () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -68,7 +70,8 @@ let test_join_creates_agent () =
   Unix.rmdir tmp_dir
 
 let test_add_and_claim_task () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -93,7 +96,8 @@ let test_add_and_claim_task () =
   Unix.rmdir tmp_dir
 
 let test_add_task_uses_archive_max_id () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -119,7 +123,8 @@ let test_add_task_uses_archive_max_id () =
   Unix.rmdir tmp_dir
 
 let test_broadcast_message () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -140,7 +145,8 @@ let test_broadcast_message () =
   Unix.rmdir tmp_dir
 
 let test_worktree_list_no_git () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -161,7 +167,8 @@ let test_worktree_list_no_git () =
   Unix.rmdir tmp_dir
 
 let test_worktree_create_no_git () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -178,7 +185,8 @@ let test_worktree_create_no_git () =
   Unix.rmdir tmp_dir
 
 let test_event_log () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -207,7 +215,8 @@ let contains_error result = String.sub result 0 3 = "\xE2\x9D\x8C"  (* ❌ *)
    Eio context + Fs_compat.set_fs are set up in the top-level runner,
    so Room.default_config gets FileSystem backend. *)
 let with_test_env f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -223,7 +232,8 @@ let with_test_env f =
     raise e
 
 let with_memory_test_env f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_mem_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -498,7 +508,8 @@ let test_operations_preserve_state () =
 (* --- Event Log Verification --- *)
 
 let test_event_log_on_join () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -518,7 +529,8 @@ let test_event_log_on_join () =
   Unix.rmdir tmp_dir
 
 let test_event_log_on_claim_done () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -929,7 +941,8 @@ let test_unicode_task_title () =
 (* ============================================================ *)
 
 let test_reset_clears_all_state () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
@@ -948,7 +961,8 @@ let test_reset_clears_all_state () =
   Unix.rmdir tmp_dir
 
 let test_reinit_after_reset () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -48,7 +48,8 @@ let str_contains s substring =
 (** Create fresh test environment with cleanup.
     Wrapped in Eio_main.run because Room.init uses Eio.Mutex internally. *)
 let with_test_env f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_coverage_%d_%d" (Unix.getpid ())
        (int_of_float (Unix.gettimeofday () *. 1000.))) in

--- a/test/test_room_messages_raw.ml
+++ b/test/test_room_messages_raw.ml
@@ -5,7 +5,8 @@ let with_test_env f =
     (Printf.sprintf "masc_room_messages_%d_%d" (Unix.getpid ())
        (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   try

--- a/test/test_room_messages_raw.ml
+++ b/test/test_room_messages_raw.ml
@@ -5,6 +5,7 @@ let with_test_env f =
     (Printf.sprintf "masc_room_messages_%d_%d" (Unix.getpid ())
        (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
+  Eio_main.run @@ fun _env ->
   let config = Room.default_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   try

--- a/test/test_room_vote.ml
+++ b/test/test_room_vote.ml
@@ -11,7 +11,8 @@ let test_base_path =
 
 (** Wrap test body in Eio runtime with filesystem backend *)
 let with_eio f () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   (* Force filesystem backend, avoid PG connection errors *)
   Unix.putenv "MASC_BASE_PATH" test_base_path;
   (try Unix.putenv "MASC_POSTGRES_URL" "" with _ -> ());

--- a/test/test_run_eio_coverage.ml
+++ b/test/test_run_eio_coverage.ml
@@ -141,8 +141,8 @@ let make_test_dir () =
 
 let with_initialized_masc f =
   let tmp_dir = make_test_dir () in
+  Eio_main.run @@ fun _env ->
   let config = Room.default_config tmp_dir in
-  (* Initialize MASC first *)
   let _ = Room.init config ~agent_name:None in
   Fun.protect
     ~finally:(fun () ->

--- a/test/test_run_eio_coverage.ml
+++ b/test/test_run_eio_coverage.ml
@@ -141,7 +141,8 @@ let make_test_dir () =
 
 let with_initialized_masc f =
   let tmp_dir = make_test_dir () in
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
   Fun.protect

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -3,7 +3,8 @@
 open Masc_mcp
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
 
   let test_register_and_get () =
     (* Registration creates a param with default *)

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -40,7 +40,8 @@ let test_cleanup_stale_respects_touch () =
   unregister alive_sid
 
 let test_concurrent_register_unregister () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let open Masc_mcp.Sse in
   let n = 50 in
   let prefix = "conc_" ^ string_of_int (Random.int 1000000) ^ "_" in

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -175,7 +175,8 @@ let test_register_defaults_to_coordinator () =
   Sse.unregister "s-default"
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Alcotest.run "sse-stream"
     [
       ( "try_pop",

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -105,7 +105,8 @@ let test_with_session_header () =
 let () =
   (* Initialize RNG for session ID generation *)
   Mirage_crypto_rng_unix.use_default ();
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Alcotest.run "Streamable HTTP" [
     "Session", [
       Alcotest.test_case "create" `Quick test_session_create;

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -74,6 +74,7 @@ let test_checkpoint_of_invalid_json () =
 let test_load_latest_checkpoint_empty () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       let sid = "test-sess-empty" in
       Team_session_store.ensure_session_dirs config sid;
@@ -84,6 +85,7 @@ let test_load_latest_checkpoint_empty () =
 let test_load_latest_checkpoint_returns_latest () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       let sid = "test-sess-ckpt" in
       Team_session_store.ensure_session_dirs config sid;
@@ -127,6 +129,7 @@ let test_event_entry_of_invalid_json () =
 let test_read_recent_events_empty () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       let sid = "test-sess-no-events" in
       Team_session_store.ensure_session_dirs config sid;
@@ -138,6 +141,7 @@ let test_read_recent_events_empty () =
 let test_read_recent_events_capped () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       let sid = "test-sess-events" in
       Team_session_store.ensure_session_dirs config sid;
@@ -210,6 +214,7 @@ let sample_session config ~session_id ~started_at ~updated_at_iso =
 let test_list_sessions_uses_recency_order_for_limit () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       ignore (Room.init config ~agent_name:(Some "tester"));
       let sessions =
@@ -231,6 +236,7 @@ let test_list_sessions_uses_recency_order_for_limit () =
 let test_list_sessions_records_fallback_diagnostics () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.default_config base in
       ignore (Room.init config ~agent_name:(Some "tester"));
       Team_session_store.save_session config
@@ -252,6 +258,7 @@ let test_list_sessions_records_fallback_diagnostics () =
 let test_list_sessions_named_scope_uses_scoped_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Room.with_scope (Room.default_config base) (Room.Named "alpha-room") in
       Team_session_store.save_session config
         (sample_session config ~session_id:"sess-room" ~started_at:10.0
@@ -273,6 +280,7 @@ let test_list_sessions_memory_backend_uses_project_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
       with_storage_type "memory" (fun () ->
+          Eio_main.run @@ fun _env ->
           let config = Room.default_config base in
           Team_session_store.save_session config
             (sample_session config ~session_id:"sess-memory" ~started_at:10.0

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -74,7 +74,8 @@ let test_checkpoint_of_invalid_json () =
 let test_load_latest_checkpoint_empty () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       let sid = "test-sess-empty" in
       Team_session_store.ensure_session_dirs config sid;
@@ -85,7 +86,8 @@ let test_load_latest_checkpoint_empty () =
 let test_load_latest_checkpoint_returns_latest () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       let sid = "test-sess-ckpt" in
       Team_session_store.ensure_session_dirs config sid;
@@ -129,7 +131,8 @@ let test_event_entry_of_invalid_json () =
 let test_read_recent_events_empty () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       let sid = "test-sess-no-events" in
       Team_session_store.ensure_session_dirs config sid;
@@ -141,7 +144,8 @@ let test_read_recent_events_empty () =
 let test_read_recent_events_capped () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       let sid = "test-sess-events" in
       Team_session_store.ensure_session_dirs config sid;
@@ -214,7 +218,8 @@ let sample_session config ~session_id ~started_at ~updated_at_iso =
 let test_list_sessions_uses_recency_order_for_limit () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       ignore (Room.init config ~agent_name:(Some "tester"));
       let sessions =
@@ -236,7 +241,8 @@ let test_list_sessions_uses_recency_order_for_limit () =
 let test_list_sessions_records_fallback_diagnostics () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base in
       ignore (Room.init config ~agent_name:(Some "tester"));
       Team_session_store.save_session config
@@ -258,7 +264,8 @@ let test_list_sessions_records_fallback_diagnostics () =
 let test_list_sessions_named_scope_uses_scoped_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.with_scope (Room.default_config base) (Room.Named "alpha-room") in
       Team_session_store.save_session config
         (sample_session config ~session_id:"sess-room" ~started_at:10.0
@@ -280,7 +287,8 @@ let test_list_sessions_memory_backend_uses_project_prefix () =
   let base = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
       with_storage_type "memory" (fun () ->
-          Eio_main.run @@ fun _env ->
+          Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
           let config = Room.default_config base in
           Team_session_store.save_session config
             (sample_session config ~session_id:"sess-memory" ~started_at:10.0

--- a/test/test_task_dispatch.ml
+++ b/test/test_task_dispatch.ml
@@ -1,6 +1,7 @@
 open Masc_mcp
 
 let with_temp_config f =
+  Eio_main.run @@ fun _env ->
   let dir = Filename.temp_file "task_dispatch_" "" in
   Unix.unlink dir;
   Unix.mkdir dir 0o755;

--- a/test/test_task_dispatch.ml
+++ b/test/test_task_dispatch.ml
@@ -1,7 +1,8 @@
 open Masc_mcp
 
 let with_temp_config f =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = Filename.temp_file "task_dispatch_" "" in
   Unix.unlink dir;
   Unix.mkdir dir 0o755;

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -357,7 +357,8 @@ let test_summarize_tool_usage_reads_date_split_store_without_fs () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config base_dir in
       Telemetry_eio.track_tool_called config ~tool_name:"masc_status"
         ~success:true ~duration_ms:42 ~agent_id:"codex" ();

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -343,7 +343,8 @@ let test_selection_entropy_empty () =
 (** {1 Test Runner} *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "Thompson_sampling" [
     "beta_sampling", [
       test_case "sample in [0,1] range" `Quick test_sample_beta_range;

--- a/test/test_tool_a2a_coverage.ml
+++ b/test/test_tool_a2a_coverage.ml
@@ -48,7 +48,8 @@ let test_get_bool_missing () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_a2a.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -58,7 +59,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_a2a.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-a2a" in
   ({ config; agent_name = "test-agent" } : Tool_a2a.context)
 

--- a/test/test_tool_a2a_coverage.ml
+++ b/test/test_tool_a2a_coverage.ml
@@ -48,6 +48,7 @@ let test_get_bool_missing () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_a2a.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -57,8 +58,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_a2a.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-a2a" in
-  { config; agent_name = "test-agent" }
+  ({ config; agent_name = "test-agent" } : Tool_a2a.context)
 
 let test_dispatch_a2a_discover () =
   let ctx = make_ctx () in

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -32,6 +32,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -32,7 +32,8 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));

--- a/test/test_tool_audit_coverage.ml
+++ b/test/test_tool_audit_coverage.ml
@@ -31,7 +31,8 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));
@@ -150,7 +151,8 @@ let test_read_audit_events_empty () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let events =
         Tool_audit.read_audit_events ctx.config
           ~since:(Unix.gettimeofday () +. 0.001)
@@ -163,7 +165,8 @@ let test_read_audit_events_reads_canonical_store_and_normalizes_tool_call () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Audit_log.log_action ctx.config ~agent_id:"test-agent"
         ~action:(Audit_log.ToolCall "masc_status")
         ~room_id:"default"
@@ -190,7 +193,8 @@ let test_audit_stats_counts_tool_call_prefixes () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun _env ->
+      Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Audit_log.log_action ctx.config ~agent_id:"test-agent"
         ~action:(Audit_log.ToolCall "masc_status")
         ~room_id:"default" ~details:`Null ~outcome:Audit_log.Success ();

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -18,7 +18,8 @@ let test name f =
 
 (* Create test context *)
 let make_test_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-auth-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -18,6 +18,7 @@ let test name f =
 
 (* Create test context *)
 let make_test_ctx () =
+  Eio_main.run @@ fun _env ->
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-auth-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -45,7 +45,8 @@ let contains_substring haystack needle =
 (** {2 Group 1: Helper / Formatting Functions} *)
 
 let test_visibility_of_string () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   Alcotest.(check string) "public" "public"
     (match Tool_board.visibility_of_string "public" with
@@ -64,7 +65,8 @@ let test_visibility_of_string () =
      | None -> "none" | _ -> "other")
 
 let test_sort_order_of_string () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   Alcotest.(check string) "hot" "hot"
     (match Tool_board.sort_order_of_string "hot" with
@@ -86,7 +88,8 @@ let test_sort_order_of_string () =
      | Tool_board.Hot -> "hot" | _ -> "x")
 
 let test_board_error_to_string () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let s = Tool_board.board_error_to_string (Board.Post_not_found "test-id") in
   Alcotest.(check bool) "post_not_found has text" true (String.length s > 0);
@@ -94,7 +97,8 @@ let test_board_error_to_string () =
   Alcotest.(check bool) "validation_error" true (String.contains s2 'b')
 
 let test_is_agent () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   Alcotest.(check bool) "lowercase no space = lodge" true
     (Tool_board.is_agent "dreamer");
@@ -106,7 +110,8 @@ let test_is_agent () =
     (Tool_board.is_agent "")
 
 let test_format_timestamp_relative () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let now = Time_compat.now () in
   let s = Tool_board.format_timestamp_relative now in
@@ -121,7 +126,8 @@ let test_format_timestamp_relative () =
 (** {2 Group 2: JSON helper functions} *)
 
 let test_get_string () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let args = make_args [("key", `String "value")] in
   Alcotest.(check string) "get existing" "value"
@@ -130,7 +136,8 @@ let test_get_string () =
     (Tool_args.get_string args "missing" "default")
 
 let test_get_string_opt () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let args = make_args [("key", `String "value")] in
   Alcotest.(check (option string)) "get existing" (Some "value")
@@ -139,7 +146,8 @@ let test_get_string_opt () =
     (Tool_args.get_string_opt args "missing")
 
 let test_get_int () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let args = make_args [("n", `Int 42)] in
   Alcotest.(check int) "get existing" 42
@@ -148,7 +156,8 @@ let test_get_int () =
     (Tool_args.get_int args "missing" 0)
 
 let test_get_bool () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let args = make_args [("flag", `Bool true)] in
   Alcotest.(check bool) "get existing" true
@@ -159,7 +168,8 @@ let test_get_bool () =
 (** {2 Group 3: Post Create / List / Get} *)
 
 let test_post_create_success () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "Hello board"); ("author", `String "tester")]) in
@@ -167,7 +177,8 @@ let test_post_create_success () =
   Alcotest.(check bool) "body has post" true (String.length body > 0)
 
 let test_post_create_structured_payload () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_post"
     (make_args
@@ -203,7 +214,8 @@ let test_post_create_structured_payload () =
     (Yojson.Safe.Util.(json |> member "meta" |> member "state_block") = `Null)
 
 let test_post_create_empty_content () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String ""); ("author", `String "tester")]) in
@@ -214,7 +226,8 @@ let test_post_create_empty_content () =
       (String.length body > 0)
 
 let test_post_create_empty_title_rejected () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_post"
     (make_args
@@ -225,7 +238,8 @@ let test_post_create_empty_title_rejected () =
     (contains_substring body "title" || contains_substring body "Title")
 
 let test_post_list_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_list" (make_args []) in
   Alcotest.(check bool) "list ok" true ok;
@@ -233,7 +247,8 @@ let test_post_list_empty () =
     (String.length body > 0)
 
 let test_cleanup_clears_persisted_jsonl () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok1, _ =
     dispatch "masc_board_post"
@@ -247,7 +262,8 @@ let test_cleanup_clears_persisted_jsonl () =
     (contains_substring body "persist me")
 
 let test_post_list_with_posts () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok1, _ = dispatch "masc_board_post"
     (make_args [("content", `String "Post 1"); ("author", `String "a")]) in
@@ -262,7 +278,8 @@ let test_post_list_with_posts () =
     (String.length body > 20)
 
 let test_post_list_limit_clamping () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   (* Create 3 posts *)
   for _ = 1 to 3 do
@@ -276,7 +293,8 @@ let test_post_list_limit_clamping () =
   Alcotest.(check bool) "body has posts" true (String.length body > 0)
 
 let test_post_list_sort_orders () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   ignore (dispatch "masc_board_post"
     (make_args [("content", `String "sort test"); ("author", `String "a")]));
@@ -289,7 +307,8 @@ let test_post_list_sort_orders () =
   ) sorts
 
 let test_post_list_invalid_sort_rejected () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   ignore (dispatch "masc_board_post"
     (make_args [("content", `String "sort test"); ("author", `String "a")]));
@@ -300,7 +319,8 @@ let test_post_list_invalid_sort_rejected () =
     (contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
 
 let test_post_get_success () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "Get me"); ("author", `String "tester")]) in
@@ -323,7 +343,8 @@ let test_post_get_success () =
   Alcotest.(check bool) "get has content" true (String.length body2 > 0)
 
 let test_post_get_not_found () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_get"
     (make_args [("post_id", `String "nonexistent-id")]) in
@@ -333,7 +354,8 @@ let test_post_get_not_found () =
 (** {2 Group 4: Voting} *)
 
 let test_vote_not_found () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_vote"
     (make_args [("post_id", `String "missing"); ("voter", `String "v"); ("direction", `String "up")]) in
@@ -343,7 +365,8 @@ let test_vote_not_found () =
 (** {2 Group 5: Comment} *)
 
 let test_comment_add_missing_post () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_comment"
     (make_args [("post_id", `String "missing"); ("content", `String "hi"); ("author", `String "a")]) in
@@ -351,7 +374,8 @@ let test_comment_add_missing_post () =
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
 let test_comment_vote_missing () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_comment_vote"
     (make_args [("comment_id", `String ""); ("voter", `String "v"); ("direction", `String "up")]) in
@@ -361,7 +385,8 @@ let test_comment_vote_missing () =
 (** {2 Group 6: Search / Stats / Profile / Hearths} *)
 
 let test_search_empty_query () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_search"
     (make_args [("query", `String "")]) in
@@ -369,7 +394,8 @@ let test_search_empty_query () =
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
 let test_search_no_results () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_search"
     (make_args [("query", `String "nonexistent_xyz_123")]) in
@@ -377,14 +403,16 @@ let test_search_no_results () =
   Alcotest.(check bool) "no results msg" true (String.length body > 0)
 
 let test_stats () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_stats" (make_args []) in
   Alcotest.(check bool) "stats ok" true ok;
   Alcotest.(check bool) "stats has content" true (String.length body > 0)
 
 let test_profile_empty_agent () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_profile"
     (make_args [("agent", `String "")]) in
@@ -392,7 +420,8 @@ let test_profile_empty_agent () =
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
 let test_profile_with_posts () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   ignore (dispatch "masc_board_post"
     (make_args [("content", `String "profiled"); ("author", `String "profiler")]));
@@ -404,7 +433,8 @@ let test_profile_with_posts () =
      with Not_found -> false)
 
 let test_hearth_list_empty () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_hearths" (make_args []) in
   Alcotest.(check bool) "hearth list ok" true ok;
@@ -413,7 +443,8 @@ let test_hearth_list_empty () =
 (** {2 Group 7: Dispatch Routing} *)
 
 let test_dispatch_unknown_tool () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let ok, body = dispatch "masc_board_nonexistent" (make_args []) in
   Alcotest.(check bool) "unknown tool fails" false ok;
@@ -422,7 +453,8 @@ let test_dispatch_unknown_tool () =
      with Not_found -> false)
 
 let test_dispatch_migrate_without_pg () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   (* Default backend is JSONL, so migrate should fail *)
   let ok, body = dispatch "masc_board_migrate" (make_args []) in
@@ -434,19 +466,22 @@ let test_dispatch_migrate_without_pg () =
 (** {2 Group 8: Tool Schema Definitions} *)
 
 let test_tools_count () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   Alcotest.(check int) "11 tool schemas" 11 (List.length Tool_board.tools)
 
 let test_tools_names_unique () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let names = List.map (fun (t : Types.tool_schema) -> t.name) Tool_board.tools in
   let unique = List.sort_uniq String.compare names in
   Alcotest.(check int) "all names unique" (List.length names) (List.length unique)
 
 let test_tools_all_have_descriptions () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   List.iter (fun (t : Types.tool_schema) ->
     Alcotest.(check bool) (Printf.sprintf "%s has description" t.name) true

--- a/test/test_tool_cache_coverage.ml
+++ b/test/test_tool_cache_coverage.ml
@@ -52,7 +52,8 @@ let test_get_string_list_mixed () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_cache.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -62,7 +63,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_cache.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-cache" in
   ({ config } : Tool_cache.context)
 

--- a/test/test_tool_cache_coverage.ml
+++ b/test/test_tool_cache_coverage.ml
@@ -52,6 +52,7 @@ let test_get_string_list_mixed () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_cache.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -61,8 +62,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_cache.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-cache" in
-  { config }
+  ({ config } : Tool_cache.context)
 
 let test_dispatch_cache_set () =
   let ctx = make_ctx () in

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -35,6 +35,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -35,7 +35,8 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "test-agent"));

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -17,7 +17,8 @@ let test name f =
 let test_counter = ref 0
 
 let make_test_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   incr test_counter;
   let tmp =
     Filename.concat (Filename.get_temp_dir_name ())

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -17,6 +17,7 @@ let test name f =
 let test_counter = ref 0
 
 let make_test_ctx () =
+  Eio_main.run @@ fun _env ->
   incr test_counter;
   let tmp =
     Filename.concat (Filename.get_temp_dir_name ())

--- a/test/test_tool_goals.ml
+++ b/test/test_tool_goals.ml
@@ -33,6 +33,7 @@ let upsert_goal_exn ctx args =
   |> Yojson.Safe.Util.to_string
 
 let test_goal_upsert_and_list () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -57,6 +58,7 @@ let test_goal_upsert_and_list () =
   cleanup_dir base_dir
 
 let test_goal_refresh_daily_reprioritizes () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -93,6 +95,7 @@ let test_goal_refresh_daily_reprioritizes () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_requires_approval () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -138,6 +141,7 @@ let test_goal_dispatch_requires_approval () =
   cleanup_dir base_dir
 
 let test_goal_review_done_and_promote () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -174,6 +178,7 @@ let test_goal_review_done_and_promote () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_runtime_validation () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -200,6 +205,7 @@ let test_goal_dispatch_runtime_validation () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_task_runtime_requires_manual_current_task_binding () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -233,6 +239,7 @@ let test_goal_dispatch_task_runtime_requires_manual_current_task_binding () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_unknown_goal_ids_fail () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));

--- a/test/test_tool_goals.ml
+++ b/test/test_tool_goals.ml
@@ -33,7 +33,8 @@ let upsert_goal_exn ctx args =
   |> Yojson.Safe.Util.to_string
 
 let test_goal_upsert_and_list () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -58,7 +59,8 @@ let test_goal_upsert_and_list () =
   cleanup_dir base_dir
 
 let test_goal_refresh_daily_reprioritizes () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -95,7 +97,8 @@ let test_goal_refresh_daily_reprioritizes () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_requires_approval () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -141,7 +144,8 @@ let test_goal_dispatch_requires_approval () =
   cleanup_dir base_dir
 
 let test_goal_review_done_and_promote () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -178,7 +182,8 @@ let test_goal_review_done_and_promote () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_runtime_validation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -205,7 +210,8 @@ let test_goal_dispatch_runtime_validation () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_task_runtime_requires_manual_current_task_binding () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -239,7 +245,8 @@ let test_goal_dispatch_task_runtime_requires_manual_current_task_binding () =
   cleanup_dir base_dir
 
 let test_goal_dispatch_unknown_goal_ids_fail () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));

--- a/test/test_tool_goals_coverage.ml
+++ b/test/test_tool_goals_coverage.ml
@@ -44,7 +44,8 @@ let make_ctx base_dir =
 (** {2 Group 1: Dispatch Routing} *)
 
 let test_dispatch_unknown_returns_none () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let result = dispatch_opt ctx ~name:"masc_goal_nonexistent" ~args:(`Assoc []) in
@@ -52,7 +53,8 @@ let test_dispatch_unknown_returns_none () =
   cleanup_dir base_dir
 
 let test_dispatch_all_tool_names () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let valid_names = [
@@ -85,7 +87,8 @@ let test_schemas_have_descriptions () =
 (** {2 Group 3: Goal Snapshot} *)
 
 let test_snapshot_manual_mode () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   (* Create a goal first *)
@@ -101,7 +104,8 @@ let test_snapshot_manual_mode () =
   cleanup_dir base_dir
 
 let test_snapshot_empty_goals () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_snapshot"
@@ -115,7 +119,8 @@ let test_snapshot_empty_goals () =
 (** {2 Group 4: Horizon / Status Validation} *)
 
 let test_list_invalid_horizon () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
@@ -127,7 +132,8 @@ let test_list_invalid_horizon () =
   cleanup_dir base_dir
 
 let test_list_invalid_status () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
@@ -139,7 +145,8 @@ let test_list_invalid_status () =
   cleanup_dir base_dir
 
 let test_list_valid_horizon_filter () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -157,7 +164,8 @@ let test_list_valid_horizon_filter () =
   cleanup_dir base_dir
 
 let test_list_with_rollup () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -176,7 +184,8 @@ let test_list_with_rollup () =
 (** {2 Group 5: Refresh Edge Cases} *)
 
 let test_refresh_invalid_mode () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_refresh"
@@ -188,7 +197,8 @@ let test_refresh_invalid_mode () =
   cleanup_dir base_dir
 
 let test_refresh_auto_no_due () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   (* Without force, auto mode may skip if no cadence window is due *)
@@ -202,7 +212,8 @@ let test_refresh_auto_no_due () =
   cleanup_dir base_dir
 
 let test_refresh_monthly_force () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -219,7 +230,8 @@ let test_refresh_monthly_force () =
 (** {2 Group 6: Dispatch (dry-run / execute=false)} *)
 
 let test_dispatch_no_execute () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -238,7 +250,8 @@ let test_dispatch_no_execute () =
 (** {2 Group 7: Review Edge Cases} *)
 
 let test_review_missing_fields () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
@@ -250,7 +263,8 @@ let test_review_missing_fields () =
   cleanup_dir base_dir
 
 let test_review_nonexistent_goal () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
@@ -262,7 +276,8 @@ let test_review_nonexistent_goal () =
   cleanup_dir base_dir
 
 let test_review_blocked_outcome () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, body1 = upsert_goal ctx

--- a/test/test_tool_goals_coverage.ml
+++ b/test/test_tool_goals_coverage.ml
@@ -44,6 +44,7 @@ let make_ctx base_dir =
 (** {2 Group 1: Dispatch Routing} *)
 
 let test_dispatch_unknown_returns_none () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let result = dispatch_opt ctx ~name:"masc_goal_nonexistent" ~args:(`Assoc []) in
@@ -51,6 +52,7 @@ let test_dispatch_unknown_returns_none () =
   cleanup_dir base_dir
 
 let test_dispatch_all_tool_names () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let valid_names = [
@@ -83,6 +85,7 @@ let test_schemas_have_descriptions () =
 (** {2 Group 3: Goal Snapshot} *)
 
 let test_snapshot_manual_mode () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   (* Create a goal first *)
@@ -98,6 +101,7 @@ let test_snapshot_manual_mode () =
   cleanup_dir base_dir
 
 let test_snapshot_empty_goals () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_snapshot"
@@ -111,6 +115,7 @@ let test_snapshot_empty_goals () =
 (** {2 Group 4: Horizon / Status Validation} *)
 
 let test_list_invalid_horizon () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
@@ -122,6 +127,7 @@ let test_list_invalid_horizon () =
   cleanup_dir base_dir
 
 let test_list_invalid_status () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
@@ -133,6 +139,7 @@ let test_list_invalid_status () =
   cleanup_dir base_dir
 
 let test_list_valid_horizon_filter () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -150,6 +157,7 @@ let test_list_valid_horizon_filter () =
   cleanup_dir base_dir
 
 let test_list_with_rollup () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -168,6 +176,7 @@ let test_list_with_rollup () =
 (** {2 Group 5: Refresh Edge Cases} *)
 
 let test_refresh_invalid_mode () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_refresh"
@@ -179,6 +188,7 @@ let test_refresh_invalid_mode () =
   cleanup_dir base_dir
 
 let test_refresh_auto_no_due () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   (* Without force, auto mode may skip if no cadence window is due *)
@@ -192,6 +202,7 @@ let test_refresh_auto_no_due () =
   cleanup_dir base_dir
 
 let test_refresh_monthly_force () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -208,6 +219,7 @@ let test_refresh_monthly_force () =
 (** {2 Group 6: Dispatch (dry-run / execute=false)} *)
 
 let test_dispatch_no_execute () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, _ = upsert_goal ctx
@@ -226,6 +238,7 @@ let test_dispatch_no_execute () =
 (** {2 Group 7: Review Edge Cases} *)
 
 let test_review_missing_fields () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
@@ -237,6 +250,7 @@ let test_review_missing_fields () =
   cleanup_dir base_dir
 
 let test_review_nonexistent_goal () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
@@ -248,6 +262,7 @@ let test_review_nonexistent_goal () =
   cleanup_dir base_dir
 
 let test_review_blocked_outcome () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let ctx, _ = make_ctx base_dir in
   let ok1, body1 = upsert_goal ctx

--- a/test/test_tool_handover_coverage.ml
+++ b/test/test_tool_handover_coverage.ml
@@ -56,13 +56,14 @@ let test_get_string_list_missing () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_handover.context = {
     config;
     agent_name = "test-agent";
     fs = None;
     proc_mgr = None;
-    sw = None;  (* Cannot create real switch without Eio runtime *)
+    sw = None;
   } in
   check string "agent_name" "test-agent" ctx.agent_name
 
@@ -71,14 +72,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_handover.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-handover" in
-  {
-    config;
-    agent_name = "test-agent";
-    fs = None;
-    proc_mgr = None;
-    sw = None;
-  }
+  ({ config; agent_name = "test-agent"; fs = None; proc_mgr = None; sw = None } : Tool_handover.context)
 
 let test_dispatch_handover_create_no_fs () =
   let ctx = make_ctx () in

--- a/test/test_tool_handover_coverage.ml
+++ b/test/test_tool_handover_coverage.ml
@@ -56,7 +56,8 @@ let test_get_string_list_missing () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_handover.context = {
     config;
@@ -72,7 +73,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_handover.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-handover" in
   ({ config; agent_name = "test-agent"; fs = None; proc_mgr = None; sw = None } : Tool_handover.context)
 

--- a/test/test_tool_hat_coverage.ml
+++ b/test/test_tool_hat_coverage.ml
@@ -17,7 +17,8 @@ let test name f =
 
 (* Create test context - initialize room to avoid "not initialized" error *)
 let make_test_ctx () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-hat-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;

--- a/test/test_tool_hat_coverage.ml
+++ b/test/test_tool_hat_coverage.ml
@@ -17,11 +17,11 @@ let test name f =
 
 (* Create test context - initialize room to avoid "not initialized" error *)
 let make_test_ctx () =
+  Eio_main.run @@ fun _env ->
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-hat-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
-  (* Initialize the room to avoid "MASC not initialized" error *)
   let _ = Room.init config ~agent_name:None in
   { Tool_hat.config; agent_name = "test-agent" }
 

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -60,7 +60,8 @@ let () = test "heartbeat_generate_id" (fun () ->
 )
 
 let () = test "heartbeat_start_stop" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let hb_id = Heartbeat.start ~agent_name:"test" ~interval:30 ~message:"ping" in
   assert (String.length hb_id > 0);
 
@@ -80,7 +81,8 @@ let () = test "heartbeat_start_stop" (fun () ->
 )
 
 let () = test "heartbeat_get" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let hb_id = Heartbeat.start ~agent_name:"getter" ~interval:60 ~message:"test" in
 
   match Heartbeat.get hb_id with
@@ -98,7 +100,8 @@ let () = test "heartbeat_get_missing" (fun () ->
 )
 
 let () = test "heartbeat_list_multiple" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let id1 = Heartbeat.start ~agent_name:"a1" ~interval:10 ~message:"m1" in
   let id2 = Heartbeat.start ~agent_name:"a2" ~interval:20 ~message:"m2" in
 

--- a/test/test_tool_improve_loop.ml
+++ b/test/test_tool_improve_loop.ml
@@ -14,6 +14,7 @@ let with_temp_dir prefix f =
     (fun () -> f dir)
 
 let make_ctx base_path =
+  Eio_main.run @@ fun _env ->
   let config = Room.default_config base_path in
   {
     Tool_improve_loop.config;

--- a/test/test_tool_improve_loop.ml
+++ b/test/test_tool_improve_loop.ml
@@ -14,7 +14,8 @@ let with_temp_dir prefix f =
     (fun () -> f dir)
 
 let make_ctx base_path =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config base_path in
   {
     Tool_improve_loop.config;

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -305,7 +305,8 @@ let write_jsonl_lines path lines =
    policy_shell_mode, initiative_* removed in #2607. *)
 
 let test_keeper_shell_tool_policy_gates () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   (* policy_mode removed: all keepers use unified mode with full tools *)
   let unified = make_keeper_exec_meta () in
   let other = make_keeper_exec_meta ~name:"other-keeper" () in
@@ -315,7 +316,8 @@ let test_keeper_shell_tool_policy_gates () =
     ~expect_bash:true ~expect_shell_readonly:true
 
 let test_keeper_shell_readonly_enforces_allowed_paths () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)
@@ -365,14 +367,16 @@ let test_keeper_shell_readonly_enforces_allowed_paths () =
         (contains_substring error_text "path_not_in_allowed_paths"))
 
 let test_keeper_fs_read_policy_gates () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   (* policy_mode removed: all keepers get fs_read *)
   let unified = make_keeper_exec_meta () in
   check_keeper_exec_tool_presence "unified fs_read" unified
     ~tool_name:"keeper_fs_read" ~expect_allowed:true
 
 let test_keeper_fs_read_enforces_allowed_paths_and_truncation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)
@@ -509,7 +513,8 @@ let test_keeper_bash_requires_cmd_and_runs () =
           code <> 0))
 
 let test_keeper_fs_edit_policy_gates () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   (* policy_mode removed: all keepers use unified mode.
      fs_edit is not in allowed tools by default *)
   let unified = make_keeper_exec_meta () in
@@ -517,7 +522,8 @@ let test_keeper_fs_edit_policy_gates () =
     ~tool_name:"keeper_fs_edit" ~expect_allowed:false
 
 let test_keeper_fs_edit_enforces_allowed_paths_and_modes () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> rm_rf base_dir)

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -40,7 +40,8 @@ let make_endpoint ~url ~model_id ~ctx_size ~total_slots ~busy =
   }
 
 let test_runtime_verify_prefers_oas_discovery_cache () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let previous_endpoints = !(Masc_mcp.Discovery_cache.cached_endpoints) in
   let previous_updated_at = Atomic.get Masc_mcp.Discovery_cache.cache_updated_at in
   Fun.protect

--- a/test/test_tool_mdal.ml
+++ b/test/test_tool_mdal.ml
@@ -593,7 +593,8 @@ let test_terminal_states_reject_iterate () =
   reset_loop_registry ()
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mdal.measure_metric_override := Some mock_measure_metric;
   Alcotest.run "Tool_mdal"
     [

--- a/test/test_tool_notifications_coverage.ml
+++ b/test/test_tool_notifications_coverage.ml
@@ -256,7 +256,8 @@ let test_schemas_names () =
    ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Alcotest.run "Tool_notifications coverage" [
     ("get_int", [
       Alcotest.test_case "present" `Quick test_get_int_present;

--- a/test/test_tool_plan_coverage.ml
+++ b/test/test_tool_plan_coverage.ml
@@ -36,6 +36,7 @@ let test_get_int_missing () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_plan.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -45,8 +46,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_plan.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-plan" in
-  { config }
+  ({ config } : Tool_plan.context)
 
 let test_dispatch_plan_init () =
   let ctx = make_ctx () in

--- a/test/test_tool_plan_coverage.ml
+++ b/test/test_tool_plan_coverage.ml
@@ -36,7 +36,8 @@ let test_get_int_missing () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_plan.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -46,7 +47,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_plan.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-plan" in
   ({ config } : Tool_plan.context)
 

--- a/test/test_tool_portal_coverage.ml
+++ b/test/test_tool_portal_coverage.ml
@@ -36,7 +36,8 @@ let test_get_string_opt_empty () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_portal.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -46,7 +47,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_portal.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-portal" in
   ({ config; agent_name = "test-agent" } : Tool_portal.context)
 

--- a/test/test_tool_portal_coverage.ml
+++ b/test/test_tool_portal_coverage.ml
@@ -36,6 +36,7 @@ let test_get_string_opt_empty () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_portal.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -45,8 +46,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_portal.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-portal" in
-  { config; agent_name = "test-agent" }
+  ({ config; agent_name = "test-agent" } : Tool_portal.context)
 
 let test_dispatch_portal_open () =
   let ctx = make_ctx () in

--- a/test/test_tool_rate_limit_coverage.ml
+++ b/test/test_tool_rate_limit_coverage.ml
@@ -35,7 +35,8 @@ let () = test "dispatch_unknown_tool" (fun () ->
 
 (* Test rate_limit_status dispatch - needs Eio for Session.get_rate_limit_status *)
 let () = test "dispatch_rate_limit_status" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_rate_limit.dispatch ctx ~name:"masc_rate_limit_status" ~args with
@@ -45,7 +46,8 @@ let () = test "dispatch_rate_limit_status" (fun () ->
 
 (* Test handle_rate_limit_status - needs Eio *)
 let () = test "handle_rate_limit_status" (fun () ->
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   let (success, result) = Tool_rate_limit.handle_rate_limit_status ctx args in

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -3,7 +3,8 @@
 module Tool_registry = Masc_mcp.Tool_registry
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let open Alcotest in
   run "Tool_registry"
     [

--- a/test/test_tool_run_coverage.ml
+++ b/test/test_tool_run_coverage.ml
@@ -36,7 +36,8 @@ let test_get_string_opt_empty () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_run.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -46,7 +47,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_run.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-run" in
   ({ config } : Tool_run.context)
 

--- a/test/test_tool_run_coverage.ml
+++ b/test/test_tool_run_coverage.ml
@@ -36,6 +36,7 @@ let test_get_string_opt_empty () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_run.context = { config } in
   check bool "context created" true (ctx.config.Masc_mcp.Room.base_path = "/tmp/test")
@@ -45,8 +46,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_run.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-run" in
-  { config }
+  ({ config } : Tool_run.context)
 
 let test_dispatch_run_init () =
   let ctx = make_ctx () in

--- a/test/test_tool_suspend_coverage.ml
+++ b/test/test_tool_suspend_coverage.ml
@@ -387,7 +387,8 @@ let test_check_can_join_expired_blacklist () =
    ============================================================ *)
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Random.self_init ();
   run "Tool_suspend Coverage" [
     "get_string", [

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -81,6 +81,7 @@ let test_recover_orphan_session () =
   cleanup_dir base_dir
 
 let test_read_events_limit () =
+  with_eio @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -277,7 +277,8 @@ let test_report_and_proof_expose_spawn_tool_usage () =
   cleanup_dir base_dir
 
 let test_bootstrap_grace_suppresses_min_agents_violation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -306,7 +307,8 @@ let test_bootstrap_grace_suppresses_min_agents_violation () =
   cleanup_dir base_dir
 
 let test_min_agents_violation_after_bootstrap_grace () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in

--- a/test/test_tool_team_session_step_followup.ml
+++ b/test/test_tool_team_session_step_followup.ml
@@ -109,6 +109,7 @@ let test_step_spawn_batch_preserves_explicit_hierarchical_assignments () =
         (Some "ctrl-worker-custom") explicit_worker.supervisor_actor)
 
 let test_reconcile_failed_spawn_actor_detaches_without_turn () =
+  with_eio @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "owner"));

--- a/test/test_tool_tempo_coverage.ml
+++ b/test/test_tool_tempo_coverage.ml
@@ -44,7 +44,8 @@ let test_get_float_missing () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_tempo.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -54,7 +55,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_tempo.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-tempo" in
   ({ config; agent_name = "test-agent" } : Tool_tempo.context)
 

--- a/test/test_tool_tempo_coverage.ml
+++ b/test/test_tool_tempo_coverage.ml
@@ -44,6 +44,7 @@ let test_get_float_missing () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_tempo.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -53,8 +54,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_tempo.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-tempo" in
-  { config; agent_name = "test-agent" }
+  ({ config; agent_name = "test-agent" } : Tool_tempo.context)
 
 let test_dispatch_tempo_get () =
   let ctx = make_ctx () in

--- a/test/test_tool_unified.ml
+++ b/test/test_tool_unified.ml
@@ -6,7 +6,8 @@ module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_registry = Masc_mcp.Tool_registry
 
 let () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let open Alcotest in
   run "Tool_unified"
     [

--- a/test/test_tool_verification_coverage.ml
+++ b/test/test_tool_verification_coverage.ml
@@ -36,6 +36,7 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_config () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "verifier-agent"));

--- a/test/test_tool_verification_coverage.ml
+++ b/test/test_tool_verification_coverage.ml
@@ -36,7 +36,8 @@ let cleanup_dir dir =
   try rm dir with _ -> ()
 
 let make_config () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "verifier-agent"));

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -32,6 +32,7 @@ let test_get_string_base_branch_default () =
    ============================================================ *)
 
 let test_context_creation () =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -41,8 +42,9 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_worktree.context =
+  Eio_main.run @@ fun _env ->
   let config = Masc_mcp.Room.default_config "/tmp/test-worktree" in
-  { config; agent_name = "test-agent" }
+  ({ config; agent_name = "test-agent" } : Tool_worktree.context)
 
 let test_dispatch_worktree_create () =
   let ctx = make_ctx () in

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -32,7 +32,8 @@ let test_get_string_base_branch_default () =
    ============================================================ *)
 
 let test_context_creation () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test" in
   let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
   check string "agent_name" "test-agent" ctx.agent_name
@@ -42,7 +43,8 @@ let test_context_creation () =
    ============================================================ *)
 
 let make_ctx () : Tool_worktree.context =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Masc_mcp.Room.default_config "/tmp/test-worktree" in
   ({ config; agent_name = "test-agent" } : Tool_worktree.context)
 

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -196,7 +196,8 @@ let test_agent_stale_counter () =
    ============================================================ *)
 
 let test_transport_health_json () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   TM.init ();
   ignore (Masc_mcp.Sse.close_all_clients ());
   let base_dir = temp_dir () in

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -3,7 +3,8 @@ module Lib = Masc_mcp
 open Alcotest
 
 let test_list_masc_tools_exposes_board_and_lodge_schemas () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     Eio.Switch.run (fun sw ->
         match
           Lib.Worker_runtime.list_masc_tools ~sw ~auth_token:None


### PR DESCRIPTION
## Summary
39개 테스트 파일에 Eio context wrapping 추가 (3 batch).

## Progress
- **Before**: 264 test failures in CI
- **After**: ~75 test failures (71% reduction)
- 39 files fixed across 3 commits

## Remaining failures (~75)
8 test suites still failing — mostly Room/team_session integration tests
that need deeper wrapping or shared helper updates.

## Batch details
1. team_session flow/followup: 2 files
2. dashboard, multi_room, orchestrator, keeper, planning, hebbian, goals, task_dispatch, drift_guard: 10 files + dune
3. 27 remaining coverage/integration files + dune

## Test plan
- [x] `dune build` passes
- [x] 264 → ~75 failures (71% reduction)
- [ ] Remaining 75 failures need follow-up

Partially addresses #3178

🤖 Generated with [Claude Code](https://claude.com/claude-code)