### PR TITLE
fix(test): align tests with ZSTD backend, Eio context, and backend-aware listing

### DIFF
--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -9,42 +9,46 @@ let current_clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
 let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option ref = ref None
 let current_sw : Eio.Switch.t option ref = ref None
 let net_initialized : bool ref = ref false
-let global_ctx_mutex = Eio.Mutex.create ()
+
+(** Stdlib.Mutex: these refs are set/read in non-yielding operations,
+    and the module is loaded before any Eio runtime exists. *)
+let global_ctx_mutex = Stdlib.Mutex.create ()
+
+let with_lock f =
+  Stdlib.Mutex.lock global_ctx_mutex;
+  Fun.protect f ~finally:(fun () -> Stdlib.Mutex.unlock global_ctx_mutex)
 
 let set_net net =
-  Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
+  with_lock (fun () ->
       current_net := Some (net :> eio_net);
       net_initialized := true)
 
 let set_clock clock =
-  Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
-      current_clock := Some clock)
+  with_lock (fun () -> current_clock := Some clock)
 
 let set_mono_clock mc =
-  Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
-      current_mono_clock := Some mc)
+  with_lock (fun () -> current_mono_clock := Some mc)
 
 let get_mono_clock () =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () ->
+  with_lock (fun () ->
       match !current_mono_clock with
       | Some mc -> mc
       | None -> invalid_arg "Eio mono_clock not initialized")
 
 let set_switch sw =
-  Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
-      current_sw := Some sw)
+  with_lock (fun () -> current_sw := Some sw)
 
 let get_net_opt () : eio_net option =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () -> !current_net)
+  with_lock (fun () -> !current_net)
 
 let get_clock_opt () =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () -> !current_clock)
+  with_lock (fun () -> !current_clock)
 
 let get_switch_opt () =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () -> !current_sw)
+  with_lock (fun () -> !current_sw)
 
 let get_net () : eio_net =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () ->
+  with_lock (fun () ->
       match !current_net with
       | Some net -> net
       | None ->
@@ -55,7 +59,7 @@ let get_net () : eio_net =
               "Eio net not initialized - ensure set_net is called during server startup")
 
 let get_clock () =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () ->
+  with_lock (fun () ->
       match !current_clock with
       | Some clock -> clock
       | None ->
@@ -63,7 +67,7 @@ let get_clock () =
             "Eio clock not initialized - ensure set_clock is called during server startup")
 
 let get_switch () =
-  Eio.Mutex.use_ro global_ctx_mutex (fun () ->
+  with_lock (fun () ->
       match !current_sw with
       | Some sw -> sw
       | None ->

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -336,23 +336,21 @@ let save_worker_run_meta_json config session_id worker_run_id json =
 
 let list_worker_run_ids config session_id =
   let dir = worker_runs_dir config session_id in
-  if not (path_exists config dir) then
-    []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.sort String.compare
+  list_dir config dir
+  |> List.filter_map (fun entry ->
+      (* list_dir returns deep paths (e.g. "wr-id/meta.json");
+         extract immediate child name *)
+      match String.index_opt entry '/' with
+      | Some idx -> Some (String.sub entry 0 idx)
+      | None -> Some entry)
+  |> List.sort_uniq String.compare
 
 let list_checkpoint_paths config session_id =
   let dir = checkpoints_dir config session_id in
-  if not (path_exists config dir) then
-    []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
-    |> List.sort String.compare
-    |> List.map (Filename.concat dir)
+  list_dir config dir
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.sort String.compare
+  |> List.map (Filename.concat dir)
 
 let load_latest_checkpoint config session_id : Team_session_types.checkpoint option =
   match List.rev (list_checkpoint_paths config session_id) with

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1460,6 +1460,7 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
 
 let test_execute_tool_explicit_alias_reuses_joined_nickname () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -2188,6 +2189,7 @@ let test_handle_request_tool_help_resource_read () =
 
 let test_handle_request_resources_read_matrix () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1235,7 +1235,7 @@ let test_cleanup_zombies_releases_tasks () =
     let agents_path = Filename.concat
       (Filename.concat config.base_path ".masc") "agents" in
     let agent_file = Filename.concat agents_path (test_agent_z ^ ".json") in
-    let json = Yojson.Safe.from_file agent_file in
+    let json = Room.read_json config agent_file in
     let updated_json = match json with
       | `Assoc pairs ->
           `Assoc (List.map (fun (k, v) ->
@@ -1243,7 +1243,7 @@ let test_cleanup_zombies_releases_tasks () =
           ) pairs)
       | other -> other
     in
-    Yojson.Safe.to_file agent_file updated_json;
+    Room.write_json config agent_file updated_json;
     (* Run cleanup — should remove zombie agent AND release its tasks *)
     let result = Room.cleanup_zombies config in
     Alcotest.(check bool) "cleanup ran" true (String.length result > 0);
@@ -1425,7 +1425,7 @@ let test_zombie_cleanup_transitions_to_inactive () =
     Unix.chmod path 0o644;
 
     (* Read agent file — should be Inactive now (Phase 2 ran before Phase 4 failed) *)
-    let json = Yojson.Safe.from_file path in
+    let json = Room.read_json config path in
     let status = Yojson.Safe.Util.(member "status" json |> to_string) in
     Alcotest.(check string) "status transitioned to inactive" "inactive" status
   )
@@ -1446,6 +1446,7 @@ let test_keeper_detection_by_agent_type () =
 
 (** BUG-6: Heartbeat Mutex protects concurrent access *)
 let test_heartbeat_concurrent_start_stop () =
+  Eio_main.run @@ fun _env ->
   (* Reset heartbeats *)
   List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))
     (Heartbeat.list ());

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -27,6 +27,7 @@ let with_temp_base f =
 
 let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   with_temp_base @@ fun base_path ->


### PR DESCRIPTION
## Summary

- **test_room.ml**: ZSTD 압축된 agent 파일을 `Yojson.Safe.from_file`로 직접 읽던 3개 테스트를 `Room.read_json`/`Room.write_json`으로 교체
- **test_room.ml**: BUG-6 heartbeat 테스트에 `Eio_main.run` 래퍼 추가 (`Eio_guard.enable()` 이후 Eio.Mutex가 스케줄러를 필요로 함)
- **team_session_store.ml**: `list_worker_run_ids`와 `list_checkpoint_paths`에서 `Sys.readdir` → `list_dir` 교체 (`path_exists`가 디렉토리에서 `false` 반환하는 문제 수정)
- **eio_context.ml**: 모듈 레벨 `Eio.Mutex` → `Stdlib.Mutex` 전환 (모듈 로드 시점에 Eio 런타임 없음, 보호 대상은 non-yielding ref 읽기/쓰기)

## 수정된 테스트

| 테스트 | 원인 | 수정 |
|--------|------|------|
| board_admin#3 cleanup zombies cascade | ZSTD binary를 JSON으로 파싱 | Room.read_json 사용 |
| lifecycle_bugs#2 BUG-4 zombie | ZSTD binary를 JSON으로 파싱 | Room.read_json 사용 |
| lifecycle_bugs#4 BUG-6 heartbeat | Eio Cancel.Get_context unhandled | Eio_main.run 래퍼 |
| projection#1 raw_trace_run_count | path_exists가 디렉토리에서 false | list_dir 사용 |
| load_latest_checkpoint#1 | path_exists가 디렉토리에서 false | list_dir 사용 |

로컬 FAIL count: 169 → 150 (19개 감소, 새로운 failure 없음)

## Test plan

- [x] board_admin#3 로컬 pass
- [x] lifecycle_bugs#2,#4 로컬 pass
- [x] projection#1 로컬 pass
- [x] load_latest_checkpoint#1 로컬 pass
- [ ] CI Build and Test 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)