### PR TITLE
fix(fiber-safety): replace Stdlib.Mutex and Stdlib.Lazy in Eio-reachable code (#3247)

### DIFF
--- a/lib/backend/pg_infix.ml
+++ b/lib/backend/pg_infix.ml
@@ -24,32 +24,31 @@ let normalize_pg_port url =
   | _ -> url
 
 let use_oneshot =
-  lazy
-    (let env_url name =
-       match Sys.getenv_opt name with
-       | Some v when String.trim v <> "" -> Some (String.trim v)
-       | _ -> None
-     in
-     let url =
-       match env_url "MASC_POSTGRES_URL" with
-       | Some _ as u -> u
-       | None -> (
-           match env_url "DATABASE_URL" with
-           | Some _ as u -> u
-           | None -> (
-               match env_url "SUPABASE_DB_URL" with
-               | Some _ as u -> u
-               | None -> env_url "SB_PG_URL"))
-     in
-     match url with
-     | None -> false
-     | Some raw_url ->
-         let url = normalize_pg_port raw_url in
-         (match Uri.port (Uri.of_string url) with
-         | Some 6543 -> true
-         | _ -> false))
+  let env_url name =
+    match Sys.getenv_opt name with
+    | Some v when String.trim v <> "" -> Some (String.trim v)
+    | _ -> None
+  in
+  let url =
+    match env_url "MASC_POSTGRES_URL" with
+    | Some _ as u -> u
+    | None -> (
+        match env_url "DATABASE_URL" with
+        | Some _ as u -> u
+        | None -> (
+            match env_url "SUPABASE_DB_URL" with
+            | Some _ as u -> u
+            | None -> env_url "SB_PG_URL"))
+  in
+  match url with
+  | None -> false
+  | Some raw_url ->
+      let url = normalize_pg_port raw_url in
+      (match Uri.port (Uri.of_string url) with
+      | Some 6543 -> true
+      | _ -> false)
 
-let oneshot () = Lazy.force use_oneshot
+let oneshot () = use_oneshot
 
 let ( ->. ) a b ?(oneshot = oneshot ()) s =
   Caqti_request.Infix.( ->. ) a b ~oneshot s

--- a/lib/keeper/keeper_recurring.ml
+++ b/lib/keeper/keeper_recurring.ml
@@ -1,7 +1,8 @@
 (** Keeper_recurring — In-memory recurring task registry.
 
-    Thread-safe via Stdlib.Mutex (this module may be accessed from
-    non-Eio contexts such as MCP tool handlers and tests).
+    Thread-safe via Eio.Mutex guarded by Eio_guard (falls through
+    without locking when Eio runtime is not yet active, e.g. in
+    non-Eio tests or module init).
 
     @since #3190 *)
 
@@ -25,12 +26,11 @@ type recurring_task = {
 (* Storage                                                           *)
 (* ================================================================ *)
 
-let mu = Mutex.create ()
+let mu = Eio.Mutex.create ()
 let tasks : (string, recurring_task) Hashtbl.t = Hashtbl.create 16
 
 let with_lock f =
-  Mutex.lock mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+  Eio_guard.with_mutex mu f
 
 (* ================================================================ *)
 (* ID generation                                                     *)

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -74,7 +74,7 @@ let is_pg_backend config =
 
 (** Shared in-memory pubsub for FileSystem and Memory backends.
     PostgreSQL backend has its own pg_notify-based pubsub. *)
-let _shared_pubsub = lazy (Backend_types.Pubsub_mem.create ())
+let _shared_pubsub = Backend_types.Pubsub_mem.create ()
 
 (** Adapt Backend get (returns Ok string | Error NotFound) to
     the (string option, error) result shape used by all callers. *)
@@ -172,14 +172,14 @@ let backend_publish config ~channel ~message =
   match config.backend with
   | PostgresNative t -> Backend.Postgres.publish t ~channel ~message
   | Memory _ | FileSystem _ ->
-      Backend_types.Pubsub_mem.publish (Lazy.force _shared_pubsub) ~channel ~message
+      Backend_types.Pubsub_mem.publish (_shared_pubsub) ~channel ~message
 
 (** Subscribe: PostgreSQL uses table polling, FileSystem/Memory use shared in-mem pubsub. *)
 let backend_subscribe config ~channel ~callback =
   match config.backend with
   | PostgresNative t -> Backend.Postgres.subscribe t ~channel ~callback
   | Memory _ | FileSystem _ ->
-      Backend_types.Pubsub_mem.subscribe (Lazy.force _shared_pubsub) ~channel ~callback
+      Backend_types.Pubsub_mem.subscribe (_shared_pubsub) ~channel ~callback
 
 let backend_name config =
   match config.backend with


### PR DESCRIPTION
## Summary
- `keeper_recurring.ml`: `Stdlib.Mutex` → `Eio.Mutex` via `Eio_guard.with_mutex` (dual-mode: fiber-safe under Eio, passthrough in non-Eio tests)
- `pg_infix.ml`: `Stdlib.Lazy` → eager init (pure env-var computation — eliminates concurrent-force `Undefined` crash)
- `room_utils_paths_backend.ml`: `Stdlib.Lazy` → eager init (`Pubsub_mem.create` is a trivial `Hashtbl` allocation)

## Acceptance Criteria
- [x] `lib/`에서 `Stdlib.Mutex` / bare `Mutex.create()` 0건
- [x] `lib/`에서 Eio-reachable 경로의 bare `lazy` 0건
- [x] `test_keeper_recurring` 7/7 통과 (Eio context 없이도 `Eio_guard` 패턴으로 정상)

Closes #3247

🤖 Generated with [Claude Code](https://claude.com/claude-code)