### PR TITLE
refactor: replace Type_error catches with Safe_ops (batch 3, #2964)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -40,22 +40,19 @@ let subscription_to_json (sub : subscription) : Yojson.Safe.t =
 
 (** Subscription from JSON *)
 let subscription_of_json (json : Yojson.Safe.t) : subscription option =
-  try
-    let module U = Yojson.Safe.Util in
-    let id = json |> U.member "id" |> U.to_string in
-    let agent_filter = match json |> U.member "agent_filter" with
-      | `Null -> None
-      | `String s -> Some s
-      | _ -> None
+  match Safe_ops.json_string_opt "id" json,
+        Safe_ops.json_string_opt "created_at" json with
+  | Some id, Some created_at ->
+    let agent_filter = Safe_ops.json_string_opt "agent_filter" json in
+    let event_types =
+      Safe_ops.json_list "event_types" json
+      |> List.filter_map (function
+           | `String s -> (match event_type_of_string s with Ok e -> Some e | Error _ -> None)
+           | _ -> None)
     in
-    let event_types = json |> U.member "event_types" |> U.to_list |> List.filter_map (function
-      | `String s -> (match event_type_of_string s with Ok e -> Some e | Error _ -> None)
-      | _ -> None)
-    in
-    let created_at = json |> U.member "created_at" |> U.to_string in
     Some { id; agent_filter; event_types; created_at }
-  with Yojson.Safe.Util.Type_error (msg, _) ->
-    Log.Misc.warn "subscription_of_json: %s" msg;
+  | _ ->
+    Log.Misc.warn "subscription_of_json: missing required fields";
     None
 
 (** Save subscriptions to file *)

--- a/lib/activity_graph_types.ml
+++ b/lib/activity_graph_types.ml
@@ -56,14 +56,10 @@ let entity_to_yojson (value : entity_ref) =
   `Assoc [ ("kind", `String value.kind); ("id", `String value.id) ]
 
 let entity_of_yojson (json : Yojson.Safe.t) : entity_ref option =
-  let open Yojson.Safe.Util in
-  try
-    Some
-      {
-        kind = json |> member "kind" |> to_string;
-        id = json |> member "id" |> to_string;
-      }
-  with Type_error _ -> None
+  match Safe_ops.json_string_opt "kind" json,
+        Safe_ops.json_string_opt "id" json with
+  | Some kind, Some id -> Some { kind; id }
+  | _ -> None
 
 let event_to_yojson (value : event) =
   `Assoc
@@ -86,27 +82,18 @@ let event_to_yojson (value : event) =
     ]
 
 let event_of_yojson (json : Yojson.Safe.t) : event option =
-  let open Yojson.Safe.Util in
-  try
-    Some
-      {
-        seq = json |> member "seq" |> to_int;
-        ts_ms = json |> member "ts_ms" |> to_int;
-        ts_iso = json |> member "ts_iso" |> to_string;
-        room_id = json |> member "room_id" |> to_string;
-        kind = json |> member "kind" |> to_string;
-        actor = entity_of_yojson (json |> member "actor");
-        subject = entity_of_yojson (json |> member "subject");
-        payload = json |> member "payload";
-        tags =
-          (match json |> member "tags" with
-          | `List items ->
-              List.filter_map
-                (function `String value -> Some value | _ -> None)
-                items
-          | _ -> []);
-      }
-  with Type_error _ -> None
+  match Safe_ops.json_int_opt "seq" json,
+        Safe_ops.json_int_opt "ts_ms" json,
+        Safe_ops.json_string_opt "ts_iso" json,
+        Safe_ops.json_string_opt "room_id" json,
+        Safe_ops.json_string_opt "kind" json with
+  | Some seq, Some ts_ms, Some ts_iso, Some room_id, Some kind ->
+    let actor = Option.bind (Safe_ops.json_member_opt "actor" json) entity_of_yojson in
+    let subject = Option.bind (Safe_ops.json_member_opt "subject" json) entity_of_yojson in
+    let payload = Safe_ops.json_member_opt "payload" json |> Option.value ~default:(`Assoc []) in
+    let tags = Safe_ops.json_string_list "tags" json in
+    Some { seq; ts_ms; ts_iso; room_id; kind; actor; subject; payload; tags }
+  | _ -> None
 
 let graph_node_to_yojson (value : graph_node) =
   `Assoc

--- a/lib/ag_ui.ml
+++ b/lib/ag_ui.ml
@@ -206,10 +206,9 @@ let of_custom ~room_id ~name (value : Yojson.Safe.t) : event =
 (** Map MASC task_update JSON to appropriate AG-UI event.
     Inspects the "status" field to determine the event type. *)
 let of_task_update ~room_id (task_json : Yojson.Safe.t) : event =
-  let module U = Yojson.Safe.Util in
-  let task_id = (try task_json |> U.member "id" |> U.to_string with Yojson.Safe.Util.Type_error _ -> "unknown") in
-  let status = (try task_json |> U.member "status" |> U.to_string with Yojson.Safe.Util.Type_error _ -> "") in
-  let agent = (try task_json |> U.member "agent" |> U.to_string with Yojson.Safe.Util.Type_error _ -> "unknown") in
+  let task_id = Safe_ops.json_string ~default:"unknown" "id" task_json in
+  let status = Safe_ops.json_string ~default:"" "status" task_json in
+  let agent = Safe_ops.json_string ~default:"unknown" "agent" task_json in
   match status with
   | "claimed" ->
     of_task_claimed ~room_id ~agent_name:agent ~task_id

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -104,8 +104,8 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
              (Printf.sprintf
                 "missing required autoresearch state field: %s" key))
   in
-  let int_ key ~default = try json |> member key |> to_int with Type_error _ -> default in
-  let float_ key ~default = try json |> member key |> to_float with Type_error _ -> default in
+  let int_ key ~default = Safe_ops.json_int ~default key json in
+  let float_ key ~default = Safe_ops.json_float ~default key json in
   {
     loop_id = required_str "loop_id";
     status = status_of_string (required_str "status") |> Option.value ~default:Error;
@@ -125,10 +125,7 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
     max_cycles = int_ "max_cycles" ~default:10;
     error_message = json |> member "error" |> to_string_option;
     elapsed_s = float_ "elapsed_s" ~default:0.0;
-    updated_at = (
-      try Some (json |> member "updated_at" |> to_float)
-      with Type_error _ -> None
-    );
+    updated_at = Safe_ops.json_float_opt "updated_at" json;
     source_workdir =
       json |> member "source_workdir" |> to_string_option
       |> Option.value ~default:(str "workdir" ~default:".");

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -91,8 +91,7 @@ let dna_quality_event_json (event : dna_quality_event) =
     ]
 
 let string_field json key =
-  try Yojson.Safe.Util.(json |> member key |> to_string)
-  with Yojson.Safe.Util.Type_error _ | Not_found -> ""
+  Safe_ops.json_string ~default:"" key json
 
 let recent_verdicts_json ?(limit = 8) ?(since = "") ?(until = "") () =
   let store = Eval_calibration.get_store () in
@@ -127,8 +126,7 @@ let recent_verdicts_json ?(limit = 8) ?(since = "") ?(until = "") () =
            else None)
     |> List.sort (fun left right ->
            let ts json =
-             try Yojson.Safe.Util.(json |> member "timestamp" |> to_float)
-             with Yojson.Safe.Util.Type_error _ | Not_found -> 0.0
+             Safe_ops.json_float ~default:0.0 "timestamp" json
            in
            Float.compare (ts right) (ts left))
     |> trim_recent limit

--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -135,22 +135,18 @@ let envelope_to_json envelope =
 
 (** Parse JSON to envelope *)
 let envelope_of_json json : envelope option =
-  let open Yojson.Safe.Util in
-  try
-    let encrypted = json |> member "_encrypted" |> to_bool in
-    let version = json |> member "v" |> to_int in
-    let nonce = json |> member "nonce" |> to_string in
-    let ciphertext = json |> member "ct" |> to_string in
-    let adata = json |> member "adata" |> to_string in
+  match Safe_ops.json_bool_opt "_encrypted" json,
+        Safe_ops.json_int_opt "v" json,
+        Safe_ops.json_string_opt "nonce" json,
+        Safe_ops.json_string_opt "ct" json,
+        Safe_ops.json_string_opt "adata" json with
+  | Some encrypted, Some version, Some nonce, Some ciphertext, Some adata ->
     Some { encrypted; version; nonce; ciphertext; adata }
-  with Yojson.Safe.Util.Type_error _ -> None
+  | _ -> None
 
 (** Check if JSON is an encrypted envelope *)
 let is_encrypted_json json =
-  let open Yojson.Safe.Util in
-  try
-    json |> member "_encrypted" |> to_bool
-  with Yojson.Safe.Util.Type_error _ -> false
+  Safe_ops.json_bool ~default:false "_encrypted" json
 
 (** Smart read: transparently decrypt if encrypted, pass through if plain *)
 let smart_read_json ~config ~adata path : (Yojson.Safe.t, encryption_error) result =

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -59,28 +59,28 @@ let to_json (p : procedure) : Yojson.Safe.t =
   ]
 
 let of_json (json : Yojson.Safe.t) : procedure option =
-  try
-    let open Yojson.Safe.Util in
-    Some {
-      id = json |> member "id" |> to_string;
-      agent_name = json |> member "agent_name" |> to_string;
-      pattern = json |> member "pattern" |> to_string;
-      evidence =
-        (try json |> member "evidence" |> to_list |> List.map to_string
-         with Type_error _ -> []);
-      success_count = json |> member "success_count" |> to_int;
-      failure_count = json |> member "failure_count" |> to_int;
-      confidence = json |> member "confidence" |> to_float;
-      created_at = json |> member "created_at" |> to_float;
-      last_applied =
-        (try json |> member "last_applied" |> to_float
-         with Type_error _ -> 0.0);
-    }
-  with
-  | Yojson.Safe.Util.Type_error _ -> None
-  | exn ->
-      Log.Memory.warn "procedure of_json unexpected: %s" (Printexc.to_string exn);
-      None
+  match Safe_ops.json_string_opt "id" json,
+        Safe_ops.json_string_opt "agent_name" json,
+        Safe_ops.json_string_opt "pattern" json with
+  | Some id, Some agent_name, Some pattern ->
+    (match Safe_ops.json_int_opt "success_count" json,
+           Safe_ops.json_int_opt "failure_count" json,
+           Safe_ops.json_float_opt "confidence" json,
+           Safe_ops.json_float_opt "created_at" json with
+     | Some success_count, Some failure_count, Some confidence, Some created_at ->
+       Some {
+         id;
+         agent_name;
+         pattern;
+         evidence = Safe_ops.json_string_list "evidence" json;
+         success_count;
+         failure_count;
+         confidence;
+         created_at;
+         last_applied = Safe_ops.json_float ~default:0.0 "last_applied" json;
+       }
+     | _ -> None)
+  | _ -> None
 
 (* ================================================================ *)
 (* File I/O                                                         *)

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -37,17 +37,16 @@ let run_record_to_json (r : run_record) : Yojson.Safe.t =
   ]
 
 let run_record_of_json (json : Yojson.Safe.t) : run_record option =
-  let open Yojson.Safe.Util in
-  try
-    let task_id = json |> member "task_id" |> to_string in
-    let agent_name = json |> member "agent_name" |> to_string_option in
-    let plan = json |> member "plan" |> to_string_option |> Option.value ~default:"" in
-    let deliverable = json |> member "deliverable" |> to_string_option |> Option.value ~default:"" in
-    let created_at = json |> member "created_at" |> to_string in
-    let updated_at = json |> member "updated_at" |> to_string in
+  match Safe_ops.json_string_opt "task_id" json,
+        Safe_ops.json_string_opt "created_at" json,
+        Safe_ops.json_string_opt "updated_at" json with
+  | Some task_id, Some created_at, Some updated_at ->
+    let agent_name = Safe_ops.json_string_opt "agent_name" json in
+    let plan = Safe_ops.json_string ~default:"" "plan" json in
+    let deliverable = Safe_ops.json_string ~default:"" "deliverable" json in
     Some { task_id; agent_name; plan; deliverable; created_at; updated_at }
-  with Yojson.Safe.Util.Type_error (msg, _) ->
-    Log.Misc.error "run_of_json type error: %s" msg;
+  | _ ->
+    Log.Misc.error "run_of_json: missing required fields";
     None
 
 let log_entry_to_json (e : log_entry) : Yojson.Safe.t =
@@ -57,13 +56,12 @@ let log_entry_to_json (e : log_entry) : Yojson.Safe.t =
   ]
 
 let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
-  let open Yojson.Safe.Util in
-  try
-    let timestamp = json |> member "timestamp" |> to_string in
-    let note = json |> member "note" |> to_string in
+  match Safe_ops.json_string_opt "timestamp" json,
+        Safe_ops.json_string_opt "note" json with
+  | Some timestamp, Some note ->
     Some { timestamp; note }
-  with Yojson.Safe.Util.Type_error (msg, _) ->
-    Log.Misc.error "log_entry_of_json type error: %s" msg;
+  | _ ->
+    Log.Misc.error "log_entry_of_json: missing required fields";
     None
 
 let runs_dir (config : config) =

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -62,16 +62,15 @@ IMPORTANT: If context_ratio exceeds 0.8, handoff to a successor agent. Do not ig
 let parse_claude_json output =
   try
     let json = Yojson.Safe.from_string output in
-    let module U = Yojson.Safe.Util in
-    let usage = json |> U.member "usage" in
-    let input_tokens = usage |> U.member "input_tokens" |> U.to_int_option in
-    let output_tokens = usage |> U.member "output_tokens" |> U.to_int_option in
-    let cache_creation = usage |> U.member "cache_creation_input_tokens" |> U.to_int_option in
-    let cache_read = usage |> U.member "cache_read_input_tokens" |> U.to_int_option in
-    let cost_usd = json |> U.member "total_cost_usd" |> U.to_float_option in
-    let result_text = json |> U.member "result" |> U.to_string_option in
+    let usage = Safe_ops.json_member_opt "usage" json |> Option.value ~default:(`Assoc []) in
+    let input_tokens = Safe_ops.json_int_opt "input_tokens" usage in
+    let output_tokens = Safe_ops.json_int_opt "output_tokens" usage in
+    let cache_creation = Safe_ops.json_int_opt "cache_creation_input_tokens" usage in
+    let cache_read = Safe_ops.json_int_opt "cache_read_input_tokens" usage in
+    let cost_usd = Safe_ops.json_float_opt "total_cost_usd" json in
+    let result_text = Safe_ops.json_string_opt "result" json in
     (result_text, input_tokens, output_tokens, cache_creation, cache_read, cost_usd)
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+  with Yojson.Json_error _ ->
     (* If JSON parsing fails, return raw output with no token info *)
     (Some output, None, None, None, None, None)
 
@@ -79,9 +78,8 @@ let parse_claude_json output =
 let extract_gemini_response_text output =
   try
     let json = Yojson.Safe.from_string output in
-    let module U = Yojson.Safe.Util in
-    json |> U.member "response" |> U.to_string_option
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+    Safe_ops.json_string_opt "response" json
+  with Yojson.Json_error _ ->
     None
 
 (** Parse Gemini output for token tracking.
@@ -89,22 +87,17 @@ let extract_gemini_response_text output =
 let parse_gemini_output output =
   try
     let json = Yojson.Safe.from_string output in
-    let module U = Yojson.Safe.Util in
-    let usage_opt =
-      match json |> U.member "usageMetadata" with
-      | `Assoc _ as usage -> Some usage
-      | _ -> None
-    in
+    let usage_opt = Safe_ops.json_member_opt "usageMetadata" json in
     let stats_models_opt =
-      match json |> U.member "stats" with
-      | `Assoc _ as stats ->
-          (match stats |> U.member "models" with
-           | `Assoc entries -> Some entries
+      match Safe_ops.json_member_opt "stats" json with
+      | Some (`Assoc _ as stats) ->
+          (match Safe_ops.json_member_opt "models" stats with
+           | Some (`Assoc entries) -> Some entries
            | _ -> None)
       | _ -> None
     in
     let input_tokens =
-      match Option.bind usage_opt (fun usage -> usage |> U.member "promptTokenCount" |> U.to_int_option) with
+      match Option.bind usage_opt (fun usage -> Safe_ops.json_int_opt "promptTokenCount" usage) with
       | Some _ as value -> value
       | None ->
           (match stats_models_opt with
@@ -113,9 +106,8 @@ let parse_gemini_output output =
                let sum_field field =
                  entries
                  |> List.fold_left (fun acc (_name, item) ->
-                        acc
-                        + (item |> U.member "tokens" |> U.member field |> U.to_int_option
-                          |> Option.value ~default:0))
+                        let tokens = Safe_ops.json_member_opt "tokens" item |> Option.value ~default:(`Assoc []) in
+                        acc + (Safe_ops.json_int_opt field tokens |> Option.value ~default:0))
                       0
                in
                let input = sum_field "input" in
@@ -124,7 +116,7 @@ let parse_gemini_output output =
                if chosen > 0 then Some chosen else None)
     in
     let output_tokens =
-      match Option.bind usage_opt (fun usage -> usage |> U.member "candidatesTokenCount" |> U.to_int_option) with
+      match Option.bind usage_opt (fun usage -> Safe_ops.json_int_opt "candidatesTokenCount" usage) with
       | Some _ as value -> value
       | None ->
           (match stats_models_opt with
@@ -133,15 +125,14 @@ let parse_gemini_output output =
                let total =
                  entries
                  |> List.fold_left (fun acc (_name, item) ->
-                        acc
-                        + (item |> U.member "tokens" |> U.member "candidates" |> U.to_int_option
-                          |> Option.value ~default:0))
+                        let tokens = Safe_ops.json_member_opt "tokens" item |> Option.value ~default:(`Assoc []) in
+                        acc + (Safe_ops.json_int_opt "candidates" tokens |> Option.value ~default:0))
                       0
                in
                if total > 0 then Some total else None)
     in
     let cached_tokens =
-      match Option.bind usage_opt (fun usage -> usage |> U.member "cachedContentTokenCount" |> U.to_int_option) with
+      match Option.bind usage_opt (fun usage -> Safe_ops.json_int_opt "cachedContentTokenCount" usage) with
       | Some _ as value -> value
       | None ->
           (match stats_models_opt with
@@ -150,9 +141,8 @@ let parse_gemini_output output =
                let total =
                  entries
                  |> List.fold_left (fun acc (_name, item) ->
-                        acc
-                        + (item |> U.member "tokens" |> U.member "cached" |> U.to_int_option
-                          |> Option.value ~default:0))
+                        let tokens = Safe_ops.json_member_opt "tokens" item |> Option.value ~default:(`Assoc []) in
+                        acc + (Safe_ops.json_int_opt "cached" tokens |> Option.value ~default:0))
                       0
                in
                if total > 0 then Some total else None)
@@ -172,7 +162,7 @@ let parse_gemini_output output =
       | _ -> None
     in
     (input_tokens, output_tokens, cached_tokens, cost)
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+  with Yojson.Json_error _ ->
     (None, None, None, None)
 
 (** Default spawn configs for known agents *)


### PR DESCRIPTION
## Summary

- Convert Type_error sites across 9 scattered files (22 sites)
- spawn, procedural_memory, autoresearch_serde, ag_ui, run_eio, encryption, dashboard_harness_health, activity_graph_types, a2a_tools
- Cumulative Type_error reduction: 132 -> 60 (-55%, with batches 1-2)
- Net -38 lines

## Test plan

- [x] dune build passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)