### PR TITLE
refactor: tighten OAS swarm fidelity and resume flow

### DIFF
--- a/docs/OAS-MIGRATION-NEXT-STEPS.md
+++ b/docs/OAS-MIGRATION-NEXT-STEPS.md
@@ -1,6 +1,6 @@
 # MASC → OAS Migration Next Steps
 
-Updated: 2026-03-21
+Updated: 2026-03-27
 Scope: `masc-mcp` only
 
 ## Current Baseline
@@ -23,10 +23,10 @@ They do. The gap is that the bridge is still lossy.
 
 ### What remains
 
-- preserve more `planned_worker` metadata in swarm entries
-- preserve richer telemetry semantics beyond the current `trace_ref`/usage/turn_count baseline when the swarm runner needs more operator-facing detail
+- preserve more `planned_worker` metadata if the upstream swarm entry model grows beyond the current closure shape
+- decide whether the current event-level telemetry detail is enough, or whether dashboard consumers need first-class swarm telemetry views
 - decide whether the current single-pass success-ratio convergence policy should become a richer multi-iteration strategy
-- replace the current room-init `resource_check` with a broader runtime-health probe if needed
+- broaden the runtime-health probe beyond room/session readiness only if a concrete failure mode appears
 - decide whether session-level budget needs token/cost enforcement beyond the current `duration_seconds` wall-clock budget
 
 ### Success criteria
@@ -43,10 +43,14 @@ This pass reduced duplication, but one important path still remains outside the 
 
 - dashboard provider single-run now routes through `Oas_worker.run_model`
 - initial local worker run now routes through `Worker_oas.run_worker_via_oas`
+- local worker resume/continue now routes through `Worker_oas.resume_worker_via_oas`
+- team-session collaboration metadata now preserves richer worker/session semantics
+- swarm lifecycle events now include per-agent telemetry detail
+- `resource_check` now validates persisted running-session state, not just room initialization
 
 ### Still remaining
 
-- local worker resume/continue path still constructs resume-specific config locally before entering the shared execution tail
+- no known local worker resume-path config duplication remains in the current OAS path
 
 ### Success criteria
 

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -207,40 +207,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
       in
       match worker_auth_token ~base_path ~worker_name with
       | Error e -> Error e
-      | Ok auth_token ->
-          let* net =
-            match Eio_context.get_net_opt () with
-            | Some net -> Ok net
-            | None -> Error "Eio net not initialized"
-          in
-          let heartbeat_cbs =
-            let interval = local_worker_heartbeat_interval_sec () in
-            if interval > 0 then
-              [ { Oas.Agent_types.interval_sec = float_of_int interval;
-                  callback = (fun () ->
-                    match
-                      call_masc_tool ~sw ~auth_token
-                        ~session_id:meta.mcp_session_id
-                        ~tool_name:"masc_heartbeat" ~args:(`Assoc [])
-                    with
-                    | Ok _ -> ()
-                    | Error e ->
-                        Log.LocalWorker.warn "heartbeat error for %s: %s"
-                          worker_name e) } ]
-            else []
-          in
-          Fun.protect
-            ~finally:(fun () ->
-              ignore
-                (leave_worker ~sw ~auth_token
-                   ~session_id:meta.mcp_session_id ~worker_name))
-            (fun () ->
-              let _ =
-                match join_worker ~sw ~auth_token
-                        ~session_id:meta.mcp_session_id ~worker_name with
-                | Ok _ -> ()
-                | Error e -> raise (Failure ("worker join failed: " ^ e))
-              in
+          | Ok auth_token ->
               let allowed_tools =
                 match meta.shell_profile with
                 | Shell_dev ->
@@ -296,27 +263,6 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                         |> Result.map_error Oas.Error.to_string)
               in
               let tools = mcp_tools @ shell_tools in
-              let tool_names_ref = ref [] in
-              let hooks =
-                {
-                  Oas.Hooks.empty with
-                  pre_tool_use =
-                    Some
-                      (function
-                        | Oas.Hooks.PreToolUse { tool_name; _ } ->
-                            tool_names_ref := tool_name :: !tool_names_ref;
-                            Oas.Hooks.Continue
-                        | _ -> Oas.Hooks.Continue);
-                }
-              in
-              let resume_model_id =
-                if checkpoint.model <> "" then checkpoint.model
-                else meta.effective_model
-              in
-              let resume_label =
-                Printf.sprintf "llama:%s" resume_model_id
-              in
-              let resume_provider = oas_provider_of_label resume_label in
               let prompt =
                 let tool_contract =
                   "Tool contract reminder: if you call masc_team_session_step \
@@ -342,40 +288,8 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                 in
                 String.concat "\n\n" [ tool_contract; workflow_contract; prompt ]
               in
-              let max_turns =
-                match meta.max_turns_override with
-                | Some value -> max 1 value
-                | None ->
-                    (match meta.execution_scope with
-                    | Team_session_types.Limited_code_change -> 20
-                    | Team_session_types.Observe_only -> 8
-                    | Team_session_types.Autonomous -> 30)
-              in
-              let thinking_enabled =
-                Option.value ~default:false meta.thinking_enabled
-              in
-              let resume_guardrails =
-                let gate =
-                  Worker_oas.gate_config_of_execution_scope meta.execution_scope
-                in
-                Verifier_oas.eval_gate_to_oas_guardrails gate
-              in
-              let config, options =
-                build_resume_config ~worker_name ~provider:resume_provider
-                  ~model_id:resume_model_id
-                  ~system_prompt:
-                    (default_system_prompt ~worker_name ~model_id:resume_model_id
-                       ?session_id:meta.team_session_id ?role:meta.role
-                       ?selection_note:meta.selection_note ())
-                  ~tools ~max_turns ~thinking_enabled ~hooks ~raw_trace
-                  ~periodic_callbacks:heartbeat_cbs
-                  ~guardrails:resume_guardrails ()
-              in
-              let agent =
-                Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
-              in
-              Worker_oas.run_existing_worker_agent ~sw ~base_path ~meta ~prompt
-                ~workspace_path ~raw_trace ?worker_run_id ~tool_names_ref agent)))
+              Worker_oas.resume_worker_via_oas ~sw ~base_path ~meta ~checkpoint
+                ~prompt ~tools ~raw_trace ?worker_run_id ()))
 
 let run_worker ~sw ~base_path ~worker_name ~model_label ~team_session_id
     ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -146,6 +146,154 @@ let execution_scope_to_participant_state
   | Some Limited_code_change -> Working
   | Some Autonomous -> Working
 
+let add_json_string_if_present key value acc =
+  match value with
+  | Some text when String.trim text <> "" -> (key, `String (String.trim text)) :: acc
+  | _ -> acc
+
+let add_json_bool_if_present key value acc =
+  match value with
+  | Some flag -> (key, `Bool flag) :: acc
+  | None -> acc
+
+let add_json_int_if_present key value acc =
+  match value with
+  | Some n -> (key, `Int n) :: acc
+  | None -> acc
+
+let add_json_float_if_present key value acc =
+  match value with
+  | Some n -> (key, `Float n) :: acc
+  | None -> acc
+
+let count_assoc_to_json counts =
+  `Assoc
+    (counts
+    |> List.map (fun (label, count) -> (label, `Int count))
+    |> List.sort (fun (a, _) (b, _) -> compare a b))
+
+let planned_worker_summary (pw : Team_session_types.planned_worker) : string option =
+  let parts = ref [] in
+  let add label value =
+    if String.trim value <> "" then
+      parts := (label ^ "=" ^ value) :: !parts
+  in
+  add "role" (Option.value ~default:"" pw.spawn_role);
+  add "actor" (Option.value ~default:"" pw.runtime_actor);
+  add "model" (Option.value ~default:"" pw.spawn_model);
+  add "scope"
+    (match pw.execution_scope with
+    | Some scope -> Team_session_types.execution_scope_to_string scope
+    | None -> "");
+  add "max_turns"
+    (match pw.max_turns with
+    | Some turns -> string_of_int turns
+    | None -> "");
+  add "class"
+    (match pw.worker_class with
+     | Some worker_class -> Team_session_types.worker_class_to_string worker_class
+     | None -> "");
+  add "tier"
+    (match pw.model_tier with
+     | Some tier -> Team_session_types.model_tier_to_string tier
+     | None -> "");
+  add "pool" (Option.value ~default:"" pw.runtime_pool);
+  add "lane" (Option.value ~default:"" pw.lane_id);
+  add "domain"
+    (match pw.control_domain with
+     | Some domain -> Team_session_types.control_domain_to_string domain
+     | None -> "");
+  add "risk"
+    (match pw.risk_level with
+     | Some risk -> Team_session_types.risk_level_to_string risk
+     | None -> "");
+  add "routing"
+    (match pw.routing_confidence with
+     | Some confidence -> Printf.sprintf "%.2f" confidence
+     | None -> "");
+  match List.rev !parts with
+  | [] -> None
+  | parts -> Some (String.concat "; " parts)
+
+let planned_worker_metadata_json (pw : Team_session_types.planned_worker) :
+    Yojson.Safe.t =
+  let fields =
+    []
+    |> add_json_string_if_present "runtime_actor" pw.runtime_actor
+    |> add_json_string_if_present "spawn_role" pw.spawn_role
+    |> add_json_string_if_present "spawn_model" pw.spawn_model
+    |> add_json_string_if_present "parent_actor" pw.parent_actor
+    |> add_json_string_if_present "runtime_pool" pw.runtime_pool
+    |> add_json_string_if_present "lane_id" pw.lane_id
+    |> add_json_string_if_present "supervisor_actor" pw.supervisor_actor
+    |> add_json_string_if_present "routing_reason" pw.routing_reason
+    |> add_json_bool_if_present "thinking_enabled" pw.thinking_enabled
+    |> add_json_int_if_present "thinking_budget" pw.thinking_budget
+    |> add_json_int_if_present "max_turns" pw.max_turns
+    |> add_json_int_if_present "timeout_seconds" pw.timeout_seconds
+    |> add_json_float_if_present "routing_confidence" pw.routing_confidence
+  in
+  let fields =
+    ("spawn_agent", `String pw.spawn_agent) :: ("routing_escalated", `Bool pw.routing_escalated) :: fields
+  in
+  let fields =
+    match pw.execution_scope with
+    | Some scope ->
+        ("execution_scope", `String (Team_session_types.execution_scope_to_string scope))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.worker_class with
+    | Some worker_class ->
+        ("worker_class", `String (Team_session_types.worker_class_to_string worker_class))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.capsule_mode with
+    | Some mode ->
+        ("capsule_mode", `String (Team_session_types.capsule_mode_to_string mode))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.controller_level with
+    | Some level ->
+        ("controller_level", `String (Team_session_types.controller_level_to_string level))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.control_domain with
+    | Some domain ->
+        ("control_domain", `String (Team_session_types.control_domain_to_string domain))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.model_tier with
+    | Some tier ->
+        ("model_tier", `String (Team_session_types.model_tier_to_string tier))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.task_profile with
+    | Some profile ->
+        ("task_profile", `String (Team_session_types.task_profile_to_string profile))
+        :: fields
+    | None -> fields
+  in
+  let fields =
+    match pw.risk_level with
+    | Some risk ->
+        ("risk_level", `String (Team_session_types.risk_level_to_string risk))
+        :: fields
+    | None -> fields
+  in
+  `Assoc (List.rev fields)
+
 let planned_worker_to_participant
     (pw : Team_session_types.planned_worker)
     : Agent_sdk.Collaboration.participant =
@@ -155,7 +303,7 @@ let planned_worker_to_participant
     state = execution_scope_to_participant_state pw.execution_scope;
     joined_at = None;
     finished_at = None;
-    summary = None;
+    summary = planned_worker_summary pw;
   }
 
 (** Project a MASC team session into an OAS {!Agent_sdk.Collaboration.t}.
@@ -195,10 +343,66 @@ let collaboration_of_session
     outcome = session.stop_reason;
     max_participants = None;
     metadata =
-      [("room_id", `String session.room_id);
-       ("orchestration_mode",
-        `String (Team_session_types.orchestration_mode_to_string
-                   session.orchestration_mode))];
+      [
+        ("room_id", `String session.room_id);
+        ("created_by", `String session.created_by);
+        ("origin_kind",
+         `String (Team_session_types.session_origin_kind_to_string
+                    session.origin_kind));
+        ("execution_scope",
+         `String
+           (Team_session_types.execution_scope_to_string session.execution_scope));
+        ("orchestration_mode",
+         `String
+           (Team_session_types.orchestration_mode_to_string
+              session.orchestration_mode));
+        ("control_profile",
+         `String
+           (Team_session_types.control_profile_to_string
+              session.control_profile));
+        ("scale_profile",
+         `String
+           (Team_session_types.scale_profile_to_string session.scale_profile));
+        ("instruction_profile",
+         `String
+           (Team_session_types.instruction_profile_to_string
+              session.instruction_profile));
+        ("fallback_policy",
+         `String
+           (Team_session_types.fallback_policy_to_string session.fallback_policy));
+        ("communication_mode",
+         `String
+           (Team_session_types.communication_mode_to_string
+              session.communication_mode));
+        ("alert_channel",
+         `String
+           (Team_session_types.alert_channel_to_string session.alert_channel));
+        ("duration_seconds", `Int session.duration_seconds);
+        ("checkpoint_interval_sec", `Int session.checkpoint_interval_sec);
+        ("min_agents", `Int session.min_agents);
+        ("auto_resume", `Bool session.auto_resume);
+        ("planned_worker_count", `Int (List.length session.planned_workers));
+        ("model_cascade", `List (List.map (fun model -> `String model) session.model_cascade));
+        ("worker_class_counts",
+         count_assoc_to_json
+           (Team_session_types.worker_class_counts session.planned_workers));
+        ("runtime_pool_counts",
+         count_assoc_to_json
+           (Team_session_types.runtime_pool_counts session.planned_workers));
+        ("lane_counts",
+         count_assoc_to_json (Team_session_types.lane_counts session.planned_workers));
+        ("controller_level_counts",
+         count_assoc_to_json
+           (Team_session_types.controller_level_counts session.planned_workers));
+        ("control_domain_counts",
+         count_assoc_to_json
+           (Team_session_types.control_domain_counts session.planned_workers));
+        ("model_tier_counts",
+         count_assoc_to_json
+           (Team_session_types.model_tier_counts session.planned_workers));
+        ("worker_specs",
+         `List (List.map planned_worker_metadata_json session.planned_workers));
+      ];
   }
 
 let truncate_list n lst =

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -266,6 +266,22 @@ let budget_of_session_timeout timeout_sec =
       }
   | None -> Swarm.Swarm_types.no_budget
 
+let session_runtime_health_check ~(config : Room.config)
+    ~(session : Team_session_types.session) () =
+  let base_path_ok =
+    String.trim config.base_path <> "" && Sys.file_exists config.base_path
+  in
+  let room_ready = Room.is_initialized config in
+  let session_ready =
+    match Team_session_store.load_session config session.session_id with
+    | Some current ->
+        current.status = Team_session_types.Running
+        && String.equal current.session_id session.session_id
+        && String.equal current.room_id session.room_id
+    | None -> false
+  in
+  base_path_ok && room_ready && session_ready
+
 (* ── planned_worker -> agent_entry ─────────────────────────────── *)
 
 let planned_worker_to_entry_with_state
@@ -369,7 +385,7 @@ let session_to_swarm_config
     budget = budget_of_session_timeout timeout_sec;
     max_agent_retries = 1;
     collaboration = Some collaboration;
-    resource_check = Some (fun () -> Room.is_initialized config);
+    resource_check = Some (session_runtime_health_check ~config ~session);
     max_concurrent_agents = Some (max 1 (List.length entries));
     enable_streaming = false }
 

--- a/lib/team_session/team_session_swarm_callbacks.ml
+++ b/lib/team_session/team_session_swarm_callbacks.ml
@@ -6,6 +6,49 @@
 
 module Swarm = Agent_sdk_swarm
 
+let preview_text text =
+  String.sub text 0 (min 200 (String.length text))
+
+let usage_to_json (usage : Agent_sdk.Types.usage_stats) =
+  `Assoc
+    [
+      ("input_tokens", `Int usage.total_input_tokens);
+      ("output_tokens", `Int usage.total_output_tokens);
+      ( "cache_creation_input_tokens",
+        `Int usage.total_cache_creation_input_tokens );
+      ("cache_read_input_tokens", `Int usage.total_cache_read_input_tokens);
+      ("api_calls", `Int usage.api_calls);
+      ("estimated_cost_usd", `Float usage.estimated_cost_usd);
+    ]
+
+let trace_ref_to_json (trace_ref : Agent_sdk.Raw_trace.run_ref) =
+  `Assoc
+    [
+      ("worker_run_id", `String trace_ref.worker_run_id);
+      ("path", `String trace_ref.path);
+      ("start_seq", `Int trace_ref.start_seq);
+      ("end_seq", `Int trace_ref.end_seq);
+      ("agent_name", `String trace_ref.agent_name);
+      ( "session_id",
+        match trace_ref.session_id with
+        | Some session_id -> `String session_id
+        | None -> `Null );
+    ]
+
+let telemetry_to_json (telemetry : Swarm.Swarm_types.agent_telemetry) =
+  `Assoc
+    [
+      ( "trace_ref",
+        match telemetry.trace_ref with
+        | Some trace_ref -> trace_ref_to_json trace_ref
+        | None -> `Null );
+      ( "usage",
+        match telemetry.usage with
+        | Some usage -> usage_to_json usage
+        | None -> `Null );
+      ("turn_count", `Int telemetry.turn_count);
+    ]
+
 let make_callbacks ~(config : Room.config) ~(session_id : string)
   : Swarm.Swarm_types.swarm_callbacks =
   let on_iteration_start iteration_num =
@@ -19,12 +62,14 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
   in
   let on_iteration_end (record : Swarm.Swarm_types.iteration_record) =
     let agent_count = List.length record.agent_results in
-    let ok_count =
-      List.fold_left (fun acc (_name, status) ->
-        match (status : Swarm.Swarm_types.agent_status) with
-        | Done_ok _ -> acc + 1
-        | _ -> acc)
-        0 record.agent_results
+    let ok_count, error_count =
+      List.fold_left
+        (fun (ok_acc, err_acc) (_name, status) ->
+          match (status : Swarm.Swarm_types.agent_status) with
+          | Done_ok _ -> (ok_acc + 1, err_acc)
+          | Done_error _ -> (ok_acc, err_acc + 1)
+          | Working | Idle -> (ok_acc, err_acc))
+        (0, 0) record.agent_results
     in
     Team_session_store.append_event config session_id
       ~event_type:"swarm_iteration_end"
@@ -32,8 +77,11 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
         ("iteration", `Int record.iteration);
         ("agent_count", `Int agent_count);
         ("ok_count", `Int ok_count);
+        ("error_count", `Int error_count);
         ("metric", match record.metric_value with
           | Some m -> `Float m | None -> `Null);
+        ( "trace_refs",
+          `List (List.map trace_ref_to_json record.trace_refs) );
       ])
   in
   let on_agent_start agent_name =
@@ -42,14 +90,14 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
       ~detail:(`Assoc [("agent", `String agent_name)])
   in
   let on_agent_done agent_name (status : Swarm.Swarm_types.agent_status) =
-    let status_str, elapsed, output_preview =
+    let status_str, elapsed, output_preview, telemetry =
       match status with
-      | Done_ok { elapsed; text; _ } ->
-        ("ok", elapsed, String.sub text 0 (min 200 (String.length text)))
-      | Done_error { elapsed; error; _ } ->
-        ("error", elapsed, String.sub error 0 (min 200 (String.length error)))
-      | Working -> ("working", 0.0, "")
-      | Idle -> ("idle", 0.0, "")
+      | Done_ok { elapsed; text; telemetry } ->
+        ("ok", elapsed, preview_text text, telemetry)
+      | Done_error { elapsed; error; telemetry } ->
+        ("error", elapsed, preview_text error, telemetry)
+      | Working -> ("working", 0.0, "", Swarm.Swarm_types.empty_telemetry)
+      | Idle -> ("idle", 0.0, "", Swarm.Swarm_types.empty_telemetry)
     in
     Team_session_store.append_event config session_id
       ~event_type:"swarm_agent_done"
@@ -58,6 +106,7 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
         ("status", `String status_str);
         ("elapsed", `Float elapsed);
         ("output_preview", `String output_preview);
+        ("telemetry", telemetry_to_json telemetry);
       ])
   in
   let on_converged (_state : Swarm.Swarm_types.swarm_state) =

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -256,6 +256,27 @@ let make_heartbeat_callbacks
       };
     ]
 
+let make_tool_tracking_hooks () =
+  let tool_names_ref = ref [] in
+  let hooks =
+    {
+      Oas.Hooks.empty with
+      pre_tool_use =
+        Some
+          (function
+            | Oas.Hooks.PreToolUse { tool_name; _ } ->
+                tool_names_ref := tool_name :: !tool_names_ref;
+                Oas.Hooks.Continue
+            | _ -> Oas.Hooks.Continue);
+    }
+  in
+  (tool_names_ref, hooks)
+
+let resume_model_id_of_checkpoint
+    (meta : Worker_container_types.worker_container_meta)
+    (checkpoint : Oas.Checkpoint.t) =
+  if checkpoint.model <> "" then checkpoint.model else meta.effective_model
+
 (* ================================================================ *)
 (* Run Worker via OAS                                                *)
 (* ================================================================ *)
@@ -294,19 +315,7 @@ let rec run_worker_via_oas
   let heartbeat_cbs =
     make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
   in
-  let tool_names_ref = ref [] in
-  let hooks =
-    {
-      Oas.Hooks.empty with
-      pre_tool_use =
-        Some
-          (function
-            | Oas.Hooks.PreToolUse { tool_name; _ } ->
-              tool_names_ref := tool_name :: !tool_names_ref;
-              Oas.Hooks.Continue
-            | _ -> Oas.Hooks.Continue);
-    }
-  in
+  let tool_names_ref, hooks = make_tool_tracking_hooks () in
   let* agent =
     build_agent ~net ~meta ~provider ~system_prompt ~tools ~hooks
       ~raw_trace ~heartbeat_callbacks:heartbeat_cbs ?gate_config ()
@@ -328,6 +337,77 @@ let rec run_worker_via_oas
         with
         | Ok _ -> ()
         | Error e -> raise (Failure ("worker join failed: " ^ e))
+      in
+      let workspace_path =
+        if String.trim meta.workspace_path <> "" then meta.workspace_path
+        else base_path
+      in
+      run_existing_worker_agent ~sw ~base_path ~meta ~prompt ~workspace_path
+        ~raw_trace ?worker_run_id ~tool_names_ref agent)
+
+and resume_worker_via_oas
+    ~(sw : Eio.Switch.t)
+    ~(base_path : string)
+    ~(meta : Worker_container_types.worker_container_meta)
+    ~(checkpoint : Oas.Checkpoint.t)
+    ~(prompt : string)
+    ~(tools : Oas.Tool.t list)
+    ~(raw_trace : Oas.Raw_trace.t)
+    ?worker_run_id
+    () : (Worker_container_types.run_result, string) result =
+  let worker_name = meta.worker_name in
+  let session_id = meta.mcp_session_id in
+  let* auth_token =
+    Worker_container_types.worker_auth_token ~base_path ~worker_name
+  in
+  let* net =
+    match Eio_context.get_net_opt () with
+    | Some net -> Ok net
+    | None -> Error "Eio net not initialized"
+  in
+  let heartbeat_cbs =
+    make_heartbeat_callbacks ~sw ~auth_token ~session_id ~worker_name
+  in
+  let tool_names_ref, hooks = make_tool_tracking_hooks () in
+  let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
+  let resume_provider =
+    oas_provider_of_label (Printf.sprintf "llama:%s" resume_model_id)
+  in
+  let system_prompt =
+    Worker_container_types.default_system_prompt ~worker_name
+      ~model_id:resume_model_id ?session_id:meta.team_session_id ?role:meta.role
+      ?selection_note:meta.selection_note ()
+  in
+  let max_turns = effective_max_turns meta in
+  let thinking_enabled =
+    Option.value ~default:false meta.thinking_enabled
+  in
+  let guardrails =
+    gate_config_of_execution_scope meta.execution_scope
+    |> Verifier_oas.eval_gate_to_oas_guardrails
+  in
+  let config, options =
+    Worker_container.build_resume_config ~worker_name
+      ~provider:resume_provider ~model_id:resume_model_id ~system_prompt ~tools
+      ~max_turns ~thinking_enabled ~hooks ~raw_trace
+      ~periodic_callbacks:heartbeat_cbs ~guardrails ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Worker_container_types.leave_worker ~sw ~auth_token ~session_id
+           ~worker_name))
+    (fun () ->
+      let _ =
+        match
+          Worker_container_types.join_worker ~sw ~auth_token ~session_id
+            ~worker_name
+        with
+        | Ok _ -> ()
+        | Error e -> raise (Failure ("worker join failed: " ^ e))
+      in
+      let agent =
+        Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
       in
       let workspace_path =
         if String.trim meta.workspace_path <> "" then meta.workspace_path

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -8,6 +8,8 @@
 
 open Masc_mcp
 
+module Oas = Agent_sdk
+
 (* ================================================================ *)
 (* Shared test infrastructure                                       *)
 (* ================================================================ *)
@@ -179,6 +181,73 @@ let test_cascade_names_produce_models () =
     let models = Oas_worker.default_model_strings ~cascade_name:name in
     Alcotest.(check bool) (name ^ " has models") true (models <> [])
   ) cascades
+
+let make_worker_meta ?(effective_model = "local-qwen") () :
+    Worker_container_types.worker_container_meta =
+  {
+    Worker_container_types.version =
+      Worker_container_types.worker_container_version;
+    worker_name = "resume-worker";
+    mcp_session_id = "session-1";
+    team_session_id = Some "team-session-1";
+    workspace_path = "/tmp/workspace";
+    role = Some "executor";
+    selection_note = Some "resume";
+    execution_scope = Team_session_types.Limited_code_change;
+    thinking_enabled = Some true;
+    max_turns_override = None;
+    timeout_seconds = Some 240;
+    tool_profile = Worker_container_types.Profile_session_min;
+    shell_profile = Worker_container_types.Shell_readonly;
+    worker_class = Some Team_session_types.Worker_executor;
+    worker_size = None;
+    effective_model;
+    effective_tier = None;
+    checkpoint_path = "/tmp/checkpoint.json";
+    turn_log_path = "/tmp/turns.jsonl";
+    last_run_at = None;
+  }
+
+let make_checkpoint ?(model = "") () : Oas.Checkpoint.t =
+  {
+    Oas.Checkpoint.version = Oas.Checkpoint.checkpoint_version;
+    session_id = "session-1";
+    agent_name = "resume-worker";
+    model;
+    system_prompt = None;
+    messages = [];
+    usage = Oas.Types.empty_usage;
+    turn_count = 0;
+    created_at = 0.0;
+    tools = [];
+    tool_choice = None;
+    disable_parallel_tool_use = false;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = None;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
+    context = Oas.Context.create ();
+    mcp_sessions = [];
+    working_context = None;
+  }
+
+let test_resume_model_id_prefers_checkpoint_model () =
+  let meta = make_worker_meta ~effective_model:"meta-model" () in
+  let checkpoint = make_checkpoint ~model:"checkpoint-model" () in
+  Alcotest.(check string) "checkpoint model wins" "checkpoint-model"
+    (Worker_oas.resume_model_id_of_checkpoint meta checkpoint)
+
+let test_resume_model_id_falls_back_to_meta_model () =
+  let meta = make_worker_meta ~effective_model:"meta-model" () in
+  let checkpoint = make_checkpoint () in
+  Alcotest.(check string) "meta model fallback" "meta-model"
+    (Worker_oas.resume_model_id_of_checkpoint meta checkpoint)
 
 (* ================================================================ *)
 (* Module 2: Tool_council_oas tests                                 *)
@@ -704,6 +773,12 @@ let () =
         test_default_config_path;
       Alcotest.test_case "all cascade names produce models" `Quick
         test_cascade_names_produce_models;
+    ];
+    "resume_config", [
+      Alcotest.test_case "checkpoint model wins" `Quick
+        test_resume_model_id_prefers_checkpoint_model;
+      Alcotest.test_case "meta model fallback" `Quick
+        test_resume_model_id_falls_back_to_meta_model;
     ];
     "tool_council_oas", [
       Alcotest.test_case "petition creates case without decorative collaboration" `Quick

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -194,6 +194,8 @@ let test_session_to_swarm_config_health_contract () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let config = Room.default_config tmp in
   ignore (Room.init config ~agent_name:(Some "tester"));
+  Team_session_store.ensure_session_dirs config session.session_id;
+  Team_session_store.save_session config session;
   let swarm_cfg =
     Team_session_oas_bridge.session_to_swarm_config ~config ~masc_tools:[]
       ~dispatch:(fun ~name:_ ~args:_ -> (false, "no"))
@@ -225,9 +227,33 @@ let test_session_to_swarm_config_health_contract () =
   Alcotest.(check int) "initial telemetry turn_count" 0 telemetry.turn_count;
   Alcotest.(check bool) "initial telemetry usage empty" true
     (Option.is_none telemetry.usage);
+  let collaboration = Option.get swarm_cfg.collaboration in
+  Alcotest.(check int) "participants projected" 2
+    (List.length collaboration.Agent_sdk.Collaboration.participants);
+  let first_participant =
+    List.hd collaboration.Agent_sdk.Collaboration.participants
+  in
+  Alcotest.(check bool) "participant summary present" true
+    (Option.is_some first_participant.Agent_sdk.Collaboration.summary);
+  let worker_specs =
+    match List.assoc_opt "worker_specs" collaboration.metadata with
+    | Some (`List specs) -> specs
+    | _ -> []
+  in
+  Alcotest.(check int) "worker specs preserved" 2 (List.length worker_specs);
+  (match List.assoc_opt "execution_scope" collaboration.metadata with
+   | Some (`String scope) ->
+       Alcotest.(check string) "session execution_scope metadata" "autonomous"
+         scope
+   | _ -> Alcotest.fail "expected execution_scope metadata");
   let resource_ok = Option.get swarm_cfg.resource_check () in
   Alcotest.(check bool) "resource check passes for initialized room" true
-    resource_ok
+    resource_ok;
+  Team_session_store.save_session config
+    { session with status = Team_session_types.Paused };
+  let resource_stale = Option.get swarm_cfg.resource_check () in
+  Alcotest.(check bool) "resource check fails when session no longer running"
+    false resource_stale
 
 let test_telemetry_of_run_result_carries_trace_ref () =
   let trace_ref =

--- a/test/test_team_session_swarm_runner.ml
+++ b/test/test_team_session_swarm_runner.ml
@@ -93,6 +93,61 @@ let test_callbacks_all_some () =
   Alcotest.(check bool) "on_error present"
     true (Option.is_some cbs.on_error)
 
+let test_agent_done_event_includes_telemetry () =
+  let tmp = Filename.temp_dir "masc-test" "" in
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Room.default_config tmp in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let session_id = "test-telemetry" in
+  Team_session_store.ensure_session_dirs config session_id;
+  let cbs = Team_session_swarm_callbacks.make_callbacks ~config ~session_id in
+  let trace_ref =
+    {
+      Agent_sdk.Raw_trace.worker_run_id = "run-telemetry";
+      path = "/tmp/run-telemetry.jsonl";
+      start_seq = 2;
+      end_seq = 9;
+      agent_name = "agent-a";
+      session_id = Some session_id;
+    }
+  in
+  let usage =
+    {
+      Agent_sdk.Types.total_input_tokens = 11;
+      total_output_tokens = 7;
+      total_cache_creation_input_tokens = 0;
+      total_cache_read_input_tokens = 0;
+      api_calls = 2;
+      estimated_cost_usd = 0.13;
+    }
+  in
+  let telemetry =
+    {
+      Swarm.Swarm_types.trace_ref = Some trace_ref;
+      usage = Some usage;
+      turn_count = 3;
+    }
+  in
+  Option.get cbs.on_agent_done "agent-a"
+    (Swarm.Swarm_types.Done_ok
+       { elapsed = 1.25; text = "completed"; telemetry });
+  let events = Team_session_store.read_events ~max_events:1 config session_id in
+  let event = List.hd events in
+  let open Yojson.Safe.Util in
+  let detail = event |> member "detail" in
+  Alcotest.(check string) "event type" "swarm_agent_done"
+    (event |> member "event_type" |> to_string);
+  Alcotest.(check int) "telemetry turn_count" 3
+    (detail |> member "telemetry" |> member "turn_count" |> to_int);
+  Alcotest.(check string) "trace ref worker_run_id" "run-telemetry"
+    (detail |> member "telemetry" |> member "trace_ref"
+     |> member "worker_run_id" |> to_string);
+  Alcotest.(check int) "usage api_calls" 2
+    (detail |> member "telemetry" |> member "usage" |> member "api_calls"
+     |> to_int)
+
 (* ================================================================ *)
 (* apply_swarm_result tests                                         *)
 (* ================================================================ *)
@@ -333,6 +388,8 @@ let () =
     "callbacks", [
       Alcotest.test_case "all callbacks present" `Quick
         test_callbacks_all_some;
+      Alcotest.test_case "agent done event includes telemetry" `Quick
+        test_agent_done_event_includes_telemetry;
     ];
     "apply_swarm_result", [
       Alcotest.test_case "converged result" `Quick


### PR DESCRIPTION
## Summary
- preserve richer team-session worker/session semantics in OAS collaboration metadata
- emit per-agent swarm telemetry in lifecycle events and harden the swarm runtime health check
- route local worker resume/continue through a shared `Worker_oas.resume_worker_via_oas` helper instead of rebuilding resume config inline
- update OAS migration notes to reflect the new consolidation state

## Testing
- `dune build --root . --build-dir _build_local`
- `_build_local/default/test/test_oas_worker.exe`
- `_build_local/default/test/test_team_session_oas_bridge.exe`
- `_build_local/default/test/test_team_session_swarm_runner.exe`