### PR TITLE
refactor(mli): add interfaces for 4 medium-complexity modules (#2994)

### DIFF
--- a/lib/command_plane/cp_lifecycle_policy.mli
+++ b/lib/command_plane/cp_lifecycle_policy.mli
@@ -1,0 +1,67 @@
+(** Cp_lifecycle_policy -- dispatch, rebalance, escalate, recall,
+    unit management, policy decisions, and tick-based automation.
+
+    This module is [include]d by {!Command_plane_v2}; all bindings
+    are therefore part of the public Command_plane_v2 interface. *)
+
+include module type of Cp_lifecycle
+
+(** {1 Dispatch operations} *)
+
+val dispatch_assign_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val dispatch_rebalance_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val dispatch_escalate_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val dispatch_recall_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+(** {1 Unit management} *)
+
+val unit_update_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val unit_reparent_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val unit_reassign_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+(** {1 Policy decisions} *)
+
+val policy_status_json : Room.config -> Yojson.Safe.t
+
+val policy_freeze_unit_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val policy_kill_switch_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val policy_update_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val policy_approve_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+val policy_deny_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+(** {1 Detachment status} *)
+
+val detachment_status_json :
+  Room.config -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+(** {1 Tick automation} *)
+
+val dispatch_tick_json :
+  Room.config -> actor:string -> Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
+(** {1 Observation} *)
+
+val observe_operations_json : Room.config -> Yojson.Safe.t
+
+val observe_capacity_json : Room.config -> Yojson.Safe.t

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -1,0 +1,194 @@
+(** Keeper_types -- shared keeper contract, registry/store helpers,
+    path resolution, and model-selection utilities.
+
+    Re-exports everything from {!Keeper_types_profile} (context, schemas,
+    profile defaults, path helpers) and {!Keeper_types_resident}
+    (model selection, JSONL helpers, metrics store). *)
+
+include module type of Keeper_types_profile
+
+(** {1 Compaction state} *)
+
+type compaction_state = {
+  profile: string;
+  ratio_gate: float;
+  message_gate: int;
+  token_gate: int;
+  cooldown_sec: int;
+  count: int;
+  last_ts: float;
+  last_before_tokens: int;
+  last_after_tokens: int;
+  last_check_ts: float;
+  last_decision: string;
+}
+
+(** {1 Usage metrics} *)
+
+type usage_metrics = {
+  total_turns: int;
+  total_input_tokens: int;
+  total_output_tokens: int;
+  total_tokens: int;
+  total_cost_usd: float;
+  last_turn_ts: float;
+  last_model_used: string;
+  last_input_tokens: int;
+  last_output_tokens: int;
+  last_total_tokens: int;
+  last_latency_ms: int;
+}
+
+(** {1 Proactive config} *)
+
+type proactive_config = {
+  enabled: bool;
+  idle_sec: int;
+  cooldown_sec: int;
+  count_total: int;
+  last_ts: float;
+  last_reason: string;
+  last_preview: string;
+}
+
+(** {1 Keeper meta} *)
+
+type keeper_meta = {
+  name: string;
+  agent_name: string;
+  trace_id: string;
+  trace_history: string list;
+  goal: string;
+  short_goal: string;
+  mid_goal: string;
+  long_goal: string;
+  soul_profile: string;
+  cascade_name: string;
+  will: string;
+  needs: string;
+  desires: string;
+  instructions: string;
+  policy_voice_enabled: bool;
+  execution_scope: string;
+  allowed_paths: string list;
+  scope_kind: string;
+  room_scope: string;
+  mention_targets: string list;
+  joined_room_ids: string list;
+  last_seen_seq_by_room: (string * int) list;
+  generation: int;
+  presence_keepalive: bool;
+  presence_keepalive_sec: int;
+  proactive: proactive_config;
+  compaction: compaction_state;
+  auto_handoff: bool;
+  handoff_threshold: float;
+  handoff_cooldown_sec: int;
+  voice_enabled: bool;
+  voice_channel: string;
+  voice_agent_id: string;
+  last_handoff_ts: float;
+  created_at: string;
+  updated_at: string;
+  usage: usage_metrics;
+  last_continuity_update_ts: float;
+  continuity_summary: string;
+  active_goal_ids: string list;
+  active_team_session_id: string option;
+  last_team_session_started_at: string;
+  team_session_start_count_total: int;
+  last_autonomous_action_at: string;
+  autonomous_action_count: int;
+  autonomous_turn_count: int;
+  autonomous_text_turn_count: int;
+  autonomous_tool_turn_count: int;
+  board_reactive_turn_count: int;
+  mention_reactive_turn_count: int;
+  noop_turn_count: int;
+  last_triage_triggers: string;
+  paused: bool;
+  current_task_id: string option;
+  (** Currently claimed task ID for cost attribution. *)
+}
+
+val now_iso : unit -> string
+
+(** {1 Legacy model arg rejection} *)
+
+val keeper_legacy_model_arg_names : string list
+
+val reject_legacy_model_args :
+  tool_name:string -> Yojson.Safe.t -> (unit, string) result
+
+(** {1 Runtime meta write sync hook} *)
+
+val runtime_meta_write_sync_hook : (Room.config -> keeper_meta -> unit) ref
+val register_runtime_meta_write_sync : (Room.config -> keeper_meta -> unit) -> unit
+
+(** {1 JSON field scrubbing} *)
+
+val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
+val reject_removed_keeper_meta_fields : Yojson.Safe.t -> (unit, string) result
+val scrub_persisted_keeper_meta_json :
+  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool
+
+(** {1 Meta serialization} *)
+
+val meta_to_json : keeper_meta -> Yojson.Safe.t
+val meta_of_json : Yojson.Safe.t -> (keeper_meta, string) result
+
+(** {1 Keeper boot entry (resident keepers)} *)
+
+type keeper_boot_entry = {
+  name : string;
+  persona_name : string;
+  voice_enabled : bool;
+  voice_channel : string;
+  voice_agent_id : string;
+  created_at : string;
+  updated_at : string;
+}
+
+val resident_keeper_dir : Room.config -> string
+val resident_keeper_path : Room.config -> string -> string
+val keeper_boot_to_json : keeper_boot_entry -> Yojson.Safe.t
+val keeper_boot_of_json : Yojson.Safe.t -> (keeper_boot_entry, string) result
+val keeper_boot_entry_of_meta : ?created_at:string -> keeper_meta -> keeper_boot_entry
+
+val write_resident_keeper : Room.config -> keeper_boot_entry -> (unit, string) result
+val read_resident_keeper : Room.config -> string -> (keeper_boot_entry option, string) result
+val remove_resident_keeper : Room.config -> string -> unit
+val list_resident_keepers : Room.config -> keeper_boot_entry list
+val resident_keeper_names : Room.config -> string list
+val is_resident_keeper : Room.config -> string -> bool
+
+(** {1 Meta file I/O} *)
+
+val read_meta_file_path : string -> (keeper_meta option, string) result
+val register_resident_keeper : Room.config -> string -> (unit, string) result
+val persistent_agent_names : ?resident_names:string list -> Room.config -> string list
+val sync_registered_resident_keeper : Room.config -> string -> (unit, string) result
+val fresher_meta : Room.config -> keeper_meta -> keeper_meta
+val write_meta : Room.config -> keeper_meta -> (unit, string) result
+val read_meta : Room.config -> string -> (keeper_meta option, string) result
+
+(** {1 Re-exports from Keeper_types_resident} *)
+
+include module type of Keeper_types_resident
+
+(** {1 Fiber health (for keeper supervisor)} *)
+
+type fiber_health =
+  | Fiber_alive
+  | Fiber_zombie
+  | Fiber_dead
+  | Fiber_unknown
+
+(** {1 Per-tool usage tracking} *)
+
+type tool_call_entry = {
+  mutable count : int;
+  mutable successes : int;
+  mutable failures : int;
+  mutable last_used_at : float;
+}

--- a/lib/room/room_task.mli
+++ b/lib/room/room_task.mli
@@ -1,0 +1,97 @@
+(** Room_task -- Task lifecycle: add, claim, transition, complete, cancel.
+
+    This module is [include]d by {!Room}; all bindings are part of
+    the public Room interface.  Re-exports {!Room_utils} and
+    {!Room_state}. *)
+
+include module type of Room_utils
+include module type of Room_state
+
+(** {1 Task activity helpers} *)
+
+val emit_task_activity :
+  config -> agent_name:string -> task_id:string ->
+  kind:string -> payload:Yojson.Safe.t -> unit
+
+val task_status_to_string : Types.task_status -> string
+
+val task_started_at_unix : Types.task_status -> float
+
+val task_transition_details :
+  from_status:Types.task_status ->
+  to_status:Types.task_status ->
+  ?notes:string -> ?reason:string -> ?duration_ms:int ->
+  ?forced:bool -> unit -> Yojson.Safe.t
+
+val observe_task_transition :
+  config -> agent_name:string -> task_id:string ->
+  transition:string -> details:Yojson.Safe.t -> unit
+
+(** {1 Task creation} *)
+
+val add_task :
+  config -> title:string -> priority:int -> description:string -> string
+
+val add_task_with_role :
+  config -> title:string -> priority:int -> description:string ->
+  required_role:Types_core.role -> string
+
+val batch_add_tasks :
+  config -> (string * int * string) list -> string
+
+(** {1 Task claiming} *)
+
+val claim_task :
+  config -> agent_name:string -> task_id:string -> string
+
+val claim_task_r :
+  config -> agent_name:string -> task_id:string ->
+  ?agent_role:Types_core.role -> unit -> string Types.masc_result
+
+(** {1 Task transitions} *)
+
+val transition_task_r :
+  config -> agent_name:string -> task_id:string -> action:string ->
+  ?expected_version:int -> ?notes:string -> ?reason:string ->
+  ?force:bool -> unit -> string Types.masc_result
+
+val release_task_r :
+  config -> agent_name:string -> task_id:string ->
+  ?expected_version:int -> unit -> string Types.masc_result
+
+val force_release_task_r :
+  config -> agent_name:string -> task_id:string ->
+  unit -> string Types.masc_result
+
+val force_done_task_r :
+  config -> agent_name:string -> task_id:string ->
+  notes:string -> unit -> string Types.masc_result
+
+(** {1 Task completion} *)
+
+val complete_task :
+  config -> agent_name:string -> task_id:string -> notes:string -> string
+
+val complete_task_r :
+  config -> agent_name:string -> task_id:string ->
+  notes:string -> string Types.masc_result
+
+(** {1 Task cancellation} *)
+
+val cancel_task_r :
+  config -> agent_name:string -> task_id:string ->
+  reason:string -> string Types.masc_result
+
+(** {1 Re-exported type (backward compatibility)} *)
+
+type claim_next_result = Types.claim_next_result =
+  | Claim_next_claimed of {
+      task_id : string;
+      title : string;
+      priority : int;
+      released_task_id : string option;
+      message : string;
+    }
+  | Claim_next_no_unclaimed
+  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_error of string

--- a/lib/tool_command_plane_chain_query.ml
+++ b/lib/tool_command_plane_chain_query.ml
@@ -480,12 +480,12 @@ let string_member_opt json key =
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
-let assoc_member_opt json key =
+let _assoc_member_opt json key =
   match U.member key json with
   | `Assoc _ as value -> Some value
   | _ -> None
 
-let list_member json key =
+let _list_member json key =
   match U.member key json with
   | `List rows -> rows
   | _ -> []

--- a/lib/tool_command_plane_chain_query.mli
+++ b/lib/tool_command_plane_chain_query.mli
@@ -1,0 +1,37 @@
+(** Tool_command_plane_chain_query -- chain snapshot, run retrieval,
+    operation/intent/checkpoint, topology, alerts, swarm, and trace
+    observation handlers for the command-plane tool surface.
+
+    Only {!backfill_chain_overlays} is called externally by name;
+    the [handle_*] functions are dispatched via tool routing. *)
+
+open Tool_command_plane_support
+
+(** {1 Chain overlay backfill} *)
+
+(** Backfill chain history, mermaid, and preview_run overlays
+    for all operations that have a linked chain. *)
+val backfill_chain_overlays : Room.config -> unit
+
+(** {1 Chain summary and run} *)
+
+val handle_chain_snapshot : ('a, 'b) context -> result
+val handle_chain_run_get  : ('a, 'b) context -> Yojson.Safe.t -> result
+
+(** {1 Operation and intent} *)
+
+val handle_operation_status     : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_intent_create        : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_intent_status        : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_intent_update        : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_intent_forecast      : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_operation_checkpoint : ('a, 'b) context -> Yojson.Safe.t -> result
+
+(** {1 Observation} *)
+
+val handle_observe_topology   : ('a, 'b) context -> result
+val handle_observe_alerts     : ('a, 'b) context -> result
+val handle_observe_operations : ('a, 'b) context -> result
+val handle_observe_swarm      : ('a, 'b) context -> Yojson.Safe.t -> result
+val handle_observe_capacity   : ('a, 'b) context -> result
+val handle_observe_traces     : ('a, 'b) context -> Yojson.Safe.t -> result


### PR DESCRIPTION
## Summary

- Add .mli for cp_lifecycle_policy, tool_command_plane_chain_query, keeper_types, room_task
- room_eio.mli already existed, skipped
- Hides internal helpers from public API surface
- Dead code fix: underscore-prefix unused helpers in chain_query

## Test plan

- [x] dune build lib/ passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)