### PR TITLE
feat(dashboard): extract mission cache timeout to env var

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -57,6 +57,10 @@ let room_scoped_cache_key (config : Room.config) prefix suffix =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
     (room_scope_cache_segment config) suffix
 
+let _dashboard_mission_timeout_s =
+  float_of_env_default "MASC_DASHBOARD_MISSION_TIMEOUT_S"
+    ~default:25.0 ~min_v:10.0 ~max_v:120.0
+
 let dashboard_session_list_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
     ~default:5.0 ~min_v:1.0 ~max_v:30.0
@@ -689,7 +693,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
            bootstrap that success instead of staying "initializing" forever
            when proactive warm-up misses its first build window. *)
         cached_surface_or_first_success_json _mission_cache
-          ~cache_key:"mission:default" ~ttl:120.0 ~clock ~timeout_sec:25.0
+          ~cache_key:"mission:default" ~ttl:120.0 ~clock ~timeout_sec:_dashboard_mission_timeout_s
           (fun () -> compute ())
     | Some _ ->
       (* Actor-parameterized: on-demand with SWR cache. *)
@@ -698,7 +702,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
           (Option.value ~default:"" actor)
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
-        ~clock ~timeout_sec:25.0 (compute ?actor)
+        ~clock ~timeout_sec:_dashboard_mission_timeout_s (compute ?actor)
   in
   full_json
 
@@ -741,7 +745,7 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
         (Option.value ~default:"" actor)
     in
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
-      ~clock ~timeout_sec:25.0 compute
+      ~clock ~timeout_sec:_dashboard_mission_timeout_s compute
 
 let dashboard_proof_http_json ~state request =
   let session_id = query_param request "session_id" in


### PR DESCRIPTION
## Summary
- `MASC_DASHBOARD_MISSION_TIMEOUT_S` 환경변수 추가 (default 25s, range 10-120s)
- on-demand mission compute의 하드코딩 `timeout_sec:25.0`을 3곳 교체
- proactive refresh loop은 이미 `MASC_DASHBOARD_MISSION_REFRESH_TIMEOUT_S` (60s)를 사용 중이므로 별도 유지

## Motivation
`dashboard-eager-manta` actor가 25s timeout을 매번 초과하여 30초마다 WARN 반복 (#3481).
환경변수로 운영 시 timeout 튜닝 가능하게 하여 로그 노이즈 및 불필요한 재계산 감소.

## Test plan
- [ ] `dune build` 성공 확인
- [ ] `MASC_DASHBOARD_MISSION_TIMEOUT_S=60` 설정 후 서버 시작, WARN 감소 확인
- [ ] 환경변수 미설정 시 기존 동작(25s) 유지 확인

Closes #3482

Generated with [Claude Code](https://claude.com/claude-code)