### PR TITLE
fix(http): migrate remaining cohttp-eio call sites to closing client (#3221)

### DIFF
--- a/lib/council/dune
+++ b/lib/council/dune
@@ -3,5 +3,5 @@
  (name council)
  (public_name masc_mcp.council)
  (modules router debate consensus balance executor conversation governance_v2 governance_v2_types governance_v2_serde loop_guard thread_persist council)
- (libraries re.str yojson base64 unix eio eio.unix cohttp cohttp-eio uuidm time_compat masc_process masc_log masc_core fs_compat)
+ (libraries re.str yojson base64 unix eio eio.unix cohttp cohttp-eio uuidm time_compat masc_process masc_log masc_core fs_compat masc_http_client)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -314,13 +314,13 @@ let execute_cypher_raw ~cypher : (Yojson.Safe.t, string) result =
 
       let run () =
         Eio.Switch.run (fun sw ->
-          let is_https = Uri.scheme endpoint_uri = Some "https" in
           let client =
-            if not is_https then Cohttp_eio.Client.make ~https:None net
+            if Uri.scheme endpoint_uri <> Some "https" then
+              Masc_http_client.make_closing_client ~sw ~net ~https:None
             else
               match ctx.https_connector with
               | Some (Https_connector c) ->
-                  Cohttp_eio.Client.make ~https:(Some c) net
+                  Masc_http_client.make_closing_client ~sw ~net ~https:(Some c)
               | None ->
                   failwith "HTTPS requested but no https_connector provided to eio_context"
           in

--- a/lib/dune
+++ b/lib/dune
@@ -513,7 +513,6 @@
    keeper_persona
    ;; Context management (used by keeper agents)
    masc_eio_env
-   masc_http_client
    discovery_cache
    oas_model_resolve
    context_compact_oas
@@ -783,6 +782,8 @@
    fs_compat
    ;; Date-split JSONL storage (YYYY-MM/DD.jsonl)
    dated_jsonl
+   ;; HTTP client with fd-leak prevention (extracted sub-library)
+   masc_http_client
    ;; Council - multi-agent governance
    council
    ;; Neo4j Bolt native driver (OCaml 5.x Eio)

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -202,31 +202,22 @@ let post_json_via_eio ~sw:_ ~(auth_token : string option) ~session_id
   | None -> Error "Eio net not initialized"
   | Some net ->
       try
-        Eio.Switch.run @@ fun sw ->
-        let client = Cohttp_eio.Client.make ~https:None net in
         let headers =
-          Cohttp.Header.of_list
-            ([
+            [
                ("content-type", "application/json");
                ("accept", "application/json, text/event-stream");
                ("x-masc-force-json", "1");
                ("mcp-session-id", session_id);
              ]
             @
-            match auth_token with
+            (match auth_token with
             | Some token when String.trim token <> "" ->
                 [ ("authorization", "Bearer " ^ token) ]
             | _ -> [])
         in
-        let uri = Uri.of_string (mcp_endpoint_url ~auth_token) in
-        let body = Eio.Flow.string_source request_body in
-        let response, response_body =
-          Cohttp_eio.Client.post client ~sw uri ~headers ~body
-        in
-        let status = Cohttp.Response.status response |> Cohttp.Code.code_of_status in
-        let raw_body =
-          Eio.Buf_read.(parse_exn take_all) response_body
-            ~max_size:(8 * 1024 * 1024)
+        let url = mcp_endpoint_url ~auth_token in
+        let status, raw_body =
+          Masc_http_client.post_sync ~net ~url ~headers ~body:request_body ()
         in
         if Cohttp.Code.is_success status then Ok raw_body
         else Error (sprintf "MASC HTTP %d: %s" status raw_body)

--- a/lib/masc_http_client/dune
+++ b/lib/masc_http_client/dune
@@ -1,0 +1,5 @@
+(include_subdirs no)
+(library
+ (name masc_http_client)
+ (public_name masc_mcp.http_client)
+ (libraries eio eio.unix cohttp cohttp-eio uri))

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -37,9 +37,9 @@ let make_closing_client ~sw ~net ~https =
         match https with
         | Some wrap ->
             (wrap uri sock
-              :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+              :> [ `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
         | None -> failwith "HTTPS requested but not enabled")
-    | _ -> (sock :> [ `Close | `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
+    | _ -> (sock :> [ `Flow | `R | `Shutdown | `W ] Eio.Resource.t)
   in
   let client = Cohttp_eio.Client.make_generic connect in
   Eio.Switch.on_release sw (fun () ->

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -412,7 +412,7 @@ let call_voice_mcp ~sw:_ ~clock ~net ~tool_name ~arguments =
   ] in
   let operation () =
     Eio.Switch.run @@ fun inner_sw ->
-    match client_for_uri_result ~net uri with
+    match client_for_uri_result ~sw:inner_sw ~net uri with
     | Error error -> Error error
     | Ok client ->
         with_timeout ~clock (fun () ->
@@ -474,7 +474,7 @@ let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
     Cohttp.Header.of_list
       [ ("Content-Type", "application/json"); ("Accept", "application/json") ]
   in
-  match client_for_uri_result ~net uri with
+  match client_for_uri_result ~sw ~net uri with
   | Error error -> Error error
   | Ok client ->
       let operation () =
@@ -588,7 +588,7 @@ let is_voice_server_available ~sw:_ ~clock ~net =
               | Ok url -> Uri.of_string url
               | Error _ -> voice_health_uri ()
             in
-            match client_for_uri_result ~net uri with
+            match client_for_uri_result ~sw:inner_sw ~net uri with
             | Error error -> Error error
             | Ok client ->
                 let resp, _ = Cohttp_eio.Client.get ~sw:inner_sw client uri in
@@ -845,7 +845,7 @@ let health_check ~sw:_ ~clock:_ ~net () =
       in
       try
         Eio.Switch.run @@ fun inner_sw ->
-        let client = client_for_uri ~net uri in
+        let client = client_for_uri ~sw:inner_sw ~net uri in
         let resp, body = Cohttp_eio.Client.get ~sw:inner_sw client uri in
         let status = Cohttp.Response.status resp in
         let body_str = Eio.Buf_read.(parse_exn take_all) body ~max_size:max_int in

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -95,14 +95,14 @@ let voice_mcp_port () =
   | Some port -> port
   | None -> Env_config_runtime.Voice.default_port
 
-let client_for_uri ~net uri =
-  if Uri.scheme uri = Some "https" then
-    Cohttp_eio.Client.make ~https:(Some (Eio_context.get_https_connector ())) net
-  else
-    Cohttp_eio.Client.make ~https:None net
+let client_for_uri ~sw ~net uri =
+  let https = if Uri.scheme uri = Some "https" then
+    Some (Eio_context.get_https_connector ())
+  else None in
+  Masc_http_client.make_closing_client ~sw ~net ~https
 
-let client_for_uri_result ~net uri =
-  try Ok (client_for_uri ~net uri)
+let client_for_uri_result ~sw ~net uri =
+  try Ok (client_for_uri ~sw ~net uri)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->


### PR DESCRIPTION
## Summary
- voice_bridge, thread_persist, worker_container_types의 raw `Cohttp_eio.Client.make` 호출을 `Masc_http_client.make_closing_client`로 교체
- `masc_http_client`를 독립 sub-library로 추출하여 council/ 라이브러리에서도 사용 가능하게 함 (순환 의존성 해소)
- HTTPS coercion 타입을 `[Flow|R|Shutdown|W]`로 완화하여 GADT-wrapped TLS connector 지원

## Context
#3326에서 graphql_client와 auto_responder를 수정했지만, 3곳(voice_bridge 3, thread_persist 1, worker_container_types 1)이 남아있었음. 이 PR로 lib/ 내 모든 raw `Cohttp_eio.Client.make` 호출 제거 완료.

## Test plan
- [x] `dune build bin/main_eio.exe` 성공
- [ ] CI green
- [ ] 서버 재시작 후 fd 누적 속도 모니터링 (`lsof -p <pid> | wc -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)