### PR TITLE
[codex] Split lab tools and experiments surfaces

### DIFF
--- a/dashboard/src/components/command/warroom-guide-callout.test.ts
+++ b/dashboard/src/components/command/warroom-guide-callout.test.ts
@@ -32,14 +32,14 @@ describe('WarroomGuideCallout', () => {
     const text = container.textContent ?? ''
     expect(text).toContain('관제면은 실험 화면입니다.')
     expect(text).toContain('메인 메뉴 숨김')
-    expect(text).toContain('운영 화면 안내')
+    expect(text).toContain('실험 안내')
     expect(text).toContain('실시간 개입 열기')
 
     const buttons = Array.from(container.querySelectorAll('button'))
     buttons[0]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     buttons[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
 
-    expect(mocks.navigate).toHaveBeenNthCalledWith(1, 'lab', { section: 'tools' })
+    expect(mocks.navigate).toHaveBeenNthCalledWith(1, 'lab', { section: 'experiments' })
     expect(mocks.navigate).toHaveBeenNthCalledWith(2, 'command', { section: 'intervene' })
   })
 })

--- a/dashboard/src/components/command/warroom-guide-callout.ts
+++ b/dashboard/src/components/command/warroom-guide-callout.ts
@@ -18,16 +18,16 @@ export function WarroomGuideCallout() {
           </div>
           <span class="text-[12px] text-[var(--text-muted)] leading-[1.5]">
             오케스트라, 스웜, 체인 제어는 아직 실험 단계입니다. 기본 운영은 실시간 개입 화면에서 하고,
-            검증 기준과 진입 경로는 실험실의 운영 화면 안내에서 확인합니다.
+            검증 기준과 진입 경로는 실험실의 실험 섹션에서 확인합니다.
           </span>
         </div>
         <div class="flex gap-2 flex-wrap">
           <button
             type="button"
             class=${ACTION_BUTTON}
-            onClick=${() => navigate('lab', { section: 'tools' })}
+            onClick=${() => navigate('lab', { section: 'experiments' })}
           >
-            운영 화면 안내
+            실험 안내
           </button>
           <button
             type="button"

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -11,7 +11,11 @@ export function Lab() {
   return html`
     <div>
       ${section === 'tools' ? html`
-        <${Tools} />
+        <${Tools} mode="tools" />
+      ` : null}
+
+      ${section === 'experiments' ? html`
+        <${Tools} mode="experiments" />
       ` : null}
 
       ${section === 'autoresearch' ? html`

--- a/dashboard/src/components/tools/surface-readiness-panel.test.ts
+++ b/dashboard/src/components/tools/surface-readiness-panel.test.ts
@@ -112,7 +112,8 @@ describe('SurfaceReadinessPanel', () => {
     expect(groups[0]?.textContent).toContain('세션 & 룸')
     expect(groups[0]?.textContent).not.toContain('관제면')
     expect(groups[1]?.textContent).toContain('관제면')
-    expect(groups[1]?.textContent).toContain('도구 & 실험')
+    expect(groups[1]?.textContent).toContain('도구')
+    expect(groups[1]?.textContent).not.toContain('도구 & 실험')
 
     const text = container.textContent ?? ''
     expect(text).toContain('검증 기준')

--- a/dashboard/src/components/tools/surface-readiness-panel.ts
+++ b/dashboard/src/components/tools/surface-readiness-panel.ts
@@ -20,7 +20,11 @@ const SURFACE_SUMMARY_BY_ID: Record<string, string> = {
   'command.warroom': '오케스트라, 스웜, 체인 제어를 시험하는 실험 화면입니다.',
   'command.governance': '판단과 판결 흐름을 확인하는 운영 화면입니다.',
   'workspace.evidence': '증빙과 작업 이력을 확인하는 기본 운영 화면입니다.',
-  'lab.tools': '도구 현황과 준비 상태를 점검하는 실험 화면입니다.',
+  'lab.tools': '도구 인벤토리와 경로/사용량 진단을 확인하는 실험실 화면입니다.',
+}
+
+const SURFACE_LABEL_BY_ID: Record<string, string> = {
+  'lab.tools': '도구',
 }
 
 const VERIFICATION_LABELS: Record<string, string> = {
@@ -65,6 +69,10 @@ function formatProofBar(value: string): string {
 
 function surfaceSummary(item: DashboardSurfaceReadinessItem): string {
   return SURFACE_SUMMARY_BY_ID[item.id] ?? item.rationale
+}
+
+function surfaceLabel(item: DashboardSurfaceReadinessItem): string {
+  return SURFACE_LABEL_BY_ID[item.id] ?? item.label
 }
 
 function surfaceStatusLabel(item: DashboardSurfaceReadinessItem): string {
@@ -126,7 +134,7 @@ function SurfaceReadinessRow({ item }: { item: DashboardSurfaceReadinessItem }) 
       <div class="flex items-start justify-between gap-3">
         <div class="grid gap-2">
           <div class="flex items-center gap-2 flex-wrap">
-            <strong class="text-[14px] text-[var(--text-strong)]">${item.label}</strong>
+            <strong class="text-[14px] text-[var(--text-strong)]">${surfaceLabel(item)}</strong>
             <span class="px-2 py-0.5 rounded-full border text-[10px] tracking-[0.04em] ${surfaceStatusTone(item)}">
               ${surfaceStatusLabel(item)}
             </span>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -1,0 +1,108 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  loadTools: vi.fn(),
+  toolsData: { value: null as null | { generated_at?: string; tool_inventory: { tools: unknown[] }; tool_usage: { registered_count: number; distinct_tools_called: number; never_called_count: number } } },
+  toolsLoading: { value: false },
+  toolsError: { value: null as string | null },
+  showFullInventory: { value: false },
+}))
+
+vi.mock('./tool-state', () => ({
+  loadTools: mocks.loadTools,
+  showFullInventory: mocks.showFullInventory,
+  toolsData: mocks.toolsData,
+  toolsError: mocks.toolsError,
+  toolsLoading: mocks.toolsLoading,
+}))
+
+vi.mock('../common/card', () => ({
+  Card: ({ title, children }: { title: string; children: unknown }) => html`
+    <section data-card-title=${title}>
+      <h2>${title}</h2>
+      ${children}
+    </section>
+  `,
+}))
+
+vi.mock('../tool-metrics', () => ({
+  ToolMetrics: () => html`<div>ToolMetrics</div>`,
+}))
+
+vi.mock('./tool-summary-view', () => ({
+  ToolSummaryView: () => html`<div>ToolSummaryView</div>`,
+}))
+
+vi.mock('./tool-full-inventory', () => ({
+  FullInventoryView: () => html`<div>FullInventoryView</div>`,
+}))
+
+vi.mock('./prompt-registry-panel', () => ({
+  PromptRegistryPanel: () => html`<div>PromptRegistryPanel</div>`,
+}))
+
+vi.mock('./surface-readiness-panel', () => ({
+  SurfaceReadinessPanel: () => html`<div>SurfaceReadinessPanel</div>`,
+}))
+
+vi.mock('./config-resolution-panel', () => ({
+  ConfigResolutionPanel: () => html`<div>ConfigResolutionPanel</div>`,
+}))
+
+import { Tools } from './tools-main'
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+}
+
+describe('Tools', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.loadTools.mockClear()
+    mocks.toolsData.value = null
+    mocks.toolsLoading.value = false
+    mocks.toolsError.value = null
+    mocks.showFullInventory.value = false
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders the experiments mode without tool inventory panels', async () => {
+    render(html`<${Tools} mode="experiments" />`, container)
+    await flush()
+
+    expect(mocks.loadTools).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('운영 화면 안내')
+    expect(container.textContent).toContain('SurfaceReadinessPanel')
+    expect(container.textContent).toContain('PromptRegistryPanel')
+    expect(container.textContent).not.toContain('시스템 도구 목록')
+    expect(container.textContent).not.toContain('도구 사용 현황')
+  })
+
+  it('loads tool data when switching from experiments to tools mode', async () => {
+    render(html`<${Tools} mode="experiments" />`, container)
+    await flush()
+
+    render(html`<${Tools} mode="tools" />`, container)
+    await flush()
+
+    expect(mocks.loadTools).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('ConfigResolutionPanel')
+    expect(container.textContent).toContain('시스템 도구 목록')
+    expect(container.textContent).toContain('ToolSummaryView')
+    expect(container.textContent).toContain('도구 사용 현황')
+    expect(container.textContent).toContain('ToolMetrics')
+    expect(container.textContent).not.toContain('PromptRegistryPanel')
+  })
+})

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -17,7 +17,10 @@ import { PromptRegistryPanel } from './prompt-registry-panel'
 import { SurfaceReadinessPanel } from './surface-readiness-panel'
 import { ConfigResolutionPanel } from './config-resolution-panel'
 
-export function Tools() {
+export type ToolsMode = 'tools' | 'experiments'
+
+export function Tools({ mode = 'tools' }: { mode?: ToolsMode }) {
+  const isToolsMode = mode === 'tools'
   const data = toolsData.value
   const loading = toolsLoading.value
   const error = toolsError.value
@@ -25,10 +28,22 @@ export function Tools() {
   const usage = data?.tool_usage ?? null
 
   useEffect(() => {
-    if (!toolsData.value && !toolsLoading.value) {
+    if (isToolsMode && !toolsData.value && !toolsLoading.value) {
       void loadTools()
     }
-  }, [])
+  }, [isToolsMode])
+
+  if (!isToolsMode) {
+    return html`
+      <div>
+        <${Card} title="운영 화면 안내" class="section mb-4">
+          <${SurfaceReadinessPanel} />
+        <//>
+
+        <${PromptRegistryPanel} />
+      </div>
+    `
+  }
 
   return html`
     <div>
@@ -36,10 +51,6 @@ export function Tools() {
         resolution=${data?.config_resolution}
         runtimeResolution=${data?.runtime_resolution}
       />
-
-      <${Card} title="운영 화면 안내" class="section mb-4">
-        <${SurfaceReadinessPanel} />
-      <//>
 
       <${Card} title="시스템 도구 목록" class="section mb-4">
         <div class="mb-4">
@@ -76,7 +87,6 @@ export function Tools() {
           : null}
         <${ToolMetrics} />
       <//>
-      <${PromptRegistryPanel} />
       ${data?.generated_at
         ? html`<div class="flex flex-wrap gap-x-3 gap-y-2 mt-3 text-[var(--text-muted)] text-[12px]">
             <span>생성 시각: ${data.generated_at}</span>

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultParamsForTab, visibleSectionItemsForTab } from './navigation'
+
+describe('lab navigation', () => {
+  it('keeps tools as the default section and exposes experiments separately', () => {
+    expect(defaultParamsForTab('lab')).toEqual({ section: 'tools' })
+
+    const labSections = visibleSectionItemsForTab('lab')
+
+    expect(labSections.map(item => item.id)).toEqual([
+      'tools',
+      'experiments',
+      'autoresearch',
+      'harness',
+    ])
+
+    expect(labSections.map(item => item.label)).toEqual([
+      '도구',
+      '실험',
+      '오토리서치',
+      '하네스 헬스',
+    ])
+  })
+})

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -13,6 +13,7 @@ export type SurfaceSectionId =
   | 'intervene'
   | 'warroom'
   | 'tools'
+  | 'experiments'
   | 'autoresearch'
   | 'harness'
 
@@ -91,7 +92,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'lab',
     label: '실험실',
     icon: '🧪',
-    description: '시스템 도구 테스트',
+    description: '도구 진단과 실험 제어',
     defaultTab: 'lab',
     defaultParams: { section: 'tools' },
     tabs: ['lab'],
@@ -185,9 +186,15 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   lab: [
     {
       id: 'tools',
-      label: '도구 & 실험',
-      description: '도구 인벤토리와 기타 실험을 진행합니다.',
+      label: '도구',
+      description: '도구 인벤토리, 사용량, 경로 진단을 봅니다.',
       params: { section: 'tools' },
+    },
+    {
+      id: 'experiments',
+      label: '실험',
+      description: '운영 화면 readiness와 runtime override를 다룹니다.',
+      params: { section: 'experiments' },
     },
     {
       id: 'autoresearch',

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -58,5 +58,10 @@ describe('refreshPlanForRoute', () => {
       tab: 'lab',
       params: { section: 'tools' },
     })).toEqual([])
+
+    expect(refreshPlanForRoute({
+      tab: 'lab',
+      params: { section: 'experiments' },
+    })).toEqual([])
   })
 })


### PR DESCRIPTION
## What changed
- split the Lab navigation so `도구` and `실험` are separate sections
- keep the tools surface focused on inventory, usage, and config/runtime path diagnostics
- move surface readiness guidance and prompt override controls into a dedicated experiments surface
- update the warroom guidance shortcut to point at the new experiments section

## Why
The previous `도구 & 실험` label mixed two different axes in one menu item:
- `도구` is a functional category
- `실험` is a maturity/status category

That made the side navigation feel awkward and made the tools screen act like a catch-all. This change separates the information architecture so the menu matches the actual content.

## Impact
- Lab navigation is clearer and less redundant
- tool inventory and diagnostics are easier to find as a single-purpose surface
- experimental guidance and overrides are grouped together instead of being mixed into the tools screen

## Validation
- `npm run typecheck`
- `npx vitest run src/tab-refresh.test.ts src/components/command/warroom-guide-callout.test.ts src/components/tools/surface-readiness-panel.test.ts`

Cross-model review evidence will be added in a follow-up PR comment.