### PR TITLE
fix(test): use fork_daemon for Perpetual Pulse to prevent CI timeout

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -177,6 +177,14 @@ let supervisor_sweep_running base_path =
     | Some pulse -> Pulse.is_alive pulse
     | None -> false)
 
+let stop_supervisor_sweep base_path =
+  with_sweeps_rw (fun () ->
+    match Hashtbl.find_opt supervisor_sweeps base_path with
+    | Some pulse ->
+      Pulse.shutdown pulse;
+      Hashtbl.remove supervisor_sweeps base_path
+    | None -> ())
+
 let start_supervisor_sweep ctx =
   let base_path = ctx.config.base_path in
   if supervisor_sweep_running base_path then ()
@@ -247,3 +255,8 @@ let start_existing_keepalives ctx =
 
 let stop_keepalive name =
   Keeper_keepalive.stop_keepalive name
+
+let reset_test_state base_path =
+  stop_supervisor_sweep base_path;
+  with_bootstrap_rw (fun () ->
+    Hashtbl.remove existing_keepalive_bootstrap_done base_path)

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -263,11 +263,19 @@ let create ~clock ~rhythm ~lifecycle ~consumers =
 let run ~sw t =
   t.alive    <- true;
   t.start_ts <- now t.clock;
-  Eio.Fiber.fork ~sw (fun () ->
-    Fun.protect
-      (fun () -> loop t)
-      ~finally:(fun () -> t.alive <- false)
-  )
+  match t.lifecycle with
+  | Perpetual ->
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      Fun.protect
+        (fun () -> loop t; `Stop_daemon)
+        ~finally:(fun () -> t.alive <- false)
+    )
+  | Bounded _ ->
+    Eio.Fiber.fork ~sw (fun () ->
+      Fun.protect
+        (fun () -> loop t)
+        ~finally:(fun () -> t.alive <- false)
+    )
 
 let nudge t ~reason =
   if t.alive && Eio.Stream.is_empty t.nudge_stream then

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -90,7 +90,9 @@ let test_keeper_status_exposes_summary_and_recoverable () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
+    ~finally:(fun () ->
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
     (fun () ->
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
@@ -169,6 +171,7 @@ let test_keeper_config_exposes_live_runtime_and_sources () =
   let cwd = Sys.getcwd () in
   Fun.protect
     ~finally:(fun () ->
+      Keeper_runtime.reset_test_state base_dir;
       Unix.chdir cwd;
       cleanup_dir base_dir)
     (fun () ->
@@ -300,7 +303,9 @@ let test_snapshot_keeper_tool_audit_fallback () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
+    ~finally:(fun () ->
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
     (fun () ->
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
@@ -373,7 +378,9 @@ let test_keeper_msg_auto_team_session_bridge () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
+    ~finally:(fun () ->
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
     (fun () ->
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));


### PR DESCRIPTION
## Summary

- **근본 원인**: `Pulse.run`이 Perpetual lifecycle에도 `Eio.Fiber.fork` (non-daemon)를 사용하여 `Eio.Switch.run`이 fiber 완료를 무한 대기. operator control keeper 테스트에서 600초 CI 타임아웃 발생 (main 포함 전 브랜치 영향).
- `Pulse.run`: Perpetual → `fork_daemon`, Bounded → `fork` 분기
- `Keeper_runtime`: `stop_supervisor_sweep` + `reset_test_state` 추가
- operator keeper 테스트 4곳에 `~finally` cleanup 추가 (방어적 이중 안전)

## Verification

- operator control tests: 600s timeout → 7.6s 완료 (32 tests)
- pulse tests: 21 passed, 0 failed
- test 026 failure (`room_scope`)는 기존 이슈, 본 수정과 무관

## Test plan

- [ ] CI "Build and Test" green 확인
- [ ] 기존 5개 Draft PR rebase 후 CI 재실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)