### PR TITLE
fix: remove fake unreachable fallbacks

### DIFF
--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -265,144 +265,157 @@ let update_state state result =
 (** Main bounded execution loop *)
 let bounded_run ~constraints ~goal ~agents ~prompt ~spawn_fn =
   (* Pre-check: empty agents *)
-  if List.length agents = 0 then
-    {
-      status = `Error;
-      reason = "No agents available";
-      final_output = None;
-      stats = create_state constraints;
-      history = [];
-      warning = None;
-    }
-  else
-    let state = create_state constraints in
-    let history = ref [] in
-    let sleep_s = Time_compat.sleep in
+  match agents with
+  | [] ->
+      {
+        status = `Error;
+        reason = "No agents available";
+        final_output = None;
+        stats = create_state constraints;
+        history = [];
+        warning = None;
+      }
+  | fallback_agent :: _ ->
+      let state = create_state constraints in
+      let history = ref [] in
+      let sleep_s = Time_compat.sleep in
 
-    let rec loop () =
-      (* 1. Hard limit check (failsafe) *)
-      if state.turns >= constraints.hard_max_iterations then
-        {
-          status = `Constraint_exceeded;
-          reason = Printf.sprintf "Hard iteration limit reached (%d)"
-            constraints.hard_max_iterations;
-          final_output = None;
-          stats = state;
-          history = List.rev !history;
-          warning = None;
-        }
-      else
-      (* 2. Predictive constraint check *)
-      match check_constraints_with_buffer state with
-      | Some reason ->
+      let rec loop () =
+        (* 1. Hard limit check (failsafe) *)
+        if state.turns >= constraints.hard_max_iterations then
           {
             status = `Constraint_exceeded;
-            reason;
+            reason = Printf.sprintf "Hard iteration limit reached (%d)"
+              constraints.hard_max_iterations;
             final_output = None;
             stats = state;
             history = List.rev !history;
             warning = None;
           }
-      | None ->
-          (* 3. Select next agent (round-robin) *)
-          let agent_idx = state.turns mod (List.length agents) in
-          let agent = match List.nth_opt agents agent_idx with
-            | Some a -> a
-            | None -> assert false (* unreachable: idx = turns mod length *)
-          in
-
-          (* 4. Execute agent with retry logic *)
-          let rec try_spawn attempt =
-            let result =
-              try Ok (spawn_fn agent prompt)
-              with e -> Error (Printexc.to_string e)
+        else
+        (* 2. Predictive constraint check *)
+        match check_constraints_with_buffer state with
+        | Some reason ->
+            {
+              status = `Constraint_exceeded;
+              reason;
+              final_output = None;
+              stats = state;
+              history = List.rev !history;
+              warning = None;
+            }
+        | None ->
+            (* 3. Select next agent (round-robin) *)
+            let agent_idx = state.turns mod (List.length agents) in
+            let agent =
+              match List.nth_opt agents agent_idx with
+              | Some a -> a
+              | None -> fallback_agent
             in
-            match result with
-            | Ok spawn_result when spawn_result.success ->
-                (* Success - return result with retry count *)
-                Ok (spawn_result, attempt)
-            | Ok spawn_result ->
-                (* Agent returned failure (non-zero exit) *)
-                let err_msg = spawn_result.output in
-                if attempt < constraints.retry.max_retries && is_retryable_error err_msg then begin
-                  let delay_ms = calc_backoff_delay constraints.retry attempt in
-                  sleep_s (float_of_int delay_ms /. 1000.0);
-                  state.total_retries <- state.total_retries + 1;
-                  try_spawn (attempt + 1)
-                end else
-                  Error (Printf.sprintf "Agent failed after %d attempts: %s" (attempt + 1) err_msg)
-            | Error msg ->
-                (* Exception during spawn *)
-                if attempt < constraints.retry.max_retries && is_retryable_error msg then begin
-                  let delay_ms = calc_backoff_delay constraints.retry attempt in
-                  sleep_s (float_of_int delay_ms /. 1000.0);
-                  state.total_retries <- state.total_retries + 1;
-                  try_spawn (attempt + 1)
-                end else
-                  Error (Printf.sprintf "Agent execution failed after %d attempts: %s" (attempt + 1) msg)
-          in
 
-          match try_spawn 0 with
-          | Error msg ->
-              {
-                status = `Error;
-                reason = msg;
-                final_output = None;
-                stats = state;
-                history = List.rev !history;
-                warning = None;
-              }
-          | Ok (spawn_result, retries_used) ->
-              (* 5. Update state AFTER execution *)
-              update_state state spawn_result;
-
-              (* 6. Parse output as JSON for goal check *)
-              let output_json =
-                try Yojson.Safe.from_string spawn_result.output
-                with Yojson.Json_error _ -> `Assoc [("raw", `String spawn_result.output)]
+            (* 4. Execute agent with retry logic *)
+            let rec try_spawn attempt =
+              let result =
+                try Ok (spawn_fn agent prompt)
+                with e -> Error (Printexc.to_string e)
               in
+              match result with
+              | Ok spawn_result when spawn_result.success ->
+                  (* Success - return result with retry count *)
+                  Ok (spawn_result, attempt)
+              | Ok spawn_result ->
+                  (* Agent returned failure (non-zero exit) *)
+                  let err_msg = spawn_result.output in
+                  if attempt < constraints.retry.max_retries
+                     && is_retryable_error err_msg
+                  then begin
+                    let delay_ms = calc_backoff_delay constraints.retry attempt in
+                    sleep_s (float_of_int delay_ms /. 1000.0);
+                    state.total_retries <- state.total_retries + 1;
+                    try_spawn (attempt + 1)
+                  end else
+                    Error
+                      (Printf.sprintf "Agent failed after %d attempts: %s"
+                         (attempt + 1) err_msg)
+              | Error msg ->
+                  (* Exception during spawn *)
+                  if attempt < constraints.retry.max_retries
+                     && is_retryable_error msg
+                  then begin
+                    let delay_ms = calc_backoff_delay constraints.retry attempt in
+                    sleep_s (float_of_int delay_ms /. 1000.0);
+                    state.total_retries <- state.total_retries + 1;
+                    try_spawn (attempt + 1)
+                  end else
+                    Error
+                      (Printf.sprintf
+                         "Agent execution failed after %d attempts: %s"
+                         (attempt + 1) msg)
+            in
 
-              let goal_met = check_goal output_json goal in
-
-              (* 7. Record history *)
-              let entry = {
-                turn = state.turns;
-                agent;
-                retries = retries_used;
-                tokens_in = Option.value spawn_result.input_tokens ~default:0;
-                tokens_out = Option.value spawn_result.output_tokens ~default:0;
-                cost_usd = Option.value spawn_result.cost_usd ~default:0.0;
-                elapsed_ms = spawn_result.elapsed_ms;
-                goal_met;
-              } in
-              history := entry :: !history;
-
-              (* 8. Post-check: did we exceed constraints? *)
-              let warning = check_constraints state in
-
-              if goal_met then
+            match try_spawn 0 with
+            | Error msg ->
                 {
-                  status = `Goal_reached;
-                  reason = Printf.sprintf "Goal met: %s" goal.path;
-                  final_output = Some spawn_result.output;
+                  status = `Error;
+                  reason = msg;
+                  final_output = None;
                   stats = state;
                   history = List.rev !history;
-                  warning;
+                  warning = None;
                 }
-              else match warning with
-                | Some warn_msg ->
-                  (* Exceeded but return partial result *)
+            | Ok (spawn_result, retries_used) ->
+                (* 5. Update state AFTER execution *)
+                update_state state spawn_result;
+
+                (* 6. Parse output as JSON for goal check *)
+                let output_json =
+                  try Yojson.Safe.from_string spawn_result.output
+                  with Yojson.Json_error _ ->
+                    `Assoc [ ("raw", `String spawn_result.output) ]
+                in
+
+                let goal_met = check_goal output_json goal in
+
+                (* 7. Record history *)
+                let entry = {
+                  turn = state.turns;
+                  agent;
+                  retries = retries_used;
+                  tokens_in = Option.value spawn_result.input_tokens ~default:0;
+                  tokens_out = Option.value spawn_result.output_tokens ~default:0;
+                  cost_usd = Option.value spawn_result.cost_usd ~default:0.0;
+                  elapsed_ms = spawn_result.elapsed_ms;
+                  goal_met;
+                } in
+                history := entry :: !history;
+
+                (* 8. Post-check: did we exceed constraints? *)
+                let warning = check_constraints state in
+
+                if goal_met then
                   {
-                    status = `Constraint_exceeded;
-                    reason = warn_msg;
+                    status = `Goal_reached;
+                    reason = Printf.sprintf "Goal met: %s" goal.path;
                     final_output = Some spawn_result.output;
                     stats = state;
                     history = List.rev !history;
                     warning;
                   }
-                | None -> loop ()
-    in
-    loop ()
+                else
+                  match warning with
+                  | Some warn_msg ->
+                      (* Exceeded but return partial result *)
+                      {
+                        status = `Constraint_exceeded;
+                        reason = warn_msg;
+                        final_output = Some spawn_result.output;
+                        stats = state;
+                        history = List.rev !history;
+                        warning;
+                      }
+                  | None -> loop ()
+      in
+      loop ()
 
 (** Convert bounded_result to JSON *)
 let result_to_json result =

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -374,6 +374,11 @@ module Router = struct
     handler: request_handler;
   }
 
+  type resolution =
+    [ `Matched of route
+    | `Method_not_allowed
+    | `Not_found ]
+
   type t = route list
 
   let empty : t = []
@@ -398,7 +403,7 @@ module Router = struct
   let prefix_post prefix handler routes =
     add ~path:("PREFIX:" ^ prefix) ~methods:[`POST] ~handler routes
 
-  let dispatch routes request reqd =
+  let resolve routes request =
     let req_path = Request.path request in
     let req_method = Request.method_ request in
     (* Try exact matches first *)
@@ -410,7 +415,7 @@ module Router = struct
       ) routes
     in
     match List.find_opt (fun route -> List.mem req_method route.methods) path_matches with
-    | Some route -> route.handler request reqd
+    | Some route -> `Matched route
     | None ->
         (* Try prefix matches *)
         let prefix_matches =
@@ -432,12 +437,18 @@ module Router = struct
             prefix_matches
         in
         (match prefix_matches with
-         | route :: _ -> route.handler request reqd
+         | route :: _ -> `Matched route
          | [] ->
              if path_matches = [] then
-               Response.not_found reqd
+               `Not_found
              else
-               Response.method_not_allowed reqd)
+               `Method_not_allowed)
+
+  let dispatch routes request reqd =
+    match resolve routes request with
+    | `Matched route -> route.handler request reqd
+    | `Not_found -> Response.not_found reqd
+    | `Method_not_allowed -> Response.method_not_allowed reqd
 end
 
 (** Health check endpoint - JSON response *)

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -204,11 +204,13 @@ let handle_agent_fitness ctx args =
     (true, Yojson.Safe.pretty_to_string json)
 
 (** Pick random from list *)
-let pick_random lst =
-  let idx = Random.int (List.length lst) in
-  match List.nth_opt lst idx with
-  | Some x -> x
-  | None -> assert false (* unreachable: idx < length *)
+let pick_random = function
+  | [] -> invalid_arg "Tool_agent.pick_random: empty list"
+  | fallback :: _ as lst ->
+      let idx = Random.int (List.length lst) in
+      match List.nth_opt lst idx with
+      | Some x -> x
+      | None -> fallback
 
 (** Handle masc_select_agent *)
 let handle_select_agent ctx args =

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -6,6 +6,9 @@ let () =
   Mirage_crypto_rng_unix.use_default ();
 
   Printf.printf "\n=== Board TTL Tests ===\n";
+  let fail_board_test label error =
+    failwith (Printf.sprintf "%s: %s" label (show_board_error error))
+  in
 
   (* Test 1: Default TTL is 0 (permanent) - no Eio needed *)
   let test_default_ttl () =
@@ -26,9 +29,7 @@ let () =
     | Ok post ->
         assert (post.expires_at = 0.0);
         Printf.printf "✓ Permanent post has expires_at = 0.0\n"
-    | Error e ->
-        Printf.printf "✗ Failed to create post: %s\n" (show_board_error e);
-        assert false
+    | Error e -> fail_board_test "Failed to create post" e
   in
 
   (* Test 3: Create post with explicit TTL *)
@@ -38,16 +39,17 @@ let () =
     | Ok post ->
         assert (post.expires_at > 0.0);
         Printf.printf "✓ Expiring post has expires_at > 0.0 (%.0f)\n" post.expires_at
-    | Error e ->
-        Printf.printf "✗ Failed to create post: %s\n" (show_board_error e);
-        assert false
+    | Error e -> fail_board_test "Failed to create expiring post" e
   in
 
   (* Test 4: Sweeper skips permanent posts *)
   let test_sweeper_skips_permanent () =
     let store = create_store () in
     (* Create permanent post *)
-    let _ = create_post store ~author:"test-agent" ~content:"Permanent" () in
+    (match create_post store ~author:"test-agent" ~content:"Permanent" () with
+     | Ok _ -> ()
+     | Error e ->
+         fail_board_test "Failed to create permanent post for sweep test" e);
     (* Run sweep *)
     let (removed_posts, _) = sweep store in
     assert (removed_posts = 0);
@@ -62,9 +64,7 @@ let () =
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
         assert (String.equal kind "human");
         Printf.printf "✓ Default board post kind is human\n"
-    | Error e ->
-        Printf.printf "✗ Failed to create human post: %s\n" (show_board_error e);
-        assert false
+    | Error e -> fail_board_test "Failed to create human post" e
   in
 
   let test_post_kind_automation_contract () =
@@ -76,9 +76,7 @@ let () =
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
         assert (String.equal kind "automation");
         Printf.printf "✓ Harness metadata classifies post as automation\n"
-    | Error e ->
-        Printf.printf "✗ Failed to create automation post: %s\n" (show_board_error e);
-        assert false
+    | Error e -> fail_board_test "Failed to create automation post" e
   in
 
   let test_post_kind_system_author () =
@@ -89,9 +87,7 @@ let () =
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
         assert (String.equal kind "system");
         Printf.printf "✓ System author classifies post as system\n"
-    | Error e ->
-        Printf.printf "✗ Failed to create system post: %s\n" (show_board_error e);
-        assert false
+    | Error e -> fail_board_test "Failed to create system post" e
   in
 
   (* Run Eio tests *)

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -38,22 +38,22 @@ let test_router_add_multiple () =
   Alcotest.(check int) "three routes" 3 (List.length routes)
 
 let test_router_prefix_specificity () =
-  let matched = ref "" in
-  let generic_handler _req _reqd = matched := "generic" in
-  let asset_handler _req _reqd = matched := "asset" in
+  let generic_handler _req _reqd = () in
+  let asset_handler _req _reqd = () in
   let routes =
     Router.empty
     |> Router.prefix_get "/dashboard/assets/" asset_handler
     |> Router.prefix_get "/dashboard/" generic_handler
   in
   let request = Httpun.Request.create `GET "/dashboard/assets/index.css" in
-  (* Httpun.Reqd.t is opaque and cannot be constructed outside the HTTP
-     stack. The test handlers ignore the reqd parameter entirely.
-     This unsafe cast is a known limitation; Router.dispatch should be
-     refactored to separate route resolution from request handling.
-     See: https://github.com/jeong-sik/masc-mcp/issues/1498 *)
-  Router.dispatch routes request (Obj.magic () : Httpun.Reqd.t);
-  Alcotest.(check string) "longest prefix route should win" "asset" !matched
+  match Router.resolve routes request with
+  | `Matched route ->
+      Alcotest.(check string) "longest prefix route should win"
+        "PREFIX:/dashboard/assets/" route.path
+  | `Method_not_allowed ->
+      Alcotest.fail "expected a matched prefix route, got method_not_allowed"
+  | `Not_found ->
+      Alcotest.fail "expected a matched prefix route, got not_found"
 
 let test_frontend_transport_routes_present () =
   let routes =


### PR DESCRIPTION
## Summary
- remove fake unreachable fallbacks from bounded and tool-agent selection paths
- replace board TTL test `assert false` branches with explicit failures
- add pure router resolution so HTTP router tests avoid `Obj.magic`

## Verification
- `git diff --check`
- attempted focused dune verification in an isolated copy, but an unrelated existing compile blocker stops the build first: `lib/team_session/team_session_oas_bridge.ml:364` is missing `enable_streaming`

## Review evidence
- implementer: Codex GPT-5
- local verification blocker recorded as GitHub issue #3204
