### PR TITLE
chore: bump OAS agent-sdk pin to v0.91.0

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="b94be7bcf7b9698dcb7e8fa2e1b1d30287e17beb"
+readonly OAS_AGENT_SDK_SHA="088a7346537339cde8a01a4b973d1bb229fdc9ef"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#b94be7bcf7b9698dcb7e8fa2e1b1d30287e17beb}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#088a7346537339cde8a01a4b973d1bb229fdc9ef}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary

- OAS upstream main이 pinned SHA보다 4커밋 앞서 있어 모든 PR의 Health check가 실패
- `scripts/oas-agent-sdk-pin.sh`와 `scripts/opam-pin-external-deps.sh`의 SHA를 `088a734` (v0.91.0)으로 업데이트
- 공개 .mli API 변경 없음 — 호환성 유지

### OAS 변경 내역 (b94be7b → 088a734)
- `chore: bump version to 0.91.0`
- `feat(swarm): add opt-in Eio.Stream-based inter-agent communication`
- `feat: defensive Eio.Mutex protection for Context.t`
- `refactor: purge Stdlib.Mutex/Lazy/Thread.delay for 100% Eio compliance`

## Test plan
- [ ] Health CI check passes (OAS pin ratchet)
- [ ] Build and Test passes
- [ ] 머지 후 다른 open PR들의 Health check도 re-run으로 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)