### PR TITLE
perf(dashboard): configurable transport_health interval + reduce log noise (#3483)

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -96,7 +96,11 @@ let start ~sw ~clock ~config ~compute ~on_result =
              config.label !consecutive_failures;
          consecutive_failures := 0;
          current_interval := config.interval_s;
-         Log.Dashboard.info "%s refreshed (%.1fs)" config.label dt
+         (* Sub-second refreshes are cache hits — log at debug to reduce noise *)
+         if dt >= 1.0 then
+           Log.Dashboard.info "%s refreshed (%.1fs)" config.label dt
+         else
+           Log.Dashboard.debug "%s refreshed (%.1fs)" config.label dt
          | Error `Timeout ->
              let dt = Time_compat.now () -. t0 in
              let timeout_exn = Failure "timeout" in

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -14,7 +14,7 @@ type config = {
 
 val default_config : label:string -> interval_s:float -> config
 (** [default_config ~label ~interval_s] returns a config with
-    [max_backoff_s = 600.0], [failure_threshold = 3], [timeout_s = 10.0]. *)
+    [max_backoff_s = 120.0], [failure_threshold = 5], [timeout_s = 10.0]. *)
 
 val start :
   sw:Eio.Switch.t ->

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -457,10 +457,14 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
         mark_cached_surface_error _transport_health_cache exn;
         raise exn
   in
+  let interval_s =
+    float_of_env_default "MASC_DASHBOARD_TRANSPORT_HEALTH_INTERVAL_S"
+      ~default:30.0 ~min_v:5.0 ~max_v:120.0
+  in
   Proactive_refresh.start ~sw ~clock
     ~config:
       { (Proactive_refresh.default_config
-           ~label:"transport_health" ~interval_s:15.0)
+           ~label:"transport_health" ~interval_s)
         with timeout_s }
     ~compute
     ~on_result:(fun json ->
@@ -758,7 +762,10 @@ let dashboard_room_truth_http_json ~state ~sw:_ ~clock _request =
   let execution_json = !execution_ref in
   let command_summary_json = !command_ref in
   let parallel_ms = (Time_compat.now () -. t0) *. 1000.0 in
-  Log.Dashboard.info "room-truth fetch: %.0fms" parallel_ms;
+  if parallel_ms >= 100.0 then
+    Log.Dashboard.info "room-truth fetch: %.0fms" parallel_ms
+  else
+    Log.Dashboard.debug "room-truth fetch: %.0fms" parallel_ms;
   let execution_cache_state =
     json_assoc_field "projection_diagnostics" execution_json
     |> json_string_field_opt "cache_state"


### PR DESCRIPTION
## Summary
- transport_health refresh interval: 15s -> 30s default
- 환경변수 `MASC_DASHBOARD_TRANSPORT_HEALTH_INTERVAL_S` (5-120s)
- sub-second proactive refresh: info -> debug (cache hit noise 제거)
- sub-100ms room-truth fetch: info -> debug

## Impact
정상 운영 시 ~5,400/일 INFO 로그 -> 거의 0. 느린 fetch (>= 1s / >= 100ms)만 INFO로 남음.

## Test plan
- [ ] CI green
- [ ] 서버 시작 후 transport_health log가 debug로 출력되는지 확인
- [ ] `MASC_DASHBOARD_TRANSPORT_HEALTH_INTERVAL_S=60` 설정 시 60초 간격 확인

Closes #3483

Generated with [Claude Code](https://claude.com/claude-code)