### PR TITLE
fix(keeper): deactivate instead of delete on keeper_down (#3271)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -122,6 +122,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
     in
     let specs =
       list_resident_keepers ctx.config
+      |> List.filter (fun (spec : resident_keeper_spec) -> spec.desired)
       |> take max_scan
     in
     let (enabled, scanned, started, stale, recovering) =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -668,6 +668,13 @@ let remove_resident_keeper config name =
   Safe_ops.remove_file_logged ~context:"resident_keeper_remove"
     (resident_keeper_path config name)
 
+let deactivate_resident_keeper config name =
+  match read_resident_keeper config name with
+  | Ok (Some spec) ->
+      write_resident_keeper config
+        { spec with desired = false; updated_at = now_iso () }
+  | _ -> Ok ()
+
 let list_resident_keepers config : resident_keeper_spec list =
   let dir = resident_keeper_dir config in
   match Safe_ops.list_dir_safe dir with
@@ -687,7 +694,9 @@ let resident_keeper_names config =
   list_resident_keepers config |> List.map (fun spec -> spec.name)
 
 let is_resident_keeper config name =
-  List.mem name (resident_keeper_names config)
+  match read_resident_keeper config name with
+  | Ok (Some spec) -> spec.desired
+  | _ -> false
 
 let register_resident_keeper_from_meta config (meta : keeper_meta) :
     (unit, string) result =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -348,7 +348,7 @@ let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
 
 let handle_resident_keeper_down ctx args : tool_result =
   let name = get_string args "name" "" in
-  if validate_name name then remove_resident_keeper ctx.config name;
+  if validate_name name then ignore (deactivate_resident_keeper ctx.config name);
   invalidate_resident_keeper_list_cache ();
   Turn.handle_keeper_down ctx args
 


### PR DESCRIPTION
## Summary
- `keeper_down` deleted the resident-keepers JSON file → keeper invisible on restart
- `desired` flag was always `true` (dead code)
- Server restart skipped all previously-downed keepers

## Changes
- `deactivate_resident_keeper`: sets `desired=false` instead of deleting
- `bootstrap_existing_keepers`: filters on `spec.desired=true`
- `is_resident_keeper`: returns `false` when `desired=false`

## Test
- `test_tool_keeper`: 31/32 passed (1 pre-existing failure: `masc_keeper_autonomy` dispatch)
- No new regressions from this change

Closes #3271

🤖 Generated with [Claude Code](https://claude.com/claude-code)