### PR TITLE
chore: migrate to single mcp_protocol opam package

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
   (ocaml (>= 5.4))
   (dune (>= 3.13))
   ; External dependencies (opam pin)
-  (mcp_protocol (>= 1.0.0))
+  (mcp_protocol (>= 1.1.0))
   (ocaml-webrtc (>= 0.2.3))
   (grpc-direct-core (>= 0.1.0))
   (grpc-direct (>= 0.1.0))

--- a/lib/time_compat/dune
+++ b/lib/time_compat/dune
@@ -3,4 +3,4 @@
  (name time_compat)
  (public_name masc_mcp.time_compat)
  (modules time_compat)
- (libraries eio unix mcp_protocol_eio))
+ (libraries eio unix mcp_protocol.eio))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
   "ocaml" {>= "5.4"}
   "dune" {>= "3.13" & >= "3.13"}
-  "mcp_protocol" {>= "1.0.0"}
+  "mcp_protocol" {>= "1.1.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
   "grpc-direct" {>= "0.1.0"}


### PR DESCRIPTION
## Summary
- Update `mcp_protocol_eio` -> `mcp_protocol.eio` in dune files
- Bump `mcp_protocol` version constraint to `>= 1.1.0`
- Follows mcp-protocol-sdk v1.1.0 (3 opam packages merged into 1)

## Test plan
- [x] `lib/time_compat` builds with `mcp_protocol.eio`
- [ ] CI green (note: pre-existing `Metric_contract` build issue with oas is unrelated)