### PR TITLE
refactor(core): extract Executor_pool_ref as shared pool accessor

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax)
+ (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax executor_pool_ref)
  (libraries yojson unix str eio time_compat fs_compat masc_log))

--- a/lib/core/executor_pool_ref.ml
+++ b/lib/core/executor_pool_ref.ml
@@ -1,0 +1,30 @@
+(** Executor_pool_ref — Shared reference to the Eio.Executor_pool.
+
+    Set once at server startup in [server_runtime_bootstrap.ml].
+    Used by dashboard compute and (future) chain adapter offloading.
+
+    [submit_or_inline] provides graceful fallback: if the pool is not
+    available (e.g. during tests or before server init), the computation
+    runs inline in the current fiber. *)
+
+let pool : Eio.Executor_pool.t option ref = ref None
+
+let get () = !pool
+
+let set p = pool := Some p
+
+(** Submit [f] to the executor pool if available, or run inline.
+    Inline fallback ensures callers work in tests and before server init.
+    Re-raises [Eio.Cancel.Cancelled] to preserve structured concurrency. *)
+let submit_or_inline ?(weight = 1.0) f =
+  match !pool with
+  | Some p ->
+      (try Eio.Executor_pool.submit_exn p ~weight (fun () ->
+         Eio.Switch.run (fun _sw -> f ()))
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Misc.warn "executor_pool submit failed, running inline: %s"
+             (Printexc.to_string exn);
+           f ())
+  | None -> f ()

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -10,12 +10,9 @@ type dashboard_compute_mode =
   | Inline_shared
   | Offloaded_readonly
 
-(** Executor pool for CPU-heavy dashboard compute.  Parameterized dashboard
-    requests can otherwise monopolize the main Eio domain long enough to
-    starve unrelated MCP tool calls. *)
-let _executor_pool : Eio.Executor_pool.t option ref = ref None
-
-let set_executor_pool pool = _executor_pool := Some pool
+(** Executor pool for CPU-heavy dashboard compute.
+    Pool reference is shared via [Executor_pool_ref] in masc_core. *)
+let set_executor_pool pool = Executor_pool_ref.set pool
 
 let isolated_readonly_dashboard_config ~sw ~clock ~(config : Room.config) =
   match config.backend_config.Backend.backend_type with
@@ -50,7 +47,7 @@ let run_dashboard_compute ?(mode = Offloaded_readonly) ~sw ~clock
         `Done (compute ~config ~sw:pool_sw)
   in
   let offloaded () =
-    match !_executor_pool with
+    match Executor_pool_ref.get () with
     | Some pool ->
         (try
            match


### PR DESCRIPTION
## Summary
- `Eio.Executor_pool` 참조를 `server_dashboard_http_core.ml` 로컬 ref에서 `masc_core`의 공유 모듈로 추출
- chain/backend 등 다른 sub-library에서 pool에 접근 가능하게 준비

## New module: `lib/core/executor_pool_ref.ml`
```ocaml
val get : unit -> Eio.Executor_pool.t option
val set : Eio.Executor_pool.t -> unit
val submit_or_inline : ?weight:float -> (unit -> 'a) -> 'a
```

`submit_or_inline`: pool이 있으면 offload, 없으면 inline 실행. 테스트/서버 초기화 전에도 동작.

## Changes
| File | Change |
|------|--------|
| `lib/core/executor_pool_ref.ml` | 신규 — 공유 pool ref + submit_or_inline |
| `lib/core/dune` | modules에 `executor_pool_ref` 추가 |
| `lib/server/server_dashboard_http_core.ml` | 로컬 `_executor_pool` ref → `Executor_pool_ref.get/set` |

## Deferred
Chain adapter CPU offloading (`chain_adapter_eio.ml`)은 별도 PR로 진행 예정.
(domain-safety 감사 + full build 검증 필요)

## Test plan
- [x] `dune build --root . lib/core/` 성공
- [x] `dune build --root . lib/server/` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)