### PR TITLE
fix(keeper): register loop tool schemas in MCP surface (#3190)

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -490,6 +490,69 @@ let resident_schemas : tool_schema list = [
       ("required", `List [`String "name"]);
     ];
   };
+
+  {
+    name = "masc_keeper_add_loop";
+    description = "Register a recurring broadcast task on a keeper. The keeper dispatches it automatically on each heartbeat cycle when the interval has elapsed.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("keeper_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Target keeper handle");
+        ]);
+        ("label", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Short label for this recurring task");
+        ]);
+        ("interval_sec", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Seconds between dispatches (minimum 10)");
+        ]);
+        ("message", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Broadcast message content");
+        ]);
+        ("max_failures", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Auto-disable after this many consecutive failures (default 5)");
+        ]);
+      ]);
+      ("required", `List [
+        `String "keeper_name"; `String "label";
+        `String "interval_sec"; `String "message"
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_list_loops";
+    description = "List recurring tasks registered on a keeper.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("keeper_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle (omit for all keepers)");
+        ]);
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_remove_loop";
+    description = "Remove a recurring task by its ID.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Recurring task ID (from add_loop or list_loops)");
+        ]);
+      ]);
+      ("required", `List [`String "id"]);
+    ];
+  };
 ]
 
 let persistent_alias_name = function


### PR DESCRIPTION
## Summary

- `masc_keeper_add_loop`, `masc_keeper_list_loops`, `masc_keeper_remove_loop` 스키마를 `Keeper_schema.schemas`에 추가
- PR #3200에서 dispatch handler는 추가했지만 스키마 등록이 누락됨
- MCP 클라이언트에서 "Tool not available" 에러 발생

## 발견 경위

Dogfooding: `curl` → MCP initialize → `tools/call masc_keeper_add_loop` → `-32601 Tool not available`

## Test plan

- [x] `test_keeper_recurring` 7/7 통과
- [x] 로컬 빌드 성공 (이전 worktree에서 검증)
- [ ] CI Build and Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)