### PR TITLE
chore(ci): refresh OAS pin ratchet to current main

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="088a7346537339cde8a01a4b973d1bb229fdc9ef"
+readonly OAS_AGENT_SDK_SHA="226bbe7f8e13b5e6a9bd788eab96923a3794605c"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#088a7346537339cde8a01a4b973d1bb229fdc9ef}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
OAS SHA 088a734 → 226bbe7. opam-pin SHA를 oas-agent-sdk-pin.sh에서 참조하도록 중복 제거.