### PR TITLE
fix(dashboard): compute profiling + PG pool idle age reduction

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -219,7 +219,7 @@ let create ~sw ~env ~url ~cluster_name ~node_id =
   let max_pool = configured_pool_size () in
   let pool_config = Caqti_pool_config.create
       ~max_size:max_pool ~max_idle_size:(min max_pool 3)
-      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 30_000_000_000L))
+      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 15_000_000_000L))
       ~max_use_count:(Some 50) () in
   let uri = uri_with_keepalive uri in
   Log.Backend.info "[EioPG] connecting pool (max_size=%d, max_idle_size=%d, keepalives=on)..."
@@ -270,7 +270,10 @@ let create_readonly ~sw ~env ~url ~cluster_name ~node_id =
      usage" when multiple Eio fibers within the same executor domain
      call Pool.use concurrently. Use 2/3 of the main pool size, minimum 4. *)
   let max_pool = max 4 (configured_pool_size () * 2 / 3) in
-  let pool_config = Caqti_pool_config.create ~max_size:max_pool () in
+  let pool_config = Caqti_pool_config.create ~max_size:max_pool
+      ~max_idle_size:(min max_pool 2)
+      ~max_idle_age:(Some (Mtime.Span.of_uint64_ns 15_000_000_000L))
+      ~max_use_count:(Some 50) () in
   let uri = uri_with_keepalive uri in
   match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
   | Error err -> Error (caqti_error_to_masc err)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -342,12 +342,14 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
     try
       run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config
         (fun ~config ~sw ->
+          let t_sessions = Unix.gettimeofday () in
           let sessions =
             if Room.is_initialized config then
               dashboard_active_or_recent_sessions_cached ~clock config
             else
               []
           in
+          let dt_sessions = Unix.gettimeofday () -. t_sessions in
           let ctx : _ Operator_control.context =
             {
               config;
@@ -358,11 +360,21 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
               mcp_session_id = None;
             }
           in
-          Operator_control.snapshot_json ~actor:"dashboard" ~view:"summary"
-            ~include_messages:true ~include_sessions:true ~include_keepers:true
-            ~include_summary_fields:false
-            ~lightweight_summary:true
-            ~include_command_plane:false ~sessions ctx
+          let t_snapshot = Unix.gettimeofday () in
+          let json =
+            Operator_control.snapshot_json ~actor:"dashboard" ~view:"summary"
+              ~include_messages:true ~include_sessions:true ~include_keepers:true
+              ~include_summary_fields:false
+              ~lightweight_summary:true
+              ~include_command_plane:false ~sessions ctx
+          in
+          let dt_snapshot = Unix.gettimeofday () -. t_snapshot in
+          let dt_total = Unix.gettimeofday () -. started_at in
+          if dt_total >= 5.0 then
+            Log.Dashboard.warn
+              "[operator_snapshot profile] total=%.1fs sessions=%.1fs(%d) snapshot=%.1fs"
+              dt_total dt_sessions (List.length sessions) dt_snapshot;
+          json
           |> with_projection_diagnostics ~surface:"operator_snapshot" ~started_at
                ~extra:(operator_snapshot_extra sessions))
     with
@@ -639,14 +651,25 @@ let start_mission_refresh_loop ~state ~sw ~clock =
   in
   let compute () =
     mark_cached_surface_attempt _mission_cache;
+    let t0_mission = Unix.gettimeofday () in
     try
+      let t_cp = Unix.gettimeofday () in
       let command_plane_summary, swarm_status =
         command_plane_summary_cache_parts ~allow_initializing:false ~state
       in
-      run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config:room_config
-        (fun ~config ~sw ->
-          Dashboard_mission.json ?command_plane_summary ?swarm_status ~config ~sw
-            ~clock ~proc_mgr ())
+      let dt_cp = Unix.gettimeofday () -. t_cp in
+      let result =
+        run_dashboard_compute ~mode:Offloaded_readonly ~sw ~clock ~config:room_config
+          (fun ~config ~sw ->
+            Dashboard_mission.json ?command_plane_summary ?swarm_status ~config ~sw
+              ~clock ~proc_mgr ())
+      in
+      let dt_total = Unix.gettimeofday () -. t0_mission in
+      if dt_total >= 5.0 then
+        Log.Dashboard.warn
+          "[mission profile] total=%.1fs cp_summary=%.1fs compute=%.1fs"
+          dt_total dt_cp (dt_total -. dt_cp);
+      result
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->


### PR DESCRIPTION
## Summary
- operator_snapshot/mission compute에 구간별 타이밍 로그 추가 (5s+ 시 WARN)
- Caqti pool `max_idle_age` 30s → 15s (stale connection 조기 폐기)
- readonly pool에 `max_idle_age`, `max_idle_size`, `max_use_count` 추가 (기존 미설정)

## Motivation
Supabase PgBouncer(ap-south-1) 연결 불안정으로 ~15-25분 후 모든 proactive refresh loop가 cascade timeout. 프로파일링으로 병목 식별 + idle age 단축으로 stale connection window 축소.

상세 분석: #3485

## Test plan
- [ ] `dune build` 성공
- [ ] 배포 후 `[operator_snapshot profile]` `[mission profile]` 로그 출현 확인
- [ ] 15분+ uptime 유지 확인
- [ ] PG connection 재생성 빈도 모니터링 (약간 증가 예상)

Refs #3485

Generated with [Claude Code](https://claude.com/claude-code)