### PR TITLE
fix(stability): prevent FD exhaustion from concurrent cache scans

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -270,6 +270,16 @@ let base_path =
 
 let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
 
+let is_server_responsive port =
+  try
+    let url = Printf.sprintf "http://127.0.0.1:%d/health/live" port in
+    let cmd = Printf.sprintf "curl -s --max-time 3 -o /dev/null -w '%%{http_code}' %s" url in
+    let ic = Unix.open_process_in cmd in
+    let code = In_channel.input_all ic |> String.trim in
+    let _ = Unix.close_process_in ic in
+    code = "200"
+  with _ -> false
+
 let acquire_pid_lock port =
   let path = pid_lock_path port in
   (let contents =
@@ -285,11 +295,30 @@ let acquire_pid_lock port =
      (match int_of_string_opt pid_str with
       | Some pid ->
         (try Unix.kill pid 0;
-           Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
-             (Printf.sprintf
-                "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
-                pid port pid);
-           exit 1
+           (* Process exists — check if it is actually responsive *)
+           if is_server_responsive port then begin
+             Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+               (Printf.sprintf
+                  "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
+                  pid port pid);
+             exit 1
+           end else begin
+             (* Process alive but unresponsive (e.g. FD exhaustion) — kill and take over *)
+             Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+               (Printf.sprintf
+                  "[WARN] PID %d alive but unresponsive on port %d; sending SIGTERM to reclaim"
+                  pid port);
+             (try Unix.kill pid Sys.sigterm with _ -> ());
+             Unix.sleepf 1.0;
+             (* If still alive after SIGTERM, force kill *)
+             (try
+                Unix.kill pid 0;
+                Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+                  (Printf.sprintf "[WARN] PID %d did not exit; sending SIGKILL" pid);
+                (try Unix.kill pid Sys.sigkill with _ -> ());
+                Unix.sleepf 0.5
+              with Unix.Unix_error (Unix.ESRCH, _, _) -> ())
+           end
          with Unix.Unix_error (Unix.ESRCH, _, _) ->
            Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
              (Printf.sprintf

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -98,28 +98,57 @@ let last_batch_eviction = Atomic.make 0.0
 (** Minimum interval between batch evictions (seconds). *)
 let batch_eviction_interval = 60.0
 
-(** Evict all expired cache entries. Returns count of evicted entries. *)
+(** Cached entry count to avoid Sys.readdir on every set() call.
+    -1 = uninitialized; lazily populated on first count_entries call.
+    Updated incrementally on set/delete/evict/clear to prevent
+    file descriptor exhaustion from repeated concurrent directory scans.
+    See: system_log seq 8719 "Too many open files" on .masc/cache. *)
+let cached_entry_count = Atomic.make (-1)
+
+(** Reset cached entry count. Call when switching cache directories (tests). *)
+let reset_cached_entry_count () = Atomic.set cached_entry_count (-1)
+
+(** Guard to prevent concurrent directory scan stampedes.
+    Only one fiber may scan the cache directory at a time;
+    concurrent callers return [fallback] immediately. *)
+let scan_in_progress = Atomic.make false
+
+let with_scan_guard ~fallback f =
+  if Atomic.compare_and_set scan_in_progress false true then
+    Fun.protect ~finally:(fun () -> Atomic.set scan_in_progress false) f
+  else fallback
+
+(** Read .json filenames from cache directory. Single readdir call. *)
+let read_cache_filenames dir =
+  if not (Sys.file_exists dir) then []
+  else
+    Sys.readdir dir |> Array.to_list
+    |> List.filter (fun f -> Filename.check_suffix f ".json")
+
+(** Evict all expired cache entries. Returns count of evicted entries.
+    Guarded: only one scan runs at a time; concurrent calls return 0. *)
 let evict_expired config =
   let dir = cache_dir config in
-  if not (Sys.file_exists dir) then 0
-  else
-    let entries = Sys.readdir dir |> Array.to_list in
-    List.fold_left (fun count filename ->
-      if Filename.check_suffix filename ".json" then
-        let path = Filename.concat dir filename in
-        match Safe_ops.read_file_safe path with
+  with_scan_guard ~fallback:0 (fun () ->
+    let filenames = read_cache_filenames dir in
+    let evicted = List.fold_left (fun count filename ->
+      let path = Filename.concat dir filename in
+      match Safe_ops.read_file_safe path with
+      | Error _ -> count
+      | Ok content ->
+        match Safe_ops.parse_json_safe ~context:"cache_evict" content with
         | Error _ -> count
-        | Ok content ->
-          match Safe_ops.parse_json_safe ~context:"cache_evict" content with
-          | Error _ -> count
-          | Ok json ->
-            match entry_of_json json with
-            | Some entry when is_expired entry ->
-                Safe_ops.remove_file_logged ~context:"cache_evict" path;
-                count + 1
-            | _ -> count
-      else count
-    ) 0 entries
+        | Ok json ->
+          match entry_of_json json with
+          | Some entry when is_expired entry ->
+              Safe_ops.remove_file_logged ~context:"cache_evict" path;
+              count + 1
+          | _ -> count
+    ) 0 filenames in
+    (* Refresh cached count after eviction *)
+    let remaining = List.length filenames - evicted in
+    Atomic.set cached_entry_count remaining;
+    evicted)
 
 (** Check expired ratio and evict if > 50% are expired.
     Throttled to run at most once per [batch_eviction_interval] seconds.
@@ -135,8 +164,7 @@ let maybe_evict_expired config =
     let dir = cache_dir config in
     if not (Sys.file_exists dir) then 0
     else
-      let files = Sys.readdir dir |> Array.to_list
-        |> List.filter (fun f -> Filename.check_suffix f ".json") in
+      let files = read_cache_filenames dir in
       let total = List.length files in
       if total = 0 then 0
       else begin
@@ -163,14 +191,19 @@ let maybe_evict_expired config =
       end
   end
 
-(** Count current number of cache entries *)
+(** Count current number of cache entries.
+    Uses cached count when available; falls back to directory scan on first call. *)
 let count_entries config =
-  let dir = cache_dir config in
-  if not (Sys.file_exists dir) then 0
+  let c = Atomic.get cached_entry_count in
+  if c >= 0 then c
   else
-    Sys.readdir dir |> Array.to_list
-    |> List.filter (fun f -> Filename.check_suffix f ".json")
-    |> List.length
+    let dir = cache_dir config in
+    let count =
+      if not (Sys.file_exists dir) then 0
+      else List.length (read_cache_filenames dir)
+    in
+    Atomic.set cached_entry_count count;
+    count
 
 (** Set cache entry - synchronous *)
 let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []) ()
@@ -202,6 +235,7 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
         let content = Yojson.Safe.pretty_to_string json in
         try
           Fs_compat.save_file path content;
+          ignore (Atomic.fetch_and_add cached_entry_count 1);
           Ok entry
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
@@ -216,6 +250,7 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
       let content = Yojson.Safe.pretty_to_string json in
       try
         Fs_compat.save_file path content;
+        ignore (Atomic.fetch_and_add cached_entry_count 1);
         Ok entry
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
@@ -241,6 +276,7 @@ let get config ~key : (cache_entry option, string) result =
         if is_expired entry then begin
           (* Auto-delete expired entries *)
           Sys.remove path;
+          ignore (Atomic.fetch_and_add cached_entry_count (-1));
           let _evicted = maybe_evict_expired config in
           Ok None
         end else begin
@@ -260,22 +296,22 @@ let delete config ~key : (bool, string) result =
   else
     try
       Sys.remove path;
+      ignore (Atomic.fetch_and_add cached_entry_count (-1));
       Ok true
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (Printexc.to_string e)
 
-(** List all cache entries - synchronous *)
+(** List all cache entries - synchronous.
+    Guarded: concurrent calls return empty list to prevent FD stampede. *)
 let list config ?(tag : string option) () : cache_entry list =
   let dir = cache_dir config in
   if not (Sys.file_exists dir) then
     []
   else
-    let entries = Sys.readdir dir |> Array.to_list in
-    List.filter_map (fun filename ->
-      if not (Filename.check_suffix filename ".json") then
-        None
-      else
+    with_scan_guard ~fallback:[] (fun () ->
+      let entries = read_cache_filenames dir in
+      List.filter_map (fun filename ->
         let path = Filename.concat dir filename in
         match Safe_ops.read_file_safe path with
         | Error _ -> None  (* File read error - skip this entry *)
@@ -298,7 +334,7 @@ let list config ?(tag : string option) () : cache_entry list =
                   else None
               end
             | None -> None
-    ) entries
+      ) entries)
 
 (** Clear all cache entries - synchronous *)
 let clear config : (int, string) result =
@@ -307,30 +343,30 @@ let clear config : (int, string) result =
     Ok 0
   else
     try
-      let entries = Sys.readdir dir |> Array.to_list in
+      let entries = read_cache_filenames dir in
       let count = List.fold_left (fun acc filename ->
-        if Filename.check_suffix filename ".json" then begin
-          let path = Filename.concat dir filename in
-          Safe_ops.remove_file_logged ~context:"cache_clear" path;
-          acc + 1
-        end else acc
+        let path = Filename.concat dir filename in
+        Safe_ops.remove_file_logged ~context:"cache_clear" path;
+        acc + 1
       ) 0 entries in
+      Atomic.set cached_entry_count 0;
       Ok count
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e -> Error (Printexc.to_string e)
 
-(** Get cache statistics - synchronous *)
+(** Get cache statistics - synchronous.
+    Guarded: concurrent calls return zeros to prevent FD stampede. *)
 let stats config : (int * int * float, string) result =
   (* Returns: (total_entries, expired_entries, total_size_bytes) *)
   let dir = cache_dir config in
   if not (Sys.file_exists dir) then
     Ok (0, 0, 0.0)
   else
-    try
-      let entries = Sys.readdir dir |> Array.to_list in
-      let total, expired, size = List.fold_left (fun (t, e, s) filename ->
-        if Filename.check_suffix filename ".json" then
+    with_scan_guard ~fallback:(Ok (0, 0, 0.0)) (fun () ->
+      try
+        let entries = read_cache_filenames dir in
+        let total, expired, size = List.fold_left (fun (t, e, s) filename ->
           let path = Filename.concat dir filename in
           let file_size = (Unix.stat path).st_size in
           let is_exp =
@@ -345,12 +381,11 @@ let stats config : (int * int * float, string) result =
                 | None -> false
           in
           (t + 1, e + (if is_exp then 1 else 0), s +. float_of_int file_size)
-        else (t, e, s)
-      ) (0, 0, 0.0) entries in
-      Ok (total, expired, size)
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | e -> Error (Printexc.to_string e)
+        ) (0, 0, 0.0) entries in
+        Ok (total, expired, size)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error (Printexc.to_string e))
 
 (** Format stats for display *)
 let format_stats (total, expired, size) =

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -231,11 +231,13 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
         let expires_at = Option.map (fun ttl -> now +. float_of_int ttl) ttl_seconds in
         let entry = { key; value; created_at = now; expires_at; tags } in
         let path = cache_file config key in
+        let is_overwrite = Sys.file_exists path in
         let json = entry_to_json entry in
         let content = Yojson.Safe.pretty_to_string json in
         try
           Fs_compat.save_file path content;
-          ignore (Atomic.fetch_and_add cached_entry_count 1);
+          if not is_overwrite then
+            ignore (Atomic.fetch_and_add cached_entry_count 1);
           Ok entry
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
@@ -246,11 +248,13 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
       let expires_at = Option.map (fun ttl -> now +. float_of_int ttl) ttl_seconds in
       let entry = { key; value; created_at = now; expires_at; tags } in
       let path = cache_file config key in
+      let is_overwrite = Sys.file_exists path in
       let json = entry_to_json entry in
       let content = Yojson.Safe.pretty_to_string json in
       try
         Fs_compat.save_file path content;
-        ignore (Atomic.fetch_and_add cached_entry_count 1);
+        if not is_overwrite then
+          ignore (Atomic.fetch_and_add cached_entry_count 1);
         Ok entry
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -882,7 +882,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     in
     let init_state_blocking () =
       let pg_pool_timeout =
-        Safe_ops.get_env_float_logged "MASC_PG_POOL_TIMEOUT_SEC" ~default:15.0
+        Safe_ops.get_env_float_logged "MASC_PG_POOL_TIMEOUT_SEC" ~default:30.0
       in
       let t0 = Eio.Time.now clock in
       let state =

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -64,8 +64,9 @@ let is_live () = true
 let elapsed_since_start () =
   Unix.gettimeofday () -. !state.started_at
 
-(** Default startup watchdog timeout in seconds. Override with MASC_STARTUP_WATCHDOG_SEC. *)
-let default_watchdog_timeout_sec = 120.0
+(** Default startup watchdog timeout in seconds. Override with MASC_STARTUP_WATCHDOG_SEC.
+    Raised from 120 to 240 to accommodate PG cold-start + keeper bootstrap delays. *)
+let default_watchdog_timeout_sec = 240.0
 
 (** Read watchdog timeout from env, clamped to [30, 600]. *)
 let watchdog_timeout_sec () =

--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -21,6 +21,8 @@ let with_temp_masc_dir f =
   Unix.mkdir base 0o755;
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  (* Reset cached entry count to prevent cross-test contamination *)
+  Cache_eio.reset_cached_entry_count ();
   let config = Room.default_config base in
   let _ = Room.init config ~agent_name:None in
   try


### PR DESCRIPTION
## Summary

- cache_eio: `cached_entry_count` Atomic으로 hot path(set→count_entries)에서 `Sys.readdir` 제거. `with_scan_guard`로 동시 디렉토리 스캔 방지.
- server_startup_state: watchdog timeout 120s → 240s (PG cold-start 대응).
- server_runtime_bootstrap: PG pool timeout 15s → 30s.
- main_eio: PID lock에서 `/health/live` 체크 후 먹통 서버 자동 회수.
- team_session_oas_bridge: OAS 의존성 업데이트로 인한 빌드 에러 수정 (`enable_streaming` 필드 추가).

## Root cause

Dashboard proactive refresh loop 6개가 10~120초 간격으로 동시 실행되면서 각각 `Sys.readdir` + N개 파일 읽기를 수행. 장시간 운영 시 동시 FD 사용량이 시스템 한계를 초과하여 `EMFILE` 발생 (system_log seq 8719). 서버가 새 연결/파일을 열 수 없어 먹통 상태에 빠짐.

## Test plan

- [x] `test_cache_eio.exe` 12개 테스트 통과
- [x] `test_cache_eio_coverage.exe` 11개 테스트 통과
- [x] `dune build` 성공 (기존 `enable_streaming` 빌드 에러도 수정)
- [ ] 서버 재시작 후 1시간+ 운영하며 `lsof -p <PID> | wc -l`로 FD 증가 추세 모니터링
- [ ] `curl --max-time 5 http://127.0.0.1:8935/health` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)