### PR TITLE
fix(test): backend-aware worker-run listing fixes CI dashboard_proof failure

### DIFF
--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -336,23 +336,22 @@ let save_worker_run_meta_json config session_id worker_run_id json =
 
 let list_worker_run_ids config session_id =
   let dir = worker_runs_dir config session_id in
-  if not (path_exists config dir) then
-    []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.sort String.compare
+  list_dir config dir
+  |> List.filter_map (fun entry ->
+       match String.split_on_char '/' entry with
+       | name :: _ when name <> "" -> Some name
+       | _ -> None)
+  |> List.sort_uniq String.compare
 
 let list_checkpoint_paths config session_id =
   let dir = checkpoints_dir config session_id in
-  if not (path_exists config dir) then
-    []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
-    |> List.sort String.compare
-    |> List.map (Filename.concat dir)
+  list_dir config dir
+  |> List.filter_map (fun entry ->
+       match String.split_on_char '/' entry with
+       | name :: _ when Filename.check_suffix name ".json" -> Some name
+       | _ -> None)
+  |> List.sort_uniq String.compare
+  |> List.map (Filename.concat dir)
 
 let load_latest_checkpoint config session_id : Team_session_types.checkpoint option =
   match List.rev (list_checkpoint_paths config session_id) with


### PR DESCRIPTION
## Summary
`list_worker_run_ids` and `list_checkpoint_paths` in `team_session_store.ml` used `Sys.readdir` directly, bypassing the backend layer. This caused `test_dashboard_proof` to fail:

1. `path_exists config dir` checked via `Backend.FileSystem.exists` which only matches `Regular_file`, not `Directory` → returned `false` for the `worker-runs/` directory
2. `list_worker_run_ids` returned `[]` → `raw_trace_run_count = 0`

**Fix**: Replace `Sys.readdir` with the existing backend-aware `list_dir` function, extracting top-level entries from key-based results.

## Test
- `test_dashboard_proof`: 7/7 passed (was 6/7, projection #1 now fixed)

## Impact
This is the **only remaining test failure on main CI** (after #3262 fixed the OAS pin ratchet). Merging this should make main CI green, unblocking all pending PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)