### PR TITLE
fix(test): wrap Room-dependent tests in Eio context batch 4

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -290,7 +290,7 @@
 (test
  (name test_memory_oas_5tier)
  (modules test_memory_oas_5tier)
- (libraries masc_mcp agent_sdk alcotest yojson unix))
+ (libraries masc_mcp agent_sdk alcotest eio eio_main yojson unix))
 
 ; Verifier_oas bridge tests (eval_gate→guardrails, verdict→hook, read-only)
 (test
@@ -624,13 +624,13 @@
 (test
  (name test_pubsub_postgres)
  (modules test_pubsub_postgres)
- (libraries masc_mcp alcotest))
+ (libraries masc_mcp alcotest eio eio_main))
 
 ; Fs_compat tests (mkdir_p fallback must be shell-free and safe)
 (test
  (name test_fs_compat)
  (modules test_fs_compat)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest eio eio_main unix))
 
 ; ============================================================
 ; Concurrency stress tests (20+ agents)
@@ -888,7 +888,7 @@
 (test
  (name test_tool_compact)
  (modules test_tool_compact)
- (libraries masc_mcp fs_compat alcotest str yojson))
+ (libraries masc_mcp fs_compat alcotest eio eio_main str yojson))
 
 
 ; ============================================================

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -41,6 +41,9 @@ let test_mkdir_p_does_not_shell_inject () =
   check bool "dangerous path exists" true (Sys.file_exists dangerous && Sys.is_directory dangerous)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "fs_compat" [
     ( "mkdir_p"
     , [

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -486,6 +486,9 @@ let test_flush_episodes_appends_only_new_records () =
 (* ================================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   Alcotest.run "memory_oas_5tier" [
     ("oas_procedure_of_masc", [
       Alcotest.test_case "basic conversion" `Quick test_procedure_basic;

--- a/test/test_pubsub_postgres.ml
+++ b/test/test_pubsub_postgres.ml
@@ -82,6 +82,9 @@ let test_hybrid_approach_doc () =
   ()
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "Pubsub Postgres" [
     "compile", [
       test_case "notify_q query compiles" `Quick test_notify_query_compiles;

--- a/test/test_tool_compact.ml
+++ b/test/test_tool_compact.ml
@@ -206,6 +206,9 @@ let test_backend_create_local_explicit () =
 (* ================================================================ *)
 
 let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
   run "tool_compact + fs_compat_backend" [
     ("compact_dispatch", [
       test_case "basic compact" `Quick test_basic_compact;


### PR DESCRIPTION
## Summary
- Wraps 4 standalone test executables in `Eio_main.run` + `Fs_compat.set_fs` + `Eio_guard.enable` to ensure they run with proper Eio context instead of falling back to Memory backend
- Modified tests: `test_pubsub_postgres`, `test_fs_compat`, `test_tool_compact`, `test_memory_oas_5tier`
- Updated `test/dune` to add `eio eio_main` libraries to each test stanza

Closes #3178 (batch 4)

## Test plan
- [x] All 4 modified tests pass locally (`dune exec`)
- [x] `dune build --root .` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)