### PR TITLE
refactor: replace Type_error catches with Safe_ops (batch 1, #2964)

### DIFF
--- a/lib/progress.ml
+++ b/lib/progress.ml
@@ -207,11 +207,9 @@ let stop_tracking task_id =
 
 (** MCP tool handler for progress - with input validation *)
 let handle_progress_tool arguments =
-  let module U = Yojson.Safe.Util in
-  (* Catch Type_error specifically - thrown by member/to_* on missing or wrong type *)
-  let get_string key = try Some (arguments |> U.member key |> U.to_string) with U.Type_error _ -> None in
-  let get_float key = try Some (arguments |> U.member key |> U.to_float) with U.Type_error _ -> None in
-  let get_int key = try Some (arguments |> U.member key |> U.to_int) with U.Type_error _ -> None in
+  let get_string key = Safe_ops.json_string_opt key arguments in
+  let get_float key = Safe_ops.json_float_opt key arguments in
+  let get_int key = Safe_ops.json_int_opt key arguments in
 
   (* Validate and get task_id *)
   let validated_task_id () =

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -63,17 +63,14 @@ let completion_response ~model ~content : string =
     Returns the concatenation of all user messages if multiple exist,
     or the last user message content. *)
 let extract_user_message (messages : Yojson.Safe.t) : string option =
-  let open Yojson.Safe.Util in
-  try
-    let msgs = to_list messages in
-    let user_msgs = List.filter (fun m ->
-      let role = m |> member "role" |> to_string in
-      String.equal role "user"
-    ) msgs in
-    match List.rev user_msgs with
-    | last :: _ -> Some (last |> member "content" |> to_string)
-    | [] -> None
-  with Type_error _ -> None
+  let msgs = match messages with `List items -> items | _ -> [] in
+  let user_msgs = List.filter (fun m ->
+    String.equal (Safe_ops.json_string ~default:"" "role" m) "user"
+  ) msgs in
+  match List.rev user_msgs with
+  | last :: _ ->
+    Safe_ops.json_string_opt "content" last
+  | [] -> None
 
 (** Route to a keeper via Keeper_turn.handle_keeper_msg.
     Constructs the args JSON and context, then extracts the reply. *)
@@ -94,9 +91,10 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
     (* body is JSON with "reply" field *)
     (try
       let json = Yojson.Safe.from_string body in
-      let reply = Yojson.Safe.Util.(json |> member "reply" |> to_string) in
-      Ok reply
-    with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+      match Safe_ops.json_string_opt "reply" json with
+      | Some reply -> Ok reply
+      | None -> Ok body
+    with Yojson.Json_error _ ->
       (* If not JSON, use the body as-is *)
       Ok body)
   else
@@ -125,15 +123,21 @@ let route_cascade ~message ~system_prompt ~max_tokens ~temperature
     and returns an OpenAI-format response. *)
 let handle_chat_completions ~config ~sw ~clock (body : string)
   : Httpun.Status.t * string =
-  let open Yojson.Safe.Util in
   try
     let json = Yojson.Safe.from_string body in
-    let model = json |> member "model" |> to_string in
-    let messages = json |> member "messages" in
-    let max_tokens = json |> member "max_tokens"
-      |> to_int_option |> Option.value ~default:4096 in
-    let temperature = json |> member "temperature"
-      |> to_float_option |> Option.value ~default:0.7 in
+    let model = Safe_ops.json_string ~default:"" "model" json in
+    let messages =
+      match Safe_ops.json_member_opt "messages" json with
+      | Some v -> v
+      | None -> `List []
+    in
+    let max_tokens = Safe_ops.json_int ~default:4096 "max_tokens" json in
+    let temperature = Safe_ops.json_float ~default:0.7 "temperature" json in
+    if model = "" then
+      (`Bad_request,
+       error_response ~status:"invalid_request_error"
+         ~message:"Missing or invalid 'model' field")
+    else
     match extract_user_message messages with
     | None ->
       (`Bad_request,
@@ -159,15 +163,14 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
         (* Build system prompt from system messages *)
         let system_prompt =
           try
-            let msgs = to_list messages in
+            let msgs = match messages with `List items -> items | _ -> [] in
             let sys_msgs = List.filter_map (fun m ->
-              let role = m |> member "role" |> to_string in
-              if String.equal role "system" then
-                Some (m |> member "content" |> to_string)
+              if String.equal (Safe_ops.json_string ~default:"" "role" m) "system" then
+                Safe_ops.json_string_opt "content" m
               else None
             ) msgs in
             String.concat "\n" sys_msgs
-          with Yojson.Safe.Util.Type_error _ | Failure _ -> ""
+          with Failure _ -> ""
         in
         match route_cascade ~message:user_message ~system_prompt
                 ~max_tokens ~temperature with
@@ -183,7 +186,3 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
     (`Bad_request,
      error_response ~status:"invalid_request_error"
        ~message:(Printf.sprintf "Invalid JSON: %s" e))
-  | Type_error (e, _) ->
-    (`Bad_request,
-     error_response ~status:"invalid_request_error"
-       ~message:(Printf.sprintf "Invalid request format: %s" e))

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -36,15 +36,11 @@ let handle_a2a_delegate ctx args =
   let task_type_str = get_string args "task_type" "async" in
   let timeout = get_int args "timeout" 300 in
   let artifacts =
-    try match Yojson.Safe.Util.member "artifacts" args with
-      | `Null -> []
-      | `List items ->
-          List.filter_map (fun item ->
-            match A2a_tools.artifact_of_yojson item with
-            | Ok a -> Some a
-            | Error _ -> None) items
-      | _ -> []
-    with Yojson.Safe.Util.Type_error _ -> []
+    Safe_ops.json_list "artifacts" args
+    |> List.filter_map (fun item ->
+         match A2a_tools.artifact_of_yojson item with
+         | Ok a -> Some a
+         | Error _ -> None)
   in
   match A2a_tools.delegate ctx.config ~agent_name:delegate_agent_name ~target ~message
            ~task_type_str ~artifacts ~timeout () with
@@ -54,10 +50,7 @@ let handle_a2a_delegate ctx args =
 let handle_a2a_subscribe _ctx args =
   let agent_filter = get_string_opt args "agent_name" in
   let events =
-    try match Yojson.Safe.Util.member "events" args with
-      | `List items -> List.filter_map (function `String s -> Some s | _ -> None) items
-      | _ -> []
-    with Yojson.Safe.Util.Type_error _ -> []
+    Safe_ops.json_string_list "events" args
   in
   (try
     match A2a_tools.subscribe ?agent_filter ~events () with
@@ -93,18 +86,11 @@ let handle_heartbeat_result _ctx args =
   let summary = get_string args "summary" "" in
   let tool_call_count = get_int args "tool_call_count" 0 in
   let tool_names =
-    try match Yojson.Safe.Util.member "tool_names" args with
-      | `List items -> List.filter_map (function `String s -> Some s | _ -> None) items
-      | _ -> []
-    with Yojson.Safe.Util.Type_error _ -> []
+    Safe_ops.json_string_list "tool_names" args
   in
   let decision_reason = get_string args "decision_reason" "" in
   let decision_confidence =
-    try match Yojson.Safe.Util.member "decision_confidence" args with
-      | `Float f -> f
-      | `Int n -> float_of_int n
-      | _ -> -1.0
-    with Yojson.Safe.Util.Type_error _ -> -1.0
+    Safe_ops.json_float ~default:(-1.0) "decision_confidence" args
   in
   let failure_reason = get_string_opt args "failure_reason" in
   if worker_name = "" || agent = "" || status = "" || summary = "" || decision_reason = "" then

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -61,29 +61,18 @@ let type_name_of (value : Yojson.Safe.t) : string =
     @param args The actual arguments passed to the tool call *)
 let validate ~(tool_name : string) ~(schema : Yojson.Safe.t)
     ~(args : Yojson.Safe.t) : (unit, string) result =
-  let open Yojson.Safe.Util in
   (* Only validate object-type schemas *)
   let schema_type =
-    try schema |> member "type" |> to_string
-    with Type_error _ -> "object"
+    Safe_ops.json_string ~default:"object" "type" schema
   in
   if schema_type <> "object" then Ok ()
   else
     (* Extract properties and required list from schema *)
     let properties =
-      try
-        match schema |> member "properties" with
-        | `Assoc props -> props
-        | _ -> []
-      with Type_error _ -> []
+      Safe_ops.json_assoc "properties" schema
     in
     let required =
-      try
-        match schema |> member "required" with
-        | `List items ->
-          List.filter_map (function `String s -> Some s | _ -> None) items
-        | _ -> []
-      with Type_error _ -> []
+      Safe_ops.json_string_list "required" schema
     in
     let arg_fields =
       match args with
@@ -108,11 +97,7 @@ let validate ~(tool_name : string) ~(schema : Yojson.Safe.t)
           | None -> None  (* Extra fields allowed — open schema *)
           | Some prop_schema ->
             let expected_type =
-              try
-                match prop_schema |> member "type" with
-                | `String t -> Some t
-                | _ -> None
-              with Type_error _ -> None
+              Safe_ops.json_string_opt "type" prop_schema
             in
             (match expected_type with
              | None -> None  (* No type declared — skip *)


### PR DESCRIPTION
## Summary

- Convert 15 Type_error exception-based JSON extraction sites to Safe_ops pattern-match helpers
- 4 files: tool_input_validation, tool_a2a, progress, server_openai_compat
- Reduces total Type_error count from 132 to 116 (-12%)
- Net -31 lines (50 insertions, 81 deletions)

## Why

Yojson.Safe.Util.member raises Type_error on non-Assoc inputs. In Eio fiber context, uncaught exceptions kill the fiber. Safe_ops helpers use pattern matching, returning defaults safely.

## Test plan

- [x] dune build lib/ test/ passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)