### PR TITLE
fix(ci): raise quick suite timeout from 600s to 900s (#3234)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
-          CI_TEST_TIMEOUT_SEC: 600
+          CI_TEST_TIMEOUT_SEC: 900
           CI_TEST_HEARTBEAT_SEC: 30
           MASC_LLAMA_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
           MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"

--- a/test/test_tool_team_session_support.ml
+++ b/test/test_tool_team_session_support.ml
@@ -80,6 +80,8 @@ let add_task_id config ~title =
 
 let with_eio f =
   Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Time_compat.set_clock (Eio.Stdenv.clock env);
   Fun.protect
     ~finally:(fun () -> Time_compat.clear_clock ())


### PR DESCRIPTION
## Summary

- 모든 main CI 실패: 172개 test stanza가 600s 타임아웃 초과
- CI_TEST_TIMEOUT_SEC를 600→900으로 상향 (SSE storm/transport harness와 동일 수준)

## Evidence

Last 3 main runs all timeout:
- 23578610536: "test command timed out after 600s"
- 23578382592: same
- 23577625777: same

Test suite timeline: first test 06:48:16, last test 06:58:13 = ~600s exact.

## Test plan

- [ ] CI Build and Test 통과 (이 PR 자체가 검증)

Closes #3234
