### PR TITLE
fix: dashboard 3 root causes — keeper hang, PG contention, evaluator fallback

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -202,6 +202,7 @@ let review
     ?(completion_contract : string list option)
     ?(on_verdict : (review_result -> unit) option)
     ?(few_shot_block = "")
+    ?sw
     (req : review_request) : review_result =
   let emit result =
     (match on_verdict with Some f -> f result | None -> ());
@@ -256,6 +257,7 @@ let review
          ~max_turns:1
          ~temperature:0.0
          ~max_tokens:200
+         ?sw
          ()
      with
      | Ok result ->
@@ -276,8 +278,8 @@ let review
 
 (** Backward-compatible wrapper that returns only the verdict.
     Use [review] directly for structured results with audit metadata. *)
-let review_verdict ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block req =
-  (review ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block req).verdict
+let review_verdict ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block ?sw req =
+  (review ?evaluator_cascade ?generator_cascade ?completion_contract ?on_verdict ?few_shot_block ?sw req).verdict
 
 let review_result_to_json (r : review_result) : Yojson.Safe.t =
   let base = [

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -50,6 +50,7 @@ val review :
   ?completion_contract:string list ->
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
+  ?sw:Eio.Switch.t ->
   review_request -> review_result
 
 (** Backward-compatible wrapper returning only the verdict. *)
@@ -59,6 +60,7 @@ val review_verdict :
   ?completion_contract:string list ->
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
+  ?sw:Eio.Switch.t ->
   review_request -> verdict
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -276,8 +276,8 @@ let create_readonly ~sw ~env ~url ~cluster_name ~node_id =
   let uri = Uri.of_string url in
   (* Readonly pools need >1 connection to avoid "Invalid concurrent
      usage" when multiple Eio fibers within the same executor domain
-     call Pool.use concurrently. Use half the main pool size, minimum 3. *)
-  let max_pool = max 3 (configured_pool_size () / 2) in
+     call Pool.use concurrently. Use 2/3 of the main pool size, minimum 4. *)
+  let max_pool = max 4 (configured_pool_size () * 2 / 3) in
   let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
   let uri = uri_with_keepalive uri in
   match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -11,11 +11,12 @@ open Keeper_status_bridge
 include Dashboard_http_keeper_detail
 
 let prompt_block_json key =
+  let resolved = Prompt_registry.resolve_prompt key in
   `Assoc
     [
       ("key", `String key);
-      ("source", `String (Prompt_registry.prompt_source key));
-      ("text", `String (Prompt_registry.get_prompt key));
+      ("source", `String resolved.source);
+      ("text", `String resolved.effective);
     ]
 
 let tokens_per_sec_json ~tokens ~latency_ms =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -20,6 +20,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
   let module U = Yojson.Safe.Util in
 
+  (* Defensive: ensure Eio global context is set for downstream OAS calls *)
+  if Eio_context.get_switch_opt () = None then Eio_context.set_switch sw;
+
   (* Prometheus: count every inbound tool call *)
   Prometheus.record_request ();
 

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -396,8 +396,10 @@ let default_model_strings ~cascade_name:_ =
 (* Named model execution                                            *)
 (* ================================================================ *)
 
-let require_eio () =
-  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+let require_eio ?sw ?net () =
+  let sw = match sw with Some s -> Some s | None -> Eio_context.get_switch_opt () in
+  let net = match net with Some n -> Some n | None -> Eio_context.get_net_opt () in
+  match sw, net with
   | Some sw, Some net -> Ok (sw, net)
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
@@ -492,9 +494,11 @@ let run_named
     ?transport
     ?(allowed_paths = [])
     ?working_context
+    ?sw
+    ?net
     ()
   : (run_result, string) result =
-  match require_eio () with
+  match require_eio ?sw ?net () with
   | Error e -> Error e
   | Ok (sw, net) ->
   let defaults = default_model_strings ~cascade_name in

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -57,6 +57,8 @@ val run_named :
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
   ?working_context:Yojson.Safe.t ->
+  ?sw:Eio.Switch.t ->
+  ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->
   (run_result, string) result
 

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -706,9 +706,35 @@ let register_default ~key ~default ~description ?(category="general") () =
       Hashtbl.replace version_index key versions
   )
 
+(** Resolve a prompt with file I/O performed outside the mutex.
+    Reads the markdown file first, then acquires the mutex for
+    hashtbl lookups only. Prevents Eio.Mutex contention when
+    file I/O blocks a fiber (#3335). *)
+let resolve_prompt key =
+  let file_path = prompt_markdown_path key in
+  let file_value = Option.bind file_path read_file_if_exists in
+  with_mutex (fun () ->
+    let override_value = Hashtbl.find_opt override_tbl key in
+    let default_value = default_prompt_value_unlocked key in
+    let source, effective =
+      match override_value with
+      | Some value -> ("override", value)
+      | None -> (
+          match file_value with
+          | Some value -> ("file", value)
+          | None -> (
+              match default_value with
+              | Some value -> ("default", value)
+              | None -> ("missing", "")))
+    in
+    {
+      effective; source; file_value; override_value; default_value;
+      file_path; file_exists = Option.is_some file_value;
+      has_override = Option.is_some override_value;
+    })
+
 (** Get a prompt value. Resolution: override > file > registered default *)
-let get_prompt key =
-  with_mutex (fun () -> (resolve_prompt_unlocked key).effective)
+let get_prompt key = (resolve_prompt key).effective
 
 let render_prompt_template key vars =
   let template = get_prompt key in
@@ -752,8 +778,7 @@ let clear_prompt_override key =
   with_mutex (fun () -> Hashtbl.remove override_tbl key)
 
 (** Get source of current value *)
-let prompt_source key =
-  with_mutex (fun () -> (resolve_prompt_unlocked key).source)
+let prompt_source key = (resolve_prompt key).source
 
 let validate_required_prompt_files () =
   with_mutex (fun () ->

--- a/lib/prompt_registry.mli
+++ b/lib/prompt_registry.mli
@@ -127,6 +127,7 @@ val register_default :
   unit ->
   unit
 
+val resolve_prompt : string -> prompt_resolution
 val get_prompt : string -> string
 val set_override : string -> string -> (unit, string) result
 val clear_prompt_override : string -> unit

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -81,7 +81,8 @@ let start ~sw ~clock ~config ~compute ~on_result =
     let consecutive_failures = ref 0 in
     let current_interval = ref config.interval_s in
     let rec loop () =
-      Eio.Time.sleep clock !current_interval;
+      let jitter = Random.float (min 5.0 (!current_interval *. 0.1)) in
+      Eio.Time.sleep clock (!current_interval +. jitter);
       let t0 = Time_compat.now () in
       (try
          match

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -404,20 +404,17 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          queries — exceeding pool capacity on Supabase session pooler.
          A short sleep between PG-heavy launches spreads the initial burst. *)
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 0.5;
+      Eio.Time.sleep clock 2.0;
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 0.5;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
-      Eio.Time.sleep clock 0.5;
       (* transport_health is light (no PG), start immediately. *)
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
-      (* mission and operator loops are PG-heavy — stagger to avoid pool
-         exhaustion that causes "Invalid concurrent usage" errors. *)
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 1.0;
+      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
       (* Start auxiliary transports before optional warmups and resident loops.
          Otherwise HTTP can report ready while gRPC/WS startup is still stuck

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -211,8 +211,9 @@ let test_session_to_swarm_config_health_contract () =
   let metric_value =
     match convergence.metric with
     | Swarm.Swarm_types.Callback f -> f ()
-    | Swarm.Swarm_types.Shell_command cmd ->
-        Alcotest.failf "expected callback metric, got shell command %s" cmd
+    | Swarm.Swarm_types.Argv_command cmd ->
+        Alcotest.failf "expected callback metric, got argv command %s"
+          (String.concat " " cmd)
   in
   Alcotest.(check (float 0.001)) "initial success ratio" 0.0 metric_value;
   Alcotest.(check int) "single-pass convergence iterations" 1


### PR DESCRIPTION
## Summary

QA 5라운드에서 발견된 17개 이슈의 3개 근본 원인을 수정.

### Fix 1: Keeper config hang (#3335)
- `prompt_registry.ml`의 `read_file_if_exists`가 Eio.Mutex 안에서 blocking stdlib I/O 수행 → fiber hang
- file I/O를 mutex 밖으로 이동, `resolve_prompt` 공개 API 추가
- `prompt_block_json`을 단일 호출로 최적화 (6 mutex acquisitions → 3)

### Fix 2: PG connection pool contention (#3305)
- 6 PG-heavy refresh loop이 12 fiber로 readonly pool (5 connections) 경합
- Readonly pool size 상향: `max 3 (pool/2)` → `max 4 (pool*2/3)` (5 → 7)
- Refresh loop에 10% jitter 추가 (lock-step 방지)
- Startup stagger 확대: 0.5-1.0s → 2.0s

### Fix 3: Evaluator 100% fallback (#3296)
- `Oas_worker.require_eio()`가 global Atomic만 확인, `~sw`가 콜 스택에 있지만 전달 안 됨
- `require_eio`에 `?sw ?net` optional params 추가
- `anti_rationalization.review`에 `?sw` threading
- `execute_tool_eio`에서 defensive global re-set

### Bonus: OAS API compatibility
- `Shell_command` → `Argv_command` 테스트 수정

## Closes
- #3296 (evaluator 100% fallback)
- #3305 (PG concurrent usage)
- #3335 (keeper config hang)

## Related (improved by these fixes)
- #3297, #3298, #3302, #3306, #3311, #3319

## Test plan
- [x] `dune build` passes
- [ ] `make test` — 1 pre-existing flaky failure (EINTR in server bootstrap test, unrelated)
- [ ] Server start → `curl keepers/sangsu/config` < 1s
- [ ] 2min log check: no "Invalid concurrent usage"
- [ ] harness-health: fallback_count < total_verdicts (when LLM available)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>