### PR TITLE
refactor(safe_ops): expand JSON extraction helpers for Type_error migration

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -185,6 +185,26 @@ let json_bool_opt key json =
   | `Bool b -> Some b
   | _ -> None
 
+let json_list key json =
+  match Yojson.Safe.Util.member key json with
+  | `List l -> l
+  | _ -> []
+
+let json_list_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `List l -> Some l
+  | _ -> None
+
+let json_assoc key json =
+  match Yojson.Safe.Util.member key json with
+  | `Assoc a -> a
+  | _ -> []
+
+let json_member_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> None
+  | v -> Some v
+
 (** {1 Safe Process Execution} *)
 
 (* Intentionally empty: process execution lives in Process_eio (argv-only). *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -77,3 +77,15 @@ val json_string_opt : string -> Yojson.Safe.t -> string option
 val json_int_opt : string -> Yojson.Safe.t -> int option
 val json_float_opt : string -> Yojson.Safe.t -> float option
 val json_bool_opt : string -> Yojson.Safe.t -> bool option
+
+val json_list : string -> Yojson.Safe.t -> Yojson.Safe.t list
+(** Extract a JSON list by key. Returns [[]] if missing or non-list. *)
+
+val json_list_opt : string -> Yojson.Safe.t -> Yojson.Safe.t list option
+(** Extract a JSON list by key. Returns [None] if missing or non-list. *)
+
+val json_assoc : string -> Yojson.Safe.t -> (string * Yojson.Safe.t) list
+(** Extract a JSON object by key. Returns [[]] if missing or non-object. *)
+
+val json_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
+(** Extract any non-null JSON value by key. Returns [None] for [`Null] or missing key. *)


### PR DESCRIPTION
## Summary

Phase 2 (Type_error → pattern match, 126 sites) 마이그레이션의 foundation.

`lib/core/safe_ops.ml`에 4개 helper 추가:
- `json_list` — JSON list 추출, default `[]`
- `json_list_opt` — JSON list 추출, option 반환
- `json_assoc` — JSON object를 assoc list로 추출, default `[]`
- `json_member_opt` — 임의 non-null JSON 값 추출, option 반환

기존 9개 helper (`json_string`, `json_int`, `json_float`, `json_bool`, `*_opt`, `json_string_list`)와 동일한 pattern match 방식. `.mli` 시그니처도 동시 업데이트.

## Test plan
- [x] `dune build` 성공
- [ ] CI green
- [ ] Phase 2에서 실제 사용 시 검증

Closes #2964 (partial — foundation only)

Generated with [Claude Code](https://claude.com/claude-code)