### PR TITLE
fix(dashboard): keeper 상세 UX 개선 (모델 통계, 상태 라벨, 죽은 KPI 제거)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -46,7 +46,7 @@ function statusLabel(status: string | undefined): string {
   if (!status) return '상태 미수집'
   const labels: Record<string, string> = {
     active: '온라인', busy: '처리 중', listening: '응답 대기', working: '작업 실행 중',
-    idle: '작업 없음', offline: '연결 끊김', inactive: '중지됨',
+    idle: '대기', offline: '오프라인', inactive: '종료됨',
   }
   return labels[status.toLowerCase()] ?? status
 }
@@ -59,8 +59,8 @@ function statusDescription(status: string | undefined): string {
     listening: '연결된 상태에서 입력이나 다음 지시를 기다리고 있습니다.',
     working: '현재 작업을 수행 중입니다.',
     idle: '연결은 유지되지만 지금 표시할 작업은 없습니다.',
-    offline: '현재 런타임이 보이지 않거나 하트비트가 없습니다.',
-    inactive: '등록은 남아 있지만 현재는 내려간 상태입니다.',
+    offline: '하트비트가 없어 현재 접근할 수 없습니다. 수동으로 내렸거나 연결이 끊겼을 수 있습니다.',
+    inactive: '등록은 남아 있지만 명시적으로 내려간 상태입니다.',
   }
   return descriptions[status.toLowerCase()] ?? '정의되지 않은 상태값입니다.'
 }
@@ -494,7 +494,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   </span>
                   ${isKeeper ? html`
                     <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1 text-[11px] text-[var(--text-muted)]">
-                      컨텍스트 ${ctxPct != null ? `${ctxPct}% 사용` : '수집 전'}
+                      컨텍스트 ${ctxPct != null ? `${ctxPct}% 사용` : '대기 중'}
                     </span>
                   ` : null}
                 </div>
@@ -518,9 +518,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <div class="rounded-2xl border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-3 py-3">
                       <div class="flex items-center justify-between gap-3 text-[11px]">
                         <span class="text-[var(--text-muted)]">컨텍스트 사용량</span>
-                        <strong class="text-[var(--text-strong)]">수집 전</strong>
+                        <strong class="text-[var(--text-strong)]">대기 중</strong>
                       </div>
-                      <p class="mt-2 text-[11px] leading-[1.45] text-[var(--text-muted)]">키퍼가 아직 컨텍스트 메트릭을 보고하지 않았습니다.</p>
+                      <p class="mt-2 text-[11px] leading-[1.45] text-[var(--text-muted)]">아직 메트릭이 보고되지 않았습니다. 키퍼가 첫 턴을 시작하면 자동으로 갱신됩니다.</p>
                     </div>
                   `}
                 ` : null}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -86,13 +86,20 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
   const ctxTone: KpiTone = ctxPct == null ? 'default' : ctxPct > 85 ? 'bad' : ctxPct > 70 ? 'warn' : ctxPct > 0 ? 'ok' : 'default'
   const ctxHint = ctxPct != null && ctxPct > 80 ? '한계 접근 중' : undefined
 
-  const actLevel = typeof keeper.activityLevel === 'number' ? keeper.activityLevel : null
-  const actTone: KpiTone = actLevel == null ? 'default' : actLevel >= 4 ? 'ok' : actLevel >= 2 ? 'warn' : 'default'
+  // Provider-model call statistics from metrics_series
+  const modelCounts: Record<string, number> = {}
+  for (const pt of series) {
+    if (pt.model_used) {
+      modelCounts[pt.model_used] = (modelCounts[pt.model_used] ?? 0) + 1
+    }
+  }
+  const modelEntries = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])
+  const totalCalls = modelEntries.reduce((s, [, c]) => s + c, 0)
 
   return html`
     <div class="flex flex-col gap-3 mb-5">
-      ${'' /* Primary KPIs — 4 cols */}
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      ${'' /* Primary KPIs — 3 cols (activityLevel removed) */}
+      <div class="grid grid-cols-3 gap-3">
         <${KpiCard}
           label="Generation"
           value=${keeper.generation ?? '-'}
@@ -110,13 +117,30 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
           tone=${ctxTone}
           progress=${ctxPct ?? undefined}
         />
-        <${KpiCard}
-          label="Activity"
-          value=${keeper.activityLevel ?? '-'}
-          hint="레벨 0-5"
-          tone=${actTone}
-        />
       </div>
+      ${'' /* Model usage distribution */}
+      ${totalCalls > 0 ? html`
+        <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-3">
+          <div class="mb-2 text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Provider-Model 호출 분포</div>
+          <div class="flex flex-col gap-1.5">
+            ${modelEntries.slice(0, 4).map(([model, count]) => {
+              const pct = Math.round((count / totalCalls) * 100)
+              return html`
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="shrink-0 w-[140px] truncate font-mono text-[11px] text-[#9ad9ff]" title=${model}>${model}</span>
+                  <div class="flex-1 h-1.5 bg-[var(--white-6)] rounded-full overflow-hidden">
+                    <div class="h-full rounded-full bg-[var(--accent)]" style="width:${pct}%"></div>
+                  </div>
+                  <span class="shrink-0 w-10 text-right text-[var(--text-muted)]">${count}회</span>
+                </div>
+              `
+            })}
+          </div>
+          ${modelEntries.length > 4 ? html`
+            <div class="mt-1 text-[10px] text-[var(--text-muted)]">외 ${modelEntries.length - 4}개 모델</div>
+          ` : null}
+        </div>
+      ` : null}
       ${'' /* Secondary KPIs — 3-4 cols, smaller feel */}
       <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
         <${KpiCard}
@@ -201,7 +225,6 @@ export function RawDataDebug({ keeper }: { keeper: Keeper }) {
     { title: 'Model', key: 'model', value: keeper.model ?? '-' },
     { title: 'Status', key: 'status', value: keeper.status },
     { title: 'Primary', key: 'primaryValue', value: keeper.primaryValue ?? '-' },
-    { title: 'Activity', key: 'activityLevel', value: String(keeper.activityLevel ?? '-') },
     { title: 'Gen', key: 'generation', value: String(keeper.generation ?? '-') },
     { title: 'Turns', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
     { title: 'Context', key: 'context_ratio', value: formatPct(keeper.context_ratio) },

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -175,9 +175,16 @@ export function KeeperDetailOverlay() {
               <div class="flex items-center gap-2.5">
                 <h2 class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
                 <${KeeperStatusPill} status=${keeper.status} />
-                ${keeper.model ? html`
-                  <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.2)]">${keeper.model}</span>
-                ` : null}
+                ${(() => {
+                  const series = keeper.metrics_series ?? []
+                  const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
+                  const display = lastUsed || keeper.active_model || keeper.model
+                  return display ? html`
+                    <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-mono bg-[var(--accent-12)] text-[#9ad9ff] border border-[rgba(71,184,255,0.2)]"
+                      title=${lastUsed && keeper.model ? `마지막 호출: ${lastUsed}\n설정: ${keeper.model}` : ''}
+                    >${display}</span>
+                  ` : null
+                })()}
               </div>
               ${keeper.koreanName ? html`<span class="text-xs text-[var(--text-muted)]">${keeper.koreanName}</span>` : null}
             </div>


### PR DESCRIPTION
## Summary
- 죽은 `activityLevel` KPI 제거 (keeper에서 값 미설정, 항상 `-`)
- Provider-Model 호출 분포 차트 추가 (`metrics_series[].model_used` 집계)
- 헤더 모델 배지: 정적 config 모델 → 마지막 실제 호출 모델 표시
- 상태 라벨: "연결 끊김" → "오프라인", "중지됨" + 설명 개선
- "컨텍스트 수집 전" → "대기 중" + 자동 갱신 안내 문구

## 변경 파일 (3개, 프론트엔드만)
- `dashboard/src/components/keeper-detail-panels.ts` — KPI 그리드 + 모델 통계 차트
- `dashboard/src/components/keeper-detail.ts` — 헤더 모델 배지
- `dashboard/src/components/agent-roster.ts` — 상태 라벨 + 컨텍스트 텍스트

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `npm run build` 성공
- [ ] 브라우저에서 keeper 상세 화면 확인
- [ ] metrics_series 비어있을 때 graceful 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)