### PR TITLE
fix(harness): add max-time to grpc Subscribe check

### DIFF
--- a/scripts/harness/transport/verify_grpc_subscribe.sh
+++ b/scripts/harness/transport/verify_grpc_subscribe.sh
@@ -71,7 +71,7 @@ else
 fi
 
 subscribe_resp="$(
-  grpcurl -plaintext \
+  grpcurl -plaintext -max-time 5 \
     -import-path "${PROTO_DIR}" \
     -proto masc_coordination.proto \
     -d '{"agent_name":"e2e-harness","session_id":"grpc-e2e-harness","since_seq":"0","event_types":["message"]}' \


### PR DESCRIPTION
## Summary
- Add `-max-time 5` to the initial gRPC Subscribe call in `verify_grpc_subscribe.sh`
- Prevents grpcurl from hanging indefinitely on the server stream
- Root cause: CI timing race where pipe closes before `subscription_started` event flushes to stdout

Fixes #3477

## Test plan
- [ ] Contract Harness CI passes (gRPC subscribe leg)
- [ ] Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)