### PR TITLE
fix(ux): add retry/delete actions for autoresearch error loops (#3300)

### DIFF
--- a/dashboard/src/api/autoresearch.ts
+++ b/dashboard/src/api/autoresearch.ts
@@ -56,9 +56,10 @@ export interface AutoresearchLoopDetail extends AutoresearchLoopSummary {
 
 export interface AutoresearchLoopActionResponse {
   ok: boolean
-  action: 'retry' | 'delete'
+  action?: 'retry' | 'delete'
   loop_id?: string
   loop?: AutoresearchLoopSummary
+  error?: string
 }
 
 export function fetchAutoresearchLoops(): Promise<AutoresearchLoopsResponse> {

--- a/dashboard/src/api/autoresearch.ts
+++ b/dashboard/src/api/autoresearch.ts
@@ -1,7 +1,7 @@
 // MASC Dashboard — Autoresearch API client
 // Fetches loop list and detail from dedicated HTTP endpoints.
 
-import { get } from './core'
+import { get, post } from './core'
 
 export interface AutoresearchCycleRecord {
   cycle: number
@@ -54,6 +54,13 @@ export interface AutoresearchLoopDetail extends AutoresearchLoopSummary {
   history_count: number
 }
 
+export interface AutoresearchLoopActionResponse {
+  ok: boolean
+  action: 'retry' | 'delete'
+  loop_id?: string
+  loop?: AutoresearchLoopSummary
+}
+
 export function fetchAutoresearchLoops(): Promise<AutoresearchLoopsResponse> {
   return get('/api/v1/autoresearch/loops')
 }
@@ -63,4 +70,12 @@ export function fetchAutoresearchLoopDetail(
   historyLimit = 100,
 ): Promise<AutoresearchLoopDetail> {
   return get(`/api/v1/autoresearch/loops/${encodeURIComponent(loopId)}?history_limit=${historyLimit}`)
+}
+
+export function retryAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
+  return post('/api/v1/autoresearch/loops/retry', { loop_id: loopId })
+}
+
+export function deleteAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
+  return post('/api/v1/autoresearch/loops/delete', { loop_id: loopId })
 }

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -79,9 +79,15 @@ async function flushUi(): Promise<void> {
 async function loadComponentWithApi(api: {
   fetchAutoresearchLoops: () => Promise<AutoresearchLoopsResponse>
   fetchAutoresearchLoopDetail: (loopId: string) => Promise<AutoresearchLoopDetail>
+  retryAutoresearchLoop?: (loopId: string) => Promise<unknown>
+  deleteAutoresearchLoop?: (loopId: string) => Promise<unknown>
 }) {
   vi.resetModules()
-  vi.doMock('../api', () => api)
+  vi.doMock('../api', () => ({
+    ...api,
+    retryAutoresearchLoop: api.retryAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'retry' }),
+    deleteAutoresearchLoop: api.deleteAutoresearchLoop ?? vi.fn().mockResolvedValue({ ok: true, action: 'delete' }),
+  }))
   return import('./autoresearch')
 }
 
@@ -203,5 +209,88 @@ describe('Autoresearch surface refresh', () => {
 
     expect(fetchDetail).toHaveBeenLastCalledWith('loop-a111')
     expect(container.textContent).toContain('target-a.ml')
+  })
+
+  it('offers a retry action for persisted error loops', async () => {
+    const erroredLoop = loopSummary('loop-err0', {
+      status: 'error',
+      live: false,
+      error: 'managed worktree missing',
+      current_cycle: 0,
+      max_cycles: 1,
+    })
+    const recoveredLoop = {
+      ...erroredLoop,
+      status: 'running' as const,
+      live: true,
+      error: null,
+    }
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+      .mockResolvedValueOnce({ loops: [recoveredLoop], total: 1 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+      .mockResolvedValueOnce(loopDetail(recoveredLoop))
+    const retryLoop = vi.fn<(loopId: string) => Promise<unknown>>()
+      .mockResolvedValue({ ok: true, action: 'retry' })
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+      retryAutoresearchLoop: retryLoop,
+    })
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    const retryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('재시도'))
+    const deleteButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('삭제'))
+
+    expect(retryButton).toBeTruthy()
+    expect(deleteButton).toBeTruthy()
+
+    retryButton?.click()
+    await flushUi()
+
+    expect(retryLoop).toHaveBeenCalledWith('loop-err0')
+    expect(container.textContent).toContain('실행 중')
+  })
+
+  it('offers a delete action for persisted error loops', async () => {
+    const erroredLoop = loopSummary('loop-del0', {
+      status: 'error',
+      live: false,
+      error: 'managed worktree missing',
+      current_cycle: 0,
+      max_cycles: 1,
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+      .mockResolvedValueOnce({ loops: [], total: 0 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+    const deleteLoop = vi.fn<(loopId: string) => Promise<unknown>>()
+      .mockResolvedValue({ ok: true, action: 'delete' })
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+      deleteAutoresearchLoop: deleteLoop,
+    })
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    const deleteButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('삭제'))
+    deleteButton?.click()
+    await flushUi()
+
+    expect(deleteLoop).toHaveBeenCalledWith('loop-del0')
+    expect(container.textContent).toContain('실행된 오토리서치 루프가 없습니다.')
   })
 })

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -93,10 +93,13 @@ async function loadComponentWithApi(api: {
 
 describe('Autoresearch surface refresh', () => {
   let container: HTMLDivElement
+  let confirmMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    confirmMock = vi.fn(() => true)
+    vi.stubGlobal('confirm', confirmMock)
   })
 
   afterEach(() => {
@@ -105,6 +108,7 @@ describe('Autoresearch surface refresh', () => {
     vi.resetModules()
     vi.clearAllMocks()
     vi.doUnmock('../api')
+    vi.unstubAllGlobals()
   })
 
   it('reloads selected detail when the surface refreshes', async () => {
@@ -290,7 +294,136 @@ describe('Autoresearch surface refresh', () => {
     deleteButton?.click()
     await flushUi()
 
+    expect(confirmMock).toHaveBeenCalledTimes(1)
     expect(deleteLoop).toHaveBeenCalledWith('loop-del0')
     expect(container.textContent).toContain('실행된 오토리서치 루프가 없습니다.')
+  })
+
+  it('does not delete when the confirmation is cancelled', async () => {
+    confirmMock.mockReturnValueOnce(false)
+    const erroredLoop = loopSummary('loop-del1', {
+      status: 'error',
+      live: false,
+      error: 'managed worktree missing',
+      current_cycle: 0,
+      max_cycles: 1,
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+    const deleteLoop = vi.fn<(loopId: string) => Promise<unknown>>()
+      .mockResolvedValue({ ok: true, action: 'delete' })
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+      deleteAutoresearchLoop: deleteLoop,
+    })
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    const deleteButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('삭제'))
+    deleteButton?.click()
+    await flushUi()
+
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    expect(deleteLoop).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('managed worktree missing')
+  })
+
+  it('shows loop action errors and re-enables buttons after a failed retry', async () => {
+    const erroredLoop = loopSummary('loop-err1', {
+      status: 'error',
+      live: false,
+      error: 'managed worktree missing',
+      current_cycle: 0,
+      max_cycles: 1,
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+    const retryLoop = vi.fn<(loopId: string) => Promise<unknown>>()
+      .mockRejectedValue(new Error('retry failed'))
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+      retryAutoresearchLoop: retryLoop,
+    })
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    const retryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('재시도')) as HTMLButtonElement | undefined
+    const deleteButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('삭제')) as HTMLButtonElement | undefined
+    retryButton?.click()
+    await flushUi()
+
+    expect(retryLoop).toHaveBeenCalledWith('loop-err1')
+    expect(container.textContent).toContain('retry failed')
+    expect(retryButton?.disabled).toBe(false)
+    expect(deleteButton?.disabled).toBe(false)
+  })
+
+  it('disables loop action buttons while a retry is in flight', async () => {
+    const erroredLoop = loopSummary('loop-err2', {
+      status: 'error',
+      live: false,
+      error: 'managed worktree missing',
+      current_cycle: 0,
+      max_cycles: 1,
+    })
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+      .mockResolvedValueOnce({ loops: [erroredLoop], total: 1 })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+      .mockResolvedValueOnce(loopDetail(erroredLoop))
+    let resolveRetry!: () => void
+    const retryLoop = vi.fn<(loopId: string) => Promise<unknown>>()
+      .mockImplementation(
+        () =>
+          new Promise<void>(resolve => {
+            resolveRetry = () => resolve()
+          }),
+      )
+
+    const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
+      fetchAutoresearchLoops: fetchLoops,
+      fetchAutoresearchLoopDetail: fetchDetail,
+      retryAutoresearchLoop: retryLoop,
+    })
+
+    render(html`<${Autoresearch} />`, container)
+    await refreshAutoresearchSurface()
+    await flushUi()
+
+    const retryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('재시도')) as HTMLButtonElement | undefined
+    retryButton?.click()
+    await flushUi()
+
+    const busyRetryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('복구 중...')) as HTMLButtonElement | undefined
+    const busyDeleteButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('삭제')) as HTMLButtonElement | undefined
+
+    expect(busyRetryButton?.disabled).toBe(true)
+    expect(busyDeleteButton?.disabled).toBe(true)
+
+    resolveRetry()
+    await flushUi()
+
+    const settledRetryButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('재시도')) as HTMLButtonElement | undefined
+    expect(settledRetryButton?.disabled).toBe(false)
   })
 })

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -8,8 +8,10 @@ import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { formatElapsedCompact } from '../lib/format-time'
 import {
+  deleteAutoresearchLoop,
   fetchAutoresearchLoops,
   fetchAutoresearchLoopDetail,
+  retryAutoresearchLoop,
   type AutoresearchLoopsResponse,
   type AutoresearchLoopDetail,
   type AutoresearchLoopSummary,
@@ -26,6 +28,8 @@ const selectedLoopId = signal<string | null>(null)
 const loopDetail = signal<AutoresearchLoopDetail | null>(null)
 const detailLoading = signal(false)
 const detailError = signal<string | null>(null)
+const loopActionBusy = signal(false)
+const loopActionError = signal<string | null>(null)
 
 let loopsRequest: Promise<void> | null = null
 let pendingRefreshDetail = false
@@ -380,12 +384,40 @@ function LoopDetailView() {
   const cycles = detail?.history ?? loop.recent_cycles ?? []
   const insights = detail?.insights ?? loop.insights ?? []
   const warnings = loop.warnings ?? []
+  const canRepairErrorLoop = loop.status === 'error'
 
   return html`
     <div class="flex flex-col gap-5">
       <${SurfaceCard} variant="compact">
-        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">루프 개요</div>
+        <div class="flex items-start justify-between gap-3 mb-3">
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">루프 개요</div>
+          ${canRepairErrorLoop ? html`
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                class="px-2.5 py-1 rounded text-[11px] text-[var(--text-body)] border border-card-border hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled=${loopActionBusy.value}
+                onClick=${() => { void retrySelectedLoop() }}
+              >
+                ${loopActionBusy.value ? '복구 중...' : '재시도'}
+              </button>
+              <button
+                type="button"
+                class="px-2.5 py-1 rounded text-[11px] text-red-400 border border-red-500/30 hover:border-red-400/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled=${loopActionBusy.value}
+                onClick=${() => { void deleteSelectedLoop() }}
+              >
+                삭제
+              </button>
+            </div>
+          ` : null}
+        </div>
         <${LoopOverview} loop=${loop} />
+        ${loopActionError.value ? html`
+          <div class="mt-3 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs">
+            ${loopActionError.value}
+          </div>
+        ` : null}
       <//>
 
       ${warnings.length > 0 ? html`
@@ -463,4 +495,29 @@ export function Autoresearch() {
       <${LoopDetailView} />
     </div>
   `
+}
+
+async function runLoopAction(action: () => Promise<unknown>) {
+  loopActionBusy.value = true
+  loopActionError.value = null
+  try {
+    await action()
+    await refreshAutoresearchSurface()
+  } catch (err) {
+    loopActionError.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loopActionBusy.value = false
+  }
+}
+
+async function retrySelectedLoop() {
+  const loop = selectedLoop.value
+  if (!loop?.loop_id) return
+  await runLoopAction(() => retryAutoresearchLoop(loop.loop_id))
+}
+
+async function deleteSelectedLoop() {
+  const loop = selectedLoop.value
+  if (!loop?.loop_id) return
+  await runLoopAction(() => deleteAutoresearchLoop(loop.loop_id))
 }

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -519,5 +519,11 @@ async function retrySelectedLoop() {
 async function deleteSelectedLoop() {
   const loop = selectedLoop.value
   if (!loop?.loop_id) return
+  if (typeof globalThis.confirm === 'function') {
+    const confirmed = globalThis.confirm(
+      `루프 ${loop.loop_id}와 연결된 worktree/branch/results를 삭제합니다. 계속할까요?`,
+    )
+    if (!confirmed) return
+  }
   await runLoopAction(() => deleteAutoresearchLoop(loop.loop_id))
 }

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -294,3 +294,204 @@ let autoresearch_loop_detail_json ~(base_path : string)
               ("history_count", `Int (List.length full_history));
             ]))
   | other -> Ok other
+
+let rehydrate_persisted_loop (persisted : Autoresearch_types.persisted_summary) =
+  let now = Time_compat.now () in
+  {
+    Autoresearch_types.loop_id = persisted.loop_id;
+    goal = persisted.goal;
+    metric_fn = persisted.metric_fn;
+    model_model = persisted.model_model;
+    target_file = persisted.target_file;
+    status = persisted.status;
+    error_message = persisted.error_message;
+    current_cycle = persisted.current_cycle;
+    baseline = persisted.baseline;
+    best_score = persisted.best_score;
+    best_cycle = persisted.best_cycle;
+    queued_hypothesis = persisted.queued_hypothesis;
+    history = [];
+    total_keeps = persisted.total_keeps;
+    total_discards = persisted.total_discards;
+    insights = [];
+    start_time = now -. max 0.0 persisted.elapsed_s;
+    updated_at = Option.value ~default:now persisted.updated_at;
+    cycle_timeout_s = persisted.cycle_timeout_s;
+    max_cycles = persisted.max_cycles;
+    workdir = persisted.workdir;
+    source_workdir = persisted.source_workdir;
+    program_note = persisted.program_note;
+    warnings = persisted.warnings;
+  }
+
+let load_loop_state ~base_path loop_id =
+  match Hashtbl.find_opt Autoresearch.active_loops loop_id with
+  | Some state -> Ok state
+  | None -> (
+      match Autoresearch.load_state ~base_path loop_id with
+      | Some persisted ->
+          let state = rehydrate_persisted_loop persisted in
+          Hashtbl.replace Autoresearch.active_loops loop_id state;
+          Autoresearch.latest_loop_id := Some loop_id;
+          Ok state
+      | None -> Error (Printf.sprintf "Loop %s not found" loop_id))
+
+let git_branch_exists ~repo_root branch =
+  let cmd =
+    Printf.sprintf "cd %s && git show-ref --verify --quiet refs/heads/%s"
+      (Filename.quote repo_root)
+      (Filename.quote branch)
+  in
+  match Autoresearch.run_capture_lines cmd with
+  | Unix.WEXITED 0, _ -> true
+  | _ -> false
+
+let ensure_managed_worktree ~base_path ~source_workdir ~loop_id =
+  match Autoresearch.git_top_level ~workdir:source_workdir with
+  | Error _ as err -> err
+  | Ok repo_root ->
+      let warnings = ref [] in
+      if Autoresearch.git_is_dirty ~workdir:source_workdir then
+        warnings := "source_workdir_dirty" :: !warnings;
+      (match Autoresearch.git_current_branch ~workdir:source_workdir with
+      | Some branch
+        when not (String.equal branch "main" || String.equal branch "master") ->
+          warnings := ("source_branch:" ^ branch) :: !warnings
+      | _ -> ());
+      let workdir =
+        Autoresearch.managed_worktree_dir ~base_path loop_id
+      in
+      if Sys.file_exists workdir then
+        Ok (workdir, repo_root, List.rev !warnings)
+      else begin
+        Autoresearch.ensure_dir (Filename.dirname workdir);
+        let branch = Autoresearch.managed_branch_name loop_id in
+        let cmd =
+          if git_branch_exists ~repo_root branch then
+            Printf.sprintf
+              "cd %s && git worktree add %s %s 2>&1"
+              (Filename.quote repo_root)
+              (Filename.quote workdir)
+              (Filename.quote branch)
+          else
+            Printf.sprintf
+              "cd %s && git worktree add -b %s %s HEAD 2>&1"
+              (Filename.quote repo_root)
+              (Filename.quote branch)
+              (Filename.quote workdir)
+        in
+        match Autoresearch.run_capture_lines cmd with
+        | Unix.WEXITED 0, _ ->
+            Ok (workdir, repo_root, List.rev !warnings)
+        | _, lines ->
+            Error
+              (Printf.sprintf "failed to create managed worktree: %s"
+                 (String.concat "\n" lines))
+      end
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name ->
+        rm_rf (Filename.concat path name)
+      );
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let delete_session_link ~base_path loop_id =
+  match Autoresearch.load_swarm_link_by_loop ~base_path loop_id with
+  | Some link ->
+      let session_path =
+        Autoresearch.session_link_file ~base_path link.session_id
+      in
+      if Sys.file_exists session_path then Sys.remove session_path
+  | None -> ()
+
+let retry_loop_json ~(base_path : string) ~(loop_id : string) :
+    (Yojson.Safe.t, string) result =
+  Autoresearch.with_loops_rw (fun () ->
+    match load_loop_state ~base_path loop_id with
+    | Error _ as error -> error
+    | Ok state -> (
+        match
+          ensure_managed_worktree ~base_path
+            ~source_workdir:state.source_workdir ~loop_id
+        with
+        | Error message ->
+            state.status <- Autoresearch.Error;
+            state.error_message <- Some message;
+            state.updated_at <- Time_compat.now ();
+            Autoresearch.save_state ~base_path state;
+            Error message
+        | Ok (workdir, _repo_root, warnings) ->
+            state.workdir <- workdir;
+            state.status <- Autoresearch.Running;
+            state.error_message <- None;
+            state.warnings <- warnings;
+            state.updated_at <- Time_compat.now ();
+            Hashtbl.replace Autoresearch.active_loops loop_id state;
+            Autoresearch.latest_loop_id := Some loop_id;
+            Autoresearch.save_state ~base_path state;
+            Ok
+              (`Assoc
+                [
+                  ("ok", `Bool true);
+                  ("action", `String "retry");
+                  ("loop", loop_summary_json base_path state);
+                ])))
+
+let delete_loop_json ~(base_path : string) ~(loop_id : string) :
+    (Yojson.Safe.t, string) result =
+  let state_or_persisted =
+    Autoresearch.with_loops_rw (fun () ->
+      let active = Hashtbl.find_opt Autoresearch.active_loops loop_id in
+      Hashtbl.remove Autoresearch.active_loops loop_id;
+      if !(Autoresearch.latest_loop_id) = Some loop_id then
+        Autoresearch.latest_loop_id := None;
+      match active with
+      | Some state -> Ok state
+      | None -> (
+          match Autoresearch.load_state ~base_path loop_id with
+          | Some persisted -> Ok (rehydrate_persisted_loop persisted)
+          | None -> Error (Printf.sprintf "Loop %s not found" loop_id)))
+  in
+  match state_or_persisted with
+  | Error _ as error -> error
+  | Ok state ->
+      Tool_autoresearch_registry.with_hypotheses_rw (fun () ->
+        Hashtbl.remove Tool_autoresearch_registry.pending_hypotheses loop_id;
+        Hashtbl.remove Tool_autoresearch_registry.custom_generators loop_id);
+      delete_session_link ~base_path loop_id;
+      (match
+         Autoresearch.git_top_level ~workdir:state.source_workdir
+       with
+      | Ok repo_root ->
+          let workdir =
+            Autoresearch.managed_worktree_dir ~base_path loop_id
+          in
+          if Sys.file_exists workdir then
+            let remove_cmd =
+              Printf.sprintf "cd %s && git worktree remove --force %s 2>&1"
+                (Filename.quote repo_root)
+                (Filename.quote workdir)
+            in
+            ignore (Autoresearch.run_capture_lines remove_cmd);
+          let branch = Autoresearch.managed_branch_name loop_id in
+          if git_branch_exists ~repo_root branch then
+            let branch_cmd =
+              Printf.sprintf "cd %s && git branch -D %s 2>&1"
+                (Filename.quote repo_root)
+                (Filename.quote branch)
+            in
+            ignore (Autoresearch.run_capture_lines branch_cmd)
+      | Error _ -> ());
+      let bundle_dir = Autoresearch.results_dir ~base_path loop_id in
+      if Sys.file_exists bundle_dir then rm_rf bundle_dir;
+      Ok
+        (`Assoc
+          [
+            ("ok", `Bool true);
+            ("action", `String "delete");
+            ("loop_id", `String loop_id);
+          ])

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -336,11 +336,26 @@ let load_loop_state ~base_path loop_id =
           Ok state
       | None -> Error (Printf.sprintf "Loop %s not found" loop_id))
 
+let validate_loop_id loop_id =
+  let len = String.length loop_id in
+  let rec all_safe idx =
+    if idx >= len then
+      true
+    else
+      match loop_id.[idx] with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> all_safe (idx + 1)
+      | _ -> false
+  in
+  if len > 0 && all_safe 0 then
+    Ok ()
+  else
+    Error "invalid loop_id"
+
 let git_branch_exists ~repo_root branch =
   let cmd =
-    Printf.sprintf "cd %s && git show-ref --verify --quiet refs/heads/%s"
+    Printf.sprintf "cd %s && git show-ref --verify --quiet %s"
       (Filename.quote repo_root)
-      (Filename.quote branch)
+      (Filename.quote ("refs/heads/" ^ branch))
   in
   match Autoresearch.run_capture_lines cmd with
   | Unix.WEXITED 0, _ -> true
@@ -411,87 +426,93 @@ let delete_session_link ~base_path loop_id =
 let retry_loop_json ~(base_path : string) ~(loop_id : string) :
     (Yojson.Safe.t, string) result =
   Autoresearch.with_loops_rw (fun () ->
-    match load_loop_state ~base_path loop_id with
+    match validate_loop_id loop_id with
     | Error _ as error -> error
-    | Ok state -> (
-        match
-          ensure_managed_worktree ~base_path
-            ~source_workdir:state.source_workdir ~loop_id
-        with
-        | Error message ->
-            state.status <- Autoresearch.Error;
-            state.error_message <- Some message;
-            state.updated_at <- Time_compat.now ();
-            Autoresearch.save_state ~base_path state;
-            Error message
-        | Ok (workdir, _repo_root, warnings) ->
-            state.workdir <- workdir;
-            state.status <- Autoresearch.Running;
-            state.error_message <- None;
-            state.warnings <- warnings;
-            state.updated_at <- Time_compat.now ();
-            Hashtbl.replace Autoresearch.active_loops loop_id state;
-            Autoresearch.latest_loop_id := Some loop_id;
-            Autoresearch.save_state ~base_path state;
-            Ok
-              (`Assoc
-                [
-                  ("ok", `Bool true);
-                  ("action", `String "retry");
-                  ("loop", loop_summary_json base_path state);
-                ])))
+    | Ok () -> (
+        match load_loop_state ~base_path loop_id with
+        | Error _ as error -> error
+        | Ok state -> (
+            match
+              ensure_managed_worktree ~base_path
+                ~source_workdir:state.source_workdir ~loop_id
+            with
+            | Error message ->
+                state.status <- Autoresearch.Error;
+                state.error_message <- Some message;
+                state.updated_at <- Time_compat.now ();
+                Autoresearch.save_state ~base_path state;
+                Error message
+            | Ok (workdir, _repo_root, warnings) ->
+                state.workdir <- workdir;
+                state.status <- Autoresearch.Running;
+                state.error_message <- None;
+                state.warnings <- warnings;
+                state.updated_at <- Time_compat.now ();
+                Hashtbl.replace Autoresearch.active_loops loop_id state;
+                Autoresearch.latest_loop_id := Some loop_id;
+                Autoresearch.save_state ~base_path state;
+                Ok
+                  (`Assoc
+                    [
+                      ("ok", `Bool true);
+                      ("action", `String "retry");
+                      ("loop", loop_summary_json base_path state);
+                    ]))))
 
 let delete_loop_json ~(base_path : string) ~(loop_id : string) :
     (Yojson.Safe.t, string) result =
-  let state_or_persisted =
-    Autoresearch.with_loops_rw (fun () ->
-      let active = Hashtbl.find_opt Autoresearch.active_loops loop_id in
-      Hashtbl.remove Autoresearch.active_loops loop_id;
-      if !(Autoresearch.latest_loop_id) = Some loop_id then
-        Autoresearch.latest_loop_id := None;
-      match active with
-      | Some state -> Ok state
-      | None -> (
-          match Autoresearch.load_state ~base_path loop_id with
-          | Some persisted -> Ok (rehydrate_persisted_loop persisted)
-          | None -> Error (Printf.sprintf "Loop %s not found" loop_id)))
-  in
-  match state_or_persisted with
+  match validate_loop_id loop_id with
   | Error _ as error -> error
-  | Ok state ->
-      Tool_autoresearch_registry.with_hypotheses_rw (fun () ->
-        Hashtbl.remove Tool_autoresearch_registry.pending_hypotheses loop_id;
-        Hashtbl.remove Tool_autoresearch_registry.custom_generators loop_id);
-      delete_session_link ~base_path loop_id;
-      (match
-         Autoresearch.git_top_level ~workdir:state.source_workdir
-       with
-      | Ok repo_root ->
-          let workdir =
-            Autoresearch.managed_worktree_dir ~base_path loop_id
-          in
-          if Sys.file_exists workdir then
-            let remove_cmd =
-              Printf.sprintf "cd %s && git worktree remove --force %s 2>&1"
-                (Filename.quote repo_root)
-                (Filename.quote workdir)
-            in
-            ignore (Autoresearch.run_capture_lines remove_cmd);
-          let branch = Autoresearch.managed_branch_name loop_id in
-          if git_branch_exists ~repo_root branch then
-            let branch_cmd =
-              Printf.sprintf "cd %s && git branch -D %s 2>&1"
-                (Filename.quote repo_root)
-                (Filename.quote branch)
-            in
-            ignore (Autoresearch.run_capture_lines branch_cmd)
-      | Error _ -> ());
-      let bundle_dir = Autoresearch.results_dir ~base_path loop_id in
-      if Sys.file_exists bundle_dir then rm_rf bundle_dir;
-      Ok
-        (`Assoc
-          [
-            ("ok", `Bool true);
-            ("action", `String "delete");
-            ("loop_id", `String loop_id);
-          ])
+  | Ok () ->
+      let state_or_persisted =
+        Autoresearch.with_loops_rw (fun () ->
+          let active = Hashtbl.find_opt Autoresearch.active_loops loop_id in
+          Hashtbl.remove Autoresearch.active_loops loop_id;
+          if !(Autoresearch.latest_loop_id) = Some loop_id then
+            Autoresearch.latest_loop_id := None;
+          match active with
+          | Some state -> Ok state
+          | None -> (
+              match Autoresearch.load_state ~base_path loop_id with
+              | Some persisted -> Ok (rehydrate_persisted_loop persisted)
+              | None -> Error (Printf.sprintf "Loop %s not found" loop_id)))
+      in
+      match state_or_persisted with
+      | Error _ as error -> error
+      | Ok state ->
+          Tool_autoresearch_registry.with_hypotheses_rw (fun () ->
+            Hashtbl.remove Tool_autoresearch_registry.pending_hypotheses loop_id;
+            Hashtbl.remove Tool_autoresearch_registry.custom_generators loop_id);
+          delete_session_link ~base_path loop_id;
+          (match
+             Autoresearch.git_top_level ~workdir:state.source_workdir
+           with
+          | Ok repo_root ->
+              let workdir =
+                Autoresearch.managed_worktree_dir ~base_path loop_id
+              in
+              if Sys.file_exists workdir then
+                let remove_cmd =
+                  Printf.sprintf "cd %s && git worktree remove --force %s 2>&1"
+                    (Filename.quote repo_root)
+                    (Filename.quote workdir)
+                in
+                ignore (Autoresearch.run_capture_lines remove_cmd);
+              let branch = Autoresearch.managed_branch_name loop_id in
+              if git_branch_exists ~repo_root branch then
+                let branch_cmd =
+                  Printf.sprintf "cd %s && git branch -D %s 2>&1"
+                    (Filename.quote repo_root)
+                    (Filename.quote branch)
+                in
+                ignore (Autoresearch.run_capture_lines branch_cmd)
+          | Error _ -> ());
+          let bundle_dir = Autoresearch.results_dir ~base_path loop_id in
+          if Sys.file_exists bundle_dir then rm_rf bundle_dir;
+          Ok
+            (`Assoc
+              [
+                ("ok", `Bool true);
+                ("action", `String "delete");
+                ("loop_id", `String loop_id);
+              ])

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -567,6 +567,62 @@ let add_routes ~sw ~clock router =
                reqd
        ) request reqd)
 
+  |> Http.Router.post "/api/v1/autoresearch/loops/retry" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             let loop_id =
+               json |> Yojson.Safe.Util.member "loop_id"
+               |> Yojson.Safe.Util.to_string
+             in
+             let base_path = state.Mcp_server.room_config.base_path in
+             match
+               Dashboard_http_autoresearch.retry_loop_json ~base_path ~loop_id
+             with
+             | Ok result ->
+                 Http.Response.json ~compress:true ~request:req
+                   (Yojson.Safe.to_string result) reqd
+             | Error message ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                      (String.escaped message))
+                   reqd
+           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
+               reqd
+         )
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/autoresearch/loops/delete" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             let loop_id =
+               json |> Yojson.Safe.Util.member "loop_id"
+               |> Yojson.Safe.Util.to_string
+             in
+             let base_path = state.Mcp_server.room_config.base_path in
+             match
+               Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
+             with
+             | Ok result ->
+                 Http.Response.json ~compress:true ~request:req
+                   (Yojson.Safe.to_string result) reqd
+             | Error message ->
+                 Http.Response.json ~status:`Not_found ~request:req
+                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                      (String.escaped message))
+                   reqd
+           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
+               reqd
+         )
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/dashboard/repo-synthesis" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -568,7 +568,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/autoresearch/loops/retry" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_tool_auth ~tool_name:"masc_autoresearch_stop" (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -577,17 +577,24 @@ let add_routes ~sw ~clock router =
                |> Yojson.Safe.Util.to_string
              in
              let base_path = state.Mcp_server.room_config.base_path in
-             match
-               Dashboard_http_autoresearch.retry_loop_json ~base_path ~loop_id
-             with
-             | Ok result ->
-                 Http.Response.json ~compress:true ~request:req
-                   (Yojson.Safe.to_string result) reqd
+             (match Dashboard_http_autoresearch.validate_loop_id loop_id with
              | Error message ->
                  Http.Response.json ~status:`Bad_request ~request:req
                    (Printf.sprintf {|{"ok":false,"error":"%s"}|}
                       (String.escaped message))
                    reqd
+             | Ok () -> (
+                 match
+                   Dashboard_http_autoresearch.retry_loop_json ~base_path ~loop_id
+                 with
+                 | Ok result ->
+                     Http.Response.json ~compress:true ~request:req
+                       (Yojson.Safe.to_string result) reqd
+                 | Error message ->
+                     Http.Response.json ~status:`Bad_request ~request:req
+                       (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                          (String.escaped message))
+                       reqd))
            with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
@@ -596,7 +603,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.post "/api/v1/autoresearch/loops/delete" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_tool_auth ~tool_name:"masc_autoresearch_stop" (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -605,17 +612,24 @@ let add_routes ~sw ~clock router =
                |> Yojson.Safe.Util.to_string
              in
              let base_path = state.Mcp_server.room_config.base_path in
-             match
-               Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
-             with
-             | Ok result ->
-                 Http.Response.json ~compress:true ~request:req
-                   (Yojson.Safe.to_string result) reqd
+             (match Dashboard_http_autoresearch.validate_loop_id loop_id with
              | Error message ->
-                 Http.Response.json ~status:`Not_found ~request:req
+                 Http.Response.json ~status:`Bad_request ~request:req
                    (Printf.sprintf {|{"ok":false,"error":"%s"}|}
                       (String.escaped message))
                    reqd
+             | Ok () -> (
+                 match
+                   Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
+                 with
+                 | Ok result ->
+                     Http.Response.json ~compress:true ~request:req
+                       (Yojson.Safe.to_string result) reqd
+                 | Error message ->
+                     Http.Response.json ~status:`Not_found ~request:req
+                       (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                          (String.escaped message))
+                       reqd))
            with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -377,6 +377,30 @@ let test_delete_loop_json_removes_bundle_and_branch () =
         (Sys.file_exists
            (Lib.Autoresearch.session_link_file ~base_path "session-delete"))
 
+let test_retry_loop_json_rejects_unsafe_loop_id () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  match
+    Lib.Dashboard_http_autoresearch.retry_loop_json
+      ~base_path ~loop_id:"../escape"
+  with
+  | Ok _ -> failwith "expected invalid loop_id to fail"
+  | Error message ->
+      check string "invalid retry loop_id" "invalid loop_id" message
+
+let test_delete_loop_json_rejects_unsafe_loop_id () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  match
+    Lib.Dashboard_http_autoresearch.delete_loop_json
+      ~base_path ~loop_id:"../escape"
+  with
+  | Ok _ -> failwith "expected invalid loop_id to fail"
+  | Error message ->
+      check string "invalid delete loop_id" "invalid loop_id" message
+
 let () =
   run "dashboard_autoresearch"
     [
@@ -396,5 +420,9 @@ let () =
             test_retry_loop_json_restores_missing_worktree;
           test_case "delete removes bundle and branch" `Quick
             test_delete_loop_json_removes_bundle_and_branch;
+          test_case "retry rejects unsafe loop id" `Quick
+            test_retry_loop_json_rejects_unsafe_loop_id;
+          test_case "delete rejects unsafe loop id" `Quick
+            test_delete_loop_json_rejects_unsafe_loop_id;
         ] );
     ]

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -34,6 +34,25 @@ let write_file path contents =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc contents)
 
+let run_cmd_exn cmd =
+  match Sys.command cmd with
+  | 0 -> ()
+  | code -> failwith (Printf.sprintf "command failed (%d): %s" code cmd)
+
+let init_git_repo path =
+  Unix.mkdir path 0o755;
+  run_cmd_exn (Printf.sprintf "git -C %s init -q" (Filename.quote path));
+  run_cmd_exn
+    (Printf.sprintf "git -C %s config user.email dashboard@test.local"
+       (Filename.quote path));
+  run_cmd_exn
+    (Printf.sprintf "git -C %s config user.name dashboard-test"
+       (Filename.quote path));
+  write_file (Filename.concat path "README.md") "initial\n";
+  run_cmd_exn (Printf.sprintf "git -C %s add README.md" (Filename.quote path));
+  run_cmd_exn
+    (Printf.sprintf "git -C %s commit -q -m init" (Filename.quote path))
+
 let with_temp_base f =
   let dir = test_dir () in
   Fun.protect
@@ -89,7 +108,10 @@ let legacy_state_json ?(loop_id = "legacy-loop") ?(model = "glm:legacy") () =
 
 let persisted_state_json ?(loop_id = "persisted-loop") ?updated_at
     ?(status = "running") ?(current_cycle = 0) ?(best_score = 0.75)
-    ?(best_cycle = 0) ?(elapsed_s = 0.5) () =
+    ?(best_cycle = 0) ?(elapsed_s = 0.5)
+    ?(workdir = "/tmp/autoresearch/worktree")
+    ?(source_workdir = "/tmp/autoresearch")
+    ?(error = "null") ?(warnings = "[]") () =
   let updated_at_field =
     match updated_at with
     | Some ts -> Printf.sprintf ",\n  \"updated_at\": %.6f" ts
@@ -113,17 +135,18 @@ let persisted_state_json ?(loop_id = "persisted-loop") ?updated_at
   "total_discards": 0,
   "max_cycles": 3,
   "cycle_timeout_s": 30.0,
-  "workdir": "/tmp/autoresearch/worktree",
-  "source_workdir": "/tmp/autoresearch",
+  "workdir": "%s",
+  "source_workdir": "%s",
   "elapsed_s": %.3f%s,
   "history_count": 0,
   "insights_count": 0,
   "program_note": null,
-  "warnings": [],
-  "error": null
+  "warnings": %s,
+  "error": %s
 }
 |}
-    loop_id status current_cycle best_score best_cycle elapsed_s updated_at_field
+    loop_id status current_cycle best_score best_cycle workdir source_workdir
+    elapsed_s updated_at_field warnings error
 
 let test_loops_json_skips_invalid_persisted_state () =
   with_eio_test @@ fun () ->
@@ -254,6 +277,106 @@ let test_loops_json_uses_state_file_mtime_for_updated_at () =
   check bool "updated_at falls back to state file mtime" true
     (abs_float (updated_at -. expected_mtime) < 0.001)
 
+let test_retry_loop_json_restores_missing_worktree () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let repo_root = Filename.concat base_path "repo" in
+  init_git_repo repo_root;
+  let loop_id = "retry-loop" in
+  run_cmd_exn
+    (Printf.sprintf "git -C %s branch %s" (Filename.quote repo_root)
+       (Filename.quote (Lib.Autoresearch.managed_branch_name loop_id)));
+  let workdir = Lib.Autoresearch.managed_worktree_dir ~base_path loop_id in
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"repair loop"
+      ~metric_fn:"echo 1"
+      ~model_model:"glm"
+      ~target_file:"README.md"
+      ~cycle_timeout_s:30.0
+      ~max_cycles:1
+      ~workdir:repo_root
+      ()
+  in
+  let state = { state with loop_id; source_workdir = repo_root } in
+  state.status <- Lib.Autoresearch.Error;
+  state.error_message <- Some "managed worktree missing";
+  state.workdir <- workdir;
+  state.warnings <- [ "source_workdir_dirty" ];
+  Lib.Autoresearch.save_state ~base_path state;
+  match
+    Lib.Dashboard_http_autoresearch.retry_loop_json ~base_path ~loop_id
+  with
+  | Error message -> failwith message
+  | Ok json ->
+      check bool "retry ok" true
+        Yojson.Safe.Util.(json |> member "ok" |> to_bool);
+      check string "retry action" "retry"
+        Yojson.Safe.Util.(json |> member "action" |> to_string);
+      check string "loop status" "running"
+        Yojson.Safe.Util.(json |> member "loop" |> member "status" |> to_string);
+      check bool "loop marked live" true
+        Yojson.Safe.Util.(json |> member "loop" |> member "live" |> to_bool);
+      check bool "worktree recreated" true (Sys.file_exists workdir);
+      check bool "active loop restored" true
+        (Lib.Autoresearch.with_loops_ro (fun () ->
+             Hashtbl.mem Lib.Autoresearch.active_loops loop_id))
+
+let test_delete_loop_json_removes_bundle_and_branch () =
+  with_eio_test @@ fun () ->
+  with_clean_loops @@ fun () ->
+  with_temp_base @@ fun base_path ->
+  let repo_root = Filename.concat base_path "repo" in
+  init_git_repo repo_root;
+  let loop_id = "delete-loop" in
+  run_cmd_exn
+    (Printf.sprintf "git -C %s branch %s" (Filename.quote repo_root)
+       (Filename.quote (Lib.Autoresearch.managed_branch_name loop_id)));
+  let workdir = Lib.Autoresearch.managed_worktree_dir ~base_path loop_id in
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"delete loop"
+      ~metric_fn:"echo 1"
+      ~model_model:"glm"
+      ~target_file:"README.md"
+      ~cycle_timeout_s:30.0
+      ~max_cycles:1
+      ~workdir:repo_root
+      ()
+  in
+  let state = { state with loop_id; source_workdir = repo_root } in
+  state.status <- Lib.Autoresearch.Error;
+  state.error_message <- Some "managed worktree missing";
+  state.workdir <- workdir;
+  Lib.Autoresearch.save_state ~base_path state;
+  let link : Lib.Autoresearch.swarm_link =
+    {
+      loop_id;
+      session_id = "session-delete";
+      operation_id = None;
+      target_file = "README.md";
+      program_note = None;
+      created_by = None;
+      linked_at = Unix.gettimeofday ();
+    }
+  in
+  Lib.Autoresearch.save_swarm_link ~base_path link;
+  match
+    Lib.Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
+  with
+  | Error message -> failwith message
+  | Ok json ->
+      check bool "delete ok" true
+        Yojson.Safe.Util.(json |> member "ok" |> to_bool);
+      check string "delete action" "delete"
+        Yojson.Safe.Util.(json |> member "action" |> to_string);
+      check bool "bundle removed" false
+        (Sys.file_exists (Lib.Autoresearch.results_dir ~base_path loop_id));
+      check bool "session link removed" false
+        (Sys.file_exists
+           (Lib.Autoresearch.session_link_file ~base_path "session-delete"))
+
 let () =
   run "dashboard_autoresearch"
     [
@@ -269,5 +392,9 @@ let () =
             test_loops_json_orders_live_then_recent;
           test_case "uses state file mtime for updated_at" `Quick
             test_loops_json_uses_state_file_mtime_for_updated_at;
+          test_case "retry restores missing worktree" `Quick
+            test_retry_loop_json_restores_missing_worktree;
+          test_case "delete removes bundle and branch" `Quick
+            test_delete_loop_json_removes_bundle_and_branch;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add dashboard retry/delete actions for persisted autoresearch loops stuck in `error`
- restore missing managed worktrees when retrying persisted loops
- delete the loop bundle, worktree, branch, and session link when explicitly confirmed
- validate `loop_id`, fix managed-branch lookup for slash-containing refs, and require autoresearch tool auth for the mutation routes

## Verification
- `dune build --root .`
- `dune build --root . test/test_dashboard_autoresearch.exe`
- `./_build/default/test/test_dashboard_autoresearch.exe`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/components/autoresearch.test.ts`

## Review
- GLM-5 via `sb glm-text` on 2026-03-27: findings addressed (delete confirmation, unsafe loop id validation, auth surface, action response typing).

Closes #3300