### PR TITLE
chore: remove deprecated SSE_legacy transport variant

### DIFF
--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -8,9 +8,7 @@
     - Thread-safe session storage using Mutex
 *)
 
-type transport =
-  | SSE_legacy
-  | Streamable_HTTP
+type transport = Streamable_HTTP
 
 type session = {
   id: string;

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -1,21 +1,16 @@
 (** Streamable HTTP Transport for MCP
 
     Implements MCP spec 2025-03-26 Streamable HTTP transport.
-    Replaces SSE as primary transport while maintaining backward compatibility.
-
     Key features:
     - POST /mcp: JSON-RPC request/response (stateless or session-bound)
     - GET /mcp: Optional SSE stream for server-initiated notifications
     - Session management via mcp-session-id header
-    - Graceful upgrade path from SSE-only clients
 
     @see <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
 *)
 
-(** Transport type selection *)
-type transport =
-  | SSE_legacy      (** Legacy SSE-only transport *)
-  | Streamable_HTTP (** New Streamable HTTP transport *)
+(** Transport type *)
+type transport = Streamable_HTTP
 
 (** Session state *)
 type session = {

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -9,7 +9,7 @@ let test_session_create () =
   Alcotest.(check int) "subscriptions empty" 0 (List.length session.subscriptions)
 
 let test_session_find () =
-  let session = SH.Session.create ~transport:SH.SSE_legacy in
+  let session = SH.Session.create ~transport:SH.Streamable_HTTP in
   let found = SH.Session.find session.id in
   Alcotest.(check bool) "session found" true (Option.is_some found);
   let not_found = SH.Session.find "nonexistent-id" in


### PR DESCRIPTION
## Summary
- Streamable HTTP가 유일한 transport. `SSE_legacy` variant 제거
- 테스트에서 `SSE_legacy` → `Streamable_HTTP`로 변경

## Changes
- `lib/streamable_http.ml` — `SSE_legacy` variant 삭제
- `lib/streamable_http.mli` — 동일
- `test/test_streamable_http.ml` — transport 타입 변경

## Test plan
- [x] `dune build` 통과 (exhaustiveness check가 누락 match를 검출)
- [x] `rg SSE_legacy` 결과 0건
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)