### PR TITLE
refactor(autoresearch): immutable loop_state — 15 mutable fields removed

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -174,20 +174,27 @@ let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_tim
     build_verify_fn;
   }
 
-(** Append an insight, maintaining FIFO max 10 entries. *)
+(** Append an insight, maintaining FIFO max 10 entries.
+    Returns updated state. *)
 let add_insight (state : loop_state) msg =
   let max_insights = 10 in
-  state.insights <- msg :: state.insights;
-  if List.length state.insights > max_insights then
-    state.insights <- List.filteri (fun i _ -> i < max_insights) state.insights
+  let insights = msg :: state.insights in
+  let insights =
+    if List.length insights > max_insights then
+      List.filteri (fun i _ -> i < max_insights) insights
+    else insights
+  in
+  { state with insights }
 
-(** Record one completed experiment cycle. *)
+(** Record one completed experiment cycle.
+    Returns [(state, record)] with the updated state. *)
 let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
     ~commit_hash ~elapsed_ms ~model_used =
   let delta = score_after -. score_before in
   (* Compare against the maintained baseline, not score_before which can dip
      below baseline due to metric noise -- preventing ratchet-down regressions *)
   let decision = if score_after > state.baseline then Keep else Discard in
+  let now = Time_compat.now () in
   let record = {
     cycle = state.current_cycle;
     hypothesis;
@@ -198,25 +205,28 @@ let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
     commit_hash;
     elapsed_ms;
     model_used;
-    timestamp = Time_compat.now ();
+    timestamp = now;
   } in
-  state.history <- record :: state.history;
-  state.updated_at <- Time_compat.now ();
-  (match decision with
-   | Keep ->
-     state.total_keeps <- state.total_keeps + 1;
-     state.baseline <- score_after;
-     if score_after > state.best_score then begin
-       state.best_score <- score_after;
-       state.best_cycle <- state.current_cycle
-     end;
-     add_insight state
-       (Printf.sprintf "Cycle %d: %s improved +%.4f" state.current_cycle hypothesis delta)
-   | Discard ->
-     state.total_discards <- state.total_discards + 1;
-     add_insight state
-       (Printf.sprintf "Cycle %d: %s no improvement (%.4f)" state.current_cycle hypothesis delta));
-  record
+  let state = { state with history = record :: state.history; updated_at = now } in
+  let state =
+    match decision with
+    | Keep ->
+      let state = { state with
+        total_keeps = state.total_keeps + 1;
+        baseline = score_after } in
+      let state =
+        if score_after > state.best_score then
+          { state with best_score = score_after; best_cycle = state.current_cycle }
+        else state
+      in
+      add_insight state
+        (Printf.sprintf "Cycle %d: %s improved +%.4f" state.current_cycle hypothesis delta)
+    | Discard ->
+      let state = { state with total_discards = state.total_discards + 1 } in
+      add_insight state
+        (Printf.sprintf "Cycle %d: %s no improvement (%.4f)" state.current_cycle hypothesis delta)
+  in
+  (state, record)
 
 (** Check if the loop should continue. *)
 let should_continue (state : loop_state) =
@@ -226,10 +236,12 @@ let should_continue (state : loop_state) =
     Acquires [loops_mu] write lock internally. *)
 let stop_loop ~base_path ?reason loop_id =
   let stop_state (state : loop_state) =
-    state.status <- Stopped;
-    state.error_message <- reason;
-    state.updated_at <- Time_compat.now ();
+    let state = { state with
+      status = Stopped;
+      error_message = reason;
+      updated_at = Time_compat.now () } in
     save_state ~base_path state;
+    Hashtbl.replace active_loops loop_id state;
     state
   in
   with_loops_rw (fun () ->

--- a/lib/autoresearch/autoresearch_storage.ml
+++ b/lib/autoresearch/autoresearch_storage.ml
@@ -48,7 +48,7 @@ let append_cycle ~base_path loop_id record =
 let save_state ~base_path (state : Autoresearch_types.loop_state) =
   let dir = results_dir ~base_path state.loop_id in
   Fs_compat.mkdir_p dir;
-  state.updated_at <- Time_compat.now ();
+  let state = { state with updated_at = Time_compat.now () } in
   let path = state_file ~base_path state.loop_id in
   let json = Yojson.Safe.pretty_to_string (Autoresearch_serde.state_to_yojson state) in
   Fs_compat.save_file path json

--- a/lib/autoresearch/autoresearch_storage.ml
+++ b/lib/autoresearch/autoresearch_storage.ml
@@ -48,7 +48,6 @@ let append_cycle ~base_path loop_id record =
 let save_state ~base_path (state : Autoresearch_types.loop_state) =
   let dir = results_dir ~base_path state.loop_id in
   Fs_compat.mkdir_p dir;
-  let state = { state with updated_at = Time_compat.now () } in
   let path = state_file ~base_path state.loop_id in
   let json = Yojson.Safe.pretty_to_string (Autoresearch_serde.state_to_yojson state) in
   Fs_compat.save_file path json

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -25,27 +25,27 @@ type loop_state = {
   metric_fn : string;
   model_model : string;
   target_file : string;  (** File the MODEL reads and modifies, relative to workdir *)
-  mutable status : status;
-  mutable error_message : string option;
-  mutable current_cycle : int;
-  mutable baseline : float;
-  mutable best_score : float;
-  mutable best_cycle : int;
-  mutable queued_hypothesis : string option;
-  mutable history : cycle_record list;  (** Most recent first *)
-  mutable total_keeps : int;
-  mutable total_discards : int;
-  mutable insights : string list;  (** Accumulated experiment insights, FIFO max 10 *)
+  status : status;
+  error_message : string option;
+  current_cycle : int;
+  baseline : float;
+  best_score : float;
+  best_cycle : int;
+  queued_hypothesis : string option;
+  history : cycle_record list;  (** Most recent first *)
+  total_keeps : int;
+  total_discards : int;
+  insights : string list;  (** Accumulated experiment insights, FIFO max 10 *)
   start_time : float;
-  mutable updated_at : float;
+  updated_at : float;
   cycle_timeout_s : float;
   max_cycles : int;
-  mutable workdir : string;
+  workdir : string;
   source_workdir : string;
-  mutable program_note : string option;
-  mutable warnings : string list;
+  program_note : string option;
+  warnings : string list;
   patience : int;  (** Max consecutive discards before early stop *)
-  mutable consecutive_discards : int;  (** Counter for consecutive discards without improvement *)
+  consecutive_discards : int;  (** Counter for consecutive discards without improvement *)
   build_verify_fn : string option;  (** Optional shell command that must exit 0 for a Keep to succeed *)
 }
 

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -452,17 +452,20 @@ let retry_loop_json ~(base_path : string) ~(loop_id : string) :
                 ~source_workdir:state.source_workdir ~loop_id
             with
             | Error message ->
-                state.status <- Autoresearch.Error;
-                state.error_message <- Some message;
-                state.updated_at <- Time_compat.now ();
+                let state = { state with
+                  status = Autoresearch.Error;
+                  error_message = Some message;
+                  updated_at = Time_compat.now () } in
+                Hashtbl.replace Autoresearch.active_loops loop_id state;
                 Autoresearch.save_state ~base_path state;
                 Error message
             | Ok (workdir, _repo_root, warnings) ->
-                state.workdir <- workdir;
-                state.status <- Autoresearch.Running;
-                state.error_message <- None;
-                state.warnings <- warnings;
-                state.updated_at <- Time_compat.now ();
+                let state = { state with
+                  workdir;
+                  status = Autoresearch.Running;
+                  error_message = None;
+                  warnings;
+                  updated_at = Time_compat.now () } in
                 Hashtbl.replace Autoresearch.active_loops loop_id state;
                 Autoresearch.latest_loop_id := Some loop_id;
                 Autoresearch.save_state ~base_path state;

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -134,8 +134,7 @@ let setup_running_loop (ctx : context) (params : start_params) =
   with
   | Error message -> Error message
   | Ok (managed_workdir, source_workdir, warnings) -> (
-      state.workdir <- managed_workdir;
-      state.warnings <- warnings;
+      let state = { state with workdir = managed_workdir; warnings } in
       let baseline_result =
         match Autoresearch.validate_target_file ~workdir:managed_workdir params.target_file with
         | Error e ->
@@ -156,11 +155,8 @@ let setup_running_loop (ctx : context) (params : start_params) =
       match baseline_result with
       | Error message -> Error message
       | Ok baseline ->
-          state.baseline <- baseline;
-          state.best_score <- baseline;
-          let state =
-            { state with source_workdir }
-          in
+          let state = { state with
+            baseline; best_score = baseline; source_workdir } in
           Ok (register_loop ctx state))
 
 let status_json (ctx : context) ~loop_id json_fields =
@@ -266,9 +262,9 @@ let handle_swarm_start (ctx : context) args =
             Progress.stop_tracking swarm_task_id;
             `Assoc [ ("error", `String message) ]
           | Ok state ->
-          state.program_note <- program_note;
+          let state = { state with program_note } in
           broadcast_loop_lifecycle "autoresearch_started" state;
-          let warnings = ref state.warnings in
+          let warnings_acc = ref state.warnings in
           let operation_id =
             match ctx.start_operation with
             | None -> None
@@ -278,11 +274,13 @@ let handle_swarm_start (ctx : context) args =
                 with
                 | Ok json -> parse_operation_id json
                 | Error message ->
-                    warnings := message :: !warnings;
+                    warnings_acc := message :: !warnings_acc;
                     None)
           in
-          state.warnings <- List.rev !warnings;
+          let state = { state with warnings = List.rev !warnings_acc } in
           Autoresearch.save_state ~base_path:ctx.base_path state;
+          Autoresearch.with_loops_rw (fun () ->
+            Hashtbl.replace active_loops state.loop_id state);
           Progress.Tracker.step swarm_tracker ~message:"Launching team session" ();
           let session_goal =
             build_swarm_goal ~goal:params.goal ~target_file:params.target_file
@@ -293,9 +291,12 @@ let handle_swarm_start (ctx : context) args =
               ~loop_id:state.loop_id ~target_file:params.target_file ~program_note
           with
           | Error message ->
-              state.status <- Autoresearch.Error;
-              state.error_message <- Some message;
+              let state = { state with
+                status = Autoresearch.Error;
+                error_message = Some message } in
               Autoresearch.save_state ~base_path:ctx.base_path state;
+              Autoresearch.with_loops_rw (fun () ->
+                Hashtbl.replace active_loops state.loop_id state);
               Progress.stop_tracking swarm_task_id;
               `Assoc
                 [
@@ -305,9 +306,12 @@ let handle_swarm_start (ctx : context) args =
           | Ok session_json -> (
               match parse_session_launch ctx session_json with
               | Error message ->
-                  state.status <- Autoresearch.Error;
-                  state.error_message <- Some message;
+                  let state = { state with
+                    status = Autoresearch.Error;
+                    error_message = Some message } in
                   Autoresearch.save_state ~base_path:ctx.base_path state;
+                  Autoresearch.with_loops_rw (fun () ->
+                    Hashtbl.replace active_loops state.loop_id state);
                   Progress.stop_tracking swarm_task_id;
                   `Assoc
                     [
@@ -340,7 +344,7 @@ let handle_swarm_start (ctx : context) args =
                       ("artifacts_dir", `String artifacts_dir);
                       ("linked_status", Autoresearch.linked_status_json ~base_path:ctx.base_path link);
                       ( "warnings",
-                        `List (List.rev_map (fun message -> `String message) !warnings) );
+                        `List (List.map (fun w -> `String w) state.warnings) );
                       ("goal", `String params.goal);
                       ( "program_note",
                         match program_note with
@@ -417,7 +421,8 @@ let handle_inject (ctx : context) args =
           if state.status <> Autoresearch.Running then
             `Assoc [("error", `String "Loop is not running")]
           else begin
-            state.queued_hypothesis <- Some hypothesis;
+            let state = { state with queued_hypothesis = Some hypothesis } in
+            Hashtbl.replace active_loops id state;
             Autoresearch.save_state ~base_path:ctx.base_path state;
             with_hypotheses_rw (fun () ->
               Hashtbl.replace pending_hypotheses id hypothesis);

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -142,18 +142,19 @@ let persist_failure_feedback
   ignore (Autoresearch_knowledge.record_finding ~finding)
 
 let check_patience_limit (state : Autoresearch.loop_state) =
-  if state.consecutive_discards >= state.patience then begin
-    state.status <- Autoresearch.Completed;
+  if state.consecutive_discards >= state.patience then
+    let state = { state with status = Autoresearch.Completed } in
     Autoresearch.add_insight state
       (Printf.sprintf "Early stopped: %d consecutive discards without improvement"
          state.patience)
-  end
+  else state
 
 let forced_discard_record
     (state : Autoresearch.loop_state)
     ~hypothesis ~score_before ?score_after ?commit_hash
     ~elapsed_ms ~reason () =
   let score_after = Option.value ~default:score_before score_after in
+  let now = Time_compat.now () in
   let record : Autoresearch.cycle_record =
     {
       cycle = state.current_cycle;
@@ -165,25 +166,30 @@ let forced_discard_record
       commit_hash;
       elapsed_ms;
       model_used = state.model_model;
-      timestamp = Time_compat.now ();
+      timestamp = now;
     }
   in
-  state.history <- record :: state.history;
-  state.total_discards <- state.total_discards + 1;
-  state.consecutive_discards <- state.consecutive_discards + 1;
-  state.updated_at <- Time_compat.now ();
-  Autoresearch.add_insight state
-    (Printf.sprintf "Cycle %d: %s discarded (%s)"
-       state.current_cycle hypothesis reason);
-  check_patience_limit state;
-  record
+  let state = { state with
+    history = record :: state.history;
+    total_discards = state.total_discards + 1;
+    consecutive_discards = state.consecutive_discards + 1;
+    updated_at = now } in
+  let state =
+    Autoresearch.add_insight state
+      (Printf.sprintf "Cycle %d: %s discarded (%s)"
+         state.current_cycle hypothesis reason)
+  in
+  let state = check_patience_limit state in
+  (state, record)
 
 let persist_discard_record
     (ctx : Tool_autoresearch_repo_synthesis.context)
     (state : Autoresearch.loop_state)
     ~loop_id ~hypothesis ~reason record =
   Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
-  state.current_cycle <- state.current_cycle + 1;
+  let state = { state with current_cycle = state.current_cycle + 1 } in
+  Autoresearch.with_loops_rw (fun () ->
+    Hashtbl.replace Autoresearch.active_loops loop_id state);
   Autoresearch.save_state ~base_path:ctx.base_path state;
   broadcast_cycle_result state record;
   `Assoc
@@ -254,7 +260,8 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
             if state.status <> Autoresearch.Running then
               Error "Loop is not running"
             else if not (Autoresearch.should_continue state) then begin
-              state.status <- Autoresearch.Completed;
+              let state = { state with status = Autoresearch.Completed } in
+              Hashtbl.replace active_loops id state;
               Autoresearch.save_state ~base_path:ctx.base_path state;
               Error "completed"
             end else
@@ -298,7 +305,8 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                     match Hashtbl.find_opt pending_hypotheses id with
                     | Some h ->
                       Hashtbl.remove pending_hypotheses id;
-                      state.queued_hypothesis <- None;
+                      let state = { state with queued_hypothesis = None } in
+                      Hashtbl.replace active_loops id state;
                       Autoresearch.save_state ~base_path:ctx.base_path state;
                       Some h
                     | None -> get_string_opt args "hypothesis"))
@@ -402,7 +410,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                         | _ -> false)
                       report.issues
                  then
-                   let record =
+                   let (state, record) =
                      forced_discard_record state
                        ~hypothesis ~score_before ~elapsed_ms:0
                        ~reason:"no diff produced"
@@ -422,7 +430,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                      ~diff_summary:summary
                      ~tags:["diff-guard"]
                      ();
-                   let record =
+                   let (state, record) =
                      forced_discard_record state
                        ~hypothesis ~score_before ~elapsed_ms:0
                        ~reason:("diff guard rejected patch: " ^ summary)
@@ -459,7 +467,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                          ("cycle", `Int state.current_cycle);
                        ]
                    | Ok None ->
-                     let record =
+                     let (state, record) =
                        forced_discard_record state
                          ~hypothesis ~score_before ~elapsed_ms:0
                          ~reason:"no diff produced"
@@ -485,7 +493,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                          ~stderr:e
                          ~tags:["post-metric-failure"]
                          ();
-                       let record =
+                       let (state, record) =
                          forced_discard_record state
                            ~hypothesis ~score_before ~commit_hash:commit_hash
                            ~elapsed_ms:0
@@ -497,11 +505,11 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                          ~reason:(Printf.sprintf "metric_fn failed: %s" e)
                          record
                      | Ok (score_after, elapsed_ms) ->
-                       (* Snapshot before record_cycle mutates state — needed if
+                       (* Snapshot before record_cycle — needed if
                           build gate later downgrades Keep to Discard *)
                        let prev_best_score = state.best_score in
                        let prev_best_cycle = state.best_cycle in
-                       let record =
+                       let (state, record) =
                          Autoresearch.record_cycle state
                            ~hypothesis ~score_before ~score_after
                            ~commit_hash:(Some commit_hash)
@@ -519,7 +527,7 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                                true
                              | Ok argv ->
                                match Autoresearch_metric.run_metric_argv ~workdir ~timeout_s argv with
-                               | Ok _ -> false  (* exit 0 = build passes *)
+                               | Ok _ -> false
                                | Error reason ->
                                  Log.Autoresearch.info "build verification failed: %s" reason;
                                  persist_failure_feedback ctx state
@@ -532,42 +540,50 @@ let handle_cycle (ctx : Tool_autoresearch_repo_synthesis.context) args =
                                  true)
                          | Autoresearch.Discard -> false
                        in
-                       let effective_decision =
-                         if build_gate_override then begin
-                           (* Undo record_cycle's Keep bookkeeping *)
-                           state.total_keeps <- state.total_keeps - 1;
-                           state.total_discards <- state.total_discards + 1;
-                           state.baseline <- score_before;
-                           if state.best_cycle = state.current_cycle then begin
-                             state.best_score <- prev_best_score;
-                             state.best_cycle <- prev_best_cycle
-                           end;
-                           Autoresearch.add_insight state
-                             (Printf.sprintf "Cycle %d: %s build verification failed, downgraded to discard"
-                                state.current_cycle hypothesis);
-                           Autoresearch.Discard
-                         end else
-                           record.decision
+                       let (effective_decision, state) =
+                         if build_gate_override then
+                           let state = { state with
+                             total_keeps = state.total_keeps - 1;
+                             total_discards = state.total_discards + 1;
+                             baseline = score_before } in
+                           let state =
+                             if state.best_cycle = state.current_cycle then
+                               { state with best_score = prev_best_score; best_cycle = prev_best_cycle }
+                             else state
+                           in
+                           let state =
+                             Autoresearch.add_insight state
+                               (Printf.sprintf "Cycle %d: %s build verification failed, downgraded to discard"
+                                  state.current_cycle hypothesis)
+                           in
+                           (Autoresearch.Discard, state)
+                         else
+                           (record.decision, state)
                        in
-                       (match effective_decision with
-                        | Autoresearch.Discard ->
-                          Autoresearch.git_reset_last ~workdir;
-                          state.consecutive_discards <- state.consecutive_discards + 1;
-                          check_patience_limit state
-                        | Autoresearch.Keep ->
-                          state.consecutive_discards <- 0;
-                          if score_after >= state.best_score then
-                            Autoresearch.git_tag_best ~workdir
-                              ~cycle:state.current_cycle ~score:score_after);
+                       let state =
+                         match effective_decision with
+                         | Autoresearch.Discard ->
+                           Autoresearch.git_reset_last ~workdir;
+                           let state = { state with
+                             consecutive_discards = state.consecutive_discards + 1 } in
+                           check_patience_limit state
+                         | Autoresearch.Keep ->
+                           let state = { state with consecutive_discards = 0 } in
+                           if score_after >= state.best_score then
+                             Autoresearch.git_tag_best ~workdir
+                               ~cycle:state.current_cycle ~score:score_after;
+                           state
+                       in
                        let effective_record =
                          if build_gate_override then
                            { record with decision = Autoresearch.Discard }
                          else record
                        in
                        Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id effective_record;
-                       if effective_decision = Autoresearch.Keep then
-                         state.baseline <- score_after;
-                       state.current_cycle <- state.current_cycle + 1;
+                       let state = { state with
+                         current_cycle = state.current_cycle + 1 } in
+                       Autoresearch.with_loops_rw (fun () ->
+                         Hashtbl.replace Autoresearch.active_loops id state);
                        Autoresearch.save_state ~base_path:ctx.base_path state;
                        let config =
                          Room.default_config ctx.base_path

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -197,7 +197,11 @@ let test_cycle_reinjects_diff_guard_lesson () =
   check bool "lesson context injected" true
     (contains injected_goal "Relevant prior failure lessons:"
      || contains injected_goal "Diff guard rejected patch");
-  check int "cycle advanced twice" 2 state.current_cycle
+  let final_cycle = Lib.Autoresearch.with_loops_ro (fun () ->
+    match Hashtbl.find_opt Lib.Autoresearch.active_loops state.loop_id with
+    | Some s -> s.current_cycle
+    | None -> -1) in
+  check int "cycle advanced twice" 2 final_cycle
 
 let () =
   run "autoresearch_oas_primitives"

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -230,7 +230,7 @@ let test_loops_json_orders_live_then_recent () =
       ~workdir:base_path
       ()
   in
-  active.updated_at <- 10.0;
+  let active = { active with updated_at = 10.0 } in
   Lib.Autoresearch.with_loops_rw (fun () ->
     Hashtbl.replace Lib.Autoresearch.active_loops active.loop_id active);
   let newer_persisted_path =
@@ -299,11 +299,12 @@ let test_retry_loop_json_restores_missing_worktree () =
       ~workdir:repo_root
       ()
   in
-  let state = { state with loop_id; source_workdir = repo_root } in
-  state.status <- Lib.Autoresearch.Error;
-  state.error_message <- Some "managed worktree missing";
-  state.workdir <- workdir;
-  state.warnings <- [ "source_workdir_dirty" ];
+  let state = { state with
+    loop_id; source_workdir = repo_root;
+    status = Lib.Autoresearch.Error;
+    error_message = Some "managed worktree missing";
+    workdir;
+    warnings = [ "source_workdir_dirty" ] } in
   Lib.Autoresearch.save_state ~base_path state;
   match
     Lib.Dashboard_http_autoresearch.retry_loop_json ~base_path ~loop_id
@@ -345,10 +346,11 @@ let test_delete_loop_json_removes_bundle_and_branch () =
       ~workdir:repo_root
       ()
   in
-  let state = { state with loop_id; source_workdir = repo_root } in
-  state.status <- Lib.Autoresearch.Error;
-  state.error_message <- Some "managed worktree missing";
-  state.workdir <- workdir;
+  let state = { state with
+    loop_id; source_workdir = repo_root;
+    status = Lib.Autoresearch.Error;
+    error_message = Some "managed worktree missing";
+    workdir } in
   Lib.Autoresearch.save_state ~base_path state;
   let link : Lib.Autoresearch.swarm_link =
     {


### PR DESCRIPTION
## Summary

OCaml 5.x 감사 Tier 2의 마지막 대형 항목. `loop_state` 레코드의 15개 `mutable` 필드를 전부 제거하고, 7개 파일에 걸친 47개 mutation site를 functional update 패턴으로 전환.

- `autoresearch_types.ml`: `mutable` 키워드 15개 전부 제거
- `add_insight`: `state → string → state` (was `unit`)
- `record_cycle`: `state → ... → state * cycle_record` (was `cycle_record`)
- `forced_discard_record`: `state → ... → state * cycle_record` (was `cycle_record`)
- 모든 mutation site: `{ state with ... }` + `Hashtbl.replace` writeback
- `save_state`: `updated_at` 부작용 제거 (caller가 설정)
- 테스트: stale local binding 대신 Hashtbl에서 최종 state 읽기
- `time_compat/dune`: `mcp_protocol_eio` → `mcp_protocol.eio` (pre-existing fix)

Closes #3460

## Test plan

- [x] `dune build` 전체 성공
- [x] `test_dashboard_autoresearch` 9/9 pass
- [x] `test_autoresearch_oas_primitives` 3/3 pass
- [x] `grep mutable autoresearch_types.ml` → 0건
- [ ] CI green
- [ ] 교차 모델 리뷰 (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)