### PR TITLE
fix(test): wrap coverage test helpers in Eio context (#3396)

### DIFF
--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -7,21 +7,22 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 let () = Printf.printf "\n=== Tool_auth Coverage Tests ===\n"
 
-(* Test helper *)
+(* Test helper — wraps in Eio context so dispatch paths that use
+   Eio.Mutex or structured concurrency work correctly. *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
     exit 1
 
-(* Create test context *)
+(* Create test context — called inside Eio scope from test helper *)
+let test_counter = ref 0
 let make_test_ctx () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  incr test_counter;
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "masc-auth-test-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
+    (Printf.sprintf "masc-auth-test-%d-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) !test_counter) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
   { Tool_auth.config; agent_name = "test-agent" }

--- a/test/test_tool_cost_coverage.ml
+++ b/test/test_tool_cost_coverage.ml
@@ -6,10 +6,11 @@ let () = Random.self_init ()
 
 let () = Printf.printf "\n=== Tool_cost Coverage Tests ===\n"
 
-(* Test helper *)
+(* Test helper — wraps in Eio context so dispatch paths that use
+   Eio.Mutex or structured concurrency work correctly. *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);

--- a/test/test_tool_encryption_coverage.ml
+++ b/test/test_tool_encryption_coverage.ml
@@ -6,10 +6,11 @@ let () = Random.self_init ()
 
 let () = Printf.printf "\n=== Tool_encryption Coverage Tests ===\n"
 
-(* Test helper *)
+(* Test helper — wraps in Eio context so dispatch paths that use
+   Eio.Mutex or structured concurrency work correctly. *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);

--- a/test/test_tool_rate_limit_coverage.ml
+++ b/test/test_tool_rate_limit_coverage.ml
@@ -6,10 +6,11 @@ let () = Random.self_init ()
 
 let () = Printf.printf "\n=== Tool_rate_limit Coverage Tests ===\n"
 
-(* Test helper *)
+(* Test helper — wraps in Eio context so dispatch paths that use
+   Eio.Mutex or Session operations work correctly. *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
@@ -33,10 +34,8 @@ let () = test "dispatch_unknown_tool" (fun () ->
   assert (Tool_rate_limit.dispatch ctx ~name:"unknown_tool" ~args = None)
 )
 
-(* Test rate_limit_status dispatch - needs Eio for Session.get_rate_limit_status *)
+(* Test rate_limit_status dispatch *)
 let () = test "dispatch_rate_limit_status" (fun () ->
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_rate_limit.dispatch ctx ~name:"masc_rate_limit_status" ~args with
@@ -44,10 +43,8 @@ let () = test "dispatch_rate_limit_status" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
-(* Test handle_rate_limit_status - needs Eio *)
+(* Test handle_rate_limit_status *)
 let () = test "handle_rate_limit_status" (fun () ->
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   let (success, result) = Tool_rate_limit.handle_rate_limit_status ctx args in

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -18,10 +18,11 @@ let str_contains s sub =
     in
     loop 0
 
-(* Test helper *)
+(* Test helper — wraps in Eio context so dispatch paths that use
+   Eio.Mutex, Fs_compat, or structured concurrency work correctly. *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env); f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);


### PR DESCRIPTION
## Summary
- 5개 coverage 테스트의 `test` 헬퍼를 `Eio_main.run`으로 래핑하여 dispatch 경로가 Eio context 안에서 실행되도록 수정
- `make_test_ctx`가 Eio scope 밖에서 context를 생성/반환하는 시한폭탄 패턴 제거
- 현재 main CI는 green이지만, dispatch 경로에 Eio.Mutex나 Fs_compat 사용이 추가되면 `Stdlib.Effect.Unhandled` 크래시 발생 가능

## Changes
| 파일 | 변경 |
|------|------|
| `test_tool_room_coverage.ml` | test helper에 Eio_main.run 추가 |
| `test_tool_auth_coverage.ml` | make_test_ctx의 Eio_main.run을 test helper로 이동 |
| `test_tool_encryption_coverage.ml` | test helper에 Eio_main.run 추가 |
| `test_tool_cost_coverage.ml` | test helper에 Eio_main.run 추가 |
| `test_tool_rate_limit_coverage.ml` | test helper에 Eio_main.run 추가, 개별 래퍼 제거 |

## Not changed (already correct)
- `test_tool_task_coverage` / `test_tool_misc_coverage` — test helper가 이미 Eio 래핑
- `test_tool_relay_coverage` — entry point에서 Eio_main.run
- `test_tool_hat_coverage` / `test_tool_control_coverage` — with_ctx 패턴 (#3418)

## Test plan
- [ ] CI Build and Test green (로컬 빌드는 agent_sdk 번들 의존성으로 불가)
- [ ] CI Contract Harness green

Closes #3396

🤖 Generated with [Claude Code](https://claude.com/claude-code)