### PR TITLE
fix: export with_mutex_ro in eio_guard.mli

### DIFF
--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -15,8 +15,11 @@ val is_ready : unit -> bool
 val with_mutex : Eio.Mutex.t -> (unit -> 'a) -> 'a
 (** Acquire read-write lock if Eio is ready, run [f] directly otherwise. *)
 
+val with_mutex_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
+(** Acquire read-only lock if Eio is ready, run [f] directly otherwise. *)
+
 val with_rw : Eio.Mutex.t -> (unit -> 'a) -> 'a
-(** Read-write guard with exception fallback (legacy). *)
+(** @deprecated Alias for {!with_mutex}. *)
 
 val with_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
-(** Read-only guard with exception fallback (legacy). *)
+(** @deprecated Alias for {!with_mutex_ro}. *)


### PR DESCRIPTION
## Summary
#3177에서 추가된 `eio_guard.mli`에 `with_mutex_ro`가 누락되어 main 빌드가 깨짐.

4개 파일에서 `Eio_guard.with_mutex_ro`를 사용:
- `task_dispatch.ml`, `board_dispatch.ml`, `keeper_exec_tools.ml`, `orchestrator.ml`

1줄 추가로 빌드 복구.

## Test plan
- [x] `dune build` 성공 (컴파일 에러 해소)

Generated with [Claude Code](https://claude.com/claude-code)