### PR TITLE
feat: progress messages and _meta tracing

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -81,6 +81,10 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
     with
     | Error e -> (false, "❌ " ^ e)
     | Ok meta0 ->
+      let turn_task_id = Printf.sprintf "keeper_turn_%s_%d"
+        name (int_of_float (Time_compat.now () *. 1000.0)) in
+      let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
+      Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
       let meta =
         apply_settings_update
           ~args ~meta0 ~new_short_goal ~new_mid_goal ~new_long_goal
@@ -101,9 +105,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~generation:meta.generation
       in
       let effective_models = effective_model_labels_for_turn meta in
+      Progress.Tracker.step turn_tracker ~message:"Validating API keys" ();
       (match ensure_api_keys_for_labels effective_models with
-       | Error e -> (false, "❌ " ^ e)
+       | Error e ->
+         Progress.stop_tracking turn_task_id;
+         (false, "❌ " ^ e)
        | Ok () ->
+         Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          let primary_max_context =
            Oas_model_resolve.resolve_primary_max_context effective_models
          in
@@ -184,6 +192,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   Printf.sprintf "%s\n\n--- Turn-specific instructions ---\n%s"
                     prompt ti
             in
+            Progress.Tracker.step turn_tracker
+              ~message:(Printf.sprintf "Executing Agent.run for %s" name) ();
             match
               Keeper_agent_run.run_turn
                 ~config:ctx.config ~meta ~base_dir
@@ -202,6 +212,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run error)" exn);
               start_keepalive ctx meta;
+              Progress.stop_tracking turn_task_id;
               (false, Printf.sprintf "❌ Agent.run failed: %s" e)
             | Ok result ->
               (try ignore (Trajectory.finalize trajectory_acc
@@ -209,6 +220,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run ok)" exn);
               start_keepalive ctx meta;
+              Progress.Tracker.complete turn_tracker
+                ~message:(Printf.sprintf "Turn completed: %d tool calls" result.tool_calls_made) ();
               let reply_json = `Assoc [
                 ("reply", `String result.response_text);
                 ("model", `String result.model_used);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -10,6 +10,9 @@ open Keeper_execution
 open Keeper_turn_up_args
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
+  let task_id = Printf.sprintf "keeper_create_%s" p.name in
+  let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
+  Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
   let now_ts = Time_compat.now () in
   let goal =
     match p.goal_opt with
@@ -142,10 +145,14 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ~fallback_message:env_message_gate
         ~fallback_token:env_token_gate
     in
+    Progress.Tracker.step tracker ~message:"Validating API keys for cascade" ();
     let cascade_models = Oas_model_resolve.models_of_cascade_name "keeper_unified" in
     (match ensure_api_keys_for_labels cascade_models with
-     | Error e -> (false, e)
+     | Error e ->
+       Progress.stop_tracking task_id;
+       (false, e)
      | Ok () ->
+       Progress.Tracker.step tracker ~message:"Initializing session directory" ();
        let primary_max_context = Oas_model_resolve.resolve_primary_max_context cascade_models in
        let trace_id = generate_trace_id () in
          let base_dir = session_base_dir ctx.config in
@@ -259,6 +266,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             paused = false;
             current_task_id = None;
          } in
+         Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
          (try
             ignore
               (Keeper_exec_context.save_oas_checkpoint
@@ -271,10 +279,15 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
               log_keeper_exn ~label:"save_oas_checkpoint (init) failed" exn);
+         Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
          match write_meta ctx.config meta with
-         | Error e -> (false, e)
+         | Error e ->
+           Progress.stop_tracking task_id;
+           (false, e)
          | Ok () ->
+           Progress.Tracker.step tracker ~message:"Starting keepalive loop" ();
            start_keepalive ctx meta;
+           Progress.Tracker.complete tracker ~message:"Keeper created" ();
            let json = `Assoc [
              ("name", `String meta.name);
              ("agent_name", `String meta.agent_name);

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -346,11 +346,23 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ]
   in
   let structured_content = Tool_result.structured_payload_of_message message in
+  let meta_fields =
+    [
+      ("trace_id", `String trace_id);
+      ("agent_id", `String agent_name);
+      ("tool", `String name);
+      ("duration_ms", `Int duration_ms);
+      ("attempts", `Int attempts);
+      ("timestamp", `String (Types.now_iso ()));
+    ]
+    @ (if !timeout_hit then [ ("timeout_hit", `Bool true) ] else [])
+  in
   let result_fields =
     [
       ("resultEnvelope", envelope);
       ("content", `List content_items);
       ("isError", `Bool (not success));
+      ("_meta", `Assoc meta_fields);
     ]
     @
     match structured_content with

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -174,6 +174,16 @@ let handle_initialize_eio ?(profile = Full) id params =
                  | Full -> TP.default_instructions
                  | Managed_agent -> TP.managed_agent_instructions
                  | Operator_remote -> TP.operator_remote_instructions) );
+             ( "_meta",
+               `Assoc [
+                 ("serverStartedAt", `String (Types.now_iso ()));
+                 ("serverVersion", `String Version.version);
+                 ("profile", `String
+                   (match profile with
+                    | Full -> "full"
+                    | Managed_agent -> "managed_agent"
+                    | Operator_remote -> "operator_remote"));
+               ] );
            ]))
 
 let public_tool_help_schemas () =

--- a/lib/team_session/team_session_engine_eio.ml
+++ b/lib/team_session/team_session_engine_eio.ml
@@ -24,6 +24,10 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
     : (Yojson.Safe.t, string) result =
   try
     Room_utils.ensure_initialized config;
+    let session_task_id = Printf.sprintf "team_session_start_%s"
+      (string_of_int (int_of_float (Time_compat.now () *. 1000.0))) in
+    let session_tracker = Progress.start_tracking ~task_id:session_task_id ~total_steps:5 () in
+    Progress.Tracker.step session_tracker ~message:"Validating session parameters" ();
     let duration_seconds = clamp_int ~min_v:60 ~max_v:28800 duration_seconds in
     let checkpoint_interval_sec =
       clamp_int ~min_v:10 ~max_v:600 checkpoint_interval_sec
@@ -109,6 +113,7 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
     in
     (* Create dirs only after validation succeeds — prevents orphaned
        directories when validate_operation_attachment returns Error. *)
+    Progress.Tracker.step session_tracker ~message:"Creating session directories" ();
     Team_session_store.ensure_session_dirs config session_id;
     Team_session_store.save_session config session;
     let* () =
@@ -136,6 +141,7 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
           | Error err -> Error err)
       | None -> Ok ()
     in
+    Progress.Tracker.step session_tracker ~message:"Recording session start event" ();
     Team_session_store.append_event config session_id ~event_type:"session_started"
       ~detail:
         (`Assoc
@@ -179,6 +185,7 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
               ("ts_iso", `String (now_iso ()));
             ]);
     write_checkpoint config session;
+    Progress.Tracker.step session_tracker ~message:"Registering runtime state" ();
     with_runtimes_lock (fun () ->
         Hashtbl.replace runtimes session_id
           {
@@ -214,6 +221,8 @@ let start_session ~sw ~(env : < clock : _ Eio.Time.clock ; process_mgr : _ Eio.P
             ~final_status:Team_session_types.Failed ~reason
             ~generate_report:true);
           with_runtimes_lock (fun () -> Hashtbl.remove runtimes session_id));
+    Progress.Tracker.complete session_tracker
+      ~message:(Printf.sprintf "Team session %s started" session_id) ();
     Ok
       (`Assoc
         [

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -234,9 +234,15 @@ let handle_swarm_start (ctx : context) args =
       match prepare_start_params ctx args with
       | Error message -> `Assoc [ ("error", `String message) ]
       | Ok params ->
+          let swarm_task_id = Printf.sprintf "swarm_start_%s"
+            (string_of_int (int_of_float (Time_compat.now () *. 1000.0))) in
+          let swarm_tracker = Progress.start_tracking ~task_id:swarm_task_id ~total_steps:4 () in
+          Progress.Tracker.step swarm_tracker ~message:"Initializing autoresearch loop" ();
           let program_note = normalize_string_opt (get_string_opt args "program_note") in
           (match setup_running_loop ctx params with
-          | Error message -> `Assoc [ ("error", `String message) ]
+          | Error message ->
+            Progress.stop_tracking swarm_task_id;
+            `Assoc [ ("error", `String message) ]
           | Ok state ->
           state.program_note <- program_note;
           broadcast_loop_lifecycle "autoresearch_started" state;
@@ -255,6 +261,7 @@ let handle_swarm_start (ctx : context) args =
           in
           state.warnings <- List.rev !warnings;
           Autoresearch.save_state ~base_path:ctx.base_path state;
+          Progress.Tracker.step swarm_tracker ~message:"Launching team session" ();
           let session_goal =
             build_swarm_goal ~goal:params.goal ~target_file:params.target_file
               ~program_note
@@ -267,6 +274,7 @@ let handle_swarm_start (ctx : context) args =
               state.status <- Autoresearch.Error;
               state.error_message <- Some message;
               Autoresearch.save_state ~base_path:ctx.base_path state;
+              Progress.stop_tracking swarm_task_id;
               `Assoc
                 [
                   ("error", `String message);
@@ -278,12 +286,15 @@ let handle_swarm_start (ctx : context) args =
                   state.status <- Autoresearch.Error;
                   state.error_message <- Some message;
                   Autoresearch.save_state ~base_path:ctx.base_path state;
+                  Progress.stop_tracking swarm_task_id;
                   `Assoc
                     [
                       ("error", `String message);
                       ("loop_id", `String state.loop_id);
                     ]
               | Ok (session_id, artifacts_dir) ->
+                  Progress.Tracker.complete swarm_tracker
+                    ~message:(Printf.sprintf "Swarm launched: session %s" session_id) ();
                   let link : Autoresearch.swarm_link =
                     {
                       loop_id = state.loop_id;


### PR DESCRIPTION
## Summary
- Add descriptive `~message` to `send_progress` in keeper, team session, autoresearch
- Add `_meta` with execution timing to tool results and server info to initialize_result
- 6 files, +72/-4

## Test plan
- [x] `dune build --root .` passes
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)