### PR TITLE
fix(dashboard): compute context_ratio for keeper detail cards

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -2,6 +2,17 @@ module U = Yojson.Safe.Util
 include Operator_pending_confirm
 include Operator_digest
 
+let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
+  let input_tokens = meta.usage.last_input_tokens in
+  if input_tokens = 0 then None
+  else
+    let active_model = Keeper_exec_status.active_model_of_meta meta in
+    if active_model = "" then None
+    else
+      let max_ctx = Oas_model_resolve.max_context_of_label active_model in
+      if max_ctx = 0 then None
+      else Some (float_of_int input_tokens /. float_of_int max_ctx)
+
 type action_log_entry = {
   trace_id : string;
   actor : string;
@@ -225,7 +236,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = true) config =
                   ("diagnostic", diagnostic);
                   ("generation", `Int meta.generation);
                   ("turn_count", `Int meta.usage.total_turns);
-                  ("context_ratio", `Null);
+                  ("context_ratio",
+                    (match compute_context_ratio meta with
+                     | Some r -> `Float r
+                     | None -> `Null));
                   ("context_tokens", `Int meta.usage.last_total_tokens);
                   ("last_model_used", `String meta.usage.last_model_used);
                   ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
@@ -301,7 +315,10 @@ let persistent_agents_json ?keeper_names config =
                   ("status", `String agent_status);
                   ("generation", `Int meta.generation);
                   ("turn_count", `Int meta.usage.total_turns);
-                  ("context_ratio", `Null);
+                  ("context_ratio",
+                    (match compute_context_ratio meta with
+                     | Some r -> `Float r
+                     | None -> `Null));
                   ("context_tokens", `Int meta.usage.last_total_tokens);
                   ("last_model_used", `String meta.usage.last_model_used);
                   ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));


### PR DESCRIPTION
## Summary

- 대시보드 키퍼 상세 카드가 "상세 runtime 동기화 중"으로만 표시되던 문제 수정
- `operator_control_snapshot.ml`에서 `context_ratio`를 `Null` 하드코딩 → `meta.usage.last_input_tokens / max_context` 계산으로 변경
- `Oas_model_resolve.max_context_of_label`로 모델별 max context 조회 (SSOT인 OAS Provider_Registry 경유)
- 턴 데이터 없거나 모델 미확인 시 기존처럼 `Null` 반환 (graceful fallback)

## 변경 파일

- `lib/operator/operator_control_snapshot.ml` — `compute_context_ratio` 헬퍼 추가, resident keeper + persistent agent 양쪽 적용

## 프론트엔드 변경: 없음

프론트엔드는 이미 `context_ratio`가 `number`일 때 올바르게 렌더링하도록 구현됨:
- `ops-keeper-column.ts`: 퍼센트 표시
- `mission-agent-cards.ts`: 세대/컨텍스트 표시
- `helpers.ts`: 80%+ 경고

## Test plan

- [x] `dune build` 성공
- [x] `make test` — pre-existing 실패만 (context_ratio 변경 무관)
- [ ] MASC 서버 재시작 후 대시보드에서 키퍼 카드 컨텍스트 퍼센트 표시 확인
- [ ] 턴 0인 새 키퍼에서 Null fallback 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)