### PR TITLE
[codex] enforce issue triage and scope Eio test context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,8 @@ body:
       value: |
         Use this for behavior that is broken, incorrect, or regressed.
         Human reporters, Codex, and internal agents may all file this form.
-        Add exactly one `target:*` label after triage.
+        Choose exactly one target train below. Automation will keep `triage-required`
+        on the issue until it has exactly one `type:*` and one `target:*` label.
   - type: input
     id: version
     attributes:
@@ -27,6 +28,23 @@ body:
         - major workflow broken
         - moderate incorrect behavior
         - minor but real bug
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target train
+      description: Choose the smallest plausible release lane. Triage can retarget later.
+      options:
+        - "target:v2.86.1"
+        - "target:v2.87.0"
+        - "target:v2.88.0"
+        - "target:v2.89.0"
+        - "target:v2.90.0"
+        - "target:v2.91.0"
+        - "target:v2.92.0"
+        - "target:v2.93+"
+        - "target:v2.148+"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Versioned roadmap
     url: https://github.com/jeong-sik/masc-mcp/blob/main/docs/VERSIONED-ROADMAP.md

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,12 +9,30 @@ body:
       value: |
         Use this for net-new capability work.
         Human reporters, Codex, and internal agents may all file this form.
-        Every accepted feature should be assigned to exactly one `target:*` release train.
+        Choose exactly one target train below. Automation will keep `triage-required`
+        on the issue until it has exactly one `type:*` and one `target:*` label.
   - type: input
     id: outcome
     attributes:
       label: Desired outcome
       placeholder: What becomes possible if this exists?
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target train
+      description: Choose the smallest plausible release lane. Triage can retarget later.
+      options:
+        - "target:v2.86.1"
+        - "target:v2.87.0"
+        - "target:v2.88.0"
+        - "target:v2.89.0"
+        - "target:v2.90.0"
+        - "target:v2.91.0"
+        - "target:v2.92.0"
+        - "target:v2.93+"
+        - "target:v2.148+"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/friction-report.yml
+++ b/.github/ISSUE_TEMPLATE/friction-report.yml
@@ -9,8 +9,8 @@ body:
       value: |
         Use this for dogfooding discomfort.
         Human reporters, Codex, and internal agents may all file this form.
-        If the fix is small, it should land in the current patch lane.
-        If the fix needs workflow redesign, it should be promoted into the next feature train.
+        Choose exactly one target train below. Automation will keep `triage-required`
+        on the issue until it has exactly one `type:*` and one `target:*` label.
   - type: input
     id: version
     attributes:
@@ -31,6 +31,23 @@ body:
         - missing affordance
         - naming or discoverability
         - other
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target train
+      description: Choose the smallest plausible release lane. Triage can retarget later.
+      options:
+        - "target:v2.86.1"
+        - "target:v2.87.0"
+        - "target:v2.88.0"
+        - "target:v2.89.0"
+        - "target:v2.90.0"
+        - "target:v2.91.0"
+        - "target:v2.92.0"
+        - "target:v2.93+"
+        - "target:v2.148+"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,105 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  enforce-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce type/target planning labels
+        uses: actions/github-script@v8
+        env:
+          TRIAGE_LABEL: triage-required
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+            const targetLabels = [
+              "target:v2.86.1",
+              "target:v2.87.0",
+              "target:v2.88.0",
+              "target:v2.89.0",
+              "target:v2.90.0",
+              "target:v2.91.0",
+              "target:v2.92.0",
+              "target:v2.93+",
+              "target:v2.148+"
+            ];
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color,
+                  description
+                });
+              }
+            }
+
+            function getLabelNames(labels) {
+              return labels.map((label) => (typeof label === "string" ? label : label.name));
+            }
+
+            function findTargetInBody(body) {
+              if (!body) return null;
+              return targetLabels.find((label) => body.includes(label)) || null;
+            }
+
+            await ensureLabel(
+              process.env.TRIAGE_LABEL,
+              "BFDADC",
+              "Issue is missing exactly one planning type/target label."
+            );
+
+            const labelNames = new Set(getLabelNames(issue.labels));
+            let typeMatches = [...labelNames].filter((name) => name.startsWith("type:"));
+            let targetMatches = [...labelNames].filter((name) => name.startsWith("target:"));
+
+            if (targetMatches.length === 0) {
+              const inferredTarget = findTargetInBody(issue.body || "");
+              if (inferredTarget) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  labels: [inferredTarget]
+                });
+                labelNames.add(inferredTarget);
+                targetMatches = [inferredTarget];
+              }
+            }
+
+            typeMatches = [...labelNames].filter((name) => name.startsWith("type:"));
+            targetMatches = [...labelNames].filter((name) => name.startsWith("target:"));
+
+            const needsTriage = typeMatches.length !== 1 || targetMatches.length !== 1;
+            const hasTriageLabel = labelNames.has(process.env.TRIAGE_LABEL);
+
+            if (needsTriage && !hasTriageLabel) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: [process.env.TRIAGE_LABEL]
+              });
+            } else if (!needsTriage && hasTriageLabel) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                name: process.env.TRIAGE_LABEL
+              });
+            }

--- a/docs/VERSIONED-ROADMAP.md
+++ b/docs/VERSIONED-ROADMAP.md
@@ -54,6 +54,11 @@ Release labeling rules:
 - `release-blocker` means the issue must be closed before the tagged release.
 - Legacy labels such as `bug` or `enhancement` may remain, but `type:*` and `target:*` are the planning SSOT going forward.
 - Agent-filed reports should include reproducible evidence, a concrete symptom, and the smallest plausible target train.
+- Blank issues stay disabled so intake goes through a typed issue form by default.
+- New issue forms require a target-train choice, and automation adds `triage-required`
+  until the issue has exactly one `type:*` and one `target:*` label.
+- `triage-required` means the issue is not in the execution queue yet. Ownership,
+  duplicate handling, and exact release placement must be resolved before work starts.
 
 ## Source Documents
 

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -54,6 +54,9 @@ let get_mono_clock () =
   | Some mc -> mc
   | None -> invalid_arg "Eio mono_clock not initialized"
 
+let get_mono_clock_opt () =
+  Atomic.get current_mono_clock
+
 let set_switch sw =
   Atomic.set current_sw (Some sw)
 

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -8,11 +8,35 @@
 
 type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
 
+type state_snapshot = {
+  net : eio_net option;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
+  mono_clock : Eio.Time.Mono.ty Eio.Resource.t option;
+  sw : Eio.Switch.t option;
+  net_initialized : bool;
+}
+
 let current_net : eio_net option Atomic.t = Atomic.make None
 let current_clock : float Eio.Time.clock_ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_sw : Eio.Switch.t option Atomic.t = Atomic.make None
 let net_initialized : bool Atomic.t = Atomic.make false
+
+let snapshot_state () =
+  {
+    net = Atomic.get current_net;
+    clock = Atomic.get current_clock;
+    mono_clock = Atomic.get current_mono_clock;
+    sw = Atomic.get current_sw;
+    net_initialized = Atomic.get net_initialized;
+  }
+
+let restore_state snapshot =
+  Atomic.set current_net snapshot.net;
+  Atomic.set current_clock snapshot.clock;
+  Atomic.set current_mono_clock snapshot.mono_clock;
+  Atomic.set current_sw snapshot.sw;
+  Atomic.set net_initialized snapshot.net_initialized
 
 let set_net net =
   Atomic.set current_net (Some (net :> eio_net));
@@ -31,6 +55,14 @@ let get_mono_clock () =
 
 let set_switch sw =
   Atomic.set current_sw (Some sw)
+
+let with_test_env ~net ~clock ~mono_clock ~sw f =
+  let snapshot = snapshot_state () in
+  set_net net;
+  set_clock clock;
+  set_mono_clock mono_clock;
+  set_switch sw;
+  Fun.protect ~finally:(fun () -> restore_state snapshot) f
 
 let get_net_opt () : eio_net option =
   Atomic.get current_net

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -21,6 +21,7 @@ let current_clock : float Eio.Time.clock_ty Eio.Resource.t option Atomic.t = Ato
 let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_sw : Eio.Switch.t option Atomic.t = Atomic.make None
 let net_initialized : bool Atomic.t = Atomic.make false
+let with_test_env_lock = Mutex.create ()
 
 let snapshot_state () =
   {
@@ -57,12 +58,17 @@ let set_switch sw =
   Atomic.set current_sw (Some sw)
 
 let with_test_env ~net ~clock ~mono_clock ~sw f =
+  Mutex.lock with_test_env_lock;
   let snapshot = snapshot_state () in
   set_net net;
   set_clock clock;
   set_mono_clock mono_clock;
   set_switch sw;
-  Fun.protect ~finally:(fun () -> restore_state snapshot) f
+  Fun.protect
+    ~finally:(fun () ->
+      restore_state snapshot;
+      Mutex.unlock with_test_env_lock)
+    f
 
 let get_net_opt () : eio_net option =
   Atomic.get current_net

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -20,6 +20,15 @@ val get_mono_clock : unit -> Eio.Time.Mono.ty Eio.Resource.t
 val set_switch : Eio.Switch.t -> unit
 (** Set the global Eio switch. *)
 
+val with_test_env :
+  net:[> `Network | `Platform of [> `Generic | `Unix ]] Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  mono_clock:Eio.Time.Mono.ty Eio.Resource.t ->
+  sw:Eio.Switch.t ->
+  (unit -> 'a) -> 'a
+(** Temporarily override the global Eio context for a test scope and restore the
+    previous values afterwards. *)
+
 val get_net_opt : unit -> eio_net option
 (** Get the Eio network handle if available. *)
 

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -17,6 +17,9 @@ val get_mono_clock : unit -> Eio.Time.Mono.ty Eio.Resource.t
 (** Get the global Eio monotonic clock.
     @raise Invalid_argument if not initialized. *)
 
+val get_mono_clock_opt : unit -> Eio.Time.Mono.ty Eio.Resource.t option
+(** Get the global Eio monotonic clock if available. *)
+
 val set_switch : Eio.Switch.t -> unit
 (** Set the global Eio switch. *)
 
@@ -27,7 +30,9 @@ val with_test_env :
   sw:Eio.Switch.t ->
   (unit -> 'a) -> 'a
 (** Temporarily override the global Eio context for a test scope and restore the
-    previous values afterwards. *)
+    previous values afterwards.
+    Callers should keep all spawned work inside the provided structured Eio switch
+    so the override does not outlive the test scope. *)
 
 val get_net_opt : unit -> eio_net option
 (** Get the Eio network handle if available. *)

--- a/test/test_a2a_e2e.ml
+++ b/test/test_a2a_e2e.ml
@@ -46,13 +46,18 @@ let with_eio_env f =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let clock = Eio.Stdenv.clock env in
-  (* Ensure clock is available for atomic lock-retry sleep on Linux *)
-  Eio_context.set_clock clock;
   let tmp_dir = make_test_dir () in
   let config = Room_eio.test_config ~fs tmp_dir in
   Fun.protect
     ~finally:(fun () -> try rm_rf tmp_dir with _ -> ())
-    (fun () -> f config)
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      Eio_context.with_test_env
+        ~net:(Eio.Stdenv.net env)
+        ~clock
+        ~mono_clock:(Eio.Stdenv.mono_clock env)
+        ~sw
+        (fun () -> f config))
 
 (** {1 E2E Tests} *)
 

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -163,14 +163,20 @@ let with_eio_backend f =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let clock = Eio.Stdenv.clock env in
-  (* Ensure clock is available for atomic lock-retry sleep on Linux *)
-  Eio_context.set_clock clock;
   let tmp_dir = make_test_dir "masc_eio" in
   let config = { Backend.default_config with base_path = tmp_dir; node_id = "test"; cluster_name = "test" } in
-  let backend = Backend.FileSystem.create ~fs config in
   Fun.protect
     ~finally:(fun () -> try rm_rf tmp_dir with _ -> ())
-    (fun () -> f backend)
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      Eio_context.with_test_env
+        ~net:(Eio.Stdenv.net env)
+        ~clock
+        ~mono_clock:(Eio.Stdenv.mono_clock env)
+        ~sw
+        (fun () ->
+          let backend = Backend.FileSystem.create ~fs config in
+          f backend))
 
 let test_eio_lock_acquire () =
   with_eio_backend @@ fun backend ->

--- a/test/test_code_navigation_eio.ml
+++ b/test/test_code_navigation_eio.ml
@@ -10,11 +10,12 @@ module Mcp_eio = Masc_mcp.Mcp_server_eio
 
 (* ===== Test Helpers ===== *)
 
-let init_eio env =
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  Eio_context.set_net (Eio.Stdenv.net env);
-  Eio_context.set_clock (Eio.Stdenv.clock env)
+let with_eio_context env sw f =
+  Eio_context.with_test_env
+    ~net:(Eio.Stdenv.net env)
+    ~clock:(Eio.Stdenv.clock env)
+    ~mono_clock:(Eio.Stdenv.mono_clock env)
+    ~sw f
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -88,9 +89,9 @@ let prepare_code_surface ~clock:_ ~sw:_ _state = ()
 let test_code_search_basic () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
 
   (* Use current repo as base_path for real code search *)
   let base_path = Sys.getcwd () in
@@ -168,9 +169,9 @@ let test_code_search_basic () =
 let test_code_symbols_basic () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
 
   let base_path = Sys.getcwd () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
@@ -221,9 +222,9 @@ let test_code_symbols_basic () =
 let test_code_read_basic () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
 
   let base_path = Sys.getcwd () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
@@ -287,9 +288,9 @@ let test_code_read_basic () =
 let test_code_read_offset_limit () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  init_eio env;
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
 
   let base_path = Sys.getcwd () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -43,7 +43,12 @@ let with_test_env f =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room_utils.default_config dir in
       Eio.Switch.run @@ fun sw ->
-      f ~env ~sw ~config)
+      Eio_context.with_test_env
+        ~net:(Eio.Stdenv.net env)
+        ~clock:(Eio.Stdenv.clock env)
+        ~mono_clock:(Eio.Stdenv.mono_clock env)
+        ~sw
+        (fun () -> f ~env ~sw ~config))
 
 let with_pg_test_env f =
   match Sys.getenv_opt "MASC_POSTGRES_URL" with
@@ -61,14 +66,18 @@ let with_pg_test_env f =
           Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
           Eio.Switch.run @@ fun sw ->
-          Eio_context.set_net (Eio.Stdenv.net env);
-          Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);
-          let config =
-            Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
-          in
-          match config.Room_utils.backend with
-          | Room_utils.PostgresNative _ -> f ~env ~sw ~config
-          | Room_utils.Memory _ | Room_utils.FileSystem _ -> ())
+          Eio_context.with_test_env
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~mono_clock:(Eio.Stdenv.mono_clock env)
+            ~sw
+            (fun () ->
+              let config =
+                Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
+              in
+              match config.Room_utils.backend with
+              | Room_utils.PostgresNative _ -> f ~env ~sw ~config
+              | Room_utils.Memory _ | Room_utils.FileSystem _ -> ()))
 
 let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
   with_test_env @@ fun ~env ~sw ~config ->

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -360,6 +360,7 @@ let test_eio_context_with_test_env_restores () =
   let mono_clock = Eio.Stdenv.mono_clock env in
   let before_net = Eio_context.get_net_opt () in
   let before_clock = Eio_context.get_clock_opt () in
+  let before_mono_clock = Eio_context.get_mono_clock_opt () in
   let before_switch = Eio_context.get_switch_opt () in
   Eio.Switch.run @@ fun sw ->
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
@@ -367,12 +368,16 @@ let test_eio_context_with_test_env_restores () =
       (Option.is_some (Eio_context.get_net_opt ()));
     Alcotest.(check bool) "scoped clock set" true
       (Option.is_some (Eio_context.get_clock_opt ()));
+    Alcotest.(check bool) "scoped mono_clock set" true
+      (Option.is_some (Eio_context.get_mono_clock_opt ()));
     Alcotest.(check bool) "scoped switch set" true
       (Option.is_some (Eio_context.get_switch_opt ())));
   Alcotest.(check bool) "net restored" true
     (option_ref_equal before_net (Eio_context.get_net_opt ()));
   Alcotest.(check bool) "clock restored" true
     (option_ref_equal before_clock (Eio_context.get_clock_opt ()));
+  Alcotest.(check bool) "mono_clock restored" true
+    (option_ref_equal before_mono_clock (Eio_context.get_mono_clock_opt ()));
   Alcotest.(check bool) "switch restored" true
     (option_ref_equal before_switch (Eio_context.get_switch_opt ()))
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -346,6 +346,36 @@ let test_eio_context_delegation () =
   Alcotest.(check bool) "clock delegated to shared Eio_context" true
     (Eio_context.get_clock () == alias_clock)
 
+let option_ref_equal left right =
+  match left, right with
+  | None, None -> true
+  | Some l, Some r -> l == r
+  | None, Some _ | Some _, None -> false
+
+let test_eio_context_with_test_env_restores () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  let before_net = Eio_context.get_net_opt () in
+  let before_clock = Eio_context.get_clock_opt () in
+  let before_switch = Eio_context.get_switch_opt () in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+    Alcotest.(check bool) "scoped net set" true
+      (Option.is_some (Eio_context.get_net_opt ()));
+    Alcotest.(check bool) "scoped clock set" true
+      (Option.is_some (Eio_context.get_clock_opt ()));
+    Alcotest.(check bool) "scoped switch set" true
+      (Option.is_some (Eio_context.get_switch_opt ())));
+  Alcotest.(check bool) "net restored" true
+    (option_ref_equal before_net (Eio_context.get_net_opt ()));
+  Alcotest.(check bool) "clock restored" true
+    (option_ref_equal before_clock (Eio_context.get_clock_opt ()));
+  Alcotest.(check bool) "switch restored" true
+    (option_ref_equal before_switch (Eio_context.get_switch_opt ()))
+
 (* ===== Unit Tests for Protocol Helpers ===== *)
 
 let test_is_jsonrpc_v2 () =
@@ -2524,6 +2554,7 @@ let state_tests = [
   "create_state", `Quick, test_create_state;
   "type compatibility", `Quick, test_type_compatibility;
   "eio context delegation", `Quick, test_eio_context_delegation;
+  "eio context scoped restore", `Quick, test_eio_context_with_test_env_restores;
   "resolve_join_state skips read-only lookup", `Quick,
     test_resolve_join_state_skips_read_only_lookup;
   "resolve_join_state checks join-required tools", `Quick,

--- a/test/test_room_messages_pg.ml
+++ b/test/test_room_messages_pg.ml
@@ -43,18 +43,22 @@ let with_pg_test_env f =
           Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
           Eio.Switch.run @@ fun sw ->
-          Eio_context.set_net (Eio.Stdenv.net env);
-          Eio_context.set_mono_clock (Eio.Stdenv.mono_clock env);
-          let config =
-            Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
-          in
-          match config.Room_utils.backend with
-          | Room_utils.PostgresNative _ ->
-              let _ = Room.init config ~agent_name:(Some "claude") in
-              Fun.protect
-                ~finally:(fun () -> ignore (Room.reset config))
-                (fun () -> f ~env ~sw ~config)
-          | Room_utils.Memory _ | Room_utils.FileSystem _ -> ())
+          Eio_context.with_test_env
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~mono_clock:(Eio.Stdenv.mono_clock env)
+            ~sw
+            (fun () ->
+              let config =
+                Room_utils.default_config_eio ~sw ~env:(env :> Caqti_eio.stdenv) dir
+              in
+              match config.Room_utils.backend with
+              | Room_utils.PostgresNative _ ->
+                  let _ = Room.init config ~agent_name:(Some "claude") in
+                  Fun.protect
+                    ~finally:(fun () -> ignore (Room.reset config))
+                    (fun () -> f ~env ~sw ~config)
+              | Room_utils.Memory _ | Room_utils.FileSystem _ -> ()))
 
 let test_get_messages_raw_uses_postgres_backend () =
   with_pg_test_env @@ fun ~env:_ ~sw:_ ~config ->


### PR DESCRIPTION
## Summary
- disable blank issues and require target-train selection in issue forms
- add issue-triage automation that keeps `triage-required` on issues until they have exactly one `type:*` and one `target:*` label
- add `Eio_context.with_test_env` and migrate affected tests to scoped Eio context overrides instead of direct global setter calls

## Why
- the backlog was drifting away from the documented planning SSOT because issues could bypass typed intake and stay unlabeled
- Eio-backed tests were mutating global context directly, which made it harder to reason about setup/restore boundaries while hardening runtime tests

## Impact
- new issue intake is forced through typed forms by default and triage state is explicit
- issue planning labels now have an automated enforcement path
- tests that need temporary Eio globals now use a scoped helper that restores the previous state automatically

## Validation
- `dune build --root . @check`
- `_build/default/test/test_mcp_server_eio.exe`
- `_build/default/test/test_dashboard_http_core.exe`
- `_build/default/test/test_a2a_e2e.exe`
- `_build/default/test/test_backend_coverage.exe`
- `_build/default/test/test_code_navigation_eio.exe`
- `_build/default/test/test_room_messages_pg.exe`