### PR TITLE
fix(ci): update mcp_protocol pin after 3-to-1 opam merge

### DIFF
--- a/lib/time_compat/dune
+++ b/lib/time_compat/dune
@@ -3,4 +3,4 @@
  (name time_compat)
  (public_name masc_mcp.time_compat)
  (modules time_compat)
- (libraries eio unix mcp_protocol_eio))
+ (libraries eio unix mcp_protocol.eio))

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -38,8 +38,6 @@ if $include_compact_protocol; then
 fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## Summary
- mcp-protocol-sdk PR #60이 3개 opam 패키지를 단일 `mcp_protocol`로 통합
- `mcp_protocol_eio`, `mcp_protocol_http` dead pin 제거
- `time_compat/dune` 의존성명 `mcp_protocol_eio` -> `mcp_protocol.eio`

## Impact
이 수정 없이는 **모든 MASC PR의 CI가 실패**함 (Pin external dependencies 단계).

Fixes #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)