### PR TITLE
refactor(mli): add interface files for 4 large modules (#2994)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.mli
+++ b/lib/dashboard/dashboard_http_keeper_detail.mli
@@ -1,0 +1,16 @@
+(** Dashboard_http_keeper_detail — metrics window computation for keeper dashboard.
+
+    Extracts the metrics series iteration loop from keepers_dashboard_json.
+    Re-exports [Dashboard_http_keeper_metrics] for downstream consumers. *)
+
+include module type of Dashboard_http_keeper_metrics
+
+val compute_metrics_window :
+  parsed_metrics:Yojson.Safe.t list ->
+  generation:int ->
+  compact:bool ->
+  series_points:int ->
+  metrics_window_max_bytes:int ->
+  primary_model_norm:string ->
+  primary_model:string ->
+  Yojson.Safe.t list * Yojson.Safe.t * Yojson.Safe.t option * Yojson.Safe.t option

--- a/lib/server/server_h2_gateway.mli
+++ b/lib/server/server_h2_gateway.mli
@@ -1,0 +1,20 @@
+(** Server_h2_gateway — HTTP/2 request and error handlers.
+
+    Provides [make_request_handler] and [make_error_handler] closures
+    consumed by [Server_runtime_bootstrap.run] when MASC_USE_H2 is set. *)
+
+val make_error_handler :
+  unit ->
+  'a ->
+  ?request:H2.Request.t ->
+  H2.Server_connection.error ->
+  (H2.Headers.t -> H2.Body.Writer.t) ->
+  unit
+
+val make_request_handler :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  server_start_time:float ->
+  'a ->
+  H2.Reqd.t ->
+  unit

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -264,86 +264,6 @@ let handle_webrtc_answer _ctx args : result =
   | Ok response -> (true, pretty_json_string response)
   | Error msg -> error_result msg
 
-(** Flat default keeper gate config.
-    allowlist_enabled=false: all tools are available by default.
-    Safety is enforced through the denied_tools list (eval_gate). *)
-let keeper_default_gate_config () : Eval_gate.gate_config =
-  {
-    max_cost_usd = 0.10;
-    max_tool_calls_per_turn = 5;
-    entropy_threshold = 2;
-    destructive_check_enabled = true;
-    allowlist_enabled = false;
-    allowed_tools = [];
-    denied_tools = [
-      "keeper_bash"; "keeper_edit"; "keeper_fs_edit"; "keeper_github";
-    ];
-  }
-
-let keeper_tool_policy_json () =
-  let gate = keeper_default_gate_config () in
-  `Assoc
-    [
-      ("configured_tool_policy", `String (if gate.allowlist_enabled then "allowlist" else "all"));
-      ( "configured_tool_names",
-        `List
-          (if gate.allowlist_enabled
-           then List.map (fun name -> `String name) gate.allowed_tools
-           else []) );
-      ("denied_tool_names", `List (List.map (fun name -> `String name) gate.denied_tools));
-      ("max_tool_calls_per_turn", `Int gate.max_tool_calls_per_turn);
-      ("destructive_check_enabled", `Bool gate.destructive_check_enabled);
-    ]
-
-let keeper_policy_row ctx ~runtime_class (meta : Keeper_types.keeper_meta) =
-  let status_json =
-    Keeper_exec_status.parse_agent_status ctx.config ~agent_name:meta.agent_name
-  in
-  let status =
-    match U.member "status" status_json with
-    | `String value -> value
-    | _ -> "unknown"
-  in
-  let policy_json =
-    match keeper_tool_policy_json () with
-    | `Assoc fields -> fields
-    | _ -> []
-  in
-  `Assoc
-    ([
-       ("name", `String meta.name);
-       ("runtime_class", `String runtime_class);
-       ("agent_name", `String meta.agent_name);
-       ("status", `String status);
-       ("action_budget", `String "conversation");
-       ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
-       ("updated_at", `String meta.updated_at);
-     ]
-    @ policy_json)
-
-let keeper_policies_json ctx =
-  let registered_rows =
-    Keeper_types.resident_keeper_names ctx.config
-    |> List.filter_map (fun name ->
-           match Keeper_types.read_meta ctx.config name with
-           | Ok (Some meta) ->
-               Some (keeper_policy_row ctx ~runtime_class:"resident_keeper" meta)
-           | Ok None | Error _ -> None)
-  in
-  let unregistered_rows =
-    Keeper_types.persistent_agent_names ctx.config
-    |> List.filter_map (fun name ->
-           match Keeper_types.read_meta ctx.config name with
-           | Ok (Some meta) ->
-               Some (keeper_policy_row ctx ~runtime_class:"persistent_agent" meta)
-           | Ok None | Error _ -> None)
-  in
-  `Assoc
-    [
-      ("registered_keepers", `List registered_rows);
-      ("unregistered_keepers", `List unregistered_rows);
-    ]
-
 let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
   (* Build reverse index: tool_name -> surface string list.
      Also index by backend_tool_name so keeper/privileged surfaces
@@ -477,27 +397,6 @@ let handle_tool_admin_snapshot ctx args =
       ]
   in
   (true, Yojson.Safe.pretty_to_string payload)
-
-let apply_keeper_policy_update config ~runtime_class args =
-  let name = get_string args "name" "" |> String.trim in
-  let membership_ok =
-    match runtime_class with
-    | "keeper" ->
-      List.mem name (Keeper_types.resident_keeper_names config)
-      || List.mem name (Keeper_types.persistent_agent_names config)
-    | _ -> false
-  in
-  if not (Keeper_types.validate_name name) then
-    Error "invalid keeper name"
-  else if not membership_ok then
-    Error
-      (Printf.sprintf "%s not found in %s set" name runtime_class)
-  else
-    match Keeper_types.read_meta config name with
-    | Error err -> Error err
-    | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
-    | Ok (Some _meta) ->
-        Error "keeper policy update is removed; keepers use a fixed tool policy now"
 
 let handle_tool_admin_update ctx args =
   let section =

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -1,0 +1,19 @@
+(** Tool_misc — miscellaneous MASC tool handlers.
+
+    Dispatches: transport_status, websocket_discovery, webrtc,
+    dashboard, verify_handoff, gc, cleanup_zombies, tool_stats,
+    tool_help, tool_admin, keeper_tool_catalog, deep_review. *)
+
+type result = bool * string
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+}
+
+val schemas : Types.tool_schema list
+
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+
+val tool_inventory_json :
+  context -> include_hidden:bool -> include_deprecated:bool -> Yojson.Safe.t

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -29,79 +29,6 @@ let write_text path content =
 let read_file path =
   Fs_compat.load_file path
 
-let show_process_status = function
-  | Unix.WEXITED code -> Printf.sprintf "exit %d" code
-  | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
-  | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
-
-let playback_success_json ~attempted ~succeeded ~method_name ?detail () =
-  `Assoc
-    [
-      ("enabled", `Bool attempted);
-      ("attempted", `Bool attempted);
-      ("succeeded", `Bool succeeded);
-      ("method", `String method_name);
-      ("detail", match detail with Some value -> `String value | None -> `Null);
-    ]
-
-let playback_skipped_json reason =
-  `Assoc
-    [
-      ("enabled", `Bool false);
-      ("attempted", `Bool false);
-      ("succeeded", `Bool false);
-      ("method", `Null);
-      ("detail", `String reason);
-    ]
-
-let play_audio_locally ~agent_id ~audio_file =
-  if not (local_playback_enabled_for_agent agent_id) then
-    Ok (playback_skipped_json "local playback disabled")
-  else
-    let run argv =
-      Process_eio.run_argv_with_status ~timeout_sec:120.0 argv
-    in
-    let run_afplay path =
-      let argv =
-        if Sys.file_exists "/usr/bin/afplay" then [ "/usr/bin/afplay"; path ]
-        else [ "afplay"; path ]
-      in
-      run argv
-    in
-    match run_afplay audio_file with
-    | Unix.WEXITED 0, _ ->
-        Ok (playback_success_json ~attempted:true ~succeeded:true ~method_name:"afplay" ())
-    | status, output ->
-        let wav_file = Filename.temp_file "masc_voice_playback" ".wav" in
-        Fun.protect
-          ~finally:(fun () -> try Sys.remove wav_file with Sys_error _ -> ())
-          (fun () ->
-            let ffmpeg_argv =
-              [ "ffmpeg"; "-y"; "-loglevel"; "error"; "-i"; audio_file; wav_file ]
-            in
-            match run ffmpeg_argv with
-            | Unix.WEXITED 0, _ -> (
-                match run_afplay wav_file with
-                | Unix.WEXITED 0, _ ->
-                    Ok
-                      (playback_success_json ~attempted:true ~succeeded:true
-                         ~method_name:"ffmpeg+afplay"
-                         ~detail:"converted to wav for playback" ())
-                | status2, output2 ->
-                    Error
-                      (Printf.sprintf
-                         "local playback failed after wav conversion: afplay=%s output=%s"
-                         (show_process_status status2)
-                         (String.trim output2)) )
-            | status_ffmpeg, output_ffmpeg ->
-                Error
-                  (Printf.sprintf
-                     "local playback failed: afplay=%s output=%s; ffmpeg=%s output=%s"
-                     (show_process_status status)
-                     (String.trim output)
-                     (show_process_status status_ffmpeg)
-                     (String.trim output_ffmpeg)) )
-
 let resolve_api_key endpoint =
   let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
   match Provider_adapter.voice_endpoint_auth_env_name endpoint with
@@ -183,11 +110,6 @@ let available_tts_endpoints ?provider () =
   match load_voice_config () with
   | Error _ -> []
   | Ok config -> Provider_adapter.select_voice_endpoints ?provider config.tts.endpoints
-
-let provider_error_json endpoint message =
-  append_provider_metadata
-    (`Assoc [ ("status", `String "error"); ("message", `String message) ])
-    endpoint
 
 let public_config_json () =
   match load_voice_config () with
@@ -391,43 +313,6 @@ let single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Error (Printf.sprintf "Connection error: %s" (Printexc.to_string exn))
-
-(** Make HTTP POST request to Voice MCP server with timeout and retry - Eio version *)
-let call_voice_mcp ~sw:_ ~clock ~net ~tool_name ~arguments =
-  log_debug (Printf.sprintf "Calling tool: %s" tool_name);
-  let uri = voice_mcp_uri () in
-  let request_body = `Assoc [
-    ("jsonrpc", `String "2.0");
-    ("method", `String "tools/call");
-    ("id", `Int 1);
-    ("params", `Assoc [
-      ("name", `String tool_name);
-      ("arguments", arguments);
-    ]);
-  ] in
-  let body_str = Yojson.Safe.to_string request_body in
-  let headers = Cohttp.Header.of_list [
-    ("Content-Type", "application/json");
-    ("Accept", "application/json");
-  ] in
-  let operation () =
-    Eio.Switch.run @@ fun inner_sw ->
-    match client_for_uri_result ~sw:inner_sw ~net uri with
-    | Error error -> Error error
-    | Ok client ->
-        with_timeout ~clock (fun () ->
-          single_voice_mcp_call ~sw:inner_sw ~client ~uri ~headers ~body_str)
-  in
-      let result = retry_with_backoff ~clock
-        ~attempt:1
-        ~max_attempts:(max_retries ())
-        ~backoff_sec:(initial_backoff_seconds ())
-        operation
-      in
-      (match result with
-      | Ok _ -> log_debug (Printf.sprintf "Tool %s succeeded" tool_name)
-      | Error e -> log_error (Printf.sprintf "Tool %s failed: %s" tool_name e));
-      result
 
 (** Extract result from MCP response *)
 let extract_mcp_result json =

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -1,0 +1,120 @@
+(** Voice_bridge — TTS synthesis, MCP voice sessions, conferences.
+
+    Re-exports [Voice_bridge_core] (config, helpers, local playback)
+    and adds higher-level session, conference, and agent_speak APIs.
+
+    External callers use [agent_speak], [get_agent_voice],
+    and [public_config_json]. *)
+
+include module type of Voice_bridge_core
+
+(** {1 Types} *)
+
+type voice_session_status = {
+  session_id : string;
+  agent_id : string;
+  voice : string;
+  is_active : bool;
+  turn_count : int;
+  duration_seconds : float option;
+}
+
+type conference_status = {
+  conference_id : string;
+  state : string;
+  participants : string list;
+  current_speaker : string option;
+  queue_size : int;
+  turn_count : int;
+}
+
+type turn_request_result = {
+  status : string;
+  agent_id : string;
+  message_preview : string;
+  voice : string;
+  queue_position : int;
+}
+
+exception Timeout of string
+
+(** {1 Public API} *)
+
+val public_config_json : unit -> (Yojson.Safe.t, Yojson.Safe.t) result
+
+val agent_speak :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_id:string ->
+  message:string ->
+  ?provider:string ->
+  ?priority:int ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val get_agent_voice :
+  agent_id:string -> (Yojson.Safe.t, string) result
+
+val available_tts_endpoints :
+  ?provider:string -> unit -> Voice_config.endpoint list
+
+val tts_preview_bytes_from_request_json :
+  Yojson.Safe.t -> (string, string) result
+
+(** {1 Voice Session Management} *)
+
+val start_voice_session :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_id:string ->
+  ?session_name:string ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val end_voice_session :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_id:string ->
+  (Yojson.Safe.t, string) result
+
+val list_voice_sessions :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  (Yojson.Safe.t, string) result
+
+(** {1 Conference Management} *)
+
+val start_conference :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_ids:string list ->
+  ?conference_name:string ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val end_conference :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  agent_ids:string list ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val get_transcript :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val health_check :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  net:_ Eio.Net.t ->
+  unit ->
+  (Yojson.Safe.t, string) result

--- a/test/test_verifier_oas_bridge.ml
+++ b/test/test_verifier_oas_bridge.ml
@@ -233,7 +233,16 @@ let test_verify_skips_readonly () =
 (* ================================================================ *)
 
 let test_default_gate_roundtrip () =
-  let gate = Tool_misc.keeper_default_gate_config () in
+  let gate : Masc_mcp.Eval_gate.gate_config =
+    { max_cost_usd = 0.10;
+      max_tool_calls_per_turn = 5;
+      entropy_threshold = 2;
+      destructive_check_enabled = true;
+      allowlist_enabled = false;
+      allowed_tools = [];
+      denied_tools = [ "keeper_bash"; "keeper_edit"; "keeper_fs_edit"; "keeper_github" ];
+    }
+  in
   let g = Verifier_oas.eval_gate_to_oas_guardrails gate in
   (* Mode removal: allowlist_enabled=false. Safety via denied_tools list.
      eval_gate_to_oas_guardrails produces DenyList when denied_tools is non-empty. *)


### PR DESCRIPTION
## Summary

- Add `.mli` interface files for 4 large modules (3,317 LOC → 4 public APIs)
  - `server_h2_gateway.mli` — 2 functions (make_error_handler, make_request_handler)
  - `dashboard_http_keeper_detail.mli` — 1 function + include re-export
  - `tool_misc.mli` — 4 functions (dispatch, schemas, tool_inventory_json, context type)
  - `voice_bridge.mli` — 15 functions + include re-export
- Remove 187 LOC dead code discovered by `.mli` addition (tool_misc: 72 LOC, voice_bridge: 115 LOC)
- Fix test_verifier_oas_bridge to inline removed gate config

## Why

Part of Phase 1b of the master improvement plan (#2994). Large files without `.mli` expose all internal helpers as public API, making dependency tracking impossible and encouraging coupling to implementation details.

## Test plan

- [x] `dune build lib/ test/` passes
- [x] `make test` passes (32/33, 1 pre-existing Operator_control flaky)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)