### PR TITLE
refactor: replace Type_error exception flow with pattern matching

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -84,8 +84,9 @@ let generate_session_key () =
 let from_mcp_params params =
   let module U = Yojson.Safe.Util in
   let get_opt key =
-    try Some (params |> U.member key |> U.to_string)
-    with Yojson.Safe.Util.Type_error _ -> None
+    match U.member key params with
+    | `String s -> Some s
+    | _ -> None
   in
   let session_key_prefix session_key =
     let prefix_len = min 8 (String.length session_key) in
@@ -113,9 +114,10 @@ let from_mcp_params params =
   in
   let user_id = get_opt "_user_id" in
   let room_id = get_opt "room" in
-  let capabilities = try
-    params |> U.member "_capabilities" |> U.to_list |> List.map U.to_string
-  with Yojson.Safe.Util.Type_error _ -> []
+  let capabilities =
+    match U.member "_capabilities" params with
+    | `List l -> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l
+    | _ -> []
   in
   let now = Time_compat.now () in
   {

--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -67,15 +67,19 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
       conclusion = str "conclusion";
       confidence = confidence_of_string
         (match str_opt "confidence" with Some s -> s | None -> "medium");
-      tags = (try member "tags" json |> to_list |> List.map to_string
-              with Yojson.Safe.Util.Type_error _ -> []);
-      related_findings = (try member "related_findings" json |> to_list |> List.map to_string
-                          with Yojson.Safe.Util.Type_error _ -> []);
+      tags = (match member "tags" json with
+              | `List l -> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l
+              | _ -> []);
+      related_findings = (match member "related_findings" json with
+                          | `List l -> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l
+                          | _ -> []);
       cycle_range = (match member "cycle_range" json with
         | `List [`Int a; `Int b] -> Some (a, b)
         | _ -> None);
-      timestamp = (try member "timestamp" json |> to_float
-                   with Yojson.Safe.Util.Type_error _ -> Unix.gettimeofday ());
+      timestamp = (match member "timestamp" json with
+                   | `Float f -> f
+                   | `Int i -> float_of_int i
+                   | _ -> Unix.gettimeofday ());
     }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -137,70 +137,53 @@ let get_env_float_logged name ~default =
 *)
 
 let json_string ?(default = "") key json =
-  let open Yojson.Safe.Util in
-  try json |> member key |> to_string
-  with Type_error _ -> default
+  match Yojson.Safe.Util.member key json with
+  | `String s -> s
+  | _ -> default
 
 let json_int ?(default = 0) key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Float f -> int_of_float f
-    | j -> to_int j
-  with Type_error _ -> default
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> i
+  | `Float f -> int_of_float f
+  | _ -> default
 
 let json_float ?(default = 0.0) key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Int i -> float_of_int i
-    | j -> to_float j
-  with Type_error _ -> default
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> f
+  | `Int i -> float_of_int i
+  | _ -> default
 
 let json_bool ?(default = false) key json =
-  let open Yojson.Safe.Util in
-  try json |> member key |> to_bool
-  with Type_error _ -> default
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> b
+  | _ -> default
 
 let json_string_list key json =
-  let open Yojson.Safe.Util in
-  try
-    json |> member key |> to_list |> List.filter_map (fun v ->
-      try Some (to_string v) with Type_error _ -> None)
-  with Type_error _ -> []
+  match Yojson.Safe.Util.member key json with
+  | `List l ->
+      List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) l
+  | _ -> []
 
 let json_string_opt key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Null -> None
-    | j -> Some (to_string j)
-  with Type_error _ -> None
+  match Yojson.Safe.Util.member key json with
+  | `String s -> Some s
+  | _ -> None
 
 let json_int_opt key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Null -> None
-    | j -> Some (to_int j)
-  with Type_error _ -> None
+  match Yojson.Safe.Util.member key json with
+  | `Int i -> Some i
+  | _ -> None
 
 let json_float_opt key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Null -> None
-    | `Int i -> Some (float_of_int i)
-    | j -> Some (to_float j)
-  with Type_error _ -> None
+  match Yojson.Safe.Util.member key json with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
 
 let json_bool_opt key json =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member key with
-    | `Null -> None
-    | j -> Some (to_bool j)
-  with Type_error _ -> None
+  match Yojson.Safe.Util.member key json with
+  | `Bool b -> Some b
+  | _ -> None
 
 (** {1 Safe Process Execution} *)
 

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -151,14 +151,10 @@ let parse_worktrees (json : Yojson.Safe.t) : (string * string) list =
   match json |> U.member "worktrees" with
   | `List items ->
       List.filter_map (fun item ->
-        try
-          let worktree = item |> U.member "worktree" |> U.to_string in
-          let branch = item |> U.member "branch" |> U.to_string in
-          if String.length branch > 0 && not (String.equal branch "HEAD") then
+        match U.member "worktree" item, U.member "branch" item with
+        | `String worktree, `String branch
+          when String.length branch > 0 && not (String.equal branch "HEAD") ->
             Some (branch, worktree)
-          else None
-        with
-        | Yojson.Safe.Util.Type_error _ -> None
         | _ -> None
       ) items
   | `Null -> []

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -199,21 +199,26 @@ module Ring = struct
     | None -> ()
 
   let entry_of_json json =
-    let open Yojson.Safe.Util in
-    try
-      Some {
-        seq = json |> member "seq" |> to_int;
-        ts = json |> member "ts" |> to_string;
-        level = json |> member "level" |> to_string;
-        raw_level = json |> member "raw_level" |> to_string;
-        normalized_level = json |> member "normalized_level" |> to_string;
-        source = json |> member "source" |> to_string;
-        legacy_classified = json |> member "legacy_classified" |> to_bool;
-        module_name = json |> member "module" |> to_string;
-        message = json |> member "message" |> to_string;
-        details = (try json |> member "details" with Type_error _ -> `Null);
-      }
-    with Type_error _ -> None
+    match json with
+    | `Assoc _ ->
+        let open Yojson.Safe.Util in
+        (match
+           member "seq" json, member "ts" json, member "level" json,
+           member "raw_level" json, member "normalized_level" json,
+           member "source" json, member "legacy_classified" json,
+           member "module" json, member "message" json
+         with
+         | `Int seq, `String ts, `String level,
+           `String raw_level, `String normalized_level,
+           `String source, `Bool legacy_classified,
+           `String module_name, `String message ->
+             Some {
+               seq; ts; level; raw_level; normalized_level;
+               source; legacy_classified; module_name; message;
+               details = member "details" json;
+             }
+         | _ -> None)
+    | _ -> None
 
   let load_from_file dir =
     ensure_dir dir;


### PR DESCRIPTION
## Summary
- JSON 파싱에서 `try ... with Type_error` 예외 흐름을 직접 패턴 매칭으로 교체
- 5파일, 16건 Type_error catch 제거
- 순 변경: -10줄 (71 추가, 81 삭제)

## Changes
- `safe_ops.ml`: 9개 함수 (`json_string`, `json_int`, `json_float`, `json_bool`, `*_opt`, `*_list`) 패턴 매칭으로 전환
- `agent_identity.ml`: `get_opt` 헬퍼 + `capabilities` 파싱
- `log.ml`: `entry_of_json`을 `Assoc` 매치 후 9개 필드 한 번에 구조 분해
- `dashboard.ml`: `parse_worktrees` 가드 패턴 매칭
- `autoresearch_knowledge.ml`: `tags`, `related_findings`, `timestamp` 필드 파싱

## Skipped
- `board_pg_queries.ml:42` — `Yojson.Safe.from_string` 파싱 실패 처리로, Type_error 제어 흐름과 다른 관심사

## Test plan
- [x] `dune build` 클린 빌드
- [ ] `dune runtest` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)