### PR TITLE
fix(dashboard): remove blocking bootstrap from keeper config API (#3335)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -557,9 +557,8 @@ let keeper_config_json (config : Room.config) (name : string)
       (`Not_found,
        `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
   | Ok (Some (m : Keeper_types.keeper_meta)) ->
-      ignore
-        (Prompt_defaults.bootstrap_runtime ~workspace_path:config.workspace_path
-           ~base_path:config.base_path);
+      (* bootstrap_runtime is called at server startup — skip here to
+         avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
       let active_model = Keeper_exec_status.active_model_of_meta m in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt


### PR DESCRIPTION
## Problem
GET /api/v1/keepers/:name/config hung indefinitely (0 bytes, 60s+). The handler called \`Prompt_defaults.bootstrap_runtime\` which uses \`Eio.Mutex\` + blocking \`In_channel\` file I/O, causing deadlock under mutex contention.

## Fix
Remove the redundant \`bootstrap_runtime\` call from the API handler. It is already called once at server startup (\`server_runtime_bootstrap.ml:84\`). \`active_model_of_meta\` returns safe defaults if bootstrap hasn't completed.

Closes #3335

🤖 Generated with [Claude Code](https://claude.com/claude-code)