### PR TITLE
fix(dashboard): raise room-truth fiber timeout during cold startup (#3223)

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -491,7 +491,9 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
   let shell_timeout_s =
     if !_shell_warmed then base_timeout_s else 15.0
   in
-  let execution_timeout_s = if is_cold then 20.0 else base_timeout_s in
+  let execution_timeout_s =
+    if is_cold then Float.max base_timeout_s 20.0 else base_timeout_s
+  in
   Eio.Fiber.all [
     (fun () -> shell_ref := fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
       (fun () -> dashboard_shell_http_json config) (`Assoc []));

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -483,12 +483,15 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       Log.Dashboard.warn "room-truth fiber %s failed: %s" label (Printexc.to_string exn);
       fallback
   in
+  let is_cold = not (cached_surface_has_success _execution_cache) in
+  let base_timeout_s =
+    Safe_ops.get_env_float_logged "MASC_ROOM_TRUTH_TIMEOUT_SEC"
+      ~default:(if is_cold then 15.0 else default_timeout_s)
+  in
   let shell_timeout_s =
-    if !_shell_warmed then default_timeout_s else 15.0
+    if !_shell_warmed then base_timeout_s else 15.0
   in
-  let execution_timeout_s =
-    if cached_surface_has_success _execution_cache then default_timeout_s else 20.0
-  in
+  let execution_timeout_s = if is_cold then 20.0 else base_timeout_s in
   Eio.Fiber.all [
     (fun () -> shell_ref := fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
       (fun () -> dashboard_shell_http_json config) (`Assoc []));
@@ -496,7 +499,7 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       (fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
       (cached_surface_json _execution_cache));
     (fun () ->
-      command_ref := fiber_with_timeout "command"
+      command_ref := fiber_with_timeout ~timeout_s:base_timeout_s "command"
         (fun () ->
           if Room.is_initialized config then
             Server_command_plane_http.command_plane_summary_http_json ~state


### PR DESCRIPTION
## Summary

- room-truth parallel fetch에서 shell/command fiber가 cold 상태에서도 5s 고정 timeout을 사용하여 warn 87회/일 발생
- cold 상태(execution cache 미완) 감지 시 shell/command timeout을 15s로 상향
- `MASC_ROOM_TRUTH_TIMEOUT_SEC` 환경변수로 warm 상태 기본 timeout 조정 가능

## Changes

| 상태 | shell/command | execution |
|------|-------------|-----------|
| cold (before) | 5s | 20s |
| cold (after) | 15s | 20s |
| warm (before) | 5s | 5s |
| warm (after) | 5s | 5s |

## Test plan

- [x] `dune build @check` 통과
- [ ] CI Build and Test 통과
- [ ] 서버 재시작 후 cold 상태에서 room-truth warn 빈도 감소 확인

Closes #3223
