### PR TITLE
feat(keeper): wire gRPC client for keeper heartbeat (P1)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -19,11 +19,14 @@ let bus_ref : Agent_sdk.Event_bus.t option ref = ref None
 let set_bus bus = bus_ref := Some bus
 let get_bus () = !bus_ref
 
-(** Optional gRPC client — set at server bootstrap when
-    [MASC_AGENT_TRANSPORT=grpc]. When set, heartbeat also sends
-    pings over the gRPC bidirectional stream. *)
+(** Optional gRPC client + env — set at server bootstrap when
+    [MASC_AGENT_TRANSPORT=grpc]. When set, heartbeat sends
+    status pings over gRPC unary RPC. *)
 let grpc_client_ref : Masc_grpc_client.t option ref = ref None
-let set_grpc_client c = grpc_client_ref := Some c
+let grpc_env_ref : Eio_unix.Stdenv.base option ref = ref None
+let set_grpc_client ?(env : Eio_unix.Stdenv.base option) c =
+  grpc_client_ref := Some c;
+  grpc_env_ref := env
 
 (** Sleep in short chunks so [stop_keepalive] or [wakeup_keeper] takes
     effect within ~2 s instead of waiting for the full 30-300 s interval. *)
@@ -512,30 +515,33 @@ let run_grpc_heartbeat_fiber ~sw ~stop
     ~(grpc_client : Masc_grpc_client.t)
     ~(agent_name : string) ~(session_id : string)
     ~(interval_sec : float) ~(clock : _ Eio.Time.clock) =
-  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+  match Eio_context.get_switch_opt (), !grpc_env_ref with
   | None, _ | _, None ->
-    Log.Keeper.warn "gRPC heartbeat: Eio context not available";
+    Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
     None
-  | Some grpc_sw, Some _net ->
-  (* Use periodic unary gRPC calls instead of a bidi stream, since the
-     bidi stream requires Eio_unix.Stdenv.base which is not stored
-     globally. The server processes individual heartbeats. *)
-  ignore grpc_sw;
-  ignore grpc_client;
+  | Some grpc_sw, Some env ->
+  (* Periodic unary gRPC get_status as heartbeat signal.
+     Bidi streaming deferred to P2 (requires env threading). *)
+  ignore session_id;
   let close_ref = ref false in
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       if Atomic.get stop || !close_ref then ()
       else (
         (try
-          Log.Keeper.info "grpc heartbeat tick: agent=%s session=%s"
-            agent_name session_id;
           let no_wakeup = Atomic.make false in
-          interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec
+          interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
+          if not (Atomic.get stop || !close_ref) then
+            match Masc_grpc_client.get_status grpc_client ~sw:grpc_sw ~env with
+            | Ok status ->
+                Log.Keeper.debug "gRPC heartbeat: agent=%s agents=%d tasks=%d"
+                  agent_name (List.length status.agents) (List.length status.tasks)
+            | Error err ->
+                Log.Keeper.warn "gRPC heartbeat failed: %s" err
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
-          Log.Keeper.error "grpc heartbeat tick failed: %s"
+          Log.Keeper.error "gRPC heartbeat tick error: %s"
             (Printexc.to_string exn));
         if not (Atomic.get stop) then loop ())
     in

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -8,8 +8,8 @@ val get_bus : unit -> Agent_sdk.Event_bus.t option
 
 (** Inject a gRPC client for heartbeat streaming.
     When set and [MASC_AGENT_TRANSPORT=grpc], keepalive will also
-    send heartbeat pings over the gRPC bidirectional stream. *)
-val set_grpc_client : Masc_grpc_client.t -> unit
+    send heartbeat pings over gRPC unary RPC. *)
+val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -367,6 +367,17 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       Masc_grpc_server.start ~sw ~env ~room_config:state.room_config
         ~tool_dispatcher;
+      (* Initialize gRPC client for keeper heartbeat when transport is gRPC *)
+      (match Masc_grpc_transport.from_env () with
+       | Masc_grpc_transport.Grpc ->
+           (try
+              let client = Masc_grpc_client.create_from_env ~sw ~env in
+              Keeper_keepalive.set_grpc_client ~env client;
+              Log.Server.info "gRPC keeper client initialized"
+            with exn ->
+              Log.Server.warn "gRPC keeper client init failed: %s"
+                (Printexc.to_string exn))
+       | _ -> ());
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)
       Server_ws_standalone.start ~sw ~env
         ~on_message:(fun ws_session_id body_str ->


### PR DESCRIPTION
## Summary

Phase 1 of #2880 (keeper gRPC/WS transport).

Wire the gRPC client to keeper heartbeat fiber. Previously `set_grpc_client` was never called and the heartbeat fiber was a placeholder that only logged messages.

**What changed:**
- `server_runtime_bootstrap.ml`: Initialize `Masc_grpc_client.create_from_env` after gRPC server starts, call `set_grpc_client` with env reference
- `keeper_keepalive.ml`: Replace placeholder with actual `get_status` unary RPC call as heartbeat signal
- `keeper_keepalive.mli`: Add `?env` parameter to `set_grpc_client`

**Activation:** Set `MASC_AGENT_TRANSPORT=grpc` to enable. Default behavior unchanged.

**Deferred (P2/P3):**
- P2: Bidirectional heartbeat streaming
- P3: Task assignment via gRPC directives

## Test plan
- [x] `dune build` passes
- [ ] CI green
- [ ] Manual: `MASC_AGENT_TRANSPORT=grpc` → observe debug logs "gRPC heartbeat: agent=... agents=N tasks=N"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>