### PR TITLE
ux(dashboard): add governance feed empty state guidance

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -135,4 +135,66 @@ describe('Governance surface', () => {
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('command:governance 렌더링 오류')
   }, 20000)
+
+  it('shows keeper guidance when governance feed is empty', async () => {
+    const emptyResponse: DashboardGovernanceResponse = {
+      generated_at: '2026-03-26T00:00:00Z',
+      summary: {
+        cases_open: 0,
+        pending_ruling: 0,
+        ready_auto_execute: 0,
+        needs_human_gate: 0,
+        executed: 0,
+      },
+      items: [],
+      activity: [],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(emptyResponse),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
+  }, 20000)
+
+  it('shows last activity age when governance feed is empty but has past activity', async () => {
+    const emptyWithAge: DashboardGovernanceResponse = {
+      generated_at: '2026-03-26T00:00:00Z',
+      summary: {
+        cases_open: 0,
+        pending_ruling: 0,
+        ready_auto_execute: 0,
+        needs_human_gate: 0,
+        executed: 0,
+        last_activity_age_s: 7200,
+      },
+      items: [],
+      activity: [],
+      pending_actions: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: vi.fn().mockResolvedValue(emptyWithAge),
+      fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      submitGovernanceCaseBrief: vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('마지막 활동: 2시간 전')
+    expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
+  }, 20000)
 })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -131,13 +131,31 @@ function GovernanceToolbar() {
   `
 }
 
+function governanceEmptyMessage(): string {
+  const data = governanceData.value
+  const allItems = data?.items ?? []
+  const lastActivityAge = data?.summary?.last_activity_age_s
+
+  // All items empty (not just filtered) — show guidance
+  if (allItems.length === 0) {
+    const ageText = formatAgeSummary(lastActivityAge)
+    if (ageText != null) {
+      return `거버넌스 사건이 없습니다. 마지막 활동: ${ageText} 전. keeper가 활동 중일 때 자동 생성됩니다.`
+    }
+    return '거버넌스 사건은 keeper가 활동 중일 때 자동 생성됩니다.'
+  }
+
+  // Items exist but filtered results are empty
+  return '이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요.'
+}
+
 function DecisionInbox() {
   const items = filteredItemsByFilter(governanceFilter.value, governanceData.value?.items ?? [])
   return html`
     <${Card} title="사건 수신함" class="section mb-5" variant="compact">
       <div class="flex flex-col gap-3 governance-inbox">
         ${items.length === 0
-          ? html`<${EmptyState} message="이 필터에 해당하는 사건이 없습니다. 청원을 접수하거나 필터를 변경해 보세요." />`
+          ? html`<${EmptyState} message=${governanceEmptyMessage()} />`
           : items.map(item => {
               const selected = selectedDecisionKey.value === itemKey(item)
               return html`


### PR DESCRIPTION
## Summary
- 거버넌스 피드가 빈 상태일 때 맥락에 맞는 안내 메시지 표시 (#3301)
- 전체 items가 비어 있을 때: keeper 활동 안내 + 마지막 활동 시간(있는 경우)
- 필터 결과만 비어 있을 때: 기존 필터 변경 안내 유지

## Changes
- `governance.ts`: `governanceEmptyMessage()` 함수 추가 — 전체 empty vs 필터 empty 구분
- `governance.test.ts`: empty state 테스트 2건 추가 (keeper 안내, 마지막 활동 시간)

## Test plan
- [x] `npm run build` (tsc + vite) 통과
- [x] vitest governance.test.ts 3/3 통과
- [ ] 실제 대시보드에서 빈 거버넌스 탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)