### PR TITLE
fix: stabilize team session artifacts and keeper tests

### DIFF
--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -44,7 +44,8 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
                | Ok (proof_json, proof_markdown) ->
                    Room_utils.write_json config path proof_json;
                    let md_path = Team_session_store.proof_md_path config current in
-                   Team_session_store.write_text_file md_path proof_markdown;
+                   Team_session_store.write_artifact_text config md_path
+                     proof_markdown;
                    Some proof_json
                | Error e ->
                    Log.Misc.error "dashboard proof auto-gen failed: %s" e;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -124,15 +124,17 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
       list_resident_keepers ctx.config
       |> take max_scan
     in
-    let (scanned, started, stale, recovering) =
+    let (enabled, scanned, started, stale, recovering) =
       List.fold_left
-        (fun (scanned_acc, started_acc, stale_acc, recovering_acc) spec ->
+        (fun (enabled_acc, scanned_acc, started_acc, stale_acc, recovering_acc) spec ->
           match ensure_resident_meta ctx.config spec with
-          | Error _ -> (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
+          | Error _ ->
+              (enabled_acc, scanned_acc + 1, started_acc, stale_acc, recovering_acc)
           | Ok m ->
               if m.paused then
-                (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
+                (enabled_acc, scanned_acc + 1, started_acc, stale_acc, recovering_acc)
               else
+              let wants_keepalive = m.presence_keepalive in
               let stale_now =
                 stale_turn_sec > 0.0
                 && (m.usage.last_turn_ts <= 0.0
@@ -142,7 +144,8 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                 Keeper_registry.is_running ~base_path:ctx.config.base_path m.name
               in
               let started_here =
-                if already_running then false
+                if not wants_keepalive then false
+                else if already_running then false
                 else if max_keepers > 0 && !remaining_slots <= 0 then false
                 else (
                   Keeper_resident_supervisor.supervise_keepalive
@@ -151,14 +154,15 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
                   true
                 )
               in
-              ( scanned_acc + 1,
+              ( enabled_acc || wants_keepalive,
+                scanned_acc + 1,
                 started_acc + (if started_here then 1 else 0),
                 stale_acc + (if stale_now then 1 else 0),
                 recovering_acc + (if stale_now && started_here then 1 else 0) ))
-        (0, 0, 0, 0)
+        (false, 0, 0, 0, 0)
         specs
     in
-    { enabled = true; scanned; started; stale; recovering }
+    { enabled; scanned; started; stale; recovering }
 
 (** Start the supervisor sweep Pulse loop.
     Runs alongside existing keepalive bootstrap, scanning for

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -188,6 +188,17 @@ let read_json config path =
     end
   | None -> read_json_local path
 
+let read_text config path =
+  match key_of_path config path with
+  | Some key -> begin
+      match backend_get config ~key with
+      | Ok (Some content) -> content
+      | Ok None | Error _ -> ""
+    end
+  | None ->
+      if Fs_compat.file_exists path then Fs_compat.load_file path
+      else ""
+
 let write_json config path json =
   match key_of_path config path with
   | Some key ->
@@ -196,6 +207,20 @@ let write_json config path json =
        | Ok () -> ()
        | Error e -> Log.Misc.warn "write_json backend_set failed for %s: %s" key (Backend_types.show_error e))
   | None -> write_json_local path json
+
+let write_text config path content =
+  match key_of_path config path with
+  | Some key ->
+      (match backend_set config ~key ~value:content with
+       | Ok () -> ()
+       | Error e ->
+           Log.Misc.warn "write_text backend_set failed for %s: %s" key
+             (Backend_types.show_error e))
+  | None ->
+      mkdir_p (Filename.dirname path);
+      let tmp_path = path ^ ".tmp" in
+      Fs_compat.save_file tmp_path content;
+      Unix.rename tmp_path path
 
 let delete_path config path =
   match key_of_path config path with
@@ -209,6 +234,23 @@ let path_exists config path =
   match key_of_path config path with
   | Some key -> backend_exists config ~key
   | None -> Sys.file_exists path
+
+let append_text config path content =
+  match key_of_path config path with
+  | Some key ->
+      let existing =
+        match backend_get config ~key with
+        | Ok (Some value) -> value
+        | Ok None | Error _ -> ""
+      in
+      (match backend_set config ~key ~value:(existing ^ content) with
+       | Ok () -> ()
+       | Error e ->
+           Log.Misc.warn "append_text backend_set failed for %s: %s" key
+             (Backend_types.show_error e))
+  | None ->
+      mkdir_p (Filename.dirname path);
+      Fs_compat.append_file path content
 
 let read_json_opt config path =
   match key_of_path config path with

--- a/lib/team_session/team_session_engine_status.ml
+++ b/lib/team_session/team_session_engine_status.ml
@@ -372,7 +372,8 @@ let prove_session ~(config : Room.config) ~(session_id : string)
                 Team_session_store.proof_md_path config session_id
               in
               Room_utils.write_json config proof_json_path proof_json;
-              Team_session_store.write_text_file proof_md_path proof_markdown;
+              Team_session_store.write_artifact_text config proof_md_path
+                proof_markdown;
               Team_session_store.append_event config session_id
                 ~event_type:"session_proof_generated"
                 ~detail:

--- a/lib/team_session/team_session_report_core.ml
+++ b/lib/team_session/team_session_report_core.ml
@@ -859,7 +859,6 @@ let generate config (session : Team_session_types.session) :
     let report_md_path =
       Team_session_store.report_md_path config session.session_id
     in
-    Team_session_store.write_text_file report_md_path markdown;
+    Team_session_store.write_artifact_text config report_md_path markdown;
     Ok (report_json, markdown)
   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Error (Printexc.to_string exn)
-

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -132,6 +132,15 @@ let append_text_file path content =
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.append_file path content
 
+let read_artifact_text config path =
+  Room_utils.read_text config path
+
+let write_artifact_text config path content =
+  Room_utils.write_text config path content
+
+let append_artifact_text config path content =
+  Room_utils.append_text config path content
+
 let save_session config (session : Team_session_types.session) =
   let path = session_json_path config session.session_id in
   with_file_lock config path (fun () ->
@@ -206,7 +215,7 @@ let append_event config session_id ~(event_type : string) ~(detail : Yojson.Safe
   in
   let line = Yojson.Safe.to_string (Team_session_types.event_entry_to_yojson entry) ^ "\n" in
   let path = events_jsonl_path config session_id in
-  with_file_lock config path (fun () -> append_text_file path line);
+  with_file_lock config path (fun () -> append_artifact_text config path line);
   emit_activity_event config ~session_id ~event_type ~detail
 
 let take_last n lst =
@@ -280,25 +289,33 @@ let read_events ?max_events config session_id : Yojson.Safe.t list =
   if not (path_exists config path) then
     []
   else
-    match max_events with
-    | Some n when n > 0 ->
-        let tail_lines =
-          read_tail_lines path
-            ~max_bytes:(max 262_144 (n * 4096))
-            ~max_lines:(n * 3)
-        in
-        let tail_parsed = parse_event_lines tail_lines in
-        if List.length tail_parsed >= n then
-          take_last n tail_parsed
-        else
-          (* Fallback for unusually large JSON lines or sparse parseable rows. *)
-          let content = Fs_compat.load_file path in
-          let all_lines = String.split_on_char '\n' content in
-          parse_event_lines all_lines |> take_last n
+    match config.backend with
+    | FileSystem _ when Fs_compat.file_exists path -> (
+        match max_events with
+        | Some n when n > 0 ->
+            let tail_lines =
+              read_tail_lines path
+                ~max_bytes:(max 262_144 (n * 4096))
+                ~max_lines:(n * 3)
+            in
+            let tail_parsed = parse_event_lines tail_lines in
+            if List.length tail_parsed >= n then
+              take_last n tail_parsed
+            else
+              let content = read_artifact_text config path in
+              let all_lines = String.split_on_char '\n' content in
+              parse_event_lines all_lines |> take_last n
+        | _ ->
+            let content = read_artifact_text config path in
+            let all_lines = String.split_on_char '\n' content in
+            parse_event_lines all_lines)
     | _ ->
-        let content = Fs_compat.load_file path in
+        let content = read_artifact_text config path in
         let all_lines = String.split_on_char '\n' content in
-        parse_event_lines all_lines
+        let parsed = parse_event_lines all_lines in
+        (match max_events with
+         | Some n when n > 0 -> take_last n parsed
+         | _ -> parsed)
 
 let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoint) =
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -198,7 +198,12 @@ proactive_enabled = true
       let keeper_name = "config-provenance" in
       let ok, _ =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
-          ~args:(`Assoc [ ("name", `String keeper_name) ])
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("presence_keepalive", `Bool false);
+              ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
       let meta =
@@ -348,7 +353,12 @@ let test_snapshot_keeper_tool_audit_fallback () =
       Alcotest.(check string) "diagnostic health offline" "offline"
         (keeper |> member "diagnostic" |> member "health_state" |> to_string);
       Alcotest.(check string) "diagnostic continuity disabled" "disabled"
-        (keeper |> member "diagnostic" |> member "continuity_state" |> to_string))
+        (keeper |> member "diagnostic" |> member "continuity_state" |> to_string);
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "keeper down ok" true ok)
 
 let test_keeper_msg_auto_team_session_bridge () =
   (* This test triggers a real LLM cascade call (keeper_msg -> run_turn).

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -294,7 +294,8 @@ let test_turn_events_and_prove () =
   in
   Alcotest.(check bool) "proof json exists" true
     (Room_utils.path_exists config proof_json_path);
-  Alcotest.(check bool) "proof md exists" true (Sys.file_exists proof_md_path);
+  Alcotest.(check bool) "proof md exists" true
+    (Room_utils.path_exists config proof_md_path);
   Alcotest.(check string) "verdict proved" "proved" verdict;
   let proof_doc = Room_utils.read_json config proof_json_path in
   let proof_schema_version =

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -143,11 +143,7 @@ let test_proof_exposes_spawn_selection_rationale () =
     prove_result |> Yojson.Safe.Util.member "proof_md_path"
     |> Yojson.Safe.Util.to_string
   in
-  let ic = open_in proof_md_path in
-  let proof_md =
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-        really_input_string ic (in_channel_length ic))
-  in
+  let proof_md = Team_session_store.read_artifact_text config proof_md_path in
   Alcotest.(check bool) "markdown includes model" true
     (try
        let _ = Str.search_forward (Str.regexp_string spawn_model) proof_md 0 in
@@ -247,7 +243,7 @@ let test_report_and_proof_expose_spawn_tool_usage () =
   let report_json_path =
     report_result |> Yojson.Safe.Util.member "json_path" |> Yojson.Safe.Util.to_string
   in
-  let report_json = Yojson.Safe.from_file report_json_path in
+  let report_json = Room_utils.read_json config report_json_path in
   let report_evidence = report_json |> Yojson.Safe.Util.member "evidence" in
   Alcotest.(check int) "report spawn tool call count" 3
     Yojson.Safe.Util.(report_evidence |> member "spawn_tool_call_count" |> to_int);

--- a/test/test_tool_team_session_step_followup.ml
+++ b/test/test_tool_team_session_step_followup.ml
@@ -324,7 +324,7 @@ let test_proof_exposes_failed_spawn_and_detach_counts () =
     prove_result |> Yojson.Safe.Util.member "proof_md_path"
     |> Yojson.Safe.Util.to_string
   in
-  let proof_md = Stdlib.In_channel.with_open_bin proof_md_path Stdlib.In_channel.input_all in
+  let proof_md = Team_session_store.read_artifact_text config proof_md_path in
   Alcotest.(check bool) "markdown includes failed spawn count" true
     (try
        let _ = Str.search_forward (Str.regexp_string "Failed spawn events: 1") proof_md 0 in
@@ -438,7 +438,7 @@ let test_report_and_proof_expose_empty_note_turn_evidence () =
     prove_result |> Yojson.Safe.Util.member "proof_md_path"
     |> Yojson.Safe.Util.to_string
   in
-  let proof_md = Stdlib.In_channel.with_open_bin proof_md_path Stdlib.In_channel.input_all in
+  let proof_md = Team_session_store.read_artifact_text config proof_md_path in
   Alcotest.(check bool) "proof markdown includes empty note evidence" true
     (try
        let _ =


### PR DESCRIPTION
## Summary
- make team session report/proof/event artifact I/O backend-aware so Memory fallback matches FileSystem behavior
- update team session tests to read artifacts through backend-aware helpers instead of direct filesystem opens
- avoid starting keeper supervisor sweep when no keepalive-enabled resident keepers exist, and add explicit keeper teardown in operator tests

## Validation
- `env DUNE_BUILD_DIR=_build_ci_timeout opam exec -- dune build ./test/test_tool_team_session.exe ./test/test_operator_control.exe` in `/tmp/masc-mcp-ci-timeout-root-causes-20260326`
- `./_build_ci_timeout/default/test/test_tool_team_session.exe test team_session 6 -e -v`
- `./_build_ci_timeout/default/test/test_tool_team_session.exe test team_session 34 -e -v`
- `/opt/homebrew/bin/gtimeout 10s ./_build_ci_timeout/default/test/test_operator_control.exe test operator 25 -e -v`
- `/opt/homebrew/bin/gtimeout 10s ./_build_ci_timeout/default/test/test_operator_control.exe test operator 26 -e -v`
- `/opt/homebrew/bin/gtimeout 10s ./_build_ci_timeout/default/test/test_operator_control.exe test operator 27 -e -v`
- `/opt/homebrew/bin/gtimeout 120s ./_build_ci_timeout/default/test/test_operator_control.exe -q`

## Notes
- `./_build_ci_timeout/default/test/test_tool_team_session.exe -q` still has pre-existing failures outside this change set: 0, 1, 5, 12, 14
- cross-model review evidence will be added in a follow-up comment on this PR