### PR TITLE
feat(harness): record fallback_reason and show evaluator alert in dashboard

### DIFF
--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -22,6 +22,8 @@ interface CalibrationStats {
   false_positive_count: number
   false_negative_count: number
   agreement_rate: number
+  fallback_count?: number
+  recent_fallback_reasons?: string[]
 }
 
 interface HarnessHealthData {
@@ -139,6 +141,12 @@ export function HarnessHealth() {
     : '0'
   const agreementPct = cal ? (cal.agreement_rate * 100).toFixed(1) : '-'
 
+  // Detect evaluator degradation: fallback > 80% of total verdicts
+  const fallbackCount = cal?.fallback_count ?? 0
+  const isFallbackDominant = cal != null && cal.total_verdicts > 0
+    && (fallbackCount / cal.total_verdicts) > 0.8
+  const fallbackReasons = cal?.recent_fallback_reasons ?? []
+
   return html`
     <div class="space-y-4">
       <${Card} title="Evaluator 캘리브레이션" class="section">
@@ -149,6 +157,26 @@ export function HarnessHealth() {
         ` : !cal ? html`
           <div class="text-slate-500 text-sm">데이터 없음</div>
         ` : html`
+          ${isFallbackDominant ? html`
+            <div class="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3">
+              <div class="text-yellow-400 text-sm font-medium mb-1">Evaluator 미연결</div>
+              <div class="text-yellow-400/80 text-xs">
+                전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됨.
+                LLM evaluator cascade가 동작하지 않아 모든 verdict가 자동 승인 상태입니다.
+              </div>
+              ${fallbackReasons.length > 0 ? html`
+                <details class="mt-2">
+                  <summary class="text-yellow-400/60 text-xs cursor-pointer">최근 에러 (${fallbackReasons.length}건)</summary>
+                  <div class="mt-1 space-y-1">
+                    ${fallbackReasons.map(r => html`
+                      <div class="text-xs text-yellow-400/50 font-mono break-all">${r}</div>
+                    `)}
+                  </div>
+                </details>
+              ` : null}
+            </div>
+          ` : null}
+
           <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
             <${StatCard} label="총 Verdict" value=${cal.total_verdicts} />
             <${StatCard} label="Reject 비율" value="${rejectRate}%" />

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -117,6 +117,9 @@ export function ToolMetrics() {
       ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-base rounded-lg">${error}</div>` : null}
 
       ${data ? html`
+        <div class="text-[11px] text-[var(--text-muted)] mb-3">
+          서버 시작 이후 메모리 기반 집계. 재시작 시 초기화됩니다.
+        </div>
         <div class="grid grid-cols-[repeat(5,minmax(0,1fr))] gap-3 max-[880px]:grid-cols-[repeat(2,minmax(0,1fr))]">
           <div class="flex flex-col items-center gap-1 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3">
             <span class="mt-1.5 text-[var(--text-strong)] text-[30px] font-bold leading-none tabular-nums">${data.total_calls}</span>

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -33,6 +33,7 @@ type review_result = {
   evaluator_cascade : string;
   generator_cascade : string option;
   gate : string;  (** Which gate produced this verdict: "length", "excuse", "llm", "fallback" *)
+  fallback_reason : string option;  (** Error message when gate="fallback" — aids debugging *)
 }
 
 (* ================================================================ *)
@@ -211,7 +212,7 @@ let review
   if String.length notes_trimmed < min_notes_length then
     emit { verdict = Reject (sprintf "completion notes too short (%d chars, minimum %d)"
                           (String.length notes_trimmed) min_notes_length);
-      evaluator_cascade; generator_cascade; gate = "length" }
+      evaluator_cascade; generator_cascade; gate = "length"; fallback_reason = None }
   else
   (* Gate 2: local excuse pattern detection *)
   match find_excuse_pattern notes_trimmed with
@@ -220,7 +221,7 @@ let review
       req.agent_name req.task_title pattern;
     emit { verdict = Reject (sprintf "avoidance pattern detected: \"%s\" (%s). Revise your notes to describe actual completed work."
                           pattern reason);
-      evaluator_cascade; generator_cascade; gate = "excuse" }
+      evaluator_cascade; generator_cascade; gate = "excuse"; fallback_reason = None }
   | None ->
   (* Gate 2.5: contract verification (local, no LLM) *)
   let contract_rejection =
@@ -239,7 +240,7 @@ let review
   match contract_rejection with
   | Some reason ->
     emit { verdict = Reject reason;
-      evaluator_cascade; generator_cascade; gate = "contract" }
+      evaluator_cascade; generator_cascade; gate = "contract"; fallback_reason = None }
   | None ->
     (* Gate 3: LLM review via evaluator cascade *)
     let prompt = build_prompt ~few_shot_block req in
@@ -267,11 +268,11 @@ let review
         | Approve ->
           Log.Task.info "[anti-rationalization] LLM approved: agent=%s task=%s cascade=%s"
             req.agent_name req.task_title evaluator_cascade);
-       emit { verdict = v; evaluator_cascade; generator_cascade; gate = "llm" }
+       emit { verdict = v; evaluator_cascade; generator_cascade; gate = "llm"; fallback_reason = None }
      | Error msg ->
        (* Liveness > correctness: if LLM is unavailable, approve *)
        Log.Task.warn "[anti-rationalization] LLM unavailable: %s (approving by default)" msg;
-       emit { verdict = Approve; evaluator_cascade; generator_cascade; gate = "fallback" })
+       emit { verdict = Approve; evaluator_cascade; generator_cascade; gate = "fallback"; fallback_reason = Some msg })
 
 (** Backward-compatible wrapper that returns only the verdict.
     Use [review] directly for structured results with audit metadata. *)
@@ -279,9 +280,14 @@ let review_verdict ?evaluator_cascade ?generator_cascade ?completion_contract ?o
   (review ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block req).verdict
 
 let review_result_to_json (r : review_result) : Yojson.Safe.t =
-  `Assoc [
+  let base = [
     ("verdict", `String (match r.verdict with Approve -> "approve" | Reject s -> "reject:" ^ s));
     ("evaluator_cascade", `String r.evaluator_cascade);
     ("generator_cascade", match r.generator_cascade with Some s -> `String s | None -> `Null);
     ("gate", `String r.gate);
-  ]
+  ] in
+  let extra = match r.fallback_reason with
+    | Some reason -> [("fallback_reason", `String reason)]
+    | None -> []
+  in
+  `Assoc (base @ extra)

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -34,6 +34,7 @@ type review_result = {
   evaluator_cascade : string;
   generator_cascade : string option;
   gate : string;
+  fallback_reason : string option;  (** Error message when gate="fallback" *)
 }
 
 (** Review a task completion claim with optional cross-model separation.

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -21,6 +21,7 @@ type verdict_record = {
   gate : string;                  (** "length" | "excuse" | "contract" | "llm" | "fallback" *)
   evaluator_cascade : string;
   generator_cascade : string option;
+  fallback_reason : string option; (** Error message when gate="fallback" *)
   timestamp : float;
 }
 
@@ -85,7 +86,7 @@ let notes_hash ~(task_title : string) ~(notes : string) : string =
 (* ================================================================ *)
 
 let verdict_record_to_json (r : verdict_record) : Yojson.Safe.t =
-  `Assoc [
+  let base = [
     ("record_type", `String r.record_type);
     ("notes_hash", `String r.notes_hash);
     ("task_id", `String r.task_id);
@@ -97,7 +98,12 @@ let verdict_record_to_json (r : verdict_record) : Yojson.Safe.t =
     ("generator_cascade",
      (match r.generator_cascade with Some s -> `String s | None -> `Null));
     ("timestamp", `Float r.timestamp);
-  ]
+  ] in
+  let extra = match r.fallback_reason with
+    | Some reason -> [("fallback_reason", `String reason)]
+    | None -> []
+  in
+  `Assoc (base @ extra)
 
 let label_record_to_json (r : label_record) : Yojson.Safe.t =
   `Assoc [
@@ -154,6 +160,7 @@ let record_verdict
     gate = result.gate;
     evaluator_cascade = result.evaluator_cascade;
     generator_cascade = result.generator_cascade;
+    fallback_reason = result.fallback_reason;
     timestamp = Unix.gettimeofday ();
   } in
   Dated_jsonl.append (get_store ()) (verdict_record_to_json record);
@@ -290,6 +297,8 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   let gate_counts : (string, int) Hashtbl.t = Hashtbl.create 8 in
   let labeled_hashes : (string, string) Hashtbl.t = Hashtbl.create 64 in
   let verdict_hashes : (string, string) Hashtbl.t = Hashtbl.create 64 in
+  let recent_fallback_reasons : string list ref = ref [] in
+  let max_fallback_reasons = 5 in
   List.iter (fun json ->
     let rt = string_field json "record_type" in
     let hash = string_field json "notes_hash" in
@@ -301,7 +310,11 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
       let gate = string_field json "gate" in
       let prev = try Hashtbl.find gate_counts gate with Not_found -> 0 in
       Hashtbl.replace gate_counts gate (prev + 1);
-      Hashtbl.replace verdict_hashes hash v
+      Hashtbl.replace verdict_hashes hash v;
+      if gate = "fallback" && List.length !recent_fallback_reasons < max_fallback_reasons then
+        (let reason = string_field json "fallback_reason" in
+         if reason <> "" then
+           recent_fallback_reasons := reason :: !recent_fallback_reasons)
     end else if rt = "label" then
       Hashtbl.replace labeled_hashes hash (string_field json "human_verdict")
   ) records;
@@ -328,6 +341,9 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   in
   let gate_json = Hashtbl.fold (fun k v acc ->
     (k, `Int v) :: acc) gate_counts [] in
+  let fallback_count =
+    try Hashtbl.find gate_counts "fallback" with Not_found -> 0
+  in
   `Assoc [
     ("total_verdicts", `Int !total_verdicts);
     ("approve_count", `Int !approve_count);
@@ -337,4 +353,7 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
     ("false_positive_count", `Int !false_pos);
     ("false_negative_count", `Int !false_neg);
     ("agreement_rate", `Float agreement_rate);
+    ("fallback_count", `Int fallback_count);
+    ("recent_fallback_reasons",
+     `List (List.rev_map (fun s -> `String s) !recent_fallback_reasons));
   ]

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -19,6 +19,7 @@ type verdict_record = {
   gate : string;
   evaluator_cascade : string;
   generator_cascade : string option;
+  fallback_reason : string option;
   timestamp : float;
 }
 

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -37,9 +37,9 @@ let make_req ?(title = "Fix auth bug") ?(desc = "Fix the login issue")
     completion_notes = notes; agent_name = agent }
 
 let make_result ?(verdict = AR.Approve) ?(cascade = "verifier")
-    ?gen_cascade ?(gate = "llm") () : AR.review_result =
+    ?gen_cascade ?(gate = "llm") ?fallback_reason () : AR.review_result =
   { verdict; evaluator_cascade = cascade;
-    generator_cascade = gen_cascade; gate }
+    generator_cascade = gen_cascade; gate; fallback_reason }
 
 (* ================================================================ *)
 (* Hashing tests                                                     *)
@@ -289,7 +289,8 @@ let test_to_harness_verdict_approve () =
     task_id = "t1"; task_title = "Fix login";
     agent_name = "dreamer"; verdict = "approve";
     gate = "llm"; evaluator_cascade = "glm5";
-    generator_cascade = Some "claude"; timestamp = 0.0;
+    generator_cascade = Some "claude"; fallback_reason = None;
+    timestamp = 0.0;
   } in
   let hv = Cal.to_harness_verdict record in
   check bool "passed" true hv.Agent_sdk.Harness.passed;
@@ -304,7 +305,8 @@ let test_to_harness_verdict_reject () =
     task_id = "t2"; task_title = "Deploy fix";
     agent_name = "coder"; verdict = "reject:too short";
     gate = "length"; evaluator_cascade = "local";
-    generator_cascade = None; timestamp = 0.0;
+    generator_cascade = None; fallback_reason = None;
+    timestamp = 0.0;
   } in
   let hv = Cal.to_harness_verdict record in
   check bool "not passed" false hv.passed;


### PR DESCRIPTION
## Summary
- anti-rationalization verdict에 `fallback_reason` 필드 추가 — cascade 실패 시 에러 메시지를 JSONL에 기록
- calibration_stats API에 `fallback_count`와 `recent_fallback_reasons` 노출
- Dashboard harness-health 패널에 evaluator 미연결 경고 배너 (fallback >80% 시 표시)
- Tool metrics 패널에 in-memory 집계 안내 문구 추가

## Context
현재 28건 verdict 전부 fallback gate 통과 — LLM evaluator cascade가 한 번도 성공하지 못하는 상태.
에러 메시지가 기록되지 않아 원인 추적이 불가능했음. 이 PR로 다음 fallback 발생 시 정확한 에러 메시지가 verdict 파일에 남음.

## Test plan
- [x] `dune exec test/test_eval_calibration.exe` — 21 tests passed
- [x] `dune build` — clean
- [x] `tsc --noEmit` — no TypeScript errors
- [x] `vite build` — dashboard builds successfully
- [ ] `make test` — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)