### PR TITLE
refactor: share monitoring card utilities

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -370,7 +370,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   return html`
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
-      <section class="rounded-[24px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(17,26,46,0.94),rgba(11,18,32,0.92))] p-5 shadow-[0_12px_30px_rgba(0,0,0,0.16)]">
+      <section class="monitor-surface-card monitor-surface-card-strong bg-[linear-gradient(180deg,rgba(17,26,46,0.94),rgba(11,18,32,0.92))] p-5">
         <div class="flex flex-col gap-5">
           <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div class="flex min-w-0 flex-col gap-3">
@@ -395,7 +395,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             </label>
           </div>
 
-          <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] p-3.5 md:p-4">
+          <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
                 <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">연결 상태</div>
@@ -431,7 +431,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             ${legendCards.map(card => html`
-              <div class="rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] px-4 py-4 shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
+              <div class="monitor-muted-panel px-4 py-4 shadow-[0_8px_24px_rgba(0,0,0,0.12)]">
                 <div class="text-[11px] font-semibold text-[var(--text-strong)]">${card.title}</div>
                 <p class="m-0 mt-2 text-[12px] leading-[1.55] text-[var(--text-muted)]">${card.body}</p>
               </div>
@@ -453,7 +453,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="group flex min-h-[308px] w-full flex-col gap-4 rounded-[22px] border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(17,26,46,0.92),rgba(11,18,32,0.92))] p-5 text-left shadow-[0_10px_24px_rgba(0,0,0,0.14)] transition-all duration-200 cursor-pointer hover:border-[rgba(71,184,255,0.3)] hover:bg-[linear-gradient(180deg,rgba(20,30,52,0.96),rgba(12,19,35,0.94))] hover:-translate-y-0.5"
+              class="monitor-surface-card monitor-surface-card-medium group flex min-h-[308px] w-full flex-col gap-4 rounded-[22px] bg-[linear-gradient(180deg,rgba(17,26,46,0.92),rgba(11,18,32,0.92))] p-5 text-left transition-all duration-200 cursor-pointer hover:border-[rgba(71,184,255,0.3)] hover:bg-[linear-gradient(180deg,rgba(20,30,52,0.96),rgba(12,19,35,0.94))] hover:-translate-y-0.5"
               key=${agent.name}
               aria-label=${`${agent.name} 상세 보기`}
               onClick=${() => openAgentDetail(agent.name)}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -91,9 +91,9 @@ export function AgentsUnified() {
         }}
         size="md"
         tone="accent"
-        class="w-fit rounded-2xl border border-[var(--white-8)] bg-[rgba(8,16,32,0.55)] p-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
+        class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
       />
-      <div class="rounded-2xl border border-[var(--white-8)] bg-[linear-gradient(180deg,rgba(71,184,255,0.08),rgba(255,255,255,0.02))] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-body)]">
+      <div class="monitor-muted-panel bg-[linear-gradient(180deg,rgba(71,184,255,0.08),rgba(255,255,255,0.02))] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-body)]">
         <strong class="mr-2 text-[var(--text-strong)]">${currentViewMeta.label}</strong>
         <span>${currentViewMeta.description} ${currentViewSummary}</span>
       </div>

--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -13,7 +13,7 @@ export function Live() {
 
   return html`
     <div class="flex flex-col gap-5">
-      <section class="rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] px-5 py-4 shadow-[0_12px_30px_rgba(0,0,0,0.16)]">
+      <section class="monitor-surface-card monitor-surface-card-strong px-5 py-4">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div class="flex flex-col gap-2">
             <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
@@ -35,10 +35,10 @@ export function Live() {
       </section>
 
       <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-        <section class="live-panel-main min-h-[420px] xl:min-h-[520px] rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] p-4 shadow-[0_10px_24px_rgba(0,0,0,0.14)]">
+        <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
           <${ActivityStream} />
         </section>
-        <section class="live-panel-side min-h-[420px] xl:min-h-[520px] rounded-[24px] border border-[var(--card-border)] bg-[var(--card)] p-4 shadow-[0_10px_24px_rgba(0,0,0,0.14)]">
+        <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
           <${FocusSidebar} />
         </section>
       </div>

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -307,6 +307,26 @@ a:hover {
   margin-top: 6px;
 }
 
+@utility monitor-surface-card {
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  background: var(--card);
+}
+
+@utility monitor-surface-card-strong {
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.16);
+}
+
+@utility monitor-surface-card-medium {
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
+}
+
+@utility monitor-muted-panel {
+  border: 1px solid var(--white-8);
+  border-radius: 16px;
+  background: rgba(8, 16, 32, 0.55);
+}
+
 /* ── Section header (reusable pattern) ─────────────────────── */
 
 @utility section-header {


### PR DESCRIPTION
## Summary
- add shared monitoring card utilities in `dashboard/src/styles/global.css`
- replace repeated monitoring card shell classes in the live and agents surfaces with those shared utilities
- keep the one intentional 22px agent-card radius override while removing the repeated 24px shell declarations

## Verification
- npm run typecheck
- npm run build

## Review note
- refactor-only change; no intended behavior change