### PR TITLE
[codex] fix api_usage cost_usd regressions

### DIFF
--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -30,7 +30,13 @@ let total_tokens (u : Agent_sdk.Types.api_usage) = u.input_tokens + u.output_tok
 (** Zero usage marker — delegates to OAS Types.zero_api_usage.
     @since 2.123.0 — delegated to OAS *)
 let zero_usage : Agent_sdk.Types.api_usage =
-  { input_tokens = 0; output_tokens = 0; cache_read_input_tokens = 0; cache_creation_input_tokens = 0 }
+  {
+    input_tokens = 0;
+    output_tokens = 0;
+    cache_read_input_tokens = 0;
+    cache_creation_input_tokens = 0;
+    cost_usd = None;
+  }
 
 (** Extract usage from an api_response, defaulting to zero.
     @since 2.123.0 *)

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -6,6 +6,13 @@ open Keeper_memory
 
 let keeper_model_tools = Tool_shard.keeper_model_tools
 
+let merge_cost_usd (a : float option) (b : float option) : float option =
+  match a, b with
+  | Some x, Some y -> Some (x +. y)
+  | Some _, None -> a
+  | None, Some _ -> b
+  | None, None -> None
+
 let merge_usage
     (a : Agent_sdk.Types.api_usage)
     (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
@@ -14,7 +21,8 @@ let merge_usage
     cache_creation_input_tokens =
       a.cache_creation_input_tokens + b.cache_creation_input_tokens;
     cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens }
+      a.cache_read_input_tokens + b.cache_read_input_tokens;
+    cost_usd = merge_cost_usd a.cost_usd b.cost_usd }
 
 let contains_ci (haystack : string) (needle : string) : bool =
   let h = String.lowercase_ascii haystack in

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -558,7 +558,15 @@ let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Agent_sdk.Types.api
   { Agent_sdk.Types.input_tokens;
     output_tokens;
     cache_creation_input_tokens = 0;
-    cache_read_input_tokens = 0 }
+    cache_read_input_tokens = 0;
+    cost_usd = None }
+
+let merge_cost_usd (a : float option) (b : float option) : float option =
+  match a, b with
+  | Some x, Some y -> Some (x +. y)
+  | Some _, None -> a
+  | None, Some _ -> b
+  | None, None -> None
 
 let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) : Agent_sdk.Types.api_usage =
   { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
@@ -566,7 +574,8 @@ let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) 
     cache_creation_input_tokens =
       a.cache_creation_input_tokens + b.cache_creation_input_tokens;
     cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens }
+      a.cache_read_input_tokens + b.cache_read_input_tokens;
+    cost_usd = merge_cost_usd a.cost_usd b.cost_usd }
 
 let estimate_cost_usd ~(model_id : string)
     (usage : Agent_sdk.Types.api_usage) : float option =
@@ -648,5 +657,3 @@ let worker_auth_token ~base_path ~worker_name =
     | Error err -> Error (Types.masc_error_to_string err)
   else
     Ok None
-
-

--- a/lib/oas_response.ml
+++ b/lib/oas_response.ml
@@ -20,4 +20,5 @@ let usage_or_zero (response : api_response) =
         output_tokens = 0;
         cache_creation_input_tokens = 0;
         cache_read_input_tokens = 0;
+        cost_usd = None;
       }

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.92.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="3c6a5750d040f690c6448b7ec5e5c3e7d3b7921c"
+readonly OAS_AGENT_SDK_SHA="f384f9143a340e756a6b280aebfc83124d3a3c89"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.92.1"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -358,7 +358,13 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     model_used = model;
     turn_count = 1;
     tool_calls_made = List.length tools;
-    usage = { input_tokens = input_tok; output_tokens = output_tok; cache_creation_input_tokens = 0; cache_read_input_tokens = 0 };
+    usage = {
+      input_tokens = input_tok;
+      output_tokens = output_tok;
+      cache_creation_input_tokens = 0;
+      cache_read_input_tokens = 0;
+      cost_usd = None;
+    };
     tools_used = tools;
     checkpoint = None;
   }

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -158,6 +158,31 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "provenance" "fallback" resolved.provenance;
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
+let keeper_usage ?cost_usd ~input_tokens ~output_tokens () : Agent_sdk.Types.api_usage =
+  {
+    input_tokens;
+    output_tokens;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd;
+  }
+
+let test_keeper_merge_usage_preserves_present_cost () =
+  let a = keeper_usage ~input_tokens:10 ~output_tokens:5 ~cost_usd:0.2 () in
+  let b = keeper_usage ~input_tokens:3 ~output_tokens:7 () in
+  let merged = Masc_mcp.Keeper_alerting.merge_usage a b in
+  check int "input tokens merged" 13 merged.input_tokens;
+  check int "output tokens merged" 12 merged.output_tokens;
+  check (option (float 0.000001)) "cost preserved from left" (Some 0.2)
+    merged.cost_usd
+
+let test_keeper_merge_usage_sums_costs_when_both_present () =
+  let a = keeper_usage ~input_tokens:10 ~output_tokens:5 ~cost_usd:0.2 () in
+  let b = keeper_usage ~input_tokens:3 ~output_tokens:7 ~cost_usd:0.05 () in
+  let merged = Masc_mcp.Keeper_alerting.merge_usage a b in
+  check (option (float 0.000001)) "costs summed" (Some 0.25)
+    merged.cost_usd
+
 let test_keeper_model_set_removed () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1883,6 +1908,10 @@ let () =
            test_resolved_keeper_skill_route_marks_agent_judgment;
          test_case "resolved skill route falls back when parse missing" `Quick
            test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing;
+         test_case "keeper merge usage preserves present cost" `Quick
+           test_keeper_merge_usage_preserves_present_cost;
+         test_case "keeper merge usage sums costs" `Quick
+           test_keeper_merge_usage_sums_costs_when_both_present;
          test_case "keeper model set removed" `Quick
            test_keeper_model_set_removed;
          test_case "keeper up rejects legacy model args" `Quick

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -1,6 +1,16 @@
 open Alcotest
 open Masc_mcp
 
+let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
+    Agent_sdk.Types.api_usage =
+  {
+    input_tokens;
+    output_tokens;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd;
+  }
+
 let test_parse_text_tool_calls_single () =
   let content =
     {|mcp__masc__masc_team_session_step(session_id="ts-123", turn_kind="note", message="[local64-smoke-01] manager decide online for hybrid smoke")|}
@@ -38,6 +48,22 @@ done:local64-smoke-02
       check string "second tool" "masc_team_session_step" name2
   | _ -> fail "expected two parsed text tool calls"
 
+let test_merge_usage_preserves_present_cost () =
+  let a = worker_usage ~input_tokens:8 ~output_tokens:2 ~cost_usd:0.12 () in
+  let b = worker_usage ~input_tokens:1 ~output_tokens:4 () in
+  let merged = Worker_container_types.merge_usage a b in
+  check int "input tokens merged" 9 merged.input_tokens;
+  check int "output tokens merged" 6 merged.output_tokens;
+  check (option (float 0.000001)) "cost preserved from left" (Some 0.12)
+    merged.cost_usd
+
+let test_merge_usage_sums_costs_when_both_present () =
+  let a = worker_usage ~input_tokens:8 ~output_tokens:2 ~cost_usd:0.12 () in
+  let b = worker_usage ~input_tokens:1 ~output_tokens:4 ~cost_usd:0.03 () in
+  let merged = Worker_container_types.merge_usage a b in
+  check (option (float 0.000001)) "costs summed" (Some 0.15)
+    merged.cost_usd
+
 let () =
   run "Worker_runtime"
     [
@@ -47,5 +73,9 @@ let () =
             test_parse_text_tool_calls_single;
           test_case "parse text tool calls multiple" `Quick
             test_parse_text_tool_calls_multiple;
+          test_case "merge usage preserves present cost" `Quick
+            test_merge_usage_preserves_present_cost;
+          test_case "merge usage sums costs" `Quick
+            test_merge_usage_sums_costs_when_both_present;
         ] );
     ]


### PR DESCRIPTION
## Summary

Fix `Agent_sdk.Types.api_usage` call sites that still used the pre-`cost_usd` record shape.

- fill `cost_usd = None` in zero/default `api_usage` constructors
- update usage merge helpers to preserve or sum optional cost values safely
- add regression tests for optional `cost_usd` merge behavior

## Product impact

- restores local `dune build` / `@check`
- prevents follow-on regressions in keeper/local worker usage accounting
- keeps missing cost data explicit as `None` instead of silently coercing to `0.0`

## Evidence

- `dune build --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build_codex_fix_cost_usd @check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-token-usage-cost --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-token-usage-cost/_build_codex_fix test/test_tool_keeper.exe test/test_worker_container_coverage.exe`
- `_build_codex_fix/default/test/test_tool_keeper.exe`
- `_build_codex_fix/default/test/test_worker_container_coverage.exe`

## Review evidence

- `GLM-5` via direct `sb glm-text` review completed
- initial medium finding was missing merge-cost test coverage
- follow-up tests added in `test/test_tool_keeper.ml` and `test/test_worker_container_coverage.ml`
- no high/critical findings remain from the GLM review

## Linked issue

Refs #3495
