### PR TITLE
feat(eval): wire record_verdict → OAS Eval.collector + fix loop tool schemas (#3165, #3190)

### DIFF
--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -158,7 +158,11 @@ let record_verdict
   } in
   Dated_jsonl.append (get_store ()) (verdict_record_to_json record);
   match on_harness_verdict with
-  | Some cb -> cb (to_harness_verdict record)
+  | Some cb ->
+    (try cb (to_harness_verdict record)
+     with exn ->
+       Log.Harness.warn "[eval_calibration] on_harness_verdict callback failed: %s"
+         (Printexc.to_string exn))
   | None -> ()
 
 let record_human_label

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -110,13 +110,35 @@ let label_record_to_json (r : label_record) : Yojson.Safe.t =
   ]
 
 (* ================================================================ *)
+(* OAS Harness.verdict conversion (#3165)                            *)
+(* ================================================================ *)
+
+(** Convert a MASC [verdict_record] to an OAS [Harness.verdict].
+    Maps "approve" → passed=true, "reject:*" → passed=false.
+    The gate name is recorded as evidence for traceability. *)
+let to_harness_verdict (r : verdict_record) : Agent_sdk.Harness.verdict =
+  let passed = r.verdict = "approve" in
+  let score = if passed then Some 1.0 else Some 0.0 in
+  let evidence = [
+    Printf.sprintf "gate=%s" r.gate;
+    Printf.sprintf "evaluator=%s" r.evaluator_cascade;
+    Printf.sprintf "task_id=%s" r.task_id;
+  ] in
+  let detail = if passed then None
+    else Some (Printf.sprintf "rejected at %s gate: %s" r.gate r.verdict)
+  in
+  { Agent_sdk.Harness.passed; score; evidence; detail }
+
+(* ================================================================ *)
 (* Record writing                                                    *)
 (* ================================================================ *)
 
 let record_verdict
     ~(task_id : string)
     ~(req : Anti_rationalization.review_request)
-    ~(result : Anti_rationalization.review_result) : unit =
+    ~(result : Anti_rationalization.review_result)
+    ?(on_harness_verdict : (Agent_sdk.Harness.verdict -> unit) option)
+    () : unit =
   let hash = notes_hash ~task_title:req.task_title ~notes:req.completion_notes in
   let verdict_str = match result.verdict with
     | Anti_rationalization.Approve -> "approve"
@@ -134,7 +156,10 @@ let record_verdict
     generator_cascade = result.generator_cascade;
     timestamp = Unix.gettimeofday ();
   } in
-  Dated_jsonl.append (get_store ()) (verdict_record_to_json record)
+  Dated_jsonl.append (get_store ()) (verdict_record_to_json record);
+  match on_harness_verdict with
+  | Some cb -> cb (to_harness_verdict record)
+  | None -> ()
 
 let record_human_label
     ~(notes_hash : string)
@@ -240,25 +265,6 @@ let format_few_shot_block (examples : calibration_example list) : string =
     "Here are examples of correct verdicts for calibration:\n\n"
     ^ String.concat "\n\n" lines
 
-(* ================================================================ *)
-(* OAS Harness.verdict conversion (#3165)                            *)
-(* ================================================================ *)
-
-(** Convert a MASC [verdict_record] to an OAS [Harness.verdict].
-    Maps "approve" → passed=true, "reject:*" → passed=false.
-    The gate name is recorded as evidence for traceability. *)
-let to_harness_verdict (r : verdict_record) : Agent_sdk.Harness.verdict =
-  let passed = r.verdict = "approve" in
-  let score = if passed then Some 1.0 else Some 0.0 in
-  let evidence = [
-    Printf.sprintf "gate=%s" r.gate;
-    Printf.sprintf "evaluator=%s" r.evaluator_cascade;
-    Printf.sprintf "task_id=%s" r.task_id;
-  ] in
-  let detail = if passed then None
-    else Some (Printf.sprintf "rejected at %s gate: %s" r.gate r.verdict)
-  in
-  { Agent_sdk.Harness.passed; score; evidence; detail }
 
 (* ================================================================ *)
 (* Statistics                                                        *)

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -68,8 +68,13 @@ val record_verdict :
   task_id:string ->
   req:Anti_rationalization.review_request ->
   result:Anti_rationalization.review_result ->
+  ?on_harness_verdict:(Agent_sdk.Harness.verdict -> unit) ->
+  unit ->
   unit
-(** Append a verdict record to the JSONL store. *)
+(** Append a verdict record to the JSONL store.
+    If [~on_harness_verdict] is provided, converts the record to an OAS
+    [Harness.verdict] and invokes the callback after persistence.
+    This enables wiring to [Eval.add_verdict] or SSE event publishers. *)
 
 val record_human_label :
   notes_hash:string ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -294,7 +294,7 @@ let handle_transition ctx args =
         } in
         let on_verdict result =
           Eval_calibration.record_verdict
-            ~task_id ~req:ar_req ~result in
+            ~task_id ~req:ar_req ~result () in
         let few_shot_block =
           Eval_calibration.format_few_shot_block
             (Eval_calibration.select_examples ~max_examples:3) in

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -346,6 +346,21 @@ let test_on_harness_verdict_with_collector () =
   check bool "passed" true hv.passed;
   Cal.reset_store_for_testing ()
 
+let test_on_harness_verdict_exception_safe () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir () in
+  Cal.set_store_for_testing ~base_dir:dir;
+  let req = make_req () in
+  let result = make_result () in
+  Cal.record_verdict ~task_id:"exc-1" ~req ~result
+    ~on_harness_verdict:(fun _hv -> failwith "boom") ();
+  let store = Cal.get_store () in
+  let records = Dated_jsonl.read_recent store 10 in
+  check bool "record persisted despite callback failure" true
+    (List.length records >= 1);
+  Cal.reset_store_for_testing ()
+
 (* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
@@ -387,5 +402,6 @@ let () =
     "oas_integration", [
       test_case "callback invoked" `Quick test_on_harness_verdict_callback;
       test_case "with Eval.collector" `Quick test_on_harness_verdict_with_collector;
+      test_case "callback exception safe" `Quick test_on_harness_verdict_exception_safe;
     ];
   ]

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -70,7 +70,7 @@ let test_record_verdict_writes () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
-  Cal.record_verdict ~task_id:"task-1" ~req ~result;
+  Cal.record_verdict ~task_id:"task-1" ~req ~result ();
   let store = Cal.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
   check bool "at least 1 record written" true (List.length records >= 1);
@@ -86,7 +86,7 @@ let test_record_verdict_reject () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
   let result = make_result ~verdict:(AR.Reject "vague notes") ~gate:"excuse" () in
-  Cal.record_verdict ~task_id:"task-2" ~req ~result;
+  Cal.record_verdict ~task_id:"task-2" ~req ~result ();
   let store = Cal.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
   let first = List.hd records in
@@ -101,7 +101,7 @@ let test_record_verdict_hash_matches () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
-  Cal.record_verdict ~task_id:"task-3" ~req ~result;
+  Cal.record_verdict ~task_id:"task-3" ~req ~result ();
   let expected_hash = Cal.notes_hash
     ~task_title:req.task_title ~notes:req.completion_notes in
   let store = Cal.get_store () in
@@ -143,7 +143,7 @@ let test_find_divergences_false_positive () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FP task" ~notes:"looks ok but not" () in
   let result = make_result ~verdict:AR.Approve ~gate:"llm" () in
-  Cal.record_verdict ~task_id:"t1" ~req ~result;
+  Cal.record_verdict ~task_id:"t1" ~req ~result ();
   let hash = Cal.notes_hash ~task_title:"FP task" ~notes:"looks ok but not" in
   Cal.record_human_label
     ~notes_hash:hash ~human_verdict:"reject"
@@ -162,7 +162,7 @@ let test_find_divergences_false_negative () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"FN task" ~notes:"actually good work" () in
   let result = make_result ~verdict:(AR.Reject "unclear") ~gate:"excuse" () in
-  Cal.record_verdict ~task_id:"t2" ~req ~result;
+  Cal.record_verdict ~task_id:"t2" ~req ~result ();
   let hash = Cal.notes_hash ~task_title:"FN task" ~notes:"actually good work" in
   Cal.record_human_label
     ~notes_hash:hash ~human_verdict:"approve"
@@ -180,7 +180,7 @@ let test_find_divergences_agreement () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req ~title:"OK task" ~notes:"done correctly" () in
   let result = make_result ~verdict:AR.Approve () in
-  Cal.record_verdict ~task_id:"t3" ~req ~result;
+  Cal.record_verdict ~task_id:"t3" ~req ~result ();
   let hash = Cal.notes_hash ~task_title:"OK task" ~notes:"done correctly" in
   Cal.record_human_label
     ~notes_hash:hash ~human_verdict:"approve"
@@ -196,7 +196,7 @@ let test_find_divergences_no_labels () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
-  Cal.record_verdict ~task_id:"t4" ~req ~result;
+  Cal.record_verdict ~task_id:"t4" ~req ~result ();
   let divs = Cal.find_divergences () in
   check int "no divergences without labels" 0 (List.length divs);
   Cal.reset_store_for_testing ()
@@ -216,7 +216,7 @@ let test_select_examples_max () =
     let notes = Printf.sprintf "notes-%d" i in
     let req = make_req ~title ~notes () in
     let result = make_result ~verdict:AR.Approve () in
-    Cal.record_verdict ~task_id:(Printf.sprintf "t%d" i) ~req ~result;
+    Cal.record_verdict ~task_id:(Printf.sprintf "t%d" i) ~req ~result ();
     let hash = Cal.notes_hash ~task_title:title ~notes in
     Cal.record_human_label
       ~notes_hash:hash ~human_verdict:"reject"
@@ -263,13 +263,13 @@ let test_calibration_stats () =
   (* 2 approvals, 1 rejection *)
   let req1 = make_req ~title:"t1" ~notes:"n1" () in
   Cal.record_verdict ~task_id:"id1" ~req:req1
-    ~result:(make_result ~verdict:AR.Approve ~gate:"llm" ());
+    ~result:(make_result ~verdict:AR.Approve ~gate:"llm" ()) ();
   let req2 = make_req ~title:"t2" ~notes:"n2" () in
   Cal.record_verdict ~task_id:"id2" ~req:req2
-    ~result:(make_result ~verdict:AR.Approve ~gate:"length" ());
+    ~result:(make_result ~verdict:AR.Approve ~gate:"length" ()) ();
   let req3 = make_req ~title:"t3" ~notes:"n3" () in
   Cal.record_verdict ~task_id:"id3" ~req:req3
-    ~result:(make_result ~verdict:(AR.Reject "bad") ~gate:"excuse" ());
+    ~result:(make_result ~verdict:(AR.Reject "bad") ~gate:"excuse" ()) ();
   let stats = Cal.calibration_stats () in
   let total = Yojson.Safe.Util.(stats |> member "total_verdicts" |> to_int) in
   let approves = Yojson.Safe.Util.(stats |> member "approve_count" |> to_int) in
@@ -312,6 +312,40 @@ let test_to_harness_verdict_reject () =
   check bool "detail mentions gate" true
     (match hv.detail with Some d -> contains ~sub:"length" d | None -> false)
 
+let test_on_harness_verdict_callback () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir () in
+  Cal.set_store_for_testing ~base_dir:dir;
+  let received = ref None in
+  let req = make_req () in
+  let result = make_result () in
+  Cal.record_verdict ~task_id:"cb-1" ~req ~result
+    ~on_harness_verdict:(fun hv -> received := Some hv) ();
+  (match !received with
+   | None -> Alcotest.fail "on_harness_verdict not called"
+   | Some hv ->
+     check bool "passed" true hv.Agent_sdk.Harness.passed;
+     check (option (float 0.01)) "score" (Some 1.0) hv.score);
+  Cal.reset_store_for_testing ()
+
+let test_on_harness_verdict_with_collector () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir () in
+  Cal.set_store_for_testing ~base_dir:dir;
+  let collector = Agent_sdk.Eval.create_collector
+    ~agent_name:"test-agent" ~run_id:"run-1" in
+  let req = make_req () in
+  let result = make_result () in
+  Cal.record_verdict ~task_id:"col-1" ~req ~result
+    ~on_harness_verdict:(Agent_sdk.Eval.add_verdict collector) ();
+  let metrics = Agent_sdk.Eval.finalize collector in
+  check int "1 harness verdict" 1 (List.length metrics.harness_verdicts);
+  let hv = List.hd metrics.harness_verdicts in
+  check bool "passed" true hv.passed;
+  Cal.reset_store_for_testing ()
+
 (* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
@@ -349,5 +383,9 @@ let () =
     "oas_conversion", [
       test_case "approve verdict" `Quick test_to_harness_verdict_approve;
       test_case "reject verdict" `Quick test_to_harness_verdict_reject;
+    ];
+    "oas_integration", [
+      test_case "callback invoked" `Quick test_on_harness_verdict_callback;
+      test_case "with Eval.collector" `Quick test_on_harness_verdict_with_collector;
     ];
   ]


### PR DESCRIPTION
## Summary

**OAS Eval.collector 통합 (#3165 Phase 2-2):**
- `record_verdict`에 `?on_harness_verdict:(Harness.verdict -> unit)` 콜백 추가
- JSONL 기록 후 MASC verdict → OAS Harness.verdict 변환 + 콜백 호출
- 콜백 예외 보호 (try-with) — GLM-5 리뷰 반영
- `to_harness_verdict`를 `record_verdict` 앞으로 이동 (forward reference 해소)

**Loop 도구 스키마 등록 버그 수정 (#3190):**
- `masc_keeper_add_loop`, `list_loops`, `remove_loop`의 schema를 `Keeper_schema.schemas`에 추가
- Dogfooding으로 발견: handler는 있지만 MCP surface에 미노출 → "Tool not available"

## Test plan

- [x] eval_calibration 21/21 통과 (oas_integration 3개 포함)
- [x] keeper_recurring 7/7 통과
- [x] 전체 빌드 성공

Closes #3165 (Phase 2-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)