### PR TITLE
test(eio): keep hat/control coverage inside a live Eio scope (#3418)

### DIFF
--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -16,7 +16,7 @@ let test name f =
 
 let test_counter = ref 0
 
-let make_test_ctx () =
+let with_test_ctx f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   incr test_counter;
@@ -29,16 +29,17 @@ let make_test_ctx () =
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:(Some "test-agent") in
-  { Tool_control.config; agent_name = "test-agent" }
+  let ctx = { Tool_control.config; agent_name = "test-agent" } in
+  f ctx
 
 let () =
   test "dispatch_unknown_tool" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       assert (Tool_control.dispatch ctx ~name:"unknown_tool" ~args:(`Assoc []) = None))
 
 let () =
   test "dispatch_pause" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       match
         Tool_control.dispatch ctx ~name:"masc_pause"
           ~args:(`Assoc [ ("reason", `String "Test pause") ])
@@ -50,7 +51,7 @@ let () =
 
 let () =
   test "dispatch_pause_status_paused" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       let _ =
         Tool_control.handle_pause ctx
           (`Assoc [ ("reason", `String "For status test") ])
@@ -63,7 +64,7 @@ let () =
 
 let () =
   test "dispatch_resume" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       let _ =
         Tool_control.handle_pause ctx
           (`Assoc [ ("reason", `String "For resume test") ])
@@ -76,7 +77,7 @@ let () =
 
 let () =
   test "dispatch_pause_status_running" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
       | Some (success, result) ->
           assert success;
@@ -85,7 +86,7 @@ let () =
 
 let () =
   test "removed_mode_tools_do_not_dispatch" (fun () ->
-      let ctx = make_test_ctx () in
+      with_test_ctx @@ fun ctx ->
       let args = `Assoc [] in
       assert (Tool_control.dispatch ctx ~name:"masc_switch_mode" ~args = None);
       assert (Tool_control.dispatch ctx ~name:"masc_get_config" ~args = None);

--- a/test/test_tool_hat_coverage.ml
+++ b/test/test_tool_hat_coverage.ml
@@ -5,6 +5,7 @@ open Masc_mcp
 let () = Random.self_init ()
 
 let () = Printf.printf "\n=== Tool_hat Coverage Tests ===\n"
+let test_counter = ref 0
 
 (* Test helper *)
 let test name f =
@@ -15,27 +16,31 @@ let test name f =
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
     exit 1
 
-(* Create test context - initialize room to avoid "not initialized" error *)
-let make_test_ctx () =
+(* Keep context creation and tool dispatch in the same Eio scope. *)
+let with_test_ctx f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  incr test_counter;
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "masc-hat-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
+    (Printf.sprintf "masc-hat-test-%d-%d"
+       (int_of_float (Unix.gettimeofday () *. 1000.0))
+       !test_counter) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   let _ = Room.init config ~agent_name:None in
-  { Tool_hat.config; agent_name = "test-agent" }
+  let ctx = { Tool_hat.config; agent_name = "test-agent" } in
+  f ctx
 
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [] in
   assert (Tool_hat.dispatch ctx ~name:"unknown_tool" ~args = None)
 )
 
 (* Test hat_wear dispatch *)
 let () = test "dispatch_hat_wear" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "builder")] in
   match Tool_hat.dispatch ctx ~name:"masc_hat_wear" ~args with
   | Some (success, _result) -> assert success
@@ -44,7 +49,7 @@ let () = test "dispatch_hat_wear" (fun () ->
 
 (* Test handle_hat_wear with different hats *)
 let () = test "handle_hat_wear_builder" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "builder")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -52,7 +57,7 @@ let () = test "handle_hat_wear_builder" (fun () ->
 )
 
 let () = test "handle_hat_wear_reviewer" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "reviewer")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -60,7 +65,7 @@ let () = test "handle_hat_wear_reviewer" (fun () ->
 )
 
 let () = test "handle_hat_wear_researcher" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "researcher")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -68,7 +73,7 @@ let () = test "handle_hat_wear_researcher" (fun () ->
 )
 
 let () = test "handle_hat_wear_tester" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "tester")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -76,7 +81,7 @@ let () = test "handle_hat_wear_tester" (fun () ->
 )
 
 let () = test "handle_hat_wear_architect" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "architect")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -84,7 +89,7 @@ let () = test "handle_hat_wear_architect" (fun () ->
 )
 
 let () = test "handle_hat_wear_debugger" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "debugger")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -92,7 +97,7 @@ let () = test "handle_hat_wear_debugger" (fun () ->
 )
 
 let () = test "handle_hat_wear_documenter" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "documenter")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -100,7 +105,7 @@ let () = test "handle_hat_wear_documenter" (fun () ->
 )
 
 let () = test "handle_hat_wear_custom" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [("hat", `String "custom-hat")] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -108,7 +113,7 @@ let () = test "handle_hat_wear_custom" (fun () ->
 )
 
 let () = test "handle_hat_wear_default" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [] in
   let (success, result) = Tool_hat.handle_hat_wear ctx args in
   assert success;
@@ -118,7 +123,7 @@ let () = test "handle_hat_wear_default" (fun () ->
 
 (* Test hat_status dispatch *)
 let () = test "dispatch_hat_status" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   let args = `Assoc [] in
   match Tool_hat.dispatch ctx ~name:"masc_hat_status" ~args with
   | Some (success, _result) -> assert success
@@ -127,7 +132,7 @@ let () = test "dispatch_hat_status" (fun () ->
 
 (* Test handle_hat_status with agents *)
 let () = test "handle_hat_status_with_agents" (fun () ->
-  let ctx = make_test_ctx () in
+  with_test_ctx @@ fun ctx ->
   (* First wear a hat *)
   let _ = Tool_hat.handle_hat_wear ctx (`Assoc [("hat", `String "tester")]) in
   let args = `Assoc [] in


### PR DESCRIPTION
## Summary
- keep `test_tool_hat_coverage` and `test_tool_control_coverage` inside the same `Eio_main.run` scope as context creation
- remove the baseline quick-suite blocker causing `Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)` in CI
- make the hat coverage temp dir unique enough for fast consecutive runs

## Verification
- `dune build --root . ./test/test_tool_hat_coverage.exe ./test/test_tool_control_coverage.exe`
- `./_build/default/test/test_tool_hat_coverage.exe`
- `./_build/default/test/test_tool_control_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build/default/test/test_tool_hat_coverage.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build/default/test/test_tool_control_coverage.exe`

## Review
- GLM-5 via `sb glm-text` on 2026-03-27: No findings.

Closes #3418