### PR TITLE
chore: upgrade agent_sdk to 0.91.2 (Runner.run ~env compat)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -528,7 +528,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_autoresearch ->
         let start_team_session ~goal ~operation_id ~loop_id:_ ~target_file:_
             ~program_note:_ =
-          Team_session_engine_eio.start_session ~sw ~clock ~config
+          Team_session_engine_eio.start_session ~sw ~clock
+            ~process_mgr:(Option.get state.Mcp_server.proc_mgr) ~config
             ~created_by:agent_name ~goal ~duration_seconds:900
             ~execution_scope:Team_session_types.Limited_code_change
             ~checkpoint_interval_sec:60 ~min_agents:1

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -338,6 +338,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ( "recover_running_team_sessions",
             fun () ->
               Team_session_engine_eio.recover_running_sessions ~sw ~clock
+                ~process_mgr:proc_mgr
                 ~config:state.Mcp_server.room_config );
           ("chain_bootstrap", fun () -> bootstrap_chain_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -7,7 +7,8 @@ open Result_syntax
    All modes now use Team_session_swarm_runner.run_swarm via OAS Runner.
    Checkpoint/policy logic is handled by swarm callbacks. *)
 
-let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
+let start_session ~sw ~(clock : _ Eio.Time.clock)
+    ~(process_mgr : _ Eio.Process.mgr) ~(config : Room.config)
     ~(created_by : string) ~(goal : string) ~(duration_seconds : int)
     ~(execution_scope : Team_session_types.execution_scope)
     ~(checkpoint_interval_sec : int) ~(min_agents : int)
@@ -197,8 +198,8 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         let result =
           match Team_session_oas_bridge.supported_local_worker_tools () with
           | Ok masc_tools ->
-            Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-              ~session_id ~masc_tools
+            Team_session_swarm_runner.run_swarm ~sw ~clock ~process_mgr
+              ~config ~session_id ~masc_tools
               ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
                 ~sw ~clock ~config)
           | Error reason -> Error reason
@@ -614,6 +615,7 @@ let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
 
 
 let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
+    ~(process_mgr : _ Eio.Process.mgr)
     ~(config : Room.config) : unit =
   let sessions = Team_session_store.list_sessions config in
   let now = Time_compat.now () in
@@ -687,8 +689,8 @@ let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
                 let result =
                   match Team_session_oas_bridge.supported_local_worker_tools () with
                   | Ok masc_tools ->
-                    Team_session_swarm_runner.run_swarm ~sw ~clock ~config
-                      ~session_id:session.session_id ~masc_tools
+                    Team_session_swarm_runner.run_swarm ~sw ~clock ~process_mgr
+                      ~config ~session_id:session.session_id ~masc_tools
                       ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
                         ~sw ~clock ~config)
                   | Error reason -> Error reason

--- a/lib/team_session/team_session_swarm_runner.ml
+++ b/lib/team_session/team_session_swarm_runner.ml
@@ -7,7 +7,9 @@
 
 module Swarm = Agent_sdk_swarm
 
-let run_swarm ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
+let run_swarm ~sw ~(clock : _ Eio.Time.clock)
+    ~(process_mgr : _ Eio.Process.mgr)
+    ~(config : Room.config)
     ~(session_id : string)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -38,7 +40,11 @@ let run_swarm ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         let callbacks =
           Team_session_swarm_callbacks.make_callbacks ~config ~session_id
         in
-        match Swarm.Runner.run ~sw ~clock ~callbacks swarm_config with
+        let env = object
+          method clock = clock
+          method process_mgr = process_mgr
+        end in
+        match Swarm.Runner.run ~sw ~env ~callbacks swarm_config with
         | Ok swarm_result ->
           let updated =
             Team_session_oas_bridge.apply_swarm_result session swarm_result

--- a/lib/team_session/team_session_swarm_runner.mli
+++ b/lib/team_session/team_session_swarm_runner.mli
@@ -20,6 +20,7 @@ module Swarm = Agent_sdk_swarm
 
     @param sw Eio switch for fiber management
     @param clock Eio clock for timeouts
+    @param process_mgr Eio process manager for shell metric evaluation
     @param config Room configuration
     @param session_id Session to execute
     @param masc_tools Available MCP tools for agents
@@ -28,6 +29,7 @@ module Swarm = Agent_sdk_swarm
 val run_swarm :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
+  process_mgr:_ Eio.Process.mgr ->
   config:Room.config ->
   session_id:string ->
   masc_tools:Types.tool_schema list ->

--- a/lib/tool_team_session_handlers.ml
+++ b/lib/tool_team_session_handlers.ml
@@ -37,6 +37,7 @@ let handle_start ctx args : result =
     let operation_id = get_string_opt args "operation_id" in
     match
       Team_session_engine_eio.start_session ~sw:ctx.sw ~clock:ctx.clock
+        ~process_mgr:(Option.get ctx.proc_mgr)
         ~config:ctx.config ~created_by:ctx.agent_name ~goal ~duration_seconds
         ~execution_scope ~checkpoint_interval_sec ~min_agents
         ~scale_profile ~control_profile

--- a/test/test_team_session_swarm_runner.ml
+++ b/test/test_team_session_swarm_runner.ml
@@ -297,7 +297,8 @@ let test_run_swarm_empty_workers_keeps_session_running () =
   Team_session_store.ensure_session_dirs config session.session_id;
   Team_session_store.save_session config session;
   match
-    Team_session_swarm_runner.run_swarm ~sw ~clock:(Eio.Stdenv.clock env) ~config
+    Team_session_swarm_runner.run_swarm ~sw ~clock:(Eio.Stdenv.clock env)
+      ~process_mgr:(Eio.Stdenv.process_mgr env) ~config
       ~session_id:session.session_id ~masc_tools:[]
       ~dispatch:(fun ~name:_ ~args:_ -> (false, "no"))
   with

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -37,6 +37,7 @@ let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
     Lib.Team_session_engine_eio.start_session
       ~sw
       ~clock
+      ~process_mgr:(Eio.Stdenv.process_mgr env)
       ~config
       ~created_by:"owner"
       ~goal

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -62,7 +62,8 @@ let test_recover_orphan_session () =
   in
   Team_session_store.save_session config session;
   Team_session_engine_eio.recover_running_sessions ~sw
-    ~clock:(Eio.Stdenv.clock env) ~config;
+    ~clock:(Eio.Stdenv.clock env)
+    ~process_mgr:(Eio.Stdenv.process_mgr env) ~config;
   let rec wait_loaded attempts =
     if attempts <= 0 then
       failwith "orphan session not transitioned after recover"

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -385,7 +385,8 @@ let test_recover_elapsed_session () =
   in
   Team_session_store.save_session config session;
   Team_session_engine_eio.recover_running_sessions ~sw
-    ~clock:(Eio.Stdenv.clock env) ~config;
+    ~clock:(Eio.Stdenv.clock env)
+    ~process_mgr:(Eio.Stdenv.process_mgr env) ~config;
   let rec wait_loaded attempts =
     if attempts <= 0 then
       failwith "missing session after recover"


### PR DESCRIPTION
## Summary
- OAS agent_sdk 0.91.2 업그레이드 (Fiber.fork exception guard, cohttp-eio 6.2 compat 등 포함)
- `Swarm.Runner.run` API 변경: `~clock` → `~env` (clock + process_mgr object)
- `~process_mgr` 파라미터를 team session call chain에 전파
- `run_swarm`에서 OCaml structural typing으로 env object 구성

## Changed files
- `lib/team_session/team_session_swarm_runner.{ml,mli}` — ~process_mgr 추가, env object 구성
- `lib/team_session/team_session_engine_eio.ml` — ~process_mgr 전파
- `lib/mcp_server_eio_execute.ml` — state.proc_mgr 전달
- `lib/server/server_runtime_bootstrap.ml` — proc_mgr 전달
- `lib/tool_team_session_handlers.ml` — ctx.proc_mgr unwrap
- `test/` — 4개 테스트 파일 업데이트

## Test plan
- [x] 로컬 빌드 통과
- [x] test_team_session_swarm_runner 통과 (10/10)
- [ ] CI