### PR TITLE
fix(test): recover quick-suite regressions (#3396)

### DIFF
--- a/test/test_fire_task.ml
+++ b/test/test_fire_task.ml
@@ -119,40 +119,47 @@ let test_dispatch_missing_goal () =
    ============================================================ *)
 
 let test_task_creation_in_backlog () =
-  with_temp_dir (fun dir ->
-    let config = init_room dir in
-    let result = Room.add_task config
-      ~title:"Test fire task goal"
-      ~priority:2
-      ~description:"Fire-and-forget task" in
-    (* Verify task was created *)
-    check bool "result contains task-" true
-      (try ignore (Str.search_forward (Str.regexp_string "task-") result 0); true
-       with Not_found -> false);
-    (* Verify it shows in status *)
-    let status = Room.status config in
-    check bool "task visible in status" true
-      (try ignore (Str.search_forward (Str.regexp_string "Test fire task goal") status 0); true
-       with Not_found -> false)
-  )
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    with_temp_dir (fun dir ->
+      let config = init_room dir in
+      let result = Room.add_task config
+        ~title:"Test fire task goal"
+        ~priority:2
+        ~description:"Fire-and-forget task" in
+      (* Verify task was created *)
+      check bool "result contains task-" true
+        (try ignore (Str.search_forward (Str.regexp_string "task-") result 0); true
+         with Not_found -> false);
+      (* Verify it shows in status *)
+      let status = Room.status config in
+      check bool "task visible in status" true
+        (try ignore (Str.search_forward (Str.regexp_string "Test fire task goal") status 0); true
+         with Not_found -> false)
+    ))
 
 let test_task_priority_defaults () =
-  with_temp_dir (fun dir ->
-    let config = init_room dir in
-    let _result = Room.add_task config
-      ~title:"Default priority task"
-      ~priority:3
-      ~description:"Fire-and-forget task" in
-    (* Verify task exists in status output *)
-    let status = Room.status config in
-    check bool "task title in status" true
-      (try ignore (Str.search_forward (Str.regexp_string "Default priority task") status 0); true
-       with Not_found -> false);
-    (* Verify priority is persisted in backlog (status output does not include priority) *)
-    let backlog = Room.read_backlog config in
-    check bool "task has correct priority" true
-      (List.exists (fun (t : Types_core.task) -> t.title = "Default priority task" && t.priority = 3) backlog.tasks)
-  )
+  Eio_main.run (fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    with_temp_dir (fun dir ->
+      let config = init_room dir in
+      let _result = Room.add_task config
+        ~title:"Default priority task"
+        ~priority:3
+        ~description:"Fire-and-forget task" in
+      (* Verify task exists in status output *)
+      let status = Room.status config in
+      check bool "task title in status" true
+        (try ignore (Str.search_forward (Str.regexp_string "Default priority task") status 0); true
+         with Not_found -> false);
+      (* Verify priority is persisted in backlog (status output does not include priority) *)
+      let backlog = Room.read_backlog config in
+      check bool "task has correct priority" true
+        (List.exists
+           (fun (t : Types_core.task) ->
+             t.title = "Default priority task" && t.priority = 3)
+           backlog.tasks)
+    ))
 
 (* ============================================================
    Argument Parsing Tests

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -756,12 +756,12 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
           resident_json |> member "keepers" |> to_list
           |> List.find (fun row -> member "meta" row |> member "name" = `String "resident-demo"))
       in
-      check string "resident runtime_class" "keeper"
+      check string "resident runtime_class" "resident_keeper"
         Yojson.Safe.Util.(resident_row |> member "runtime_class" |> to_string);
-      check bool "resident desired removed" true
-        Yojson.Safe.Util.(resident_row |> member "desired" = `Null);
+      check bool "resident desired" true
+        Yojson.Safe.Util.(resident_row |> member "desired" |> to_bool);
       check bool "resident registered" true
-        Yojson.Safe.Util.(resident_row |> member "registered" |> to_bool);
+        Yojson.Safe.Util.(resident_row |> member "resident_registered" |> to_bool);
       let ok, persistent_body =
         dispatch "masc_persistent_agent_list" (`Assoc [ ("detailed", `Bool true) ])
       in
@@ -772,12 +772,12 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
           persistent_json |> member "persistent_agents" |> to_list
           |> List.find (fun row -> member "meta" row |> member "name" = `String "persistent-demo"))
       in
-      check string "persistent runtime_class" "keeper"
+      check string "persistent runtime_class" "persistent_agent"
         Yojson.Safe.Util.(persistent_row |> member "runtime_class" |> to_string);
-      check bool "persistent desired removed" true
-        Yojson.Safe.Util.(persistent_row |> member "desired" = `Null);
+      check bool "persistent desired" false
+        Yojson.Safe.Util.(persistent_row |> member "desired" |> to_bool);
       check bool "persistent registered" false
-        Yojson.Safe.Util.(persistent_row |> member "registered" |> to_bool))
+        Yojson.Safe.Util.(persistent_row |> member "resident_registered" |> to_bool))
 
 let test_resident_list_items_expose_runtime_config_summary () =
   Eio_main.run @@ fun env ->
@@ -828,7 +828,7 @@ let test_resident_list_items_expose_runtime_config_summary () =
           json |> member "items" |> to_list
           |> List.find (fun item -> member "name" item = `String "resident-demo"))
       in
-      check string "runtime class" "keeper"
+      check string "runtime class" "resident_keeper"
         Yojson.Safe.Util.(row |> member "runtime_class" |> to_string);
       check string "scope kind" "global"
         Yojson.Safe.Util.(row |> member "scope_kind" |> to_string);
@@ -1035,26 +1035,23 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
             ])
       in
       check bool "persistent up ok" true ok;
-      check bool "resident autonomy removed (no dispatch)" true
-        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
-           ~name:"masc_keeper_autonomy"
-           ~args:(`Assoc [ ("name", `String "resident-demo") ])
-        = None);
-      check bool "resident autonomy set removed (no dispatch)" true
-        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
-           ~name:"masc_keeper_autonomy"
-           ~args:
-             (`Assoc
-               [
-                 ("name", `String "resident-demo");
-                 ("level", `String "L1_Reactive");
-               ])
-        = None);
-      check bool "resident goals removed (no dispatch)" true
-        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
-           ~name:"masc_keeper_goals"
-           ~args:(`Assoc [ ("name", `String "resident-demo") ])
-        = None);
+      let ok, _autonomy_body =
+        dispatch "masc_keeper_autonomy" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident autonomy removed" false ok;
+      let ok, _ =
+        dispatch "masc_keeper_autonomy"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("level", `String "L1_Reactive");
+            ])
+      in
+      check bool "resident autonomy set removed" false ok;
+      let ok, _goals_body =
+        dispatch "masc_keeper_goals" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident goals removed" false ok;
       let ok, trajectory_body =
         dispatch "masc_keeper_trajectory"
           (`Assoc [ ("name", `String "resident-demo"); ("limit", `Int 5) ])
@@ -1095,10 +1092,10 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
       in
       check bool "persistent alias status ok" true ok;
       let persistent_status_json = parse_json_exn persistent_status_body in
-      check string "persistent alias runtime_class" "keeper"
+      check string "persistent alias runtime_class" "persistent_agent"
         Yojson.Safe.Util.(persistent_status_json |> member "runtime_class" |> to_string);
       check bool "persistent alias marks resident" true
-        Yojson.Safe.Util.(persistent_status_json |> member "registered" |> to_bool);
+        Yojson.Safe.Util.(persistent_status_json |> member "resident_registered" |> to_bool);
       let ok, _ =
         dispatch "masc_keeper_down" (`Assoc [ ("name", `String "resident-demo") ])
       in
@@ -1259,8 +1256,11 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
       in
       check bool "resident spec exists" true (Sys.file_exists resident_path);
       let resident_json = Yojson.Safe.from_file resident_path in
-      check string "resident spec name" "sangsu"
-        Yojson.Safe.Util.(resident_json |> member "name" |> to_string))
+      check bool "resident voice enabled" voice_enabled
+        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
+      let expected_channel = if voice_enabled then "voice_text" else "text_only" in
+      check string "resident voice channel" expected_channel
+        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string))
 
 let test_keeper_up_update_preserves_proactive_when_omitted () =
   Eio_main.run @@ fun env ->
@@ -1389,19 +1389,23 @@ let test_write_meta_syncs_registered_resident_seed () =
       in
       check bool "resident spec exists" true (Sys.file_exists resident_path);
       let resident_json = Yojson.Safe.from_file resident_path in
-      check string "resident spec name" "buddy"
-        Yojson.Safe.Util.(resident_json |> member "name" |> to_string);
-      check bool "voice_enabled absent in boot entry" true
-        (Yojson.Safe.Util.(resident_json |> member "voice_enabled") = `Null);
-      check bool "seed_meta absent in thin format" true
-        (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null);
+      check bool "resident voice disabled sync" false
+        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
+      check string "resident voice channel sync" "text_only"
+        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string);
+      check string "resident voice agent id sync" ""
+        Yojson.Safe.Util.(resident_json |> member "voice_agent_id" |> to_string);
+      check string "persona_name in resident spec" "buddy"
+        Yojson.Safe.Util.(resident_json |> member "persona_name" |> to_string);
       (match Masc_mcp.Keeper_registry.get ~base_path:config.base_path "buddy" with
        | Some entry ->
            check bool "registry meta syncs proactive" false
              entry.Masc_mcp.Keeper_registry.meta.proactive.enabled;
            check bool "registry meta syncs voice enabled" false
              entry.Masc_mcp.Keeper_registry.meta.voice_enabled
-       | None -> ()))
+       | None -> ());
+      check bool "seed_meta absent in thin format" true
+        (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null))
 
 let test_keeper_up_persists_allowed_paths_to_status_policy () =
   Eio_main.run @@ fun env ->
@@ -1525,11 +1529,7 @@ let test_parse_agent_status_reads_compressed_filesystem_backend () =
               | Ok content -> content
               | Error e -> fail e
             in
-            check bool "raw content is valid JSON" true
-              (try
-                 ignore (Yojson.Safe.from_string raw);
-                 true
-               with Yojson.Json_error _ -> false);
+            check string "compressed header prefix" "ZSTD" (String.sub raw 0 4);
             let status_json =
               Masc_mcp.Keeper_exec_status.parse_agent_status config ~agent_name
             in

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -756,12 +756,12 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
           resident_json |> member "keepers" |> to_list
           |> List.find (fun row -> member "meta" row |> member "name" = `String "resident-demo"))
       in
-      check string "resident runtime_class" "resident_keeper"
+      check string "resident runtime_class" "keeper"
         Yojson.Safe.Util.(resident_row |> member "runtime_class" |> to_string);
-      check bool "resident desired" true
-        Yojson.Safe.Util.(resident_row |> member "desired" |> to_bool);
+      check bool "resident desired removed" true
+        Yojson.Safe.Util.(resident_row |> member "desired" = `Null);
       check bool "resident registered" true
-        Yojson.Safe.Util.(resident_row |> member "resident_registered" |> to_bool);
+        Yojson.Safe.Util.(resident_row |> member "registered" |> to_bool);
       let ok, persistent_body =
         dispatch "masc_persistent_agent_list" (`Assoc [ ("detailed", `Bool true) ])
       in
@@ -772,12 +772,12 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
           persistent_json |> member "persistent_agents" |> to_list
           |> List.find (fun row -> member "meta" row |> member "name" = `String "persistent-demo"))
       in
-      check string "persistent runtime_class" "persistent_agent"
+      check string "persistent runtime_class" "keeper"
         Yojson.Safe.Util.(persistent_row |> member "runtime_class" |> to_string);
-      check bool "persistent desired" false
-        Yojson.Safe.Util.(persistent_row |> member "desired" |> to_bool);
+      check bool "persistent desired removed" true
+        Yojson.Safe.Util.(persistent_row |> member "desired" = `Null);
       check bool "persistent registered" false
-        Yojson.Safe.Util.(persistent_row |> member "resident_registered" |> to_bool))
+        Yojson.Safe.Util.(persistent_row |> member "registered" |> to_bool))
 
 let test_resident_list_items_expose_runtime_config_summary () =
   Eio_main.run @@ fun env ->
@@ -828,7 +828,7 @@ let test_resident_list_items_expose_runtime_config_summary () =
           json |> member "items" |> to_list
           |> List.find (fun item -> member "name" item = `String "resident-demo"))
       in
-      check string "runtime class" "resident_keeper"
+      check string "runtime class" "keeper"
         Yojson.Safe.Util.(row |> member "runtime_class" |> to_string);
       check string "scope kind" "global"
         Yojson.Safe.Util.(row |> member "scope_kind" |> to_string);
@@ -1035,23 +1035,26 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
             ])
       in
       check bool "persistent up ok" true ok;
-      let ok, _autonomy_body =
-        dispatch "masc_keeper_autonomy" (`Assoc [ ("name", `String "resident-demo") ])
-      in
-      check bool "resident autonomy removed" false ok;
-      let ok, _ =
-        dispatch "masc_keeper_autonomy"
-          (`Assoc
-            [
-              ("name", `String "resident-demo");
-              ("level", `String "L1_Reactive");
-            ])
-      in
-      check bool "resident autonomy set removed" false ok;
-      let ok, _goals_body =
-        dispatch "masc_keeper_goals" (`Assoc [ ("name", `String "resident-demo") ])
-      in
-      check bool "resident goals removed" false ok;
+      check bool "resident autonomy removed (no dispatch)" true
+        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
+           ~name:"masc_keeper_autonomy"
+           ~args:(`Assoc [ ("name", `String "resident-demo") ])
+        = None);
+      check bool "resident autonomy set removed (no dispatch)" true
+        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
+           ~name:"masc_keeper_autonomy"
+           ~args:
+             (`Assoc
+               [
+                 ("name", `String "resident-demo");
+                 ("level", `String "L1_Reactive");
+               ])
+        = None);
+      check bool "resident goals removed (no dispatch)" true
+        (Masc_mcp.Tool_keeper.dispatch keeper_ctx
+           ~name:"masc_keeper_goals"
+           ~args:(`Assoc [ ("name", `String "resident-demo") ])
+        = None);
       let ok, trajectory_body =
         dispatch "masc_keeper_trajectory"
           (`Assoc [ ("name", `String "resident-demo"); ("limit", `Int 5) ])
@@ -1092,10 +1095,10 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
       in
       check bool "persistent alias status ok" true ok;
       let persistent_status_json = parse_json_exn persistent_status_body in
-      check string "persistent alias runtime_class" "persistent_agent"
+      check string "persistent alias runtime_class" "keeper"
         Yojson.Safe.Util.(persistent_status_json |> member "runtime_class" |> to_string);
       check bool "persistent alias marks resident" true
-        Yojson.Safe.Util.(persistent_status_json |> member "resident_registered" |> to_bool);
+        Yojson.Safe.Util.(persistent_status_json |> member "registered" |> to_bool);
       let ok, _ =
         dispatch "masc_keeper_down" (`Assoc [ ("name", `String "resident-demo") ])
       in
@@ -1256,11 +1259,8 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
       in
       check bool "resident spec exists" true (Sys.file_exists resident_path);
       let resident_json = Yojson.Safe.from_file resident_path in
-      check bool "resident voice enabled" voice_enabled
-        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
-      let expected_channel = if voice_enabled then "voice_text" else "text_only" in
-      check string "resident voice channel" expected_channel
-        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string))
+      check string "resident spec name" "sangsu"
+        Yojson.Safe.Util.(resident_json |> member "name" |> to_string))
 
 let test_keeper_up_update_preserves_proactive_when_omitted () =
   Eio_main.run @@ fun env ->
@@ -1389,23 +1389,19 @@ let test_write_meta_syncs_registered_resident_seed () =
       in
       check bool "resident spec exists" true (Sys.file_exists resident_path);
       let resident_json = Yojson.Safe.from_file resident_path in
-      check bool "resident voice disabled sync" false
-        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
-      check string "resident voice channel sync" "text_only"
-        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string);
-      check string "resident voice agent id sync" ""
-        Yojson.Safe.Util.(resident_json |> member "voice_agent_id" |> to_string);
-      check string "persona_name in resident spec" "buddy"
-        Yojson.Safe.Util.(resident_json |> member "persona_name" |> to_string);
+      check string "resident spec name" "buddy"
+        Yojson.Safe.Util.(resident_json |> member "name" |> to_string);
+      check bool "voice_enabled absent in boot entry" true
+        (Yojson.Safe.Util.(resident_json |> member "voice_enabled") = `Null);
+      check bool "seed_meta absent in thin format" true
+        (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null);
       (match Masc_mcp.Keeper_registry.get ~base_path:config.base_path "buddy" with
        | Some entry ->
            check bool "registry meta syncs proactive" false
              entry.Masc_mcp.Keeper_registry.meta.proactive.enabled;
            check bool "registry meta syncs voice enabled" false
              entry.Masc_mcp.Keeper_registry.meta.voice_enabled
-       | None -> ());
-      check bool "seed_meta absent in thin format" true
-        (Yojson.Safe.Util.(resident_json |> member "seed_meta") = `Null))
+       | None -> ()))
 
 let test_keeper_up_persists_allowed_paths_to_status_policy () =
   Eio_main.run @@ fun env ->
@@ -1529,7 +1525,11 @@ let test_parse_agent_status_reads_compressed_filesystem_backend () =
               | Ok content -> content
               | Error e -> fail e
             in
-            check string "compressed header prefix" "ZSTD" (String.sub raw 0 4);
+            check bool "raw content is valid JSON" true
+              (try
+                 ignore (Yojson.Safe.from_string raw);
+                 true
+               with Yojson.Json_error _ -> false);
             let status_json =
               Masc_mcp.Keeper_exec_status.parse_agent_status config ~agent_name
             in

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -177,6 +177,8 @@ let () = test "dispatch_check_claim_next_marks_current_task_set" (fun () ->
 )
 
 let () = test "dispatch_room_strategy_get" (fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
   match Tool_room.dispatch ctx ~name:"masc_room_strategy_get" ~args:(`Assoc []) with
@@ -188,6 +190,8 @@ let () = test "dispatch_room_strategy_get" (fun () ->
 )
 
 let () = test "dispatch_room_strategy_set" (fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
   let args =


### PR DESCRIPTION
## Summary
- restore the quick-suite regressions on current `main`
- keep the Eio/fs fixes for `test_fire_task` and `test_tool_room_coverage`
- keep `test_tool_keeper` aligned with the current keeper runtime contract after rebasing
- supersedes #3398, which carried unrelated stacked CI/build commits

## Verification
- `dune build --root . --build-dir _build_test ./test/test_fire_task.exe ./test/test_tool_keeper.exe ./test/test_dashboard_coverage.exe ./test/test_tool_room_coverage.exe ./test/test_dashboard_mission.exe ./test/test_tool_misc_coverage.exe ./test/test_tool_task_coverage.exe ./test/test_error_logging_coverage.exe ./test/test_ci_run_tests_script.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_fire_task.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_tool_keeper.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_dashboard_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_tool_room_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_dashboard_mission.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_tool_misc_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_tool_task_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_error_logging_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build_test/default/test/test_ci_run_tests_script.exe`

## Review
- GLM-5 via `sb glm-text` on 2026-03-27: No findings.

Closes #3396