### PR TITLE
fix(swarm): align Runner.run call with OAS env parameter

### DIFF
--- a/lib/team_session/team_session_swarm_runner.ml
+++ b/lib/team_session/team_session_swarm_runner.ml
@@ -7,6 +7,18 @@
 
 module Swarm = Agent_sdk_swarm
 
+(** Build a minimal env object for OAS Swarm Runner.
+    Runner uses [Eio.Stdenv.clock env] and [Eio.Stdenv.process_mgr env]. *)
+let make_swarm_env ~clock =
+  let proc_mgr = match Process_eio.get_proc_mgr () with
+    | Ok mgr -> mgr
+    | Error _ -> failwith "Process_eio not initialized"
+  in
+  object
+    method clock = clock
+    method process_mgr = proc_mgr
+  end
+
 let run_swarm ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     ~(session_id : string)
     ~(masc_tools : Types.tool_schema list)
@@ -38,7 +50,8 @@ let run_swarm ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         let callbacks =
           Team_session_swarm_callbacks.make_callbacks ~config ~session_id
         in
-        match Swarm.Runner.run ~sw ~clock ~callbacks swarm_config with
+        let env = make_swarm_env ~clock in
+        match Swarm.Runner.run ~sw ~env ~callbacks swarm_config with
         | Ok swarm_result ->
           let updated =
             Team_session_oas_bridge.apply_swarm_result session swarm_result

--- a/test/dune
+++ b/test/dune
@@ -238,7 +238,7 @@
 (test
  (name test_server_runtime_bootstrap)
  (modules test_server_runtime_bootstrap)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest unix eio_main))
 
 (test
  (name test_harness_shell_helpers)

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1,5 +1,11 @@
 open Masc_mcp
 
+let with_eio f =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  f ()
+
 let with_env name value f =
   let saved = Sys.getenv_opt name in
   (match value with
@@ -178,6 +184,7 @@ let test_force_jsonl_fallback_env () =
         [ "MASC_POSTGRES_URL"; "DATABASE_URL"; "SUPABASE_DB_URL"; "SB_PG_URL" ])
 
 let test_constructor_is_pure () =
+  with_eio @@ fun () ->
   with_temp_dir "startup-pure" (fun dir ->
       let agents_dir = Room.agents_dir (Room.default_config dir |> Room.config_with_resolved_scope) in
       Fs_compat.mkdir_p agents_dir;
@@ -187,6 +194,7 @@ let test_constructor_is_pure () =
         (List.length (Session.connected_agents state.Mcp_server.session_registry)))
 
 let test_restore_persisted_sessions_uses_scoped_agents_dir () =
+  with_eio @@ fun () ->
   with_temp_dir "startup-scope" (fun dir ->
       let state = Mcp_server.create_state ~base_path:dir in
       let root_agents = Room.agents_dir state.Mcp_server.room_config in
@@ -206,6 +214,7 @@ let test_restore_persisted_sessions_uses_scoped_agents_dir () =
         [ "room-agent" ] restored)
 
 let test_keeper_paths_use_cluster_root () =
+  with_eio @@ fun () ->
   with_temp_dir "startup-cluster" (fun dir ->
       with_env "MASC_CLUSTER_NAME" (Some "cluster-alpha") (fun () ->
           let config = Room.default_config dir |> Room.config_with_resolved_scope in


### PR DESCRIPTION
## Summary

OAS `Swarm.Runner.run` 시그니처가 `~sw ~clock ~callbacks`에서 `~sw ~env ~callbacks`로 변경됨.
MASC에서 `make_swarm_env ~clock`으로 minimal env 객체를 구성하여 전달.

## 변경

`team_session_swarm_runner.ml`:
- `make_swarm_env`: clock + process_mgr를 포함한 object 생성
- `Runner.run ~sw ~env ~callbacks` 호출로 변경

## Test plan
- [ ] `dune build --root .` 컴파일 통과
- [ ] `make test` 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)