### PR TITLE
chore: remove dead libdatachannel path helpers

### DIFF
--- a/lib/env_config_core.ml
+++ b/lib/env_config_core.ml
@@ -198,30 +198,6 @@ and masc_http_base_url_result () =
         (fun host -> Printf.sprintf "http://%s:%s" host (masc_http_port ()))
         host
 
-let libdatachannel_path_candidates () =
-  let env_path =
-    Sys.getenv_opt "LIBDATACHANNEL_PATH" |> trim_opt |> Option.to_list
-  in
-  let common =
-    [
-      "/usr/local/lib/libdatachannel.dylib";
-      "/opt/homebrew/lib/libdatachannel.dylib";
-      "/usr/lib/libdatachannel.dylib";
-      "/usr/local/lib/libdatachannel.so";
-      "/usr/lib/libdatachannel.so";
-    ]
-  in
-  let home_local =
-    match home_dir_opt () with
-    | Some home -> [ Filename.concat home "local/lib/libdatachannel.dylib" ]
-    | None -> []
-  in
-  env_path @ common @ home_local
-
-let libdatachannel_path_opt () =
-  libdatachannel_path_candidates ()
-  |> List.find_opt existing_file
-
 (** {1 Additional Helpers} *)
 
 (** Read a TCP port from env, validated to [1, 65535]. Returns default on

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -147,11 +147,6 @@ let test_cluster_name_opt_trims_empty () =
     check string "cluster_name empty -> default" "default"
       (Env_config.cluster_name ()))
 
-let test_libdatachannel_candidates_include_env_override () =
-  with_env "LIBDATACHANNEL_PATH" "/tmp/libdatachannel-custom.dylib" (fun () ->
-    check bool "env path present" true
-      (List.mem "/tmp/libdatachannel-custom.dylib" (Env_config.libdatachannel_path_candidates ())))
-
 let test_endpoints_result_helpers () =
   with_env "MASC_HTTP_BASE_URL" "https://masc.example.test" (fun () ->
     check (result string string) "masc_host_result"
@@ -403,7 +398,6 @@ let () =
       test_case "assets dir prefers primary over deprecated" `Quick test_assets_dir_prefers_primary_over_deprecated;
       test_case "cluster_name_opt trims empty" `Quick test_cluster_name_opt_trims_empty;
       test_case "endpoint result helpers" `Quick test_endpoints_result_helpers;
-      test_case "libdatachannel candidates include env override" `Quick test_libdatachannel_candidates_include_env_override;
     ];
     "print_summary", [
       test_case "no error" `Quick test_print_summary_no_error;


### PR DESCRIPTION
## Summary
- WebRTC가 `ocaml-webrtc`로 추출된 후 caller가 0인 `libdatachannel_path_candidates()`, `libdatachannel_path_opt()` 삭제
- 관련 테스트 제거

## Changes
- `lib/env_config_core.ml` — dead code 24줄 삭제
- `test/test_env_config_coverage.ml` — 관련 테스트 6줄 삭제

## Test plan
- [x] `dune build` 통과
- [x] `rg libdatachannel` 결과 0건
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)