### PR TITLE
refactor(process): extract acquire_flock_retry to deduplicate file lock pattern

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -108,26 +108,14 @@ module FileSystem = struct
 
   let with_locked_rw_fd path_str f =
     run_blocking_file_op (fun () ->
-        let fd = Unix.openfile path_str [ Unix.O_RDWR; Unix.O_CREAT ] 0o644 in
-        Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer"
-          ~finally:(fun () -> Unix.close fd)
-        @@ fun () ->
-        let rec try_lock retries =
-          if retries <= 0 then
-            raise (Failure "Failed to acquire lock after max retries")
-          else
-            try Unix.lockf fd Unix.F_TLOCK 0
-            with
-            | Unix.Unix_error (Unix.EAGAIN, _, _)
-            | Unix.Unix_error (Unix.EACCES, _, _) ->
-                (* Safe: inside run_blocking_file_op (Eio_unix.run_in_systhread).
-                   Blocks systhread only, not Eio domain. *)
-                Unix.sleepf 0.01;
-                try_lock (retries - 1)
+        let fd = File_lock_eio.acquire_flock_retry ~lock_path:path_str
+            ~mode:[ Unix.O_RDWR; Unix.O_CREAT ] ~perm:0o644
+            ~max_attempts:100 ~caller:"backend_eio" ()
         in
-        let _ = try_lock 100 in
         Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer"
-          ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0)
+          ~finally:(fun () ->
+            (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
+            Unix.close fd)
         @@ fun () -> f fd)
 
   (** {2 Core Operations} *)

--- a/lib/backend/dune
+++ b/lib/backend/dune
@@ -14,6 +14,7 @@
  (libraries
   masc_types
   masc_core
+  masc_process
   masc_log
   masc_eio_context
   time_compat

--- a/lib/council/dune
+++ b/lib/council/dune
@@ -3,5 +3,5 @@
  (name council)
  (public_name masc_mcp.council)
  (modules router debate consensus balance executor conversation governance_v2 governance_v2_types governance_v2_serde loop_guard thread_persist council)
- (libraries str yojson base64 unix eio eio.unix cohttp cohttp-eio uuidm time_compat masc_log masc_core fs_compat)
+ (libraries str yojson base64 unix eio eio.unix cohttp cohttp-eio uuidm time_compat masc_process masc_log masc_core fs_compat)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -283,24 +283,9 @@ let submit_petition base_path ~title ~origin ~subject_type ~risk_class
      Uses F_TLOCK (non-blocking) in systhread to avoid blocking Eio scheduler. *)
   let lock_path = Filename.concat (cases_dir base_path) "_submit.lock" in
   let fd = run_blocking_lock_op (fun () ->
-    let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
-    let rec acquire attempts =
-      if attempts <= 0 then begin
-        Unix.close fd;
-        raise (Failure "governance_v2: submit lock timeout after 200 attempts")
-      end
-      else
-        try Unix.lockf fd Unix.F_TLOCK 0; fd
-        with
-        | Unix.Unix_error (Unix.EAGAIN, _, _)
-        | Unix.Unix_error (Unix.EACCES, _, _) ->
-            (* Safe: inside run_blocking_lock_op (Eio_unix.run_in_systhread).
-               Blocks systhread only, not Eio domain. *)
-            Unix.sleepf 0.01;
-            acquire (attempts - 1)
-    in
-    try acquire 200
-    with exn -> Unix.close fd; raise exn
+    File_lock_eio.acquire_flock_retry ~lock_path
+      ~mode:[Unix.O_CREAT; Unix.O_WRONLY] ~perm:0o644
+      ~caller:"governance_v2" ()
   ) in
   Fun.protect ~finally:(fun () ->
       run_blocking_lock_op (fun () ->

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -97,24 +97,9 @@ let with_graph_lock config f =
   let start_time = Time_compat.now () in
   (* Acquire lock in systhread (non-blocking F_TLOCK + retry) *)
   let fd = run_blocking_op (fun () ->
-    let fd = Unix.openfile lock_file [Unix.O_WRONLY; Unix.O_CREAT] 0o600 in
-    let rec acquire attempts =
-      if attempts <= 0 then begin
-        Unix.close fd;
-        raise (Failure "hebbian_eio: graph lock timeout after 200 attempts")
-      end
-      else
-        try Unix.lockf fd Unix.F_TLOCK 0; fd
-        with
-        | Unix.Unix_error (Unix.EAGAIN, _, _)
-        | Unix.Unix_error (Unix.EACCES, _, _) ->
-            (* Safe: inside run_blocking_op (Eio_unix.run_in_systhread).
-               Blocks systhread only, not Eio domain. *)
-            Unix.sleepf 0.01;
-            acquire (attempts - 1)
-    in
-    try acquire 200
-    with exn -> Unix.close fd; raise exn
+    File_lock_eio.acquire_flock_retry ~lock_path:lock_file
+      ~mode:[Unix.O_WRONLY; Unix.O_CREAT] ~perm:0o600
+      ~caller:"hebbian_eio" ()
   ) in
   (* Record lock metrics *)
   let wait_ms = (Time_compat.now () -. start_time) *. 1000.0 in

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -52,29 +52,38 @@ let get_lock path =
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 
+(** Acquire a non-blocking Unix file lock (F_TLOCK) with retry.
+    Must be called from a systhread — the caller is responsible for
+    wrapping in [run_blocking_lock_op] or [Eio_unix.run_in_systhread].
+    On success, returns the open file descriptor with the lock held.
+    On timeout, closes the fd and raises [Failure]. *)
+let acquire_flock_retry ~lock_path ~mode ~perm
+    ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
+  let fd = Unix.openfile lock_path mode perm in
+  let rec acquire attempts =
+    if attempts <= 0 then
+      raise (Failure (Printf.sprintf "%s: flock timeout on %s after %d attempts"
+                        caller lock_path max_attempts))
+    else
+      try
+        Unix.lockf fd Unix.F_TLOCK 0;
+        fd
+      with
+      | Unix.Unix_error (Unix.EAGAIN, _, _)
+      | Unix.Unix_error (Unix.EACCES, _, _) ->
+          Unix.sleepf sleep_sec;
+          acquire (attempts - 1)
+  in
+  try acquire max_attempts
+  with exn ->
+    (try Unix.close fd with Unix.Unix_error _ -> ());
+    raise exn
+
 let acquire_flock_fd lock_path =
   run_blocking_lock_op (fun () ->
-      let fd = Unix.openfile lock_path [ Unix.O_CREAT; Unix.O_WRONLY ] 0o644 in
-      let rec acquire attempts =
-        if attempts <= 0 then
-          raise (Failure (Printf.sprintf "File_lock_eio: flock timeout on %s" lock_path))
-        else
-          try
-            Unix.lockf fd Unix.F_TLOCK 0;
-            fd
-          with
-          | Unix.Unix_error (Unix.EAGAIN, _, _)
-          | Unix.Unix_error (Unix.EACCES, _, _) ->
-              (* Safe: inside Eio_unix.run_in_systhread — blocks this OS
-                 thread only, not the Eio event loop. *)
-              Unix.sleepf 0.01;
-              acquire (attempts - 1)
-      in
-      try
-        acquire 200
-      with exn ->
-        Unix.close fd;
-        raise exn)
+      acquire_flock_retry ~lock_path
+        ~mode:[ Unix.O_CREAT; Unix.O_WRONLY ] ~perm:0o644
+        ~caller:"File_lock_eio" ())
 
 let release_flock_fd fd =
   run_blocking_lock_op (fun () ->


### PR DESCRIPTION
## Summary
- 4곳에 copy-paste된 flock retry 패턴을 `File_lock_eio.acquire_flock_retry`로 추출
- `eio_guard.mli`에 누락된 `with_mutex_ro` export 추가 (선행 빌드 에러 수정)
- `masc_backend`, `council` 라이브러리에 `masc_process` 의존성 추가

## Changes
| File | Change |
|------|--------|
| `lib/process/file_lock_eio.ml` | `acquire_flock_retry` 추출 (configurable params) |
| `lib/backend/backend.ml` | inline retry → `acquire_flock_retry` 호출 |
| `lib/council/governance_v2.ml` | inline retry → `acquire_flock_retry` 호출 |
| `lib/hebbian_eio.ml` | inline retry → `acquire_flock_retry` 호출 |
| `lib/core/eio_guard.mli` | `with_mutex_ro` export 추가 |
| `lib/backend/dune` | `masc_process` 의존성 추가 |
| `lib/council/dune` | `masc_process` 의존성 추가 |

## Note
`Unix.sleepf`는 systhread 내부에서 호출되므로 Eio 이벤트 루프를 블로킹하지 않음. 교체 불필요.
EIO_REFACTOR_ISSUES.md Issue 1의 심각도: Critical → Low (dedup only).

## Test plan
- [x] `dune build --root .` 성공
- [ ] `make test` (선행 test_file_lock_eio Poisoned mutex 이슈 있음 — 별도 수정 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)