### PR TITLE
[codex] fix dashboard PG hot path timeouts

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -156,9 +156,17 @@ let create_pubsub_table_q =
      created_at TIMESTAMP DEFAULT NOW() \
    )"
 
-let create_index_q =
+let create_expires_index_q =
   (Caqti_type.unit ->. Caqti_type.unit)
   "CREATE INDEX IF NOT EXISTS idx_masc_kv_expires ON masc_kv(expires_at)"
+
+let create_updated_at_index_q =
+  (Caqti_type.unit ->. Caqti_type.unit)
+  "CREATE INDEX IF NOT EXISTS idx_masc_kv_updated_at_desc ON masc_kv(updated_at DESC)"
+
+let create_key_prefix_index_q =
+  (Caqti_type.unit ->. Caqti_type.unit)
+  "CREATE INDEX IF NOT EXISTS idx_masc_kv_key_prefix ON masc_kv(key text_pattern_ops)"
 
 let create_pubsub_index_q =
   (Caqti_type.unit ->. Caqti_type.unit)
@@ -249,7 +257,9 @@ let create ~sw ~env ~url ~cluster_name ~node_id =
         ];
         (* Phase 2: create indexes in parallel (tables must exist) *)
         Eio.Fiber.all [
-          exec_ddl create_index_q;
+          exec_ddl create_expires_index_q;
+          exec_ddl create_updated_at_index_q;
+          exec_ddl create_key_prefix_index_q;
           exec_ddl create_pubsub_index_q;
           exec_ddl create_pubsub_created_at_index_q;
         ];

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -26,6 +26,10 @@ let int_of_env_default name ~default ~min_v ~max_v =
   in
   max min_v (min max_v v)
 
+let dashboard_session_list_limit () =
+  int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
+    ~default:200 ~min_v:20 ~max_v:1000
+
 let float_of_env_default name ~default ~min_v ~max_v =
   let v =
     match Sys.getenv_opt name with

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -37,6 +37,10 @@ type attention_context = Dashboard_mission_assembly.attention_context = {
   json : Yojson.Safe.t;
 }
 
+let dashboard_session_list_limit =
+  Dashboard_http_helpers.int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
+    ~default:200 ~min_v:20 ~max_v:1000
+
 let active_or_recent_sessions config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
   let cutoff_iso = iso_of_unix cutoff_unix in
@@ -45,7 +49,8 @@ let active_or_recent_sessions config =
     | Running | Paused -> true
     | _ -> session.updated_at_iso >= cutoff_iso
   in
-  Team_session_store.list_sessions ~since_unix:cutoff_unix config
+  Team_session_store.list_sessions ~since_unix:cutoff_unix
+    ~limit:dashboard_session_list_limit config
   |> List.filter is_active_or_recent
 
 let room_scope_cache_segment (config : Room_utils.config) =

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -37,10 +37,6 @@ type attention_context = Dashboard_mission_assembly.attention_context = {
   json : Yojson.Safe.t;
 }
 
-let dashboard_session_list_limit =
-  Dashboard_http_helpers.int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
-    ~default:200 ~min_v:20 ~max_v:1000
-
 let active_or_recent_sessions config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
   let cutoff_iso = iso_of_unix cutoff_unix in
@@ -50,7 +46,7 @@ let active_or_recent_sessions config =
     | _ -> session.updated_at_iso >= cutoff_iso
   in
   Team_session_store.list_sessions ~since_unix:cutoff_unix
-    ~limit:dashboard_session_list_limit config
+    ~limit:(Dashboard_http_helpers.dashboard_session_list_limit ()) config
   |> List.filter is_active_or_recent
 
 let room_scope_cache_segment (config : Room_utils.config) =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -68,18 +68,19 @@ let dashboard_session_list_timeout_s =
 let dashboard_active_or_recent_sessions ~clock config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
   let cutoff_iso = Dashboard_utils.iso_of_unix cutoff_unix in
+  let limit = dashboard_session_list_limit () in
   let sessions =
     match
       Eio.Time.with_timeout clock dashboard_session_list_timeout_s (fun () ->
           Ok
             (Team_session_store.list_sessions ~since_unix:cutoff_unix
-               ~limit:(dashboard_session_list_limit ()) config))
+               ~limit config))
     with
     | Ok rows -> rows
     | Error `Timeout ->
         Log.Dashboard.warn
           "dashboard session list timed out after %.0fs (limit=%d); serving without session rows"
-          dashboard_session_list_timeout_s (dashboard_session_list_limit ());
+          dashboard_session_list_timeout_s limit;
         []
   in
   sessions

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -65,19 +65,25 @@ let dashboard_session_list_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
     ~default:5.0 ~min_v:1.0 ~max_v:30.0
 
+let dashboard_session_list_limit =
+  int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
+    ~default:200 ~min_v:20 ~max_v:1000
+
 let dashboard_active_or_recent_sessions ~clock config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
   let cutoff_iso = Dashboard_utils.iso_of_unix cutoff_unix in
   let sessions =
     match
       Eio.Time.with_timeout clock dashboard_session_list_timeout_s (fun () ->
-          Ok (Team_session_store.list_sessions ~since_unix:cutoff_unix config))
+          Ok
+            (Team_session_store.list_sessions ~since_unix:cutoff_unix
+               ~limit:dashboard_session_list_limit config))
     with
     | Ok rows -> rows
     | Error `Timeout ->
         Log.Dashboard.warn
-          "dashboard session list timed out after %.0fs; serving without session rows"
-          dashboard_session_list_timeout_s;
+          "dashboard session list timed out after %.0fs (limit=%d); serving without session rows"
+          dashboard_session_list_timeout_s dashboard_session_list_limit;
         []
   in
   sessions

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -65,10 +65,6 @@ let dashboard_session_list_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
     ~default:5.0 ~min_v:1.0 ~max_v:30.0
 
-let dashboard_session_list_limit =
-  int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
-    ~default:200 ~min_v:20 ~max_v:1000
-
 let dashboard_active_or_recent_sessions ~clock config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
   let cutoff_iso = Dashboard_utils.iso_of_unix cutoff_unix in
@@ -77,13 +73,13 @@ let dashboard_active_or_recent_sessions ~clock config =
       Eio.Time.with_timeout clock dashboard_session_list_timeout_s (fun () ->
           Ok
             (Team_session_store.list_sessions ~since_unix:cutoff_unix
-               ~limit:dashboard_session_list_limit config))
+               ~limit:(dashboard_session_list_limit ()) config))
     with
     | Ok rows -> rows
     | Error `Timeout ->
         Log.Dashboard.warn
           "dashboard session list timed out after %.0fs (limit=%d); serving without session rows"
-          dashboard_session_list_timeout_s dashboard_session_list_limit;
+          dashboard_session_list_timeout_s (dashboard_session_list_limit ());
         []
   in
   sessions


### PR DESCRIPTION
## What changed

- add `masc_kv` indexes for recent dashboard reads on `updated_at` and key prefix scans
- cap dashboard recent-session scans with `MASC_DASHBOARD_SESSION_LIST_LIMIT` for mission and operator hydration paths
- keep the existing execution behavior while aligning mission/operator warm-cache reads to the same bounded session loading pattern

## Why it changed

Dashboard rich projections were timing out on the PG-backed `masc_kv` read path. The hot query pattern uses recent lookups with key prefix filters and `updated_at` ordering, but the schema only indexed `expires_at`. Mission/operator refresh loops also used uncapped recent session scans, so cold-cache hydration could fan out into slow PG reads before any cached surface was established.

## Impact

- reduces the amount of work required for dashboard recent-session hydration on PG-backed rooms
- gives PostgreSQL a better plan for `get_all_matching_recent` callers used by dashboard session/message reads
- lowers the chance that mission/operator/execution warm-cache loops stall in `initializing`

## Root cause

`Team_session_store.list_sessions ~since_unix` and recent-message readers rely on `Backend.Postgres.get_all_matching_recent`, but `masc_kv` only had an `expires_at` index. Rich dashboard surfaces were therefore issuing broad recent scans and ordering on unindexed columns, which can exceed the 45-75s refresh timeouts under load.

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3513-dashboard-pg-hotpath test/test_dashboard_http_core.exe test/test_dashboard_mission.exe test/test_backend.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3513-dashboard-pg-hotpath test/test_dashboard_http_core.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3513-dashboard-pg-hotpath test/test_dashboard_mission.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/3513-dashboard-pg-hotpath test/test_backend.exe`
