### PR TITLE
refactor(autoresearch): simplify patience + build gate code

### DIFF
--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -88,26 +88,17 @@ let prepare_start_params (ctx : context) args =
     | Error e -> Error e
     | Ok metric_fn ->
     let build_verify_fn = get_string_opt args "build_verify_fn" in
-    (* Validate build_verify_fn for shell injection if provided *)
-    match build_verify_fn with
-    | Some cmd -> (
-      match Autoresearch_metric.validate_metric_fn cmd with
-      | Error e -> Error (Printf.sprintf "build_verify_fn: %s" e)
-      | Ok _ ->
-        Ok
-          {
-            goal;
-            metric_fn;
-            target_file;
-            source_workdir;
-            max_cycles;
-            cycle_timeout_s;
-            model_model;
-            baseline_override = get_float_opt args "baseline";
-            patience = get_int_opt args "patience";
-            build_verify_fn = Some cmd;
-          })
-    | None ->
+    let validated_build_verify_fn =
+      match build_verify_fn with
+      | Some cmd -> (
+        match Autoresearch_metric.validate_metric_fn cmd with
+        | Error e -> Error (Printf.sprintf "build_verify_fn: %s" e)
+        | Ok _ -> Ok (Some cmd))
+      | None -> Ok None
+    in
+    match validated_build_verify_fn with
+    | Error e -> Error e
+    | Ok build_verify_fn ->
       Ok
         {
           goal;
@@ -119,7 +110,7 @@ let prepare_start_params (ctx : context) args =
           model_model;
           baseline_override = get_float_opt args "baseline";
           patience = get_int_opt args "patience";
-          build_verify_fn = None;
+          build_verify_fn;
         }
 
 let register_loop (ctx : context) state =

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -167,13 +167,16 @@ let forced_discard_record
   Autoresearch.add_insight state
     (Printf.sprintf "Cycle %d: %s discarded (%s)"
        state.current_cycle hypothesis reason);
+  check_patience_limit state;
+  record
+
+let check_patience_limit (state : Autoresearch.loop_state) =
   if state.consecutive_discards >= state.patience then begin
     state.status <- Autoresearch.Completed;
     Autoresearch.add_insight state
       (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
          state.patience)
-  end;
-  record
+  end
 
 let persist_discard_record
     (ctx : Tool_autoresearch_repo_synthesis.context)
@@ -494,16 +497,16 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                          ~reason:(Printf.sprintf "metric_fn failed: %s" e)
                          record
                      | Ok (score_after, elapsed_ms) ->
+                       (* Snapshot before record_cycle mutates state — needed if
+                          build gate later downgrades Keep to Discard *)
+                       let prev_best_score = state.best_score in
+                       let prev_best_cycle = state.best_cycle in
                        let record =
                          Autoresearch.record_cycle state
                            ~hypothesis ~score_before ~score_after
                            ~commit_hash:(Some commit_hash)
                            ~elapsed_ms ~model_used:state.model_model
                        in
-                       (* Build verification gate: if Keep and build_verify_fn is set,
-                          run the command and downgrade to Discard on non-zero exit.
-                          record_cycle already updated total_keeps/total_discards and
-                          baseline, so we fix up counters if overriding Keep -> Discard. *)
                        let build_gate_override =
                          match record.decision with
                          | Autoresearch.Keep -> (
@@ -536,17 +539,8 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                            state.total_discards <- state.total_discards + 1;
                            state.baseline <- score_before;
                            if state.best_cycle = state.current_cycle then begin
-                             (* Find actual best from history, excluding current cycle *)
-                             let prev_best =
-                               state.history
-                               |> List.filter (fun (r : Autoresearch.cycle_record) ->
-                                    r.decision = Autoresearch.Keep && r.cycle <> state.current_cycle)
-                               |> List.fold_left (fun (bs, bc) (r : Autoresearch.cycle_record) ->
-                                    if r.score_after > bs then (r.score_after, r.cycle) else (bs, bc))
-                                  (score_before, 0)
-                             in
-                             state.best_score <- fst prev_best;
-                             state.best_cycle <- snd prev_best
+                             state.best_score <- prev_best_score;
+                             state.best_cycle <- prev_best_cycle
                            end;
                            Autoresearch.add_insight state
                              (Printf.sprintf "Cycle %d: %s build verification failed, downgraded to discard"
@@ -559,12 +553,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                         | Autoresearch.Discard ->
                           Autoresearch.git_reset_last ~workdir;
                           state.consecutive_discards <- state.consecutive_discards + 1;
-                          if state.consecutive_discards >= state.patience then begin
-                            state.status <- Autoresearch.Completed;
-                            Autoresearch.add_insight state
-                              (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
-                                 state.patience)
-                          end
+                          check_patience_limit state
                         | Autoresearch.Keep ->
                           state.consecutive_discards <- 0;
                           if score_after >= state.best_score then


### PR DESCRIPTION
## Summary
- Extract `check_patience_limit` helper — removes duplicated patience check from 2 locations
- Deduplicate `prepare_start_params` record construction (was copy-pasted for Some/None branch)
- Replace O(n) history scan in build gate rollback with pre-recorded `prev_best` snapshot

Follow-up cleanup from #3462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)