### PR TITLE
fix: plan_file failwith → Result + expose missing .mli signatures (#3156 P4.2)

### DIFF
--- a/lib/auto_responder.mli
+++ b/lib/auto_responder.mli
@@ -5,6 +5,10 @@ type mode = Disabled | Spawn | Model
 val get_mode : unit -> mode
 val is_enabled : unit -> bool
 val activity_log_file : unit -> string
+val build_response_prompt : from_agent:string -> content:string -> mention:string -> string
+val extract_nickname : string -> string option
+val chain_limit : int
+val chain_window : float
 
 (** Mention helpers (re-exported from Mention) *)
 val spawnable_agents : string list

--- a/lib/backend/backend.mli
+++ b/lib/backend/backend.mli
@@ -32,6 +32,7 @@ module FileSystem : sig
   }
 
   val lock_info_to_json : lock_info -> string
+  val lock_info_of_json : string -> lock_info option
   val acquire_lock : t -> key:string -> owner:string -> ttl_seconds:int -> bool result
   val release_lock : t -> key:string -> owner:string -> bool result
   val extend_lock : t -> key:string -> owner:string -> ttl_seconds:int -> bool result

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -78,8 +78,9 @@ let validate_plan_id plan_id =
 
 let plan_file base_path plan_id =
   if not (validate_plan_id plan_id) then
-    failwith (sprintf "Invalid plan_id: %s" plan_id);
-  Filename.concat (plans_dir base_path) (plan_id ^ ".json")
+    Error (sprintf "Invalid plan_id: %s" plan_id)
+  else
+    Ok (Filename.concat (plans_dir base_path) (plan_id ^ ".json"))
 
 let save_plan (plan : swarm_plan) =
   let workers_json =
@@ -108,11 +109,14 @@ let save_plan (plan : swarm_plan) =
         ("base_path", `String plan.base_path);
       ]
   in
-  let path = plan_file plan.base_path plan.plan_id in
-  Fs_compat.save_file path (Yojson.Safe.pretty_to_string json)
+  match plan_file plan.base_path plan.plan_id with
+  | Error e -> Log.Misc.error "save_plan: %s" e
+  | Ok path -> Fs_compat.save_file path (Yojson.Safe.pretty_to_string json)
 
 let load_plan base_path plan_id : (swarm_plan, string) result =
-  let path = plan_file base_path plan_id in
+  match plan_file base_path plan_id with
+  | Error e -> Error e
+  | Ok path ->
   if not (Sys.file_exists path) then Error (sprintf "Plan not found: %s" plan_id)
   else
     try

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -15,6 +15,7 @@ val default_config : config
 (** Load config from environment or use defaults *)
 val load_config : unit -> config
 val make_orchestrator_prompt : port:int -> string
+val should_orchestrate : Room.config -> bool
 
 (** Start the orchestrator background services using Pulse.
     Returns a cancel function to gracefully stop both Pulse engines. *)


### PR DESCRIPTION
## Summary

1. **code_swarm_plan.ml**: `plan_file`의 `failwith "Invalid plan_id"` → `Result` 변환.
   호출자(save_plan, load_plan)가 Error를 명시적으로 처리하도록 변경.

2. **.mli gap fix** (post-#3209):
   - `auto_responder.mli`: build_response_prompt, extract_nickname, chain_limit, chain_window
   - `backend.mli`: FileSystem.lock_info_of_json
   - `orchestrator.mli`: should_orchestrate

## Test plan
- [x] `dune build` 로컬 통과
- [ ] CI Build and Test 통과

Part of #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)