### PR TITLE
refactor(room): replace Re.Str with Re for fiber safety (#3246)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -733,6 +733,7 @@
    caqti-driver-postgresql
    sqlite3
    unix
+   re
    re.str
    mirage-crypto
    mirage-crypto-ec

--- a/lib/room/mention.ml
+++ b/lib/room/mention.ml
@@ -43,28 +43,35 @@ let is_nickname mention =
 *)
 let parse content =
   (* Pattern 1: @@agent (broadcast) *)
-  let broadcast_re = Re.Str.regexp "@@\\([a-zA-Z0-9_]+\\)" in
-  try
-    let _ = Re.Str.search_forward broadcast_re content 0 in
-    Broadcast (Re.Str.matched_group 1 content)
-  with Not_found ->
+  let broadcast_re = Re.(compile (seq [str "@@"; group (rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']))])) in
+  match Re.exec_opt broadcast_re content with
+  | Some g -> Broadcast (Re.Group.get g 1)
+  | None ->
     (* Pattern 2: @agent-xxx-yyy (stateful - 3+ parts, alphanumeric allowed) *)
-    let stateful_re = Re.Str.regexp "@\\([a-zA-Z0-9_]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+\\)" in
-    try
-      let _ = Re.Str.search_forward stateful_re content 0 in
-      Stateful (Re.Str.matched_group 1 content)
-    with Not_found ->
+    let stateful_re = Re.(compile (seq [
+      char '@';
+      group (seq [
+        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']);
+        char '-';
+        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9']);
+        char '-';
+        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'])
+      ])
+    ])) in
+    match Re.exec_opt stateful_re content with
+    | Some g -> Stateful (Re.Group.get g 1)
+    | None ->
       (* Pattern 3: @agent (stateless) or @agent-something (stateful) *)
-      let mention_re = Re.Str.regexp "@\\([a-zA-Z0-9_-]+\\)" in
-      try
-        let _ = Re.Str.search_forward mention_re content 0 in
-        let matched = Re.Str.matched_group 1 content in
+      let mention_re = Re.(compile (seq [char '@'; group (rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_'; char '-']))])) in
+      match Re.exec_opt mention_re content with
+      | Some g ->
+        let matched = Re.Group.get g 1 in
         (* Heuristic: if contains hyphen but not 3-part nickname, still stateful *)
         if String.contains matched '-' then
           Stateful matched
         else
           Stateless matched
-      with Not_found -> None
+      | None -> None
 
 (** Extract raw mention target (backward-compatible with old extract_mention) *)
 let extract content =
@@ -102,14 +109,14 @@ let is_mentioned target content =
   if target = "" then
     false
   else
-    let pattern =
-      Printf.sprintf "\\(^\\|[^@A-Za-z0-9_-]\\)@%s\\([^A-Za-z0-9_-]\\|$\\)"
-        (Re.Str.quote target)
-    in
-    try
-      ignore (Re.Str.search_forward (Re.Str.regexp_case_fold pattern) content 0);
-      true
-    with Not_found -> false
+    let re = Re.(compile (seq [
+      (* Start of string or non-mention character *)
+      group (alt [bos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '@'; char '_'; char '-']]);
+      no_case (seq [char '@'; str target]);
+      (* End of string or non-mention character *)
+      group (alt [eos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '_'; char '-']])
+    ])) in
+    Re.execp re content
 
 let any_mentioned ~targets content =
   targets

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -247,8 +247,8 @@ let gc config ?(days=7) () =
   (* Helper to check if content mentions an open task *)
   let mentions_open_task content =
     List.exists (fun task_id ->
-      try ignore (Re.Str.search_forward (Re.Str.regexp_string task_id) content 0); true
-      with Not_found -> false
+      let re = Re.(compile (str task_id)) in
+      Re.execp re content
     ) open_task_ids
   in
 

--- a/lib/room/room_git.ml
+++ b/lib/room/room_git.ml
@@ -216,9 +216,7 @@ let list ~base_path =
                 ("path", `String !path);
                 ("branch", `String !branch);
                 (* Check if path contains .worktrees - stdlib compatible *)
-                ("is_masc", `Bool (try
-                  let _ = Re.Str.search_forward (Re.Str.regexp_string ".worktrees") !path 0 in true
-                with Not_found -> false));
+                ("is_masc", `Bool (Re.execp (Re.compile (Re.str ".worktrees")) !path));
               ])
         else None
       in

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -31,7 +31,7 @@ let validate_room_id room_id =
     Error "Room id cannot contain path separators"
   else if contains_substring room_id ".." then
     Error "Room id cannot contain traversal segments"
-  else if not (Re.Str.string_match (Re.Str.regexp "^[A-Za-z0-9._-]+$") room_id 0) then
+  else if not (Re.execp (Re.compile (Re.(whole_string (rep1 (alt [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-']))))) room_id) then
     Error "Room id may only contain letters, digits, dot, underscore, and hyphen"
   else Ok room_id
 


### PR DESCRIPTION
## Summary
- Replace all 14 `Re.Str` occurrences in `lib/room/` with direct `Re` API calls (`exec_opt`, `execp`, `Group.get`)
- `Re.Str` inherits Str's global mutable state, which can corrupt data under Eio fiber context switches between `search_forward` and `matched_group`
- Files changed: `mention.ml` (11 occurrences), `room_gc.ml` (1), `room_utils_ops.ml` (1), `room_git.ml` (1)
- Added `re` (core) to `lib/dune` alongside existing `re.str`

## Test plan
- [x] `dune build --root .` compiles
- [x] `test_pbt_mention` (5 PBT properties, 1000 iterations each) passes
- [x] `test_mention` (14 unit tests) passes
- [x] `test_mention_coverage` (44 tests) passes
- [x] `test_mention_monkey` (crash resistance, consistency, perf) passes
- [x] `test_room_coverage` (55 tests) passes
- [x] Zero `Re.Str` references remain in `lib/room/`

Part of #3246 (batch 1 of Str → Re migration).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>