### PR TITLE
Fix board filter classification and trim keeper diagnostics

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,7 +1,7 @@
 import { get, post, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import type {
-  BoardPost, BoardComment,
+  BoardPost, BoardComment, BoardSortMode,
   GovernanceCaseBrief, GovernanceCaseBundle, GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute, GovernanceExecutionOrder,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
@@ -380,6 +380,24 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   }
 }
 
+export async function fetchBoard(
+  sortBy?: BoardSortMode,
+  options?: { excludeSystem?: boolean; excludeAutomation?: boolean },
+): Promise<{ posts: BoardPost[] }> {
+  return withRetries('fetchBoard', async () => {
+    const params = new URLSearchParams()
+    if (sortBy) params.set('sort_by', sortBy)
+    if (options?.excludeSystem) params.set('exclude_system', 'true')
+    if (options?.excludeAutomation) params.set('exclude_automation', 'true')
+    params.set('limit', options?.excludeSystem || options?.excludeAutomation ? '150' : '100')
+    const qs = params.toString()
+    const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
+    const posts = Array.isArray(raw.posts)
+      ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
+      : []
+    return { posts }
+  })
+}
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
   return withRetries('fetchBoardPost', async () => {
     const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)

--- a/dashboard/src/components/common/tool-audit.ts
+++ b/dashboard/src/components/common/tool-audit.ts
@@ -15,7 +15,6 @@ function normalizeStatus(value: string | null | undefined): string {
 export function linkedRuntimeState(keeper: Keeper | null | undefined): 'offline' | 'online' | 'unlinked' {
   if (!keeper) return 'unlinked'
   if (keeper.agent?.exists === false) return 'offline'
-  if (normalizeStatus(keeper.diagnostic?.health_state) === 'offline') return 'offline'
   if (normalizeStatus(keeper.status) === 'offline' || normalizeStatus(keeper.status) === 'inactive') {
     return 'offline'
   }

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -27,6 +27,7 @@ vi.mock('./common/toast', () => ({
 }))
 
 import { keeperActionErrors, keeperHydrating, keeperSending, keeperStreamStartedAt, keeperThreads } from '../keeper-runtime'
+import { hydrateKeeperStatus } from '../keeper-runtime'
 import { KeeperConversationPanel } from './keeper-shared'
 
 describe('KeeperConversationPanel', () => {
@@ -115,5 +116,6 @@ describe('KeeperConversationPanel', () => {
     expect(container.textContent).not.toContain('Lane state')
     expect(container.querySelector('[data-chat-variant="messenger"]')).not.toBeNull()
     expect(container.querySelector('textarea')?.getAttribute('placeholder')).toBe('메시지 입력...')
+    expect(hydrateKeeperStatus).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -126,7 +126,7 @@ function conversationStateClass(sending: boolean, hydrating: boolean): string {
 function effectiveDiagnostic(keeper: Keeper | null | undefined): KeeperDiagnostic | null {
   if (!keeper) return null
   const detail = keeperStatusDetails.value[keeper.name]
-  return detail?.diagnostic ?? keeper.diagnostic ?? null
+  return detail?.diagnostic ?? null
 }
 
 // ── Diagnostic chip ──────────────────────────────────────
@@ -146,12 +146,6 @@ export function KeeperDiagnosticSummary({
   keeper: Keeper | null | undefined
   showRawStatus?: boolean
 }) {
-  useEffect(() => {
-    if (keeper?.name) {
-      void hydrateKeeperStatus(keeper.name)
-    }
-  }, [keeper?.name])
-
   if (!keeper) {
     return html`<div class="text-xs text-[var(--text-muted)] leading-relaxed py-2">키퍼를 선택하여 직접 응답 상태를 확인하세요.</div>`
   }
@@ -159,25 +153,50 @@ export function KeeperDiagnosticSummary({
   const detail = keeperStatusDetails.value[keeper.name]
   const diagnostic = effectiveDiagnostic(keeper)
   const busy = keeperHydrating.value[keeper.name]
+  const refreshStatus = async () => {
+    try {
+      await hydrateKeeperStatus(keeper.name, true)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `Failed to inspect ${keeper.name}`
+      showToast(message, 'error')
+    }
+  }
 
   return html`
     <div class="py-3 px-4 rounded-xl border border-[var(--card-border)] bg-[rgba(5,14,31,0.55)]">
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">명시적 상태 조회</div>
+        <button
+          type="button"
+          class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--white-6)] hover:text-[var(--text-body)]"
+          disabled=${busy}
+          onClick=${() => { void refreshStatus() }}
+        >
+          ${busy ? '불러오는 중...' : (detail ? '상태 새로고침' : '상태 불러오기')}
+        </button>
+      </div>
       <div class="flex flex-wrap gap-1.5 mb-2">
         ${continuityStateLabel(diagnostic?.continuity_state)
           ? html`<${DiagChip} label=${continuityStateLabel(diagnostic?.continuity_state)} />`
           : null}
-        <${DiagChip} label=${diagnostic?.health_state ?? 'unknown'} />
-        <${DiagChip} label=${quietReasonLabel(diagnostic?.quiet_reason)} />
-        <${DiagChip} label=${'next: ' + nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')} />
+        ${diagnostic?.health_state
+          ? html`<${DiagChip} label=${diagnostic.health_state} />`
+          : null}
+        ${diagnostic?.quiet_reason
+          ? html`<${DiagChip} label=${quietReasonLabel(diagnostic.quiet_reason)} />`
+          : null}
+        ${diagnostic?.next_action_path
+          ? html`<${DiagChip} label=${'next: ' + nextActionLabel(diagnostic.next_action_path)} />`
+          : null}
         ${busy ? html`<${DiagChip} label="refreshing" />` : null}
       </div>
       <div class="text-xs text-[var(--text-body)] leading-relaxed">
         ${diagnostic?.continuity_summary
           ?? diagnostic?.summary
-          ?? '키퍼 진단 요약을 아직 사용할 수 없습니다. 프로브하거나 상세 오버레이를 열어 런타임 상태를 확인하세요.'}
+          ?? '자동 판단 필드는 기본으로 채우지 않습니다. 필요할 때만 상태를 불러오세요.'}
       </div>
       <div class="text-xs text-[var(--text-body)] leading-relaxed mt-1">
-        응답: ${diagnostic?.last_reply_status ?? 'unknown'}
+        응답: ${diagnostic?.last_reply_status ?? '미조회'}
         ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}
         ${diagnostic?.next_eligible_at_s ? html` -- 다음 응답 가능 ${formatEligible(diagnostic.next_eligible_at_s)}` : null}
       </div>
@@ -202,12 +221,6 @@ export function KeeperConversationPanel({
 }) {
   const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
-
-  useEffect(() => {
-    if (keeperName) {
-      void hydrateKeeperStatus(keeperName)
-    }
-  }, [keeperName])
 
   useEffect(() => {
     writeKeeperChatMetadataVisible(showMetadata)
@@ -265,7 +278,7 @@ export function KeeperConversationPanel({
             >
               ${showMetadata ? '메타데이터 숨김' : '메타데이터 표시'}
             </button>
-            ${!historyExpanded && rawThread.length >= 10
+            ${!historyExpanded
               ? html`
                   <button
                     type="button"
@@ -273,7 +286,11 @@ export function KeeperConversationPanel({
                     disabled=${hydrating}
                     onClick=${() => { void expandHistory() }}
                   >
-                    ${hydrating ? '불러오는 중...' : `전체 이력 불러오기 (직접 대화 ${thread.length}건 표시 중)`}
+                    ${hydrating
+                      ? '불러오는 중...'
+                      : rawThread.length === 0
+                        ? '대화 이력 불러오기'
+                        : `전체 이력 불러오기 (직접 대화 ${thread.length}건 표시 중)`}
                   </button>
                 `
               : null}
@@ -331,8 +348,8 @@ export function KeeperRuntimeActions({
   const diagnostic = effectiveDiagnostic(keeper)
   const probing = keeperProbing.value[keeper.name] ?? false
   const recovering = keeperRecovering.value[keeper.name] ?? false
-  const recommended = diagnostic?.next_action_path ?? 'direct_message'
-  const canRecover = diagnostic?.recoverable ?? recommended === 'recover'
+  const recommended = diagnostic?.next_action_path ?? null
+  const canRecover = diagnostic?.recoverable === true
 
   const btnBase = 'py-1.5 px-4 rounded-lg text-xs font-medium cursor-pointer transition-colors border'
   const ghostBtn = `${btnBase} border-[var(--card-border)] bg-[var(--white-3)] text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]`

--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Memory } from './memory'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem } from '../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation } from '../store'
 import { route } from '../router'
 
 // Ensure jest-dom matchers are available
@@ -14,6 +14,7 @@ vi.mock('../store', () => ({
   boardLoading: { value: false },
   boardSortMode: { value: 'recent' },
   boardExcludeSystem: { value: false },
+  boardExcludeAutomation: { value: false },
   lastBoardRefreshAt: { value: 0 },
   refreshBoard: vi.fn(),
 }))
@@ -42,6 +43,7 @@ describe('Memory Component', () => {
     boardLoading.value = false
     boardSortMode.value = 'recent'
     boardExcludeSystem.value = false
+    boardExcludeAutomation.value = false
     route.value = { params: {} } as any
   })
 
@@ -72,5 +74,24 @@ describe('Memory Component', () => {
     ] as any
     render(h(Memory, null))
     expect(screen.getByText('Test Post')).toBeInTheDocument()
+  })
+
+  it('hides automation posts when the automation filter is enabled', () => {
+    boardExcludeAutomation.value = true
+    boardPosts.value = [
+      {
+        id: 'post-automation',
+        title: 'Automation Post',
+        body: 'noise',
+        author: 'dm-keeper',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        comment_count: 0,
+        votes: 0,
+        post_kind: 'automation',
+      },
+    ] as any
+    render(h(Memory, null))
+    expect(screen.queryByText('Automation Post')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -11,6 +11,7 @@ import {
   boardPosts,
   boardSortMode,
   boardExcludeSystem,
+  boardExcludeAutomation,
   boardLoading,
   lastBoardRefreshAt,
   refreshBoard,
@@ -39,7 +40,6 @@ const detailLoading = signal(false)
 const detailPostId = signal<string | null>(null)
 const commentText = signal('')
 const commentSubmitting = signal(false)
-const hideAutomationPosts = signal(false)
 const showNewPostForm = signal(false)
 const newPostTitle = signal('')
 const newPostContent = signal('')
@@ -72,24 +72,8 @@ function isUpdated(post: BoardPost): boolean {
   return post.updated_at !== post.created_at
 }
 
-function isAutomationBoardPost(post: BoardPost): boolean {
-  if (post.post_kind) return post.post_kind === 'automation'
-  const hearth = (post.hearth ?? '').toLowerCase()
-  if (post.visibility !== 'internal' || !post.expires_at || !hearth) return false
-  if (hearth.startsWith('mdal')) return true
-  if (hearth.includes('harness')) return true
-  return false
-}
-
-function isSystemBoardAuthor(author: string): boolean {
-  return author === 'team-session'
-}
-
 function boardPostKind(post: BoardPost): 'human' | 'automation' | 'system' {
-  if (post.post_kind) return post.post_kind
-  if (isSystemBoardAuthor(post.author)) return 'system'
-  if (isAutomationBoardPost(post)) return 'automation'
-  return 'human'
+  return post.post_kind ?? 'human'
 }
 
 function splitVisiblePosts(posts: BoardPost[]): { human: BoardPost[]; operations: BoardPost[]; hiddenAutomation: number } {
@@ -99,7 +83,7 @@ function splitVisiblePosts(posts: BoardPost[]): { human: BoardPost[]; operations
   posts.forEach(post => {
     const kind = boardPostKind(post)
     if (kind === 'system' && boardExcludeSystem.value) return
-    if (kind === 'automation' && hideAutomationPosts.value) {
+    if (kind === 'automation' && boardExcludeAutomation.value) {
       hiddenAutomation += 1
       return
     }
@@ -276,7 +260,7 @@ function NewPostForm() {
 
 function SortBar() {
   const current = boardSortMode.value
-  const hideLabel = hideAutomationPosts.value ? '자동화 제외' : '자동화 포함'
+  const hideLabel = boardExcludeAutomation.value ? '자동화 제외' : '자동화 포함'
   return html`
     <div class="flex flex-col gap-3 mb-4 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
       <div class="flex items-center gap-1.5 flex-wrap">
@@ -301,12 +285,12 @@ function SortBar() {
       <div class="flex items-center gap-2 flex-wrap">
         <button type="button"
           class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
-            ${hideAutomationPosts.value
+            ${boardExcludeAutomation.value
               ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
               : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
             }"
           onClick=${() => {
-            hideAutomationPosts.value = !hideAutomationPosts.value
+            boardExcludeAutomation.value = !boardExcludeAutomation.value
             refreshBoard()
           }}
         >
@@ -355,7 +339,7 @@ function MemorySummary() {
       </div>
       <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
         <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">잡음 필터</span>
-        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${hideAutomationPosts.value ? `자동화 ${grouped.hiddenAutomation}건 제외` : '모두 표시'}</strong>
+        <strong class="text-[13px] font-semibold text-[var(--text-strong)]">${boardExcludeAutomation.value ? `자동화 ${grouped.hiddenAutomation}건 제외` : '모두 표시'}</strong>
       </div>
       <div class="flex flex-col gap-1.5 p-4 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
         <span class="text-[10px] text-[var(--text-muted)] tracking-[0.08em] uppercase font-medium">시스템 글 정책</span>

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -176,12 +176,10 @@ export function enrichedKeeperRow(brief: DashboardMissionKeeperBrief): EnrichedK
       trimText(keeper?.recent_input_preview, 120) ?? null,
     recentOutput:
       trimText(keeper?.recent_output_preview, 120)
-      ?? trimText(keeper?.diagnostic?.last_reply_preview, 120)
       ?? trimText(keeper?.last_proactive_preview, 120)
       ?? null,
     recentEvent:
       trimText(keeper?.last_proactive_reason, 120)
-      ?? trimText(keeper?.diagnostic?.summary, 120)
       ?? null,
     recentTools: keeper?.recent_tool_names ?? [],
   }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -29,13 +29,10 @@ import {
   setActiveStream,
   setRecordValue,
   setStatusDetail,
-  updateDiagnostic,
 } from './keeper-state'
 import { abortKeeperThreadMessage, applyKeeperStreamEvent } from './keeper-stream'
 import {
   KEEPER_HISTORY_TAIL_MESSAGES,
-  KEEPER_REPLY_PREVIEW_MAX,
-  KEEPER_STATUS_TAIL_MESSAGES,
   KEEPER_STREAM_IDLE_POLL_MS,
   KEEPER_STREAM_IDLE_TIMEOUT_MS,
 } from './config/constants'
@@ -62,14 +59,14 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
   try {
     const text = await callMcpTool('masc_keeper_status', {
       name: keeperName,
-      fast: false,
-      include_context: true,
-      include_metrics_overview: true,
+      fast: true,
+      include_context: false,
+      include_metrics_overview: false,
       include_memory_bank: false,
-      include_history_tail: true,
+      include_history_tail: false,
       include_compaction_history: false,
-      tail_turns: 5,
-      tail_messages: KEEPER_STATUS_TAIL_MESSAGES,
+      tail_turns: 0,
+      tail_messages: 0,
     })
     let parsed: unknown = null
     try {
@@ -187,12 +184,6 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
       timestamp: new Date().toISOString(),
       error: null,
     })
-    updateDiagnostic(keeperName, {
-      last_reply_status: 'delivered',
-      last_reply_at: new Date().toISOString(),
-      last_reply_preview: finalText.slice(0, KEEPER_REPLY_PREVIEW_MAX),
-      last_error: null,
-    })
   } catch (err) {
     const isAbort =
       err instanceof Error && err.name === 'AbortError'
@@ -202,10 +193,6 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
         streamState: null,
         error: 'Stream cancelled',
         timestamp: new Date().toISOString(),
-      })
-      updateDiagnostic(keeperName, {
-        last_reply_status: 'error',
-        last_error: 'Stream cancelled',
       })
       setRecordValue(keeperActionErrors, keeperName, 'Stream cancelled')
       throw err
@@ -227,12 +214,6 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
           timestamp: new Date().toISOString(),
         })
         finalizeAssistantEntry(keeperName, localId, { delivery: 'delivered', error: null })
-        updateDiagnostic(keeperName, {
-          last_reply_status: 'delivered',
-          last_reply_at: new Date().toISOString(),
-          last_reply_preview: (reply.text.trim() || '(empty reply)').slice(0, KEEPER_REPLY_PREVIEW_MAX),
-          last_error: null,
-        })
         await refreshDashboardState()
         return
       } catch (fallbackErr) {
@@ -251,10 +232,6 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
     finalizeAssistantEntry(keeperName, localId, {
       delivery: 'error' as KeeperConversationDelivery,
       error: errorMessage,
-    })
-    updateDiagnostic(keeperName, {
-      last_reply_status: 'error',
-      last_error: errorMessage,
     })
     setRecordValue(keeperActionErrors, keeperName, errorMessage)
     throw err

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -13,7 +13,6 @@ export {
   normalizeKeeperDiagnostic,
   normalizeKeeperProbeResult,
   normalizeKeeperRecoverResult,
-  deriveKeeperDiagnostic,
 } from './keeper-state'
 export { abortKeeperThreadMessage } from './keeper-stream'
 export {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -2,7 +2,6 @@ import { signal } from '@preact/signals'
 import { formatKeeperVisibleReply } from './keeper-message'
 import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './components/common/normalize'
 import type {
-  Keeper,
   KeeperConversationEntry,
   KeeperConversationRole,
   KeeperConversationSource,
@@ -105,48 +104,6 @@ export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry)
     && entry.source !== 'system'
 }
 
-// --- Diagnostic helpers ---
-
-function classifyKeeperErrorKind(errorText: string): KeeperDiagnostic['quiet_reason'] {
-  const lowered = errorText.toLowerCase()
-  if (lowered.includes('graphql')) return 'graphql_error'
-  if (
-    lowered.includes('timeout')
-    || lowered.includes('model')
-    || lowered.includes('api key')
-    || lowered.includes('api_key')
-    || lowered.includes('provider')
-  ) {
-    return 'model_error'
-  }
-  return 'unknown'
-}
-
-function quietReasonSummary(healthState: KeeperDiagnostic['health_state'], quietReason: KeeperDiagnostic['quiet_reason']): string {
-  if (healthState === 'offline' || healthState === 'degraded' || healthState === 'stale') {
-    return 'Keeper is not in a healthy reply state. Probe or recover before relying on automation.'
-  }
-  if (quietReason === 'quiet_hours') {
-    return 'Social quiet hours are active. Direct messages still work, but scheduled public-square reactions may look asleep.'
-  }
-  if (quietReason === 'min_gap') {
-    return 'Keeper is inside its proactive cooldown window. Direct messages work now; autonomous check-ins will wait.'
-  }
-  if (quietReason === 'never_started') {
-    return 'Keeper metadata exists but no reply turn has been recorded yet.'
-  }
-  return 'Keeper is reachable. Send a direct message for an immediate response.'
-}
-
-function diagnosticSummary(rawSummary: unknown, healthState: KeeperDiagnostic['health_state'], quietReason: KeeperDiagnostic['quiet_reason']): string {
-  return asString(rawSummary) ?? quietReasonSummary(healthState, quietReason)
-}
-
-function diagnosticRecoverable(rawRecoverable: unknown, nextActionPath: KeeperDiagnostic['next_action_path']): boolean {
-  if (typeof rawRecoverable === 'boolean') return rawRecoverable
-  return nextActionPath === 'recover'
-}
-
 // --- Normalizers ---
 
 export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
@@ -164,8 +121,8 @@ export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null
     last_reply_preview: asString(raw.last_reply_preview) ?? null,
     last_error: asString(raw.last_error) ?? null,
     next_eligible_at_s: asNumber(raw.next_eligible_at_s) ?? null,
-    recoverable: diagnosticRecoverable(raw.recoverable, nextActionPath as KeeperDiagnostic['next_action_path']),
-    summary: diagnosticSummary(raw.summary, healthState as KeeperDiagnostic['health_state'], (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']),
+    recoverable: typeof raw.recoverable === 'boolean' ? raw.recoverable : undefined,
+    summary: asString(raw.summary),
     keepalive_running: typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
     continuity_state:
       (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
@@ -190,85 +147,6 @@ export function normalizeKeeperRecoverResult(raw: unknown): KeeperRecoverResult 
     after: normalizeKeeperDiagnostic(raw.after),
     down: raw.down,
     up: raw.up,
-  }
-}
-
-export function deriveKeeperDiagnostic(
-  keeper: Partial<Keeper> | null | undefined,
-): KeeperDiagnostic | null {
-  if (!keeper?.name) return null
-
-  const agentStatus = asString(keeper.agent?.status) ?? asString(keeper.status) ?? 'unknown'
-  const agentError = asString(keeper.agent?.error) ?? null
-  const keepaliveExpected = keeper.presence_keepalive ?? true
-  const keepaliveRunning = keeper.keepalive_running ?? false
-  const totalTurns = keeper.turn_count ?? 0
-  const lastTurnAgo = keeper.last_turn_ago_s ?? null
-  const proactiveEnabled = keeper.proactive_enabled ?? false
-  const proactiveCooldownSec = keeper.proactive_cooldown_sec ?? 0
-  const lastProactiveAgo = keeper.last_proactive_ago_s ?? null
-  const nextEligibleAtS =
-    proactiveEnabled && lastProactiveAgo != null
-      ? Math.max(0, proactiveCooldownSec - lastProactiveAgo)
-      : null
-
-  const lastReplyStatus: KeeperDiagnostic['last_reply_status'] =
-    totalTurns <= 0 || lastTurnAgo == null ? 'never' : lastTurnAgo > 900 ? 'stale' : 'fresh'
-
-  const lastReplyAt = (() => {
-    if (typeof keeper.last_heartbeat === 'string' && keeper.last_heartbeat.trim()) return keeper.last_heartbeat
-    return null
-  })()
-
-  const lastError =
-    agentError
-    ?? (keepaliveExpected && !keepaliveRunning ? 'keeper keepalive is not running' : null)
-
-  const healthState: KeeperDiagnostic['health_state'] =
-    agentStatus === 'offline' || agentStatus === 'inactive'
-      ? 'offline'
-      : lastError
-        ? 'degraded'
-        : lastReplyStatus === 'stale'
-          ? 'stale'
-          : lastReplyStatus === 'never'
-            ? 'idle'
-            : 'healthy'
-
-  const quietReason: KeeperDiagnostic['quiet_reason'] =
-    lastError
-      ? classifyKeeperErrorKind(lastError)
-      : keepaliveExpected && !keepaliveRunning
-        ? 'disabled'
-        : totalTurns <= 0
-          ? 'never_started'
-          : nextEligibleAtS != null && nextEligibleAtS > 0
-            ? 'min_gap'
-            : lastReplyStatus === 'fresh' || lastReplyStatus === 'stale'
-              ? 'no_recent_activity'
-              : 'unknown'
-
-  const nextActionPath: KeeperDiagnostic['next_action_path'] =
-    healthState === 'offline' || healthState === 'degraded' || healthState === 'stale'
-      ? 'recover'
-      : quietReason === 'quiet_hours'
-        ? 'manual_social_sweep'
-        : quietReason === 'unknown'
-          ? 'probe'
-          : 'direct_message'
-
-  return {
-    health_state: healthState,
-    quiet_reason: quietReason,
-    next_action_path: nextActionPath,
-    last_reply_status: lastReplyStatus,
-    last_reply_at: lastReplyAt,
-    last_reply_preview: null,
-    last_error: lastError,
-    next_eligible_at_s: nextEligibleAtS != null && nextEligibleAtS > 0 ? nextEligibleAtS : null,
-    recoverable: diagnosticRecoverable(undefined, nextActionPath),
-    summary: diagnosticSummary(undefined, healthState, quietReason),
-    keepalive_running: keepaliveRunning,
   }
 }
 
@@ -409,23 +287,6 @@ export function setStatusDetail(name: string, detail: KeeperStatusDetail): void 
     [name]: detail,
   }
   replaceThread(name, detail.history)
-}
-
-export function updateDiagnostic(name: string, patch: Partial<KeeperDiagnostic>): void {
-  const existing = keeperStatusDetails.value[name]
-  if (!existing) return
-  const current = existing.diagnostic ?? {
-    health_state: 'idle',
-    next_action_path: 'direct_message',
-    last_reply_status: 'unknown',
-  }
-  setStatusDetail(name, {
-    ...existing,
-    diagnostic: {
-      ...current,
-      ...patch,
-    },
-  })
 }
 
 // --- Stream controller management ---

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -1,6 +1,5 @@
 import type {
   Keeper,
-  KeeperDiagnostic,
   KeeperLifecycleState,
   KeeperMetricPoint,
 } from './types'
@@ -114,35 +113,6 @@ function normalizeMetricsWindow(raw: unknown): Keeper['metrics_window'] | undefi
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined
-}
-
-function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
-  if (!isRecord(raw)) return null
-  const healthState = asString(raw.health_state)
-  const nextActionPath = asString(raw.next_action_path)
-  const lastReplyStatus = asString(raw.last_reply_status)
-  if (!healthState || !nextActionPath || !lastReplyStatus) return null
-  const quietReason = (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']
-  return {
-    health_state: healthState as KeeperDiagnostic['health_state'],
-    quiet_reason: quietReason,
-    next_action_path: nextActionPath as KeeperDiagnostic['next_action_path'],
-    last_reply_status: lastReplyStatus as KeeperDiagnostic['last_reply_status'],
-    last_reply_at: toIsoTimestamp(raw.last_reply_at) ?? asString(raw.last_reply_at) ?? null,
-    last_reply_preview: asString(raw.last_reply_preview) ?? null,
-    last_error: asString(raw.last_error) ?? null,
-    next_eligible_at_s: asNumber(raw.next_eligible_at_s) ?? null,
-    recoverable:
-      typeof raw.recoverable === 'boolean'
-        ? raw.recoverable
-        : nextActionPath === 'recover',
-    summary: asString(raw.summary),
-    keepalive_running:
-      typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
-    continuity_state:
-      (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
-    continuity_summary: asString(raw.continuity_summary) ?? null,
-  }
 }
 
 export function normalizeKeepers(raw: unknown): Keeper[] {
@@ -261,7 +231,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),
         compaction_count: asNumber(row.compaction_count),
         last_compaction_saved_tokens: asNumber(row.last_compaction_saved_tokens),
-        diagnostic: normalizeKeeperDiagnostic(row.diagnostic),
         skill_primary: asString(row.skill_primary) ?? null,
         skill_secondary: skillSecondary,
         skill_reason: asString(row.skill_reason) ?? null,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -87,6 +87,7 @@ export const keeperHeartbeats = signal<Map<string, number>>(new Map())
 export const boardPosts = signal<BoardPost[]>([])
 export const boardSortMode = signal<BoardSortMode>('recent')
 export const boardExcludeSystem = signal(true)
+export const boardExcludeAutomation = signal(false)
 
 // --- Goals state ---
 
@@ -456,7 +457,10 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
 export async function refreshBoard(): Promise<void> {
   boardLoading.value = true
   try {
-    const data = await fetchDashboardMemory(boardSortMode.value, { excludeSystem: boardExcludeSystem.value })
+    const data = await fetchDashboardMemory(boardSortMode.value, {
+      excludeSystem: boardExcludeSystem.value,
+      excludeAutomation: boardExcludeAutomation.value,
+    })
     boardPosts.value = data.posts ?? []
     lastBoardRefreshAt.value = new Date().toISOString()
   } catch (err) {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -380,7 +380,6 @@ export interface Keeper {
   handoff_count_total?: number
   compaction_count?: number
   last_compaction_saved_tokens?: number
-  diagnostic?: KeeperDiagnostic | null
   skill_primary?: string | null
   skill_secondary?: string[]
   skill_reason?: string | null

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -55,7 +55,7 @@ type post = {
 ```
 
 **post_kind 분류:** 명시 지정이 없으면 `infer_post_kind`로 자동 추론.
-- `System_post`: author가 lodge-system, team-session, operator, keeper 등
+- `System_post`: author가 lodge-system, team-session, operator, keeper, keeper-alert-bot 등인 경우, 또는 `meta.source = keeper_board_post`
 - `Automation_post`: Internal + TTL + MDAL/harness hearth, 또는 author가 auto-/qa- prefix
 - `Human_post`: 기본값
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -321,6 +321,7 @@ let permission_for_tool = function
       Some CanReadState
   | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
   | "masc_board_comment_vote" -> Some CanBroadcast
+  | "masc_board_reclassify" -> Some CanAdmin
   (* Auth tools - special handling *)
   | "masc_auth_enable" | "masc_auth_disable"
   | "masc_auth_revoke" -> Some CanInit  (* Admin only *)

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -208,15 +208,30 @@ let author_looks_automation author =
   || contains_substring author "smoke"
   || contains_substring author "probe"
 
-let infer_post_kind ~author ~visibility ~expires_at ~hearth =
+let is_system_board_author author =
+  List.mem author
+    [ "ecosystem"; "keeper"; "keeper-alert-bot"; "lodge-system"; "operator";
+      "team-session" ]
+
+let meta_source = function
+  | Some (`Assoc fields) -> (
+      match List.assoc_opt "source" fields with
+      | Some (`String source) ->
+          let source = String.lowercase_ascii (String.trim source) in
+          if source = "" then None else Some source
+      | _ -> None)
+  | _ -> None
+
+let infer_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth =
   let author = String.lowercase_ascii author in
   let hearth =
     match hearth with
     | Some value -> String.lowercase_ascii (String.trim value)
     | None -> ""
   in
-  if author = "lodge-system" || author = "team-session"
-     || author = "keeper" || author = "ecosystem" then
+  if is_system_board_author author
+     || meta_source meta_json = Some "keeper_board_post"
+  then
     System_post
   else if visibility = Internal && expires_at > 0.0 && hearth <> ""
           && (String.starts_with ~prefix:"mdal" hearth
@@ -232,6 +247,7 @@ let classify_post_kind (p : post) =
   let inferred =
     infer_post_kind
       ~author:(Agent_id.to_string p.author)
+      ~meta_json:p.meta_json
       ~visibility:p.visibility
       ~expires_at:p.expires_at
       ~hearth:p.hearth
@@ -240,6 +256,36 @@ let classify_post_kind (p : post) =
   | Human_post, (Automation_post | System_post as upgraded) -> upgraded
   | Automation_post, System_post -> System_post
   | stored, _ -> stored
+
+let post_matches_filters ~exclude_system ~exclude_automation (p : post) =
+  let kind = classify_post_kind p in
+  (not exclude_system || kind <> System_post)
+  && (not exclude_automation || kind <> Automation_post)
+
+type reclassify_report = {
+  backend : string;
+  dry_run : bool;
+  scanned : int;
+  changed : int;
+  unchanged : int;
+  skipped : int;
+  apply_failures : int;
+  changed_post_ids : string list;
+}
+
+let reclassify_report_to_yojson (report : reclassify_report) =
+  `Assoc
+    [
+      ("backend", `String report.backend);
+      ("dry_run", `Bool report.dry_run);
+      ("scanned", `Int report.scanned);
+      ("changed", `Int report.changed);
+      ("unchanged", `Int report.unchanged);
+      ("skipped", `Int report.skipped);
+      ("apply_failures", `Int report.apply_failures);
+      ( "changed_post_ids",
+        `List (List.map (fun id -> `String id) report.changed_post_ids) );
+    ]
 
 let state_start_marker = "[STATE]"
 let state_end_marker = "[/STATE]"
@@ -323,7 +369,7 @@ let normalize_post_payload ~author ~content ?title ?body ?post_kind ?meta_json
   let normalized_kind =
     match post_kind with
     | Some kind -> kind
-    | None -> infer_post_kind ~author ~visibility ~expires_at ~hearth
+    | None -> infer_post_kind ~meta_json ~author ~visibility ~expires_at ~hearth
   in
   let merged_meta = merge_meta_json ?state_block:extracted_state meta_json in
   normalized_title, normalized_body, normalized_kind, merged_meta
@@ -334,7 +380,7 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
     ("author", `String (Agent_id.to_string p.author));
     ("title", `String p.title);
     ("body", `String p.body);
-    ("post_kind", `String (post_kind_to_string p.post_kind));
+    ("post_kind", `String (post_kind_to_string (classify_post_kind p)));
     ("content", `String p.content);
     ("visibility", `String (visibility_to_string p.visibility));
     ("created_at", `Float p.created_at);
@@ -489,6 +535,54 @@ let get_post store ~post_id : (post, board_error) result =
         | Some post -> Ok post
         | None -> Error (Post_not_found post_id)
       )
+
+let reclassify_posts store ?(limit = 5200) ?(dry_run = true) () =
+  maybe_sweep store;
+  with_lock store (fun () ->
+    let scan_limit = max 0 (min limit 5200) in
+    let total = !(store.post_count) in
+    let scanned = ref 0 in
+    let changed = ref 0 in
+    let unchanged = ref 0 in
+    let changed_post_ids = ref [] in
+    let record_changed_id id =
+      if List.length !changed_post_ids < 20 then
+        changed_post_ids := id :: !changed_post_ids
+    in
+    let sorted_posts =
+      Hashtbl.fold (fun _ (post : post) acc -> post :: acc) store.posts []
+      |> List.sort (fun (a : post) (b : post) -> compare b.created_at a.created_at)
+    in
+    sorted_posts
+    |> List.filteri (fun idx _ -> idx < scan_limit)
+    |> List.iter (fun (post : post) ->
+           incr scanned;
+           let canonical_kind = classify_post_kind post in
+           if canonical_kind = post.post_kind then
+             incr unchanged
+           else begin
+             incr changed;
+             record_changed_id (Post_id.to_string post.id);
+             if not dry_run then
+               Hashtbl.replace store.posts (Post_id.to_string post.id)
+                 { post with post_kind = canonical_kind }
+           end);
+    if not dry_run && !changed > 0 then begin
+      invalidate_post_caches store;
+      rewrite_posts store;
+      store.dirty_posts <- false;
+      store.last_flush <- Time_compat.now ()
+    end;
+    {
+      backend = "jsonl";
+      dry_run;
+      scanned = !scanned;
+      changed = !changed;
+      unchanged = !unchanged;
+      skipped = max 0 (total - !scanned);
+      apply_failures = 0;
+      changed_post_ids = List.rev !changed_post_ids;
+    })
 
 let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post list =
   maybe_sweep store;

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -192,17 +192,16 @@ let get_post ~post_id =
   | Postgres t -> Board_pg.get_post t ~post_id
 
 let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot)
-    ?(exclude_automation=false) ?(limit=50) () =
+    ?(exclude_system=false) ?(exclude_automation=false) ?(limit=50) () =
   let apply_post_kind_filter posts =
-    match (post_kind_filter, exclude_automation) with
-    | Some kind, _ ->
-        List.filter
-          (fun (p : Board.post) -> Board.classify_post_kind p = kind)
-          posts
-    | None, true ->
-        List.filter (fun (p : Board.post) ->
-          Board.classify_post_kind p <> Board.Automation_post) posts
-    | None, false -> posts
+    posts
+    |> List.filter (fun (p : Board.post) ->
+           Board.post_matches_filters ~exclude_system ~exclude_automation p)
+    |> (match post_kind_filter with
+       | Some kind ->
+           List.filter
+             (fun (p : Board.post) -> Board.classify_post_kind p = kind)
+       | None -> Fun.id)
   in
   match backend () with
   | Jsonl store ->
@@ -220,7 +219,7 @@ let list_posts ?(visibility_filter=None) ?hearth ?post_kind_filter ?(sort_by=Hot
         | Discussed -> Board_pg.Discussed
       in
       let needs_filter =
-        Option.is_some post_kind_filter || exclude_automation
+        Option.is_some post_kind_filter || exclude_system || exclude_automation
       in
       (* Over-fetch when post-query filtering is needed to avoid short results *)
       let fetch_limit = if needs_filter then max limit (limit * 3) else limit in
@@ -366,6 +365,11 @@ let get_agent_karma ~agent_name =
 (** Post to JSON with karma (delegates to Board for flair extraction) *)
 let post_to_yojson_with_karma (p : Board.post) ~author_karma =
   Board.post_to_yojson_with_karma p ~author_karma
+
+let reclassify_posts ?(limit=5200) ?(dry_run=true) () =
+  match backend () with
+  | Jsonl store -> Board.reclassify_posts store ~limit ~dry_run ()
+  | Postgres t -> Board_pg.reclassify_posts t ~limit ~dry_run ()
 
 (** Backend name for diagnostics *)
 let backend_name () =

--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -551,6 +551,68 @@ let stats t =
       Log.BoardPg.error "stats error: %s" (Caqti_error.show err);
       `Assoc [("error", `String "Database operation failed")]
 
+let reclassify_posts t ?(limit = 5200) ?(dry_run = true) () =
+  let scan_limit = max 0 (min limit 5200) in
+  match Caqti_eio.Pool.use (fun conn ->
+    let module C = (val conn : Caqti_eio.CONNECTION) in
+    let* total = C.find post_count_q () in
+    let* rows =
+      if scan_limit = 0 then
+        Ok []
+      else
+        C.collect_list list_recent_q (None, None, scan_limit)
+    in
+    let posts = List.filter_map post_of_row rows in
+    let changed = ref 0 in
+    let unchanged = ref 0 in
+    let apply_failures = ref 0 in
+    let changed_post_ids = ref [] in
+    let record_changed_id id =
+      if List.length !changed_post_ids < 20 then
+        changed_post_ids := id :: !changed_post_ids
+    in
+    List.iter (fun (post : post) ->
+      let canonical_kind = classify_post_kind post in
+      if canonical_kind = post.post_kind then
+        incr unchanged
+      else begin
+        incr changed;
+        let post_id = Post_id.to_string post.id in
+        record_changed_id post_id;
+        if not dry_run then
+          match C.exec update_post_kind_q (post_id, post_kind_to_string canonical_kind) with
+          | Ok () -> ()
+          | Error err ->
+              incr apply_failures;
+              Log.BoardPg.error "reclassify post_kind failed for %s: %s"
+                post_id (Caqti_error.show err)
+      end) posts;
+    Ok
+      {
+        backend = "postgresql";
+        dry_run;
+        scanned = List.length posts;
+        changed = !changed;
+        unchanged = !unchanged;
+        skipped = max 0 (total - List.length posts);
+        apply_failures = !apply_failures;
+        changed_post_ids = List.rev !changed_post_ids;
+      }
+  ) t.pool with
+  | Ok report -> report
+  | Error err ->
+      Log.BoardPg.error "reclassify_posts error: %s" (Caqti_error.show err);
+      {
+        backend = "postgresql";
+        dry_run;
+        scanned = 0;
+        changed = 0;
+        unchanged = 0;
+        skipped = 0;
+        apply_failures = 1;
+        changed_post_ids = [];
+      }
+
 (** {1 Search} *)
 
 let search t ~query ~limit =

--- a/lib/board_pg_queries.ml
+++ b/lib/board_pg_queries.ml
@@ -111,6 +111,10 @@ let post_count_q =
   (Printf.sprintf
     "SELECT COUNT(*)::int FROM masc_board_posts WHERE %s" ttl_where)
 
+let update_post_kind_q =
+  (Caqti_type.(t2 string string) ->. Caqti_type.unit)
+  "UPDATE masc_board_posts SET post_kind = $2 WHERE id = $1"
+
 (* Sort-order specific list queries. $1=visibility (NULL=any), $2=hearth (NULL=any), $3=limit.
    NOTE: PostgreSQL cannot infer type from `$n IS NULL` alone, so explicit ::TEXT cast needed. *)
 let mk_list_q order_clause =

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -423,7 +423,6 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 `String
                   (Keeper_exec_status.keeper_surface_status ~agent_status:agent
                      ~diagnostic) );
-              ("diagnostic", diagnostic);
               ("keeper_age_s", `Float keeper_age_s);
               ("uptime_hours", `Float (keeper_age_s /. 3600.0));
               ("last_turn_ago_s", `Float last_turn_ago_s);

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -14,7 +14,7 @@ let ensure_keeper_board_post_args ~author ~source = function
       `Assoc
         ([
            ("author", `String author);
-           ("post_kind", `String "automation");
+           ("post_kind", `String "system");
            ("meta", `Assoc [ ("source", `String source) ]);
          ]
         @ fields)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -293,25 +293,6 @@ let handle_keeper_status ctx args : tool_result =
              in
              (`List (List.rev items_rev), raw_count, fragment_count, filtered_count)
          in
-         let history_items =
-           match history_tail with
-           | `List xs -> xs
-           | _ -> []
-         in
-         let diagnostic =
-           keeper_diagnostic_json
-             ~meta:m
-             ~agent_status
-             ~keepalive_running
-             ~history_items
-             ~now_ts
-           |> augment_keeper_diagnostic_json
-                ~registered:(is_resident_keeper ctx.config m.name)
-                ~meta:m
-                ~keepalive_running
-                ~keepalive_started_at:(runtime_keepalive_started_at ctx.config m)
-                ~now_ts
-         in
          let compaction_history_tail =
            if not include_compaction_history then
              (`List [], 0)
@@ -427,7 +408,6 @@ let handle_keeper_status ctx args : tool_result =
            ("paused", `Bool m.paused);
            ("keepalive_running", `Bool keepalive_running);
            ("agent", agent_status);
-           ("diagnostic", diagnostic);
            ("keeper_age_s", `Float keeper_age_s);
            ("last_turn_ago_s", `Float last_turn_ago_s);
            ("last_handoff_ago_s", `Float last_handoff_ago_s);

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -219,7 +219,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
                (false,
                 Printf.sprintf
-                  "Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_DEFAULT_SEC or MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+                  "Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_DEFAULT_SEC)"
                   timeout_sec
                   name))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -21,6 +21,33 @@ let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
   | Some (false, err) -> Error err
   | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
 
+let keeper_diagnostic_for_name (ctx : 'a context) ~(name : string) =
+  match Keeper_types.read_meta ctx.config name with
+  | Error err -> Error err
+  | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
+  | Ok (Some meta) ->
+      let keepalive_running =
+        Keeper_status_bridge.runtime_keepalive_running ctx.config meta
+      in
+      let agent_status =
+        Keeper_exec_status.parse_agent_status ctx.config ~agent_name:meta.agent_name
+      in
+      let now_ts = Time_compat.now () in
+      Ok
+        (Keeper_exec_status.keeper_diagnostic_json
+           ~meta
+           ~agent_status
+           ~keepalive_running
+           ~history_items:[]
+           ~now_ts
+        |> Keeper_exec_status.augment_keeper_diagnostic_json
+             ~registered:(Keeper_types.is_resident_keeper ctx.config meta.name)
+             ~meta
+             ~keepalive_running
+             ~keepalive_started_at:
+               (Keeper_status_bridge.runtime_keepalive_started_at ctx.config meta)
+             ~now_ts)
+
 let dispatch_team_session_json_as (ctx : 'a context) ~session_id ~requested_actor
     ~tool_name ~args =
   let* authorized_actor =
@@ -340,11 +367,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
       let* status_json =
         dispatch_keeper_json ctx ~tool_name:"masc_keeper_status" ~args:status_args
       in
-      let diagnostic =
-        match U.member "diagnostic" status_json with
-        | `Assoc _ as json -> json
-        | _ -> `Null
-      in
+      let* diagnostic = keeper_diagnostic_for_name ctx ~name in
       Ok
         (`Assoc
           [
@@ -359,26 +382,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
   | "keeper_recover" ->
       let* () = validate_target_type "keeper" request in
       let* name = require_target_id request in
-      let status_args =
-        `Assoc
-          [
-            ("name", `String name);
-            ("fast", `Bool false);
-            ("include_context", `Bool false);
-            ("include_metrics_overview", `Bool true);
-            ("include_memory_bank", `Bool false);
-            ("include_history_tail", `Bool false);
-            ("include_compaction_history", `Bool false);
-          ]
-      in
-      let* before_status =
-        dispatch_keeper_json ctx ~tool_name:"masc_keeper_status" ~args:status_args
-      in
-      let before_diagnostic =
-        match U.member "diagnostic" before_status with
-        | `Assoc _ as json -> json
-        | _ -> `Null
-      in
+      let* before_diagnostic = keeper_diagnostic_for_name ctx ~name in
       let recoverable =
         match U.member "recoverable" before_diagnostic with
         | `Bool value -> value
@@ -406,14 +410,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
           dispatch_keeper_json ctx ~tool_name:"masc_keeper_up"
             ~args:(`Assoc [ ("name", `String name) ])
         in
-        let* after_status =
-          dispatch_keeper_json ctx ~tool_name:"masc_keeper_status" ~args:status_args
-        in
-        let after_diagnostic =
-          match U.member "diagnostic" after_status with
-          | `Assoc _ as json -> json
-          | _ -> `Null
-        in
+        let* after_diagnostic = keeper_diagnostic_for_name ctx ~name in
         let recovered, skipped_reason =
           keeper_recovery_outcome after_diagnostic
         in

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -232,7 +232,6 @@ let keepers_json ?keeper_names ?(include_recent_activity = true) config =
                   ("long_goal", `String meta.long_goal);
                   ("status", `String agent_status);
                   ("agent", agent_json);
-                  ("diagnostic", diagnostic);
                   ("generation", `Int meta.generation);
                   ("turn_count", `Int meta.usage.total_turns);
                   ("context_ratio",

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -283,54 +283,14 @@ let keepalive_running_of_lifecycle_event = function
   | "stopped" | "crashed" | "dead" -> Some false
   | _ -> None
 
-let patch_keeper_diagnostic ~keepalive_running (json : Yojson.Safe.t) =
-  match json with
-  | `Assoc fields ->
-      let fields =
-        upsert_assoc_field "keepalive_running" (`Bool keepalive_running) fields
-      in
-      let fields =
-        if keepalive_running then
-          let fields =
-            match List.assoc_opt "continuity_state" fields with
-            | Some (`String ("not_running" | "disabled")) ->
-                upsert_assoc_field "continuity_state" (`String "recovering") fields
-            | _ -> fields
-          in
-          match List.assoc_opt "quiet_reason" fields with
-          | Some (`String "not_running") ->
-              upsert_assoc_field "quiet_reason" `Null fields
-          | _ -> fields
-        else
-          fields
-          |> upsert_assoc_field "continuity_state" (`String "not_running")
-          |> upsert_assoc_field "quiet_reason" (`String "not_running")
-      in
-      `Assoc fields
-  | other -> other
-
 let patch_keeper_row ~keeper_name ~keepalive_running = function
   | `Assoc fields as row -> (
       match Yojson.Safe.Util.member "name" row with
       | `String name when String.equal name keeper_name ->
-          let diagnostic =
-            match Yojson.Safe.Util.member "diagnostic" row with
-            | `Assoc _ as json ->
-                patch_keeper_diagnostic ~keepalive_running json
-            | `Null ->
-                `Assoc
-                  [
-                    ("keepalive_running", `Bool keepalive_running);
-                    ( "continuity_state",
-                      `String (if keepalive_running then "recovering" else "not_running") );
-                  ]
-            | other -> other
-          in
           let row_fields : (string * Yojson.Safe.t) list = fields in
           `Assoc
             (row_fields
-            |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running)
-            |> upsert_assoc_field "diagnostic" diagnostic)
+            |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running))
       | _ -> row)
   | other -> other
 
@@ -958,9 +918,9 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
     board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset
   in
   let posts =
-    Board_dispatch.list_posts ?hearth ~sort_by ~limit:fetch_limit ()
+    Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
+      ~exclude_automation ~limit:fetch_limit ()
   in
-  let posts = filter_board_posts ~exclude_system ~exclude_automation posts in
   let karma_map = Board_dispatch.get_all_karma () in
   let get_karma author =
     Option.value ~default:0 (List.assoc_opt author karma_map)

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -61,8 +61,10 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let fetch_limit =
         board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset
       in
-      let posts = Board_dispatch.list_posts ?hearth ~sort_by ~limit:fetch_limit () in
-      let posts = filter_board_posts ~exclude_system ~exclude_automation posts in
+      let posts =
+        Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
+          ~exclude_automation ~limit:fetch_limit ()
+      in
       let karma_map = Board_dispatch.get_all_karma () in
       let get_karma author =
         Option.value ~default:0 (List.assoc_opt author karma_map)

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -97,8 +97,10 @@ let add_routes router =
          let fetch_limit =
            board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset
          in
-         let posts = Board_dispatch.list_posts ?hearth ~sort_by ~limit:fetch_limit () in
-         let posts = filter_board_posts ~exclude_system ~exclude_automation posts in
+         let posts =
+           Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
+             ~exclude_automation ~limit:fetch_limit ()
+         in
          let karma_map = Board_dispatch.get_all_karma () in
          let get_karma author =
            try List.assoc author karma_map with Not_found -> 0

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -48,17 +48,10 @@ let board_sort_label = function
   | Board_dispatch.Updated -> "updated"
   | Board_dispatch.Discussed -> "discussed"
 
-let is_system_board_author author =
-  author = "lodge-system" || author = "team-session"
-
 let filter_board_posts ~exclude_system ~exclude_automation posts =
   posts
-  |> List.filter (fun (p : Board.post) ->
-         let kind = Board.classify_post_kind p in
-         (not exclude_system
-          || (kind <> Board.System_post
-              && not (is_system_board_author (Board.Agent_id.to_string p.author))))
-         && (not exclude_automation || kind <> Board.Automation_post))
+  |> List.filter
+       (Board.post_matches_filters ~exclude_system ~exclude_automation)
 
 let max_filtered_board_window = 5200
 

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -248,17 +248,9 @@ let handle_post_list args =
   | Error msg -> (false, Printf.sprintf "❌ %s" msg)
   | Ok sort_by ->
       let all_posts = Board_dispatch.list_posts ~visibility_filter ?hearth
+        ~exclude_system
         ~exclude_automation
         ~sort_by:(dispatch_sort_of sort_by) ~limit:(limit + offset + 100) () in
-
-      (* Filter out system posts when exclude_system is true *)
-      let all_posts = if exclude_system then
-        List.filter (fun (p : Board.post) ->
-          Board.classify_post_kind p <> Board.System_post
-          && Board.Agent_id.to_string p.author <> "system"
-        ) all_posts
-      else all_posts
-      in
 
       (* Sorting is already handled by Board_dispatch *)
       let sorted_posts = all_posts in
@@ -624,12 +616,30 @@ let handle_migrate _args =
   | Board_dispatch.Jsonl _ ->
       (false, "❌ Migration requires PostgreSQL backend. Set MASC_POSTGRES_URL and restart.")
 
+let handle_reclassify args =
+  let dry_run = get_bool args "dry_run" true in
+  let limit = get_int args "limit" 5200 |> max 0 |> min 5200 in
+  let report = Board_dispatch.reclassify_posts ~limit ~dry_run () in
+  (true, Yojson.Safe.pretty_to_string (Board.reclassify_report_to_yojson report))
+
 let tool_migrate : Types.tool_schema = {
   name = "masc_board_migrate";
   description = "Migrate Board data from JSONL files to PostgreSQL (idempotent, safe to re-run)";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc []);
+  ];
+}
+
+let tool_reclassify : Types.tool_schema = {
+  name = "masc_board_reclassify";
+  description = "Recompute canonical board post kinds from explicit author/provenance contracts. Hidden admin tool for safe dry-run backfills.";
+  input_schema = `Assoc [
+    ("type", `String "object");
+    ("properties", `Assoc [
+      ("dry_run", `Assoc [("type", `String "boolean"); ("description", `String "Preview changes without writing (default: true)")]);
+      ("limit", `Assoc [("type", `String "integer"); ("description", `String "Max active posts to scan (default: 5200, max: 5200)")]);
+    ]);
   ];
 }
 
@@ -646,6 +656,7 @@ let tools = [
   tool_profile;
   tool_hearth_list;
   tool_migrate;
+  tool_reclassify;
 ]
 
 (** Tool dispatcher *)
@@ -662,4 +673,5 @@ let handle_tool name args =
   | "masc_board_profile" -> handle_profile args
   | "masc_board_hearths" -> handle_hearth_list args
   | "masc_board_migrate" -> handle_migrate args
+  | "masc_board_reclassify" -> handle_reclassify args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)

--- a/lib/tool_council_feed.ml
+++ b/lib/tool_council_feed.ml
@@ -44,7 +44,7 @@ let handle_governance_feed ctx args =
   if filter = "human_only" || filter = "all" then begin
     let posts = Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit () in
     let human = List.filter (fun (p : Board.post) ->
-      p.post_kind = Board.Human_post) posts in
+      Board.classify_post_kind p = Board.Human_post) posts in
     List.iter (fun p ->
       items := `Assoc [
         ("kind", `String "human_post");

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -438,7 +438,8 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   | "masc_board_list" | "masc_board_get"
   | "masc_board_stats"
   | "masc_board_search" | "masc_board_profile"
-  | "masc_board_hearths" | "masc_board_migrate" ->
+  | "masc_board_hearths" | "masc_board_migrate"
+  | "masc_board_reclassify" ->
       Some (Tool_board.handle_tool name arguments)
 
   | "masc_convo_start" ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -156,7 +156,6 @@ let keeper_list_row_json ~registered ~runtime_class config name =
             ("meta", keeper_brief_meta_json meta);
             ("agent_name", `String meta.agent_name);
             ("status", `String status);
-            ("diagnostic", diagnostic);
             ("keepalive_running", `Bool keepalive_running);
             ("presence_keepalive", `Bool meta.presence_keepalive);
             ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);

--- a/lib/tool_tag_init.ml
+++ b/lib/tool_tag_init.ml
@@ -30,6 +30,7 @@ let register_all () =
     "masc_board_vote"; "masc_board_stats";
     "masc_board_search"; "masc_board_comment_vote";
     "masc_board_profile"; "masc_board_hearths"; "masc_board_migrate";
+    "masc_board_reclassify";
     (* conversations *)
     "masc_convo_start"; "masc_convo_reply"; "masc_convo_conclude";
     "masc_convo_get"; "masc_convo_list";

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -250,6 +250,11 @@ let test_permission_for_tool_board_post () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_board_reclassify () =
+  match Auth.permission_for_tool "masc_board_reclassify" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
 let test_permission_for_tool_portal_open () =
   match Auth.permission_for_tool "masc_portal_open" with
   | Some Types.CanOpenPortal -> ()
@@ -548,6 +553,7 @@ let () =
       test_case "webrtc_answer" `Quick test_permission_for_tool_webrtc_answer;
       test_case "board_list" `Quick test_permission_for_tool_board_list;
       test_case "board_post" `Quick test_permission_for_tool_board_post;
+      test_case "board_reclassify" `Quick test_permission_for_tool_board_reclassify;
       test_case "portal_open" `Quick test_permission_for_tool_portal_open;
       test_case "portal_send" `Quick test_permission_for_tool_portal_send;
       test_case "worktree_create" `Quick test_permission_for_tool_worktree_create;

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -3,10 +3,14 @@
 open Masc_mcp
 
 let () = Mirage_crypto_rng_unix.use_default ()
+let () = Random.self_init ()
 
 (** Temp directory for test isolation — set before any Board.global call *)
-let test_base_path =
-  let dir = Filename.concat (Filename.get_temp_dir_name ()) "masc-test-board-dispatch" in
+let fresh_test_base_path () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-dispatch-%06x" (Random.bits ()))
+  in
   Unix.putenv "MASC_BASE_PATH" dir;
   dir
 
@@ -14,7 +18,7 @@ let test_base_path =
 let with_eio f () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Unix.putenv "MASC_BASE_PATH" test_base_path;
+  ignore (fresh_test_base_path ());
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
   Board_dispatch.init_jsonl ();
@@ -95,6 +99,70 @@ let test_list_posts_with_sort () =
   let counts = List.map List.length [posts_hot; posts_recent; posts_trending; posts_updated; posts_discussed] in
   let all_same = List.for_all (fun c -> c = List.hd counts) counts in
   Alcotest.(check bool) "all sort orders return same count" true all_same
+
+let test_list_posts_with_filters () =
+  let keeper_meta = `Assoc [ ("source", `String "keeper_board_post") ] in
+  let scoped_authors = [ "filter-human"; "filter-harness-bot"; "filter-keeper" ] in
+  let is_scoped_author (p : Board.post) =
+    List.mem (Board.Agent_id.to_string p.author) scoped_authors
+  in
+  ignore (Board_dispatch.create_post ~author:"filter-human" ~content:"human-filter-test" ());
+  ignore (Board_dispatch.create_post ~author:"filter-harness-bot"
+            ~content:"automation" ~visibility:Board.Internal ~ttl_hours:1
+            ~hearth:"dashboard-harness" ());
+  ignore (Board_dispatch.create_post ~author:"filter-keeper" ~content:"keeper"
+            ~post_kind:Board.Automation_post ~meta_json:keeper_meta ());
+  let all_posts =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:50 ()
+    |> List.filter is_scoped_author
+  in
+  let no_system =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~exclude_system:true
+      ~limit:50 ()
+    |> List.filter is_scoped_author
+  in
+  let no_automation =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent
+      ~exclude_automation:true ~limit:50 ()
+    |> List.filter is_scoped_author
+  in
+  let human_only =
+    Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~exclude_system:true
+      ~exclude_automation:true ~limit:50 ()
+    |> List.filter is_scoped_author
+  in
+  Alcotest.(check int) "all posts" 3 (List.length all_posts);
+  Alcotest.(check int) "exclude system" 2 (List.length no_system);
+  Alcotest.(check int) "exclude automation" 2 (List.length no_automation);
+  Alcotest.(check int) "exclude both" 1 (List.length human_only);
+  Alcotest.(check string) "human remains" "filter-human"
+    (human_only |> List.hd |> fun (p : Board.post) -> Board.Agent_id.to_string p.author)
+
+let test_reclassify_posts_dry_run_and_apply () =
+  let keeper_meta = `Assoc [ ("source", `String "keeper_board_post") ] in
+  match
+    Board_dispatch.create_post ~author:"dm-keeper" ~content:"keeper"
+      ~post_kind:Board.Automation_post ~meta_json:keeper_meta ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let post_id = Board.Post_id.to_string post.id in
+      let dry_run = Board_dispatch.reclassify_posts ~dry_run:true () in
+      Alcotest.(check int) "dry run changed" 1 dry_run.changed;
+      (match Board_dispatch.get_post ~post_id with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok fetched ->
+           Alcotest.(check string) "still automation before apply" "automation"
+             (Board.post_kind_to_string fetched.post_kind));
+      let applied = Board_dispatch.reclassify_posts ~dry_run:false () in
+      Alcotest.(check int) "apply changed" 1 applied.changed;
+      Board_dispatch.reset_for_test ();
+      Board_dispatch.init_jsonl ();
+      match Board_dispatch.get_post ~post_id with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok fetched ->
+          Alcotest.(check string) "persisted as system" "system"
+            (Board.post_kind_to_string fetched.post_kind)
 
 (** {1 Comment Operations} *)
 
@@ -234,6 +302,9 @@ let () =
       Alcotest.test_case "structured roundtrip" `Quick (with_eio test_structured_post_roundtrip);
       Alcotest.test_case "list" `Quick (with_eio test_list_posts);
       Alcotest.test_case "sort orders" `Quick (with_eio test_list_posts_with_sort);
+      Alcotest.test_case "filters" `Quick (with_eio test_list_posts_with_filters);
+      Alcotest.test_case "reclassify dry-run and apply" `Quick
+        (with_eio test_reclassify_posts_dry_run_and_apply);
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick (with_eio test_add_and_get_comments);

--- a/test/test_board_pg.ml
+++ b/test/test_board_pg.ml
@@ -89,6 +89,31 @@ let test_list_posts_sort_orders = with_pg_backend (fun t ->
   ()
 )
 
+let test_reclassify_posts = with_pg_backend (fun t ->
+  let meta = `Assoc [ ("source", `String "keeper_board_post") ] in
+  match
+    Board_pg.create_post t ~author:"pg-test-keeper" ~content:"keeper"
+      ~post_kind:Board.Automation_post ~meta_json:meta ()
+  with
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+  | Ok post ->
+      let pid = Board.Post_id.to_string post.id in
+      let dry_run = Board_pg.reclassify_posts t ~dry_run:true () in
+      Alcotest.(check int) "dry run changed" 1 dry_run.changed;
+      (match Board_pg.get_post t ~post_id:pid with
+       | Error e -> Alcotest.fail (Board.show_board_error e)
+       | Ok fetched ->
+           Alcotest.(check string) "still automation before apply" "automation"
+             (Board.post_kind_to_string fetched.post_kind));
+      let applied = Board_pg.reclassify_posts t ~dry_run:false () in
+      Alcotest.(check int) "apply changed" 1 applied.changed;
+      match Board_pg.get_post t ~post_id:pid with
+      | Error e -> Alcotest.fail (Board.show_board_error e)
+      | Ok fetched ->
+          Alcotest.(check string) "persisted as system" "system"
+            (Board.post_kind_to_string fetched.post_kind)
+)
+
 (** {1 Comment Operations} *)
 
 let test_add_and_get_comments = with_pg_backend (fun t ->
@@ -263,6 +288,7 @@ let () =
       Alcotest.test_case "create and get" `Quick test_create_and_get_post;
       Alcotest.test_case "list" `Quick test_list_posts;
       Alcotest.test_case "sort orders" `Quick test_list_posts_sort_orders;
+      Alcotest.test_case "reclassify posts" `Quick test_reclassify_posts;
     ];
     "comments", [
       Alcotest.test_case "add and get" `Quick test_add_and_get_comments;

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -82,13 +82,29 @@ let () =
 
   let test_post_kind_system_author () =
     let store = create_store () in
-    match create_post store ~author:"lodge-system" ~content:"System post" () with
+    match create_post store ~author:"operator" ~content:"System post" () with
     | Ok post ->
         let json = post_to_yojson post in
         let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
         assert (String.equal kind "system");
         Printf.printf "✓ System author classifies post as system\n"
     | Error e -> fail_board_test "Failed to create system post" e
+  in
+
+  let test_post_kind_keeper_provenance_upgrade () =
+    let store = create_store () in
+    let meta = `Assoc [ ("source", `String "keeper_board_post") ] in
+    match
+      create_post store ~author:"dm-keeper" ~content:"Keeper board post"
+        ~post_kind:Automation_post ~meta_json:meta ()
+    with
+    | Ok post ->
+        assert (classify_post_kind post = System_post);
+        let json = post_to_yojson post in
+        let kind = Yojson.Safe.Util.(json |> member "post_kind" |> to_string) in
+        assert (String.equal kind "system");
+        Printf.printf "✓ Keeper provenance upgrades automation post to system\n"
+    | Error e -> fail_board_test "Failed to create keeper provenance post" e
   in
 
   (* Run Eio tests *)
@@ -98,5 +114,6 @@ let () =
   test_post_kind_human_default ();
   test_post_kind_automation_contract ();
   test_post_kind_system_author ();
+  test_post_kind_keeper_provenance_upgrade ();
 
   Printf.printf "\n✅ All Board TTL tests passed!\n\n"

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -79,6 +79,7 @@ let all_known_tool_names =
     "masc_board_migrate";
     "masc_board_post";
     "masc_board_profile";
+    "masc_board_reclassify";
     "masc_board_search";
     "masc_board_stats";
     "masc_board_vote";

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -156,18 +156,13 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       in
       Alcotest.(check bool) "persistent status ok" true ok;
       let status_json = parse_json_exn body in
-      let diagnostic = status_json |> Yojson.Safe.Util.member "diagnostic" in
-      Alcotest.(check string) "health_state" "offline"
-        Yojson.Safe.Util.(diagnostic |> member "health_state" |> to_string);
-      Alcotest.(check string) "next action recover" "recover"
-        Yojson.Safe.Util.(diagnostic |> member "next_action_path" |> to_string);
-      Alcotest.(check bool) "recoverable true" true
-        Yojson.Safe.Util.(diagnostic |> member "recoverable" |> to_bool);
+      Alcotest.(check bool) "diagnostic removed from status" true
+        Yojson.Safe.Util.(status_json |> member "diagnostic" = `Null);
       Alcotest.(check string) "auto team session removed" "removed"
         Yojson.Safe.Util.(
           status_json |> member "auto_team_session" |> member "status" |> to_string);
-      Alcotest.(check bool) "summary present" true
-        (String.length Yojson.Safe.Util.(diagnostic |> member "summary" |> to_string) > 0))
+      Alcotest.(check bool) "keepalive running false" false
+        Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool))
 
 let test_keeper_config_exposes_live_runtime_and_sources () =
   Eio_main.run @@ fun env ->
@@ -369,12 +364,8 @@ let test_snapshot_keeper_tool_audit_fallback () =
         ((keeper |> member "allowed_tool_names" |> to_list) <> []);
       Alcotest.(check bool) "tool audit source omitted without evidence" true
         (keeper |> member "tool_audit_source" = `Null);
-      Alcotest.(check bool) "diagnostic present" true
-        (keeper |> member "diagnostic" <> `Null);
-      Alcotest.(check string) "diagnostic health offline" "offline"
-        (keeper |> member "diagnostic" |> member "health_state" |> to_string);
-      Alcotest.(check string) "diagnostic continuity disabled" "disabled"
-        (keeper |> member "diagnostic" |> member "continuity_state" |> to_string);
+      Alcotest.(check bool) "diagnostic removed from snapshot" true
+        (keeper |> member "diagnostic" = `Null);
       let ok, _ =
         dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
           ~args:(`Assoc [ ("name", `String keeper_name) ])

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -318,6 +318,64 @@ let test_post_list_invalid_sort_rejected () =
   Alcotest.(check bool) "error mentions valid sorts" true
     (contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
 
+let test_post_list_filter_combinations () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  ignore (dispatch "masc_board_post"
+    (make_args [("content", `String "human"); ("author", `String "human-author")]));
+  ignore (dispatch "masc_board_post"
+    (make_args
+      [ ("content", `String "automation");
+        ("author", `String "dashboard-harness-bot");
+        ("visibility", `String "internal");
+        ("ttl_hours", `Int 1);
+        ("hearth", `String "dashboard-harness") ]));
+  ignore (dispatch "masc_board_post"
+    (make_args
+      [ ("content", `String "keeper");
+        ("author", `String "dm-keeper");
+        ("post_kind", `String "automation");
+        ("meta", `Assoc [ ("source", `String "keeper_board_post") ]) ]));
+  let ok1, body1 = dispatch "masc_board_list"
+    (make_args [("exclude_system", `Bool true)]) in
+  let ok2, body2 = dispatch "masc_board_list"
+    (make_args [("exclude_automation", `Bool true)]) in
+  let ok3, body3 = dispatch "masc_board_list"
+    (make_args [("exclude_system", `Bool true); ("exclude_automation", `Bool true)]) in
+  Alcotest.(check bool) "exclude_system ok" true ok1;
+  Alcotest.(check bool) "exclude_automation ok" true ok2;
+  Alcotest.(check bool) "exclude both ok" true ok3;
+  Alcotest.(check bool) "exclude_system hides keeper" false
+    (contains_substring body1 "dm-keeper");
+  Alcotest.(check bool) "exclude_automation hides harness" false
+    (contains_substring body2 "dashboard-harness-bot");
+  Alcotest.(check bool) "exclude both keeps human" true
+    (contains_substring body3 "human-author");
+  Alcotest.(check bool) "exclude both hides keeper" false
+    (contains_substring body3 "dm-keeper");
+  Alcotest.(check bool) "exclude both hides harness" false
+    (contains_substring body3 "dashboard-harness-bot")
+
+let test_dispatch_reclassify_dry_run () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  ignore (dispatch "masc_board_post"
+    (make_args
+      [ ("content", `String "keeper");
+        ("author", `String "dm-keeper");
+        ("post_kind", `String "automation");
+        ("meta", `Assoc [ ("source", `String "keeper_board_post") ]) ]));
+  let ok, body = dispatch "masc_board_reclassify"
+    (make_args [("dry_run", `Bool true)]) in
+  Alcotest.(check bool) "reclassify ok" true ok;
+  let json = Yojson.Safe.from_string body in
+  Alcotest.(check bool) "dry_run true" true
+    Yojson.Safe.Util.(json |> member "dry_run" |> to_bool);
+  Alcotest.(check int) "changed one" 1
+    Yojson.Safe.Util.(json |> member "changed" |> to_int)
+
 let test_post_get_success () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -469,7 +527,7 @@ let test_tools_count () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  Alcotest.(check int) "11 tool schemas" 11 (List.length Tool_board.tools)
+  Alcotest.(check int) "12 tool schemas" 12 (List.length Tool_board.tools)
 
 let test_tools_names_unique () =
   Eio_main.run @@ fun env ->
@@ -524,6 +582,8 @@ let () =
           Alcotest.test_case "list sort orders" `Quick test_post_list_sort_orders;
           Alcotest.test_case "list invalid sort rejected" `Quick
             test_post_list_invalid_sort_rejected;
+          Alcotest.test_case "list filter combinations" `Quick
+            test_post_list_filter_combinations;
           Alcotest.test_case "get success" `Quick test_post_get_success;
           Alcotest.test_case "get not found" `Quick test_post_get_not_found;
         ] );
@@ -549,6 +609,7 @@ let () =
         [
           Alcotest.test_case "unknown tool" `Quick test_dispatch_unknown_tool;
           Alcotest.test_case "migrate without pg" `Quick test_dispatch_migrate_without_pg;
+          Alcotest.test_case "reclassify dry run" `Quick test_dispatch_reclassify_dry_run;
         ] );
       ( "schemas",
         [

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -916,12 +916,10 @@ let test_keepalive_gap_reports_not_running_instead_of_disabled () =
       in
       check bool "status ok" true ok;
       let json = parse_json_exn body in
-      check string "quiet reason not_running" "not_running"
-        Yojson.Safe.Util.(
-          json |> member "diagnostic" |> member "quiet_reason" |> to_string);
-      check string "continuity state not_running" "not_running"
-        Yojson.Safe.Util.(
-          json |> member "diagnostic" |> member "continuity_state" |> to_string);
+      check bool "diagnostic removed from status" true
+        Yojson.Safe.Util.(json |> member "diagnostic" = `Null);
+      check bool "keepalive stopped" false
+        Yojson.Safe.Util.(json |> member "keepalive_running" |> to_bool);
       check string "runtime registry state stopped" "stopped"
         Yojson.Safe.Util.(
           json |> member "runtime" |> member "registry_state" |> to_string);
@@ -1814,10 +1812,8 @@ let test_resident_bootstrap_marks_stale_explicit_keeper () =
       let status_json = Yojson.Safe.from_string status_body in
       check bool "keepalive running" true
         Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool);
-      check string "continuity state recovering" "recovering"
-        Yojson.Safe.Util.(
-          status_json |> member "diagnostic" |> member "continuity_state"
-          |> to_string))
+      check bool "diagnostic removed from status" true
+        Yojson.Safe.Util.(status_json |> member "diagnostic" = `Null))
 
 let test_resident_supervisor_recovers_missing_desired_keeper () =
   Eio_main.run @@ fun env ->
@@ -1871,12 +1867,8 @@ let test_resident_supervisor_recovers_missing_desired_keeper () =
       let status_json = Yojson.Safe.from_string status_body in
       check bool "keepalive running after supervisor recovery" true
         Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool);
-      check bool "continuity state reaches recovering or healthy" true
-        Yojson.Safe.Util.(
-          match status_json |> member "diagnostic" |> member "continuity_state"
-                |> to_string with
-          | "recovering" | "healthy" -> true
-          | _ -> false))
+      check bool "diagnostic removed from status" true
+        Yojson.Safe.Util.(status_json |> member "diagnostic" = `Null))
 
 let () =
   run "Tool_keeper" [


### PR DESCRIPTION
## Summary
- unify board post classification and filtering across dispatch, HTTP routes, and dashboard state
- add board reclassification support for JSONL/PG and classify keeper-origin board posts as system
- remove ambient keeper diagnostic fields from status/chat projections and require explicit status/history loading

## Verification
- dune build --root . test/test_tool_keeper.exe test/test_operator_control.exe test/test_board_dispatch.exe test/test_tool_board_coverage.exe test/test_auth_coverage.exe test/test_board_ttl.exe
- ./_build/default/test/test_tool_keeper.exe test read_file_tail_lines 14,18,32
- ./_build/default/test/test_operator_control.exe test operator 25,27
- ./_build/default/test/test_board_dispatch.exe
- ./_build/default/test/test_tool_board_coverage.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_board_ttl.exe
- git diff --check

## Notes
- full test_tool_keeper and test_operator_control suites still have pre-existing unrelated failures in this checkout
- dashboard npm typecheck/test could not run here because tsc/vitest are not installed in the worktree