### PR TITLE
fix(test): Fs_compat.set_fs sweep + ZSTD backend-aware test reads

### DIFF
--- a/test/test_code_navigation_eio.ml
+++ b/test/test_code_navigation_eio.ml
@@ -87,6 +87,7 @@ let prepare_code_surface ~clock:_ ~sw:_ _state = ()
 
 let test_code_search_basic () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
@@ -166,6 +167,7 @@ let test_code_search_basic () =
 
 let test_code_symbols_basic () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
@@ -218,6 +220,7 @@ let test_code_symbols_basic () =
 
 let test_code_read_basic () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
@@ -283,6 +286,7 @@ let test_code_read_basic () =
 
 let test_code_read_offset_limit () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -40,6 +40,7 @@ let with_test_env f =
       with_env "SUPABASE_DB_URL" "" @@ fun () ->
       with_env "SB_PG_URL" "" @@ fun () ->
       Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       Eio.Switch.run @@ fun sw ->
       f ~env ~sw ~config)
@@ -58,6 +59,7 @@ let with_pg_test_env f =
           with_env "SUPABASE_DB_URL" "" @@ fun () ->
           with_env "SB_PG_URL" "" @@ fun () ->
           Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
           Eio.Switch.run @@ fun sw ->
           Eio_context.set_net (Eio.Stdenv.net env);
           Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -74,6 +74,7 @@ let test_briefing_cold_call_returns_pending () =
   let saved_storage = Sys.getenv_opt "MASC_STORAGE_TYPE" in
   Unix.putenv "MASC_STORAGE_TYPE" "filesystem";
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -101,6 +102,7 @@ let test_briefing_cold_call_returns_pending () =
 
 let test_force_refresh_without_cache_returns_pending () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -124,6 +126,7 @@ let test_force_refresh_without_cache_returns_pending () =
 
 let test_force_refresh_with_cached_result_returns_stale_cached_payload () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -31,6 +31,7 @@ let test_dashboard_room_truth_empty_room () =
     (fun () ->
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -59,6 +60,7 @@ let test_dashboard_room_truth_execution_fixture () =
     (fun () ->
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -82,6 +84,7 @@ let test_dashboard_room_truth_empty_room_focus_label () =
     (fun () ->
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -103,6 +106,7 @@ let test_operator_digest_shape_matches_room_truth () =
     (fun () ->
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
       Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json

--- a/test/test_fire_task.ml
+++ b/test/test_fire_task.ml
@@ -81,7 +81,8 @@ let test_schema_optional_fields () =
    ============================================================ *)
 
 let test_dispatch_unknown_tool () =
-  Eio_main.run (fun _env ->
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
     Eio.Switch.run (fun sw ->
       with_temp_dir (fun dir ->
         let config = init_room dir in
@@ -94,7 +95,8 @@ let test_dispatch_unknown_tool () =
   )
 
 let test_dispatch_missing_goal () =
-  Eio_main.run (fun _env ->
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
     Eio.Switch.run (fun sw ->
       with_temp_dir (fun dir ->
         let config = init_room dir in

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -322,6 +322,7 @@ let test_type_compatibility () =
 
 let test_eio_context_delegation () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
   Mcp_eio.set_net net;
@@ -422,6 +423,7 @@ let test_make_error () =
 
 let test_handle_request_initialize () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -465,6 +467,7 @@ let test_handle_request_initialize () =
 
 let test_handle_request_initialize_rejects_unsupported_protocol_version () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -494,6 +497,7 @@ let test_handle_request_initialize_rejects_unsupported_protocol_version () =
 
 let test_handle_request_tools_list () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -560,6 +564,7 @@ let test_handle_request_tools_list () =
 let test_handle_request_tools_list_mdal_descriptions () =
   with_env "MASC_FULL_SURFACE" "1" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -600,6 +605,7 @@ let test_handle_request_tools_list_mdal_descriptions () =
 
 let test_handle_request_initialize_operator_profile () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -639,6 +645,7 @@ let test_handle_request_initialize_operator_profile () =
 
 let test_handle_request_tools_list_operator_profile () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -723,6 +730,7 @@ let test_handle_request_tools_list_operator_profile () =
 
 let test_handle_request_initialize_managed_profile () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -762,6 +770,7 @@ let test_handle_request_initialize_managed_profile () =
 
 let test_handle_request_tools_list_managed_profile () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -805,6 +814,7 @@ let test_handle_request_tools_list_managed_profile () =
 
 let test_handle_request_tools_call_managed_profile_sdk_alias_claim () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -849,6 +859,7 @@ let test_handle_request_tools_call_managed_profile_sdk_alias_claim () =
 
 let test_handle_request_tools_call_transition_claim_guidance () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -900,6 +911,7 @@ let test_handle_request_tools_call_transition_claim_guidance () =
 
 let test_handle_request_tools_call_transition_done_guidance () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -965,6 +977,7 @@ let test_handle_request_tools_call_transition_done_guidance () =
 
 let test_handle_request_tools_call_transition_claim_requires_action () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1011,6 +1024,7 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
 
 let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1042,6 +1056,7 @@ let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
 
 let test_handle_request_tools_list_rejects_nonstandard_names_filter () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1072,6 +1087,7 @@ let test_handle_request_tools_list_rejects_nonstandard_names_filter () =
 let test_handle_request_tools_list_with_placeholder_flag () =
   with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" "1" (fun () ->
     Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
     let clock = Eio.Stdenv.clock env in
     Eio.Switch.run @@ fun sw ->
 
@@ -1094,6 +1110,7 @@ let test_handle_request_tools_list_with_placeholder_flag () =
 
 let test_handle_request_tools_list_include_hidden_metadata () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1122,6 +1139,7 @@ let test_handle_request_tools_list_include_hidden_metadata () =
 
 let test_handle_request_tools_list_include_deprecated_claim_alias_metadata () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1158,6 +1176,7 @@ let test_handle_request_tools_list_include_deprecated_claim_alias_metadata () =
 
 let test_handle_request_tools_list_hides_team_session_turn_by_default () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1177,6 +1196,7 @@ let test_handle_request_tools_list_hides_team_session_turn_by_default () =
 
 let test_handle_request_tools_list_include_usage_metadata () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1207,6 +1227,7 @@ let test_handle_request_tools_list_include_usage_metadata () =
 
 let _test_execute_tool_trpg_flow () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1277,6 +1298,7 @@ let _test_execute_tool_trpg_flow () =
 
 let test_execute_tool_coding_mode_allows_governance_status () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1298,6 +1320,7 @@ let test_execute_tool_coding_mode_allows_governance_status () =
 
 let test_execute_tool_team_session_step_direct_call () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1360,6 +1383,7 @@ let test_execute_tool_team_session_step_direct_call () =
 
 let _test_execute_tool_trpg_validation () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1418,6 +1442,7 @@ let _test_execute_tool_trpg_validation () =
 
 let test_execute_tool_explicit_agent_name_not_overridden () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1460,6 +1485,7 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
 
 let test_execute_tool_explicit_alias_reuses_joined_nickname () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1519,6 +1545,7 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
 
 let test_execute_tool_mcp_session_ignores_term_persistence () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1560,6 +1587,7 @@ let test_execute_tool_mcp_session_ignores_term_persistence () =
 
 let test_convo_start_uses_current_room () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -1607,6 +1635,7 @@ let test_convo_start_uses_current_room () =
 
 let _test_handle_request_tools_call_trpg () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1640,6 +1669,7 @@ let _test_handle_request_tools_call_trpg () =
 
 let test_handle_request_invalid_json () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1657,6 +1687,7 @@ let test_handle_request_invalid_json () =
 
 let test_handle_request_tools_call_cache_get_structured_content () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1682,6 +1713,7 @@ let test_handle_request_tools_call_cache_get_structured_content () =
 
 let test_handle_request_tools_call_board_post_structured_content () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1710,6 +1742,7 @@ let test_handle_request_tools_call_board_post_structured_content () =
 
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1735,6 +1768,7 @@ let test_handle_request_batch_rejected () =
 
 let test_handle_request_jsonrpc_response_returns_null () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1754,6 +1788,7 @@ let test_handle_request_jsonrpc_response_returns_null () =
 
 let test_handle_request_method_not_found () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
 
@@ -1783,6 +1818,7 @@ let test_handle_request_method_not_found () =
 
 let test_handle_request_tools_list_rejects_empty_cursor () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1806,6 +1842,7 @@ let test_handle_request_tools_list_rejects_empty_cursor () =
 
 let test_handle_request_tools_list_rejects_invalid_tier () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1828,6 +1865,7 @@ let test_handle_request_tools_list_rejects_invalid_tier () =
 
 let test_handle_request_resources_list_rejects_unknown_field () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1850,6 +1888,7 @@ let test_handle_request_resources_list_rejects_unknown_field () =
 
 let test_handle_request_resources_templates_rejects_invalid_cursor () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1873,6 +1912,7 @@ let test_handle_request_resources_templates_rejects_invalid_cursor () =
 
 let test_handle_request_prompts_list_rejects_invalid_cursor () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1896,6 +1936,7 @@ let test_handle_request_prompts_list_rejects_invalid_cursor () =
 
 let test_handle_request_prompts_list_non_empty () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1928,6 +1969,7 @@ let test_handle_request_prompts_list_non_empty () =
 
 let test_handle_request_prompts_list_cursor () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -1960,6 +2002,7 @@ let test_handle_request_prompts_list_cursor () =
 
 let test_handle_request_prompts_get_tool_help () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2053,6 +2096,7 @@ let test_handle_request_prompts_get_command_truth_filters_run_id () =
 let test_handle_request_resources_list_includes_tool_help () =
   with_env "MASC_LIST_PAGE_SIZE" "10" @@ fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2070,6 +2114,7 @@ let test_handle_request_resources_list_includes_tool_help () =
 
 let test_handle_request_resources_list_paginates () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2105,6 +2150,7 @@ let test_handle_request_resources_list_paginates () =
 let test_handle_request_tools_list_paginates () =
   with_env "MASC_LIST_PAGE_SIZE" "10" @@ fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2153,6 +2199,7 @@ let test_handle_request_tools_list_paginates () =
 
 let test_handle_request_tool_help_resource_read () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2188,6 +2235,7 @@ let test_handle_request_tool_help_resource_read () =
 
 let test_handle_request_resources_read_matrix () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2276,6 +2324,7 @@ Alpha body
 
 let test_handle_request_resources_subscribe_requires_session () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2300,6 +2349,7 @@ let test_handle_request_resources_subscribe_requires_session () =
 
 let test_handle_request_resources_subscribe_roundtrip () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -2346,6 +2396,7 @@ let test_handle_request_resources_subscribe_roundtrip () =
 
 let test_execute_tool_help_tool () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -2364,6 +2415,7 @@ let test_execute_tool_help_tool () =
 
 let test_execute_tool_tag_dispatch_respects_pre_hooks () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in
@@ -2397,6 +2449,7 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
 
 let test_execute_tool_autoresearch_uses_resolved_session_agent () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let clock = Eio.Stdenv.clock env in

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1235,7 +1235,7 @@ let test_cleanup_zombies_releases_tasks () =
     let agents_path = Filename.concat
       (Filename.concat config.base_path ".masc") "agents" in
     let agent_file = Filename.concat agents_path (test_agent_z ^ ".json") in
-    let json = Yojson.Safe.from_file agent_file in
+    let json = Room.read_json config agent_file in
     let updated_json = match json with
       | `Assoc pairs ->
           `Assoc (List.map (fun (k, v) ->
@@ -1243,7 +1243,7 @@ let test_cleanup_zombies_releases_tasks () =
           ) pairs)
       | other -> other
     in
-    Yojson.Safe.to_file agent_file updated_json;
+    Room.write_json config agent_file updated_json;
     (* Run cleanup — should remove zombie agent AND release its tasks *)
     let result = Room.cleanup_zombies config in
     Alcotest.(check bool) "cleanup ran" true (String.length result > 0);
@@ -1425,7 +1425,7 @@ let test_zombie_cleanup_transitions_to_inactive () =
     Unix.chmod path 0o644;
 
     (* Read agent file — should be Inactive now (Phase 2 ran before Phase 4 failed) *)
-    let json = Yojson.Safe.from_file path in
+    let json = Room.read_json config path in
     let status = Yojson.Safe.Util.(member "status" json |> to_string) in
     Alcotest.(check string) "status transitioned to inactive" "inactive" status
   )
@@ -1446,6 +1446,7 @@ let test_keeper_detection_by_agent_type () =
 
 (** BUG-6: Heartbeat Mutex protects concurrent access *)
 let test_heartbeat_concurrent_start_stop () =
+  Eio_main.run @@ fun _env ->
   (* Reset heartbeats *)
   List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))
     (Heartbeat.list ());

--- a/test/test_room_messages_pg.ml
+++ b/test/test_room_messages_pg.ml
@@ -41,6 +41,7 @@ let with_pg_test_env f =
           with_env "SUPABASE_DB_URL" "" @@ fun () ->
           with_env "SB_PG_URL" "" @@ fun () ->
           Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
           Eio.Switch.run @@ fun sw ->
           Eio_context.set_net (Eio.Stdenv.net env);
           Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -197,6 +197,7 @@ let test_full_lifecycle () =
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
     Eio_main.run (fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       (* Setup git repo with origin *)
       let git d args =
         run_cmd (Printf.sprintf "git -C %s %s" (Filename.quote d) args)
@@ -286,6 +287,7 @@ let test_with_sandbox_lifecycle () =
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
     Eio_main.run (fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let git d args =
         run_cmd (Printf.sprintf "git -C %s %s" (Filename.quote d) args)
       in
@@ -335,6 +337,7 @@ let test_with_sandbox_cleans_up_on_exception () =
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
     Eio_main.run (fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
       let git d args =
         run_cmd (Printf.sprintf "git -C %s %s" (Filename.quote d) args)
       in

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -66,6 +66,7 @@ let tools_list_response ~clock ~sw ?(include_hidden = false) ?names state =
 
 let test_visible_tools_expose_only_truthful_statuses () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
@@ -82,6 +83,7 @@ let test_visible_tools_expose_only_truthful_statuses () =
 
 let test_hidden_tools_report_contract_status () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in

--- a/test/test_tool_mdal_pg.ml
+++ b/test/test_tool_mdal_pg.ml
@@ -104,6 +104,7 @@ let with_pg_room f () =
       in
       with_envs bindings (fun () ->
           Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
           Eio.Switch.run @@ fun sw ->
           reset_loop_registry ();
           let base_dir = temp_dir () in

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -390,6 +390,7 @@ let () = test "dispatch_tool_admin_update_unit_policy" (fun () ->
 
 let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
   let ctx = make_test_ctx () in
   let keeper_ctx : _ Tool_keeper.context =

--- a/test/test_tool_relay_coverage.ml
+++ b/test/test_tool_relay_coverage.ml
@@ -212,6 +212,7 @@ let run ~sw ~proc_mgr =
 
 let () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio.Switch.run @@ fun sw ->
   let proc_mgr = Some (Eio.Stdenv.process_mgr env) in
   run ~sw ~proc_mgr

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -27,6 +27,7 @@ let with_temp_base f =
 
 let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   with_temp_base @@ fun base_path ->

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -124,7 +124,8 @@ let () = test "dispatch_removed_named_room_tools" (fun () ->
 )
 
 let () = test "dispatch_check_transition_claim_requires_plan_task" (fun () ->
-  Eio_main.run @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
   let task_ctx = { Tool_task.config = ctx.config; agent_name = ctx.agent_name } in
@@ -150,7 +151,8 @@ let () = test "dispatch_check_transition_claim_requires_plan_task" (fun () ->
 )
 
 let () = test "dispatch_check_claim_next_marks_current_task_set" (fun () ->
-  Eio_main.run @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
   let task_ctx = { Tool_task.config = ctx.config; agent_name = ctx.agent_name } in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -9,7 +9,7 @@ let () = Printf.printf "\n=== Tool_task Coverage Tests ===\n"
 (* Test helper *)
 let test name f =
   try
-    Eio_main.run @@ (fun _env -> f ());
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);

--- a/test/test_tool_walph_coverage.ml
+++ b/test/test_tool_walph_coverage.ml
@@ -18,6 +18,7 @@ let test name f =
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -31,6 +32,7 @@ let () = test "dispatch_unknown_tool" (fun () ->
 (* Test walph_control dispatch *)
 let () = test "dispatch_walph_control" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test2-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -47,6 +49,7 @@ let () = test "dispatch_walph_control" (fun () ->
 (* Test walph_status dispatch *)
 let () = test "dispatch_walph_status" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test-status-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -70,6 +73,7 @@ let () = test "dispatch_walph_status" (fun () ->
 (* Test walph_natural with stop command *)
 let () = test "walph_natural_stop" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test3-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -85,6 +89,7 @@ let () = test "walph_natural_stop" (fun () ->
 (* Test walph_natural with pause command *)
 let () = test "walph_natural_pause" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test4-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -100,6 +105,7 @@ let () = test "walph_natural_pause" (fun () ->
 (* Test walph_natural with resume command *)
 let () = test "walph_natural_resume" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test5-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -115,6 +121,7 @@ let () = test "walph_natural_resume" (fun () ->
 (* Test walph_natural with status command *)
 let () = test "walph_natural_status" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test6-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -130,6 +137,7 @@ let () = test "walph_natural_status" (fun () ->
 (* Test walph_natural with unrecognized message *)
 let () = test "walph_natural_ignore" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test7-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;
@@ -145,6 +153,7 @@ let () = test "walph_natural_ignore" (fun () ->
 (* Test walph_natural with empty message *)
 let () = test "walph_natural_empty" (fun () ->
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-walph-test8-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
   Unix.mkdir tmp 0o755;

--- a/test/test_verify_handoff_tool.ml
+++ b/test/test_verify_handoff_tool.ml
@@ -21,6 +21,7 @@ let cleanup_dir dir =
 
 let test_verify_handoff_tool_call () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -45,6 +45,7 @@ let file_contains_pattern file_rel pattern =
 (** Test fixture: Create isolated config with Eio environment *)
 let with_test_config name f =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "walph_eio_%s_%d_%d" name (Unix.getpid ())
       (int_of_float (Unix.gettimeofday () *. 1000.))) in

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -12,6 +12,7 @@ let find_tool name tools =
 
 let test_tool_count () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -19,6 +20,7 @@ let test_tool_count () =
 
 let test_tool_names () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -28,6 +30,7 @@ let test_tool_names () =
 
 let test_readonly_tool_names () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_readonly_tools ~proc_mgr ~clock () in
@@ -39,6 +42,7 @@ let test_readonly_tool_names () =
 
 let test_file_read_existing () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -58,6 +62,7 @@ let test_file_read_existing () =
 
 let test_file_read_nonexistent () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -70,6 +75,7 @@ let test_file_read_nonexistent () =
 
 let test_file_read_blocked_path () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -86,6 +92,7 @@ let test_file_read_blocked_path () =
 
 let test_file_read_path_traversal () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -99,6 +106,7 @@ let test_file_read_path_traversal () =
 
 let test_file_read_rejects_prefix_sibling () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -112,6 +120,7 @@ let test_file_read_rejects_prefix_sibling () =
 
 let test_file_read_rejects_tmp_symlink_escape () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -129,6 +138,7 @@ let test_file_read_rejects_tmp_symlink_escape () =
 
 let test_file_read_truncation () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -158,6 +168,7 @@ let test_file_read_truncation () =
 
 let test_file_write_new () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -179,6 +190,7 @@ let test_file_write_new () =
 
 let test_file_write_blocked_path () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -192,6 +204,7 @@ let test_file_write_blocked_path () =
 
 let test_file_write_rejects_prefix_sibling () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -206,6 +219,7 @@ let test_file_write_rejects_prefix_sibling () =
 
 let test_file_write_rejects_tmp_symlink_escape () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -227,6 +241,7 @@ let test_file_write_rejects_tmp_symlink_escape () =
 
 let test_shell_exec_echo () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -241,6 +256,7 @@ let test_shell_exec_echo () =
 
 let test_shell_exec_blocked_command () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -255,6 +271,7 @@ let test_shell_exec_blocked_command () =
 
 let test_tool_exec_observer_bridges_to_telemetry () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let fs = Eio.Stdenv.fs env in
@@ -322,6 +339,7 @@ let test_tool_exec_observer_bridges_to_telemetry () =
 
 let test_shell_exec_rejects_shell_metacharacters () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -345,6 +363,7 @@ let test_shell_exec_rejects_shell_metacharacters () =
 
 let test_shell_exec_nonexistent_cmd () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -357,6 +376,7 @@ let test_shell_exec_nonexistent_cmd () =
 
 let test_shell_exec_missing_param () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
@@ -370,6 +390,7 @@ let test_shell_exec_missing_param () =
 
 let test_readonly_shell_exec_blocks_git () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_readonly_tools ~proc_mgr ~clock () in
@@ -382,6 +403,7 @@ let test_readonly_shell_exec_blocks_git () =
 
 let test_workdir_enforcement () =
   Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
   let clock = Eio.Stdenv.clock env in
   let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock


### PR DESCRIPTION
## Summary

- **Fs_compat.set_fs sweep** (19 files): `Eio_main.run` + `Room.default_config` 조합에서 `Fs_compat.set_fs` 누락 시 FileSystem → Memory fallback 발생. `Sys.readdir` 기반 nickname lookup과 agent listing이 깨짐.
- **test_room.ml ZSTD reads**: `Yojson.Safe.from_file` → `Room.read_json` (ZSTD 압축 투명 처리)
- **test_room.ml BUG-6**: heartbeat 테스트에 `Eio_main.run` 래퍼 추가

Refs: #3291 (backend abstraction leak issue)

## Test plan

- [ ] CI Build and Test 확인
- [ ] 로컬 FAIL count 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)