### PR TITLE
[codex] Clarify lab autoresearch and safety harness surfaces

### DIFF
--- a/dashboard/src/api/autoresearch.ts
+++ b/dashboard/src/api/autoresearch.ts
@@ -41,6 +41,8 @@ export interface AutoresearchLoopSummary {
   recent_cycles: AutoresearchCycleRecord[]
   error: string | null
   session_id: string | null
+  operation_id: string | null
+  linked_at: number | null
   queued_hypothesis: string | null
 }
 

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -52,6 +52,8 @@ function loopSummary(
     recent_cycles: [cycleRecord(0)],
     error: null,
     session_id: null,
+    operation_id: null,
+    linked_at: null,
     queued_hypothesis: null,
     ...overrides,
   }
@@ -120,6 +122,8 @@ describe('Autoresearch surface refresh', () => {
     await refreshAutoresearchSurface()
     await flushUi()
 
+    expect(container.textContent).toContain('Research Brief')
+    expect(container.textContent).toContain('이 화면은 generator loop 자체를 설명합니다.')
     expect(container.textContent).toContain('1 / 5')
     expect(container.textContent).toContain('사이클 이력 (1건)')
 

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -355,6 +355,59 @@ function WarningsList({ warnings }: { warnings: string[] }) {
   `
 }
 
+function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
+  const linkedAt = loop.linked_at != null ? formatTimestamp(loop.linked_at) : '미연결'
+
+  return html`
+    <${SurfaceCard} variant="compact">
+      <div class="flex flex-col gap-3">
+        <div>
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 font-medium">Research Brief</div>
+          <div class="text-[13px] leading-[1.55] text-[var(--text-body)]">
+            이 루프는 <span class="font-semibold text-[var(--text-strong)]">${loop.goal}</span> 를 목표로
+            <span class="font-mono text-[var(--text-strong)]"> ${loop.target_file} </span>
+            변경을 시도하고,
+            <span class="font-mono text-[var(--text-strong)]"> ${loop.metric_fn} </span>
+            결과로 keep/discard를 반복합니다.
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">무엇을 연구하나</div>
+            <div class="leading-relaxed text-[var(--text-body)]">${loop.goal}</div>
+          </div>
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">무엇으로 성공을 보나</div>
+            <div class="font-mono text-[var(--text-body)]">${loop.metric_fn}</div>
+            <div class="mt-1 text-[var(--text-dim)]">baseline ${loop.baseline.toFixed(4)} -> best ${loop.best_score.toFixed(4)}</div>
+          </div>
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">연결된 실행 컨텍스트</div>
+            <div class="flex flex-col gap-1 text-[var(--text-body)]">
+              <span>session ${loop.session_id ?? '없음'}</span>
+              <span>operation ${loop.operation_id ?? '없음'}</span>
+              <span>linked ${linkedAt}</span>
+            </div>
+          </div>
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+            <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">현재 가설 / 메모</div>
+            <div class="flex flex-col gap-1 text-[var(--text-body)] leading-relaxed">
+              <span>${loop.queued_hypothesis ?? '대기 가설 없음'}</span>
+              <span class="text-[var(--text-dim)]">${loop.program_note ?? 'program note 없음'}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[12px] leading-[1.5] text-[var(--text-muted)]">
+          이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
+          각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
+        </div>
+      </div>
+    <//>
+  `
+}
+
 // --- Detail view ---
 
 function LoopDetailView() {
@@ -383,6 +436,8 @@ function LoopDetailView() {
 
   return html`
     <div class="flex flex-col gap-5">
+      <${ResearchBrief} loop=${loop} />
+
       <${SurfaceCard} variant="compact">
         <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-3 font-medium">루프 개요</div>
         <${LoopOverview} loop=${loop} />

--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -44,6 +44,7 @@ describe('HarnessHealth', () => {
     const get = vi.fn<(path: string) => Promise<unknown>>()
       .mockResolvedValue({
         generated_at: 1711440000,
+        scope_note: 'Autoresearch는 generator loop, Harness는 safety rail을 설명합니다.',
         calibration: {
           total_verdicts: 12,
           approve_count: 9,
@@ -55,6 +56,52 @@ describe('HarnessHealth', () => {
           agreement_rate: 0.75,
           fallback_count: 2,
           recent_fallback_reasons: [],
+        },
+        recent_verdicts: [
+          {
+            timestamp: 1711440000,
+            task_id: 'task-1',
+            task_title: 'Review task notes',
+            agent_name: 'judge',
+            gate: 'llm',
+            verdict: 'approve',
+            evaluator_cascade: 'verifier',
+            fallback_reason: null,
+          },
+        ],
+        pre_compact: {
+          description: 'Pre-compaction signal',
+          total_recent: 1,
+          recent_events: [
+            {
+              timestamp: 1711440000,
+              keeper_name: 'keeper-a',
+              context_ratio: 0.91,
+              message_count: 88,
+              token_count: 32000,
+              strategies: ['PruneToolOutputs'],
+              model_family: 'verifier',
+              trigger: 'ratio(0.91>=0.85)',
+            },
+          ],
+        },
+        dna_quality: {
+          description: 'DNA signal',
+          total_recent: 1,
+          recent_events: [
+            {
+              timestamp: 1711440000,
+              keeper_name: 'keeper-a',
+              score: 0.82,
+              dimensions: {
+                has_goal_anchor: true,
+                has_task_anchor: true,
+                has_recent_context: true,
+                truncation_artifacts: 0,
+                content_length: 420,
+              },
+            },
+          ],
         },
       })
 
@@ -75,7 +122,11 @@ describe('HarnessHealth', () => {
     await flushUi()
 
     expect(get).toHaveBeenCalledWith('/api/v1/dashboard/harness-health')
-    expect(container.textContent).toContain('Evaluator 캘리브레이션')
+    expect(container.textContent).toContain('Safety Harness')
+    expect(container.textContent).toContain('Evaluator Calibration')
+    expect(container.textContent).toContain('Pre-Compaction Rail')
+    expect(container.textContent).toContain('DNA Quality Rail')
+    expect(container.textContent).toContain('Autoresearch는 generator loop')
 
     const markup = container.innerHTML
     expect(markup).toContain('text-[var(--accent)]')

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -1,4 +1,4 @@
-// Harness Health panel — calibration stats, compaction strategy, DNA quality (#3165)
+// Safety Harness panel — evaluator calibration and long-running runtime rails.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -6,8 +6,6 @@ import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { lastEvent } from '../sse'
 import { Card } from './common/card'
-
-// --- Types ---
 
 interface GateDistribution {
   [gate: string]: number
@@ -26,21 +24,61 @@ interface CalibrationStats {
   recent_fallback_reasons?: string[]
 }
 
-interface HarnessHealthData {
-  generated_at: number
-  calibration: CalibrationStats
+interface HarnessVerdictItem {
+  timestamp: number
+  task_id: string
+  task_title: string
+  agent_name: string
+  gate: string
+  verdict: string
+  evaluator_cascade: string
+  fallback_reason?: string | null
 }
 
-// --- Signals ---
+interface PreCompactEvent {
+  timestamp: number
+  keeper_name: string
+  context_ratio: number
+  message_count: number
+  token_count: number
+  strategies: string[]
+  model_family: string
+  trigger: string
+}
+
+interface DnaQualityDimensions {
+  has_goal_anchor?: boolean
+  has_task_anchor?: boolean
+  has_recent_context?: boolean
+  truncation_artifacts?: number
+  content_length?: number
+}
+
+interface DnaQualityEvent {
+  timestamp: number
+  keeper_name: string
+  score: number
+  dimensions: DnaQualityDimensions
+}
+
+interface HarnessSignalSection<T> {
+  description: string
+  recent_events: T[]
+  total_recent: number
+}
+
+interface HarnessHealthData {
+  generated_at: number
+  scope_note: string
+  calibration: CalibrationStats
+  recent_verdicts: HarnessVerdictItem[]
+  pre_compact: HarnessSignalSection<PreCompactEvent>
+  dna_quality: HarnessSignalSection<DnaQualityEvent>
+}
 
 const harnessData = signal<HarnessHealthData | null>(null)
 const harnessLoading = signal(false)
 const harnessError = signal<string | null>(null)
-
-// SSE-driven counters (live updates between API polls)
-const recentVerdicts = signal<Array<{ gate: string; verdict: string; ts: number }>>([])
-
-// --- Data loading ---
 
 async function loadHarnessHealth(): Promise<void> {
   if (harnessLoading.value) return
@@ -56,25 +94,123 @@ async function loadHarnessHealth(): Promise<void> {
   }
 }
 
-// --- SSE handler ---
+function mergeRecent<T>(
+  current: T[],
+  nextItem: T,
+  isSame: (left: T, right: T) => boolean,
+  maxItems: number,
+) {
+  const filtered = current.filter(item => !isSame(item, nextItem))
+  return [nextItem, ...filtered].slice(0, maxItems)
+}
+
+function updateHarnessData(
+  update: (data: HarnessHealthData) => HarnessHealthData,
+): void {
+  const current = harnessData.value
+  if (!current) return
+  harnessData.value = update(current)
+}
 
 function handleHarnessSSE(): void {
   const evt = lastEvent.value
   if (!evt) return
   const type = evt.type ?? ''
+  const payload = (evt as unknown as { payload?: Record<string, unknown> }).payload
+  if (!payload) return
+
   if (type === 'oas:masc:harness:verdict_recorded') {
-    const p = (evt as unknown as { payload?: Record<string, unknown> }).payload
-    if (p) {
-      const next = [
-        { gate: String(p.gate ?? ''), verdict: String(p.verdict ?? ''), ts: Date.now() },
-        ...recentVerdicts.value,
-      ].slice(0, 20)
-      recentVerdicts.value = next
+    const nextItem: HarnessVerdictItem = {
+      timestamp:
+        typeof payload.timestamp === 'number'
+          ? payload.timestamp
+          : Date.now() / 1000,
+      task_id: String(payload.task_id ?? ''),
+      task_title: String(payload.task_title ?? 'task'),
+      agent_name: String(payload.agent_name ?? ''),
+      gate: String(payload.gate ?? ''),
+      verdict: String(payload.verdict ?? ''),
+      evaluator_cascade: String(payload.evaluator_cascade ?? ''),
+      fallback_reason:
+        payload.fallback_reason == null ? null : String(payload.fallback_reason),
     }
+    updateHarnessData(data => ({
+      ...data,
+      recent_verdicts: mergeRecent(
+        data.recent_verdicts,
+        nextItem,
+        (left, right) =>
+          left.timestamp === right.timestamp
+          && left.task_id === right.task_id
+          && left.verdict === right.verdict,
+        8,
+      ),
+    }))
+  }
+
+  if (type === 'oas:masc:harness:pre_compact') {
+    const nextItem: PreCompactEvent = {
+      timestamp:
+        typeof payload.timestamp === 'number'
+          ? payload.timestamp
+          : Date.now() / 1000,
+      keeper_name: String(payload.keeper_name ?? ''),
+      context_ratio: Number(payload.context_ratio ?? 0),
+      message_count: Number(payload.message_count ?? 0),
+      token_count: Number(payload.token_count ?? 0),
+      strategies: Array.isArray(payload.strategies)
+        ? payload.strategies.map(value => String(value))
+        : [],
+      model_family: String(payload.model_family ?? ''),
+      trigger: String(payload.trigger ?? ''),
+    }
+    updateHarnessData(data => ({
+      ...data,
+      pre_compact: {
+        ...data.pre_compact,
+        recent_events: mergeRecent(
+          data.pre_compact.recent_events,
+          nextItem,
+          (left, right) =>
+            left.timestamp === right.timestamp
+            && left.keeper_name === right.keeper_name
+            && left.trigger === right.trigger,
+          8,
+        ),
+      },
+    }))
+  }
+
+  if (type === 'oas:masc:harness:dna_quality') {
+    const nextItem: DnaQualityEvent = {
+      timestamp:
+        typeof payload.timestamp === 'number'
+          ? payload.timestamp
+          : Date.now() / 1000,
+      keeper_name: String(payload.keeper_name ?? ''),
+      score: Number(payload.score ?? 0),
+      dimensions:
+        payload.dimensions && typeof payload.dimensions === 'object'
+          ? payload.dimensions as DnaQualityDimensions
+          : {},
+    }
+    updateHarnessData(data => ({
+      ...data,
+      dna_quality: {
+        ...data.dna_quality,
+        recent_events: mergeRecent(
+          data.dna_quality.recent_events,
+          nextItem,
+          (left, right) =>
+            left.timestamp === right.timestamp
+            && left.keeper_name === right.keeper_name
+            && left.score === right.score,
+          8,
+        ),
+      },
+    }))
   }
 }
-
-// --- Sub-components ---
 
 function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
   return html`
@@ -86,17 +222,25 @@ function StatCard({ label, value, sub }: { label: string; value: string | number
   `
 }
 
+function EmptySignal({ text }: { text: string }) {
+  return html`
+    <div class="rounded-lg border border-dashed border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-sm text-[var(--text-dim)]">
+      ${text}
+    </div>
+  `
+}
+
 function GateChart({ distribution }: { distribution: GateDistribution }) {
   const entries = Object.entries(distribution).sort((a, b) => b[1] - a[1])
   const max = entries[0]?.[1] ?? 1
   if (entries.length === 0) {
-    return html`<div class="text-sm text-[var(--text-dim)]">아직 verdict 기록 없음</div>`
+    return html`<${EmptySignal} text="아직 verdict 기록이 없습니다." />`
   }
   return html`
     <div class="space-y-2">
       ${entries.map(([gate, count]) => html`
         <div class="flex items-center gap-2">
-          <span class="w-16 text-right font-mono text-xs text-[var(--text-muted)]">${gate}</span>
+          <span class="w-20 text-right font-mono text-xs text-[var(--text-muted)]">${gate}</span>
           <div class="h-4 flex-1 overflow-hidden rounded bg-[var(--white-6)]">
             <div
               class="h-full rounded opacity-80 transition-all"
@@ -110,38 +254,134 @@ function GateChart({ distribution }: { distribution: GateDistribution }) {
   `
 }
 
-function RecentVerdictsFeed() {
-  const items = recentVerdicts.value
-  if (items.length === 0) return null
+function formatTimestamp(ts: number): string {
+  return new Date(ts * 1000).toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function verdictTone(verdict: string): string {
+  return verdict.startsWith('approve')
+    ? 'bg-[var(--ok)]'
+    : 'bg-[var(--bad)]'
+}
+
+function verdictSummary(verdict: string): string {
+  if (!verdict.startsWith('reject:')) return verdict
+  return verdict.slice('reject:'.length).trim() || 'reject'
+}
+
+function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
+  if (items.length === 0) {
+    return html`<${EmptySignal} text="최근 evaluator verdict가 없습니다." />`
+  }
+
   return html`
-    <div class="mt-3 space-y-1">
-      <div class="mb-1 text-xs uppercase tracking-wider text-[var(--text-dim)]">Live Feed</div>
-      ${items.slice(0, 8).map(v => html`
-        <div class="flex items-center gap-2 text-xs">
-          <span class=${`inline-block w-2 h-2 rounded-full ${
-            v.verdict === 'approve' ? 'bg-[var(--ok)]' : 'bg-[var(--bad)]'
-          }`} />
-          <span class="font-mono text-[var(--text-muted)]">${v.gate}</span>
-          <span class="text-[var(--text-dim)]">${v.verdict}</span>
+    <div class="space-y-2">
+      ${items.map(item => html`
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <div class="text-sm font-medium text-[var(--text-strong)]">${item.task_title || item.task_id}</div>
+              <div class="mt-1 text-xs text-[var(--text-muted)]">
+                ${item.agent_name || 'agent'} · ${item.gate || 'gate'} · ${item.evaluator_cascade || 'cascade'} · ${formatTimestamp(item.timestamp)}
+              </div>
+            </div>
+            <span class=${`inline-block h-2.5 w-2.5 rounded-full ${verdictTone(item.verdict)}`} />
+          </div>
+          <div class="mt-2 text-sm text-[var(--text-body)]">${verdictSummary(item.verdict)}</div>
+          ${item.fallback_reason ? html`
+            <div class="mt-2 break-all text-xs text-[var(--warn)]">${item.fallback_reason}</div>
+          ` : null}
         </div>
       `)}
     </div>
   `
 }
 
-// --- Main Component ---
+function PreCompactList({ section }: { section: HarnessSignalSection<PreCompactEvent> }) {
+  if (section.recent_events.length === 0) {
+    return html`<${EmptySignal} text="최근 pre-compaction 신호가 없습니다." />`
+  }
+
+  return html`
+    <div class="space-y-2">
+      ${section.recent_events.map(item => html`
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+          <div class="flex items-start justify-between gap-3">
+            <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
+            <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+          </div>
+          <div class="mt-2 grid grid-cols-2 gap-2 text-xs text-[var(--text-body)]">
+            <span>ratio ${item.context_ratio.toFixed(3)}</span>
+            <span>messages ${item.message_count}</span>
+            <span>tokens ${item.token_count}</span>
+            <span>${item.model_family || 'model 미상'}</span>
+          </div>
+          <div class="mt-2 text-xs text-[var(--text-muted)]">${item.trigger}</div>
+          ${item.strategies.length > 0 ? html`
+            <div class="mt-2 flex flex-wrap gap-1">
+              ${item.strategies.map(strategy => html`
+                <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${strategy}</span>
+              `)}
+            </div>
+          ` : null}
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function DnaQualityList({ section }: { section: HarnessSignalSection<DnaQualityEvent> }) {
+  if (section.recent_events.length === 0) {
+    return html`<${EmptySignal} text="최근 DNA quality 신호가 없습니다." />`
+  }
+
+  return html`
+    <div class="space-y-2">
+      ${section.recent_events.map(item => html`
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+          <div class="flex items-start justify-between gap-3">
+            <div class="text-sm font-medium text-[var(--text-strong)]">${item.keeper_name}</div>
+            <div class="text-xs text-[var(--text-muted)]">${formatTimestamp(item.timestamp)}</div>
+          </div>
+          <div class="mt-2 text-sm text-[var(--text-body)]">score ${item.score.toFixed(2)}</div>
+          <div class="mt-2 flex flex-wrap gap-1 text-[10px]">
+            <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[var(--text-muted)]">
+              goal ${item.dimensions.has_goal_anchor ? 'yes' : 'no'}
+            </span>
+            <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[var(--text-muted)]">
+              task ${item.dimensions.has_task_anchor ? 'yes' : 'no'}
+            </span>
+            <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[var(--text-muted)]">
+              recent ${item.dimensions.has_recent_context ? 'yes' : 'no'}
+            </span>
+            <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[var(--text-muted)]">
+              truncation ${item.dimensions.truncation_artifacts ?? 0}
+            </span>
+            <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[var(--text-muted)]">
+              length ${item.dimensions.content_length ?? 0}
+            </span>
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}
 
 export function HarnessHealth() {
   useEffect(() => { void loadHarnessHealth() }, [])
   useEffect(handleHarnessSSE, [lastEvent.value])
 
-  const cal = harnessData.value?.calibration
+  const data = harnessData.value
+  const cal = data?.calibration
   const rejectRate = cal && cal.total_verdicts > 0
     ? ((cal.reject_count / cal.total_verdicts) * 100).toFixed(1)
     : '0'
   const agreementPct = cal ? (cal.agreement_rate * 100).toFixed(1) : '-'
-
-  // Detect evaluator degradation: fallback > 80% of total verdicts
   const fallbackCount = cal?.fallback_count ?? 0
   const isFallbackDominant = cal != null && cal.total_verdicts > 0
     && (fallbackCount / cal.total_verdicts) > 0.8
@@ -149,27 +389,56 @@ export function HarnessHealth() {
 
   return html`
     <div class="space-y-4">
-      <${Card} title="Evaluator 캘리브레이션" class="section">
+      <${Card} title="Safety Harness" class="section">
         ${harnessLoading.value ? html`
           <div class="text-sm text-[var(--text-dim)]">로딩 중...</div>
         ` : harnessError.value ? html`
           <div class="text-sm text-[var(--bad)]">${harnessError.value}</div>
-        ` : !cal ? html`
-          <div class="text-sm text-[var(--text-dim)]">데이터 없음</div>
+        ` : !data ? html`
+          <${EmptySignal} text="Harness 데이터가 없습니다." />
+        ` : html`
+          <div class="space-y-3">
+            <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-[1.6] text-[var(--text-body)]">
+              ${data.scope_note}
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+              <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+                <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Autoresearch가 답하는 것</div>
+                <div class="text-[var(--text-body)] leading-relaxed">
+                  어떤 파일을 어떻게 바꿔서 어떤 metric을 개선하려는지, 그리고 cycle별 keep/discard가 어땠는지.
+                </div>
+              </div>
+              <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+                <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Harness가 답하는 것</div>
+                <div class="text-[var(--text-body)] leading-relaxed">
+                  evaluator가 건강한지, 장기 keeper turn에서 compaction이 어떻게 걸리는지, continuity DNA가 얼마나 안전한지.
+                </div>
+              </div>
+            </div>
+            <div class="text-xs text-[var(--text-dim)]">
+              generated ${formatTimestamp(data.generated_at)}
+            </div>
+          </div>
+        `}
+      <//>
+
+      <${Card} title="Evaluator Calibration" class="section">
+        ${!cal ? html`
+          <${EmptySignal} text="Evaluator calibration 데이터가 없습니다." />
         ` : html`
           ${isFallbackDominant ? html`
             <div class="mb-4 rounded-lg border border-[var(--warn-30)] bg-[var(--warn-12)] px-4 py-3">
               <div class="mb-1 text-sm font-medium text-[var(--warn)]">Evaluator 미연결</div>
               <div class="text-xs text-[var(--warn)]">
-                전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됨.
-                LLM evaluator cascade가 동작하지 않아 모든 verdict가 자동 승인 상태입니다.
+                전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됐습니다.
+                지금은 LLM evaluator가 자주 빠져서 calibration 신뢰도가 낮습니다.
               </div>
               ${fallbackReasons.length > 0 ? html`
                 <details class="mt-2">
                   <summary class="cursor-pointer text-xs text-[var(--warn)] opacity-70">최근 에러 (${fallbackReasons.length}건)</summary>
                   <div class="mt-1 space-y-1">
-                    ${fallbackReasons.map(r => html`
-                      <div class="break-all font-mono text-xs text-[var(--warn)] opacity-70">${r}</div>
+                    ${fallbackReasons.map(reason => html`
+                      <div class="break-all font-mono text-xs text-[var(--warn)] opacity-70">${reason}</div>
                     `)}
                   </div>
                 </details>
@@ -188,15 +457,31 @@ export function HarnessHealth() {
             />
           </div>
 
-          <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">Gate별 분포</div>
+          <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">Gate 분포</div>
           <${GateChart} distribution=${cal.gate_distribution} />
-          <${RecentVerdictsFeed} />
+
+          <div class="mt-4 mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 Verdict</div>
+          <${RecentVerdictsList} items=${data?.recent_verdicts ?? []} />
 
           <button
             class="mt-3 text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--accent)]"
             onClick=${() => void loadHarnessHealth()}
           >새로고침</button>
         `}
+      <//>
+
+      <${Card} title="Pre-Compaction Rail" class="section">
+        ${data ? html`
+          <div class="mb-3 text-sm leading-[1.6] text-[var(--text-muted)]">${data.pre_compact.description}</div>
+          <${PreCompactList} section=${data.pre_compact} />
+        ` : html`<${EmptySignal} text="Pre-compaction 데이터가 없습니다." />`}
+      <//>
+
+      <${Card} title="DNA Quality Rail" class="section">
+        ${data ? html`
+          <div class="mb-3 text-sm leading-[1.6] text-[var(--text-muted)]">${data.dna_quality.description}</div>
+          <${DnaQualityList} section=${data.dna_quality} />
+        ` : html`<${EmptySignal} text="DNA quality 데이터가 없습니다." />`}
       <//>
     </div>
   `

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -197,8 +197,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'harness',
-      label: '하네스 헬스',
-      description: 'Evaluator 캘리브레이션, 컴팩션 전략, DNA 품질 추이를 봅니다.',
+      label: '세이프티 하네스',
+      description: 'Evaluator, compaction, DNA safety rail이 실험을 어떻게 감시하는지 봅니다.',
       params: { section: 'harness' },
     },
   ],

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -1,0 +1,172 @@
+(** Dashboard_harness_health — read model for Lab safety harness.
+
+    Aggregates evaluator calibration stats with recent runtime safety signals
+    so the Lab surface can explain what the harness is watching. *)
+
+type pre_compact_event = {
+  timestamp : float;
+  keeper_name : string;
+  context_ratio : float;
+  message_count : int;
+  token_count : int;
+  strategies : string list;
+  model_family : string;
+  trigger : string;
+}
+
+type dna_quality_event = {
+  timestamp : float;
+  keeper_name : string;
+  score : float;
+  dimensions : Yojson.Safe.t;
+}
+
+let max_runtime_events = 12
+
+let pre_compact_events : pre_compact_event list ref = ref []
+let dna_quality_events : dna_quality_event list ref = ref []
+let runtime_mu = Eio.Mutex.create ()
+
+let trim_recent max_items values =
+  if List.length values <= max_items then values
+  else List.filteri (fun idx _ -> idx < max_items) values
+
+let push_pre_compact event =
+  Eio.Mutex.use_rw ~protect:true runtime_mu (fun () ->
+      pre_compact_events := trim_recent max_runtime_events (event :: !pre_compact_events))
+
+let push_dna_quality event =
+  Eio.Mutex.use_rw ~protect:true runtime_mu (fun () ->
+      dna_quality_events := trim_recent max_runtime_events (event :: !dna_quality_events))
+
+let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
+    ~strategies ~model_family ~trigger =
+  let event =
+    {
+      timestamp = Time_compat.now ();
+      keeper_name;
+      context_ratio;
+      message_count;
+      token_count;
+      strategies;
+      model_family;
+      trigger;
+    }
+  in
+  push_pre_compact event;
+  event
+
+let record_dna_quality ~keeper_name ~score ~dimensions =
+  let event =
+    {
+      timestamp = Time_compat.now ();
+      keeper_name;
+      score;
+      dimensions;
+    }
+  in
+  push_dna_quality event;
+  event
+
+let pre_compact_event_json (event : pre_compact_event) =
+  `Assoc
+    [
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("context_ratio", `Float event.context_ratio);
+      ("message_count", `Int event.message_count);
+      ("token_count", `Int event.token_count);
+      ("strategies", `List (List.map (fun value -> `String value) event.strategies));
+      ("model_family", `String event.model_family);
+      ("trigger", `String event.trigger);
+    ]
+
+let dna_quality_event_json (event : dna_quality_event) =
+  `Assoc
+    [
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("score", `Float event.score);
+      ("dimensions", event.dimensions);
+    ]
+
+let string_field json key =
+  try Yojson.Safe.Util.(json |> member key |> to_string)
+  with Yojson.Safe.Util.Type_error _ | Not_found -> ""
+
+let recent_verdicts_json ?(limit = 8) ?(since = "") ?(until = "") () =
+  let store = Eval_calibration.get_store () in
+  let records =
+    if since = "" && until = "" then
+      Dated_jsonl.read_recent store 500
+    else
+      let start_date = if since = "" then "2020-01-01" else since in
+      let end_date = if until = "" then "2099-12-31" else until in
+      Dated_jsonl.read_range store ~since:start_date ~until:end_date
+  in
+  let verdicts =
+    records
+    |> List.filter_map (fun json ->
+           if String.equal (string_field json "record_type") "verdict" then
+             Some
+               (`Assoc
+                 [
+                   ("timestamp", json |> Yojson.Safe.Util.member "timestamp");
+                   ("task_id", `String (string_field json "task_id"));
+                   ("task_title", `String (string_field json "task_title"));
+                   ("agent_name", `String (string_field json "agent_name"));
+                   ("gate", `String (string_field json "gate"));
+                   ("verdict", `String (string_field json "verdict"));
+                   ( "evaluator_cascade",
+                     `String (string_field json "evaluator_cascade") );
+                   ( "fallback_reason",
+                     match string_field json "fallback_reason" with
+                     | "" -> `Null
+                     | reason -> `String reason );
+                 ])
+           else None)
+    |> List.sort (fun left right ->
+           let ts json =
+             try Yojson.Safe.Util.(json |> member "timestamp" |> to_float)
+             with Yojson.Safe.Util.Type_error _ | Not_found -> 0.0
+           in
+           Float.compare (ts right) (ts left))
+    |> trim_recent limit
+  in
+  `List verdicts
+
+let recent_pre_compact_json () =
+  let events = Eio.Mutex.use_ro runtime_mu (fun () -> !pre_compact_events) in
+  `Assoc
+    [
+      ( "description",
+        `String
+          "Shows recent context compaction attempts before long-running keeper turns are condensed." );
+      ("recent_events", `List (List.map pre_compact_event_json events));
+      ("total_recent", `Int (List.length events));
+    ]
+
+let recent_dna_quality_json () =
+  let events = Eio.Mutex.use_ro runtime_mu (fun () -> !dna_quality_events) in
+  `Assoc
+    [
+      ( "description",
+        `String
+          "Shows recent continuity DNA quality checks before keeper mitosis or handoff-style spawn flows continue." );
+      ("recent_events", `List (List.map dna_quality_event_json events));
+      ("total_recent", `Int (List.length events));
+    ]
+
+let json ?since ?until () =
+  let calibration = Eval_calibration.calibration_stats ?since ?until () in
+  `Assoc
+    [
+      ("generated_at", `Float (Time_compat.now ()));
+      ( "scope_note",
+        `String
+          "Autoresearch tracks the generator loop itself. The safety harness tracks supporting evaluator and long-running continuity rails, so these signals are related but not a direct keep/discard judge for each autoresearch cycle." );
+      ("calibration", calibration);
+      ("recent_verdicts", recent_verdicts_json ?since ?until ());
+      ("pre_compact", recent_pre_compact_json ());
+      ("dna_quality", recent_dna_quality_json ());
+    ]

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -56,6 +56,12 @@ let loop_summary_json (base_path : string)
         match state.error_message with Some e -> `String e | None -> `Null );
       ( "session_id",
         match link with Some l -> `String l.session_id | None -> `Null );
+      ( "operation_id",
+        match link with Some l -> (
+          match l.operation_id with Some value -> `String value | None -> `Null)
+        | None -> `Null );
+      ( "linked_at",
+        match link with Some l -> `Float l.linked_at | None -> `Null );
       ( "queued_hypothesis",
         match state.queued_hypothesis with
         | Some v -> `String v
@@ -96,6 +102,12 @@ let persisted_to_loop_summary_json (base_path : string)
         match p.error_message with Some e -> `String e | None -> `Null );
       ( "session_id",
         match link with Some l -> `String l.session_id | None -> `Null );
+      ( "operation_id",
+        match link with Some l -> (
+          match l.operation_id with Some value -> `String value | None -> `Null)
+        | None -> `Null );
+      ( "linked_at",
+        match link with Some l -> `Float l.linked_at | None -> `Null );
       ( "queued_hypothesis",
         match p.queued_hypothesis with
         | Some v -> `String v

--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
    dashboard_http_keeper
    dashboard_http_mdal
    dashboard_http_autoresearch
+   dashboard_harness_health
    dashboard_http_repo_synthesis
    dashboard_provider_runs
    proactive_refresh
@@ -594,6 +595,7 @@
  dashboard_http_keeper
  dashboard_http_mdal
  dashboard_http_autoresearch
+ dashboard_harness_health
  server_routes_http_common
  server_routes_http_pages
  server_routes_http_runtime

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -335,9 +335,52 @@ let compact_if_needed
         PruneToolOutputs; MergeContiguous;
         DropLowImportance; SummarizeOld]
       in
+      let strategy_names =
+        List.map
+          (function
+            | Context_compact_oas.PruneToolOutputs -> "PruneToolOutputs"
+            | Context_compact_oas.MergeContiguous -> "MergeContiguous"
+            | Context_compact_oas.DropLowImportance -> "DropLowImportance"
+            | Context_compact_oas.SummarizeOld -> "SummarizeOld"
+            | Context_compact_oas.Dynamic _ -> "Dynamic")
+          strategies
+      in
       Log.Harness.info
         "[pre_compact] keeper=%s ratio=%.4f messages=%d tokens=%d trigger=%s"
         meta.name ratio message_count token_count reason;
+      let pre_compact_event =
+        Dashboard_harness_health.record_pre_compact
+          ~keeper_name:meta.name ~context_ratio:ratio ~message_count
+          ~token_count ~strategies:strategy_names
+          ~model_family:meta.cascade_name ~trigger:reason
+      in
+      (try
+         Sse.broadcast
+           (`Assoc
+             [
+               ("type", `String "oas:masc:harness:pre_compact");
+               ( "payload",
+                 `Assoc
+                   [
+                     ("timestamp", `Float pre_compact_event.timestamp);
+                     ("keeper_name", `String pre_compact_event.keeper_name);
+                     ("context_ratio", `Float pre_compact_event.context_ratio);
+                     ("message_count", `Int pre_compact_event.message_count);
+                     ("token_count", `Int pre_compact_event.token_count);
+                     ( "strategies",
+                       `List
+                         (List.map
+                            (fun value -> `String value)
+                            pre_compact_event.strategies) );
+                     ("model_family", `String pre_compact_event.model_family);
+                     ("trigger", `String pre_compact_event.trigger);
+                   ] );
+             ])
+       with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          Log.Harness.warn "[pre_compact] sse broadcast failed: %s"
+            (Printexc.to_string exn));
       let messages, token_count =
           Context_compact_oas.compact
             ~system_prompt:ctx.system_prompt

--- a/lib/mitosis.ml
+++ b/lib/mitosis.ml
@@ -239,6 +239,30 @@ let prepare_for_division ~config ~cell ~full_context =
   let dna = extract_dna ~config ~parent_cell:cell ~full_context in
   let continuity_anchors = Mitosis_dna.build_continuity_anchors full_context in
   let quality = Mitosis_dna.validate_dna ~dna ~anchors:continuity_anchors in
+  let dna_event =
+    Dashboard_harness_health.record_dna_quality ~keeper_name:cell.id
+      ~score:quality.Mitosis_dna.score
+      ~dimensions:(Mitosis_dna.dna_quality_to_json quality)
+  in
+  (try
+     Sse.broadcast
+       (`Assoc
+         [
+           ("type", `String "oas:masc:harness:dna_quality");
+           ( "payload",
+             `Assoc
+               [
+                 ("timestamp", `Float dna_event.timestamp);
+                 ("keeper_name", `String dna_event.keeper_name);
+                 ("score", `Float dna_event.score);
+                 ("dimensions", dna_event.dimensions);
+               ] );
+         ])
+   with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Harness.warn "[mitosis] dna quality sse broadcast failed: %s"
+        (Printexc.to_string exn));
   if quality.Mitosis_dna.score < 0.3 then begin
     Log.Mitosis_log.warn
       "[mitosis] DNA quality too low (%.2f): goal=%b task=%b recent=%b truncation=%d. Skipping division."

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -215,11 +215,7 @@ let add_routes ~sw ~clock router =
        with_public_read (fun _state req reqd ->
          let since = Server_utils.query_param req "since" in
          let until = Server_utils.query_param req "until" in
-         let stats = Eval_calibration.calibration_stats ?since ?until () in
-         let json = `Assoc [
-           ("generated_at", `Float (Time_compat.now ()));
-           ("calibration", stats);
-         ] in
+         let json = Dashboard_harness_health.json ?since ?until () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) _request reqd)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -20,6 +20,11 @@ let result_to_response = function
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)
 
+let verdict_to_string (result : Anti_rationalization.review_result) =
+  match result.verdict with
+  | Anti_rationalization.Approve -> "approve"
+  | Anti_rationalization.Reject reason -> "reject:" ^ reason
+
 (** Validate task_id is non-empty. Prevents phantom operations on empty IDs. *)
 let validate_task_id task_id =
   if task_id = "" then Error (Types.TaskNotFound "")
@@ -295,7 +300,35 @@ let handle_transition ctx args =
         } in
         let on_verdict result =
           Eval_calibration.record_verdict
-            ~task_id ~req:ar_req ~result () in
+            ~task_id ~req:ar_req ~result ();
+          (try
+             Sse.broadcast
+               (`Assoc
+                 [
+                   ("type", `String "oas:masc:harness:verdict_recorded");
+                   ( "payload",
+                     `Assoc
+                       [
+                         ("timestamp", `Float (Time_compat.now ()));
+                         ("task_id", `String task_id);
+                         ("task_title", `String ar_req.task_title);
+                         ("agent_name", `String ar_req.agent_name);
+                         ("gate", `String result.gate);
+                         ("verdict", `String (verdict_to_string result));
+                         ( "evaluator_cascade",
+                           `String result.evaluator_cascade );
+                         ( "fallback_reason",
+                           match result.fallback_reason with
+                           | Some reason -> `String reason
+                           | None -> `Null );
+                       ] );
+                 ])
+           with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Harness.warn
+                "[anti-rationalization] verdict sse broadcast failed: %s"
+                (Printexc.to_string exn)) in
         let few_shot_block =
           Eval_calibration.format_few_shot_block
             (Eval_calibration.select_examples ~max_examples:3) in


### PR DESCRIPTION
## Summary
Clarifies the Lab autoresearch flow and reframes the harness surface as a safety/evaluator view instead of a vague secondary dashboard.

## What changed
- Added a `Research Brief` to the autoresearch surface so each loop explains its goal, metric, target file, linked session/operation, and current hypothesis.
- Reworked the harness surface into a `Safety Harness` view with explicit scope copy, recent evaluator verdicts, pre-compaction signals, and DNA quality signals.
- Extended the backend read models to return linked autoresearch metadata and a dedicated harness-health payload.
- Wired runtime signal collection for verdict, pre-compaction, and DNA quality events so the dashboard has live, explainable safety context.

## Why
The previous Lab IA made it hard to tell what was being researched, what the evaluator was actually judging, and which parts were direct autoresearch loop signals versus indirect long-running safety rails.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/lab-harness-explainability @default`
- `npm run typecheck`
- `npm test -- src/components/autoresearch.test.ts src/components/harness-health.test.ts`
