### PR TITLE
Remove keeper legacy model surface

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -56,14 +56,13 @@ describe('sendKeeperMessageDetailed', () => {
   it('forces direct reply mode for raw keeper tool calls', async () => {
     callMcpTool.mockResolvedValueOnce(JSON.stringify({ reply: 'pong' }))
 
-    const reply = await sendKeeperMessageDetailed('sangsu', 'ping', ['llama:test'])
+    const reply = await sendKeeperMessageDetailed('sangsu', 'ping')
 
     expect(callMcpTool).toHaveBeenCalledWith('masc_keeper_msg', {
       name: 'sangsu',
       message: 'ping',
       direct_reply: true,
       timeout_sec: 120,
-      models: ['llama:test'],
     })
     expect(reply.text).toBe('pong')
   })
@@ -80,7 +79,7 @@ describe('streamKeeperMessage', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const events: string[] = []
-    await streamKeeperMessage('sangsu', 'ping', undefined, {
+    await streamKeeperMessage('sangsu', 'ping', {
       onEvent: event => {
         events.push(event.type)
       },

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1,18 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { runOperatorAction, currentDashboardActor, callMcpTool } = vi.hoisted(() => ({
+const { runOperatorAction, currentDashboardActor } = vi.hoisted(() => ({
   runOperatorAction: vi.fn(),
   currentDashboardActor: vi.fn(() => 'dashboard'),
-  callMcpTool: vi.fn(),
 }))
 
 vi.mock('./core', () => ({
   currentDashboardActor,
   runOperatorAction,
-}))
-
-vi.mock('./mcp', () => ({
-  callMcpTool,
 }))
 
 import { sendKeeperMessageDetailed, streamKeeperMessage } from './keeper'
@@ -49,20 +44,6 @@ describe('sendKeeperMessageDetailed', () => {
         direct_reply: true,
         timeout_sec: 120,
       },
-    })
-    expect(reply.text).toBe('pong')
-  })
-
-  it('forces direct reply mode for raw keeper tool calls', async () => {
-    callMcpTool.mockResolvedValueOnce(JSON.stringify({ reply: 'pong' }))
-
-    const reply = await sendKeeperMessageDetailed('sangsu', 'ping')
-
-    expect(callMcpTool).toHaveBeenCalledWith('masc_keeper_msg', {
-      name: 'sangsu',
-      message: 'ping',
-      direct_reply: true,
-      timeout_sec: 120,
     })
     expect(reply.text).toBe('pong')
   })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -36,7 +36,6 @@ export interface KeeperChatStreamEvent {
 async function callKeeperMessageRaw(
   name: string,
   message: string,
-  models?: string[],
 ): Promise<string> {
   const args: Record<string, unknown> = {
     name,
@@ -44,21 +43,18 @@ async function callKeeperMessageRaw(
     direct_reply: true,
     timeout_sec: KEEPER_DIRECT_REPLY_TIMEOUT_SEC,
   }
-  if (models && models.length > 0) args.models = models
   return callMcpTool('masc_keeper_msg', args)
 }
 
 async function callKeeperMessageViaOperator(
   name: string,
   message: string,
-  models?: string[],
 ): Promise<KeeperToolReply> {
   const payload: Record<string, unknown> = {
     message,
     direct_reply: true,
     timeout_sec: KEEPER_DIRECT_REPLY_TIMEOUT_SEC,
   }
-  if (models && models.length > 0) payload.models = models
   const response = await runOperatorAction({
     actor: currentDashboardActor(),
     action_type: 'keeper_message',
@@ -84,13 +80,9 @@ async function callKeeperMessageViaOperator(
 export async function sendKeeperMessageDetailed(
   name: string,
   message: string,
-  models?: string[],
 ): Promise<KeeperToolReply> {
-  if (models && models.length > 0) {
-    const raw = await callKeeperMessageRaw(name, message, models)
-    return normalizeKeeperToolResponse(raw)
-  }
-  return callKeeperMessageViaOperator(name, message)
+  const raw = await callKeeperMessageRaw(name, message)
+  return normalizeKeeperToolResponse(raw)
 }
 
 // --- SSE streaming ---
@@ -150,7 +142,6 @@ function isTerminalKeeperStreamEvent(event: KeeperChatStreamEvent): boolean {
 export async function streamKeeperMessage(
   name: string,
   message: string,
-  models: string[] | undefined,
   {
     signal,
     onEvent,
@@ -170,7 +161,6 @@ export async function streamKeeperMessage(
       message,
       direct_reply: true,
       timeout_sec: KEEPER_DIRECT_REPLY_TIMEOUT_SEC,
-      ...(models && models.length > 0 ? { models } : {}),
     }),
     signal,
   })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -4,11 +4,9 @@ import { isRecord } from '../components/common/normalize'
 import {
   formatKeeperVisibleReply,
   normalizeKeeperConversationDetails,
-  normalizeKeeperToolResponse,
 } from '../keeper-message'
 import type { KeeperConversationDetails } from '../types'
 import { currentDashboardActor, runOperatorAction } from './core'
-import { callMcpTool } from './mcp'
 
 // --- Types ---
 
@@ -32,19 +30,6 @@ export interface KeeperChatStreamEvent {
 }
 
 // --- Direct and operator-mediated messaging ---
-
-async function callKeeperMessageRaw(
-  name: string,
-  message: string,
-): Promise<string> {
-  const args: Record<string, unknown> = {
-    name,
-    message,
-    direct_reply: true,
-    timeout_sec: KEEPER_DIRECT_REPLY_TIMEOUT_SEC,
-  }
-  return callMcpTool('masc_keeper_msg', args)
-}
 
 async function callKeeperMessageViaOperator(
   name: string,
@@ -81,8 +66,7 @@ export async function sendKeeperMessageDetailed(
   name: string,
   message: string,
 ): Promise<KeeperToolReply> {
-  const raw = await callKeeperMessageRaw(name, message)
-  return normalizeKeeperToolResponse(raw)
+  return callKeeperMessageViaOperator(name, message)
 }
 
 // --- SSE streaming ---

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -88,7 +88,7 @@ async function sendChat(keeperName: string): Promise<void> {
   activeAbort = new AbortController()
 
   try {
-    await streamKeeperMessage(keeperName, text, undefined, {
+    await streamKeeperMessage(keeperName, text, {
       signal: activeAbort.signal,
       onEvent: (event: KeeperChatStreamEvent) => {
         if (isKeeperTextContentEvent(event) && event.delta) {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -381,15 +381,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
         <${ModelList} models=${c.execution.models} />
       </div>
-      ${'' /* Show allowed_models only when it differs from models */}
-      ${c.execution.allowed_models.length > 0
-        && JSON.stringify(c.execution.allowed_models.slice().sort()) !== JSON.stringify(c.execution.models.slice().sort())
-        ? html`
-        <div class="mt-1.5">
-          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">허용 모델</div>
-          <${ModelList} models=${c.execution.allowed_models} />
-        </div>
-      ` : null}
 
       ${'' /* --- Compaction (read-only) --- */}
       <${SectionHeader} title="컴팩션" />

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -158,7 +158,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
       }
     }, 5_000)
 
-    await streamKeeperMessage(keeperName, message, undefined, {
+    await streamKeeperMessage(keeperName, message, {
       signal: controller.signal,
       onEvent: event => {
         lastEventAt = Date.now()

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -451,7 +451,6 @@ export interface KeeperConfigPrompt {
 
 export interface KeeperConfigExecution {
   models: string[]
-  allowed_models: string[]
   active_model: string
   verify: boolean
 }

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -249,7 +249,7 @@ spawn 시 인자로 직접 설정하는 필드.
 | `last_heartbeat` | MASC | 마지막 heartbeat 타임스탬프 | keepalive 미실행 |
 | `trace_id` | MASC | `trace-{timestamp}-{random}` 형식 | (항상 존재) |
 | `agent_name` | MASC | `keeper-{name}-agent` 형식 | (항상 존재) |
-| `active_model` | Cascade | 현재 실행 모델 (아래 5장 참조) | models 미설정 |
+| `active_model` | Cascade | `last_model_used` 우선, 없으면 `cascade_name`의 첫 모델 fallback | 아직 실행 기록 없음 |
 | `total_cost_usd` | MASC | 누적 MODEL 호출 비용 | 아직 호출 없음 |
 | `compaction_count` | MASC | compaction 수행 횟수 | 아직 compaction 없음 |
 
@@ -259,8 +259,8 @@ spawn 시 인자로 직접 설정하는 필드.
 
 | 필드 | 결정 로직 | 코드 위치 |
 |------|----------|----------|
-| **Active Model** | (1) `active_model` 인자 → (2) `last_model_used` → (3) `allowed_models[0]` → (4) `models[0]` | `keeper_exec_status.ml:active_model_of_meta` |
-| **Next Model Hint** | `(allowed_models ++ models)`에서 중복 제거 후, active_model과 다른 첫 번째 모델. 없으면 현재 모델 반환 | `keeper_exec_status.ml:next_model_hint_of_meta` |
+| **Active Model** | `last_model_used` 우선, 없으면 `cascade_name`의 첫 모델 fallback | `keeper_exec_status.ml:active_model_of_meta` |
+| **Next Model Hint** | `config/cascade.json`에서 해석한 cascade 목록에서 현재 active_model과 다른 첫 모델. 없으면 현재 모델 또는 `None` | `keeper_exec_status.ml:next_model_hint_of_meta` |
 | **Skill (Primary/Secondary)** | 마지막 메트릭 항목의 `skill_primary`, `skill_secondary` 필드 | `keeper_status.ml:last_skill_route` |
 
 ---
@@ -288,9 +288,6 @@ spawn 시 인자로 직접 설정하는 필드.
     "needs": "(선택) 필요 — 무엇이 필요한가",
     "desires": "(선택) 욕구 — 무엇을 원하는가",
     "instructions": "(선택) 커스텀 시스템 프롬프트",
-    "models": ["(필수) provider:model_id", "..."],
-    "allowed_models": ["(선택) 허용 모델 목록"],
-    "active_model": "(선택) 초기 활성 모델",
     "soul_profile": "(선택) compaction 시 보존 우선순위 결정"
   }
 }
@@ -309,21 +306,18 @@ Soul Profile은 compaction 시 어떤 정보를 우선 보존할지 결정하는
 | `minimal` | 현재 목표, 가장 중요한 결정 1개, 최우선 차단 요소, 다음 행동만 보존 |
 | `balanced` (기본) | 안전/신뢰 → 목표 진행/결정 → 미해결 리스크 → 도구 결과 → 스타일 선호 순서 |
 
-### 4.3 Profile Defaults --- 모델 Cascade 입력
+### 4.3 Profile Defaults --- 모델 해석
 
-`profile.json`의 `keeper` 오브젝트에 설정된 `models`, `allowed_models`, `active_model`이 모델 cascade의 입력이 된다. spawn 시 인자가 없으면 매니페스트 값이 사용된다.
-
-모델 선택 우선순위: spawn 인자 > profile.json > fallback.
+Keeper 모델 선택은 profile.json 인자가 아니라 `cascade_name`으로 결정된다. 기본 keeper는 `keeper_unified` cascade를 사용하고, 실제 모델 목록은 `config/cascade.json`에서 해석된다.
 
 ### 4.4 작성 예시
 
-**최소 (name + model만)**:
+**최소**:
 ```json
 {
   "name": "helper",
   "keeper": {
-    "goal": "사용자 질문에 응답",
-    "models": ["glm:glm-4.7-flash"]
+    "goal": "사용자 질문에 응답"
   }
 }
 ```
@@ -337,8 +331,6 @@ Soul Profile은 compaction 시 어떤 정보를 우선 보존할지 결정하는
   "keeper": {
     "goal": "에이전트 커뮤니티의 건강한 소통을 촉진",
     "soul_profile": "relationship",
-    "models": ["glm:glm-4.7-flash"],
-    "allowed_models": ["glm:glm-4.7-flash"],
     "will": "공동체의 화합과 성장을 돕겠다",
     "needs": "구성원들의 신뢰와 참여",
     "desires": "모든 에이전트가 자기 역할에서 보람을 느끼는 환경"
@@ -359,9 +351,6 @@ Soul Profile은 compaction 시 어떤 정보를 우선 보존할지 결정하는
     "long_goal": "팀의 기술 의사결정에 근거 기반 인사이트 제공",
     "soul_profile": "research",
     "instructions": "arXiv, HuggingFace, 공식 블로그를 우선 참조하라. 검증 안 된 수치는 사용하지 마라.",
-    "models": ["glm:glm-4.7-flash"],
-    "allowed_models": ["glm:glm-4.7-flash", "claude:sonnet"],
-    "active_model": "glm:glm-4.7-flash",
     "will": "정확한 정보를 찾아 전달하겠다",
     "needs": "충분한 탐색 시간과 다양한 소스",
     "desires": "팀이 데이터 기반으로 판단하는 문화"
@@ -399,13 +388,10 @@ masc_keeper_create_from_persona(persona_name: "sangsu")
 
 ```mermaid
 flowchart TD
-    A[spawn 인자: active_model] -->|있으면| Z[Active Model 결정]
-    A -->|없으면| B[profile.json: keeper.active_model]
-    B -->|있으면| Z
-    B -->|없으면| C[last_model_used 확인]
-    C -->|비어있지 않으면| Z
-    C -->|비어있으면| D["allowed_models ++ models 첫 번째"]
-    D --> Z
+    A[last_model_used 확인] -->|있으면| Z[Active Model 결정]
+    A -->|없으면| B[cascade_name 해석]
+    B --> C[config/cascade.json 첫 모델]
+    C --> Z
 
     style Z fill:#e8f5e9
 ```
@@ -414,10 +400,10 @@ flowchart TD
 
 Next Model Hint는 handoff 시 successor에게 추천할 모델이다.
 
-1. `allowed_models`와 `models`를 결합하여 중복 제거 (순서 유지)
-2. 결합된 pool에서 현재 `active_model`과 다른 첫 번째 모델을 선택
-3. pool에 현재 모델만 있으면 그 모델을 반환
-4. pool이 비어있으면 `None`
+1. `config/cascade.json`에서 `cascade_name`의 모델 목록을 읽는다
+2. 현재 `active_model`과 다른 첫 번째 모델을 고른다
+3. 다른 모델이 없으면 현재 모델을 반환한다
+4. cascade가 비어 있으면 `None`
 
 코드 근거: `keeper_exec_status.ml:next_model_hint_of_meta`
 
@@ -435,9 +421,9 @@ Next Model Hint는 handoff 시 successor에게 추천할 모델이다.
 
 ### 5.4 모델 변경 시 주의사항
 
-- `active_model`은 반드시 `models` 또는 `allowed_models`에 포함되어야 한다 (유효성 검증에서 에러 발생)
+- keeper는 per-call `models` override나 persisted `active_model` pinning을 지원하지 않는다
 - handoff 시 cross-model 정규화가 자동 적용된다: Llama는 Tool 메시지 변환, Claude는 alternating 규칙 적용
-- cascade fallback은 `models` 리스트 순서대로 시도한다
+- cascade fallback은 `config/cascade.json`의 해당 cascade 순서대로 시도한다
 
 ---
 
@@ -591,7 +577,7 @@ flowchart TD
 |------|----------|
 | 의도한 모델이 사용 안 됨 | `active_model` vs `last_model_used` 비교 |
 | cascade가 fallback으로 넘어감 | MODEL provider 연결 상태 확인 (API key, 서버 상태 등) |
-| `active_model`이 빈 문자열 | `models` 리스트가 비어있지 않은지 확인 |
+| `active_model`이 빈 문자열 | `config/cascade.json`의 `keeper_unified` 설정 확인 |
 
 **Cascade 디버깅**:
 ```

--- a/docs/design/oas-masc-state-boundary.md
+++ b/docs/design/oas-masc-state-boundary.md
@@ -30,7 +30,7 @@ State that describes an agent's runtime, cognitive context, and operational life
 | Checkpoint | `checkpoint_id`, `generation`, `serialized` | **MASC** (`keeper_working_context`) | OAS `Checkpoint` |
 | Memory (5-tier) | `long_term`, `episodic`, `procedural`, `working`, `scratchpad` | **Bridge** (`memory_oas_bridge`) | OAS `Memory.t` (already the target) |
 | Context reduction | `PruneToolOutputs`, `MergeContiguous`, `DropLowImportance`, `SummarizeOld` | **MASC** (`context_compact_oas`) | OAS `Context_reducer` |
-| Model selection | `active_model`, `last_model_used`, `allowed_models` | **MASC** (`keeper_meta`) | OAS `Cascade_config` |
+| Model selection | `last_model_used`, derived `active_model`, `cascade_name` | **MASC** (`keeper_meta`) | OAS `Cascade_config` |
 | System prompt | `system_prompt`, `build_turn_prompt` | **MASC** (`keeper_prompt`, `keeper_agent_run`) | OAS `Agent.config` |
 | Collaboration phase | `phase`, `participants`, `artifacts`, `contributions` | **OAS** (`Collaboration.t`) | OAS (correct) |
 | Session lifecycle | `session_id`, `created_at`, `updated_at` | **OAS** (`Session.t`) | OAS (correct) |
@@ -61,7 +61,7 @@ State that describes the coordination domain — not how an agent thinks, but wh
 - `total_turns`, `total_input_tokens`, `total_output_tokens`, `total_tokens`, `total_cost_usd` — cumulative usage stats
 - `last_turn_ts`, `last_model_used`, `last_input_tokens`, `last_output_tokens`, `last_total_tokens`, `last_latency_ms` — per-turn metrics
 - `compaction_count`, `last_compaction_ts`, `last_compaction_before_tokens`, `last_compaction_after_tokens` — context management stats
-- `active_model`, `allowed_models`, `models` — model selection state
+- `last_model_used`, `cascade_name`, derived `active_model` — model selection state
 - `trace_id`, `trace_history` — session tracing
 - `generation` — checkpoint generation counter
 - `context_budget` — context window budget ratio

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -86,7 +86,7 @@ Keeper의 전체 상태를 담는 레코드. `lib/keeper/keeper_types.ml`에 정
 - **Identity**: `name`, `agent_name`, `trace_id`, `trace_history`
 - **Goal (3-horizon)**: `goal`, `short_goal`, `mid_goal`, `long_goal`
 - **Self-Model (BDI)**: `soul_profile`, `will`, `needs`, `desires`
-- **Model**: `models`, `allowed_models`, `active_model`
+- **Model**: `cascade_name`, `last_model_used`, derived `active_model`
 - **Capability**: `policy_voice_enabled`, `allowed_paths`
 - **Scope**: `scope_kind`, `room_scope`, `mention_targets`
 - **Proactive**: `proactive_enabled`, `proactive_idle_sec`, `proactive_cooldown_sec`

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -287,8 +287,6 @@ let permission_for_tool = function
   | "masc_persistent_agent_create_from_persona"
   | "masc_persistent_agent_up" | "masc_persistent_agent_down"
   | "masc_persistent_agent_msg"
-  | "masc_keeper_model_set"
-  | "masc_persistent_agent_model_set"
   | "masc_voice_speak" | "masc_voice_session_start"
   | "masc_voice_session_end" | "masc_voice_conference_start"
   | "masc_voice_conference_end"

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -103,13 +103,13 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           let trace_history_count = List.length m.trace_history in
           let active_model = Keeper_exec_status.active_model_of_meta m in
           let next_model_hint = Keeper_exec_status.next_model_hint_of_meta m in
+          let cascade_models =
+            Oas_model_resolve.models_of_cascade_name m.cascade_name
+          in
           let primary_model =
-            match m.models with
+            match cascade_models with
             | model :: _ -> model
-            | [] ->
-              (match Oas_model_resolve.models_of_cascade_name m.cascade_name with
-               | model :: _ -> model
-               | [] -> "")
+            | [] -> ""
           in
           let primary_model_norm = normalize_model_name primary_model in
           let last_compaction_saved_tokens =
@@ -188,9 +188,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                     ("max_context", `Int 0);
                   ])
               | _ -> None
-            ) (let ms = m.models in
-               if ms <> [] then ms
-               else Oas_model_resolve.models_of_cascade_name m.cascade_name))
+            ) cascade_models)
           in
 
           (* In compact mode (used by execution surface), skip heavy memory bank I/O.
@@ -283,9 +281,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 ]
             | None ->
                 (let effective_models =
-                   let ms = m.models in
-                   if ms <> [] then ms
-                   else Oas_model_resolve.models_of_cascade_name m.cascade_name
+                   Oas_model_resolve.models_of_cascade_name m.cascade_name
                  in
                  let cfgs = Llm_provider.Cascade_config.parse_model_strings effective_models in
                  match cfgs with
@@ -410,7 +406,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 ("needs", if String.trim m.needs = "" then `Null else `String m.needs);
                 ("desires", if String.trim m.desires = "" then `Null else `String m.desires);
               ]);
-              ("models", `List (List.map (fun s -> `String s) m.models));
+              ("models", `List (List.map (fun s -> `String s) cascade_models));
               ("models_resolved", models_resolved);
               ("primary_model", `String primary_model);
               ("active_model", `String active_model);
@@ -595,8 +591,10 @@ let keeper_config_json (config : Room.config) (name : string)
       in
       let execution =
         `Assoc [
-          ("models", `List (List.map (fun s -> `String s) m.models));
-          ("allowed_models", `List (List.map (fun s -> `String s) m.allowed_models));
+          ( "models",
+            `List
+              (List.map (fun s -> `String s)
+                 (Oas_model_resolve.models_of_cascade_name m.cascade_name)) );
           ("active_model", `String active_model);
           ("verify", `Bool false);
         ]

--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -20,18 +20,8 @@ let keeper_board_write_tool_names = Keeper_exec_context.keeper_board_write_tool_
 let keeper_write_done = Keeper_exec_context.keeper_write_done
 let keeper_action_kind_of_tool_names = Keeper_exec_context.keeper_action_kind_of_tool_names
 
-let effective_model_labels_for_turn
-    (m : keeper_meta)
-    ~(inline_models : string list) : string list =
-  if inline_models <> [] then
-    inline_models
-  else
-    match Keeper_exec_status.active_model_of_meta m with
-    | "" ->
-        let pool = dedupe_keep_order (m.allowed_models @ m.models) in
-        if pool = [] then Oas_model_resolve.models_of_cascade_name m.cascade_name
-        else pool
-    | model -> [ model ]
+let effective_model_labels_for_turn (m : keeper_meta) : string list =
+  Keeper_exec_context.effective_model_labels_for_turn m
 
 let room_cursor_for meta room_id =
   meta.last_seen_seq_by_room

--- a/lib/keeper/keeper_coordination.mli
+++ b/lib/keeper/keeper_coordination.mli
@@ -32,8 +32,7 @@ val keeper_write_done : string list -> bool
 
 val keeper_action_kind_of_tool_names : string list -> string
 
-val effective_model_labels_for_turn :
-  keeper_meta -> inline_models:string list -> string list
+val effective_model_labels_for_turn : keeper_meta -> string list
 
 val room_cursor_for : keeper_meta -> string -> int
 

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -83,8 +83,8 @@ let context_of_legacy_checkpoint
 
 let checkpoint_model_of_meta (meta : keeper_meta) =
   let candidates =
-    [ meta.usage.last_model_used; meta.active_model; meta.cascade_name ]
-    @ meta.models
+    meta.usage.last_model_used
+    :: Oas_model_resolve.models_of_cascade_name meta.cascade_name
   in
   List.find_opt (fun value -> String.trim value <> "") candidates
   |> Option.value ~default:"keeper_unified"
@@ -369,18 +369,12 @@ let keeper_action_kind_of_tool_names tool_names =
   else "none"
 
 
-let effective_model_labels_for_turn
-    (m : keeper_meta)
-    ~(inline_models : string list) : string list =
-  if inline_models <> [] then
-    inline_models
-  else
-    match active_model_of_meta m with
-    | "" ->
-        let pool = dedupe_keep_order (m.allowed_models @ m.models) in
-        if pool = [] then Oas_model_resolve.models_of_cascade_name m.cascade_name
-        else pool
-    | model -> [ model ]
+let effective_model_labels_for_turn (m : keeper_meta) : string list =
+  match active_model_of_meta m with
+  | "" -> Oas_model_resolve.models_of_cascade_name m.cascade_name
+  | model ->
+      dedupe_keep_order
+        (model :: Oas_model_resolve.models_of_cascade_name m.cascade_name)
 
 let room_cursor_for meta room_id =
   meta.last_seen_seq_by_room

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -107,7 +107,7 @@ val keeper_action_kind_of_tool_names : string list -> string
 (** {1 Model and Room Utilities} *)
 
 val effective_model_labels_for_turn :
-  keeper_meta -> inline_models:string list -> string list
+  keeper_meta -> string list
 
 val room_cursor_for : keeper_meta -> string -> int
 
@@ -165,11 +165,25 @@ type proactive_generation_result = {
 val proactive_retry_instruction : int -> reason:string -> string
 val proactive_temperature : cascade_name:string -> int -> float
 
-(** {1 Text Processing and Proactive Quality Checks}
+(** {1 Text Processing} *)
 
-    Re-exported from [Keeper_text_processing]. *)
+val strip_state_blocks_text : string -> string
+val trim_to_option : string -> string option
+val state_snapshot_reply_fallback : keeper_state_snapshot option -> string option
+val strip_internal_reply_markup : string -> string
+val user_visible_reply_text : ?fallback:string -> string -> string
+val normalize_proactive_text : string -> string
+val extract_checkin_text : string -> string option
 
-include module type of Keeper_text_processing
+(** {1 Proactive Quality Checks} *)
+
+val proactive_has_terminal_punct : string -> bool
+val proactive_has_terminal_korean_ending : string -> bool
+val proactive_has_terminal_ending : string -> bool
+val proactive_looks_fragmentary : string -> bool
+val proactive_fallback_reply : meta:keeper_meta -> idle_seconds:int -> string
+val proactive_quality_check : string -> (string, string) result
+val looks_fragmentary_history_text : string -> bool
 
 (** {1 Proactive Generation Entry Point} *)
 

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -35,8 +35,7 @@ let find_jsonl_row_by_action_id rows action_id =
 
 let resolved_keeper_args_to_json
     ~name ~persona_name ~persona_profile_path ~goal ~short_goal ~mid_goal ~long_goal
-    ~instructions ~soul_profile ~will ~needs ~desires ~models ~allowed_models
-    ~active_model ~policy_voice_enabled
+    ~instructions ~soul_profile ~will ~needs ~desires ~policy_voice_enabled
     ~room_scope ~scope_kind ~mention_targets
     ~presence_keepalive ~presence_keepalive_sec ~proactive_enabled
     ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec =
@@ -54,9 +53,6 @@ let resolved_keeper_args_to_json
       ("will", `String will);
       ("needs", `String needs);
       ("desires", `String desires);
-      ("models", string_list_to_json models);
-      ("allowed_models", string_list_to_json allowed_models);
-      ("active_model", `String active_model);
       ("policy_voice_enabled", `Bool policy_voice_enabled);
       ("room_scope", `String room_scope);
       ("scope_kind", `String scope_kind);
@@ -93,6 +89,9 @@ let resolved_keeper_args_from_persona args :
       if not (validate_name persona_name) then
         Error "persona_name is required"
       else
+        match reject_legacy_model_args ~tool_name:"masc_keeper_create_from_persona" args with
+        | Error err -> Error err
+        | Ok () ->
         match load_persona_summary persona_name with
         | None ->
             Error
@@ -153,13 +152,6 @@ let resolved_keeper_args_from_persona args :
               |> first_some defaults.desires
               |> Option.value ~default:default_keeper_desires
             in
-            (* Legacy model fields: cascade_name is the authority. *)
-            let _explicit_models = get_string_list args "models" in
-            let _explicit_allowed_models = get_string_list args "allowed_models" in
-            let _active_model_opt = get_string_opt args "active_model" in
-            let base_models = [] in
-            let allowed_models = [] in
-            let active_model = "" in
             let policy_voice_enabled =
               first_some
                 (get_bool_opt args "policy_voice_enabled")
@@ -221,7 +213,6 @@ let resolved_keeper_args_from_persona args :
                 ~persona_profile_path:persona.profile_path
                 ~goal ~short_goal ~mid_goal ~long_goal
                 ~instructions ~soul_profile ~will ~needs ~desires
-                ~models:base_models ~allowed_models ~active_model
                 ~policy_voice_enabled
                 ~room_scope ~scope_kind ~mention_targets
                 ~presence_keepalive ~presence_keepalive_sec ~proactive_enabled

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -5,23 +5,16 @@
 open Keeper_types
 
 let active_model_of_meta (m : keeper_meta) : string =
-  if String.trim m.active_model <> "" then m.active_model
-  else if m.usage.last_model_used <> "" then m.usage.last_model_used
+  if m.usage.last_model_used <> "" then m.usage.last_model_used
   else
-    let pool = m.allowed_models @ m.models in
-    match pool with
+    match Oas_model_resolve.models_of_cascade_name m.cascade_name with
     | model :: _ -> model
-    | [] ->
-      (match Oas_model_resolve.models_of_cascade_name m.cascade_name with
-       | model :: _ -> model
-       | [] -> "")
+    | [] -> ""
 
 let next_model_hint_of_meta (m : keeper_meta) : string option =
   let active = active_model_of_meta m in
-  let base_pool = m.allowed_models @ m.models in
-  let pool = dedupe_keep_order
-    (if base_pool = [] then Oas_model_resolve.models_of_cascade_name m.cascade_name
-     else base_pool)
+  let pool =
+    dedupe_keep_order (Oas_model_resolve.models_of_cascade_name m.cascade_name)
   in
   match List.filter (fun model -> model <> active) pool with
   | next_model :: _ -> Some next_model

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -59,8 +59,7 @@ val compact_if_needed :
 val generate_trace_id : unit -> string
 
 (** Resolve effective model labels for a turn. *)
-val effective_model_labels_for_turn :
-  keeper_meta -> inline_models:string list -> string list
+val effective_model_labels_for_turn : keeper_meta -> string list
 
 (** {1 Room Cursor} *)
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -116,6 +116,10 @@ let update_meta ~base_path name meta =
     | Some entry -> entry.meta <- meta
     | None -> ())
 
+let () =
+  register_runtime_meta_write_sync (fun config meta ->
+      update_meta ~base_path:config.base_path meta.name meta)
+
 let set_state ~base_path name state =
   with_lock_rw (fun () ->
     match Hashtbl.find_opt registry (registry_key ~base_path name) with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -227,8 +227,16 @@ let bootstrap_done_mu = Eio.Mutex.create ()
 
 let with_bootstrap_rw f = Eio_guard.with_mutex bootstrap_done_mu f
 
+let has_desired_resident_keepers config =
+  list_resident_keepers config
+  |> List.exists (fun (spec : resident_keeper_spec) -> spec.desired)
+
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
-  if stats.enabled then start_supervisor_sweep ctx
+  if stats.enabled
+     && (stats.started > 0
+         || Keeper_registry.count_running ~base_path:ctx.config.base_path () > 0
+         || has_desired_resident_keepers ctx.config)
+  then start_supervisor_sweep ctx
 
 let start_existing_keepalives ctx =
   let base_path = ctx.config.base_path in

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -44,15 +44,6 @@ let resident_schemas : tool_schema list = [
         ("will", `Assoc [("type", `String "string")]);
         ("needs", `Assoc [("type", `String "string")]);
         ("desires", `Assoc [("type", `String "string")]);
-        ("models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-        ]);
-        ("allowed_models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-        ]);
-        ("active_model", `Assoc [("type", `String "string")]);
         ("room_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "current"; `String "all"]);
@@ -121,20 +112,6 @@ let resident_schemas : tool_schema list = [
         ("desires", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: keeper's desire/drive statement (욕구).");
-        ]);
-        ("models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Model cascade. Accepts 'default' or 'default:<model>' as the primary public path, plus explicit 'provider:model' overrides when needed.");
-        ]);
-        ("allowed_models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Explicitly allowed persistent models for this keeper. Used by exact model switching and explicit-only runtimes.");
-        ]);
-        ("active_model", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Current persisted model label. Prefer 'default' for adapter-managed selection; explicit-only keepers may still pin a concrete provider:model label.");
         ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");
@@ -326,11 +303,6 @@ let resident_schemas : tool_schema list = [
           ("type", `String "string");
           ("description", `String "Optional: set keeper desires (욕구) when creating keeper inline");
         ]);
-        ("models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Optional: set models when creating keeper inline. If keeper already exists, this acts as a runtime-only cascade override for this message call.");
-        ]);
         ("timeout_sec", `Assoc [
           ("type", `String "number");
           ("description", `String "Optional: overall cascade timeout (sec) for this keeper message call");
@@ -385,30 +357,6 @@ let resident_schemas : tool_schema list = [
         ]);
       ]);
       ("required", `List [`String "name"; `String "message"]);
-    ];
-  };
-
-  {
-    name = "masc_keeper_model_set";
-    description = "Change a keeper's persisted active model explicitly. Restarts keepalive with the new exact model selection.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Keeper handle");
-        ]);
-        ("model", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Exact provider:model label to persist as the active model.");
-        ]);
-        ("allowed_models", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Optional persistent allowlist extension to store alongside the newly active model.");
-        ]);
-      ]);
-      ("required", `List [`String "name"; `String "model"]);
     ];
   };
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -9,7 +9,7 @@
     - Keeper_turn_up: start/reconfigure
     - Keeper_turn_session: team-session helpers
     - Keeper_turn_setup: ensure_keeper_exists, apply_settings_update
-    - Keeper_turn_lifecycle: model-set, shutdown *)
+    - Keeper_turn_lifecycle: shutdown *)
 
 open Tool_args
 open Keeper_types
@@ -23,7 +23,6 @@ open Keeper_turn_setup
 type tool_result = Keeper_types.tool_result
 
 let handle_keeper_up = Keeper_turn_up.handle_keeper_up
-let handle_keeper_model_set = Keeper_turn_lifecycle.handle_keeper_model_set
 let handle_keeper_down = Keeper_turn_lifecycle.handle_keeper_down
 
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
@@ -64,16 +63,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     let new_will = parse_self_model_opt args "new_will" in
     let new_needs = parse_self_model_opt args "new_needs" in
     let new_desires = parse_self_model_opt args "new_desires" in
-    let inline_models = get_string_list args "models" in
     let require_existing = get_bool args "require_existing" false in
     match inline_soul_profile_res, new_soul_profile_res with
     | Error e, _ | _, Error e -> (false, "❌ " ^ e)
     | Ok inline_soul_profile, Ok new_soul_profile ->
+    (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    | Error e -> (false, "❌ " ^ e)
+    | Ok () ->
     match ensure_keeper_exists
       ~ctx ~name ~require_existing ~profile_defaults
       ~inline_goal ~inline_short_goal ~inline_mid_goal ~inline_long_goal
       ~inline_instructions ~inline_will ~inline_needs ~inline_desires
-      ~inline_soul_profile ~inline_models
+      ~inline_soul_profile
     with
     | Error e -> (false, "❌ " ^ e)
     | Ok meta0 ->
@@ -96,9 +97,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~trace_id:meta.trace_id
           ~generation:meta.generation
       in
-      let effective_models =
-        effective_model_labels_for_turn meta ~inline_models
-      in
+      let effective_models = effective_model_labels_for_turn meta in
       (match ensure_api_keys_for_labels effective_models with
        | Error e -> (false, "❌ " ^ e)
        | Ok () ->
@@ -209,4 +208,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               ] in
               (true, Yojson.Safe.to_string reply_json)
 
-)
+))

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -1,7 +1,7 @@
 (** Keeper_turn — keeper lifecycle and message-turn handlers.
 
     Provides MCP tool handlers for keeper agent management:
-    start/stop, message dispatch, and model switching.
+    start/stop and message dispatch.
     Internal helpers (team session dispatch, planner/executor spawn,
     JSON serialization) are hidden.
 *)
@@ -23,9 +23,6 @@ val handle_keeper_up : _ Keeper_types.context -> Yojson.Safe.t -> tool_result
 val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result
-
-(** Set the active model for a keeper agent. *)
-val handle_keeper_model_set : _ Keeper_types.context -> Yojson.Safe.t -> tool_result
 
 (** Stop a running keeper agent. *)
 val handle_keeper_down : _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -1,7 +1,6 @@
-(** Keeper_turn_lifecycle -- keeper model-set and shutdown handlers.
+(** Keeper_turn_lifecycle -- keeper shutdown handlers.
 
-    Extracted from keeper_turn.ml.  Provides [handle_keeper_model_set] and
-    [handle_keeper_down]. *)
+    Extracted from keeper_turn.ml. Provides [handle_keeper_down]. *)
 
 open Tool_args
 open Keeper_types
@@ -9,35 +8,6 @@ open Keeper_keepalive
 open Keeper_turn_session
 
 type tool_result = Keeper_types.tool_result
-
-(* Legacy model-set handler.  cascade_name is the execution authority;
-   this tool now only touches updated_at and restarts keepalive. *)
-let handle_keeper_model_set ctx args : tool_result =
-  let name = get_string args "name" "" in
-  let _model = get_string args "model" "" |> String.trim in
-  let _allowed_models_arg = get_string_list args "allowed_models" in
-  if not (validate_name name) then
-    (false, "❌ invalid keeper name")
-  else
-    match read_meta ctx.config name with
-    | Error e -> (false, "❌ " ^ e)
-    | Ok None -> (false, Printf.sprintf "❌ keeper not found: %s" name)
-    | Ok (Some meta) ->
-        let updated = { meta with updated_at = now_iso () } in
-        (match write_meta ctx.config updated with
-         | Error e -> (false, "❌ " ^ e)
-         | Ok () ->
-             stop_keepalive updated.name;
-             start_keepalive ctx updated;
-             ( true,
-               Yojson.Safe.pretty_to_string
-                 (`Assoc
-                    [
-                      ("name", `String updated.name);
-                      ("cascade_name", `String updated.cascade_name);
-                      ("room_scope", `String updated.room_scope);
-                    ]) ))
-
 
 let handle_keeper_down ctx args : tool_result =
   let name = get_string args "name" "" in

--- a/lib/keeper/keeper_turn_session.ml
+++ b/lib/keeper/keeper_turn_session.ml
@@ -16,13 +16,9 @@ let write_meta_logged config (meta : keeper_meta) =
       Log.Keeper.error "write_meta failed: %s" msg
 
 let _keeper_team_session_model (meta : keeper_meta) =
-  let active_model = String.trim meta.active_model in
-  if active_model <> "" && not (String.equal active_model "default") then
-    active_model
-  else
-    match meta.models with
-    | model :: _ -> model
-    | [] ->
+  match String.trim meta.usage.last_model_used with
+  | value when value <> "" -> value
+  | _ ->
       (match Oas_model_resolve.models_of_cascade_name meta.cascade_name with
        | model :: _ -> model
        | [] -> "default")
@@ -183,10 +179,12 @@ let start_keeper_auto_team_session (ctx : _ context) (meta : keeper_meta)
         ("communication_mode", `String "hybrid");
         ("instruction_profile", `String "strict");
         ("alert_channel", `String "both");
-        ("model_cascade", `List (List.map (fun model -> `String model)
-           (let m = meta.models in
-            if m <> [] then m
-            else Oas_model_resolve.models_of_cascade_name meta.cascade_name)));
+        ( "model_cascade",
+          `List
+            (List.map (fun model -> `String model)
+               (Team_session_types.dedup_strings
+                  (_keeper_team_session_model meta
+                  :: Oas_model_resolve.models_of_cascade_name meta.cascade_name))) );
         ( "agents",
           `List
             (Team_session_types.dedup_strings

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -21,7 +21,6 @@ let ensure_keeper_exists
     ~inline_needs
     ~inline_desires
     ~inline_soul_profile
-    ~inline_models:_inline_models_ignored
   : (keeper_meta, string) result =
   match read_meta ctx.config name with
   | Error e -> Error e
@@ -37,8 +36,6 @@ let ensure_keeper_exists
           profile_defaults.goal |> Option.value ~default:""
           |> normalize_goal_horizon_text
     in
-    (* Legacy model resolution removed: cascade_name is the authority. *)
-    let inline_models = [] in
     if goal = "" then Error "keeper not found and goal not provided"
     else
     let now_ts = Time_compat.now () in
@@ -81,8 +78,6 @@ let ensure_keeper_exists
       Option.value ~default:(Option.value ~default:"" profile_defaults.instructions)
         inline_instructions
     in
-    let allowed_models = [] in
-    let active_model = "" in
     let policy_voice_enabled =
       profile_defaults.policy_voice_enabled
       |> Option.value ~default:false
@@ -120,9 +115,6 @@ let ensure_keeper_exists
       needs;
       desires;
       instructions;
-      models = inline_models;
-      allowed_models;
-      active_model;
       policy_voice_enabled;
       execution_scope = default_execution_scope;
       allowed_paths;

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -15,9 +15,6 @@ type parsed_args = {
   short_goal_opt : string option;
   mid_goal_opt : string option;
   long_goal_opt : string option;
-  models_in : string list;
-  allowed_models_in : string list;
-  active_model_opt : string option;
   policy_voice_enabled_opt : bool option;
   allowed_paths_opt : string list option;
   room_scope_opt : string option;
@@ -51,6 +48,9 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
   if not (validate_name name) then
     Error (false, "invalid keeper name (allowed: [A-Za-z0-9._-])")
   else
+    match reject_legacy_model_args ~tool_name:"masc_keeper_up" args with
+    | Error e -> Error (false, e)
+    | Ok () ->
     let soul_profile_opt_res = parse_soul_profile_opt args "soul_profile" in
     let compaction_profile_opt_res =
       parse_compaction_profile_opt args "compaction_profile"
@@ -62,9 +62,6 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
     let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
-    let models_in = get_string_list args "models" in
-    let allowed_models_in = get_string_list args "allowed_models" in
-    let active_model_opt = get_string_opt args "active_model" in
     let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
     let allowed_paths_opt =
       let raw = get_string_list args "allowed_paths" in
@@ -131,9 +128,6 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       short_goal_opt;
       mid_goal_opt;
       long_goal_opt;
-      models_in;
-      allowed_models_in;
-      active_model_opt;
       policy_voice_enabled_opt;
       allowed_paths_opt;
       room_scope_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -30,11 +30,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     |> Option.value ~default:(if room_scope = "all" then "global" else "local")
     |> canonical_scope_kind
   in
-  (* Legacy model fields: cascade_name is the authority.
-     These fields are kept empty; downstream reads cascade_name. *)
-  let requested_models = [] in
-  let allowed_models = [] in
-  let active_model = "" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
@@ -192,9 +187,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            needs;
            desires;
            instructions;
-           models = requested_models;
-           allowed_models;
-           active_model;
            policy_voice_enabled;
            execution_scope = default_execution_scope;
            allowed_paths;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -32,11 +32,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     Option.value ~default:long_goal_default p.long_goal_opt
     |> normalize_goal_horizon_text
   in
-  (* Legacy model fields: cascade_name is the authority.
-     Pass through empty defaults; downstream reads cascade_name. *)
-  let models = [] in
-  let allowed_models = [] in
-  let active_model = "" in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
@@ -119,9 +114,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
           (if String.trim old.instructions <> "" then old.instructions
            else Option.value ~default:"" p.profile_defaults.instructions)
         p.instructions_opt;
-    models;
-    allowed_models;
-    active_model;
     policy_voice_enabled;
     allowed_paths;
     scope_kind;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -60,9 +60,6 @@ type keeper_meta = {
   needs: string;
   desires: string;
   instructions: string;
-  models: string list;
-  allowed_models: string list;
-  active_model: string;
   policy_voice_enabled: bool;
   execution_scope: string;
   allowed_paths: string list;
@@ -114,6 +111,30 @@ type keeper_meta = {
 
 let now_iso () = Types.now_iso ()
 
+let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]
+
+let runtime_meta_write_sync_hook : (Room.config -> keeper_meta -> unit) ref =
+  ref (fun _ _ -> ())
+
+let register_runtime_meta_write_sync f =
+  runtime_meta_write_sync_hook := f
+
+let reject_legacy_model_args ~tool_name (args : Yojson.Safe.t) =
+  let present =
+    keeper_legacy_model_arg_names
+    |> List.filter (fun key ->
+           match Yojson.Safe.Util.member key args with
+           | `Null -> false
+           | _ -> true)
+  in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+      Error
+        (Printf.sprintf
+           "legacy keeper model args removed for %s: %s. Keepers now use cascade_name and last_model_used only."
+           tool_name (String.concat ", " fields))
+
 let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
   `Assoc
     [
@@ -132,9 +153,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("needs", `String m.needs);
       ("desires", `String m.desires);
       ("instructions", `String m.instructions);
-      ("models", `List (List.map (fun s -> `String s) m.models));
-      ("allowed_models", `List (List.map (fun s -> `String s) m.allowed_models));
-      ("active_model", `String m.active_model);
       ("policy_voice_enabled", `Bool m.policy_voice_enabled);
       ("execution_scope", `String m.execution_scope);
       ("allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths));
@@ -250,17 +268,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let cascade_name =
       Safe_ops.json_string ~default:"keeper_unified" "cascade_name" json
     in
-    let models_raw = Safe_ops.json_string_list "models" json in
-    let models =
-      if models_raw <> [] then models_raw
-      else Oas_model_resolve.models_of_cascade_name cascade_name
-    in
-    let allowed_models_raw = Safe_ops.json_string_list "allowed_models" json in
-    let allowed_models =
-      let base = if allowed_models_raw <> [] then allowed_models_raw else models in
-      dedupe_keep_order base
-    in
-    let active_model = Safe_ops.json_string ~default:"" "active_model" json in
     let policy_voice_enabled =
       Safe_ops.json_bool ~default:(default_voice_enabled_for name) "policy_voice_enabled" json
     in
@@ -455,9 +462,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           needs;
           desires;
           instructions;
-          models;
-          allowed_models;
-          active_model;
           policy_voice_enabled;
           execution_scope;
           allowed_paths;
@@ -738,18 +742,38 @@ let sync_registered_resident_keeper_from_meta config (meta : keeper_meta) :
   | Ok (Some _) -> register_resident_keeper_from_meta config meta
   | Error e -> Error e
 
+let fresher_meta config (meta : keeper_meta) : keeper_meta =
+  let path = keeper_meta_path config meta.name in
+  match Safe_ops.read_json_file_safe path with
+  | Ok json -> (
+      match meta_of_json json with
+      | Ok existing ->
+          let existing_ts =
+            Resilience.Time.parse_iso8601_opt existing.updated_at
+            |> Option.value ~default:0.0
+          in
+          let incoming_ts =
+            Resilience.Time.parse_iso8601_opt meta.updated_at
+            |> Option.value ~default:0.0
+          in
+          if existing_ts > incoming_ts then existing else meta
+      | Error _ -> meta)
+  | Error _ -> meta
+
 let write_meta config (m : keeper_meta) : (unit, string) result =
-  let path = keeper_meta_path config m.name in
-  let content = Yojson.Safe.pretty_to_string (meta_to_json m) in
+  let persisted = fresher_meta config m in
+  let path = keeper_meta_path config persisted.name in
+  let content = Yojson.Safe.pretty_to_string (meta_to_json persisted) in
   try
     Fs_compat.save_file path content;
-    (match sync_registered_resident_keeper_from_meta config m with
+    (!runtime_meta_write_sync_hook) config persisted;
+    (match sync_registered_resident_keeper_from_meta config persisted with
      | Ok () -> Ok ()
      | Error e ->
          Error
            (Printf.sprintf
               "meta written but resident sync failed for %s: %s"
-              m.name e))
+              persisted.name e))
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -141,14 +141,6 @@ let dedupe_keep_order items =
 
 let first_some = Dashboard_utils.first_some
 
-let resolve_allowed_models ~explicit_allowed_models ~seed_allowed_models ~models =
-  if explicit_allowed_models <> [] then
-    dedupe_keep_order explicit_allowed_models
-  else if seed_allowed_models <> [] then
-    dedupe_keep_order seed_allowed_models
-  else
-    dedupe_keep_order models
-
 let canonical_room_scope = function
   | "all" -> "all"
   | _ -> "current"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -196,9 +196,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int) : (keeper_meta, string) result =
   (* 1. Check API keys *)
-  let model_labels =
-    Keeper_coordination.effective_model_labels_for_turn meta ~inline_models:[]
-  in
+  let model_labels = Keeper_coordination.effective_model_labels_for_turn meta in
   match ensure_api_keys_for_labels model_labels with
   | Error e -> Error e
   | Ok () ->

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -443,16 +443,12 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | Some value -> Ok value
         | None -> Error "payload.message is required"
       in
-      let models =
+      let* () =
         match request.payload |> U.member "models" with
-        | `List items ->
-            items
-            |> List.filter_map (function
-                   | `String value ->
-                       let trimmed = String.trim value in
-                       if trimmed = "" then None else Some (`String trimmed)
-                   | _ -> None)
-        | _ -> []
+        | `Null -> Ok ()
+        | _ ->
+            Error
+              "legacy keeper model args removed for masc_keeper_msg: models. Keepers now use cascade_name and last_model_used only."
       in
       let direct_reply =
         match request.payload |> U.member "direct_reply" with
@@ -475,8 +471,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
            @
            match timeout_sec with
            | Some value -> [ ("timeout_sec", `Int value) ]
-           | None -> []
-          @ if models = [] then [] else [ ("models", `List models) ])
+           | None -> [])
       in
       let keeper_ctx : _ Tool_keeper.context =
         {

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -6,7 +6,6 @@ module Mcp_eio = Mcp_server_eio
 type keeper_chat_stream_request = {
   name : string;
   message : string;
-  models : string list;
   timeout_sec : int option;
 }
 
@@ -139,22 +138,10 @@ let parse_keeper_chat_stream_request body_str =
         json |> member "message" |> to_string_option |> Option.value ~default:""
         |> String.trim
       in
-      let models =
+      let legacy_models_present =
         match json |> member "models" with
-        | `Null -> Ok []
-        | `List items ->
-            let rec collect acc = function
-              | [] -> Ok (List.rev acc)
-              | `String model :: rest ->
-                  let trimmed = String.trim model in
-                  if trimmed = "" then
-                    Error "models must be an array of non-empty strings"
-                  else
-                    collect (trimmed :: acc) rest
-              | _ -> Error "models must be an array of non-empty strings"
-            in
-            collect [] items
-        | _ -> Error "models must be an array of strings"
+        | `Null -> false
+        | _ -> true
       in
       let timeout_sec =
         match json |> member "timeout_sec" with
@@ -169,10 +156,13 @@ let parse_keeper_chat_stream_request body_str =
         Error "name is required"
       else if message = "" then
         Error "message is required"
+      else if legacy_models_present then
+        Error
+          "legacy keeper model args removed for masc_keeper_msg: models. Keepers now use cascade_name and last_model_used only."
       else
-        match models, timeout_sec with
-        | Ok models, Ok timeout_sec -> Ok { name; message; models; timeout_sec }
-        | Error err, _ | _, Error err -> Error err
+        match timeout_sec with
+        | Ok timeout_sec -> Ok { name; message; timeout_sec }
+        | Error err -> Error err
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
 
@@ -446,15 +436,7 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               @
               (match payload.timeout_sec with
                | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
-               | None -> [])
-              @
-              (if payload.models = [] then []
-               else
-                  [ ("models",
-                    `List
-                      (List.map
-                         (fun model -> `String model)
-                         payload.models)) ]))
+               | None -> []))
           in
           let agent_name =
             match agent_from_request request with

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -352,28 +352,6 @@ let handle_resident_keeper_down ctx args : tool_result =
   invalidate_resident_keeper_list_cache ();
   Turn.handle_keeper_down ctx args
 
-let handle_resident_keeper_model_set ctx args : tool_result =
-  let name = get_string args "name" "" in
-  match read_resident_keeper ctx.config name with
-  | Error e -> (false, "❌ " ^ e)
-  | Ok None -> (false, Printf.sprintf "resident keeper not found: %s" name)
-  | Ok (Some _spec) ->
-      let ok, body = Turn.handle_keeper_model_set ctx args in
-      if not ok then (ok, body)
-      else begin
-        invalidate_resident_keeper_list_cache ();
-        (match read_meta ctx.config name with
-        | Ok (Some meta) -> ignore (register_resident_keeper_from_meta ctx.config meta)
-        | _ -> ());
-        let json =
-          try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
-        in
-        (true,
-         Yojson.Safe.pretty_to_string
-           (annotate_keeper_json ~runtime_class:"resident_keeper" ~desired:true
-              ~resident_registered:true json))
-      end
-
 let handle_resident_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
@@ -497,9 +475,6 @@ let handle_persistent_agent_msg ctx args : tool_result =
 let handle_persistent_agent_down ctx args : tool_result =
   Turn.handle_keeper_down ctx args
 
-let handle_persistent_agent_model_set ctx args : tool_result =
-  Turn.handle_keeper_model_set ctx args
-
 let handle_persistent_agent_create_from_persona ctx args : tool_result =
   Persona.handle_keeper_create_from_persona ctx args
 
@@ -543,18 +518,29 @@ let handle_keeper_remove_loop _ctx (args : Yojson.Safe.t) : tool_result =
   else
     (false, Printf.sprintf "Task '%s' not found" id)
 
+let should_bootstrap_existing_keepalives name args =
+  match name with
+  | "masc_keeper_msg" | "masc_persistent_agent_msg" ->
+      String.trim (get_string args "message" "") <> ""
+  | _ -> false
+
+let maybe_bootstrap_existing_keepalives ctx ~name ~args =
+  if should_bootstrap_existing_keepalives name args then
+    (try start_existing_keepalives ctx
+     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+       Log.Keeper.error "start_existing_keepalives failed: %s"
+         (Printexc.to_string exn))
+
 let dispatch ctx ~name ~args : tool_result option =
-  (* Resident keepers are bootstrapped lazily on tool use as a fallback.
+  (* Resident keepers are bootstrapped lazily on keeper messages as a fallback.
      Server startup also calls bootstrap_existing_keepers for always-on presence. *)
-  (try start_existing_keepalives ctx with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Keeper.error "start_existing_keepalives failed: %s" (Printexc.to_string exn));
+  maybe_bootstrap_existing_keepalives ctx ~name ~args;
   match name with
   | "masc_persona_list" -> Some (Persona.handle_persona_list ctx args)
   | "masc_keeper_create_from_persona" -> Some (handle_resident_keeper_create_from_persona ctx args)
   | "masc_keeper_up" -> Some (handle_resident_keeper_up ctx args)
   | "masc_keeper_status" -> Some (handle_resident_keeper_status ctx args)
   | "masc_keeper_msg" -> Some (handle_resident_keeper_msg ctx args)
-  | "masc_keeper_model_set" -> Some (handle_resident_keeper_model_set ctx args)
   | "masc_keeper_down" -> Some (handle_resident_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_resident_keeper_list ctx args)
   | "masc_keeper_trajectory" -> Some (Status.handle_keeper_trajectory ctx args)
@@ -564,7 +550,6 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_persistent_agent_up" -> Some (handle_persistent_agent_up ctx args)
   | "masc_persistent_agent_status" -> Some (handle_persistent_agent_status ctx args)
   | "masc_persistent_agent_msg" -> Some (handle_persistent_agent_msg ctx args)
-  | "masc_persistent_agent_model_set" -> Some (handle_persistent_agent_model_set ctx args)
   | "masc_persistent_agent_down" -> Some (handle_persistent_agent_down ctx args)
   | "masc_persistent_agent_list" -> Some (handle_persistent_agent_list ctx args)
   | "masc_persistent_agent_trajectory" -> Some (Status.handle_keeper_trajectory ctx args)
@@ -582,8 +567,7 @@ let dispatch ctx ~name ~args : tool_result option =
     Returns None for all other tool names.
     Called from server_routes_http_keeper_stream. *)
 let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
-  (try start_existing_keepalives ctx with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Keeper.error "start_existing_keepalives failed: %s" (Printexc.to_string exn));
+  maybe_bootstrap_existing_keepalives ctx ~name ~args;
   match name with
   | "masc_keeper_msg" ->
       Some (handle_resident_keeper_msg_stream ~on_text_delta ctx args)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -332,7 +332,6 @@ let keeper_policy_row ctx ~runtime_class (meta : Keeper_types.keeper_meta) =
        ("status", `String status);
        ("action_budget", `String "conversation");
        ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
-       ("allowed_models", `List (List.map (fun model -> `String model) meta.allowed_models));
        ("updated_at", `String meta.updated_at);
      ]
     @ policy_json)

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -498,6 +498,39 @@ let test_dashboard_mission_http_default_bootstraps_first_success () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      let config = Room_utils.default_config dir in
+      let session_id = "ts-mission-http-default-001" in
+      seed_room config session_id;
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_mission_http_json
+            ~state
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/mission")
+        in
+        let open Yojson.Safe.Util in
+        check string "default mission cache becomes fresh" "fresh"
+          (json |> member "projection_diagnostics" |> member "cache_state"
+          |> to_string);
+        check bool "default mission records first success" true
+          (json |> member "projection_diagnostics" |> member "last_success_at"
+           <> `Null);
+        check bool "default mission leaves initializing placeholder" true
+          (json |> member "summary" |> member "room_health" |> to_string
+           <> "initializing");
+        check bool "default mission includes session briefs" true
+          (json |> member "session_briefs" |> to_list
+         |> List.exists (fun row -> row |> member "session_id" |> to_string = session_id));
+      ))
+
+let test_dashboard_mission_keeper_tool_audit_fallback () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
       let session_id = "ts-mission-http-default-001" in
       Eio_main.run @@ fun env ->
       Eio_guard.enable ();
@@ -635,6 +668,8 @@ let () =
             test_dashboard_mission_http_full_contract;
           Alcotest.test_case "http mission default bootstraps first success"
             `Quick test_dashboard_mission_http_default_bootstraps_first_success;
+          Alcotest.test_case "keeper tool audit fallback" `Quick
+            test_dashboard_mission_keeper_tool_audit_fallback;
           Alcotest.test_case "http mission cache stays room-scoped" `Quick
             test_dashboard_mission_http_cache_isolation;
           Alcotest.test_case "keeper brief prefers heartbeat task" `Quick

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -259,7 +259,6 @@ let test_keeper_meta_deliberation_fields_roundtrip () =
         ("name", `String "test-keeper");
         ("trace_id", `String "trace-1");
         ("goal", `String "test deliberation");
-        ("models", `List [ `String "custom:test-model" ]);
         (* legacy keys — should be ignored by meta_of_json *)
         ("deliberation_count", `Int 5);
         ("deliberation_cost_total_usd", `Float 0.03);
@@ -280,7 +279,6 @@ let test_keeper_meta_deliberation_fields_default () =
         ("name", `String "test-keeper-2");
         ("trace_id", `String "trace-2");
         ("goal", `String "test defaults");
-        ("models", `List [ `String "custom:test-model" ]);
       ]
   in
   match Keeper_types.meta_of_json json with
@@ -773,7 +771,7 @@ let test_prompt_always_includes_multi_step () =
 
 let test_initiative_enabled_default_true () =
   (* When JSON has initiative_enabled = true, roundtrip preserves it *)
-  let json_str = {|{"name":"test","initiative_enabled":true,"trace_id":"t1","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json_str = {|{"name":"test","initiative_enabled":true,"trace_id":"t1","goal":"g","cascade_name":"local","presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
   match Keeper_types.meta_of_json json with
   | Ok m -> check bool "initiative_enabled default" true m.initiative_enabled
@@ -781,7 +779,7 @@ let test_initiative_enabled_default_true () =
 
 let test_initiative_enabled_roundtrip_false () =
   (* When JSON has initiative_enabled = false, roundtrip preserves it *)
-  let json_str = {|{"name":"test","initiative_enabled":false,"trace_id":"t2","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json_str = {|{"name":"test","initiative_enabled":false,"trace_id":"t2","goal":"g","cascade_name":"local","presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
   match Keeper_types.meta_of_json json with
   | Ok m ->
@@ -808,7 +806,7 @@ let test_initiative_idle_sec_overrides_idle_gate () =
       (List.exists (fun t -> t = D.IdleTimeout) triggers)
 
 let test_initiative_cooldown_sec_roundtrip () =
-  let json_str = {|{"name":"test","initiative_enabled":true,"initiative_idle_sec":120,"initiative_cooldown_sec":30,"trace_id":"t4","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json_str = {|{"name":"test","initiative_enabled":true,"initiative_idle_sec":120,"initiative_cooldown_sec":30,"trace_id":"t4","goal":"g","cascade_name":"local","presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
   match Keeper_types.meta_of_json json with
   | Ok m ->
@@ -825,7 +823,7 @@ let test_initiative_cooldown_sec_roundtrip () =
 
 let test_initiative_enabled_missing_defaults_true () =
   (* When JSON omits initiative_enabled, defaults to true (backward compat) *)
-  let json_str = {|{"name":"test","trace_id":"t3","goal":"g","cascade_name":"local","models":["m"],"presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
+  let json_str = {|{"name":"test","trace_id":"t3","goal":"g","cascade_name":"local","presence_keepalive":true,"presence_keepalive_sec":30,"proactive_enabled":true,"proactive_idle_sec":300,"proactive_cooldown_sec":60}|} in
   let json = Yojson.Safe.from_string json_str in
   match Keeper_types.meta_of_json json with
   | Ok m -> check bool "missing initiative_enabled defaults to true" true m.initiative_enabled

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -14,8 +14,6 @@ let keeper_meta ~name ~mention_targets =
         ("name", `String name);
         ("trace_id", `String "trace-1");
         ("goal", `String "keep continuity");
-        ("models", `List [ `String "custom:test-model" ]);
-        ("active_model", `String "custom:test-model");
         ("mention_targets", `List (List.map (fun target -> `String target) mention_targets));
       ]
   in

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -11,7 +11,6 @@ let make_meta name =
     ("agent_name", `String ("agent-" ^ name));
     ("trace_id", `String ("trace-test-" ^ name));
     ("goal", `String "test goal");
-    ("models", `List [ `String "custom:test" ]);
   ] in
   match Keeper_types.meta_of_json json with
   | Ok meta -> meta

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -170,9 +170,6 @@ will = "detect issues"
 needs = "log access"
 desires = "low false positives"
 instructions = "You are a log analyzer."
-models = ["llama:qwen3.5-35b-a3b-ud-q4-xl"]
-allowed_models = ["llama:qwen3.5-35b-a3b-ud-q4-xl", "llama:qwen3.5-35b-a3b-ud-q8-xl"]
-active_model = "llama:qwen3.5-35b-a3b-ud-q4-xl"
 room_scope = "all"
 scope_kind = "global"
 mention_targets = ["sherlock", "log-analyzer"]
@@ -225,7 +222,6 @@ let test_load_from_file () =
 [keeper]
 name = "test-keeper"
 goal = "testing file load"
-models = ["llama:test-model"]
 soul_profile = "balanced"
 |} in
   let oc = open_out tmp in
@@ -245,7 +241,6 @@ let test_load_name_from_filename () =
   let content = {|
 [keeper]
 goal = "analyze stuff"
-models = ["llama:test"]
 |} in
   let oc = open_out path in
   output_string oc content;
@@ -297,12 +292,10 @@ let test_discover_with_files () =
   write_file "alpha.toml" {|
 [keeper]
 goal = "alpha goal"
-models = ["llama:alpha"]
 |};
   write_file "beta.toml" {|
 [keeper]
 goal = "beta goal"
-models = ["llama:beta"]
 |};
   write_file "not-toml.json" {|{"ignored": true}|};
   let result = KTP.discover_keepers_toml tmp_dir in
@@ -333,7 +326,6 @@ let test_discover_skips_bad_files () =
   write_file "good.toml" {|
 [keeper]
 goal = "works"
-models = ["llama:test"]
 |};
   write_file "bad.toml" "[broken";
   let result = KTP.discover_keepers_toml tmp_dir in

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -91,6 +91,10 @@ let () =
             Test_operator_control_keeper.test_snapshot_keeper_tool_audit_fallback;
           Alcotest.test_case "keeper msg auto team session bridge" `Quick
             Test_operator_control_keeper.test_keeper_msg_auto_team_session_bridge;
+          Alcotest.test_case "operator keeper_message rejects legacy models"
+            `Quick
+            Test_operator_control_keeper
+            .test_operator_keeper_message_rejects_legacy_model_args;
           Alcotest.test_case "expired confirmation rejected" `Quick
             Test_operator_control_swarm.test_confirm_rejects_expired_token;
           Alcotest.test_case "swarm run continue removed from operator actions" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -113,7 +113,6 @@ let test_keeper_status_exposes_summary_and_recoverable () =
               [
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
-                ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
                 ("presence_keepalive", `Bool false);
                 ("proactive_enabled", `Bool false);
               ])
@@ -183,7 +182,6 @@ let test_keeper_config_exposes_live_runtime_and_sources () =
         {|
 [keeper]
 goal = "Defaults goal"
-models = ["llama:qwen3.5-35b-a3b-ud-q8-xl"]
 room_scope = "all"
 proactive_enabled = true
 |};
@@ -331,7 +329,6 @@ let test_snapshot_keeper_tool_audit_fallback () =
               [
                 ("name", `String keeper_name);
                 ("goal", `String "Expose dashboard fallback keeper audit");
-                ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
                 ("presence_keepalive", `Bool false);
                 ("proactive_enabled", `Bool false);
               ])
@@ -411,7 +408,6 @@ let test_keeper_msg_auto_team_session_bridge () =
               [
                 ("name", `String keeper_name);
                 ("goal", `String "Start projected team sessions from explicit keeper messages");
-                ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
                 ("presence_keepalive", `Bool false);
                 ("proactive_enabled", `Bool false);
               ])
@@ -578,3 +574,35 @@ let test_keeper_msg_auto_team_session_bridge () =
           meta_after_down.last_team_session_started_at;
         Alcotest.(check int) "start count retained on down" 1
           meta_after_down.team_session_start_count_total)
+
+let test_operator_keeper_message_rejects_legacy_model_args () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let ctx = operator_ctx env sw config "operator" in
+      match
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "operator");
+              ("action_type", `String "keeper_message");
+              ("target_type", `String "keeper");
+              ("target_id", `String "sangsu");
+              ( "payload",
+                `Assoc
+                  [
+                    ("message", `String "ping");
+                    ("models", `List [ `String "llama:test-model" ]);
+                  ] );
+            ])
+      with
+      | Ok _ -> Alcotest.fail "keeper_message should reject legacy models payload"
+      | Error err ->
+          Alcotest.(check bool) "legacy model error surfaced" true
+            (contains_substring err "legacy keeper model args removed"))

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -185,54 +185,76 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "provenance" "fallback" resolved.provenance;
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
-(* Model-set now returns cascade_name instead of active_model/allowed_models.
-   cascade_name is the authority for model resolution. *)
-let test_keeper_model_set_persists_active_model () =
-  let _provider_model = "custom:test-model@http://127.0.0.1:9999" in
+let test_keeper_model_set_removed () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
-      rm_rf base_dir)
+    ~finally:(fun () -> rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
-      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
         { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
-      let dispatch name args =
-        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
-        | Some result -> result
-        | None -> fail ("missing dispatch for " ^ name)
-      in
-      let ok, _ =
-        dispatch "masc_keeper_up"
-          (`Assoc
-            [
-              ("name", `String "sangsu");
-              ("goal", `String "Maintain Sangsu persona");
-              ("room_scope", `String "all");
-              ("trigger_mode", `String "explicit_only");
-              ("mention_targets", `List [ `String "sangsu" ]);
-              ("presence_keepalive", `Bool false);
-              ("proactive_enabled", `Bool false);
-            ])
-      in
-      check bool "keeper up ok" true ok;
-      let ok, body =
-        dispatch "masc_keeper_model_set"
+      match
+        Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_model_set"
+          ~args:
           (`Assoc
             [
               ("name", `String "sangsu");
               ("model", `String "any-model");
             ])
+      with
+      | None -> ()
+      | Some _ -> fail "masc_keeper_model_set should be removed")
+
+let test_keeper_up_rejects_legacy_model_args () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
-      check bool "model set ok" true ok;
-      let json = Yojson.Safe.from_string body in
-      check string "cascade_name present" "keeper_unified"
-        Yojson.Safe.Util.(json |> member "cascade_name" |> to_string))
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_up keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("goal", `String "Maintain Sangsu persona");
+              ("models", `List [ `String "llama:test-model" ]);
+            ])
+      in
+      check bool "keeper up rejects legacy model args" false ok;
+      check bool "legacy model error surfaced" true
+        (contains_substring body "legacy keeper model args removed"))
+
+let test_keeper_msg_rejects_legacy_model_args () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      let keeper_ctx : _ Masc_mcp.Keeper_types.context =
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+      in
+      let ok, body =
+        Masc_mcp.Keeper_turn.handle_keeper_msg keeper_ctx
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("message", `String "ping");
+              ("models", `List [ `String "llama:test-model" ]);
+            ])
+      in
+      check bool "keeper msg rejects legacy model args" false ok;
+      check bool "legacy model error surfaced" true
+        (contains_substring body "legacy keeper model args removed"))
 
 (* write_persona_profile removed: persona concept deleted, see CLAUDE.md *)
 
@@ -641,7 +663,6 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -654,7 +675,6 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
             [
               ("name", `String "persistent-demo");
               ("goal", `String "Stay on demand");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -710,7 +730,6 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -722,7 +741,6 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
             [
               ("name", `String "persistent-demo");
               ("goal", `String "Stay on demand");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -792,7 +810,6 @@ let test_resident_list_items_expose_runtime_config_summary () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "custom:test-model" ]);
               ("room_scope", `String "all");
               ("scope_kind", `String "global");
               ("presence_keepalive", `Bool true);
@@ -859,7 +876,6 @@ let test_keepalive_gap_reports_not_running_instead_of_disabled () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool true);
               ("proactive_enabled", `Bool true);
             ])
@@ -926,7 +942,6 @@ let test_resident_keeper_msg_bootstraps_then_requires_message () =
             [
               ("name", `String "bootstrap-demo");
               ("goal", `String "Bootstrap resident keeper");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -962,7 +977,6 @@ let test_persistent_agent_msg_rejects_missing_message () =
             [
               ("name", `String "persistent-demo");
               ("goal", `String "Stay on demand");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -1005,7 +1019,6 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -1017,7 +1030,6 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
             [
               ("name", `String "persistent-demo");
               ("goal", `String "Stay on demand");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -1051,19 +1063,18 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
       in
       check bool "resident eval ok" true ok;
       check bool "eval body non-empty" true (String.length eval_body > 0);
-      let ok, model_set_body =
-        dispatch "masc_persistent_agent_model_set"
-          (`Assoc
-            [
-              ("name", `String "persistent-demo");
-              ("model", `String "custom:alt-model");
-            ])
-      in
-      check bool "persistent model set ok" true ok;
-      let model_set_json = parse_json_exn model_set_body in
-      (* model_set now returns cascade_name instead of active_model *)
-      check string "persistent cascade_name" "keeper_unified"
-        Yojson.Safe.Util.(model_set_json |> member "cascade_name" |> to_string);
+      (match
+         Masc_mcp.Tool_keeper.dispatch keeper_ctx
+           ~name:"masc_persistent_agent_model_set"
+           ~args:
+             (`Assoc
+               [
+                 ("name", `String "persistent-demo");
+                 ("model", `String "custom:alt-model");
+               ])
+       with
+      | None -> ()
+      | Some _ -> fail "masc_persistent_agent_model_set should be removed");
       let ok, persistent_status_body =
         dispatch "masc_persistent_agent_status"
           (`Assoc
@@ -1115,7 +1126,6 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
             [
               ("name", `String "detail-demo");
               ("goal", `String "Inspect detailed status");
-              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -1218,7 +1228,6 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Maintain Sangsu persona");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -1272,7 +1281,6 @@ let test_keeper_up_update_preserves_proactive_when_omitted () =
           [
             ("name", `String "buddy");
             ("goal", `String "Stay focused");
-            ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
             ("presence_keepalive", `Bool false);
             ("proactive_enabled", `Bool true);
           ]
@@ -1352,7 +1360,6 @@ let test_write_meta_syncs_registered_resident_seed () =
             [
               ("name", `String "buddy");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool true);
             ])
@@ -1390,6 +1397,13 @@ let test_write_meta_syncs_registered_resident_seed () =
         Yojson.Safe.Util.(resident_json |> member "voice_agent_id" |> to_string);
       check string "persona_name in resident spec" "buddy"
         Yojson.Safe.Util.(resident_json |> member "persona_name" |> to_string);
+      (match Masc_mcp.Keeper_registry.get ~base_path:config.base_path "buddy" with
+       | Some entry ->
+           check bool "registry meta syncs proactive" false
+             entry.Masc_mcp.Keeper_registry.meta.proactive.enabled;
+           check bool "registry meta syncs voice enabled" false
+             entry.Masc_mcp.Keeper_registry.meta.voice_enabled
+       | None -> ());
       check bool "seed_meta absent in thin format" true
         (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null))
 
@@ -1417,7 +1431,6 @@ let test_keeper_up_persists_allowed_paths_to_status_policy () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
               ("allowed_paths", `List (List.map (fun path -> `String path) allowed_paths));
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
@@ -1553,7 +1566,6 @@ let test_resident_bootstrap_marks_stale_explicit_keeper () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
               ("presence_keepalive", `Bool true);
               ("proactive_enabled", `Bool false);
             ])
@@ -1628,7 +1640,6 @@ let test_resident_supervisor_recovers_missing_desired_keeper () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
               ("presence_keepalive", `Bool true);
               ("proactive_enabled", `Bool false);
             ])
@@ -1680,8 +1691,12 @@ let () =
            test_resolved_keeper_skill_route_marks_agent_judgment;
          test_case "resolved skill route falls back when parse missing" `Quick
            test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing;
-         test_case "keeper model set persists active model" `Quick
-           test_keeper_model_set_persists_active_model;
+         test_case "keeper model set removed" `Quick
+           test_keeper_model_set_removed;
+         test_case "keeper up rejects legacy model args" `Quick
+           test_keeper_up_rejects_legacy_model_args;
+         test_case "keeper msg rejects legacy model args" `Quick
+           test_keeper_msg_rejects_legacy_model_args;
          test_case "resident and persistent lists split" `Quick
            test_resident_keeper_and_persistent_agent_lists_split;
          test_case "resident and persistent detailed lists annotate runtime class" `Quick

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -408,7 +408,6 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
           [
             ("name", `String "admin-keeper");
             ("goal", `String "Admin tool policy test");
-            ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
             ("presence_keepalive", `Bool false);
             ("proactive_enabled", `Bool false);
           ])

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -675,6 +675,12 @@ let test_masc_keeper_up_schema () =
       | Some props ->
           Alcotest.(check bool) "has scope_kind" true
             (List.mem_assoc "scope_kind" props);
+          Alcotest.(check bool) "omits models" false
+            (List.mem_assoc "models" props);
+          Alcotest.(check bool) "omits allowed_models" false
+            (List.mem_assoc "allowed_models" props);
+          Alcotest.(check bool) "omits active_model" false
+            (List.mem_assoc "active_model" props);
           Alcotest.(check bool) "has presence_keepalive" true
             (List.mem_assoc "presence_keepalive" props)
       | None -> Alcotest.fail "masc_keeper_up missing properties"


### PR DESCRIPTION
## Summary
- remove keeper legacy model-set tools and legacy model input fields from keeper create/update/message surfaces
- make keeper model selection cascade-only via `cascade_name` plus `usage.last_model_used`
- align dashboard, operator, HTTP stream, docs, and tests with the new keeper SSOT

## What Changed
- removed public keeper model mutation tools from dispatch/auth/schema
- reject legacy `models`, `allowed_models`, and persisted/input `active_model` on remaining keeper tool surfaces
- removed per-call `models` override from dashboard chat, operator `keeper_message`, and HTTP keeper stream
- kept `active_model` only as a derived read-model/status field
- fixed live-meta/runtime races so stale keepalive writes do not overwrite fresher keeper config state
- narrowed lazy bootstrap so invalid `*_msg` requests do not start resident supervisor/keepalive side effects

## Validation
- `dune build --root /tmp/masc-mcp-keeper-verify-clean test/test_tool_keeper.exe test/test_operator_control.exe test/test_dashboard_execution.exe test/test_tools_coverage.exe test/test_tool_misc_coverage.exe test/test_keeper_memory.exe test/test_keeper_registry.exe test/test_keeper_deliberation.exe`
- `./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 8,9,10,11,12,13,14,15,16,28 -e --color=never`
- `./_build/default/test/test_operator_control.exe test operator 26,29 -e --color=never`
- `./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`
- `./_build/default/test/test_keeper_memory.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_deliberation.exe`

## Notes
- This is an intentional breaking change for keeper legacy model payloads.
- `npx tsc --noEmit --pretty` was not run because this worktree does not have `node_modules` installed.
