### PR TITLE
chore: upgrade agent_sdk pin to v0.91.2 (Runner.run ~env compat)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.90.0))
+  (agent_sdk (>= 0.91.2))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.90.0"}
+  "agent_sdk" {>= "0.91.2"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.90.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.91.2"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="088a7346537339cde8a01a4b973d1bb229fdc9ef"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.90.0"
+readonly OAS_AGENT_SDK_SHA="47bef58e6d3016d103543494eaa0cee179c8fba9"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.91.2"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -14,7 +14,7 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 
 include_bisect=false
 include_compact_protocol=false
-agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#088a7346537339cde8a01a4b973d1bb229fdc9ef}"
+agent_sdk_pin_url="${AGENT_SDK_PIN_URL:-https://github.com/jeong-sik/oas.git#47bef58e6d3016d103543494eaa0cee179c8fba9}"
 
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
- OAS pin을 v0.90.0 (088a734) → v0.91.2 (47bef58)로 갱신
- main의 `Swarm.Runner.run ~env` 호출이 pinned OAS의 `~clock` 시그니처와 불일치하여 빌드 실패
- v0.91.2는 `~env:<clock;process_mgr>` 시그니처를 제공하여 호환성 복구

## Changed files
- `scripts/oas-agent-sdk-pin.sh` — SHA + version bump
- `scripts/opam-pin-external-deps.sh` — fallback URL 갱신
- `dune-project` + `masc_mcp.opam` — min version 0.91.2

## Test plan
- [ ] CI Build and Test pass (main 빌드 복구 확인)
- [ ] Health ratchet pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)