### PR TITLE
fix(eio): revive sleep guards and lock retry checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,11 @@ jobs:
             sleep 15
           done
 
+      - name: Check Eio conventions
+        run: |
+          chmod +x scripts/check-eio-conventions.sh
+          scripts/check-eio-conventions.sh
+
       - name: Build with warnings as errors
         run: |
           opam exec -- dune build @install --force

--- a/lib/board_listener.ml
+++ b/lib/board_listener.ml
@@ -84,7 +84,7 @@ let poll_and_broadcast t =
       Error (Caqti_error.show err)
 
 (** Start the listener loop (call from Eio fiber) *)
-let start t =
+let start ~clock t =
   t.running <- true;
   Log.BoardListener.info "Started (poll_interval=%.1fs, channel=%s)"
     poll_interval_s channel;
@@ -94,7 +94,7 @@ let start t =
          t.consecutive_errors <- 0;
          if count > 0 then
            Log.BoardListener.info "Processed %d events" count;
-         Eio_unix.sleep poll_interval_s
+         Eio.Time.sleep clock poll_interval_s
      | Error msg ->
          t.consecutive_errors <- t.consecutive_errors + 1;
          if t.consecutive_errors mod 5 = 0 then
@@ -103,7 +103,7 @@ let start t =
          let backoff =
            Float.min (0.5 *. Float.pow 2.0 (Float.of_int t.consecutive_errors)) 30.0
          in
-         Eio_unix.sleep backoff)
+         Eio.Time.sleep clock backoff)
   done;
   Log.BoardListener.info "Stopped"
 

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -284,7 +284,76 @@ let read_json_opt config path =
 (* File locking                                 *)
 (* ============================================ *)
 
-let with_file_lock config path f =
+let sleep_lock_retry ?clock delay =
+  match clock with
+  | Some clock -> Eio.Time.sleep clock delay
+  | None -> Time_compat.sleep delay
+
+let with_distributed_lock ?clock config _path key f =
+  let owner = config.backend_config.node_id in
+  let ttl_seconds = config.lock_expiry_minutes * 60 in
+  let rec acquire attempts delay =
+    if attempts <= 0 then false
+    else
+      match backend_acquire_lock config ~key ~ttl_seconds ~owner with
+      | Ok true -> true
+      | _ ->
+          sleep_lock_retry ?clock delay;
+          acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
+  in
+  if acquire 20 0.005 then
+    Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
+      ~finally:(fun () ->
+        match backend_release_lock config ~key ~owner with
+        | Ok _ -> ()
+        | Error e ->
+            let msg =
+              match e with
+              | Backend_types.ConnectionFailed s | NotFound s
+              | IOError s | BackendNotSupported s | InvalidKey s
+              | AlreadyExists s -> s
+            in
+            Log.Room.warn "lock release failed for %s: %s" key msg)
+      f
+  else
+    invalid_arg
+      (Printf.sprintf
+         "Failed to acquire distributed lock for key: %s (20 attempts exhausted)"
+         key)
+
+let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
+  let owner = config.backend_config.node_id in
+  let ttl_seconds = config.lock_expiry_minutes * 60 in
+  let rec acquire attempts delay =
+    if attempts <= 0 then false
+    else
+      match backend_acquire_lock config ~key ~ttl_seconds ~owner with
+      | Ok true -> true
+      | _ ->
+          sleep_lock_retry ?clock delay;
+          acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
+  in
+  if acquire 20 0.005 then
+    Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
+      ~finally:(fun () ->
+        match backend_release_lock config ~key ~owner with
+        | Ok _ -> ()
+        | Error e ->
+            let msg =
+              match e with
+              | Backend_types.ConnectionFailed s | NotFound s
+              | IOError s | BackendNotSupported s | InvalidKey s
+              | AlreadyExists s -> s
+            in
+            Log.Room.warn "lock release failed for %s: %s" key msg)
+      (fun () -> Ok (f ()))
+  else
+    Error
+      (IoError
+         (Printf.sprintf "Failed to acquire distributed lock for %s"
+            path))
+
+let with_file_lock_impl ?clock config path f =
   match key_of_path config path with
   | None ->
       (* Fix 2: Use cooperative Eio.Mutex instead of blocking Unix.lockf.
@@ -298,38 +367,15 @@ let with_file_lock config path f =
              races in append/readback helpers. *)
           File_lock_eio.with_mutex path f
       | FileSystem _ | PostgresNative _ ->
-          let owner = config.backend_config.node_id in
-          let ttl_seconds = config.lock_expiry_minutes * 60 in
-          let rec acquire attempts delay =
-            if attempts <= 0 then false
-            else
-              match backend_acquire_lock config ~key ~ttl_seconds ~owner with
-              | Ok true -> true
-              | _ ->
-                  Eio_unix.sleep delay;
-                  acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
-          in
-          if acquire 20 0.005 then
-            Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
-              ~finally:(fun () ->
-                match backend_release_lock config ~key ~owner with
-                | Ok _ -> ()
-                | Error e ->
-                    let msg =
-                      match e with
-                      | Backend_types.ConnectionFailed s | NotFound s
-                      | IOError s | BackendNotSupported s | InvalidKey s
-                      | AlreadyExists s -> s
-                    in
-                    Log.Room.warn "lock release failed for %s: %s" key msg)
-              f
-          else
-            invalid_arg
-              (Printf.sprintf
-                 "Failed to acquire distributed lock for key: %s (20 attempts exhausted)"
-                 key))
+          with_distributed_lock ?clock config path key f)
 
-let with_file_lock_r config path f : ('a, masc_error) result =
+let with_file_lock_eio ~clock config path f =
+  with_file_lock_impl ~clock config path f
+
+let with_file_lock config path f =
+  with_file_lock_impl ?clock:(Eio_context.get_clock_opt ()) config path f
+
+let with_file_lock_r_impl ?clock config path f : ('a, masc_error) result =
   match key_of_path config path with
   | None ->
       (* Fix 2: Cooperative lock — same as with_file_lock *)
@@ -338,36 +384,13 @@ let with_file_lock_r config path f : ('a, masc_error) result =
       match config.backend with
       | Memory _ -> File_lock_eio.with_mutex path (fun () -> Ok (f ()))
       | FileSystem _ | PostgresNative _ ->
-          let owner = config.backend_config.node_id in
-          let ttl_seconds = config.lock_expiry_minutes * 60 in
-          let rec acquire attempts delay =
-            if attempts <= 0 then false
-            else
-              match backend_acquire_lock config ~key ~ttl_seconds ~owner with
-              | Ok true -> true
-              | _ ->
-                  Eio_unix.sleep delay;
-                  acquire (attempts - 1) (Float.min 0.05 (delay *. 2.0))
-          in
-          if acquire 20 0.005 then
-            Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
-              ~finally:(fun () ->
-                match backend_release_lock config ~key ~owner with
-                | Ok _ -> ()
-                | Error e ->
-                    let msg =
-                      match e with
-                      | Backend_types.ConnectionFailed s | NotFound s
-                      | IOError s | BackendNotSupported s | InvalidKey s
-                      | AlreadyExists s -> s
-                    in
-                    Log.Room.warn "lock release failed for %s: %s" key msg)
-              (fun () -> Ok (f ()))
-          else
-            Error
-              (IoError
-                 (Printf.sprintf "Failed to acquire distributed lock for %s"
-                    path)))
+          with_distributed_lock_r ?clock config path key f)
+
+let with_file_lock_r_eio ~clock config path f : ('a, masc_error) result =
+  with_file_lock_r_impl ~clock config path f
+
+let with_file_lock_r config path f : ('a, masc_error) result =
+  with_file_lock_r_impl ?clock:(Eio_context.get_clock_opt ()) config path f
 
 (* ============================================ *)
 (* Event logging                                *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -218,7 +218,7 @@ let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
   | Some pool ->
       let listener = Board_listener.create pool in
       Eio.Fiber.fork ~sw (fun () ->
-        try Board_listener.start listener
+        try Board_listener.start ~clock listener
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/scripts/check-eio-conventions.sh
+++ b/scripts/check-eio-conventions.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+count_matches() {
+  local pattern="$1"
+  shift
+  rg -o "$pattern" "$@" 2>/dev/null || true
+}
+
+count_total() {
+  local pattern="$1"
+  shift
+  count_matches "$pattern" "$@" | wc -l | tr -d '[:space:]'
+}
+
+fail=0
+
+eio_sleep_hits="$(rg -n 'Eio_unix\.sleep\b' lib || true)"
+if [ -n "$eio_sleep_hits" ]; then
+  echo "ERROR: forbidden Eio_unix.sleep usage under lib/" >&2
+  printf '%s\n' "$eio_sleep_hits" >&2
+  fail=1
+fi
+
+blocking_sleep_hits="$(rg -n 'Unix\.sleep(f)?\b' lib || true)"
+if [ -n "$blocking_sleep_hits" ]; then
+  disallowed_blocking_sleep_hits="$(
+    printf '%s\n' "$blocking_sleep_hits" \
+      | rg -v '^lib/(process/file_lock_eio\.ml|shutdown\.ml):' || true
+  )"
+  if [ -n "$disallowed_blocking_sleep_hits" ]; then
+    echo "ERROR: raw Unix.sleep/Unix.sleepf usage is only allowed in lib/process/file_lock_eio.ml and lib/shutdown.ml" >&2
+    printf '%s\n' "$disallowed_blocking_sleep_hits" >&2
+    fail=1
+  fi
+fi
+
+echo "Eio convention snapshot:"
+echo "  lib/Eio_unix.sleep: $(count_total 'Eio_unix\.sleep\b' lib)"
+echo "  lib/Unix.sleep*: $(count_total 'Unix\.sleep(f)?\b' lib)"
+echo "  lib/Eio.Mutex.create (): $(count_total 'Eio\.Mutex\.create \(\)' lib)"
+echo "  lib/Eio.Fiber.fork: $(count_total 'Eio\.Fiber\.fork\b' lib)"
+echo "  lib+test/fork_promise: $(count_total 'fork_promise\b' lib test)"
+
+exit "$fail"

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -101,5 +101,9 @@ let () =
             `Quick
             Test_tool_team_session_flow
               .test_memory_backend_event_lock_serializes_fibers;
+          Alcotest.test_case "filesystem-backend-event-lock-serializes-fibers"
+            `Quick
+            Test_tool_team_session_flow
+              .test_filesystem_backend_event_lock_serializes_fibers;
         ] );
     ]

--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -128,6 +128,30 @@ let test_memory_backend_event_lock_serializes_fibers () =
                decr active)));
   Alcotest.(check bool) "memory event lock is exclusive" false !overlapped
 
+let test_filesystem_backend_event_lock_serializes_fibers () =
+  let cluster_name = "team-session-lock-" ^ Team_session_store.make_session_id () in
+  with_env "MASC_STORAGE_TYPE" (Some "filesystem") @@ fun () ->
+  with_env "MASC_CLUSTER_NAME" (Some cluster_name) @@ fun () ->
+  with_eio @@ fun env ->
+  Eio_guard.enable ();
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) @@ fun () ->
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let path = Team_session_store.events_jsonl_path config "lock-regression-fs" in
+  let active = ref 0 in
+  let overlapped = ref false in
+  Eio.Fiber.all
+    (List.init 8 (fun _ ->
+         fun () ->
+           Room_utils.with_file_lock_eio ~clock:(Eio.Stdenv.clock env) config path
+             (fun () ->
+               incr active;
+               if !active > 1 then overlapped := true;
+               Eio.Fiber.yield ();
+               decr active)));
+  Alcotest.(check bool) "filesystem event lock is exclusive" false !overlapped
+
 let test_list_and_compare () =
   with_eio @@ fun env ->
   Eio.Switch.run @@ fun sw ->


### PR DESCRIPTION
## Summary
- revive the stalled sleep-guard changes onto current `main`
- replace direct `Eio_unix.sleep` usage with clock-based sleep guards in runtime loops
- add regression coverage and CI guardrails for Eio sleep/lock conventions

## Testing
- `scripts/check-eio-conventions.sh`
- `env DUNE_BUILD_DIR=.ci_build_eio_guard_revive opam exec -- dune build --root . test/test_tool_team_session.exe --display short`
- `env DUNE_BUILD_DIR=.ci_build_eio_guard_revive opam exec -- dune exec --root . ./test/test_tool_team_session.exe`

## Context
This revives a stalled worktree onto current `main` instead of reopening the old benchmark-based branch.