### PR TITLE
fix(test): update source guard + dashboard proof for post-consolidation (#3178)

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -144,7 +144,7 @@ let test_dashboard_warm_hydration_contracts () =
        "cached_surface_or_first_success_json _execution_cache");
   check bool "mission default route serves cached surface immediately" true
     (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
-       "cached_surface_json _mission_cache");
+       "cached_surface_or_first_success_json _mission_cache");
   check bool "room truth advertises initializing while execution warms" true
     (file_contains_pattern "lib/server/server_dashboard_http.ml"
        {|("status", `String "initializing")|});


### PR DESCRIPTION
## Summary

최근 리팩토링(#3208 dashboard consolidation) 후 2개 테스트 실패 수정:

1. **test_ci_hardening_source.ml**: `cached_surface_json` → `cached_surface_or_first_success_json` 패턴 업데이트
2. **test_dashboard_proof.ml**: 별도 조사 필요 (Dashboard_proof.json 로직 변경 관련, Eio context 무관)

## Test plan
- [x] `dune build` 통과
- [ ] CI Build and Test 통과

Part of #3178

🤖 Generated with [Claude Code](https://claude.com/claude-code)