### PR TITLE
fix(runtime): stagger PG-heavy refresh loops at startup (#3222)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -966,9 +966,18 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let exec_pool = Eio.Executor_pool.create ~sw ~domain_count:2 domain_mgr in
       Server_dashboard_http.set_executor_pool exec_pool;
       Log.Server.info "Executor_pool created (2 domains) for dashboard";
+      (* Stagger PG-heavy refresh loop warm-cache runs at startup.
+         Each Proactive_refresh.start forks a fiber that immediately calls
+         compute(), so starting all 7 loops at once creates 7+ concurrent PG
+         queries — exceeding pool capacity on Supabase session pooler.
+         A short sleep between PG-heavy launches spreads the initial burst. *)
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
+      Eio.Time.sleep clock 0.5;
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
+      Eio.Time.sleep clock 0.5;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
+      Eio.Time.sleep clock 0.5;
+      (* Remaining loops are lighter (no PG or use cached data). *)
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;


### PR DESCRIPTION
## Summary

- 서버 시작 시 7개 proactive refresh loop이 동시에 PG pool.use를 호출하여 "Invalid concurrent usage of PostgreSQL connection detected" 에러 발생 (로그 3회/시작)
- PG-heavy loop 3개(cp-summary, cp-snapshot, execution) 사이에 0.5s sleep 추가하여 초기 connection burst 분산
- 나머지 4개 loop(transport-health, mission, operator-snapshot, operator-digest)은 PG 미사용 또는 캐시 데이터 사용으로 stagger 불필요

## Changes

1 file, +9 lines (server_runtime_bootstrap.ml)

## Test plan

- [x] `dune build bin/main_eio.exe` 통과
- [ ] CI Build and Test 통과
- [ ] 서버 재시작 후 "Invalid concurrent usage" 에러 소멸 확인

Closes #3222
