### PR TITLE
fix(transport): isolate WS bind failure and add listen_status (#3408)

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -495,6 +495,6 @@ let start
           port
       | exn ->
         Transport_metrics.set_grpc_runtime_listening false;
-        Transport_metrics.set_grpc_listen_status "bind_failed";
+        Transport_metrics.set_grpc_listen_status "stopped";
         Log.Server.error "gRPC server failed: %s" (Printexc.to_string exn)))
   end

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -462,6 +462,7 @@ let start
   : unit =
   if not (is_enabled ()) then begin
     Transport_metrics.set_grpc_runtime_listening false;
+    Transport_metrics.set_grpc_listen_status "disabled";
     Log.Server.info "gRPC transport disabled (set MASC_GRPC_ENABLED=0 to disable)";
   end
   else begin
@@ -477,18 +478,23 @@ let start
         Log.Server.info
           "  methods: Join, Leave, Broadcast, GetStatus, ToolCall, Subscribe, Heartbeat";
         Transport_metrics.set_grpc_runtime_listening true;
+        Transport_metrics.set_grpc_listen_status "listening";
         (* Safe: finally is Atomic.set — no I/O, no exception risk *)
         Fun.protect
-          ~finally:(fun () -> Transport_metrics.set_grpc_runtime_listening false)
+          ~finally:(fun () ->
+            Transport_metrics.set_grpc_runtime_listening false;
+            Transport_metrics.set_grpc_listen_status "stopped")
           (fun () -> Grpc_eio.Server.serve ~sw ~env server)
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | Unix.Unix_error (Unix.EADDRINUSE, _, _) ->
         Transport_metrics.set_grpc_runtime_listening false;
+        Transport_metrics.set_grpc_listen_status "bind_failed";
         Log.Server.error
           "gRPC coordination transport unavailable on 127.0.0.1:%d: port already in use"
           port
       | exn ->
         Transport_metrics.set_grpc_runtime_listening false;
+        Transport_metrics.set_grpc_listen_status "bind_failed";
         Log.Server.error "gRPC server failed: %s" (Printexc.to_string exn)))
   end

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -64,11 +64,13 @@ let websocket_discovery_json request =
   let configured = Server_ws_standalone.is_enabled () in
   let port = Server_ws_standalone.configured_port () in
   let listening = Transport_metrics.ws_listening () in
+  let listen_status = Atomic.get Transport_metrics.ws_listen_status in
   let base_fields =
     [
       ("enabled", `Bool configured);
       ("configured", `Bool configured);
       ("listening", `Bool listening);
+      ("listen_status", `String listen_status);
       ("mode", `String "standalone");
       ("discovery_path", `String "/ws");
       ("session_count", `Int (Server_mcp_transport_ws.session_count ()));
@@ -92,6 +94,7 @@ let transport_json request =
   let grpc_enabled = Masc_grpc_server.is_enabled () in
   let grpc_port = Masc_grpc_server.configured_port () in
   let grpc_listening = Transport_metrics.grpc_listening () in
+  let grpc_listen_status = Atomic.get Transport_metrics.grpc_listen_status in
   let webrtc_enabled = Server_webrtc_transport.is_enabled () in
   `Assoc
     [
@@ -112,6 +115,7 @@ let transport_json request =
              ("enabled", `Bool grpc_enabled);
              ("configured", `Bool grpc_enabled);
              ("listening", `Bool grpc_listening);
+             ("listen_status", `String grpc_listen_status);
              ("port", `Int grpc_port);
              ("service", `String Masc_grpc_service.service_name);
              ("health_service", `String Masc_grpc_server.health_service_name);

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -94,6 +94,8 @@ let transport_json request =
   let grpc_enabled = Masc_grpc_server.is_enabled () in
   let grpc_port = Masc_grpc_server.configured_port () in
   let grpc_listening = Transport_metrics.grpc_listening () in
+  (* Note: listen_status is read separately from listening — brief tearing is
+     possible but acceptable for this diagnostic-only endpoint. *)
   let grpc_listen_status = Atomic.get Transport_metrics.grpc_listen_status in
   let webrtc_enabled = Server_webrtc_transport.is_enabled () in
   `Assoc

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -106,50 +106,67 @@ let start
   : unit =
   if not (is_enabled ()) then begin
     Transport_metrics.set_ws_runtime_listening false;
+    Transport_metrics.set_ws_listen_status "disabled";
     Log.Server.info "WebSocket transport disabled (MASC_WS_ENABLED=0)"
   end else begin
     let port = configured_port () in
     let net = Eio.Stdenv.net env in
     let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
-    let socket =
-      Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:128 addr
-    in
-    Transport_metrics.set_ws_runtime_listening true;
-    let connection_handler =
-      Ws_eio.Server.create_connection_handler ~sw
-        (make_websocket_handler ~on_message)
-    in
-    Eio.Fiber.fork ~sw (fun () ->
-      (* Safe: finally is Atomic.set — no I/O, no exception risk *)
-      Fun.protect
-        ~finally:(fun () -> Transport_metrics.set_ws_runtime_listening false)
-        (fun () ->
-          Log.Server.info "WebSocket server starting on port %d" port;
-          let rec accept_loop backoff_s =
-            try
-              let flow, client_addr = Eio.Net.accept ~sw socket in
-              Eio.Fiber.fork ~sw (fun () ->
-                try connection_handler client_addr flow
-                with
-                | Eio.Cancel.Cancelled _ as e -> raise e
-                | exn ->
-                  Log.Server.warn "WS standalone handler error: %s"
-                    (Printexc.to_string exn));
-              accept_loop 0.05
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-              Log.Server.error "WS standalone accept error: %s"
-                (Printexc.to_string exn);
-              (* Backoff to avoid tight error loops *)
-              (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s
-               with Eio.Cancel.Cancelled _ as e -> raise e
+    (* Isolate bind failure so it does not propagate to the bootstrap
+       catch-all and mark the entire startup as Degraded (#3408). *)
+    match Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:128 addr with
+    | socket ->
+      Transport_metrics.set_ws_runtime_listening true;
+      Transport_metrics.set_ws_listen_status "listening";
+      let connection_handler =
+        Ws_eio.Server.create_connection_handler ~sw
+          (make_websocket_handler ~on_message)
+      in
+      Eio.Fiber.fork ~sw (fun () ->
+        (* Safe: finally is Atomic.set — no I/O, no exception risk *)
+        Fun.protect
+          ~finally:(fun () ->
+            Transport_metrics.set_ws_runtime_listening false;
+            Transport_metrics.set_ws_listen_status "stopped")
+          (fun () ->
+            Log.Server.info "WebSocket server starting on port %d" port;
+            let rec accept_loop backoff_s =
+              try
+                let flow, client_addr = Eio.Net.accept ~sw socket in
+                Eio.Fiber.fork ~sw (fun () ->
+                  try connection_handler client_addr flow
+                  with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
                   | exn ->
-                      Log.Server.warn
-                        "WS standalone backoff sleep failed on port %d (backoff=%.2fs): %s"
-                        port backoff_s (Printexc.to_string exn));
-              let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
-              accept_loop next_backoff
-          in
-          accept_loop 0.05))
+                    Log.Server.warn "WS standalone handler error: %s"
+                      (Printexc.to_string exn));
+                accept_loop 0.05
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                Log.Server.error "WS standalone accept error: %s"
+                  (Printexc.to_string exn);
+                (* Backoff to avoid tight error loops *)
+                (try Eio.Time.sleep (Eio.Stdenv.clock env) backoff_s
+                 with Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                        Log.Server.warn
+                          "WS standalone backoff sleep failed on port %d (backoff=%.2fs): %s"
+                          port backoff_s (Printexc.to_string exn));
+                let next_backoff = Float.min 2.0 (backoff_s *. 1.5) in
+                accept_loop next_backoff
+            in
+            accept_loop 0.05))
+    | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+    | exception Unix.Unix_error (Unix.EADDRINUSE, _, _) ->
+      Transport_metrics.set_ws_runtime_listening false;
+      Transport_metrics.set_ws_listen_status "bind_failed";
+      Log.Server.error
+        "WebSocket transport unavailable on 127.0.0.1:%d: port already in use"
+        port
+    | exception exn ->
+      Transport_metrics.set_ws_runtime_listening false;
+      Transport_metrics.set_ws_listen_status "bind_failed";
+      Log.Server.error "WebSocket bind failed on port %d: %s"
+        port (Printexc.to_string exn)
   end

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -95,11 +95,23 @@ let set_ws_sessions count =
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false
 let ws_runtime_listening : bool Atomic.t = Atomic.make false
 
+(** Explanatory status for why a transport is or is not listening.
+    Valid values: ["not_started"], ["disabled"], ["listening"],
+    ["bind_failed"], ["stopped"]. *)
+let grpc_listen_status : string Atomic.t = Atomic.make "not_started"
+let ws_listen_status : string Atomic.t = Atomic.make "not_started"
+
 let set_grpc_runtime_listening listening =
   Atomic.set grpc_runtime_listening listening
 
 let set_ws_runtime_listening listening =
   Atomic.set ws_runtime_listening listening
+
+let set_grpc_listen_status status =
+  Atomic.set grpc_listen_status status
+
+let set_ws_listen_status status =
+  Atomic.set ws_listen_status status
 
 let grpc_enabled () =
   match Sys.getenv_opt "MASC_GRPC_ENABLED" with
@@ -143,7 +155,9 @@ let init () =
   register_ws_metrics ();
   register_agent_metrics ();
   set_grpc_runtime_listening false;
-  set_ws_runtime_listening false
+  set_grpc_listen_status "not_started";
+  set_ws_runtime_listening false;
+  set_ws_listen_status "not_started"
 
 (** {1 Transport Health JSON Snapshot} *)
 
@@ -302,6 +316,7 @@ let transport_health_json ~config =
       ("enabled", `Bool grpc_configured);
       ("configured", `Bool grpc_configured);
       ("listening", `Bool grpc_live);
+      ("listen_status", `String (Atomic.get grpc_listen_status));
       ("port", `Int (grpc_port ()));
       ("active_streams", `Int (int_of_float grpc_streams));
       ("subscribers", `Int grpc_subscribers_i);
@@ -312,6 +327,7 @@ let transport_health_json ~config =
       ("enabled", `Bool ws_configured);
       ("configured", `Bool ws_configured);
       ("listening", `Bool ws_live);
+      ("listen_status", `String (Atomic.get ws_listen_status));
       ("mode", `String "standalone");
       ("port", `Int (ws_port ()));
       ("sessions", `Int ws_sessions);

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -233,8 +233,12 @@ let test_transport_health_json () =
     (grpc_json |> U.member "subscribers" |> U.to_int);
   check bool "grpc listening field exists" true
     (match grpc_json |> U.member "listening" with `Bool _ -> true | _ -> false);
+  check bool "grpc listen_status field exists" true
+    (match grpc_json |> U.member "listen_status" with `String _ -> true | _ -> false);
   check bool "websocket listening field exists" true
     (match ws_json |> U.member "listening" with `Bool _ -> true | _ -> false);
+  check bool "ws listen_status field exists" true
+    (match ws_json |> U.member "listen_status" with `String _ -> true | _ -> false);
   check bool "websocket section exists" true
     (match ws_json with `Assoc _ -> true | _ -> false);
   check bool "webrtc section exists" true
@@ -245,6 +249,62 @@ let test_transport_health_json () =
     (String.length (summary_json |> U.member "primary_path" |> U.to_string) > 0);
   ignore (Masc_mcp.Sse.close_all_clients ());
   cleanup_dir base_dir
+
+(* ============================================================
+   Listen Status (#3408)
+   ============================================================ *)
+
+let test_grpc_listen_status_lifecycle () =
+  TM.init ();
+  check string "grpc status after init" "not_started"
+    (Atomic.get TM.grpc_listen_status);
+  TM.set_grpc_listen_status "listening";
+  TM.set_grpc_runtime_listening true;
+  check string "grpc status after listening" "listening"
+    (Atomic.get TM.grpc_listen_status);
+  check bool "grpc listening returns true" true (TM.grpc_listening ());
+  TM.set_grpc_listen_status "stopped";
+  TM.set_grpc_runtime_listening false;
+  check string "grpc status after stopped" "stopped"
+    (Atomic.get TM.grpc_listen_status);
+  check bool "grpc listening returns false" false (TM.grpc_listening ())
+
+let test_ws_listen_status_lifecycle () =
+  TM.init ();
+  check string "ws status after init" "not_started"
+    (Atomic.get TM.ws_listen_status);
+  TM.set_ws_listen_status "listening";
+  TM.set_ws_runtime_listening true;
+  check string "ws status after listening" "listening"
+    (Atomic.get TM.ws_listen_status);
+  check bool "ws listening returns true" true (TM.ws_listening ());
+  TM.set_ws_listen_status "stopped";
+  TM.set_ws_runtime_listening false;
+  check string "ws status after stopped" "stopped"
+    (Atomic.get TM.ws_listen_status);
+  check bool "ws listening returns false" false (TM.ws_listening ())
+
+let test_listen_status_bind_failed () =
+  TM.init ();
+  TM.set_grpc_listen_status "bind_failed";
+  TM.set_grpc_runtime_listening false;
+  TM.set_ws_listen_status "bind_failed";
+  TM.set_ws_runtime_listening false;
+  check bool "grpc not listening on bind_failed" false (TM.grpc_listening ());
+  check bool "ws not listening on bind_failed" false (TM.ws_listening ());
+  check string "grpc status is bind_failed" "bind_failed"
+    (Atomic.get TM.grpc_listen_status);
+  check string "ws status is bind_failed" "bind_failed"
+    (Atomic.get TM.ws_listen_status)
+
+let test_listen_status_disabled () =
+  TM.init ();
+  TM.set_grpc_listen_status "disabled";
+  TM.set_ws_listen_status "disabled";
+  check string "grpc status disabled" "disabled"
+    (Atomic.get TM.grpc_listen_status);
+  check string "ws status disabled" "disabled"
+    (Atomic.get TM.ws_listen_status)
 
 (* ============================================================
    Test Runner
@@ -282,5 +342,15 @@ let () =
     ]);
     ("json", [
       test_case "transport_health_json structure" `Quick test_transport_health_json;
+    ]);
+    ("listen_status", [
+      test_case "grpc listen_status lifecycle" `Quick
+        test_grpc_listen_status_lifecycle;
+      test_case "ws listen_status lifecycle" `Quick
+        test_ws_listen_status_lifecycle;
+      test_case "listen_status bind_failed" `Quick
+        test_listen_status_bind_failed;
+      test_case "listen_status disabled" `Quick
+        test_listen_status_disabled;
     ]);
   ]


### PR DESCRIPTION
## Summary
- WS `Eio.Net.listen`의 EADDRINUSE가 bootstrap catch-all로 전파되어 전체 startup을 Degraded로 마킹하고 WebRTC/refresh loop/resident loop을 skip하던 버그 수정
- `listen_status` 문자열 필드를 transport health JSON, `/ws` discovery, `/health` transport 섹션에 추가하여 `listening=false`의 원인을 구분 가능하게 개선
- gRPC/WS 양쪽 transport에 status 전이 설정 (`not_started` → `disabled` | `listening` | `bind_failed` → `stopped`)

## Changes
| 파일 | 변경 |
|------|------|
| `lib/server/server_ws_standalone.ml` | `Eio.Net.listen`을 match-with-exception로 격리 |
| `lib/transport_metrics.ml` | `grpc_listen_status`, `ws_listen_status` Atomic 필드 + health JSON 포함 |
| `lib/grpc/masc_grpc_server.ml` | listen_status 전이 설정 |
| `lib/server/server_routes_http_runtime.ml` | discovery/transport JSON에 `listen_status` 필드 노출 |
| `test/test_transport_metrics.ml` | listen_status lifecycle/bind_failed/disabled 테스트 4개 추가 |

## Test plan
- [x] `test_transport_metrics` 20/20 통과 (신규 4개 포함)
- [x] `test_transport_coverage` 100/100 통과
- [x] `test_transport_integration` 8/8 통과
- [x] `test_grpc_coordination` 18/18 통과
- [ ] CI full suite 확인

Closes #3408

🤖 Generated with [Claude Code](https://claude.com/claude-code)