### PR TITLE
fix(build): revert ~env back to ~clock for OAS v0.91.2 compatibility

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -537,11 +537,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Mod_autoresearch ->
         let start_team_session ~goal ~operation_id ~loop_id:_ ~target_file:_
             ~program_note:_ =
-          let env = object
-            method clock = clock
-            method process_mgr = match state.Mcp_server.proc_mgr with Some pm -> pm | None -> failwith "process_mgr not available"
-          end in
-          Team_session_engine_eio.start_session ~sw ~env ~config
+          Team_session_engine_eio.start_session ~sw ~clock ~config
             ~created_by:agent_name ~goal ~duration_seconds:900
             ~execution_scope:Team_session_types.Limited_code_change
             ~checkpoint_interval_sec:60 ~min_agents:1

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -341,11 +341,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("reconcile_active_agents", fun () -> reconcile_active_agents_gauge state);
           ( "recover_running_team_sessions",
             fun () ->
-              let env = object
-                method clock = clock
-                method process_mgr = match state.Mcp_server.proc_mgr with Some pm -> pm | None -> failwith "process_mgr not available"
-              end in
-              Team_session_engine_eio.recover_running_sessions ~sw ~env
+              Team_session_engine_eio.recover_running_sessions ~sw ~clock
                 ~config:state.Mcp_server.room_config );
           ("chain_bootstrap", fun () -> bootstrap_chain_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -7,7 +7,7 @@ open Result_syntax
    All modes now use Team_session_swarm_runner.run_swarm via OAS Runner.
    Checkpoint/policy logic is handled by swarm callbacks. *)
 
-let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. >) ~(config : Room.config)
+let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     ~(created_by : string) ~(goal : string) ~(duration_seconds : int)
     ~(execution_scope : Team_session_types.execution_scope)
     ~(checkpoint_interval_sec : int) ~(min_agents : int)
@@ -197,10 +197,10 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
         let result =
           match Team_session_oas_bridge.supported_local_worker_tools () with
           | Ok masc_tools ->
-            Team_session_swarm_runner.run_swarm ~sw ~env ~config
+            Team_session_swarm_runner.run_swarm ~sw ~clock ~config
               ~session_id ~masc_tools
               ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
-                ~sw ~clock:env#clock ~config)
+                ~sw ~clock ~config)
           | Error reason -> Error reason
         in
         match result with
@@ -613,7 +613,7 @@ let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
               ]))
 
 
-let recover_running_sessions ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. >)
+let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
     ~(config : Room.config) : unit =
   let sessions = Team_session_store.list_sessions config in
   let now = Time_compat.now () in
@@ -687,10 +687,10 @@ let recover_running_sessions ~sw ~(env : < clock : _ Eio.Time.clock ; process_mg
                 let result =
                   match Team_session_oas_bridge.supported_local_worker_tools () with
                   | Ok masc_tools ->
-                    Team_session_swarm_runner.run_swarm ~sw ~env ~config
+                    Team_session_swarm_runner.run_swarm ~sw ~clock ~config
                       ~session_id:session.session_id ~masc_tools
                       ~dispatch:(Team_session_oas_bridge.dispatch_supported_tool
-                        ~sw ~clock:env#clock ~config)
+                        ~sw ~clock ~config)
                   | Error reason -> Error reason
                 in
                 match result with

--- a/lib/team_session/team_session_swarm_runner.ml
+++ b/lib/team_session/team_session_swarm_runner.ml
@@ -7,7 +7,7 @@
 
 module Swarm = Agent_sdk_swarm
 
-let run_swarm ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. >) ~(config : Room.config)
+let run_swarm ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     ~(session_id : string)
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
@@ -38,7 +38,7 @@ let run_swarm ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.Proce
         let callbacks =
           Team_session_swarm_callbacks.make_callbacks ~config ~session_id
         in
-        match Swarm.Runner.run ~sw ~env ~callbacks swarm_config with
+        match Swarm.Runner.run ~sw ~clock ~callbacks swarm_config with
         | Ok swarm_result ->
           let updated =
             Team_session_oas_bridge.apply_swarm_result session swarm_result

--- a/lib/team_session/team_session_swarm_runner.mli
+++ b/lib/team_session/team_session_swarm_runner.mli
@@ -27,7 +27,7 @@ module Swarm = Agent_sdk_swarm
     @return Updated session or error message *)
 val run_swarm :
   sw:Eio.Switch.t ->
-  env:< clock : _ Eio.Time.clock ; process_mgr : _ Eio.Process.mgr ; .. > ->
+  clock:_ Eio.Time.clock ->
   config:Room.config ->
   session_id:string ->
   masc_tools:Types.tool_schema list ->

--- a/lib/tool_team_session_handlers.ml
+++ b/lib/tool_team_session_handlers.ml
@@ -36,11 +36,7 @@ let handle_start ctx args : result =
     let agents = get_agent_names args "agents" in
     let operation_id = get_string_opt args "operation_id" in
     match
-      let env = object
-        method clock = ctx.clock
-        method process_mgr = match ctx.proc_mgr with Some pm -> pm | None -> failwith "process_mgr not available"
-      end in
-      Team_session_engine_eio.start_session ~sw:ctx.sw ~env
+      Team_session_engine_eio.start_session ~sw:ctx.sw ~clock:ctx.clock
         ~config:ctx.config ~created_by:ctx.agent_name ~goal ~duration_seconds
         ~execution_scope ~checkpoint_interval_sec ~min_agents
         ~scale_profile ~control_profile

--- a/test/test_team_session_swarm_runner.ml
+++ b/test/test_team_session_swarm_runner.ml
@@ -297,7 +297,7 @@ let test_run_swarm_empty_workers_keeps_session_running () =
   Team_session_store.ensure_session_dirs config session.session_id;
   Team_session_store.save_session config session;
   match
-    Team_session_swarm_runner.run_swarm ~sw ~env ~config
+    Team_session_swarm_runner.run_swarm ~sw ~clock ~config
       ~session_id:session.session_id ~masc_tools:[]
       ~dispatch:(fun ~name:_ ~args:_ -> (false, "no"))
   with

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -37,7 +37,7 @@ let test_repo_synthesis_swarm_start_creates_operation_session_and_run () =
   let start_team_session ~goal ~operation_id ~loop_id:_ ~target_file:_ ~program_note:_ =
     Lib.Team_session_engine_eio.start_session
       ~sw
-      ~env
+      ~clock
       ~config
       ~created_by:"owner"
       ~goal

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -62,7 +62,7 @@ let test_recover_orphan_session () =
   in
   Team_session_store.save_session config session;
   Team_session_engine_eio.recover_running_sessions ~sw
-    ~env ~config;
+    ~clock ~config;
   let rec wait_loaded attempts =
     if attempts <= 0 then
       failwith "orphan session not transitioned after recover"

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -385,7 +385,7 @@ let test_recover_elapsed_session () =
   in
   Team_session_store.save_session config session;
   Team_session_engine_eio.recover_running_sessions ~sw
-    ~env ~config;
+    ~clock ~config;
   let rec wait_loaded attempts =
     if attempts <= 0 then
       failwith "missing session after recover"


### PR DESCRIPTION
## Summary

PR #3317이 코드를 `~env` API로 변경했지만, OAS upstream(v0.91.2, SHA 47bef58)은 여전히 `~clock` API를 제공. CI에서 pinned OAS가 설치되어 전체 빌드 실패.

**main 빌드 블로커 수정.**

## 변경

- `run_swarm`: `~env` → `~clock`
- `start_session`: `~env` → `~clock`
- `recover_running_sessions`: `~env` → `~clock`
- 6개 caller에서 불필요한 env 객체 생성 제거

## Test plan

- [ ] CI Build and Test green
- [ ] CI Lint, Health, Contract Harness green

Fixes: #3342

🤖 Generated with [Claude Code](https://claude.com/claude-code)