### PR TITLE
fix(sse): broadcast keeper/mdal/autoresearch events to observers

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -283,7 +283,7 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
                      in
                      Dated_jsonl.append metrics_store snapshot;
                      (try
-                        Sse.broadcast_to Coordinators
+                        Sse.broadcast
                           (`Assoc
                             [
                               ("type", `String "keeper_heartbeat");

--- a/lib/tool_autoresearch_broadcast.ml
+++ b/lib/tool_autoresearch_broadcast.ml
@@ -1,7 +1,7 @@
 (** Tool_autoresearch_broadcast — SSE broadcast for autoresearch events. *)
 
 let broadcast_cycle_result (state : Autoresearch.loop_state) (record : Autoresearch.cycle_record) =
-  try Sse.broadcast_to Coordinators (`Assoc [
+  try Sse.broadcast (`Assoc [
     ("type", `String "autoresearch_cycle");
     ("loop_id", `String state.loop_id);
     ("cycle", `Int record.cycle);
@@ -16,7 +16,7 @@ let broadcast_cycle_result (state : Autoresearch.loop_state) (record : Autoresea
     Log.Autoresearch.warn "broadcast_cycle_result failed: %s" (Printexc.to_string exn)
 
 let broadcast_loop_lifecycle event_type (state : Autoresearch.loop_state) =
-  try Sse.broadcast_to Coordinators (`Assoc [
+  try Sse.broadcast (`Assoc [
     ("type", `String event_type);
     ("loop_id", `String state.loop_id);
     ("status", `String (Autoresearch.status_to_string state.status));

--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -131,7 +131,7 @@ let handle_start (ctx : context) args =
       persist_loop config state;
 
       (* Broadcast via SSE *)
-      (try Sse.broadcast_to Coordinators (`Assoc [
+      (try Sse.broadcast (`Assoc [
          ("type", `String "mdal_started");
          ("loop_id", `String loop_id);
          ("profile", `String profile.name);
@@ -307,7 +307,7 @@ let handle_iterate (ctx : context) args =
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
 
                    (* Broadcast via SSE *)
-                   (try Sse.broadcast_to Coordinators (`Assoc [
+                   (try Sse.broadcast (`Assoc [
                       ("type", `String "mdal_iteration");
                       ("loop_id", `String state.loop_id);
                       ("iteration", `Int iter_num);

--- a/lib/tool_mdal_handlers.ml
+++ b/lib/tool_mdal_handlers.ml
@@ -270,7 +270,7 @@ let terminal_response ?config (state : Mdal.loop_state) ~reason ~error_message =
 let emit_stop_event (state : Mdal.loop_state) ~reason =
   let final_metric = current_metric_of_state state in
   try
-    Sse.broadcast_to Coordinators
+    Sse.broadcast
       (`Assoc
         [
           ("type", `String "mdal_stopped");
@@ -286,7 +286,7 @@ let emit_stop_event (state : Mdal.loop_state) ~reason =
 
 let emit_completed_event ~loop_id ~final_metric ~iterations =
   try
-    Sse.broadcast_to Coordinators
+    Sse.broadcast
       (`Assoc
         [
           ("type", `String "mdal_completed");


### PR DESCRIPTION
## Summary

- 대시보드 "최근 활동"이 항상 "이벤트 대기 중"으로 표시되던 문제 수정
- 근본 원인: 대시보드는 `sse_kind=observer`로 연결하지만, keeper/mdal/autoresearch 이벤트가 `broadcast_to Coordinators`로만 전송되어 Observer에 도달하지 않음
- `Coordinators` → `All`(=broadcast)로 변경: keeper_heartbeat, autoresearch, mdal 이벤트
- OAS bridge, run_log는 Coordinators 유지 (내부/고빈도)

## 변경 파일 (4개)

| 파일 | 이벤트 |
|------|--------|
| `lib/keeper/keeper_keepalive.ml` | keeper_heartbeat |
| `lib/tool_autoresearch_broadcast.ml` | autoresearch_cycle, lifecycle |
| `lib/tool_mdal.ml` | mdal_started, mdal_iteration |
| `lib/tool_mdal_handlers.ml` | mdal_stopped, mdal_completed |

## Test plan

- [x] `dune build` 성공
- [ ] 키퍼 활성 상태에서 대시보드 "최근 활동"에 heartbeat 이벤트 표시 확인
- [ ] MDAL loop 실행 시 started/iteration/completed 이벤트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)