### PR TITLE
feat(cdal): contract-driven execution bridge to OAS

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.92.1))
+  (agent_sdk (>= 0.93.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/dune
+++ b/lib/dune
@@ -465,6 +465,7 @@
    keeper_config
    keeper_toml_loader
    keeper_contract
+   keeper_cdal_contract
    keeper_deliberation
    keeper_types_profile
    keeper_types_support

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -189,6 +189,7 @@ let run_turn
     { strategy = Agent_sdk.Context_reducer.Merge_contiguous };
   ] in
   (* 8. Run Agent *)
+  let contract = Keeper_cdal_contract.of_keeper_meta meta in
   match
     Oas_worker.run_named
       ~cascade_name
@@ -206,6 +207,7 @@ let run_turn
       ?guardrails
       ?on_event
       ~agent_ref
+      ?contract
       ~allowed_paths:meta.allowed_paths
       ~working_context:checkpoint_sidecar
       ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -19,6 +19,7 @@ type run_result = {
   usage : Agent_sdk.Types.api_usage;
   tools_used : string list;
   checkpoint : Agent_sdk.Checkpoint.t option;
+  proof : Agent_sdk.Cdal_proof.t option;
 }
 
 let normalize_response_text ~(text : string) ~(tool_names : string list) :
@@ -244,6 +245,14 @@ let run_turn
            ~source:history_assistant_source
            session assistant_msg;
          ctx_ref := Keeper_exec_context.append !ctx_ref assistant_msg;
+         (match result.proof with
+          | Some p ->
+            Log.Keeper.info "keeper:%s proof: run_id=%s mode=%s status=%s violations=%d"
+              meta.name p.run_id
+              (Agent_sdk.Execution_mode.to_string p.effective_execution_mode)
+              (Agent_sdk.Cdal_proof.show_result_status p.result_status)
+              (List.length p.raw_evidence_refs)
+          | None -> ());
          Ok {
            response_text;
            model_used = model;
@@ -252,4 +261,5 @@ let run_turn
            usage;
            tools_used = tool_names;
            checkpoint = result.checkpoint;
+           proof = result.proof;
          })

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -1,0 +1,39 @@
+module Oas = Agent_sdk
+
+let infer_risk_class (meta : Keeper_types.keeper_meta) : Oas.Risk_class.t =
+  match String.lowercase_ascii meta.scope_kind with
+  | "read_only" | "readonly" | "observe" -> Oas.Risk_class.Low
+  | "workspace" | "local" -> Oas.Risk_class.Medium
+  | "full" | "unrestricted" -> Oas.Risk_class.Medium
+  | _ -> Oas.Risk_class.Medium
+
+let infer_execution_mode (meta : Keeper_types.keeper_meta) : Oas.Execution_mode.t =
+  match String.lowercase_ascii meta.scope_kind with
+  | "read_only" | "readonly" | "observe" -> Oas.Execution_mode.Diagnose
+  | "workspace" | "local" -> Oas.Execution_mode.Draft
+  | _ -> Oas.Execution_mode.Execute
+
+let infer_allowed_mutations (meta : Keeper_types.keeper_meta) : string list =
+  match String.lowercase_ascii meta.execution_scope with
+  | "workspace" | "local" -> ["workspace_only"]
+  | _ ->
+    if meta.allowed_paths <> [] then ["workspace_only"]
+    else []
+
+let of_keeper_meta (meta : Keeper_types.keeper_meta)
+    : Oas.Risk_contract.t option =
+  let risk_class = infer_risk_class meta in
+  let mode = infer_execution_mode meta in
+  let allowed_mutations = infer_allowed_mutations meta in
+  Some Oas.Risk_contract.{
+    runtime_constraints = {
+      requested_execution_mode = mode;
+      risk_class;
+      allowed_mutations;
+      review_requirement = None;
+    };
+    eval_criteria = `Assoc [
+      "keeper_name", `String meta.name;
+      "goal", `String meta.short_goal;
+    ];
+  }

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -128,6 +128,7 @@ type run_result = {
   session_id : string;
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
+  proof : Oas.Cdal_proof.t option;
 }
 
 (* ================================================================ *)
@@ -265,6 +266,7 @@ let run
     ~(config : config)
     ?(on_event : (Oas.Types.sse_event -> unit) option)
     ?(agent_ref : Oas.Agent.t option ref option)
+    ?(contract : Oas.Risk_contract.t option)
     (goal : string)
   : (run_result, string) result =
   let session_id = match config.session_id with
@@ -296,9 +298,16 @@ let run
      honouring the (run_result, string) result return type promised by .mli.
      Eio.Cancel.Cancelled is re-raised for structured-concurrency safety. *)
   (try
-    let result = match on_event with
-      | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
-      | None -> Oas.Agent.run ~sw agent goal
+    let result, proof = match contract with
+      | Some c ->
+        let cr = Oas.Contract_runner.run ~sw ~contract:c agent goal in
+        (cr.response, Some cr.proof)
+      | None ->
+        let r = match on_event with
+          | Some cb -> Oas.Agent.run_stream ~sw ~on_event:cb agent goal
+          | None -> Oas.Agent.run ~sw agent goal
+        in
+        (r, None)
     in
     let checkpoint = match config.checkpoint_dir with
       | Some dir ->
@@ -323,7 +332,7 @@ let run
     let trace_ref = Oas.Agent.last_raw_trace_run agent in
     Oas.Agent.close agent;
     (match result with
-    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref }
+    | Ok response -> Ok { response; checkpoint; session_id; turns; trace_ref; proof }
     | Error err ->
       Error (Printf.sprintf "Agent run failed: %s" (Oas.Error.to_string err)))
   with
@@ -477,6 +486,7 @@ let run_named
     ?raw_trace
     ?on_event
     ?agent_ref
+    ?contract
     ?transport
     ?(allowed_paths = [])
     ?working_context
@@ -525,7 +535,7 @@ let run_named
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace } in
-  match run ~sw ~net ~config ?on_event ?agent_ref goal with
+  match run ~sw ~net ~config ?on_event ?agent_ref ?contract goal with
   | Ok result when accept result.response ->
     record_cascade ~cascade_name ~outcome:`Success;
     Ok result

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -24,6 +24,7 @@ type run_result = {
   session_id : string;
   turns : int;
   trace_ref : Oas.Raw_trace.run_ref option;
+  proof : Oas.Cdal_proof.t option;
 }
 
 (** Cascade call/error metrics as JSON array, sorted by call count. *)
@@ -54,6 +55,7 @@ val run_named :
   ?raw_trace:Oas.Raw_trace.t ->
   ?on_event:(Oas.Types.sse_event -> unit) ->
   ?agent_ref:Oas.Agent.t option ref ->
+  ?contract:Oas.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?allowed_paths:string list ->
   ?working_context:Yojson.Safe.t ->

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.92.1"}
+  "agent_sdk" {>= "0.93.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.92.1"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.93.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="f384f9143a340e756a6b280aebfc83124d3a3c89"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.92.1"
+readonly OAS_AGENT_SDK_SHA="67d7e0c43c5ed4382f91c3d457d7a70d104a359c"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.93.0"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -361,6 +361,7 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     usage = { input_tokens = input_tok; output_tokens = output_tok; cache_creation_input_tokens = 0; cache_read_input_tokens = 0; cost_usd = None };
     tools_used = tools;
     checkpoint = None;
+    proof = None;
   }
 
 let test_metrics_text_response () =

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -282,6 +282,7 @@ let test_telemetry_of_run_result_carries_trace_ref () =
       session_id = "session-1";
       turns = 3;
       trace_ref = Some trace_ref;
+      proof = None;
     }
   in
   let telemetry = Team_session_oas_bridge.telemetry_of_run_result result in


### PR DESCRIPTION
## Summary

MASC -> OAS CDAL bridge. `Oas_worker.run_named`에 `?contract` 파라미터 추가.

- OAS agent_sdk pin v0.93.0으로 업데이트 (CDAL PoC-1 + PoC-1.5 포함)
- `?contract:Oas.Risk_contract.t` 전달 시 `Contract_runner.run` 사용
- `run_result.proof: Oas.Cdal_proof.t option` 필드 추가
- 기존 caller는 contract 미전달 -> 기존 Agent.run 경로 (zero overhead)

## OAS CDAL이 제공하는 것

| 기능 | 설명 |
|------|------|
| Mode enforcement | Diagnose/Draft/Execute에 따라 tool call 차단 |
| Capability downgrade | read-only tools -> Diagnose 자동 downgrade |
| Evidence enrichment | violations, token_usage, review_warning JSON |
| Proof bundle | 15-field manifest + artifact refs |

## Test plan

- [x] `dune build` success
- [x] test_team_session_oas_bridge: 18 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)