### PR TITLE
[codex] isolate startup takeover probe and reclaim path

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -62,6 +62,7 @@ module Server_h2_gateway = Masc_mcp.Server_h2_gateway
 module Server_runtime_bootstrap = Masc_mcp.Server_runtime_bootstrap
 module Server_routes_http_runtime = Masc_mcp.Server_routes_http_runtime
 module Server_openai_compat = Masc_mcp.Server_openai_compat
+module Server_startup_takeover = Masc_mcp.Server_startup_takeover
 
 let mcp_protocol_versions = Server_mcp_transport_http.mcp_protocol_versions
 
@@ -264,70 +265,15 @@ let base_path =
 (* Shutdown exception removed: graceful shutdown returns normally from
    await_shutdown_signal, letting Eio.Fiber.first cancel run_server. *)
 
-let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
-
-let is_server_responsive port =
-  try
-    let url = Printf.sprintf "http://127.0.0.1:%d/health/live" port in
-    let cmd = Printf.sprintf "curl -s --max-time 3 -o /dev/null -w '%%{http_code}' %s" url in
-    let ic = Unix.open_process_in cmd in
-    let code = In_channel.input_all ic |> String.trim in
-    let _ = Unix.close_process_in ic in
-    code = "200"
-  with _ -> false
-
 let acquire_pid_lock port =
-  let path = pid_lock_path port in
-  (let contents =
-     try
-       let ic = open_in path in
-       let s = In_channel.input_all ic in
-       close_in ic; Some s
-     with _ -> None
-   in
-   match contents with
-   | Some data ->
-     let pid_str = String.trim data in
-     (match int_of_string_opt pid_str with
-      | Some pid ->
-        (try Unix.kill pid 0;
-           (* Process exists — check if it is actually responsive *)
-           if is_server_responsive port then begin
-             Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
-               (Printf.sprintf
-                  "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
-                  pid port pid);
-             exit 1
-           end else begin
-             (* Process alive but unresponsive (e.g. FD exhaustion) — kill and take over *)
-             Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
-               (Printf.sprintf
-                  "[WARN] PID %d alive but unresponsive on port %d; sending SIGTERM to reclaim"
-                  pid port);
-             (try Unix.kill pid Sys.sigterm with _ -> ());
-             Unix.sleepf 1.0;
-             (* If still alive after SIGTERM, force kill *)
-             (try
-                Unix.kill pid 0;
-                Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
-                  (Printf.sprintf "[WARN] PID %d did not exit; sending SIGKILL" pid);
-                (try Unix.kill pid Sys.sigkill with _ -> ());
-                Unix.sleepf 0.5
-              with Unix.Unix_error (Unix.ESRCH, _, _) -> ())
-           end
-         with Unix.Unix_error (Unix.ESRCH, _, _) ->
-           Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
-             (Printf.sprintf
-                "[WARN] Removing stale PID file (PID %d no longer running)"
-                pid))
-      | None ->
-        Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
-          "[WARN] Invalid PID file contents, overwriting")
-   | None -> ());
-  let oc = open_out path in
-  Printf.fprintf oc "%d\n" (Unix.getpid ());
-  close_out oc;
-  at_exit (fun () -> try Sys.remove path with _ -> ())
+  match Server_startup_takeover.acquire_pid_lock port with
+  | Server_startup_takeover.Acquired -> ()
+  | Server_startup_takeover.Already_running { pid } ->
+      Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+        (Printf.sprintf
+           "[FATAL] Another MASC server (PID %d) is already running on port %d. Kill it first: kill %d"
+           pid port pid);
+      exit 1
 
 let run_cmd host port base_path =
   acquire_pid_lock port;

--- a/lib/dune
+++ b/lib/dune
@@ -118,6 +118,7 @@
    server_bootstrap_loops
    server_runtime_bootstrap
    server_startup_state
+   server_startup_takeover
    server_command_plane_http
    server_command_plane_http_support
    server_command_plane_http_stream

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -51,6 +51,45 @@ let status_line_from_buffer buf =
   | Some idx ->
       Some (String.sub contents 0 idx |> String.trim)
 
+let status_line_is_healthy line =
+  let parts =
+    String.split_on_char ' ' line
+    |> List.filter (fun value -> String.trim value <> "")
+  in
+  match parts with
+  | version :: code :: _ ->
+      (String.equal version "HTTP/1.1" || String.equal version "HTTP/1.0")
+      && String.equal code "200"
+  | _ -> false
+
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  needle_len > 0 && loop 0
+
+let looks_like_server_command command =
+  List.exists
+    (fun marker -> contains_substring ~needle:marker command)
+    [ "main_eio"; "masc-mcp" ]
+
+let process_command pid =
+  match
+    Process_eio.run_argv_with_status ~timeout_sec:1.0
+      [ "ps"; "-p"; string_of_int pid; "-o"; "command=" ]
+  with
+  | Unix.WEXITED 0, output -> (
+      let trimmed = String.trim output in
+      if trimmed = "" then None else Some trimmed)
+  | _ -> None
+
 let read_status_line fd ~timeout_sec =
   let deadline = Unix.gettimeofday () +. max 0.0 timeout_sec in
   let scratch = Bytes.create 256 in
@@ -91,9 +130,7 @@ let probe_liveness ?(timeout_sec = 3.0) ?(path = "/health/live") port =
         in
         write_all socket request 0 (String.length request);
         match read_status_line socket ~timeout_sec with
-        | Some line ->
-            String.starts_with ~prefix:"HTTP/1.1 200" line
-            || String.starts_with ~prefix:"HTTP/1.0 200" line
+        | Some line -> status_line_is_healthy line
         | None -> false)
   with _ -> false
 
@@ -144,6 +181,17 @@ let acquire_pid_lock
           if pid_exists pid then
             if probe_liveness ~timeout_sec:probe_timeout_sec port then
               Already_running { pid }
+            else if (
+              match process_command pid with
+              | Some command -> not (looks_like_server_command command)
+              | None -> true)
+            then begin
+              Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+                (Printf.sprintf
+                   "[FATAL] PID %d is alive but does not look like a masc-mcp server; refusing takeover"
+                   pid);
+              Already_running { pid }
+            end
             else begin
               Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
                 (Printf.sprintf

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -1,0 +1,188 @@
+type acquire_result =
+  | Acquired
+  | Already_running of { pid : int }
+
+let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
+
+let close_quietly fd =
+  try Unix.close fd with
+  | Unix.Unix_error _ -> ()
+
+let pid_exists pid =
+  try
+    Unix.kill pid 0;
+    true
+  with
+  | Unix.Unix_error (Unix.ESRCH, _, _) -> false
+  | Unix.Unix_error (Unix.EPERM, _, _) -> true
+
+let sleep_poll seconds =
+  if seconds > 0.0 then
+    ignore (Unix.select [] [] [] seconds)
+
+let wait_for_pid_exit ?(poll_interval_sec = 0.1) ~timeout_sec pid =
+  let deadline = Unix.gettimeofday () +. max 0.0 timeout_sec in
+  let rec loop () =
+    if not (pid_exists pid) then
+      true
+    else
+      let remaining = deadline -. Unix.gettimeofday () in
+      if remaining <= 0.0 then
+        false
+      else begin
+        sleep_poll (Float.min poll_interval_sec remaining);
+        loop ()
+      end
+  in
+  loop ()
+
+let rec write_all fd payload off len =
+  if len > 0 then
+    let written = Unix.write_substring fd payload off len in
+    if written = 0 then
+      raise End_of_file
+    else
+      write_all fd payload (off + written) (len - written)
+
+let status_line_from_buffer buf =
+  let contents = Buffer.contents buf in
+  match String.index_opt contents '\n' with
+  | None -> None
+  | Some idx ->
+      Some (String.sub contents 0 idx |> String.trim)
+
+let read_status_line fd ~timeout_sec =
+  let deadline = Unix.gettimeofday () +. max 0.0 timeout_sec in
+  let scratch = Bytes.create 256 in
+  let buf = Buffer.create 128 in
+  let rec loop () =
+    match status_line_from_buffer buf with
+    | Some line -> Some line
+    | None ->
+        let remaining = deadline -. Unix.gettimeofday () in
+        if remaining <= 0.0 then
+          None
+        else
+          let readable, _, _ = Unix.select [ fd ] [] [] remaining in
+          if readable = [] then
+            None
+          else
+            match Unix.read fd scratch 0 (Bytes.length scratch) with
+            | 0 -> status_line_from_buffer buf
+            | count ->
+                Buffer.add_subbytes buf scratch 0 count;
+                loop ()
+  in
+  loop ()
+
+let probe_liveness ?(timeout_sec = 3.0) ?(path = "/health/live") port =
+  try
+    let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    Fun.protect
+      ~finally:(fun () -> close_quietly socket)
+      (fun () ->
+        (* Keep the startup probe in-process so takeover logic does not depend on
+           shelling out to curl before the Eio runtime is initialized. *)
+        Unix.connect socket (Unix.ADDR_INET (Unix.inet_addr_loopback, port));
+        let request =
+          Printf.sprintf
+            "GET %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nConnection: close\r\n\r\n"
+            path port
+        in
+        write_all socket request 0 (String.length request);
+        match read_status_line socket ~timeout_sec with
+        | Some line ->
+            String.starts_with ~prefix:"HTTP/1.1 200" line
+            || String.starts_with ~prefix:"HTTP/1.0 200" line
+        | None -> false)
+  with _ -> false
+
+let read_pid_file path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> Some (In_channel.input_all ic))
+  with _ -> None
+
+let parsed_pid path =
+  match read_pid_file path with
+  | Some data -> (
+      match String.trim data |> int_of_string_opt with
+      | Some pid when pid > 0 -> Some pid
+      | _ -> None)
+  | None -> None
+
+let register_pid_cleanup ~path ~pid =
+  at_exit (fun () ->
+      match parsed_pid path with
+      | Some current when current = pid -> (try Sys.remove path with _ -> ())
+      | _ -> ())
+
+let write_pid_file path pid =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> Printf.fprintf oc "%d\n" pid)
+
+let acquire_pid_lock
+    ?lock_path
+    ?(probe_timeout_sec = 3.0)
+    ?(term_timeout_sec = 1.0)
+    ?(kill_wait_sec = 0.5)
+    ?(poll_interval_sec = 0.1)
+    port =
+  let path =
+    match lock_path with
+    | Some value -> value
+    | None -> pid_lock_path port
+  in
+  (match read_pid_file path with
+  | Some data -> (
+      match String.trim data |> int_of_string_opt with
+      | Some pid when pid > 0 ->
+          if pid_exists pid then
+            if probe_liveness ~timeout_sec:probe_timeout_sec port then
+              Already_running { pid }
+            else begin
+              Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+                (Printf.sprintf
+                   "[WARN] PID %d alive but unresponsive on port %d; sending SIGTERM to reclaim"
+                   pid port);
+              (try Unix.kill pid Sys.sigterm with _ -> ());
+              if not (wait_for_pid_exit ~poll_interval_sec
+                        ~timeout_sec:term_timeout_sec pid)
+              then begin
+                Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+                  (Printf.sprintf
+                     "[WARN] PID %d did not exit; sending SIGKILL" pid);
+                (try Unix.kill pid Sys.sigkill with _ -> ());
+                if not (wait_for_pid_exit ~poll_interval_sec
+                          ~timeout_sec:kill_wait_sec pid)
+                then
+                  Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+                    (Printf.sprintf
+                       "[WARN] PID %d still appears alive after SIGKILL escalation"
+                       pid)
+              end;
+              Acquired
+            end
+          else begin
+            Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+              (Printf.sprintf
+                 "[WARN] Removing stale PID file (PID %d no longer running)"
+                 pid);
+            Acquired
+          end
+      | _ ->
+          Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+            "[WARN] Invalid PID file contents, overwriting";
+          Acquired)
+  | None -> Acquired)
+  |> function
+  | Already_running _ as result -> result
+  | Acquired ->
+      let pid = Unix.getpid () in
+      write_pid_file path pid;
+      register_pid_cleanup ~path ~pid;
+      Acquired

--- a/lib/server/server_startup_takeover.mli
+++ b/lib/server/server_startup_takeover.mli
@@ -4,6 +4,10 @@ type acquire_result =
 
 val pid_lock_path : int -> string
 
+val status_line_is_healthy : string -> bool
+
+val looks_like_server_command : string -> bool
+
 val probe_liveness : ?timeout_sec:float -> ?path:string -> int -> bool
 
 val wait_for_pid_exit :

--- a/lib/server/server_startup_takeover.mli
+++ b/lib/server/server_startup_takeover.mli
@@ -1,0 +1,19 @@
+type acquire_result =
+  | Acquired
+  | Already_running of { pid : int }
+
+val pid_lock_path : int -> string
+
+val probe_liveness : ?timeout_sec:float -> ?path:string -> int -> bool
+
+val wait_for_pid_exit :
+  ?poll_interval_sec:float -> timeout_sec:float -> int -> bool
+
+val acquire_pid_lock :
+  ?lock_path:string ->
+  ?probe_timeout_sec:float ->
+  ?term_timeout_sec:float ->
+  ?kill_wait_sec:float ->
+  ?poll_interval_sec:float ->
+  int ->
+  acquire_result

--- a/test/dune
+++ b/test/dune
@@ -248,6 +248,11 @@
  (libraries masc_mcp alcotest unix eio eio_main))
 
 (test
+ (name test_server_startup_takeover)
+ (modules test_server_startup_takeover)
+ (libraries masc_mcp alcotest unix))
+
+(test
  (name test_harness_shell_helpers)
  (modules test_harness_shell_helpers)
  (libraries alcotest unix))

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -145,6 +145,25 @@ let pid_from_file path =
   | Some pid -> pid
   | None -> Alcotest.failf "invalid pid file contents in %s" path
 
+let test_status_line_parser () =
+  Alcotest.(check bool) "200 ok" true
+    (Server_startup_takeover.status_line_is_healthy "HTTP/1.1 200 OK");
+  Alcotest.(check bool) "2000 rejected" false
+    (Server_startup_takeover.status_line_is_healthy "HTTP/1.1 2000 Weird");
+  Alcotest.(check bool) "503 rejected" false
+    (Server_startup_takeover.status_line_is_healthy "HTTP/1.1 503 Service Unavailable")
+
+let test_server_command_heuristic () =
+  Alcotest.(check bool) "main_eio path accepted" true
+    (Server_startup_takeover.looks_like_server_command
+       "/tmp/_build/default/bin/main_eio.exe --port 8935");
+  Alcotest.(check bool) "public name accepted" true
+    (Server_startup_takeover.looks_like_server_command
+       "/usr/local/bin/masc-mcp --host 127.0.0.1");
+  Alcotest.(check bool) "unrelated process rejected" false
+    (Server_startup_takeover.looks_like_server_command
+       "python3 -m http.server 8935")
+
 let test_rejects_responsive_holder () =
   with_temp_dir "startup-takeover-responsive" (fun dir ->
       with_http_server ~status_code:200 (fun ~pid ~port ->
@@ -205,6 +224,13 @@ let test_escalates_sigkill_for_unresponsive_holder () =
 let () =
   Alcotest.run "Server_startup_takeover"
     [
+      ( "helpers",
+        [
+          Alcotest.test_case "status line parser is exact" `Quick
+            test_status_line_parser;
+          Alcotest.test_case "server command heuristic rejects unrelated processes"
+            `Quick test_server_command_heuristic;
+        ] );
       ( "takeover",
         [
           Alcotest.test_case "responsive holder blocks takeover" `Quick

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -1,0 +1,219 @@
+open Masc_mcp
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let close_quietly fd =
+  try Unix.close fd with
+  | Unix.Unix_error _ -> ()
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> close_quietly socket)
+    (fun () ->
+      (match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
+       | () -> ()
+       | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) ->
+           Alcotest.skip ());
+      match Unix.getsockname socket with
+      | Unix.ADDR_INET (_, port) -> port
+      | _ -> Alcotest.fail "unexpected socket address")
+
+let process_alive pid =
+  match Unix.waitpid [ Unix.WNOHANG ] pid with
+  | 0, _ -> true
+  | _ -> false
+  | exception Unix.Unix_error (Unix.ECHILD, _, _) -> false
+
+let rec waitpid_nointr pid =
+  try Some (Unix.waitpid [] pid) with
+  | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_nointr pid
+  | Unix.Unix_error (Unix.ECHILD, _, _) -> None
+
+let wait_until ~timeout_sec f =
+  let deadline = Unix.gettimeofday () +. timeout_sec in
+  let rec loop () =
+    if f () then
+      true
+    else if Unix.gettimeofday () >= deadline then
+      false
+    else begin
+      ignore (Unix.select [] [] [] 0.02);
+      loop ()
+    end
+  in
+  loop ()
+
+let port_accepting port =
+  try
+    let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+    Fun.protect
+      ~finally:(fun () -> close_quietly socket)
+      (fun () ->
+        Unix.connect socket (Unix.ADDR_INET (Unix.inet_addr_loopback, port));
+        true)
+  with _ -> false
+
+let rec write_all fd payload off len =
+  if len > 0 then
+    let written = Unix.write_substring fd payload off len in
+    if written = 0 then
+      raise End_of_file
+    else
+      write_all fd payload (off + written) (len - written)
+
+let spawn_http_server ~status_code =
+  let port = find_free_port () in
+  match Unix.fork () with
+  | 0 ->
+      let server = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+      Unix.setsockopt server Unix.SO_REUSEADDR true;
+      Fun.protect
+        ~finally:(fun () ->
+          close_quietly server;
+          Unix._exit 0)
+        (fun () ->
+          Unix.bind server (Unix.ADDR_INET (Unix.inet_addr_loopback, port));
+          Unix.listen server 8;
+          let response =
+            Printf.sprintf
+              "HTTP/1.1 %d Test\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+              status_code
+          in
+          let scratch = Bytes.create 256 in
+          while true do
+            let client, _ = Unix.accept server in
+            ignore (Unix.read client scratch 0 (Bytes.length scratch));
+            write_all client response 0 (String.length response);
+            close_quietly client
+          done)
+  | pid ->
+      if not (wait_until ~timeout_sec:1.0 (fun () -> port_accepting port)) then begin
+        (try Unix.kill pid Sys.sigkill with _ -> ());
+        ignore (waitpid_nointr pid);
+        Alcotest.fail "HTTP test server did not start"
+      end;
+      (pid, port)
+
+let spawn_forever_process ~ignore_sigterm =
+  match Unix.fork () with
+  | 0 ->
+      if ignore_sigterm then
+        Sys.set_signal Sys.sigterm Sys.Signal_ignore;
+      while true do
+        ignore (Unix.select [] [] [] 1.0)
+      done
+  | pid -> pid
+
+let stop_process pid =
+  if process_alive pid then
+    (try Unix.kill pid Sys.sigkill with _ -> ());
+  ignore (waitpid_nointr pid)
+
+let with_http_server ~status_code f =
+  let pid, port = spawn_http_server ~status_code in
+  Fun.protect ~finally:(fun () -> stop_process pid) (fun () -> f ~pid ~port)
+
+let with_forever_process ~ignore_sigterm f =
+  let pid = spawn_forever_process ~ignore_sigterm in
+  Fun.protect ~finally:(fun () -> stop_process pid) (fun () -> f pid)
+
+let lock_path dir =
+  Filename.concat dir "masc.pid"
+
+let pid_from_file path =
+  match read_file path |> String.trim |> int_of_string_opt with
+  | Some pid -> pid
+  | None -> Alcotest.failf "invalid pid file contents in %s" path
+
+let test_rejects_responsive_holder () =
+  with_temp_dir "startup-takeover-responsive" (fun dir ->
+      with_http_server ~status_code:200 (fun ~pid ~port ->
+          let path = lock_path dir in
+          write_file path (Printf.sprintf "%d\n" pid);
+          match Server_startup_takeover.acquire_pid_lock ~lock_path:path port with
+          | Server_startup_takeover.Already_running { pid = running_pid } ->
+              Alcotest.(check int) "pid preserved" pid running_pid;
+              Alcotest.(check bool) "server process stays alive" true
+                (process_alive pid)
+          | Server_startup_takeover.Acquired ->
+              Alcotest.fail "responsive holder should block takeover"))
+
+let test_reclaims_stale_pid_file () =
+  with_temp_dir "startup-takeover-stale" (fun dir ->
+      with_forever_process ~ignore_sigterm:false (fun pid ->
+          stop_process pid;
+          let path = lock_path dir in
+          write_file path (Printf.sprintf "%d\n" pid);
+          let port = find_free_port () in
+          match Server_startup_takeover.acquire_pid_lock ~lock_path:path port with
+          | Server_startup_takeover.Acquired ->
+              Alcotest.(check int) "current pid written" (Unix.getpid ())
+                (pid_from_file path)
+          | Server_startup_takeover.Already_running _ ->
+              Alcotest.fail "stale pid should be reclaimed"))
+
+let test_tolerates_invalid_pid_file () =
+  with_temp_dir "startup-takeover-invalid" (fun dir ->
+      let path = lock_path dir in
+      write_file path "not-a-pid\n";
+      let port = find_free_port () in
+      match Server_startup_takeover.acquire_pid_lock ~lock_path:path port with
+      | Server_startup_takeover.Acquired ->
+          Alcotest.(check int) "current pid written" (Unix.getpid ())
+            (pid_from_file path)
+      | Server_startup_takeover.Already_running _ ->
+          Alcotest.fail "invalid pid file should be overwritten")
+
+let test_escalates_sigkill_for_unresponsive_holder () =
+  with_temp_dir "startup-takeover-unresponsive" (fun dir ->
+      with_forever_process ~ignore_sigterm:true (fun pid ->
+          let path = lock_path dir in
+          write_file path (Printf.sprintf "%d\n" pid);
+          let port = find_free_port () in
+          match
+            Server_startup_takeover.acquire_pid_lock ~lock_path:path
+              ~probe_timeout_sec:0.1 ~term_timeout_sec:0.05 ~kill_wait_sec:0.2
+              ~poll_interval_sec:0.01 port
+          with
+          | Server_startup_takeover.Acquired ->
+              Alcotest.(check bool) "child terminated" false (process_alive pid);
+              Alcotest.(check int) "current pid written" (Unix.getpid ())
+                (pid_from_file path)
+          | Server_startup_takeover.Already_running _ ->
+              Alcotest.fail "unresponsive holder should be reclaimed"))
+
+let () =
+  Alcotest.run "Server_startup_takeover"
+    [
+      ( "takeover",
+        [
+          Alcotest.test_case "responsive holder blocks takeover" `Quick
+            test_rejects_responsive_holder;
+          Alcotest.test_case "stale pid file is reclaimed" `Quick
+            test_reclaims_stale_pid_file;
+          Alcotest.test_case "invalid pid file is overwritten" `Quick
+            test_tolerates_invalid_pid_file;
+          Alcotest.test_case "unresponsive holder escalates to sigkill" `Quick
+            test_escalates_sigkill_for_unresponsive_holder;
+        ] );
+    ]

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -114,15 +114,26 @@ let spawn_http_server ~status_code =
       end;
       (pid, port)
 
-let spawn_forever_process ~ignore_sigterm =
-  match Unix.fork () with
-  | 0 ->
-      if ignore_sigterm then
-        Sys.set_signal Sys.sigterm Sys.Signal_ignore;
-      while true do
-        ignore (Unix.select [] [] [] 1.0)
-      done
-  | pid -> pid
+let spawn_forever_process ?argv0 ~ignore_sigterm () =
+  match argv0 with
+  | Some name ->
+      let script =
+        if ignore_sigterm then
+          "trap '' TERM; while :; do sleep 1; done"
+        else
+          "while :; do sleep 1; done"
+      in
+      Unix.create_process "/bin/sh" [| name; "-c"; script |]
+        Unix.stdin Unix.stdout Unix.stderr
+  | None ->
+      match Unix.fork () with
+      | 0 ->
+          if ignore_sigterm then
+            Sys.set_signal Sys.sigterm Sys.Signal_ignore;
+          while true do
+            ignore (Unix.select [] [] [] 1.0)
+          done
+      | pid -> pid
 
 let stop_process pid =
   if process_alive pid then
@@ -133,8 +144,8 @@ let with_http_server ~status_code f =
   let pid, port = spawn_http_server ~status_code in
   Fun.protect ~finally:(fun () -> stop_process pid) (fun () -> f ~pid ~port)
 
-let with_forever_process ~ignore_sigterm f =
-  let pid = spawn_forever_process ~ignore_sigterm in
+let with_forever_process ?argv0 ~ignore_sigterm f =
+  let pid = spawn_forever_process ?argv0 ~ignore_sigterm () in
   Fun.protect ~finally:(fun () -> stop_process pid) (fun () -> f pid)
 
 let lock_path dir =
@@ -205,7 +216,7 @@ let test_tolerates_invalid_pid_file () =
 
 let test_escalates_sigkill_for_unresponsive_holder () =
   with_temp_dir "startup-takeover-unresponsive" (fun dir ->
-      with_forever_process ~ignore_sigterm:true (fun pid ->
+      with_forever_process ~argv0:"main_eio.exe" ~ignore_sigterm:true (fun pid ->
           let path = lock_path dir in
           write_file path (Printf.sprintf "%d\n" pid);
           let port = find_free_port () in


### PR DESCRIPTION
## Summary

- extract PID lock and takeover handling out of `main_eio`
- replace shell-invoked `curl` liveness probing with an internal loopback HTTP probe
- isolate reclaim waiting logic behind bounded helper functions and add focused takeover tests

## Product impact

- Promise affected: `repo coordination`
- User-visible change: startup no longer depends on shell-based liveness checks in the PID takeover path; stale or invalid PID lock recovery keeps the same behavior but is more predictable and testable

## Evidence

- `dune build --root . ./bin/main_eio.exe ./test/test_server_startup_takeover.exe ./test/test_server_runtime_bootstrap.exe`
- `env -u DATABASE_URL -u SUPABASE_DB_URL -u MASC_POSTGRES_URL -u SB_PG_URL MASC_STORAGE_TYPE=filesystem ./_build/default/test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_startup_takeover.exe` (`SKIP` in this environment because loopback ephemeral bind returned `EPERM`)

## Review evidence

- Pending GLM-5 review; result will be added as a PR comment.

## Linked issue

- Closes #3429
- Relates #3408
