### PR TITLE
feat(dashboard): delta push — skip unchanged SSE broadcasts

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -252,19 +252,35 @@ let warm_shell_cache (state : Mcp_server.server_state) =
      Log.Dashboard.warn "shell cache pre-warm failed: %s"
        (Printexc.to_string exn))
 
+(* Delta-push: track last broadcast hash per event_type to skip unchanged payloads. *)
+let _last_broadcast_hash : (string, Digestif.SHA256.t) Hashtbl.t =
+  Hashtbl.create 8
+
 (** Broadcast a single cached surface to all Observer SSE sessions.
     [event_type] becomes the SSE event "type" field.
+    Skips broadcast when payload hash matches the previous one (delta push).
     Safe to call from any fiber — reads only from a cached ref. *)
 let broadcast_cached_surface ~event_type (json : Yojson.Safe.t) : unit =
-  let sse_json =
-    `Assoc
-      [
-        ("type", `String event_type);
-        ("payload", json);
-        ("ts_unix", `Float (Time_compat.now ()));
-      ]
+  let serialized = Yojson.Safe.to_string json in
+  let hash = Digestif.SHA256.digest_string serialized in
+  let changed =
+    match Hashtbl.find_opt _last_broadcast_hash event_type with
+    | Some prev -> not (Digestif.SHA256.equal prev hash)
+    | None -> true
   in
-  Sse.broadcast_to Observers sse_json
+  if changed then begin
+    Hashtbl.replace _last_broadcast_hash event_type hash;
+    let sse_json =
+      `Assoc
+        [
+          ("type", `String event_type);
+          ("payload", json);
+          ("ts_unix", `Float (Time_compat.now ()));
+        ]
+    in
+    Sse.broadcast_to Observers sse_json
+  end else
+    Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type
 
 (* Wire operator broadcast refs now that Sse is in scope. *)
 let () = _operator_snapshot_broadcast_ref :=


### PR DESCRIPTION
## Summary
- SHA256 hash guard in `broadcast_cached_surface` — skip SSE broadcast when payload unchanged
- All 5 proactive refresh surfaces benefit automatically (room_truth, execution, operator_snapshot, operator_digest, transport_health)
- 15 lines added to single function, zero caller changes

## How it works
1. Serialize `Yojson.Safe.t` payload to string
2. `Digestif.SHA256.digest_string` → compare with stored hash per event_type
3. Same hash → skip broadcast + debug log
4. Different hash → broadcast + update stored hash

## Expected impact
Steady-state에서 대부분의 refresh cycle은 데이터 변화 없이 전체 JSON을 push했음.
이제 변화 있을 때만 push → SSE 대역폭 대폭 감소.

Closes #3466

## Test plan
- [x] `dune build --root .` 성공
- [x] `test_dashboard.exe` 10/10 통과
- [ ] CI Build and Test
- [ ] 실제 dashboard에서 SSE event 빈도 감소 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>