### PR TITLE
fix: revive dashboard root-cause fixes

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -202,6 +202,7 @@ let review
     ?(completion_contract : string list option)
     ?(on_verdict : (review_result -> unit) option)
     ?(few_shot_block = "")
+    ?sw
     (req : review_request) : review_result =
   let emit result =
     (match on_verdict with Some f -> f result | None -> ());
@@ -256,6 +257,7 @@ let review
          ~max_turns:1
          ~temperature:0.0
          ~max_tokens:200
+         ?sw
          ()
      with
      | Ok result ->
@@ -276,8 +278,8 @@ let review
 
 (** Backward-compatible wrapper that returns only the verdict.
     Use [review] directly for structured results with audit metadata. *)
-let review_verdict ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block req =
-  (review ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block req).verdict
+let review_verdict ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block ?sw req =
+  (review ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block ?sw req).verdict
 
 let review_result_to_json (r : review_result) : Yojson.Safe.t =
   let base = [

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -50,6 +50,7 @@ val review :
   ?completion_contract:string list ->
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
+  ?sw:Eio.Switch.t ->
   review_request -> review_result
 
 (** Backward-compatible wrapper returning only the verdict. *)
@@ -59,6 +60,7 @@ val review_verdict :
   ?completion_contract:string list ->
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
+  ?sw:Eio.Switch.t ->
   review_request -> verdict
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -276,8 +276,8 @@ let create_readonly ~sw ~env ~url ~cluster_name ~node_id =
   let uri = Uri.of_string url in
   (* Readonly pools need >1 connection to avoid "Invalid concurrent
      usage" when multiple Eio fibers within the same executor domain
-     call Pool.use concurrently. Use half the main pool size, minimum 3. *)
-  let max_pool = max 3 (configured_pool_size () / 2) in
+     call Pool.use concurrently. Use 2/3 of the main pool size, minimum 4. *)
+  let max_pool = max 4 (configured_pool_size () * 2 / 3) in
   let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
   let uri = uri_with_keepalive uri in
   match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -11,11 +11,12 @@ open Keeper_status_bridge
 include Dashboard_http_keeper_detail
 
 let prompt_block_json key =
+  let resolved = Prompt_registry.resolve_prompt key in
   `Assoc
     [
       ("key", `String key);
-      ("source", `String (Prompt_registry.prompt_source key));
-      ("text", `String (Prompt_registry.get_prompt key));
+      ("source", `String resolved.source);
+      ("text", `String resolved.effective);
     ]
 
 let tokens_per_sec_json ~tokens ~latency_ms =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -26,6 +26,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
   let module U = Yojson.Safe.Util in
 
+  (* Defensive: ensure Eio global context is set for downstream OAS calls *)
+  if Eio_context.get_switch_opt () = None then Eio_context.set_switch sw;
+
   (* Prometheus: count every inbound tool call *)
   Prometheus.record_request ();
 

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -396,8 +396,10 @@ let default_model_strings ~cascade_name:_ =
 (* Named model execution                                            *)
 (* ================================================================ *)
 
-let require_eio () =
-  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+let require_eio ?sw ?net () =
+  let sw = match sw with Some s -> Some s | None -> Eio_context.get_switch_opt () in
+  let net = match net with Some n -> Some n | None -> Eio_context.get_net_opt () in
+  match sw, net with
   | Some sw, Some net -> Ok (sw, net)
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
@@ -492,9 +494,11 @@ let run_named
     ?transport
     ?(allowed_paths = [])
     ?working_context
+    ?sw
+    ?net
     ()
   : (run_result, string) result =
-  match require_eio () with
+  match require_eio ?sw ?net () with
   | Error e -> Error e
   | Ok (sw, net) ->
   let defaults = default_model_strings ~cascade_name in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -57,6 +57,8 @@ val run_named :
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
   ?working_context:Yojson.Safe.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->
   (run_result, string) result
 

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -706,9 +706,35 @@ let register_default ~key ~default ~description ?(category="general") () =
       Hashtbl.replace version_index key versions
   )
 
+(** Resolve a prompt with file I/O performed outside the mutex.
+    Reads the markdown file first, then acquires the mutex for
+    hashtbl lookups only. Prevents Eio.Mutex contention when
+    file I/O blocks a fiber (#3335). *)
+let resolve_prompt key =
+  let file_path = prompt_markdown_path key in
+  let file_value = Option.bind file_path read_file_if_exists in
+  with_mutex (fun () ->
+    let override_value = Hashtbl.find_opt override_tbl key in
+    let default_value = default_prompt_value_unlocked key in
+    let source, effective =
+      match override_value with
+      | Some value -> ("override", value)
+      | None -> (
+          match file_value with
+          | Some value -> ("file", value)
+          | None -> (
+              match default_value with
+              | Some value -> ("default", value)
+              | None -> ("missing", "")))
+    in
+    {
+      effective; source; file_value; override_value; default_value;
+      file_path; file_exists = Option.is_some file_value;
+      has_override = Option.is_some override_value;
+    })
+
 (** Get a prompt value. Resolution: override > file > registered default *)
-let get_prompt key =
-  with_mutex (fun () -> (resolve_prompt_unlocked key).effective)
+let get_prompt key = (resolve_prompt key).effective
 
 let render_prompt_template key vars =
   let template = get_prompt key in
@@ -752,8 +778,7 @@ let clear_prompt_override key =
   with_mutex (fun () -> Hashtbl.remove override_tbl key)
 
 (** Get source of current value *)
-let prompt_source key =
-  with_mutex (fun () -> (resolve_prompt_unlocked key).source)
+let prompt_source key = (resolve_prompt key).source
 
 let validate_required_prompt_files () =
   with_mutex (fun () ->

--- a/lib/prompt_registry.mli
+++ b/lib/prompt_registry.mli
@@ -127,6 +127,7 @@ val register_default :
   unit ->
   unit
 
+val resolve_prompt : string -> prompt_resolution
 val get_prompt : string -> string
 val set_override : string -> string -> (unit, string) result
 val clear_prompt_override : string -> unit

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -81,7 +81,8 @@ let start ~sw ~clock ~config ~compute ~on_result =
     let consecutive_failures = ref 0 in
     let current_interval = ref config.interval_s in
     let rec loop () =
-      Eio.Time.sleep clock !current_interval;
+      let jitter = Random.float (min 5.0 (!current_interval *. 0.1)) in
+      Eio.Time.sleep clock (!current_interval +. jitter);
       let t0 = Time_compat.now () in
       (try
          match

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -404,20 +404,17 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          queries — exceeding pool capacity on Supabase session pooler.
          A short sleep between PG-heavy launches spreads the initial burst. *)
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 0.5;
+      Eio.Time.sleep clock 2.0;
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 0.5;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
-      Eio.Time.sleep clock 0.5;
       (* transport_health is light (no PG), start immediately. *)
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
-      (* mission and operator loops are PG-heavy — stagger to avoid pool
-         exhaustion that causes "Invalid concurrent usage" errors. *)
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
       (* Start auxiliary transports before optional warmups and resident loops.
          Otherwise HTTP can report ready while gRPC/WS startup is still stuck

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -25,6 +25,44 @@ let write_file path content =
     ~finally:(fun () -> close_out oc)
     (fun () -> output_string oc content)
 
+let prompt_metadata key =
+  match key with
+  | "keeper.proactive_turn" ->
+      ("test prompt for " ^ key,
+       [ "idle_seconds"; "profile"; "goal"; "last_preview";
+         "continuity_snapshot"; "seed" ])
+  | "keeper.proactive_retry" ->
+      ("test prompt for " ^ key, [ "attempt_phrase"; "reason"; "directive" ])
+  | "keeper.unified.system" ->
+      ("test prompt for " ^ key,
+       [ "identity_header"; "trait_lines"; "instructions_block"; "goal_lines" ])
+  | "keeper.deliberation" ->
+      ("test prompt for " ^ key,
+       [ "keeper_name"; "soul_profile"; "goal"; "triggers"; "world_state" ])
+  | "dashboard.operator_judge" | "dashboard.governance_judge" ->
+      ("test prompt for " ^ key, [ "facts_json" ])
+  | _ -> ("test prompt for " ^ key, [])
+
+let markdown_fixture key body =
+  let description, template_variables = prompt_metadata key in
+  let meta_lines =
+    [
+      "---";
+      "description: " ^ description;
+      "category: test";
+    ]
+    @
+    (if template_variables = [] then []
+     else
+       [
+         "template_variables: ["
+         ^ String.concat ", " template_variables
+         ^ "]";
+       ])
+    @ [ "---" ]
+  in
+  String.concat "\n" (meta_lines @ [ body ])
+
 let fixtures =
   [
     ("keeper.constitution", "Continuity rules from file");
@@ -47,7 +85,9 @@ let with_registry f =
   Unix.mkdir prompts_dir 0o755;
   List.iter
     (fun (key, content) ->
-      write_file (Filename.concat prompts_dir (key ^ ".md")) content)
+      write_file
+        (Filename.concat prompts_dir (key ^ ".md"))
+        (markdown_fixture key content))
     fixtures;
   Fun.protect
     ~finally:(fun () ->


### PR DESCRIPTION
## Summary
- revive three stalled dashboard root-cause fixes onto current `main`
- move prompt-registry file reads out of the mutex, widen readonly PG pool startup jitter, and thread the Eio switch into anti-rationalization evaluation
- align prompt-registry markdown fixtures with the current frontmatter loading contract

## Testing
- `env DUNE_BUILD_DIR=.ci_build_dashboard_roots opam exec -- dune build --root . bin/main_eio.exe test/test_prompt_registry_defaults.exe test/test_anti_rationalization_coverage.exe test/test_oas_worker.exe test/test_pubsub_postgres.exe --display short`
- `./.ci_build_dashboard_roots/default/test/test_prompt_registry_defaults.exe`
- `./.ci_build_dashboard_roots/default/test/test_anti_rationalization_coverage.exe`
- `./.ci_build_dashboard_roots/default/test/test_oas_worker.exe`
- `./.ci_build_dashboard_roots/default/test/test_pubsub_postgres.exe`

## Context
This branch was rebuilt by cherry-picking the stalled worktree commits onto current `main` and fixing the prompt-registry test assumptions exposed by the newer prompt-loading contract.