### PR TITLE
Fix room-truth cold execution timeout fallback

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -467,7 +467,7 @@ let dashboard_room_truth_focus_json ~initialized ~runtime_count ~operator_digest
                   ("suggested_params", `Assoc []);
                 ]))
 
-let dashboard_room_truth_http_json ~state ~sw ~clock request =
+let dashboard_room_truth_http_json ~state ~sw:_ ~clock _request =
   (* Fast-path: if the proactive execution refresh hasn't produced a result
      yet, return "initializing" immediately instead of blocking for 15-20s
      on cold-start on-demand compute.  The frontend retries every 3s via
@@ -504,12 +504,13 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
   let config = state.Mcp_server.room_config in
   let started_at = Unix.gettimeofday () in
   let t0 = Time_compat.now () in
-  (* Parallel fetch: shell, execution, and command_summary are independent. *)
+  (* Staged fetch: shell may still need a guarded refresh, while execution
+     stays on the proactive cache to keep room-truth off the cold path. *)
   let shell_ref = ref (`Assoc []) in
   let execution_ref = ref (`Assoc []) in
   let command_ref = ref (`Assoc []) in
   (* Single env var for room-truth fiber timeouts.
-     Cold start uses higher defaults to allow PG + caching to warm up. *)
+     Cold start uses higher defaults to allow shell/room reads to warm up. *)
   let warm_timeout_s =
     float_of_env_default "MASC_DASHBOARD_ROOM_TRUTH_TIMEOUT_S"
       ~default:5.0 ~min_v:2.0 ~max_v:25.0
@@ -534,21 +535,12 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
   let shell_timeout_s =
     if !_shell_warmed then base_timeout_s else cold_timeout_s
   in
-  let execution_timeout_s =
-    if is_cold then Float.max base_timeout_s 20.0 else base_timeout_s
-  in
   (* Sequential fetch to avoid PG connection concurrent usage (#3305).
      Each component has its own timeout guard and cache fallback,
      so sequential execution adds minimal latency on cache hit. *)
   shell_ref := fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
     (fun () -> dashboard_shell_http_json config) (`Assoc []);
-  execution_ref := (
-    if cached_surface_has_success _execution_cache then
-      cached_surface_json _execution_cache
-    else
-      fiber_with_timeout ~timeout_s:execution_timeout_s "execution"
-        (fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
-        (cached_surface_json _execution_cache));
+  execution_ref := cached_surface_json _execution_cache;
   (* command_plane_summary_http_json reads from a proactive cache ref —
      no PG I/O needed.  Skip the Room.is_initialized guard (which does a
      PG query in PostgresNative mode) to avoid 200-500ms latency. *)
@@ -559,21 +551,11 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
   let execution_json = !execution_ref in
   let command_summary_json = !command_ref in
   let parallel_ms = (Time_compat.now () -. t0) *. 1000.0 in
-  Log.Dashboard.info "room-truth parallel fetch: %.0fms" parallel_ms;
+  Log.Dashboard.info "room-truth fetch: %.0fms" parallel_ms;
   let execution_cache_state =
     json_assoc_field "projection_diagnostics" execution_json
     |> json_string_field_opt "cache_state"
   in
-  if execution_cache_state = Some "initializing" then
-    `Assoc
-      [
-        ("status", `String "initializing");
-        ("generated_at", `String (Types.now_iso ()));
-        ( "message",
-          `String
-            "Execution snapshot is still warming up. The dashboard will retry automatically." );
-      ]
-  else
   (* Derive digest fields from execution_json to avoid duplicate
      Operator_control.digest_json call (saves ~3s).
      execution_json already calls digest_json internally. *)

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -39,6 +39,13 @@ let warm_execution_cache () =
     Lib.Server_dashboard_http._execution_cache
     (`Assoc [("status", `String "ok")])
 
+let expire_execution_warmup () =
+  let surface = Lib.Server_dashboard_http._execution_cache in
+  Lib.Server_dashboard_http_cache.invalidate_cached_surface surface;
+  let stale_attempt_ts = Unix.gettimeofday () -. 120.0 in
+  surface.last_attempt_unix <- Some stale_attempt_ts;
+  surface.last_attempt_at <- Some "stale_attempt_for_test"
+
 let keeper_boot_entry name : Lib.Keeper_types.keeper_boot_entry =
   let now = "2026-03-25T08:05:54Z" in
   {
@@ -243,6 +250,38 @@ let test_operator_digest_shape_matches_room_truth () =
         ) expected_keys;
       ))
 
+let test_dashboard_room_truth_cold_cache_falls_back_to_partial_truth () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      warm_execution_cache ();
+      cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      expire_execution_warmup ();
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        check bool "expired warmup skips top-level initializing payload"
+          true
+          (json |> member "status" = `Null);
+        check bool "room block still present"
+          true
+          (json |> member "room" <> `Null);
+        check int "execution summary falls back to zero sessions"
+          0
+          (json |> member "execution" |> member "summary" |> member "active_sessions" |> to_int);
+        check string "room truth diagnostics keep execution cache state"
+          "initializing"
+          (json |> member "projection_diagnostics" |> member "execution_cache_state" |> to_string);
+      ))
+
 let () =
   Alcotest.run "Dashboard Room Truth"
     [
@@ -256,5 +295,7 @@ let () =
           test_case "mixed runtimes keep counts aligned" `Quick
             test_dashboard_room_truth_mixed_runtime_counts;
           test_case "operator digest shape matches room-truth" `Quick test_operator_digest_shape_matches_room_truth;
+          test_case "expired execution warmup falls back to partial truth" `Quick
+            test_dashboard_room_truth_cold_cache_falls_back_to_partial_truth;
         ] );
     ]


### PR DESCRIPTION
## Summary
- keep `room-truth` off the cold execution compute path after the initial proactive warm-up window
- keep using the cached execution surface so expired warm-up falls back to partial truth instead of waiting on a 20s execution timeout
- add a regression test for the expired warm-up fallback path

## Testing
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-room-truth-cold-path --build-dir _build_codex_room_truth ./test/test_dashboard_room_truth.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-room-truth-cold-path --build-dir _build_codex_room_truth ./test/test_ci_hardening_source.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-room-truth-cold-path --build-dir _build_codex_room_truth @default`