### PR TITLE
fix: stabilize team session backend state

### DIFF
--- a/lib/command_plane/cp_lifecycle_search.ml
+++ b/lib/command_plane/cp_lifecycle_search.ml
@@ -8,7 +8,7 @@ let unit_guard_json config unit_id =
   | Some unit ->
       let live_count =
         unit.roster
-        |> List.filter (fun name -> List.mem name (live_agent_names agents))
+        |> List.filter (roster_name_is_live (live_agent_names agents))
         |> List.length
       in
       let active_count =
@@ -779,4 +779,3 @@ let operation_search_json config units operations (operation : operation_record)
              ] )
         :: fields )
   | other -> other
-

--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -149,6 +149,29 @@ let _make_section_cache () =
     last_state = None;
   }
 
+let snapshot_state_of_sections ~config ~agents ~managed_units ~units ~source
+    ~sessions ~intents ~operations ~detachments ~decisions =
+  let live_agents = live_agent_names agents in
+  let status_map = agent_status_map agents in
+  let child_map = children_map units in
+  let unit_lookup = unit_map units in
+  {
+    config;
+    agents;
+    managed_units;
+    units;
+    source;
+    sessions;
+    intents;
+    operations;
+    detachments;
+    decisions;
+    live_agents;
+    status_map;
+    child_map;
+    unit_lookup;
+  }
+
 let build_snapshot_state ?sessions config =
   let sc = match !_section_cache with
     | Some cache -> cache
@@ -165,98 +188,86 @@ let build_snapshot_state ?sessions config =
       let operations = all_operations ~sessions:provided_sessions config units in
       let detachments = all_detachments ~sessions:provided_sessions config units operations in
       let decisions = all_policy_decisions config in
-      let live_agents = live_agent_names agents in
-      let status_map = agent_status_map agents in
-      let child_map = children_map units in
-      let unit_lookup = unit_map units in
-      {
-        config; agents; managed_units; units; source;
-        sessions = provided_sessions; intents; operations;
-        detachments; decisions; live_agents; status_map;
-        child_map; unit_lookup;
-      }
+      snapshot_state_of_sections ~config ~agents ~managed_units ~units ~source
+        ~sessions:provided_sessions ~intents ~operations ~detachments ~decisions
   | None ->
-  (* Per-section mtime check: only re-read sections whose files changed. *)
-  let units_mt = _file_mtime (units_path config) in
-  let agents_dir =
-    Filename.concat (Room.masc_dir config) "agents"
-  in
-  let agents_mt = _file_mtime agents_dir in
-  let sessions_dir = Team_session_store.sessions_root config in
-  let sessions_mt = _file_mtime sessions_dir in
-  let intents_mt = _file_mtime (intents_path config) in
-  let ops_mt = _file_mtime (operations_path config) in
-  let det_mt = _file_mtime (detachments_path config) in
-  let decisions_mt = _file_mtime (decisions_path config) in
-  let operator_mt = _file_mtime (operator_pending_confirms_path config) in
-  (* Section 1: topology (agents + units) — re-read if units.json or agents dir changed *)
-  if units_mt <> sc.topo_units_mtime || agents_mt <> sc.topo_agents_mtime then begin
-    let agents, managed_units, units, source = topology_units config in
-    sc.agents <- agents;
-    sc.managed_units <- managed_units;
-    sc.units <- units;
-    sc.source <- source;
-    sc.topo_units_mtime <- units_mt;
-    sc.topo_agents_mtime <- agents_mt
-  end;
-  (* Section 2: sessions — cap at _session_limit most recent *)
-  if sessions_mt <> sc.sessions_mtime then begin
-    sc.sessions <- Team_session_store.list_sessions ~limit:_session_limit config;
-    sc.sessions_mtime <- sessions_mt
-  end;
-  (* Section 3: intents *)
-  if intents_mt <> sc.intents_mtime then begin
-    sc.intents <- read_intents config;
-    sc.intents_mtime <- intents_mt
-  end;
-  (* Section 4: operations — re-read if ops file, topology, or sessions changed *)
-  if ops_mt <> sc.ops_mtime
-     || sc.topo_units_mtime <> sc.ops_topo_units_mtime
-     || sc.topo_agents_mtime <> sc.ops_topo_agents_mtime
-     || sc.sessions_mtime <> sc.ops_sessions_mtime then begin
-    sc.operations <- all_operations ~sessions:sc.sessions config sc.units;
-    sc.ops_mtime <- ops_mt;
-    sc.ops_topo_units_mtime <- sc.topo_units_mtime;
-    sc.ops_topo_agents_mtime <- sc.topo_agents_mtime;
-    sc.ops_sessions_mtime <- sc.sessions_mtime
-  end;
-  (* Section 5: detachments — re-read if detachments file or operations changed *)
-  if det_mt <> sc.det_mtime || sc.ops_mtime <> sc.det_ops_mtime then begin
-    sc.detachments <- all_detachments ~sessions:sc.sessions config sc.units sc.operations;
-    sc.det_mtime <- det_mt;
-    sc.det_ops_mtime <- sc.ops_mtime
-  end;
-  (* Section 6: decisions — re-read if decisions file or operator confirms changed *)
-  if decisions_mt <> sc.decisions_mtime
-     || operator_mt <> sc.decisions_operator_mtime then begin
-    sc.decisions <- all_policy_decisions config;
-    sc.decisions_mtime <- decisions_mt;
-    sc.decisions_operator_mtime <- operator_mt
-  end;
-  (* Assemble snapshot from cached sections *)
-  let live_agents = live_agent_names sc.agents in
-  let status_map = agent_status_map sc.agents in
-  let child_map = children_map sc.units in
-  let unit_lookup = unit_map sc.units in
-  let state = {
-    config;
-    agents = sc.agents;
-    managed_units = sc.managed_units;
-    units = sc.units;
-    source = sc.source;
-    sessions = sc.sessions;
-    intents = sc.intents;
-    operations = sc.operations;
-    detachments = sc.detachments;
-    decisions = sc.decisions;
-    live_agents;
-    status_map;
-    child_map;
-    unit_lookup;
-  } in
-  sc.last_built <- Time_compat.now ();
-  sc.last_state <- Some state;
-  state
+      (match config.backend with
+      | FileSystem _ ->
+          (* Per-section mtime check: only re-read sections whose files changed. *)
+          let units_mt = _file_mtime (units_path config) in
+          let agents_dir =
+            Filename.concat (Room.masc_dir config) "agents"
+          in
+          let agents_mt = _file_mtime agents_dir in
+          let sessions_dir = Team_session_store.sessions_root config in
+          let sessions_mt = _file_mtime sessions_dir in
+          let intents_mt = _file_mtime (intents_path config) in
+          let ops_mt = _file_mtime (operations_path config) in
+          let det_mt = _file_mtime (detachments_path config) in
+          let decisions_mt = _file_mtime (decisions_path config) in
+          let operator_mt = _file_mtime (operator_pending_confirms_path config) in
+          (* Section 1: topology (agents + units) — re-read if units.json or agents dir changed *)
+          if units_mt <> sc.topo_units_mtime || agents_mt <> sc.topo_agents_mtime then begin
+            let agents, managed_units, units, source = topology_units config in
+            sc.agents <- agents;
+            sc.managed_units <- managed_units;
+            sc.units <- units;
+            sc.source <- source;
+            sc.topo_units_mtime <- units_mt;
+            sc.topo_agents_mtime <- agents_mt
+          end;
+          (* Section 2: sessions — cap at _session_limit most recent *)
+          if sessions_mt <> sc.sessions_mtime then begin
+            sc.sessions <- Team_session_store.list_sessions ~limit:_session_limit config;
+            sc.sessions_mtime <- sessions_mt
+          end;
+          (* Section 3: intents *)
+          if intents_mt <> sc.intents_mtime then begin
+            sc.intents <- read_intents config;
+            sc.intents_mtime <- intents_mt
+          end;
+          (* Section 4: operations — re-read if ops file, topology, or sessions changed *)
+          if ops_mt <> sc.ops_mtime
+             || sc.topo_units_mtime <> sc.ops_topo_units_mtime
+             || sc.topo_agents_mtime <> sc.ops_topo_agents_mtime
+             || sc.sessions_mtime <> sc.ops_sessions_mtime then begin
+            sc.operations <- all_operations ~sessions:sc.sessions config sc.units;
+            sc.ops_mtime <- ops_mt;
+            sc.ops_topo_units_mtime <- sc.topo_units_mtime;
+            sc.ops_topo_agents_mtime <- sc.topo_agents_mtime;
+            sc.ops_sessions_mtime <- sc.sessions_mtime
+          end;
+          (* Section 5: detachments — re-read if detachments file or operations changed *)
+          if det_mt <> sc.det_mtime || sc.ops_mtime <> sc.det_ops_mtime then begin
+            sc.detachments <- all_detachments ~sessions:sc.sessions config sc.units sc.operations;
+            sc.det_mtime <- det_mt;
+            sc.det_ops_mtime <- sc.ops_mtime
+          end;
+          (* Section 6: decisions — re-read if decisions file or operator confirms changed *)
+          if decisions_mt <> sc.decisions_mtime
+             || operator_mt <> sc.decisions_operator_mtime then begin
+            sc.decisions <- all_policy_decisions config;
+            sc.decisions_mtime <- decisions_mt;
+            sc.decisions_operator_mtime <- operator_mt
+          end;
+          let state =
+            snapshot_state_of_sections ~config ~agents:sc.agents
+              ~managed_units:sc.managed_units ~units:sc.units ~source:sc.source
+              ~sessions:sc.sessions ~intents:sc.intents ~operations:sc.operations
+              ~detachments:sc.detachments ~decisions:sc.decisions
+          in
+          sc.last_built <- Time_compat.now ();
+          sc.last_state <- Some state;
+          state
+      | Memory _ | PostgresNative _ ->
+          let agents, managed_units, units, source = topology_units config in
+          let sessions = Team_session_store.list_sessions ~limit:_session_limit config in
+          let intents = read_intents config in
+          let operations = all_operations ~sessions config units in
+          let detachments = all_detachments ~sessions config units operations in
+          let decisions = all_policy_decisions config in
+          snapshot_state_of_sections ~config ~agents ~managed_units ~units
+            ~source ~sessions ~intents ~operations ~detachments ~decisions)
 
 let topology_json_from_state (state : snapshot_state) =
   let agents = state.agents in
@@ -433,7 +444,9 @@ let capacity_json_from_state (state : snapshot_state) =
     units
     |> List.map (fun (unit : unit_record) ->
            let live_count =
-             unit.roster |> List.filter (fun agent_name -> List.mem agent_name live_agents) |> List.length
+             unit.roster
+             |> List.filter (roster_name_is_live live_agents)
+             |> List.length
            in
            let active_ops =
              operations
@@ -498,7 +511,9 @@ let list_alerts_json_from_state config (state : snapshot_state) =
   List.iter
     (fun (unit : unit_record) ->
       let live_roster =
-        unit.roster |> List.filter (fun name -> List.mem name live_agents) |> List.length
+        unit.roster
+        |> List.filter (roster_name_is_live live_agents)
+        |> List.length
       in
       let active_ops =
         operations

--- a/lib/command_plane/cp_unit.ml
+++ b/lib/command_plane/cp_unit.ml
@@ -295,11 +295,27 @@ let live_agent_names agents =
   |> List.map (fun (agent : Types.agent) -> agent.name)
   |> List.sort_uniq String.compare
 
+let live_agent_name_matches expected live_name =
+  String.equal expected live_name
+  || String.starts_with ~prefix:(expected ^ "-") live_name
+
+let roster_name_is_live live_agents roster_name =
+  List.exists (live_agent_name_matches roster_name) live_agents
+
 let agent_status_map agents =
   List.map (fun (agent : Types.agent) -> (agent.name, Types.string_of_agent_status agent.status)) agents
 
 let agent_status_for agents agent_name =
-  List.assoc_opt agent_name agents |> Option.value ~default:"offline"
+  match List.assoc_opt agent_name agents with
+  | Some status -> status
+  | None ->
+      agents
+      |> List.find_map (fun (live_name, status) ->
+             if live_agent_name_matches agent_name live_name then
+               Some status
+             else
+               None)
+      |> Option.value ~default:"offline"
 
 let active_operation_status = function
   | Active | Planned -> true
@@ -346,7 +362,9 @@ let rec build_tree_json ~child_map ~unit_lookup ~agent_statuses ~live_agents ~op
         |> List.length
       in
       let live_roster =
-        unit.roster |> List.filter (fun name -> List.mem name live_agents) |> List.length
+        unit.roster
+        |> List.filter (roster_name_is_live live_agents)
+        |> List.length
       in
       let leader_status =
         match unit.leader_id with

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -41,54 +41,66 @@ let with_io ~path f =
   with Eio.Io _ as e ->
     raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
 
+let with_fs_or_fallback ~path ~fallback f =
+  match !global_fs with
+  | Some fs -> (
+      try with_io ~path (fun () -> f fs)
+      with Stdlib.Effect.Unhandled _ -> fallback ())
+  | None -> fallback ()
+
+let load_file_unix (path : string) : string =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let len = in_channel_length ic in
+    really_input_string ic len
+  )
+
+let save_file_unix (path : string) (content : string) : unit =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc content
+  )
+
+let append_file_unix (path : string) (content : string) : unit =
+  let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc content
+  )
+
+let mkdir_p_unix (path : string) : unit =
+  let rec ensure_dir (p : string) : unit =
+    if p = "" || p = "." || p = "/" then ()
+    else if Sys.file_exists p then ()
+    else begin
+      ensure_dir (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  ensure_dir path
+
 (** Load entire file contents as string.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let load_file (path : string) : string =
-  match !global_fs with
-  | Some fs ->
-    with_io ~path (fun () ->
+  with_fs_or_fallback ~path ~fallback:(fun () -> load_file_unix path) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.load eio_path)
-  | None ->
-    (* Fallback: blocking Unix I/O *)
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
-      let len = in_channel_length ic in
-      really_input_string ic len
-    )
 
 (** Save string to file (overwrite).
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let save_file (path : string) (content : string) : unit =
-  match !global_fs with
-  | Some fs ->
-    with_io ~path (fun () ->
+  with_fs_or_fallback ~path ~fallback:(fun () -> save_file_unix path content) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
-  | None ->
-    (* Fallback: blocking Unix I/O *)
-    let oc = open_out path in
-    Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
-      output_string oc content
-    )
 
 (** Append string to file.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let append_file (path : string) (content : string) : unit =
-  match !global_fs with
-  | Some fs ->
-    with_io ~path (fun () ->
+  with_fs_or_fallback ~path ~fallback:(fun () -> append_file_unix path content) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
-  | None ->
-    (* Fallback: blocking Unix I/O *)
-    let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
-    Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
-      output_string oc content
-    )
 
 (** Check if file exists.
     Uses Sys.file_exists (works in both Eio and non-Eio contexts). *)
@@ -98,22 +110,9 @@ let file_exists (path : string) : bool =
 (** Create directory recursively if not exists.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let mkdir_p (path : string) : unit =
-  match !global_fs with
-  | Some fs ->
-    with_io ~path (fun () ->
+  with_fs_or_fallback ~path ~fallback:(fun () -> mkdir_p_unix path) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
-  | None ->
-    (* Fallback: recursive mkdir without invoking a shell. *)
-    let rec ensure_dir (p : string) : unit =
-      if p = "" || p = "." || p = "/" then ()
-      else if Sys.file_exists p then ()
-      else begin
-        ensure_dir (Filename.dirname p);
-        try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-      end
-    in
-    ensure_dir path
 
 (** Load JSONL file as list of JSON values.
     Filters out malformed lines. *)

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -90,6 +90,13 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
+(** Run [f] while holding only the cooperative per-path mutex.
+    Use this for in-memory backends that need single-process fiber
+    serialization but do not have a real filesystem artifact to flock. *)
+let with_mutex path f =
+  let mu = get_lock path in
+  Eio_guard.with_mutex mu f
+
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock.  The flock is acquired with F_TLOCK
     (non-blocking) from a system thread so the Eio scheduler stays free.
@@ -105,8 +112,7 @@ let with_lock path f =
       ~finally:(fun () -> release_flock_fd fd)
       f
   in
-  let mu = get_lock path in
-  Eio_guard.with_mutex mu (fun () -> run_with_flock ())
+  with_mutex path (fun () -> run_with_flock ())
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = Hashtbl.length table

--- a/lib/room/room_query.ml
+++ b/lib/room/room_query.ml
@@ -69,41 +69,37 @@ let take_first n xs =
     in
     loop [] n xs
 
+let list_leaf_json_names config dir =
+  list_dir config dir
+  |> List.filter (fun name ->
+         name <> ""
+         && not (String.contains name '/')
+         && Filename.check_suffix name ".json")
+
+let load_agents_from_dir config dir ~include_inactive =
+  list_leaf_json_names config dir
+  |> List.filter_map (fun name ->
+         safe_yield ();
+         let path = Filename.concat dir name in
+         let json = read_json config path in
+         match agent_of_yojson json with
+         | Ok agent when include_inactive || agent.status <> Types.Inactive ->
+             Some agent
+         | Ok _ | Error _ -> None)
+
 (** Get raw agent list (for orchestrator) *)
 let get_agents_raw config =
   ensure_initialized config;
-  let agents_path = agents_dir (with_scope config (Named (current_room_id config))) in
-  if not (Sys.file_exists agents_path) then []
-  else
-    Sys.readdir agents_path
-    |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
-    |> List.filter_map (fun name ->
-        safe_yield ();
-        let path = Filename.concat agents_path name in
-        let json = read_json config path in
-        match agent_of_yojson json with
-        | Ok agent -> Some agent
-        | Error _ -> None
-      )
+  let agents_path =
+    agents_dir (with_scope config (Named (current_room_id config)))
+  in
+  load_agents_from_dir config agents_path ~include_inactive:true
 
 let get_agents_raw_in_room config room_id =
   if not (root_is_initialized config) then []
   else
     let agents_path = agents_dir (with_scope config (Named room_id)) in
-    if not (Sys.file_exists agents_path) then []
-    else
-      Sys.readdir agents_path
-      |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
-      |> List.filter_map (fun name ->
-          safe_yield ();
-          let path = Filename.concat agents_path name in
-          let json = read_json config path in
-          match agent_of_yojson json with
-          | Ok agent when agent.status <> Types.Inactive -> Some agent
-          | Ok _ | Error _ -> None
-        )
+    load_agents_from_dir config agents_path ~include_inactive:false
 
 (** Like [get_agents_raw_in_room] but includes Inactive agents.
     Useful for keeper backlog-triage enrollment where inactive agents
@@ -112,19 +108,7 @@ let get_all_agents_in_room config room_id =
   if not (root_is_initialized config) then []
   else
     let agents_path = agents_dir (with_scope config (Named room_id)) in
-    if not (Sys.file_exists agents_path) then []
-    else
-      Sys.readdir agents_path
-      |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
-      |> List.filter_map (fun name ->
-          safe_yield ();
-          let path = Filename.concat agents_path name in
-          let json = read_json config path in
-          match agent_of_yojson json with
-          | Ok agent -> Some agent
-          | Error _ -> None
-        )
+    load_agents_from_dir config agents_path ~include_inactive:true
 
 (** Audit tasks: find claimed/in_progress tasks whose assignees are not active agents.
     Matches assignees by exact name or agent-type prefix (e.g. "claude" matches "claude-xxx").
@@ -135,18 +119,8 @@ let audit_orphan_tasks config : (Types.task * string) list =
     (* Read agent files from the same path that cleanup_zombies and join use *)
     let agents_path = agents_dir config in
     let active_names =
-      if Sys.file_exists agents_path then
-        Sys.readdir agents_path
-        |> Array.to_list
-        |> List.filter (fun name -> Filename.check_suffix name ".json")
-        |> List.filter_map (fun name ->
-            safe_yield ();
-            let path = Filename.concat agents_path name in
-            let json = read_json config path in
-            match agent_of_yojson json with
-            | Ok agent when agent.status <> Types.Inactive -> Some agent.name
-            | Ok _ | Error _ -> None)
-      else []
+      load_agents_from_dir config agents_path ~include_inactive:false
+      |> List.map (fun (agent : Types.agent) -> agent.name)
     in
     let is_active_agent assignee =
       List.mem assignee active_names

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -279,62 +279,84 @@ let with_file_lock config path f =
       (* Fix 2: Use cooperative Eio.Mutex instead of blocking Unix.lockf.
          Single-process assumption (MASC runs as one process). *)
       File_lock_eio.with_lock path f
-  | Some key ->
-      let owner = config.backend_config.node_id in
-      let ttl_seconds = config.lock_expiry_minutes * 60 in
-      let rec acquire attempts delay =
-        if attempts <= 0 then false
-        else
-          match backend_acquire_lock config ~key ~ttl_seconds ~owner with
-          | Ok true -> true
-          | _ ->
-              Eio_unix.sleep delay;
-              acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
-      in
-      if acquire 20 0.005 then
-        Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
-          ~finally:(fun () ->
-            match backend_release_lock config ~key ~owner with
-            | Ok _ -> ()
-            | Error e ->
-              let msg = match e with
-                | Backend_types.ConnectionFailed s | NotFound s
-                | IOError s | BackendNotSupported s | InvalidKey s
-                | AlreadyExists s -> s in
-              Log.Room.warn "lock release failed for %s: %s" key msg)
-          f
-      else
-        invalid_arg (Printf.sprintf "Failed to acquire distributed lock for key: %s (20 attempts exhausted)" key)
+  | Some key -> (
+      match config.backend with
+      | Memory _ ->
+          (* Memory backend is single-process but still multi-fiber.
+             Serialize same-path updates cooperatively to avoid read-modify-write
+             races in append/readback helpers. *)
+          File_lock_eio.with_mutex path f
+      | FileSystem _ | PostgresNative _ ->
+          let owner = config.backend_config.node_id in
+          let ttl_seconds = config.lock_expiry_minutes * 60 in
+          let rec acquire attempts delay =
+            if attempts <= 0 then false
+            else
+              match backend_acquire_lock config ~key ~ttl_seconds ~owner with
+              | Ok true -> true
+              | _ ->
+                  Eio_unix.sleep delay;
+                  acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
+          in
+          if acquire 20 0.005 then
+            Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
+              ~finally:(fun () ->
+                match backend_release_lock config ~key ~owner with
+                | Ok _ -> ()
+                | Error e ->
+                    let msg =
+                      match e with
+                      | Backend_types.ConnectionFailed s | NotFound s
+                      | IOError s | BackendNotSupported s | InvalidKey s
+                      | AlreadyExists s -> s
+                    in
+                    Log.Room.warn "lock release failed for %s: %s" key msg)
+              f
+          else
+            invalid_arg
+              (Printf.sprintf
+                 "Failed to acquire distributed lock for key: %s (20 attempts exhausted)"
+                 key))
 
 let with_file_lock_r config path f : ('a, masc_error) result =
   match key_of_path config path with
   | None ->
       (* Fix 2: Cooperative lock — same as with_file_lock *)
       File_lock_eio.with_lock path (fun () -> Ok (f ()))
-  | Some key ->
-      let owner = config.backend_config.node_id in
-      let ttl_seconds = config.lock_expiry_minutes * 60 in
-      let rec acquire attempts delay =
-        if attempts <= 0 then false
-        else
-          match backend_acquire_lock config ~key ~ttl_seconds ~owner with
-          | Ok true -> true
-          | _ -> Eio_unix.sleep delay; acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
-      in
-      if acquire 20 0.005 then
-        Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
-          ~finally:(fun () ->
-            match backend_release_lock config ~key ~owner with
-            | Ok _ -> ()
-            | Error e ->
-              let msg = match e with
-                | Backend_types.ConnectionFailed s | NotFound s
-                | IOError s | BackendNotSupported s | InvalidKey s
-                | AlreadyExists s -> s in
-              Log.Room.warn "lock release failed for %s: %s" key msg)
-          (fun () -> Ok (f ()))
-      else
-        Error (IoError (Printf.sprintf "Failed to acquire distributed lock for %s" path))
+  | Some key -> (
+      match config.backend with
+      | Memory _ -> File_lock_eio.with_mutex path (fun () -> Ok (f ()))
+      | FileSystem _ | PostgresNative _ ->
+          let owner = config.backend_config.node_id in
+          let ttl_seconds = config.lock_expiry_minutes * 60 in
+          let rec acquire attempts delay =
+            if attempts <= 0 then false
+            else
+              match backend_acquire_lock config ~key ~ttl_seconds ~owner with
+              | Ok true -> true
+              | _ ->
+                  Eio_unix.sleep delay;
+                  acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
+          in
+          if acquire 20 0.005 then
+            Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
+              ~finally:(fun () ->
+                match backend_release_lock config ~key ~owner with
+                | Ok _ -> ()
+                | Error e ->
+                    let msg =
+                      match e with
+                      | Backend_types.ConnectionFailed s | NotFound s
+                      | IOError s | BackendNotSupported s | InvalidKey s
+                      | AlreadyExists s -> s
+                    in
+                    Log.Room.warn "lock release failed for %s: %s" key msg)
+              (fun () -> Ok (f ()))
+          else
+            Error
+              (IoError
+                 (Printf.sprintf "Failed to acquire distributed lock for %s"
+                    path)))
 
 (* ============================================ *)
 (* Event logging                                *)

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -334,23 +334,27 @@ let save_worker_run_meta_json config session_id worker_run_id json =
   let path = worker_run_meta_path config session_id worker_run_id in
   write_json config path json
 
+let immediate_dir_entries config dir =
+  Room_utils.list_dir config dir
+  |> List.filter_map (fun entry ->
+         match String.split_on_char '/' entry with
+         | segment :: _ when String.trim segment <> "" -> Some segment
+         | _ -> None)
+  |> Team_session_types.dedup_strings
+  |> List.sort String.compare
+
 let list_worker_run_ids config session_id =
   let dir = worker_runs_dir config session_id in
-  list_dir config dir
-  |> List.filter_map (fun entry ->
-       match String.split_on_char '/' entry with
-       | name :: _ when name <> "" -> Some name
-       | _ -> None)
-  |> List.sort_uniq String.compare
+  immediate_dir_entries config dir
 
 let list_checkpoint_paths config session_id =
   let dir = checkpoints_dir config session_id in
-  list_dir config dir
-  |> List.filter_map (fun entry ->
-       match String.split_on_char '/' entry with
-       | name :: _ when Filename.check_suffix name ".json" -> Some name
-       | _ -> None)
-  |> List.sort_uniq String.compare
+  Room_utils.list_dir config dir
+  |> List.filter (fun name ->
+         name <> ""
+         && not (String.contains name '/')
+         && Filename.check_suffix name ".json")
+  |> List.sort String.compare
   |> List.map (Filename.concat dir)
 
 let load_latest_checkpoint config session_id : Team_session_types.checkpoint option =

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -97,5 +97,9 @@ let () =
           Alcotest.test_case
             "verify-trace-reports-summary-only-without-checkpoint" `Quick
             Test_tool_team_session_misc.test_verify_trace_reports_summary_only_without_checkpoint;
+          Alcotest.test_case "memory-backend-event-lock-serializes-fibers"
+            `Quick
+            Test_tool_team_session_flow
+              .test_memory_backend_event_lock_serializes_fibers;
         ] );
     ]

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -105,6 +105,29 @@ let test_read_events_limit () =
   Alcotest.(check (list int)) "tail events kept" [ 16; 17; 18; 19; 20 ] seqs;
   cleanup_dir base_dir
 
+let test_memory_backend_event_lock_serializes_fibers () =
+  let cluster_name = "team-session-lock-" ^ Team_session_store.make_session_id () in
+  with_env "MASC_STORAGE_TYPE" (Some "memory") @@ fun () ->
+  with_env "MASC_CLUSTER_NAME" (Some cluster_name) @@ fun () ->
+  with_eio @@ fun _env ->
+  Eio_guard.enable ();
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) @@ fun () ->
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let path = Team_session_store.events_jsonl_path config "lock-regression" in
+  let active = ref 0 in
+  let overlapped = ref false in
+  Eio.Fiber.all
+    (List.init 16 (fun _ ->
+         fun () ->
+           Room_utils.with_file_lock config path (fun () ->
+               incr active;
+               if !active > 1 then overlapped := true;
+               Eio.Fiber.yield ();
+               decr active)));
+  Alcotest.(check bool) "memory event lock is exclusive" false !overlapped
+
 let test_list_and_compare () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -67,7 +67,8 @@ let test_start_status_report_stop () =
     report_result |> Yojson.Safe.Util.member "json_path"
     |> Yojson.Safe.Util.to_string
   in
-  Alcotest.(check bool) "markdown exists" true (Sys.file_exists md_path);
+  Alcotest.(check bool) "markdown exists" true
+    (Room_utils.path_exists config md_path);
   Alcotest.(check bool) "json report exists" true
     (Room_utils.path_exists config json_path);
   let report_doc = Room_utils.read_json config json_path in

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -275,6 +275,7 @@ let test_report_and_proof_expose_spawn_tool_usage () =
 let test_bootstrap_grace_suppresses_min_agents_violation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -305,6 +306,7 @@ let test_bootstrap_grace_suppresses_min_agents_violation () =
 let test_min_agents_violation_after_bootstrap_grace () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -311,7 +311,7 @@ let test_status_reports_worker_run_progress_summary () =
              ];
            updated_at_iso = Types.now_iso ();
          }));
-  Team_session_store.write_text_file
+  Team_session_store.write_artifact_text config
     (Team_session_store.worker_container_checkpoint_path config session_id
        "worker-a")
     "checkpoint";


### PR DESCRIPTION
## Summary
- make room and team-session state reads work under Memory backend fallback
- bypass stale command-plane section-cache assumptions on non-filesystem backends
- align team_session tests with backend-aware artifact contracts and clean up Fs_compat leakage between tests

## Validation
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 0 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 1 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 5 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 12 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 14 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 28 -e -v`
- `./_build_ci_timeout2/default/test/test_tool_team_session.exe test team_session 41 -e -v`
- `/opt/homebrew/bin/gtimeout 180s ./_build_ci_timeout2/default/test/test_tool_team_session.exe -q`

Validation ran in `/tmp/masc-mcp-ci-timeout-root-causes-20260326` because nested worktree dune resolution in the repo worktree is noisy.
