### PR TITLE
chore: remove 5 deprecated env var fallbacks

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -482,7 +482,7 @@ export interface DashboardBuildIdentity {
 export interface DashboardRuntimeResolution {
   status: 'ready' | 'warn' | string
   warnings: string[]
-  base_path_input: DashboardConfigResolutionItem
+  base_path: DashboardConfigResolutionItem
   workspace_path: DashboardConfigResolutionItem
   resolved_base_path: DashboardConfigResolutionItem
   data_root: DashboardConfigResolutionItem

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -32,7 +32,7 @@ describe('ConfigResolutionPanel', () => {
         runtimeResolution=${{
           status: 'warn',
           warnings: ['Runtime build commit (deadbee) differs from workspace HEAD (cafef00d).'],
-          base_path_input: { path: '/tmp/runtime-input', exists: true, source: 'input' },
+          base_path: { path: '/tmp/runtime-input', exists: true, source: 'input' },
           workspace_path: { path: '/tmp/workspace', exists: true, source: 'workspace' },
           resolved_base_path: { path: '/tmp/workspace', exists: true, source: 'resolved_base' },
           data_root: { path: '/tmp/workspace/.masc', exists: true, source: 'runtime_data' },

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -293,7 +293,7 @@ export function ConfigResolutionPanel({
               </div>
 
               <div class="grid gap-3 md:grid-cols-2">
-                <${ConfigRow} label="base path input" item=${runtimeResolution.base_path_input} />
+                <${ConfigRow} label="base path" item=${runtimeResolution.base_path} />
                 <${ConfigRow} label="workspace path" item=${runtimeResolution.workspace_path} />
                 <${ConfigRow} label="resolved base path" item=${runtimeResolution.resolved_base_path} />
                 <${ConfigRow} label="data root" item=${runtimeResolution.data_root} />

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -46,8 +46,7 @@
 | `DUNE_SOURCEROOT` | string | - | 테스트 환경 fallback (3순위) |
 | `MASC_CONFIG_DIR` | string | 자동 탐색 | repo-managed config root (`config/cascade.json`, `config/prompts`, `config/keepers`, `config/personas`) |
 | `MASC_PERSONAS_DIR` | string | unset | persona root override. 설정 시 `config/personas` 대신 이 디렉토리를 사용 |
-| `MASC_SB_PATH` | string | `{root}/scripts/sb` | sb CLI 경로 |
-| `MASC_HTTP_PORT` / `MASC_PORT` | string | `"8935"` | HTTP 서버 포트 |
+| `MASC_HTTP_PORT` | string | `"8935"` | HTTP 서버 포트 |
 | `MASC_HTTP_BASE_URL` | string | - | 전체 base URL (설정 시 host/port 무시) |
 | `MASC_HOST` | string | - | 바인드 호스트 (base URL 미설정 시 필수) |
 | `LIBDATACHANNEL_PATH` | string | 자동 탐색 | WebRTC 라이브러리 경로 |

--- a/lib/chain/chain_native_eio.ml
+++ b/lib/chain/chain_native_eio.ml
@@ -118,7 +118,7 @@ let chain_source_roots (config : Room.config) =
   in
   let roots = add [] config.base_path in
   let roots =
-    match Env_config_core.base_path_input_opt () with
+    match Env_config_core.base_path_opt () with
     | Some path -> add roots path
     | None -> roots
   in

--- a/lib/env_config_core.ml
+++ b/lib/env_config_core.ml
@@ -138,15 +138,11 @@ let get_bool_deprecated ~default ~primary ~deprecated =
   | None -> default
 
 let sb_path_opt () =
-  match deprecated_opt ~old_name:"MASC_SB_PATH"
-          ~new_name:"MASC_WORKSPACE_ROOT or ME_ROOT" with
-  | Some path -> Some path
-  | None -> (
-      match me_root_opt () with
-      | Some root ->
-          let path = Filename.concat root "scripts/sb" in
-          if existing_file path then Some path else None
-      | None -> None)
+  match me_root_opt () with
+  | Some root ->
+      let path = Filename.concat root "scripts/sb" in
+      if existing_file path then Some path else None
+  | None -> None
 
 let sb_path_result () =
   match sb_path_opt () with
@@ -163,23 +159,16 @@ let sb_path () =
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
   | Some port -> port
-  | None -> (
-      match Sys.getenv_opt "MASC_PORT" |> trim_opt with
-      | Some port ->
-          warn_deprecated ~old_name:"MASC_PORT" ~new_name:"MASC_HTTP_PORT";
-          port
-      | None -> "8935")
+  | None -> "8935"
 
 let masc_http_port_int () =
   Safe_ops.int_of_string_with_default ~default:8935 (masc_http_port ())
 
 let masc_host_opt () =
-  match Sys.getenv_opt "MASC_HOST" |> trim_opt with
-  | Some host -> Some host
-  | None -> deprecated_opt ~old_name:"MASC_HTTP_BIND_HOST" ~new_name:"MASC_HOST"
+  Sys.getenv_opt "MASC_HOST" |> trim_opt
 
 (** Centralized MASC_HOST reader.
-    Reads MASC_HOST (primary) with MASC_HTTP_BIND_HOST (deprecated) fallback.
+    Reads MASC_HOST env var.
     Default: "127.0.0.1". *)
 let masc_host () =
   match masc_host_opt () with
@@ -187,13 +176,9 @@ let masc_host () =
   | None -> "127.0.0.1"
 
 (** Centralized MASC_ASSETS_DIR reader.
-    Reads MASC_ASSETS_DIR (primary) with MASC_ASSETS_ROOT (deprecated) fallback.
-    Returns None when neither is set. *)
+    Returns None when MASC_ASSETS_DIR is unset or empty. *)
 let assets_dir_opt () =
-  match Sys.getenv_opt "MASC_ASSETS_DIR" |> trim_opt with
-  | Some dir -> Some dir
-  | None ->
-      deprecated_opt ~old_name:"MASC_ASSETS_ROOT" ~new_name:"MASC_ASSETS_DIR"
+  Sys.getenv_opt "MASC_ASSETS_DIR" |> trim_opt
 
 let cluster_name_opt () =
   Sys.getenv_opt "MASC_CLUSTER_NAME" |> trim_opt
@@ -252,11 +237,6 @@ let base_path () =
   match base_path_opt () with
   | Some path -> path
   | None -> "."
-
-(** Deprecated input path alias. Reads MASC_BASE_PATH_INPUT with deprecation
-    warning. Call sites should migrate to [base_path]. *)
-let base_path_input_opt () =
-  deprecated_opt ~old_name:"MASC_BASE_PATH_INPUT" ~new_name:"MASC_BASE_PATH"
 
 (** Storage backend type. Set at runtime by server_runtime_bootstrap.
     Valid: "filesystem", "postgres-native". *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -136,7 +136,7 @@ let runtime_resolution_json (config : Room.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    Env_config_core.base_path_input_opt ()
+    Env_config_core.base_path_opt ()
     |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =
@@ -207,7 +207,7 @@ let runtime_resolution_json (config : Room.config) =
     [
       ("status", `String status);
       ("warnings", `List (List.map (fun warning -> `String warning) warnings));
-      ("base_path_input", path_item_json ~source:"input" base_path_input);
+      ("base_path", path_item_json ~source:"input" base_path_input);
       ("workspace_path", path_item_json ~source:"workspace" config.workspace_path);
       ("resolved_base_path", path_item_json ~source:"resolved_base" config.base_path);
       ("data_root", path_item_json ~source:"runtime_data" (Room.masc_root_dir config));

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -51,7 +51,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
       method mono_clock = mono_clock
     end
   in
-  Unix.putenv "MASC_BASE_PATH_INPUT" base_path;
+  Unix.putenv "MASC_BASE_PATH" base_path;
   let state =
     Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~net
       ~base_path

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -36,7 +36,6 @@ let assets_root () =
         | Some value -> value :: acc
         | None -> acc)
       [
-        base_path_assets "MASC_BASE_PATH_INPUT";
         base_path_assets "MASC_BASE_PATH";
         Some inferred_repo_assets;
         Some (Filename.concat exe_dir "assets");

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -113,32 +113,19 @@ let test_sb_path_result_missing_is_error () =
       check bool "sb path result is error" true
         (match Env_config.sb_path_result () with Error _ -> true | Ok _ -> false)))
 
-let test_sb_path_legacy_env_still_works () =
-  let path = Filename.temp_file "masc-sb" ".sh" in
-  Fun.protect
-    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
-    (fun () ->
-      with_env "MASC_SB_PATH" path (fun () ->
-        with_env "MASC_WORKSPACE_ROOT" "" (fun () ->
-          with_env "ME_ROOT" "" (fun () ->
-            check (result string string) "legacy sb path still accepted"
-              (Ok path) (Env_config.sb_path_result ())))))
-
 let test_masc_host_prefers_primary_over_deprecated () =
   with_env "MASC_HOST" "primary.example.test" (fun () ->
-    with_env "MASC_HTTP_BIND_HOST" "legacy.example.test" (fun () ->
-      let resolved = Env_config.masc_host () in
-      let explicit = Env_config.masc_host_opt () in
-      check string "primary host wins" "primary.example.test" resolved;
-      check (option string) "explicit host wins" (Some "primary.example.test")
-        explicit))
+    let resolved = Env_config.masc_host () in
+    let explicit = Env_config.masc_host_opt () in
+    check string "primary host wins" "primary.example.test" resolved;
+    check (option string) "explicit host wins" (Some "primary.example.test")
+      explicit)
 
 let test_assets_dir_prefers_primary_over_deprecated () =
   with_env "MASC_ASSETS_DIR" "/tmp/assets-primary" (fun () ->
-    with_env "MASC_ASSETS_ROOT" "/tmp/assets-legacy" (fun () ->
-      let resolved = Env_config.assets_dir_opt () in
-      check (option string) "primary assets dir wins" (Some "/tmp/assets-primary")
-        resolved))
+    let resolved = Env_config.assets_dir_opt () in
+    check (option string) "primary assets dir wins" (Some "/tmp/assets-primary")
+      resolved)
 
 let test_cluster_name_opt_trims_empty () =
   with_env "MASC_CLUSTER_NAME" "   " (fun () ->
@@ -393,9 +380,8 @@ let () =
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
       test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;
-      test_case "sb_path legacy env still works" `Quick test_sb_path_legacy_env_still_works;
-      test_case "masc_host prefers primary over deprecated" `Quick test_masc_host_prefers_primary_over_deprecated;
-      test_case "assets dir prefers primary over deprecated" `Quick test_assets_dir_prefers_primary_over_deprecated;
+      test_case "masc_host reads primary env" `Quick test_masc_host_prefers_primary_over_deprecated;
+      test_case "assets dir reads primary env" `Quick test_assets_dir_prefers_primary_over_deprecated;
       test_case "cluster_name_opt trims empty" `Quick test_cluster_name_opt_trims_empty;
       test_case "endpoint result helpers" `Quick test_endpoints_result_helpers;
     ];

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -41,7 +41,7 @@ let project_root () =
             | None -> Sys.getcwd ()))
 
 let () =
-  if Sys.getenv_opt "MASC_ASSETS_DIR" = None && Sys.getenv_opt "MASC_ASSETS_ROOT" = None then
+  if Sys.getenv_opt "MASC_ASSETS_DIR" = None then
     let assets = Filename.concat (project_root ()) "assets" in
     if Sys.file_exists assets then Unix.putenv "MASC_ASSETS_DIR" assets
 
@@ -212,8 +212,6 @@ let test_fallback_on_missing_asset () =
       with_env
         [
           ("MASC_ASSETS_DIR", missing_assets_root);
-          ("MASC_ASSETS_ROOT", "");
-          ("MASC_BASE_PATH_INPUT", "");
           ("MASC_BASE_PATH", "");
         ]
         (fun () ->
@@ -224,43 +222,35 @@ let test_fallback_on_missing_asset () =
           check string "fallback etag is none" "none" etag))
     ~finally:(fun () -> Unix.rmdir missing_assets_root)
 
-let test_html_ignores_invalid_explicit_assets_root () =
-  let input_root = make_temp_dashboard_root "input-invalid-env" "dashboard-from-base-path-input" in
+let test_html_ignores_invalid_explicit_assets_dir () =
+  let base_root = make_temp_dashboard_root "base-fallback" "dashboard-from-base-path" in
   Fun.protect
     (fun () ->
       with_env
         [
-          ("MASC_ASSETS_ROOT", "/tmp/nonexistent_masc_assets_67890");
-          ("MASC_ASSETS_DIR", "");
-          ("MASC_BASE_PATH_INPUT", input_root);
-          ("MASC_BASE_PATH", "");
+          ("MASC_ASSETS_DIR", "/tmp/nonexistent_masc_assets_67890");
+          ("MASC_BASE_PATH", base_root);
         ]
         (fun () ->
           let html = Web_dashboard.html () in
-          check bool "falls back to base_path_input assets" true
-            (contains_substr "dashboard-from-base-path-input" html)))
-    ~finally:(fun () -> cleanup_temp_dashboard_root input_root)
+          check bool "falls back to base_path assets" true
+            (contains_substr "dashboard-from-base-path" html)))
+    ~finally:(fun () -> cleanup_temp_dashboard_root base_root)
 
-let test_html_uses_base_path_input_assets () =
-  let input_root = make_temp_dashboard_root "input" "dashboard-from-base-path-input" in
+let test_html_uses_base_path_assets () =
   let base_root = make_temp_dashboard_root "base" "dashboard-from-base-path" in
   Fun.protect
     (fun () ->
       with_env
         [
-          ("MASC_ASSETS_ROOT", "");
           ("MASC_ASSETS_DIR", "");
-          ("MASC_BASE_PATH_INPUT", input_root);
           ("MASC_BASE_PATH", base_root);
         ]
         (fun () ->
           let html = Web_dashboard.html () in
-          check bool "uses base_path_input assets first" true
-            (contains_substr "dashboard-from-base-path-input" html);
-          check bool "does not fall back to base_path assets" false
-            (contains_substr "dashboard-from-base-path</body>" html)))
+          check bool "uses base_path assets" true
+            (contains_substr "dashboard-from-base-path" html)))
     ~finally:(fun () ->
-      cleanup_temp_dashboard_root input_root;
       cleanup_temp_dashboard_root base_root)
 
 (* ============================================================
@@ -312,8 +302,8 @@ let () =
     ];
     "fallback", [
       test_case "missing asset dir" `Quick test_fallback_on_missing_asset;
-      test_case "invalid explicit assets root falls back" `Quick test_html_ignores_invalid_explicit_assets_root;
-      test_case "base_path_input assets" `Quick test_html_uses_base_path_input_assets;
+      test_case "invalid explicit assets dir falls back" `Quick test_html_ignores_invalid_explicit_assets_dir;
+      test_case "base_path assets" `Quick test_html_uses_base_path_assets;
     ];
     "asset_path_safety", [
       test_case "accept normal" `Quick test_safe_asset_relative_path_accepts_normal;


### PR DESCRIPTION
## Summary
- `MASC_SB_PATH`, `MASC_PORT`, `MASC_HTTP_BIND_HOST`, `MASC_ASSETS_ROOT`, `MASC_BASE_PATH_INPUT` fallback 제거
- 각각 `ME_ROOT/MASC_WORKSPACE_ROOT`, `MASC_HTTP_PORT`, `MASC_HOST`, `MASC_ASSETS_DIR`, `MASC_BASE_PATH`로 이미 대체됨
- Dashboard의 `base_path_input` → `base_path` 필드 rename

## Changes (11 files)
- `lib/env_config_core.ml` — deprecated fallback 분기 삭제 (-40L)
- `lib/server/` — `base_path_input` → `base_path` 참조 변경
- `lib/web_dashboard.ml` — `MASC_BASE_PATH_INPUT` 후보 제거
- `dashboard/src/` — TS 타입/컴포넌트 업데이트
- `test/` — deprecated var 테스트 삭제

## Note
`warn_deprecated`/`deprecated_opt` 인프라는 Lodge→Autonomy transition (PR #xxx)이 사용하므로 유지.

## Test plan
- [x] `dune build` 통과
- [x] deprecated var 잔여 참조 0건 (lib/test/dashboard)
- [ ] CI green
- [ ] Dashboard runtime resolution 패널 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)