### PR TITLE
fix(dashboard): guard iterable access and enable sourcemaps

### DIFF
--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -163,7 +163,7 @@ export function GraphView({ data }: GraphViewProps) {
     ctx.fillRect(0, 0, width, height)
 
     // Draw edges
-    for (const edge of data.edges) {
+    for (const edge of data.edges ?? []) {
       const sp = positions.get(edge.source)
       const tp = positions.get(edge.target)
       if (!sp || !tp) continue
@@ -185,7 +185,7 @@ export function GraphView({ data }: GraphViewProps) {
     }
 
     // Draw nodes
-    for (const node of data.nodes) {
+    for (const node of data.nodes ?? []) {
       const pos = positions.get(node.id)
       if (!pos) continue
 
@@ -273,7 +273,7 @@ export function GraphView({ data }: GraphViewProps) {
   // Edges connected to selected node
   const connectedEdges: Array<{ edge: ActivityGraphEdge; otherLabel: string }> = []
   if (selectedNode) {
-    for (const edge of data.edges) {
+    for (const edge of data.edges ?? []) {
       if (edge.source === selectedNode.id || edge.target === selectedNode.id) {
         const otherId = edge.source === selectedNode.id ? edge.target : edge.source
         const otherNode = data.nodes.find(n => n.id === otherId)

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -22,12 +22,12 @@ type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
 function gatherSpotlightItems(snap: DashboardMissionResponse): SpotlightItem[] {
   const items: SpotlightItem[] = []
 
-  for (const aq of snap.attention_queue) {
+  for (const aq of snap.attention_queue ?? []) {
     items.push({
       id: aq.id,
       severity: aq.severity,
       summary: aq.summary,
-      relatedNames: [...aq.related_agent_names],
+      relatedNames: [...(aq.related_agent_names ?? [])],
       lastSeen: aq.last_seen_at ?? null,
     })
   }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(({ command }) => {
     build: {
       outDir: '../assets/dashboard',
       emptyOutDir: true,
+      sourcemap: true,
       rollupOptions: {
         output: {
           manualChunks: {


### PR DESCRIPTION
## Summary

- 간헐적 "e is not iterable" 런타임 에러 수정
- API 응답에서 배열 필드가 null/undefined일 때 `for...of`와 spread에서 crash
- 소스맵 활성화로 향후 minified 에러 추적 가능

## 수정 위치

| 파일 | 수정 |
|------|------|
| `attention-spotlight.ts` | `snap.attention_queue ?? []`, `aq.related_agent_names ?? []` |
| `activity-graph-view.ts` | `data.edges ?? []`, `data.nodes ?? []` (3곳) |
| `vite.config.ts` | `sourcemap: true` 추가 |

## Test plan

- [x] `npm run build` 성공 (소스맵 포함)
- [ ] 대시보드에서 "e is not iterable" 에러 재발 여부 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)