### PR TITLE
refactor: add session.mli (#2994)

### DIFF
--- a/lib/progress.mli
+++ b/lib/progress.mli
@@ -1,0 +1,71 @@
+(** Progress Notifications — MCP 2025-11-25 MAY requirement.
+
+    Send real-time progress updates for long-running tasks.
+    Uses JSON-RPC 2.0 notifications/progress method. *)
+
+(** {1 Types} *)
+
+type progress = {
+  task_id : string;
+  progress : float;
+  message : string option;
+  estimated_remaining : float option;
+}
+
+type validation_error =
+  | TaskIdEmpty
+  | TaskIdTooLong of int
+  | TaskIdInvalidChars
+  | ProgressOutOfRange of float
+
+(** {1 Validation} *)
+
+val validate_task_id : string -> (string, validation_error) result
+val validate_progress : float -> (float, validation_error) result
+val validation_error_to_string : validation_error -> string
+
+(** {1 JSON serialization} *)
+
+val progress_to_jsonrpc : progress -> Yojson.Safe.t
+
+(** {1 Tracker}
+
+    Step-based progress tracking with automatic rate estimation. *)
+module Tracker : sig
+  type t = {
+    task_id : string;
+    mutable current : float;
+    total_steps : int;
+    mutable completed_steps : int;
+    start_time : float;
+  }
+
+  val notify_ref :
+    (task_id:string -> progress:float -> ?message:string ->
+     ?estimated_remaining:float -> unit -> unit) ref
+
+  val assert_wired : unit -> unit
+
+  val create : task_id:string -> ?total_steps:int -> unit -> t
+  val update : t -> progress:float -> ?message:string -> unit -> unit
+  val step : t -> ?message:string -> unit -> unit
+  val complete : t -> ?message:string -> unit -> unit
+end
+
+(** {1 State management} *)
+
+val set_sse_callback : (Yojson.Safe.t -> unit) -> unit
+val notify :
+  task_id:string -> progress:float -> ?message:string ->
+  ?estimated_remaining:float -> unit -> unit
+val start_tracking : task_id:string -> ?total_steps:int -> unit -> Tracker.t
+val get_tracker : string -> Tracker.t option
+val stop_tracking : string -> unit
+
+(** {1 Tool handler} *)
+
+val handle_progress_tool : Yojson.Safe.t -> bool * string
+
+(** {1 Testing} *)
+
+val reset_for_testing : unit -> unit

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -1,0 +1,206 @@
+(** Session -- Agent session registry with rate limiting.
+
+    Tracks connected agents, enforces per-category rate limits,
+    manages notification queues, and provides MCP session-id
+    lifecycle (create, get, cleanup). *)
+
+open Types
+
+(** {1 Session Types} *)
+
+(** Session info stored in the registry. *)
+type session = {
+  agent_name: string;
+  connected_at: float;
+  mutable last_activity: float;
+  mutable is_listening: bool;
+  mutable message_queue: Yojson.Safe.t list;
+}
+
+(** Rate-limit tracking per category.
+
+    Uses OCaml 5.4 [[@atomic]] fields for lock-free concurrent access
+    to burst counters. *)
+type rate_tracker = {
+  mutable general_timestamps: float list;
+  mutable broadcast_timestamps: float list;
+  mutable task_ops_timestamps: float list;
+  mutable burst_used: int; [@atomic]
+  mutable last_burst_reset: float; [@atomic]
+}
+
+(** Session registry managing all connected agents. *)
+type registry = {
+  mutable sessions: (string, session) Hashtbl.t;
+  mutable rate_trackers: (string, rate_tracker) Hashtbl.t;
+  config: rate_limit_config;
+  lock: Eio.Mutex.t;
+}
+
+(** {1 Registry Lifecycle} *)
+
+(** Create a new session registry with optional rate-limit config. *)
+val create : ?config:rate_limit_config -> unit -> registry
+
+(** Run a critical section under the registry's mutex. *)
+val with_lock : registry -> (unit -> 'a) -> 'a
+
+(** {1 Agent Sessions} *)
+
+(** Register a new agent session (or replace if name exists). *)
+val register : registry -> agent_name:string -> session
+
+(** Unregister an agent session (mutex-protected). *)
+val unregister : registry -> agent_name:string -> unit
+
+(** Unregister synchronously without extra mutex layer.
+    Safe in single-fiber Eio context. *)
+val unregister_sync : registry -> agent_name:string -> unit
+
+(** Update the activity timestamp and optionally the listening flag. *)
+val update_activity :
+  registry -> agent_name:string -> ?is_listening:bool option -> unit -> unit
+
+(** {1 Rate Limiting} *)
+
+(** Create an empty rate tracker. *)
+val create_tracker : unit -> rate_tracker
+
+(** Atomic read of [burst_used]. *)
+val get_burst_used : rate_tracker -> int
+
+(** Atomic write of [burst_used]. *)
+val set_burst_used : rate_tracker -> int -> unit
+
+(** Atomic increment of [burst_used] (fetch-and-add). *)
+val incr_burst_used : rate_tracker -> unit
+
+(** Atomic read of [last_burst_reset]. *)
+val get_last_burst_reset : rate_tracker -> float
+
+(** Atomic write of [last_burst_reset]. *)
+val set_last_burst_reset : rate_tracker -> float -> unit
+
+(** Get timestamps for a given rate-limit category. *)
+val get_timestamps : rate_tracker -> rate_limit_category -> float list
+
+(** Set timestamps for a given rate-limit category. *)
+val set_timestamps : rate_tracker -> rate_limit_category -> float list -> unit
+
+(** Check rate limit for an agent (simple, uses GeneralLimit + Worker). *)
+val check_rate_limit :
+  registry -> agent_name:string -> bool * int
+
+(** Check rate limit with explicit category and role.
+    Returns [(allowed, wait_seconds)]. *)
+val check_rate_limit_ex :
+  registry -> agent_name:string ->
+  category:rate_limit_category -> role:agent_role ->
+  bool * int
+
+(** Return rate-limit status as JSON for an agent. *)
+val get_rate_limit_status :
+  registry -> agent_name:string -> role:agent_role -> Yojson.Safe.t
+
+(** {1 Message Queue} *)
+
+(** Max notification queue size per session. *)
+val max_notification_queue : int
+
+(** Push a broadcast/direct message to matching session queues.
+    Returns the list of target agent names that received the message. *)
+val push_message :
+  registry -> from_agent:string -> content:string ->
+  mention:string option -> string list
+
+(** Push a system notification to all active sessions.
+    Does not exclude the sender and has no mention filter. *)
+val push_notification_to_active_agents :
+  registry -> event:Yojson.Safe.t -> int
+
+(** Pop the next message from an agent's queue, if any. *)
+val pop_message : registry -> agent_name:string -> Yojson.Safe.t option
+
+(** Block until a message arrives or [timeout] seconds elapse. *)
+val wait_for_message :
+  registry -> agent_name:string -> timeout:float ->
+  Yojson.Safe.t option
+
+(** {1 Status & Diagnostics} *)
+
+(** Return names of agents idle longer than [threshold] seconds. *)
+val get_inactive_agents : registry -> threshold:float -> string list
+
+(** Return all agent statuses as JSON objects. *)
+val get_agent_statuses : registry -> Yojson.Safe.t list
+
+(** Formatted multi-line status string for display. *)
+val status_string : registry -> string
+
+(** List of currently connected agent names. *)
+val connected_agents : registry -> string list
+
+(** Restore sessions from on-disk agent files (call at startup). *)
+val restore_from_disk : registry -> agents_path:string -> unit
+
+(** {1 MCP Session Store} *)
+
+(** MCP session-id management (separate from agent sessions). *)
+module McpSessionStore : sig
+
+  (** An MCP session record. *)
+  type mcp_session = {
+    id: string;
+    created_at: float;
+    mutable last_activity: float;
+    mutable agent_name: string option;
+    mutable metadata: (string * string) list;
+    mutable request_count: int;
+  }
+
+  (** Generate a cryptographically random MCP session ID. *)
+  val generate_id : unit -> string
+
+  (** Create and store a new MCP session. *)
+  val create : ?agent_name:string -> unit -> mcp_session
+
+  (** Look up an MCP session by ID (updates activity). *)
+  val get : string -> mcp_session option
+
+  (** Remove stale sessions exceeding max age.
+      Returns the number removed. *)
+  val cleanup_stale : unit -> int
+
+  (** Serialize an MCP session to JSON. *)
+  val to_json : mcp_session -> Yojson.Safe.t
+
+  (** List all active MCP sessions. *)
+  val list_all : unit -> mcp_session list
+
+  (** Remove an MCP session by ID.  Returns [true] if found. *)
+  val remove : string -> bool
+end
+
+(** Start a background fiber that periodically cleans up stale
+    MCP sessions.  Call once at server startup. *)
+val start_mcp_session_cleanup_loop :
+  sw:Eio.Switch.t -> clock:_ Eio.Time.clock ->
+  ?interval:float -> unit -> unit
+
+(** {1 MCP Session Helpers} *)
+
+(** Extract MCP session ID from HTTP headers.
+    Prefers canonical [Mcp-Session-Id], falls back to legacy
+    [X-MCP-Session-ID]. *)
+val extract_mcp_session_id : Cohttp.Header.t -> string option
+
+(** Retrieve or create an MCP session from request headers. *)
+val get_or_create_mcp_session :
+  Cohttp.Header.t -> McpSessionStore.mcp_session
+
+(** Add [Mcp-Session-Id] to response headers. *)
+val add_mcp_session_header :
+  Cohttp.Header.t -> McpSessionStore.mcp_session -> Cohttp.Header.t
+
+(** Handle the [mcp_session] tool (get/create/list/cleanup/remove). *)
+val handle_mcp_session_tool : Yojson.Safe.t -> bool * string


### PR DESCRIPTION
session.mli 추가 — 755회 참조되는 최대 규모 모듈의 공개 API 명시화 (206줄). 타입 투명, McpSessionStore 포함.