### PR TITLE
[codex] Rebuild harness live surface

### DIFF
--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -116,12 +116,18 @@ describe('Autoresearch surface refresh', () => {
   it('reloads selected detail when the surface refreshes', async () => {
     const loopA1 = loopSummary('loop-a111', { current_cycle: 1 })
     const loopA2 = loopSummary('loop-a111', { current_cycle: 2, best_score: 0.8 })
-    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
-      .mockResolvedValueOnce({ loops: [loopA1], total: 1 })
-      .mockResolvedValueOnce({ loops: [loopA2], total: 1 })
-    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
-      .mockResolvedValueOnce(loopDetail(loopA1, { history: [cycleRecord(0)], history_count: 1 }))
-      .mockResolvedValueOnce(loopDetail(loopA2, { history: [cycleRecord(0), cycleRecord(1)], history_count: 2 }))
+    let loopFetchCount = 0
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
+      loopFetchCount += 1
+      return loopFetchCount >= 2
+        ? { loops: [loopA2], total: 1 }
+        : { loops: [loopA1], total: 1 }
+    })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async () =>
+      loopFetchCount >= 2
+        ? loopDetail(loopA2, { history: [cycleRecord(0), cycleRecord(1)], history_count: 2 })
+        : loopDetail(loopA1, { history: [cycleRecord(0)], history_count: 1 }),
+    )
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
       fetchAutoresearchLoops: fetchLoops,
@@ -154,13 +160,18 @@ describe('Autoresearch surface refresh', () => {
   it('preserves the current selection when that loop still exists after refresh', async () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })
     const loopB = loopSummary('loop-b222', { target_file: 'target-b.ml', current_cycle: 3 })
-    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
-      .mockResolvedValueOnce({ loops: [loopA, loopB], total: 2 })
-      .mockResolvedValueOnce({ loops: [loopA, { ...loopB, best_score: 0.9 }], total: 2 })
-    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
-      .mockResolvedValueOnce(loopDetail(loopA))
-      .mockResolvedValueOnce(loopDetail(loopB))
-      .mockResolvedValueOnce(loopDetail({ ...loopB, best_score: 0.9 }))
+    const refreshedLoopB = { ...loopB, best_score: 0.9 }
+    let loopFetchCount = 0
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
+      loopFetchCount += 1
+      return loopFetchCount >= 2
+        ? { loops: [loopA, refreshedLoopB], total: 2 }
+        : { loops: [loopA, loopB], total: 2 }
+    })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async loopId => {
+      if (loopId === 'loop-a111') return loopDetail(loopA)
+      return loopFetchCount >= 2 ? loopDetail(refreshedLoopB) : loopDetail(loopB)
+    })
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
       fetchAutoresearchLoops: fetchLoops,
@@ -189,13 +200,18 @@ describe('Autoresearch surface refresh', () => {
   it('reselects the first loop when the previous selection disappears on refresh', async () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })
     const loopB = loopSummary('loop-b222', { target_file: 'target-b.ml' })
-    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>()
-      .mockResolvedValueOnce({ loops: [loopA, loopB], total: 2 })
-      .mockResolvedValueOnce({ loops: [loopA], total: 1 })
-    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>()
-      .mockResolvedValueOnce(loopDetail(loopA))
-      .mockResolvedValueOnce(loopDetail(loopB))
-      .mockResolvedValueOnce(loopDetail(loopA, { best_score: 0.95 }))
+    const refreshedLoopA = loopDetail(loopA, { best_score: 0.95 })
+    let loopFetchCount = 0
+    const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
+      loopFetchCount += 1
+      return loopFetchCount >= 2
+        ? { loops: [loopA], total: 1 }
+        : { loops: [loopA, loopB], total: 2 }
+    })
+    const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async loopId => {
+      if (loopId === 'loop-b222') return loopDetail(loopB)
+      return loopFetchCount >= 2 ? refreshedLoopA : loopDetail(loopA)
+    })
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
       fetchAutoresearchLoops: fetchLoops,

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -132,6 +132,8 @@ describe('Autoresearch surface refresh', () => {
     await refreshAutoresearchSurface()
     await flushUi()
 
+    expect(container.textContent).toContain('Experiment Outcomes')
+    expect(container.textContent).toContain('하네스 열기')
     expect(container.textContent).toContain('Research Brief')
     expect(container.textContent).toContain('이 화면은 generator loop 자체를 설명합니다.')
     expect(container.textContent).toContain('1 / 5')
@@ -147,7 +149,7 @@ describe('Autoresearch surface refresh', () => {
       .toBeGreaterThanOrEqual(2)
     expect(container.textContent).toContain('2 / 5')
     expect(container.textContent).toContain('사이클 이력 (2건)')
-  })
+  }, 10000)
 
   it('preserves the current selection when that loop still exists after refresh', async () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -116,18 +116,14 @@ describe('Autoresearch surface refresh', () => {
   it('reloads selected detail when the surface refreshes', async () => {
     const loopA1 = loopSummary('loop-a111', { current_cycle: 1 })
     const loopA2 = loopSummary('loop-a111', { current_cycle: 2, best_score: 0.8 })
-    let loopFetchCount = 0
     const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
-      loopFetchCount += 1
-      return loopFetchCount >= 2
-        ? { loops: [loopA2], total: 1 }
-        : { loops: [loopA1], total: 1 }
+      return { loops: [loopA2], total: 1 }
     })
+      .mockResolvedValueOnce({ loops: [loopA1], total: 1 })
     const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async () =>
-      loopFetchCount >= 2
-        ? loopDetail(loopA2, { history: [cycleRecord(0), cycleRecord(1)], history_count: 2 })
-        : loopDetail(loopA1, { history: [cycleRecord(0)], history_count: 1 }),
+      loopDetail(loopA2, { history: [cycleRecord(0), cycleRecord(1)], history_count: 2 }),
     )
+      .mockResolvedValueOnce(loopDetail(loopA1, { history: [cycleRecord(0)], history_count: 1 }))
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
       fetchAutoresearchLoops: fetchLoops,
@@ -161,16 +157,15 @@ describe('Autoresearch surface refresh', () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })
     const loopB = loopSummary('loop-b222', { target_file: 'target-b.ml', current_cycle: 3 })
     const refreshedLoopB = { ...loopB, best_score: 0.9 }
-    let loopFetchCount = 0
     const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
-      loopFetchCount += 1
-      return loopFetchCount >= 2
-        ? { loops: [loopA, refreshedLoopB], total: 2 }
-        : { loops: [loopA, loopB], total: 2 }
+      return { loops: [loopA, refreshedLoopB], total: 2 }
     })
+      .mockResolvedValueOnce({ loops: [loopA, loopB], total: 2 })
+    let loopBDetailCalls = 0
     const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async loopId => {
       if (loopId === 'loop-a111') return loopDetail(loopA)
-      return loopFetchCount >= 2 ? loopDetail(refreshedLoopB) : loopDetail(loopB)
+      loopBDetailCalls += 1
+      return loopBDetailCalls >= 2 ? loopDetail(refreshedLoopB) : loopDetail(loopB)
     })
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({
@@ -201,16 +196,15 @@ describe('Autoresearch surface refresh', () => {
     const loopA = loopSummary('loop-a111', { target_file: 'target-a.ml' })
     const loopB = loopSummary('loop-b222', { target_file: 'target-b.ml' })
     const refreshedLoopA = loopDetail(loopA, { best_score: 0.95 })
-    let loopFetchCount = 0
     const fetchLoops = vi.fn<() => Promise<AutoresearchLoopsResponse>>(async () => {
-      loopFetchCount += 1
-      return loopFetchCount >= 2
-        ? { loops: [loopA], total: 1 }
-        : { loops: [loopA, loopB], total: 2 }
+      return { loops: [loopA], total: 1 }
     })
+      .mockResolvedValueOnce({ loops: [loopA, loopB], total: 2 })
+    let loopADetailCalls = 0
     const fetchDetail = vi.fn<(loopId: string) => Promise<AutoresearchLoopDetail>>(async loopId => {
       if (loopId === 'loop-b222') return loopDetail(loopB)
-      return loopFetchCount >= 2 ? refreshedLoopA : loopDetail(loopA)
+      loopADetailCalls += 1
+      return loopADetailCalls >= 2 ? refreshedLoopA : loopDetail(loopA)
     })
 
     const { Autoresearch, refreshAutoresearchSurface } = await loadComponentWithApi({

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -7,6 +7,7 @@ import { useEffect } from 'preact/hooks'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { formatElapsedCompact } from '../lib/format-time'
+import { navigate } from '../router'
 import {
   deleteAutoresearchLoop,
   fetchAutoresearchLoops,
@@ -412,6 +413,35 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
   `
 }
 
+function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
+  return html`
+    <${SurfaceCard} variant="compact">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.3fr_1fr]">
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Experiment Outcomes</div>
+          <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">이 화면은 keep/discard 루프를 봅니다.</div>
+          <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
+            어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] p-3">
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Safety Harness</div>
+          <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
+          <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
+            evaluator fallback, pre-compaction pressure, continuity DNA quality는 하네스에서 봅니다.
+          </div>
+          <button
+            type="button"
+            class="mt-3 rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+            onClick=${() => navigate('lab', { section: 'harness' })}
+          >하네스 열기</button>
+        </div>
+      </div>
+    <//>
+  `
+}
+
 // --- Detail view ---
 
 function LoopDetailView() {
@@ -534,6 +564,8 @@ export function Autoresearch() {
 
   return html`
     <div class="flex flex-col gap-5">
+      <${OutcomeVsHarnessCallout} loopCount=${loops.length} />
+
       <div class="flex items-center justify-between">
         <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] font-medium">
           전체 ${loops.length}개 루프

--- a/dashboard/src/components/harness-health.test.ts
+++ b/dashboard/src/components/harness-health.test.ts
@@ -1,6 +1,90 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function sampleResponse() {
+  return {
+    generated_at: 1711440000,
+    scope_note: 'Autoresearch는 generator loop, Harness는 safety rail을 설명합니다.',
+    overview: {
+      evaluator_status: 'warning',
+      pre_compact_status: 'healthy',
+      dna_status: 'stale',
+      last_signal_at: 1711440300,
+      evaluator_last_event_at: 1711440300,
+      pre_compact_last_event_at: 1711440000,
+      dna_last_event_at: 1711430000,
+      fallback_ratio: 0.83,
+      latest_pre_compact_ratio: 0.91,
+      latest_dna_score: 0.82,
+    },
+    calibration: {
+      total_verdicts: 12,
+      approve_count: 9,
+      reject_count: 3,
+      gate_distribution: { fallback: 7, judge: 5 },
+      labeled_count: 4,
+      false_positive_count: 1,
+      false_negative_count: 0,
+      agreement_rate: 0.75,
+      fallback_count: 10,
+      recent_fallback_reasons: ['judge timeout'],
+    },
+    recent_verdicts: [
+      {
+        timestamp: 1711440000,
+        task_id: 'task-1',
+        task_title: 'Review task notes',
+        agent_name: 'judge',
+        gate: 'llm',
+        verdict: 'approve',
+        evaluator_cascade: 'verifier',
+        fallback_reason: null,
+      },
+    ],
+    pre_compact: {
+      description: 'Pre-compaction signal',
+      status: 'healthy',
+      last_event_at: 1711440000,
+      empty_reason: null,
+      total_recent: 1,
+      recent_events: [
+        {
+          timestamp: 1711440000,
+          keeper_name: 'keeper-a',
+          context_ratio: 0.91,
+          message_count: 88,
+          token_count: 32000,
+          strategies: ['PruneToolOutputs'],
+          model_family: 'verifier',
+          trigger: 'ratio(0.91>=0.85)',
+        },
+      ],
+    },
+    dna_quality: {
+      description: 'DNA signal',
+      status: 'stale',
+      last_event_at: 1711430000,
+      empty_reason: null,
+      total_recent: 1,
+      recent_events: [
+        {
+          timestamp: 1711440000,
+          keeper_name: 'keeper-a',
+          score: 0.82,
+          dimensions: {
+            has_goal_anchor: true,
+            has_task_anchor: true,
+            has_recent_context: true,
+            truncation_artifacts: 0,
+            content_length: 420,
+          },
+        },
+      ],
+    },
+  }
+}
 
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
@@ -12,6 +96,7 @@ async function flushUi(): Promise<void> {
 async function loadComponentWithApi(api: {
   get: (path: string) => Promise<unknown>
   lastEvent: { value: unknown }
+  navigate?: (tab: string, params?: Record<string, string>) => void
 }) {
   vi.resetModules()
   vi.doMock('../api/core', () => ({
@@ -19,6 +104,9 @@ async function loadComponentWithApi(api: {
   }))
   vi.doMock('../sse', () => ({
     lastEvent: api.lastEvent,
+  }))
+  vi.doMock('../router', () => ({
+    navigate: api.navigate ?? vi.fn(),
   }))
   return import('./harness-health')
 }
@@ -34,88 +122,21 @@ describe('HarnessHealth', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    vi.useRealTimers()
     vi.resetModules()
     vi.clearAllMocks()
     vi.doUnmock('../api/core')
     vi.doUnmock('../sse')
+    vi.doUnmock('../router')
   })
 
-  it('uses shared theme tokens instead of hardcoded slate palette classes', async () => {
+  it('renders the live harness hierarchy with shared theme tokens', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>()
-      .mockResolvedValue({
-        generated_at: 1711440000,
-        scope_note: 'Autoresearch는 generator loop, Harness는 safety rail을 설명합니다.',
-        calibration: {
-          total_verdicts: 12,
-          approve_count: 9,
-          reject_count: 3,
-          gate_distribution: { fallback: 7, judge: 5 },
-          labeled_count: 4,
-          false_positive_count: 1,
-          false_negative_count: 0,
-          agreement_rate: 0.75,
-          fallback_count: 2,
-          recent_fallback_reasons: [],
-        },
-        recent_verdicts: [
-          {
-            timestamp: 1711440000,
-            task_id: 'task-1',
-            task_title: 'Review task notes',
-            agent_name: 'judge',
-            gate: 'llm',
-            verdict: 'approve',
-            evaluator_cascade: 'verifier',
-            fallback_reason: null,
-          },
-        ],
-        pre_compact: {
-          description: 'Pre-compaction signal',
-          total_recent: 1,
-          recent_events: [
-            {
-              timestamp: 1711440000,
-              keeper_name: 'keeper-a',
-              context_ratio: 0.91,
-              message_count: 88,
-              token_count: 32000,
-              strategies: ['PruneToolOutputs'],
-              model_family: 'verifier',
-              trigger: 'ratio(0.91>=0.85)',
-            },
-          ],
-        },
-        dna_quality: {
-          description: 'DNA signal',
-          total_recent: 1,
-          recent_events: [
-            {
-              timestamp: 1711440000,
-              keeper_name: 'keeper-a',
-              score: 0.82,
-              dimensions: {
-                has_goal_anchor: true,
-                has_task_anchor: true,
-                has_recent_context: true,
-                truncation_artifacts: 0,
-                content_length: 420,
-              },
-            },
-          ],
-        },
-      })
+      .mockResolvedValue(sampleResponse())
 
     const { HarnessHealth } = await loadComponentWithApi({
       get,
-      lastEvent: {
-        value: {
-          type: 'oas:masc:harness:verdict_recorded',
-          payload: {
-            gate: 'judge',
-            verdict: 'approve',
-          },
-        },
-      },
+      lastEvent: { value: null },
     })
 
     render(html`<${HarnessHealth} />`, container)
@@ -123,20 +144,58 @@ describe('HarnessHealth', () => {
 
     expect(get).toHaveBeenCalledWith('/api/v1/dashboard/harness-health')
     expect(container.textContent).toContain('Safety Harness')
-    expect(container.textContent).toContain('Evaluator Calibration')
-    expect(container.textContent).toContain('Pre-Compaction Rail')
-    expect(container.textContent).toContain('DNA Quality Rail')
-    expect(container.textContent).toContain('Autoresearch는 generator loop')
+    expect(container.textContent).toContain('Can I Trust The Experiment Machinery?')
+    expect(container.textContent).toContain('Judge of the Judge')
+    expect(container.textContent).toContain('Continuity Pressure')
+    expect(container.textContent).toContain('Continuity DNA')
+    expect(container.textContent).toContain('오토리서치 열기')
+    expect(container.textContent).toContain('Fallback 비율')
+    expect(container.textContent).toContain('judge timeout')
 
     const markup = container.innerHTML
     expect(markup).toContain('text-[var(--accent)]')
-    expect(markup).toContain('bg-[var(--ok)]')
+    expect(markup).toContain('bg-[var(--ok-12)]')
     expect(markup).not.toContain('bg-slate-800')
     expect(markup).not.toContain('bg-slate-700')
     expect(markup).not.toContain('text-slate-400')
     expect(markup).not.toContain('text-slate-500')
-    expect(markup).not.toContain('text-amber-400')
-    expect(markup).not.toContain('bg-green-500')
-    expect(markup).not.toContain('bg-red-500')
+  })
+
+  it('debounces a full reload after a harness SSE event', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>()
+      .mockResolvedValue(sampleResponse())
+    const lastEvent = signal<unknown>(null)
+
+    const { HarnessHealth } = await loadComponentWithApi({
+      get,
+      lastEvent,
+    })
+
+    render(html`<${HarnessHealth} />`, container)
+    await flushUi()
+    expect(get).toHaveBeenCalledTimes(1)
+
+    lastEvent.value = {
+      type: 'oas:masc:harness:verdict_recorded',
+      payload: {
+        timestamp: 1711440600,
+        task_id: 'task-2',
+        task_title: 'transition-done',
+        agent_name: 'codex',
+        gate: 'fallback',
+        verdict: 'reject:vague notes',
+        evaluator_cascade: 'cross_verifier',
+        fallback_reason: 'judge timeout',
+      },
+    }
+    await flushUi()
+
+    expect(container.textContent).toContain('transition-done')
+    expect(get).toHaveBeenCalledTimes(1)
+
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    await flushUi()
+
+    expect(get).toHaveBeenCalledTimes(2)
   })
 })

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -5,7 +5,11 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { lastEvent } from '../sse'
-import { Card } from './common/card'
+import { navigate } from '../router'
+import { formatTimeAgo } from '../lib/format-time'
+import { Card, SurfaceCard } from './common/card'
+
+type RailStatus = 'healthy' | 'warning' | 'stale' | 'idle'
 
 interface GateDistribution {
   [gate: string]: number
@@ -22,6 +26,19 @@ interface CalibrationStats {
   agreement_rate: number
   fallback_count?: number
   recent_fallback_reasons?: string[]
+}
+
+interface HarnessOverview {
+  evaluator_status: RailStatus
+  pre_compact_status: RailStatus
+  dna_status: RailStatus
+  last_signal_at: number | null
+  evaluator_last_event_at: number | null
+  pre_compact_last_event_at: number | null
+  dna_last_event_at: number | null
+  fallback_ratio: number
+  latest_pre_compact_ratio: number | null
+  latest_dna_score: number | null
 }
 
 interface HarnessVerdictItem {
@@ -65,33 +82,66 @@ interface HarnessSignalSection<T> {
   description: string
   recent_events: T[]
   total_recent: number
+  status: RailStatus
+  last_event_at: number | null
+  empty_reason?: string | null
 }
 
 interface HarnessHealthData {
   generated_at: number
   scope_note: string
+  overview: HarnessOverview
   calibration: CalibrationStats
   recent_verdicts: HarnessVerdictItem[]
   pre_compact: HarnessSignalSection<PreCompactEvent>
   dna_quality: HarnessSignalSection<DnaQualityEvent>
 }
 
+const HARNESS_RELOAD_DEBOUNCE_MS = 700
+
 const harnessData = signal<HarnessHealthData | null>(null)
 const harnessLoading = signal(false)
 const harnessError = signal<string | null>(null)
 
+let harnessRequest: Promise<void> | null = null
+let reloadTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearHarnessReloadTimer(): void {
+  if (reloadTimer) {
+    clearTimeout(reloadTimer)
+    reloadTimer = null
+  }
+}
+
+function scheduleHarnessReload(): void {
+  clearHarnessReloadTimer()
+  reloadTimer = setTimeout(() => {
+    void loadHarnessHealth()
+  }, HARNESS_RELOAD_DEBOUNCE_MS)
+}
+
 async function loadHarnessHealth(): Promise<void> {
-  if (harnessLoading.value) return
+  if (harnessRequest) return harnessRequest
+
   harnessLoading.value = true
   harnessError.value = null
-  try {
-    const data = await get<HarnessHealthData>('/api/v1/dashboard/harness-health')
-    harnessData.value = data
-  } catch (e) {
-    harnessError.value = e instanceof Error ? e.message : String(e)
-  } finally {
-    harnessLoading.value = false
-  }
+  harnessRequest = (async () => {
+    try {
+      const data = await get<HarnessHealthData>('/api/v1/dashboard/harness-health')
+      harnessData.value = data
+    } catch (e) {
+      harnessError.value = e instanceof Error ? e.message : String(e)
+    } finally {
+      harnessLoading.value = false
+      harnessRequest = null
+    }
+  })()
+
+  return harnessRequest
+}
+
+export async function refreshHarnessSurface(): Promise<void> {
+  await loadHarnessHealth()
 }
 
 function mergeRecent<T>(
@@ -110,6 +160,139 @@ function updateHarnessData(
   const current = harnessData.value
   if (!current) return
   harnessData.value = update(current)
+}
+
+function statusLabel(status: RailStatus): string {
+  switch (status) {
+    case 'healthy':
+      return '정상'
+    case 'warning':
+      return '주의'
+    case 'stale':
+      return '오래됨'
+    case 'idle':
+    default:
+      return '대기'
+  }
+}
+
+function statusChipClass(status: RailStatus): string {
+  switch (status) {
+    case 'healthy':
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)] text-[var(--ok)]'
+    case 'warning':
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)] text-[var(--warn)]'
+    case 'stale':
+      return 'border-[var(--white-12)] bg-[var(--white-4)] text-[var(--text-muted)]'
+    case 'idle':
+    default:
+      return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
+  }
+}
+
+function statusCardClass(status: RailStatus): string {
+  switch (status) {
+    case 'healthy':
+      return 'border-[var(--ok-30)] bg-[var(--ok-12)]'
+    case 'warning':
+      return 'border-[var(--warn-30)] bg-[var(--warn-12)]'
+    case 'stale':
+      return 'border-[var(--white-12)] bg-[var(--white-4)]'
+    case 'idle':
+    default:
+      return 'border-[var(--white-8)] bg-[var(--white-4)]'
+  }
+}
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts * 1000).toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function freshnessLabel(ts: number | null | undefined, fallback = '기록 없음'): string {
+  if (ts == null) return fallback
+  return formatTimeAgo(ts)
+}
+
+function emptyReasonText(reason?: string | null): string {
+  switch (reason) {
+    case 'window_empty':
+      return '선택된 범위에는 신호가 없습니다.'
+    case 'no_recent_events':
+      return '기록은 있지만 최근 신호가 없습니다.'
+    case 'no_runtime_activity':
+    default:
+      return '아직 이 rail을 통과한 실행이 없습니다.'
+  }
+}
+
+function verdictTone(verdict: string): string {
+  return verdict.startsWith('approve')
+    ? 'bg-[var(--ok)]'
+    : 'bg-[var(--bad)]'
+}
+
+function verdictSummary(verdict: string): string {
+  if (!verdict.startsWith('reject:')) return verdict
+  return verdict.slice('reject:'.length).trim() || 'reject'
+}
+
+function heroTitle(data: HarnessHealthData): string {
+  const statuses = [
+    data.overview.evaluator_status,
+    data.overview.pre_compact_status,
+    data.overview.dna_status,
+  ]
+  if (statuses.includes('warning')) return '실험 기계에 주의가 필요합니다.'
+  if (statuses.includes('stale')) return '신호는 있지만 최신성이 떨어집니다.'
+  if (statuses.every(status => status === 'idle')) return '아직 안전 rail 기록이 없습니다.'
+  return '실험 기계는 현재 안정적입니다.'
+}
+
+function heroBody(data: HarnessHealthData): string {
+  if (data.overview.evaluator_status === 'warning') {
+    const ratio = Math.round((data.overview.fallback_ratio ?? 0) * 100)
+    return `Evaluator fallback 비중이 ${ratio}%라 verdict를 그대로 신뢰하기 어렵습니다.`
+  }
+  if (data.overview.dna_status === 'warning') {
+    return 'Continuity DNA 품질이 낮아 handoff/mitosis 전 점검이 필요합니다.'
+  }
+  if (data.overview.pre_compact_status === 'warning') {
+    return 'Compaction 직전 컨텍스트 압력이 높아 keeper continuity가 흔들릴 수 있습니다.'
+  }
+  if (data.overview.last_signal_at == null) {
+    return 'Autoresearch는 cycle outcome을 보고, Harness는 evaluator와 continuity rail의 건강도를 봅니다.'
+  }
+  return `마지막 안전 신호는 ${freshnessLabel(data.overview.last_signal_at)}에 들어왔습니다.`
+}
+
+function railDetail(data: HarnessHealthData, rail: 'evaluator' | 'pre_compact' | 'dna'): string {
+  if (rail === 'evaluator') {
+    if (data.calibration.total_verdicts === 0) return 'verdict 기록 없음'
+    return `${data.calibration.total_verdicts} verdict`
+  }
+  if (rail === 'pre_compact') {
+    if (data.overview.latest_pre_compact_ratio == null) return '최근 compaction 없음'
+    return `ratio ${data.overview.latest_pre_compact_ratio.toFixed(2)}`
+  }
+  if (data.overview.latest_dna_score == null) return '최근 DNA 검사 없음'
+  return `score ${data.overview.latest_dna_score.toFixed(2)}`
+}
+
+function railFreshness(data: HarnessHealthData, rail: 'evaluator' | 'pre_compact' | 'dna'): string {
+  switch (rail) {
+    case 'evaluator':
+      return freshnessLabel(data.overview.evaluator_last_event_at, '기록 없음')
+    case 'pre_compact':
+      return freshnessLabel(data.overview.pre_compact_last_event_at, '기록 없음')
+    case 'dna':
+    default:
+      return freshnessLabel(data.overview.dna_last_event_at, '기록 없음')
+  }
 }
 
 function handleHarnessSSE(): void {
@@ -145,7 +328,13 @@ function handleHarnessSSE(): void {
           && left.verdict === right.verdict,
         8,
       ),
+      overview: {
+        ...data.overview,
+        last_signal_at: nextItem.timestamp,
+        evaluator_last_event_at: nextItem.timestamp,
+      },
     }))
+    scheduleHarnessReload()
   }
 
   if (type === 'oas:masc:harness:pre_compact') {
@@ -177,8 +366,18 @@ function handleHarnessSSE(): void {
             && left.trigger === right.trigger,
           8,
         ),
+        total_recent: data.pre_compact.total_recent + 1,
+        last_event_at: nextItem.timestamp,
+        empty_reason: null,
+      },
+      overview: {
+        ...data.overview,
+        last_signal_at: nextItem.timestamp,
+        pre_compact_last_event_at: nextItem.timestamp,
+        latest_pre_compact_ratio: nextItem.context_ratio,
       },
     }))
+    scheduleHarnessReload()
   }
 
   if (type === 'oas:masc:harness:dna_quality') {
@@ -207,9 +406,27 @@ function handleHarnessSSE(): void {
             && left.score === right.score,
           8,
         ),
+        total_recent: data.dna_quality.total_recent + 1,
+        last_event_at: nextItem.timestamp,
+        empty_reason: null,
+      },
+      overview: {
+        ...data.overview,
+        last_signal_at: nextItem.timestamp,
+        dna_last_event_at: nextItem.timestamp,
+        latest_dna_score: nextItem.score,
       },
     }))
+    scheduleHarnessReload()
   }
+}
+
+function StatusPill({ status }: { status: RailStatus }) {
+  return html`
+    <span class=${`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusChipClass(status)}`}>
+      ${statusLabel(status)}
+    </span>
+  `
 }
 
 function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
@@ -254,24 +471,87 @@ function GateChart({ distribution }: { distribution: GateDistribution }) {
   `
 }
 
-function formatTimestamp(ts: number): string {
-  return new Date(ts * 1000).toLocaleString('ko-KR', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+function HeroRailCard({
+  label,
+  status,
+  detail,
+  freshness,
+}: {
+  label: string
+  status: RailStatus
+  detail: string
+  freshness: string
+}) {
+  return html`
+    <div class=${`rounded-xl border p-3 ${statusCardClass(status)}`}>
+      <div class="flex items-start justify-between gap-3">
+        <div class="text-sm font-medium text-[var(--text-strong)]">${label}</div>
+        <${StatusPill} status=${status} />
+      </div>
+      <div class="mt-3 text-lg font-semibold text-[var(--text-body)]">${detail}</div>
+      <div class="mt-1 text-xs text-[var(--text-dim)]">최근 신호 ${freshness}</div>
+    </div>
+  `
 }
 
-function verdictTone(verdict: string): string {
-  return verdict.startsWith('approve')
-    ? 'bg-[var(--ok)]'
-    : 'bg-[var(--bad)]'
+function ScopePairing() {
+  return html`
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <${SurfaceCard} variant="compact">
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Generator Loop</div>
+              <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">Autoresearch가 답하는 것</div>
+            </div>
+            <button
+              type="button"
+              class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+              onClick=${() => navigate('lab', { section: 'autoresearch' })}
+            >오토리서치 열기</button>
+          </div>
+          <div class="text-sm leading-[1.6] text-[var(--text-body)]">
+            어떤 파일을 어떻게 바꿔 어떤 metric을 밀어 올리려는지, 그리고 cycle별 keep/discard가 어땠는지 봅니다.
+          </div>
+        </div>
+      <//>
+
+      <${SurfaceCard} variant="compact">
+        <div class="flex flex-col gap-2">
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Safety Rails</div>
+          <div class="text-sm font-medium text-[var(--text-strong)]">Harness가 답하는 것</div>
+          <div class="text-sm leading-[1.6] text-[var(--text-body)]">
+            evaluator가 건강한지, 장기 keeper turn에서 compaction이 어떻게 걸리는지, continuity DNA가 안전한지 봅니다.
+          </div>
+        </div>
+      <//>
+    </div>
+  `
 }
 
-function verdictSummary(verdict: string): string {
-  if (!verdict.startsWith('reject:')) return verdict
-  return verdict.slice('reject:'.length).trim() || 'reject'
+function RailHeader({
+  title,
+  description,
+  status,
+  lastEventAt,
+}: {
+  title: string
+  description: string
+  status: RailStatus
+  lastEventAt: number | null
+}) {
+  return html`
+    <div class="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+      <div>
+        <div class="flex items-center gap-2">
+          <div class="text-sm font-medium text-[var(--text-strong)]">${title}</div>
+          <${StatusPill} status=${status} />
+        </div>
+        <div class="mt-1 text-sm leading-[1.6] text-[var(--text-muted)]">${description}</div>
+      </div>
+      <div class="text-xs text-[var(--text-dim)]">최근 신호 ${freshnessLabel(lastEventAt)}</div>
+    </div>
+  `
 }
 
 function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
@@ -304,7 +584,7 @@ function RecentVerdictsList({ items }: { items: HarnessVerdictItem[] }) {
 
 function PreCompactList({ section }: { section: HarnessSignalSection<PreCompactEvent> }) {
   if (section.recent_events.length === 0) {
-    return html`<${EmptySignal} text="최근 pre-compaction 신호가 없습니다." />`
+    return html`<${EmptySignal} text=${emptyReasonText(section.empty_reason)} />`
   }
 
   return html`
@@ -337,7 +617,7 @@ function PreCompactList({ section }: { section: HarnessSignalSection<PreCompactE
 
 function DnaQualityList({ section }: { section: HarnessSignalSection<DnaQualityEvent> }) {
   if (section.recent_events.length === 0) {
-    return html`<${EmptySignal} text="최근 DNA quality 신호가 없습니다." />`
+    return html`<${EmptySignal} text=${emptyReasonText(section.empty_reason)} />`
   }
 
   return html`
@@ -373,7 +653,12 @@ function DnaQualityList({ section }: { section: HarnessSignalSection<DnaQualityE
 }
 
 export function HarnessHealth() {
-  useEffect(() => { void loadHarnessHealth() }, [])
+  useEffect(() => {
+    void loadHarnessHealth()
+    return () => {
+      clearHarnessReloadTimer()
+    }
+  }, [])
   useEffect(handleHarnessSSE, [lastEvent.value])
 
   const data = harnessData.value
@@ -383,105 +668,196 @@ export function HarnessHealth() {
     : '0'
   const agreementPct = cal ? (cal.agreement_rate * 100).toFixed(1) : '-'
   const fallbackCount = cal?.fallback_count ?? 0
-  const isFallbackDominant = cal != null && cal.total_verdicts > 0
-    && (fallbackCount / cal.total_verdicts) > 0.8
+  const fallbackPct = data ? Math.round((data.overview.fallback_ratio ?? 0) * 100) : 0
   const fallbackReasons = cal?.recent_fallback_reasons ?? []
 
   return html`
     <div class="space-y-4">
       <${Card} title="Safety Harness" class="section">
-        ${harnessLoading.value ? html`
+        ${harnessLoading.value && !data ? html`
           <div class="text-sm text-[var(--text-dim)]">로딩 중...</div>
-        ` : harnessError.value ? html`
+        ` : harnessError.value && !data ? html`
           <div class="text-sm text-[var(--bad)]">${harnessError.value}</div>
         ` : !data ? html`
           <${EmptySignal} text="Harness 데이터가 없습니다." />
         ` : html`
-          <div class="space-y-3">
-            <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-[1.6] text-[var(--text-body)]">
+          <div class="space-y-4">
+            <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-4)] p-4">
+              <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div class="max-w-3xl">
+                  <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-muted)]">Can I Trust The Experiment Machinery?</div>
+                  <div class="mt-2 text-2xl font-semibold text-[var(--text-strong)]">${heroTitle(data)}</div>
+                  <div class="mt-2 text-sm leading-[1.7] text-[var(--text-body)]">${heroBody(data)}</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--accent)] hover:text-[var(--text-body)]"
+                    onClick=${() => { void loadHarnessHealth() }}
+                  >새로고침</button>
+                  <button
+                    type="button"
+                    class="rounded border border-[var(--white-8)] px-2.5 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:border-[var(--ok-30)] hover:text-[var(--text-body)]"
+                    onClick=${() => navigate('lab', { section: 'autoresearch' })}
+                  >오토리서치 보기</button>
+                </div>
+              </div>
+
+              <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+                <${HeroRailCard}
+                  label="Evaluator"
+                  status=${data.overview.evaluator_status}
+                  detail=${railDetail(data, 'evaluator')}
+                  freshness=${railFreshness(data, 'evaluator')}
+                />
+                <${HeroRailCard}
+                  label="Pre-Compaction"
+                  status=${data.overview.pre_compact_status}
+                  detail=${railDetail(data, 'pre_compact')}
+                  freshness=${railFreshness(data, 'pre_compact')}
+                />
+                <${HeroRailCard}
+                  label="DNA Quality"
+                  status=${data.overview.dna_status}
+                  detail=${railDetail(data, 'dna')}
+                  freshness=${railFreshness(data, 'dna')}
+                />
+              </div>
+
+              <div class="mt-4 text-xs text-[var(--text-dim)]">
+                generated ${formatTimestamp(data.generated_at)} · 마지막 안전 신호 ${freshnessLabel(data.overview.last_signal_at)}
+              </div>
+            </div>
+
+            <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] px-4 py-3 text-sm leading-[1.7] text-[var(--text-body)]">
               ${data.scope_note}
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
-              <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-                <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Autoresearch가 답하는 것</div>
-                <div class="text-[var(--text-body)] leading-relaxed">
-                  어떤 파일을 어떻게 바꿔서 어떤 metric을 개선하려는지, 그리고 cycle별 keep/discard가 어땠는지.
-                </div>
-              </div>
-              <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-4)] p-3">
-                <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Harness가 답하는 것</div>
-                <div class="text-[var(--text-body)] leading-relaxed">
-                  evaluator가 건강한지, 장기 keeper turn에서 compaction이 어떻게 걸리는지, continuity DNA가 얼마나 안전한지.
-                </div>
-              </div>
-            </div>
-            <div class="text-xs text-[var(--text-dim)]">
-              generated ${formatTimestamp(data.generated_at)}
-            </div>
+
+            <${ScopePairing} />
           </div>
         `}
       <//>
 
       <${Card} title="Evaluator Calibration" class="section">
-        ${!cal ? html`
+        ${!data || !cal ? html`
           <${EmptySignal} text="Evaluator calibration 데이터가 없습니다." />
         ` : html`
-          ${isFallbackDominant ? html`
-            <div class="mb-4 rounded-lg border border-[var(--warn-30)] bg-[var(--warn-12)] px-4 py-3">
-              <div class="mb-1 text-sm font-medium text-[var(--warn)]">Evaluator 미연결</div>
-              <div class="text-xs text-[var(--warn)]">
-                전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됐습니다.
-                지금은 LLM evaluator가 자주 빠져서 calibration 신뢰도가 낮습니다.
-              </div>
-              ${fallbackReasons.length > 0 ? html`
-                <details class="mt-2">
-                  <summary class="cursor-pointer text-xs text-[var(--warn)] opacity-70">최근 에러 (${fallbackReasons.length}건)</summary>
-                  <div class="mt-1 space-y-1">
-                    ${fallbackReasons.map(reason => html`
-                      <div class="break-all font-mono text-xs text-[var(--warn)] opacity-70">${reason}</div>
-                    `)}
-                  </div>
-                </details>
-              ` : null}
-            </div>
-          ` : null}
-
-          <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-            <${StatCard} label="총 Verdict" value=${cal.total_verdicts} />
-            <${StatCard} label="Reject 비율" value="${rejectRate}%" />
-            <${StatCard} label="인간 라벨" value=${cal.labeled_count} />
-            <${StatCard}
-              label="일치율"
-              value="${agreementPct}%"
-              sub="FP:${cal.false_positive_count} FN:${cal.false_negative_count}"
+          <div class="space-y-4">
+            <${RailHeader}
+              title="Judge of the Judge"
+              description="실험 cycle 자체가 아니라, verdict 기계가 얼마나 건강하게 작동하는지 봅니다."
+              status=${data.overview.evaluator_status}
+              lastEventAt=${data.overview.evaluator_last_event_at}
             />
+
+            ${fallbackPct > 80 ? html`
+              <div class="rounded-lg border border-[var(--warn-30)] bg-[var(--warn-12)] px-4 py-3">
+                <div class="mb-1 text-sm font-medium text-[var(--warn)]">Evaluator 미연결</div>
+                <div class="text-xs text-[var(--warn)]">
+                  전체 ${cal.total_verdicts}건 중 ${fallbackCount}건이 fallback으로 처리됐습니다.
+                  지금은 LLM evaluator보다 fallback gate가 더 많이 작동합니다.
+                </div>
+                ${fallbackReasons.length > 0 ? html`
+                  <details class="mt-2">
+                    <summary class="cursor-pointer text-xs text-[var(--warn)] opacity-70">최근 에러 (${fallbackReasons.length}건)</summary>
+                    <div class="mt-1 space-y-1">
+                      ${fallbackReasons.map(reason => html`
+                        <div class="break-all font-mono text-xs text-[var(--warn)] opacity-70">${reason}</div>
+                      `)}
+                    </div>
+                  </details>
+                ` : null}
+              </div>
+            ` : null}
+
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <${StatCard} label="총 Verdict" value=${cal.total_verdicts} />
+              <${StatCard} label="Reject 비율" value="${rejectRate}%" />
+              <${StatCard} label="Fallback 비율" value="${fallbackPct}%" />
+              <${StatCard}
+                label="일치율"
+                value="${agreementPct}%"
+                sub="FP:${cal.false_positive_count} FN:${cal.false_negative_count}"
+              />
+            </div>
+
+            <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] p-3 text-xs leading-[1.6] text-[var(--text-muted)]">
+              인간 라벨 ${cal.labeled_count}건이 calibration ground truth입니다. 값이 0이면 runtime health는 볼 수 있어도 evaluator accuracy는 아직 검증되지 않았습니다.
+            </div>
+
+            <div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">Gate 분포</div>
+              <${GateChart} distribution=${cal.gate_distribution} />
+            </div>
+
+            <div>
+              <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 Verdict</div>
+              <${RecentVerdictsList} items=${data.recent_verdicts} />
+            </div>
           </div>
-
-          <div class="mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">Gate 분포</div>
-          <${GateChart} distribution=${cal.gate_distribution} />
-
-          <div class="mt-4 mb-2 text-xs uppercase tracking-wider text-[var(--text-dim)]">최근 Verdict</div>
-          <${RecentVerdictsList} items=${data?.recent_verdicts ?? []} />
-
-          <button
-            class="mt-3 text-xs text-[var(--text-muted)] transition-colors hover:text-[var(--accent)]"
-            onClick=${() => void loadHarnessHealth()}
-          >새로고침</button>
         `}
       <//>
 
       <${Card} title="Pre-Compaction Rail" class="section">
-        ${data ? html`
-          <div class="mb-3 text-sm leading-[1.6] text-[var(--text-muted)]">${data.pre_compact.description}</div>
-          <${PreCompactList} section=${data.pre_compact} />
-        ` : html`<${EmptySignal} text="Pre-compaction 데이터가 없습니다." />`}
+        ${!data ? html`
+          <${EmptySignal} text="Pre-compaction 데이터가 없습니다." />
+        ` : html`
+          <div class="space-y-4">
+            <${RailHeader}
+              title="Continuity Pressure"
+              description=${data.pre_compact.description}
+              status=${data.pre_compact.status}
+              lastEventAt=${data.pre_compact.last_event_at}
+            />
+            <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <${StatCard}
+                label="최근 ratio"
+                value=${data.overview.latest_pre_compact_ratio != null ? data.overview.latest_pre_compact_ratio.toFixed(2) : '-'}
+                sub=${`최근 ${data.pre_compact.total_recent}건`}
+              />
+              <${StatCard}
+                label="최근 freshness"
+                value=${freshnessLabel(data.pre_compact.last_event_at)}
+              />
+              <${StatCard}
+                label="status"
+                value=${statusLabel(data.pre_compact.status)}
+              />
+            </div>
+            <${PreCompactList} section=${data.pre_compact} />
+          </div>
+        `}
       <//>
 
       <${Card} title="DNA Quality Rail" class="section">
-        ${data ? html`
-          <div class="mb-3 text-sm leading-[1.6] text-[var(--text-muted)]">${data.dna_quality.description}</div>
-          <${DnaQualityList} section=${data.dna_quality} />
-        ` : html`<${EmptySignal} text="DNA quality 데이터가 없습니다." />`}
+        ${!data ? html`
+          <${EmptySignal} text="DNA quality 데이터가 없습니다." />
+        ` : html`
+          <div class="space-y-4">
+            <${RailHeader}
+              title="Continuity DNA"
+              description=${data.dna_quality.description}
+              status=${data.dna_quality.status}
+              lastEventAt=${data.dna_quality.last_event_at}
+            />
+            <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <${StatCard}
+                label="최근 score"
+                value=${data.overview.latest_dna_score != null ? data.overview.latest_dna_score.toFixed(2) : '-'}
+                sub=${`최근 ${data.dna_quality.total_recent}건`}
+              />
+              <${StatCard}
+                label="최근 freshness"
+                value=${freshnessLabel(data.dna_quality.last_event_at)}
+              />
+              <${StatCard}
+                label="status"
+                value=${statusLabel(data.dna_quality.status)}
+              />
+            </div>
+            <${DnaQualityList} section=${data.dna_quality} />
+          </div>
+        `}
       <//>
     </div>
   `

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -121,10 +121,7 @@ function scheduleHarnessReload(): void {
 }
 
 async function loadHarnessHealth(): Promise<void> {
-  if (harnessRequest) {
-    harnessLoading.value = true
-    return harnessRequest
-  }
+  if (harnessRequest) return harnessRequest
 
   harnessLoading.value = true
   harnessError.value = null

--- a/dashboard/src/components/harness-health.ts
+++ b/dashboard/src/components/harness-health.ts
@@ -121,7 +121,10 @@ function scheduleHarnessReload(): void {
 }
 
 async function loadHarnessHealth(): Promise<void> {
-  if (harnessRequest) return harnessRequest
+  if (harnessRequest) {
+    harnessLoading.value = true
+    return harnessRequest
+  }
 
   harnessLoading.value = true
   harnessError.value = null

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -1,4 +1,32 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('./store', () => ({
+  refreshExecution: vi.fn(),
+  refreshBoard: vi.fn(),
+  refreshGoals: vi.fn(),
+}))
+
+vi.mock('./room-truth-store', () => ({
+  requestRoomTruth: vi.fn(),
+}))
+
+vi.mock('./operator-store', () => ({
+  refreshOperatorRoomDigest: vi.fn(),
+  refreshOperatorSnapshot: vi.fn(),
+}))
+
+vi.mock('./mission-store', () => ({
+  refreshMissionSnapshot: vi.fn(),
+}))
+
+vi.mock('./command-store', () => ({
+  commandPlaneSurface: { value: 'overview' },
+  refreshCommandPlaneChainSummary: vi.fn(),
+  refreshCommandPlaneCurrentSurface: vi.fn(),
+  refreshCommandPlaneOrchestra: vi.fn(),
+  refreshCommandPlaneSwarm: vi.fn(),
+}))
+
 import { refreshPlanForRoute } from './tab-refresh'
 
 describe('refreshPlanForRoute', () => {
@@ -53,6 +81,11 @@ describe('refreshPlanForRoute', () => {
       tab: 'lab',
       params: { section: 'autoresearch' },
     })).toEqual(['autoresearch'])
+
+    expect(refreshPlanForRoute({
+      tab: 'lab',
+      params: { section: 'harness' },
+    })).toEqual(['harness'])
 
     expect(refreshPlanForRoute({
       tab: 'lab',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -21,6 +21,11 @@ async function refreshAutoresearchLabSurface(): Promise<void> {
   await refreshAutoresearchSurface()
 }
 
+async function refreshHarnessLabSurface(): Promise<void> {
+  const { refreshHarnessSurface } = await import('./components/harness-health')
+  await refreshHarnessSurface()
+}
+
 async function refreshGovernanceSurface(): Promise<void> {
   const { refreshGovernance } = await import('./components/governance-store')
   await refreshGovernance()
@@ -34,6 +39,7 @@ export type RefreshTask =
   | 'board'
   | 'goals'
   | 'autoresearch'
+  | 'harness'
   | 'commandCurrentSurface'
   | 'commandChainSummary'
   | 'commandSwarm'
@@ -91,6 +97,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'autoresearch') {
         return ['autoresearch']
       }
+      if (routeState.params.section === 'harness') {
+        return ['harness']
+      }
       if (routeState.params.section === 'overview') {
         return ['roomTruth']
       }
@@ -109,6 +118,7 @@ const REFRESHERS: Record<RefreshTask, () => void> = {
   board: () => { void refreshBoard() },
   goals: () => { void refreshGoals() },
   autoresearch: () => { void refreshAutoresearchLabSurface() },
+  harness: () => { void refreshHarnessLabSurface() },
   commandCurrentSurface: () => { void refreshCommandPlaneCurrentSurface({ force: true }) },
   commandChainSummary: () => { void refreshCommandPlaneChainSummary({ force: true }) },
   commandSwarm: () => { void refreshCommandPlaneSwarm(undefined, undefined, { force: true }) },

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -57,9 +57,20 @@ let trim_recent (type a) max_items (values : a list) : a list =
   if List.length values <= max_items then values
   else List.filteri (fun idx _ -> idx < max_items) values
 
+let trimmed_env_opt key =
+  match Sys.getenv_opt key with
+  | Some value ->
+      let value = String.trim value in
+      if String.equal value "" then None else Some value
+  | None -> None
+
 let me_root () =
-  try Sys.getenv "ME_ROOT" with
-  | Not_found -> Sys.getenv "HOME" ^ "/me"
+  match trimmed_env_opt "ME_ROOT" with
+  | Some root -> root
+  | None -> (
+      match trimmed_env_opt "HOME" with
+      | Some home -> Filename.concat home "me"
+      | None -> Filename.concat (Filename.get_temp_dir_name ()) "me")
 
 let pre_compact_store_base_dir () =
   Filename.concat (me_root ()) "data/harness-pre-compact"
@@ -118,15 +129,6 @@ let read_store_records store ?since ?until () =
     let start_date = if since = "" then "2020-01-01" else since in
     let end_date = if until = "" then "2099-12-31" else until in
     Dated_jsonl.read_range store ~since:start_date ~until:end_date
-
-let latest_from_store (type a) store (event_of_json : Yojson.Safe.t -> a option)
-    : a option =
-  match Dated_jsonl.read_recent store 1 |> List.filter_map event_of_json with
-  | event :: _ -> Some event
-  | [] -> None
-
-let has_any_records store =
-  Dated_jsonl.read_recent store 1 <> []
 
 let max_timestamp left right =
   match (left, right) with
@@ -327,6 +329,10 @@ let latest_timestamp_of_verdicts (verdicts : harness_verdict_item list) =
   | item :: _ -> Some item.timestamp
   | [] -> None
 
+let latest_sorted = function
+  | item :: _ -> Some item
+  | [] -> None
+
 let pre_compact_timestamp (event : pre_compact_event) = event.timestamp
 let pre_compact_ratio (event : pre_compact_event) = event.context_ratio
 let dna_quality_timestamp (event : dna_quality_event) = event.timestamp
@@ -367,11 +373,11 @@ let overview_json
         json_float_option (Option.map dna_quality_score latest_dna) );
     ]
 
-let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
-    ~strategies ~model_family ~trigger =
+let record_pre_compact_at ~timestamp ~keeper_name ~context_ratio ~message_count
+    ~token_count ~strategies ~model_family ~trigger =
   let event =
     {
-      timestamp = Time_compat.now ();
+      timestamp;
       keeper_name;
       context_ratio;
       message_count;
@@ -384,10 +390,16 @@ let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
   Dated_jsonl.append (get_pre_compact_store ()) (pre_compact_record_json event);
   event
 
-let record_dna_quality ~keeper_name ~score ~dimensions =
+let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
+    ~strategies ~model_family ~trigger =
+  record_pre_compact_at ~timestamp:(Time_compat.now ()) ~keeper_name
+    ~context_ratio ~message_count ~token_count ~strategies ~model_family
+    ~trigger
+
+let record_dna_quality_at ~timestamp ~keeper_name ~score ~dimensions =
   let event =
     {
-      timestamp = Time_compat.now ();
+      timestamp;
       keeper_name;
       score;
       dimensions;
@@ -396,16 +408,16 @@ let record_dna_quality ~keeper_name ~score ~dimensions =
   Dated_jsonl.append (get_dna_quality_store ()) (dna_quality_record_json event);
   event
 
+let record_dna_quality ~keeper_name ~score ~dimensions =
+  record_dna_quality_at ~timestamp:(Time_compat.now ()) ~keeper_name ~score
+    ~dimensions
+
 let recent_verdicts_json ?since ?until () =
   `List (List.map verdict_item_json (read_recent_verdicts ?since ?until ()))
 
-let recent_pre_compact_json ?since ?until () =
-  let events = read_pre_compact_events ?since ?until () in
-  let latest : pre_compact_event option =
-    latest_from_store (get_pre_compact_store ()) pre_compact_event_of_json
-  in
+let recent_pre_compact_json ?since ?until ~has_any
+    ~(latest : pre_compact_event option) ~(events : pre_compact_event list) () =
   let status = status_to_string (pre_compact_status latest) in
-  let has_any = has_any_records (get_pre_compact_store ()) in
   let recent_events = trim_recent max_runtime_events events in
   `Assoc
     [
@@ -422,13 +434,9 @@ let recent_pre_compact_json ?since ?until () =
       ("total_recent", `Int (List.length events));
     ]
 
-let recent_dna_quality_json ?since ?until () =
-  let events = read_dna_quality_events ?since ?until () in
-  let latest : dna_quality_event option =
-    latest_from_store (get_dna_quality_store ()) dna_quality_event_of_json
-  in
+let recent_dna_quality_json ?since ?until ~has_any
+    ~(latest : dna_quality_event option) ~(events : dna_quality_event list) () =
   let status = status_to_string (dna_quality_status latest) in
-  let has_any = has_any_records (get_dna_quality_store ()) in
   let recent_events = trim_recent max_runtime_events events in
   `Assoc
     [
@@ -448,11 +456,20 @@ let recent_dna_quality_json ?since ?until () =
 let json ?since ?until () =
   let calibration = Eval_calibration.calibration_stats ?since ?until () in
   let recent_verdicts = read_recent_verdicts ?since ?until () in
+  let has_window = Option.is_some since || Option.is_some until in
+  let all_pre_compact_events = read_pre_compact_events () in
   let latest_pre_compact : pre_compact_event option =
-    latest_from_store (get_pre_compact_store ()) pre_compact_event_of_json
+    latest_sorted all_pre_compact_events
   in
-  let latest_dna : dna_quality_event option =
-    latest_from_store (get_dna_quality_store ()) dna_quality_event_of_json
+  let pre_compact_events =
+    if has_window then read_pre_compact_events ?since ?until ()
+    else all_pre_compact_events
+  in
+  let all_dna_quality_events = read_dna_quality_events () in
+  let latest_dna : dna_quality_event option = latest_sorted all_dna_quality_events in
+  let dna_quality_events =
+    if has_window then read_dna_quality_events ?since ?until ()
+    else all_dna_quality_events
   in
   `Assoc
     [
@@ -465,6 +482,12 @@ let json ?since ?until () =
           ~latest_dna );
       ("calibration", calibration);
       ("recent_verdicts", `List (List.map verdict_item_json recent_verdicts));
-      ("pre_compact", recent_pre_compact_json ?since ?until ());
-      ("dna_quality", recent_dna_quality_json ?since ?until ());
+      ( "pre_compact",
+        recent_pre_compact_json ?since ?until
+          ~has_any:(all_pre_compact_events <> [])
+          ~latest:latest_pre_compact ~events:pre_compact_events () );
+      ( "dna_quality",
+        recent_dna_quality_json ?since ?until
+          ~has_any:(all_dna_quality_events <> []) ~latest:latest_dna
+          ~events:dna_quality_events () );
     ]

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -70,7 +70,7 @@ let me_root () =
   | None -> (
       match trimmed_env_opt "HOME" with
       | Some home -> Filename.concat home "me"
-      | None -> Sys.getcwd ())
+      | None -> Env_config.me_root ())
 
 let pre_compact_store_base_dir () =
   Filename.concat (me_root ()) "data/harness-pre-compact"

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -3,6 +3,23 @@
     Aggregates evaluator calibration stats with recent runtime safety signals
     so the Lab surface can explain what the harness is watching. *)
 
+type rail_status =
+  | Healthy
+  | Warning
+  | Stale
+  | Idle
+
+type harness_verdict_item = {
+  timestamp : float;
+  task_id : string;
+  task_title : string;
+  agent_name : string;
+  gate : string;
+  verdict : string;
+  evaluator_cascade : string;
+  fallback_reason : string option;
+}
+
 type pre_compact_event = {
   timestamp : float;
   keeper_name : string;
@@ -22,22 +39,333 @@ type dna_quality_event = {
 }
 
 let max_runtime_events = 12
+let max_recent_verdicts = 8
+let max_signal_scan = 500
+let runtime_stale_after_s = 30. *. 60.
+let evaluator_stale_after_s = 12. *. 3600.
 
-let pre_compact_events : pre_compact_event list ref = ref []
-let dna_quality_events : dna_quality_event list ref = ref []
-let runtime_mu = Eio.Mutex.create ()
+let pre_compact_store_ref : Dated_jsonl.t option ref = ref None
+let dna_quality_store_ref : Dated_jsonl.t option ref = ref None
 
-let trim_recent max_items values =
+let status_to_string = function
+  | Healthy -> "healthy"
+  | Warning -> "warning"
+  | Stale -> "stale"
+  | Idle -> "idle"
+
+let trim_recent (type a) max_items (values : a list) : a list =
   if List.length values <= max_items then values
   else List.filteri (fun idx _ -> idx < max_items) values
 
-let push_pre_compact event =
-  Eio.Mutex.use_rw ~protect:true runtime_mu (fun () ->
-      pre_compact_events := trim_recent max_runtime_events (event :: !pre_compact_events))
+let me_root () =
+  try Sys.getenv "ME_ROOT" with
+  | Not_found -> Sys.getenv "HOME" ^ "/me"
 
-let push_dna_quality event =
-  Eio.Mutex.use_rw ~protect:true runtime_mu (fun () ->
-      dna_quality_events := trim_recent max_runtime_events (event :: !dna_quality_events))
+let pre_compact_store_base_dir () =
+  Filename.concat (me_root ()) "data/harness-pre-compact"
+
+let dna_quality_store_base_dir () =
+  Filename.concat (me_root ()) "data/harness-dna-quality"
+
+let get_or_create_store store_ref base_dir_fn =
+  match !store_ref with
+  | Some store -> store
+  | None ->
+      let store = Dated_jsonl.create ~base_dir:(base_dir_fn ()) () in
+      store_ref := Some store;
+      store
+
+let get_pre_compact_store () =
+  get_or_create_store pre_compact_store_ref pre_compact_store_base_dir
+
+let get_dna_quality_store () =
+  get_or_create_store dna_quality_store_ref dna_quality_store_base_dir
+
+let reset_runtime_stores_for_testing () =
+  pre_compact_store_ref := None;
+  dna_quality_store_ref := None
+
+let set_pre_compact_store_for_testing ~base_dir =
+  pre_compact_store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let set_dna_quality_store_for_testing ~base_dir =
+  dna_quality_store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let json_float_option = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let json_string_option = function
+  | Some value -> `String value
+  | None -> `Null
+
+let string_field json key =
+  Safe_ops.json_string ~default:"" key json
+
+let is_stale ~threshold_s timestamp =
+  (Time_compat.now () -. timestamp) > threshold_s
+
+let date_bounds ?since ?until () =
+  let since = match since with Some value -> value | None -> "" in
+  let until = match until with Some value -> value | None -> "" in
+  (since, until)
+
+let read_store_records store ?since ?until () =
+  let since, until = date_bounds ?since ?until () in
+  if since = "" && until = "" then
+    Dated_jsonl.read_recent store max_signal_scan
+  else
+    let start_date = if since = "" then "2020-01-01" else since in
+    let end_date = if until = "" then "2099-12-31" else until in
+    Dated_jsonl.read_range store ~since:start_date ~until:end_date
+
+let latest_from_store (type a) store (event_of_json : Yojson.Safe.t -> a option)
+    : a option =
+  match Dated_jsonl.read_recent store 1 |> List.filter_map event_of_json with
+  | event :: _ -> Some event
+  | [] -> None
+
+let has_any_records store =
+  Dated_jsonl.read_recent store 1 <> []
+
+let max_timestamp left right =
+  match (left, right) with
+  | Some l, Some r -> Some (Float.max l r)
+  | Some _ as value, None
+  | None, (Some _ as value) -> value
+  | None, None -> None
+
+let verdict_item_json (item : harness_verdict_item) =
+  `Assoc
+    [
+      ("timestamp", `Float item.timestamp);
+      ("task_id", `String item.task_id);
+      ("task_title", `String item.task_title);
+      ("agent_name", `String item.agent_name);
+      ("gate", `String item.gate);
+      ("verdict", `String item.verdict);
+      ("evaluator_cascade", `String item.evaluator_cascade);
+      ("fallback_reason", json_string_option item.fallback_reason);
+    ]
+
+let verdict_item_of_json json =
+  if not (String.equal (string_field json "record_type") "verdict") then None
+  else
+    Some
+      {
+        timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json;
+        task_id = string_field json "task_id";
+        task_title = string_field json "task_title";
+        agent_name = string_field json "agent_name";
+        gate = string_field json "gate";
+        verdict = string_field json "verdict";
+        evaluator_cascade = string_field json "evaluator_cascade";
+        fallback_reason = Safe_ops.json_string_opt "fallback_reason" json;
+      }
+
+let pre_compact_record_json (event : pre_compact_event) =
+  `Assoc
+    [
+      ("record_type", `String "pre_compact");
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("context_ratio", `Float event.context_ratio);
+      ("message_count", `Int event.message_count);
+      ("token_count", `Int event.token_count);
+      ("strategies", `List (List.map (fun value -> `String value) event.strategies));
+      ("model_family", `String event.model_family);
+      ("trigger", `String event.trigger);
+    ]
+
+let pre_compact_event_json (event : pre_compact_event) =
+  `Assoc
+    [
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("context_ratio", `Float event.context_ratio);
+      ("message_count", `Int event.message_count);
+      ("token_count", `Int event.token_count);
+      ("strategies", `List (List.map (fun value -> `String value) event.strategies));
+      ("model_family", `String event.model_family);
+      ("trigger", `String event.trigger);
+    ]
+
+let pre_compact_event_of_json json =
+  let record_type = string_field json "record_type" in
+  if record_type <> "" && not (String.equal record_type "pre_compact") then None
+  else
+    Some
+      {
+        timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json;
+        keeper_name = string_field json "keeper_name";
+        context_ratio = Safe_ops.json_float ~default:0.0 "context_ratio" json;
+        message_count = Safe_ops.json_int ~default:0 "message_count" json;
+        token_count = Safe_ops.json_int ~default:0 "token_count" json;
+        strategies = Safe_ops.json_string_list "strategies" json;
+        model_family = string_field json "model_family";
+        trigger = string_field json "trigger";
+      }
+
+let dna_quality_record_json (event : dna_quality_event) =
+  `Assoc
+    [
+      ("record_type", `String "dna_quality");
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("score", `Float event.score);
+      ("dimensions", event.dimensions);
+    ]
+
+let dna_quality_event_json (event : dna_quality_event) =
+  `Assoc
+    [
+      ("timestamp", `Float event.timestamp);
+      ("keeper_name", `String event.keeper_name);
+      ("score", `Float event.score);
+      ("dimensions", event.dimensions);
+    ]
+
+let dna_quality_event_of_json json =
+  let record_type = string_field json "record_type" in
+  if record_type <> "" && not (String.equal record_type "dna_quality") then None
+  else
+    let dimensions =
+      match Safe_ops.json_member_opt "dimensions" json with
+      | Some value -> value
+      | None -> `Assoc []
+    in
+    Some
+      {
+        timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json;
+        keeper_name = string_field json "keeper_name";
+        score = Safe_ops.json_float ~default:0.0 "score" json;
+        dimensions;
+      }
+
+let read_recent_verdicts ?since ?until ?(limit = max_recent_verdicts) ()
+    : harness_verdict_item list =
+  let records = read_store_records (Eval_calibration.get_store ()) ?since ?until () in
+  let verdicts : harness_verdict_item list =
+    records |> List.filter_map verdict_item_of_json
+  in
+  let verdicts =
+    List.sort
+      (fun (left : harness_verdict_item) (right : harness_verdict_item) ->
+        Float.compare right.timestamp left.timestamp)
+      verdicts
+  in
+  trim_recent limit verdicts
+
+let read_pre_compact_events ?since ?until () =
+  let records = read_store_records (get_pre_compact_store ()) ?since ?until () in
+  let events : pre_compact_event list =
+    records |> List.filter_map pre_compact_event_of_json
+  in
+  List.sort
+    (fun (left : pre_compact_event) (right : pre_compact_event) ->
+      Float.compare right.timestamp left.timestamp)
+    events
+
+let read_dna_quality_events ?since ?until () =
+  let records = read_store_records (get_dna_quality_store ()) ?since ?until () in
+  let events : dna_quality_event list =
+    records |> List.filter_map dna_quality_event_of_json
+  in
+  List.sort
+    (fun (left : dna_quality_event) (right : dna_quality_event) ->
+      Float.compare right.timestamp left.timestamp)
+    events
+
+let empty_reason ~has_any ?since ?until () =
+  let since, until = date_bounds ?since ?until () in
+  if has_any && (since <> "" || until <> "") then Some "window_empty"
+  else if has_any then Some "no_recent_events"
+  else Some "no_runtime_activity"
+
+let pre_compact_status (latest_event : pre_compact_event option) =
+  match latest_event with
+  | None -> Idle
+  | Some event ->
+      if is_stale ~threshold_s:runtime_stale_after_s event.timestamp then Stale
+      else if event.context_ratio >= 0.95 || event.token_count >= 50_000 then Warning
+      else Healthy
+
+let dna_quality_status (latest_event : dna_quality_event option) =
+  match latest_event with
+  | None -> Idle
+  | Some event ->
+      if is_stale ~threshold_s:runtime_stale_after_s event.timestamp then Stale
+      else
+        let goal_anchor = Safe_ops.json_bool ~default:false "has_goal_anchor" event.dimensions in
+        let task_anchor = Safe_ops.json_bool ~default:false "has_task_anchor" event.dimensions in
+        let recent_context =
+          Safe_ops.json_bool ~default:false "has_recent_context" event.dimensions
+        in
+        let truncation =
+          Safe_ops.json_int ~default:0 "truncation_artifacts" event.dimensions
+        in
+        if event.score < 0.6 || not goal_anchor || not task_anchor
+           || not recent_context || truncation > 0
+        then Warning
+        else Healthy
+
+let evaluator_status ~calibration latest_timestamp =
+  let total_verdicts = Safe_ops.json_int ~default:0 "total_verdicts" calibration in
+  let fallback_count = Safe_ops.json_int ~default:0 "fallback_count" calibration in
+  if total_verdicts = 0 then Idle
+  else
+    match latest_timestamp with
+    | Some ts when is_stale ~threshold_s:evaluator_stale_after_s ts -> Stale
+    | _ ->
+        let fallback_ratio =
+          float_of_int fallback_count /. float_of_int (max 1 total_verdicts)
+        in
+        if fallback_ratio > 0.8 then Warning else Healthy
+
+let latest_timestamp_of_verdicts (verdicts : harness_verdict_item list) =
+  match verdicts with
+  | item :: _ -> Some item.timestamp
+  | [] -> None
+
+let pre_compact_timestamp (event : pre_compact_event) = event.timestamp
+let pre_compact_ratio (event : pre_compact_event) = event.context_ratio
+let dna_quality_timestamp (event : dna_quality_event) = event.timestamp
+let dna_quality_score (event : dna_quality_event) = event.score
+
+let overview_json
+    ~(calibration : Yojson.Safe.t)
+    ~(recent_verdicts : harness_verdict_item list)
+    ~(latest_pre_compact : pre_compact_event option)
+    ~(latest_dna : dna_quality_event option) =
+  let verdict_last = latest_timestamp_of_verdicts recent_verdicts in
+  let pre_compact_last = Option.map pre_compact_timestamp latest_pre_compact in
+  let dna_last = Option.map dna_quality_timestamp latest_dna in
+  let fallback_count = Safe_ops.json_int ~default:0 "fallback_count" calibration in
+  let total_verdicts = Safe_ops.json_int ~default:0 "total_verdicts" calibration in
+  let fallback_ratio =
+    if total_verdicts = 0 then 0.0
+    else float_of_int fallback_count /. float_of_int total_verdicts
+  in
+  let last_signal_at =
+    max_timestamp verdict_last (max_timestamp pre_compact_last dna_last)
+  in
+  `Assoc
+    [
+      ( "evaluator_status",
+        `String (status_to_string (evaluator_status ~calibration verdict_last)) );
+      ( "pre_compact_status",
+        `String (status_to_string (pre_compact_status latest_pre_compact)) );
+      ("dna_status", `String (status_to_string (dna_quality_status latest_dna)));
+      ("last_signal_at", json_float_option last_signal_at);
+      ("evaluator_last_event_at", json_float_option verdict_last);
+      ("pre_compact_last_event_at", json_float_option pre_compact_last);
+      ("dna_last_event_at", json_float_option dna_last);
+      ("fallback_ratio", `Float fallback_ratio);
+      ( "latest_pre_compact_ratio",
+        json_float_option (Option.map pre_compact_ratio latest_pre_compact) );
+      ( "latest_dna_score",
+        json_float_option (Option.map dna_quality_score latest_dna) );
+    ]
 
 let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
     ~strategies ~model_family ~trigger =
@@ -53,7 +381,7 @@ let record_pre_compact ~keeper_name ~context_ratio ~message_count ~token_count
       trigger;
     }
   in
-  push_pre_compact event;
+  Dated_jsonl.append (get_pre_compact_store ()) (pre_compact_record_json event);
   event
 
 let record_dna_quality ~keeper_name ~score ~dimensions =
@@ -65,106 +393,78 @@ let record_dna_quality ~keeper_name ~score ~dimensions =
       dimensions;
     }
   in
-  push_dna_quality event;
+  Dated_jsonl.append (get_dna_quality_store ()) (dna_quality_record_json event);
   event
 
-let pre_compact_event_json (event : pre_compact_event) =
-  `Assoc
-    [
-      ("timestamp", `Float event.timestamp);
-      ("keeper_name", `String event.keeper_name);
-      ("context_ratio", `Float event.context_ratio);
-      ("message_count", `Int event.message_count);
-      ("token_count", `Int event.token_count);
-      ("strategies", `List (List.map (fun value -> `String value) event.strategies));
-      ("model_family", `String event.model_family);
-      ("trigger", `String event.trigger);
-    ]
+let recent_verdicts_json ?since ?until () =
+  `List (List.map verdict_item_json (read_recent_verdicts ?since ?until ()))
 
-let dna_quality_event_json (event : dna_quality_event) =
-  `Assoc
-    [
-      ("timestamp", `Float event.timestamp);
-      ("keeper_name", `String event.keeper_name);
-      ("score", `Float event.score);
-      ("dimensions", event.dimensions);
-    ]
-
-let string_field json key =
-  Safe_ops.json_string ~default:"" key json
-
-let recent_verdicts_json ?(limit = 8) ?(since = "") ?(until = "") () =
-  let store = Eval_calibration.get_store () in
-  let records =
-    if since = "" && until = "" then
-      Dated_jsonl.read_recent store 500
-    else
-      let start_date = if since = "" then "2020-01-01" else since in
-      let end_date = if until = "" then "2099-12-31" else until in
-      Dated_jsonl.read_range store ~since:start_date ~until:end_date
+let recent_pre_compact_json ?since ?until () =
+  let events = read_pre_compact_events ?since ?until () in
+  let latest : pre_compact_event option =
+    latest_from_store (get_pre_compact_store ()) pre_compact_event_of_json
   in
-  let verdicts =
-    records
-    |> List.filter_map (fun json ->
-           if String.equal (string_field json "record_type") "verdict" then
-             Some
-               (`Assoc
-                 [
-                   ("timestamp", json |> Yojson.Safe.Util.member "timestamp");
-                   ("task_id", `String (string_field json "task_id"));
-                   ("task_title", `String (string_field json "task_title"));
-                   ("agent_name", `String (string_field json "agent_name"));
-                   ("gate", `String (string_field json "gate"));
-                   ("verdict", `String (string_field json "verdict"));
-                   ( "evaluator_cascade",
-                     `String (string_field json "evaluator_cascade") );
-                   ( "fallback_reason",
-                     match string_field json "fallback_reason" with
-                     | "" -> `Null
-                     | reason -> `String reason );
-                 ])
-           else None)
-    |> List.sort (fun left right ->
-           let ts json =
-             Safe_ops.json_float ~default:0.0 "timestamp" json
-           in
-           Float.compare (ts right) (ts left))
-    |> trim_recent limit
-  in
-  `List verdicts
-
-let recent_pre_compact_json () =
-  let events = Eio.Mutex.use_ro runtime_mu (fun () -> !pre_compact_events) in
+  let status = status_to_string (pre_compact_status latest) in
+  let has_any = has_any_records (get_pre_compact_store ()) in
+  let recent_events = trim_recent max_runtime_events events in
   `Assoc
     [
       ( "description",
         `String
           "Shows recent context compaction attempts before long-running keeper turns are condensed." );
-      ("recent_events", `List (List.map pre_compact_event_json events));
+      ("status", `String status);
+      ("last_event_at", json_float_option (Option.map pre_compact_timestamp latest));
+      ( "empty_reason",
+        match recent_events with
+        | _ :: _ -> `Null
+        | [] -> json_string_option (empty_reason ~has_any ?since ?until ()) );
+      ("recent_events", `List (List.map pre_compact_event_json recent_events));
       ("total_recent", `Int (List.length events));
     ]
 
-let recent_dna_quality_json () =
-  let events = Eio.Mutex.use_ro runtime_mu (fun () -> !dna_quality_events) in
+let recent_dna_quality_json ?since ?until () =
+  let events = read_dna_quality_events ?since ?until () in
+  let latest : dna_quality_event option =
+    latest_from_store (get_dna_quality_store ()) dna_quality_event_of_json
+  in
+  let status = status_to_string (dna_quality_status latest) in
+  let has_any = has_any_records (get_dna_quality_store ()) in
+  let recent_events = trim_recent max_runtime_events events in
   `Assoc
     [
       ( "description",
         `String
           "Shows recent continuity DNA quality checks before keeper mitosis or handoff-style spawn flows continue." );
-      ("recent_events", `List (List.map dna_quality_event_json events));
+      ("status", `String status);
+      ("last_event_at", json_float_option (Option.map dna_quality_timestamp latest));
+      ( "empty_reason",
+        match recent_events with
+        | _ :: _ -> `Null
+        | [] -> json_string_option (empty_reason ~has_any ?since ?until ()) );
+      ("recent_events", `List (List.map dna_quality_event_json recent_events));
       ("total_recent", `Int (List.length events));
     ]
 
 let json ?since ?until () =
   let calibration = Eval_calibration.calibration_stats ?since ?until () in
+  let recent_verdicts = read_recent_verdicts ?since ?until () in
+  let latest_pre_compact : pre_compact_event option =
+    latest_from_store (get_pre_compact_store ()) pre_compact_event_of_json
+  in
+  let latest_dna : dna_quality_event option =
+    latest_from_store (get_dna_quality_store ()) dna_quality_event_of_json
+  in
   `Assoc
     [
       ("generated_at", `Float (Time_compat.now ()));
       ( "scope_note",
         `String
           "Autoresearch tracks the generator loop itself. The safety harness tracks supporting evaluator and long-running continuity rails, so these signals are related but not a direct keep/discard judge for each autoresearch cycle." );
+      ( "overview",
+        overview_json ~calibration ~recent_verdicts ~latest_pre_compact
+          ~latest_dna );
       ("calibration", calibration);
-      ("recent_verdicts", recent_verdicts_json ?since ?until ());
-      ("pre_compact", recent_pre_compact_json ());
-      ("dna_quality", recent_dna_quality_json ());
+      ("recent_verdicts", `List (List.map verdict_item_json recent_verdicts));
+      ("pre_compact", recent_pre_compact_json ?since ?until ());
+      ("dna_quality", recent_dna_quality_json ?since ?until ());
     ]

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -65,12 +65,12 @@ let trimmed_env_opt key =
   | None -> None
 
 let me_root () =
-  match trimmed_env_opt "ME_ROOT" with
+  match Env_config.me_root_opt () with
   | Some root -> root
   | None -> (
       match trimmed_env_opt "HOME" with
       | Some home -> Filename.concat home "me"
-      | None -> Filename.concat (Filename.get_temp_dir_name ()) "me")
+      | None -> Sys.getcwd ())
 
 let pre_compact_store_base_dir () =
   Filename.concat (me_root ()) "data/harness-pre-compact"
@@ -129,6 +129,9 @@ let read_store_records store ?since ?until () =
     let start_date = if since = "" then "2020-01-01" else since in
     let end_date = if until = "" then "2099-12-31" else until in
     Dated_jsonl.read_range store ~since:start_date ~until:end_date
+
+let has_any_records store =
+  Dated_jsonl.read_recent store 1 <> []
 
 let max_timestamp left right =
   match (left, right) with
@@ -329,9 +332,13 @@ let latest_timestamp_of_verdicts (verdicts : harness_verdict_item list) =
   | item :: _ -> Some item.timestamp
   | [] -> None
 
-let latest_sorted = function
-  | item :: _ -> Some item
-  | [] -> None
+let latest_by_timestamp timestamp_of items =
+  List.fold_left
+    (fun acc item ->
+      match acc with
+      | Some current when timestamp_of current >= timestamp_of item -> acc
+      | _ -> Some item)
+    None items
 
 let pre_compact_timestamp (event : pre_compact_event) = event.timestamp
 let pre_compact_ratio (event : pre_compact_event) = event.context_ratio
@@ -457,19 +464,31 @@ let json ?since ?until () =
   let calibration = Eval_calibration.calibration_stats ?since ?until () in
   let recent_verdicts = read_recent_verdicts ?since ?until () in
   let has_window = Option.is_some since || Option.is_some until in
-  let all_pre_compact_events = read_pre_compact_events () in
+  let pre_compact_store = get_pre_compact_store () in
+  let pre_compact_events = read_pre_compact_events ?since ?until () in
   let latest_pre_compact : pre_compact_event option =
-    latest_sorted all_pre_compact_events
+    if has_window then
+      Dated_jsonl.read_recent pre_compact_store 1
+      |> List.filter_map pre_compact_event_of_json
+      |> latest_by_timestamp pre_compact_timestamp
+    else latest_by_timestamp pre_compact_timestamp pre_compact_events
   in
-  let pre_compact_events =
-    if has_window then read_pre_compact_events ?since ?until ()
-    else all_pre_compact_events
+  let pre_compact_has_any =
+    if has_window then has_any_records pre_compact_store
+    else pre_compact_events <> []
   in
-  let all_dna_quality_events = read_dna_quality_events () in
-  let latest_dna : dna_quality_event option = latest_sorted all_dna_quality_events in
-  let dna_quality_events =
-    if has_window then read_dna_quality_events ?since ?until ()
-    else all_dna_quality_events
+  let dna_quality_store = get_dna_quality_store () in
+  let dna_quality_events = read_dna_quality_events ?since ?until () in
+  let latest_dna : dna_quality_event option =
+    if has_window then
+      Dated_jsonl.read_recent dna_quality_store 1
+      |> List.filter_map dna_quality_event_of_json
+      |> latest_by_timestamp dna_quality_timestamp
+    else latest_by_timestamp dna_quality_timestamp dna_quality_events
+  in
+  let dna_quality_has_any =
+    if has_window then has_any_records dna_quality_store
+    else dna_quality_events <> []
   in
   `Assoc
     [
@@ -484,10 +503,10 @@ let json ?since ?until () =
       ("recent_verdicts", `List (List.map verdict_item_json recent_verdicts));
       ( "pre_compact",
         recent_pre_compact_json ?since ?until
-          ~has_any:(all_pre_compact_events <> [])
+          ~has_any:pre_compact_has_any
           ~latest:latest_pre_compact ~events:pre_compact_events () );
       ( "dna_quality",
         recent_dna_quality_json ?since ?until
-          ~has_any:(all_dna_quality_events <> []) ~latest:latest_dna
+          ~has_any:dna_quality_has_any ~latest:latest_dna
           ~events:dna_quality_events () );
     ]

--- a/test/dune
+++ b/test/dune
@@ -164,6 +164,11 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_dashboard_harness_health)
+ (modules test_dashboard_harness_health)
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
+
+(test
  (name test_dashboard_repo_synthesis)
  (modules test_dashboard_repo_synthesis)
  (libraries masc_mcp alcotest yojson unix))

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -1,0 +1,152 @@
+open Alcotest
+
+module Harness = Masc_mcp.Dashboard_harness_health
+module Cal = Masc_mcp.Eval_calibration
+module AR = Masc_mcp.Anti_rationalization
+
+let test_counter = ref 0
+
+let tmpdir prefix =
+  incr test_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%d"
+         prefix (Unix.getpid ()) !test_counter
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let with_test_stores f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let verdict_dir = tmpdir "harness_verdicts" in
+  let pre_dir = tmpdir "harness_pre" in
+  let dna_dir = tmpdir "harness_dna" in
+  Cal.set_store_for_testing ~base_dir:verdict_dir;
+  Harness.set_pre_compact_store_for_testing ~base_dir:pre_dir;
+  Harness.set_dna_quality_store_for_testing ~base_dir:dna_dir;
+  Fun.protect
+    ~finally:(fun () ->
+      Cal.reset_store_for_testing ();
+      Harness.reset_runtime_stores_for_testing ())
+    f
+
+let require_assoc key json =
+  Yojson.Safe.Util.(json |> member key)
+
+let today_string ?(offset_days = 0) () =
+  let ts = Unix.gettimeofday () +. (float_of_int offset_days *. 86400.0) in
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+
+let make_req ?(title = "Task") ?(notes = "Detailed completion notes") () :
+    AR.review_request =
+  {
+    task_title = title;
+    task_description = "desc";
+    completion_notes = notes;
+    agent_name = "codex";
+  }
+
+let make_result ?(verdict = AR.Approve) ?(gate = "llm")
+    ?fallback_reason () : AR.review_result =
+  {
+    verdict;
+    evaluator_cascade = "cross_verifier";
+    generator_cascade = None;
+    gate;
+    fallback_reason;
+  }
+
+let test_runtime_signals_are_persisted () =
+  with_test_stores @@ fun () ->
+  ignore
+    (Harness.record_pre_compact ~keeper_name:"keeper-a" ~context_ratio:0.91
+       ~message_count:88 ~token_count:32000
+       ~strategies:[ "PruneToolOutputs"; "SummarizeOld" ]
+       ~model_family:"verifier" ~trigger:"ratio(0.91>=0.85)");
+  ignore
+    (Harness.record_dna_quality ~keeper_name:"keeper-a" ~score:0.82
+       ~dimensions:
+         (`Assoc
+           [
+             ("has_goal_anchor", `Bool true);
+             ("has_task_anchor", `Bool true);
+             ("has_recent_context", `Bool true);
+             ("truncation_artifacts", `Int 0);
+             ("content_length", `Int 420);
+           ]));
+  let json = Harness.json () in
+  let overview = require_assoc "overview" json in
+  let pre_compact = require_assoc "pre_compact" json in
+  let dna_quality = require_assoc "dna_quality" json in
+  check string "pre status" "healthy"
+    Yojson.Safe.Util.(pre_compact |> member "status" |> to_string);
+  check string "dna status" "healthy"
+    Yojson.Safe.Util.(dna_quality |> member "status" |> to_string);
+  check string "overview pre status" "healthy"
+    Yojson.Safe.Util.(overview |> member "pre_compact_status" |> to_string);
+  check string "overview dna status" "healthy"
+    Yojson.Safe.Util.(overview |> member "dna_status" |> to_string);
+  check int "pre events count" 1
+    Yojson.Safe.Util.(pre_compact |> member "recent_events" |> to_list |> List.length);
+  check int "dna events count" 1
+    Yojson.Safe.Util.(dna_quality |> member "recent_events" |> to_list |> List.length);
+  check bool "last_signal_at present" true
+    Yojson.Safe.Util.(overview |> member "last_signal_at" <> `Null)
+
+let test_runtime_window_empty_reason () =
+  with_test_stores @@ fun () ->
+  ignore
+    (Harness.record_pre_compact ~keeper_name:"keeper-a" ~context_ratio:0.91
+       ~message_count:88 ~token_count:32000 ~strategies:[ "PruneToolOutputs" ]
+       ~model_family:"verifier" ~trigger:"ratio(0.91>=0.85)");
+  ignore
+    (Harness.record_dna_quality ~keeper_name:"keeper-a" ~score:0.82
+       ~dimensions:(`Assoc [ ("has_goal_anchor", `Bool true) ]));
+  let tomorrow = today_string ~offset_days:1 () in
+  let json = Harness.json ~since:tomorrow ~until:tomorrow () in
+  let pre_compact = require_assoc "pre_compact" json in
+  let dna_quality = require_assoc "dna_quality" json in
+  check string "pre empty reason" "window_empty"
+    Yojson.Safe.Util.(pre_compact |> member "empty_reason" |> to_string);
+  check string "dna empty reason" "window_empty"
+    Yojson.Safe.Util.(dna_quality |> member "empty_reason" |> to_string);
+  check int "pre filtered empty" 0
+    Yojson.Safe.Util.(pre_compact |> member "recent_events" |> to_list |> List.length);
+  check int "dna filtered empty" 0
+    Yojson.Safe.Util.(dna_quality |> member "recent_events" |> to_list |> List.length)
+
+let test_overview_warns_when_evaluator_falls_back () =
+  with_test_stores @@ fun () ->
+  let req = make_req ~title:"Fallback task" () in
+  let result =
+    make_result ~gate:"fallback" ~fallback_reason:"judge timeout" ()
+  in
+  Cal.record_verdict ~task_id:"task-1" ~req ~result ();
+  let json = Harness.json ~since:(today_string ()) ~until:(today_string ()) () in
+  let overview = require_assoc "overview" json in
+  check string "evaluator status" "warning"
+    Yojson.Safe.Util.(overview |> member "evaluator_status" |> to_string);
+  check (float 0.0001) "fallback ratio" 1.0
+    Yojson.Safe.Util.(overview |> member "fallback_ratio" |> to_float)
+
+let () =
+  run "Dashboard_harness_health"
+    [
+      ( "runtime signals",
+        [
+          test_case "persisted runtime signals surface as healthy" `Quick
+            test_runtime_signals_are_persisted;
+          test_case "filtered windows explain empty runtime rails" `Quick
+            test_runtime_window_empty_reason;
+          test_case "fallback-heavy evaluator shows warning overview" `Quick
+            test_overview_warns_when_evaluator_falls_back;
+        ] );
+    ]

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -123,6 +123,38 @@ let test_runtime_window_empty_reason () =
   check int "dna filtered empty" 0
     Yojson.Safe.Util.(dna_quality |> member "recent_events" |> to_list |> List.length)
 
+let test_runtime_stale_status () =
+  with_test_stores @@ fun () ->
+  let stale_timestamp = Time_compat.now () -. (31. *. 60.) in
+  ignore
+    (Harness.record_pre_compact_at ~timestamp:stale_timestamp
+       ~keeper_name:"keeper-a" ~context_ratio:0.91 ~message_count:88
+       ~token_count:32000 ~strategies:[ "PruneToolOutputs" ]
+       ~model_family:"verifier" ~trigger:"ratio(0.91>=0.85)");
+  ignore
+    (Harness.record_dna_quality_at ~timestamp:stale_timestamp
+       ~keeper_name:"keeper-a" ~score:0.82
+       ~dimensions:
+         (`Assoc
+           [
+             ("has_goal_anchor", `Bool true);
+             ("has_task_anchor", `Bool true);
+             ("has_recent_context", `Bool true);
+             ("truncation_artifacts", `Int 0);
+           ]));
+  let json = Harness.json () in
+  let overview = require_assoc "overview" json in
+  let pre_compact = require_assoc "pre_compact" json in
+  let dna_quality = require_assoc "dna_quality" json in
+  check string "pre stale" "stale"
+    Yojson.Safe.Util.(pre_compact |> member "status" |> to_string);
+  check string "dna stale" "stale"
+    Yojson.Safe.Util.(dna_quality |> member "status" |> to_string);
+  check string "overview pre stale" "stale"
+    Yojson.Safe.Util.(overview |> member "pre_compact_status" |> to_string);
+  check string "overview dna stale" "stale"
+    Yojson.Safe.Util.(overview |> member "dna_status" |> to_string)
+
 let test_overview_warns_when_evaluator_falls_back () =
   with_test_stores @@ fun () ->
   let req = make_req ~title:"Fallback task" () in
@@ -146,6 +178,8 @@ let () =
             test_runtime_signals_are_persisted;
           test_case "filtered windows explain empty runtime rails" `Quick
             test_runtime_window_empty_reason;
+          test_case "stale runtime signals surface as stale" `Quick
+            test_runtime_stale_status;
           test_case "fallback-heavy evaluator shows warning overview" `Quick
             test_overview_warns_when_evaluator_falls_back;
         ] );


### PR DESCRIPTION
## Summary
- rebuild the Harness page into a live operator surface with a trust-focused hero and separate Evaluator, Pre-Compaction, and DNA rails
- pair Autoresearch and Harness with clearer role framing, shared refresh semantics, and direct navigation between outcome judgment and judge-of-the-judge health
- persist pre-compaction and DNA quality signals in the backend, expose normalized overview and rail status fields, and add regression coverage for the new read model
- fold in the compile blockers uncovered during verification so the touched dashboard and backend targets build cleanly again

## What Changed
- redesigned the Harness frontend hierarchy around freshness, rail health, empty-state reasoning, and live SSE append plus debounced reload behavior
- updated the Harness API/read model to return `overview`, rail `status`, `last_event_at`, and `empty_reason`, with persisted event history for pre-compaction and DNA quality rails
- updated Autoresearch copy and linking so it explicitly owns experiment keep/discard outcomes while Harness owns evaluator and continuity safety rails
- added frontend tests for Harness, Autoresearch, and tab refresh behavior, plus backend tests for persisted Harness signal loading and window filtering
- fixed adjacent compile issues required to get the validated targets green, including the `dashboard/src/store.ts` type import issue and backend `Env_config` dependency leakage in council code

## Why
The previous Harness page explained the system but did not behave like a trustworthy live surface. Important rails were missing persisted history, empty states were ambiguous, and the relationship between Autoresearch and Harness was easy to misread. This change makes the page operational instead of descriptive.

## Validation
- `pnpm exec vitest run src/components/harness-health.test.ts src/components/autoresearch.test.ts src/tab-refresh.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/harness-live-surface --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/harness-live-surface/_build_harness_fix test/test_dashboard_harness_health.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/harness-live-surface/_build_harness_fix/default/test/test_dashboard_harness_health.exe`
