### PR TITLE
refactor: replace Type_error catches with Safe_ops (batch 2, #2964)

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -180,7 +180,7 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
 
     let protocol_versions =
       match json |> member "protocolVersions" with
-      | `List vs -> List.filter_map (fun v -> try Some (to_string v) with Yojson.Safe.Util.Type_error _ -> None) vs
+      | `List vs -> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None) vs
       | _ -> ["0.3"]
     in
 
@@ -223,13 +223,13 @@ let from_json (json : Yojson.Safe.t) : (agent_card, string) result =
     let default_input_modes =
       (match json |> member "defaultInputModes" with
       | `List vs -> vs | _ -> [])
-      |> List.filter_map (fun v -> try Some (to_string v) with Yojson.Safe.Util.Type_error _ -> None)
+      |> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None)
     in
 
     let default_output_modes =
       (match json |> member "defaultOutputModes" with
       | `List vs -> vs | _ -> [])
-      |> List.filter_map (fun v -> try Some (to_string v) with Yojson.Safe.Util.Type_error _ -> None)
+      |> List.filter_map (fun v -> match v with `String s -> Some s | _ -> None)
     in
 
     let extensions =

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -132,36 +132,21 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
     let action = json |> U.member "action" |> U.to_string |> string_to_action in
     let room_id = json |> U.member "room_id" |> U.to_string_option in
     let details =
-      try json |> U.member "details"
-      with Yojson.Safe.Util.Type_error _ -> `Null
+      match Safe_ops.json_member_opt "details" json with
+      | Some v -> v
+      | None -> `Null
     in
     let outcome =
       let o = json |> U.member "outcome" in
       let status = o |> U.member "status" |> U.to_string in
       if status = "success" then Success
       else
-        let reason = try o |> U.member "reason" |> U.to_string with Yojson.Safe.Util.Type_error _ -> "unknown" in
+        let reason = Safe_ops.json_string ~default:"unknown" "reason" o in
         Failure reason
     in
-    let cost_estimate =
-      try
-        match json |> U.member "cost_estimate" with
-        | `Float f -> Some f
-        | `Int i -> Some (float_of_int i)
-        | _ -> None
-      with Yojson.Safe.Util.Type_error _ -> None
-    in
-    let token_count =
-      try
-        match json |> U.member "token_count" with
-        | `Int i -> Some i
-        | _ -> None
-      with Yojson.Safe.Util.Type_error _ -> None
-    in
-    let trace_id =
-      try json |> U.member "trace_id" |> U.to_string_option
-      with Yojson.Safe.Util.Type_error _ -> None
-    in
+    let cost_estimate = Safe_ops.json_float_opt "cost_estimate" json in
+    let token_count = Safe_ops.json_int_opt "token_count" json in
+    let trace_id = Safe_ops.json_string_opt "trace_id" json in
     Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count; trace_id }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.warn "audit_log: entry parse failed: %s" (Printexc.to_string exn);
@@ -358,11 +343,11 @@ let get_stats (config : config) =
   let oldest = ref None in
   let newest = ref None in
   List.iter (fun json ->
-    (try
-       let ts = Yojson.Safe.Util.(json |> member "timestamp" |> to_float) in
+    (match Safe_ops.json_float_opt "timestamp" json with
+     | Some ts ->
        if !oldest = None then oldest := Some ts;
        newest := Some ts
-     with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ())
+     | None -> ())
   ) entries;
   {
     total_entries = count;

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -186,38 +186,42 @@ let visibility_of_string = function
   | _ -> None
 
 let post_of_yojson (json : Yojson.Safe.t) : post option =
-  try
-    let open Yojson.Safe.Util in
-    let id_str = json |> member "id" |> to_string in
-    let author_str = json |> member "author" |> to_string in
-    let content = json |> member "content" |> to_string in
-    let title_opt = json |> member "title" |> to_string_option in
-    let body_opt = json |> member "body" |> to_string_option in
-    let vis_str = json |> member "visibility" |> to_string in
-    let created_at = json |> member "created_at" |> to_float in
+  match
+    Safe_ops.json_string_opt "id" json,
+    Safe_ops.json_string_opt "author" json,
+    Safe_ops.json_string_opt "content" json,
+    Safe_ops.json_string_opt "visibility" json,
+    Safe_ops.json_float_opt "created_at" json,
+    Safe_ops.json_float_opt "expires_at" json
+  with
+  | Some id_str, Some author_str, Some content, Some vis_str,
+    Some created_at, Some expires_at ->
+    let title_opt = Safe_ops.json_string_opt "title" json in
+    let body_opt = Safe_ops.json_string_opt "body" json in
     (* Backward compat: default updated_at to created_at if missing *)
-    let updated_at = json |> member "updated_at" |> to_float_option |> Option.value ~default:created_at in
-    let expires_at = json |> member "expires_at" |> to_float in
-    let votes_up = json |> member "votes_up" |> to_int in
-    let votes_down = json |> member "votes_down" |> to_int in
-    let reply_count = json |> member "reply_count" |> to_int_option |> Option.value ~default:0 in
-    let hearth = json |> member "hearth" |> to_string_option in
-    let thread_id = json |> member "thread_id" |> to_string_option in
+    let updated_at =
+      Safe_ops.json_float_opt "updated_at" json
+      |> Option.value ~default:created_at
+    in
+    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
+    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
+    let reply_count = Safe_ops.json_int ~default:0 "reply_count" json in
+    let hearth = Safe_ops.json_string_opt "hearth" json in
+    let thread_id = Safe_ops.json_string_opt "thread_id" json in
     let post_kind_opt =
-      match json |> member "post_kind" |> to_string_option with
+      match Safe_ops.json_string_opt "post_kind" json with
       | Some raw -> post_kind_of_string raw
       | None -> None
     in
     let meta_json =
-      match json |> member "meta" with
-      | `Assoc _ as meta -> Some meta
-      | `Null -> None
-      | _ -> (
-          match json |> member "meta_json" |> to_string_option with
-          | Some raw -> (try Some (Yojson.Safe.from_string raw) with Yojson.Json_error _ -> None)
-          | None -> None)
+      match Safe_ops.json_member_opt "meta" json with
+      | Some (`Assoc _ as meta) -> Some meta
+      | Some _ | None ->
+        (match Safe_ops.json_string_opt "meta_json" json with
+         | Some raw -> (try Some (Yojson.Safe.from_string raw) with Yojson.Json_error _ -> None)
+         | None -> None)
     in
-    match Post_id.of_string id_str, Agent_id.of_string author_str, visibility_of_string vis_str with
+    (match Post_id.of_string id_str, Agent_id.of_string author_str, visibility_of_string vis_str with
     | Ok id, Ok author, Some visibility ->
         let title, body, post_kind, meta_json =
           normalize_post_payload ~author:author_str ~content ?title:title_opt
@@ -242,30 +246,32 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
           hearth;
           thread_id;
         }
-    | _ -> None
-  with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> None
+    | _ -> None)
+  | _ -> None
 
 let comment_of_yojson (json : Yojson.Safe.t) : comment option =
-  try
-    let open Yojson.Safe.Util in
-    let id_str = json |> member "id" |> to_string in
-    let post_id_str = json |> member "post_id" |> to_string in
-    let parent_id_opt = json |> member "parent_id" |> to_string_option in
-    let author_str = json |> member "author" |> to_string in
-    let content = json |> member "content" |> to_string in
-    let created_at = json |> member "created_at" |> to_float in
-    let expires_at = json |> member "expires_at" |> to_float in
-    let votes_up = json |> member "votes_up" |> to_int in
-    let votes_down = json |> member "votes_down" |> to_int in
-    match Comment_id.of_string id_str, Post_id.of_string post_id_str, Agent_id.of_string author_str with
+  match
+    Safe_ops.json_string_opt "id" json,
+    Safe_ops.json_string_opt "post_id" json,
+    Safe_ops.json_string_opt "author" json,
+    Safe_ops.json_string_opt "content" json,
+    Safe_ops.json_float_opt "created_at" json,
+    Safe_ops.json_float_opt "expires_at" json
+  with
+  | Some id_str, Some post_id_str, Some author_str, Some content,
+    Some created_at, Some expires_at ->
+    let parent_id_opt = Safe_ops.json_string_opt "parent_id" json in
+    let votes_up = Safe_ops.json_int ~default:0 "votes_up" json in
+    let votes_down = Safe_ops.json_int ~default:0 "votes_down" json in
+    (match Comment_id.of_string id_str, Post_id.of_string post_id_str, Agent_id.of_string author_str with
     | Ok id, Ok post_id, Ok author ->
         let parent_id = match parent_id_opt with
           | Some s -> (match Comment_id.of_string s with Ok cid -> Some cid | _ -> None)
           | None -> None
         in
         Some { id; post_id; parent_id; author; content; created_at; expires_at; votes_up; votes_down }
-    | _ -> None
-  with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> None
+    | _ -> None)
+  | _ -> None
 
 let load_persisted_posts store =
   let path = persist_path () in
@@ -346,14 +352,13 @@ let load_persisted_votes store =
       let loaded = ref 0 in
       let lines = Fs_compat.load_jsonl path in
       List.iter (fun json ->
-        try
-          let open Yojson.Safe.Util in
-          let target = json |> member "target" |> to_string in
-          let dir_str = json |> member "direction" |> to_string in
+        match Safe_ops.json_string_opt "target" json,
+              Safe_ops.json_string_opt "direction" json with
+        | Some target, Some dir_str ->
           let direction = if dir_str = "down" then Down else Up in
           Hashtbl.replace store.vote_log target direction;
           incr loaded
-        with Yojson.Safe.Util.Type_error _ -> ()
+        | _ -> ()
       ) lines;
       if !loaded > 0 then
         Log.BoardLog.info "loaded %d vote entries from %s" !loaded path

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -230,16 +230,11 @@ let pre_check
                 let cmd_str =
                   try
                     let json = Yojson.Safe.from_string args_json in
-                    let open Yojson.Safe.Util in
                     (* keeper_bash uses "command", keeper_fs_edit/edit uses "content" *)
-                    let cmd = json |> member "command" in
-                    (match cmd with
-                     | `String s -> s
-                     | `Null ->
-                         let c = json |> member "content" in
-                         (match c with `String s -> s | _ -> "")
-                     | _ -> "")
-                  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error (_, _) -> ""
+                    match Safe_ops.json_string_opt "command" json with
+                    | Some s -> s
+                    | None -> Safe_ops.json_string ~default:"" "content" json
+                  with Yojson.Json_error _ -> ""
                 in
                 begin match detect_destructive cmd_str with
                 | Some (pattern, desc) ->
@@ -259,15 +254,10 @@ let pre_check
           let cmd_str =
             try
               let json = Yojson.Safe.from_string args_json in
-              let open Yojson.Safe.Util in
-              let cmd = json |> member "command" in
-              (match cmd with
-               | `String s -> s
-               | `Null ->
-                   let c = json |> member "content" in
-                   (match c with `String s -> s | _ -> "")
-               | _ -> "")
-            with Yojson.Json_error _ | Yojson.Safe.Util.Type_error (_, _) -> ""
+              match Safe_ops.json_string_opt "command" json with
+              | Some s -> s
+              | None -> Safe_ops.json_string ~default:"" "content" json
+            with Yojson.Json_error _ -> ""
           in
           begin match detect_destructive cmd_str with
           | Some (pattern, desc) ->
@@ -320,9 +310,10 @@ let post_eval
     if has_error then
       try
         let json = Yojson.Safe.from_string result in
-        let open Yojson.Safe.Util in
-        Some (json |> member "error" |> to_string)
-      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error (_, _) -> Some "unknown error in result"
+        match Safe_ops.json_string_opt "error" json with
+        | Some s -> Some s
+        | None -> Some "unknown error in result"
+      with Yojson.Json_error _ -> Some "unknown error in result"
     else None
   in
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -183,7 +183,7 @@ let handle_keeper_status ctx args : tool_result =
                                | None -> `Null );
                            ])
                     | _ -> find_latest tl
-                  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> find_latest tl)
+                  with Yojson.Json_error _ -> find_latest tl)
              in
              find_latest (List.rev metrics_window_lines)
          in
@@ -217,24 +217,14 @@ let handle_keeper_status ctx args : tool_result =
                  ~max_bytes:tail_bytes
                  ~max_lines:tail_messages
              in
-             let open Yojson.Safe.Util in
              let (items_rev, raw_count, fragment_count, filtered_count) =
                List.fold_left
                  (fun (acc, raw_count, fragment_count, filtered_count) line ->
                    try
                      let j = Yojson.Safe.from_string line in
-                     let role =
-                       j |> member "role" |> to_string_option
-                       |> Option.value ~default:"unknown"
-                     in
-                     let content =
-                       j |> member "content" |> to_string_option
-                       |> Option.value ~default:""
-                     in
-                     let source =
-                       j |> member "source" |> to_string_option
-                       |> Option.value ~default:"unknown"
-                     in
+                     let role = Safe_ops.json_string ~default:"unknown" "role" j in
+                     let content = Safe_ops.json_string ~default:"" "content" j in
+                     let source = Safe_ops.json_string ~default:"unknown" "source" j in
                      let ts_unix =
                        let ts0 = Safe_ops.json_float ~default:0.0 "ts_unix" j in
                        if ts0 > 0.0 then ts0
@@ -288,7 +278,7 @@ let handle_keeper_status ctx args : tool_result =
                        raw_count + 1,
                        fragment_count + (if is_fragment then 1 else 0),
                        filtered_count )
-                   with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> (acc, raw_count, fragment_count, filtered_count))
+                   with Yojson.Json_error _ -> (acc, raw_count, fragment_count, filtered_count))
                  ([], 0, 0, 0) lines
              in
              (`List (List.rev items_rev), raw_count, fragment_count, filtered_count)
@@ -386,7 +376,7 @@ let handle_keeper_status ctx args : tool_result =
                          ]
                        in
                        item :: acc
-                   with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> acc)
+                   with Yojson.Json_error _ -> acc)
                  [] lines
              in
              let events = List.rev events_rev in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -216,10 +216,11 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let post_id =
-               json |> Yojson.Safe.Util.member "post_id"
-               |> Yojson.Safe.Util.to_string
-             in
+             match Safe_ops.json_string_opt "post_id" json with
+             | None ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   {|{"ok":false,"error":"invalid request: requires {\"post_id\":\"...\"}"}|} reqd
+             | Some post_id ->
              match Board_dispatch.delete_post ~post_id with
              | Ok () ->
                  Http.Response.json ~compress:true ~request:req
@@ -227,7 +228,7 @@ let add_routes ~sw ~clock router =
              | Error _ ->
                  Http.Response.json ~status:`Not_found ~request:req
                    {|{"ok":false,"error":"post not found or delete failed"}|} reqd
-           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+           with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"post_id\":\"...\"}"}|} reqd
          )
@@ -238,10 +239,11 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let task_id =
-               json |> Yojson.Safe.Util.member "task_id"
-               |> Yojson.Safe.Util.to_string
-             in
+             match Safe_ops.json_string_opt "task_id" json with
+             | None ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   {|{"ok":false,"error":"invalid request: requires {\"task_id\":\"...\"}"}|} reqd
+             | Some task_id ->
              let config = state.Mcp_server.room_config in
              match Task_dispatch.delete_task config ~task_id with
              | Ok () ->
@@ -250,7 +252,7 @@ let add_routes ~sw ~clock router =
              | Error _ ->
                  Http.Response.json ~status:`Not_found ~request:req
                    {|{"ok":false,"error":"task not found or delete failed"}|} reqd
-           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+           with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"task_id\":\"...\"}"}|} reqd
          )
@@ -261,10 +263,11 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let goal_id =
-               json |> Yojson.Safe.Util.member "goal_id"
-               |> Yojson.Safe.Util.to_string
-             in
+             match Safe_ops.json_string_opt "goal_id" json with
+             | None ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   {|{"ok":false,"error":"invalid request: requires {\"goal_id\":\"...\"}"}|} reqd
+             | Some goal_id ->
              let config = state.Mcp_server.room_config in
              match Goal_store.delete_goal config ~goal_id with
              | Ok () ->
@@ -274,7 +277,7 @@ let add_routes ~sw ~clock router =
                  Http.Response.json ~status:`Not_found ~request:req
                    (Printf.sprintf {|{"ok":false,"error":"%s"}|} (String.escaped msg))
                    reqd
-           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+           with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"goal_id\":\"...\"}"}|} reqd
          )
@@ -557,10 +560,12 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let loop_id =
-               json |> Yojson.Safe.Util.member "loop_id"
-               |> Yojson.Safe.Util.to_string
-             in
+             match Safe_ops.json_string_opt "loop_id" json with
+             | None ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
+                   reqd
+             | Some loop_id ->
              let base_path = state.Mcp_server.room_config.base_path in
              (match Dashboard_http_autoresearch.validate_loop_id loop_id with
              | Error message ->
@@ -580,7 +585,7 @@ let add_routes ~sw ~clock router =
                        (Printf.sprintf {|{"ok":false,"error":"%s"}|}
                           (String.escaped message))
                        reqd))
-           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+           with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
                reqd
@@ -592,10 +597,12 @@ let add_routes ~sw ~clock router =
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
-             let loop_id =
-               json |> Yojson.Safe.Util.member "loop_id"
-               |> Yojson.Safe.Util.to_string
-             in
+             match Safe_ops.json_string_opt "loop_id" json with
+             | None ->
+                 Http.Response.json ~status:`Bad_request ~request:req
+                   {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
+                   reqd
+             | Some loop_id ->
              let base_path = state.Mcp_server.room_config.base_path in
              (match Dashboard_http_autoresearch.validate_loop_id loop_id with
              | Error message ->
@@ -615,7 +622,7 @@ let add_routes ~sw ~clock router =
                        (Printf.sprintf {|{"ok":false,"error":"%s"}|}
                           (String.escaped message))
                        reqd))
-           with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ ->
+           with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"loop_id\":\"...\"}"}|}
                reqd


### PR DESCRIPTION
## Summary

- Convert 23 Type_error sites to Safe_ops across 6 files
- audit_log(6), server_routes_dashboard(5), keeper_status_detail(3), eval_gate(3), agent_card(3), board_votes(3)
- Total Type_error: 132 -> 93 (-30%, cumulative with batch 1)
- Net -22 lines

## Test plan

- [x] dune build passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)