### PR TITLE
fix(ci): add OAS pin SHA to opam cache prefix (#3334)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+          cache-prefix: oas-47bef58
 
       - name: Pin external dependencies
         run: |
@@ -165,6 +166,7 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+          cache-prefix: oas-47bef58
 
       - name: Pin external dependencies
         run: |
@@ -280,6 +282,7 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+          cache-prefix: oas-47bef58
 
       - name: Pin external dependencies
         run: |
@@ -349,6 +352,7 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+          cache-prefix: oas-47bef58
 
       - name: Pin external dependencies
         run: |
@@ -397,6 +401,7 @@ jobs:
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true
+          cache-prefix: oas-47bef58
 
       - name: Pin external dependencies
         run: |


### PR DESCRIPTION
## Problem
CI opam cache has a stale agent_sdk build with \`Swarm.Runner.run ~clock\` API, but MASC code uses \`~env\` (since #3317). The OAS source (v0.91.2, SHA 47bef58) already has \`~env\` in both .ml and .mli, but CI restores the pre-change cached build.

## Fix
Add OAS pin SHA to \`cache-prefix\` in all 5 \`ocaml/setup-ocaml@v3\` steps. When the OAS pin changes, the cache is invalidated and rebuilt with the correct API.

## Note
When updating \`scripts/oas-agent-sdk-pin.sh\`, also update the \`cache-prefix: oas-XXXXXXX\` in \`ci.yml\`.

Closes #3334, #3342

🤖 Generated with [Claude Code](https://claude.com/claude-code)