### PR TITLE
refactor(dashboard): coalesce room-truth fetches via FetchScheduler

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -6,7 +6,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { route, initRouter } from './router'
 import { connectSSE, disconnectSSE } from './sse'
-import { refreshRoomTruth } from './room-truth-store'
+import { requestRoomTruthNow, disposeRoomTruthScheduler } from './room-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForRoute } from './tab-refresh'
 import { refreshMissionSnapshot } from './mission-store'
@@ -36,7 +36,7 @@ export function App() {
     // Prime the lightweight shell status first so build/version metadata lands
     // while room-truth warms heavier execution/command projections.
     void refreshShell()
-    void refreshRoomTruth()
+    requestRoomTruthNow()
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.
@@ -52,6 +52,7 @@ export function App() {
       disconnectSSE()
       unsubSSE()
       stopPeriodicRefresh()
+      disposeRoomTruthScheduler()
     }
   }, [])
 

--- a/dashboard/src/lib/fetch-scheduler.test.ts
+++ b/dashboard/src/lib/fetch-scheduler.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FetchScheduler } from './fetch-scheduler'
+
+describe('FetchScheduler', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('debounces rapid requests into a single fetch', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 300 })
+
+    scheduler.request()
+    scheduler.request()
+    scheduler.request()
+
+    expect(fetchFn).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('enforces cooldown between fetches', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 100 })
+
+    scheduler.requestNow()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // Request right after — should be delayed by cooldown, not debounce
+    scheduler.request()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(fetchFn).toHaveBeenCalledTimes(1) // debounce expired but cooldown blocks
+
+    await vi.advanceTimersByTimeAsync(1900)
+    expect(fetchFn).toHaveBeenCalledTimes(2) // cooldown expired
+  })
+
+  it('requestNow() fires immediately without debounce', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 300 })
+
+    scheduler.requestNow()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates during inflight — urgent pending triggers immediate re-fetch', async () => {
+    let resolveFn!: () => void
+    const fetchFn = vi.fn().mockImplementation(
+      () => new Promise<void>(r => { resolveFn = r }),
+    )
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 100 })
+
+    scheduler.requestNow()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // Multiple requests absorbed during inflight
+    scheduler.request()
+    scheduler.request()
+    scheduler.requestNow() // upgrades to urgent
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // Complete the inflight fetch
+    resolveFn()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Urgent pending → immediate re-fetch (no debounce/cooldown)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates during inflight — normal pending schedules cooldown-gated fetch', async () => {
+    let resolveFn!: () => void
+    const fetchFn = vi.fn().mockImplementation(
+      () => new Promise<void>(r => { resolveFn = r }),
+    )
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 500, debounceMs: 100 })
+
+    scheduler.requestNow()
+    scheduler.request() // normal priority during inflight
+
+    resolveFn()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1) // not yet — cooldown
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(fetchFn).toHaveBeenCalledTimes(2) // cooldown expired
+  })
+
+  it('no re-fetch when nothing is pending after inflight completes', async () => {
+    let resolveFn!: () => void
+    const fetchFn = vi.fn().mockImplementation(
+      () => new Promise<void>(r => { resolveFn = r }),
+    )
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 500, debounceMs: 100 })
+
+    scheduler.requestNow()
+    resolveFn()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // Wait well past cooldown — no extra fetch
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispose cancels pending timers', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 300 })
+
+    scheduler.request()
+    scheduler.dispose()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('recovers after fetch error — scheduler keeps working', async () => {
+    const fetchFn = vi.fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 100, debounceMs: 50 })
+
+    scheduler.requestNow()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Scheduler still functional after error
+    await vi.advanceTimersByTimeAsync(100)
+    scheduler.requestNow()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('fetching getter reflects inflight state', async () => {
+    let resolveFn!: () => void
+    const fetchFn = vi.fn().mockImplementation(
+      () => new Promise<void>(r => { resolveFn = r }),
+    )
+    const scheduler = new FetchScheduler(fetchFn)
+
+    expect(scheduler.fetching).toBe(false)
+
+    scheduler.requestNow()
+    expect(scheduler.fetching).toBe(true)
+
+    resolveFn()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(scheduler.fetching).toBe(false)
+  })
+
+  it('inflightPromise is accessible for await-based callers', async () => {
+    let resolveFn!: () => void
+    const fetchFn = vi.fn().mockImplementation(
+      () => new Promise<void>(r => { resolveFn = r }),
+    )
+    const scheduler = new FetchScheduler(fetchFn)
+
+    expect(scheduler.inflightPromise).toBeNull()
+
+    scheduler.requestNow()
+    expect(scheduler.inflightPromise).not.toBeNull()
+
+    resolveFn()
+    await scheduler.inflightPromise
+    // After microtask drain, should be null
+    await vi.advanceTimersByTimeAsync(0)
+    expect(scheduler.inflightPromise).toBeNull()
+  })
+
+  it('does not double-schedule when request() is called multiple times before timer fires', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(undefined)
+    const scheduler = new FetchScheduler(fetchFn, { cooldownMs: 2000, debounceMs: 300 })
+
+    scheduler.request()
+    scheduler.request()
+    scheduler.request()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // No extra fetches
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/lib/fetch-scheduler.ts
+++ b/dashboard/src/lib/fetch-scheduler.ts
@@ -1,0 +1,156 @@
+/**
+ * FetchScheduler — coalesces multiple refresh requests into minimal fetches.
+ *
+ * Pattern: write-back cache flush (same principle as OS page cache).
+ * - Multiple callers mark data as stale via request() / requestNow()
+ * - Scheduler debounces, enforces cooldown, deduplicates inflight requests
+ * - At most one fetch is in flight at any time
+ *
+ * Comparable to: TanStack Query deduplication, SWR dedupingInterval,
+ *                Elm single-update-channel, RTK Query cache invalidation.
+ */
+
+type FetchFn = () => Promise<void>
+type Priority = 'none' | 'normal' | 'urgent'
+
+export interface FetchSchedulerConfig {
+  /** Minimum ms between consecutive fetches. Prevents burst after rapid events. */
+  cooldownMs: number
+  /** Trailing-edge debounce window. Batches rapid invalidations into one fetch. */
+  debounceMs: number
+}
+
+const DEFAULT_CONFIG: FetchSchedulerConfig = {
+  cooldownMs: 2_000,
+  debounceMs: 300,
+}
+
+export class FetchScheduler {
+  private readonly fetchFn: FetchFn
+  private readonly config: FetchSchedulerConfig
+
+  private inflight: Promise<void> | null = null
+  private lastFetchAt = 0
+  private pendingPriority: Priority = 'none'
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null
+  private cooldownTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(fetchFn: FetchFn, config?: Partial<FetchSchedulerConfig>) {
+    this.fetchFn = fetchFn
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  /**
+   * Request a refresh. Debounced and cooldown-enforced.
+   * Multiple rapid calls collapse into a single fetch.
+   */
+  request(): void {
+    if (this.inflight) {
+      this.raisePriority('normal')
+      return
+    }
+    this.raisePriority('normal')
+    this.scheduleFlush()
+  }
+
+  /**
+   * Request an immediate refresh. Skips debounce window, but still
+   * deduplicates with any inflight request — sets urgent dirty flag
+   * so a re-fetch fires as soon as the current one completes.
+   */
+  requestNow(): void {
+    if (this.inflight) {
+      this.raisePriority('urgent')
+      return
+    }
+    this.clearTimers()
+    this.pendingPriority = 'none'
+    void this.doFetch()
+  }
+
+  /** Cancel all pending timers. Does not abort inflight requests. */
+  dispose(): void {
+    this.clearTimers()
+    this.pendingPriority = 'none'
+  }
+
+  /** Whether a fetch is currently in progress. */
+  get fetching(): boolean {
+    return this.inflight !== null
+  }
+
+  /**
+   * Expose inflight promise for callers that need to await current fetch.
+   * Returns null when idle.
+   */
+  get inflightPromise(): Promise<void> | null {
+    return this.inflight
+  }
+
+  private raisePriority(p: Priority): void {
+    const rank: Record<Priority, number> = { none: 0, normal: 1, urgent: 2 }
+    if (rank[p] > rank[this.pendingPriority]) {
+      this.pendingPriority = p
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.debounceTimer || this.cooldownTimer) return
+
+    const elapsed = Date.now() - this.lastFetchAt
+    const cooldownRemaining = this.config.cooldownMs - elapsed
+
+    if (cooldownRemaining <= 0) {
+      // Past cooldown — use debounce to batch rapid requests
+      this.debounceTimer = setTimeout(() => {
+        this.debounceTimer = null
+        this.pendingPriority = 'none'
+        void this.doFetch()
+      }, this.config.debounceMs)
+    } else {
+      // Within cooldown — schedule at cooldown expiry
+      this.cooldownTimer = setTimeout(() => {
+        this.cooldownTimer = null
+        this.pendingPriority = 'none'
+        void this.doFetch()
+      }, cooldownRemaining)
+    }
+  }
+
+  private async doFetch(): Promise<void> {
+    this.inflight = this.fetchFn()
+    try {
+      await this.inflight
+    } catch {
+      // Error handling is the fetchFn's responsibility (signals, retries, etc.).
+      // Scheduler only manages timing.
+    } finally {
+      this.lastFetchAt = Date.now()
+      this.inflight = null
+      this.drainPending()
+    }
+  }
+
+  /** After a fetch completes, decide what to do with accumulated requests. */
+  private drainPending(): void {
+    const priority = this.pendingPriority
+    this.pendingPriority = 'none'
+
+    if (priority === 'urgent') {
+      void this.doFetch()
+    } else if (priority === 'normal') {
+      this.scheduleFlush()
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+      this.debounceTimer = null
+    }
+    if (this.cooldownTimer) {
+      clearTimeout(this.cooldownTimer)
+      this.cooldownTimer = null
+    }
+  }
+}

--- a/dashboard/src/room-truth-actions.ts
+++ b/dashboard/src/room-truth-actions.ts
@@ -9,68 +9,106 @@ import {
 } from './room-truth-signals'
 import { normalizeRoomTruth } from './room-truth-normalizers'
 import { mergeServerStatus } from './store-normalizers'
+import { FetchScheduler } from './lib/fetch-scheduler'
 
-let inflightRoomTruthRefresh: Promise<void> | null = null
-let lastRoomTruthRefreshAt = 0
-const ROOM_TRUTH_TTL_MS = 60_000
+// --- Warm-up retry state ---
 
 const WARM_RETRY_DELAY_MS = 3_000
 const WARM_MAX_RETRIES = 10
+let warmRetryAttempt = 0
+let warmRetryTimer: ReturnType<typeof setTimeout> | null = null
 
-export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void> {
-  if (inflightRoomTruthRefresh) return inflightRoomTruthRefresh
-  if (!opts?.force && Date.now() - lastRoomTruthRefreshAt < ROOM_TRUTH_TTL_MS) return
+// --- Core fetch function (owns signal updates) ---
 
+async function doFetchRoomTruth(): Promise<void> {
   roomTruthLoading.value = true
   roomTruthError.value = null
-  inflightRoomTruthRefresh = (async () => {
-    try {
-      const raw = await fetchDashboardRoomTruth()
-      const isInitializing =
-        isRecord(raw)
-        && asString((raw as Record<string, unknown>).status) === 'initializing'
-      if (isInitializing) {
-        console.debug('[room-truth] server initializing, scheduling warm-up retry')
-        roomTruthInitializing.value = true
-        scheduleWarmRetry(1)
-        return
-      }
-      roomTruthInitializing.value = false
-      const normalized = normalizeRoomTruth(raw)
-      roomTruth.value = normalized
-      serverStatus.value = mergeServerStatus(
-        serverStatus.value,
-        normalized.room.status ?? null,
-      )
-      lastRoomTruthRefreshAt = Date.now()
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : 'Failed to load room truth'
-      console.warn('[room-truth] fetch failed:', detail)
-      roomTruthError.value = detail
-    } finally {
-      roomTruthLoading.value = false
-      inflightRoomTruthRefresh = null
+  try {
+    const raw = await fetchDashboardRoomTruth()
+    const isInitializing =
+      isRecord(raw)
+      && asString((raw as Record<string, unknown>).status) === 'initializing'
+    if (isInitializing) {
+      console.debug('[room-truth] server initializing, scheduling warm-up retry')
+      roomTruthInitializing.value = true
+      scheduleWarmRetry()
+      return
     }
-  })()
-
-  return inflightRoomTruthRefresh
+    roomTruthInitializing.value = false
+    warmRetryAttempt = 0
+    const normalized = normalizeRoomTruth(raw)
+    roomTruth.value = normalized
+    serverStatus.value = mergeServerStatus(
+      serverStatus.value,
+      normalized.room.status ?? null,
+    )
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'Failed to load room truth'
+    console.warn('[room-truth] fetch failed:', detail)
+    roomTruthError.value = detail
+  } finally {
+    roomTruthLoading.value = false
+  }
 }
 
-function scheduleWarmRetry(attempt: number): void {
-  console.debug(`[room-truth] warm-up retry ${attempt}/${WARM_MAX_RETRIES}`)
-  if (attempt > WARM_MAX_RETRIES) {
+function scheduleWarmRetry(): void {
+  warmRetryAttempt++
+  console.debug(`[room-truth] warm-up retry ${warmRetryAttempt}/${WARM_MAX_RETRIES}`)
+  if (warmRetryAttempt > WARM_MAX_RETRIES) {
     roomTruthInitializing.value = false
     roomTruthError.value = 'Server warm-up timed out. Try refreshing.'
     roomTruthLoading.value = false
-    inflightRoomTruthRefresh = null
+    warmRetryAttempt = 0
     return
   }
-  window.setTimeout(() => {
-    inflightRoomTruthRefresh = null
-    void refreshRoomTruth().then(() => {
-      if (roomTruthInitializing.value) {
-        scheduleWarmRetry(attempt + 1)
-      }
-    })
+  if (warmRetryTimer) clearTimeout(warmRetryTimer)
+  warmRetryTimer = setTimeout(() => {
+    warmRetryTimer = null
+    roomTruthScheduler.requestNow()
   }, WARM_RETRY_DELAY_MS)
+}
+
+// --- Scheduler instance ---
+
+export const roomTruthScheduler = new FetchScheduler(doFetchRoomTruth, {
+  cooldownMs: 2_000,
+  debounceMs: 300,
+})
+
+// --- Public API ---
+
+/** Request a room-truth refresh (debounced, cooldown-enforced). */
+export function requestRoomTruth(): void {
+  roomTruthScheduler.request()
+}
+
+/** Request an immediate room-truth refresh (deduped with inflight). */
+export function requestRoomTruthNow(): void {
+  roomTruthScheduler.requestNow()
+}
+
+/**
+ * Backward-compatible wrapper. Prefer requestRoomTruth() / requestRoomTruthNow().
+ *
+ * When opts.force is true, delegates to requestNow() and returns a promise
+ * that resolves when the inflight fetch completes (for callers that await).
+ */
+export async function refreshRoomTruth(opts?: { force?: boolean }): Promise<void> {
+  if (opts?.force) {
+    requestRoomTruthNow()
+  } else {
+    requestRoomTruth()
+  }
+  if (roomTruthScheduler.inflightPromise) {
+    await roomTruthScheduler.inflightPromise
+  }
+}
+
+export function disposeRoomTruthScheduler(): void {
+  if (warmRetryTimer) {
+    clearTimeout(warmRetryTimer)
+    warmRetryTimer = null
+  }
+  warmRetryAttempt = 0
+  roomTruthScheduler.dispose()
 }

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -7,4 +7,4 @@ export {
   roomTruthInitializing,
 } from './room-truth-signals'
 export { normalizeRoomTruth } from './room-truth-normalizers'
-export { refreshRoomTruth } from './room-truth-actions'
+export { refreshRoomTruth, requestRoomTruth, requestRoomTruthNow, disposeRoomTruthScheduler } from './room-truth-actions'

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -14,7 +14,7 @@ import {
   refreshBoard,
   refreshMdal,
 } from './store'
-import { refreshRoomTruth } from './room-truth-store'
+import { requestRoomTruth, requestRoomTruthNow, roomTruthError } from './room-truth-store'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
 import { route } from './router'
@@ -171,7 +171,7 @@ function handleDashboardRefresh(): void {
   invalidateDashboardCache()
   if (!_fetchDebounce) {
     _fetchDebounce = setTimeout(() => {
-      void refreshRoomTruth({ force: true })
+      requestRoomTruthNow()
       void refreshActiveRoute()
       _fetchDebounce = null
     }, SSE_DEFAULT_DEBOUNCE_MS)
@@ -217,21 +217,21 @@ function handleReconnect(): void {
   void hydrateAfterReconnect()
 }
 
-async function hydrateAfterReconnect(): Promise<void> {
-  try {
-    await refreshRoomTruth({ force: true })
-    await refreshActiveRoute()
-  } catch (err) {
-    console.warn('[SSE] reconnect hydration failed, retrying in 3s', err instanceof Error ? err.message : err)
-    setTimeout(() => {
-      void refreshRoomTruth({ force: true }).catch(retryErr =>
-        console.warn('[SSE] reconnect room-truth retry failed', retryErr instanceof Error ? retryErr.message : retryErr),
-      )
-      void refreshActiveRoute().catch(retryErr =>
-        console.warn('[SSE] reconnect route retry failed', retryErr instanceof Error ? retryErr.message : retryErr),
-      )
-    }, SSE_RECONNECT_RETRY_MS)
-  }
+function hydrateAfterReconnect(): void {
+  requestRoomTruthNow()
+  void refreshActiveRoute().catch(err =>
+    console.warn('[SSE] reconnect route refresh failed', err instanceof Error ? err.message : err),
+  )
+  // Safety-net retry: if room-truth fetch failed (e.g. server warm-up),
+  // the scheduler's error signal will be set. Retry once after delay.
+  setTimeout(() => {
+    if (roomTruthError.value) {
+      requestRoomTruthNow()
+    }
+    void refreshActiveRoute().catch(retryErr =>
+      console.warn('[SSE] reconnect route retry failed', retryErr instanceof Error ? retryErr.message : retryErr),
+    )
+  }, SSE_RECONNECT_RETRY_MS)
 }
 
 // --- SSE reaction setup ---
@@ -319,9 +319,7 @@ export function startPeriodicRefresh(): void {
     if (!connected.value) {
       invalidateDashboardCache()
     }
-    void refreshRoomTruth().catch(err =>
-      console.warn('[periodic] room-truth refresh failed', err instanceof Error ? err.message : err),
-    )
+    requestRoomTruth()
     void refreshActiveRoute().catch(err =>
       console.warn('[periodic] route refresh failed', err instanceof Error ? err.message : err),
     )

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -1,6 +1,6 @@
 import type { RouteState } from './types'
 import { refreshExecution, refreshBoard, refreshGoals } from './store'
-import { refreshRoomTruth } from './room-truth-store'
+import { requestRoomTruth } from './room-truth-store'
 import { refreshOperatorRoomDigest, refreshOperatorSnapshot } from './operator-store'
 import { refreshMissionSnapshot } from './mission-store'
 import {
@@ -102,7 +102,7 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
 }
 
 const REFRESHERS: Record<RefreshTask, () => void> = {
-  roomTruth: () => { void refreshRoomTruth() },
+  roomTruth: () => { requestRoomTruth() },
   missionSnapshot: () => { void refreshMissionSnapshot() },
   execution: () => { void refreshExecution({ force: true }) },
   activityGraph: () => { void refreshActivityGraphSurface() },


### PR DESCRIPTION
## Summary
- 5개 독립 트리거(SSE event, reconnect, periodic timer, tab change, app init)가 각자 `refreshRoomTruth()`를 직접 호출하여 동일 초에 10-12개 중복 HTTP 요청 발생
- `FetchScheduler` 도입 (write-back cache flush 패턴): inflight dedup + 2s cooldown + 300ms trailing-edge debounce
- 모든 caller를 `requestRoomTruth()` / `requestRoomTruthNow()`로 전환, backward-compat wrapper 유지

## Changes
| 파일 | 변경 |
|------|------|
| `lib/fetch-scheduler.ts` | 범용 FetchScheduler 클래스 (신규) |
| `lib/fetch-scheduler.test.ts` | 11개 단위 테스트 (신규) |
| `room-truth-actions.ts` | 수동 inflight guard + 60s TTL → FetchScheduler 위임 |
| `room-truth-store.ts` | 새 API export 추가 |
| `sse-store.ts` | `refreshRoomTruth({ force })` → `requestRoomTruthNow()`, reconnect를 signal 기반 재시도로 전환 |
| `tab-refresh.ts` / `app.ts` | caller 전환 + cleanup 추가 |

## Before / After
```
Before:  동일 초 12+ HTTP 요청 (각 트리거가 독립 fetch)
After:   최대 1-2회/2초 (cooldown + debounce + inflight dedup)
```

## Test plan
- [x] FetchScheduler 단위 테스트 11/11 통과
- [x] 기존 room-truth-store 테스트 통과 (backward compat)
- [x] tab-refresh, runtime-counts 테스트 통과
- [ ] 실서버에서 SSE reconnect 시 room-truth fetch 로그 빈도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)