### PR TITLE
fix(lint): replace Masc_mcp.Env_config ref in masc_tui (#3381)

### DIFF
--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -1416,9 +1416,9 @@ let parse_args () =
 
   (* Resolve room *)
   let r = if !room <> "" then !room
-    else match Masc_mcp.Env_config.cluster_name_opt () with
-      | Some name -> name
-      | None -> Filename.basename base
+    else match Sys.getenv_opt "MASC_CLUSTER_NAME" with
+      | Some name when String.trim name <> "" -> String.trim name
+      | _ -> Filename.basename base
   in
 
   (base, r, !port, !refresh)


### PR DESCRIPTION
## Summary
- `masc_tui`가 `masc_mcp` 라이브러리를 링크하지 않는데 `Masc_mcp.Env_config.cluster_name_opt`를 참조하여 `@install` 빌드 실패
- `Sys.getenv_opt "MASC_CLUSTER_NAME"`으로 인라인 교체 (TUI의 경량 의존성 유지)

## Changes
- `bin/masc_tui.ml`: 1줄 변경 (Masc_mcp 참조 → Sys.getenv_opt)

## Verification
- `env OCAMLPARAM='_,warn-error=+a' dune build --root . @install --force` 통과

Closes #3381

🤖 Generated with [Claude Code](https://claude.com/claude-code)