### PR TITLE
Improve config path diagnostics and keeper voice runtime

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -446,6 +446,7 @@ export interface ToolMetricsResponse {
 export interface DashboardToolsResponse {
   generated_at?: string
   config_resolution?: DashboardConfigResolution
+  runtime_resolution?: DashboardRuntimeResolution
   tool_inventory: DashboardToolInventoryResponse
   tool_usage: ToolMetricsResponse
 }
@@ -464,6 +465,35 @@ export interface DashboardConfigResolution {
   prompts: DashboardConfigResolutionItem
   keepers: DashboardConfigResolutionItem
   personas: DashboardConfigResolutionItem
+}
+
+export interface DashboardRuntimeDiagnostic {
+  ts: string
+  kind: string
+  signal?: string
+  message: string
+}
+
+export interface DashboardBuildIdentity {
+  release_version: string
+  commit: string | null
+  started_at: string
+  uptime_seconds: number
+}
+
+export interface DashboardRuntimeResolution {
+  status: 'ready' | 'warn' | string
+  warnings: string[]
+  base_path_input: DashboardConfigResolutionItem
+  workspace_path: DashboardConfigResolutionItem
+  resolved_base_path: DashboardConfigResolutionItem
+  data_root: DashboardConfigResolutionItem
+  prompt_markdown_dir: DashboardConfigResolutionItem
+  workspace_git_commit: string | null
+  resolved_base_git_commit: string | null
+  source_mismatch: boolean
+  diagnostics: DashboardRuntimeDiagnostic[]
+  build: DashboardBuildIdentity
 }
 
 export function fetchToolMetrics(): Promise<ToolMetricsResponse> {

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1,0 +1,151 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetchKeeperConfig: vi.fn(async () => ({
+    name: 'keeper-sangsu',
+    prompt: {
+      goal: 'Ship stable keeper ops',
+      short_goal: 'Diagnose agent liveness',
+      mid_goal: 'Reduce restart confusion',
+      long_goal: 'Keep command plane stable',
+      soul_profile: 'delivery',
+      will: 'Stay on call',
+      needs: 'Accurate runtime state',
+      desires: 'Clear operator feedback',
+      instructions: 'Prefer direct remediation',
+      system_prompt_blocks: {
+        constitution: { key: 'keeper.constitution', source: 'file', text: 'constitution text' },
+        world: { key: 'keeper.world', source: 'override', text: 'world text' },
+        capabilities: { key: 'keeper.capabilities', source: 'file', text: 'capabilities text' },
+      },
+      effective_system_prompt: 'full prompt',
+    },
+    execution: {
+      models: ['gpt-5.4'],
+      active_model: 'gpt-5.4',
+      verify: true,
+    },
+    compaction: {
+      profile: 'balanced',
+      ratio_gate: 0.85,
+      message_gate: 16,
+      token_gate: 24000,
+      cooldown_sec: 120,
+    },
+    proactive: {
+      enabled: true,
+      idle_sec: 900,
+      cooldown_sec: 1800,
+    },
+    drift: {
+      status: 'wired',
+      enabled: true,
+      min_turn_gap: 4,
+      count_total: 2,
+      last_reason: 'board quiet',
+    },
+    auto_team_session: {
+      status: 'source_only',
+      enabled: null,
+    },
+    handoff: {
+      auto: true,
+      threshold: 0.85,
+      cooldown_sec: 300,
+    },
+    runtime: {
+      paused: false,
+      registered: true,
+      keepalive_running: true,
+      fiber_health: 'healthy',
+      presence_keepalive: true,
+      presence_keepalive_sec: 30,
+    },
+    coordination: {
+      room_scope: 'global',
+      scope_kind: 'global',
+      mention_targets: ['sangsu'],
+      joined_room_ids: ['default'],
+    },
+    sources: {
+      live_meta_path: '/tmp/.masc/keepers/keeper-sangsu/live.json',
+      resident_spec_path: '/tmp/.masc/keepers/keeper-sangsu.toml',
+      resident_spec_exists: true,
+      default_manifest_path: '/tmp/config/keepers/default.toml',
+      default_source_kind: 'toml' as const,
+      precedence: ['live_override', 'resident_spec', 'default_manifest'],
+      has_live_override: true,
+      override_fields: ['goal', 'instructions'],
+    },
+    metrics: {
+      generation: 3,
+      total_turns: 12,
+      total_input_tokens: 1200,
+      total_output_tokens: 800,
+      total_tokens: 2000,
+      total_cost_usd: 0.12,
+      last_model_used: 'gpt-5.4',
+      last_input_tokens: 120,
+      last_output_tokens: 80,
+      last_total_tokens: 200,
+      last_latency_ms: 2400,
+      last_total_tokens_per_sec: 22.4,
+      last_output_tokens_per_sec: 11.2,
+      compaction_count: 1,
+    },
+  })),
+  patchKeeperConfig: vi.fn(),
+}))
+
+vi.mock('../api/dashboard', () => ({
+  fetchKeeperConfig: mocks.fetchKeeperConfig,
+  patchKeeperConfig: mocks.patchKeeperConfig,
+}))
+
+import { KeeperConfigPanel, resetKeeperConfig } from './keeper-config-panel'
+
+async function flush() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('KeeperConfigPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    resetKeeperConfig()
+    mocks.fetchKeeperConfig.mockClear()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    resetKeeperConfig()
+  })
+
+  it('separates editable prompt controls from read-only runtime metadata', async () => {
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('편집 가능 범위')
+    expect(container.textContent).toContain('config/cascade.json')
+    expect(container.textContent).toContain('읽기 전용 런타임')
+    expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')
+    expect(container.textContent).toContain('활성 모델')
+
+    const editButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('편집'),
+    )
+    editButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    const textareas = Array.from(container.querySelectorAll('textarea'))
+    expect(textareas.length).toBeGreaterThan(0)
+    expect(textareas[0]?.value).toContain('Ship stable keeper ops')
+  })
+})

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -107,6 +107,27 @@ function SectionHeader({ title }: { title: string }) {
   `
 }
 
+function Callout({
+  title,
+  body,
+  tone = 'neutral',
+}: {
+  title: string
+  body: string
+  tone?: 'neutral' | 'warn'
+}) {
+  const toneClass =
+    tone === 'warn'
+      ? 'border-amber-400/20 bg-amber-500/10 text-amber-100'
+      : 'border-card-border/60 bg-card/35 text-text-body'
+  return html`
+    <div class="rounded-xl border px-3 py-3 shadow-sm ${toneClass}">
+      <div class="text-[11px] font-bold uppercase tracking-widest text-text-muted mb-1">${title}</div>
+      <div class="text-[12px] leading-relaxed">${body}</div>
+    </div>
+  `
+}
+
 function BoolBadge({ value }: { value: boolean }) {
   return value
     ? html`<span class="text-[11px] font-bold px-2 py-0.5 rounded-md bg-ok/10 text-ok border border-ok/20 shadow-sm shadow-ok/5">ON</span>`
@@ -366,113 +387,22 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
   return html`
     <div class="flex flex-col gap-1.5">
-
       ${toolbar}
 
-      ${'' /* --- Execution (read-only) --- */}
-      ${'' /* Active model is shown in the header badge — not duplicated here */}
-      <${SectionHeader} title="실행" />
-      <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">검증</span>
-        <${BoolBadge} value=${c.execution.verify} />
-      </div>
-      <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
-        <${ModelList} models=${c.execution.models} />
+      <${Callout}
+        title="편집 가능 범위"
+        body="여기서 저장되는 값은 keeper 프롬프트와 live override 계층입니다. 활성 모델은 keeper별 설정이 아니라 config/cascade.json 해석 결과로 결정됩니다."
+      />
+
+      ${promptSection}
+
+      <div class="mt-2">
+        <${Callout}
+          title="읽기 전용 런타임"
+          body="아래 값은 현재 서버가 해석한 실행 상태와 소스 경로입니다. 참고용이며, 이 패널에서 직접 변경되지는 않습니다."
+        />
       </div>
 
-      ${'' /* --- Compaction (read-only) --- */}
-      <${SectionHeader} title="컴팩션" />
-      <${ConfigRow} label="프로필" value=${c.compaction.profile || '--'} />
-      <${ConfigRow} label="비율 게이트" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
-      <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
-      <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
-
-      ${'' /* --- Proactive (read-only) --- */}
-      <${SectionHeader} title="프로액티브" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">활성</span>
-        <${BoolBadge} value=${c.proactive.enabled} />
-      </div>
-      <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
-      <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
-
-      ${'' /* --- Runtime (read-only) --- */}
-      <${SectionHeader} title="런타임" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">일시정지</span>
-        <${BoolBadge} value=${c.runtime.paused} />
-      </div>
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">자동 부팅 등록</span>
-        <${BoolBadge} value=${c.runtime.registered} />
-      </div>
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
-        <${BoolBadge} value=${c.runtime.keepalive_running} />
-      </div>
-      <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>
-        <${BoolBadge} value=${c.runtime.presence_keepalive} />
-      </div>
-      <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
-
-      ${'' /* --- Coordination (read-only) --- */}
-      <${SectionHeader} title="조율" />
-      <${ConfigRow} label="룸 범위" value=${c.coordination.room_scope || '--'} />
-      <${ConfigRow} label="범위 유형" value=${c.coordination.scope_kind || '--'} />
-      <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
-        <${ModelList} models=${c.coordination.mention_targets} />
-      </div>
-      <div class="mt-1.5">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 룸</div>
-        <${ModelList} models=${c.coordination.joined_room_ids} />
-      </div>
-
-      ${'' /* --- Drift (read-only) --- */}
-      <${SectionHeader} title="드리프트" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">상태</span>
-        <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
-      </div>
-      <${ConfigRow} label="최소 턴 간격" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
-      <${ConfigRow} label="총 횟수" value=${formatMaybeNumber(c.drift.count_total)} />
-      ${c.drift.last_reason ? html`<${ConfigRow} label="마지막 사유" value=${c.drift.last_reason} />` : null}
-
-      ${'' /* --- Team Session (read-only) --- */}
-      <${SectionHeader} title="자동 팀 세션" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">상태</span>
-        <${FeatureBadge} status=${c.auto_team_session.status} value=${c.auto_team_session.enabled} />
-      </div>
-
-      ${'' /* --- Handoff (read-only) --- */}
-      <${SectionHeader} title="핸드오프" />
-      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
-        <span class="text-xs text-[var(--text-muted)]">자동</span>
-        <${BoolBadge} value=${c.handoff.auto} />
-      </div>
-      <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
-      <${ConfigRow} label="쿨다운" value=${c.handoff.cooldown_sec + 's'} />
-
-      ${'' /* --- Last Call Performance (read-only) --- */}
-      ${'' /* Totals (generation, turns, tokens, cost, compactions) are in KpiGrid */}
-      <${SectionHeader} title="마지막 호출 성능" />
-      <${ConfigRow} label="총 입력 토큰" value=${formatTokens(c.metrics.total_input_tokens)} />
-      <${ConfigRow} label="총 출력 토큰" value=${formatTokens(c.metrics.total_output_tokens)} />
-      <${ConfigRow} label="마지막 모델" value=${c.metrics.last_model_used || '--'} />
-      <${ConfigRow} label="마지막 입력 토큰" value=${formatTokens(c.metrics.last_input_tokens)} />
-      <${ConfigRow} label="마지막 출력 토큰" value=${formatTokens(c.metrics.last_output_tokens)} />
-      <${ConfigRow} label="마지막 총 토큰" value=${formatTokens(c.metrics.last_total_tokens)} />
-      <${ConfigRow} label="마지막 지연" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
-      <${ConfigRow} label="마지막 처리량" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
-      <${ConfigRow} label="마지막 출력 처리량" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
-
-      ${'' /* --- Sources (read-only) --- */}
       <${SectionHeader} title="소스" />
       <${ConfigRow} label="기본 소스" value=${c.sources.default_source_kind || '--'} />
       <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
@@ -500,8 +430,97 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${ModelList} models=${c.sources.override_fields} />
       </div>
 
-      ${'' /* --- Prompt (editable) --- */}
-      ${promptSection}
+      <${SectionHeader} title="실행" />
+      <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">검증</span>
+        <${BoolBadge} value=${c.execution.verify} />
+      </div>
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">모델</div>
+        <${ModelList} models=${c.execution.models} />
+      </div>
+
+      <${SectionHeader} title="컴팩션" />
+      <${ConfigRow} label="프로필" value=${c.compaction.profile || '--'} />
+      <${ConfigRow} label="비율 게이트" value=${(c.compaction.ratio_gate * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
+      <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
+      <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
+
+      <${SectionHeader} title="프로액티브" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">활성</span>
+        <${BoolBadge} value=${c.proactive.enabled} />
+      </div>
+      <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
+      <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
+
+      <${SectionHeader} title="런타임" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">일시정지</span>
+        <${BoolBadge} value=${c.runtime.paused} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">자동 부팅 등록</span>
+        <${BoolBadge} value=${c.runtime.registered} />
+      </div>
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">킵얼라이브 실행</span>
+        <${BoolBadge} value=${c.runtime.keepalive_running} />
+      </div>
+      <${ConfigRow} label="파이버 상태" value=${c.runtime.fiber_health || '--'} />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">프레즌스 킵얼라이브</span>
+        <${BoolBadge} value=${c.runtime.presence_keepalive} />
+      </div>
+      <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
+
+      <${SectionHeader} title="조율" />
+      <${ConfigRow} label="룸 범위" value=${c.coordination.room_scope || '--'} />
+      <${ConfigRow} label="범위 유형" value=${c.coordination.scope_kind || '--'} />
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>
+        <${ModelList} models=${c.coordination.mention_targets} />
+      </div>
+      <div class="mt-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">참여 룸</div>
+        <${ModelList} models=${c.coordination.joined_room_ids} />
+      </div>
+
+      <${SectionHeader} title="드리프트" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">상태</span>
+        <${FeatureBadge} status=${c.drift.status} value=${c.drift.enabled} />
+      </div>
+      <${ConfigRow} label="최소 턴 간격" value=${formatMaybeNumber(c.drift.min_turn_gap)} />
+      <${ConfigRow} label="총 횟수" value=${formatMaybeNumber(c.drift.count_total)} />
+      ${c.drift.last_reason ? html`<${ConfigRow} label="마지막 사유" value=${c.drift.last_reason} />` : null}
+
+      <${SectionHeader} title="자동 팀 세션" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">상태</span>
+        <${FeatureBadge} status=${c.auto_team_session.status} value=${c.auto_team_session.enabled} />
+      </div>
+
+      <${SectionHeader} title="핸드오프" />
+      <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+        <span class="text-xs text-[var(--text-muted)]">자동</span>
+        <${BoolBadge} value=${c.handoff.auto} />
+      </div>
+      <${ConfigRow} label="임계값" value=${(c.handoff.threshold * 100).toFixed(0) + '%'} />
+      <${ConfigRow} label="쿨다운" value=${c.handoff.cooldown_sec + 's'} />
+
+      <${SectionHeader} title="마지막 호출 성능" />
+      <${ConfigRow} label="총 입력 토큰" value=${formatTokens(c.metrics.total_input_tokens)} />
+      <${ConfigRow} label="총 출력 토큰" value=${formatTokens(c.metrics.total_output_tokens)} />
+      <${ConfigRow} label="마지막 모델" value=${c.metrics.last_model_used || '--'} />
+      <${ConfigRow} label="마지막 입력 토큰" value=${formatTokens(c.metrics.last_input_tokens)} />
+      <${ConfigRow} label="마지막 출력 토큰" value=${formatTokens(c.metrics.last_output_tokens)} />
+      <${ConfigRow} label="마지막 총 토큰" value=${formatTokens(c.metrics.last_total_tokens)} />
+      <${ConfigRow} label="마지막 지연" value=${formatMaybeNumber(c.metrics.last_latency_ms, 'ms')} />
+      <${ConfigRow} label="마지막 처리량" value=${formatMaybeFloat(c.metrics.last_total_tokens_per_sec, 1, ' tok/s')} />
+      <${ConfigRow} label="마지막 출력 처리량" value=${formatMaybeFloat(c.metrics.last_output_tokens_per_sec, 1, ' tok/s')} />
     </div>
   `
 }

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -29,6 +29,32 @@ describe('ConfigResolutionPanel', () => {
           keepers: { path: '/tmp/legacy/config/keepers', exists: false, source: 'legacy_me_root' },
           personas: { path: '/tmp/custom-personas', exists: false, source: 'invalid_env' },
         }}
+        runtimeResolution=${{
+          status: 'warn',
+          warnings: ['Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).'],
+          base_path_input: { path: '/tmp/runtime-input', exists: true, source: 'input' },
+          workspace_path: { path: '/tmp/workspace', exists: true, source: 'workspace' },
+          resolved_base_path: { path: '/tmp/workspace', exists: true, source: 'resolved_base' },
+          data_root: { path: '/tmp/workspace/.masc', exists: true, source: 'runtime_data' },
+          prompt_markdown_dir: { path: '/tmp/shared/prompts', exists: true, source: 'prompt_registry' },
+          workspace_git_commit: 'cafef00d',
+          resolved_base_git_commit: 'cafef00d',
+          source_mismatch: true,
+          diagnostics: [
+            {
+              ts: '2026-03-27T00:00:00Z',
+              kind: 'external_signal',
+              signal: 'SIGTERM',
+              message: 'Received SIGTERM, shutting down server.',
+            },
+          ],
+          build: {
+            release_version: 'dev',
+            commit: 'deadbee',
+            started_at: '2026-03-27T00:00:00Z',
+            uptime_seconds: 42,
+          },
+        }}
       />`,
       container,
     )
@@ -38,5 +64,10 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('Using legacy config fallback from ME_ROOT-style path')
     expect(container.textContent).toContain('/tmp/custom-personas')
     expect(container.textContent).toContain('INVALID ENV')
+    expect(container.textContent).toContain('/tmp/workspace/.masc')
+    expect(container.textContent).toContain('/tmp/shared/prompts')
+    expect(container.textContent).toContain('source mismatch')
+    expect(container.textContent).toContain('SIGTERM')
+    expect(container.textContent).toContain('Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).')
   })
 })

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -2,6 +2,8 @@ import { html } from 'htm/preact'
 import type {
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
+  DashboardRuntimeDiagnostic,
+  DashboardRuntimeResolution,
 } from '../../api/dashboard'
 import { Card } from '../common/card'
 
@@ -30,6 +32,16 @@ function sourceLabel(source: string): string {
       return 'CWD'
     case 'legacy_me_root':
       return 'LEGACY'
+    case 'input':
+      return 'INPUT'
+    case 'workspace':
+      return 'WORKSPACE'
+    case 'resolved_base':
+      return 'BASE'
+    case 'runtime_data':
+      return 'DATA'
+    case 'prompt_registry':
+      return 'PROMPTS'
     default:
       return 'MISSING'
   }
@@ -58,44 +70,156 @@ function ConfigRow({
   `
 }
 
+function WarningBlock({
+  title,
+  warnings,
+}: {
+  title: string
+  warnings: string[]
+}) {
+  if (warnings.length === 0) return null
+
+  return html`
+    <div class="rounded-lg border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.08)] px-3 py-3">
+      <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[#fde68a]">${title}</div>
+      <div class="flex flex-col gap-2">
+        ${warnings.map(warning => html`
+          <div class="text-[12px] leading-relaxed text-[var(--text-body)]">${warning}</div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function RuntimeMetaRow({
+  label,
+  value,
+}: {
+  label: string
+  value: string
+}) {
+  return html`
+    <div class="flex items-center justify-between gap-3 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2">
+      <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+      <div class="break-all text-right font-mono text-[12px] text-[var(--text-body)]">${value}</div>
+    </div>
+  `
+}
+
+function DiagnosticRow({ item }: { item: DashboardRuntimeDiagnostic }) {
+  return html`
+    <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3">
+      <div class="mb-1 flex flex-wrap items-center gap-2">
+        <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          ${item.kind}
+        </span>
+        ${item.signal
+          ? html`
+              <span class="rounded-full border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fde68a]">
+                ${item.signal}
+              </span>
+            `
+          : null}
+        <span class="text-[11px] text-[var(--text-muted)]">${item.ts}</span>
+      </div>
+      <div class="text-[12px] leading-relaxed text-[var(--text-body)]">${item.message}</div>
+    </div>
+  `
+}
+
 export function ConfigResolutionPanel({
   resolution,
+  runtimeResolution,
 }: {
   resolution: DashboardConfigResolution | undefined
+  runtimeResolution?: DashboardRuntimeResolution
 }) {
-  if (!resolution) return null
+  if (!resolution && !runtimeResolution) return null
 
   return html`
     <${Card} title="설정 경로" class="section mb-4">
-      <div class="mb-4 flex flex-wrap items-center gap-2">
-        <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(resolution.status)}">
-          ${resolution.status}
-        </span>
-        <span class="text-[12px] text-[var(--text-muted)]">
-          runtime data root와 별개로, repo-managed config root 해석 결과를 보여줍니다.
-        </span>
+      <div class="mb-4 text-[12px] leading-relaxed text-[var(--text-muted)]">
+        repo-managed config root와 실제 runtime/data root를 함께 보여줍니다. 실행 중인 서버가 어떤 worktree와 경로를 보고 있는지 바로 비교할 수 있습니다.
       </div>
 
-      ${resolution.warnings.length > 0
+      ${resolution
         ? html`
-            <div class="mb-4 rounded-lg border border-[rgba(250,204,21,0.28)] bg-[rgba(250,204,21,0.08)] px-3 py-3">
-              <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[#fde68a]">warnings</div>
-              <div class="flex flex-col gap-2">
-                ${resolution.warnings.map(warning => html`
-                  <div class="text-[12px] leading-relaxed text-[var(--text-body)]">${warning}</div>
-                `)}
+            <div class="mb-6">
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(resolution.status)}">
+                  ${resolution.status}
+                </span>
+                <span class="text-[12px] text-[var(--text-muted)]">repo-managed config root</span>
+              </div>
+
+              <div class="mb-4">
+                <${WarningBlock} title="config warnings" warnings=${resolution.warnings} />
+              </div>
+
+              <div class="grid gap-3 md:grid-cols-2">
+                <${ConfigRow} label="config root" item=${resolution.config_root} />
+                <${ConfigRow} label="cascade" item=${resolution.cascade} />
+                <${ConfigRow} label="prompts" item=${resolution.prompts} />
+                <${ConfigRow} label="keepers" item=${resolution.keepers} />
+                <${ConfigRow} label="personas" item=${resolution.personas} />
               </div>
             </div>
           `
         : null}
 
-      <div class="grid gap-3 md:grid-cols-2">
-        <${ConfigRow} label="config root" item=${resolution.config_root} />
-        <${ConfigRow} label="cascade" item=${resolution.cascade} />
-        <${ConfigRow} label="prompts" item=${resolution.prompts} />
-        <${ConfigRow} label="keepers" item=${resolution.keepers} />
-        <${ConfigRow} label="personas" item=${resolution.personas} />
-      </div>
+      ${runtimeResolution
+        ? html`
+            <div>
+              <div class="mb-3 flex flex-wrap items-center gap-2">
+                <span class="rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${toneClass(runtimeResolution.status)}">
+                  ${runtimeResolution.status}
+                </span>
+                <span class="text-[12px] text-[var(--text-muted)]">runtime path resolution</span>
+                ${runtimeResolution.source_mismatch
+                  ? html`
+                      <span class="rounded-full border border-[rgba(244,63,94,0.28)] bg-[rgba(244,63,94,0.10)] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#fecdd3]">
+                        source mismatch
+                      </span>
+                    `
+                  : null}
+              </div>
+
+              <div class="mb-4">
+                <${WarningBlock} title="runtime warnings" warnings=${runtimeResolution.warnings} />
+              </div>
+
+              <div class="grid gap-3 md:grid-cols-2">
+                <${ConfigRow} label="base path input" item=${runtimeResolution.base_path_input} />
+                <${ConfigRow} label="workspace path" item=${runtimeResolution.workspace_path} />
+                <${ConfigRow} label="resolved base path" item=${runtimeResolution.resolved_base_path} />
+                <${ConfigRow} label="data root" item=${runtimeResolution.data_root} />
+                <${ConfigRow} label="prompt markdown dir" item=${runtimeResolution.prompt_markdown_dir} />
+              </div>
+
+              <div class="mt-4 grid gap-3 md:grid-cols-2">
+                <${RuntimeMetaRow} label="workspace head" value=${runtimeResolution.workspace_git_commit ?? '--'} />
+                <${RuntimeMetaRow} label="resolved base head" value=${runtimeResolution.resolved_base_git_commit ?? '--'} />
+                <${RuntimeMetaRow} label="runtime build" value=${runtimeResolution.build.commit ?? runtimeResolution.build.release_version} />
+                <${RuntimeMetaRow} label="started at" value=${runtimeResolution.build.started_at} />
+              </div>
+
+              <div class="mt-4">
+                <div class="mb-2 text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                  recent diagnostics
+                </div>
+                <div class="flex flex-col gap-3">
+                  ${runtimeResolution.diagnostics.length > 0
+                    ? runtimeResolution.diagnostics.map(item => html`<${DiagnosticRow} item=${item} />`)
+                    : html`
+                        <div class="rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+                          최근 runtime warning이 없습니다.
+                        </div>
+                      `}
+                </div>
+              </div>
+            </div>
+          `
+        : null}
     <//>
   `
 }

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -32,7 +32,10 @@ export function Tools() {
 
   return html`
     <div>
-      <${ConfigResolutionPanel} resolution=${data?.config_resolution} />
+      <${ConfigResolutionPanel}
+        resolution=${data?.config_resolution}
+        runtimeResolution=${data?.runtime_resolution}
+      />
 
       <${Card} title="운영 화면 안내" class="section mb-4">
         <${SurfaceReadinessPanel} />

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -137,16 +137,26 @@ module FileSystem = struct
   let _compress = Compression.compress_with_header
   let _decompress = Compression.decompress_auto
 
+  let has_zstd_header content =
+    String.length content >= 4 && String.sub content 0 4 = "ZSTD"
+
+  let decompress_with_context ~context content =
+    let had_header = has_zstd_header content in
+    let decompressed = _decompress content in
+    if had_header && String.equal decompressed content then
+      Log.Backend.warn "[EioFS] decompress fallback for %s" context;
+    decompressed
+
   (** Get value by key (auto-decompresses ZSTD if detected) *)
   let get t key =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
       match key_to_path t key with
       | Error e -> Error e
-      | Ok path ->
+        | Ok path ->
           try
             let content = Eio.Path.load path in
             (* Compact Protocol v4: Auto-decompress if ZSTD header present *)
-            let decompressed = _decompress content in
+            let decompressed = decompress_with_context ~context:key content in
             Ok decompressed
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
@@ -502,7 +512,7 @@ module FileSystem = struct
               if n = 0 then None
               else
                 let raw = Bytes.sub_string buf 0 n in
-                Some (_decompress raw)
+                Some (decompress_with_context ~context:path_str raw)
             end
           in
           let new_content = f current in

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -1,23 +1,15 @@
 (** Backend_pg - Eio-native PostgreSQL backend implementation.
-
-    Extracted from Backend.Postgres for separation of concerns.
-    Uses Caqti-eio for non-blocking PostgreSQL access with zstd compression.
-
-    Types come from Backend_types (shared with Backend).
-    Backend.Postgres delegates to this module.
-*)
+    Extracted from Backend.Postgres for separation of concerns and uses
+    Caqti-eio for non-blocking PostgreSQL access with zstd compression.
+    Types come from Backend_types (shared with Backend). *)
 
 module Compression = Backend_compression
 
 let _compress = Compression.compress_with_header
 let _decompress = Compression.decompress_auto
-
 (** {1 Types} *)
-
 include Backend_types
-
 (** {1 PostgreSQL Backend} *)
-
 type t = {
   pool: (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t;
   namespace: string;
@@ -289,11 +281,8 @@ let close _t = ()
 
 let get_pool t = t.pool
 
-let has_zstd_header content =
-  String.length content >= 4 && String.sub content 0 4 = "ZSTD"
-
 let decompress_with_context ~key content =
-  let had_header = has_zstd_header content in
+  let had_header = String.length content >= 4 && String.sub content 0 4 = "ZSTD" in
   let decompressed = _decompress content in
   if had_header && String.equal decompressed content then
     Log.Backend.warn "[EioPG] decompress fallback for %s" key;
@@ -361,8 +350,7 @@ let get_all t ~prefix =
   ) t.pool with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
-        let logical_key = strip_namespace t.namespace k in
-        (logical_key, decompress_with_context ~key:k v)
+        (strip_namespace t.namespace k, decompress_with_context ~key:k v)
       ) pairs)
   | Error err -> Error (caqti_error_to_masc err)
 
@@ -378,8 +366,7 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     ) t.pool with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
-          let logical_key = strip_namespace t.namespace k in
-          (logical_key, decompress_with_context ~key:k v)
+          (strip_namespace t.namespace k, decompress_with_context ~key:k v)
         ) pairs)
     | Error err -> Error (caqti_error_to_masc err)
 

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -289,13 +289,23 @@ let close _t = ()
 
 let get_pool t = t.pool
 
+let has_zstd_header content =
+  String.length content >= 4 && String.sub content 0 4 = "ZSTD"
+
+let decompress_with_context ~key content =
+  let had_header = has_zstd_header content in
+  let decompressed = _decompress content in
+  if had_header && String.equal decompressed content then
+    Log.Backend.warn "[EioPG] decompress fallback for %s" key;
+  decompressed
+
 let get t key =
   let nkey = namespaced_key t.namespace key in
   match Caqti_eio.Pool.use (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find_opt get_q nkey
   ) t.pool with
-  | Ok (Some v) -> Ok (_decompress v)
+  | Ok (Some v) -> Ok (decompress_with_context ~key:nkey v)
   | Ok None -> Error (NotFound key)
   | Error err -> Error (caqti_error_to_masc err)
 
@@ -351,7 +361,8 @@ let get_all t ~prefix =
   ) t.pool with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
-        (strip_namespace t.namespace k, _decompress v)
+        let logical_key = strip_namespace t.namespace k in
+        (logical_key, decompress_with_context ~key:k v)
       ) pairs)
   | Error err -> Error (caqti_error_to_masc err)
 
@@ -367,7 +378,8 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     ) t.pool with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
-          (strip_namespace t.namespace k, _decompress v)
+          let logical_key = strip_namespace t.namespace k in
+          (logical_key, decompress_with_context ~key:k v)
         ) pairs)
     | Error err -> Error (caqti_error_to_masc err)
 

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -112,18 +112,12 @@ let keeper_masc_tool_schemas (_meta : keeper_meta) : Types.tool_schema list =
 let dedupe_tool_names names =
   dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)
 
-let keeper_default_tool_names (meta : keeper_meta) : string list =
+let keeper_default_tool_names (_meta : keeper_meta) : string list =
   let base_names = keeper_model_tools |> List.map (fun tool -> tool.Types.name) in
-  if meta.policy_voice_enabled then
-    dedupe_tool_names (keeper_voice_tool_names @ base_names)
-  else
-    base_names
+  dedupe_tool_names (keeper_voice_tool_names @ base_names)
 
-let keeper_default_model_tools (meta : keeper_meta) : Types.tool_schema list =
-  if meta.policy_voice_enabled then
-    keeper_model_tools @ keeper_voice_tool_schemas
-  else
-    keeper_model_tools
+let keeper_default_model_tools (_meta : keeper_meta) : Types.tool_schema list =
+  keeper_model_tools @ keeper_voice_tool_schemas
 
 (** Return all keeper tool names unconditionally.
     Mode-based categorization removed: every keeper gets the full tool set.
@@ -146,11 +140,7 @@ let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) :
       @ (keeper_masc_tool_names meta)
       @ (keeper_default_tool_names meta)
     in
-    let with_voice =
-      if meta.policy_voice_enabled then keeper_voice_tool_names @ all_names
-      else all_names
-    in
-    dedupe_tool_names with_voice
+    dedupe_tool_names all_names
 
 (** Return all keeper model tool schemas unconditionally.
     Mode-based categorization removed: every keeper gets the full tool set.

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -180,19 +180,6 @@ let resident_schemas : tool_schema list = [
           ("type", `String "integer");
           ("description", `String "Minimum seconds between handoffs (default: 300).");
         ]);
-        ("voice_enabled", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "If true, keeper lifecycle/check-in events may trigger voice output.");
-        ]);
-        ("voice_channel", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "voice_text"; `String "voice_only"; `String "text_only"]);
-          ("description", `String "How keeper event output is surfaced: voice+text, voice only, or text only.");
-        ]);
-        ("voice_agent_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Voice bridge agent id to use when emitting keeper voice events.");
-        ]);
       ]);
       ("required", `List [`String "name"]);
     ];

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -461,7 +461,7 @@ let handle_keeper_status ctx args : tool_result =
            ]);
            ("drift", drift_surface_json ());
            ("policy", `Assoc [
-             ("voice_enabled", `Bool m.policy_voice_enabled);
+             ("voice_tools_available", `Bool (List.mem "keeper_voice_speak" allowed_tools));
              ("allowed_paths", string_list_to_json m.allowed_paths);
            ("allowed_tools", string_list_to_json allowed_tools);
             ("available_internal_tools", string_list_to_json all_internal_tools);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -156,12 +156,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     (fun (active, line) -> if active then Some line else None)
                     policy_guards
                 in
-                match policy_lines with
+                let tool_use_lines = [
+                  "Tool-use guidance:";
+                  "- If the user asks you to speak, use voice, make sound, or output TTS, prefer keeper_voice_session_start and keeper_voice_speak.";
+                  "- Do not simulate spoken audio with plain text roleplay when a voice tool can handle the request.";
+                  "- If voice execution fails, say that voice output is unavailable and continue in text.";
+                ] in
+                match policy_lines @ tool_use_lines with
                 | [] -> prompt
                 | _ ->
                     Printf.sprintf "%s\n\n%s"
                       prompt
-                      (String.concat "\n" policy_lines)
+                      (String.concat "\n" (policy_lines @ tool_use_lines))
               in
               let prompt =
                 match live_worktree_change with

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -6,10 +6,24 @@
 
     @since 2.95.0 *)
 
+let trim_opt = function
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let resolved_base_path_opt () =
+  match trim_opt (Sys.getenv_opt "MASC_BASE_PATH") with
+  | Some path -> Some path
+  | None -> Room_utils_backend_setup.find_git_root (Sys.getcwd ())
+
 let masc_base_dir () =
-  match Sys.getenv_opt "ME_ROOT" with
-  | Some root when String.trim root <> "" -> Filename.concat root ".masc"
-  | _ -> ".masc"
+  match resolved_base_path_opt () with
+  | Some base_path -> Filename.concat base_path ".masc"
+  | None -> (
+      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      | Some root -> Filename.concat root ".masc"
+      | None -> ".masc")
 
 (** Singleton session manager, lazily initialized.
     Thread-safety: safe under single Eio domain — all fibers share one

--- a/lib/room/room_agent.ml
+++ b/lib/room/room_agent.ml
@@ -19,8 +19,7 @@ let get_agents_status config =
         Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat agents_path name in
-        let json = read_json config path in
-        match agent_of_yojson json with
+        match read_agent_with_repair config path with
         | Ok agent ->
             let is_zombie = is_zombie_agent ~agent_name:agent.name agent.last_seen in
             let status = if is_zombie then "zombie" else agent_status_to_string agent.status in
@@ -55,8 +54,7 @@ let register_capabilities config ~agent_name ~capabilities =
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
   if Sys.file_exists agent_file then begin
     with_file_lock config agent_file (fun () ->
-      let json = read_json config agent_file in
-      match agent_of_yojson json with
+      match read_agent_with_repair config agent_file with
       | Ok agent ->
           let updated = { agent with capabilities; last_seen = now_iso () } in
           write_json config agent_file (agent_to_yojson updated);
@@ -99,8 +97,7 @@ let update_agent_r config ~agent_name ?status ?capabilities () : string Types.ma
         else
           let locked =
             with_file_lock_r config agent_file (fun () ->
-              let json = read_json config agent_file in
-              match agent_of_yojson json with
+              match read_agent_with_repair config agent_file with
               | Error _ -> Error (Types.InvalidJson "Invalid agent file")
               | Ok agent ->
                   let status_opt =
@@ -170,8 +167,7 @@ let find_agents_by_capability config ~capability =
         Room_query.safe_yield ();
       if Filename.check_suffix name ".json" then begin
         let path = Filename.concat agents_path name in
-        let json = read_json config path in
-        match agent_of_yojson json with
+        match read_agent_with_repair config path with
         | Ok agent when List.mem capability agent.capabilities && not (is_zombie_agent ~agent_name:agent.name agent.last_seen) ->
             matching := `Assoc [
               ("name", `String agent.name);

--- a/lib/room/room_gc.ml
+++ b/lib/room/room_gc.ml
@@ -23,8 +23,7 @@ let heartbeat_in_room config ~room_id ~agent_name =
   let agent_file = Filename.concat (agents_dir scoped) filename in
   if path_exists scoped agent_file then begin
     with_file_lock scoped agent_file (fun () ->
-      let json = read_json scoped agent_file in
-      match agent_of_yojson json with
+      match read_agent_with_repair scoped agent_file with
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
           write_json scoped agent_file (agent_to_yojson updated);
@@ -44,8 +43,7 @@ let heartbeat config ~agent_name =
   let agent_file = Filename.concat (agents_dir config) filename in
   if path_exists config agent_file then begin
     with_file_lock config agent_file (fun () ->
-      let json = read_json config agent_file in
-      match agent_of_yojson json with
+      match read_agent_with_repair config agent_file with
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
           write_json config agent_file (agent_to_yojson updated);
@@ -81,8 +79,7 @@ let cleanup_zombies
         Room_query.safe_yield ();
         if Filename.check_suffix name ".json" then begin
           let path = Filename.concat agents_path name in
-          let json = read_json config path in
-          match agent_of_yojson json with
+          match read_agent_with_repair config path with
           | Ok agent
             when (not (List.exists (fun (n, _) -> n = agent.name) !zombie_entries)) &&
                  (let threshold =
@@ -108,8 +105,7 @@ let cleanup_zombies
          Active+dead (the old behavior) is invisible to monitoring. *)
       List.iter (fun (name, path) ->
         (try
-          let json = read_json config path in
-          match agent_of_yojson json with
+          match read_agent_with_repair config path with
           | Ok agent ->
               let updated = { agent with status = Inactive; last_seen = now_iso () } in
               write_json config path (agent_to_yojson updated)

--- a/lib/room/room_lifecycle.ml
+++ b/lib/room/room_lifecycle.ml
@@ -63,8 +63,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
       Sys.file_exists agent_file_dedup
   in
   if already_joined then begin
-    let existing_json = read_json config agent_file_dedup in
-    (match agent_of_yojson existing_json with
+    (match read_agent_with_repair config agent_file_dedup with
      | Ok existing_agent ->
        let is_inactive = existing_agent.status = Inactive in
        let new_session_id = if is_inactive then generate_session_id () else
@@ -216,8 +215,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
        heartbeat can update current_task/status between our read and write,
        and the rejoin write would silently discard those changes. *)
     let was_inactive = with_file_lock scoped agent_file_dedup (fun () ->
-      let existing_json = read_json scoped agent_file_dedup in
-      match agent_of_yojson existing_json with
+      match read_agent_with_repair scoped agent_file_dedup with
       | Ok existing_agent ->
           let is_inactive = existing_agent.status = Inactive in
           let updated = { existing_agent with
@@ -324,8 +322,7 @@ let leave config ~agent_name =
     (* Mark agent as Inactive instead of deleting, so re-join can restore identity.
        This prevents orphan state when the same agent_type re-joins later. *)
     (if in_fs then
-      let existing_json = read_json config agent_file in
-      match agent_of_yojson existing_json with
+      match read_agent_with_repair config agent_file with
       | Ok existing_agent ->
         let updated = { existing_agent with status = Inactive; last_seen = now_iso () } in
         write_json config agent_file (agent_to_yojson updated)

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -280,6 +280,25 @@ let read_json_opt config path =
       if Sys.file_exists path then Some (read_json_local path)
       else None
 
+let agent_json_needs_repair = function
+  | `Assoc fields -> (
+      match List.assoc_opt "last_seen" fields with
+      | Some (`Int _ | `Float _) -> true
+      | _ -> false)
+  | _ -> false
+
+let read_agent_with_repair config path =
+  let json = read_json config path in
+  match Types.agent_of_yojson json with
+  | Ok agent as ok ->
+      if agent_json_needs_repair json then (
+        Log.Room.warn
+          "agent state repair: repaired agent JSON and rewrote canonical state for %s"
+          path;
+        write_json config path (Types.agent_to_yojson agent));
+      ok
+  | Error _ as error -> error
+
 (* ============================================ *)
 (* File locking                                 *)
 (* ============================================ *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -4,6 +4,221 @@ include Server_dashboard_http_core
 open Types
 open Server_utils
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > hay_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  needle_len = 0 || loop 0
+
+let take n xs =
+  let rec loop acc remaining xs =
+    if remaining <= 0 then List.rev acc
+    else
+      match xs with
+      | [] -> List.rev acc
+      | x :: tl -> loop (x :: acc) (remaining - 1) tl
+  in
+  loop [] n xs
+
+let trim_to_option raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then None else Some trimmed
+
+let git_rev_parse_short path =
+  match trim_to_option path with
+  | None -> None
+  | Some dir when not (Sys.file_exists dir) -> None
+  | Some dir ->
+      let channels =
+        Unix.open_process_args_full "git"
+          [| "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" |]
+          (Unix.environment ())
+      in
+      let stdout, stdin, stderr = channels in
+      (try
+         close_out_noerr stdin;
+         let output = In_channel.input_all stdout in
+         ignore (In_channel.input_all stderr);
+         match Unix.close_process_full channels with
+         | Unix.WEXITED 0 -> trim_to_option output
+         | _ -> None
+       with
+       | Sys_error _ | Unix.Unix_error _ ->
+           ignore
+             (try Unix.close_process_full channels
+              with Unix.Unix_error _ -> Unix.WEXITED 1);
+           None)
+
+let path_item_json ~source path =
+  `Assoc
+    [
+      ("path", `String path);
+      ("exists", `Bool (String.trim path <> "" && Sys.file_exists path));
+      ("source", `String source);
+    ]
+
+let shutdown_signal_of_message message =
+  if contains_substring ~needle:"Received SIGTERM" message then Some "SIGTERM"
+  else if contains_substring ~needle:"Received SIGINT" message then Some "SIGINT"
+  else None
+
+let runtime_diagnostics_json () =
+  let entries = Log.Ring.recent ~limit:200 ~order:`Newest_first () in
+  let diagnostics =
+    entries
+    |> List.filter_map (fun (entry : Log.Ring.entry) ->
+           let message = entry.message in
+           match shutdown_signal_of_message message with
+           | Some signal ->
+               Some
+                 (`Assoc
+                   [
+                     ("ts", `String entry.ts);
+                     ("kind", `String "external_signal");
+                     ("signal", `String signal);
+                     ("message", `String message);
+                   ])
+           | None when contains_substring
+                           ~needle:"repairing state and rewriting canonical JSON"
+                           message ->
+               Some
+                 (`Assoc
+                   [
+                     ("ts", `String entry.ts);
+                     ("kind", `String "state_repair");
+                     ("message", `String message);
+                   ])
+           | None when contains_substring ~needle:"invalid agent JSON" message
+                       || contains_substring ~needle:"repaired agent JSON" message
+                       || contains_substring
+                            ~needle:"parse error: Types_core.agent.last_seen"
+                            message ->
+               Some
+                 (`Assoc
+                   [
+                     ("ts", `String entry.ts);
+                     ("kind", `String "agent_state");
+                     ("message", `String message);
+                   ])
+           | None when contains_substring ~needle:"MaxClientsInSessionMode" message
+                       || contains_substring
+                            ~needle:
+                              "Invalid concurrent usage of PostgreSQL connection"
+                            message ->
+               Some
+                 (`Assoc
+                   [
+                     ("ts", `String entry.ts);
+                     ("kind", `String "backend_pressure");
+                     ("message", `String message);
+                   ])
+           | None -> None)
+    |> take 8
+  in
+  let count kind =
+    List.fold_left
+      (fun acc json ->
+        match Yojson.Safe.Util.member "kind" json with
+        | `String value when String.equal value kind -> acc + 1
+        | _ -> acc)
+      0 diagnostics
+  in
+  (`List diagnostics, count "external_signal", count "state_repair",
+   count "agent_state", count "backend_pressure")
+
+let runtime_resolution_json (config : Room.config) =
+  let build = Build_identity.current () in
+  let runtime_commit = build.commit in
+  let workspace_commit = git_rev_parse_short config.workspace_path in
+  let resolved_base_commit = git_rev_parse_short config.base_path in
+  let base_path_input =
+    Sys.getenv_opt "MASC_BASE_PATH_INPUT"
+    |> Option.value ~default:config.workspace_path
+  in
+  let prompt_markdown_dir =
+    Prompt_registry.get_markdown_dir () |> Option.value ~default:""
+  in
+  let prompt_outside_workspace =
+    prompt_markdown_dir <> ""
+    && not (String.starts_with ~prefix:config.workspace_path prompt_markdown_dir)
+  in
+  let source_mismatch =
+    match runtime_commit, workspace_commit with
+    | Some runtime, Some workspace -> not (String.equal runtime workspace)
+    | _ -> false
+  in
+  let diagnostics, signal_count, repair_count, agent_issue_count, backend_pressure_count =
+    runtime_diagnostics_json ()
+  in
+  let warnings =
+    []
+    |> fun acc ->
+      if source_mismatch then
+        let runtime = Option.value ~default:"unknown" runtime_commit in
+        let workspace = Option.value ~default:"unknown" workspace_commit in
+        (Printf.sprintf
+           "Runtime build commit (%s) differs from workspace HEAD (%s). Rebuild/restart from the intended worktree."
+           runtime workspace)
+        :: acc
+      else acc
+    |> fun acc ->
+      if prompt_outside_workspace then
+        (Printf.sprintf
+           "Prompt markdown dir resolves outside workspace path: %s"
+           prompt_markdown_dir)
+        :: acc
+      else acc
+    |> fun acc ->
+      if signal_count > 0 then
+        (Printf.sprintf
+           "Recent external shutdown signals detected in server logs (%d). Ephemeral agents will not auto-rejoin after these restarts."
+           signal_count)
+        :: acc
+      else acc
+    |> fun acc ->
+      if repair_count > 0 then
+        (Printf.sprintf
+           "Recent room-state repair events detected (%d)."
+           repair_count)
+        :: acc
+      else acc
+    |> fun acc ->
+      if agent_issue_count > 0 then
+        (Printf.sprintf
+           "Recent agent-state compatibility warnings detected (%d)."
+           agent_issue_count)
+        :: acc
+      else acc
+    |> fun acc ->
+      if backend_pressure_count > 0 then
+        (Printf.sprintf
+           "Recent PostgreSQL pressure warnings detected (%d)."
+           backend_pressure_count)
+        :: acc
+      else acc
+    |> List.rev
+  in
+  let status = if warnings = [] then "ready" else "warn" in
+  `Assoc
+    [
+      ("status", `String status);
+      ("warnings", `List (List.map (fun warning -> `String warning) warnings));
+      ("base_path_input", path_item_json ~source:"input" base_path_input);
+      ("workspace_path", path_item_json ~source:"workspace" config.workspace_path);
+      ("resolved_base_path", path_item_json ~source:"resolved_base" config.base_path);
+      ("data_root", path_item_json ~source:"runtime_data" (Room.masc_root_dir config));
+      ("prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir);
+      ("workspace_git_commit", Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit);
+      ("resolved_base_git_commit", Option.fold ~none:`Null ~some:(fun value -> `String value) resolved_base_commit);
+      ("source_mismatch", `Bool source_mismatch);
+      ("diagnostics", diagnostics);
+      ("build", Build_identity.to_yojson build);
+    ]
+
 let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =
   let ctx : Tool_misc.context =
     {
@@ -15,6 +230,7 @@ let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =
     [
       ("generated_at", `String (Types.now_iso ()));
       ("config_resolution", Config_dir_resolver.(resolve () |> to_json));
+      ("runtime_resolution", runtime_resolution_json config);
       ("tool_inventory", Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true);
       ("tool_usage", Tool_unified.summary_report ());
     ]

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -163,6 +163,43 @@ type agent = {
   meta: agent_meta option; [@default None] (* session metadata *)
 } [@@deriving yojson { strict = false }, show]
 
+let agent_of_yojson_generated = agent_of_yojson
+
+let iso8601_of_unix_seconds ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let normalize_agent_last_seen = function
+  | `String _ as value -> Some value
+  | `Int seconds ->
+      Some (`String (iso8601_of_unix_seconds (float_of_int seconds)))
+  | `Float seconds ->
+      Some (`String (iso8601_of_unix_seconds seconds))
+  | _ -> None
+
+let agent_of_yojson json =
+  match agent_of_yojson_generated json with
+  | Ok _ as ok -> ok
+  | Error original_error -> (
+      match json with
+      | `Assoc fields -> (
+          match
+            List.assoc_opt "last_seen" fields
+            |> function
+            | Some value -> normalize_agent_last_seen value
+            | None -> None
+          with
+          | Some normalized_last_seen ->
+              let normalized_fields =
+                ("last_seen", normalized_last_seen)
+                :: List.remove_assoc "last_seen" fields
+              in
+              agent_of_yojson_generated (`Assoc normalized_fields)
+          | None -> Error original_error)
+      | _ -> Error original_error)
+
 (* ============================================ *)
 (* Multi-Room Types                             *)
 (* ============================================ *)

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -212,11 +212,25 @@ let elevenlabs_voice_ids = [
   ("Laura",  "FGY2WhTYpPnrIDTdsKH5");
 ]
 
+let trim_opt = function
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
 (** Ensure .masc/audio/ directory exists *)
+let resolved_base_path_opt () =
+  match trim_opt (Sys.getenv_opt "MASC_BASE_PATH") with
+  | Some path -> Some path
+  | None -> Room_utils_backend_setup.find_git_root (Sys.getcwd ())
+
 let masc_base_dir () =
-  match Sys.getenv_opt "ME_ROOT" with
-  | Some root when String.trim root <> "" -> Filename.concat root ".masc"
-  | _ -> ".masc"
+  match resolved_base_path_opt () with
+  | Some base_path -> Filename.concat base_path ".masc"
+  | None -> (
+      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      | Some root -> Filename.concat root ".masc"
+      | None -> ".masc")
 
 let ensure_audio_dir () =
   let dir = Filename.concat (masc_base_dir ()) "audio" in
@@ -259,4 +273,3 @@ let append_provider_metadata json endpoint =
             ("endpoint_url", endpoint_url_json endpoint);
           ])
   | other -> other
-

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -53,10 +53,55 @@ open Result_syntax
 
 let default_elevenlabs_base_url = "https://api.elevenlabs.io/v1"
 
+let trim_opt = function
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let dedupe_keep_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+        if List.mem value seen then loop seen acc rest
+        else loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+
+let base_path_voice_config_path_opt () =
+  trim_opt (Sys.getenv_opt "MASC_BASE_PATH")
+  |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
+
+let repo_voice_config_path_opt () =
+  let cwd = Sys.getcwd () in
+  let root =
+    match Room_utils_backend_setup.find_git_root cwd with
+    | Some path -> path
+    | None -> cwd
+  in
+  Some (Filename.concat root ".masc/voice_config.json")
+
+let me_root_voice_config_path_opt () =
+  trim_opt (Sys.getenv_opt "ME_ROOT")
+  |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
+
+let cwd_voice_config_path () =
+  Filename.concat (Sys.getcwd ()) ".masc/voice_config.json"
+
+let config_path_candidates () =
+  [
+    base_path_voice_config_path_opt ();
+    repo_voice_config_path_opt ();
+    me_root_voice_config_path_opt ();
+    Some (cwd_voice_config_path ());
+  ]
+  |> List.filter_map Fun.id
+  |> dedupe_keep_order
+
 let config_path () =
-  match Sys.getenv_opt "ME_ROOT" with
-  | Some root -> Filename.concat root ".masc/voice_config.json"
-  | None -> ".masc/voice_config.json"
+  match List.find_opt Sys.file_exists (config_path_candidates ()) with
+  | Some path -> path
+  | None -> List.hd (config_path_candidates ())
 
 let trim_nonempty = function
   | `String value ->

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -99,9 +99,11 @@ let config_path_candidates () =
   |> dedupe_keep_order
 
 let config_path () =
-  match List.find_opt Sys.file_exists (config_path_candidates ()) with
-  | Some path -> path
-  | None -> List.hd (config_path_candidates ())
+  let candidates = config_path_candidates () in
+  match List.find_opt Sys.file_exists candidates, candidates with
+  | Some path, _ -> path
+  | None, path :: _ -> path
+  | None, [] -> cwd_voice_config_path ()
 
 let trim_nonempty = function
   | `String value ->

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -540,7 +540,7 @@ if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
-    exec "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$BASE_PATH"
+    exec "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$RESOLVED_BASE_PATH"
 elif [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2
     echo "  Host: $HOST" >&2
@@ -557,7 +557,7 @@ elif [ "$HTTP_MODE" = "true" ]; then
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
-    exec "$SELECTED_EXE" --http --port "$PORT" --path "$BASE_PATH"
+    exec "$SELECTED_EXE" --http --port "$PORT" --path "$RESOLVED_BASE_PATH"
 else
     echo "Starting MASC MCP server (stdio mode, $RUNTIME_NAME)..." >&2
     echo "  Base path: $RESOLVED_BASE_PATH" >&2
@@ -566,8 +566,8 @@ else
     fi
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
     if [ "$EIO_MODE" = "true" ]; then
-        exec "$SELECTED_EXE" --base-path "$BASE_PATH"
+        exec "$SELECTED_EXE" --base-path "$RESOLVED_BASE_PATH"
     else
-        exec "$SELECTED_EXE" --stdio --path "$BASE_PATH"
+        exec "$SELECTED_EXE" --stdio --path "$RESOLVED_BASE_PATH"
     fi
 fi

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -36,6 +36,7 @@ let test_dashboard_tools_projection () =
       let inventory_rows = inventory |> member "tools" |> to_list in
       let usage = json |> member "tool_usage" in
       let config_resolution = json |> member "config_resolution" in
+      let runtime_resolution = json |> member "runtime_resolution" in
       check bool "inventory has tools" true (List.length inventory_rows > 0);
       (* Verify registered_count is a valid integer field *)
       let reg_count = usage |> member "registered_count" |> to_int in
@@ -47,6 +48,22 @@ let test_dashboard_tools_projection () =
       check bool "config warnings surfaced as list" true
         (match config_resolution |> member "warnings" with
          | `List _ -> true
+         | _ -> false);
+      check bool "runtime data_root path surfaced" true
+        (match runtime_resolution |> member "data_root" |> member "path" with
+         | `String value -> String.length value > 0
+         | _ -> false);
+      check bool "runtime source_mismatch surfaced" true
+        (match runtime_resolution |> member "source_mismatch" with
+         | `Bool _ -> true
+         | _ -> false);
+      check bool "runtime diagnostics surfaced as list" true
+        (match runtime_resolution |> member "diagnostics" with
+         | `List _ -> true
+         | _ -> false);
+      check bool "build started_at surfaced" true
+        (match runtime_resolution |> member "build" |> member "started_at" with
+         | `String value -> String.length value > 0
          | _ -> false);
       check bool "usage dispatch flag present" true
         (match usage |> member "dispatch_v2_enabled" with

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -174,7 +174,7 @@ let test_safe_empty () =
 (* ================================================================ *)
 
 (* Mode removal: all keepers get all tools unconditionally.
-   Only voice (policy_voice_enabled) and write_done remain as gates.
+   write_done remains the only exposure gate.
    Safety is enforced through eval_gate deny lists. *)
 
 let test_write_done_kills_all () =
@@ -192,8 +192,7 @@ let test_all_keepers_get_full_toolset () =
   check bool "has keeper_board_list" true (List.mem "keeper_board_list" tools);
   check bool "has keeper_board_get" true (List.mem "keeper_board_get" tools);
   check bool "has keeper_shell_readonly" true (List.mem "keeper_shell_readonly" tools);
-  (* Voice still gated by policy_voice_enabled *)
-  check bool "no keeper_voice_speak (voice disabled)" false
+  check bool "keeper_voice_speak available" true
     (List.mem "keeper_voice_speak" tools)
 
 let test_voice_enabled () =
@@ -205,8 +204,8 @@ let test_voice_enabled () =
 let test_voice_disabled () =
   let meta = make_meta ~policy_voice_enabled:false () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "no keeper_voice_speak" false (List.mem "keeper_voice_speak" tools);
-  check bool "no keeper_voice_agent" false (List.mem "keeper_voice_agent" tools)
+  check bool "keeper_voice_speak still available" true (List.mem "keeper_voice_speak" tools);
+  check bool "keeper_voice_agent still available" true (List.mem "keeper_voice_agent" tools)
 
 let test_all_keepers_have_research_tools () =
   (* Mode removal: research tools available to all keepers *)

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -1,7 +1,7 @@
 (** Keeper Tool Exposure Tests
 
     Verifies that keeper_allowed_tool_names returns the full tool set
-    unconditionally (mode removal), with voice gated by policy_voice_enabled
+    unconditionally, with voice tools available by default,
     and write_done producing empty list. *)
 
 open Alcotest
@@ -60,10 +60,10 @@ let test_default_has_base_tools () =
   check bool "has keeper_time_now" true (has_tool "keeper_time_now" tools);
   check bool "has keeper_context_status" true (has_tool "keeper_context_status" tools)
 
-let test_default_has_no_voice () =
+let test_default_has_voice () =
   let meta = make_meta ~policy_voice_enabled:false () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "no voice tools when voice disabled" false
+  check bool "voice tools available by default" true
     (has_tool "keeper_voice_speak" tools)
 
 let test_default_has_governance_tools () =
@@ -81,7 +81,7 @@ let test_default_has_research_tools () =
   check bool "has autoresearch" true (has_any_prefix "masc_autoresearch_" tools)
 
 (* ============================================================
-   3. Voice profile (still gated by policy_voice_enabled)
+   3. Voice tools are always available
    ============================================================ *)
 
 let test_voice_enabled_adds_voice_tools () =
@@ -94,8 +94,8 @@ let test_voice_enabled_adds_voice_tools () =
 let test_voice_disabled_no_voice_tools () =
   let meta = make_meta ~policy_voice_enabled:false () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "no voice_speak" false (has_tool "keeper_voice_speak" tools);
-  check bool "no voice_agent" false (has_tool "keeper_voice_agent" tools)
+  check bool "voice_speak still available" true (has_tool "keeper_voice_speak" tools);
+  check bool "voice_agent still available" true (has_tool "keeper_voice_agent" tools)
 
 (* ============================================================
    4. All keepers get shell tools (mode removed)
@@ -343,7 +343,7 @@ let () =
     ]);
     ("default_profile", [
       test_case "has base tools" `Quick test_default_has_base_tools;
-      test_case "no voice tools" `Quick test_default_has_no_voice;
+      test_case "has voice tools" `Quick test_default_has_voice;
       test_case "has governance tools" `Quick test_default_has_governance_tools;
       test_case "has research tools" `Quick test_default_has_research_tools;
     ]);

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -173,7 +173,12 @@ let test_heartbeat_repairs_legacy_agent_last_seen () =
       ignore (Room.heartbeat config ~agent_name:"keeper-sangsu-agent");
 
       let repaired_json =
-        Yojson.Safe.from_file (agent_path config "keeper-sangsu-agent")
+        match Safe_ops.read_file_safe (agent_path config "keeper-sangsu-agent") with
+        | Error error -> fail error
+        | Ok raw ->
+            raw
+            |> Backend.Compression.decompress_auto
+            |> Yojson.Safe.from_string
       in
       check bool "last_seen rewritten as string" true
         (match Yojson.Safe.Util.member "last_seen" repaired_json with

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -26,6 +26,9 @@ let write_text_file path content =
 let state_path base_dir =
   Filename.concat (Filename.concat base_dir ".masc") "state.json"
 
+let agent_path config agent_name =
+  Filename.concat (Room.agents_dir config) (Room.safe_filename agent_name ^ ".json")
+
 let test_read_state_repairs_empty_object () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -123,6 +126,60 @@ let test_read_state_filters_invalid_active_agent_entries () =
         [ "codex-swift-fox"; "gemini-brave-bear" ]
         state.active_agents)
 
+let test_agent_of_yojson_accepts_numeric_last_seen () =
+  let json =
+    `Assoc
+      [
+        ("name", `String "keeper-sangsu-agent");
+        ("agent_type", `String "keeper");
+        ("status", `String "active");
+        ("capabilities", `List []);
+        ("current_task", `Null);
+        ("joined_at", `String "2026-03-26T00:00:00Z");
+        ("last_seen", `Float 1711411200.0);
+      ]
+  in
+  match Types.agent_of_yojson json with
+  | Ok agent ->
+      check string "agent parsed" "keeper-sangsu-agent" agent.name;
+      check bool "last_seen normalized to ISO" true
+        (String.length agent.last_seen > 0 && String.contains agent.last_seen 'T')
+  | Error msg -> fail ("expected numeric last_seen compatibility: " ^ msg)
+
+let test_heartbeat_repairs_legacy_agent_last_seen () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:None);
+      let legacy_agent_json =
+        `Assoc
+          [
+            ("name", `String "keeper-sangsu-agent");
+            ("agent_type", `String "keeper");
+            ("status", `String "active");
+            ("capabilities", `List [ `String "heartbeat" ]);
+            ("current_task", `Null);
+            ("joined_at", `String "2026-03-26T00:00:00Z");
+            ("last_seen", `Int 1711411200);
+          ]
+      in
+      write_text_file (agent_path config "keeper-sangsu-agent")
+        (Yojson.Safe.to_string legacy_agent_json);
+
+      ignore (Room.heartbeat config ~agent_name:"keeper-sangsu-agent");
+
+      let repaired_json =
+        Yojson.Safe.from_file (agent_path config "keeper-sangsu-agent")
+      in
+      check bool "last_seen rewritten as string" true
+        (match Yojson.Safe.Util.member "last_seen" repaired_json with
+         | `String value -> String.length value > 0
+         | _ -> false))
+
 let () =
   run "Room_state_recovery"
     [
@@ -134,5 +191,9 @@ let () =
             test_read_state_recovers_legacy_active_agent_entries;
           test_case "filters invalid active_agents entries" `Quick
             test_read_state_filters_invalid_active_agent_entries;
+          test_case "agent parser accepts numeric last_seen" `Quick
+            test_agent_of_yojson_accepts_numeric_last_seen;
+          test_case "heartbeat repairs legacy agent last_seen" `Quick
+            test_heartbeat_repairs_legacy_agent_last_seen;
         ] );
     ]

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -41,6 +41,13 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
+let with_cwd path f =
+  let old = Sys.getcwd () in
+  Unix.chdir path;
+  Fun.protect
+    ~finally:(fun () -> Unix.chdir old)
+    f
+
 let with_temp_voice_config config_json f =
   let root = temp_dir () in
   let masc_dir = Filename.concat root ".masc" in
@@ -52,6 +59,14 @@ let with_temp_voice_config config_json f =
   Fun.protect
     ~finally:(fun () -> cleanup_dir root)
     (fun () -> with_env "ME_ROOT" root f)
+
+let write_voice_config root config_json =
+  let masc_dir = Filename.concat root ".masc" in
+  if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
+  let config_path = Filename.concat masc_dir "voice_config.json" in
+  let oc = open_out config_path in
+  output_string oc config_json;
+  close_out oc
 
 let with_ctx_no_net f =
   Eio_main.run (fun env ->
@@ -612,6 +627,140 @@ let test_voice_tools_count () =
   (* Verify we have a known number of voice tools *)
   check bool "at least 6 voice tools" true (List.length voice_tools >= 6)
 
+let test_voice_config_prefers_repo_root_over_me_root () =
+  let repo_root = temp_dir () in
+  let me_root = temp_dir () in
+  let repo_json =
+    {|
+{
+  "tts": {
+    "default_model": "repo-model",
+    "default_voice": "RepoVoice",
+    "default_voice_settings": { "stability": 0.5, "similarity_boost": 0.75, "style": 0.0 },
+    "agent_voices": {},
+    "agent_voice_settings": {},
+    "endpoints": [
+      { "id": "repo-tts", "kind": "openai_compat", "base_url": "https://example.invalid/v1", "enabled": true }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      { "id": "repo-stt", "kind": "openai_compat", "base_url": "https://api.openai.com/v1", "enabled": true }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      { "id": "repo-session", "kind": "voice_mcp", "base_url": "http://127.0.0.1:8936", "enabled": true }
+    ]
+  },
+  "local_playback": { "enabled": false, "agents": [] }
+}
+|}
+  in
+  let global_json =
+    {|
+{
+  "tts": {
+    "default_model": "global-model",
+    "default_voice": "GlobalVoice",
+    "default_voice_settings": { "stability": 0.5, "similarity_boost": 0.75, "style": 0.0 },
+    "agent_voices": {},
+    "agent_voice_settings": {},
+    "endpoints": [
+      { "id": "global-tts", "kind": "openai_compat", "base_url": "https://example.invalid/v1", "enabled": true }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      { "id": "global-stt", "kind": "openai_compat", "base_url": "https://api.openai.com/v1", "enabled": true }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      { "id": "global-session", "kind": "voice_mcp", "base_url": "http://127.0.0.1:8936", "enabled": true }
+    ]
+  },
+  "local_playback": { "enabled": false, "agents": [] }
+}
+|}
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir repo_root;
+      cleanup_dir me_root)
+    (fun () ->
+      Unix.mkdir (Filename.concat repo_root ".git") 0o755;
+      write_voice_config repo_root repo_json;
+      write_voice_config me_root global_json;
+      let nested = Filename.concat repo_root "subdir" in
+      Unix.mkdir nested 0o755;
+      with_env "ME_ROOT" me_root (fun () ->
+        with_cwd nested (fun () ->
+          match Masc_mcp.Voice_config.load () with
+          | Ok config ->
+              check string "repo config wins" "RepoVoice"
+                config.tts.default_voice;
+              let expected_path = Filename.concat repo_root ".masc/voice_config.json" in
+              let actual_path = Masc_mcp.Voice_config.config_path () in
+              let expected_stat = Unix.stat expected_path in
+              let actual_stat = Unix.stat actual_path in
+              check int "resolved path inode matches repo config"
+                expected_stat.st_ino actual_stat.st_ino;
+              check int "resolved path device matches repo config"
+                expected_stat.st_dev actual_stat.st_dev
+          | Error e ->
+              failf "expected repo voice config to load: %s" e)))
+
+let test_voice_runtime_paths_prefer_masc_base_path () =
+  let base_root = temp_dir () in
+  let me_root = temp_dir () in
+  let config_json =
+    {|
+{
+  "tts": {
+    "default_model": "base-model",
+    "default_voice": "BaseVoice",
+    "default_voice_settings": { "stability": 0.5, "similarity_boost": 0.75, "style": 0.0 },
+    "agent_voices": {},
+    "agent_voice_settings": {},
+    "endpoints": [
+      { "id": "base-tts", "kind": "openai_compat", "base_url": "https://example.invalid/v1", "enabled": true }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      { "id": "base-stt", "kind": "openai_compat", "base_url": "https://api.openai.com/v1", "enabled": true }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      { "id": "base-session", "kind": "voice_mcp", "base_url": "http://127.0.0.1:8936", "enabled": true }
+    ]
+  },
+  "local_playback": { "enabled": false, "agents": [] }
+}
+|}
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir base_root;
+      cleanup_dir me_root)
+    (fun () ->
+      write_voice_config base_root config_json;
+      with_env "MASC_BASE_PATH" base_root (fun () ->
+        with_env "ME_ROOT" me_root (fun () ->
+          let expected = Filename.concat base_root ".masc" in
+          check string "voice bridge uses MASC_BASE_PATH" expected
+            (Masc_mcp.Voice_bridge.masc_base_dir ());
+          check string "keeper voice local uses MASC_BASE_PATH" expected
+            (Masc_mcp.Keeper_voice_local.masc_base_dir ());
+          check string "voice config path uses MASC_BASE_PATH"
+            (Filename.concat expected "voice_config.json")
+            (Masc_mcp.Voice_config.config_path ()))))
+
 let () =
   run "Tool_voice"
     [
@@ -653,6 +802,10 @@ let () =
             test_voice_conference_end_with_unavailable_server_errors;
           test_case "voice public config json" `Quick
             test_voice_public_config_json;
+          test_case "voice config prefers repo root over me root" `Quick
+            test_voice_config_prefers_repo_root_over_me_root;
+          test_case "voice runtime paths prefer MASC_BASE_PATH" `Quick
+            test_voice_runtime_paths_prefer_masc_base_path;
           test_case "local playback argv prefers ffplay" `Quick
             test_local_playback_argv_prefers_ffplay;
           test_case "local playback argv falls back to open" `Quick

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -58,7 +58,8 @@ let with_temp_voice_config config_json f =
   close_out oc;
   Fun.protect
     ~finally:(fun () -> cleanup_dir root)
-    (fun () -> with_env "ME_ROOT" root f)
+    (fun () ->
+      with_env "MASC_BASE_PATH" root (fun () -> with_env "ME_ROOT" root f))
 
 let write_voice_config root config_json =
   let masc_dir = Filename.concat root ".masc" in


### PR DESCRIPTION
## Summary
- expand dashboard config/runtime path diagnostics and keeper settings readability
- repair legacy agent state and expose clearer runtime liveness context
- make keeper voice tools/tool-use always available and align voice/config/session paths with repo runtime

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/config-path-agent-liveness test/test_dashboard_tools.exe test/test_room_state_recovery.exe test/test_tool_voice.exe test/test_keeper_tool_exposure.exe test/test_keeper_safety_gates.exe
- ./_build/default/test/test_dashboard_tools.exe
- ./_build/default/test/test_room_state_recovery.exe
- ./_build/default/test/test_tool_voice.exe
- ./_build/default/test/test_keeper_tool_exposure.exe
- ./_build/default/test/test_keeper_safety_gates.exe
- bash -n start-masc-mcp.sh
- runtime smoke: restarted 8935 from this worktree, MCP initialize + masc_voice_agent + masc_voice_session_start + masc_voice_speak; confirmed /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.masc/audio/1774575763_sangsu.mp3 and /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.masc/voice_sessions/sangsu.json