### PR TITLE
fix(proactive_refresh): report timeout as cached surface error (#3264)

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -45,7 +45,7 @@ let log_refresh_failure ~config ~consecutive_failures ~current_interval ~dt exn 
     config.label !consecutive_failures !current_interval dt
     (Printexc.to_string exn)
 
-let start ~sw ~clock ~config ~compute ~on_result =
+let start ~sw ~clock ~config ~compute ~on_result ?(on_error = fun _ -> ()) () =
   Eio.Fiber.fork ~sw (fun () ->
     let t0 = Time_compat.now () in
     (try
@@ -57,15 +57,17 @@ let start ~sw ~clock ~config ~compute ~on_result =
          Log.Dashboard.info "%s warm cache done (%.1fs)" config.label
            (Time_compat.now () -. t0)
        | Error `Timeout ->
+         on_error (Failure "timeout");
          Log.Dashboard.warn "%s warm cache skipped (%.1fs timeout)" config.label
            (Time_compat.now () -. t0)
      with
      | exn ->
        if should_reraise_cancel exn then
          raise exn
-       else
+       else (
+         on_error exn;
          Log.Dashboard.warn "%s warm cache failed (%.1fs): %s" config.label
-           (Time_compat.now () -. t0) (Printexc.to_string exn)));
+           (Time_compat.now () -. t0) (Printexc.to_string exn))));
   Eio.Fiber.fork ~sw (fun () ->
     Log.Dashboard.info "starting %s refresh loop" config.label;
     let consecutive_failures = ref 0 in
@@ -88,11 +90,13 @@ let start ~sw ~clock ~config ~compute ~on_result =
          Log.Dashboard.info "%s refreshed (%.1fs)" config.label dt
          | Error `Timeout ->
              let dt = Time_compat.now () -. t0 in
+             on_error (Failure "timeout");
              log_refresh_failure ~config ~consecutive_failures ~current_interval
                ~dt (Failure "timeout")
        with exn ->
          if should_reraise_cancel exn then raise exn;
          let dt = Time_compat.now () -. t0 in
+         on_error exn;
          log_refresh_failure ~config ~consecutive_failures ~current_interval
            ~dt exn);
       loop ()

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -21,9 +21,13 @@ val start :
   config:config ->
   compute:(unit -> 'a) ->
   on_result:('a -> unit) ->
+  ?on_error:(exn -> unit) ->
+  unit ->
   unit
 (** Start a refresh loop with warm cache and circuit breaker.
 
     [compute] produces a value; [on_result] stores it (typically writing
-    to a ref).  A warm-cache run executes synchronously before the async
-    loop, bounded by [config.timeout_s]. *)
+    to a ref).  [on_error], when provided, is called on timeout or
+    exception so callers can record the failure (e.g. cached surface
+    error tracking).  A warm-cache run executes synchronously before
+    the async loop, bounded by [config.timeout_s]. *)

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -124,6 +124,7 @@ let start_cp_snapshot_refresh_loop ~state ~sw ~clock =
               with timeout_s = 30.0 }
     ~compute:(fun () -> compute_cp_snapshot ~state)
     ~on_result:(fun snapshot -> _cp_snapshot_ref := snapshot)
+    ()
 
 let command_plane_snapshot_http_json ~state:_ =
   !_cp_snapshot_ref

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -227,6 +227,8 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
               with timeout_s = execution_refresh_timeout_s }
     ~compute
     ~on_result:(mark_cached_surface_success _execution_cache)
+    ~on_error:(mark_cached_surface_error _execution_cache)
+    ()
 
 let start_transport_health_refresh_loop ~state ~sw ~clock =
   let timeout_s =
@@ -251,6 +253,8 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
         with timeout_s }
     ~compute
     ~on_result:(mark_cached_surface_success _transport_health_cache)
+    ~on_error:(mark_cached_surface_error _transport_health_cache)
+    ()
 
 let dashboard_execution_http_json ~state ~sw ~clock request =
   let fixture = query_param request "fixture" in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -434,6 +434,8 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
                        ~default:45.0 ~min_v:10.0 ~max_v:120.0 }
     ~compute
     ~on_result:(mark_cached_surface_success _operator_snapshot_cache)
+    ~on_error:(mark_cached_surface_error _operator_snapshot_cache)
+    ()
 
 let start_operator_digest_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
@@ -487,6 +489,8 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
                        ~default:45.0 ~min_v:10.0 ~max_v:120.0 }
     ~compute
     ~on_result:(mark_cached_surface_success _operator_digest_cache)
+    ~on_error:(mark_cached_surface_error _operator_digest_cache)
+    ()
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
   let actor = operator_actor_hint request in
@@ -707,6 +711,8 @@ let start_mission_refresh_loop ~state ~sw ~clock =
               with timeout_s = mission_refresh_timeout_s }
     ~compute
     ~on_result:(mark_cached_surface_success _mission_cache)
+    ~on_error:(mark_cached_surface_error _mission_cache)
+    ()
 
 let dashboard_mission_http_json ~state ~sw ~clock request =
   let actor = operator_actor_hint request in


### PR DESCRIPTION
## Summary

- `Proactive_refresh.start`에 optional `~on_error:(exn -> unit)` 콜백 추가
- timeout 시 `mark_cached_surface_error`가 호출되어 `last_error_unix`에 기록됨
- 이전에는 timeout → 로그만 남기고 cached surface는 "시도한 적 없음" 상태로 남았음

## Changes

| 파일 | 변경 |
|------|------|
| `proactive_refresh.ml` | `?on_error` param 추가, timeout/exception 경로에서 호출 |
| `proactive_refresh.mli` | 시그니처에 `?on_error` + `unit ->` 추가 |
| `server_dashboard_http_core.ml` | 3개 loop에 `~on_error` 전달 |
| `server_dashboard_http.ml` | 2개 loop에 `~on_error` 전달 |
| `server_command_plane_http_support.ml` | `()` unit param 추가 (no cached surface) |

## Test plan

- [x] `dune build` 성공
- [ ] CI green (pre-existing failures는 이 변경과 무관)
- [ ] timeout 발생 시 dashboard에서 `last_error` 확인 가능한지 수동 검증

Closes #3264

Generated with [Claude Code](https://claude.com/claude-code)