### PR TITLE
fix(ci): install ripgrep before check-eio-conventions (#3404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,9 @@ jobs:
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
+      - name: Install OS dependencies
+        run: sudo apt-get install -y ripgrep
+
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary
- install `ripgrep` before the CI lint/check-eio-conventions step runs
- split this change out of stacked branches so `#3404` stays isolated

## Verification
- change is limited to `.github/workflows/ci.yml`
- acceptance gate is the GitHub Actions `check-eio-conventions` job on this PR

## Review
- GLM-5 via `sb glm-text` on 2026-03-27: No findings.

Closes #3404