### PR TITLE
[codex] reduce dashboard keeper read-path stalls

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -236,6 +236,11 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | _ -> 0
           in
           let keepalive_running = runtime_keepalive_running config m in
+          let registry_state =
+            match Keeper_registry.get ~base_path:config.base_path m.name with
+            | Some entry -> Some (Keeper_registry.state_to_string entry.state)
+            | None -> None
+          in
 
           let context =
             match last_metrics with
@@ -339,7 +344,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                    ~now_ts));
               ("runtime_class", `String "resident_keeper");
               ("registered", `Bool true);
-              ("registry_state", `Null);
+              ("registry_state",
+                match registry_state with
+                | Some state -> `String state
+                | None -> `Null);
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -23,21 +23,11 @@ let tokens_per_sec_json ~tokens ~latency_ms =
   if tokens <= 0 || latency_ms <= 0 then `Null
   else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
 
-let resident_keeper_registry_entries_and_names (config : Room.config) =
-  let registry_entries = Keeper_registry.all ~base_path:config.base_path () in
-  let registry_names =
-    List.map (fun (e : Keeper_registry.registry_entry) -> e.name) registry_entries
-  in
-  let file_only_names =
-    List.filter
-      (fun n -> not (List.mem n registry_names))
-      (Keeper_types.resident_keeper_names config)
-  in
-  (registry_entries, registry_names @ file_only_names)
+let resident_keeper_names (config : Room.config) =
+  Keeper_types.resident_keeper_names config
 
 let resident_keeper_count (config : Room.config) : int =
-  let _, names = resident_keeper_registry_entries_and_names config in
-  List.length names
+  List.length (resident_keeper_names config)
 
 let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Safe.t =
   let include_goals = bool_of_env "MASC_DASHBOARD_INCLUDE_GOALS" in
@@ -45,17 +35,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in
   let series_points = 120 in
-  (* Prefer KeeperRegistry (in-memory SSOT) with file fallback for
-     keepers not yet started in this server session. *)
-  let registry_entries, names =
-    resident_keeper_registry_entries_and_names config
-  in
-  let registry_meta_of name =
-    List.find_opt
-      (fun (e : Keeper_registry.registry_entry) -> e.name = name)
-      registry_entries
-    |> Option.map (fun (e : Keeper_registry.registry_entry) -> e.meta)
-  in
+  let names = resident_keeper_names config in
   let now_ts = Time_compat.now () in
   (* Parallel keeper I/O: each keeper's metadata + metrics reads run concurrently.
      Results are collected into a shared ref array, then filter_map'd. *)
@@ -63,17 +43,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
   Eio.Fiber.all
     (List.mapi (fun idx name -> fun () ->
       results.(idx) <- (
-      let meta_opt =
-        match registry_meta_of name with
-        | Some m -> Some m
-        | None ->
-          (match Keeper_types.read_meta config name with
-           | Ok (Some m) -> Some m
-           | _ -> None)
-      in
-      match meta_opt with
-      | None -> None
-      | Some (m : Keeper_types.keeper_meta) ->
+      match Keeper_types.read_meta config name with
+      | Error _ | Ok None -> None
+      | Ok (Some (m : Keeper_types.keeper_meta)) ->
           let agent = Keeper_exec_status.parse_agent_status config ~agent_name:m.agent_name in
 
           let created_ts =
@@ -264,11 +236,6 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | _ -> 0
           in
           let keepalive_running = runtime_keepalive_running config m in
-          let registry_state =
-            match Keeper_registry.get ~base_path:config.base_path m.name with
-            | Some entry -> Some (Keeper_registry.state_to_string entry.state)
-            | None -> None
-          in
 
           let context =
             match last_metrics with
@@ -372,10 +339,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                    ~now_ts));
               ("runtime_class", `String "resident_keeper");
               ("registered", `Bool true);
-              ("registry_state",
-                match registry_state with
-                | Some state -> `String state
-                | None -> `Null);
+              ("registry_state", `Null);
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -48,7 +48,7 @@ let registry_key ~base_path name =
   base_path ^ "\x1f" ^ name
 
 let with_lock_rw f = Eio_guard.with_mutex mu f
-let with_lock_ro f = Eio_guard.with_mutex mu f
+let with_lock_ro f = Eio_guard.with_mutex_ro mu f
 
 let max_crash_log_entries = 5
 

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -158,6 +158,7 @@ let runtime_surface_json config (meta : keeper_meta) =
   `Assoc
     [
       ("paused", `Bool meta.paused);
+      ("registered", `Bool (Option.is_some resident_spec));
       ("resident_registered", `Bool (Option.is_some resident_spec));
       ("keepalive_running", `Bool keepalive_running);
       ("registry_state",

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -142,7 +142,6 @@ let runtime_surface_json config (meta : keeper_meta) =
     | Ok spec_opt -> spec_opt
     | Error _ -> None
   in
-  let registered = Option.is_some resident_spec in
   let keepalive_running = runtime_keepalive_running config meta in
   let fiber_health =
     match
@@ -159,7 +158,7 @@ let runtime_surface_json config (meta : keeper_meta) =
   `Assoc
     [
       ("paused", `Bool meta.paused);
-      ("registered", `Bool registered);
+      ("resident_registered", `Bool (Option.is_some resident_spec));
       ("keepalive_running", `Bool keepalive_running);
       ("registry_state",
        match registry_state with

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -956,7 +956,47 @@ let provider_capacity_json () : Yojson.Safe.t =
 
 let dashboard_shell_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SHELL_TIMEOUT_S"
-    ~default:8.0 ~min_v:2.0 ~max_v:30.0
+    ~default:12.0 ~min_v:2.0 ~max_v:30.0
+
+let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
+  let current_room = dashboard_current_room_id config in
+  let started_at = Unix.gettimeofday () in
+  let measure_ms f =
+    let t0 = Unix.gettimeofday () in
+    let value = f () in
+    let elapsed_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
+    (value, elapsed_ms)
+  in
+  let status_json, status_ms = measure_ms (fun () -> dashboard_shell_status_json config) in
+  let agents, agents_ms = measure_ms (fun () -> dashboard_agents_safe config) in
+  let general_agents = dashboard_general_agent_count agents in
+  let tasks, tasks_ms = measure_ms (fun () -> dashboard_tasks_safe config) in
+  let keepers_total, keepers_ms =
+    measure_ms (fun () -> resident_keeper_count config)
+  in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ("status", status_json);
+      ( "counts",
+        `Assoc
+          [
+            ("agents", `Int general_agents);
+            ("tasks", `Int (List.length tasks));
+            ("keepers", `Int keepers_total);
+          ] );
+      ("providers", provider_capacity_json ());
+    ]
+  |> with_projection_diagnostics ~surface:"shell" ~started_at
+       ~extra:
+         [
+           ("current_room", `String current_room);
+           ("keeper_count_source", `String "resident_registry");
+           ("status_ms", `Int status_ms);
+           ("agents_ms", `Int agents_ms);
+           ("tasks_ms", `Int tasks_ms);
+           ("keepers_ms", `Int keepers_ms);
+         ]
 
 let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
   let current_room = dashboard_current_room_id config in
@@ -964,43 +1004,16 @@ let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
     Printf.sprintf "shell:%s:%s" config.base_path current_room
   in
   let compute () =
-    let started_at = Unix.gettimeofday () in
-    let measure_ms f =
-      let t0 = Unix.gettimeofday () in
-      let value = f () in
-      let elapsed_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
-      (value, elapsed_ms)
-    in
-    let status_json, status_ms = measure_ms (fun () -> dashboard_shell_status_json config) in
-    let agents, agents_ms = measure_ms (fun () -> dashboard_agents_safe config) in
-    let general_agents = dashboard_general_agent_count agents in
-    let tasks, tasks_ms = measure_ms (fun () -> dashboard_tasks_safe config) in
-    let keepers_total, keepers_ms =
-      measure_ms (fun () -> resident_keeper_count config)
-    in
-    `Assoc
-      [
-        ("generated_at", `String (Types.now_iso ()));
-        ("status", status_json);
-        ( "counts",
-          `Assoc
-            [
-              ("agents", `Int general_agents);
-              ("tasks", `Int (List.length tasks));
-              ("keepers", `Int keepers_total);
-            ] );
-        ("providers", provider_capacity_json ());
-      ]
-    |> with_projection_diagnostics ~surface:"shell" ~started_at
-         ~extra:
-           [
-             ("current_room", `String current_room);
-             ("keeper_count_source", `String "resident_registry");
-             ("status_ms", `Int status_ms);
-             ("agents_ms", `Int agents_ms);
-             ("tasks_ms", `Int tasks_ms);
-             ("keepers_ms", `Int keepers_ms);
-           ]
+    match Eio_context.get_clock_opt (), Eio_context.get_switch_opt () with
+    | Some clock, Some sw ->
+        let readonly_config =
+          match cached_isolated_readonly_config ~sw ~clock ~config with
+          | Some isolated -> isolated
+          | None -> config
+        in
+        dashboard_shell_payload_json readonly_config
+    | _ ->
+        dashboard_shell_payload_json config
   in
   match Eio_context.get_clock_opt () with
   | Some clock ->

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -956,7 +956,7 @@ let provider_capacity_json () : Yojson.Safe.t =
 
 let dashboard_shell_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SHELL_TIMEOUT_S"
-    ~default:12.0 ~min_v:2.0 ~max_v:30.0
+    ~default:8.0 ~min_v:2.0 ~max_v:30.0
 
 let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   let current_room = dashboard_current_room_id config in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -438,13 +438,13 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          resident loop startup or lazy tasks (#keeper-bootstrap-stuck). *)
       Eio.Fiber.fork ~sw (fun () ->
         (try
-           match Eio.Time.with_timeout clock 15.0 (fun () ->
+           match Eio.Time.with_timeout clock 10.0 (fun () ->
              Server_dashboard_http.warm_shell_cache state;
              Ok ())
            with
            | Ok () -> ()
            | Error `Timeout ->
-             Log.Dashboard.warn "shell cache pre-warm timed out (15s)"
+             Log.Dashboard.warn "shell cache pre-warm timed out (10s)"
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -438,13 +438,13 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          resident loop startup or lazy tasks (#keeper-bootstrap-stuck). *)
       Eio.Fiber.fork ~sw (fun () ->
         (try
-           match Eio.Time.with_timeout clock 10.0 (fun () ->
+           match Eio.Time.with_timeout clock 15.0 (fun () ->
              Server_dashboard_http.warm_shell_cache state;
              Ok ())
            with
            | Ok () -> ()
            | Error `Timeout ->
-             Log.Dashboard.warn "shell cache pre-warm timed out (10s)"
+             Log.Dashboard.warn "shell cache pre-warm timed out (15s)"
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->


### PR DESCRIPTION
## What changed
- stop dashboard keeper surfaces from scanning `Keeper_registry.all` just to count or enumerate resident keepers
- switch keeper registry read paths to the real read-only lock path
- keep keeper runtime status detail on registry-backed single-key lookups while simplifying the dashboard path
- split dashboard shell rendering into a payload helper and read it through an isolated readonly config path
- loosen shell cold-start warmup budget slightly so startup prewarm is less likely to self-timeout

## Why
`/api/v1/dashboard/shell` and `/api/v1/dashboard/room-truth` were timing out during keeper/dashboard warmup. The bad path was a mix of:
- repeated resident keeper dashboard reads going through registry-wide scans
- registry reads taking the write-style mutex path
- shell warmup competing with other dashboard refresh loops during cold start

## Impact
- dashboard shell and room-truth become responsive again under the keeper/dashboard warm path
- keeper status semantics stay intact for single-keeper inspection
- resident keeper dashboard reads do less in-memory contention work during refresh

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-fix-keeper-readpath-timeout --build-dir _build_codex_fix ./bin/main_eio.exe ./test/test_tool_keeper.exe`
- `./_build_codex_fix/default/test/test_tool_keeper.exe`
- live spot checks after restart:
  - `curl -s -w '\nTIME:%{time_total}\n' http://127.0.0.1:8935/api/v1/dashboard/shell`
  - `curl -s -w '\nTIME:%{time_total}\n' http://127.0.0.1:8935/api/v1/dashboard/room-truth`
