### PR TITLE
fix(server): use configurable shutdown timeout instead of hardcoded 5s

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -322,13 +322,16 @@ let run_cmd host port base_path =
             Eio.Time.sleep clock 0.05;
             await_shutdown_signal ()
         | Some signal_name ->
+            let shutdown_cfg = Masc_mcp.Shutdown.config_from_env () in
+            let force_timeout = shutdown_cfg.force_timeout_s in
             Log.Server.info
-              "[MASC] Received %s, shutting down gracefully..."
-              signal_name;
+              "[MASC] Received %s, shutting down gracefully (timeout=%.0fs)..."
+              signal_name force_timeout;
             Eio.Fiber.fork_daemon ~sw (fun () ->
-                Eio.Time.sleep clock 5.0;
+                Eio.Time.sleep clock force_timeout;
                 Log.Server.error
-                  "[MASC] Graceful shutdown timed out after 5s, forcing exit.";
+                  "[MASC] Graceful shutdown timed out after %.0fs, forcing exit."
+                  force_timeout;
                 exit 1);
             let shutdown_data =
               Printf.sprintf


### PR DESCRIPTION
## Summary

Closes #3486.

- Replace hardcoded `sleep 5.0; exit 1` daemon in `main_eio.ml` with `Shutdown.config_from_env().force_timeout_s` (default 10s).
- `lib/shutdown.ml` already supported `MASC_SHUTDOWN_FORCE_TIMEOUT` env var but was never wired into the actual shutdown path.
- Error log now includes the configured timeout value.

**Before**: `[MASC] Graceful shutdown timed out after 5s, forcing exit.`
**After**: `[MASC] Graceful shutdown timed out after 10s, forcing exit.` (or configured value)

## Root cause

Two separate shutdown mechanisms existed:
1. `lib/shutdown.ml` — well-structured 4-phase module with configurable timeouts (never called from `main_eio.ml`)
2. `bin/main_eio.ml` — inline daemon fiber with hardcoded 5s timeout (actual production path)

This PR connects the two by reading the timeout from `Shutdown.config_from_env()`.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>