### PR TITLE
Prefer ~/.masc/config over worktree config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl http://127.0.0.1:8935/health
 
 - HTTP / MCP port: `8935`
 - 기본 bind host: `127.0.0.1`
-- repo-managed config root: `MASC_CONFIG_DIR` 우선, 없으면 실행 파일 기준 `config/` 자동 탐색
+- repo-managed config root: `MASC_CONFIG_DIR` 우선, 없으면 `~/.masc/config` 우선, 그 다음 repo `config/` 자동 탐색
 
 `0.0.0.0` 같은 non-loopback 주소에 바인드할 때는 auth 설정을 먼저 맞춘 뒤 원격 노출 경로로 취급하세요. 자세한 내용은 `docs/REMOTE-MCP-OPERATOR.md`, `docs/spec/09-server-transport.md`를 봅니다.
 

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -39,4 +39,24 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('/tmp/custom-personas')
     expect(container.textContent).toContain('INVALID ENV')
   })
+
+  it('renders home config source label', () => {
+    render(
+      html`<${ConfigResolutionPanel}
+        resolution=${{
+          status: 'ready',
+          warnings: [],
+          config_root: { path: '/home/test/.masc/config', exists: true, source: 'home_masc' },
+          cascade: { path: '/home/test/.masc/config/cascade.json', exists: true, source: 'home_masc' },
+          prompts: { path: '/home/test/.masc/config/prompts', exists: true, source: 'home_masc' },
+          keepers: { path: '/home/test/.masc/config/keepers', exists: true, source: 'home_masc' },
+          personas: { path: '/home/test/.masc/config/personas', exists: true, source: 'home_masc' },
+        }}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('HOME')
+    expect(container.textContent).toContain('/home/test/.masc/config')
+  })
 })

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -22,6 +22,8 @@ function sourceLabel(source: string): string {
   switch (source) {
     case 'env':
       return 'ENV'
+    case 'home_masc':
+      return 'HOME'
     case 'invalid_env':
       return 'INVALID ENV'
     case 'exe_relative':

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -616,7 +616,7 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는 `docs/
 
 Resident-keeper (`.masc/resident-keepers/<name>.json`)는 등록 메타데이터(persona_name, desired, timestamps)만 저장한다.
 
-repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 실행 파일 기준 `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다.
+repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `~/.masc/config`를 먼저 본 뒤 repo `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다.
 
 ### 8.2 Template 변경 반영
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -109,7 +109,7 @@ masc_keeper_up(name: "sangsu")
 전제조건:
 - `config/personas/<name>/profile.json`이 존재해야 한다 (또는 `config/keepers/<name>.toml`)
 - 서버가 **repo root**에서 실행되어야 `.masc/` 디렉토리에 접근 가능. worktree에서 실행하면 keeper 상태를 찾지 못한다. 필요 시 `--base-path`를 repo root로 지정.
-- repo-managed config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 실행 파일 기준 `config/` 자동 탐색을 사용한다.
+- repo-managed config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 `~/.masc/config`를 먼저 보고, 없을 때만 repo `config/` 자동 탐색을 사용한다.
 - `MASC_PERSONAS_DIR` 환경변수로 커스텀 persona 경로 지정 가능.
 
 상세: `docs/KEEPER-USER-MANUAL.md`

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -52,7 +52,7 @@
 | `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |
 
 작업공간 루트 해석 체인: `MASC_WORKSPACE_ROOT` -> `ME_ROOT` -> `DUNE_SOURCEROOT`. 세 곳 모두 미설정 시 `failwith`.
-repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> executable-relative `config/` -> `cwd/config` -> legacy `ME_ROOT/workspace/yousleepwhen/masc-mcp/config`.
+repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `~/.masc/config` -> `cwd/config` -> executable-relative `config/` -> legacy `ME_ROOT/workspace/yousleepwhen/masc-mcp/config`.
 
 ### 3.2 Runtime (Env_config_runtime)
 

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -1,5 +1,6 @@
 type source =
   | Env
+  | Home_masc
   | Invalid_env
   | Exe_relative
   | Cwd
@@ -33,6 +34,7 @@ type inputs = {
   executable_name : string;
   env_config_dir : string option;
   env_personas_dir : string option;
+  env_home : string option;
   env_me_root : string option;
   env_workspace_root : string option;
   env_dune_sourceroot : string option;
@@ -58,6 +60,7 @@ let existing_file path =
 
 let source_to_string = function
   | Env -> "env"
+  | Home_masc -> "home_masc"
   | Invalid_env -> "invalid_env"
   | Exe_relative -> "exe_relative"
   | Cwd -> "cwd"
@@ -118,6 +121,13 @@ let path_from_cwd cwd =
   let candidate = Filename.concat cwd "config" |> absolute_path_from ~cwd in
   if config_signature_exists candidate then Some candidate else None
 
+let path_from_home_masc (inputs : inputs) =
+  match trim_opt inputs.env_home with
+  | None -> None
+  | Some home ->
+      let candidate = Filename.concat home ".masc/config" in
+      if config_signature_exists candidate then Some candidate else None
+
 let legacy_me_root_candidates (inputs : inputs) =
   [ inputs.env_me_root; inputs.env_workspace_root; inputs.env_dune_sourceroot ]
   |> List.filter_map trim_opt
@@ -130,8 +140,10 @@ let path_from_legacy_me_root inputs =
   legacy_me_root_candidates inputs
   |> List.find_opt config_signature_exists
 
-let default_missing_root cwd =
-  Filename.concat cwd "config" |> absolute_path_from ~cwd
+let default_missing_root (inputs : inputs) =
+  match trim_opt inputs.env_home with
+  | Some home -> Filename.concat home ".masc/config"
+  | None -> Filename.concat inputs.cwd "config" |> absolute_path_from ~cwd:inputs.cwd
 
 let config_root_resolution (inputs : inputs) =
   match trim_opt inputs.env_config_dir with
@@ -146,6 +158,9 @@ let config_root_resolution (inputs : inputs) =
               "MASC_CONFIG_DIR is set but does not point to a directory: %s"
               path ] )
   | None -> (
+      match path_from_home_masc inputs with
+      | Some path -> ({ path; exists = true; source = Home_masc }, [])
+      | None -> (
       match path_from_cwd inputs.cwd with
       | Some path -> ({ path; exists = true; source = Cwd }, [])
       | None -> (
@@ -159,11 +174,11 @@ let config_root_resolution (inputs : inputs) =
                         "Using legacy config fallback from ME_ROOT-style path: %s"
                         path ] )
               | None ->
-                  let path = default_missing_root inputs.cwd in
+                  let path = default_missing_root inputs in
                   ( { path; exists = false; source = Missing },
                     [ Printf.sprintf
                         "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                        path ] ) ) ) )
+                        path ] ) ) ) ))
 
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in
@@ -193,6 +208,7 @@ let inputs_from_env () =
     executable_name = Sys.executable_name;
     env_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR";
     env_personas_dir = Sys.getenv_opt "MASC_PERSONAS_DIR";
+    env_home = Sys.getenv_opt "HOME";
     env_me_root = Sys.getenv_opt "ME_ROOT";
     env_workspace_root = Sys.getenv_opt "MASC_WORKSPACE_ROOT";
     env_dune_sourceroot = Sys.getenv_opt "DUNE_SOURCEROOT";
@@ -217,7 +233,7 @@ let resolve_with inputs =
     match config_root.source with
     | Invalid_env -> Invalid_env_status
     | Missing -> Missing_status
-    | Env | Exe_relative | Cwd | Legacy_me_root ->
+    | Env | Home_masc | Exe_relative | Cwd | Legacy_me_root ->
         if warnings = [] then Ready else Warn
   in
   { status; warnings; config_root; cascade; prompts; keepers; personas }

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -440,7 +440,14 @@ resolve_base_path() {
 RESOLVED_BASE_PATH="$(resolve_base_path "$BASE_PATH")"
 export MASC_BASE_PATH="$RESOLVED_BASE_PATH"
 if [ -z "${MASC_CONFIG_DIR:-}" ]; then
-    export MASC_CONFIG_DIR="$SCRIPT_DIR/config"
+    home_config_root="${HOME:-}/.masc/config"
+    if [ -n "${HOME:-}" ] && [ -d "$home_config_root" ] && {
+        [ -f "$home_config_root/cascade.json" ] || [ -d "$home_config_root/prompts" ] || [ -d "$home_config_root/keepers" ] || [ -d "$home_config_root/personas" ];
+    }; then
+        export MASC_CONFIG_DIR="$home_config_root"
+    else
+        export MASC_CONFIG_DIR="$SCRIPT_DIR/config"
+    fi
 fi
 
 # Wait for port to become available.

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -38,13 +38,14 @@ let make_config_root root =
   config
 
 let make_inputs ?env_config_dir ?env_personas_dir ?env_me_root ?env_workspace_root
-    ?env_dune_sourceroot ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
+    ?env_dune_sourceroot ?env_home ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
   Lib.Config_dir_resolver.
     {
       cwd;
       executable_name;
       env_config_dir;
       env_personas_dir;
+      env_home;
       env_me_root;
       env_workspace_root;
       env_dune_sourceroot;
@@ -91,6 +92,22 @@ let test_cwd_fallback () =
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check bool "keepers exists" true resolution.keepers.exists
 
+let test_home_masc_fallback () =
+  with_temp_dir "config-dir-home" @@ fun home ->
+  let home_root = Filename.concat home ".masc" in
+  let config = make_config_root home_root in
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~env_home:home ~cwd:"/tmp/missing-cwd"
+         ~executable_name:"/tmp/nonexistent-masc" ())
+  in
+  check string "status" "ready"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "root source" "home_masc"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check string "root path" config resolution.config_root.path;
+  check bool "prompts exists" true resolution.prompts.exists
+
 let test_legacy_me_root_fallback () =
   with_temp_dir "config-dir-legacy" @@ fun me_root ->
   let repo_root =
@@ -118,6 +135,7 @@ let () =
           test_case "env override invalid does not fallback" `Quick
             test_env_override_invalid_no_fallback;
           test_case "cwd fallback" `Quick test_cwd_fallback;
+          test_case "home masc fallback" `Quick test_home_masc_fallback;
           test_case "legacy me_root fallback" `Quick
             test_legacy_me_root_fallback;
         ] );

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -149,12 +149,16 @@ let test_realtime_transports_default_enabled_and_preserve_override () =
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
       make_fake_eio_exe dir;
+      let home_dir = Filename.concat dir "home" in
+      mkdir_p (Filename.concat home_dir ".masc/config/prompts");
+      write_file (Filename.concat home_dir ".masc/config/cascade.json") "{}";
       let capture_default = Filename.concat dir "captured-default.txt" in
       let code_default, stdout_default, stderr_default =
         run_shell ~cwd:dir
           ~env:
             [
               ("FAKE_CAPTURE_FILE", capture_default);
+              ("HOME", home_dir);
               ("MASC_BASE_PATH", dir);
             ]
           (Printf.sprintf "%s --http --port 9956 --base-path %s"
@@ -168,9 +172,9 @@ let test_realtime_transports_default_enabled_and_preserve_override () =
         (contains_substring captured_default "MASC_WS_ENABLED=1");
       check bool "webrtc enabled by default" true
         (contains_substring captured_default "MASC_WEBRTC_ENABLED=1");
-      check bool "config dir defaults to local config" true
+      check bool "config dir defaults to home masc config when present" true
         (contains_substring captured_default
-           ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config"));
+           ("MASC_CONFIG_DIR=" ^ Filename.concat home_dir ".masc/config"));
       let capture_override = Filename.concat dir "captured-override.txt" in
       let code_override, stdout_override, stderr_override =
         run_shell ~cwd:dir
@@ -196,6 +200,31 @@ let test_realtime_transports_default_enabled_and_preserve_override () =
         (contains_substring captured_override "MASC_WS_ENABLED=0");
       check bool "webrtc override preserved" true
         (contains_substring captured_override "MASC_WEBRTC_ENABLED=0"))
+
+let test_realtime_transports_fall_back_to_repo_config_when_home_missing () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe dir;
+      let capture = Filename.concat dir "captured-fallback.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", Filename.concat dir "empty-home");
+              ("MASC_BASE_PATH", dir);
+            ]
+          (Printf.sprintf "%s --http --port 9959 --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      let captured = read_file capture in
+      check bool "falls back to repo-local config" true
+        (contains_substring captured
+           ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -240,6 +269,9 @@ let () =
           test_case "realtime transports default enabled and preserve override"
             `Quick
             test_realtime_transports_default_enabled_and_preserve_override;
+          test_case "realtime transports fall back to repo config when home missing"
+            `Quick
+            test_realtime_transports_fall_back_to_repo_config_when_home_missing;
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
         ] );


### PR DESCRIPTION
## Summary
- prefer `~/.masc/config` over worktree/repo config when `MASC_CONFIG_DIR` is unset
- keep repo `config/` as fallback when home config is missing
- surface the new `HOME` config source in the dashboard and document the new precedence

## Verification
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-home-config-default test/test_config_dir_resolver.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-home-config-default test/test_start_masc_mcp_script.exe

## Notes
- dashboard vitest was not run in this environment because `vitest` is not installed in the worktree (`npm test` -> `sh: vitest: command not found`).