### PR TITLE
fix(test): seed execution cache and force filesystem in room-truth tests

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -44,6 +44,13 @@ let _execution_cache =
         ("message", `String "Execution data is being computed. Refresh in a few seconds.");
       ])
 
+(** Bypass the proactive warm-up guard so tests that call
+    [dashboard_room_truth_http_json] get the full response instead of
+    the "initializing" short-circuit. *)
+let seed_execution_cache_for_test () =
+  mark_cached_surface_success _execution_cache
+    (`Assoc [("status", `String "seeded_for_test")])
+
 let _transport_health_cache =
   create_cached_surface
     (`Assoc

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -4,6 +4,13 @@ module Lib = Masc_mcp
 
 open Alcotest
 
+(* Force filesystem backend so tests run without PG auto-detect dependency. *)
+let () = Unix.putenv "MASC_STORAGE_TYPE" "filesystem"
+
+(* Bypass the proactive execution cache warm-up guard so tests get the full
+   room-truth response instead of the "initializing" short-circuit. *)
+let () = Lib.Server_dashboard_http.seed_execution_cache_for_test ()
+
 let test_dir () =
   let tmp = Filename.temp_file "masc_dashboard_room_truth" "" in
   Sys.remove tmp;


### PR DESCRIPTION
## Summary
- `test_dashboard_room_truth` 테스트가 로컬(PG env var 있는 환경)과 CI 모두에서 실패하던 문제 수정
- proactive execution cache warm-up guard가 "initializing" 응답을 반환하여 테스트가 기대하는 JSON shape과 불일치
- `seed_execution_cache_for_test()` 함수 추가로 테스트 전에 cache bypass
- `MASC_STORAGE_TYPE=filesystem` 강제로 PG auto-detect 방지

## Changes
- `lib/server/server_dashboard_http.ml`: `seed_execution_cache_for_test()` 추가 (5줄)
- `test/test_dashboard_room_truth.ml`: filesystem 강제 + cache seed 호출

## Test plan
- [x] `test_dashboard_room_truth` 4/4 pass (local, with MASC_POSTGRES_URL set)
- [ ] CI Build and Test pass
- [ ] CI Health pass

Supersedes #3360 — covers both PG suppression and execution cache seeding.

Generated with [Claude Code](https://claude.com/claude-code)