### PR TITLE
fix(test): suppress PG auto-detect in room-truth tests (#3354)

### DIFF
--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -35,11 +35,17 @@ let with_fs_backend f =
   Unix.putenv "SUPABASE_DB_URL" "";
   Unix.putenv "SB_PG_URL" "";
   Unix.putenv "DATABASE_URL" "";
+  (* OCaml stdlib has no unsetenv; empty string is equivalent for PG
+     auto-detect since all callers filter empty values. *)
+  let restore key = function
+    | Some v -> Unix.putenv key v
+    | None -> Unix.putenv key ""
+  in
   Fun.protect ~finally:(fun () ->
-    (match saved with Some v -> Unix.putenv "MASC_POSTGRES_URL" v | None -> ());
-    (match saved2 with Some v -> Unix.putenv "SUPABASE_DB_URL" v | None -> ());
-    (match saved3 with Some v -> Unix.putenv "SB_PG_URL" v | None -> ());
-    (match saved4 with Some v -> Unix.putenv "DATABASE_URL" v | None -> ()))
+    restore "MASC_POSTGRES_URL" saved;
+    restore "SUPABASE_DB_URL" saved2;
+    restore "SB_PG_URL" saved3;
+    restore "DATABASE_URL" saved4)
   f
 
 let test_dashboard_room_truth_empty_room () =

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -24,11 +24,30 @@ let cleanup_dir dir =
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
 
+let with_fs_backend f =
+  (* Force FileSystem backend: suppress PG auto-detect so tests use
+     the local temp dir instead of falling back to Memory. *)
+  let saved = Sys.getenv_opt "MASC_POSTGRES_URL" in
+  let saved2 = Sys.getenv_opt "SUPABASE_DB_URL" in
+  let saved3 = Sys.getenv_opt "SB_PG_URL" in
+  let saved4 = Sys.getenv_opt "DATABASE_URL" in
+  Unix.putenv "MASC_POSTGRES_URL" "";
+  Unix.putenv "SUPABASE_DB_URL" "";
+  Unix.putenv "SB_PG_URL" "";
+  Unix.putenv "DATABASE_URL" "";
+  Fun.protect ~finally:(fun () ->
+    (match saved with Some v -> Unix.putenv "MASC_POSTGRES_URL" v | None -> ());
+    (match saved2 with Some v -> Unix.putenv "SUPABASE_DB_URL" v | None -> ());
+    (match saved3 with Some v -> Unix.putenv "SB_PG_URL" v | None -> ());
+    (match saved4 with Some v -> Unix.putenv "DATABASE_URL" v | None -> ()))
+  f
+
 let test_dashboard_room_truth_empty_room () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_fs_backend (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
@@ -51,13 +70,14 @@ let test_dashboard_room_truth_empty_room () =
         check string "focus source"
           "orchestra"
           (json |> member "focus" |> member "source" |> to_string);
-      ))
+      )))
 
 let test_dashboard_room_truth_execution_fixture () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_fs_backend (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
@@ -75,13 +95,14 @@ let test_dashboard_room_truth_execution_fixture () =
         check bool "fixture top queue absent when no blockers"
           true
           (json |> member "execution" |> member "top_queue" = `Null);
-      ))
+      )))
 
 let test_dashboard_room_truth_empty_room_focus_label () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_fs_backend (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
@@ -97,13 +118,14 @@ let test_dashboard_room_truth_empty_room_focus_label () =
           true
           (String.length focus_label > 0
            && focus_label <> "지금은 방 전체가 비교적 안정적입니다");
-      ))
+      )))
 
 let test_operator_digest_shape_matches_room_truth () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      with_fs_backend (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
@@ -122,7 +144,7 @@ let test_operator_digest_shape_matches_room_truth () =
             true
             (value <> `Null)
         ) expected_keys;
-      ))
+      )))
 
 let () =
   Alcotest.run "Dashboard Room Truth"


### PR DESCRIPTION
## Problem
4 read_model tests fail because PG env vars (MASC_POSTGRES_URL, SUPABASE_DB_URL) trigger PostgresNative backend, which fails without Eio PG pool, causing Memory fallback where room-truth returns null for all fields.

## Fix
\`with_fs_backend\` helper temporarily clears PG-related env vars, forcing FileSystem backend. Applied to all 4 read_model tests.

Note: local clean build fails due to OAS API mismatch (Shell_command constructor). This is the same opam cache issue (#3334/#3352). CI verification pending cache fix.

Closes #3354

🤖 Generated with [Claude Code](https://claude.com/claude-code)