### PR TITLE
feat(keeper): recurring task loop — scheduled broadcast execution (#3190)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -492,6 +492,7 @@
    keeper_coordination
    keeper_execution
    keeper_keepalive
+   keeper_recurring
    keeper_registry
    keeper_resident_supervisor
    keeper_runtime

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -460,6 +460,33 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                    meta_after_triage)
               else meta_after_triage
             in
+            (* Recurring task dispatch (#3190) *)
+            let _recurring_dispatched =
+              try
+                Keeper_recurring.dispatch_due
+                  ~keeper_name:meta_after_proactive.name
+                  ~now_ts
+                  ~dispatch:(fun task action ->
+                    match action with
+                    | Keeper_recurring.Broadcast msg ->
+                      (try
+                         let _ = Room.broadcast ctx.config
+                           ~from_agent:meta_after_proactive.agent_name
+                           ~content:(Printf.sprintf "[loop:%s] %s" task.label msg) in
+                         Log.Keeper.info "[recurring] %s dispatched: %s"
+                           task.id task.label;
+                         Ok ()
+                       with exn ->
+                         Log.Keeper.warn "[recurring] %s failed: %s"
+                           task.id (Printexc.to_string exn);
+                         Error (Printexc.to_string exn)))
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Keeper.warn "[recurring] dispatch error: %s"
+                  (Printexc.to_string exn);
+                0
+            in
             let base =
               float_of_int
                 (max 30 (min 300 meta_after_proactive.presence_keepalive_sec))

--- a/lib/keeper/keeper_recurring.ml
+++ b/lib/keeper/keeper_recurring.ml
@@ -1,0 +1,134 @@
+(** Keeper_recurring — In-memory recurring task registry.
+
+    Thread-safe via Stdlib.Mutex (this module may be accessed from
+    non-Eio contexts such as MCP tool handlers and tests).
+
+    @since #3190 *)
+
+type action =
+  | Broadcast of string
+
+type recurring_task = {
+  id : string;
+  keeper_name : string;
+  label : string;
+  interval_sec : int;
+  action : action;
+  mutable last_run_ts : float;
+  mutable run_count : int;
+  mutable failure_count : int;
+  max_failures : int;
+  mutable enabled : bool;
+}
+
+(* ================================================================ *)
+(* Storage                                                           *)
+(* ================================================================ *)
+
+let mu = Mutex.create ()
+let tasks : (string, recurring_task) Hashtbl.t = Hashtbl.create 16
+
+let with_lock f =
+  Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+
+(* ================================================================ *)
+(* ID generation                                                     *)
+(* ================================================================ *)
+
+let id_counter = ref 0
+
+let generate_id () =
+  incr id_counter;
+  let ts = int_of_float (Unix.gettimeofday () *. 1000.0) mod 100_000 in
+  Printf.sprintf "loop-%d-%d" ts !id_counter
+
+(* ================================================================ *)
+(* CRUD                                                              *)
+(* ================================================================ *)
+
+let add ~keeper_name ~label ~interval_sec ?(max_failures = 5) action =
+  let id = generate_id () in
+  let task = {
+    id; keeper_name; label; interval_sec; action;
+    last_run_ts = 0.0; run_count = 0; failure_count = 0;
+    max_failures; enabled = true;
+  } in
+  with_lock (fun () -> Hashtbl.replace tasks id task);
+  task
+
+let remove ~id =
+  with_lock (fun () ->
+    if Hashtbl.mem tasks id then begin
+      Hashtbl.remove tasks id; true
+    end else false)
+
+let list ~keeper_name =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _id task acc ->
+      if task.keeper_name = keeper_name then task :: acc else acc
+    ) tasks [])
+
+let list_all () =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _id task acc -> task :: acc) tasks [])
+
+(* ================================================================ *)
+(* Dispatch                                                          *)
+(* ================================================================ *)
+
+let dispatch_due ~keeper_name ~now_ts ~dispatch =
+  let due_tasks = with_lock (fun () ->
+    Hashtbl.fold (fun _id task acc ->
+      if task.keeper_name = keeper_name
+         && task.enabled
+         && now_ts -. task.last_run_ts >= float_of_int task.interval_sec
+      then task :: acc
+      else acc
+    ) tasks [])
+  in
+  let count = ref 0 in
+  List.iter (fun task ->
+    match dispatch task task.action with
+    | Ok () ->
+      with_lock (fun () ->
+        task.last_run_ts <- now_ts;
+        task.run_count <- task.run_count + 1;
+        task.failure_count <- 0);
+      incr count
+    | Error _msg ->
+      with_lock (fun () ->
+        task.failure_count <- task.failure_count + 1;
+        if task.max_failures > 0
+           && task.failure_count >= task.max_failures
+        then task.enabled <- false)
+  ) due_tasks;
+  !count
+
+(* ================================================================ *)
+(* Serialization                                                     *)
+(* ================================================================ *)
+
+let action_to_json = function
+  | Broadcast msg -> `Assoc [("type", `String "broadcast"); ("message", `String msg)]
+
+let task_to_json (t : recurring_task) : Yojson.Safe.t =
+  `Assoc [
+    ("id", `String t.id);
+    ("keeper_name", `String t.keeper_name);
+    ("label", `String t.label);
+    ("interval_sec", `Int t.interval_sec);
+    ("action", action_to_json t.action);
+    ("last_run_ts", `Float t.last_run_ts);
+    ("run_count", `Int t.run_count);
+    ("failure_count", `Int t.failure_count);
+    ("max_failures", `Int t.max_failures);
+    ("enabled", `Bool t.enabled);
+  ]
+
+(* ================================================================ *)
+(* Testing                                                           *)
+(* ================================================================ *)
+
+let clear () =
+  with_lock (fun () -> Hashtbl.clear tasks)

--- a/lib/keeper/keeper_recurring.mli
+++ b/lib/keeper/keeper_recurring.mli
@@ -1,0 +1,63 @@
+(** Keeper_recurring — In-memory recurring task registry.
+
+    Keepers can register recurring tasks (broadcast, board post)
+    that fire on a configurable interval.  The heartbeat loop calls
+    [dispatch_due] each cycle to execute overdue tasks.
+
+    Tasks are stored in memory only — they do not survive keeper restart.
+    Re-register via MCP tools after restart if needed.
+
+    Thread-safe: protected by Eio.Mutex when available. *)
+
+type action =
+  | Broadcast of string   (** Broadcast a message to the keeper's room *)
+
+type recurring_task = {
+  id : string;
+  keeper_name : string;
+  label : string;          (** Human-readable description *)
+  interval_sec : int;      (** Minimum seconds between runs *)
+  action : action;
+  mutable last_run_ts : float;
+  mutable run_count : int;
+  mutable failure_count : int;
+  max_failures : int;      (** Auto-disable after this many consecutive failures, 0 = unlimited *)
+  mutable enabled : bool;
+}
+
+(** Generate a short unique task ID. *)
+val generate_id : unit -> string
+
+(** Register a new recurring task. Returns the task. *)
+val add :
+  keeper_name:string ->
+  label:string ->
+  interval_sec:int ->
+  ?max_failures:int ->
+  action ->
+  recurring_task
+
+(** Remove a recurring task by ID. Returns true if found and removed. *)
+val remove : id:string -> bool
+
+(** List all recurring tasks for a keeper. *)
+val list : keeper_name:string -> recurring_task list
+
+(** List all recurring tasks across all keepers. *)
+val list_all : unit -> recurring_task list
+
+(** Dispatch all due recurring tasks for a given keeper.
+    [~now_ts] is the current timestamp.
+    [~dispatch] is called for each due task's action.
+    Returns the number of tasks dispatched. *)
+val dispatch_due :
+  keeper_name:string ->
+  now_ts:float ->
+  dispatch:(recurring_task -> action -> (unit, string) result) ->
+  int
+
+(** Serialize a task to JSON. *)
+val task_to_json : recurring_task -> Yojson.Safe.t
+
+(** Clear all tasks.  For testing only. *)
+val clear : unit -> unit

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -369,7 +369,8 @@ let session_to_swarm_config
     max_agent_retries = 1;
     collaboration = Some collaboration;
     resource_check = Some (fun () -> Room.is_initialized config);
-    max_concurrent_agents = Some (max 1 (List.length entries)) }
+    max_concurrent_agents = Some (max 1 (List.length entries));
+    enable_streaming = false }
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -503,6 +503,46 @@ let handle_persistent_agent_model_set ctx args : tool_result =
 let handle_persistent_agent_create_from_persona ctx args : tool_result =
   Persona.handle_keeper_create_from_persona ctx args
 
+(* ================================================================ *)
+(* Recurring loop tools (#3190)                                      *)
+(* ================================================================ *)
+
+let handle_keeper_add_loop _ctx (args : Yojson.Safe.t) : tool_result =
+  let keeper_name = Safe_ops.json_string ~default:"" "keeper_name" args in
+  let label = Safe_ops.json_string ~default:"" "label" args in
+  let interval_sec = Safe_ops.json_int ~default:600 "interval_sec" args in
+  let message = Safe_ops.json_string ~default:"" "message" args in
+  let max_failures = Safe_ops.json_int ~default:5 "max_failures" args in
+  if keeper_name = "" then (false, "keeper_name required")
+  else if message = "" then (false, "message required")
+  else if interval_sec < 30 then (false, "interval_sec minimum is 30")
+  else
+    let task = Keeper_recurring.add
+      ~keeper_name ~label:(if label = "" then message else label)
+      ~interval_sec ~max_failures
+      (Keeper_recurring.Broadcast message) in
+    (true, Printf.sprintf "Recurring task registered: %s (every %ds)\n%s"
+       task.id interval_sec
+       (Yojson.Safe.to_string (Keeper_recurring.task_to_json task)))
+
+let handle_keeper_list_loops _ctx (args : Yojson.Safe.t) : tool_result =
+  let keeper_name = Safe_ops.json_string ~default:"" "keeper_name" args in
+  let tasks =
+    if keeper_name = "" then Keeper_recurring.list_all ()
+    else Keeper_recurring.list ~keeper_name
+  in
+  let tasks_json = `List (List.map Keeper_recurring.task_to_json tasks) in
+  (true, Printf.sprintf "%d recurring task(s)\n%s"
+     (List.length tasks) (Yojson.Safe.to_string tasks_json))
+
+let handle_keeper_remove_loop _ctx (args : Yojson.Safe.t) : tool_result =
+  let id = Safe_ops.json_string ~default:"" "id" args in
+  if id = "" then (false, "id required")
+  else if Keeper_recurring.remove ~id then
+    (true, Printf.sprintf "Task '%s' removed" id)
+  else
+    (false, Printf.sprintf "Task '%s' not found" id)
+
 let dispatch ctx ~name ~args : tool_result option =
   (* Resident keepers are bootstrapped lazily on tool use as a fallback.
      Server startup also calls bootstrap_existing_keepers for always-on presence. *)
@@ -529,6 +569,10 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_persistent_agent_list" -> Some (handle_persistent_agent_list ctx args)
   | "masc_persistent_agent_trajectory" -> Some (Status.handle_keeper_trajectory ctx args)
   | "masc_persistent_agent_eval" -> Some (Status.handle_keeper_eval ctx args)
+  (* Recurring loops (#3190) *)
+  | "masc_keeper_add_loop" -> Some (handle_keeper_add_loop ctx args)
+  | "masc_keeper_list_loops" -> Some (handle_keeper_list_loops ctx args)
+  | "masc_keeper_remove_loop" -> Some (handle_keeper_remove_loop ctx args)
   (* Housekeeping: keepers maintain their own world *)
   | "masc_housekeep_scan" | "masc_housekeep_delete" | "masc_housekeep_prune" ->
       Tool_housekeep.dispatch ctx.config ~name ~args

--- a/test/dune
+++ b/test/dune
@@ -1125,3 +1125,9 @@
  (name test_prompt_registry_defaults)
  (modules test_prompt_registry_defaults)
  (libraries masc_mcp alcotest str yojson unix))
+
+; Keeper recurring task loop tests (#3190)
+(test
+ (name test_keeper_recurring)
+ (modules test_keeper_recurring)
+ (libraries masc_mcp alcotest yojson unix))

--- a/test/test_keeper_recurring.ml
+++ b/test/test_keeper_recurring.ml
@@ -1,0 +1,120 @@
+(** Tests for Keeper_recurring — in-memory recurring task registry. *)
+
+open Alcotest
+module Rec = Masc_mcp.Keeper_recurring
+
+let check = Alcotest.check
+
+let test_add_and_list () =
+  Rec.clear ();
+  let _t = Rec.add ~keeper_name:"k1" ~label:"status"
+    ~interval_sec:60 (Rec.Broadcast "hello") in
+  let tasks = Rec.list ~keeper_name:"k1" in
+  check int "1 task" 1 (List.length tasks);
+  let t = List.hd tasks in
+  check string "label" "status" t.label;
+  check int "interval" 60 t.interval_sec;
+  check bool "enabled" true t.enabled;
+  check int "run_count" 0 t.run_count
+
+let test_list_filters_by_keeper () =
+  Rec.clear ();
+  let _t1 = Rec.add ~keeper_name:"k1" ~label:"a"
+    ~interval_sec:60 (Rec.Broadcast "a") in
+  let _t2 = Rec.add ~keeper_name:"k2" ~label:"b"
+    ~interval_sec:60 (Rec.Broadcast "b") in
+  check int "k1 tasks" 1 (List.length (Rec.list ~keeper_name:"k1"));
+  check int "k2 tasks" 1 (List.length (Rec.list ~keeper_name:"k2"));
+  check int "all tasks" 2 (List.length (Rec.list_all ()))
+
+let test_remove () =
+  Rec.clear ();
+  let t = Rec.add ~keeper_name:"k1" ~label:"x"
+    ~interval_sec:60 (Rec.Broadcast "x") in
+  check bool "remove existing" true (Rec.remove ~id:t.id);
+  check bool "remove again" false (Rec.remove ~id:t.id);
+  check int "empty" 0 (List.length (Rec.list ~keeper_name:"k1"))
+
+let test_dispatch_due () =
+  Rec.clear ();
+  let _t = Rec.add ~keeper_name:"k1" ~label:"tick"
+    ~interval_sec:60 (Rec.Broadcast "tick msg") in
+  (* Not due yet at t=30 *)
+  let dispatched_early = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:30.0
+    ~dispatch:(fun _task _action -> Ok ()) in
+  check int "too early" 0 dispatched_early;
+  (* Due at t=100 (100 - 0 = 100 >= 60) *)
+  let dispatched = ref 0 in
+  let count = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:100.0
+    ~dispatch:(fun _task action ->
+      (match action with Rec.Broadcast msg ->
+        check string "broadcast msg" "tick msg" msg);
+      incr dispatched; Ok ()) in
+  check int "dispatched 1" 1 count;
+  check int "callback called" 1 !dispatched;
+  (* Not due again immediately *)
+  let count2 = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:110.0
+    ~dispatch:(fun _task _action -> Ok ()) in
+  check int "not due yet" 0 count2;
+  (* Due again after interval *)
+  let count3 = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:200.0
+    ~dispatch:(fun _task _action -> Ok ()) in
+  check int "due again" 1 count3
+
+let test_failure_auto_disable () =
+  Rec.clear ();
+  let t = Rec.add ~keeper_name:"k1" ~label:"fail"
+    ~interval_sec:30 ~max_failures:2 (Rec.Broadcast "oops") in
+  (* Fail twice *)
+  let _ = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:100.0
+    ~dispatch:(fun _task _action -> Error "boom") in
+  let tasks = Rec.list ~keeper_name:"k1" in
+  let task = List.hd tasks in
+  check int "failure 1" 1 task.failure_count;
+  check bool "still enabled" true task.enabled;
+  (* Need to set last_run_ts back to allow re-dispatch *)
+  (* Actually, on failure we don't update last_run_ts, so it stays 0.0 *)
+  let _ = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:200.0
+    ~dispatch:(fun _task _action -> Error "boom again") in
+  let tasks2 = Rec.list ~keeper_name:"k1" in
+  let task2 = List.hd tasks2 in
+  check int "failure 2" 2 task2.failure_count;
+  check bool "auto-disabled" false task2.enabled;
+  (* No more dispatches *)
+  let count = Rec.dispatch_due ~keeper_name:"k1" ~now_ts:300.0
+    ~dispatch:(fun _task _action -> Ok ()) in
+  check int "disabled no dispatch" 0 count;
+  ignore t
+
+let test_task_to_json () =
+  Rec.clear ();
+  let t = Rec.add ~keeper_name:"k1" ~label:"json test"
+    ~interval_sec:120 (Rec.Broadcast "test msg") in
+  let json = Rec.task_to_json t in
+  let open Yojson.Safe.Util in
+  check string "id" t.id (json |> member "id" |> to_string);
+  check string "keeper" "k1" (json |> member "keeper_name" |> to_string);
+  check int "interval" 120 (json |> member "interval_sec" |> to_int);
+  check bool "enabled" true (json |> member "enabled" |> to_bool)
+
+let test_generate_id_unique () =
+  let id1 = Rec.generate_id () in
+  let id2 = Rec.generate_id () in
+  check bool "unique ids" true (id1 <> id2)
+
+let () =
+  run "keeper_recurring" [
+    "crud", [
+      test_case "add and list" `Quick test_add_and_list;
+      test_case "filter by keeper" `Quick test_list_filters_by_keeper;
+      test_case "remove" `Quick test_remove;
+    ];
+    "dispatch", [
+      test_case "due tasks" `Quick test_dispatch_due;
+      test_case "failure auto-disable" `Quick test_failure_auto_disable;
+    ];
+    "serialization", [
+      test_case "task to json" `Quick test_task_to_json;
+      test_case "unique ids" `Quick test_generate_id_unique;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Keeper에 반복 작업(loop) 기능 추가. 설정한 간격마다 broadcast 메시지를 자동 실행.

## Architecture

- **In-memory registry**: `Keeper_recurring` 모듈 — keeper_meta를 수정하지 않고 독립적 관리
- **Heartbeat 통합**: proactive turn 이후, sleep 이전에 `dispatch_due` 호출
- **Stdlib.Mutex**: non-Eio context (MCP tool handler, 테스트)에서도 안전하게 접근

## MCP Tools (hidden surface)

| Tool | Description |
|------|-------------|
| `masc_keeper_add_loop` | 반복 작업 등록 (keeper_name, message, interval_sec) |
| `masc_keeper_list_loops` | 등록된 반복 작업 조회 |
| `masc_keeper_remove_loop` | 반복 작업 제거 |

## Changes (8 files, +397/-1)

- `lib/keeper/keeper_recurring.ml` + `.mli` — 134줄 in-memory registry
- `lib/keeper/keeper_keepalive.ml` — heartbeat dispatch 연동
- `lib/tool_keeper.ml` — 3개 MCP tool handler
- `lib/dune` — 모듈 등록
- `test/test_keeper_recurring.ml` — 7 tests
- `lib/team_session/team_session_oas_bridge.ml` — pre-existing enable_streaming fix

## Verification
- `test_keeper_recurring` — 7/7 통과
- `dune build --root . lib bin` — 성공 (pre-existing team_session 에러 수정 포함)

## Test plan
- [ ] `masc_keeper_add_loop {"keeper_name":"alice","message":"status check","interval_sec":60}`
- [ ] `masc_keeper_list_loops {"keeper_name":"alice"}` → 등록 확인
- [ ] Keeper heartbeat에서 60초 이후 자동 broadcast 확인
- [ ] `masc_keeper_remove_loop {"id":"..."}` → 제거 확인
- [ ] 5회 연속 실패 시 자동 비활성화 확인

Closes #3190