### PR TITLE
perf(dashboard): skip PG is_initialized in room-truth command fiber

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -541,12 +541,10 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       fiber_with_timeout ~timeout_s:execution_timeout_s "execution"
         (fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
         (cached_surface_json _execution_cache));
-  command_ref := fiber_with_timeout ~timeout_s:base_timeout_s "command"
-    (fun () ->
-      if Room.is_initialized config then
-        Server_command_plane_http.command_plane_summary_http_json ~state
-      else `Assoc [])
-    (`Assoc []);
+  (* command_plane_summary_http_json reads from a proactive cache ref —
+     no PG I/O needed.  Skip the Room.is_initialized guard (which does a
+     PG query in PostgresNative mode) to avoid 200-500ms latency. *)
+  command_ref := Server_command_plane_http.command_plane_summary_http_json ~state;
   let shell_json = !shell_ref in
   if (not !_shell_warmed) && shell_json <> `Assoc [] then
     _shell_warmed := true;


### PR DESCRIPTION
command fiber에서 Room.is_initialized(PG query) 제거. cp_summary_ref는 이미 캐시값.