### PR TITLE
feat(dashboard): client handlers for operator/transport SSE push

### DIFF
--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -110,6 +110,11 @@ type PracticalCase = {
 const transportHealth: Signal<TransportHealthData | null> = signal(null)
 const loading: Signal<boolean> = signal(false)
 const error: Signal<string | null> = signal(null)
+
+/** Hydrate transport health from SSE payload — zero HTTP fetch. */
+export function hydrateTransportHealthFromSSE(data: unknown): void {
+  transportHealth.value = data as TransportHealthData
+}
 let inflightTransportHealthRefresh: Promise<void> | null = null
 
 const PRACTICAL_CASES: PracticalCase[] = [

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -23,6 +23,9 @@ import {
   normalizeRoomTruth,
 } from './room-truth-store'
 import { mergeServerStatus } from './store-normalizers'
+import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
+import { operatorSnapshot, operatorRoomDigest } from './operator-signals'
+import { hydrateTransportHealthFromSSE } from './components/transport-health'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
 import { route } from './router'
@@ -171,6 +174,30 @@ function handleExecutionSnapshot(payload: unknown): void {
   }
 }
 
+function handleOperatorSnapshot(payload: unknown): void {
+  try {
+    operatorSnapshot.value = normalizeOperatorSnapshot(payload)
+  } catch (err) {
+    console.debug('[SSE] operator snapshot hydration failed', err instanceof Error ? err.message : '')
+  }
+}
+
+function handleOperatorDigest(payload: unknown): void {
+  try {
+    operatorRoomDigest.value = normalizeOperatorDigest(payload)
+  } catch (err) {
+    console.debug('[SSE] operator digest hydration failed', err instanceof Error ? err.message : '')
+  }
+}
+
+function handleTransportHealth(payload: unknown): void {
+  try {
+    hydrateTransportHealthFromSSE(payload)
+  } catch (err) {
+    console.debug('[SSE] transport health hydration failed', err instanceof Error ? err.message : '')
+  }
+}
+
 function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void {
   if (!event.name) return
   const newTs = event.ts_unix ? event.ts_unix * 1000 : Date.now()
@@ -275,6 +302,20 @@ export function setupSSEReaction(): () => void {
     // 0b. Execution snapshot — server push, no HTTP fetch needed
     if (event.type === 'execution_snapshot' && event.payload) {
       handleExecutionSnapshot(event.payload)
+      return
+    }
+
+    // 0c. Operator/transport snapshots — server push, no HTTP fetch needed
+    if (event.type === 'operator_snapshot' && event.payload) {
+      handleOperatorSnapshot(event.payload)
+      return
+    }
+    if (event.type === 'operator_digest' && event.payload) {
+      handleOperatorDigest(event.payload)
+      return
+    }
+    if (event.type === 'transport_health_snapshot' && event.payload) {
+      handleTransportHealth(event.payload)
       return
     }
 

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -168,7 +168,7 @@ function handleRoomTruthSnapshot(payload: unknown): void {
 /** Hydrate execution signals directly from SSE payload — zero HTTP fetch. */
 function handleExecutionSnapshot(payload: unknown): void {
   try {
-    hydrateExecutionSnapshot(payload)
+    hydrateExecutionSnapshot(payload as Record<string, unknown>)
   } catch (err) {
     console.debug('[SSE] execution snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
   }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -375,8 +375,7 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
 
 /** Hydrate all execution-related signals from a raw data payload.
  *  Shared by doFetchExecution (HTTP) and SSE execution_snapshot handler. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function hydrateExecutionSnapshot(data: any): void {
+export function hydrateExecutionSnapshot(data: Record<string, unknown>): void {
   const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
   const previousRoom = serverStatus.value?.room
   if (normalizedStatus) {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -36,6 +36,12 @@ export type SSEEventType =
   | 'oas:masc:harness:verdict_recorded'
   | 'oas:masc:harness:pre_compact'
   | 'oas:masc:harness:dna_quality'
+  // Server-push snapshot events (proactive cache broadcasts)
+  | 'room_truth_snapshot'
+  | 'execution_snapshot'
+  | 'operator_snapshot'
+  | 'operator_digest'
+  | 'transport_health_snapshot'
 
 export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
 export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse'


### PR DESCRIPTION
## Summary
- operator_snapshot, operator_digest, transport_health_snapshot SSE 이벤트의 클라이언트 핸들러 추가
- 5개 proactive cache surface 전부 SSE push 완전 전환 달성

### SSE Push Coverage (완료)

| Surface | 서버 broadcast | 클라이언트 handler | PR |
|---------|---------------|-------------------|-----|
| room_truth_snapshot | #3445 | #3445 | merged |
| execution_snapshot | #3461 | #3461 | merged |
| **operator_snapshot** | #3461 | **이 PR** | new |
| **operator_digest** | #3461 | **이 PR** | new |
| **transport_health_snapshot** | #3461 | **이 PR** | new |

### 기술 노트
- operator hydration은 `operator-signals` + `operator-normalizers`에서 직접 import (NOT `operator-actions`) — `sse-store` ↔ `operator-actions` 순환 참조 방지
- transport-health는 `hydrateTransportHealthFromSSE` export 추가
- 기존 SSE→HTTP fetch 경로는 유지 (graceful fallback)

## Test plan
- [ ] vitest 전체 통과 (navigation.test.ts 1개 실패는 기존 main 이슈)
- [ ] CI 전체 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)