### PR TITLE
chore(toolchain): bump minimum OCaml version to 5.4

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (synopsis "Multi-Agent Streaming Coordination MCP Server in OCaml")
  (description "MASC Protocol: File-based coordination for Claude, Gemini, and Codex agents")
  (depends
-  (ocaml (>= 5.1))
+  (ocaml (>= 5.4))
   (dune (>= 3.13))
   ; External dependencies (opam pin)
   (mcp_protocol (>= 0.15.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc-mcp"
 doc: "https://github.com/jeong-sik/masc-mcp"
 bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.4"}
   "dune" {>= "3.13" & >= "3.13"}
   "mcp_protocol" {>= "0.15.0"}
   "ocaml-webrtc" {>= "0.2.3"}


### PR DESCRIPTION
## Summary

- `dune-project`: `(ocaml (>= 5.1))` → `(ocaml (>= 5.4))`
- `masc_mcp.opam`: 자동 갱신

iarray 전환은 보류: `public_mcp_tools`, `chain_category` 등 정적 리스트가 fiber 간 공유되지 않아 실질 이점 없음.

## Test plan

- [x] `dune build` 성공
- [ ] CI green

Closes #3251
