### PR TITLE
feat(dashboard): add server config introspection view (#3365)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -148,6 +148,31 @@ export function fetchAgentRelations(agentName: string): Promise<AgentRelationsRe
   return get(`/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`)
 }
 
+export interface ConfigEntry {
+  env: string
+  description: string
+  value: string | null
+  default: string
+  source: 'env' | 'default'
+  sensitive: boolean
+}
+
+export interface DashboardConfigResponse {
+  generated_at: string
+  server: {
+    version: string
+    git_commit: string | null
+    ocaml_version: string
+    uptime_seconds: number
+    pid: number
+  }
+  categories: Record<string, ConfigEntry[]>
+}
+
+export function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
+  return get('/api/v1/dashboard/config')
+}
+
 export function fetchDashboardRoomTruth(): Promise<DashboardRoomTruthResponse> {
   return get('/api/v1/dashboard/room-truth', { timeoutMs: ROOM_TRUTH_GET_TIMEOUT_MS })
 }

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -4,6 +4,7 @@ import { Card } from './common/card'
 import { Tools } from './tools'
 import { Autoresearch } from './autoresearch'
 import { HarnessHealth } from './harness-health'
+import { ServerConfig } from './server-config'
 
 export function Lab() {
   const section = route.value.params.section ?? 'tools'
@@ -26,6 +27,10 @@ export function Lab() {
 
       ${section === 'harness' ? html`
         <${HarnessHealth} />
+      ` : null}
+
+      ${section === 'config' ? html`
+        <${ServerConfig} />
       ` : null}
     </div>
   `

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -1,0 +1,195 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { Card } from './common/card'
+import { fetchDashboardConfig } from '../api/dashboard'
+import type { DashboardConfigResponse, ConfigEntry } from '../api/dashboard'
+
+const configData = signal<DashboardConfigResponse | null>(null)
+const configLoading = signal(false)
+const configError = signal<string | null>(null)
+const searchQuery = signal('')
+const expandedCategories = signal<Set<string>>(new Set())
+
+export async function refreshServerConfig(): Promise<void> {
+  configLoading.value = true
+  configError.value = null
+  try {
+    configData.value = await fetchDashboardConfig()
+    if (expandedCategories.value.size === 0 && configData.value) {
+      expandedCategories.value = new Set(Object.keys(configData.value.categories))
+    }
+  } catch (err) {
+    configError.value = err instanceof Error ? err.message : 'Failed to load config'
+  } finally {
+    configLoading.value = false
+  }
+}
+
+function toggleCategory(name: string) {
+  const next = new Set(expandedCategories.value)
+  if (next.has(name)) next.delete(name)
+  else next.add(name)
+  expandedCategories.value = next
+}
+
+function formatUptime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  if (h > 0) return `${h}h ${m}m ${s}s`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+function matchesSearch(entry: ConfigEntry, query: string): boolean {
+  if (!query) return true
+  const lower = query.toLowerCase()
+  return (
+    entry.env.toLowerCase().includes(lower) ||
+    entry.description.toLowerCase().includes(lower) ||
+    (entry.value ?? '').toLowerCase().includes(lower)
+  )
+}
+
+function EntryRow({ entry }: { entry: ConfigEntry }) {
+  const isDefault = entry.source === 'default'
+  const valueClass = entry.sensitive
+    ? 'text-[var(--text-muted)] italic'
+    : isDefault
+      ? 'text-[var(--text-muted)]'
+      : 'text-[var(--accent-primary)] font-medium'
+
+  return html`
+    <div class="flex items-start gap-3 py-2 px-3 rounded hover:bg-[var(--bg-hover)] transition-colors">
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <code class="text-xs font-mono text-[var(--text-primary)]">${entry.env}</code>
+          ${!isDefault ? html`
+            <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">custom</span>
+          ` : null}
+          ${entry.sensitive ? html`
+            <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">sensitive</span>
+          ` : null}
+        </div>
+        <div class="text-xs text-[var(--text-muted)] mt-0.5">${entry.description}</div>
+      </div>
+      <div class="text-right shrink-0">
+        <div class=${`text-xs font-mono ${valueClass}`}>
+          ${entry.value ?? entry.default}
+        </div>
+        ${!isDefault && entry.default ? html`
+          <div class="text-[10px] text-[var(--text-muted)] mt-0.5">
+            default: ${entry.default}
+          </div>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function CategoryPanel({ name, entries }: { name: string; entries: ConfigEntry[] }) {
+  const query = searchQuery.value
+  const filtered = entries.filter(e => matchesSearch(e, query))
+  const isExpanded = expandedCategories.value.has(name)
+  const customCount = filtered.filter(e => e.source !== 'default').length
+
+  if (filtered.length === 0) return null
+
+  return html`
+    <div class="border border-[var(--border-subtle)] rounded-lg overflow-hidden mb-3">
+      <button
+        class="w-full flex items-center justify-between px-4 py-2.5 bg-[var(--bg-surface)] hover:bg-[var(--bg-hover)] transition-colors text-left"
+        onClick=${() => toggleCategory(name)}
+      >
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-[var(--text-muted)]">${isExpanded ? '\u25BC' : '\u25B6'}</span>
+          <span class="text-sm font-medium text-[var(--text-primary)] capitalize">${name}</span>
+          <span class="text-xs text-[var(--text-muted)]">(${filtered.length})</span>
+        </div>
+        ${customCount > 0 ? html`
+          <span class="text-[10px] px-2 py-0.5 rounded-full bg-[var(--accent-primary)]/10 text-[var(--accent-primary)]">
+            ${customCount} custom
+          </span>
+        ` : null}
+      </button>
+      ${isExpanded ? html`
+        <div class="divide-y divide-[var(--border-subtle)]">
+          ${filtered.map(entry => html`<${EntryRow} entry=${entry} />`)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+function ServerMeta() {
+  const data = configData.value
+  if (!data) return null
+  const { server } = data
+
+  return html`
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+      <div class="px-3 py-2 rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
+        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Version</div>
+        <div class="text-sm font-mono text-[var(--text-primary)]">${server.version}</div>
+      </div>
+      <div class="px-3 py-2 rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
+        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Uptime</div>
+        <div class="text-sm font-mono text-[var(--text-primary)]">${formatUptime(server.uptime_seconds)}</div>
+      </div>
+      <div class="px-3 py-2 rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
+        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">OCaml</div>
+        <div class="text-sm font-mono text-[var(--text-primary)]">${server.ocaml_version}</div>
+      </div>
+      <div class="px-3 py-2 rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)]">
+        <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">PID</div>
+        <div class="text-sm font-mono text-[var(--text-primary)]">${server.pid}</div>
+      </div>
+    </div>
+  `
+}
+
+export function ServerConfig() {
+  const data = configData.value
+  const loading = configLoading.value
+  const error = configError.value
+
+  if (!data && !loading && !error) {
+    void refreshServerConfig()
+  }
+
+  return html`
+    <${Card} title="서버 설정" class="section">
+      <div class="mb-3 flex items-center gap-2">
+        <input
+          type="text"
+          placeholder="환경변수 또는 설명으로 검색..."
+          class="flex-1 px-3 py-1.5 text-sm rounded-lg bg-[var(--bg-input)] border border-[var(--border-subtle)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-primary)]"
+          value=${searchQuery.value}
+          onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+        />
+        <button
+          class="px-3 py-1.5 text-xs rounded-lg bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
+          onClick=${() => void refreshServerConfig()}
+          disabled=${loading}
+        >
+          ${loading ? '...' : 'Refresh'}
+        </button>
+      </div>
+
+      ${error ? html`
+        <div class="text-sm text-red-400 mb-3">${error}</div>
+      ` : null}
+
+      ${loading && !data ? html`
+        <div class="text-sm text-[var(--text-muted)] py-8 text-center">Loading...</div>
+      ` : null}
+
+      ${data ? html`
+        <${ServerMeta} />
+        ${Object.entries(data.categories).map(([name, entries]) =>
+          html`<${CategoryPanel} name=${name} entries=${entries} />`
+        )}
+      ` : null}
+    <//>
+  `
+}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -16,6 +16,7 @@ export type SurfaceSectionId =
   | 'experiments'
   | 'autoresearch'
   | 'harness'
+  | 'config'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 const OPERATIONS_COMMAND_SURFACES = new Set([
@@ -207,6 +208,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '세이프티 하네스',
       description: 'Evaluator, compaction, DNA safety rail이 실험을 어떻게 감시하는지 봅니다.',
       params: { section: 'harness' },
+    },
+    {
+      id: 'config',
+      label: '서버 설정',
+      description: '환경변수, 트랜스포트, 추론 모델 등 서버 설정을 확인합니다.',
+      params: { section: 'config' },
     },
   ],
 }

--- a/lib/dune
+++ b/lib/dune
@@ -535,6 +535,7 @@
    env_config_runtime
    env_config_governance
    env_config_keeper
+   env_config_introspect
    runtime_params
    governance_registry
    governance_pipeline

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -1,0 +1,161 @@
+(** Env_config_introspect — serialize all MASC env config into categorized JSON.
+
+    Used by the dashboard config endpoint to expose server configuration.
+    Sensitive values (tokens, passwords, URLs with credentials) are masked.
+
+    @since 2.158.0 *)
+
+let mask_sensitive value =
+  if String.length value <= 4 then "***"
+  else
+    let visible = min 4 (String.length value) in
+    String.sub value 0 visible ^ "***"
+
+let is_sensitive_name name =
+  let lower = String.lowercase_ascii name in
+  List.exists (fun pat ->
+    let rec contains_at i =
+      if i + String.length pat > String.length lower then false
+      else if String.sub lower i (String.length pat) = pat then true
+      else contains_at (i + 1)
+    in
+    contains_at 0)
+    [ "token"; "password"; "secret"; "key"; "credential"; "postgres_url";
+      "neo4j_url"; "supabase" ]
+
+type entry = {
+  env_name : string;
+  description : string;
+  default_display : string;
+  sensitive : bool;
+}
+
+let entry ?(sensitive = false) ~default env_name description =
+  let sensitive = sensitive || is_sensitive_name env_name in
+  { env_name; description; default_display = default; sensitive }
+
+let read_entry e =
+  let raw = Sys.getenv_opt e.env_name in
+  let display_value =
+    match raw with
+    | None -> None
+    | Some v when e.sensitive -> Some (mask_sensitive v)
+    | Some v -> Some v
+  in
+  `Assoc [
+    ("env", `String e.env_name);
+    ("description", `String e.description);
+    ("value", match display_value with Some v -> `String v | None -> `Null);
+    ("default", `String e.default_display);
+    ("source", `String (if raw = None then "default" else "env"));
+    ("sensitive", `Bool e.sensitive);
+  ]
+
+let category name entries =
+  (name, `List (List.map read_entry entries))
+
+(* ================================================================ *)
+(* Category definitions                                              *)
+(* ================================================================ *)
+
+let server_entries = [
+  entry ~default:"(cwd)" "MASC_BASE_PATH" "Base storage directory";
+  entry ~default:"filesystem" "MASC_STORAGE_TYPE" "Backend storage type (filesystem|postgres)";
+  entry ~default:"8935" "MASC_HTTP_PORT" "HTTP server port";
+  entry ~default:"127.0.0.1" "MASC_HOST" "Server bind host";
+  entry ~default:"(derived)" "MASC_HTTP_BASE_URL" "Public HTTP base URL";
+  entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
+  entry ~sensitive:true ~default:"(none)" "MASC_ADMIN_TOKEN" "Admin authentication token";
+  entry ~default:"false" "MASC_TOOL_AUTH_STRICT" "Require auth for all tool calls";
+  entry ~default:"(auto)" "MASC_LOG_LEVEL" "Log level override";
+  entry ~default:"true" "MASC_TELEMETRY_ENABLED" "Enable telemetry collection";
+  entry ~default:"true" "MASC_PARSE_WARN_ENABLED" "Enable JSON parse warnings";
+  entry ~default:"standard" "MASC_GOVERNANCE_LEVEL" "Governance enforcement level";
+  entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
+  entry ~default:"(none)" "MASC_AUTO_RESPOND" "Auto-respond mode";
+]
+
+let storage_entries = [
+  entry ~sensitive:true ~default:"(none)" "MASC_POSTGRES_URL" "PostgreSQL connection URL";
+  entry ~default:"4" "MASC_PG_POOL_SIZE" "PostgreSQL connection pool size";
+  entry ~default:"100" "MASC_PUBSUB_MAX_MESSAGES" "Max pubsub messages per batch";
+]
+
+let transport_entries = [
+  entry ~default:"8936" "MASC_GRPC_PORT" "gRPC server port";
+  entry ~default:"true" "MASC_GRPC_ENABLED" "Enable gRPC transport";
+  entry ~default:"(derived)" "MASC_GRPC_TARGET" "gRPC client target address";
+  entry ~default:"8937" "MASC_WS_PORT" "WebSocket server port";
+  entry ~default:"true" "MASC_WS_ENABLED" "Enable WebSocket transport";
+  entry ~default:"true" "MASC_WEBRTC_ENABLED" "Enable WebRTC transport";
+  entry ~default:"auto" "MASC_USE_H2" "HTTP mode (auto|h2_only|h1_only)";
+  entry ~default:"240" "MASC_STARTUP_WATCHDOG_SEC" "Startup watchdog timeout (seconds)";
+  entry ~default:"(none)" "MASC_AGENT_TRANSPORT" "Agent transport preference";
+  entry ~default:"false" "MASC_OPENAI_COMPAT_ENABLED" "Enable OpenAI-compatible endpoint";
+]
+
+let chain_entries = [
+  entry ~default:"3" "MASC_CHAIN_MAX_RETRIES" "Chain max retry attempts";
+  entry ~default:"5.0" "MASC_CHAIN_TIMEOUT_S" "Chain step timeout (seconds)";
+  entry ~default:"0.6" "MASC_CHAIN_DEFAULT_TEMPERATURE" "Default sampling temperature";
+  entry ~default:"(auto)" "MASC_CHAIN_MCP_URL" "MCP endpoint URL for chain";
+]
+
+let inference_entries = [
+  entry ~default:"30" "MASC_INFERENCE_TIMEOUT_S" "Inference call timeout (seconds)";
+  entry ~default:"true" "MASC_INFERENCE_CACHE_ENABLED" "Enable inference result cache";
+  entry ~default:"glm-4-plus" "MASC_GLM_DEFAULT_MODEL" "Default GLM model";
+  entry ~default:"glm-4-flash" "MASC_GLM_FLASH_MODEL" "GLM flash model";
+  entry ~default:"gemini-2.5-flash" "MASC_GEMINI_DEFAULT_MODEL" "Default Gemini model";
+  entry ~default:"claude-sonnet-4-20250514" "MASC_CLAUDE_DEFAULT_MODEL" "Default Claude model";
+  entry ~default:"gpt-4o" "MASC_OPENAI_DEFAULT_MODEL" "Default OpenAI model";
+]
+
+let keeper_entries = [
+  entry ~default:"true" "MASC_KEEPER_BOOTSTRAP_ENABLED" "Enable keeper auto-bootstrap";
+  entry ~default:"3" "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE" "Max concurrent active keepers";
+  entry ~default:"300" "MASC_KEEPER_SNAPSHOT_SEC" "Keeper keepalive snapshot interval";
+  entry ~default:"false" "MASC_KEEPER_DEBUG" "Enable keeper debug logging";
+  entry ~default:"0.10" "MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD" "Daily deliberation budget (USD)";
+  entry ~default:"(auto)" "MASC_KEEPER_SKILL_MODE" "Keeper skill selection mode";
+]
+
+let dashboard_entries = [
+  entry ~default:"false" "MASC_DASHBOARD_FIXTURES_ENABLED" "Enable dashboard test fixtures";
+  entry ~default:"(none)" "MASC_DASHBOARD_FIXTURE" "Dashboard fixture name override";
+  entry ~default:"75" "MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S" "Execution refresh timeout";
+  entry ~default:"8" "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S" "Transport health timeout";
+]
+
+(* ================================================================ *)
+(* Main JSON builder                                                 *)
+(* ================================================================ *)
+
+let server_meta () =
+  let git_commit =
+    match Sys.getenv_opt "MASC_BUILD_GIT_COMMIT" with
+    | Some c when String.trim c <> "" -> Some (String.trim c)
+    | _ -> None
+  in
+  `Assoc [
+    ("version", `String Version.version);
+    ("git_commit", match git_commit with Some c -> `String c | None -> `Null);
+    ("ocaml_version", `String Sys.ocaml_version);
+    ("uptime_seconds", `Float (Server_startup_state.elapsed_since_start ()));
+    ("pid", `Int (Unix.getpid ()));
+  ]
+
+let to_json () =
+  `Assoc [
+    ("generated_at", `String (Types.now_iso ()));
+    ("server", server_meta ());
+    ("categories", `Assoc [
+      category "server" server_entries;
+      category "storage" storage_entries;
+      category "transport" transport_entries;
+      category "chain" chain_entries;
+      category "inference" inference_entries;
+      category "keeper" keeper_entries;
+      category "dashboard" dashboard_entries;
+    ]);
+  ]

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -484,6 +484,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           let json = dashboard_shell_http_json state.Mcp_server.room_config in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/config" ->
+          let json = Env_config_introspect.to_json () in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/dashboard/room-truth" ->
           let state = get_server_state () in
           let json =

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -122,6 +122,11 @@ let add_routes ~sw ~clock router =
                     (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
                  reqd)
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/config" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Env_config_introspect.to_json () in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_room_truth_http_json ~state ~sw ~clock req in


### PR DESCRIPTION
## Summary
- `GET /api/v1/dashboard/config` endpoint (H1 + H2)
- `Env_config_introspect.to_json()` — 7 카테고리, 민감값 마스킹
- "서버 설정" section (lab > config) — 접이식 패널 + 검색

## Changes
- **lib/env_config_introspect.ml** (new) — descriptor 기반 env config JSON 직렬화
- **lib/server/server_routes_http_routes_dashboard.ml** — H1 route 추가
- **lib/server/server_h2_gateway.ml** — H2 route 추가
- **dashboard/src/components/server-config.ts** (new) — Config 컴포넌트
- **dashboard/src/api/dashboard.ts** — fetch 함수 + types
- **dashboard/src/components/lab.ts** — config section 렌더링
- **dashboard/src/config/navigation.ts** — "서버 설정" nav item

## Test plan
- [ ] `curl localhost:8935/api/v1/dashboard/config | jq` 응답 확인
- [ ] 민감값 (ADMIN_TOKEN, POSTGRES_URL) 마스킹 확인
- [ ] Dashboard lab > 서버 설정 탭에서 전체 설정 조회
- [ ] 검색 필터 동작 확인
- [ ] CI green

Closes #3365

Generated with [Claude Code](https://claude.com/claude-code)