### PR TITLE
feat(autoresearch): patience-based early stopping + build verification gate

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.156.0)
+(version 2.157.0)
 
 (generate_opam_files true)
 

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -138,8 +138,12 @@ let generate_code_change = Autoresearch_codegen.generate_code_change
 (* Loop State Management                                             *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ~workdir () =
+let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ~workdir () =
   let now = Time_compat.now () in
+  let patience = match patience with
+    | Some p -> p
+    | None -> max 3 (max_cycles / 3)
+  in
   {
     loop_id = generate_loop_id ();
     goal;
@@ -165,6 +169,9 @@ let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_tim
     source_workdir = workdir;
     program_note = None;
     warnings = [];
+    patience;
+    consecutive_discards = 0;
+    build_verify_fn;
   }
 
 (** Append an insight, maintaining FIFO max 10 entries. *)
@@ -259,6 +266,9 @@ let stop_loop ~base_path ?reason loop_id =
                 source_workdir = persisted.source_workdir;
                 program_note = persisted.program_note;
                 warnings = persisted.warnings;
+                patience = persisted.patience;
+                consecutive_discards = persisted.consecutive_discards;
+                build_verify_fn = persisted.build_verify_fn;
               }
             in
             Some (stop_state state)))

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -88,6 +88,10 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
       | Some value -> `String value
       | None -> `Null );
     ("warnings", `List (List.map (fun value -> `String value) s.warnings));
+    ("patience", `Int s.patience);
+    ("consecutive_discards", `Int s.consecutive_discards);
+    ("build_verify_fn", match s.build_verify_fn with
+      | Some cmd -> `String cmd | None -> `Null);
     ("error", match s.error_message with
       | Some e -> `String e | None -> `Null);
   ]
@@ -131,7 +135,7 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
       |> Option.value ~default:(str "workdir" ~default:".");
     program_note = json |> member "program_note" |> to_string_option;
     warnings =
-      match json |> member "warnings" with
+      (match json |> member "warnings" with
       | `List items ->
           items
           |> List.filter_map (function
@@ -139,7 +143,10 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
                    let trimmed = String.trim value in
                    if trimmed = "" then None else Some trimmed
                | _ -> None)
-      | _ -> [];
+      | _ -> []);
+    patience = int_ "patience" ~default:(max 3 (int_ "max_cycles" ~default:10 / 3));
+    consecutive_discards = int_ "consecutive_discards" ~default:0;
+    build_verify_fn = json |> member "build_verify_fn" |> to_string_option;
   }
 
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -44,6 +44,9 @@ type loop_state = {
   source_workdir : string;
   mutable program_note : string option;
   mutable warnings : string list;
+  patience : int;  (** Max consecutive discards before early stop *)
+  mutable consecutive_discards : int;  (** Counter for consecutive discards without improvement *)
+  build_verify_fn : string option;  (** Optional shell command that must exit 0 for a Keep to succeed *)
 }
 
 type swarm_link = {
@@ -79,4 +82,7 @@ type persisted_summary = {
   source_workdir : string;
   program_note : string option;
   warnings : string list;
+  patience : int;
+  consecutive_discards : int;
+  build_verify_fn : string option;
 }

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -334,6 +334,9 @@ let rehydrate_persisted_loop (persisted : Autoresearch_types.persisted_summary) 
     source_workdir = persisted.source_workdir;
     program_note = persisted.program_note;
     warnings = persisted.warnings;
+    patience = persisted.patience;
+    consecutive_discards = persisted.consecutive_discards;
+    build_verify_fn = persisted.build_verify_fn;
   }
 
 let load_loop_state ~base_path loop_id =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -44,6 +44,9 @@ let persisted_summary_json (summary : Autoresearch.persisted_summary) =
       ( "program_note",
         match summary.program_note with Some value -> `String value | None -> `Null );
       ("warnings", `List (List.map (fun value -> `String value) summary.warnings));
+      ("patience", `Int summary.patience);
+      ("consecutive_discards", `Int summary.consecutive_discards);
+      ("build_verify_fn", match summary.build_verify_fn with Some cmd -> `String cmd | None -> `Null);
       ("error", match summary.error_message with Some e -> `String e | None -> `Null);
     ]
 
@@ -61,6 +64,8 @@ type start_params = {
   cycle_timeout_s : float;
   model_model : string;
   baseline_override : float option;
+  patience : int option;
+  build_verify_fn : string option;
 }
 
 let prepare_start_params (ctx : context) args =
@@ -82,17 +87,40 @@ let prepare_start_params (ctx : context) args =
     match Autoresearch_metric.validate_metric_fn metric_fn with
     | Error e -> Error e
     | Ok metric_fn ->
-    Ok
-      {
-        goal;
-        metric_fn;
-        target_file;
-        source_workdir;
-        max_cycles;
-        cycle_timeout_s;
-        model_model;
-        baseline_override = get_float_opt args "baseline";
-      }
+    let build_verify_fn = get_string_opt args "build_verify_fn" in
+    (* Validate build_verify_fn for shell injection if provided *)
+    match build_verify_fn with
+    | Some cmd -> (
+      match Autoresearch_metric.validate_metric_fn cmd with
+      | Error e -> Error (Printf.sprintf "build_verify_fn: %s" e)
+      | Ok _ ->
+        Ok
+          {
+            goal;
+            metric_fn;
+            target_file;
+            source_workdir;
+            max_cycles;
+            cycle_timeout_s;
+            model_model;
+            baseline_override = get_float_opt args "baseline";
+            patience = get_int_opt args "patience";
+            build_verify_fn = Some cmd;
+          })
+    | None ->
+      Ok
+        {
+          goal;
+          metric_fn;
+          target_file;
+          source_workdir;
+          max_cycles;
+          cycle_timeout_s;
+          model_model;
+          baseline_override = get_float_opt args "baseline";
+          patience = get_int_opt args "patience";
+          build_verify_fn = None;
+        }
 
 let register_loop (ctx : context) state =
   Autoresearch.save_state ~base_path:ctx.base_path state;
@@ -106,6 +134,7 @@ let setup_running_loop (ctx : context) (params : start_params) =
     Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
       ~model_model:params.model_model ~target_file:params.target_file
       ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles
+      ?patience:params.patience ?build_verify_fn:params.build_verify_fn
       ~workdir:params.source_workdir ()
   in
   match
@@ -213,6 +242,8 @@ let handle_start (ctx : context) args =
         ("workdir", `String state.workdir);
         ("source_workdir", `String state.source_workdir);
         ("queued_hypothesis", `Null);
+        ("patience", `Int state.patience);
+        ("build_verify_fn", match state.build_verify_fn with Some cmd -> `String cmd | None -> `Null);
         ("warnings", `List (List.map (fun value -> `String value) state.warnings));
       ])
 

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -536,10 +536,17 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                            state.total_discards <- state.total_discards + 1;
                            state.baseline <- score_before;
                            if state.best_cycle = state.current_cycle then begin
-                             state.best_score <- score_before;
-                             state.best_cycle <- (match state.history with
-                               | _ :: prev :: _ -> prev.cycle
-                               | _ -> 0)
+                             (* Find actual best from history, excluding current cycle *)
+                             let prev_best =
+                               state.history
+                               |> List.filter (fun (r : Autoresearch.cycle_record) ->
+                                    r.decision = Autoresearch.Keep && r.cycle <> state.current_cycle)
+                               |> List.fold_left (fun (bs, bc) (r : Autoresearch.cycle_record) ->
+                                    if r.score_after > bs then (r.score_after, r.cycle) else (bs, bc))
+                                  (score_before, 0)
+                             in
+                             state.best_score <- fst prev_best;
+                             state.best_cycle <- snd prev_best
                            end;
                            Autoresearch.add_insight state
                              (Printf.sprintf "Cycle %d: %s build verification failed, downgraded to discard"

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -162,10 +162,17 @@ let forced_discard_record
   in
   state.history <- record :: state.history;
   state.total_discards <- state.total_discards + 1;
+  state.consecutive_discards <- state.consecutive_discards + 1;
   state.updated_at <- Time_compat.now ();
   Autoresearch.add_insight state
     (Printf.sprintf "Cycle %d: %s discarded (%s)"
        state.current_cycle hypothesis reason);
+  if state.consecutive_discards >= state.patience then begin
+    state.status <- Autoresearch.Completed;
+    Autoresearch.add_insight state
+      (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
+         state.patience)
+  end;
   record
 
 let persist_discard_record
@@ -493,15 +500,76 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                            ~commit_hash:(Some commit_hash)
                            ~elapsed_ms ~model_used:state.model_model
                        in
-                       (match record.decision with
+                       (* Build verification gate: if Keep and build_verify_fn is set,
+                          run the command and downgrade to Discard on non-zero exit.
+                          record_cycle already updated total_keeps/total_discards and
+                          baseline, so we fix up counters if overriding Keep -> Discard. *)
+                       let build_gate_override =
+                         match record.decision with
+                         | Autoresearch.Keep -> (
+                           match state.build_verify_fn with
+                           | None -> false
+                           | Some cmd ->
+                             match Autoresearch_metric.split_metric_fn_argv cmd with
+                             | Error e ->
+                               Log.Autoresearch.warn "build_verify_fn validation failed: %s" e;
+                               true
+                             | Ok argv ->
+                               match Autoresearch_metric.run_metric_argv ~workdir ~timeout_s argv with
+                               | Ok _ -> false  (* exit 0 = build passes *)
+                               | Error reason ->
+                                 Log.Autoresearch.info "build verification failed: %s" reason;
+                                 persist_failure_feedback ctx state
+                                   ~hypothesis
+                                   ~summary:(Printf.sprintf "Build verification failed: %s" reason)
+                                   ~action:"Fix the build before the metric can improve."
+                                   ~stderr:reason
+                                   ~tags:["build-verify-failure"]
+                                   ();
+                                 true)
+                         | Autoresearch.Discard -> false
+                       in
+                       let effective_decision =
+                         if build_gate_override then begin
+                           (* Undo record_cycle's Keep bookkeeping *)
+                           state.total_keeps <- state.total_keeps - 1;
+                           state.total_discards <- state.total_discards + 1;
+                           state.baseline <- score_before;
+                           if state.best_cycle = state.current_cycle then begin
+                             state.best_score <- score_before;
+                             state.best_cycle <- (match state.history with
+                               | _ :: prev :: _ -> prev.cycle
+                               | _ -> 0)
+                           end;
+                           Autoresearch.add_insight state
+                             (Printf.sprintf "Cycle %d: %s build verification failed, downgraded to discard"
+                                state.current_cycle hypothesis);
+                           Autoresearch.Discard
+                         end else
+                           record.decision
+                       in
+                       (match effective_decision with
                         | Autoresearch.Discard ->
-                          Autoresearch.git_reset_last ~workdir
+                          Autoresearch.git_reset_last ~workdir;
+                          state.consecutive_discards <- state.consecutive_discards + 1;
+                          if state.consecutive_discards >= state.patience then begin
+                            state.status <- Autoresearch.Completed;
+                            Autoresearch.add_insight state
+                              (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
+                                 state.patience)
+                          end
                         | Autoresearch.Keep ->
+                          state.consecutive_discards <- 0;
                           if score_after >= state.best_score then
                             Autoresearch.git_tag_best ~workdir
                               ~cycle:state.current_cycle ~score:score_after);
-                       Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
-                       if record.decision = Autoresearch.Keep then
+                       let effective_record =
+                         if build_gate_override then
+                           { record with decision = Autoresearch.Discard }
+                         else record
+                       in
+                       Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id effective_record;
+                       if effective_decision = Autoresearch.Keep then
                          state.baseline <- score_after;
                        state.current_cycle <- state.current_cycle + 1;
                        Autoresearch.save_state ~base_path:ctx.base_path state;
@@ -521,13 +589,13 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                                 (`Assoc
                                   [
                                     ("loop_id", `String id);
-                                    ("cycle", `Int record.cycle);
+                                    ("cycle", `Int effective_record.cycle);
                                     ("hypothesis", `String hypothesis);
                                     ( "decision",
                                       `String
                                         (Autoresearch.decision_to_string
-                                           record.decision) );
-                                    ("delta", `Float record.delta);
+                                           effective_record.decision) );
+                                    ("delta", `Float effective_record.delta);
                                     ("baseline", `Float state.baseline);
                                     ("best_score", `Float state.best_score);
                                   ])
@@ -537,18 +605,18 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                             Log.Autoresearch.warn "cycle event append failed: %s"
                               (Printexc.to_string exn))
                        | None -> ());
-                       broadcast_cycle_result state record;
+                       broadcast_cycle_result state effective_record;
                        `Assoc
                          [
                            ("loop_id", `String id);
-                           ("cycle", `Int record.cycle);
+                           ("cycle", `Int effective_record.cycle);
                            ("hypothesis", `String hypothesis);
                            ("score_before", `Float score_before);
                            ("score_after", `Float score_after);
-                           ("delta", `Float record.delta);
+                           ("delta", `Float effective_record.delta);
                            ( "decision",
                              `String
-                               (Autoresearch.decision_to_string record.decision) );
+                               (Autoresearch.decision_to_string effective_record.decision) );
                            ("commit_hash", `String commit_hash);
                            ("baseline", `Float state.baseline);
                            ("best_score", `Float state.best_score);


### PR DESCRIPTION
## Summary
- **Patience**: `consecutive_discards` 카운터. Keep 시 0으로 리셋, Discard 시 증가. `>= patience` 도달 시 조기 중단
- **Build gate**: optional `build_verify_fn` shell command. metric 개선됐어도 빌드/테스트 실패하면 Keep→Discard 다운그레이드
- lesson memory에 실패 피드백 기록, MASC broadcast 연동

## Files changed
- `autoresearch_types.ml` — patience, consecutive_discards, build_verify_fn 필드 추가
- `autoresearch_serde.ml` — JSON 직렬화 (backward compatible)
- `autoresearch.ml` — create_state에 optional params
- `tool_autoresearch_cycle.ml` — 핵심 로직 (patience check + build gate)
- `tool_autoresearch.ml` — start_params 파싱 + validation
- `dashboard_http_autoresearch.ml` — rehydrate 시 새 필드 포함

## MASC/OAS 경계 준수
- OAS harness/Swiss Cheese 타입 import 없음
- Build gate는 단순 shell command exit code 기반
- OAS 의존성은 기존 agent_sdk 범위 내

## Test plan
- [x] `dune build --root .` — 빌드 성공 (기존 Metric_contract 에러 제외)
- [ ] 5회 연속 discard 시 자동 중단 검증 (수동 테스트 필요)
- [ ] build_verify_fn 실패 시 Keep→Discard 검증 (수동 테스트 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)