### PR TITLE
fix(dashboard): guard transport health SSE hydration

### DIFF
--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -113,6 +113,7 @@ const error: Signal<string | null> = signal(null)
 
 /** Hydrate transport health from SSE payload — zero HTTP fetch. */
 export function hydrateTransportHealthFromSSE(data: unknown): void {
+  if (data == null || typeof data !== 'object') return
   transportHealth.value = data as TransportHealthData
 }
 let inflightTransportHealthRefresh: Promise<void> | null = null


### PR DESCRIPTION
## Summary
- `hydrateTransportHealthFromSSE`에 `null`/`typeof` 가드 추가
- SSE payload가 non-object일 때 silent skip (렌더링 시점 crash 방지)

## Context
`/simplify` 셀프 리뷰에서 발견. 다른 surface 핸들러(execution, operator)는 normalizer를 통해 검증하지만, transport health만 bare `as` cast 사용 중이었음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)