### PR TITLE
fix(room): dual-write to local filesystem in PG-native mode

### DIFF
--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -32,14 +32,27 @@ let init config ~agent_name =
       speculation_budget = None;
     } in
     write_json_root config (root_state_path config) (room_state_to_yojson root_state)
+  end else begin
+    (* Sync PG state to local file on startup so filesystem fallback has fresh data *)
+    let root_json = read_json_root config (root_state_path config) in
+    (try write_json_local (root_state_path config) root_json
+     with _exn -> ())
   end;
   if not (path_exists_root config root_backlog_path) then begin
     let root_backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
     write_json_root config root_backlog_path (backlog_to_yojson root_backlog)
+  end else begin
+    let root_backlog_json = read_json_root config root_backlog_path in
+    (try write_json_local root_backlog_path root_backlog_json
+     with _exn -> ())
   end;
 
-  if is_initialized config then
+  if is_initialized config then begin
+    (* Sync PG scoped state to local file so filesystem fallback has fresh data *)
+    let scoped_json = read_json config (state_path config) in
+    (try write_json_local (state_path config) scoped_json with _exn -> ());
     "MASC already initialized."
+  end
   else begin
     (* Create directories *)
     List.iter mkdir_p [

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -29,20 +29,22 @@ let read_state config =
   in
   match room_state_of_yojson json with
   | Ok state -> state
-  | Error _ -> {
-      protocol_version = "0.1.0";
-      project = Filename.basename config.base_path;
-      started_at = now_iso ();
-      message_seq = 0;
-      active_agents = [];
-      paused = false;
-      pause_reason = None;
-      paused_by = None;
-      paused_at = None;
-      search_strategy_default = Some "best_first_v1";
-      speculation_enabled = false;
-      speculation_budget = None;
-    }
+  | Error msg ->
+      Log.Misc.warn "read_state: deserialization failed (%s), returning empty default — dashboard will show stale data" msg;
+      {
+        protocol_version = "0.1.0";
+        project = Filename.basename config.base_path;
+        started_at = now_iso ();
+        message_seq = 0;
+        active_agents = [];
+        paused = false;
+        pause_reason = None;
+        paused_by = None;
+        paused_at = None;
+        search_strategy_default = Some "best_first_v1";
+        speculation_enabled = false;
+        speculation_budget = None;
+      }
 
 (** Write room state — persists to both filesystem and PostgreSQL *)
 let write_state config state =

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -157,7 +157,10 @@ let write_json_root config path json =
       let content = Yojson.Safe.pretty_to_string json in
       (match backend_set config ~key ~value:content with
        | Ok () -> ()
-       | Error e -> Log.Misc.warn "write_json_root backend_set failed for %s: %s" key (Backend_types.show_error e))
+       | Error e -> Log.Misc.warn "write_json_root backend_set failed for %s: %s" key (Backend_types.show_error e));
+      (* Dual-write: mirror to local filesystem so PG-timeout fallback reads fresh data *)
+      (try write_json_local path json
+       with _exn -> ())
   | None -> write_json_local path json
 
 let delete_path_root config path =
@@ -205,8 +208,17 @@ let write_json config path json =
       let content = Yojson.Safe.pretty_to_string json in
       (match backend_set config ~key ~value:content with
        | Ok () -> ()
-       | Error e -> Log.Misc.warn "write_json backend_set failed for %s: %s" key (Backend_types.show_error e))
+       | Error e -> Log.Misc.warn "write_json backend_set failed for %s: %s" key (Backend_types.show_error e));
+      (* Dual-write: mirror to local filesystem so PG-timeout fallback reads fresh data *)
+      (try write_json_local path json
+       with _exn -> ())
   | None -> write_json_local path json
+
+let write_text_local path content =
+  mkdir_p (Filename.dirname path);
+  let tmp_path = path ^ ".tmp" in
+  Fs_compat.save_file tmp_path content;
+  Unix.rename tmp_path path
 
 let write_text config path content =
   match key_of_path config path with
@@ -215,12 +227,11 @@ let write_text config path content =
        | Ok () -> ()
        | Error e ->
            Log.Misc.warn "write_text backend_set failed for %s: %s" key
-             (Backend_types.show_error e))
-  | None ->
-      mkdir_p (Filename.dirname path);
-      let tmp_path = path ^ ".tmp" in
-      Fs_compat.save_file tmp_path content;
-      Unix.rename tmp_path path
+             (Backend_types.show_error e));
+      (* Dual-write: mirror to local filesystem so PG-timeout fallback reads fresh data *)
+      (try write_text_local path content
+       with _exn -> ())
+  | None -> write_text_local path content
 
 let delete_path config path =
   match key_of_path config path with


### PR DESCRIPTION
## Summary
- PG-native 모드에서 로컬 `.masc/` 파일에 dual-write 추가
- PG 타임아웃으로 filesystem fallback 발생 시, 한 달 전 stale 데이터 대신 최신 데이터를 읽을 수 있게 함
- `read_state` 파싱 실패 시 silent empty default 대신 경고 로그 추가

## Problem
`MASC_POSTGRES_URL` 설정 시 `write_json`/`write_text`가 PG에만 쓰고 로컬 파일을 건드리지 않았음.
서버 재시작 시 PG 연결 타임아웃(30s) 발생하면 `force_jsonl_fallback_env()`가 filesystem 모드로 전환하는데, 이때 읽히는 로컬 파일은 PG 전환 시점(2월 25일) 이후 한 번도 갱신되지 않은 빈 상태.

**증거**: `root-state.json` 수정일 = 2026-02-25, `active_agents: []`, `message_seq: 0`

## Fix
`write_json`, `write_json_root`, `write_text` 함수에서 PG write 후 `try write_*_local ... with _ -> ()` 로 로컬 파일에 best-effort mirror. 로컬 쓰기 실패가 PG 경로를 차단하지 않음.

## Test plan
- [x] `dune build` 성공
- [x] `dune runtest` — 기존 87개 테스트 중 86개 통과 (1개 기존 Eio context 이슈, 변경 무관)
- [ ] 서버 재시작 후 `.masc/root-state.json` 수정일이 갱신되는지 확인
- [ ] PG 타임아웃 시뮬레이션 (`MASC_PG_INIT_TIMEOUT_SEC=1`) 후 대시보드 데이터 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)