### PR TITLE
docs: annotate Unix.sleepf as systhread-safe (#3180)

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -120,6 +120,8 @@ module FileSystem = struct
             with
             | Unix.Unix_error (Unix.EAGAIN, _, _)
             | Unix.Unix_error (Unix.EACCES, _, _) ->
+                (* Safe: inside run_blocking_file_op (Eio_unix.run_in_systhread).
+                   Blocks systhread only, not Eio domain. *)
                 Unix.sleepf 0.01;
                 try_lock (retries - 1)
         in

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -296,6 +296,8 @@ let submit_petition base_path ~title ~origin ~subject_type ~risk_class
         with
         | Unix.Unix_error (Unix.EAGAIN, _, _)
         | Unix.Unix_error (Unix.EACCES, _, _) ->
+            (* Safe: inside run_blocking_lock_op (Eio_unix.run_in_systhread).
+               Blocks systhread only, not Eio domain. *)
             Unix.sleepf 0.01;
             acquire (attempts - 1)
     in

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -110,6 +110,8 @@ let with_graph_lock config f =
         with
         | Unix.Unix_error (Unix.EAGAIN, _, _)
         | Unix.Unix_error (Unix.EACCES, _, _) ->
+            (* Safe: inside run_blocking_op (Eio_unix.run_in_systhread).
+               Blocks systhread only, not Eio domain. *)
             Unix.sleepf 0.01;
             acquire (attempts - 1)
     in

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -68,6 +68,8 @@ let acquire_flock_fd lock_path =
           with
           | Unix.Unix_error (Unix.EAGAIN, _, _)
           | Unix.Unix_error (Unix.EACCES, _, _) ->
+              (* Safe: inside Eio_unix.run_in_systhread — blocks this OS
+                 thread only, not the Eio event loop. *)
               Unix.sleepf 0.01;
               acquire (attempts - 1)
       in


### PR DESCRIPTION
## Summary

- lib/ 4곳의 `Unix.sleepf` 호출이 모두 `Eio_unix.run_in_systhread` 내부에서 실행됨을 확인
- OS systhread만 sleep하며 Eio event loop에는 영향 없음
- systhread 내부에서 `Eio.Time.sleep`은 scheduler context가 없어 동작 불가
- 미래 오분류 방지를 위해 인라인 주석 추가

### 변경 파일
| 파일 | wrapper |
|------|---------|
| `lib/process/file_lock_eio.ml:71` | `run_blocking_lock_op` → `Eio_unix.run_in_systhread` |
| `lib/backend/backend.ml:123` | `run_blocking_file_op` → `Eio_unix.run_in_systhread` |
| `lib/hebbian_eio.ml:113` | `run_blocking_op` → `Eio_unix.run_in_systhread` |
| `lib/council/governance_v2.ml:299` | `run_blocking_lock_op` → `Eio_unix.run_in_systhread` |

test/ 파일의 `Unix.sleepf`는 #3178에서 처리.

## Test plan
- [x] `dune build` 통과
- [ ] `make test` 통과 확인

Closes #3180

🤖 Generated with [Claude Code](https://claude.com/claude-code)