### PR TITLE
fix: OAS v0.91.0 compat — enable_streaming + stale ref deref

### DIFF
--- a/lib/chain/chain_executor_eio.ml
+++ b/lib/chain/chain_executor_eio.ml
@@ -215,7 +215,7 @@ and execute_fanout ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) (nodes : n
   end else begin
     let errors = List.filter_map (fun (id, r) ->
       match r with Error e -> Some (Printf.sprintf "%s: %s" id e) | Ok _ -> None
-    ) !results in
+    ) results in
     let msg = String.concat "; " errors in
     record_complete ctx parent.id ~duration_ms ~success:false;
     record_error ctx parent.id msg;
@@ -374,7 +374,7 @@ and execute_parallel_group ctx ~sw ~clock ~exec_fn ~tool_exec (group : string li
     | None ->
         let outputs = List.filter_map (fun (_, r) ->
           match r with Ok o -> Some o | Error _ -> None
-        ) !results in
+        ) results in
         Ok (String.concat "\n" outputs)
 
 (** Execute inline subgraph with dependency-based parallelization *)

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -369,7 +369,8 @@ let session_to_swarm_config
     max_agent_retries = 1;
     collaboration = Some collaboration;
     resource_check = Some (fun () -> Room.is_initialized config);
-    max_concurrent_agents = Some (max 1 (List.length entries)) }
+    max_concurrent_agents = Some (max 1 (List.length entries));
+    enable_streaming = false }
 
 (* ── Inverse: swarm result -> session update ───────────────────── *)
 


### PR DESCRIPTION
## Summary

main이 빌드 깨진 상태 — 두 가지 원인:

1. **enable_streaming 누락**: OAS v0.91.0 (#3195 머지)에서 `swarm_config`에 `enable_streaming` 필드 추가. squash merge 시 두 번째 커밋(호환성 fix)이 누락됨.

2. **stale `!results` deref**: #3197 (Eio.Stream fanout)에서 `results`를 ref에서 plain list로 바꿨지만, error path의 `!results` 2곳이 남아있었음.

## Test plan
- [x] `dune build` 로컬 통과
- [ ] CI Build and Test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)