### PR TITLE
refactor(dashboard): extract formatPct, remove inline duplicates

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -142,7 +142,6 @@ function decisionLabel(decision: string): string {
   return decision === 'keep' ? '유지' : '삭제'
 }
 
-
 function formatDelta(delta: number): string {
   const sign = delta >= 0 ? '+' : ''
   return `${sign}${delta.toFixed(4)}`

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -6,6 +6,7 @@ import { signal, computed } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
+import { formatElapsedCompact } from '../lib/format-time'
 import {
   fetchAutoresearchLoops,
   fetchAutoresearchLoopDetail,
@@ -141,13 +142,6 @@ function decisionLabel(decision: string): string {
   return decision === 'keep' ? '유지' : '삭제'
 }
 
-function formatElapsed(seconds: number): string {
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
-  const h = Math.floor(seconds / 3600)
-  const m = Math.round((seconds % 3600) / 60)
-  return `${h}h ${m}m`
-}
 
 function formatDelta(delta: number): string {
   const sign = delta >= 0 ? '+' : ''
@@ -220,7 +214,7 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
           <div>
             <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">경과 시간</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsed(loop.elapsed_s)}</div>
+            <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
           </div>
           <div>
             <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>

--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -61,6 +61,8 @@ export async function getMermaid(): Promise<MermaidApi> {
   return mermaid
 }
 
+export { formatPct } from '../../lib/format-number'
+
 export function formatPercent(value?: number | null): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '정보 없음'
   return `${Math.round(value * 100)}%`

--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -61,8 +61,6 @@ export async function getMermaid(): Promise<MermaidApi> {
   return mermaid
 }
 
-export { formatPct } from '../../lib/format-number'
-
 export function formatPercent(value?: number | null): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '정보 없음'
   return `${Math.round(value * 100)}%`

--- a/dashboard/src/components/common/agent-motion.ts
+++ b/dashboard/src/components/common/agent-motion.ts
@@ -1,3 +1,4 @@
+import { formatPct } from '../../lib/format-number'
 import type { Message, Task, JournalEntry, BoardPost, Keeper } from '../../types'
 import { trimText as trimTextBase } from '../../lib/truncate'
 
@@ -51,9 +52,7 @@ function boardPreview(post: BoardPost): string {
 
 function keeperPreview(keeper: Keeper): string {
   const generation = keeper.generation ?? '?'
-  const ratio = typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)
-    ? `${Math.round(keeper.context_ratio * 100)}%`
-    : '?'
+  const ratio = formatPct(keeper.context_ratio, '?')
   return keeper.last_heartbeat
     ? `Heartbeat gen=${generation} ctx=${ratio}`
     : `Keeper snapshot gen=${generation} ctx=${ratio}`

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -4,6 +4,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { formatPct } from '../lib/format-number'
 import type { Keeper, KeeperMetricPoint } from '../types'
 
 // ── Utility functions ────────────────────────────────────
@@ -203,7 +204,7 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
     { title: 'Activity', key: 'activityLevel', value: String(keeper.activityLevel ?? '-') },
     { title: 'Gen', key: 'generation', value: String(keeper.generation ?? '-') },
     { title: 'Turns', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
-    { title: 'Context', key: 'context_ratio', value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-' },
+    { title: 'Context', key: 'context_ratio', value: formatPct(keeper.context_ratio) },
     { title: 'Heartbeat', key: 'last_heartbeat', value: keeper.last_heartbeat ?? '-' },
     { title: 'Traits', key: 'traits', value: keeper.traits?.join(', ') || '-' },
     { title: 'Interests', key: 'interests', value: keeper.interests?.join(', ') || '-' },

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { TimeAgo } from './common/time-ago'
 import { missionSnapshot } from '../mission-store'
+import { formatPct } from '../lib/format-number'
 import type { DashboardMissionKeeperBrief, Keeper } from '../types'
 import { serverStatus } from '../store'
 import { operatorSnapshot } from '../operator-store'
@@ -65,10 +66,6 @@ function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null 
     ?? null
 }
 
-function formatPct(value: number | undefined): string {
-  if (value == null || Number.isNaN(value)) return '-'
-  return `${Math.round(value * 100)}%`
-}
 
 // ── Shared row component ─────────────────────────────────
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -66,7 +66,6 @@ function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null 
     ?? null
 }
 
-
 // ── Shared row component ─────────────────────────────────
 
 function SignalRow({ label, value }: { label: string; value: string | number }) {

--- a/dashboard/src/components/mission-agent-cards.ts
+++ b/dashboard/src/components/mission-agent-cards.ts
@@ -7,6 +7,7 @@ import { StatusChip } from './common/status-chip'
 import { openAgentDetail } from './agent-detail'
 import { openKeeperDetail } from './keeper-detail'
 import { workflowActionLabel } from '../workflow-context'
+import { formatPct } from '../lib/format-number'
 import type {
   DashboardMissionInternalSignal,
   Keeper,
@@ -87,8 +88,8 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
   const continuity = [
     `세대 ${row.brief.generation ?? row.keeper?.generation ?? 0}`,
     row.brief.context_ratio != null
-      ? `컨텍스트 ${Math.round(row.brief.context_ratio * 100)}%`
-      : (row.keeper?.context_ratio != null ? `컨텍스트 ${Math.round(row.keeper.context_ratio * 100)}%` : null),
+      ? `컨텍스트 ${formatPct(row.brief.context_ratio)}`
+      : (row.keeper?.context_ratio != null ? `컨텍스트 ${formatPct(row.keeper.context_ratio)}` : null),
     row.brief.last_turn_ago_s != null ? `최근 턴 ${Math.round(row.brief.last_turn_ago_s)}초 전` : null,
   ]
     .filter((value): value is string => value !== null)

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -79,7 +79,7 @@ export function OpsKeeperColumn() {
                 <span>${relativeAge(keeper.last_turn_ago_s)}</span>
               </div>
               ${keeper.short_goal || keeper.goal ? html`
-                <div class="text-[11px] text-[var(--text-muted)] mt-1.5 p-1 px-1.5 bg-[var(--white-3)] rounded" title=${keeper.goal ?? ''}>${truncate(keeper.short_goal ?? keeper.goal ?? '')}</div>
+                <div class="text-[11px] text-[var(--text-muted)] mt-1.5 p-1 px-1.5 bg-[var(--white-3)] rounded" title=${keeper.goal ?? ''}>${truncate(keeper.short_goal ?? keeper.goal ?? '', 60)}</div>
               ` : null}
               ${tone !== 'ok'
                 ? html`<div class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-1.5">점검 이유: ${prioritySummary}</div>`

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -22,10 +22,7 @@ import {
   submitKeeperMessage,
   logEntryBorderClass,
 } from './helpers'
-
-function truncateGoal(goal: string, maxLen = 60): string {
-  return goal.length > maxLen ? goal.slice(0, maxLen) + '...' : goal
-}
+import { truncate } from '../../lib/truncate'
 
 function openOpsKeeperDetail(opsKeeper: OperatorKeeperSnapshot): void {
   const full = findKeeper(opsKeeper.name)
@@ -82,7 +79,7 @@ export function OpsKeeperColumn() {
                 <span>${relativeAge(keeper.last_turn_ago_s)}</span>
               </div>
               ${keeper.short_goal || keeper.goal ? html`
-                <div class="text-[11px] text-[var(--text-muted)] mt-1.5 p-1 px-1.5 bg-[var(--white-3)] rounded" title=${keeper.goal ?? ''}>${truncateGoal(keeper.short_goal ?? keeper.goal ?? '')}</div>
+                <div class="text-[11px] text-[var(--text-muted)] mt-1.5 p-1 px-1.5 bg-[var(--white-3)] rounded" title=${keeper.goal ?? ''}>${truncate(keeper.short_goal ?? keeper.goal ?? '')}</div>
               ` : null}
               ${tone !== 'ok'
                 ? html`<div class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-1.5">점검 이유: ${prioritySummary}</div>`

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -1,0 +1,7 @@
+// Unified number formatting utilities.
+
+/** Format a 0–1 ratio as percentage string. Returns fallback for null/NaN. */
+export function formatPct(value: number | null | undefined, fallback = '-'): string {
+  if (value == null || !Number.isFinite(value)) return fallback
+  return `${Math.round(value * 100)}%`
+}


### PR DESCRIPTION
## Summary
2차 simplify 패스: dashboard 전반의 인라인 중복 유틸리티 통합.

- `formatPct(value, fallback)` — `lib/format-number.ts`로 추출. `Math.round(x*100)+'%'` 패턴 20곳+ 중 UI 표시용 6곳 교체
- `truncateGoal()` (ops-keeper-column) → `truncate()` (lib/truncate) 교체
- `formatElapsed()` (autoresearch) → `formatElapsedCompact()` (lib/format-time) 교체
- `formatPct` (keeper-detail-runtime) 인라인 함수 제거

## Deferred (별도 PR)
- MCP 세션 초기화 race condition (api/mcp.ts initPromise finally 패턴)
- keeperStreamControllers 메모리 누수 (keeper-state.ts)
- 리스트 가상화 / key prop 누락 (command/index.ts)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] Dashboard 수동 확인 (keeper detail, mission cards, autoresearch, ops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)