### PR TITLE
refactor(core): extract text_similarity to masc_core (#3160 P8 batch 2)

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax executor_pool_ref)
+ (modules lamport json_util safe_ops common backoff validation circuit_breaker eio_guard result_syntax executor_pool_ref text_similarity)
  (libraries yojson unix str eio eio.unix time_compat fs_compat masc_log))

--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -1,0 +1,97 @@
+(** Text_similarity — pure text similarity functions.
+
+    Lowercase + strip, word tokenization, byte-level n-gram extraction,
+    and combined word + n-gram Jaccard similarity.
+
+    These functions have no external dependencies beyond Stdlib. *)
+
+(** Strip non-alphanumeric ASCII, keep multibyte (CJK, etc.) and digits.
+    Returns a cleaned lowercase string for tokenization. *)
+let clean_for_similarity (s : string) : string =
+  let s = String.lowercase_ascii s in
+  let b = Bytes.of_string s in
+  for i = 0 to Bytes.length b - 1 do
+    let c = Bytes.get b i in
+    let code = Char.code c in
+    let keep =
+      (c >= 'a' && c <= 'z') ||
+      (c >= '0' && c <= '9') ||
+      code >= 128
+    in
+    if not keep then Bytes.set b i ' '
+  done;
+  Bytes.to_string b
+
+(** Extract unique word tokens (space-split, length >= 2). *)
+let normalize_for_similarity (s : string) : string list =
+  let cleaned = clean_for_similarity s in
+  let words =
+    cleaned
+    |> String.split_on_char ' '
+    |> List.filter (fun w -> String.length w >= 2)
+  in
+  let tbl : (string, unit) Hashtbl.t = Hashtbl.create 32 in
+  List.filter (fun w ->
+    if Hashtbl.mem tbl w then false
+    else (Hashtbl.add tbl w (); true)
+  ) words
+
+(** Extract character n-grams from a cleaned string.
+    For multibyte strings (Korean, CJK), each "character" may be multiple bytes.
+    We use byte-level n-grams which naturally captures morpheme overlap
+    for UTF-8 encoded text (Korean 3 bytes/char → 3-byte-gram captures
+    individual syllables, 6-byte-gram captures 2-syllable morphemes).
+
+    Returns a deduplicated list of n-grams. *)
+let char_ngrams ~(n : int) (s : string) : string list =
+  let cleaned = clean_for_similarity s in
+  (* Remove spaces for n-gram extraction *)
+  let buf = Buffer.create (String.length cleaned) in
+  String.iter (fun c -> if c <> ' ' then Buffer.add_char buf c) cleaned;
+  let compact = Buffer.contents buf in
+  let len = String.length compact in
+  if len < n then (if len > 0 then [compact] else [])
+  else
+    let tbl : (string, unit) Hashtbl.t = Hashtbl.create 64 in
+    let acc = ref [] in
+    for i = 0 to len - n do
+      let gram = String.sub compact i n in
+      if not (Hashtbl.mem tbl gram) then begin
+        Hashtbl.add tbl gram ();
+        acc := gram :: !acc
+      end
+    done;
+    List.rev !acc
+
+(** Jaccard similarity over a combined feature set: word tokens + character n-grams.
+    Word tokens capture exact matches; n-grams capture partial/morphological overlap.
+    This is effective for Korean where "기억해" and "기억나" share the morpheme "기억"
+    but would score 0 on word-level Jaccard.
+
+    Uses 3-byte grams (captures Korean syllables) and 6-byte grams (captures
+    2-syllable Korean morphemes) alongside word tokens. *)
+let jaccard_similarity (a : string) (b : string) : float =
+  let words_a = normalize_for_similarity a in
+  let words_b = normalize_for_similarity b in
+  let ngrams_a = char_ngrams ~n:3 a @ char_ngrams ~n:6 a in
+  let ngrams_b = char_ngrams ~n:3 b @ char_ngrams ~n:6 b in
+  let ta = words_a @ ngrams_a in
+  let tb = words_b @ ngrams_b in
+  if ta = [] && tb = [] then 1.0
+  else if ta = [] || tb = [] then 0.0
+  else
+    let h : (string, bool) Hashtbl.t = Hashtbl.create 128 in
+    List.iter (fun w -> Hashtbl.replace h w false) ta;
+    let inter = ref 0 in
+    let uniq_b = ref 0 in
+    List.iter (fun w ->
+      if Hashtbl.mem h w then begin
+        if not (Hashtbl.find h w) then begin
+          incr inter;
+          Hashtbl.replace h w true
+        end
+      end else
+        incr uniq_b
+    ) tb;
+    let union = (List.length ta) + !uniq_b in
+    if union = 0 then 0.0 else float_of_int !inter /. float_of_int union

--- a/lib/core/text_similarity.mli
+++ b/lib/core/text_similarity.mli
@@ -1,0 +1,23 @@
+(** Text_similarity — pure text similarity functions.
+
+    Lowercase + strip, word tokenization, byte-level n-gram extraction,
+    and combined word + n-gram Jaccard similarity.
+
+    These functions have no external dependencies beyond Stdlib. *)
+
+(** Strip non-alphanumeric ASCII, keep multibyte (CJK, etc.) and digits.
+    Returns a cleaned lowercase string for tokenization. *)
+val clean_for_similarity : string -> string
+
+(** Extract unique word tokens (space-split, length >= 2). *)
+val normalize_for_similarity : string -> string list
+
+(** Extract character n-grams from a cleaned string.
+    Byte-level n-grams capture morpheme overlap for UTF-8 text
+    (Korean 3 bytes/char, CJK 3 bytes/char).
+    Returns a deduplicated list of n-grams. *)
+val char_ngrams : n:int -> string -> string list
+
+(** Jaccard similarity over combined word tokens + character n-grams.
+    Uses 3-byte and 6-byte grams alongside word tokens. *)
+val jaccard_similarity : string -> string -> float

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -101,96 +101,10 @@ let expected_topic_hint (s : string) : string option =
   else
     None
 
-(** Strip non-alphanumeric ASCII, keep multibyte (CJK, etc.) and digits.
-    Returns a cleaned lowercase string for tokenization. *)
-let clean_for_similarity (s : string) : string =
-  let s = String.lowercase_ascii s in
-  let b = Bytes.of_string s in
-  for i = 0 to Bytes.length b - 1 do
-    let c = Bytes.get b i in
-    let code = Char.code c in
-    let keep =
-      (c >= 'a' && c <= 'z') ||
-      (c >= '0' && c <= '9') ||
-      code >= 128
-    in
-    if not keep then Bytes.set b i ' '
-  done;
-  Bytes.to_string b
-
-(** Extract unique word tokens (space-split, length >= 2). *)
-let normalize_for_similarity (s : string) : string list =
-  let cleaned = clean_for_similarity s in
-  let words =
-    cleaned
-    |> String.split_on_char ' '
-    |> List.filter (fun w -> String.length w >= 2)
-  in
-  let tbl : (string, unit) Hashtbl.t = Hashtbl.create 32 in
-  List.filter (fun w ->
-    if Hashtbl.mem tbl w then false
-    else (Hashtbl.add tbl w (); true)
-  ) words
-
-(** Extract character n-grams from a cleaned string.
-    For multibyte strings (Korean, CJK), each "character" may be multiple bytes.
-    We use byte-level n-grams which naturally captures morpheme overlap
-    for UTF-8 encoded text (Korean 3 bytes/char → 3-byte-gram captures
-    individual syllables, 6-byte-gram captures 2-syllable morphemes).
-
-    Returns a deduplicated list of n-grams. *)
-let char_ngrams ~(n : int) (s : string) : string list =
-  let cleaned = clean_for_similarity s in
-  (* Remove spaces for n-gram extraction *)
-  let buf = Buffer.create (String.length cleaned) in
-  String.iter (fun c -> if c <> ' ' then Buffer.add_char buf c) cleaned;
-  let compact = Buffer.contents buf in
-  let len = String.length compact in
-  if len < n then (if len > 0 then [compact] else [])
-  else
-    let tbl : (string, unit) Hashtbl.t = Hashtbl.create 64 in
-    let acc = ref [] in
-    for i = 0 to len - n do
-      let gram = String.sub compact i n in
-      if not (Hashtbl.mem tbl gram) then begin
-        Hashtbl.add tbl gram ();
-        acc := gram :: !acc
-      end
-    done;
-    List.rev !acc
-
-(** Jaccard similarity over a combined feature set: word tokens + character n-grams.
-    Word tokens capture exact matches; n-grams capture partial/morphological overlap.
-    This is effective for Korean where "기억해" and "기억나" share the morpheme "기억"
-    but would score 0 on word-level Jaccard.
-
-    Uses 3-byte grams (captures Korean syllables) and 6-byte grams (captures
-    2-syllable Korean morphemes) alongside word tokens. *)
-let jaccard_similarity (a : string) (b : string) : float =
-  let words_a = normalize_for_similarity a in
-  let words_b = normalize_for_similarity b in
-  let ngrams_a = char_ngrams ~n:3 a @ char_ngrams ~n:6 a in
-  let ngrams_b = char_ngrams ~n:3 b @ char_ngrams ~n:6 b in
-  let ta = words_a @ ngrams_a in
-  let tb = words_b @ ngrams_b in
-  if ta = [] && tb = [] then 1.0
-  else if ta = [] || tb = [] then 0.0
-  else
-    let h : (string, bool) Hashtbl.t = Hashtbl.create 128 in
-    List.iter (fun w -> Hashtbl.replace h w false) ta;
-    let inter = ref 0 in
-    let uniq_b = ref 0 in
-    List.iter (fun w ->
-      if Hashtbl.mem h w then begin
-        if not (Hashtbl.find h w) then begin
-          incr inter;
-          Hashtbl.replace h w true
-        end
-      end else
-        incr uniq_b
-    ) tb;
-    let union = (List.length ta) + !uniq_b in
-    if union = 0 then 0.0 else float_of_int !inter /. float_of_int union
+let clean_for_similarity = Text_similarity.clean_for_similarity
+let normalize_for_similarity = Text_similarity.normalize_for_similarity
+let char_ngrams = Text_similarity.char_ngrams
+let jaccard_similarity = Text_similarity.jaccard_similarity
 
 let latest_message_content_by_role
     ~(role : Agent_sdk.Types.role)


### PR DESCRIPTION
## Summary

`keeper_memory_recall.ml`에서 4개 순수 text similarity 함수를 `lib/core/text_similarity.ml`로 추출.

7+ 파일에서 사용되는 공용 유틸리티를 keeper 의존 없이 접근 가능하게 승격.

### 추출된 함수
| 함수 | 설명 |
|------|------|
| `clean_for_similarity` | lowercase + non-alnum 제거 (multibyte 보존) |
| `normalize_for_similarity` | word 토큰화 + dedup |
| `char_ngrams` | byte-level n-gram (한국어 형태소 지원) |
| `jaccard_similarity` | word + n-gram 결합 Jaccard |

keeper_memory_recall.ml: 825→737줄 (-88)

## Test plan
- [x] `dune build` 통과
- [ ] CI Build and Test 통과

Part of #3160

🤖 Generated with [Claude Code](https://claude.com/claude-code)