### PR TITLE
fix(dashboard): recover room state and slim transport health

### DIFF
--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -74,6 +74,11 @@ let topology_summary_to_json (s : topology_summary) =
       ("operation_status_counts", operation_status_counts_to_json s.operation_status_counts);
     ]
 
+let topology_summary_json_from_state (state : snapshot_state) =
+  build_topology_summary ~units:state.units ~managed_units:state.managed_units
+    ~agents:state.agents ~operations:state.operations
+  |> topology_summary_to_json
+
 (* Per-section mtime-based cache for build_snapshot_state.
    Instead of invalidating the entire cache when ANY .masc/ file changes,
    each section tracks the mtime of its specific file(s) and only re-reads
@@ -271,7 +276,6 @@ let build_snapshot_state ?sessions config =
 
 let topology_json_from_state (state : snapshot_state) =
   let agents = state.agents in
-  let managed_units = state.managed_units in
   let units = state.units in
   let source = state.source in
   let operations = state.operations in
@@ -293,18 +297,21 @@ let topology_json_from_state (state : snapshot_state) =
              ~agent_statuses:(agent_status_map agents)
              ~live_agents:(live_agent_names agents) ~operations unit.unit_id)
   in
-  let summary = build_topology_summary ~units ~managed_units ~agents ~operations in
+  let summary = topology_summary_json_from_state state in
   `Assoc
     [
       ("version", `String "cp-v2");
       ("generated_at", `String (Types.now_iso ()));
       ("source", `String source);
-      ("summary", topology_summary_to_json summary);
+      ("summary", summary);
       ("units", `List trees);
     ]
 
 let topology_json config =
   topology_json_from_state (build_snapshot_state config)
+
+let topology_summary_json config =
+  topology_summary_json_from_state (build_snapshot_state config)
 
 let list_units_json config =
   let _, managed_units, normalized_units, source = topology_units config in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -15,6 +15,12 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join 
   else
     false
 
+let is_ephemeral_agent_name name =
+  String.length name >= 6 && String.sub name 0 6 = "agent-"
+
+let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
+  (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name
+
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
@@ -150,10 +156,14 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   in
 
   let persisted_agent_name () =
-    match read_mcp_session_agent () with
-    | Some n -> Some n
-    | None ->
-        if Option.is_some mcp_session_id then None else read_term_session_agent ()
+    if should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name
+    then
+      match read_mcp_session_agent () with
+      | Some n -> Some n
+      | None ->
+          if Option.is_some mcp_session_id then None else read_term_session_agent ()
+    else
+      None
   in
 
   let agent_name =
@@ -164,10 +174,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
            && not (Nickname.is_generated_nickname agent_name) ->
         persisted
     | _ -> agent_name
-  in
-
-  let is_ephemeral_agent_name name =
-    String.length name >= 6 && String.sub name 0 6 = "agent-"
   in
 
   let agent_name =

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -13,6 +13,86 @@ open Room_utils
 (* State Read / Write / Update                  *)
 (* ============================================ *)
 
+let default_room_state config = {
+  protocol_version = "0.1.0";
+  project = Filename.basename config.base_path;
+  started_at = now_iso ();
+  message_seq = 0;
+  active_agents = [];
+  paused = false;
+  pause_reason = None;
+  paused_by = None;
+  paused_at = None;
+  search_strategy_default = Some "best_first_v1";
+  speculation_enabled = false;
+  speculation_budget = None;
+}
+
+let non_empty_string_opt = function
+  | Some value ->
+      let value = String.trim value in
+      if value = "" then None else Some value
+  | None -> None
+
+let recover_active_agent_name = function
+  | `String name -> non_empty_string_opt (Some name)
+  | `Assoc _ as json ->
+      (match non_empty_string_opt (Safe_ops.json_string_opt "name" json) with
+       | Some name -> Some name
+       | None ->
+           non_empty_string_opt (Safe_ops.json_string_opt "agent_name" json))
+  | _ -> None
+
+let recover_room_state config json =
+  let defaults = default_room_state config in
+  let active_agents =
+    match Safe_ops.json_list_opt "active_agents" json with
+    | Some agents -> List.filter_map recover_active_agent_name agents
+    | None -> defaults.active_agents
+  in
+  {
+    protocol_version =
+      non_empty_string_opt (Safe_ops.json_string_opt "protocol_version" json)
+      |> Option.value ~default:defaults.protocol_version;
+    project =
+      non_empty_string_opt (Safe_ops.json_string_opt "project" json)
+      |> Option.value ~default:defaults.project;
+    started_at =
+      non_empty_string_opt (Safe_ops.json_string_opt "started_at" json)
+      |> Option.value ~default:defaults.started_at;
+    message_seq = Safe_ops.json_int ~default:defaults.message_seq "message_seq" json;
+    active_agents;
+    paused = Safe_ops.json_bool ~default:defaults.paused "paused" json;
+    pause_reason =
+      non_empty_string_opt (Safe_ops.json_string_opt "pause_reason" json);
+    paused_by =
+      non_empty_string_opt (Safe_ops.json_string_opt "paused_by" json);
+    paused_at =
+      non_empty_string_opt (Safe_ops.json_string_opt "paused_at" json);
+    search_strategy_default =
+      (match
+         non_empty_string_opt
+           (Safe_ops.json_string_opt "search_strategy_default" json)
+       with
+       | Some value -> Some value
+       | None -> defaults.search_strategy_default);
+    speculation_enabled =
+      Safe_ops.json_bool ~default:defaults.speculation_enabled
+        "speculation_enabled" json;
+    speculation_budget =
+      Safe_ops.json_int_opt "speculation_budget" json;
+  }
+
+(** Write room state — persists to both filesystem and PostgreSQL *)
+let write_state config state =
+  write_json config (state_path config) (room_state_to_yojson state);
+  if is_pg_backend config then begin
+    let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
+    (match backend_set config ~key:"room:state" ~value:json_str with
+     | Ok () -> ()
+     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" (Backend_types.show_error e))
+  end
+
 (** Read room state — checks PostgreSQL first for HTTP state persistence *)
 let read_state config =
   let pg_state =
@@ -30,31 +110,17 @@ let read_state config =
   match room_state_of_yojson json with
   | Ok state -> state
   | Error msg ->
-      Log.Misc.warn "read_state: deserialization failed (%s), returning empty default — dashboard will show stale data" msg;
-      {
-        protocol_version = "0.1.0";
-        project = Filename.basename config.base_path;
-        started_at = now_iso ();
-        message_seq = 0;
-        active_agents = [];
-        paused = false;
-        pause_reason = None;
-        paused_by = None;
-        paused_at = None;
-        search_strategy_default = Some "best_first_v1";
-        speculation_enabled = false;
-        speculation_budget = None;
-      }
-
-(** Write room state — persists to both filesystem and PostgreSQL *)
-let write_state config state =
-  write_json config (state_path config) (room_state_to_yojson state);
-  if is_pg_backend config then begin
-    let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
-    (match backend_set config ~key:"room:state" ~value:json_str with
-     | Ok () -> ()
-     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" (Backend_types.show_error e))
-  end
+      let repaired = recover_room_state config json in
+      Log.Misc.warn
+        "read_state: deserialization failed (%s), repairing state and rewriting canonical JSON"
+        msg;
+      (try write_state config repaired
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Misc.warn "read_state: failed to persist repaired state: %s"
+             (Printexc.to_string exn));
+      repaired
 
 (** Update state with function - uses file lock for atomic read-modify-write *)
 let update_state config f =
@@ -301,22 +367,6 @@ let resolve_agent_name config agent_name =
 (* ============================================ *)
 (* Room Bootstrap                               *)
 (* ============================================ *)
-
-(** Default empty state for bootstrap. *)
-let default_room_state config = {
-  protocol_version = "0.1.0";
-  project = Filename.basename config.base_path;
-  started_at = now_iso ();
-  message_seq = 0;
-  active_agents = [];
-  paused = false;
-  pause_reason = None;
-  paused_by = None;
-  paused_at = None;
-  search_strategy_default = Some "best_first_v1";
-  speculation_enabled = false;
-  speculation_budget = None;
-}
 
 let ensure_room_bootstrap config room_id =
   let room_id =

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -158,11 +158,8 @@ let int_field key json =
   | _ -> 0
 
 let cluster_summary_json config =
-  match Command_plane_v2.topology_json config with
-  | `Assoc fields -> (
-      match List.assoc_opt "summary" fields with
-      | Some (`Assoc _ as json) -> json
-      | _ -> `Assoc [])
+  match Command_plane_v2.topology_summary_json config with
+  | `Assoc _ as json -> json
   | _ -> `Assoc []
 
 let http_listener_mode () =

--- a/test/dune
+++ b/test/dune
@@ -20,7 +20,7 @@
 ; Pure synchronous tests
 ; ============================================================
 (tests
- (names test_room test_types test_auth test_http_negotiation
+ (names test_room test_room_state_recovery test_types test_auth test_http_negotiation
         test_sse test_encryption test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_mitosis test_spawn
@@ -47,7 +47,7 @@
         test_worktree_live_context
         test_tool_input_validation
 )
- (modules test_room test_types test_auth test_http_negotiation
+ (modules test_room test_room_state_recovery test_types test_auth test_http_negotiation
           test_sse test_encryption test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_mitosis test_spawn

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -160,6 +160,18 @@ let test_resolve_join_state_skips_unknown_agent () =
   Alcotest.(check bool) "unknown agent skipped" false !called;
   Alcotest.(check bool) "unknown agent treated unjoined" false joined
 
+let test_should_read_legacy_persisted_agent_name () =
+  let should_read =
+    Masc_mcp.Mcp_server_eio_execute.should_read_legacy_persisted_agent_name
+  in
+  Alcotest.(check bool) "ephemeral fallback reads legacy state" true
+    (should_read ~has_explicit_agent_name:false ~agent_name:"agent-12345678");
+  Alcotest.(check bool) "stable nickname skips legacy read" false
+    (should_read ~has_explicit_agent_name:false
+       ~agent_name:"codex-swift-fox");
+  Alcotest.(check bool) "explicit agent name skips legacy read" false
+    (should_read ~has_explicit_agent_name:true ~agent_name:"agent-12345678")
+
 let rec collect_tools ~clock ~sw ?profile ?cursor state acc =
   let response = tools_list_response ~clock ~sw ?profile ?cursor state in
   let tools = tools_from_response response in
@@ -2611,6 +2623,8 @@ let eio_tests = [
   "coding mode allows governance status", `Quick, test_execute_tool_coding_mode_allows_governance_status;
   "canonical team_session_step direct call", `Quick,
     test_execute_tool_team_session_step_direct_call;
+  "legacy persisted agent read only for ephemeral names", `Quick,
+    test_should_read_legacy_persisted_agent_name;
   "explicit agent_name not overridden", `Quick, test_execute_tool_explicit_agent_name_not_overridden;
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -90,6 +90,39 @@ let test_read_state_recovers_legacy_active_agent_entries () =
       check (list string) "canonical active_agents rewritten" state.active_agents
         repaired_agents)
 
+let test_read_state_filters_invalid_active_agent_entries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:None);
+      let corrupted_json =
+        `Assoc
+          [
+            ("protocol_version", `String "0.1.0");
+            ("project", `String (Filename.basename base_dir));
+            ("started_at", `String "2026-03-26T00:00:00Z");
+            ( "active_agents",
+              `List
+                [
+                  `Assoc [];
+                  `Bool true;
+                  `Assoc [ ("name", `String "codex-swift-fox") ];
+                  `String "";
+                  `String "gemini-brave-bear";
+                ] );
+          ]
+      in
+      write_text_file (state_path base_dir) (Yojson.Safe.to_string corrupted_json);
+
+      let state = Room.read_state config in
+      check (list string) "invalid entries filtered"
+        [ "codex-swift-fox"; "gemini-brave-bear" ]
+        state.active_agents)
+
 let () =
   run "Room_state_recovery"
     [
@@ -99,5 +132,7 @@ let () =
             test_read_state_repairs_empty_object;
           test_case "recovers legacy active_agents entries" `Quick
             test_read_state_recovers_legacy_active_agent_entries;
+          test_case "filters invalid active_agents entries" `Quick
+            test_read_state_filters_invalid_active_agent_entries;
         ] );
     ]

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -1,0 +1,103 @@
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_room_state_recovery_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let write_text_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let state_path base_dir =
+  Filename.concat (Filename.concat base_dir ".masc") "state.json"
+
+let test_read_state_repairs_empty_object () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:None);
+      write_text_file (state_path base_dir) "{}";
+
+      let state = Room.read_state config in
+      check string "protocol default" "0.1.0" state.protocol_version;
+      check int "message_seq default" 0 state.message_seq;
+      check (list string) "active_agents default" [] state.active_agents;
+
+      let repaired_json = Yojson.Safe.from_file (state_path base_dir) in
+      check string "repaired protocol" "0.1.0"
+        (Safe_ops.json_string ~default:"" "protocol_version" repaired_json);
+      check int "repaired message_seq" 0
+        (Safe_ops.json_int ~default:(-1) "message_seq" repaired_json))
+
+let test_read_state_recovers_legacy_active_agent_entries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:None);
+      let legacy_json =
+        `Assoc
+          [
+            ("protocol_version", `String "0.1.0");
+            ("project", `String (Filename.basename base_dir));
+            ("started_at", `String "2026-03-26T00:00:00Z");
+            ("message_seq", `Int 7);
+            ( "active_agents",
+              `List
+                [
+                  `Assoc [ ("name", `String "codex-swift-fox") ];
+                  `String "gemini-brave-bear";
+                  `Assoc [ ("agent_name", `String "keeper-sangsu-agent") ];
+                  `Assoc [ ("id", `String "ignored") ];
+                ] );
+          ]
+      in
+      write_text_file (state_path base_dir) (Yojson.Safe.to_string legacy_json);
+
+      let state = Room.read_state config in
+      check int "message_seq preserved" 7 state.message_seq;
+      check (list string) "legacy active_agents recovered"
+        [ "codex-swift-fox"; "gemini-brave-bear"; "keeper-sangsu-agent" ]
+        state.active_agents;
+
+      let open Yojson.Safe.Util in
+      let repaired_json = Yojson.Safe.from_file (state_path base_dir) in
+      let repaired_agents =
+        repaired_json |> member "active_agents" |> to_list |> List.map to_string
+      in
+      check (list string) "canonical active_agents rewritten" state.active_agents
+        repaired_agents)
+
+let () =
+  run "Room_state_recovery"
+    [
+      ( "room_state",
+        [
+          test_case "repairs empty object" `Quick
+            test_read_state_repairs_empty_object;
+          test_case "recovers legacy active_agents entries" `Quick
+            test_read_state_recovers_legacy_active_agent_entries;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- repair `.masc/state.json` on read when it is `{}` or carries legacy `active_agents` entries, then rewrite canonical JSON
- stop MCP session identity resolution from consulting deprecated `/tmp` persistence when a non-ephemeral agent identity is already known
- make `dashboard/transport-health` use command-plane summary data instead of building the full topology tree

## Verification
- `_build/default/test/test_room_state_recovery.exe`
- `_build/default/test/test_transport_metrics.exe`
- `_build/default/test/test_mcp_server_eio.exe`

## Context
Fixes the stale dashboard state / deprecated agent fallback / transport health timeout symptoms seen in the reported logs.
