### PR TITLE
feat(dashboard): explain empty governance state

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -66,6 +66,27 @@ function governanceBundle(): GovernanceCaseBundle {
   }
 }
 
+function emptyGovernanceResponse(): DashboardGovernanceResponse {
+  return {
+    generated_at: '2026-03-24T00:00:00Z',
+    summary: {
+      cases_open: 0,
+      pending_ruling: 0,
+      ready_auto_execute: 0,
+      needs_human_gate: 0,
+      executed: 0,
+      blocked: 0,
+      oldest_open_case_age_s: null,
+      last_activity_age_s: 3 * 86400,
+      judge_online: true,
+      judge_last_seen_at: '2026-03-21T00:00:00Z',
+    },
+    items: [],
+    activity: [],
+    pending_actions: [],
+  }
+}
+
 async function loadComponentWithApi(api: {
   decideGovernanceExecutionOrder: () => Promise<void>
   fetchDashboardGovernance: () => Promise<DashboardGovernanceResponse>
@@ -135,4 +156,22 @@ describe('Governance surface', () => {
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
   }, 20000)
+
+  it('explains why the governance inbox is empty when no cases exist yet', async () => {
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(emptyGovernanceResponse()),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('거버넌스 사건이 아직 없습니다')
+    expect(container.textContent).toContain('마지막 활동: 3일 전')
+    expect(container.textContent).toContain('청원 콘솔에서 새 청원을 접수하세요')
+  })
 })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -35,6 +35,26 @@ import {
 // Re-export for consumers that import from './governance'
 export { refreshGovernance, loadRuntimeParams } from './governance-store'
 
+function GovernanceEmptyState() {
+  const summary = governanceData.value?.summary
+  const lastActivityAge = formatAgeSummary(summary?.last_activity_age_s)
+
+  return html`
+    <${EmptyState}
+      icon="⚖️"
+      message="거버넌스 사건이 아직 없습니다. keeper 활동이나 청원 접수 후 이곳에 자동으로 사건이 쌓입니다."
+      action=${html`
+        <div class="mt-1 flex flex-col items-center gap-1.5 text-[12px] text-[var(--text-muted)]">
+          ${lastActivityAge
+            ? html`<span>마지막 활동: ${lastActivityAge} 전</span>`
+            : html`<span>최근 거버넌스 활동 기록이 아직 없습니다.</span>`}
+          <span>지금 시작하려면 위 청원 콘솔에서 새 청원을 접수하세요.</span>
+        </div>
+      `}
+    />
+  `
+}
+
 function GovernanceSummaryStrip() {
   const data = governanceData.value
   const summary = data?.summary
@@ -132,12 +152,15 @@ function GovernanceToolbar() {
 }
 
 function DecisionInbox() {
-  const items = filteredItemsByFilter(governanceFilter.value, governanceData.value?.items ?? [])
+  const allItems = governanceData.value?.items ?? []
+  const items = filteredItemsByFilter(governanceFilter.value, allItems)
   return html`
     <${Card} title="사건 수신함" class="section mb-5" variant="compact">
       <div class="flex flex-col gap-3 governance-inbox">
         ${items.length === 0
-          ? html`<${EmptyState} message="이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요." />`
+          ? allItems.length === 0
+            ? html`<${GovernanceEmptyState} />`
+            : html`<${EmptyState} message="이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요." />`
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`


### PR DESCRIPTION
## Summary
- distinguish between a truly empty governance feed and a filter-empty state
- add last-activity context and a next-step hint when no governance cases exist yet

## Verification
- cd dashboard && npm run typecheck
- cd dashboard && npm run test -- governance.test.ts

Refs #3301