### PR TITLE
refactor(keeper): replace Str/Re.Str with direct Re API for fiber safety

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -20,11 +20,7 @@ let contains_ci (haystack : string) (needle : string) : bool =
   let h = String.lowercase_ascii haystack in
   let n = String.lowercase_ascii needle in
   if n = "" then false
-  else
-    try
-      let _ = Re.Str.search_forward (Re.Str.regexp_string n) h 0 in
-      true
-    with Not_found -> false
+  else Re.execp (Re.str n |> Re.compile) h
 
 let alert_retryable_error (msg : string) : bool =
   let text = String.lowercase_ascii (String.trim msg) in

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -20,8 +20,8 @@ let bool_of_env_default name ~(default : bool) =
 
 let validate_name name =
   (* Same rule as keeper script: conservative handle chars only. *)
-  let re = Re.Str.regexp "^[A-Za-z0-9._-]+$" in
-  name <> "" && Re.Str.string_match re name 0
+  let re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile in
+  name <> "" && Re.execp re name
 
 let default_soul_profile = "balanced"
 let default_execution_scope = "observe_only"

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -398,13 +398,14 @@ let extract_json_from_response (raw : string) : (Yojson.Safe.t, string) result =
   | json -> Ok json
   | exception Yojson.Json_error _ ->
       (* Try to find JSON between code fences *)
-      let re_fenced = Re.Str.regexp {|```\(json\)?\n?\(.*\)\n?```|} in
-      if Re.Str.string_match re_fenced trimmed 0 then
-        let inner = Re.Str.matched_group 2 trimmed in
-        match Yojson.Safe.from_string (String.trim inner) with
+      let re_fenced = Re.Pcre.re {|```(json)?\n?(.*)\n?```|} |> Re.compile in
+      (match Re.exec_opt re_fenced trimmed with
+      | Some g ->
+        let inner = Re.Group.get g 2 in
+        (match Yojson.Safe.from_string (String.trim inner) with
         | json -> Ok json
-        | exception Yojson.Json_error _ -> Error "JSON parse failed after fence extraction"
-      else
+        | exception Yojson.Json_error _ -> Error "JSON parse failed after fence extraction")
+      | None ->
         (* Try to find first { ... } substring *)
         let len = String.length trimmed in
         let rec find_brace i =
@@ -437,7 +438,7 @@ let extract_json_from_response (raw : string) : (Yojson.Safe.t, string) result =
             else Error "unmatched braces in response"
           else find_brace (i + 1)
         in
-        find_brace 0
+        find_brace 0)
 
 (** Parse a deliberation action from the "action" and "params" fields of the
     MODEL response JSON. Returns the typed action or an error string. *)

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -45,7 +45,7 @@ let normalize_memory_text_key (s : string) : string =
   s
   |> String.trim
   |> String.lowercase_ascii
-  |> Re.Str.global_replace (Re.Str.regexp "[ \t\n\r!\"#$%&'()*+,-./:;<=>?@\\[\\]^_`{|}~]+") ""
+  |> Re.replace_string (Re.Pcre.re {re|[ \t\n\r!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~]+|re} |> Re.compile) ~by:""
 
 let is_meaningful_memory_text (s : string) : bool =
   let key = normalize_memory_text_key s in

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -357,16 +357,19 @@ let strip_prefix_ci ~(prefix : string) (s : string) : string option =
       None
 
 let find_state_block (reply : string) : string option =
-  try
-    let start_idx = Re.Str.search_forward (Re.Str.regexp_string "[STATE]") reply 0 in
+  let start_re = Re.str "[STATE]" |> Re.compile in
+  let end_re = Re.str "[/STATE]" |> Re.compile in
+  match Re.exec_opt start_re reply with
+  | None -> None
+  | Some g ->
+    let start_idx = Re.Group.start g 0 in
     let body_start = start_idx + String.length "[STATE]" in
-    let end_idx =
-      Re.Str.search_forward (Re.Str.regexp_string "[/STATE]") reply body_start
-    in
-    if end_idx <= body_start then None
-    else Some (String.sub reply body_start (end_idx - body_start))
-  with Not_found ->
-    None
+    (match Re.exec_opt ~pos:body_start end_re reply with
+     | None -> None
+     | Some g2 ->
+       let end_idx = Re.Group.start g2 0 in
+       if end_idx <= body_start then None
+       else Some (String.sub reply body_start (end_idx - body_start)))
 
 let parse_state_snapshot_from_reply (reply : string) : keeper_state_snapshot option =
   match find_state_block reply with
@@ -552,12 +555,7 @@ let contains_any_ci (text : string) (needles : string list) : bool =
   List.exists
     (fun needle ->
       let n = String.lowercase_ascii needle in
-      n <> ""
-      &&
-      try
-        let _ = Re.Str.search_forward (Re.Str.regexp_string n) hay 0 in
-        true
-      with Not_found -> false)
+      n <> "" && Re.execp (Re.str n |> Re.compile) hay)
     needles
 
 let profile_signal_bonus ~(profile : string) ~(kind : string) ~(text : string) : int =

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -72,22 +72,19 @@ let is_memory_recall_query (s : string) : bool =
   ] in
   let needles = en_keywords @ ko_keywords in
   List.exists (fun n ->
-    try
-      let _ = Re.Str.search_forward (Re.Str.regexp_string n) q 0 in
-      true
-    with Not_found -> false
+    Re.execp (Re.str n |> Re.compile) q
   ) needles
 
 let expected_topic_hint (s : string) : string option =
   let q = String.lowercase_ascii s in
   let has_ko needle =
-    try let _ = Re.Str.search_forward (Re.Str.regexp_string needle) s 0 in true with Not_found -> false
+    Re.execp (Re.str needle |> Re.compile) s
   in
   let has_en needle =
-    try let _ = Re.Str.search_forward (Re.Str.regexp_string needle) q 0 in true with Not_found -> false
+    Re.execp (Re.str needle |> Re.compile) q
   in
-  if (try let _ = Re.Str.search_forward (Re.Str.regexp_string "날씨") s 0 in true with Not_found -> false)
-     || (try let _ = Re.Str.search_forward (Re.Str.regexp_string "weather") q 0 in true with Not_found -> false)
+  if Re.execp (Re.str "날씨" |> Re.compile) s
+     || Re.execp (Re.str "weather" |> Re.compile) q
   then
     Some "weather"
   else if has_ko "첫 질문"
@@ -599,8 +596,8 @@ let evaluate_memory_recall
   let expected_topic = expected_topic_hint user_message in
   let has_weather_word (s : string) =
     let q = String.lowercase_ascii s in
-    (try let _ = Re.Str.search_forward (Re.Str.regexp_string "날씨") s 0 in true with Not_found -> false)
-    || (try let _ = Re.Str.search_forward (Re.Str.regexp_string "weather") q 0 in true with Not_found -> false)
+    Re.execp (Re.str "날씨" |> Re.compile) s
+    || Re.execp (Re.str "weather" |> Re.compile) q
   in
   (* Similarity threshold for recall match acceptance.
      0.18 (default): Jaccard + character n-gram combined score.
@@ -670,8 +667,8 @@ let evaluate_memory_recall
           if has_weather_reply then 0.08 else -.0.08
       | Some "first_question" ->
           let has_first =
-            (try let _ = Re.Str.search_forward (Re.Str.regexp_string "첫") assistant_reply 0 in true with Not_found -> false)
-            || (try let _ = Re.Str.search_forward (Re.Str.regexp_string "first") (String.lowercase_ascii assistant_reply) 0 in true with Not_found -> false)
+            Re.execp (Re.str "첫" |> Re.compile) assistant_reply
+            || Re.execp (Re.str "first" |> Re.compile) (String.lowercase_ascii assistant_reply)
           in
           if has_first then 0.05 else -.0.05
       | _ -> 0.0

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -12,9 +12,7 @@ let contains_ci (haystack : string) (needle : string) : bool =
   let h = String.lowercase_ascii haystack in
   let n = String.lowercase_ascii needle in
   if n = "" then false
-  else
-    try ignore (Re.Str.search_forward (Re.Str.regexp_string n) h 0); true
-    with Not_found -> false
+  else Re.execp (Re.str n |> Re.compile) h
 
 let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -29,11 +29,7 @@ let contains_ci (haystack : string) (needle : string) : bool =
   let h = String.lowercase_ascii haystack in
   let n = String.lowercase_ascii needle in
   if n = "" then false
-  else
-    try
-      let _ = Re.Str.search_forward (Re.Str.regexp_string n) h 0 in
-      true
-    with Not_found -> false
+  else Re.execp (Re.str n |> Re.compile) h
 
 let keeper_skill_selection_mode () : keeper_skill_selection_mode =
   match Sys.getenv_opt "MASC_KEEPER_SKILL_SELECTION" with
@@ -221,12 +217,12 @@ let parse_skill_line (line : string) : (string * string list) option =
         in
         let secondary_raw_opt =
           if String.length rest >= 2 && String.sub rest 0 2 = "(+" then
-            try
-              let close_idx = Re.Str.search_forward (Re.Str.regexp_string ")") rest 2 in
+            match Re.exec_opt ~pos:2 (Re.str ")" |> Re.compile) rest with
+            | Some g ->
+              let close_idx = Re.Group.start g 0 in
               let inside = String.sub rest 2 (close_idx - 2) |> String.trim in
               if inside = "" then None else Some inside
-            with Not_found ->
-              None
+            | None -> None
           else
             None
         in

--- a/lib/keeper/keeper_text_processing.ml
+++ b/lib/keeper/keeper_text_processing.ml
@@ -10,26 +10,26 @@ open Keeper_memory_policy
 let strip_state_blocks_text (s : string) : string =
   let start_marker = "[STATE]" in
   let end_marker = "[/STATE]" in
-  let start_re = Re.Str.regexp_string start_marker in
-  let end_re = Re.Str.regexp_string end_marker in
+  let start_re = Re.str start_marker |> Re.compile in
+  let end_re = Re.str end_marker |> Re.compile in
   let len = String.length s in
   let rec loop from (buf : Buffer.t) =
     if from >= len then ()
     else
-      try
-        let i = Re.Str.search_forward start_re s from in
+      match Re.exec_opt ~pos:from start_re s with
+      | None ->
+        Buffer.add_substring buf s from (len - from)
+      | Some g ->
+        let i = Re.Group.start g 0 in
         if i > from then Buffer.add_substring buf s from (i - from);
         let block_start = i + String.length start_marker in
         let next_from =
-          try
-            let j = Re.Str.search_forward end_re s block_start in
-            j + String.length end_marker
-          with Not_found ->
-            len
+          match Re.exec_opt ~pos:block_start end_re s with
+          | None -> len
+          | Some g2 ->
+            Re.Group.start g2 0 + String.length end_marker
         in
         loop next_from buf
-      with Not_found ->
-        Buffer.add_substring buf s from (len - from)
   in
   let buf = Buffer.create len in
   loop 0 buf;
@@ -66,7 +66,7 @@ let user_visible_reply_text ?fallback (raw : string) : string =
 let normalize_proactive_text (raw : string) : string =
   raw
   |> strip_internal_reply_markup
-  |> Re.Str.global_replace (Re.Str.regexp "[ \t\r\n]+") " "
+  |> Re.replace_string (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) ~by:" "
   |> String.trim
 
 let extract_checkin_text (raw : string) : string option =
@@ -95,14 +95,14 @@ let extract_checkin_text (raw : string) : string option =
 
 let proactive_has_terminal_punct (s : string) : bool =
   let t = String.trim s in
-  t <> "" && Re.Str.string_match (Re.Str.regexp ".*[.!?。！？]$") t 0
+  t <> "" && Re.execp (Re.Pcre.re "[.!?。！？]$" |> Re.compile) t
 
 let proactive_has_terminal_korean_ending (s : string) : bool =
   let t = String.trim s in
   t <> ""
-  && Re.Str.string_match
-       (Re.Str.regexp ".*\\(다\\|요\\|니다\\|습니다\\|중입니다\\|함\\)$")
-       t 0
+  && Re.execp
+       (Re.Pcre.re "(다|요|니다|습니다|중입니다|함)$" |> Re.compile)
+       t
 
 let proactive_has_terminal_ending (s : string) : bool =
   proactive_has_terminal_punct s || proactive_has_terminal_korean_ending s
@@ -110,8 +110,8 @@ let proactive_has_terminal_ending (s : string) : bool =
 let proactive_looks_fragmentary (s : string) : bool =
   let t = String.trim s in
   t = ""
-  || Re.Str.string_match (Re.Str.regexp ".*[\"'([{]$") t 0
-  || Re.Str.string_match (Re.Str.regexp ".*[:;,\\-]$") t 0
+  || Re.execp (Re.Pcre.re {|["'(\[{]$|} |> Re.compile) t
+  || Re.execp (Re.Pcre.re "[:;,\\-]$" |> Re.compile) t
 
 let proactive_fallback_reply ~(meta : keeper_meta) ~(idle_seconds : int) : string =
   let goal =
@@ -120,7 +120,7 @@ let proactive_fallback_reply ~(meta : keeper_meta) ~(idle_seconds : int) : strin
   in
   let goal_phrase =
     goal
-    |> Re.Str.global_replace (Re.Str.regexp "[.!?。！？]+$") ""
+    |> Re.replace_string (Re.Pcre.re "[.!?。！？]+$" |> Re.compile) ~by:""
     |> String.trim
     |> fun s -> if s = "" then goal else s
   in
@@ -168,18 +168,18 @@ let looks_fragmentary_history_text (raw : string) : bool =
     let hard_fragment = proactive_looks_fragmentary t in
     let has_terminal = proactive_has_terminal_ending t in
     let ends_korean_sentence =
-      Re.Str.string_match
-        (Re.Str.regexp ".*\\(다\\|요\\|니다\\|습니다\\|중입니다\\|함\\)$")
-        t 0
+      Re.execp
+        (Re.Pcre.re "(다|요|니다|습니다|중입니다|함)$" |> Re.compile)
+        t
     in
     let short_unterminated =
       (not has_terminal) && (not ends_korean_sentence) && String.length t <= 24
     in
     let trailing_connector =
       (not has_terminal)
-      && Re.Str.string_match
-           (Re.Str.regexp
-              ".*\\(and\\|or\\|with\\|to\\|for\\|그리고\\|또는\\|및\\)$")
-           (String.lowercase_ascii t) 0
+      && Re.execp
+           (Re.Pcre.re
+              "(and|or|with|to|for|그리고|또는|및)$" |> Re.compile)
+           (String.lowercase_ascii t)
     in
     hard_fragment || short_unterminated || trailing_connector

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -47,7 +47,7 @@ let normalize_similarity_text (s : string) : string =
 let similarity_tokens (s : string) : string list =
   s
   |> normalize_similarity_text
-  |> Re.Str.split (Re.Str.regexp "[ \t\r\n]+")
+  |> Re.split (Re.Pcre.re "[ \t\r\n]+" |> Re.compile)
   |> List.filter (fun t -> String.length t >= 2)
 
 let jaccard_similarity (a : string list) (b : string list) : float =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -140,11 +140,7 @@ let board_signal_match
       |> List.filter (fun target ->
              let needle = "@" ^ String.lowercase_ascii (String.trim target) in
              needle <> "@"
-             &&
-             try
-               let _ = Re.Str.search_forward (Re.Str.regexp_string needle) haystack 0 in
-               true
-             with Not_found -> false)
+             && Re.execp (Re.str needle |> Re.compile) haystack)
     in
     if matched_targets <> [] then
       { explicit_mention = true; matched_targets; score = 100 }
@@ -270,12 +266,7 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
                  let needle =
                    "@" ^ String.lowercase_ascii target
                  in
-                 try
-                   let _ =
-                     Re.Str.search_forward (Re.Str.regexp_string needle) haystack 0
-                   in
-                   true
-                 with Not_found -> false)
+                 Re.execp (Re.str needle |> Re.compile) haystack)
                targets)
            recent)
     in


### PR DESCRIPTION
## Summary

- Migrate all 11 `lib/keeper/` files from `Re.Str` (global mutable state) to direct `Re` API
- Under Eio fiber concurrency, `Re.Str.search_forward` in one fiber can overwrite match state before `matched_group` reads it in another — this eliminates that race condition
- Pure refactoring: no behavior change, same regex semantics preserved

## Files changed (11)

| File | Occurrences |
|------|-------------|
| `keeper_text_processing.ml` | 15 |
| `keeper_memory_recall.ml` | 9 |
| `keeper_memory_policy.ml` | 3 |
| `keeper_deliberation.ml` | 3 |
| `keeper_skill_routing.ml` | 2 |
| `keeper_world_observation.ml` | 2 |
| `keeper_config.ml` | 2 |
| `keeper_memory_bank.ml` | 1 |
| `keeper_alerting.ml` | 1 |
| `keeper_types_profile.ml` | 1 |
| `keeper_prompt.ml` | 1 |

## Migration patterns applied

- `Re.Str.regexp_string` -> `Re.str ... |> Re.compile`
- `Re.Str.regexp` -> `Re.Pcre.re ... |> Re.compile`
- `Re.Str.search_forward` -> `Re.exec_opt` / `Re.execp`
- `Re.Str.global_replace` -> `Re.replace_string`
- `Re.Str.split` -> `Re.split`
- `Re.Str.string_match` -> `Re.execp`
- Emacs `\\|` -> PCRE `|`, Emacs `\\(` `\\)` -> PCRE `(` `)`

## Build note

Pre-existing build failure in `lib/team_session/team_session_swarm_runner.ml` (label mismatch on `Swarm.Runner.run`) — present on main, not caused by this PR.

## Test plan

- [x] `dune build` passes (no new errors beyond pre-existing team_session issue)
- [x] `grep -r 'Re\.Str\.' lib/keeper/` returns zero matches
- [ ] `make test` (pending CI)

Closes #3246 (batch 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)