### PR TITLE
fix(dashboard): align backend timeouts with frontend 35s (#3319)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -735,7 +735,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
            bootstrap that success instead of staying "initializing" forever
            when proactive warm-up misses its first build window. *)
         cached_surface_or_first_success_json _mission_cache
-          ~cache_key:"mission:default" ~ttl:120.0 ~clock ~timeout_sec:120.0
+          ~cache_key:"mission:default" ~ttl:120.0 ~clock ~timeout_sec:25.0
           (fun () -> compute ())
     | Some _ ->
       (* Actor-parameterized: on-demand with SWR cache. *)
@@ -744,7 +744,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
           (Option.value ~default:"" actor)
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
-        ~clock ~timeout_sec:120.0 (compute ?actor)
+        ~clock ~timeout_sec:25.0 (compute ?actor)
   in
   full_json
 
@@ -787,7 +787,7 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
         (Option.value ~default:"" actor)
     in
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
-      ~clock ~timeout_sec:60.0 compute
+      ~clock ~timeout_sec:25.0 compute
 
 let dashboard_proof_http_json ~state request =
   let session_id = query_param request "session_id" in


### PR DESCRIPTION
## Problem
Frontend abandons requests at 35s. Backend mission computed with 120s timeout, briefing with 60s. After frontend gives up, backend wastes 85-95s more, enters 15s cooldown, creating an unrecoverable loop where users never see data.

## Fix
Reduce all dashboard computation timeouts to 25s (below frontend 35s). Backend responds with cached data or timeout error before frontend abandons.

| Endpoint | Before | After |
|----------|--------|-------|
| mission (default) | 120s | 25s |
| mission (actor) | 120s | 25s |
| mission_briefing | 60s | 25s |

Cache TTL unchanged (data validity), only computation timeout reduced.

Closes #3319

🤖 Generated with [Claude Code](https://claude.com/claude-code)