### PR TITLE
refactor: consolidate inline Result.bind into open Result_syntax (#3156 P4.0)

### DIFF
--- a/lib/chain/chain_compiler.ml
+++ b/lib/chain/chain_compiler.ml
@@ -9,8 +9,7 @@
 
 open Chain_types
 
-(** Helper: Result bind operator *)
-let ( let* ) = Result.bind
+open Result_syntax
 
 (** Recursively collect all input_mapping dependencies from nested nodes *)
 let rec collect_nested_dependencies (node : Chain_types.node) : string list =

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -2,7 +2,7 @@ open Printf
 
 module U = Yojson.Safe.Util
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 type runtime = {
   config : Room.config;

--- a/lib/chain/chain_parser_helpers.ml
+++ b/lib/chain/chain_parser_helpers.ml
@@ -52,9 +52,6 @@ let security_max_fanout =
   | Some s -> (try max 1 (int_of_string s) with Failure _ -> 20)
   | None -> 20
 
-(** Helper: Result bind operator *)
-let ( let* ) = Result.bind
-
 (** {1 Safe JSON Parsing Helpers - Explicit Error Handling} *)
 
 (** Parse float from JSON with explicit error message *)

--- a/lib/chain/chain_parser_parse.ml
+++ b/lib/chain/chain_parser_parse.ml
@@ -1,5 +1,6 @@
 include Chain_parser_helpers
 open Chain_types
+open Result_syntax
 
 (** Parse adapter transform from JSON *)
 let rec parse_adapter_transform (json : Yojson.Safe.t) : (adapter_transform, string) result =

--- a/lib/chain/chain_parser_validate.ml
+++ b/lib/chain/chain_parser_validate.ml
@@ -1,5 +1,6 @@
 include Chain_parser_helpers
 open Chain_types
+open Result_syntax
 
 let rec has_placeholder_in_node_type = function
   | ChainRef "_" -> true

--- a/lib/command_plane/cp_lifecycle.ml
+++ b/lib/command_plane/cp_lifecycle.ml
@@ -1,4 +1,5 @@
 include Cp_lifecycle_intents
+open Result_syntax
 
 let snapshot_json ?sessions config =
   let state = build_snapshot_state ?sessions config in

--- a/lib/command_plane/cp_lifecycle_intents.ml
+++ b/lib/command_plane/cp_lifecycle_intents.ml
@@ -1,4 +1,5 @@
 include Cp_lifecycle_search
+open Result_syntax
 
 let update_search_stats_for_operation config operation ~outcome =
   let stage = operation_stage_key operation in

--- a/lib/command_plane/cp_lifecycle_policy.ml
+++ b/lib/command_plane/cp_lifecycle_policy.ml
@@ -1,4 +1,5 @@
 include Cp_lifecycle
+open Result_syntax
 
 let request_or_apply_assignment config ~(actor : string) ~requested_action json =
   let operation_id =

--- a/lib/command_plane/cp_types.ml
+++ b/lib/command_plane/cp_types.ml
@@ -1,7 +1,5 @@
 module U = Yojson.Safe.Util
 
-let ( let* ) = Result.bind
-
 type unit_kind =
   | Company
   | Platoon

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -7,6 +7,7 @@
 *)
 
 include Governance_v2_serde
+open Result_syntax
 
 let governance_root base_path =
   Filename.concat (Filename.concat base_path ".masc") "governance_v2"

--- a/lib/council/governance_v2_serde.ml
+++ b/lib/council/governance_v2_serde.ml
@@ -6,6 +6,7 @@
     file I/O, and normalization utilities. *)
 
 open Yojson.Safe.Util
+open Result_syntax
 
 include Governance_v2_types
 

--- a/lib/council/governance_v2_types.ml
+++ b/lib/council/governance_v2_types.ml
@@ -1,8 +1,5 @@
 (** Governance V2 types *)
 
-
-let ( let* ) = Result.bind
-
 type risk_class =
   | Low
   | High

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -10,6 +10,8 @@
     - Recovery: server startup syncs file → Neo4j
 *)
 
+open Result_syntax
+
 (** {1 Types} *)
 
 type persist_result = {
@@ -294,7 +296,6 @@ let execute_cypher_raw ~cypher : (Yojson.Safe.t, string) result =
       Error "Eio net not initialized (Neo4j persistence disabled)"
   | Some ctx ->
       let net = ctx.net in
-      let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e in
       let* endpoint_uri = neo4j_tx_commit_uri () in
       let* auth_header = neo4j_auth_header () in
 

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -1,7 +1,7 @@
 open Printf
 open Yojson.Safe.Util
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 type runtime = {
   id : string;

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -1,6 +1,7 @@
 (** Worker_container_runners — run_worker_oas, continue_worker, run_worker. *)
 
 open Printf
+open Result_syntax
 
 include Worker_container
 

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -2,8 +2,6 @@ open Printf
 
 module Oas = Agent_sdk
 
-let ( let* ) = Result.bind
-
 type tool_exec_result = {
   text : string;
   is_error : bool;

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -4,6 +4,8 @@
     Legacy handlers have been removed.
 *)
 
+open Result_syntax
+
 (** Global state for Mitosis cell lifecycle.
     Protected by [mitosis_mutex]. Use [get_cell]/[set_cell]/[with_cell_rw]
     instead of direct ref access. *)
@@ -80,7 +82,6 @@ let is_valid_request_id = function
 
 (** Validate initialize params per MCP spec. *)
 let validate_initialize_params params =
-  let ( let* ) = Result.bind in
   let require_string label = function
     | Some (`String _) -> Ok ()
     | None | Some `Null -> Error ("Missing " ^ label)

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -266,7 +266,7 @@ type tools_list_params = {
   cursor : string option;
 }
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 let strict_assoc_params params =
   match params with

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -1,4 +1,5 @@
 open Tool_args
+open Result_syntax
 
 include Operator_control_action
 

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -1,7 +1,7 @@
 open Tool_args
 include Operator_control_snapshot
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 let judgment_surface_enums =
   [ "command.warroom"; "command.swarm"; "intervene" ]

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -1,4 +1,5 @@
 open Operator_pending_confirm
+open Result_syntax
 
 include Operator_digest_types
 include Operator_digest_session

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -1,8 +1,6 @@
 module U = Yojson.Safe.Util
 open Operator_pending_confirm
 
-let ( let* ) = Result.bind
-
 type attention_item = {
   kind : string;
   severity : string;

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -1,6 +1,6 @@
 open Yojson.Safe.Util
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 type target_type =
   | Room

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -1,4 +1,5 @@
 module Mcp_eio = Mcp_server_eio
+open Result_syntax
 
 let mcp_protocol_versions = Mcp_server.supported_protocol_versions
 
@@ -192,7 +193,6 @@ let validate_protocol_version_continuity ~session_id request =
   Eio.Mutex.use_ro session_mutex (fun () ->
       match Hashtbl.find_opt protocol_version_by_session session_id with
       | Some expected -> (
-          let ( let* ) = Result.bind in
           match provided with
           | None -> Ok ()
           | Some version ->

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -1,6 +1,7 @@
 (** Eio runtime engine for long-running team sessions. *)
 
 include Team_session_engine_policy
+open Result_syntax
 
 (* Phase C-2d: start_runtime_loop removed.
    All modes now use Team_session_swarm_runner.run_swarm via OAS Runner.

--- a/lib/team_session/team_session_engine_helpers.ml
+++ b/lib/team_session/team_session_engine_helpers.ml
@@ -7,8 +7,6 @@ type runtime_state = {
   mutable generate_report_on_finalize : bool;
 }
 
-let ( let* ) = Result.bind
-
 let runtimes : (string, runtime_state) Hashtbl.t = Hashtbl.create 16
 let runtimes_mutex = Eio.Mutex.create ()
 let finalize_mutex = Eio.Mutex.create ()

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -1,6 +1,7 @@
 (** Voice_bridge — TTS synthesis, MCP voice sessions, conferences. *)
 
 include Voice_bridge_core
+open Result_syntax
 
 let safe_agent_id value =
   String.map

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -26,7 +26,6 @@ let default_timeout_seconds = 5.0
 let default_max_retries = 3
 let default_initial_backoff_seconds = 1.0
 let default_backoff_multiplier = 2.0
-let ( let* ) = Result.bind
 
 let default_agent_voices =
   [

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -49,7 +49,7 @@ type t = {
   local_playback : local_playback_config;
 }
 
-let ( let* ) = Result.bind
+open Result_syntax
 
 let default_elevenlabs_base_url = "https://api.elevenlabs.io/v1"
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -14,6 +14,7 @@
     @since Phase 5 — OAS Agent.run adapter for workers *)
 
 open Printf
+open Result_syntax
 
 module Oas = Agent_sdk
 
@@ -279,7 +280,6 @@ let rec run_worker_via_oas
     ?(gate_config : Eval_gate.gate_config option)
     ?worker_run_id
     () : (Worker_container_types.run_result, string) result =
-  let ( let* ) = Result.bind in
   let session_id = meta.mcp_session_id in
   let team_session_id = meta.team_session_id in
   let worker_name = meta.worker_name in
@@ -347,7 +347,6 @@ and run_existing_worker_agent
     ~(tool_names_ref : string list ref)
     (agent : Oas.Agent.t)
   : (Worker_container_types.run_result, string) result =
-  let ( let* ) = Result.bind in
   let team_session_id = meta.team_session_id in
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in
@@ -439,7 +438,6 @@ let orchestrate_workers
     ?on_task_start
     ?on_task_complete
     () : (Oas.Orchestrator.task_result list, string) result =
-  let ( let* ) = Result.bind in
   let rec build_agents acc = function
     | [] -> Ok (List.rev acc)
     | (meta, provider, system_prompt, tools, raw_trace, heartbeat_cbs) :: rest ->


### PR DESCRIPTION
## Summary

31개 파일에서 18개의 inline `let ( let* ) = Result.bind` 정의를 공유 `Result_syntax` 모듈로 통합.

### 변경 카테고리

| 카테고리 | 파일 수 | 설명 |
|----------|---------|------|
| 직접 교체 | 10 | inline 정의 → `open Result_syntax` |
| dead code 제거 | 7 | `let*` 정의만 있고 사용 안 함 |
| 전이 의존성 수리 | 12 | `include`로 간접 사용 → 명시적 open 추가 |
| hand-rolled 등가물 | 1 | `thread_persist.ml`의 수동 패턴매칭 → Result_syntax |

순감 4줄. behavior 변경 없음 (P4.0 foundation).

## Test plan
- [x] `dune build` 로컬 통과
- [ ] CI Build and Test 통과

Part of #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)