### PR TITLE
fix(test): align tests with ZSTD backend, Eio context, and backend-aware assertions

### DIFF
--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1460,6 +1460,7 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
 
 let test_execute_tool_explicit_alias_reuses_joined_nickname () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -2188,6 +2189,7 @@ let test_handle_request_tool_help_resource_read () =
 
 let test_handle_request_resources_read_matrix () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1235,7 +1235,7 @@ let test_cleanup_zombies_releases_tasks () =
     let agents_path = Filename.concat
       (Filename.concat config.base_path ".masc") "agents" in
     let agent_file = Filename.concat agents_path (test_agent_z ^ ".json") in
-    let json = Yojson.Safe.from_file agent_file in
+    let json = Room.read_json config agent_file in
     let updated_json = match json with
       | `Assoc pairs ->
           `Assoc (List.map (fun (k, v) ->
@@ -1243,7 +1243,7 @@ let test_cleanup_zombies_releases_tasks () =
           ) pairs)
       | other -> other
     in
-    Yojson.Safe.to_file agent_file updated_json;
+    Room.write_json config agent_file updated_json;
     (* Run cleanup — should remove zombie agent AND release its tasks *)
     let result = Room.cleanup_zombies config in
     Alcotest.(check bool) "cleanup ran" true (String.length result > 0);
@@ -1425,7 +1425,7 @@ let test_zombie_cleanup_transitions_to_inactive () =
     Unix.chmod path 0o644;
 
     (* Read agent file — should be Inactive now (Phase 2 ran before Phase 4 failed) *)
-    let json = Yojson.Safe.from_file path in
+    let json = Room.read_json config path in
     let status = Yojson.Safe.Util.(member "status" json |> to_string) in
     Alcotest.(check string) "status transitioned to inactive" "inactive" status
   )
@@ -1446,6 +1446,7 @@ let test_keeper_detection_by_agent_type () =
 
 (** BUG-6: Heartbeat Mutex protects concurrent access *)
 let test_heartbeat_concurrent_start_stop () =
+  Eio_main.run @@ fun _env ->
   (* Reset heartbeats *)
   List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))
     (Heartbeat.list ());

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -27,6 +27,7 @@ let with_temp_base f =
 
 let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   with_temp_base @@ fun base_path ->


### PR DESCRIPTION
## Summary

Supersedes #3287 (closed due to merge conflicts, now rebased).

- **test_room.ml**: Use `Room.read_json`/`Room.write_json` instead of `Yojson.Safe.from_file` for agent files (FileSystem backend uses ZSTD compression)
- **test_room.ml**: Wrap BUG-6 heartbeat test in `Eio_main.run` (`Eio.Mutex` needs active scheduler after `Eio_guard.enable`)
- **test_mcp_server_eio.ml**: Add `Fs_compat.set_fs` to tests #15 and #47 (without Eio fs context, FileSystem backend falls back to Memory)
- **test_tool_repo_synthesis.ml**: Add `Fs_compat.set_fs` to repo synthesis test (without it, `create_backend` falls back to Memory)

Note: The original PR also included `eio_context.ml` (Eio.Mutex -> Stdlib.Mutex) and `team_session_store.ml` (Sys.readdir -> list_dir) changes. Both were already superseded on main (eio_context moved to Atomic.t, team_session_store uses immediate_dir_entries/Room_utils.list_dir).

## Test plan

- [ ] `dune build --root .` passes (verified locally)
- [ ] CI checks pass
- [ ] Test count reduction from these fixes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>