### PR TITLE
fix(server): plug grow-only Hashtbl memory leaks in cleanup loop

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -111,8 +111,9 @@ let event_buffers_mutex = Eio.Mutex.create ()
 let max_buffered_events = Env_config_governance.Timeouts.event_buffer_size
 
 (** Generate stable UUIDv4 identifiers for subscriptions and delegated tasks. *)
+let a2a_rng = Random.State.make_self_init ()
 let generate_uuid () =
-  let uuid = Uuidm.v4_gen (Random.State.make_self_init ()) () in
+  let uuid = Uuidm.v4_gen a2a_rng () in
   Uuidm.to_string uuid
 
 (** Get current ISO8601 timestamp *)
@@ -739,3 +740,31 @@ let submit_heartbeat_result
        Log.Misc.info "heartbeat result rejected: %s" msg);
 
   result
+
+(** {1 Cleanup} *)
+
+(** Remove heartbeat snapshots for agents not in [active_agents].
+    Returns count of removed entries. Safe to call: entries are re-created
+    on next heartbeat emission. *)
+let cleanup_stale_heartbeats ~active_agents () =
+  Eio_guard.with_mutex heartbeat_mutex (fun () ->
+    let stale = Hashtbl.fold (fun agent _ acc ->
+      if not (List.mem agent active_agents) then agent :: acc else acc
+    ) latest_heartbeat_tasks [] in
+    List.iter (fun agent ->
+      Hashtbl.remove latest_heartbeat_tasks agent;
+      Hashtbl.remove latest_heartbeat_results agent
+    ) stale;
+    List.length stale)
+
+(** Remove event buffer entries whose subscription no longer exists.
+    Returns count of removed entries. *)
+let cleanup_orphan_buffers () =
+  Eio.Mutex.use_rw ~protect:true event_buffers_mutex (fun () ->
+    let orphans = Hashtbl.fold (fun sub_id _ acc ->
+      let exists = Eio.Mutex.use_ro subscriptions_mutex (fun () ->
+        Hashtbl.mem subscriptions sub_id) in
+      if not exists then sub_id :: acc else acc
+    ) event_buffers [] in
+    List.iter (Hashtbl.remove event_buffers) orphans;
+    List.length orphans)

--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -77,7 +77,7 @@ let string_of_channel = function
 
 (** Generate a unique session key *)
 let generate_session_key () =
-  let uuid = Uuidm.v4_gen (Random.State.make_self_init ()) () in
+  let uuid = Uuidm.v4_gen identity_rng () in
   Uuidm.to_string uuid
 
 (** Create identity from MCP request params *)

--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -312,9 +312,27 @@ let init ~base_path =
   _base_path := Some base_path;
   load_sessions base_path
 
+(** {1 Cleanup} *)
+
+(** Remove closed/cancelled sessions older than [max_age_s] seconds.
+    Returns the count of removed sessions. *)
+let cleanup_closed ?(max_age_s = 3600.0) () =
+  let now = Time_compat.now () in
+  let stale = Hashtbl.fold (fun id session acc ->
+    match session.state with
+    | Closed | Cancelled ->
+      (match session.closed_at with
+       | Some t when now -. t > max_age_s -> id :: acc
+       | _ -> acc)
+    | Open -> acc
+  ) sessions [] in
+  List.iter (Hashtbl.remove sessions) stale;
+  List.length stale
+
 (** Generate unique session ID *)
+let consensus_rng = Random.State.make_self_init ()
 let generate_id () =
-  let uuid = Uuidm.v4_gen (Random.State.make_self_init ()) () in
+  let uuid = Uuidm.v4_gen consensus_rng () in
   Uuidm.to_string uuid
 
 (** Start a new voting session *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -262,7 +262,32 @@ let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
             let webrtc_expired = Server_webrtc_transport.cleanup_expired_offers () in
             if webrtc_expired > 0 then
               Log.Server.info "WebRTC: cleaned %d expired offers" webrtc_expired
-          end
+          end;
+          (* Rate-limit buckets: evict keys unused for 5 minutes *)
+          let rl = Eio.Lazy.force Rate_limit.global in
+          let rl_reaped = Rate_limit.cleanup rl ~older_than_seconds:300 in
+          if rl_reaped > 0 then
+            Log.Server.info "Reaped %d stale rate-limit buckets" rl_reaped;
+          (* Agent registry: remove resolved-name cache for dead sessions *)
+          let ar_reaped = Agent_registry_eio.cleanup_stale_sessions () in
+          if ar_reaped > 0 then
+            Log.Server.info "Reaped %d stale agent registry sessions" ar_reaped;
+          (* Consensus: remove closed/cancelled voting sessions older than 1h *)
+          let cs_reaped = Council.Consensus.cleanup_closed () in
+          if cs_reaped > 0 then
+            Log.Server.info "Reaped %d closed consensus sessions" cs_reaped;
+          (* A2A: remove heartbeat snapshots for offline agents *)
+          let active_agents =
+            List.map (fun (id : Agent_identity.t) -> id.agent_name)
+              (Agent_registry_eio.list_active ~within_seconds:600.0 ())
+          in
+          let hb_reaped = A2a_tools.cleanup_stale_heartbeats ~active_agents () in
+          if hb_reaped > 0 then
+            Log.Server.info "Reaped %d stale heartbeat entries" hb_reaped;
+          (* A2A: remove event buffers for dead subscriptions *)
+          let buf_reaped = A2a_tools.cleanup_orphan_buffers () in
+          if buf_reaped > 0 then
+            Log.Server.info "Reaped %d orphan event buffers" buf_reaped
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->


### PR DESCRIPTION
## Summary

서버가 장시간 실행될수록 느려지는 문제의 근본 원인 수정.

- 기존 60초 cleanup loop에서 **6개 전역 Hashtbl이 누락**되어 grow-only 상태였음
- `Rate_limit.cleanup`, `Agent_registry_eio.cleanup_stale_sessions`, `Council.Consensus.cleanup_closed` 등 이미 구현된 cleanup 함수를 loop에 연결
- `A2a_tools`에 heartbeat/event_buffer cleanup 함수 신규 작성
- UUID 생성 시 `Random.State.make_self_init()` 매번 호출 → 모듈 레벨 RNG 캐싱으로 syscall 제거

## Product impact

장시간 운행 시 서버 응답 지연 해소. 메모리 사용량이 plateau 형태로 안정화될 것으로 예상.

## Evidence

- 코드 탐색으로 6개 grow-only Hashtbl 확인 (rate_limit, agent_registry, consensus, heartbeat x2, event_buffers)
- `Rate_limit.cleanup`(rate_limit.ml:90)과 `Agent_registry_eio.cleanup_stale_sessions`(agent_registry_eio.ml:191)는 이미 구현되어 있으나 cleanup loop에서 호출되지 않음을 확인
- Council 테스트 46개 전부 통과

## Review evidence

배포 후 RSS 추적 및 "Reaped" 로그 모니터링으로 검증 예정.

## Linked issue

Refs: 서버 성능 저하 분석 (ad-hoc, 이슈 없음)

## 변경 파일

| 파일 | 변경 | 설명 |
|------|------|------|
| `lib/server/server_bootstrap_loops.ml` | 5개 cleanup 호출 추가 | 핵심 수정 |
| `lib/a2a_tools.ml` | cleanup 함수 2개 + RNG 캐싱 | heartbeat/buffer leak 수정 |
| `lib/council/consensus.ml` | cleanup_closed + RNG 캐싱 | voting session leak 수정 |
| `lib/agent_identity.ml` | identity_rng 재사용 | RNG syscall 제거 |

## Test plan

- [x] Council 테스트 46개 전부 통과
- [ ] 서버 1시간 운행 후 RSS plateau 확인
- [ ] `"Reaped"` 로그 메시지로 cleanup 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)