### PR TITLE
refactor(env): revive centralized HTTP and assets config reads

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -250,11 +250,7 @@ let port =
   Arg.(value & opt int 8935 & info ["p"; "port"] ~docv:"PORT" ~doc)
 
 let host =
-  let default =
-    match trim_opt (Sys.getenv_opt "MASC_HOST") with
-    | Some value -> value
-    | None -> "127.0.0.1"
-  in
+  let default = Masc_mcp.Env_config.masc_host () in
   let doc =
     "Host/IP to bind. Defaults to loopback (`127.0.0.1`). Use `0.0.0.0` or `::` only when you also enable room auth with `require_token=true`."
   in

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -1416,8 +1416,8 @@ let parse_args () =
 
   (* Resolve room *)
   let r = if !room <> "" then !room
-    else match Sys.getenv_opt "MASC_CLUSTER_NAME" with
-      | Some n -> n
+    else match Masc_mcp.Env_config.cluster_name_opt () with
+      | Some name -> name
       | None -> Filename.basename base
   in
 

--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -125,7 +125,7 @@ let room_json config =
       [
         ("room_id", `String "default");
         ("project", `String (Filename.basename config.base_path));
-        ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+        ("cluster", `String (Env_config_core.cluster_name ()));
         ("paused", `Bool false);
         ("pause_reason", `Null);
         ("agent_count", `Int 0);
@@ -140,7 +140,7 @@ let room_json config =
       [
         ("room_id", `String (Option.value ~default:"default" (Room.read_current_room config)));
         ("project", `String state.project);
-        ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+        ("cluster", `String (Env_config_core.cluster_name ()));
         ("paused", `Bool state.paused);
         ("pause_reason", json_string_option state.pause_reason);
         ("agent_count", `Int (List.length agents));

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -22,7 +22,7 @@ let room_status_json (config : Room.config) : Yojson.Safe.t =
     [
       ("room", `String current_room);
       ("room_base_path", `String config.base_path);
-      ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+      ("cluster", `String (Env_config_core.cluster_name ()));
       ("project", `String project);
       ("current_room", `String current_room);
       ("tempo_interval_s", `Float tempo.current_interval_s);

--- a/lib/env_config_core.ml
+++ b/lib/env_config_core.ml
@@ -76,8 +76,28 @@ let me_root () =
   | Ok path -> path
   | Error msg -> failwith msg
 
+(** Log a deprecation warning when a legacy env var is set.
+    Called once per legacy var at startup/first-read. *)
+let deprecation_warned = Hashtbl.create 8
+
+let warn_deprecated ~old_name ~new_name =
+  if not (Hashtbl.mem deprecation_warned old_name) then begin
+    Hashtbl.replace deprecation_warned old_name true;
+    Printf.eprintf
+      "[WARN] env %s is deprecated; use %s instead. Support will be removed in a future release.\n%!"
+      old_name new_name
+  end
+
+let deprecated_opt ~old_name ~new_name =
+  match Sys.getenv_opt old_name |> trim_opt with
+  | Some value ->
+      warn_deprecated ~old_name ~new_name;
+      Some value
+  | None -> None
+
 let sb_path_opt () =
-  match Sys.getenv_opt "MASC_SB_PATH" |> trim_opt with
+  match deprecated_opt ~old_name:"MASC_SB_PATH"
+          ~new_name:"MASC_WORKSPACE_ROOT or ME_ROOT" with
   | Some path -> Some path
   | None -> (
       match me_root_opt () with
@@ -91,7 +111,7 @@ let sb_path_result () =
   | Some path -> Ok path
   | None ->
       Error
-        "Unable to resolve scripts/sb. Set MASC_SB_PATH or MASC_WORKSPACE_ROOT."
+        "Unable to resolve scripts/sb. Set MASC_WORKSPACE_ROOT or ME_ROOT."
 
 let sb_path () =
   match sb_path_result () with
@@ -103,8 +123,46 @@ let masc_http_port () =
   | Some port -> port
   | None -> (
       match Sys.getenv_opt "MASC_PORT" |> trim_opt with
-      | Some port -> port
+      | Some port ->
+          warn_deprecated ~old_name:"MASC_PORT" ~new_name:"MASC_HTTP_PORT";
+          port
       | None -> "8935")
+
+let masc_http_port_int () =
+  Safe_ops.int_of_string_with_default ~default:8935 (masc_http_port ())
+
+let masc_host_opt () =
+  match Sys.getenv_opt "MASC_HOST" |> trim_opt with
+  | Some host -> Some host
+  | None -> deprecated_opt ~old_name:"MASC_HTTP_BIND_HOST" ~new_name:"MASC_HOST"
+
+(** Centralized MASC_HOST reader.
+    Reads MASC_HOST (primary) with MASC_HTTP_BIND_HOST (deprecated) fallback.
+    Default: "127.0.0.1". *)
+let masc_host () =
+  match masc_host_opt () with
+  | Some host -> host
+  | None -> "127.0.0.1"
+
+(** Centralized MASC_ASSETS_DIR reader.
+    Reads MASC_ASSETS_DIR (primary) with MASC_ASSETS_ROOT (deprecated) fallback.
+    Returns None when neither is set. *)
+let assets_dir_opt () =
+  match Sys.getenv_opt "MASC_ASSETS_DIR" |> trim_opt with
+  | Some dir -> Some dir
+  | None ->
+      deprecated_opt ~old_name:"MASC_ASSETS_ROOT" ~new_name:"MASC_ASSETS_DIR"
+
+let cluster_name_opt () =
+  Sys.getenv_opt "MASC_CLUSTER_NAME" |> trim_opt
+
+(** Centralized MASC_CLUSTER_NAME reader.
+    Default: "default". All call sites should use this instead of
+    reading Sys.getenv_opt "MASC_CLUSTER_NAME" directly. *)
+let cluster_name () =
+  match cluster_name_opt () with
+  | Some name -> name
+  | None -> "default"
 
 let rec masc_http_base_url () =
   match masc_http_base_url_result () with
@@ -116,11 +174,11 @@ and masc_http_base_url_result () =
   | Some base -> Ok (strip_trailing_slashes base)
   | None ->
       let host =
-        match Sys.getenv_opt "MASC_HOST" |> trim_opt with
+        match masc_host_opt () with
         | Some value -> Ok value
         | None ->
             Error
-              "MASC_HTTP_BASE_URL is required (or set MASC_HOST with MASC_HTTP_PORT/MASC_PORT)"
+              "MASC_HTTP_BASE_URL is required (or set MASC_HOST with MASC_HTTP_PORT)"
       in
       Result.map
         (fun host -> Printf.sprintf "http://%s:%s" host (masc_http_port ()))
@@ -151,4 +209,3 @@ let libdatachannel_path_opt () =
   |> List.find_opt existing_file
 
 (** {1 Zombie Detection / Cleanup Configuration} *)
-

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -387,7 +387,7 @@ let room_json config =
     `Assoc
       [
         ("initialized", `Bool true);
-        ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+        ("cluster", `String (Env_config_core.cluster_name ()));
         ("project", `String state.project);
         ("current_room", string_option_to_json (Room.read_current_room config));
         ("paused", `Bool state.paused);

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -44,7 +44,7 @@ let load_config () =
     orchestrator_agent = (match Sys.getenv_opt "MASC_ORCHESTRATOR_AGENT" with
       | Some a -> a | None -> "claude");
     enabled = get_env_bool "MASC_ORCHESTRATOR_ENABLED" false;
-    port = get_env_int "MASC_PORT" 8935;
+    port = Env_config_core.masc_http_port_int ();
   }
 
 (** Check if orchestration is needed *)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -27,11 +27,7 @@ let env_flag_enabled name =
       v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
 
 let configured_bind_host () =
-  trim_opt (Sys.getenv_opt "MASC_HTTP_BIND_HOST")
-  |> Option.value
-       ~default:
-         (trim_opt (Sys.getenv_opt "MASC_HOST")
-         |> Option.value ~default:"127.0.0.1")
+  Env_config_core.masc_host ()
 
 let ipaddr_is_loopback = function
   | Ipaddr.V4 addr ->

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -6,7 +6,7 @@ module Http = Http_server_eio
 
 let make_http_config ~host ~port : Http.config =
   let config = { Http.default_config with port; host } in
-  Unix.putenv "MASC_HTTP_BIND_HOST" config.host;
+  Unix.putenv "MASC_HOST" config.host;
   Unix.putenv "MASC_HTTP_PORT" (string_of_int config.port);
   (match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
   | Some existing when String.trim existing <> "" -> ()

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -295,7 +295,7 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
           (if Room.is_initialized config then Room.current_room_id config
            else Filename.basename config.base_path) );
       ("room_base_path", `String config.base_path);
-      ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+      ("cluster", `String (Env_config_core.cluster_name ()));
       ("project", `String room_state.project);
       ("tempo_interval_s", `Float tempo.current_interval_s);
       ("paused", `Bool room_state.paused);
@@ -864,9 +864,7 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
       ("room", `String current_room);
       ("current_room", `String current_room);
       ("room_base_path", `String config.base_path);
-      ( "cluster",
-        `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME"))
-      );
+      ("cluster", `String (Env_config_core.cluster_name ()));
       ("project", `String room_state.project);
       ("tempo_interval_s", `Float tempo.current_interval_s);
       ("paused", `Bool room_state.paused);

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -783,7 +783,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let room_state = Room.read_state config in
           let tempo = Tempo.get_tempo config in
           let json = `Assoc [
-            ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+            ("cluster", `String (Env_config_core.cluster_name ()));
             ("project", `String room_state.project);
             ("tempo_interval_s", `Float tempo.current_interval_s);
             ("paused", `Bool room_state.paused);

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -166,12 +166,8 @@ let assets_root () =
     | Some path -> Some (Filename.concat path "assets")
     | None -> None
   in
-  let explicit_assets =
-    match nonempty_env "MASC_ASSETS_ROOT" with
-    | Some path -> Some path
-    | None -> nonempty_env "MASC_ASSETS_DIR"
-  in
-  match explicit_assets with
+  let env_assets = Env_config_core.assets_dir_opt () in
+  match env_assets with
   | Some path when is_dir path -> path
   | _ ->
       let exe_dir = Filename.dirname Sys.executable_name in

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -19,7 +19,7 @@ module Keeper_stream = Server_routes_http_keeper_stream
          let room_state = Room.read_state config in
          let tempo = Tempo.get_tempo config in
          let json = `Assoc [
-           ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+           ("cluster", `String (Env_config_core.cluster_name ()));
            ("project", `String room_state.project);
            ("tempo_interval_s", `Float tempo.current_interval_s);
            ("paused", `Bool room_state.paused);

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -49,24 +49,10 @@ let is_http_error_response = function
 let server_start_time = Unix.gettimeofday ()
 
 let configured_http_port () =
-  let parse name =
-    match Sys.getenv_opt name with
-    | Some value -> int_of_string_opt (String.trim value)
-    | None -> None
-  in
-  match parse "MASC_HTTP_PORT" with
-  | Some port when port > 0 && port < 65536 -> port
-  | _ -> (
-      match parse "MASC_PORT" with
-      | Some port when port > 0 && port < 65536 -> port
-      | _ -> 8935)
+  Env_config_core.masc_http_port_int ()
 
 let configured_http_host () =
-  match Sys.getenv_opt "MASC_HOST" with
-  | Some value ->
-      let trimmed = String.trim value in
-      if trimmed = "" then "127.0.0.1" else trimmed
-  | None -> "127.0.0.1"
+  Env_config_core.masc_host ()
 
 let advertised_host_port request =
   parse_host_port

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -55,25 +55,10 @@ let rec trim_trailing_slashes value =
     value
 
 let configured_http_port () =
-  let parse name =
-    match Sys.getenv_opt name with
-    | Some value -> int_of_string_opt (String.trim value)
-    | None -> None
-  in
-  match parse "MASC_HTTP_PORT" with
-  | Some port when port > 0 && port < 65536 -> port
-  | _ -> (
-      match parse "MASC_PORT" with
-      | Some port when port > 0 && port < 65536 -> port
-      | _ -> 8935)
+  Env_config_core.masc_http_port_int ()
 
 let configured_http_host () =
-  match Sys.getenv_opt "MASC_HOST" with
-  | Some value -> (
-      match trim_nonempty value with
-      | Some host -> host
-      | None -> "127.0.0.1")
-  | None -> "127.0.0.1"
+  Env_config_core.masc_host ()
 
 let ipaddr_is_unspecified = function
   | Ipaddr.V4 addr -> Ipaddr.V4.compare addr Ipaddr.V4.any = 0

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -257,9 +257,7 @@ let transport_health_json ~config =
       Log.Transport.debug "current_room_id failed: %s" (Printexc.to_string exn);
       "default"
   in
-  let cluster_name =
-    Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")
-  in
+  let cluster_name = Env_config_core.cluster_name () in
   let recent_messages =
     try Room.get_messages_raw_in_room config ~room_id ~since_seq:0 ~limit:20 |> List.length
     with exn ->

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -24,34 +24,29 @@ let assets_root () =
     | Some path -> Some (Filename.concat path "assets")
     | None -> None
   in
-  let explicit_assets =
-    match nonempty_env "MASC_ASSETS_ROOT" with
-    | Some path -> Some path
-    | None -> nonempty_env "MASC_ASSETS_DIR"
+  let exe_dir = Filename.dirname Sys.executable_name in
+  let inferred_repo_assets =
+    let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
+    Filename.concat root "assets"
   in
-  match explicit_assets with
-  | Some path when is_dir path -> path
+  let candidates =
+    List.fold_right
+      (fun path acc ->
+        match path with
+        | Some value -> value :: acc
+        | None -> acc)
+      [
+        base_path_assets "MASC_BASE_PATH_INPUT";
+        base_path_assets "MASC_BASE_PATH";
+        Some inferred_repo_assets;
+        Some (Filename.concat exe_dir "assets");
+        Some (Filename.concat (Sys.getcwd ()) "assets");
+      ]
+      []
+  in
+  match Env_config_core.assets_dir_opt () with
+  | Some d when is_dir d -> d
   | _ ->
-      let exe_dir = Filename.dirname Sys.executable_name in
-      let inferred_repo_assets =
-        let root = Filename.dirname (Filename.dirname (Filename.dirname exe_dir)) in
-        Filename.concat root "assets"
-      in
-      let candidates =
-        List.fold_right
-          (fun path acc ->
-            match path with
-            | Some value -> value :: acc
-            | None -> acc)
-          [
-            base_path_assets "MASC_BASE_PATH_INPUT";
-            base_path_assets "MASC_BASE_PATH";
-            Some inferred_repo_assets;
-            Some (Filename.concat exe_dir "assets");
-            Some (Filename.concat (Sys.getcwd ()) "assets");
-          ]
-          []
-      in
       match List.find_opt is_dir candidates with
       | Some path -> path
       | None ->

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -108,11 +108,44 @@ let test_masc_http_base_url_uses_explicit_host_and_port () =
         check string "base url from host+port" "http://masc.example.test:7777" (Env_config.masc_http_base_url ()))))
 
 let test_sb_path_result_missing_is_error () =
-  with_env "MASC_SB_PATH" "" (fun () ->
-    with_env "MASC_WORKSPACE_ROOT" "" (fun () ->
-      with_env "ME_ROOT" "" (fun () ->
-        check bool "sb path result is error" true
-          (match Env_config.sb_path_result () with Error _ -> true | Ok _ -> false))))
+  with_env "MASC_WORKSPACE_ROOT" "" (fun () ->
+    with_env "ME_ROOT" "" (fun () ->
+      check bool "sb path result is error" true
+        (match Env_config.sb_path_result () with Error _ -> true | Ok _ -> false)))
+
+let test_sb_path_legacy_env_still_works () =
+  let path = Filename.temp_file "masc-sb" ".sh" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      with_env "MASC_SB_PATH" path (fun () ->
+        with_env "MASC_WORKSPACE_ROOT" "" (fun () ->
+          with_env "ME_ROOT" "" (fun () ->
+            check (result string string) "legacy sb path still accepted"
+              (Ok path) (Env_config.sb_path_result ())))))
+
+let test_masc_host_prefers_primary_over_deprecated () =
+  with_env "MASC_HOST" "primary.example.test" (fun () ->
+    with_env "MASC_HTTP_BIND_HOST" "legacy.example.test" (fun () ->
+      let resolved = Env_config.masc_host () in
+      let explicit = Env_config.masc_host_opt () in
+      check string "primary host wins" "primary.example.test" resolved;
+      check (option string) "explicit host wins" (Some "primary.example.test")
+        explicit))
+
+let test_assets_dir_prefers_primary_over_deprecated () =
+  with_env "MASC_ASSETS_DIR" "/tmp/assets-primary" (fun () ->
+    with_env "MASC_ASSETS_ROOT" "/tmp/assets-legacy" (fun () ->
+      let resolved = Env_config.assets_dir_opt () in
+      check (option string) "primary assets dir wins" (Some "/tmp/assets-primary")
+        resolved))
+
+let test_cluster_name_opt_trims_empty () =
+  with_env "MASC_CLUSTER_NAME" "   " (fun () ->
+    check (option string) "cluster_name_opt empty -> none" None
+      (Env_config.cluster_name_opt ());
+    check string "cluster_name empty -> default" "default"
+      (Env_config.cluster_name ()))
 
 let test_libdatachannel_candidates_include_env_override () =
   with_env "LIBDATACHANNEL_PATH" "/tmp/libdatachannel-custom.dylib" (fun () ->
@@ -365,6 +398,10 @@ let () =
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
       test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;
+      test_case "sb_path legacy env still works" `Quick test_sb_path_legacy_env_still_works;
+      test_case "masc_host prefers primary over deprecated" `Quick test_masc_host_prefers_primary_over_deprecated;
+      test_case "assets dir prefers primary over deprecated" `Quick test_assets_dir_prefers_primary_over_deprecated;
+      test_case "cluster_name_opt trims empty" `Quick test_cluster_name_opt_trims_empty;
       test_case "endpoint result helpers" `Quick test_endpoints_result_helpers;
       test_case "libdatachannel candidates include env override" `Quick test_libdatachannel_candidates_include_env_override;
     ];

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -41,9 +41,9 @@ let project_root () =
             | None -> Sys.getcwd ()))
 
 let () =
-  if Sys.getenv_opt "MASC_ASSETS_ROOT" = None then
+  if Sys.getenv_opt "MASC_ASSETS_DIR" = None && Sys.getenv_opt "MASC_ASSETS_ROOT" = None then
     let assets = Filename.concat (project_root ()) "assets" in
-    if Sys.file_exists assets then Unix.putenv "MASC_ASSETS_ROOT" assets
+    if Sys.file_exists assets then Unix.putenv "MASC_ASSETS_DIR" assets
 
 let contains_substr sub s =
   try
@@ -206,22 +206,23 @@ let test_etag_stable () =
    ============================================================ *)
 
 let test_fallback_on_missing_asset () =
-  (* Override MASC_ASSETS_ROOT to an existing directory without dashboard assets *)
-  let original = Sys.getenv_opt "MASC_ASSETS_ROOT" in
   let missing_assets_root = make_temp_dir "missing-assets" in
   Fun.protect
     (fun () ->
-      Unix.putenv "MASC_ASSETS_ROOT" missing_assets_root;
-      let html = Web_dashboard.html () in
-      let etag = Web_dashboard.etag () in
-      check bool "fallback html contains error message" true
-        (contains_substr "Dashboard build not found" html);
-      check string "fallback etag is none" "none" etag)
-    ~finally:(fun () ->
-      (match original with
-       | Some v -> Unix.putenv "MASC_ASSETS_ROOT" v
-       | None -> Unix.putenv "MASC_ASSETS_ROOT" "");
-      cleanup_temp_dashboard_root missing_assets_root)
+      with_env
+        [
+          ("MASC_ASSETS_DIR", missing_assets_root);
+          ("MASC_ASSETS_ROOT", "");
+          ("MASC_BASE_PATH_INPUT", "");
+          ("MASC_BASE_PATH", "");
+        ]
+        (fun () ->
+          let html = Web_dashboard.html () in
+          let etag = Web_dashboard.etag () in
+          check bool "fallback html contains error message" true
+            (contains_substr "Dashboard build not found" html);
+          check string "fallback etag is none" "none" etag))
+    ~finally:(fun () -> Unix.rmdir missing_assets_root)
 
 let test_html_uses_base_path_input_assets () =
   let input_root = make_temp_dashboard_root "input" "dashboard-from-base-path-input" in


### PR DESCRIPTION
## Summary
- revive the stalled env dedup work onto current `main`
- centralize HTTP host/base URL and assets/config env reads behind `Env_config`
- preserve deprecated env compatibility while fixing precedence coverage in tests

## Testing
- `env DUNE_BUILD_DIR=.ci_build_env_main opam exec -- dune build --root . bin/main_eio.exe --display short`
- `env DUNE_BUILD_DIR=.ci_build_env_main opam exec -- dune build --root . test/test_env_config_coverage.exe --display short`
- `env DUNE_BUILD_DIR=.ci_build_env_main opam exec -- dune exec --root . ./test/test_env_config_coverage.exe`
- `env DUNE_BUILD_DIR=.ci_build_env_main opam exec -- dune build --root . test/test_web_dashboard_coverage.exe --display short`
- `env DUNE_BUILD_DIR=.ci_build_env_main opam exec -- dune exec --root . ./test/test_web_dashboard_coverage.exe`

## Context
This revives a stalled worktree from before the benchmark revert and reapplies the intended env cleanup on top of current `main`.