### PR TITLE
refactor(chain): replace mutex+ref with Eio.Stream for parallel fanout

### DIFF
--- a/lib/chain/chain_executor_eio.ml
+++ b/lib/chain/chain_executor_eio.ml
@@ -188,24 +188,23 @@ and execute_fanout ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) (nodes : n
   record_start ctx parent.id;
   let start = Time_compat.now () in
 
-  (* Collect results from parallel execution *)
-  let results = ref [] in
-  let mutex = Eio.Mutex.create () in
+  (* Collect results from parallel execution via Eio.Stream *)
+  let n = List.length nodes in
+  let stream = Eio.Stream.create n in
 
   Eio.Fiber.all (List.map (fun node ->
     fun () ->
       let result = execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node in
-      Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-        results := (node.id, result) :: !results
-      )
+      Eio.Stream.add stream (node.id, result)
   ) nodes);
 
+  let results = List.init n (fun _ -> Eio.Stream.take stream) in
   let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
 
   (* Check if all succeeded *)
   let outputs = List.filter_map (fun (id, r) ->
     match r with Ok o -> Some (id, o) | Error _ -> None
-  ) !results in
+  ) results in
 
   if List.length outputs = List.length nodes then begin
     let combined = String.concat "\n---\n"
@@ -349,30 +348,28 @@ and execute_parallel_group ctx ~sw ~clock ~exec_fn ~tool_exec (group : string li
     | Some node -> execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node
     | None -> Error (Printf.sprintf "Node '%s' not found in subgraph" node_id)
   else
-    (* Multiple nodes - execute in parallel with Eio.Fiber.all *)
-    let results = ref [] in
-    let mutex = Eio.Mutex.create () in
-    let has_error = ref None in
+    (* Multiple nodes - execute in parallel via Eio.Stream *)
+    let n = List.length group in
+    let stream = Eio.Stream.create n in
 
     Eio.Fiber.all (List.map (fun node_id ->
       fun () ->
         match Hashtbl.find_opt node_map node_id with
         | Some node ->
             let result = execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node in
-            Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-              results := (node_id, result) :: !results;
-              match result with
-              | Error msg when !has_error = None -> has_error := Some msg
-              | _ -> ()
-            )
+            Eio.Stream.add stream (node_id, result)
         | None ->
-            Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-              has_error := Some (Printf.sprintf "Node '%s' not found" node_id)
-            )
+            Eio.Stream.add stream
+              (node_id, Error (Printf.sprintf "Node '%s' not found" node_id))
     ) group);
 
+    let results = List.init n (fun _ -> Eio.Stream.take stream) in
+    let has_error = List.find_map (fun (_, r) ->
+      match r with Error msg -> Some msg | Ok _ -> None
+    ) results in
+
     (* Return first error if any, otherwise success with last output *)
-    match !has_error with
+    match has_error with
     | Some msg -> Error msg
     | None ->
         let outputs = List.filter_map (fun (_, r) ->
@@ -482,9 +479,9 @@ and execute_merge ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) ~strategy (
   record_start ctx parent.id;
   let start = Time_compat.now () in
 
-  (* Execute all nodes in parallel, handling ChainRef nodes specially *)
-  let results = ref [] in
-  let mutex = Eio.Mutex.create () in
+  (* Execute all nodes in parallel via Eio.Stream, handling ChainRef nodes specially *)
+  let n = List.length nodes in
+  let stream = Eio.Stream.create n in
 
   Eio.Fiber.all (List.map (fun (node : node) ->
     fun () ->
@@ -498,17 +495,16 @@ and execute_merge ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) ~strategy (
             (* For non-ChainRef nodes, execute normally *)
             execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node
       in
-      Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-        results := (node.id, result) :: !results
-      )
+      Eio.Stream.add stream (node.id, result)
   ) nodes);
 
+  let results = List.init n (fun _ -> Eio.Stream.take stream) in
   let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
 
   (* Merge results based on strategy *)
   let outputs = List.filter_map (fun (id, r) ->
     match r with Ok o -> Some (id, o) | Error _ -> None
-  ) !results in
+  ) results in
 
   match outputs with
   | [] ->
@@ -726,26 +722,25 @@ let execute ~sw ~(clock : _ Eio.Time.clock) ~timeout ~trace ~(exec_fn : exec_fn)
                 Ok ""  (* All nodes already completed *)
               end
               else begin
-                (* Execute remaining nodes in parallel *)
-                let results = ref [] in
-                let mutex = Eio.Mutex.create () in
+                (* Execute remaining nodes in parallel via Eio.Stream *)
+                let n_exec = List.length nodes_to_execute in
+                let stream = Eio.Stream.create n_exec in
                 Eio.Fiber.all (List.map (fun (node : node) ->
                   fun () ->
                     let r = execute_node ctx ~sw ~clock ~exec_fn ~tool_exec node in
-                    Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-                      results := (node.id, r) :: !results
-                    )
+                    Eio.Stream.add stream (node.id, r)
                 ) nodes_to_execute);
+                let results = List.init n_exec (fun _ -> Eio.Stream.take stream) in
                 (* Save checkpoint for all successfully completed parallel nodes *)
                 List.iter (fun (node_id, r) ->
                   match r with
                   | Ok _ -> save_checkpoint ctx ~chain_id:plan.chain.Chain_types.id ~node_id
                   | Error e -> Log.Chain.debug "parallel node %s failed, skipping checkpoint: %s" node_id e
-                ) !results;
+                ) results;
                 (* Check all succeeded *)
                 let errors = List.filter_map (fun (id, r) ->
                   match r with Error e -> Some (id ^ ": " ^ e) | Ok _ -> None
-                ) !results in
+                ) results in
                 if List.length errors = 0 then Ok ""
                 else Error (String.concat "; " errors)
               end

--- a/lib/chain/chain_executor_search.ml
+++ b/lib/chain/chain_executor_search.ml
@@ -216,9 +216,10 @@ let execute_mcts ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : execute_no
   let rec mcts_iteration iteration =
     if iteration >= max_iterations then ()
     else begin
-      (* Run parallel simulations *)
-      let sim_results = ref [] in
-      let results_mutex = Eio.Mutex.create () in
+      (* Run parallel simulations via Eio.Stream.
+         Not all sims succeed (select/expand may fail), so drain with
+         take_nonblocking after Fiber.all completes. *)
+      let sim_stream = Eio.Stream.create parallel_sims in
 
       Eio.Fiber.all (List.init parallel_sims (fun _ ->
         fun () ->
@@ -234,15 +235,22 @@ let execute_mcts ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : execute_no
               Log.Chain.warn "MCTS expand failed: %s" msg
           | Ok expanded ->
           let score = simulate expanded in
-          Eio.Mutex.use_rw results_mutex ~protect:true (fun () ->
+          Eio.Stream.add sim_stream (expanded, score)
+      ));
+
+      (* Drain results and track best *)
+      let sim_results = ref [] in
+      let continue = ref true in
+      while !continue do
+        match Eio.Stream.take_nonblocking sim_stream with
+        | Some (expanded, score) ->
             sim_results := (expanded, score) :: !sim_results;
-            (* Track best result *)
             if score > !best_score then begin
               best_score := score;
               best_output := !(expanded.last_output)
             end
-          )
-      ));
+        | None -> continue := false
+      done;
 
       (* Backpropagate all results *)
       List.iter (fun (node, score) ->
@@ -296,17 +304,17 @@ let execute_evaluator ctx ~sw ~clock ~(exec_fn : exec_fn) ~(execute_node : execu
   record_start ctx parent.id;
   let start = Time_compat.now () in
 
-  (* Execute all candidates in parallel *)
-  let results = ref [] in
-  let mutex = Eio.Mutex.create () in
+  (* Execute all candidates in parallel via Eio.Stream *)
+  let n = List.length candidates in
+  let stream = Eio.Stream.create n in
 
   Eio.Fiber.all (List.map (fun (candidate : node) ->
     fun () ->
       let result = execute_node ctx ~sw ~clock ~exec_fn ~tool_exec candidate in
-      Eio.Mutex.use_rw mutex ~protect:true (fun () ->
-        results := (candidate.id, result) :: !results
-      )
+      Eio.Stream.add stream (candidate.id, result)
   ) candidates);
+
+  let results = List.init n (fun _ -> Eio.Stream.take stream) in
 
   (* Helper: MODEL-based scoring via OAS chain_judge cascade *)
   let model_score output =
@@ -465,7 +473,7 @@ Reply with ONLY a number between 0.0 and 1.0:|}
                with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> 0.5)
         in
         Some (id, output, score)
-  ) !results in
+  ) results in
 
   let duration_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
 


### PR DESCRIPTION
## Summary
- chain executor의 parallel fanout/merge 패턴에서 mutex+ref 조합을 Eio.Stream으로 교체
- `Eio.Fiber.all`이 동기화 배리어를 제공하므로 Mutex가 불필요
- 6곳 변환, tree_mutex(장기 mutable state)는 유지

## Changes
**`lib/chain/chain_executor_eio.ml`** (4 sites):
- `execute_fanout`: mutex+ref → `Eio.Stream.create n` + drain
- `execute_parallel_group`: mutex+ref+has_error → Stream + `List.find_map`
- `execute_merge`: mutex+ref → Stream
- checkpoint parallel: mutex+ref → Stream

**`lib/chain/chain_executor_search.ml`** (2 sites):
- MCTS sim_results: mutex+ref → Stream + `take_nonblocking` drain (일부 sim 실패 허용)
- evaluator candidates: mutex+ref → Stream

## Design notes
- `Eio.Stream.create n` (bounded): Fiber.all에서 n개 fiber가 각각 1개씩 add
- MCTS는 select/expand 실패 시 Stream에 추가하지 않으므로 `take_nonblocking` drain 사용
- 순서 차이(ref list=last-first, Stream=FIFO): 6곳 모두 전체 순회이므로 무관

## Test plan
- [x] `dune build --root . lib/chain/` 성공
- [ ] `make test-contract` (chain execution path 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)