### PR TITLE
chore: Phase 3 batch 2 — remove unnecessary Eio.Mutex from chain/ modules

### DIFF
--- a/lib/chain/chain_executor_retry.ml
+++ b/lib/chain/chain_executor_retry.ml
@@ -169,7 +169,6 @@ type circuit_breaker = {
   mutable last_failure : float;
   failure_threshold : int;
   reset_timeout : float;
-  lock : Eio.Mutex.t;
 }
 
 (** Create a circuit breaker *)
@@ -179,38 +178,31 @@ let create_breaker ?(failure_threshold = 5) ?(reset_timeout = 30.0) () = {
   last_failure = 0.0;
   failure_threshold;
   reset_timeout;
-  lock = Eio.Mutex.create ();
 }
 
 (** Check if circuit allows execution *)
 let circuit_allows breaker =
-  Eio.Mutex.use_rw ~protect:true breaker.lock (fun () ->
-    match breaker.state with
-    | Closed -> true
-    | Open ->
-        let now = Unix.gettimeofday () in
-        if now -. breaker.last_failure > breaker.reset_timeout then begin
-          breaker.state <- HalfOpen;
-          true
-        end else false
-    | HalfOpen -> true
-  )
+  match breaker.state with
+  | Closed -> true
+  | Open ->
+      let now = Unix.gettimeofday () in
+      if now -. breaker.last_failure > breaker.reset_timeout then begin
+        breaker.state <- HalfOpen;
+        true
+      end else false
+  | HalfOpen -> true
 
 (** Record success *)
 let circuit_success breaker =
-  Eio.Mutex.use_rw ~protect:true breaker.lock (fun () ->
-    breaker.failure_count <- 0;
-    breaker.state <- Closed
-  )
+  breaker.failure_count <- 0;
+  breaker.state <- Closed
 
 (** Record failure *)
 let circuit_failure breaker =
-  Eio.Mutex.use_rw ~protect:true breaker.lock (fun () ->
-    breaker.failure_count <- breaker.failure_count + 1;
-    breaker.last_failure <- Unix.gettimeofday ();
-    if breaker.failure_count >= breaker.failure_threshold then
-      breaker.state <- Open
-  )
+  breaker.failure_count <- breaker.failure_count + 1;
+  breaker.last_failure <- Unix.gettimeofday ();
+  if breaker.failure_count >= breaker.failure_threshold then
+    breaker.state <- Open
 
 (** Execute with circuit breaker and retry *)
 let execute_with_breaker ~clock ~breaker ~node_id f =

--- a/lib/chain/chain_registry.ml
+++ b/lib/chain/chain_registry.ml
@@ -6,7 +6,7 @@
     Features:
     - In-memory storage using Hashtbl (fast lookup)
     - Optional file-based persistence (JSON files in registry directory)
-    - Thread-safe operations via Mutex
+    - Non-yielding ops (single-domain Eio atomic)
     - Support for versioning and metadata
 
     Usage:
@@ -43,10 +43,6 @@ type registry_stats = {
 (** In-memory registry storage *)
 let registry : (string, registry_entry) Hashtbl.t = Hashtbl.create 64
 
-let registry_mutex = Eio.Mutex.create ()
-
-let with_mutex f =
-  Eio.Mutex.use_rw ~protect:true registry_mutex f
 
 (** File-based persistence directory *)
 let registry_dir = ref None
@@ -93,29 +89,25 @@ let init ?persist_dir () =
 
 (** Register a chain in the registry *)
 let register ?(description : string option) (chain : chain) : unit =
-  with_mutex (fun () ->
-    let version = match Hashtbl.find_opt registry chain.id with
-      | Some entry -> entry.version + 1
-      | None -> 1
-    in
-    let entry = {
-      chain;
-      registered_at = Unix.gettimeofday ();
-      version;
-      description;
-    } in
-    Hashtbl.replace registry chain.id entry;
-
-    (* Persist to file if enabled *)
-    match !registry_dir with
-    | Some dir ->
-        let path = Filename.concat dir (chain.id ^ ".json") in
-        let json = chain_to_yojson chain in
-        Out_channel.with_open_text path (fun oc ->
-          Out_channel.output_string oc (Yojson.Safe.pretty_to_string json)
-        )
-    | None -> ()
-  )
+  let version = match Hashtbl.find_opt registry chain.id with
+    | Some entry -> entry.version + 1
+    | None -> 1
+  in
+  let entry = {
+    chain;
+    registered_at = Unix.gettimeofday ();
+    version;
+    description;
+  } in
+  Hashtbl.replace registry chain.id entry;
+  match !registry_dir with
+  | Some dir ->
+      let path = Filename.concat dir (chain.id ^ ".json") in
+      let json = chain_to_yojson chain in
+      Out_channel.with_open_text path (fun oc ->
+        Out_channel.output_string oc (Yojson.Safe.pretty_to_string json)
+      )
+  | None -> ()
 
 (** Load chain JSON files from a directory into the in-memory registry (no persistence).
 
@@ -157,11 +149,9 @@ let load_from_dir (dir : string) : (int * (string * string) list) =
 
 (** Look up a chain by ID *)
 let lookup (id : string) : chain option =
-  with_mutex (fun () ->
-    match Hashtbl.find_opt registry id with
-    | Some entry -> Some entry.chain
-    | None -> None
-  )
+  match Hashtbl.find_opt registry id with
+  | Some entry -> Some entry.chain
+  | None -> None
 
 (** Look up a chain by ID, raising Not_found if missing *)
 let lookup_exn (id : string) : chain =
@@ -171,147 +161,123 @@ let lookup_exn (id : string) : chain =
 
 (** Look up with full entry metadata *)
 let lookup_entry (id : string) : registry_entry option =
-  with_mutex (fun () ->
-    Hashtbl.find_opt registry id
-  )
+  Hashtbl.find_opt registry id
 
 (** Check if a chain is registered *)
 let exists (id : string) : bool =
-  with_mutex (fun () ->
-    Hashtbl.mem registry id
-  )
+  Hashtbl.mem registry id
 
 (** Unregister a chain by ID *)
 let unregister (id : string) : bool =
-  with_mutex (fun () ->
-    if Hashtbl.mem registry id then begin
-      Hashtbl.remove registry id;
-      (* Remove file if persistence enabled *)
-      (match !registry_dir with
-       | Some dir ->
-           let path = Filename.concat dir (id ^ ".json") in
-           if Sys.file_exists path then Sys.remove path
-       | None -> ());
-      true
-    end else
-      false
-  )
+  if Hashtbl.mem registry id then begin
+    Hashtbl.remove registry id;
+    (match !registry_dir with
+     | Some dir ->
+         let path = Filename.concat dir (id ^ ".json") in
+         if Sys.file_exists path then Sys.remove path
+     | None -> ());
+    true
+  end else
+    false
 
 (** List all registered chain IDs *)
 let list_ids () : string list =
-  with_mutex (fun () ->
-    Hashtbl.fold (fun id _ acc -> id :: acc) registry []
-  )
+  Hashtbl.fold (fun id _ acc -> id :: acc) registry []
 
 (** List all registered chains *)
 let list_all () : chain list =
-  with_mutex (fun () ->
-    Hashtbl.fold (fun _ entry acc -> entry.chain :: acc) registry []
-  )
+  Hashtbl.fold (fun _ entry acc -> entry.chain :: acc) registry []
 
 (** List all entries with metadata *)
 let list_entries () : (string * registry_entry) list =
-  with_mutex (fun () ->
-    Hashtbl.fold (fun id entry acc -> (id, entry) :: acc) registry []
-  )
+  Hashtbl.fold (fun id entry acc -> (id, entry) :: acc) registry []
 
 (** Get registry statistics *)
 let stats () : registry_stats =
-  with_mutex (fun () ->
-    let total_chains = Hashtbl.length registry in
-    let total_nodes = Hashtbl.fold (fun _ entry acc ->
-      acc + List.length entry.chain.nodes
-    ) registry 0 in
-    let oldest, newest =
-      Hashtbl.fold (fun id entry (oldest, newest) ->
-        let oldest' = match oldest with
-          | None -> Some (id, entry.registered_at)
-          | Some (_, t) when entry.registered_at < t -> Some (id, entry.registered_at)
-          | _ -> oldest
-        in
-        let newest' = match newest with
-          | None -> Some (id, entry.registered_at)
-          | Some (_, t) when entry.registered_at > t -> Some (id, entry.registered_at)
-          | _ -> newest
-        in
-        (oldest', newest')
-      ) registry (None, None)
-    in
-    {
-      total_chains;
-      total_nodes;
-      oldest_chain = Option.map fst oldest;
-      newest_chain = Option.map fst newest;
-    }
-  )
+  let total_chains = Hashtbl.length registry in
+  let total_nodes = Hashtbl.fold (fun _ entry acc ->
+    acc + List.length entry.chain.nodes
+  ) registry 0 in
+  let oldest, newest =
+    Hashtbl.fold (fun id entry (oldest, newest) ->
+      let oldest' = match oldest with
+        | None -> Some (id, entry.registered_at)
+        | Some (_, t) when entry.registered_at < t -> Some (id, entry.registered_at)
+        | _ -> oldest
+      in
+      let newest' = match newest with
+        | None -> Some (id, entry.registered_at)
+        | Some (_, t) when entry.registered_at > t -> Some (id, entry.registered_at)
+        | _ -> newest
+      in
+      (oldest', newest')
+    ) registry (None, None)
+  in
+  {
+    total_chains;
+    total_nodes;
+    oldest_chain = Option.map fst oldest;
+    newest_chain = Option.map fst newest;
+  }
 
 (** Clear all registered chains *)
 let clear () : unit =
-  with_mutex (fun () ->
-    Hashtbl.clear registry;
-    (* Clear files if persistence enabled *)
-    match !registry_dir with
-    | Some dir when Sys.file_exists dir && Sys.is_directory dir ->
-        let files = Sys.readdir dir in
-        Array.iter (fun file ->
-          if Filename.check_suffix file ".json" then
-            Sys.remove (Filename.concat dir file)
-        ) files
-    | _ -> ()
-  )
+  Hashtbl.clear registry;
+  match !registry_dir with
+  | Some dir when Sys.file_exists dir && Sys.is_directory dir ->
+      let files = Sys.readdir dir in
+      Array.iter (fun file ->
+        if Filename.check_suffix file ".json" then
+          Sys.remove (Filename.concat dir file)
+      ) files
+  | _ -> ()
 
 (** Count of registered chains *)
 let count () : int =
-  with_mutex (fun () ->
-    Hashtbl.length registry
-  )
+  Hashtbl.length registry
 
 (** Export registry to JSON *)
 let to_json () : Yojson.Safe.t =
-  with_mutex (fun () ->
-    let chains = Hashtbl.fold (fun id entry acc ->
-      let entry_json = `Assoc [
-        ("id", `String id);
-        ("chain", chain_to_yojson entry.chain);
-        ("registered_at", `Float entry.registered_at);
-        ("version", `Int entry.version);
-        ("description", match entry.description with
-          | Some d -> `String d
-          | None -> `Null);
-      ] in
-      entry_json :: acc
-    ) registry [] in
-    `List chains
-  )
+  let chains = Hashtbl.fold (fun id entry acc ->
+    let entry_json = `Assoc [
+      ("id", `String id);
+      ("chain", chain_to_yojson entry.chain);
+      ("registered_at", `Float entry.registered_at);
+      ("version", `Int entry.version);
+      ("description", match entry.description with
+        | Some d -> `String d
+        | None -> `Null);
+    ] in
+    entry_json :: acc
+  ) registry [] in
+  `List chains
 
 (** Import registry from JSON *)
 let of_json (json : Yojson.Safe.t) : (int, string) result =
-  with_mutex (fun () ->
-    try
-      let open Yojson.Safe.Util in
-      let entries = to_list json in
-      let count = ref 0 in
-      List.iter (fun entry_json ->
-        let chain_json = entry_json |> member "chain" in
-        match chain_of_yojson chain_json with
-        | Ok chain ->
-            let description = entry_json |> member "description" |> to_string_option in
-            let version = entry_json |> member "version" |> to_int_option |> Option.value ~default:1 in
-            let registered_at = entry_json |> member "registered_at" |> to_float_option
-              |> Option.value ~default:(Unix.gettimeofday ()) in
-            Hashtbl.replace registry chain.id {
-              chain;
-              registered_at;
-              version;
-              description;
-            };
-            incr count
-        | Error msg ->
-            Log.Chain.error "Failed to load entry: %s" msg
-      ) entries;
-      Ok !count
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-      Error (Printexc.to_string e)
-  )
+  try
+    let open Yojson.Safe.Util in
+    let entries = to_list json in
+    let count = ref 0 in
+    List.iter (fun entry_json ->
+      let chain_json = entry_json |> member "chain" in
+      match chain_of_yojson chain_json with
+      | Ok chain ->
+          let description = entry_json |> member "description" |> to_string_option in
+          let version = entry_json |> member "version" |> to_int_option |> Option.value ~default:1 in
+          let registered_at = entry_json |> member "registered_at" |> to_float_option
+            |> Option.value ~default:(Unix.gettimeofday ()) in
+          Hashtbl.replace registry chain.id {
+            chain;
+            registered_at;
+            version;
+            description;
+          };
+          incr count
+      | Error msg ->
+          Log.Chain.error "Failed to load entry: %s" msg
+    ) entries;
+    Ok !count
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
+    Error (Printexc.to_string e)

--- a/lib/chain/chain_run_store.ml
+++ b/lib/chain/chain_run_store.ml
@@ -226,20 +226,16 @@ let build_nodes ~(chain : chain) ~(outputs : (string, string) Hashtbl.t)
   ) nodes
 
 let store : run_record list ref = ref []
-let mutex = Eio.Mutex.create ()
 
 let append_persistent_json json =
   let path = store_path () in
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.append_jsonl path json
 
-let list_runs () : run_record list =
-  Eio.Mutex.use_rw ~protect:true mutex (fun () -> !store)
+let list_runs () : run_record list = !store
 
 let get_run ~(run_id : string) : run_record option =
-  Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-    List.find_opt (fun r -> String.equal r.run_id run_id) !store
-  )
+  List.find_opt (fun r -> String.equal r.run_id run_id) !store
 
 let output_entry_to_json (o : output_entry) : Yojson.Safe.t =
   `Assoc [
@@ -325,14 +321,12 @@ let record ~(run_id : string) ~(chain : chain) ~(plan : execution_plan)
       outputs = outputs_entries;
       chain_json = chain_to_yojson chain;
     } in
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      store := record :: !store;
-      let rec take n xs =
-        if n <= 0 then []
-        else match xs with [] -> [] | h :: t -> h :: take (n - 1) t
-      in
-      store := take max_keep !store
-    );
+    store := record :: !store;
+    let rec take n xs =
+      if n <= 0 then []
+      else match xs with [] -> [] | h :: t -> h :: take (n - 1) t
+    in
+    store := take max_keep !store;
     persist_run_record record
   end
 

--- a/lib/chain/chain_spawn_registry.ml
+++ b/lib/chain/chain_spawn_registry.ml
@@ -26,8 +26,6 @@ type snapshot = {
   updated_at: float;
 }
 
-let state_mutex = Eio.Mutex.create ()
-let with_lock f = Eio.Mutex.use_rw ~protect:true state_mutex f
 
 let parse_int value =
   try Some (int_of_string value) with Failure _ -> None
@@ -40,7 +38,7 @@ let env_int ~name ~default =
 let max_inflight = env_int ~name:"MASC_SPAWN_MAX_INFLIGHT" ~default:16
 let max_age_sec = env_int ~name:"MASC_SPAWN_MAX_AGE_SEC" ~default:900
 
-(** Consolidated mutable state — all fields accessed only under [state_mutex]. *)
+(** Consolidated mutable state — all fields are non-yielding ops (single-domain Eio atomic). *)
 type registry_state = {
   mutable next_id: int;
   mutable total: int;
@@ -113,69 +111,63 @@ let cleanup_stale now_sec =
 
 let try_start ~label =
   let now_sec = Time_compat.now () in
-  with_lock (fun () ->
-    let removed = cleanup_stale now_sec in
-    if removed > 0 then begin
-      st.failed <- st.failed + removed;
-      st.last_error <- Some "spawn_timeout"
-    end;
-    let inflight = Hashtbl.length active in
-    if max_inflight > 0 && inflight >= max_inflight then begin
-      st.last_error <- Some "spawn_inflight_limit";
-      Error (sprintf "spawn inflight limit reached (%d)" max_inflight)
-    end else begin
-      st.next_id <- st.next_id + 1;
-      let id = st.next_id in
-      Hashtbl.add active id { label; started_at = now_sec };
-      st.total <- st.total + 1;
-      let inflight' = inflight + 1 in
-      if inflight' > st.max_inflight_seen then
-        st.max_inflight_seen <- inflight';
-      Ok id
-    end
-  )
+  let removed = cleanup_stale now_sec in
+  if removed > 0 then begin
+    st.failed <- st.failed + removed;
+    st.last_error <- Some "spawn_timeout"
+  end;
+  let inflight = Hashtbl.length active in
+  if max_inflight > 0 && inflight >= max_inflight then begin
+    st.last_error <- Some "spawn_inflight_limit";
+    Error (sprintf "spawn inflight limit reached (%d)" max_inflight)
+  end else begin
+    st.next_id <- st.next_id + 1;
+    let id = st.next_id in
+    Hashtbl.add active id { label; started_at = now_sec };
+    st.total <- st.total + 1;
+    let inflight' = inflight + 1 in
+    if inflight' > st.max_inflight_seen then
+      st.max_inflight_seen <- inflight';
+    Ok id
+  end
 
 let finish ~id ~ok ~error =
   let now_sec = Time_compat.now () in
-  with_lock (fun () ->
-    (match Hashtbl.find_opt active id with
-     | Some info ->
-         Hashtbl.remove active id;
-         record_latency ((now_sec -. info.started_at) *. 1000.0)
-     | None -> ());
-    if not ok then begin
-      st.failed <- st.failed + 1;
-      st.last_error <- (match error with Some e -> Some e | None -> Some "spawn_failed")
-    end
-  )
+  (match Hashtbl.find_opt active id with
+   | Some info ->
+       Hashtbl.remove active id;
+       record_latency ((now_sec -. info.started_at) *. 1000.0)
+   | None -> ());
+  if not ok then begin
+    st.failed <- st.failed + 1;
+    st.last_error <- (match error with Some e -> Some e | None -> Some "spawn_failed")
+  end
 
 let snapshot () =
   let now_sec = Time_compat.now () in
-  with_lock (fun () ->
-    let removed = cleanup_stale now_sec in
-    if removed > 0 then begin
-      st.failed <- st.failed + removed;
-      st.last_error <- Some "spawn_timeout"
-    end;
-    let oldest =
-      Hashtbl.fold (fun _ info acc ->
-        let age = now_sec -. info.started_at in
-        match acc with
-        | None -> Some age
-        | Some v -> Some (max v age)
-      ) active None
-    in
-    {
-      inflight = Hashtbl.length active;
-      total = st.total;
-      failed = st.failed;
-      max_inflight = st.max_inflight_seen;
-      oldest_inflight_sec = oldest;
-      latency = latency_snapshot ();
-      last_error = st.last_error;
-      updated_at = now_sec;
-    }
-  )
+  let removed = cleanup_stale now_sec in
+  if removed > 0 then begin
+    st.failed <- st.failed + removed;
+    st.last_error <- Some "spawn_timeout"
+  end;
+  let oldest =
+    Hashtbl.fold (fun _ info acc ->
+      let age = now_sec -. info.started_at in
+      match acc with
+      | None -> Some age
+      | Some v -> Some (max v age)
+    ) active None
+  in
+  {
+    inflight = Hashtbl.length active;
+    total = st.total;
+    failed = st.failed;
+    max_inflight = st.max_inflight_seen;
+    oldest_inflight_sec = oldest;
+    latency = latency_snapshot ();
+    last_error = st.last_error;
+    updated_at = now_sec;
+  }
 
 let to_json () =
   let s = snapshot () in

--- a/lib/chain/chain_stats.ml
+++ b/lib/chain/chain_stats.ml
@@ -8,7 +8,7 @@
     - 비용 추정
     - 성공/실패율 계산
     - 시간별 추이 분석
-    - Thread-safe 통계 수집 (Mutex 사용)
+    - 통계 수집 (non-yielding ops, single-domain Eio atomic)
 
     @author Chain Engine
     @since 2026-01
@@ -94,15 +94,6 @@ let stats_data : raw_data = {
   active_chains = 0;
 }
 
-(** Eio mutex for fiber-cooperative synchronization.
-    Created at module init time (not lazily) to guarantee availability
-    before any concurrent fiber accesses stats_data or cascade_data. *)
-let stats_mutex = Eio.Mutex.create ()
-
-(** Helper for mutex-protected operations *)
-let with_mutex f =
-  Eio.Mutex.use_rw ~protect:true stats_mutex (fun () -> f ())
-
 (** {1 Data Collection} *)
 
 (** Get current hour (0-23) *)
@@ -117,50 +108,42 @@ let incr_counter tbl key delta =
 
 (** Event handler for statistics collection *)
 let stats_handler event =
-  with_mutex (fun () ->
-    match event with
-    | ChainStart _ ->
-      let hour = current_hour () in
-      incr_counter stats_data.hourly_chains hour 1;
-      stats_data.active_chains <- stats_data.active_chains + 1
+  match event with
+  | ChainStart _ ->
+    let hour = current_hour () in
+    incr_counter stats_data.hourly_chains hour 1;
+    stats_data.active_chains <- stats_data.active_chains + 1
 
-    | NodeComplete payload ->
-      stats_data.node_durations <- payload.node_duration_ms :: stats_data.node_durations;
-      let tokens = payload.node_tokens in
-      stats_data.total_tokens <- stats_data.total_tokens + tokens.total_tokens;
-      stats_data.total_cost <- stats_data.total_cost +. tokens.estimated_cost_usd;
+  | NodeComplete payload ->
+    stats_data.node_durations <- payload.node_duration_ms :: stats_data.node_durations;
+    let tokens = payload.node_tokens in
+    stats_data.total_tokens <- stats_data.total_tokens + tokens.total_tokens;
+    stats_data.total_cost <- stats_data.total_cost +. tokens.estimated_cost_usd;
+    let hour = current_hour () in
+    incr_counter stats_data.hourly_tokens hour tokens.total_tokens
 
-      (* Track hourly tokens *)
-      let hour = current_hour () in
-      incr_counter stats_data.hourly_tokens hour tokens.total_tokens
+  | ChainComplete payload ->
+    stats_data.chain_durations <- payload.complete_duration_ms :: stats_data.chain_durations;
+    stats_data.chain_timestamps <- Unix.gettimeofday () :: stats_data.chain_timestamps;
+    stats_data.success_count <- stats_data.success_count + 1;
+    stats_data.active_chains <- max 0 (stats_data.active_chains - 1)
 
-    | ChainComplete payload ->
-      stats_data.chain_durations <- payload.complete_duration_ms :: stats_data.chain_durations;
-      stats_data.chain_timestamps <- Unix.gettimeofday () :: stats_data.chain_timestamps;
-      stats_data.success_count <- stats_data.success_count + 1;
-      stats_data.active_chains <- max 0 (stats_data.active_chains - 1)
+  | Error payload ->
+    stats_data.failure_count <- stats_data.failure_count + 1;
+    incr_counter stats_data.errors payload.error_message 1;
+    stats_data.active_chains <- max 0 (stats_data.active_chains - 1)
 
-    | Error payload ->
-      stats_data.failure_count <- stats_data.failure_count + 1;
-      incr_counter stats_data.errors payload.error_message 1;
-      stats_data.active_chains <- max 0 (stats_data.active_chains - 1)
-
-    | NodeStart _ -> ()
-  )
+  | NodeStart _ -> ()
 
 (** Track model-specific token usage *)
 let track_model_tokens ~model ~tokens =
-  with_mutex (fun () ->
-    incr_counter stats_data.tokens_by_model model tokens;
-    incr_counter stats_data.call_counts_by_model model 1
-  )
+  incr_counter stats_data.tokens_by_model model tokens;
+  incr_counter stats_data.call_counts_by_model model 1
 
 (** Track model-specific latency *)
 let track_model_latency ~model ~latency_ms =
-  with_mutex (fun () ->
-    let current = Hashtbl.find_opt stats_data.latencies_by_model model |> Option.value ~default:[] in
-    Hashtbl.replace stats_data.latencies_by_model model (latency_ms :: current)
-  )
+  let current = Hashtbl.find_opt stats_data.latencies_by_model model |> Option.value ~default:[] in
+  Hashtbl.replace stats_data.latencies_by_model model (latency_ms :: current)
 
 (** {1 Percentile Calculation} *)
 
@@ -182,80 +165,65 @@ let percentiles ps list =
 
 (** Compute current statistics *)
 let compute ?(since=0.0) () =
-  with_mutex (fun () ->
-    (* Filter durations by timestamp if since > 0 *)
-    let filtered_durations =
-      if since <= 0.0 then stats_data.chain_durations
-      else
-        List.filter_map (fun (d, ts) -> if ts >= since then Some d else None)
-          (List.combine stats_data.chain_durations stats_data.chain_timestamps
-           |> fun pairs -> if List.length pairs = 0 then [] else pairs)
-    in
-
-    (* Calculate duration percentiles *)
-    let chain_ps = percentiles [0.5; 0.95; 0.99] filtered_durations in
-    let p50, p95, p99 = match chain_ps with
-      | [a; b; c] -> (a, b, c)
-      | _ -> (0.0, 0.0, 0.0)
-    in
-
-    (* Calculate average *)
-    let avg_duration =
-      if filtered_durations = [] then 0.0
-      else
-        let sum = List.fold_left (+) 0 filtered_durations in
-        float_of_int sum /. float_of_int (List.length filtered_durations)
-    in
-
-    (* Convert hashtables to lists *)
-    let tokens_by_model =
-      Hashtbl.fold (fun k v acc -> (k, v) :: acc) stats_data.tokens_by_model []
-      |> List.sort (fun (_, a) (_, b) -> compare b a)  (* Sort by tokens desc *)
-    in
-
-    let failure_reasons =
-      Hashtbl.fold (fun k v acc -> (k, v) :: acc) stats_data.errors []
-      |> List.sort (fun (_, a) (_, b) -> compare b a)  (* Sort by count desc *)
-    in
-
-    let hourly_tokens =
-      List.init 24 (fun h ->
-        (h, Hashtbl.find_opt stats_data.hourly_tokens h |> Option.value ~default:0))
-      |> List.filter (fun (_, v) -> v > 0)
-    in
-
-    let hourly_chains =
-      List.init 24 (fun h ->
-        (h, Hashtbl.find_opt stats_data.hourly_chains h |> Option.value ~default:0))
-      |> List.filter (fun (_, v) -> v > 0)
-    in
-
-    (* Calculate success rate *)
-    let total_attempts = stats_data.success_count + stats_data.failure_count in
-    let success_rate =
-      if total_attempts = 0 then 1.0
-      else float_of_int stats_data.success_count /. float_of_int total_attempts
-    in
-
-    {
-      total_chains = List.length stats_data.chain_durations;
-      total_nodes = List.length stats_data.node_durations;
-      active_chains = stats_data.active_chains;
-      avg_duration_ms = avg_duration;
-      p50_duration_ms = p50;
-      p95_duration_ms = p95;
-      p99_duration_ms = p99;
-      total_tokens = stats_data.total_tokens;
-      tokens_by_model;
-      estimated_cost_usd = stats_data.total_cost;
-      success_count = stats_data.success_count;
-      failure_count = stats_data.failure_count;
-      success_rate;
-      failure_reasons;
-      hourly_tokens;
-      hourly_chains;
-    }
-  )
+  let filtered_durations =
+    if since <= 0.0 then stats_data.chain_durations
+    else
+      List.filter_map (fun (d, ts) -> if ts >= since then Some d else None)
+        (List.combine stats_data.chain_durations stats_data.chain_timestamps
+         |> fun pairs -> if List.length pairs = 0 then [] else pairs)
+  in
+  let chain_ps = percentiles [0.5; 0.95; 0.99] filtered_durations in
+  let p50, p95, p99 = match chain_ps with
+    | [a; b; c] -> (a, b, c)
+    | _ -> (0.0, 0.0, 0.0)
+  in
+  let avg_duration =
+    if filtered_durations = [] then 0.0
+    else
+      let sum = List.fold_left (+) 0 filtered_durations in
+      float_of_int sum /. float_of_int (List.length filtered_durations)
+  in
+  let tokens_by_model =
+    Hashtbl.fold (fun k v acc -> (k, v) :: acc) stats_data.tokens_by_model []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+  in
+  let failure_reasons =
+    Hashtbl.fold (fun k v acc -> (k, v) :: acc) stats_data.errors []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+  in
+  let hourly_tokens =
+    List.init 24 (fun h ->
+      (h, Hashtbl.find_opt stats_data.hourly_tokens h |> Option.value ~default:0))
+    |> List.filter (fun (_, v) -> v > 0)
+  in
+  let hourly_chains =
+    List.init 24 (fun h ->
+      (h, Hashtbl.find_opt stats_data.hourly_chains h |> Option.value ~default:0))
+    |> List.filter (fun (_, v) -> v > 0)
+  in
+  let total_attempts = stats_data.success_count + stats_data.failure_count in
+  let success_rate =
+    if total_attempts = 0 then 1.0
+    else float_of_int stats_data.success_count /. float_of_int total_attempts
+  in
+  {
+    total_chains = List.length stats_data.chain_durations;
+    total_nodes = List.length stats_data.node_durations;
+    active_chains = stats_data.active_chains;
+    avg_duration_ms = avg_duration;
+    p50_duration_ms = p50;
+    p95_duration_ms = p95;
+    p99_duration_ms = p99;
+    total_tokens = stats_data.total_tokens;
+    tokens_by_model;
+    estimated_cost_usd = stats_data.total_cost;
+    success_count = stats_data.success_count;
+    failure_count = stats_data.failure_count;
+    success_rate;
+    failure_reasons;
+    hourly_tokens;
+    hourly_chains;
+  }
 
 (** {1 Cascade Data (must precede reset)} *)
 
@@ -304,27 +272,25 @@ let cascade_data : cascade_raw = {
 
 (** Reset all statistics *)
 let reset () =
-  with_mutex (fun () ->
-    stats_data.chain_durations <- [];
-    stats_data.chain_timestamps <- [];
-    stats_data.node_durations <- [];
-    Hashtbl.clear stats_data.tokens_by_model;
-    Hashtbl.clear stats_data.call_counts_by_model;
-    Hashtbl.clear stats_data.latencies_by_model;
-    Hashtbl.clear stats_data.errors;
-    Hashtbl.clear stats_data.hourly_tokens;
-    Hashtbl.clear stats_data.hourly_chains;
-    stats_data.success_count <- 0;
-    stats_data.failure_count <- 0;
-    stats_data.total_tokens <- 0;
-    stats_data.total_cost <- 0.0;
-    stats_data.active_chains <- 0;
-    cascade_data.cascade_count <- 0;
-    cascade_data.tier_resolutions <- [];
-    cascade_data.tier_resolution_count <- 0;
-    cascade_data.escalation_count <- 0;
-    cascade_data.hard_failure_count <- 0
-  )
+  stats_data.chain_durations <- [];
+  stats_data.chain_timestamps <- [];
+  stats_data.node_durations <- [];
+  Hashtbl.clear stats_data.tokens_by_model;
+  Hashtbl.clear stats_data.call_counts_by_model;
+  Hashtbl.clear stats_data.latencies_by_model;
+  Hashtbl.clear stats_data.errors;
+  Hashtbl.clear stats_data.hourly_tokens;
+  Hashtbl.clear stats_data.hourly_chains;
+  stats_data.success_count <- 0;
+  stats_data.failure_count <- 0;
+  stats_data.total_tokens <- 0;
+  stats_data.total_cost <- 0.0;
+  stats_data.active_chains <- 0;
+  cascade_data.cascade_count <- 0;
+  cascade_data.tier_resolutions <- [];
+  cascade_data.tier_resolution_count <- 0;
+  cascade_data.escalation_count <- 0;
+  cascade_data.hard_failure_count <- 0
 
 (** {1 Subscription Management} *)
 
@@ -376,77 +342,67 @@ let cost_per_1k_tokens model =
 
 (** Calculate model-specific statistics *)
 let model_statistics () : model_stats list =
-  with_mutex (fun () ->
-    Hashtbl.fold (fun model tokens (acc : model_stats list) ->
-      let cost = float_of_int tokens *. cost_per_1k_tokens model /. 1000.0 in
-      let call_count =
-        Hashtbl.find_opt stats_data.call_counts_by_model model
-        |> Option.value ~default:1
-      in
-      let avg_tokens = float_of_int tokens /. float_of_int (max 1 call_count) in
-      let avg_latency_ms =
-        match Hashtbl.find_opt stats_data.latencies_by_model model with
-        | None -> 0.0
-        | Some [] -> 0.0
-        | Some latencies ->
-            let sum = List.fold_left (+) 0 latencies in
-            float_of_int sum /. float_of_int (List.length latencies)
-      in
-      ({
-        model_name = model;
-        call_count;
-        total_tokens = tokens;
-        avg_tokens_per_call = avg_tokens;
-        total_cost_usd = cost;
-        avg_latency_ms;
-      } : model_stats) :: acc
-    ) stats_data.tokens_by_model ([] : model_stats list)
-    |> List.sort (fun (a : model_stats) (b : model_stats) -> compare b.total_tokens a.total_tokens)
-  )
+  Hashtbl.fold (fun model tokens (acc : model_stats list) ->
+    let cost = float_of_int tokens *. cost_per_1k_tokens model /. 1000.0 in
+    let call_count =
+      Hashtbl.find_opt stats_data.call_counts_by_model model
+      |> Option.value ~default:1
+    in
+    let avg_tokens = float_of_int tokens /. float_of_int (max 1 call_count) in
+    let avg_latency_ms =
+      match Hashtbl.find_opt stats_data.latencies_by_model model with
+      | None -> 0.0
+      | Some [] -> 0.0
+      | Some latencies ->
+          let sum = List.fold_left (+) 0 latencies in
+          float_of_int sum /. float_of_int (List.length latencies)
+    in
+    ({
+      model_name = model;
+      call_count;
+      total_tokens = tokens;
+      avg_tokens_per_call = avg_tokens;
+      total_cost_usd = cost;
+      avg_latency_ms;
+    } : model_stats) :: acc
+  ) stats_data.tokens_by_model ([] : model_stats list)
+  |> List.sort (fun (a : model_stats) (b : model_stats) -> compare b.total_tokens a.total_tokens)
 
 (** {1 Cascade Statistics} *)
 
 (** Track a cascade execution result *)
 let track_cascade ~resolved_tier ~escalations ~hard_failures =
-  with_mutex (fun () ->
-    cascade_data.cascade_count <- cascade_data.cascade_count + 1;
-    cascade_data.tier_resolutions <- resolved_tier :: cascade_data.tier_resolutions;
-    cascade_data.tier_resolution_count <- cascade_data.tier_resolution_count + 1;
-    (* Cap tier history to prevent unbounded memory growth.
-       Truncate at 2x threshold for amortized O(1) - avoids O(n) on every insert. *)
-    if cascade_data.tier_resolution_count > max_tier_history * 2 then begin
-      cascade_data.tier_resolutions <- list_take max_tier_history cascade_data.tier_resolutions;
-      cascade_data.tier_resolution_count <- max_tier_history
-    end;
-    cascade_data.escalation_count <- cascade_data.escalation_count + escalations;
-    cascade_data.hard_failure_count <- cascade_data.hard_failure_count + hard_failures
-  )
+  cascade_data.cascade_count <- cascade_data.cascade_count + 1;
+  cascade_data.tier_resolutions <- resolved_tier :: cascade_data.tier_resolutions;
+  cascade_data.tier_resolution_count <- cascade_data.tier_resolution_count + 1;
+  if cascade_data.tier_resolution_count > max_tier_history * 2 then begin
+    cascade_data.tier_resolutions <- list_take max_tier_history cascade_data.tier_resolutions;
+    cascade_data.tier_resolution_count <- max_tier_history
+  end;
+  cascade_data.escalation_count <- cascade_data.escalation_count + escalations;
+  cascade_data.hard_failure_count <- cascade_data.hard_failure_count + hard_failures
 
 (** Compute cascade statistics snapshot *)
 let cascade_snapshot () : cascade_stats =
-  with_mutex (fun () ->
-    let total = cascade_data.cascade_count in
-    let tiers = cascade_data.tier_resolutions in
-    let tier0 = List.length (List.filter (fun t -> t = 0) tiers) in
-    let tier1 = List.length (List.filter (fun t -> t = 1) tiers) in
-    let tier2_plus = List.length (List.filter (fun t -> t >= 2) tiers) in
-    let avg = if total = 0 then 0.0
-      else float_of_int (List.fold_left (+) 0 tiers) /. float_of_int total in
-    (* Savings: if all went to max tier, cost would be higher.
-       Estimate: tier0 saves ~100%, tier1 saves ~50%, tier2+ saves 0% *)
-    let savings = if total = 0 then 0.0
-      else (float_of_int tier0 *. 1.0 +. float_of_int tier1 *. 0.5) /. float_of_int total *. 100.0 in
-    {
-      total_cascades = total;
-      tier0_resolved = tier0;
-      tier1_resolved = tier1;
-      tier2_plus_resolved = tier2_plus;
-      total_escalations = cascade_data.escalation_count;
-      total_hard_failures = cascade_data.hard_failure_count;
-      avg_tier = avg;
-      estimated_savings_pct = savings;
-    }
-  )
+  let total = cascade_data.cascade_count in
+  let tiers = cascade_data.tier_resolutions in
+  let tier0 = List.length (List.filter (fun t -> t = 0) tiers) in
+  let tier1 = List.length (List.filter (fun t -> t = 1) tiers) in
+  let tier2_plus = List.length (List.filter (fun t -> t >= 2) tiers) in
+  let avg = if total = 0 then 0.0
+    else float_of_int (List.fold_left (+) 0 tiers) /. float_of_int total in
+  let savings = if total = 0 then 0.0
+    else (float_of_int tier0 *. 1.0 +. float_of_int tier1 *. 0.5) /. float_of_int total *. 100.0 in
+  {
+    total_cascades = total;
+    tier0_resolved = tier0;
+    tier1_resolved = tier1;
+    tier2_plus_resolved = tier2_plus;
+    total_escalations = cascade_data.escalation_count;
+    total_hard_failures = cascade_data.hard_failure_count;
+    avg_tier = avg;
+    estimated_savings_pct = savings;
+  }
 
 (** {1 Serialization} *)
 

--- a/lib/chain/chain_telemetry.ml
+++ b/lib/chain/chain_telemetry.ml
@@ -6,7 +6,7 @@
     - 비동기 이벤트 발행 (emit)
     - 다중 구독자 지원 (subscribe/unsubscribe)
     - 구조화된 이벤트 타입 (ChainStart, NodeComplete, Error 등)
-    - Fiber-safe 구독자 관리 (Eio.Mutex 사용)
+    - 구독자 관리 (non-yielding ops, single-domain Eio atomic)
 
     @author Chain Engine
     @since 2026-01
@@ -14,11 +14,6 @@
 
 
 open Chain_category
-
-(** {1 Eio-aware Mutex Guard}
-
-    Delegates to {!Eio_guard.with_mutex} for dual-mode locking. *)
-let with_mutex mutex f = Eio_guard.with_mutex mutex f
 
 (** {1 History Persistence} *)
 
@@ -108,7 +103,6 @@ type event_handler = chain_event -> unit
 (** Global subscription registry *)
 let next_sub_id = ref 0
 let subscribers : (subscription_id, event_handler) Hashtbl.t = Hashtbl.create 16
-let subscribers_mutex = Eio.Mutex.create ()
 
 (** {1 Running Chains Tracking} *)
 
@@ -122,46 +116,37 @@ type running_chain_info = {
 }
 
 let running_chains : (string, running_chain_info) Hashtbl.t = Hashtbl.create 16
-let running_chains_mutex = Eio.Mutex.create ()
 
 (** Register a chain as running *)
 let register_running_chain ~chain_id ~total_nodes =
-  with_mutex running_chains_mutex (fun () ->
-    let info = {
-      chain_id;
-      started_at = Unix.gettimeofday ();
-      progress = 0.0;
-      _nodes_completed = 0;
-      total_nodes;
-    } in
-    Hashtbl.replace running_chains chain_id info
-  )
+  let info = {
+    chain_id;
+    started_at = Unix.gettimeofday ();
+    progress = 0.0;
+    _nodes_completed = 0;
+    total_nodes;
+  } in
+  Hashtbl.replace running_chains chain_id info
 
 (** Update chain progress *)
 let update_chain_progress ~chain_id ~nodes_completed =
-  with_mutex running_chains_mutex (fun () ->
-    match Hashtbl.find_opt running_chains chain_id with
-    | Some info ->
-        info._nodes_completed <- nodes_completed;
-        info.progress <- if info.total_nodes > 0
-          then float_of_int nodes_completed /. float_of_int info.total_nodes
-          else 0.0
-    | None -> ()
-  )
+  match Hashtbl.find_opt running_chains chain_id with
+  | Some info ->
+      info._nodes_completed <- nodes_completed;
+      info.progress <- if info.total_nodes > 0
+        then float_of_int nodes_completed /. float_of_int info.total_nodes
+        else 0.0
+  | None -> ()
 
 (** Unregister a completed chain *)
 let unregister_running_chain ~chain_id =
-  with_mutex running_chains_mutex (fun () ->
-    Hashtbl.remove running_chains chain_id
-  )
+  Hashtbl.remove running_chains chain_id
 
 (** Get all running chains *)
 let get_running_chains () : (string * float * float) list =
-  with_mutex running_chains_mutex (fun () ->
-    Hashtbl.fold (fun _id info acc ->
-      (info.chain_id, info.started_at, info.progress) :: acc
-    ) running_chains []
-  )
+  Hashtbl.fold (fun _id info acc ->
+    (info.chain_id, info.started_at, info.progress) :: acc
+  ) running_chains []
 
 (** Generate next subscription ID *)
 let gen_sub_id () =
@@ -209,10 +194,9 @@ let save_to_history event =
 let emit event =
   (* Save to history file (chain_start, chain_complete, chain_error only) *)
   save_to_history event;
-  (* Get handlers snapshot under lock *)
-  let handlers = with_mutex subscribers_mutex (fun () ->
+  let handlers =
     Hashtbl.fold (fun _ handler acc -> handler :: acc) subscribers []
-  ) in
+  in
   (* Call handlers outside of lock to avoid deadlocks *)
   List.iter (fun handler ->
     try handler event
@@ -223,28 +207,23 @@ let emit event =
 
 (** Subscribe to chain events *)
 let subscribe handler =
-  with_mutex subscribers_mutex (fun () ->
-    let id = gen_sub_id () in
-    Hashtbl.add subscribers id handler;
-    { sub_id = id; active = true }
-  )
+  let id = gen_sub_id () in
+  Hashtbl.add subscribers id handler;
+  { sub_id = id; active = true }
 
 (** Unsubscribe from chain events *)
 let unsubscribe sub =
-  if sub.active then
-    with_mutex subscribers_mutex (fun () ->
-      Hashtbl.remove subscribers sub.sub_id;
-      sub.active <- false
-    )
+  if sub.active then begin
+    Hashtbl.remove subscribers sub.sub_id;
+    sub.active <- false
+  end
 
 (** Check if subscription is active *)
 let is_active sub = sub.active
 
 (** Get number of active subscribers *)
 let subscriber_count () =
-  with_mutex subscribers_mutex (fun () ->
-    Hashtbl.length subscribers
-  )
+  Hashtbl.length subscribers
 
 (** {1 Event Constructors} *)
 
@@ -299,17 +278,13 @@ let error ~node_id ~message ~retries =
 
 (** Event log buffer for persistence *)
 let event_log : chain_event list ref = ref []
-let event_log_mutex = Eio.Mutex.create ()
 let max_log_size = ref 10000
 
 (** Logging subscriber that buffers events *)
 let logging_handler event =
-  with_mutex event_log_mutex (fun () ->
-    event_log := event :: !event_log;
-    (* Trim if exceeds max size *)
-    if List.length !event_log > !max_log_size then
-      event_log := List.filteri (fun i _ -> i < !max_log_size) !event_log
-  )
+  event_log := event :: !event_log;
+  if List.length !event_log > !max_log_size then
+    event_log := List.filteri (fun i _ -> i < !max_log_size) !event_log
 
 (** Initialize logging subscriber *)
 let logging_subscription = ref None
@@ -330,16 +305,12 @@ let disable_logging () =
 
 (** Get recent events from log *)
 let get_recent_events ?(limit=100) () =
-  with_mutex event_log_mutex (fun () ->
-    let events = List.filteri (fun i _ -> i < limit) !event_log in
-    List.rev events  (* Return in chronological order *)
-  )
+  let events = List.filteri (fun i _ -> i < limit) !event_log in
+  List.rev events
 
 (** Clear event log *)
 let clear_log () =
-  with_mutex event_log_mutex (fun () ->
-    event_log := []
-  )
+  event_log := []
 
 (** {1 Filtering} *)
 

--- a/lib/chain/chain_telemetry.mli
+++ b/lib/chain/chain_telemetry.mli
@@ -6,7 +6,7 @@
     - 비동기 이벤트 발행 (emit)
     - 다중 구독자 지원 (subscribe/unsubscribe)
     - 구조화된 이벤트 타입 (ChainStart, NodeComplete, Error 등)
-    - Fiber-safe 구독자 관리 (Eio.Mutex, dual-mode guard)
+    - 구독자 관리 (non-yielding ops, single-domain Eio atomic)
 
     @author Chain Engine
     @since 2026-01


### PR DESCRIPTION
## Summary
- chain/ 모듈에서 불필요한 Eio.Mutex 8개 제거 (6개 파일, -129줄)
- 모든 보호 대상 연산이 non-yielding (Hashtbl, mutable field, ref) — single-domain Eio에서 원자적
- cross-fiber mutex (executor fork 사이트) + bootstrap guard는 유지

## 제거 대상
| 파일 | mutex | 근거 |
|------|-------|------|
| chain_telemetry.ml | 3 (subscribers, running_chains, event_log) | Hashtbl.fold/replace/remove만 |
| chain_stats.ml | 1 (stats_mutex) | mutable field + Hashtbl ops |
| chain_executor_retry.ml | 1 (circuit breaker lock) | mutable state read/write |
| chain_spawn_registry.ml | 1 (state_mutex) | Hashtbl + Array + mutable |
| chain_run_store.ml | 1 (store mutex) | ref list cons/take |
| chain_registry.ml | 1 (registry_mutex) | stdlib blocking I/O (non-yielding) |

## 유지 대상
| 파일 | mutex | 근거 |
|------|-------|------|
| chain_native_eio.ml | bootstrap_mutex | Fs_compat I/O 가능성 + once-only guard |
| chain_executor_complex.ml | count_mutex | Eio.Fiber.fork cross-fiber |
| chain_executor_search.ml | tree_mutex | parallel tree exploration |
| chain_executor_resilience.ml | 2 mutexes | Eio.Fiber.fork race |

## Test plan
- [x] `dune build` 성공
- [x] chain test suite 통과 (142 + 131 + 2 tests)
- [ ] CI 전체 통과

Refs: #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)