### PR TITLE
fix(test): warm execution cache + align OAS Argv_command (#3358)

### DIFF
--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -24,6 +24,14 @@ let cleanup_dir dir =
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
 
+(** Warm the execution cache so room-truth skips the "initializing" early return.
+    Without this, proactive_first_cycle_pending is true and the handler returns
+    a minimal {"status":"initializing"} JSON without room/execution/command data. *)
+let warm_execution_cache () =
+  Lib.Server_dashboard_http_cache.mark_cached_surface_success
+    Lib.Server_dashboard_http._execution_cache
+    (`Assoc [("status", `String "ok")])
+
 let test_dashboard_room_truth_empty_room () =
   let dir = test_dir () in
   Fun.protect
@@ -32,6 +40,7 @@ let test_dashboard_room_truth_empty_room () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -61,6 +70,7 @@ let test_dashboard_room_truth_execution_fixture () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -85,6 +95,7 @@ let test_dashboard_room_truth_empty_room_focus_label () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json
@@ -107,6 +118,7 @@ let test_operator_digest_shape_matches_room_truth () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Server_dashboard_http.dashboard_room_truth_http_json

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -211,8 +211,9 @@ let test_session_to_swarm_config_health_contract () =
   let metric_value =
     match convergence.metric with
     | Swarm.Swarm_types.Callback f -> f ()
-    | Swarm.Swarm_types.Shell_command cmd ->
-        Alcotest.failf "expected callback metric, got shell command %s" cmd
+    | Swarm.Swarm_types.Argv_command argv ->
+        Alcotest.failf "expected callback metric, got argv command %s"
+          (String.concat " " argv)
   in
   Alcotest.(check (float 0.001)) "initial success ratio" 0.0 metric_value;
   Alcotest.(check int) "single-pass convergence iterations" 1


### PR DESCRIPTION
## Problem
4 read_model tests fail on main CI: \`Type_error("Can't get member 'status' of non-object type null")\`.

Root cause: \`dashboard_room_truth_http_json\` returns \`{"status":"initializing"}\` when \`_execution_cache\` has no success yet (proactive refresh hasn't run). Tests access \`json.room.status\` which is null.

Additional: \`test_team_session_oas_bridge\` fails with \`Shell_command\` constructor not found (OAS renamed to \`Argv_command\`).

## Fix
1. \`warm_execution_cache()\` helper marks the global execution cache as successful before each test
2. \`Shell_command\` → \`Argv_command\` to match current OAS API

## Test
- \`test_dashboard_room_truth\`: 4/4 passed (was 0/4)
- \`test_team_session_oas_bridge\`: builds (was compile error)

Closes #3358

🤖 Generated with [Claude Code](https://claude.com/claude-code)