### PR TITLE
refactor(eio): make Fun.protect finally handlers cancellation-safe

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -340,7 +340,14 @@ module Reflection_bridge = struct
       let response_stream = Grpc_eio.Stream.create 16 in
       let process_loop () =
         Fun.protect
-          ~finally:(fun () -> Grpc_eio.Stream.close response_stream)
+          ~finally:(fun () ->
+            (* Cancellation-safe: catch exceptions to prevent masking *)
+            try Grpc_eio.Stream.close response_stream
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
+                Log.Server.warn "gRPC reflection stream close failed: %s"
+                  (Printexc.to_string exn))
           (fun () ->
             let rec loop () =
               let request_bytes = Grpc_eio.Stream.take request_stream in

--- a/lib/keeper/keeper_resident_supervisor.ml
+++ b/lib/keeper/keeper_resident_supervisor.ml
@@ -48,17 +48,26 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
         Eio.Promise.resolve reg.done_r `Stopped;
         publish_lifecycle "stopped" meta.name "normal exit")
       ~finally:(fun () ->
-        Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path meta.name;
+        (* Cancellation-safe: all operations catch their own exceptions
+           to prevent masking the original exception from Fun.protect. *)
+        (try Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path meta.name
+         with exn ->
+           Log.Keeper.warn "cleanup_tracking failed for %s: %s" meta.name
+             (Printexc.to_string exn));
         match Eio.Promise.peek reg.done_p with
         | Some _ -> ()  (* Already resolved in the normal path *)
         | None ->
             let msg = "fiber terminated without resolution" in
-            Keeper_registry.record_crash ~base_path:ctx.config.base_path
-              meta.name (Time_compat.now ()) msg;
-            Keeper_registry.record_error ~base_path:ctx.config.base_path
-              meta.name msg;
-            Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
-              Keeper_registry.Stopped;
+            (try
+              Keeper_registry.record_crash ~base_path:ctx.config.base_path
+                meta.name (Time_compat.now ()) msg;
+              Keeper_registry.record_error ~base_path:ctx.config.base_path
+                meta.name msg;
+              Keeper_registry.set_state ~base_path:ctx.config.base_path meta.name
+                Keeper_registry.Stopped
+             with exn ->
+               Log.Keeper.warn "crash recording failed for %s: %s" meta.name
+                 (Printexc.to_string exn));
             Eio.Promise.resolve reg.done_r (`Crashed msg);
             publish_lifecycle "crashed" meta.name msg))
 

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -231,9 +231,15 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
           in
           Fun.protect
             ~finally:(fun () ->
-              ignore
+              (* Cancellation-safe: catch exceptions to prevent masking *)
+              (try ignore
                 (leave_worker ~sw ~auth_token
-                   ~session_id:meta.mcp_session_id ~worker_name))
+                   ~session_id:meta.mcp_session_id ~worker_name)
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                   Log.LocalWorker.warn "leave_worker failed for %s: %s"
+                     worker_name (Printexc.to_string exn)))
             (fun () ->
               let _ =
                 match join_worker ~sw ~auth_token

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -266,12 +266,14 @@ let run ~sw t =
   match t.lifecycle with
   | Perpetual ->
     Eio.Fiber.fork_daemon ~sw (fun () ->
+      (* Fun.protect safe: finally is non-throwing field mutation *)
       Fun.protect
         (fun () -> loop t; `Stop_daemon)
         ~finally:(fun () -> t.alive <- false)
     )
   | Bounded _ ->
     Eio.Fiber.fork ~sw (fun () ->
+      (* Fun.protect safe: finally is non-throwing field mutation *)
       Fun.protect
         (fun () -> loop t)
         ~finally:(fun () -> t.alive <- false)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -317,9 +317,15 @@ let rec run_worker_via_oas
   in
   Fun.protect
     ~finally:(fun () ->
-      ignore
+      (* Cancellation-safe: catch exceptions to prevent masking *)
+      (try ignore
         (Worker_container_types.leave_worker ~sw ~auth_token
-           ~session_id ~worker_name))
+           ~session_id ~worker_name)
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+           Log.LocalWorker.warn "leave_worker failed for %s: %s" worker_name
+             (Printexc.to_string exn)))
     (fun () ->
       let _ =
         match


### PR DESCRIPTION
## Summary

33개 `Fun.protect` call site 감사. finally 핸들러가 I/O를 수행하면서 예외를 방어하지 않는 3개 site를 cancellation-safe로 수정.

**수정 (3 site - I/O finally without exception guard):**
- `keeper_resident_supervisor.ml`: `cleanup_tracking` + `record_crash` try-with 래핑
- `worker_oas.ml:318`: `leave_worker` try-with + Cancelled re-raise
- `worker_container_runners.ml:232`: 동일 `leave_worker` 패턴
- `masc_grpc_server.ml:342`: `Stream.close` try-with + Cancelled re-raise

**주석 추가 (안전 site):**
- `pulse.ml:269,275`: finally가 `t.alive <- false` (non-throwing 필드 변경)

**변경 불필요 (이미 cancellation-aware):**
- `server_routes_http_keeper_stream.ml:429`: `close_stream`이 이미 Cancelled re-raise
- `worker_oas.ml:353`: `Agent.close`가 이미 Cancelled re-raise
- `masc_grpc_server.ml:480`: non-throwing boolean set

## Test plan

- [x] `dune build` 컴파일 성공
- [ ] CI green 확인

Closes #3248
