### PR TITLE
refactor: remove safe_parse JSON helpers, delegate to Safe_ops (#2964)

### DIFF
--- a/lib/chain/chain_adapter_eio.ml
+++ b/lib/chain/chain_adapter_eio.ml
@@ -547,22 +547,19 @@ let rec apply_adapter_transform (transform : adapter_transform) (input : string)
            Ok (Buffer.contents buf)
        | "figma_summary_to_spec" ->
            (try
-             let open Yojson.Safe.Util in
              let json = Yojson.Safe.from_string input in
-             let get_string key = Safe_parse.json_string ~context:"FigmaSummary" ~default:"" json key in
-             let get_int key = Safe_parse.json_int ~context:"FigmaSummary" ~default:0 json key in
-             let get_bool key = Safe_parse.json_bool ~context:"FigmaSummary" ~default:false json key in
-             let get_string_opt key = Safe_parse.json_string ~context:"FigmaSummary" ~default:"" json key in
+             let get_string key = Safe_ops.json_string key json in
+             let get_int key = Safe_ops.json_int key json in
+             let get_bool key = Safe_ops.json_bool key json in
+             let get_string_opt key = Safe_ops.json_string key json in
              let name = get_string "name" in
              let typ = get_string "type" in
-             let children = Safe_parse.json_list ~context:"FigmaSummary" json "children" in
+             let children = Safe_ops.json_list "children" json in
              let child_entries =
                List.filter_map (fun child ->
-                 try
-                   let cname = child |> member "name" |> to_string in
-                   let ctype = child |> member "type" |> to_string in
-                   Some (ctype, cname)
-                 with Yojson.Safe.Util.Type_error _ -> None
+                 match Safe_ops.json_string_opt "name" child, Safe_ops.json_string_opt "type" child with
+                 | Some cname, Some ctype -> Some (ctype, cname)
+                 | _ -> None
                ) children
              in
              let texts =
@@ -627,7 +624,7 @@ let rec apply_adapter_transform (transform : adapter_transform) (input : string)
                ("implementation_notes", `List (List.map (fun s -> `String s) impl_notes));
              ] in
              Ok (Yojson.Safe.to_string spec)
-           with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+           with Yojson.Json_error _ ->
              Error "Failed to parse figma summary JSON")
        | "reverse" ->
            let chars = String.to_seq input |> List.of_seq |> List.rev in

--- a/lib/run_log_eio.ml
+++ b/lib/run_log_eio.ml
@@ -184,10 +184,10 @@ let read_events () =
         with Yojson.Json_error _ -> None)
 
 let int_field json key ~default =
-  Safe_parse.json_int ~context:"run_log" ~default json key
+  Safe_ops.json_int ~default key json
 
 let string_field json key ~default =
-  Safe_parse.json_string ~context:"run_log" ~default json key
+  Safe_ops.json_string ~default key json
 
 let take_last n lst =
   if n <= 0 then []

--- a/lib/safe_parse.ml
+++ b/lib/safe_parse.ml
@@ -81,59 +81,6 @@ let env_bool ~var ~default =
   | None -> default
   | Some v -> bool ~context:(Printf.sprintf "env:%s" var) ~default v
 
-(** {1 JSON Parsers (Yojson.Safe)} *)
-
-open Yojson.Safe.Util
-
-(** Get JSON member as string with default. *)
-let json_string ~context ~default json key =
-  try json |> member key |> to_string
-  with Type_error _ ->
-    warn ~context:(Printf.sprintf "%s.%s" context key) ~input:"<non-string>" ~fallback:default;
-    default
-
-(** Get JSON member as string option (no warning). *)
-let json_string_opt json key =
-  try Some (json |> member key |> to_string)
-  with Type_error _ -> None
-
-(** Get JSON member as int with default. *)
-let json_int ~context ~default json key =
-  try json |> member key |> to_int
-  with Type_error _ ->
-    warn ~context:(Printf.sprintf "%s.%s" context key)
-      ~input:"<non-int>" ~fallback:(string_of_int default);
-    default
-
-(** Get JSON member as int option (no warning). *)
-let json_int_opt json key =
-  try Some (json |> member key |> to_int)
-  with Type_error _ -> None
-
-(** Get JSON member as float with default. *)
-let json_float ~context ~default json key =
-  try json |> member key |> to_float
-  with Type_error _ ->
-    warn ~context:(Printf.sprintf "%s.%s" context key)
-      ~input:"<non-float>" ~fallback:(Printf.sprintf "%.2f" default);
-    default
-
-(** Get JSON member as bool with default. *)
-let json_bool ~context ~default json key =
-  try json |> member key |> to_bool
-  with Type_error _ ->
-    warn ~context:(Printf.sprintf "%s.%s" context key)
-      ~input:"<non-bool>" ~fallback:(string_of_bool default);
-    default
-
-(** Get JSON member as list with default empty list. *)
-let json_list ~context json key =
-  try json |> member key |> to_list
-  with Type_error _ ->
-    warn ~context:(Printf.sprintf "%s.%s" context key)
-      ~input:"<non-list>" ~fallback:"[]";
-    []
-
 (** {1 JSON Parsing} *)
 
 (** Parse JSON string, return None on failure. *)

--- a/test/test_chain_utils_coverage.ml
+++ b/test/test_chain_utils_coverage.ml
@@ -213,7 +213,6 @@ let test_estimate_conversation_tokens () =
 
 (* ═══ Safe_parse ═══ *)
 module SP = Masc_mcp.Safe_parse
-
 let test_sp_int_ok () =
   check int "parse" 42 (SP.int ~context:"test" ~default:0 "42")
 
@@ -244,41 +243,6 @@ let test_sp_bool () =
   check bool "0" false (SP.bool ~context:"t" ~default:true "0");
   check bool "no" false (SP.bool ~context:"t" ~default:true "no");
   check bool "fallback" true (SP.bool ~context:"t" ~default:true "maybe")
-
-let test_sp_json_string () =
-  let j = `Assoc [("k", `String "v")] in
-  check string "ok" "v" (SP.json_string ~context:"t" ~default:"d" j "k");
-  check string "missing" "d" (SP.json_string ~context:"t" ~default:"d" j "nope")
-
-let test_sp_json_string_opt () =
-  let j = `Assoc [("k", `String "v")] in
-  check (option string) "ok" (Some "v") (SP.json_string_opt j "k");
-  check (option string) "missing" None (SP.json_string_opt j "nope")
-
-let test_sp_json_int () =
-  let j = `Assoc [("n", `Int 10)] in
-  check int "ok" 10 (SP.json_int ~context:"t" ~default:0 j "n");
-  check int "missing" 0 (SP.json_int ~context:"t" ~default:0 j "nope")
-
-let test_sp_json_int_opt () =
-  let j = `Assoc [("n", `Int 10)] in
-  check (option int) "ok" (Some 10) (SP.json_int_opt j "n");
-  check (option int) "missing" None (SP.json_int_opt j "nope")
-
-let test_sp_json_float () =
-  let j = `Assoc [("f", `Float 1.5)] in
-  let v = SP.json_float ~context:"t" ~default:0.0 j "f" in
-  check bool "ok" true (Float.abs (v -. 1.5) < 0.001)
-
-let test_sp_json_bool () =
-  let j = `Assoc [("b", `Bool true)] in
-  check bool "ok" true (SP.json_bool ~context:"t" ~default:false j "b");
-  check bool "missing" false (SP.json_bool ~context:"t" ~default:false j "nope")
-
-let test_sp_json_list () =
-  let j = `Assoc [("l", `List [`Int 1; `Int 2])] in
-  check int "ok" 2 (List.length (SP.json_list ~context:"t" j "l"));
-  check int "missing" 0 (List.length (SP.json_list ~context:"t" j "nope"))
 
 let test_sp_json_of_string () =
   check (option string) "ok" (Some "ok") (match SP.json_of_string_opt {|"ok"|} with Some (`String s) -> Some s | _ -> None);
@@ -359,13 +323,6 @@ let () =
       test_case "bool" `Quick test_sp_bool;
     ];
     "safe_parse:json", [
-      test_case "json_string" `Quick test_sp_json_string;
-      test_case "json_string_opt" `Quick test_sp_json_string_opt;
-      test_case "json_int" `Quick test_sp_json_int;
-      test_case "json_int_opt" `Quick test_sp_json_int_opt;
-      test_case "json_float" `Quick test_sp_json_float;
-      test_case "json_bool" `Quick test_sp_json_bool;
-      test_case "json_list" `Quick test_sp_json_list;
       test_case "json_of_string" `Quick test_sp_json_of_string;
       test_case "json_of_string_default" `Quick test_sp_json_of_string_default;
     ];


### PR DESCRIPTION
## Summary

- Remove 7 Type_error-based JSON helpers from safe_parse.ml (53 LOC deleted)
- Migrate 2 callers (chain_adapter_eio, run_log_eio) to Safe_ops equivalents
- safe_parse.ml now focuses on primitive parsing only (int, float, bool, string)

## Test plan

- [x] dune build passes
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)