### PR TITLE
chore(oas): bump agent_sdk floor to 0.92.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.91.2))
+  (agent_sdk (>= 0.92.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.91.2"}
+  "agent_sdk" {>= "0.92.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.91.2"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.92.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="47bef58e6d3016d103543494eaa0cee179c8fba9"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.91.2"
+readonly OAS_AGENT_SDK_SHA="3fa05ae4356342973688d85215e78546eb5dd4f1"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.92.0"

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -211,8 +211,9 @@ let test_session_to_swarm_config_health_contract () =
   let metric_value =
     match convergence.metric with
     | Swarm.Swarm_types.Callback f -> f ()
-    | Swarm.Swarm_types.Shell_command cmd ->
-        Alcotest.failf "expected callback metric, got shell command %s" cmd
+    | Swarm.Swarm_types.Argv_command argv ->
+        Alcotest.failf "expected callback metric, got argv command %s"
+          (String.concat " " argv)
   in
   Alcotest.(check (float 0.001)) "initial success ratio" 0.0 metric_value;
   Alcotest.(check int) "single-pass convergence iterations" 1


### PR DESCRIPTION
## Summary
- bump the MASC `agent_sdk` dependency floor and pin metadata to OAS `v0.92.0`
- update the runtime pin SHA to OAS main merge commit `3fa05ae`
- adjust the OAS bridge test for `Argv_command` after the swarm metric API change

## Verification
- `./scripts/check-oas-pin.sh`
- `dune build --root . test/test_team_session_oas_bridge.exe && _build/default/test/test_team_session_oas_bridge.exe`
