### PR TITLE
fix(backend): PG connection retry wrapper + proactive refresh health gate

### DIFF
--- a/lib/backend/backend_pg.ml
+++ b/lib/backend/backend_pg.ml
@@ -284,6 +284,30 @@ let close _t = ()
 
 let get_pool t = t.pool
 
+(* Retry wrapper for read-only Pool.use calls.
+   On first connection-level failure, drain the pool to purge stale
+   connections (Supabase PgBouncer drops them after idle periods),
+   then retry once with a fresh connection. *)
+let _drain_mutex = Eio.Mutex.create ()
+
+let is_connection_error err =
+  let msg = Caqti_error.show err in
+  let has s = try ignore (Str.search_forward (Str.regexp_string s) msg 0); true
+    with Not_found -> false in
+  has "connection" || has "socket" || has "broken pipe" ||
+  has "Connection reset" || has "server closed" || has "Operation timed out"
+
+let use_with_retry pool f =
+  match Caqti_eio.Pool.use f pool with
+  | Ok _ as ok -> ok
+  | Error err when is_connection_error err ->
+    Log.Backend.warn "[EioPG] stale connection detected, draining pool and retrying: %s"
+      (Caqti_error.show err);
+    Eio.Mutex.use_rw ~protect:false _drain_mutex (fun () ->
+      try Caqti_eio.Pool.drain pool with _ -> ());
+    Caqti_eio.Pool.use f pool
+  | Error _ as err -> err
+
 let decompress_with_context ~key content =
   let had_header = String.length content >= 4 && String.sub content 0 4 = "ZSTD" in
   let decompressed = _decompress content in
@@ -293,10 +317,10 @@ let decompress_with_context ~key content =
 
 let get t key =
   let nkey = namespaced_key t.namespace key in
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find_opt get_q nkey
-  ) t.pool with
+  ) with
   | Ok (Some v) -> Ok (decompress_with_context ~key:nkey v)
   | Ok None -> Error (NotFound key)
   | Error err -> Error (caqti_error_to_masc err)
@@ -347,10 +371,10 @@ let list_keys t ~prefix =
 
 let get_all t ~prefix =
   let nprefix = namespaced_key t.namespace prefix in
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.collect_list get_all_q (nprefix ^ "%")
-  ) t.pool with
+  ) with
   | Ok pairs ->
       Ok (List.map (fun (k, v) ->
         (strip_namespace t.namespace k, decompress_with_context ~key:k v)
@@ -362,11 +386,11 @@ let get_all_matching_recent t ~prefix ~suffix ~updated_since ~limit =
     Ok []
   else
     let nprefix = namespaced_key t.namespace prefix in
-    match Caqti_eio.Pool.use (fun conn ->
+    match use_with_retry t.pool (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in
       C.collect_list get_all_matching_recent_q
         (nprefix ^ "%", "%" ^ suffix, updated_since, limit)
-    ) t.pool with
+    ) with
     | Ok pairs ->
         Ok (List.map (fun (k, v) ->
           (strip_namespace t.namespace k, decompress_with_context ~key:k v)
@@ -465,10 +489,10 @@ let subscribe t ~channel ~callback =
   | Error err -> Error (caqti_error_to_masc err)
 
 let health_check t =
-  match Caqti_eio.Pool.use (fun conn ->
+  match use_with_retry t.pool (fun conn ->
     let module C = (val conn : Caqti_eio.CONNECTION) in
     C.find health_check_q ()
-  ) t.pool with
+  ) with
   | Ok 1 -> Ok { latency_ms = 0.0; is_healthy = true }
   | _ -> Ok { latency_ms = 0.0; is_healthy = false }
 

--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -12,6 +12,7 @@ type config = {
   failure_threshold : int;
   timeout_s : float;
   on_error : (exn -> unit) option;
+  health_check : (unit -> bool) option;
 }
 
 let default_config ~label ~interval_s =
@@ -22,6 +23,7 @@ let default_config ~label ~interval_s =
     failure_threshold = 5;
     timeout_s = 10.0;
     on_error = None;
+    health_check = None;
   }
 
 let is_internal_race_cancel exn =
@@ -83,6 +85,19 @@ let start ~sw ~clock ~config ~compute ~on_result =
     let rec loop () =
       let jitter = Random.float (!current_interval *. 0.25) in
       Eio.Time.sleep clock (!current_interval +. jitter);
+      let health_ok = match config.health_check with
+        | None -> true
+        | Some check -> (try check () with _ -> false)
+      in
+      if not health_ok then begin
+        incr consecutive_failures;
+        if !consecutive_failures >= config.failure_threshold then
+          current_interval :=
+            min config.max_backoff_s (!current_interval *. 2.0);
+        Log.Dashboard.warn
+          "%s skipped: health gate failed (%d consecutive, next in %.0fs)"
+          config.label !consecutive_failures !current_interval
+      end else
       let t0 = Time_compat.now () in
       (try
          match

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -10,6 +10,7 @@ type config = {
   failure_threshold : int;  (** Consecutive failures before backoff kicks in. *)
   timeout_s : float;        (** Warm-cache timeout. *)
   on_error : (exn -> unit) option;  (** Called on timeout or exception. *)
+  health_check : (unit -> bool) option;  (** Pre-compute gate. If [Some f] and [f ()] returns [false], the cycle is skipped and backoff applied. *)
 }
 
 val default_config : label:string -> interval_s:float -> config


### PR DESCRIPTION
## Summary
- `use_with_retry`: 읽기 전용 PG 연산에서 connection error 시 pool drain + 1회 retry
- `health_check` config: proactive refresh loop에서 compute 전 PG 상태 gate

## Problem
Supabase PgBouncer(ap-south-1) idle connection drop → stale connection → compute hang → cascade timeout. PG는 후순위 backend인데 PG 장애가 서버를 죽이는 구조.

## Changes
- `backend_pg.ml`: `use_with_retry` (drain + retry on connection error), `Eio.Mutex` 보호
- `proactive_refresh.ml/mli`: `health_check : (unit -> bool) option` 필드

## Test plan
- [x] `dune build` 성공
- [ ] PG stale 시 `[EioPG] stale connection detected` 로그
- [ ] health gate skip 시 `skipped: health gate failed` 로그

Refs #3485

Generated with [Claude Code](https://claude.com/claude-code)