### PR TITLE
fix(server): stage cold-start warm cache to prevent timeout cascade

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -13,6 +13,7 @@ type config = {
   timeout_s : float;
   on_error : (exn -> unit) option;
   health_check : (unit -> bool) option;
+  warm_delay_s : float;
 }
 
 let default_config ~label ~interval_s =
@@ -24,6 +25,7 @@ let default_config ~label ~interval_s =
     timeout_s = 10.0;
     on_error = None;
     health_check = None;
+    warm_delay_s = 0.0;
   }
 
 let is_internal_race_cancel exn =
@@ -56,6 +58,10 @@ let notify_error config exn =
 
 let start ~sw ~clock ~config ~compute ~on_result =
   Eio.Fiber.fork ~sw (fun () ->
+    if config.warm_delay_s > 0.0 then begin
+      Log.Dashboard.debug "%s warm cache delayed %.0fs" config.label config.warm_delay_s;
+      Eio.Time.sleep clock config.warm_delay_s
+    end;
     let t0 = Time_compat.now () in
     (try
        match

--- a/lib/server/proactive_refresh.mli
+++ b/lib/server/proactive_refresh.mli
@@ -11,6 +11,7 @@ type config = {
   timeout_s : float;        (** Warm-cache timeout. *)
   on_error : (exn -> unit) option;  (** Called on timeout or exception. *)
   health_check : (unit -> bool) option;  (** Pre-compute gate. If [Some f] and [f ()] returns [false], the cycle is skipped and backoff applied. *)
+  warm_delay_s : float;    (** Delay before cold-start warm-cache compute (0.0 = immediate). *)
 }
 
 val default_config : label:string -> interval_s:float -> config

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -121,7 +121,11 @@ let start_cp_snapshot_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"cp-snapshot"
                  ~interval_s:_cp_snapshot_refresh_interval_s)
-              with timeout_s = 30.0 }
+              with timeout_s = 30.0;
+                   warm_delay_s =
+                     Dashboard_http_helpers.float_of_env_default
+                       "MASC_WARM_DELAY_CP_SNAPSHOT_S"
+                       ~default:60.0 ~min_v:0.0 ~max_v:300.0 }
     ~compute:(fun () -> compute_cp_snapshot ~state)
     ~on_result:(fun snapshot -> _cp_snapshot_ref := snapshot)
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -450,7 +450,8 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
   in
   Proactive_refresh.start ~sw ~clock
     ~config:{ (Proactive_refresh.default_config ~label:"execution" ~interval_s:60.0)
-              with timeout_s = execution_refresh_timeout_s }
+              with timeout_s = execution_refresh_timeout_s;
+                   warm_delay_s = 0.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _execution_cache json;
@@ -481,7 +482,8 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
     ~config:
       { (Proactive_refresh.default_config
            ~label:"transport_health" ~interval_s)
-        with timeout_s }
+        with timeout_s;
+             warm_delay_s = 0.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _transport_health_cache json;

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -390,7 +390,11 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
               with timeout_s =
                      float_of_env_default
                        "MASC_DASHBOARD_OPERATOR_SNAPSHOT_TIMEOUT_S"
-                       ~default:45.0 ~min_v:10.0 ~max_v:120.0 }
+                       ~default:45.0 ~min_v:10.0 ~max_v:120.0;
+                   warm_delay_s =
+                     float_of_env_default
+                       "MASC_WARM_DELAY_OPERATOR_SNAPSHOT_S"
+                       ~default:120.0 ~min_v:0.0 ~max_v:300.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _operator_snapshot_cache json;
@@ -445,7 +449,11 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
               with timeout_s =
                      float_of_env_default
                        "MASC_DASHBOARD_OPERATOR_DIGEST_TIMEOUT_S"
-                       ~default:45.0 ~min_v:10.0 ~max_v:120.0 }
+                       ~default:45.0 ~min_v:10.0 ~max_v:120.0;
+                   warm_delay_s =
+                     float_of_env_default
+                       "MASC_WARM_DELAY_OPERATOR_DIGEST_S"
+                       ~default:150.0 ~min_v:0.0 ~max_v:300.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _operator_digest_cache json;
@@ -678,7 +686,11 @@ let start_mission_refresh_loop ~state ~sw ~clock =
   in
   Proactive_refresh.start ~sw ~clock
     ~config:{ (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0)
-              with timeout_s = mission_refresh_timeout_s }
+              with timeout_s = mission_refresh_timeout_s;
+                   warm_delay_s =
+                     float_of_env_default
+                       "MASC_WARM_DELAY_MISSION_S"
+                       ~default:90.0 ~min_v:0.0 ~max_v:300.0 }
     ~compute
     ~on_result:(mark_cached_surface_success _mission_cache)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -416,23 +416,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         Server_webrtc_transport.set_connection_starter
           (fun peer_id ->
             Server_webrtc_transport.start_webrtc_connection ~sw ~env peer_id));
-      (* Stagger PG-heavy refresh loop warm-cache runs at startup.
-         Each Proactive_refresh.start forks a fiber that immediately calls
-         compute(), so starting all 7 loops at once creates 7+ concurrent PG
-         queries — exceeding pool capacity on Supabase session pooler.
-         A short sleep between PG-heavy launches spreads the initial burst. *)
+      (* Cold-start warm-cache stagger is handled by warm_delay_s in each
+         Proactive_refresh config. Heavy surfaces delay their initial warm
+         compute to avoid concurrent CPU/PG contention.  Lightweight surfaces
+         (cp-summary, execution, transport_health) start immediately. *)
       Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 2.0;
       Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
-      (* transport_health is light (no PG), start immediately. *)
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
-      Eio.Time.sleep clock 2.0;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
       (* Pre-warm shell cache in a separate fiber so it cannot block
          keeper loop startup or lazy tasks (#keeper-bootstrap-stuck). *)


### PR DESCRIPTION
## Summary
- 서버 cold start 시 7개 proactive refresh loop의 warm cache가 동시 실행되어 CPU/PG 경합 → 전부 타임아웃 → execution API hang → 대시보드 키퍼 카드 미표시
- `Proactive_refresh.config`에 `warm_delay_s` 필드를 추가하여 heavy surface의 warm cache를 순차 실행
- execution(0s) → cp-snapshot(60s) → mission(90s) → operator_snapshot(120s) → operator_digest(150s)
- 기존 bootstrap의 비효율적인 2초 sleep stagger 제거 (fork된 fiber는 어차피 동시 실행됨)

## Changes
| File | Change |
|------|--------|
| `proactive_refresh.ml/mli` | `warm_delay_s` 필드 추가, warm fiber에서 delay sleep |
| `server_runtime_bootstrap.ml` | 2초 sleep 5개 제거, 코멘트 업데이트 |
| `server_dashboard_http.ml` | execution/transport_health: delay 0 |
| `server_dashboard_http_core.ml` | mission:90s, op_snapshot:120s, op_digest:150s |
| `server_command_plane_http_support.ml` | cp-snapshot: 60s |

## Test plan
- [x] `dune build @check` 타입 체크 통과
- [ ] 서버 재시작 후 로그에서 warm cache 순차 실행 확인
- [ ] `curl` execution API 응답에 keepers 배열 포함 확인
- [ ] 대시보드에서 키퍼 카드 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)