### PR TITLE
fix: remove stale init_pg_schemas_parallel from .mli

### DIFF
--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -59,7 +59,6 @@ val bootstrap_keepers :
 val init_task_backend : unit -> unit
 val inject_shared_pg_pool : unit -> unit
 val init_memory_pg_schema : unit -> unit
-val init_pg_schemas_parallel : unit -> unit
 
 (** {1 Background Maintenance} *)
 


### PR DESCRIPTION
## Summary

#3214 (pg schema sequential init)가 `init_pg_schemas_parallel`을 제거했지만 `.mli`에서 삭제하지 않아 main 빌드가 깨짐.

1줄 삭제로 수정.

## Test plan
- [x] `dune build` 통과
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)