### PR TITLE
ux(dashboard): add data freshness indicator to overview (#3321)

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -195,6 +195,25 @@ function AgentPulse() {
 
 // --- Overview (Home) ---
 
+function FreshnessIndicator({ generatedAt }: { generatedAt?: string | null }) {
+  if (!generatedAt) return null
+  const ts = new Date(generatedAt).getTime()
+  if (isNaN(ts)) return null
+  const ageSeconds = Math.floor((Date.now() - ts) / 1000)
+  const isStale = ageSeconds > 300 // 5 minutes
+  const label = ageSeconds < 60
+    ? '방금 갱신'
+    : ageSeconds < 3600
+      ? `${Math.floor(ageSeconds / 60)}분 전 갱신`
+      : `${Math.floor(ageSeconds / 3600)}시간 전 갱신`
+  return html`
+    <div class="flex items-center gap-1.5 text-xs ${isStale ? 'text-[color:var(--warn)]' : 'text-[color:var(--text-dim)]'}">
+      <span class="inline-block w-1.5 h-1.5 rounded-full ${isStale ? 'bg-[var(--warn)]' : 'bg-[var(--ok)]'}" />
+      ${label}
+    </div>
+  `
+}
+
 export function Overview() {
   const snap = missionSnapshot.value
   const roomHealth = snap?.summary?.room_health ?? null
@@ -219,6 +238,10 @@ export function Overview() {
       <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
         <${HomeSectionHeader} label="최근 활동" />
         <${NarrativeTimeline} entries=${journal} maxItems=${8} />
+      </div>
+
+      <div class="flex justify-end px-1">
+        <${FreshnessIndicator} generatedAt=${snap?.generated_at} />
       </div>
     </div>
   `


### PR DESCRIPTION
## Summary
Add a freshness indicator at the bottom of the overview page showing when data was last refreshed.

- Uses \`missionSnapshot.generated_at\` timestamp
- Green dot + "방금 갱신" / "N분 전 갱신"
- Yellow warning when stale (>5 minutes)

Prevents users from acting on outdated data when proactive refresh loops are failing silently.

Closes #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)