### PR TITLE
refactor(council,research): replace Str with Re for fiber safety

### DIFF
--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -310,19 +310,12 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
   (* Create initial turn if content provided *)
   let turns, current_turn =
     if String.length initial_content > 0 then
-      (* Extract @mentions from initial_content using simple regex *)
+      (* Extract @mentions from initial_content using Re *)
       let mentions =
         try
-          let re = Re.Str.regexp "@\\([a-zA-Z0-9_-]+\\)" in
-          let rec collect pos acc =
-            try
-              let _ = Re.Str.search_forward re initial_content pos in
-              let target = Re.Str.matched_group 1 initial_content in
-              let next_pos = Re.Str.match_end () in
-              collect next_pos (target :: acc)
-            with Not_found -> List.rev acc
-          in
-          collect 0 []
+          let re = Re.Pcre.re "@([a-zA-Z0-9_-]+)" |> Re.compile in
+          Re.all re initial_content
+          |> List.map (fun group -> Re.Group.get group 1)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Log.Misc.warn "Council: mention extraction failed: %s"
             (Printexc.to_string exn);

--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -46,23 +46,23 @@ type action_mapping = {
 (** {1 Built-in Patterns} *)
 
 let default_mappings : action_mapping list = [
-  (* PR merge pattern - OCaml Str uses \( \) for groups *)
+  (* PR merge pattern - PCRE syntax *)
   {
-    pattern = "merge pr #?\\([0-9]+\\)";
+    pattern = "merge pr #?([0-9]+)";
     action = GitHubAction (MergePR 0);  (* 0 = placeholder, extracted from match *)
     requires_unanimous = false;
     min_threshold = 0.6;
   };
   (* PR close pattern *)
   {
-    pattern = "close pr #?\\([0-9]+\\)";
+    pattern = "close pr #?([0-9]+)";
     action = GitHubAction (ClosePR 0);
     requires_unanimous = false;
     min_threshold = 0.5;
   };
   (* Deploy pattern *)
   {
-    pattern = "deploy \\(v?[0-9.]+\\)";
+    pattern = "deploy (v?[0-9.]+)";
     action = ExecCommand ["echo"; "Deploy placeholder"];
     requires_unanimous = true;
     min_threshold = 1.0;
@@ -73,21 +73,19 @@ let default_mappings : action_mapping list = [
 
 let match_pattern pattern text =
   try
-    let re = Re.Str.regexp_case_fold pattern in
+    let re = Re.Pcre.re ~flags:[`CASELESS] pattern |> Re.compile in
     let text_lower = String.lowercase_ascii text in
-    if Re.Str.string_match re text_lower 0 then
-      Some (Re.Str.matched_string text_lower)
-    else
-      None
+    match Re.exec_opt re text_lower with
+    | Some group -> Some (Re.Group.get group 0)
+    | None -> None
   with Failure _ | Not_found -> None
 
 let extract_number text =
   try
-    let re = Re.Str.regexp "[0-9]+" in
-    if Re.Str.search_forward re text 0 >= 0 then
-      Some (int_of_string (Re.Str.matched_string text))
-    else
-      None
+    let re = Re.Pcre.re "[0-9]+" |> Re.compile in
+    match Re.exec_opt re text with
+    | Some group -> Some (int_of_string (Re.Group.get group 0))
+    | None -> None
   with Failure _ | Not_found -> None
 
 (** {1 Action Execution} *)

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -120,22 +120,18 @@ module Features = struct
 
   let contains_any words text =
     let lower = String.lowercase_ascii text in
-    List.exists (fun w -> 
+    List.exists (fun w ->
       let pattern = String.lowercase_ascii w in
-      try
-        let _ = Re.Str.search_forward (Re.Str.regexp_string pattern) lower 0 in
-        true
-      with Not_found -> false
+      let re = Re.str pattern |> Re.compile in
+      Re.execp re lower
     ) words
 
   let count_matches words text =
     let lower = String.lowercase_ascii text in
     List.fold_left (fun acc w ->
       let pattern = String.lowercase_ascii w in
-      if (try let _ = Re.Str.search_forward (Re.Str.regexp_string pattern) lower 0 in true
-          with Not_found -> false)
-      then acc + 1
-      else acc
+      let re = Re.str pattern |> Re.compile in
+      if Re.execp re lower then acc + 1 else acc
     ) 0 words
 end
 

--- a/lib/research/research_loop.ml
+++ b/lib/research/research_loop.ml
@@ -265,14 +265,12 @@ let apply_patch ~(worktree_path : string) ~(hypothesis : hypothesis) : bool =
     try
       if not (Sys.file_exists target) then false
       else if has_search_replace then begin
-        (* Search-replace mode: read file, substitute old_text → new_text *)
+        (* Search-replace mode: read file, substitute old_text -> new_text *)
         let content = Fs_compat.load_file target in
-        if String.length content > 0 &&
-           (try ignore (Re.Str.search_forward (Re.Str.regexp_string hypothesis.old_text) content 0); true
-            with Not_found -> false)
+        let re = Re.str hypothesis.old_text |> Re.compile in
+        if String.length content > 0 && Re.execp re content
         then begin
-          let replaced = Re.Str.global_replace
-            (Re.Str.regexp_string hypothesis.old_text) hypothesis.new_text content in
+          let replaced = Re.replace_string re ~by:hypothesis.new_text content in
           Fs_compat.save_file target replaced;
           true
         end else begin

--- a/lib/research/research_metric.ml
+++ b/lib/research/research_metric.ml
@@ -51,8 +51,8 @@ let run_cmd_timed ~timeout_sec (argv : string list) ~cwd : (int * string * float
 let parse_test_counts ~returncode (stdout : string) : int * int =
   let lines = String.split_on_char '\n' stdout in
   let str_contains haystack needle =
-    try ignore (Re.Str.search_forward (Re.Str.regexp_string needle) haystack 0); true
-    with Not_found -> false
+    let re = Re.str needle |> Re.compile in
+    Re.execp re haystack
   in
   let assert_lines = List.filter (fun l -> str_contains l "ASSERT") lines in
   let total = List.length assert_lines in


### PR DESCRIPTION
## Summary
- Migrate all `Re.Str`/`Str` usage in `lib/council/` (3 files, 12 occurrences) and `lib/research/` (2 files, 4 occurrences) to fiber-safe `Re` module
- Part of issue #3246 (batch 4: council + research)
- Converts Emacs-style regex patterns (`\(`, `\)`, `\|`) to PCRE syntax in `default_mappings`
- All 5 files build cleanly (`dune build lib/council/ lib/research/` passes)

## Changes
| File | Occurrences | Migration |
|------|-------------|-----------|
| `lib/council/executor.ml` | 6 | `Re.Pcre.re` + `Re.exec_opt` + PCRE patterns |
| `lib/council/conversation.ml` | 4 | `Re.all` replaces manual loop |
| `lib/council/router.ml` | 2 | `Re.str` + `Re.execp` |
| `lib/research/research_loop.ml` | 3 | `Re.str` + `Re.execp` + `Re.replace_string` |
| `lib/research/research_metric.ml` | 1 | `Re.str` + `Re.execp` |

## Test plan
- [x] `dune build --root . lib/council/` passes
- [x] `dune build --root . lib/research/` passes
- [x] Zero `Re.Str` / `Str.` references remaining in scope
- [ ] Full `dune build` (pre-existing error in `team_session_swarm_runner.ml` unrelated)

Closes part of #3246

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>