### PR TITLE
fix(dashboard): widen refresh loop jitter to prevent cascade timeout

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -81,7 +81,7 @@ let start ~sw ~clock ~config ~compute ~on_result =
     let consecutive_failures = ref 0 in
     let current_interval = ref config.interval_s in
     let rec loop () =
-      let jitter = Random.float (min 5.0 (!current_interval *. 0.1)) in
+      let jitter = Random.float (!current_interval *. 0.25) in
       Eio.Time.sleep clock (!current_interval +. jitter);
       let t0 = Time_compat.now () in
       (try


### PR DESCRIPTION
## Summary
- Proactive refresh loop jitter: `min(5s, interval*0.1)` → `interval*0.25`
- Fix .mli doc: default_config defaults were wrong (600/3 → 120/5)

## Problem
모든 proactive refresh loop가 startup 후 ~20-25분에 동시 recompute → PG pool/CPU 경합 → cascade timeout → healthcheck SIGTERM → 재시작 무한 반복. 3회 연속 재현 확인.

**근본 원인**: jitter가 너무 작아(max 1.5s for 15s interval) 몇 사이클 후 loop들이 재동기화됨.

**추가 발견**: keeper fiber가 활성(k=1)일 때만 발생. keeper의 LLM cascade 호출이 리소스 경합을 악화시킴.

## Effect
| Loop | Before (max jitter) | After (max jitter) |
|------|--------------------|--------------------|
| transport_health (15s) | 1.5s | 3.75s |
| cp-snapshot (30s) | 3.0s | 7.5s |
| operator (45s) | 4.5s | 11.25s |
| execution (60s) | 5.0s | 15.0s |
| mission (120s) | 5.0s | 30.0s |

## Test plan
- [x] `dune build` 성공
- [ ] keeper 활성 상태에서 25분+ uptime 유지 확인
- [ ] WARN cascade 빈도 감소 확인

Closes #3485

Generated with [Claude Code](https://claude.com/claude-code)