### PR TITLE
fix(voice): isolate cohttp-eio client lifetime per request (#3221)

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -393,7 +393,7 @@ let single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str =
     Error (Printf.sprintf "Connection error: %s" (Printexc.to_string exn))
 
 (** Make HTTP POST request to Voice MCP server with timeout and retry - Eio version *)
-let call_voice_mcp ~sw ~clock ~net ~tool_name ~arguments =
+let call_voice_mcp ~sw:_ ~clock ~net ~tool_name ~arguments =
   log_debug (Printf.sprintf "Calling tool: %s" tool_name);
   let uri = voice_mcp_uri () in
   let request_body = `Assoc [
@@ -410,15 +410,14 @@ let call_voice_mcp ~sw ~clock ~net ~tool_name ~arguments =
     ("Content-Type", "application/json");
     ("Accept", "application/json");
   ] in
-  match client_for_uri_result ~net uri with
-  | Error error ->
-      log_error (Printf.sprintf "Tool %s failed: %s" tool_name error);
-      Error error
-  | Ok client ->
-      let operation () =
+  let operation () =
+    Eio.Switch.run @@ fun inner_sw ->
+    match client_for_uri_result ~net uri with
+    | Error error -> Error error
+    | Ok client ->
         with_timeout ~clock (fun () ->
-          single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
-      in
+          single_voice_mcp_call ~sw:inner_sw ~client ~uri ~headers ~body_str)
+  in
       let result = retry_with_backoff ~clock
         ~attempt:1
         ~max_attempts:(max_retries ())
@@ -561,7 +560,7 @@ let session_endpoint_result () =
   | Error message -> Error message
   | Ok config -> Provider_adapter.voice_session_endpoint_result config
 
-let is_voice_server_available ~sw ~clock ~net =
+let is_voice_server_available ~sw:_ ~clock ~net =
   match session_endpoint_result () with
   | Error _ ->
       voice_server_available := Some false;
@@ -583,6 +582,7 @@ let is_voice_server_available ~sw ~clock ~net =
         voice_server_check_time := now;
         let check () =
           try
+            Eio.Switch.run @@ fun inner_sw ->
             let uri =
               match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
               | Ok url -> Uri.of_string url
@@ -591,7 +591,7 @@ let is_voice_server_available ~sw ~clock ~net =
             match client_for_uri_result ~net uri with
             | Error error -> Error error
             | Ok client ->
-                let resp, _ = Cohttp_eio.Client.get ~sw client uri in
+                let resp, _ = Cohttp_eio.Client.get ~sw:inner_sw client uri in
                 let status = Cohttp.Response.status resp in
                 let available =
                   Cohttp.Code.is_success (Cohttp.Code.code_of_status status)
@@ -834,7 +834,7 @@ let get_transcript ~sw ~clock ~net () =
     ============================================ *)
 
 (** Health check for Voice MCP server *)
-let health_check ~sw ~clock:_ ~net () =
+let health_check ~sw:_ ~clock:_ ~net () =
   match session_endpoint_result () with
   | Error error -> Error error
   | Ok endpoint ->
@@ -844,8 +844,9 @@ let health_check ~sw ~clock:_ ~net () =
         | Error _ -> voice_health_uri ()
       in
       try
+        Eio.Switch.run @@ fun inner_sw ->
         let client = client_for_uri ~net uri in
-        let resp, body = Cohttp_eio.Client.get ~sw client uri in
+        let resp, body = Cohttp_eio.Client.get ~sw:inner_sw client uri in
         let status = Cohttp.Response.status resp in
         let body_str = Eio.Buf_read.(parse_exn take_all) body ~max_size:max_int in
         if Cohttp.Code.is_success (Cohttp.Code.code_of_status status) then


### PR DESCRIPTION
## Summary

voice_bridge.ml의 3개 HTTP 호출 사이트에서 cohttp-eio client를 per-request `Eio.Switch.run`으로 격리.

PR #3220에서 `worker_container_types.ml`과 `auto_responder.ml`에 적용한 동일 패턴을 voice 모듈에 확장.

## 변경 내용

| 함수 | 변경 |
|------|------|
| `call_voice_mcp` | client+POST를 `Eio.Switch.run @@ fun inner_sw ->` 래핑 |
| `is_voice_server_available` | health GET을 inner switch 래핑 |
| `health_check` | detail GET을 inner switch 래핑 |

## 왜 이게 fd leak을 막나

`Eio.Switch`가 끝나면 switch scope 안에서 생성된 모든 리소스(socket fd 포함)가 결정론적으로 해제된다. 기존에는 client가 외부 switch에 연결되어 있어 switch lifetime 동안 fd가 살아있었다.

## 빌드 참고

main에 기존 빌드 에러 있음 (`team_session_swarm_runner.ml` OAS API 변경). 이 PR과 무관.

## Test plan
- [ ] `dune build --root .` (기존 에러 제외 voice 모듈 컴파일 확인)
- [ ] 서버 시작 후 `lsof -p <pid> | grep CLOSED | wc -l` 모니터링

Closes #3221

🤖 Generated with [Claude Code](https://claude.com/claude-code)