### PR TITLE
docs(benchmark): add agent ecosystem corpus and backlog

### DIFF
--- a/PLANS/ocaml-eio-agent-foundation-backlog.md
+++ b/PLANS/ocaml-eio-agent-foundation-backlog.md
@@ -1,0 +1,177 @@
+# OCaml Eio Agent Foundation Backlog
+
+`masc-mcp`를 Rust/Go agent substrate 수준으로 끌어올리기 위한 foundation backlog.
+
+기준:
+
+- `Adopt now`: 지금 바로 붙여서 속도를 올릴 수 있는 것
+- `Bridge / Fork`: 기능은 좋지만 production default로 쓰기 전에 소유권을 확보해야 하는 것
+- `Build net-new`: 기다릴 생태계가 아니라 우리가 직접 만들어야 하는 것
+
+참조 corpus: `benchmark/agent_ecosystem_repo_set.json`
+
+---
+
+## Adopt now
+
+### 1. `ocaml-opentelemetry` + `opentelemetry-client-cohttp-eio`
+
+- 목적: tool dispatch, operation, detachment, provider call, retry, cancellation을 span/event로 남긴다.
+- 이유: observability는 이미 라이브러리가 있고, `masc-mcp` 전반에 바로 효율이 난다.
+- 산출물:
+  - 공통 tracing bootstrap 모듈
+  - MCP tool latency / error span
+  - command-plane operation span
+  - provider request span
+- 완료 기준:
+  - local dev에서 OTLP export 가능
+  - 주요 tool path에 trace id가 붙음
+  - 최소 1개 dashboard / log correlation path가 생김
+
+### 2. `ocaml-jsonschema`
+
+- 목적: benchmark corpus, proof/report artifact, research export JSON을 schema 검증한다.
+- 이유: machine-readable corpus를 넣어도 schema gate가 없으면 계속 drift 난다.
+- 산출물:
+  - `agent_ecosystem_repo_set.schema.json`
+  - corpus validation command
+  - CI or local check hook
+- 완료 기준:
+  - corpus JSON이 schema로 검증됨
+  - 필수 필드 누락 시 실패
+  - 신규 dataset도 같은 validator를 재사용
+
+### 3. `openapi-ocaml`
+
+- 목적: OAS surfaces, benchmark payload docs, external-facing schema 문서를 한 모델로 묶는다.
+- 이유: 지금은 OAS/OA-like contract가 여러 레이어에 흩어져 있다.
+- 산출물:
+  - 최소 1개 internal schema doc generation path
+  - benchmark/resource payload와 연결되는 typed model
+- 완료 기준:
+  - 신규 JSON corpus schema와 문서가 같은 source-of-truth에서 나옴
+
+### 4. `ocaml-protoc-plugin`
+
+- 목적: 이미 쓰는 gRPC/protobuf 경로를 더 generated-contract 중심으로 단일화한다.
+- 이유: 이 영역은 gap보다 hardening 대상이다.
+- 산출물:
+  - protobuf regeneration rules 점검
+  - generated type ownership 경계 정리
+- 완료 기준:
+  - hand-written protocol glue를 줄이고 generated path를 늘림
+
+---
+
+## Bridge / Fork
+
+### 5. `tmattio/ocaml-mcp`
+
+- 목적: reusable MCP client/server substrate 후보로 검토한다.
+- 이유: OCaml community에서 제일 가까운 일반화 경로다.
+- 부족한 점:
+  - OAuth 2.1
+  - cancellation
+  - WebSocket / SSE
+  - 일부 helper coverage
+- 액션:
+  - compliance reference로 즉시 활용
+  - production dependency는 fork readiness 확보 후 판단
+- 완료 기준:
+  - missing feature matrix 작성
+  - `masc-mcp` needs와 겹치는 부분만 선별
+
+### 6. `tmattio/ocaml-anthropic`
+
+- 목적: Claude 계열 direct provider path를 Eio-native로 확보한다.
+- 이유: 기능면은 좋지만 ecosystem gravity가 아직 약하다.
+- 액션:
+  - vendor/fork 가능성까지 포함해 spike
+  - retry / streaming / tool-use / files path를 `masc-mcp` 요구사항에 맞춰 점검
+- 완료 기준:
+  - direct integration feasibility note
+  - 유지보수 리스크 평가
+
+### 7. `Nymphium/openai-ocaml`
+
+- 목적: 바로 adopt가 아니라 교체 기준선으로 사용한다.
+- 이유: opam package가 2023 `0.0.1`이고 Lwt 기반이라 현재 agent substrate 기준으로는 부족하다.
+- 액션:
+  - salvage 가치 평가
+  - fork보다 rewrite가 낫다면 바로 폐기
+- 완료 기준:
+  - `fork` vs `new Eio client` 결론
+
+---
+
+## Build Net-New
+
+### 8. `eio-cdp`
+
+- 목적: Chrome DevTools Protocol 기반 browser automation spine.
+- 이유: browser automation은 현재 OCaml stack의 가장 큰 공백이다.
+- 반드시 있어야 할 기능:
+  - browser/session lifecycle
+  - DOM query / click / type / screenshot
+  - network inspection
+  - console / page event streaming
+- 완료 기준:
+  - headless Chrome 연결
+  - screenshot + click + DOM read smoke
+  - `masc-mcp` tool로 감쌀 수 있는 API shape 확보
+
+### 9. `llm-provider-eio`
+
+- 목적: OpenAI / Anthropic / local providers를 공통 interface로 묶는다.
+- 이유: provider별 ad hoc wrapper를 늘리면 agent substrate 속도가 계속 깨진다.
+- 반드시 있어야 할 기능:
+  - sync + streaming completion
+  - tool-use / tool-call envelope
+  - retry / timeout / cancellation
+  - provider-neutral error model
+- 완료 기준:
+  - Anthropic + OpenAI + local 1종 이상 공통 API로 호출
+  - room / worker / keeper에서 같은 path 재사용
+
+### 10. `workflow-eio`
+
+- 목적: long-running agent loops에 checkpoint / replay / retry / backoff를 first-class로 준다.
+- 이유: Temporal 같은 reference는 있지만 OCaml default path는 없다.
+- 반드시 있어야 할 기능:
+  - idempotent step execution
+  - durable checkpoint
+  - explicit retry policy
+  - cancellation-safe resume
+- 완료 기준:
+  - keeper or repo-synthesis path 하나를 이 runtime 위로 옮김
+
+### 11. `agent-corpus-ingest`
+
+- 목적: 외부 ecosystem survey, benchmark fixture, repo corpus를 정규화해서 resources/dataset으로 넣는다.
+- 이유: 이번 조사 결과를 일회성 문서로 두면 다음 조사 때 또 잃는다.
+- 반드시 있어야 할 기능:
+  - source normalization
+  - JSON schema validation
+  - metadata refresh timestamp
+  - MCP resource/read export
+- 완료 기준:
+  - `agent_ecosystem_repo_set.json`을 읽는 간단한 resource or CLI 추가
+
+---
+
+## 실행 순서
+
+1. Observability
+2. JSON schema validation
+3. OpenAI Eio client decision
+4. Browser automation spine
+5. Workflow runtime
+6. Corpus ingest automation
+
+---
+
+## 제외 / 주의
+
+- `Eio`는 교체 대상이 아니다. substrate를 그 위에 쌓는 게 목표다.
+- `opam gemini`는 Google Gemini model client가 아니라 Gemini exchange API 패키지라서 이번 backlog 대상이 아니다.
+- `Qdrant` 관련 후보는 전부 제외한다. 벡터 저장 전략은 계속 Postgres/pgvector 기준이다.

--- a/benchmark/agent_ecosystem_repo_set.json
+++ b/benchmark/agent_ecosystem_repo_set.json
@@ -1,0 +1,545 @@
+[
+  {
+    "repo_id": "modelcontextprotocol/modelcontextprotocol",
+    "full_name": "modelcontextprotocol/modelcontextprotocol",
+    "url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+    "language": "TypeScript",
+    "category": "mcp_spec",
+    "maintainer_type": "official_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Canonical MCP spec and documentation source for protocol parity and compliance tests.",
+    "key_capabilities": [
+      "MCP specification",
+      "reference documentation",
+      "protocol version history"
+    ],
+    "source_urls": [
+      "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "https://modelcontextprotocol.io"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Use as the top-level truth source, not as implementation code."
+  },
+  {
+    "repo_id": "modelcontextprotocol/go-sdk",
+    "full_name": "modelcontextprotocol/go-sdk",
+    "url": "https://github.com/modelcontextprotocol/go-sdk",
+    "language": "Go",
+    "category": "mcp",
+    "maintainer_type": "official_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Official Go MCP SDK sets the reference bar for server/client completeness and examples.",
+    "key_capabilities": [
+      "official MCP server SDK",
+      "official MCP client SDK",
+      "Google-collaborated maintenance"
+    ],
+    "source_urls": [
+      "https://github.com/modelcontextprotocol/go-sdk"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference bar for docs, examples, and protocol completeness."
+  },
+  {
+    "repo_id": "modelcontextprotocol/rust-sdk",
+    "full_name": "modelcontextprotocol/rust-sdk",
+    "url": "https://github.com/modelcontextprotocol/rust-sdk",
+    "language": "Rust",
+    "category": "mcp",
+    "maintainer_type": "official_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Official Rust MCP SDK is the reference bar for async runtime integration, macros, and typed transport layers.",
+    "key_capabilities": [
+      "official Rust MCP SDK",
+      "tokio runtime integration",
+      "macro-based tool definitions"
+    ],
+    "source_urls": [
+      "https://github.com/modelcontextprotocol/rust-sdk",
+      "https://raw.githubusercontent.com/modelcontextprotocol/rust-sdk/main/README.md"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Useful reference for typed protocol models and cancellation/completions coverage."
+  },
+  {
+    "repo_id": "tmattio/ocaml-mcp",
+    "full_name": "tmattio/ocaml-mcp",
+    "url": "https://github.com/tmattio/ocaml-mcp",
+    "language": "OCaml",
+    "category": "mcp",
+    "maintainer_type": "individual",
+    "adoption_bucket": "bridge_or_fork",
+    "ocaml_status": "community_missing_prod_features",
+    "eio_strategy": "native",
+    "why_it_matters": "Closest OCaml MCP implementation to a reusable substrate outside the current masc-mcp codebase.",
+    "key_capabilities": [
+      "core protocol types",
+      "high-level SDK",
+      "stdio/socket/http transports"
+    ],
+    "source_urls": [
+      "https://github.com/tmattio/ocaml-mcp",
+      "https://raw.githubusercontent.com/tmattio/ocaml-mcp/main/README.md"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "README still lists OAuth 2.1, cancellation, WebSocket/SSE, and some client helpers as missing or in progress."
+  },
+  {
+    "repo_id": "openai/openai-go",
+    "full_name": "openai/openai-go",
+    "url": "https://github.com/openai/openai-go",
+    "language": "Go",
+    "category": "provider_sdk",
+    "maintainer_type": "vendor_official",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Official OpenAI Go SDK is the reference bar for Responses-era API coverage and vendor-backed maintenance.",
+    "key_capabilities": [
+      "official OpenAI SDK",
+      "vendor-backed API coverage",
+      "Go reference implementation"
+    ],
+    "source_urls": [
+      "https://github.com/openai/openai-go"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Use as the baseline when defining an Eio-native OpenAI client scope."
+  },
+  {
+    "repo_id": "anthropics/anthropic-sdk-go",
+    "full_name": "anthropics/anthropic-sdk-go",
+    "url": "https://github.com/anthropics/anthropic-sdk-go",
+    "language": "Go",
+    "category": "provider_sdk",
+    "maintainer_type": "vendor_official",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Official Anthropic Go SDK is the vendor baseline for Claude API coverage and maintenance cadence.",
+    "key_capabilities": [
+      "official Anthropic SDK",
+      "vendor-backed Claude API coverage",
+      "Go reference implementation"
+    ],
+    "source_urls": [
+      "https://github.com/anthropics/anthropic-sdk-go"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference point for feature parity and retry/error handling expectations."
+  },
+  {
+    "repo_id": "tmattio/ocaml-anthropic",
+    "full_name": "tmattio/ocaml-anthropic",
+    "url": "https://github.com/tmattio/ocaml-anthropic",
+    "language": "OCaml",
+    "category": "provider_sdk",
+    "maintainer_type": "individual",
+    "adoption_bucket": "bridge_or_fork",
+    "ocaml_status": "eio_native_candidate",
+    "eio_strategy": "native",
+    "why_it_matters": "Best current Eio-native provider candidate for Claude-compatible direct integration.",
+    "key_capabilities": [
+      "streaming responses",
+      "tool use",
+      "batch processing",
+      "files API beta"
+    ],
+    "source_urls": [
+      "https://github.com/tmattio/ocaml-anthropic",
+      "https://raw.githubusercontent.com/tmattio/ocaml-anthropic/main/README.md",
+      "https://opam.ocaml.org/packages/anthropic/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Promising but low-adoption. Treat as fork-ready if it becomes critical to masc-mcp."
+  },
+  {
+    "repo_id": "Nymphium/openai-ocaml",
+    "full_name": "Nymphium/openai-ocaml",
+    "url": "https://github.com/Nymphium/openai-ocaml",
+    "language": "OCaml",
+    "category": "provider_sdk",
+    "maintainer_type": "individual",
+    "adoption_bucket": "bridge_or_fork",
+    "ocaml_status": "stale_lwt_client",
+    "eio_strategy": "bridge_lwt",
+    "why_it_matters": "Visible OCaml OpenAI binding, but it is too old to serve as the default agent substrate without major work.",
+    "key_capabilities": [
+      "OpenAI API binding",
+      "Lwt-based HTTP client"
+    ],
+    "source_urls": [
+      "https://github.com/Nymphium/openai-ocaml",
+      "https://opam.ocaml.org/packages/openai/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Published opam package is 0.0.1 from 2023 and should be treated as stale baseline, not direct adoption target."
+  },
+  {
+    "repo_id": "chromedp/chromedp",
+    "full_name": "chromedp/chromedp",
+    "url": "https://github.com/chromedp/chromedp",
+    "language": "Go",
+    "category": "browser_automation",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Major Go browser automation substrate with direct CDP control and no external dependencies.",
+    "key_capabilities": [
+      "Chrome DevTools Protocol",
+      "headless browser automation",
+      "examples and screenshots"
+    ],
+    "source_urls": [
+      "https://github.com/chromedp/chromedp",
+      "https://raw.githubusercontent.com/chromedp/chromedp/master/README.md"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference bar for an eventual Eio-native CDP layer."
+  },
+  {
+    "repo_id": "go-rod/rod",
+    "full_name": "go-rod/rod",
+    "url": "https://github.com/go-rod/rod",
+    "language": "Go",
+    "category": "browser_automation",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "High-level Go CDP driver with wait helpers, request hijacking, and browser lifecycle support.",
+    "key_capabilities": [
+      "high-level browser automation",
+      "network request hooks",
+      "download helpers"
+    ],
+    "source_urls": [
+      "https://github.com/go-rod/rod",
+      "https://raw.githubusercontent.com/go-rod/rod/main/README.md"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Good reference for ergonomic helper layer on top of raw CDP."
+  },
+  {
+    "repo_id": "vrtgs/thirtyfour",
+    "full_name": "vrtgs/thirtyfour",
+    "url": "https://github.com/vrtgs/thirtyfour",
+    "language": "Rust",
+    "category": "browser_automation",
+    "maintainer_type": "individual",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Rust baseline for Selenium/WebDriver automation and async browser testing workflows.",
+    "key_capabilities": [
+      "Selenium WebDriver",
+      "async browser testing",
+      "Rust browser automation baseline"
+    ],
+    "source_urls": [
+      "https://github.com/vrtgs/thirtyfour"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Useful reference if CDP-first is not enough and WebDriver compatibility is needed."
+  },
+  {
+    "repo_id": "open-telemetry/opentelemetry-go",
+    "full_name": "open-telemetry/opentelemetry-go",
+    "url": "https://github.com/open-telemetry/opentelemetry-go",
+    "language": "Go",
+    "category": "observability",
+    "maintainer_type": "official_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Reference bar for traces, metrics, logs, exporters, and instrumentation conventions in Go services.",
+    "key_capabilities": [
+      "OpenTelemetry API and SDK",
+      "traces metrics logs",
+      "ecosystem standardization"
+    ],
+    "source_urls": [
+      "https://github.com/open-telemetry/opentelemetry-go"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference for default observability expectations in agent runtimes."
+  },
+  {
+    "repo_id": "tokio-rs/tracing",
+    "full_name": "tokio-rs/tracing",
+    "url": "https://github.com/tokio-rs/tracing",
+    "language": "Rust",
+    "category": "observability",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Rust baseline for application-level spans, structured events, and diagnostics.",
+    "key_capabilities": [
+      "application tracing",
+      "structured events",
+      "Rust diagnostics ecosystem"
+    ],
+    "source_urls": [
+      "https://github.com/tokio-rs/tracing"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference for ergonomic span/event APIs and subscriber patterns."
+  },
+  {
+    "repo_id": "ocaml-tracing/ocaml-opentelemetry",
+    "full_name": "ocaml-tracing/ocaml-opentelemetry",
+    "url": "https://github.com/ocaml-tracing/ocaml-opentelemetry",
+    "language": "OCaml",
+    "category": "observability",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "usable_but_thin",
+    "eio_strategy": "native",
+    "why_it_matters": "Best current OCaml OTel option for adding spans, metrics, and logs around masc-mcp control-plane flows.",
+    "key_capabilities": [
+      "traces metrics logs",
+      "ambient context support",
+      "collector exporters"
+    ],
+    "source_urls": [
+      "https://github.com/ocaml-tracing/ocaml-opentelemetry",
+      "https://raw.githubusercontent.com/ocaml-tracing/ocaml-opentelemetry/main/README.md"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "README still marks API polish, async collector, and semantic conventions as incomplete."
+  },
+  {
+    "repo_id": "ocaml-multicore/eio",
+    "full_name": "ocaml-multicore/eio",
+    "url": "https://github.com/ocaml-multicore/eio",
+    "language": "OCaml",
+    "category": "runtime",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "ocaml_core_stable",
+    "eio_strategy": "native",
+    "why_it_matters": "Direct-style multicore IO runtime is the foundation that masc-mcp should keep building on.",
+    "key_capabilities": [
+      "effect-based IO",
+      "fibers and switches",
+      "multicore foundation"
+    ],
+    "source_urls": [
+      "https://github.com/ocaml-multicore/eio",
+      "https://opam.ocaml.org/packages/eio/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Strong foundation; not the main ecosystem bottleneck."
+  },
+  {
+    "repo_id": "mirage/ocaml-cohttp",
+    "full_name": "mirage/ocaml-cohttp",
+    "url": "https://github.com/mirage/ocaml-cohttp",
+    "language": "OCaml",
+    "category": "http_streaming",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "ocaml_core_stable",
+    "eio_strategy": "native",
+    "why_it_matters": "Provides the Eio-backed HTTP client/server substrate already used across modern OCaml packages.",
+    "key_capabilities": [
+      "HTTP client",
+      "HTTP server",
+      "Eio backend"
+    ],
+    "source_urls": [
+      "https://github.com/mirage/ocaml-cohttp",
+      "https://opam.ocaml.org/packages/cohttp-eio/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Strong substrate for provider clients and MCP HTTP surfaces."
+  },
+  {
+    "repo_id": "paurkedal/ocaml-caqti",
+    "full_name": "paurkedal/ocaml-caqti",
+    "url": "https://github.com/paurkedal/ocaml-caqti",
+    "language": "OCaml",
+    "category": "database",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "ocaml_core_stable",
+    "eio_strategy": "native",
+    "why_it_matters": "Standard relational DB path for Eio, useful for pgvector-aligned persistence and ingestion tasks.",
+    "key_capabilities": [
+      "database access",
+      "Eio integration",
+      "PostgreSQL driver compatibility"
+    ],
+    "source_urls": [
+      "https://github.com/paurkedal/ocaml-caqti",
+      "https://opam.ocaml.org/packages/caqti-eio/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "No ecosystem gap here; continue using as the DB default."
+  },
+  {
+    "repo_id": "oapi-codegen/oapi-codegen",
+    "full_name": "oapi-codegen/oapi-codegen",
+    "url": "https://github.com/oapi-codegen/oapi-codegen",
+    "language": "Go",
+    "category": "schema_codegen",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Reference bar for OpenAPI-to-code workflows and agent/server contract generation.",
+    "key_capabilities": [
+      "OpenAPI code generation",
+      "client generation",
+      "server generation"
+    ],
+    "source_urls": [
+      "https://github.com/oapi-codegen/oapi-codegen"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference for productized codegen and schema workflows."
+  },
+  {
+    "repo_id": "GREsau/schemars",
+    "full_name": "GREsau/schemars",
+    "url": "https://github.com/GREsau/schemars",
+    "language": "Rust",
+    "category": "schema_codegen",
+    "maintainer_type": "individual",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Rust reference for deriving JSON Schema from native types.",
+    "key_capabilities": [
+      "JSON Schema generation",
+      "derive macros",
+      "Serde-aligned schemas"
+    ],
+    "source_urls": [
+      "https://github.com/GREsau/schemars"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Reference for ergonomic schema derivation patterns."
+  },
+  {
+    "repo_id": "jhuapl-saralab/openapi-ocaml",
+    "full_name": "jhuapl-saralab/openapi-ocaml",
+    "url": "https://github.com/jhuapl-saralab/openapi-ocaml",
+    "language": "OCaml",
+    "category": "schema_codegen",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "usable_but_thin",
+    "eio_strategy": "not_applicable",
+    "why_it_matters": "Provides core OpenAPI document modeling that can unify OAS and benchmark schema work in masc-mcp.",
+    "key_capabilities": [
+      "OpenAPI document types",
+      "JSON Schema-backed docs",
+      "OCaml API documentation infrastructure"
+    ],
+    "source_urls": [
+      "https://github.com/jhuapl-saralab/openapi-ocaml",
+      "https://opam.ocaml.org/packages/openapi/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Promising documentation substrate; not yet a de facto default path."
+  },
+  {
+    "repo_id": "tmattio/ocaml-jsonschema",
+    "full_name": "tmattio/ocaml-jsonschema",
+    "url": "https://github.com/tmattio/ocaml-jsonschema",
+    "language": "OCaml",
+    "category": "schema_codegen",
+    "maintainer_type": "individual",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "usable_but_thin",
+    "eio_strategy": "not_applicable",
+    "why_it_matters": "Most direct current candidate for validating machine-readable benchmark and report artifacts in OCaml.",
+    "key_capabilities": [
+      "JSON Schema validation",
+      "multiple draft support",
+      "detailed validation outputs"
+    ],
+    "source_urls": [
+      "https://github.com/tmattio/ocaml-jsonschema",
+      "https://opam.ocaml.org/packages/jsonschema/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Good fit for corpus validation and tool payload checking."
+  },
+  {
+    "repo_id": "andersfugmann/ocaml-protoc-plugin",
+    "full_name": "andersfugmann/ocaml-protoc-plugin",
+    "url": "https://github.com/andersfugmann/ocaml-protoc-plugin",
+    "language": "OCaml",
+    "category": "schema_codegen",
+    "maintainer_type": "individual",
+    "adoption_bucket": "adopt_now",
+    "ocaml_status": "ocaml_core_stable",
+    "eio_strategy": "not_applicable",
+    "why_it_matters": "Best current protobuf codegen path for keeping gRPC and contract surfaces typed.",
+    "key_capabilities": [
+      "protobuf code generation",
+      "JSON mapping",
+      "idiomatic OCaml generated types"
+    ],
+    "source_urls": [
+      "https://github.com/andersfugmann/ocaml-protoc-plugin",
+      "https://opam.ocaml.org/packages/ocaml-protoc-plugin/"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Already aligned with masc-mcp's existing protobuf-heavy stack."
+  },
+  {
+    "repo_id": "hyperium/tonic",
+    "full_name": "hyperium/tonic",
+    "url": "https://github.com/hyperium/tonic",
+    "language": "Rust",
+    "category": "runtime_reference",
+    "maintainer_type": "community_org",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Reference bar for ergonomic async gRPC client/server infrastructure in Rust.",
+    "key_capabilities": [
+      "gRPC client",
+      "gRPC server",
+      "async runtime integration"
+    ],
+    "source_urls": [
+      "https://github.com/hyperium/tonic"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Useful design reference for transport and interceptor ergonomics."
+  },
+  {
+    "repo_id": "temporalio/sdk-go",
+    "full_name": "temporalio/sdk-go",
+    "url": "https://github.com/temporalio/sdk-go",
+    "language": "Go",
+    "category": "durable_execution",
+    "maintainer_type": "vendor_official",
+    "adoption_bucket": "reference_bar",
+    "ocaml_status": "reference_non_ocaml",
+    "eio_strategy": "reference_only",
+    "why_it_matters": "Reference bar for checkpoint/replay/retry/backoff workflow primitives that masc-mcp should internalize.",
+    "key_capabilities": [
+      "durable workflows",
+      "checkpoint and replay",
+      "workflow orchestration patterns"
+    ],
+    "source_urls": [
+      "https://github.com/temporalio/sdk-go"
+    ],
+    "last_verified_at": "2026-03-27T11:35:45+09:00",
+    "notes": "Treat as a pattern source, not as a runtime to adopt."
+  }
+]


### PR DESCRIPTION
## Summary
- add a machine-readable repo corpus for OCaml vs Go/Rust agent substrate comparison
- add a focused `masc-mcp` foundation backlog based on the research findings
- keep the scope on MCP, provider SDKs, browser automation, observability, schema/codegen, and durable execution

## Validation
- `python3 -c 'import json; json.load(open("benchmark/agent_ecosystem_repo_set.json")); print("agent_ecosystem_repo_set.json: OK")'`

## Notes
- this PR is docs/data-only
- this pairs with a separate `me` draft PR that adds the human-readable gap analysis and evidence record