### PR TITLE
fix(dashboard): prevent MCP session init retry storm on failure (#3227)

### DIFF
--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -74,6 +74,8 @@ async function mcpPost(body: unknown, timeoutMs = DEFAULT_MCP_TIMEOUT_MS): Promi
   return res.text()
 }
 
+const INIT_COOLDOWN_MS = 2000
+
 async function ensureSession(): Promise<void> {
   if (mcpSessionId === '__blocked__') {
     throw new Error('MCP 연결이 차단되었습니다. 로컬 환경에서만 사용할 수 있는 기능입니다.')
@@ -112,13 +114,14 @@ async function ensureSession(): Promise<void> {
           }),
         }, 5000).catch(err => console.warn('[mcp] initialized notification failed:', err))
       }
+      initPromise = null
     } catch (err) {
       if (err instanceof Error && err.message.includes('403')) {
         mcpSessionId = '__blocked__'
       }
+      // Keep initPromise alive briefly to prevent retry storms
+      setTimeout(() => { initPromise = null }, INIT_COOLDOWN_MS)
       throw err
-    } finally {
-      initPromise = null
     }
   })()
   return initPromise


### PR DESCRIPTION
## Summary

- `ensureSession()`의 `finally` 블록에서 `initPromise = null` 설정 → 실패 시 즉시 재시도 가능 → 서버 장애 중 init 요청 폭주
- 성공 시에만 `initPromise = null`, 실패 시 2s cooldown 후 null 설정

## Before/After

| 상태 | Before | After |
|------|--------|-------|
| 성공 | initPromise = null (finally) | initPromise = null (try) |
| 실패 | initPromise = null (finally) → 즉시 재시도 | 2s cooldown → 그 후 재시도 |
| 403 | mcpSessionId = '__blocked__' | 동일 |

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `npm run build` 통과
- [ ] CI Build and Test 통과

Closes #3227
