### PR TITLE
fix(resilience): guard Fiber.fork sites against exception propagation (#3182)

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -187,7 +187,13 @@ let get_or_compute_eio key ~ttl compute =
          "Switch accessed from wrong domain!" — fall back to inline compute. *)
       (match !_bg_sw with
        | Some sw ->
-           (try Eio.Fiber.fork ~sw do_bg_compute
+           (try Eio.Fiber.fork ~sw (fun () ->
+              try do_bg_compute ()
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Dashboard.error "cache revalidation failed: %s"
+                  (Printexc.to_string exn))
             with Invalid_argument _ -> do_bg_compute ())
        | None -> do_bg_compute ());
       stale_value

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -194,7 +194,9 @@ let get_or_compute_eio key ~ttl compute =
               | exn ->
                 Log.Dashboard.error "cache revalidation failed: %s"
                   (Printexc.to_string exn))
-            with Invalid_argument _ -> do_bg_compute ())
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | Invalid_argument _ -> do_bg_compute ())
        | None -> do_bg_compute ());
       stale_value
     | `Compute cond ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -507,14 +507,16 @@ let run_grpc_heartbeat_fiber ~sw ~stop
     let rec loop () =
       if !stop || !close_ref then ()
       else (
-        (* Log the gRPC heartbeat attempt — actual delivery is
-           deferred to when full env integration is wired in the
-           server bootstrap. For now this fiber acts as a
-           placeholder that logs transport selection. *)
-        Log.Keeper.info "grpc heartbeat tick: agent=%s session=%s"
-          agent_name session_id;
-        let no_wakeup = ref false in
-        interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
+        (try
+          Log.Keeper.info "grpc heartbeat tick: agent=%s session=%s"
+            agent_name session_id;
+          let no_wakeup = ref false in
+          interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Keeper.error "grpc heartbeat tick failed: %s"
+            (Printexc.to_string exn));
         if not !stop then loop ())
     in
     loop ());
@@ -578,7 +580,12 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
            ~keeper_name:live_meta.name ~detail:"keepalive"
      | None -> ());
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
-        run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup))
+        try run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Keeper.error "heartbeat loop for %s crashed: %s"
+            live_meta.name (Printexc.to_string exn)))
 
 let stop_keepalive name =
   let entries =

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -238,7 +238,13 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   let zombie_consumer = make_zero_zombie_consumer ~room_config in
   let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Perpetual ~consumers:[zombie_consumer] in
   with_pulse_rw (fun () -> zombie_pulse := Some zp);
-  Eio.Fiber.fork ~sw (fun () -> Pulse.run ~sw zp);
+  Eio.Fiber.fork ~sw (fun () ->
+    try Pulse.run ~sw zp
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Orchestrator.error "zombie cleanup pulse crashed: %s"
+        (Printexc.to_string exn));
 
   (* Orchestrator check: respects enabled flag via should_act *)
   if config.enabled then
@@ -250,7 +256,13 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   let orch_consumer = make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config () in
   let op = Pulse.create ~clock ~rhythm:(fixed_rhythm config.check_interval_s) ~lifecycle:Perpetual ~consumers:[orch_consumer] in
   with_pulse_rw (fun () -> orchestrator_pulse := Some op);
-  Eio.Fiber.fork ~sw (fun () -> Pulse.run ~sw op);
+  Eio.Fiber.fork ~sw (fun () ->
+    try Pulse.run ~sw op
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Orchestrator.error "orchestrator check pulse crashed: %s"
+        (Printexc.to_string exn));
 
   (* Return cancel function — shuts down both Pulse engines *)
   fun () ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -333,24 +333,30 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
   in
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
-      let events = Agent_sdk.Event_bus.drain keeper_lifecycle_sub in
-      List.iter
-        (function
-          | Agent_sdk.Event_bus.Custom ("masc:keeper:resident_lifecycle", payload) ->
-              (match
-                 ( Safe_ops.json_string_opt "event" payload,
-                   Safe_ops.json_string_opt "keeper_name" payload )
-               with
-              | Some event, Some keeper_name ->
-                  Server_dashboard_http.patch_keeper_dependent_caches
-                    ~keeper_name ~event
-              | _ -> ())
-          | _ -> ())
-        events;
-      if events <> [] then
-        Log.Dashboard.info
-          "patched keeper-dependent dashboard caches (%d lifecycle event(s))"
-          (List.length events);
+      (try
+        let events = Agent_sdk.Event_bus.drain keeper_lifecycle_sub in
+        List.iter
+          (function
+            | Agent_sdk.Event_bus.Custom ("masc:keeper:resident_lifecycle", payload) ->
+                (match
+                   ( Safe_ops.json_string_opt "event" payload,
+                     Safe_ops.json_string_opt "keeper_name" payload )
+                 with
+                | Some event, Some keeper_name ->
+                    Server_dashboard_http.patch_keeper_dependent_caches
+                      ~keeper_name ~event
+                | _ -> ())
+            | _ -> ())
+          events;
+        if events <> [] then
+          Log.Dashboard.info
+            "patched keeper-dependent dashboard caches (%d lifecycle event(s))"
+            (List.length events)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Dashboard.error "keeper lifecycle listener iteration failed: %s"
+          (Printexc.to_string exn));
       Eio.Time.sleep clock 0.25;
       loop ()
     in
@@ -493,58 +499,68 @@ let start_resident_loops ~sw ~clock ~net:_net ~domain_mgr ~proc_mgr
 let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
   (* Metrics flush fiber: drains write queue every 500ms, batches file appends.
      Replaces the old mutex + synchronous file I/O pattern. *)
-  Eio.Fiber.fork ~sw (fun () -> Metrics_store_eio.start_flush_fiber ~clock);
+  Eio.Fiber.fork ~sw (fun () ->
+    try Metrics_store_eio.start_flush_fiber ~clock
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Server.error "metrics_flush fiber crashed: %s"
+        (Printexc.to_string exn));
   Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
   (match Board_dispatch.get_pg_pool () with
   | Some pool ->
       let listener = Board_listener.create pool in
-      Eio.Fiber.fork ~sw (fun () -> Board_listener.start listener);
+      Eio.Fiber.fork ~sw (fun () ->
+        try Board_listener.start listener
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.BoardListener.error "board listener fiber crashed: %s"
+            (Printexc.to_string exn));
       Log.BoardListener.info "Fiber started for real-time Board events"
   | None ->
       Log.BoardListener.info "Skipped (not using PostgreSQL backend)");
   Eio.Fiber.fork ~sw (fun () ->
       let rec loop () =
         Eio.Time.sleep clock 60.0;
-        let stale_sids = Sse.cleanup_stale () in
-        List.iter stop_sse_session stale_sids;
-        if stale_sids <> [] then
-          Log.Server.info "Reaped %d stale connections (active: %d)"
-            (List.length stale_sids) (Sse.client_count ());
-        let evicted_events = Sse.cleanup_expired_events () in
-        if evicted_events > 0 then
-          Log.Server.info "Evicted %d expired SSE buffer events" evicted_events;
-        (* Cache eviction: remove expired entries *)
-        let evicted = Cache_eio.evict_expired state.room_config in
-        if evicted > 0 then
-          Log.Server.info "Cache: evicted %d expired entries" evicted;
-        let sse_guards_reaped = Server_mcp_transport_http_sse.reap_stale_guards () in
-        let http_guards_reaped = Server_mcp_transport_http.reap_stale_guards () in
-        let is_active sid =
-          Server_mcp_transport_http_sse.is_active_sse_session sid
-          || Server_mcp_transport_http.is_active_sse_session sid
-        in
-        let sessions_reaped =
-          Server_mcp_transport_http_session.reap_stale_sessions
-            ~is_active_session:is_active
-        in
-        if sse_guards_reaped + http_guards_reaped + sessions_reaped > 0 then
-          Log.Server.info "reaped %d SSE guards + %d HTTP guards + %d stale sessions"
-            sse_guards_reaped http_guards_reaped sessions_reaped;
-        (* Reap dead external subscribers (gRPC, WebSocket, etc.)
-           that remain registered after their transport connection drops.
-           Without this, stale subscribers accumulate when no broadcasts
-           occur to trigger the lazy is_alive check. *)
-        let ext_reaped = Sse.reap_dead_external_subscribers () in
-        if ext_reaped > 0 then
-          Log.Server.info "reaped %d dead external subscribers" ext_reaped;
-        (* Clean up expired WebRTC signaling offers.
-           Offers older than 60s are removed to prevent indefinite
-           accumulation from failed handshake attempts. *)
-        if Server_webrtc_transport.is_enabled () then begin
-          let webrtc_expired = Server_webrtc_transport.cleanup_expired_offers () in
-          if webrtc_expired > 0 then
-            Log.Server.info "WebRTC: cleaned %d expired offers" webrtc_expired
-        end;
+        (try
+          let stale_sids = Sse.cleanup_stale () in
+          List.iter stop_sse_session stale_sids;
+          if stale_sids <> [] then
+            Log.Server.info "Reaped %d stale connections (active: %d)"
+              (List.length stale_sids) (Sse.client_count ());
+          let evicted_events = Sse.cleanup_expired_events () in
+          if evicted_events > 0 then
+            Log.Server.info "Evicted %d expired SSE buffer events" evicted_events;
+          let evicted = Cache_eio.evict_expired state.room_config in
+          if evicted > 0 then
+            Log.Server.info "Cache: evicted %d expired entries" evicted;
+          let sse_guards_reaped = Server_mcp_transport_http_sse.reap_stale_guards () in
+          let http_guards_reaped = Server_mcp_transport_http.reap_stale_guards () in
+          let is_active sid =
+            Server_mcp_transport_http_sse.is_active_sse_session sid
+            || Server_mcp_transport_http.is_active_sse_session sid
+          in
+          let sessions_reaped =
+            Server_mcp_transport_http_session.reap_stale_sessions
+              ~is_active_session:is_active
+          in
+          if sse_guards_reaped + http_guards_reaped + sessions_reaped > 0 then
+            Log.Server.info "reaped %d SSE guards + %d HTTP guards + %d stale sessions"
+              sse_guards_reaped http_guards_reaped sessions_reaped;
+          let ext_reaped = Sse.reap_dead_external_subscribers () in
+          if ext_reaped > 0 then
+            Log.Server.info "reaped %d dead external subscribers" ext_reaped;
+          if Server_webrtc_transport.is_enabled () then begin
+            let webrtc_expired = Server_webrtc_transport.cleanup_expired_offers () in
+            if webrtc_expired > 0 then
+              Log.Server.info "WebRTC: cleaned %d expired offers" webrtc_expired
+          end
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Server.error "cleanup loop iteration failed: %s"
+            (Printexc.to_string exn));
         loop ()
       in
       loop ());
@@ -1040,17 +1056,23 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
      Prevents zombie-listener state where the socket is open but HTTP
      requests hang because init is stuck. *)
   Eio.Fiber.fork ~sw (fun () ->
-    let timeout_sec = Server_startup_state.watchdog_timeout_sec () in
-    Eio.Time.sleep clock timeout_sec;
-    let current = Server_startup_state.(!state) in
-    if not current.state_ready then (
-      let elapsed = Server_startup_state.elapsed_since_start () in
-      Log.Server.error
-        "[watchdog] Server init did not complete within %.0fs (elapsed=%.1fs, phase=%s, backend=%s). Exiting."
-        timeout_sec elapsed
-        (Server_startup_state.phase_to_string current.phase)
-        current.backend_mode;
-      exit 1));
+    try
+      let timeout_sec = Server_startup_state.watchdog_timeout_sec () in
+      Eio.Time.sleep clock timeout_sec;
+      let current = Server_startup_state.(!state) in
+      if not current.state_ready then (
+        let elapsed = Server_startup_state.elapsed_since_start () in
+        Log.Server.error
+          "[watchdog] Server init did not complete within %.0fs (elapsed=%.1fs, phase=%s, backend=%s). Exiting."
+          timeout_sec elapsed
+          (Server_startup_state.phase_to_string current.phase)
+          current.backend_mode;
+        exit 1)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Server.error "startup watchdog fiber failed: %s"
+        (Printexc.to_string exn));
 
   (* 3. Start serving -- /health responds before init completes *)
   match http_mode with


### PR DESCRIPTION
## Summary

Eio structured concurrency에서 `Fiber.fork ~sw` 내부 예외는 부모 Switch로 전파되어 **모든 형제 fiber를 취소**합니다. 백그라운드 서비스 fiber 하나의 실패로 전체 MCP 서버가 붕괴할 수 있는 구조적 취약점입니다.

57개 `Fiber.fork` 호출 사이트를 감사하여 10개 CRITICAL/HIGH 위험 사이트에 예외 가드를 추가했습니다.

### 변경 파일 (4개)

| 파일 | 수정 사이트 | 위험도 |
|------|-----------|--------|
| `server_runtime_bootstrap.ml` | 5개 (lifecycle listener, metrics flush, board listener, SSE cleanup, watchdog) | CRITICAL |
| `orchestrator.ml` | 2개 (zombie cleanup pulse, orchestrator check pulse) | CRITICAL |
| `keeper_keepalive.ml` | 2개 (gRPC heartbeat, heartbeat loop) | HIGH |
| `dashboard_cache.ml` | 1개 (stale-while-revalidate compute) | HIGH |

### 패턴

기존 `fork_subsystem` 모범 패턴을 따릅니다:
```ocaml
Eio.Fiber.fork ~sw (fun () ->
  try <body>
  with
  | Eio.Cancel.Cancelled _ as e -> raise e  (* 취소 전파 유지 *)
  | exn -> Log.error "...: %s" (Printexc.to_string exn))
```

영구 루프는 **반복 단위로** 보호하여 한 iteration 실패 시 루프가 계속됩니다.

## Test plan
- [x] `dune build` 통과
- [ ] `make test` 통과 확인
- [ ] keeper 기동 후 의도적 에러 주입 시 다른 서비스 영향 없음 확인

Closes #3182

🤖 Generated with [Claude Code](https://claude.com/claude-code)