### PR TITLE
refactor(eio): audit Fun.protect in fiber contexts (#3248)

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -339,9 +339,9 @@ module Reflection_bridge = struct
         string Grpc_eio.Stream.t =
       let response_stream = Grpc_eio.Stream.create 16 in
       let process_loop () =
-        Fun.protect
-          ~finally:(fun () -> Grpc_eio.Stream.close response_stream)
-          (fun () ->
+        Eio.Switch.run @@ fun loop_sw ->
+        Eio.Switch.on_release loop_sw (fun () ->
+            (try Grpc_eio.Stream.close response_stream with _ -> ()));
             let rec loop () =
               let request_bytes = Grpc_eio.Stream.take request_stream in
               let services = Grpc_eio.Server.list_services !server_ref in
@@ -391,7 +391,7 @@ module Reflection_bridge = struct
             Grpc_eio.Stream.add response_stream response;
               loop ()
             in
-            try loop () with End_of_file -> ())
+            try loop () with End_of_file -> ()
       in
       Eio.Fiber.fork ~sw process_loop;
       response_stream
@@ -477,6 +477,7 @@ let start
         Log.Server.info
           "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
         Transport_metrics.set_grpc_runtime_listening true;
+        (* Safe: finally is Atomic.set — no I/O, no exception risk *)
         Fun.protect
           ~finally:(fun () -> Transport_metrics.set_grpc_runtime_listening false)
           (fun () -> Grpc_eio.Server.serve ~sw ~env server)

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -266,12 +266,14 @@ let run ~sw t =
   match t.lifecycle with
   | Perpetual ->
     Eio.Fiber.fork_daemon ~sw (fun () ->
+      (* Safe: finally is mutable field write — no I/O, no exception risk *)
       Fun.protect
         (fun () -> loop t; `Stop_daemon)
         ~finally:(fun () -> t.alive <- false)
     )
   | Bounded _ ->
     Eio.Fiber.fork ~sw (fun () ->
+      (* Safe: finally is mutable field write — no I/O, no exception risk *)
       Fun.protect
         (fun () -> loop t)
         ~finally:(fun () -> t.alive <- false)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -412,10 +412,10 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let close_stream () =
     if not !closed then begin
       closed := true;
+      (* Catch all exceptions including Cancelled — this function is called
+         from Switch.on_release where re-raising would mask the original exn. *)
       (try Httpun.Body.Writer.close writer
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
+       with exn ->
          Log.Misc.warn "keeper_stream writer close: %s"
            (Printexc.to_string exn))
     end
@@ -426,7 +426,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
   ignore (keeper_stream_send_raw writer mutex closed "retry: 1500\n\n");
   Eio.Fiber.fork ~sw (fun () ->
-      Fun.protect ~finally:close_stream (fun () ->
+      Eio.Switch.run @@ fun stream_sw ->
+      Eio.Switch.on_release stream_sw close_stream;
           (* --- 1. Lifecycle: Run_started + Text_message_start --- *)
           ignore
             (keeper_stream_send_event writer mutex closed
@@ -541,6 +542,6 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->
                 send_keeper_error writer mutex closed ~thread_id ~run_id
-                  (Printexc.to_string exn))))
+                  (Printexc.to_string exn)))
 
 (** Build routes for MCP server *)

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -120,6 +120,7 @@ let start
         (make_websocket_handler ~on_message)
     in
     Eio.Fiber.fork ~sw (fun () ->
+      (* Safe: finally is Atomic.set — no I/O, no exception risk *)
       Fun.protect
         ~finally:(fun () -> Transport_metrics.set_ws_runtime_listening false)
         (fun () ->


### PR DESCRIPTION
## Summary
- **SSE keeper stream**: `Fun.protect ~finally:close_stream` → `Switch.run` + `on_release` (writer close can throw I/O exceptions, masking `Cancelled`)
- **gRPC reflection bidi**: `Fun.protect ~finally:Stream.close` → `Switch.run` + `on_release` (same I/O risk)
- **Safe sites annotated**: WS standalone, gRPC server, Pulse — all have non-I/O finally (Atomic.set or mutable write)

## Why Switch.on_release
`Fun.protect`'s `~finally` wraps exceptions in `Fun.Finally_raised`, masking the original exception (including `Eio.Cancel.Cancelled`). `Switch.on_release` collects cleanup exceptions separately, preserving the original cancellation signal.

## Test
- Pulse: 21/21 passed
- Build: clean (no warnings)

Closes #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)