### PR TITLE
refactor(config): centralize env vars into Env_config sub-modules + to_json (#3364)

### DIFF
--- a/lib/adaptive_thresholds.ml
+++ b/lib/adaptive_thresholds.ml
@@ -187,8 +187,8 @@ let get_effective_thresholds ~(enabled : bool) ~(room : string) : thresholds =
        | _ -> default_thresholds)
   else
     (* Not enabled: check env vars, then defaults *)
-    let env_prepare = Sys.getenv_opt "MASC_MITOSIS_PREPARE_THRESHOLD" in
-    let env_handoff = Sys.getenv_opt "MASC_MITOSIS_HANDOFF_THRESHOLD" in
+    let env_prepare = Env_config.Chain.Mitosis.prepare_threshold_opt () in
+    let env_handoff = Env_config.Chain.Mitosis.handoff_threshold_opt () in
     match env_prepare, env_handoff with
     | Some p, Some h ->
       (try clamp_thresholds { prepare = float_of_string p; handoff = float_of_string h }

--- a/lib/adaptive_thresholds.ml
+++ b/lib/adaptive_thresholds.ml
@@ -134,7 +134,7 @@ let state_of_json (json : Yojson.Safe.t) : adaptive_state option =
 
 (** Path to persistence file for a given room *)
 let state_file_path ~(room : string) : string =
-  let home = match Sys.getenv_opt "HOME" with
+  let home = match Env_config_core.home_dir_opt () with
     | Some h -> h
     | None -> "/tmp"
   in
@@ -178,8 +178,8 @@ let get_effective_thresholds ~(enabled : bool) ~(room : string) : thresholds =
     | Some state -> state.thresholds
     | None -> (* Fall through to env vars *)
       (* 2. Environment variables *)
-      let env_prepare = Sys.getenv_opt "MASC_MITOSIS_PREPARE_THRESHOLD" in
-      let env_handoff = Sys.getenv_opt "MASC_MITOSIS_HANDOFF_THRESHOLD" in
+      let env_prepare = Env_config.Chain.Mitosis.prepare_threshold_opt () in
+      let env_handoff = Env_config.Chain.Mitosis.handoff_threshold_opt () in
       (match env_prepare, env_handoff with
        | Some p, Some h ->
          (try clamp_thresholds { prepare = float_of_string p; handoff = float_of_string h }

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -338,11 +338,7 @@ let permission_for_tool = function
     - 0/false: legacy fail-open for unknown tools
     - 1/true: unknown masc_* tools require at least worker-level permission *)
 let is_tool_auth_strict_enabled () =
-  match Sys.getenv_opt "MASC_TOOL_AUTH_STRICT" with
-  | Some raw ->
-      let v = String.trim raw |> String.lowercase_ascii in
-      v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
-  | None -> true
+  Env_config.Server.Auth.tool_auth_strict
 
 let is_masc_tool_name tool_name =
   String.starts_with ~prefix:"masc_" tool_name

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -17,9 +17,9 @@ open Yojson.Safe.Util
 type mode = Disabled | Spawn | Model
 
 let get_mode () =
-  match Sys.getenv_opt "MASC_AUTO_RESPOND" with
-  | Some "true" | Some "1" | Some "yes" | Some "spawn" -> Spawn
-  | Some "model" | Some "fast" -> Model
+  match Env_config.Server.Runtime.auto_respond_raw with
+  | "true" | "1" | "yes" | "spawn" -> Spawn
+  | "model" | "fast" -> Model
   | _ -> Disabled
 
 let is_enabled () = get_mode () <> Disabled
@@ -292,7 +292,7 @@ let maybe_respond ~sw ~base_path:_ ~from_agent ~content ~mention =
       debug_log "EXIT: No mention";
       None
   | Some _ when not (is_enabled ()) ->
-      let env_val = match Sys.getenv_opt "MASC_AUTO_RESPOND" with Some v -> v | None -> "not set" in
+      let env_val = match Env_config.Server.Runtime.auto_respond_raw with "" -> "not set" | v -> v in
       debug_log (Printf.sprintf "EXIT: Disabled (env=%s)" env_val);
       Log.AutoResponder.info "Disabled (MASC_AUTO_RESPOND=%s)" env_val;
       None

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -186,7 +186,10 @@ let cleanup_pubsub_limit_q =
 open Result_syntax
 
 (** Read MASC_PG_POOL_SIZE from env, clamped to [1, 50]. Default: 10. *)
-let configured_pool_size () = Env_config.Server.Storage.pg_pool_size
+let configured_pool_size () =
+  match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
+  | Some s -> (try max 1 (min (int_of_string s) 50) with Failure _ -> 10)
+  | None -> 10
 
 (** Add TCP keepalive query params to a URI if not already present. *)
 let uri_with_keepalive uri =
@@ -216,7 +219,7 @@ let create ~sw ~env ~url ~cluster_name ~node_id =
   let max_pool = configured_pool_size () in
   let pool_config = Caqti_pool_config.create
       ~max_size:max_pool ~max_idle_size:(min max_pool 3)
-      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 30_000_000_000L))
+      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 15_000_000_000L))
       ~max_use_count:(Some 50) () in
   let uri = uri_with_keepalive uri in
   Log.Backend.info "[EioPG] connecting pool (max_size=%d, max_idle_size=%d, keepalives=on)..."
@@ -267,7 +270,10 @@ let create_readonly ~sw ~env ~url ~cluster_name ~node_id =
      usage" when multiple Eio fibers within the same executor domain
      call Pool.use concurrently. Use 2/3 of the main pool size, minimum 4. *)
   let max_pool = max 4 (configured_pool_size () * 2 / 3) in
-  let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
+  let pool_config = Caqti_pool_config.create ~max_size:max_pool
+      ~max_idle_size:(min max_pool 2)
+      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 15_000_000_000L))
+      ~max_use_count:(Some 50) () in
   let uri = uri_with_keepalive uri in
   match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
   | Error err -> Error (caqti_error_to_masc err)
@@ -278,6 +284,30 @@ let close _t = ()
 
 let get_pool t = t.pool
 
+(* Retry wrapper for read-only Pool.use calls.
+   On first connection-level failure, drain the pool to purge stale
+   connections (Supabase PgBouncer drops them after idle periods),
+   then retry once with a fresh connection. *)
+let _drain_mutex = Eio.Mutex.create ()
+
+let is_connection_error err =
+  let msg = Caqti_error.show err in
+  let has s = try ignore (Str.search_forward (Str.regexp_string s) msg 0); true
+    with Not_found -> false in
+  has "connection" || has "socket" || has "broken pipe" ||
+  has "Connection reset" || has "server closed" || has "Operation timed out"
+
+let use_with_retry pool f =
+  match Caqti_eio.Pool.use f pool with
+  | Ok _ as ok -> ok
+  | Error err when is_connection_error err ->
+    Log.Backend.warn "[EioPG] stale connection detected, draining pool and retrying: %s"
+      (Caqti_error.show err);
+    Eio.Mutex.use_rw ~protect:false _drain_mutex (fun () ->
+      try Caqti_eio.Pool.drain pool with _ -> ());
+    Caqti_eio.Pool.use f pool
+  | Error _ as err -> err
+
 let decompress_with_context ~key content =
   let had_header = String.length content >= 4 && String.sub content 0 4 = "ZSTD" in
   let decompressed = _decompress content in
@@ -287,10 +317,10 @@ let decompress_with_context ~key content =
 
 let get t key =
   let nkey = namespaced_key t.namespace key in
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find_opt get_q nkey
-  ) t.pool with
+  ) with
   | Ok (Some v) -> Ok (decompress_with_context ~key:nkey v)
   | Ok None -> Error (NotFound key)
   | Error err -> Error (caqti_error_to_masc err)
@@ -341,10 +371,10 @@ let list_keys t ~prefix =
 
 let get_all t ~prefix =
   let nprefix = namespaced_key t.namespace prefix in
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.collect_list get_all_q (nprefix ^ "%")
-  ) t.pool with
+  ) with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
         (strip_namespace t.namespace k, decompress_with_context ~key:k v)
@@ -356,11 +386,11 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     Ok []
   else
     let nprefix = namespaced_key t.namespace prefix in
-    match Caqti_eio.Pool.use (fun conn ->
+    match use_with_retry t.pool (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in
       C.collect_list get_all_matching_recent_q
         (nprefix ^ "%", "%" ^ suffix, updated_since, limit)
-    ) t.pool with
+    ) with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
           (strip_namespace t.namespace k, decompress_with_context ~key:k v)
@@ -459,10 +489,10 @@ let subscribe t ~channel ~callback =
   | Error err -> Error (caqti_error_to_masc err)
 
 let health_check t =
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find health_check_q ()
-  ) t.pool with
+  ) with
   | Ok 1 -> Ok { latency_ms = 0.0; is_healthy = true }
   | _ -> Ok { latency_ms = 0.0; is_healthy = false }
 

--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -186,10 +186,7 @@ let cleanup_pubsub_limit_q =
 open Result_syntax
 
 (** Read MASC_PG_POOL_SIZE from env, clamped to [1, 50]. Default: 10. *)
-let configured_pool_size () =
-  match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-  | Some s -> (try max 1 (min (int_of_string s) 50) with Failure _ -> 10)
-  | None -> 10
+let configured_pool_size () = Env_config.Server.Storage.pg_pool_size
 
 (** Add TCP keepalive query params to a URI if not already present. *)
 let uri_with_keepalive uri =

--- a/lib/backend/backend_types.ml
+++ b/lib/backend/backend_types.ml
@@ -56,9 +56,7 @@ type config = {
 
 (** Get pubsub max messages from env or default *)
 let pubsub_max_messages_from_env () =
-  match Sys.getenv_opt "MASC_PUBSUB_MAX_MESSAGES" with
-  | Some s -> Safe_ops.int_of_string_with_default ~default:1000 s
-  | None -> 1000
+  Env_config.Server.Misc.pubsub_max_messages
 
 let generate_node_id () =
   let hostname = try Unix.gethostname () with Unix.Unix_error _ -> "unknown" in
@@ -107,9 +105,7 @@ let pool_stats_to_yojson (s : pool_stats) : Yojson.Safe.t =
   ]
 
 let configured_max_pool_size () =
-  match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-  | Some s -> (try int_of_string s with Failure _ -> 5)
-  | None -> 5
+  Env_config.Server.Storage.pg_pool_size
 
 (* ============================================ *)
 (* Safety Utilities                             *)

--- a/lib/backend/backend_types.ml
+++ b/lib/backend/backend_types.ml
@@ -56,7 +56,9 @@ type config = {
 
 (** Get pubsub max messages from env or default *)
 let pubsub_max_messages_from_env () =
-  Env_config.Server.Misc.pubsub_max_messages
+  match Sys.getenv_opt "MASC_PUBSUB_MAX_MESSAGES" with
+  | Some s -> Safe_ops.int_of_string_with_default ~default:1000 s
+  | None -> 1000
 
 let generate_node_id () =
   let hostname = try Unix.gethostname () with Unix.Unix_error _ -> "unknown" in
@@ -105,7 +107,9 @@ let pool_stats_to_yojson (s : pool_stats) : Yojson.Safe.t =
   ]
 
 let configured_max_pool_size () =
-  Env_config.Server.Storage.pg_pool_size
+  match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
+  | Some s -> (try int_of_string s with Failure _ -> 5)
+  | None -> 5
 
 (* ============================================ *)
 (* Safety Utilities                             *)

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -5,8 +5,7 @@ include Board_types
 
 (** Flush interval in seconds - configurable via MASC_BOARD_FLUSH_INTERVAL_SEC env var *)
 let flush_interval_sec =
-  try float_of_string (Sys.getenv_opt "MASC_BOARD_FLUSH_INTERVAL_SEC" |> Option.value ~default:"30")
-  with Failure _ -> 30.0
+  Env_config.Server.Misc.board_flush_interval_sec
 
 let create_store () = {
   posts = Hashtbl.create 1024;
@@ -111,10 +110,10 @@ let maybe_sweep store =
 (** {1 Persistence Paths} *)
 
 let board_base_path () =
-  match Sys.getenv_opt "MASC_BASE_PATH" with
-  | Some p when String.trim p <> "" -> p
-  | _ ->
-      (match Sys.getenv_opt "ME_ROOT" with
+  match Env_config.Server.Storage.base_path_opt () with
+  | Some p -> p
+  | None ->
+      (match Env_config_core.me_root_opt () with
        | Some p -> p
        | None -> Sys.getcwd ())
 

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -93,9 +93,7 @@ let reset_for_test () =
 
 (** Check MASC_BOARD_BACKEND env var. Returns true if JSONL is explicitly forced. *)
 let jsonl_forced () =
-  match Sys.getenv_opt "MASC_BOARD_BACKEND" with
-  | Some s -> String.lowercase_ascii (String.trim s) = "jsonl"
-  | None -> false
+  String.lowercase_ascii (String.trim Env_config.Server.Misc.board_backend) = "jsonl"
 
 (** Get backend or fail.
     Normal path: Board is initialized by room_utils_backend_setup during server startup.

--- a/lib/chain/chain_executor_leaf.ml
+++ b/lib/chain/chain_executor_leaf.ml
@@ -233,11 +233,13 @@ let execute_model_node ctx ~clock ~(exec_fn : exec_fn) ~(node : node) (model : n
 
 (** MASC MCP endpoint - configurable via MASC_MCP_URL env var *)
 let _masc_mcp_url () =
-  Option.value ~default:(Env_config.masc_http_base_url () ^ "/mcp") (Sys.getenv_opt "MASC_MCP_URL")
+  match Env_config.Server.External.mcp_url_opt () with
+  | Some url -> url
+  | None -> Env_config.masc_http_base_url () ^ "/mcp"
 
 (** Get MASC agent name from env or default *)
 let masc_agent_name () =
-  Option.value ~default:"local-worker" (Sys.getenv_opt "MASC_AGENT_NAME")
+  Option.value ~default:"local-worker" (Env_config.Server.Agent.name_opt ())
 
 (** Execute MASC broadcast node - calls masc.masc_broadcast via tool_exec *)
 let execute_masc_broadcast ctx ~tool_exec (node : node) ~message ~room ~mention : (string, string) result =

--- a/lib/chain/chain_log.ml
+++ b/lib/chain/chain_log.ml
@@ -66,13 +66,10 @@ let config = {
 }
 
 let init () =
-  (* Read from environment *)
-  (match Sys.getenv_opt "MASC_CHAIN_LOG_LEVEL" with
-   | Some s -> Atomic.set config.min_level (level_of_string (String.lowercase_ascii s))
-   | None -> ());
-  (match Sys.getenv_opt "MASC_CHAIN_LOG_FORMAT" with
-   | Some "json" -> Atomic.set config.format Json
-   | _ -> Atomic.set config.format Text)
+  Atomic.set config.min_level
+    (level_of_string (String.lowercase_ascii Env_config.Chain.Log.level));
+  Atomic.set config.format
+    (if Env_config.Chain.Log.format = "json" then Json else Text)
 
 let set_level level = Atomic.set config.min_level level
 let set_format fmt = Atomic.set config.format fmt

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -118,11 +118,11 @@ let chain_source_roots (config : Room.config) =
   in
   let roots = add [] config.base_path in
   let roots =
-    match option_trim (Sys.getenv_opt "MASC_BASE_PATH_INPUT") with
+    match Env_config.Server.Storage.base_path_input_opt () with
     | Some path -> add roots path
     | None -> roots
   in
-  match option_trim (Sys.getenv_opt "MASC_CHAIN_SOURCE_BASE_PATH") with
+  match Env_config.Chain.Paths.source_base_path_opt () with
   | Some path -> add roots path
   | None -> roots
 
@@ -491,7 +491,7 @@ let run_chain (runtime : runtime) ?chain_id ?mermaid ?input_json ~checkpoint_ena
     }
 
 let default_orchestrator_model () =
-  option_trim (Sys.getenv_opt "MASC_CHAIN_ORCHESTRATOR_MODEL")
+  Env_config.Chain.Model.orchestrator_model_opt ()
   |> Option.value ~default:"gemini:pro"
 
 let orchestrate_goal (runtime : runtime) ~(on_chain_designed : Chain_types.chain -> unit) ~goal :
@@ -606,7 +606,7 @@ let running_chains_json () =
 
 let read_history_events ~limit =
   let history_file =
-    option_trim (Sys.getenv_opt "MASC_CHAIN_HISTORY_FILE")
+    Env_config.Chain.Paths.history_file_opt ()
     |> Option.value ~default:"data/chain_history.jsonl"
   in
   if not (Sys.file_exists history_file) then []

--- a/lib/chain/chain_parser_helpers.ml
+++ b/lib/chain/chain_parser_helpers.ml
@@ -30,27 +30,16 @@ open Chain_types
 
 (** Maximum allowed chain depth to prevent stack overflow *)
 let security_max_depth =
-  match Sys.getenv_opt "MASC_CHAIN_MAX_DEPTH" with
-  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 20)
-  | None -> 20
+  Env_config.Chain.Limits.max_depth
 
-(** Maximum allowed concurrency to prevent resource exhaustion *)
 let security_max_concurrency =
-  match Sys.getenv_opt "MASC_CHAIN_MAX_CONCURRENCY" with
-  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 10)
-  | None -> 10
+  Env_config.Chain.Limits.max_concurrency
 
-(** Maximum total nodes in a chain to prevent memory exhaustion *)
 let security_max_nodes =
-  match Sys.getenv_opt "MASC_CHAIN_MAX_NODES" with
-  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 100)
-  | None -> 100
+  Env_config.Chain.Limits.max_nodes
 
-(** Maximum nodes in a single fanout/parallel to prevent exponential explosion *)
 let security_max_fanout =
-  match Sys.getenv_opt "MASC_CHAIN_MAX_FANOUT" with
-  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 20)
-  | None -> 20
+  Env_config.Chain.Limits.max_fanout
 
 (** {1 Safe JSON Parsing Helpers - Explicit Error Handling} *)
 

--- a/lib/chain/chain_run_store.ml
+++ b/lib/chain/chain_run_store.ml
@@ -11,17 +11,13 @@ let max_output_chars () = Safe_parse.env_int ~var:"MASC_CHAIN_OUTPUT_MAX_CHARS" 
 let max_preview_chars () = Safe_parse.env_int ~var:"MASC_CHAIN_OUTPUT_PREVIEW_CHARS" ~default:240
 
 let default_store_path () =
-  let home =
-    match Sys.getenv_opt "HOME" with
-    | Some path when String.trim path <> "" -> path
-    | _ -> "/tmp"
-  in
+  let home = Option.value ~default:"/tmp" (Env_config_core.home_dir_opt ()) in
   Filename.concat home "logs/masc_chain_run_store.jsonl"
 
 let store_path () =
-  match Sys.getenv_opt "MASC_CHAIN_RUN_STORE_PATH" with
-  | Some path when String.trim path <> "" -> path
-  | _ -> default_store_path ()
+  match Env_config.Chain.Paths.run_store_path_opt () with
+  | Some path -> path
+  | None -> default_store_path ()
 
 let ensure_dir path =
   Fs_compat.mkdir_p path

--- a/lib/chain/chain_telemetry.ml
+++ b/lib/chain/chain_telemetry.ml
@@ -25,12 +25,9 @@ let with_mutex mutex f = Eio_guard.with_mutex mutex f
 (** History file path - configurable via environment.
     MASC_CHAIN_HISTORY_FILE is canonical; CHAIN_HISTORY_FILE remains a generic fallback. *)
 let history_file () =
-  match Sys.getenv_opt "MASC_CHAIN_HISTORY_FILE" with
-  | Some path when String.trim path <> "" -> path
-  | _ -> (
-      match Sys.getenv_opt "CHAIN_HISTORY_FILE" with
-      | Some path when String.trim path <> "" -> path
-      | _ -> "data/chain_history.jsonl")
+  match Env_config.Chain.Paths.history_file_opt () with
+  | Some path -> path
+  | None -> "data/chain_history.jsonl"
 
 (** Append a JSON record to history file (thread-safe via OS) *)
 let append_history (json : Yojson.Safe.t) =

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -37,11 +37,11 @@ type checkpoint_store = {
 
 (** Default checkpoint directory *)
 let default_base_dir () =
-  match Sys.getenv_opt "MASC_CHAIN_CHECKPOINT_DIR" with
-  | Some path when String.trim path <> "" -> path
-  | _ ->
+  match Env_config.Chain.Paths.checkpoint_dir_opt () with
+  | Some path -> path
+  | None ->
       let home =
-        match Sys.getenv_opt "HOME" with
+        match Env_config_core.home_dir_opt () with
         | Some h -> h
         | None -> "/tmp"
       in

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -198,11 +198,11 @@ let inputs_from_env () =
   {
     cwd = Sys.getcwd ();
     executable_name = Sys.executable_name;
-    env_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR";
-    env_personas_dir = Sys.getenv_opt "MASC_PERSONAS_DIR";
+    env_config_dir = Env_config.Server.Dirs.config_dir_opt ();
+    env_personas_dir = Env_config.Server.Dirs.personas_dir_opt ();
     env_home = Sys.getenv_opt "HOME";
     env_me_root = Sys.getenv_opt "ME_ROOT";
-    env_workspace_root = Sys.getenv_opt "MASC_WORKSPACE_ROOT";
+    env_workspace_root = Env_config_core.workspace_root_opt ();
     env_dune_sourceroot = Sys.getenv_opt "DUNE_SOURCEROOT";
   }
 

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -50,14 +50,16 @@ let default_tiny_model_opt () =
     |> List.filter (fun s -> s <> "")
   in
   let label_opt =
-    match Env_config.Chain.Model.default_cascade_opt () with
+    match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
     | Some raw -> (
         match split_csv_nonempty raw with
         | first :: _ -> Some first
         | [] -> None)
     | None -> (
-        match (Env_config.Chain.Model.default_provider_opt (), Env_config.Chain.Model.default_model_opt ()) with
+        match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
         | Some provider, Some model_id ->
+            let provider = String.trim provider in
+            let model_id = String.trim model_id in
             if provider = "" || model_id = "" then None else Some (provider ^ ":" ^ model_id)
         | _ -> None)
   in

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -50,16 +50,14 @@ let default_tiny_model_opt () =
     |> List.filter (fun s -> s <> "")
   in
   let label_opt =
-    match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+    match Env_config.Chain.Model.default_cascade_opt () with
     | Some raw -> (
         match split_csv_nonempty raw with
         | first :: _ -> Some first
         | [] -> None)
     | None -> (
-        match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
+        match (Env_config.Chain.Model.default_provider_opt (), Env_config.Chain.Model.default_model_opt ()) with
         | Some provider, Some model_id ->
-            let provider = String.trim provider in
-            let model_id = String.trim model_id in
             if provider = "" || model_id = "" then None else Some (provider ^ ":" ^ model_id)
         | _ -> None)
   in

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -236,12 +236,12 @@ let looks_like_localhost host =
 
 let neo4j_http_base_uri () : (Uri.t, string) result =
   (* Prefer explicit HTTP URI if provided to avoid bolt/http port mismatches. *)
-  match Sys.getenv_opt "NEO4J_HTTP_URI" with
-  | Some uri_str when String.trim uri_str <> "" ->
+  match Env_config.Server.External.neo4j_http_uri_opt () with
+  | Some uri_str ->
       Ok (Uri.of_string uri_str)
-  | _ ->
+  | None ->
       let uri_str =
-        Sys.getenv_opt "NEO4J_URI" |> Option.value ~default:"http://localhost:7474"
+        Env_config.Server.External.neo4j_uri_opt () |> Option.value ~default:"http://localhost:7474"
       in
       let uri = Uri.of_string uri_str in
       match Uri.scheme uri with
@@ -279,8 +279,8 @@ let neo4j_tx_commit_uri () : (Uri.t, string) result =
       Ok (Uri.of_string (base_str ^ "/db/neo4j/tx/commit"))
 
 let neo4j_auth_header () : (string * string, string) result =
-  let user = Sys.getenv_opt "NEO4J_USER" |> Option.value ~default:"neo4j" in
-  let password = Sys.getenv_opt "NEO4J_PASSWORD" |> Option.value ~default:"" in
+  let user = Env_config.Server.External.neo4j_user () in
+  let password = Env_config.Server.External.neo4j_password_opt () |> Option.value ~default:"" in
   if String.trim password = "" then
     Error "NEO4J_PASSWORD not set (Neo4j persistence disabled)"
   else

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -236,12 +236,12 @@ let looks_like_localhost host =
 
 let neo4j_http_base_uri () : (Uri.t, string) result =
   (* Prefer explicit HTTP URI if provided to avoid bolt/http port mismatches. *)
-  match Env_config.Server.External.neo4j_http_uri_opt () with
-  | Some uri_str ->
+  match Sys.getenv_opt "NEO4J_HTTP_URI" with
+  | Some uri_str when String.trim uri_str <> "" ->
       Ok (Uri.of_string uri_str)
-  | None ->
+  | _ ->
       let uri_str =
-        Env_config.Server.External.neo4j_uri_opt () |> Option.value ~default:"http://localhost:7474"
+        Sys.getenv_opt "NEO4J_URI" |> Option.value ~default:"http://localhost:7474"
       in
       let uri = Uri.of_string uri_str in
       match Uri.scheme uri with
@@ -279,8 +279,8 @@ let neo4j_tx_commit_uri () : (Uri.t, string) result =
       Ok (Uri.of_string (base_str ^ "/db/neo4j/tx/commit"))
 
 let neo4j_auth_header () : (string * string, string) result =
-  let user = Env_config.Server.External.neo4j_user () in
-  let password = Env_config.Server.External.neo4j_password_opt () |> Option.value ~default:"" in
+  let user = Sys.getenv_opt "NEO4J_USER" |> Option.value ~default:"neo4j" in
+  let password = Sys.getenv_opt "NEO4J_PASSWORD" |> Option.value ~default:"" in
   if String.trim password = "" then
     Error "NEO4J_PASSWORD not set (Neo4j persistence disabled)"
   else

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -237,19 +237,11 @@ let tone_rank = function
   | _ -> 0
 
 let dashboard_fixture_name ?fixture () =
-  let fixtures_enabled =
-    match Sys.getenv_opt "MASC_DASHBOARD_FIXTURES_ENABLED" with
-    | Some v when String.lowercase_ascii (String.trim v) = "true" -> true
-    | _ -> false
-  in
-  if not fixtures_enabled then None
+  if not Env_config.Dashboard.Fixtures.enabled then None
   else
     match fixture with
     | Some value when String.trim value <> "" -> Some (String.trim value)
-    | _ -> (
-        match Sys.getenv_opt "MASC_DASHBOARD_FIXTURE" with
-        | Some value when String.trim value <> "" -> Some (String.trim value)
-        | _ -> None)
+    | _ -> Env_config.Dashboard.Fixtures.fixture_name_opt ()
 
 (** Agent profile enriched from persona profile.json or Neo4j cache. *)
 type agent_profile = {

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -275,10 +275,8 @@ let extract_persona_name (agent_name : string) : string =
 let load_persona_profile (persona_name : string) : agent_profile option =
   let me_root =
     try Env_config.me_root ()
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (
-      match Sys.getenv_opt "HOME" with
-      | Some home -> Filename.concat home "me"
-      | None -> "/tmp")
+    with Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> Env_config_core.me_root_or_home ()
   in
   let path =
     Filename.concat

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -64,20 +64,12 @@ let now_iso () = Types.now_iso ()
 let option_to_yojson f = function Some value -> f value | None -> `Null
 
 let interval_sec () =
-  match Sys.getenv_opt "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC" with
-  | Some raw -> (
-      try max 15 (int_of_string (String.trim raw)) with Failure _ -> 60)
-  | None -> 60
+  Env_config.Dashboard.GovernanceJudge.interval_sec
 
 let cache_ttl_sec () = float_of_int (interval_sec () * 2)
 
 let enabled () =
-  match Sys.getenv_opt "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED" with
-  | Some raw -> (
-      match String.lowercase_ascii (String.trim raw) with
-      | "0" | "false" | "no" | "off" -> false
-      | _ -> true)
-  | None -> true
+  Env_config.Dashboard.GovernanceJudge.enabled
 
 let keeper_name = "operator-judge"
 

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -54,30 +54,16 @@ let get_state base_path =
         st)
 
 let enabled () =
-  match Sys.getenv_opt "MASC_OPERATOR_JUDGE_ENABLED" with
-  | Some raw -> (
-      match String.lowercase_ascii (String.trim raw) with
-      | "0" | "false" | "no" | "off" -> false
-      | _ -> true)
-  | None -> true
+  Env_config.Dashboard.OperatorJudge.enabled
 
 let interval_sec () =
-  match Sys.getenv_opt "MASC_OPERATOR_JUDGE_INTERVAL_SEC" with
-  | Some raw -> (
-      try max 15 (int_of_string (String.trim raw)) with Failure _ -> 60)
-  | None -> 60
+  Env_config.Dashboard.OperatorJudge.interval_sec
 
 let room_ttl_sec () =
-  match Sys.getenv_opt "MASC_OPERATOR_JUDGE_ROOM_TTL_SEC" with
-  | Some raw -> (
-      try max 15 (int_of_string (String.trim raw)) with Failure _ -> 60)
-  | None -> 60
+  Env_config.Dashboard.OperatorJudge.room_ttl_sec
 
 let session_ttl_sec () =
-  match Sys.getenv_opt "MASC_OPERATOR_JUDGE_SESSION_TTL_SEC" with
-  | Some raw -> (
-      try max 30 (int_of_string (String.trim raw)) with Failure _ -> 300)
-  | None -> 300
+  Env_config.Dashboard.OperatorJudge.session_ttl_sec
 
 let iso_of_unix unix_ts =
   let tm = Unix.gmtime unix_ts in

--- a/lib/dune
+++ b/lib/dune
@@ -646,9 +646,6 @@
  env_config_runtime
  env_config_governance
  env_config_keeper
- env_config_server
- env_config_chain
- env_config_dashboard
   keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/dune
+++ b/lib/dune
@@ -535,6 +535,9 @@
    env_config_runtime
    env_config_governance
    env_config_keeper
+   env_config_server
+   env_config_chain
+   env_config_dashboard
    runtime_params
    governance_registry
    governance_pipeline
@@ -643,6 +646,9 @@
  env_config_runtime
  env_config_governance
  env_config_keeper
+ env_config_server
+ env_config_chain
+ env_config_dashboard
   keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -115,7 +115,7 @@ let to_json () : Yojson.Safe.t =
       "grpc_port", int_val Server.Grpc.port;
       "ws_enabled", bool_val Server.Ws.enabled;
       "ws_port", int_val Server.Ws.port;
-      "h2_enabled", bool_val Server.H2.enabled;
+      "h2_mode", str Server.H2.mode;
       "webrtc_enabled", bool_val Server.Webrtc.enabled;
       "storage_type", str Server.Storage.storage_type;
       "pg_pool_size", int_val Server.Storage.pg_pool_size;
@@ -139,9 +139,9 @@ let to_json () : Yojson.Safe.t =
     "dashboard", `Assoc [
       "fixtures_enabled", bool_val Dashboard.Fixtures.enabled;
       "governance_judge_enabled", bool_val Dashboard.GovernanceJudge.enabled;
-      "governance_judge_interval_sec", float_val Dashboard.GovernanceJudge.interval_sec;
+      "governance_judge_interval_sec", int_val Dashboard.GovernanceJudge.interval_sec;
       "operator_judge_enabled", bool_val Dashboard.OperatorJudge.enabled;
-      "operator_judge_interval_sec", float_val Dashboard.OperatorJudge.interval_sec;
+      "operator_judge_interval_sec", int_val Dashboard.OperatorJudge.interval_sec;
       "relay_calibration_enabled", bool_val Dashboard.Relay.calibration_enabled;
     ];
     "external", `Assoc [

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -9,6 +9,10 @@ include Env_config_runtime
 include Env_config_governance
 include Env_config_keeper
 
+module Server = Env_config_server
+module Chain = Env_config_chain
+module Dashboard = Env_config_dashboard
+
 let print_summary () =
   Log.Env.info "Zombie: threshold=%.0fs cleanup_interval=%.0fs"
     Env_config_runtime.Zombie.threshold_seconds
@@ -57,3 +61,94 @@ let print_summary () =
   Log.Env.info "KeeperAlert(SlackDM): enabled=%b user_id_set=%b"
     Env_config_keeper.KeeperAlert.slack_dm_enabled
     (String.trim Env_config_keeper.KeeperAlert.slack_dm_user_id <> "")
+
+(** Serialize all known configuration as JSON for dashboard introspection.
+    Sensitive values (passwords, tokens, API keys) are masked. *)
+let to_json () : Yojson.Safe.t =
+  let mask s =
+    if String.length s <= 4 then "***"
+    else String.sub s 0 2 ^ String.make (String.length s - 4) '*' ^ String.sub s (String.length s - 2) 2
+  in
+  let mask_opt f = match f () with Some v -> `String (mask v) | None -> `Null in
+  let str s = `String s in
+  let str_opt f = match f () with Some v -> `String v | None -> `Null in
+  let int_val i = `Int i in
+  let float_val f = `Float f in
+  let bool_val b = `Bool b in
+  `Assoc [
+    "core", `Assoc [
+      "me_root", str_opt me_root_opt;
+      "sb_path", str_opt sb_path_opt;
+      "http_port", str (masc_http_port ());
+      "host", str (masc_host ());
+      "http_base_url", (match masc_http_base_url_result () with Ok u -> str u | Error _ -> `Null);
+      "assets_dir", str_opt assets_dir_opt;
+      "cluster_name", str (cluster_name ());
+    ];
+    "runtime", `Assoc [
+      "zombie_threshold_sec", float_val Env_config_runtime.Zombie.threshold_seconds;
+      "zombie_keeper_threshold_sec", float_val Env_config_runtime.Zombie.keeper_threshold_seconds;
+      "zombie_cleanup_interval_sec", float_val Env_config_runtime.Zombie.cleanup_interval_seconds;
+      "lock_timeout_sec", float_val Env_config_runtime.Lock.timeout_seconds;
+      "session_max_age_sec", float_val Env_config_runtime.Session.max_age_seconds;
+      "tempo_min_sec", float_val Env_config_runtime.Tempo.min_interval_seconds;
+      "tempo_max_sec", float_val Env_config_runtime.Tempo.max_interval_seconds;
+      "tempo_default_sec", float_val Env_config_runtime.Tempo.default_interval_seconds;
+    ];
+    "governance", `Assoc [
+      "inference_timeout_sec", float_val Env_config_governance.Inference.timeout_seconds;
+      "inference_cache_enabled", bool_val Env_config_governance.Inference.cache_enabled;
+      "inference_cache_ttl_sec", int_val Env_config_governance.Inference.cache_ttl_seconds;
+      "lodge_tick_sec", float_val Env_config_governance.LodgeV2.tick_interval_seconds;
+      "lodge_agents_per_tick", int_val Env_config_governance.LodgeV2.agents_per_tick;
+    ];
+    "keeper", `Assoc [
+      "bootstrap_enabled", bool_val Env_config_keeper.KeeperBootstrap.enabled;
+      "bootstrap_stale_turn_sec", float_val Env_config_keeper.KeeperBootstrap.stale_turn_seconds;
+      "bootstrap_max_scan", int_val Env_config_keeper.KeeperBootstrap.max_scan;
+      "alert_enabled", bool_val Env_config_keeper.KeeperAlert.enabled;
+      "alert_min_score", float_val Env_config_keeper.KeeperAlert.min_score;
+      "alert_slack_enabled", bool_val Env_config_keeper.KeeperAlert.slack_enabled;
+    ];
+    "server", `Assoc [
+      "grpc_enabled", bool_val Server.Grpc.enabled;
+      "grpc_port", int_val Server.Grpc.port;
+      "ws_enabled", bool_val Server.Ws.enabled;
+      "ws_port", int_val Server.Ws.port;
+      "h2_enabled", bool_val Server.H2.enabled;
+      "webrtc_enabled", bool_val Server.Webrtc.enabled;
+      "storage_type", str Server.Storage.storage_type;
+      "pg_pool_size", int_val Server.Storage.pg_pool_size;
+      "telemetry_enabled", bool_val Server.Runtime.telemetry_enabled;
+      "openai_compat", bool_val Server.Runtime.openai_compat;
+      "dispatch_v2", bool_val Server.Runtime.dispatch_v2;
+      "rate_limit", int_val Server.Rate.limit;
+      "rate_burst", int_val Server.Rate.burst;
+      "build_git_commit", str (Server.Misc.build_git_commit ());
+    ];
+    "chain", `Assoc [
+      "max_nodes", int_val Chain.Limits.max_nodes;
+      "max_depth", int_val Chain.Limits.max_depth;
+      "max_fanout", int_val Chain.Limits.max_fanout;
+      "max_concurrency", int_val Chain.Limits.max_concurrency;
+      "default_cascade", str_opt Chain.Model.default_cascade_opt;
+      "default_provider", str_opt Chain.Model.default_provider_opt;
+      "default_model", str_opt Chain.Model.default_model_opt;
+      "llama_swarm_model", str_opt Chain.Model.llama_swarm_model_opt;
+    ];
+    "dashboard", `Assoc [
+      "fixtures_enabled", bool_val Dashboard.Fixtures.enabled;
+      "governance_judge_enabled", bool_val Dashboard.GovernanceJudge.enabled;
+      "governance_judge_interval_sec", float_val Dashboard.GovernanceJudge.interval_sec;
+      "operator_judge_enabled", bool_val Dashboard.OperatorJudge.enabled;
+      "operator_judge_interval_sec", float_val Dashboard.OperatorJudge.interval_sec;
+      "relay_calibration_enabled", bool_val Dashboard.Relay.calibration_enabled;
+    ];
+    "external", `Assoc [
+      "graphql_url", str (Server.External.graphql_url ());
+      "neo4j_uri", str_opt Server.External.neo4j_uri_opt;
+      "neo4j_password", mask_opt Server.External.neo4j_password_opt;
+      "gemini_api_key", mask_opt Server.External.gemini_api_key_opt;
+      "graphql_api_key", mask_opt Server.External.graphql_api_key_opt;
+    ];
+  ]

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -122,7 +122,7 @@ let to_json () : Yojson.Safe.t =
       "telemetry_enabled", bool_val Server.Runtime.telemetry_enabled;
       "openai_compat", bool_val Server.Runtime.openai_compat;
       "dispatch_v2", bool_val Server.Runtime.dispatch_v2;
-      "rate_limit", int_val Server.Rate.limit;
+      "rate_limit", float_val Server.Rate.limit;
       "rate_burst", int_val Server.Rate.burst;
       "build_git_commit", str (Server.Misc.build_git_commit ());
     ];

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -137,12 +137,12 @@ let to_json () : Yojson.Safe.t =
       "llama_swarm_model", str_opt Chain.Model.llama_swarm_model_opt;
     ];
     "dashboard", `Assoc [
-      "fixtures_enabled", bool_val Dashboard.Fixtures.enabled;
-      "governance_judge_enabled", bool_val Dashboard.GovernanceJudge.enabled;
-      "governance_judge_interval_sec", int_val Dashboard.GovernanceJudge.interval_sec;
-      "operator_judge_enabled", bool_val Dashboard.OperatorJudge.enabled;
-      "operator_judge_interval_sec", int_val Dashboard.OperatorJudge.interval_sec;
-      "relay_calibration_enabled", bool_val Dashboard.Relay.calibration_enabled;
+      "fixtures_enabled", bool_val Env_config_dashboard.Fixtures.enabled;
+      "governance_judge_enabled", bool_val Env_config_dashboard.GovernanceJudge.enabled;
+      "governance_judge_interval_sec", int_val Env_config_dashboard.GovernanceJudge.interval_sec;
+      "operator_judge_enabled", bool_val Env_config_dashboard.OperatorJudge.enabled;
+      "operator_judge_interval_sec", int_val Env_config_dashboard.OperatorJudge.interval_sec;
+      "relay_calibration_enabled", bool_val Env_config_dashboard.Relay.calibration_enabled;
     ];
     "external", `Assoc [
       "graphql_url", str (Server.External.graphql_url ());

--- a/lib/env_config.mli
+++ b/lib/env_config.mli
@@ -11,5 +11,18 @@ include module type of Env_config_runtime
 include module type of Env_config_governance
 include module type of Env_config_keeper
 
+module Server : module type of Env_config_server
+(** Server, transport, and storage configuration. *)
+
+module Chain : module type of Env_config_chain
+(** Chain engine, model selection, and inference routing. *)
+
+module Dashboard : module type of Env_config_dashboard
+(** Dashboard, operator, and alerting configuration. *)
+
 val print_summary : unit -> unit
 (** Print configuration summary for debugging. *)
+
+val to_json : unit -> Yojson.Safe.t
+(** Serialize all known configuration as JSON for dashboard introspection.
+    Sensitive values (passwords, tokens, API keys) are masked. *)

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -93,7 +93,7 @@ module Llama = struct
     get_bool ~default:false "MASC_LLAMA_RUNTIME_DEBUG"
 
   let runtime_cooldown_sec =
-    get_float ~default:5.0 "MASC_LLAMA_RUNTIME_COOLDOWN_SEC"
+    get_float ~default:30.0 "MASC_LLAMA_RUNTIME_COOLDOWN_SEC"
 
   let swarm_live_script_opt () =
     Sys.getenv_opt "MASC_SWARM_LIVE_SCRIPT" |> trim_opt

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -9,16 +9,16 @@ open Env_config_core
 
 module Limits = struct
   let max_nodes =
-    get_int ~default:100 "MASC_CHAIN_MAX_NODES"
+    max 1 (get_int ~default:100 "MASC_CHAIN_MAX_NODES")
 
   let max_depth =
-    get_int ~default:10 "MASC_CHAIN_MAX_DEPTH"
+    max 1 (get_int ~default:20 "MASC_CHAIN_MAX_DEPTH")
 
   let max_fanout =
-    get_int ~default:5 "MASC_CHAIN_MAX_FANOUT"
+    max 1 (get_int ~default:20 "MASC_CHAIN_MAX_FANOUT")
 
   let max_concurrency =
-    get_int ~default:4 "MASC_CHAIN_MAX_CONCURRENCY"
+    max 1 (get_int ~default:10 "MASC_CHAIN_MAX_CONCURRENCY")
 end
 
 (** {1 Chain Paths} *)

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -1,0 +1,127 @@
+(** Chain engine and model selection environment configuration.
+
+    Centralizes MASC_CHAIN_*, MASC_DEFAULT_*, LLAMA_SWARM_MODEL,
+    and related inference routing env vars. *)
+
+open Env_config_core
+
+(** {1 Chain Engine Limits} *)
+
+module Limits = struct
+  let max_nodes =
+    get_int ~default:100 "MASC_CHAIN_MAX_NODES"
+
+  let max_depth =
+    get_int ~default:10 "MASC_CHAIN_MAX_DEPTH"
+
+  let max_fanout =
+    get_int ~default:5 "MASC_CHAIN_MAX_FANOUT"
+
+  let max_concurrency =
+    get_int ~default:4 "MASC_CHAIN_MAX_CONCURRENCY"
+end
+
+(** {1 Chain Paths} *)
+
+module Paths = struct
+  let source_base_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_SOURCE_BASE_PATH" |> trim_opt
+
+  let checkpoint_dir_opt () =
+    Sys.getenv_opt "MASC_CHAIN_CHECKPOINT_DIR" |> trim_opt
+
+  let history_file_opt () =
+    match Sys.getenv_opt "MASC_CHAIN_HISTORY_FILE" |> trim_opt with
+    | Some _ as v -> v
+    | None -> Sys.getenv_opt "CHAIN_HISTORY_FILE" |> trim_opt
+
+  let run_store_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_RUN_STORE_PATH" |> trim_opt
+end
+
+(** {1 Chain Logging} *)
+
+module Log = struct
+  let level =
+    get_string ~default:"info" "MASC_CHAIN_LOG_LEVEL"
+
+  let format =
+    get_string ~default:"text" "MASC_CHAIN_LOG_FORMAT"
+
+  let run_log_enabled =
+    get_bool ~default:false "MASC_CHAIN_RUN_LOG"
+
+  let run_log_path_opt () =
+    Sys.getenv_opt "MASC_CHAIN_RUN_LOG_PATH" |> trim_opt
+
+  let run_log_stream =
+    get_bool ~default:false "MASC_CHAIN_RUN_LOG_STREAM"
+end
+
+(** {1 Model Selection & Cascade} *)
+
+module Model = struct
+  let default_cascade_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_CASCADE" |> trim_opt
+
+  let routing_cascade_opt () =
+    Sys.getenv_opt "MASC_ROUTING_CASCADE" |> trim_opt
+
+  let default_provider_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_PROVIDER" |> trim_opt
+
+  let default_model_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_MODEL" |> trim_opt
+
+  let orchestrator_model_opt () =
+    Sys.getenv_opt "MASC_CHAIN_ORCHESTRATOR_MODEL" |> trim_opt
+
+  let llama_swarm_model_opt () =
+    Sys.getenv_opt "LLAMA_SWARM_MODEL" |> trim_opt
+
+  let goal_models_opt () =
+    Sys.getenv_opt "MASC_GOAL_MODELS" |> trim_opt
+
+  let goal_dispatch_runtime =
+    get_string ~default:"local" "MASC_GOAL_DISPATCH_RUNTIME"
+end
+
+(** {1 Local LLM (Llama)} *)
+
+module Llama = struct
+  let runtime_debug =
+    get_bool ~default:false "MASC_LLAMA_RUNTIME_DEBUG"
+
+  let runtime_cooldown_sec =
+    get_float ~default:5.0 "MASC_LLAMA_RUNTIME_COOLDOWN_SEC"
+
+  let swarm_live_script_opt () =
+    Sys.getenv_opt "MASC_SWARM_LIVE_SCRIPT" |> trim_opt
+end
+
+(** {1 Mitosis Thresholds} *)
+
+module Mitosis = struct
+  let prepare_threshold_opt () =
+    Sys.getenv_opt "MASC_MITOSIS_PREPARE_THRESHOLD" |> trim_opt
+
+  let handoff_threshold_opt () =
+    Sys.getenv_opt "MASC_MITOSIS_HANDOFF_THRESHOLD" |> trim_opt
+end
+
+(** {1 Procedural Memory} *)
+
+module Procedural = struct
+  let min_evidence =
+    get_int ~default:2 "MASC_PROC_MIN_EVIDENCE"
+
+  let min_confidence =
+    get_float ~default:0.7 "MASC_PROC_MIN_CONFIDENCE"
+end
+
+(** {1 Memory OAS Bridge} *)
+
+module Memory = struct
+  let oas_default_importance =
+    get_float ~default:0.5 "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE"
+end

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -83,7 +83,7 @@ module Model = struct
     Sys.getenv_opt "MASC_GOAL_MODELS" |> trim_opt
 
   let goal_dispatch_runtime =
-    get_string ~default:"local" "MASC_GOAL_DISPATCH_RUNTIME"
+    get_string ~default:"task" "MASC_GOAL_DISPATCH_RUNTIME"
 end
 
 (** {1 Local LLM (Llama)} *)

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -95,6 +95,9 @@ module Model = struct
   let goal_models_opt () =
     Sys.getenv_opt "MASC_GOAL_MODELS" |> trim_opt
 
+  let verifier_model_opt () =
+    Sys.getenv_opt "MASC_DEFAULT_VERIFIER_MODEL" |> trim_opt
+
   let goal_dispatch_runtime =
     get_string ~default:"task" "MASC_GOAL_DISPATCH_RUNTIME"
 end

--- a/lib/env_config_chain.ml
+++ b/lib/env_config_chain.ml
@@ -39,6 +39,19 @@ module Paths = struct
     Sys.getenv_opt "MASC_CHAIN_RUN_STORE_PATH" |> trim_opt
 end
 
+(** {1 Run Store} *)
+
+module RunStore = struct
+  let max_history =
+    get_int ~default:50 "MASC_CHAIN_RUN_HISTORY"
+
+  let max_output_chars =
+    get_int ~default:4000 "MASC_CHAIN_OUTPUT_MAX_CHARS"
+
+  let max_preview_chars =
+    get_int ~default:240 "MASC_CHAIN_OUTPUT_PREVIEW_CHARS"
+end
+
 (** {1 Chain Logging} *)
 
 module Log = struct
@@ -113,15 +126,16 @@ end
 
 module Procedural = struct
   let min_evidence =
-    get_int ~default:2 "MASC_PROC_MIN_EVIDENCE"
+    max 1 (get_int ~default:3 "MASC_PROC_MIN_EVIDENCE")
 
   let min_confidence =
-    get_float ~default:0.7 "MASC_PROC_MIN_CONFIDENCE"
+    max 0.0 (min 1.0 (get_float ~default:0.7 "MASC_PROC_MIN_CONFIDENCE"))
 end
 
 (** {1 Memory OAS Bridge} *)
 
 module Memory = struct
+  (** Importance scale 1-10 (integer). *)
   let oas_default_importance =
-    get_float ~default:0.5 "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE"
+    max 1 (min 10 (get_int ~default:5 "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE"))
 end

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -45,14 +45,14 @@ end
 
 module OperatorCache = struct
   let ttl_sec =
-    get_float ~default:60.0 "MASC_OPERATOR_CACHE_TTL"
+    get_float ~default:30.0 "MASC_OPERATOR_CACHE_TTL"
 end
 
 (** {1 Alert Configuration} *)
 
 module Alert = struct
   let dedup_window_sec =
-    get_float ~default:300.0 "MASC_ALERT_DEDUP_WINDOW_SEC"
+    max 5.0 (get_float ~default:60.0 "MASC_ALERT_DEDUP_WINDOW_SEC")
 end
 
 (** {1 Relay Calibration} *)

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -1,0 +1,70 @@
+(** Dashboard and operator environment configuration.
+
+    Centralizes MASC_DASHBOARD_*, MASC_OPERATOR_*, and related
+    operator-facing env vars. *)
+
+open Env_config_core
+
+(** {1 Dashboard Fixtures} *)
+
+module Fixtures = struct
+  let enabled =
+    get_bool ~default:false "MASC_DASHBOARD_FIXTURES_ENABLED"
+
+  let fixture_name_opt () =
+    Sys.getenv_opt "MASC_DASHBOARD_FIXTURE" |> trim_opt
+end
+
+(** {1 Governance Judge} *)
+
+module GovernanceJudge = struct
+  let enabled =
+    get_bool ~default:true "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED"
+
+  let interval_sec =
+    get_float ~default:300.0 "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC"
+end
+
+(** {1 Operator Judge} *)
+
+module OperatorJudge = struct
+  let enabled =
+    get_bool ~default:true "MASC_OPERATOR_JUDGE_ENABLED"
+
+  let interval_sec =
+    get_float ~default:120.0 "MASC_OPERATOR_JUDGE_INTERVAL_SEC"
+
+  let session_ttl_sec =
+    get_float ~default:3600.0 "MASC_OPERATOR_JUDGE_SESSION_TTL_SEC"
+
+  let room_ttl_sec =
+    get_float ~default:7200.0 "MASC_OPERATOR_JUDGE_ROOM_TTL_SEC"
+end
+
+(** {1 Operator Cache} *)
+
+module OperatorCache = struct
+  let ttl_sec =
+    get_float ~default:60.0 "MASC_OPERATOR_CACHE_TTL"
+end
+
+(** {1 Alert Configuration} *)
+
+module Alert = struct
+  let dedup_window_sec =
+    get_float ~default:300.0 "MASC_ALERT_DEDUP_WINDOW_SEC"
+end
+
+(** {1 Relay Calibration} *)
+
+module Relay = struct
+  let calibration_enabled =
+    get_bool ~default:false "MASC_RELAY_CALIBRATION_ENABLED"
+end
+
+(** {1 Orchestrator} *)
+
+module Orchestrator = struct
+  let agent_opt () =
+    Sys.getenv_opt "MASC_ORCHESTRATOR_AGENT" |> trim_opt
+end

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -22,7 +22,7 @@ module GovernanceJudge = struct
     get_bool ~default:true "MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED"
 
   let interval_sec =
-    get_float ~default:300.0 "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC"
+    max 15 (get_int ~default:60 "MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC")
 end
 
 (** {1 Operator Judge} *)
@@ -32,13 +32,13 @@ module OperatorJudge = struct
     get_bool ~default:true "MASC_OPERATOR_JUDGE_ENABLED"
 
   let interval_sec =
-    get_float ~default:120.0 "MASC_OPERATOR_JUDGE_INTERVAL_SEC"
+    max 15 (get_int ~default:60 "MASC_OPERATOR_JUDGE_INTERVAL_SEC")
 
   let session_ttl_sec =
-    get_float ~default:3600.0 "MASC_OPERATOR_JUDGE_SESSION_TTL_SEC"
+    max 30 (get_int ~default:300 "MASC_OPERATOR_JUDGE_SESSION_TTL_SEC")
 
   let room_ttl_sec =
-    get_float ~default:7200.0 "MASC_OPERATOR_JUDGE_ROOM_TTL_SEC"
+    max 15 (get_int ~default:60 "MASC_OPERATOR_JUDGE_ROOM_TTL_SEC")
 end
 
 (** {1 Operator Cache} *)

--- a/lib/env_config_dashboard.ml
+++ b/lib/env_config_dashboard.ml
@@ -59,7 +59,7 @@ end
 
 module Relay = struct
   let calibration_enabled =
-    get_bool ~default:false "MASC_RELAY_CALIBRATION_ENABLED"
+    get_bool ~default:true "MASC_RELAY_CALIBRATION_ENABLED"
 end
 
 (** {1 Orchestrator} *)

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -132,6 +132,32 @@ module KeeperAlert = struct
     get_float ~default:0.85 "MASC_KEEPER_ALERT_GITHUB_MIN_SCORE"
 end
 
+(** {1 Keeper Runtime} *)
+
+module KeeperRuntime = struct
+  let debug =
+    get_bool ~default:false "MASC_KEEPER_DEBUG"
+
+  let snapshot_interval_sec =
+    max 15 (min 3600 (get_int ~default:60 "MASC_KEEPER_SNAPSHOT_SEC"))
+
+  let skill_selection_raw =
+    get_string ~default:"" "MASC_KEEPER_SKILL_SELECTION"
+
+  let deliberation_daily_budget_usd =
+    get_float ~default:0.10 "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD"
+end
+
+(** {1 Local Worker} *)
+
+module LocalWorker = struct
+  let max_tokens =
+    get_int ~default:1024 "MASC_LOCAL_WORKER_MAX_TOKENS"
+
+  let heartbeat_interval_sec =
+    get_int ~default:60 "MASC_LOCAL_WORKER_HEARTBEAT_SEC"
+end
+
 (** {1 Keeper Resident Supervisor Configuration} *)
 
 module KeeperResidentSupervisor = struct

--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -93,6 +93,41 @@ module Orchestrator = struct
   (** Orchestrator agent name *)
   let agent_name =
     get_string ~default:"orchestrator" "MASC_ORCHESTRATOR_AGENT"
+
+  let min_priority =
+    max 0 (min 10 (get_int ~default:2 "MASC_ORCHESTRATOR_MIN_PRIORITY"))
+
+  let timeout_seconds =
+    max 10 (min 3600 (get_int ~default:300 "MASC_ORCHESTRATOR_TIMEOUT"))
+
+  let enabled =
+    get_bool ~default:false "MASC_ORCHESTRATOR_ENABLED"
+end
+
+(** {1 Team Session Configuration} *)
+
+module TeamSession = struct
+  let model_35b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_35B" |> trim_opt
+
+  let model_27b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_27B" |> trim_opt
+
+  let model_9b_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_9B" |> trim_opt
+
+  let router_judge_enabled =
+    get_bool ~default:true "MASC_TEAM_SESSION_ROUTER_JUDGE"
+
+  let router_judge_timeout_sec =
+    max 5 (get_int ~default:15 "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC")
+
+  let router_judge_confidence_threshold =
+    let v = get_float ~default:0.72 "MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD" in
+    Float.max 0.0 (Float.min 1.0 v)
+
+  let router_judge_model_opt () =
+    Sys.getenv_opt "MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL" |> trim_opt
 end
 
 (** {1 Mitosis (Cell Division) Configuration} *)

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -1,0 +1,198 @@
+(** Server, transport, and storage environment configuration.
+
+    Centralizes MASC_GRPC_*, MASC_WS_*, MASC_STORAGE_*, and related
+    server-level env vars. *)
+
+open Env_config_core
+
+(** {1 gRPC Transport} *)
+
+module Grpc = struct
+  let enabled =
+    get_bool ~default:true "MASC_GRPC_ENABLED"
+
+  let port =
+    get_int ~default:8936 "MASC_GRPC_PORT"
+
+  let target =
+    get_string ~default:"" "MASC_GRPC_TARGET"
+end
+
+(** {1 WebSocket Transport} *)
+
+module Ws = struct
+  let enabled =
+    get_bool ~default:true "MASC_WS_ENABLED"
+
+  let port =
+    get_int ~default:8937 "MASC_WS_PORT"
+end
+
+(** {1 HTTP/2 Transport} *)
+
+module H2 = struct
+  let enabled =
+    get_bool ~default:false "MASC_USE_H2"
+end
+
+(** {1 WebRTC Transport} *)
+
+module Webrtc = struct
+  let enabled =
+    get_bool ~default:false "MASC_WEBRTC_ENABLED"
+end
+
+(** {1 Auth & Tools} *)
+
+module Auth = struct
+  let admin_token_opt () =
+    Sys.getenv_opt "MASC_ADMIN_TOKEN" |> trim_opt
+
+  let tool_auth_strict =
+    get_bool ~default:false "MASC_TOOL_AUTH_STRICT"
+end
+
+module Tools = struct
+  let readonly_retry_limit =
+    get_int ~default:3 "MASC_TOOL_READONLY_RETRY_LIMIT"
+
+  let description_budget =
+    get_int ~default:200 "MASC_TOOL_DESCRIPTION_BUDGET"
+
+  let public_tools_extra =
+    get_string ~default:"" "MASC_PUBLIC_TOOLS_EXTRA"
+
+  let full_surface =
+    get_bool ~default:false "MASC_FULL_SURFACE"
+end
+
+(** {1 Storage Backend} *)
+
+module Storage = struct
+  let storage_type =
+    get_string ~default:"filesystem" "MASC_STORAGE_TYPE"
+
+  let pg_pool_size =
+    get_int ~default:4 "MASC_PG_POOL_SIZE"
+
+  let base_path_opt () =
+    Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
+
+  let base_path_input_opt () =
+    Sys.getenv_opt "MASC_BASE_PATH_INPUT" |> trim_opt
+end
+
+(** {1 Server Runtime} *)
+
+module Runtime = struct
+  let startup_watchdog_sec =
+    get_float ~default:30.0 "MASC_STARTUP_WATCHDOG_SEC"
+
+  let telemetry_enabled =
+    get_bool ~default:false "MASC_TELEMETRY_ENABLED"
+
+  let openai_compat =
+    get_bool ~default:false "MASC_OPENAI_COMPAT"
+
+  let dispatch_v2 =
+    get_bool ~default:false "MASC_DISPATCH_V2"
+
+  let auto_respond =
+    get_bool ~default:false "MASC_AUTO_RESPOND"
+
+  let parse_warn =
+    get_bool ~default:false "MASC_PARSE_WARN"
+
+  let governance_level =
+    get_string ~default:"standard" "MASC_GOVERNANCE_LEVEL"
+end
+
+(** {1 Rate Limiting} *)
+
+module Rate = struct
+  let limit =
+    get_int ~default:100 "MASC_RATE_LIMIT"
+
+  let burst =
+    get_int ~default:20 "MASC_RATE_BURST"
+end
+
+(** {1 Agent Identity} *)
+
+module Agent = struct
+  let transport =
+    get_string ~default:"http" "MASC_AGENT_TRANSPORT"
+
+  let name_opt () =
+    Sys.getenv_opt "MASC_AGENT_NAME" |> trim_opt
+end
+
+(** {1 Config & Personas Directories} *)
+
+module Dirs = struct
+  let config_dir_opt () =
+    Sys.getenv_opt "MASC_CONFIG_DIR" |> trim_opt
+
+  let personas_dir_opt () =
+    Sys.getenv_opt "MASC_PERSONAS_DIR" |> trim_opt
+end
+
+(** {1 External Services} *)
+
+module External = struct
+  let graphql_url () =
+    match Sys.getenv_opt "GRAPHQL_URL" |> trim_opt with
+    | Some url -> url
+    | None ->
+        get_string ~default:"https://second-brain-graphql-production.up.railway.app/graphql"
+          "RAILWAY_GRAPHQL_URL"
+
+  let graphql_api_key_opt () =
+    Sys.getenv_opt "GRAPHQL_API_KEY" |> trim_opt
+
+  let neo4j_uri_opt () =
+    Sys.getenv_opt "NEO4J_URI" |> trim_opt
+
+  let neo4j_http_uri_opt () =
+    Sys.getenv_opt "NEO4J_HTTP_URI" |> trim_opt
+
+  let neo4j_user () =
+    get_string ~default:"neo4j" "NEO4J_USER"
+
+  let neo4j_password_opt () =
+    Sys.getenv_opt "NEO4J_PASSWORD" |> trim_opt
+
+  let gemini_api_key_opt () =
+    Sys.getenv_opt "GEMINI_API_KEY" |> trim_opt
+end
+
+(** {1 Miscellaneous} *)
+
+module Misc = struct
+  let board_backend =
+    get_string ~default:"filesystem" "MASC_BOARD_BACKEND"
+
+  let board_flush_interval_sec =
+    get_float ~default:10.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
+
+  let circuit_threshold =
+    get_int ~default:5 "MASC_CIRCUIT_THRESHOLD"
+
+  let circuit_cooldown =
+    get_float ~default:60.0 "MASC_CIRCUIT_COOLDOWN"
+
+  let pulse_max_consumer_failures =
+    get_int ~default:3 "MASC_PULSE_MAX_CONSUMER_FAILURES"
+
+  let pubsub_max_messages =
+    get_int ~default:1000 "MASC_PUBSUB_MAX_MESSAGES"
+
+  let build_git_commit () =
+    get_string ~default:"unknown" "MASC_BUILD_GIT_COMMIT"
+
+  let mcp_url_opt () =
+    Sys.getenv_opt "MASC_MCP_URL" |> trim_opt
+
+  let oas_sse_drain_interval_sec =
+    get_float ~default:5.0 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC"
+end

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -111,7 +111,7 @@ module Runtime = struct
     get_bool ~default:false "MASC_PARSE_WARN"
 
   let governance_level =
-    get_string ~default:"standard" "MASC_GOVERNANCE_LEVEL"
+    String.lowercase_ascii (get_string ~default:"production" "MASC_GOVERNANCE_LEVEL")
 end
 
 (** {1 Rate Limiting} *)

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -102,7 +102,7 @@ module Runtime = struct
     get_bool ~default:false "MASC_OPENAI_COMPAT"
 
   let dispatch_v2 =
-    get_bool ~default:false "MASC_DISPATCH_V2"
+    get_bool ~default:true "MASC_DISPATCH_V2"
 
   let auto_respond =
     get_bool ~default:false "MASC_AUTO_RESPOND"

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -31,8 +31,15 @@ end
 (** {1 HTTP/2 Transport} *)
 
 module H2 = struct
-  let enabled =
-    get_bool ~default:false "MASC_USE_H2"
+  (** "true"/"1" → h2_only, "false"/"0" → h1_only, "auto"/unset → auto *)
+  let mode =
+    match Sys.getenv_opt "MASC_USE_H2" |> trim_opt with
+    | Some raw -> (
+        match String.lowercase_ascii raw with
+        | "1" | "true" -> "h2_only"
+        | "0" | "false" -> "h1_only"
+        | _ -> "auto")
+    | None -> "auto"
 end
 
 (** {1 WebRTC Transport} *)

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -204,5 +204,12 @@ module Misc = struct
     Sys.getenv_opt "MASC_MCP_URL" |> trim_opt
 
   let oas_sse_drain_interval_sec =
-    get_float ~default:5.0 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC"
+    Float.min 5.0 (Float.max 0.05 (get_float ~default:0.25 "MASC_OAS_SSE_DRAIN_INTERVAL_SEC"))
+
+  let log_level =
+    get_string ~default:"info" "MASC_LOG_LEVEL"
+
+  let list_page_size =
+    let v = get_int ~default:512 "MASC_LIST_PAGE_SIZE" in
+    max 10 (min 1024 v)
 end

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -56,12 +56,12 @@ module Auth = struct
     Sys.getenv_opt "MASC_ADMIN_TOKEN" |> trim_opt
 
   let tool_auth_strict =
-    get_bool ~default:false "MASC_TOOL_AUTH_STRICT"
+    get_bool ~default:true "MASC_TOOL_AUTH_STRICT"
 end
 
 module Tools = struct
   let readonly_retry_limit =
-    get_int ~default:3 "MASC_TOOL_READONLY_RETRY_LIMIT"
+    min 5 (max 1 (get_int ~default:2 "MASC_TOOL_READONLY_RETRY_LIMIT"))
 
   let description_budget =
     get_int ~default:200 "MASC_TOOL_DESCRIPTION_BUDGET"
@@ -96,7 +96,7 @@ module Runtime = struct
     get_float ~default:30.0 "MASC_STARTUP_WATCHDOG_SEC"
 
   let telemetry_enabled =
-    get_bool ~default:false "MASC_TELEMETRY_ENABLED"
+    get_bool ~default:true "MASC_TELEMETRY_ENABLED"
 
   let openai_compat =
     get_bool ~default:false "MASC_OPENAI_COMPAT"

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -80,7 +80,7 @@ module Storage = struct
     get_string ~default:"filesystem" "MASC_STORAGE_TYPE"
 
   let pg_pool_size =
-    get_int ~default:4 "MASC_PG_POOL_SIZE"
+    max 1 (min 50 (get_int ~default:10 "MASC_PG_POOL_SIZE"))
 
   let base_path_opt () =
     Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
@@ -93,7 +93,7 @@ end
 
 module Runtime = struct
   let startup_watchdog_sec =
-    get_float ~default:30.0 "MASC_STARTUP_WATCHDOG_SEC"
+    Float.max 30.0 (Float.min 600.0 (get_float ~default:240.0 "MASC_STARTUP_WATCHDOG_SEC"))
 
   let telemetry_enabled =
     get_bool ~default:true "MASC_TELEMETRY_ENABLED"
@@ -104,8 +104,8 @@ module Runtime = struct
   let dispatch_v2 =
     get_bool ~default:true "MASC_DISPATCH_V2"
 
-  let auto_respond =
-    get_bool ~default:false "MASC_AUTO_RESPOND"
+  let auto_respond_raw =
+    get_string ~default:"" "MASC_AUTO_RESPOND"
 
   let parse_warn =
     get_bool ~default:false "MASC_PARSE_WARN"
@@ -132,6 +132,9 @@ module Agent = struct
 
   let name_opt () =
     Sys.getenv_opt "MASC_AGENT_NAME" |> trim_opt
+
+  let orchestrator_agent =
+    get_string ~default:"claude" "MASC_ORCHESTRATOR_AGENT"
 end
 
 (** {1 Config & Personas Directories} *)

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -118,10 +118,10 @@ end
 
 module Rate = struct
   let limit =
-    get_int ~default:100 "MASC_RATE_LIMIT"
+    get_float ~default:60.0 "MASC_RATE_LIMIT"
 
   let burst =
-    get_int ~default:20 "MASC_RATE_BURST"
+    get_int ~default:150 "MASC_RATE_BURST"
 end
 
 (** {1 Agent Identity} *)
@@ -180,7 +180,7 @@ module Misc = struct
     get_string ~default:"filesystem" "MASC_BOARD_BACKEND"
 
   let board_flush_interval_sec =
-    get_float ~default:10.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
+    get_float ~default:30.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
 
   let circuit_threshold =
     get_int ~default:5 "MASC_CIRCUIT_THRESHOLD"

--- a/lib/env_config_server.ml
+++ b/lib/env_config_server.ml
@@ -47,11 +47,29 @@ end
 module Webrtc = struct
   let enabled =
     get_bool ~default:false "MASC_WEBRTC_ENABLED"
+
+  let ice_servers_json_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_SERVERS_JSON" |> trim_opt
+
+  let ice_urls_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_URLS" |> trim_opt
+
+  let ice_username_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_USERNAME" |> trim_opt
+
+  let ice_credential_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_CREDENTIAL" |> trim_opt
+
+  let ice_tls_ca_opt () =
+    Sys.getenv_opt "MASC_WEBRTC_ICE_TLS_CA" |> trim_opt
 end
 
 (** {1 Auth & Tools} *)
 
 module Auth = struct
+  let http_auth_strict =
+    get_bool ~default:false "MASC_HTTP_AUTH_STRICT"
+
   let admin_token_opt () =
     Sys.getenv_opt "MASC_ADMIN_TOKEN" |> trim_opt
 
@@ -60,6 +78,9 @@ module Auth = struct
 end
 
 module Tools = struct
+  let timeout_default_sec =
+    max 5 (min 600 (get_int ~default:30 "MASC_TOOL_TIMEOUT_DEFAULT_SEC"))
+
   let readonly_retry_limit =
     min 5 (max 1 (get_int ~default:2 "MASC_TOOL_READONLY_RETRY_LIMIT"))
 
@@ -77,7 +98,7 @@ end
 
 module Storage = struct
   let storage_type =
-    get_string ~default:"filesystem" "MASC_STORAGE_TYPE"
+    get_string ~default:"" "MASC_STORAGE_TYPE"
 
   let pg_pool_size =
     max 1 (min 50 (get_int ~default:10 "MASC_PG_POOL_SIZE"))

--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -13,7 +13,7 @@
 let graphql_url () = Graphql_endpoint.graphql_url ()
 
 let api_key () =
-  Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:""
+  Env_config.Server.External.graphql_api_key_opt () |> Option.value ~default:""
 
 (** {1 HTTP Transport} *)
 

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -20,7 +20,7 @@ let create ~sw ~env target =
 
 let create_from_env ~sw ~env =
   let target =
-    match Sys.getenv_opt "MASC_GRPC_TARGET" with
+    match Some Env_config.Server.Grpc.target with
     | Some t -> t
     | None ->
       let port = Masc_grpc_server.configured_port () in

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -10,29 +10,10 @@ let default_port = 8936
 let health_service_name = "grpc.health.v1.Health"
 
 (** Read the configured gRPC port from environment or use default. *)
-let configured_port () =
-  match Sys.getenv_opt "MASC_GRPC_PORT" with
-  | Some s -> (
-    match int_of_string_opt s with
-    | Some p when p > 0 && p < 65536 -> p
-    | _ ->
-      Log.Server.warn "MASC_GRPC_PORT=%s is not a valid port, using %d" s default_port;
-      default_port)
-  | None -> default_port
+let configured_port () = Env_config.Server.Grpc.port
 
 (** Check whether gRPC is enabled (default: enabled, opt-out via env). *)
-let is_enabled () =
-  match Sys.getenv_opt "MASC_GRPC_ENABLED" with
-  | Some s -> (
-    match String.trim s |> String.lowercase_ascii with
-    | "1" | "true" -> true
-    | "" | "0" | "false" -> false
-    | other ->
-      Log.Server.warn
-        "MASC_GRPC_ENABLED=%s is not recognised, defaulting to enabled"
-        other;
-      true)
-  | None -> true
+let is_enabled () = Env_config.Server.Grpc.enabled
 
 module Reflection_bridge = struct
   let reflection_v1_service_name = "grpc.reflection.v1.ServerReflection"

--- a/lib/grpc/masc_grpc_transport.ml
+++ b/lib/grpc/masc_grpc_transport.ml
@@ -8,7 +8,7 @@ type t =
   | Local
 
 let from_env () =
-  match Sys.getenv_opt "MASC_AGENT_TRANSPORT" with
+  match Some Env_config.Server.Agent.transport with
   | Some "grpc" -> Grpc
   | Some "http" -> Http
   | Some "ws" | Some "websocket" -> Ws

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -98,10 +98,7 @@ let run_alert_channel_with_retry
 let dedup_strings = Dashboard_utils.dedup_strings
 
 (** Alert dedup: suppress identical alerts within a time window (default 60s). *)
-let alert_dedup_window_sec =
-  match Sys.getenv_opt "MASC_ALERT_DEDUP_WINDOW_SEC" with
-  | Some s -> (try max 5.0 (float_of_string (String.trim s)) with Failure _ -> 60.0)
-  | None -> 60.0
+let alert_dedup_window_sec = Env_config_dashboard.Alert.dedup_window_sec
 
 let alert_dedup_table : (string, float) Hashtbl.t = Hashtbl.create 32
 let alert_dedup_mutex = Eio.Mutex.create ()

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -315,9 +315,7 @@ let default_daily_budget_usd = 0.10
 
 (** Read the daily budget from env, returning the default if absent or invalid. *)
 let daily_budget_usd_from_env () : float =
-  match Sys.getenv_opt "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" with
-  | Some s -> (try float_of_string (String.trim s) with Failure _ -> default_daily_budget_usd)
-  | None -> default_daily_budget_usd
+  Env_config.KeeperRuntime.deliberation_daily_budget_usd
 
 (** Check whether the keeper has remaining budget for another deliberation call.
     Returns [true] if [cost_today_usd < daily_budget_usd]. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -122,14 +122,7 @@ let wakeup_relevant_keeper_for_board_signal
 let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
     (m : keeper_meta) (stop : bool Atomic.t) ~(wakeup : bool Atomic.t) : unit =
   let keepalive_started_ts = Time_compat.now () in
-  let snapshot_interval_sec =
-    match Sys.getenv_opt "MASC_KEEPER_SNAPSHOT_SEC" with
-    | Some s ->
-        (try
-           max 15 (min 3600 (int_of_string (String.trim s)))
-         with Failure _ -> 60)
-    | None -> 60
-  in
+  let snapshot_interval_sec = Env_config.KeeperRuntime.snapshot_interval_sec in
   let last_snapshot_ts = ref 0.0 in
   let rec loop () =
     if Atomic.get stop then ()

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -32,13 +32,9 @@ let contains_ci (haystack : string) (needle : string) : bool =
   else Re.execp (Re.str n |> Re.compile) h
 
 let keeper_skill_selection_mode () : keeper_skill_selection_mode =
-  match Sys.getenv_opt "MASC_KEEPER_SKILL_SELECTION" with
-  | None -> SkillSelectAgent
-  | Some raw ->
-      let v = String.lowercase_ascii (String.trim raw) in
-      if v = "" || v = "agent" || v = "model" || v = "auto"
-      then SkillSelectAgent
-      else SkillSelectHeuristic
+  match Env_config.KeeperRuntime.skill_selection_raw with
+  | "" | "agent" | "model" | "auto" -> SkillSelectAgent
+  | _ -> SkillSelectHeuristic
 
 let keeper_allowed_skills = [
   "masc-heartbeat";

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -5,10 +5,7 @@
     Depends only on Keeper_config (no Keeper_types dependency). *)
 
 include Keeper_config
-let keeper_debug =
-  match Sys.getenv_opt "MASC_KEEPER_DEBUG" with
-  | Some "1" -> true
-  | _ -> false
+let keeper_debug = Env_config.KeeperRuntime.debug
 
 type 'a context = {
   config: Room.config;

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -13,7 +13,7 @@ let trim_opt = function
   | None -> None
 
 let resolved_base_path_opt () =
-  match trim_opt (Sys.getenv_opt "MASC_BASE_PATH") with
+  match Env_config.Server.Storage.base_path_opt () with
   | Some path -> Some path
   | None -> Room_utils_backend_setup.find_git_root (Sys.getcwd ())
 
@@ -21,7 +21,7 @@ let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Filename.concat base_path ".masc"
   | None -> (
-      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      match Env_config_core.me_root_opt () with
       | Some root -> Filename.concat root ".masc"
       | None -> ".masc")
 

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -295,9 +295,8 @@ let current_fingerprint () =
     [
       String.concat "," (Llm_provider.Discovery.endpoints_from_env ());
       Env_config.Llama.server_url;
-      Option.value ~default:"" (Sys.getenv_opt "LLAMA_SWARM_MODEL");
-      Option.value ~default:""
-        (Sys.getenv_opt "MASC_LLAMA_RUNTIME_COOLDOWN_SEC");
+      Option.value ~default:"" (Env_config.Chain.Model.llama_swarm_model_opt ());
+      string_of_float Env_config.Chain.Llama.runtime_cooldown_sec;
       string_of_int
         (int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
            ~default:default_parallel_hint);

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -126,7 +126,7 @@ let model_of_discovery_status (status : Discovery_cache.endpoint_info) =
   | [] -> (
       match status.props with
       | Some props -> trim_opt (Some props.model)
-      | None -> trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL"))
+      | None -> Env_config.Chain.Model.llama_swarm_model_opt ())
 
 let max_concurrency_of_discovery_status (status : Discovery_cache.endpoint_info) =
   match status.slots with
@@ -162,7 +162,7 @@ let runtime_of_endpoint_url base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = Env_config.Chain.Model.llama_swarm_model_opt ();
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;
@@ -251,7 +251,7 @@ let default_runtime () =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = Env_config.Chain.Model.llama_swarm_model_opt ();
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT" ~default:default_parallel_hint;
     active_slots = 0;
@@ -269,7 +269,7 @@ let runtime_from_endpoint base_url =
   {
     id = runtime_id_of_base_url base_url;
     base_url;
-    model = trim_opt (Sys.getenv_opt "LLAMA_SWARM_MODEL");
+    model = Env_config.Chain.Model.llama_swarm_model_opt ();
     max_concurrency =
       int_of_env_default "LLAMA_SERVER_PARALLEL_HINT"
         ~default:default_parallel_hint;

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -70,7 +70,7 @@ let float_of_env_default name ~default =
       with Failure _ -> default)
 
 let cooldown_seconds () =
-  float_of_env_default "MASC_LLAMA_RUNTIME_COOLDOWN_SEC" ~default:30.0
+  Env_config.Chain.Llama.runtime_cooldown_sec
 
 let trim_opt = function
   | None -> None
@@ -79,9 +79,7 @@ let trim_opt = function
       if trimmed = "" then None else Some trimmed
 
 let debug_enabled () =
-  match trim_opt (Sys.getenv_opt "MASC_LLAMA_RUNTIME_DEBUG") with
-  | Some ("1" | "true" | "yes" | "on") -> true
-  | _ -> false
+  Env_config.Chain.Llama.runtime_debug
 
 let debug_log fmt =
   if debug_enabled () then Printf.ksprintf (fun msg -> Log.LocalWorker.debug "%s" msg) fmt

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -574,21 +574,9 @@ let estimate_cost_usd ~(model_id : string)
   Some (Llm_provider.Pricing.estimate_cost ~pricing
     ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ())
 
-let local_worker_max_tokens () =
-  match Sys.getenv_opt "MASC_LOCAL_WORKER_MAX_TOKENS" with
-  | None -> 1024
-  | Some raw -> (
-      match int_of_string_opt (String.trim raw) with
-      | Some value -> max 64 (min 2048 value)
-      | None -> 1024)
+let local_worker_max_tokens () = Env_config.LocalWorker.max_tokens
 
-let local_worker_heartbeat_interval_sec () =
-  match Sys.getenv_opt "MASC_LOCAL_WORKER_HEARTBEAT_SEC" with
-  | None -> 60
-  | Some raw -> (
-      match int_of_string_opt (String.trim raw) with
-      | Some value -> max 0 (min 600 value)
-      | None -> 60)
+let local_worker_heartbeat_interval_sec () = Env_config.LocalWorker.heartbeat_interval_sec
 
 let join_worker ~sw ~(auth_token : string option) ~session_id ~worker_name =
   let args =

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -82,9 +82,7 @@ let set_level_from_string s =
 
 (** Initialize from MASC_LOG_LEVEL env var *)
 let init_from_env () =
-  match Sys.getenv_opt "MASC_LOG_LEVEL" with
-  | Some s -> set_level_from_string s
-  | None -> ()
+  set_level_from_string Env_config.Server.Misc.log_level
 
 (** Get current timestamp *)
 let timestamp () =

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -82,7 +82,9 @@ let set_level_from_string s =
 
 (** Initialize from MASC_LOG_LEVEL env var *)
 let init_from_env () =
-  set_level_from_string Env_config.Server.Misc.log_level
+  match Sys.getenv_opt "MASC_LOG_LEVEL" with
+  | Some s -> set_level_from_string s
+  | None -> ()
 
 (** Get current timestamp *)
 let timestamp () =

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -80,13 +80,7 @@ let quality_from_result ~success ~message ~attempts =
     ]
 
 let read_only_retry_limit () =
-  match Sys.getenv_opt "MASC_TOOL_READONLY_RETRY_LIMIT" with
-  | Some raw ->
-      (try
-         let parsed = int_of_string (String.trim raw) in
-         max 1 (min 5 parsed)
-       with Failure _ -> 2)
-  | None -> 2
+  Env_config.Server.Tools.readonly_retry_limit
 
 let is_retryable_message message =
   (* Tool-level timeouts must not be retried — retrying a 30s timeout
@@ -277,11 +271,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       (Printf.sprintf "tool call failed: %s" name);
 
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
-  let telemetry_enabled =
-    match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
-    | Some "false" | Some "0" -> false
-    | _ -> true  (* Default: enabled *)
-  in
+  let telemetry_enabled = Env_config.Server.Runtime.telemetry_enabled in
   if telemetry_enabled then
     (match state.Mcp_server.fs with
      | Some fs ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -142,15 +142,7 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(arguments : Yojson.Safe.t) : fl
          A fixed external timeout conflicts with multi-turn tool-use loops. *)
       None
   | _ ->
-      let global_default_sec =
-        float_of_int
-          (int_of_env_default
-             "MASC_TOOL_TIMEOUT_DEFAULT_SEC"
-             ~default:30
-             ~min_v:5
-             ~max_v:300)
-      in
-      Some global_default_sec
+      Some (float_of_int Env_config.Server.Tools.timeout_default_sec)
 
 (** Resolve managed agent tool call to canonical operation *)
 let resolve_managed_agent_call ?mcp_session_id params =

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -688,13 +688,7 @@ let parse_cursor_only_params params =
     | `String cursor -> Ok { cursor = Some cursor }
     | _ -> Error "Invalid params: cursor must be a string"
 
-let list_page_size () =
-  match Sys.getenv_opt "MASC_LIST_PAGE_SIZE" with
-  | Some raw -> (
-      match int_of_string_opt (String.trim raw) with
-      | Some v when v >= 10 && v <= 1024 -> v
-      | _ -> 512)
-  | None -> 512
+let list_page_size () = Env_config.Server.Misc.list_page_size
 
 let encode_cursor ~kind offset =
   Base64.encode_string (Printf.sprintf "%s:%d" kind offset)

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -15,10 +15,7 @@
 
 (** Default importance for memories stored via OAS Memory.store.
     Configurable via MASC_MEMORY_OAS_DEFAULT_IMPORTANCE. *)
-let default_importance () =
-  match Sys.getenv_opt "MASC_MEMORY_OAS_DEFAULT_IMPORTANCE" with
-  | Some s -> (try max 1 (min 10 (int_of_string s)) with Failure _ -> 5)
-  | None -> 5
+let default_importance () = Env_config.Chain.Memory.oas_default_importance
 
 (** Extract importance from JSON value if present, else use default. *)
 let importance_of_json (json : Yojson.Safe.t) : int =

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -9,14 +9,7 @@
 (** Drain interval: how often we poll the Event_bus subscription.
     Lower default keeps the dashboard close to real-time, while staying
     runtime-tunable for quieter deployments. *)
-let drain_interval_s () =
-  match Sys.getenv_opt "MASC_OAS_SSE_DRAIN_INTERVAL_SEC" with
-  | Some raw -> (
-      try
-        let parsed = float_of_string raw in
-        Float.min 5.0 (Float.max 0.05 parsed)
-      with Failure _ -> 0.25)
-  | None -> 0.25
+let drain_interval_s () = Env_config.Server.Misc.oas_sse_drain_interval_sec
 
 (** Prefix for events we relay. *)
 let masc_prefix = "masc:"

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -420,10 +420,7 @@ let parse_snapshot_view = function
    (dashboard SSE polling, multiple MCP clients). *)
 let _snapshot_cache : (string * Yojson.Safe.t * float) option ref = ref None
 
-let _snapshot_ttl_s =
-  match Sys.getenv_opt "MASC_OPERATOR_CACHE_TTL" with
-  | Some s -> (try Float.of_string s with Failure _ -> 30.0)
-  | None -> 30.0
+let _snapshot_ttl_s = Env_config.Dashboard.OperatorCache.ttl_sec
 
 let invalidate_snapshot_cache () = _snapshot_cache := None
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -41,8 +41,7 @@ let load_config () =
     check_interval_s = get_env_float "MASC_ORCHESTRATOR_INTERVAL" 300.0;
     min_priority = get_env_int "MASC_ORCHESTRATOR_MIN_PRIORITY" 2;
     agent_timeout_s = get_env_int "MASC_ORCHESTRATOR_TIMEOUT" 300;
-    orchestrator_agent = (match Sys.getenv_opt "MASC_ORCHESTRATOR_AGENT" with
-      | Some a -> a | None -> "claude");
+    orchestrator_agent = Env_config.Server.Agent.orchestrator_agent;
     enabled = get_env_bool "MASC_ORCHESTRATOR_ENABLED" false;
     port = Env_config_core.masc_http_port_int ();
   }

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -21,28 +21,12 @@ let default_config = {
 
 (** Load config from environment or use defaults *)
 let load_config () =
-  let get_env_float name default =
-    match Sys.getenv_opt name with
-    | Some v -> Safe_ops.float_of_string_with_default ~default v
-    | None -> default
-  in
-  let get_env_int name default =
-    match Sys.getenv_opt name with
-    | Some v -> Safe_ops.int_of_string_with_default ~default v
-    | None -> default
-  in
-  let get_env_bool name default =
-    match Sys.getenv_opt name with
-    | Some "1" | Some "true" | Some "yes" -> true
-    | Some "0" | Some "false" | Some "no" -> false
-    | _ -> default
-  in
   {
-    check_interval_s = get_env_float "MASC_ORCHESTRATOR_INTERVAL" 300.0;
-    min_priority = get_env_int "MASC_ORCHESTRATOR_MIN_PRIORITY" 2;
-    agent_timeout_s = get_env_int "MASC_ORCHESTRATOR_TIMEOUT" 300;
-    orchestrator_agent = Env_config.Server.Agent.orchestrator_agent;
-    enabled = get_env_bool "MASC_ORCHESTRATOR_ENABLED" false;
+    check_interval_s = Env_config.Orchestrator.check_interval_seconds;
+    min_priority = Env_config.Orchestrator.min_priority;
+    agent_timeout_s = Env_config.Orchestrator.timeout_seconds;
+    orchestrator_agent = Env_config.Orchestrator.agent_name;
+    enabled = Env_config.Orchestrator.enabled;
     port = Env_config_core.masc_http_port_int ();
   }
 

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -160,17 +160,11 @@ let record_outcome ~agent_name ~pattern ~evidence_id ~success =
     Configurable via MASC_PROC_MIN_EVIDENCE (default: 3).
     High-confidence patterns (100%) with fewer evidence may still qualify
     when adaptive thresholding is enabled. *)
-let min_evidence () =
-  match Sys.getenv_opt "MASC_PROC_MIN_EVIDENCE" with
-  | Some s -> (try max 1 (int_of_string s) with Failure _ -> 3)
-  | None -> 3
+let min_evidence () = Env_config.Chain.Procedural.min_evidence
 
 (** Minimum confidence required for crystallization.
     Configurable via MASC_PROC_MIN_CONFIDENCE (default: 0.7). *)
-let min_confidence () =
-  match Sys.getenv_opt "MASC_PROC_MIN_CONFIDENCE" with
-  | Some s -> (try max 0.0 (min 1.0 (float_of_string s)) with Failure _ -> 0.7)
-  | None -> 0.7
+let min_confidence () = Env_config.Chain.Procedural.min_confidence
 
 (** Adaptive crystallization check.
     Standard: evidence >= min_evidence AND confidence >= min_confidence.

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -469,7 +469,7 @@ let gemini_direct_available () =
   env_present google_cloud_project_env || env_present "GEMINI_API_KEY"
 
 let configured_default_model_label_result () =
-  match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+  match Env_config.Chain.Model.default_cascade_opt () with
   | Some raw ->
       let labels = split_csv_nonempty raw in
       (match labels with
@@ -477,8 +477,8 @@ let configured_default_model_label_result () =
        | [] -> Error "MASC_DEFAULT_CASCADE is set but empty")
   | None -> (
       match
-        ( nonempty_env "MASC_DEFAULT_PROVIDER",
-          nonempty_env "MASC_DEFAULT_MODEL" )
+        ( Env_config.Chain.Model.default_provider_opt (),
+          Env_config.Chain.Model.default_model_opt () )
       with
       | Some provider, Some model_id -> Ok (provider ^ ":" ^ model_id)
       | Some _, None ->
@@ -628,17 +628,17 @@ let vertex_location () =
   | None -> "global"
 
 let resolve_gemini_direct_auth () =
-  match Sys.getenv_opt google_cloud_project_env with
-  | Some raw when String.trim raw <> "" ->
+  match nonempty_env google_cloud_project_env with
+  | Some project ->
       Gemini_vertex_adc
         {
-          project = String.trim raw;
+          project;
           location = vertex_location ();
         }
-  | _ -> (
-      match Sys.getenv_opt "GEMINI_API_KEY" with
-      | Some raw when String.trim raw <> "" -> Gemini_api_key
-      | _ ->
+  | None -> (
+      match Env_config.Server.External.gemini_api_key_opt () with
+      | Some _ -> Gemini_api_key
+      | None ->
           Gemini_auth_missing
             "Gemini auth unavailable; set GOOGLE_CLOUD_PROJECT for Vertex ADC or GEMINI_API_KEY")
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -438,12 +438,12 @@ let is_bare_ollama_label label =
   String.equal (normalize_label label) "ollama"
 
 let explicit_llama_model_id_result () =
-  match nonempty_env "LLAMA_DEFAULT_MODEL" with
+  match Some Env_config.Llama.default_model with
   | Some model_id -> Ok model_id
   | None -> (
       match
-        ( nonempty_env "MASC_DEFAULT_PROVIDER",
-          nonempty_env "MASC_DEFAULT_MODEL" )
+        ( Env_config.Chain.Model.default_provider_opt (),
+          Env_config.Chain.Model.default_model_opt () )
       with
       | Some provider, Some model_id
         when String.equal (String.lowercase_ascii provider) "llama" ->
@@ -490,7 +490,7 @@ let configured_default_model_label_result () =
       | None, None -> Error "No explicit default model configured")
 
 let configured_verifier_model_label_result () =
-  match nonempty_env "MASC_DEFAULT_VERIFIER_MODEL" with
+  match Env_config.Chain.Model.verifier_model_opt () with
   | Some label -> Ok label
   | None -> configured_default_model_label_result ()
 

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -59,10 +59,7 @@ let default_recovery_config = {
 }
 
 let recovery_config_from_env () = {
-  max_consecutive_failures =
-    (match Sys.getenv_opt "MASC_PULSE_MAX_CONSUMER_FAILURES" with
-     | Some s -> (try max 1 (int_of_string s) with Failure _ -> 3)
-     | None -> 3);
+  max_consecutive_failures = Env_config.Server.Misc.pulse_max_consumer_failures;
 }
 
 type t = {

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -29,14 +29,10 @@ let default_rate = 60.0  (* 12+ concurrent keepers need higher throughput *)
 let default_burst = 150
 
 let rate_from_env () =
-  Sys.getenv_opt "MASC_RATE_LIMIT"
-  |> Option.map float_of_string
-  |> Option.value ~default:default_rate
+  Env_config.Server.Rate.limit
 
 let burst_from_env () =
-  Sys.getenv_opt "MASC_RATE_BURST"
-  |> Option.map int_of_string
-  |> Option.value ~default:default_burst
+  Env_config.Server.Rate.burst
 
 (** {1 Limiter Creation} *)
 

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -62,10 +62,7 @@ let calibration_mutex = Eio.Mutex.create ()
 (** Record actual token count vs estimated for calibration.
     Keeps the last 10 samples and updates a moving-average correction factor. *)
 let record_actual_tokens ~estimated ~actual =
-  let enabled = match Sys.getenv_opt "MASC_RELAY_CALIBRATION_ENABLED" with
-    | Some "false" | Some "0" -> false
-    | _ -> true
-  in
+  let enabled = Env_config.Dashboard.Relay.calibration_enabled in
   if enabled then
     Eio.Mutex.use_rw ~protect:true calibration_mutex (fun () ->
       calibration.samples <- (estimated, actual) :: calibration.samples;
@@ -88,8 +85,7 @@ let get_calibration_info () =
     `Assoc [
       ("correction_factor", `Float calibration.correction_factor);
       ("sample_count", `Int (List.length calibration.samples));
-      ("enabled", `Bool (match Sys.getenv_opt "MASC_RELAY_CALIBRATION_ENABLED" with
-        | Some "false" | Some "0" -> false | _ -> true));
+      ("enabled", `Bool Env_config.Dashboard.Relay.calibration_enabled);
     ])
 
 (** Estimate context usage based on heuristics *)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -52,9 +52,7 @@ include Room_gc
 (* ============================================ *)
 
 let telemetry_enabled () =
-  match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
-  | Some "false" | Some "0" -> false
-  | _ -> true
+  Env_config.Server.Runtime.telemetry_enabled
 
 let merge_detail_fields fields details =
   match details with

--- a/lib/run_log_eio.ml
+++ b/lib/run_log_eio.ml
@@ -9,20 +9,16 @@
 open Types
 
 let enabled () =
-  match Sys.getenv_opt "MASC_CHAIN_RUN_LOG" with
-  | Some "0" | Some "false" | Some "no" -> false
-  | _ -> true
+  Env_config.Chain.Log.run_log_enabled
 
 let stream_enabled () =
-  match Sys.getenv_opt "MASC_CHAIN_RUN_LOG_STREAM" with
-  | Some "1" | Some "true" | Some "yes" | Some "on" -> true
-  | _ -> false
+  Env_config.Chain.Log.run_log_stream
 
 let default_log_path () =
   let home =
-    match Sys.getenv_opt "HOME" with
-    | Some path when String.trim path <> "" -> path
-    | _ -> "/tmp"
+    match Env_config_core.home_dir_opt () with
+    | Some path -> path
+    | None -> "/tmp"
   in
   Filename.concat home "logs/masc_chain_runs.jsonl"
 
@@ -41,9 +37,9 @@ let read_lines_tail ~max_bytes:_ ~max_lines path =
     all_lines |> List.to_seq |> Seq.drop (len - max_lines) |> List.of_seq
 
 let log_path () =
-  match Sys.getenv_opt "MASC_CHAIN_RUN_LOG_PATH" with
-  | Some p when String.length p > 0 -> p
-  | _ -> default_log_path ()
+  match Env_config.Chain.Log.run_log_path_opt () with
+  | Some p -> p
+  | None -> default_log_path ()
 
 (** Write mutex - created lazily per-domain *)
 let write_mutex = Eio.Mutex.create ()

--- a/lib/safe_parse.ml
+++ b/lib/safe_parse.ml
@@ -13,10 +13,7 @@
 *)
 
 (** Whether to log parse warnings. Default: false to avoid noise. *)
-let warn_enabled () =
-  match Sys.getenv_opt "MASC_PARSE_WARN" with
-  | Some "1" | Some "true" | Some "yes" -> true
-  | _ -> false
+let warn_enabled () = Env_config.Server.Runtime.parse_warn
 
 (** Log a parse warning if enabled. *)
 let warn ~context ~input ~fallback =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -250,7 +250,7 @@ let with_admin_auth handler request reqd =
   match !server_state with
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
-      let admin_token = Sys.getenv_opt "MASC_ADMIN_TOKEN" in
+      let admin_token = Env_config.Server.Auth.admin_token_opt () in
       let provided = auth_token_from_request request in
       match admin_token, provided with
       | None, _ ->

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -55,7 +55,7 @@ let is_unspecified_host host =
   | Error _ -> false
 
 let http_auth_strict_enabled () =
-  env_flag_enabled "MASC_HTTP_AUTH_STRICT"
+  Env_config.Server.Auth.http_auth_strict
   || not (is_loopback_host (configured_bind_host ()))
 
 let strict_http_auth_error endpoint =

--- a/lib/server/server_checkpoint.ml
+++ b/lib/server/server_checkpoint.ml
@@ -162,9 +162,9 @@ let of_json (json : Yojson.Safe.t) : checkpoint option =
 (** {1 File I/O} *)
 
 let checkpoint_path () =
-  let masc_dir = match Sys.getenv_opt "MASC_BASE_PATH" with
-    | Some p when String.trim p <> "" -> Filename.concat p ".masc"
-    | _ -> ".masc"
+  let masc_dir = match Env_config.Server.Storage.base_path_opt () with
+    | Some p -> Filename.concat p ".masc"
+    | None -> ".masc"
   in
   Filename.concat masc_dir "server_checkpoint.json"
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -136,7 +136,7 @@ let runtime_resolution_json (config : Room.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    Sys.getenv_opt "MASC_BASE_PATH_INPUT"
+    Env_config.Server.Storage.base_path_input_opt ()
     |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =

--- a/lib/server/server_dashboard_http_runtime_support.ml
+++ b/lib/server/server_dashboard_http_runtime_support.ml
@@ -56,12 +56,7 @@ let pg_semaphore state () =
   match state.pg_semaphore with
   | Some s -> s
   | None ->
-      let pool_size =
-        match Sys.getenv_opt "MASC_PG_POOL_SIZE" with
-        | Some s -> (
-            try max 1 (min (int_of_string s) 50) with Failure _ -> 10)
-        | None -> 10
-      in
+      let pool_size = Env_config.Server.Storage.pg_pool_size in
       let limit = max 2 (pool_size - 2) in
       let s = Eio.Semaphore.make limit in
       state.pg_semaphore <- Some s;

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -9,10 +9,7 @@
     Request/response format follows the OpenAI Chat Completions API spec. *)
 
 (** Whether the OpenAI-compatible endpoint is enabled (default: false). *)
-let is_enabled () =
-  match Sys.getenv_opt "MASC_OPENAI_COMPAT" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
+let is_enabled () = Env_config.Server.Runtime.openai_compat
 
 (** Generate a random chat completion ID. *)
 let generate_completion_id () =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -104,11 +104,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
             ("streaming", `Bool false);
           ])
       "keeper tool call failed: masc_keeper_msg";
-  let telemetry_enabled =
-    match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
-    | Some "false" | Some "0" -> false
-    | _ -> true
-  in
+  let telemetry_enabled = Env_config.Server.Runtime.telemetry_enabled in
   if telemetry_enabled then (
     match state.Mcp_server.fs with
     | Some fs ->
@@ -309,11 +305,7 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
             ("streaming", `Bool true);
           ])
       "keeper tool call failed: masc_keeper_msg";
-  let telemetry_enabled =
-    match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
-    | Some "false" | Some "0" -> false
-    | _ -> true
-  in
+  let telemetry_enabled = Env_config.Server.Runtime.telemetry_enabled in
   if telemetry_enabled then (
     match state.Mcp_server.fs with
     | Some fs ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -253,14 +253,10 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   in
   let h2_error_handler = make_h2_error_handler () in
   let http_mode =
-    match Sys.getenv_opt "MASC_USE_H2" with
-    | Some "1" | Some "true" -> `H2_only
-    | Some "0" | Some "false" -> `H1_only
-    | Some "auto" -> `Auto
-    | None -> `Auto
-    | Some other ->
-      Log.Server.warn "MASC_USE_H2=%s unrecognised, falling back to auto" other;
-      `Auto
+    match Env_config.Server.H2.mode with
+    | "h2_only" -> `H2_only
+    | "h1_only" -> `H1_only
+    | _ -> `Auto
   in
   let socket = Server_bootstrap_http.listen_socket ~sw ~net config in
   let initial_backend_mode = requested_backend_mode () in
@@ -271,9 +267,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   Eio.Fiber.fork ~sw (fun () ->
     refresh_llama_endpoints ();
     let governance_level =
-      Sys.getenv_opt "MASC_GOVERNANCE_LEVEL"
-      |> Option.value ~default:"production"
-      |> String.lowercase_ascii
+      Env_config.Server.Runtime.governance_level
     in
     let init_state_blocking () =
       let t0 = Eio.Time.now clock in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -13,23 +13,24 @@ let force_jsonl_fallback_env () =
   Array.iter (fun name -> Unix.putenv name "") pg_env_var_names
 
 let requested_backend_mode () =
-  match Sys.getenv_opt "MASC_STORAGE_TYPE" with
-  | Some raw -> (
-      match String.lowercase_ascii (String.trim raw) with
-      | "postgres" | "postgresql" | "postgres-native" -> "postgres-native"
-      | "filesystem" | "file" | "jsonl" -> "filesystem"
-      | "memory" -> "memory"
-      | other -> other)
-  | None ->
-      let has_pg =
-        Array.exists
-          (fun name ->
-            match Sys.getenv_opt name with
-            | Some value -> String.trim value <> ""
-            | None -> false)
-          pg_env_var_names
-      in
-      if has_pg then "postgres-native" else "filesystem"
+  let raw = String.lowercase_ascii (String.trim Env_config.Server.Storage.storage_type) in
+  if raw = "" then
+    (* No explicit type set — auto-detect from PG env vars *)
+    let has_pg =
+      Array.exists
+        (fun name ->
+          match Sys.getenv_opt name with
+          | Some value -> String.trim value <> ""
+          | None -> false)
+        pg_env_var_names
+    in
+    if has_pg then "postgres-native" else "filesystem"
+  else
+    match raw with
+    | "postgres" | "postgresql" | "postgres-native" -> "postgres-native"
+    | "filesystem" | "file" | "jsonl" -> "filesystem"
+    | "memory" -> "memory"
+    | other -> other
 
 let init_runtime_context env =
   let clock = Eio.Stdenv.clock env in

--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -69,13 +69,13 @@ let parse_ice_servers_json raw =
   with Yojson.Json_error _ -> []
 
 let configured_ice_servers () =
-  match getenv_nonempty "MASC_WEBRTC_ICE_SERVERS_JSON" with
+  match Env_config.Server.Webrtc.ice_servers_json_opt () with
   | Some raw -> (
       match parse_ice_servers_json raw with
       | [] -> Webrtc.Webrtc_eio.default_ice_config.Webrtc.Ice.ice_servers
       | servers -> servers)
   | None -> (
-      match getenv_nonempty "MASC_WEBRTC_ICE_URLS" with
+      match Env_config.Server.Webrtc.ice_urls_opt () with
       | Some raw ->
         let urls = split_csv raw in
         if urls = [] then
@@ -84,9 +84,9 @@ let configured_ice_servers () =
           [
             {
               Webrtc.Ice.urls;
-              username = getenv_nonempty "MASC_WEBRTC_ICE_USERNAME";
-              credential = getenv_nonempty "MASC_WEBRTC_ICE_CREDENTIAL";
-              tls_ca = getenv_nonempty "MASC_WEBRTC_ICE_TLS_CA";
+              username = Env_config.Server.Webrtc.ice_username_opt ();
+              credential = Env_config.Server.Webrtc.ice_credential_opt ();
+              tls_ca = Env_config.Server.Webrtc.ice_tls_ca_opt ();
             };
           ]
       | None -> Webrtc.Webrtc_eio.default_ice_config.Webrtc.Ice.ice_servers)

--- a/lib/server/server_webrtc_transport.ml
+++ b/lib/server/server_webrtc_transport.ml
@@ -17,10 +17,7 @@
     Enabled by default. Opt-out via MASC_WEBRTC_ENABLED=0. *)
 
 (** Whether WebRTC transport is enabled (default: true). *)
-let is_enabled () =
-  match Sys.getenv_opt "MASC_WEBRTC_ENABLED" with
-  | Some "0" | Some "false" -> false
-  | _ -> true
+let is_enabled () = Env_config.Server.Webrtc.enabled
 
 let trim_nonempty value =
   let trimmed = String.trim value in

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -18,15 +18,7 @@ module Ws_eio = Httpun_ws_eio
 let default_port = 8937
 
 (** Read the configured WS port from environment or use default. *)
-let configured_port () =
-  match Sys.getenv_opt "MASC_WS_PORT" with
-  | Some s -> (
-    match int_of_string_opt s with
-    | Some p when p > 0 && p < 65536 -> p
-    | _ ->
-      Log.Server.warn "MASC_WS_PORT=%s is not a valid port, using %d" s default_port;
-      default_port)
-  | None -> default_port
+let configured_port () = Env_config.Server.Ws.port
 
 (** Check whether standalone WS is enabled (default: enabled).
     Disable with MASC_WS_ENABLED=0 or MASC_WS_ENABLED=false. *)

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -69,13 +69,7 @@ let elapsed_since_start () =
 let default_watchdog_timeout_sec = 240.0
 
 (** Read watchdog timeout from env, clamped to [30, 600]. *)
-let watchdog_timeout_sec () =
-  match Sys.getenv_opt "MASC_STARTUP_WATCHDOG_SEC" with
-  | Some s ->
-    (match float_of_string_opt s with
-     | Some v -> Float.max 30.0 (Float.min 600.0 v)
-     | None -> default_watchdog_timeout_sec)
-  | None -> default_watchdog_timeout_sec
+let watchdog_timeout_sec () = Env_config.Server.Runtime.startup_watchdog_sec
 
 let mark_state_ready ~backend_mode =
   update (fun current ->

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -70,7 +70,7 @@ let stats_path () =
     | Some p -> p
     | None ->
         (* Fallback: try to get from environment or use current dir *)
-        Sys.getenv_opt "MASC_BASE_PATH" |> Option.value ~default:"."
+        Env_config.Server.Storage.base_path_opt () |> Option.value ~default:"."
   in
   let masc_dir = Filename.concat base ".masc" in
   Fs_compat.mkdir_p masc_dir;

--- a/lib/tool_budget.ml
+++ b/lib/tool_budget.ml
@@ -45,9 +45,7 @@ let filter_by_budget ~budget_tokens ~usage_counts
     List.rev accepted
 
 let default_budget () : int option =
-  match Sys.getenv_opt "MASC_TOOL_DESCRIPTION_BUDGET" with
-  | Some raw -> (
-      match int_of_string_opt (String.trim raw) with
-      | Some v when v > 0 -> Some v
-      | _ -> None)
+  let v = Env_config.Server.Tools.description_budget in
+  match v with
+  | v when v > 0 -> Some v
   | None -> None

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -184,21 +184,18 @@ let public_mcp_set : (string, unit) Hashtbl.t =
   List.iter (fun name -> Hashtbl.replace tbl name ()) public_mcp_tools;
   (* MASC_PUBLIC_TOOLS_EXTRA: comma-separated tool names to add at runtime.
      Example: MASC_PUBLIC_TOOLS_EXTRA=masc_goal_upsert,masc_pause *)
-  (match Sys.getenv_opt "MASC_PUBLIC_TOOLS_EXTRA" with
-   | Some raw ->
-       String.split_on_char ',' raw
-       |> List.iter (fun s ->
-              let name = String.trim s in
-              if name <> "" then Hashtbl.replace tbl name ())
-   | None -> ());
+  (let extra = Env_config.Server.Tools.public_tools_extra in
+   if extra <> "" then
+     String.split_on_char ',' extra
+     |> List.iter (fun s ->
+            let name = String.trim s in
+            if name <> "" then Hashtbl.replace tbl name ()));
   tbl
 
 let is_public_mcp name = Hashtbl.mem public_mcp_set name
 
 let full_surface_override () =
-  match Sys.getenv_opt "MASC_FULL_SURFACE" with
-  | Some "1" | Some "true" -> true
-  | _ -> false
+  Env_config.Server.Tools.full_surface
 
 let implementation_status_to_string = function
   | Real -> "real"

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -131,10 +131,8 @@ let rec find_repo_root_with_script dir depth =
       else find_repo_root_with_script parent (depth - 1)
 
 let resolve_swarm_live_script () =
-  match Sys.getenv_opt "MASC_SWARM_LIVE_SCRIPT" with
-  | Some value when String.trim value <> "" ->
-      let path = String.trim value in
-      if Sys.file_exists path then Some path else None
+  match Env_config.Chain.Llama.swarm_live_script_opt () with
+  | Some path when Sys.file_exists path -> Some path
   | _ ->
       let seeds =
         [ Sys.getcwd (); Filename.dirname Sys.executable_name ]

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -120,9 +120,7 @@ let dispatch_structured ~name ~args : Tool_result.t option =
 (** Feature flag: use the new dispatch path.
     Default ON since v2.102 — use MASC_DISPATCH_V2=0 to disable. *)
 let v2_enabled =
-  match Sys.getenv_opt "MASC_DISPATCH_V2" with
-  | Some "0" | Some "false" | Some "FALSE" -> false
-  | _ -> true
+  Env_config.Server.Runtime.dispatch_v2
 
 (** Number of registered tool names. *)
 let registered_count () = Hashtbl.length registry

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -357,7 +357,7 @@ let normalize_runtime value =
   | _ -> None
 
 let env_keeper_models () =
-  match Sys.getenv_opt "MASC_GOAL_MODELS" with
+  match Env_config.Chain.Model.goal_models_opt () with
   | None -> []
   | Some raw -> split_csv raw
 
@@ -547,9 +547,7 @@ let handle_goal_dispatch ctx args =
     match get_string_opt args "runtime" with
     | Some v -> v
     | None -> (
-        match Sys.getenv_opt "MASC_GOAL_DISPATCH_RUNTIME" with
-        | Some env_v -> env_v
-        | None -> "task")
+        Env_config.Chain.Model.goal_dispatch_runtime)
   in
   let runtime_opt = normalize_runtime runtime_raw in
   let goal_ids = get_string_list args "goal_ids" in

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -35,10 +35,10 @@ let handle_start (ctx : context) : result option =
     end else begin
       let expanded =
         if String.length path >= 2 && path.[0] = '~' && path.[1] = '/' then
-          let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
+          let home = match Env_config_core.home_dir_opt () with Some h -> h | None -> "/tmp" in
           Filename.concat home (String.sub path 2 (String.length path - 2))
         else if String.length path = 1 && path.[0] = '~' then
-          (match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp")
+          (match Env_config_core.home_dir_opt () with Some h -> h | None -> "/tmp")
         else if Filename.is_relative path then
           Filename.concat (Sys.getcwd ()) path
         else
@@ -112,7 +112,7 @@ let handle_lock (ctx : context) : result option =
   else begin
     let expanded =
       if String.length file > 0 && file.[0] = '~' then
-        match Sys.getenv_opt "HOME" with
+        match Env_config_core.home_dir_opt () with
         | Some home -> Filename.concat home (String.sub file 1 (String.length file - 1))
         | None -> file
       else if Filename.is_relative file then
@@ -154,7 +154,7 @@ let handle_unlock (ctx : context) : result option =
   else begin
     let expanded =
       if String.length file > 0 && file.[0] = '~' then
-        match Sys.getenv_opt "HOME" with
+        match Env_config_core.home_dir_opt () with
         | Some home -> Filename.concat home (String.sub file 1 (String.length file - 1))
         | None -> file
       else if Filename.is_relative file then
@@ -193,10 +193,10 @@ let handle_set_room (ctx : context) : result option =
   else
   let expanded =
     if String.length path >= 2 && path.[0] = '~' && path.[1] = '/' then
-      let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
+      let home = match Env_config_core.home_dir_opt () with Some h -> h | None -> "/tmp" in
       Filename.concat home (String.sub path 2 (String.length path - 2))
     else if String.length path = 1 && path.[0] = '~' then
-      (match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp")
+      (match Env_config_core.home_dir_opt () with Some h -> h | None -> "/tmp")
     else if Filename.is_relative path then
       Filename.concat (Sys.getcwd ()) path
     else

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -29,7 +29,7 @@ type context = {
 
 (* Paths *)
 let library_root () =
-  let home = Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp" in
+  let home = Env_config_core.home_dir_opt () |> Option.value ~default:"/tmp" in
   Filename.concat home "me/docs/library"
 
 let candidates_dir () =

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -173,15 +173,15 @@ let runtime_inventory_models () =
          trim_opt runtime.model)
   |> Team_session_types.dedup_strings
 
-let explicit_lead_model () = env_trim_opt "MASC_TEAM_SESSION_MODEL_35B"
-let explicit_middle_model () = env_trim_opt "MASC_TEAM_SESSION_MODEL_27B"
-let explicit_worker_model () = env_trim_opt "MASC_TEAM_SESSION_MODEL_9B"
+let explicit_lead_model () = Env_config.TeamSession.model_35b_opt ()
+let explicit_middle_model () = Env_config.TeamSession.model_27b_opt ()
+let explicit_worker_model () = Env_config.TeamSession.model_9b_opt ()
 
 let inferred_lead_model () =
   match explicit_lead_model () with
   | Some _ as explicit -> explicit
   | None -> (
-      match env_trim_opt "LLAMA_SWARM_MODEL" with
+      match Env_config.Chain.Model.llama_swarm_model_opt () with
       | Some _ as env_model -> env_model
       | None ->
           runtime_inventory_models ()
@@ -286,20 +286,16 @@ let high_risk_keywords =
   [ "security"; "policy"; "final"; "merge"; "customer"; "public"; "external"; "production"; "critical"; "architecture"; "decision" ]
 
 let router_judge_enabled () =
-  bool_env_default "MASC_TEAM_SESSION_ROUTER_JUDGE" ~default:true
+  Env_config.TeamSession.router_judge_enabled
 
 let router_judge_timeout_sec () =
-  max 5 (int_env_default "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC" ~default:15)
+  Env_config.TeamSession.router_judge_timeout_sec
 
 let router_judge_confidence_threshold () =
-  let value =
-    float_env_default "MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD"
-      ~default:0.72
-  in
-  if value < 0.0 then 0.0 else if value > 1.0 then 1.0 else value
+  Env_config.TeamSession.router_judge_confidence_threshold
 
 let router_judge_model () =
-  match env_trim_opt "MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL" with
+  match Env_config.TeamSession.router_judge_model_opt () with
   | Some _ as explicit -> explicit
   | None -> inferred_lead_model ()
 

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -456,8 +456,8 @@ let model_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
           worker_class_text role_text spawn_prompt
       in
       (match
-        Oas_worker.run_named ~cascade_name:(match Sys.getenv_opt "MASC_ROUTING_CASCADE" with
-          | Some s when String.trim s <> "" -> String.trim s | _ -> "routing_judge")
+        Oas_worker.run_named ~cascade_name:(match Env_config.Chain.Model.routing_cascade_opt () with
+          | Some s -> s | None -> "routing_judge")
           ~system_prompt:"You are a routing judge for a hybrid swarm. Output only JSON."
           ~goal:prompt ~max_turns:1
           ~temperature:0.0 ~max_tokens:220 ()

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -114,20 +114,10 @@ let set_ws_listen_status status =
   Atomic.set ws_listen_status status
 
 let grpc_enabled () =
-  match Sys.getenv_opt "MASC_GRPC_ENABLED" with
-  | Some raw -> (
-      match String.trim raw |> String.lowercase_ascii with
-      | "0" | "false" | "" -> false
-      | _ -> true)
-  | None -> true
+  Env_config.Server.Grpc.enabled
 
 let grpc_port () =
-  match Sys.getenv_opt "MASC_GRPC_PORT" with
-  | Some raw -> (
-      match int_of_string_opt raw with
-      | Some port when port > 0 && port < 65536 -> port
-      | _ -> 8936)
-  | None -> 8936
+  Env_config.Server.Grpc.port
 
 let grpc_listening () =
   grpc_enabled () && Atomic.get grpc_runtime_listening
@@ -189,14 +179,7 @@ let int_option_json = function
   | None -> `Null
 
 let http_listener_mode () =
-  match Sys.getenv_opt "MASC_USE_H2" with
-  | Some raw -> (
-      match String.trim raw |> String.lowercase_ascii with
-      | "1" | "true" -> "h2_only"
-      | "0" | "false" -> "h1_only"
-      | "auto" | "" -> "auto"
-      | _ -> "auto")
-  | None -> "auto"
+  Env_config.Server.H2.mode
 
 let primary_path ~webrtc_channels ~grpc_subscribers ~ws_sessions ~sse_sessions =
   if webrtc_channels > 0 then "webrtc_datachannel"
@@ -211,20 +194,10 @@ let queue_pressure max_queue_depth =
   else "steady"
 
 let ws_enabled () =
-  match Sys.getenv_opt "MASC_WS_ENABLED" with
-  | Some raw -> (
-      match String.trim raw |> String.lowercase_ascii with
-      | "0" | "false" -> false
-      | _ -> true)
-  | None -> true
+  Env_config.Server.Ws.enabled
 
 let ws_port () =
-  match Sys.getenv_opt "MASC_WS_PORT" with
-  | Some raw -> (
-      match int_of_string_opt raw with
-      | Some port when port > 0 && port < 65536 -> port
-      | _ -> 8937)
-  | None -> 8937
+  Env_config.Server.Ws.port
 
 let ws_listening () =
   ws_enabled () && Atomic.get ws_runtime_listening

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -226,7 +226,7 @@ let trim_opt = function
 
 (** Ensure .masc/audio/ directory exists *)
 let resolved_base_path_opt () =
-  match trim_opt (Sys.getenv_opt "MASC_BASE_PATH") with
+  match Env_config.Server.Storage.base_path_opt () with
   | Some path -> Some path
   | None -> Room_utils_backend_setup.find_git_root (Sys.getcwd ())
 
@@ -234,7 +234,7 @@ let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Filename.concat base_path ".masc"
   | None -> (
-      match trim_opt (Sys.getenv_opt "ME_ROOT") with
+      match Env_config_core.me_root_opt () with
       | Some root -> Filename.concat root ".masc"
       | None -> ".masc")
 

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -69,7 +69,7 @@ let dedupe_keep_order values =
   loop [] [] values
 
 let base_path_voice_config_path_opt () =
-  trim_opt (Sys.getenv_opt "MASC_BASE_PATH")
+  Env_config.Server.Storage.base_path_opt ()
   |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
 
 let repo_voice_config_path_opt () =
@@ -82,7 +82,7 @@ let repo_voice_config_path_opt () =
   Some (Filename.concat root ".masc/voice_config.json")
 
 let me_root_voice_config_path_opt () =
-  trim_opt (Sys.getenv_opt "ME_ROOT")
+  Env_config_core.me_root_opt ()
   |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
 
 let cwd_voice_config_path () =


### PR DESCRIPTION
## Summary
- Add 3 new Env_config sub-modules: `Env_config_server` (transport/auth/storage), `Env_config_chain` (chain/model/inference), `Env_config_dashboard` (operator/governance judge)
- Add `Env_config.to_json()` for dashboard config introspection (unblocks #3365)
- Migrate first batch: `transport_metrics`, `dashboard_operator_judge`, `dashboard_governance_judge`, `dashboard_execution_helpers`
- Fix default value mismatches discovered during migration
- Absorbs #3363 (env var dedup is part of this centralization)

## Remaining work (follow-up commits)
- ~100 files still have direct `Sys.getenv` calls to migrate
- Batch migration in groups of 10-20 files per commit

## Test plan
- [x] `dune build --root . @check` passes
- [ ] `dune test --root . ` passes
- [ ] Cross-model review

Closes #3364
Ref: #3363 (absorbed), #3365 (unblocked by to_json)