### PR TITLE
fix(server): sequence pg schema init (#3113)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -267,37 +267,26 @@ let init_memory_pg_schema () =
   | None ->
       Log.MemoryPg.info "No PG pool available; long_term_backend will use JSONL fallback"
 
-(** Run independent PG schema inits in parallel via Eio fibers.
-    Each init only needs the shared PG pool (created in create_server_state).
-    Parallel execution reduces worst-case 3x RTT to 1x RTT. *)
-let init_pg_schemas_parallel () =
-  let errors = Atomic.make [] in
-  let record_error label exn =
-    let msg = Printf.sprintf "%s: %s" label (Printexc.to_string exn) in
-    let rec loop () =
-      let old = Atomic.get errors in
-      if not (Atomic.compare_and_set errors old (msg :: old)) then loop ()
-    in
-    loop ()
+(** Run PG schema/bootstrap steps in a fixed order.
+    These steps share the same PG pool and some of them mutate startup state,
+    so deterministic sequencing is preferred over parallel fan-out. *)
+let init_pg_schemas_sequential () =
+  let errors = ref [] in
+  let run_step label f =
+    try f ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        errors := Printf.sprintf "%s: %s" label (Printexc.to_string exn) :: !errors
   in
-  Eio.Fiber.all [
-    (fun () ->
-      try init_task_backend ()
-      with Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> record_error "task_backend" exn);
-    (fun () ->
-      try inject_shared_pg_pool ()
-      with Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> record_error "shared_pg_pool" exn);
-    (fun () ->
-      try init_memory_pg_schema ()
-      with Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> record_error "memory_pg_schema" exn);
-  ];
-  let errs = Atomic.get errors in
-  if errs <> [] then
-    Log.Server.warn "PG schema init completed with errors: %s"
-      (String.concat "; " errs)
+  run_step "task_backend" init_task_backend;
+  run_step "shared_pg_pool" inject_shared_pg_pool;
+  run_step "memory_pg_schema" init_memory_pg_schema;
+  match List.rev !errors with
+  | [] -> ()
+  | errs ->
+      Log.Server.warn "PG schema init completed with errors: %s"
+        (String.concat "; " errs)
 
 let install_tooling ~governance_level (state : Mcp_server.server_state) =
   Governance_pipeline.install ~config:state.room_config ~governance_level;
@@ -903,7 +892,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let t2 = Eio.Time.now clock in
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       install_tooling ~governance_level state;
-      init_pg_schemas_parallel ();
+      init_pg_schemas_sequential ();
       Log.Server.info "Tooling + schemas in %.1fs" (Eio.Time.now clock -. t2);
       state
     in

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -358,6 +358,25 @@ let test_dashboard_executor_pool_contracts () =
     (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
        "Server_dashboard_http.set_executor_pool exec_pool")
 
+let test_pg_schema_init_contracts () =
+  check bool "server bootstrap defines sequential pg schema init" true
+    (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+       "let init_pg_schemas_sequential () =");
+  check bool "server bootstrap no longer defines parallel pg schema init" true
+    (not
+       (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+          "let init_pg_schemas_parallel () ="));
+  check bool "server bootstrap runs task backend before shared pool and memory schema" true
+    (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+       "run_step \"task_backend\" init_task_backend;\n  run_step \"shared_pg_pool\" inject_shared_pg_pool;\n  run_step \"memory_pg_schema\" init_memory_pg_schema");
+  check bool "server bootstrap no longer fans out pg schema init via fiber all" true
+    (not
+       (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+          "Eio.Fiber.all ["));
+  check bool "startup path calls sequential pg schema init" true
+    (file_contains_pattern "lib/server/server_runtime_bootstrap.ml"
+       "init_pg_schemas_sequential ();")
+
 let test_transport_route_contracts () =
   check bool "frontend exposes ws discovery route" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
@@ -448,6 +467,8 @@ let () =
            test_case "keeper oas cleanup contracts" `Quick test_keeper_oas_cleanup_contracts;
            test_case "dashboard executor pool contracts" `Quick
              test_dashboard_executor_pool_contracts;
+           test_case "pg schema init contracts" `Quick
+             test_pg_schema_init_contracts;
            test_case "transport route contracts" `Quick
              test_transport_route_contracts;
            test_case "transport health contracts" `Quick


### PR DESCRIPTION
## Summary
- sequence PG startup schema initialization instead of running the three bootstrap steps in parallel
- add a source-guard regression test to keep the startup path sequential
- set `enable_streaming = false` in the team session swarm bridge to match the current `Agent_sdk_swarm.Swarm_types.swarm_config` contract

## Validation
- `DUNE_BUILD_DIR=_build_3113_compile2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3113-backend-pg-sequential-schema-init ./test/test_server_runtime_bootstrap.exe`
- `DUNE_BUILD_DIR=_build_3113_compile2 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3113-backend-pg-sequential-schema-init ./test/test_ci_hardening_source.exe`
  - new `pg schema init contracts` case passes
  - suite still has an existing unrelated failure: `dashboard warm hydration contracts`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3113-backend-pg-sequential-schema-init/_build_3113_compile2/default/test/test_server_runtime_bootstrap.exe`
  - existing unrelated failures: `prompt markdown dir falls back to repo root`, `main_eio serves health before lazy startup`
- `DUNE_BUILD_DIR=_build_3113_compile2 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3113-backend-pg-sequential-schema-init ./test/test_team_session_oas_bridge.exe`
  - existing unrelated failure: `heartbeat autojoin`

## Review Evidence
- GLM-5 via direct `sb glm-text` on 2026-03-26T04:14:32Z: `No findings.`

Refs #3113