### PR TITLE
refactor(dashboard): consolidate duplicate utilities into shared libs

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -110,7 +110,7 @@ async function ensureSession(): Promise<void> {
             jsonrpc: '2.0',
             method: 'notifications/initialized',
           }),
-        }, 5000).catch(() => {})
+        }, 5000).catch(err => console.warn('[mcp] initialized notification failed:', err))
       }
     } catch (err) {
       if (err instanceof Error && err.message.includes('403')) {

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -9,6 +9,7 @@ import { EmptyState, LoadingState } from './common/feedback-state'
 import { fetchSwimlane } from '../api'
 import type { SwimlaneResponse, AgentSpan } from '../types'
 import { selectedNodeId, highlightedAgentId } from './activity-graph-view'
+import { formatDurationMs } from '../lib/format-time'
 
 const swimlaneData = signal<SwimlaneResponse | null>(null)
 const swimlaneLoading = signal(false)
@@ -29,23 +30,6 @@ function spanColor(kind: string): string {
     case 'presence': return 'rgba(148, 163, 184, 0.25)'
     default: return '#94a3b8'
   }
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 0) ms = 0
-  const totalMinutes = Math.floor(ms / 60_000)
-  const totalHours = Math.floor(totalMinutes / 60)
-  const totalDays = Math.floor(totalHours / 24)
-
-  if (totalDays >= 1) {
-    const remainHours = totalHours % 24
-    return remainHours > 0 ? `${totalDays}일 ${remainHours}시간` : `${totalDays}일`
-  }
-  if (totalHours >= 1) {
-    const remainMinutes = totalMinutes % 60
-    return remainMinutes > 0 ? `${totalHours}시간 ${remainMinutes}분` : `${totalHours}시간`
-  }
-  return `${totalMinutes}분`
 }
 
 async function loadSwimlane() {
@@ -168,7 +152,7 @@ function drawSwimlane(
   // Tooltip
   if (tooltip) {
     const { x, y, span } = tooltip
-    const duration = formatDuration(span.end_ms - span.start_ms)
+    const duration = formatDurationMs(span.end_ms - span.start_ms)
     const lines = [
       span.label || span.kind,
       `종류: ${span.kind}`,

--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -4,7 +4,8 @@ import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
-import { agentJournalEntries, compactCopy, journalKindIcon } from './agent-detail-state'
+import { agentJournalEntries, journalKindIcon } from './agent-detail-state'
+import { trimText } from '../lib/truncate'
 import type { JournalEntry } from '../types'
 
 export function AgentJournalStream({ agentName }: { agentName: string }) {
@@ -20,7 +21,7 @@ export function AgentJournalStream({ agentName }: { agentName: string }) {
                 <div class="agent-journal-entry flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                   <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
                   <span class="agent-journal-type">${entry.eventType}</span>
-                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
+                  <span class="agent-journal-text">${trimText(entry.text, 120) ?? ''}</span>
                   ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
                 </div>
               `)}

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -184,12 +184,6 @@ export async function submitMention(): Promise<void> {
 
 // --- Helpers ---
 
-export function compactCopy(value: string | null | undefined, max = 160): string | null {
-  const text = (value ?? '').replace(/\s+/g, ' ').trim()
-  if (!text) return null
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text
-}
-
 export function journalKindIcon(entry: JournalEntry): string {
   if (entry.kind === 'board') return 'B'
   if (entry.kind === 'tasks') return 'T'

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -4,7 +4,8 @@ import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
-import { agentTimeline, compactCopy } from './agent-detail-state'
+import { agentTimeline } from './agent-detail-state'
+import { trimText } from '../lib/truncate'
 import type { AgentTimelineEvent } from '../api'
 
 function timelineEventIcon(type: string): string {
@@ -54,7 +55,7 @@ export function AgentTimelineSection() {
                   <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                     <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
                     <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}
+                    ${title ? html`<span class="agent-timeline-detail">${trimText(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
                   </div>
                 `

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -4,7 +4,8 @@ import { html } from 'htm/preact'
 import { Card } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
-import { compactCopy, workerBriefForAgent } from './agent-detail-state'
+import { workerBriefForAgent } from './agent-detail-state'
+import { trimText } from '../lib/truncate'
 
 export function AgentWorkerBrief({ agentName }: { agentName: string }) {
   const worker = workerBriefForAgent(agentName)
@@ -26,7 +27,7 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
         ${worker.recent_output_preview ? html`
           <div class="flex items-baseline gap-2 text-[13px]">
             <span class="text-[11px] text-[var(--text-muted)] min-w-[60px] shrink-0">출력</span>
-            <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
+            <span class="agent-worker-brief__preview">${trimText(worker.recent_output_preview, 200)}</span>
           </div>
         ` : null}
         ${worker.related_session_id ? html`

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -23,7 +23,6 @@ import {
   keeperForAgent,
   missionAgentBrief,
   continuityBriefForAgent,
-  compactCopy,
   closeAgentDetail,
   refreshAgentDetail,
   submitMention,
@@ -31,6 +30,7 @@ import {
   type TaskHistoryRow,
 } from './agent-detail-state'
 import { openKeeperDetail } from './keeper-detail'
+import { trimText } from '../lib/truncate'
 import type { Task } from '../types'
 
 // Re-export public API for external consumers
@@ -102,8 +102,8 @@ export function AgentDetailOverlay() {
   const koreanName = rawKoreanName && rawKoreanName !== agentName && rawKoreanName !== displayName
     ? rawKoreanName : null
   const continuitySummary =
-    compactCopy(continuityBrief?.continuity_summary)
-    ?? compactCopy(continuityBrief?.skill_route_summary)
+    trimText(continuityBrief?.continuity_summary, 160)
+    ?? trimText(continuityBrief?.skill_route_summary, 160)
     ?? null
   const keeperIdentity = keeperIdentityHint(keeper?.name, keeper?.agent_name)
   // Skip secondaryLabel when keeperIdentity already shows the agent runtime name

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -34,6 +34,7 @@ import {
 import { missionSnapshot } from '../mission-store'
 import { navigate } from '../router'
 import { formatDuration } from './mission-utils'
+import { trimText } from '../lib/truncate'
 import type {
   Agent,
   DashboardExecutionContinuityBrief,
@@ -93,12 +94,6 @@ function continuityBrief(name: string): DashboardExecutionContinuityBrief | null
 
 function workerBrief(name: string) {
   return executionWorkerSupportBriefs.value.find(w => w.name === name) ?? null
-}
-
-function compactCopy(value: string | null | undefined, max = 160): string | null {
-  const text = (value ?? '').replace(/\s+/g, ' ').trim()
-  if (!text) return null
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text
 }
 
 async function loadProfile(name: string): Promise<void> {
@@ -207,8 +202,8 @@ function CharacterPlate({ name }: { name: string }) {
   const keeperIdent = keeperIdentityHint(keeper?.name, keeper?.agent_name)
   const signalTruth = brief?.signal_truth
   const continuitySummary =
-    compactCopy(contBrief?.continuity_summary)
-    ?? compactCopy(contBrief?.skill_route_summary)
+    trimText(contBrief?.continuity_summary, 160)
+    ?? trimText(contBrief?.skill_route_summary, 160)
     ?? null
   const isKeeper = keeper != null
   const workerState = worker?.state
@@ -393,7 +388,7 @@ export function AgentProfile({ name }: { name: string }) {
                 return html`
                   <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
                     <span class="text-[11px] font-semibold text-[var(--ff-gold)] min-w-8">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="flex-1 text-[13px] text-[#c8daf7]">${compactCopy(title, 80)}</span>` : null}
+                    ${title ? html`<span class="flex-1 text-[13px] text-[#c8daf7]">${trimText(title, 80)}</span>` : null}
                     ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
                   </div>
                 `

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -29,6 +29,24 @@ export function formatDuration(seconds?: number | null): string {
   return `${Math.round(seconds / 86400)}일`
 }
 
+/** Format duration in milliseconds as Korean text — "5분", "2시간 30분", "1일 3시간". */
+export function formatDurationMs(ms: number): string {
+  if (ms < 0) ms = 0
+  const totalMinutes = Math.floor(ms / 60_000)
+  const totalHours = Math.floor(totalMinutes / 60)
+  const totalDays = Math.floor(totalHours / 24)
+
+  if (totalDays >= 1) {
+    const remainHours = totalHours % 24
+    return remainHours > 0 ? `${totalDays}일 ${remainHours}시간` : `${totalDays}일`
+  }
+  if (totalHours >= 1) {
+    const remainMinutes = totalMinutes % 60
+    return remainMinutes > 0 ? `${totalHours}시간 ${remainMinutes}분` : `${totalHours}시간`
+  }
+  return `${totalMinutes}분`
+}
+
 /** Format elapsed seconds in compact English — "3s", "5m", "2h 30m". */
 export function formatElapsedCompact(seconds?: number | null): string {
   if (seconds == null) return ''


### PR DESCRIPTION
## Summary
- `compactCopy` 함수 3곳 중복 (agent-detail-state, agent-profile, lib/truncate의 trimText) → `trimText` 1곳으로 통합
- `formatDuration(ms)` 인라인 함수 (activity-swimlane) → `formatDurationMs`로 lib/format-time에 추출
- `mcp.ts`의 무음 `.catch(() => {})` → `console.warn`으로 디버깅 가능하게 전환

## Details
`compactCopy`와 `trimText`는 동일 로직 (whitespace collapse + trim + ellipsis truncate)이었으므로 기존 `trimText`를 재사용하고 call site에서 max 값만 명시했습니다.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vite build` 성공
- [ ] Dashboard 수동 확인 (agent-detail, agent-profile, swimlane tooltip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)