### PR TITLE
fix(test): add setup/teardown cleanup for board PG tests (#3310)

### DIFF
--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -13,6 +13,21 @@ let pg_url () =
   | Some s when String.trim s <> "" -> Some s
   | _ -> None
 
+(** Delete all pg-test-* rows from board tables (votes -> comments -> posts).
+    Best-effort: errors are silently ignored (table may not exist yet). *)
+let cleanup_test_data pool =
+  let open Caqti_request.Infix in
+  let exec_del sql =
+    match Caqti_eio.Pool.use (fun (module C : Caqti_eio.CONNECTION) ->
+      C.exec ((Caqti_type.unit ->. Caqti_type.unit) sql) ()
+    ) pool with
+    | Ok () -> ()
+    | Error _ -> ()
+  in
+  exec_del "DELETE FROM masc_board_votes WHERE voter LIKE 'pg-test-%' OR voter LIKE 'pg-voter-%' OR voter LIKE 'pg-cv-%'";
+  exec_del "DELETE FROM masc_board_comments WHERE author LIKE 'pg-test-%'";
+  exec_del "DELETE FROM masc_board_posts WHERE author LIKE 'pg-test-%'"
+
 (** {1 Helper: run test inside Eio with PG pool} *)
 
 let with_pg_backend f () =
@@ -32,7 +47,10 @@ let with_pg_backend f () =
       | Error e ->
           Alcotest.fail (Printf.sprintf "Board_pg.create failed: %s" (Board.show_board_error e))
       | Ok t ->
-          f t
+          cleanup_test_data pool;
+          Fun.protect
+            (fun () -> f t)
+            ~finally:(fun () -> cleanup_test_data pool)
 
 (** {1 Post CRUD} *)
 

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -14,19 +14,23 @@ let pg_url () =
   | _ -> None
 
 (** Delete all pg-test-* rows from board tables (votes -> comments -> posts).
+    Uses a single connection for all three DELETEs.
     Best-effort: errors are silently ignored (table may not exist yet). *)
 let cleanup_test_data pool =
   let open Caqti_request.Infix in
-  let exec_del sql =
-    match Caqti_eio.Pool.use (fun (module C : Caqti_eio.CONNECTION) ->
-      C.exec ((Caqti_type.unit ->. Caqti_type.unit) sql) ()
-    ) pool with
-    | Ok () -> ()
-    | Error _ -> ()
-  in
-  exec_del "DELETE FROM masc_board_votes WHERE voter LIKE 'pg-test-%' OR voter LIKE 'pg-voter-%' OR voter LIKE 'pg-cv-%'";
-  exec_del "DELETE FROM masc_board_comments WHERE author LIKE 'pg-test-%'";
-  exec_del "DELETE FROM masc_board_posts WHERE author LIKE 'pg-test-%'"
+  let del_votes = (Caqti_type.unit ->. Caqti_type.unit)
+    "DELETE FROM masc_board_votes WHERE voter LIKE 'pg-test-%' OR voter LIKE 'pg-voter-%' OR voter LIKE 'pg-cv-%'" in
+  let del_comments = (Caqti_type.unit ->. Caqti_type.unit)
+    "DELETE FROM masc_board_comments WHERE author LIKE 'pg-test-%'" in
+  let del_posts = (Caqti_type.unit ->. Caqti_type.unit)
+    "DELETE FROM masc_board_posts WHERE author LIKE 'pg-test-%'" in
+  match Caqti_eio.Pool.use (fun (module C : Caqti_eio.CONNECTION) ->
+    Result.bind (C.exec del_votes ()) (fun () ->
+    Result.bind (C.exec del_comments ()) (fun () ->
+    C.exec del_posts ()))
+  ) pool with
+  | Ok () -> ()
+  | Error _ -> ()
 
 (** {1 Helper: run test inside Eio with PG pool} *)
 


### PR DESCRIPTION
## Summary
- Board PG 테스트가 production에 `pg-test-*` 데이터를 남기는 문제 수정
- `cleanup_test_data` 함수 추가: votes → comments → posts 순서로 `pg-test-*` 행 삭제
- `with_pg_backend`에 setup (테스트 전 cleanup) + teardown (`Fun.protect ~finally`) 적용
- Production 데이터 수동 정리 완료 (posts 11, comments 2, votes 3 삭제)

## Changes
- `test/test_board_pg.ml`: `cleanup_test_data` + `Fun.protect` teardown 추가 (19 LOC)

## Verification
- 16/16 board PG 테스트 통과
- 테스트 실행 후 production에 `pg-test-*` 잔류 0건 확인

Closes #3310

🤖 Generated with [Claude Code](https://claude.com/claude-code)