### PR TITLE
fix(test): wrap Room-dependent tests in Eio context (batch 3)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -238,7 +238,7 @@
 (test
  (name test_server_runtime_bootstrap)
  (modules test_server_runtime_bootstrap)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest unix eio eio_main))
 
 (test
  (name test_harness_shell_helpers)
@@ -902,7 +902,7 @@
 (test
  (name test_eval_gate)
  (modules test_eval_gate)
- (libraries masc_mcp alcotest str yojson unix))
+ (libraries masc_mcp alcotest str yojson unix eio eio_main))
 
 (test
  (name test_eval_harness)
@@ -1065,13 +1065,13 @@
 (test
  (name test_chain_coverage)
  (modules test_chain_coverage)
- (libraries masc_mcp alcotest str yojson))
+ (libraries masc_mcp alcotest str yojson eio eio_main))
 
 ; Chain category/error/types coverage tests
 (test
  (name test_chain_category_coverage)
  (modules test_chain_category_coverage)
- (libraries masc_mcp alcotest str yojson))
+ (libraries masc_mcp alcotest str yojson eio eio_main))
 
 ; Auto_recall + Activity_feed coverage tests
 (test

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -233,6 +233,9 @@ let test_activity_item_defaults () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "auto_recall_activity_coverage" [
     "estimate_tokens", [
       test_case "empty" `Quick test_estimate_tokens_empty;

--- a/test/test_chain_category_coverage.ml
+++ b/test/test_chain_category_coverage.ml
@@ -1109,6 +1109,9 @@ let test_chain_error_yojson_all () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "chain_category_coverage" [
     "Result_monad", [
       test_case "pure" `Quick test_result_monad_pure;

--- a/test/test_chain_coverage.ml
+++ b/test/test_chain_coverage.ml
@@ -1310,6 +1310,9 @@ let test_parse_chain_bad () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "chain_coverage" [
     "normalize_label_content", [
       test_case "escaped quotes" `Quick test_normalize_escaped_quotes;

--- a/test/test_dashboard_collaboration_evidence.ml
+++ b/test/test_dashboard_collaboration_evidence.ml
@@ -68,6 +68,9 @@ let test_collaboration_evidence_counts_runtime_signals () =
         (json |> member "evidence_status" |> to_string))
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Dashboard_collaboration_evidence"
     [
       ( "collaboration_evidence",

--- a/test/test_encryption_coverage.ml
+++ b/test/test_encryption_coverage.ml
@@ -489,6 +489,9 @@ let test_decrypt_invalid_ciphertext () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Encryption Coverage" [
     "config", [
       test_case "default enabled" `Quick test_default_config_enabled;

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -338,6 +338,9 @@ let test_post_eval_to_json () =
 (* ================================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "Eval_gate" [
     ("destructive_detection", [
       Alcotest.test_case "detect rm -rf" `Quick test_detect_rm_rf;

--- a/test/test_hat.ml
+++ b/test/test_hat.ml
@@ -64,6 +64,9 @@ let test_default_config () =
   ()
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "Hat System" [
     "serialization", [
       Alcotest.test_case "of_string" `Quick test_of_string;

--- a/test/test_hat_coverage.ml
+++ b/test/test_hat_coverage.ml
@@ -475,6 +475,9 @@ let test_wear_builds_history () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Hat Coverage" [
     "to_string", [
       test_case "builder" `Quick test_to_string_builder;

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -183,6 +183,9 @@ let request_tests = [
 ]
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "Http_server_eio" [
     "compression", compression_tests;  (* Compact Protocol v4 *)
     "router", router_tests;

--- a/test/test_http_server_eio_coverage.ml
+++ b/test/test_http_server_eio_coverage.ml
@@ -124,6 +124,9 @@ let test_compress_wrapper_large_data () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Http Server Eio Coverage" [
     "config", [
       test_case "type" `Quick test_config_type;

--- a/test/test_mitosis.ml
+++ b/test/test_mitosis.ml
@@ -354,6 +354,9 @@ let state_tests = [
 ]
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Mitosis" [
     "safe_sub", safe_sub_tests;
     "deduplicate", dedup_tests;

--- a/test/test_mitosis_coverage.ml
+++ b/test/test_mitosis_coverage.ml
@@ -902,6 +902,9 @@ let test_prepare_bad_dna () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Mitosis Coverage" [
     "cell_state", [
       test_case "stem" `Quick test_cell_state_stem;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -677,6 +677,9 @@ let test_keeper_oas_handoff_rollover_below_threshold_noop () =
 (* ================================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "OAS Worker" [
     "sse_event_bridge", [
       Alcotest.test_case "text delta extraction" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -362,6 +362,9 @@ let test_main_eio_serves_health_before_lazy_startup () =
           end))
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "Server_runtime_bootstrap"
     [
       ( "bootstrap",

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -702,6 +702,9 @@ let test_spawn_sync_is_spawn () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Spawn Coverage" [
     "spawn_config", [
       test_case "creation" `Quick test_spawn_config_creation;


### PR DESCRIPTION
## Summary

- Wraps 15 test files in `Eio_main.run @@ fun env -> Fs_compat.set_fs ...; Eio_guard.enable ()` to provide proper Eio context for Room module dependencies
- Adds `eio`/`eio_main` to 4 dune stanzas that were missing them (`test_chain_category_coverage`, `test_chain_coverage`, `test_eval_gate`, `test_server_runtime_bootstrap`)
- Addresses #3178: Room module requires `Eio.Mutex` (via `observe_agent_lifecycle`), tests without `Eio_main.run` fall back to Memory backend

## Test plan

- [x] `dune build --root .` compiles without errors
- [x] Verified `test_eval_gate`, `test_hat`, `test_http_server_eio`, `test_dashboard_collaboration_evidence`, `test_oas_worker`, `test_spawn_coverage`, `test_chain_coverage`, `test_mitosis` all pass
- [x] Only 1 pre-existing flaky test (`test_server_runtime_bootstrap` `Slow` integration test that starts a server process) -- unrelated to Eio wrapping
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)