### PR TITLE
fix(ci): adapt to mcp_protocol single-package merge (#3467)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
   (ocaml (>= 5.4))
   (dune (>= 3.13))
   ; External dependencies (opam pin)
-  (mcp_protocol (>= 1.0.0))
+  (mcp_protocol (>= 1.1.0))
   (ocaml-webrtc (>= 0.2.3))
   (grpc-direct-core (>= 0.1.0))
   (grpc-direct (>= 0.1.0))

--- a/lib/time_compat/dune
+++ b/lib/time_compat/dune
@@ -3,4 +3,4 @@
  (name time_compat)
  (public_name masc_mcp.time_compat)
  (modules time_compat)
- (libraries eio unix mcp_protocol_eio))
+ (libraries eio unix mcp_protocol.eio))

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -141,6 +141,14 @@ let persist_failure_feedback
   in
   ignore (Autoresearch_knowledge.record_finding ~finding)
 
+let check_patience_limit (state : Autoresearch.loop_state) =
+  if state.consecutive_discards >= state.patience then begin
+    state.status <- Autoresearch.Completed;
+    Autoresearch.add_insight state
+      (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
+         state.patience)
+  end
+
 let forced_discard_record
     (state : Autoresearch.loop_state)
     ~hypothesis ~score_before ?score_after ?commit_hash
@@ -169,14 +177,6 @@ let forced_discard_record
        state.current_cycle hypothesis reason);
   check_patience_limit state;
   record
-
-let check_patience_limit (state : Autoresearch.loop_state) =
-  if state.consecutive_discards >= state.patience then begin
-    state.status <- Autoresearch.Completed;
-    Autoresearch.add_insight state
-      (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
-         state.patience)
-  end
 
 let persist_discard_record
     (ctx : Tool_autoresearch_repo_synthesis.context)

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
   "ocaml" {>= "5.4"}
   "dune" {>= "3.13" & >= "3.13"}
-  "mcp_protocol" {>= "1.0.0"}
+  "mcp_protocol" {>= "1.1.0"}
   "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
   "grpc-direct" {>= "0.1.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.92.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="402b6827a8f457fe301b0eb7d8f053cf4268a885"
+readonly OAS_AGENT_SDK_SHA="3c6a5750d040f690c6448b7ec5e5c3e7d3b7921c"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.92.1"

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.92.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="045ee2f0d243e23e93eb629ed1b5ef6ca2a5508d"
+readonly OAS_AGENT_SDK_SHA="402b6827a8f457fe301b0eb7d8f053cf4268a885"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.92.1"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -37,9 +37,9 @@ if $include_compact_protocol; then
   opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
 fi
 
+# mcp_protocol_eio and mcp_protocol_http merged into mcp_protocol
+# as sub-libraries (mcp-protocol-sdk#60). Single pin covers all.
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -42,8 +42,9 @@ fi
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
+# TODO: revert to #main after jeong-sik/grpc-direct#61 merges
+opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#fix/mcp-protocol-merge -n -y
+opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#fix/mcp-protocol-merge -n -y
 opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 opam pin add neo4j_bolt_common https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y


### PR DESCRIPTION
## Summary

- `mcp-protocol-sdk#60`에서 3개 opam 패키지(`mcp_protocol`, `mcp_protocol_eio`, `mcp_protocol_http`)가 단일 패키지로 병합됨
- CI의 `opam-pin-external-deps.sh`가 존재하지 않는 `mcp_protocol_eio` 패키지를 pin하려다 실패
- 모든 브랜치의 CI가 블록됨 (main 포함)

### 변경

| 파일 | 변경 |
|------|------|
| `scripts/opam-pin-external-deps.sh` | `mcp_protocol_eio`/`mcp_protocol_http` pin 제거 |
| `lib/time_compat/dune` | `mcp_protocol_eio` -> `mcp_protocol.eio` |
| `dune-project` | `mcp_protocol >= 1.0.0` -> `>= 1.1.0` |
| `masc_mcp.opam` | 동일 버전 범프 |

## Test plan

- [ ] CI green (이 PR이 CI blocker를 해결)

Fixes #3467

Generated with [Claude Code](https://claude.com/claude-code)