### PR TITLE
fix: pass runtime_support state to cached_isolated_readonly_config

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -881,7 +881,7 @@ let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
     match Eio_context.get_clock_opt (), Eio_context.get_switch_opt () with
     | Some clock, Some sw ->
         let readonly_config =
-          match cached_isolated_readonly_config ~sw ~clock ~config with
+          match Server_dashboard_http_runtime_support.cached_isolated_readonly_config runtime_support ~sw ~clock ~config with
           | Some isolated -> isolated
           | None -> config
         in


### PR DESCRIPTION
## Summary
- `dashboard_shell_http_json`에서 `cached_isolated_readonly_config` 호출 시 `state` 인자 누락으로 빌드 실패
- #3428과 #3435 squash merge 과정에서 시그니처 불일치 발생
- `runtime_support` (기존 line 14 바인딩) + 모듈 접두사 추가로 해결

## Changes
- `lib/server/server_dashboard_http_core.ml`: 1줄 수정

## Test plan
- [x] `dune build --root .` 성공
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)