### PR TITLE
chore(ci): revert grpc-direct pin to main

### DIFF
--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -42,9 +42,8 @@ fi
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-# TODO: revert to #main after jeong-sik/grpc-direct#61 merges
-opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#fix/mcp-protocol-merge -n -y
-opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#fix/mcp-protocol-merge -n -y
+opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
+opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
 opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 opam pin add neo4j_bolt_common https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y


### PR DESCRIPTION
## Summary
- Revert grpc-direct pin from `fix/mcp-protocol-merge` branch back to `#main`
- grpc-direct#62 already merged the `mcp_protocol.eio` rename

## Test plan
- [ ] CI pin step passes
- [ ] Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)