### PR TITLE
fix: expose missing .mli signatures to unbreak main build

### DIFF
--- a/lib/auto_responder.mli
+++ b/lib/auto_responder.mli
@@ -4,6 +4,7 @@ type mode = Disabled | Spawn | Model
 
 val get_mode : unit -> mode
 val is_enabled : unit -> bool
+val activity_log_file : unit -> string
 
 (** Mention helpers (re-exported from Mention) *)
 val spawnable_agents : string list

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -532,7 +532,7 @@ end
 
 module Memory = struct
   type t = {
-    mutable data: (string, string) Hashtbl.t;
+    data: (string, string) Hashtbl.t;
     mutex: Eio.Mutex.t;
   }
 

--- a/lib/backend/backend.mli
+++ b/lib/backend/backend.mli
@@ -31,6 +31,7 @@ module FileSystem : sig
     expires_at: float;
   }
 
+  val lock_info_to_json : lock_info -> string
   val acquire_lock : t -> key:string -> owner:string -> ttl_seconds:int -> bool result
   val release_lock : t -> key:string -> owner:string -> bool result
   val extend_lock : t -> key:string -> owner:string -> ttl_seconds:int -> bool result
@@ -58,6 +59,7 @@ module Memory : sig
   val get_all : t -> prefix:string -> (string * string) list result
   val set_if_not_exists : t -> string -> string -> bool result
   val clear : t -> unit
+  val get_or_create : base_path:string -> t
 end
 
 (** {1 PostgreSQL Backend (Eio)} *)

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -23,3 +23,6 @@ val with_rw : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
 val with_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
 (** @deprecated Alias for {!with_mutex_ro}. *)
+
+val run_in_systhread : (unit -> 'a) -> 'a
+(** Run [f] in a system thread if Eio is ready, directly otherwise. *)

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -14,6 +14,7 @@ val default_config : config
 
 (** Load config from environment or use defaults *)
 val load_config : unit -> config
+val make_orchestrator_prompt : port:int -> string
 
 (** Start the orchestrator background services using Pulse.
     Returns a cancel function to gracefully stop both Pulse engines. *)


### PR DESCRIPTION
## Summary

#3185 (P3 .mli batch 1) 머지 후 main 빌드가 깨진 상태.
6개 값이 `.mli`에 노출되지 않아 다른 모듈/테스트에서 접근 불가.

### 수정 내역
| .mli | 추가된 값 | 사용처 |
|------|----------|--------|
| `eio_guard.mli` | `run_in_systhread` | 7개 lib/ 파일 |
| `backend.mli` | `Memory.get_or_create` | room_utils_backend_setup |
| `backend.mli` | `FileSystem.lock_info_to_json` | test_backend_coverage |
| `auto_responder.mli` | `activity_log_file` | test_auto_responder_coverage |
| `orchestrator.mli` | `make_orchestrator_prompt` | test_orchestrator_coverage |
| `backend.ml` | remove unused `mutable` | warning 69 fix |

## Test plan
- [x] `dune build` 로컬 통과
- [ ] CI Build and Test 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)