### PR TITLE
chore: Phase 3 batch 3a — remove unnecessary Eio.Mutex from core leaf modules

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -440,24 +440,19 @@ type cached_card = {
 
 let _cache : cached_card option ref = ref None
 let _cache_generation : int ref = ref 0
-let card_mu = Eio.Mutex.create ()
-
-let with_card_rw f = Eio_guard.with_mutex card_mu f
-
 (** Get cached agent card, generating if needed.
     [schemas] is used only on first generation or after invalidation.
     Returns [(card, json_string)] for direct HTTP response. *)
 let get_cached ?(port=8935) ?(host="127.0.0.1") ~schemas () : agent_card * string =
-  with_card_rw (fun () ->
-    let gen = !_cache_generation in
-    match !_cache with
-    | Some c when c.generation = gen -> (c.card, c.card_json)
-    | _ ->
-      let card = generate_default ~port ~host ~schemas () in
-      let json_str = to_json card |> Yojson.Safe.to_string in
-      _cache := Some { card; card_json = json_str; generation = gen };
-      (card, json_str))
+  let gen = !_cache_generation in
+  match !_cache with
+  | Some c when c.generation = gen -> (c.card, c.card_json)
+  | _ ->
+    let card = generate_default ~port ~host ~schemas () in
+    let json_str = to_json card |> Yojson.Safe.to_string in
+    _cache := Some { card; card_json = json_str; generation = gen };
+    (card, json_str)
 
 (** Invalidate the cached agent card. Call when tools are added/removed. *)
 let invalidate_cache () =
-  with_card_rw (fun () -> incr _cache_generation)
+  incr _cache_generation

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -7,32 +7,21 @@
 open Result_syntax
 
 (** Global state for Mitosis cell lifecycle.
-    Protected by [mitosis_mutex]. Use [get_cell]/[set_cell]/[with_cell_rw]
-    instead of direct ref access. *)
+    Non-yielding ref operations — atomic in single-domain Eio. *)
 let current_cell = ref (Mitosis.create_stem_cell ~generation:0)
 let stem_pool = ref (Mitosis.init_pool ~config:Mitosis.default_config)
-let mitosis_mutex = Eio.Mutex.create ()
 
-let with_ro f = Eio_guard.with_mutex_ro mitosis_mutex f
-let with_rw f = Eio_guard.with_mutex mitosis_mutex f
+let get_cell () = !current_cell
+let get_pool () = !stem_pool
 
-let get_cell () = with_ro (fun () -> !current_cell)
-let get_pool () = with_ro (fun () -> !stem_pool)
-
-let set_cell cell =
-  with_rw (fun () ->
-    current_cell := cell)
-
-let set_pool pool =
-  with_rw (fun () ->
-    stem_pool := pool)
+let set_cell cell = current_cell := cell
+let set_pool pool = stem_pool := pool
 
 let with_cell_rw f =
-  with_rw (fun () ->
-    let cell, pool, result = f !current_cell !stem_pool in
-    current_cell := cell;
-    stem_pool := pool;
-    result)
+  let cell, pool, result = f !current_cell !stem_pool in
+  current_cell := cell;
+  stem_pool := pool;
+  result
 
 (** JSON-RPC request *)
 type jsonrpc_request = {

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -24,47 +24,44 @@ type cascade_counter = {
   mutable rejected : int;
 }
 
-let cascade_counters_mu = Eio.Mutex.create ()
 let cascade_counters : (string, cascade_counter) Hashtbl.t = Hashtbl.create 8
 let cascade_max_keys = 256
 
 let record_cascade ~cascade_name ~outcome =
-  Eio_guard.with_mutex cascade_counters_mu (fun () ->
-    let c = match Hashtbl.find_opt cascade_counters cascade_name with
-      | Some c -> c
-      | None ->
-        if Hashtbl.length cascade_counters >= cascade_max_keys then
-          { calls = 0; successes = 0; failures = 0; rejected = 0 }
-        else begin
-          let c = { calls = 0; successes = 0; failures = 0; rejected = 0 } in
-          Hashtbl.replace cascade_counters cascade_name c; c
-        end
-    in
-    c.calls <- c.calls + 1;
-    match outcome with
-    | `Success -> c.successes <- c.successes + 1
-    | `Failure -> c.failures <- c.failures + 1
-    | `Rejected -> c.rejected <- c.rejected + 1)
+  let c = match Hashtbl.find_opt cascade_counters cascade_name with
+    | Some c -> c
+    | None ->
+      if Hashtbl.length cascade_counters >= cascade_max_keys then
+        { calls = 0; successes = 0; failures = 0; rejected = 0 }
+      else begin
+        let c = { calls = 0; successes = 0; failures = 0; rejected = 0 } in
+        Hashtbl.replace cascade_counters cascade_name c; c
+      end
+  in
+  c.calls <- c.calls + 1;
+  (match outcome with
+  | `Success -> c.successes <- c.successes + 1
+  | `Failure -> c.failures <- c.failures + 1
+  | `Rejected -> c.rejected <- c.rejected + 1)
 
 let cascade_metrics_json () : Yojson.Safe.t =
-  Eio_guard.with_mutex_ro cascade_counters_mu (fun () ->
-    let entries = Hashtbl.fold (fun name c acc ->
-      let error_rate = if c.calls > 0
-        then float_of_int (c.failures + c.rejected) /. float_of_int c.calls
-        else 0.0 in
-      `Assoc [
-        ("cascade_name", `String name);
-        ("calls", `Int c.calls);
-        ("successes", `Int c.successes);
-        ("failures", `Int c.failures);
-        ("rejected", `Int c.rejected);
+  let entries = Hashtbl.fold (fun name c acc ->
+    let error_rate = if c.calls > 0
+      then float_of_int (c.failures + c.rejected) /. float_of_int c.calls
+      else 0.0 in
+    `Assoc [
+      ("cascade_name", `String name);
+      ("calls", `Int c.calls);
+      ("successes", `Int c.successes);
+      ("failures", `Int c.failures);
+      ("rejected", `Int c.rejected);
         ("error_rate", `Float error_rate);
       ] :: acc
     ) cascade_counters [] in
     `List (List.sort (fun a b ->
       let get_calls j = Yojson.Safe.Util.(j |> member "calls" |> to_int) in
       Int.compare (get_calls b) (get_calls a)
-    ) entries))
+    ) entries)
 
 (* ================================================================ *)
 (* Configuration                                                     *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -32,79 +32,64 @@ type metric = {
 (** {1 Global Metrics Store} *)
 
 let metrics : (string, metric) Hashtbl.t = Hashtbl.create 64
-let metrics_mutex = Eio.Mutex.create ()
-
-let with_lock f = Eio_guard.with_mutex metrics_mutex f
 
 (** {1 Metric Registration} *)
 
 let register_counter ~name ~help ?(labels=[]) () =
-  with_lock (fun () ->
-    let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-    if not (Hashtbl.mem metrics key) then
-      Hashtbl.add metrics key { name; help; metric_type = Counter; value = 0.0; labels }
-  )
+  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  if not (Hashtbl.mem metrics key) then
+    Hashtbl.add metrics key { name; help; metric_type = Counter; value = 0.0; labels }
 
 let register_gauge ~name ~help ?(labels=[]) () =
-  with_lock (fun () ->
-    let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-    if not (Hashtbl.mem metrics key) then
-      Hashtbl.add metrics key { name; help; metric_type = Gauge; value = 0.0; labels }
-  )
+  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  if not (Hashtbl.mem metrics key) then
+    Hashtbl.add metrics key { name; help; metric_type = Gauge; value = 0.0; labels }
 
 let register_histogram ~name ~help ?(labels=[]) () =
-  with_lock (fun () ->
-    let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-    if not (Hashtbl.mem metrics key) then
-      Hashtbl.add metrics key { name; help; metric_type = Histogram; value = 0.0; labels }
-  )
+  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  if not (Hashtbl.mem metrics key) then
+    Hashtbl.add metrics key { name; help; metric_type = Histogram; value = 0.0; labels }
 
 (** {1 Metric Updates} *)
 
 let inc_counter name ?(labels=[]) ?(delta=1.0) () =
   let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  with_lock (fun () ->
-    match Hashtbl.find_opt metrics key with
-    | Some m -> m.value <- m.value +. delta
-    | None ->
-        Hashtbl.add metrics key {
-          name;
-          help = name;
-          metric_type = Counter;
-          value = delta;
-          labels;
-        }
-  )
+  match Hashtbl.find_opt metrics key with
+  | Some m -> m.value <- m.value +. delta
+  | None ->
+      Hashtbl.add metrics key {
+        name;
+        help = name;
+        metric_type = Counter;
+        value = delta;
+        labels;
+      }
 
 let set_gauge name ?(labels=[]) value =
   let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  with_lock (fun () ->
-    match Hashtbl.find_opt metrics key with
-    | Some m -> m.value <- value
-    | None ->
-        Hashtbl.add metrics key {
-          name;
-          help = name;
-          metric_type = Gauge;
-          value;
-          labels;
-        }
-  )
+  match Hashtbl.find_opt metrics key with
+  | Some m -> m.value <- value
+  | None ->
+      Hashtbl.add metrics key {
+        name;
+        help = name;
+        metric_type = Gauge;
+        value;
+        labels;
+      }
 
 let inc_gauge name ?(labels=[]) ?(delta=1.0) () =
   let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  with_lock (fun () ->
-    match Hashtbl.find_opt metrics key with
-    | Some m -> m.value <- m.value +. delta
-    | None ->
-        Hashtbl.add metrics key {
-          name;
-          help = name;
-          metric_type = Gauge;
-          value = delta;
-          labels;
-        }
-  )
+  match Hashtbl.find_opt metrics key with
+  | Some m -> m.value <- m.value +. delta
+  | None ->
+      Hashtbl.add metrics key {
+        name;
+        help = name;
+        metric_type = Gauge;
+        value = delta;
+        labels;
+      }
 
 let dec_gauge name ?(labels=[]) ?(delta=1.0) () =
   inc_gauge name ~labels ~delta:(-.delta) ()
@@ -112,9 +97,7 @@ let dec_gauge name ?(labels=[]) ?(delta=1.0) () =
 (** Get current metric value by name + labels (if any). *)
 let get_metric_value name ?(labels=[]) () =
   let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  with_lock (fun () ->
-    Hashtbl.find_opt metrics key |> Option.map (fun m -> m.value)
-  )
+  Hashtbl.find_opt metrics key |> Option.map (fun m -> m.value)
 
 let metric_value_or_zero name ?(labels=[]) () =
   get_metric_value name ~labels () |> Option.value ~default:0.0
@@ -125,21 +108,19 @@ let metric_value_or_zero name ?(labels=[]) () =
 let observe_histogram name ?(labels=[]) value =
   let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
   let count_key = name ^ "_count" ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  with_lock (fun () ->
-    (match Hashtbl.find_opt metrics key with
-    | Some m -> m.value <- m.value +. value
-    | None ->
-        Hashtbl.add metrics key {
-          name; help = name; metric_type = Histogram; value; labels;
-        });
-    (match Hashtbl.find_opt metrics count_key with
-    | Some m -> m.value <- m.value +. 1.0
-    | None ->
-        Hashtbl.add metrics count_key {
-          name = name ^ "_count"; help = name ^ " observation count";
-          metric_type = Counter; value = 1.0; labels;
-        })
-  )
+  (match Hashtbl.find_opt metrics key with
+  | Some m -> m.value <- m.value +. value
+  | None ->
+      Hashtbl.add metrics key {
+        name; help = name; metric_type = Histogram; value; labels;
+      });
+  (match Hashtbl.find_opt metrics count_key with
+  | Some m -> m.value <- m.value +. 1.0
+  | None ->
+      Hashtbl.add metrics count_key {
+        name = name ^ "_count"; help = name ^ " observation count";
+        metric_type = Counter; value = 1.0; labels;
+      })
 
 (** {1 Built-in Metrics} *)
 
@@ -195,12 +176,10 @@ let to_prometheus_text () =
   update_uptime ();
   let buf = Buffer.create 1024 in
   let by_name = Hashtbl.create 32 in
-  with_lock (fun () ->
-    Hashtbl.iter (fun _ m ->
-      let existing = Hashtbl.find_opt by_name m.name |> Option.value ~default:[] in
-      Hashtbl.replace by_name m.name (m :: existing)
-    ) metrics
-  );
+  Hashtbl.iter (fun _ m ->
+    let existing = Hashtbl.find_opt by_name m.name |> Option.value ~default:[] in
+    Hashtbl.replace by_name m.name (m :: existing)
+  ) metrics;
   Hashtbl.iter (fun name ms ->
     match ms with
     | [] -> ()

--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -20,58 +20,48 @@ type backend_state =
 (** Current backend state. Single ref avoids contradictory initialized/backend pairs. *)
 let backend_state : backend_state ref = ref Uninitialized
 
-let task_mu = Eio.Mutex.create ()
-let with_task_rw f = Eio_guard.with_mutex task_mu f
-let with_task_ro f = Eio_guard.with_mutex_ro task_mu f
-
 let is_initialized () =
-  with_task_ro (fun () ->
-    match !backend_state with
-    | Active _ -> true
-    | Uninitialized -> false)
+  match !backend_state with
+  | Active _ -> true
+  | Uninitialized -> false
 
 (** Initialize PostgreSQL backend if URL is available *)
 let init_pg pool =
-  with_task_rw (fun () ->
-    if match !backend_state with Active _ -> true | Uninitialized -> false then begin
-      Log.Task.warn "WARNING: already initialized, ignoring init_pg";
+  if match !backend_state with Active _ -> true | Uninitialized -> false then begin
+    Log.Task.warn "WARNING: already initialized, ignoring init_pg";
+    Ok ()
+  end else
+  match Task_pg.create pool with
+  | Ok t ->
+      backend_state := Active (Postgres t);
+      Log.Task.info "PostgreSQL backend initialized.";
       Ok ()
-    end else
-    match Task_pg.create pool with
-    | Ok t ->
-        backend_state := Active (Postgres t);
-        Log.Task.info "PostgreSQL backend initialized.";
-        Ok ()
-    | Error e ->
-        Log.Task.error "PG init failed, falling back to JSONL: %s"
-          (show_masc_error e);
-        Error e)
+  | Error e ->
+      Log.Task.error "PG init failed, falling back to JSONL: %s"
+        (show_masc_error e);
+      Error e
 
 (** Initialize JSONL backend. Default fallback. *)
 let init_jsonl () =
-  with_task_rw (fun () ->
-    if match !backend_state with Active _ -> true | Uninitialized -> false then
-      Log.Task.warn "WARNING: already initialized, ignoring init_jsonl"
-    else begin
-      backend_state := Active Jsonl;
-      Log.Task.info "JSONL backend initialized (using Room.* functions)."
-    end)
+  if match !backend_state with Active _ -> true | Uninitialized -> false then
+    Log.Task.warn "WARNING: already initialized, ignoring init_jsonl"
+  else begin
+    backend_state := Active Jsonl;
+    Log.Task.info "JSONL backend initialized (using Room.* functions)."
+  end
 
 (** Reset for testing *)
 let reset_for_test () =
-  with_task_rw (fun () -> backend_state := Uninitialized)
+  backend_state := Uninitialized
 
 (** Get current backend, auto-init JSONL if not set *)
 let backend () =
-  with_task_rw (fun () ->
-    match !backend_state with
-    | Active backend -> backend
-    | Uninitialized ->
-        backend_state := Active Jsonl;
-        Log.Task.info "JSONL backend initialized (using Room.* functions).";
-        (match !backend_state with
-         | Active backend -> backend
-         | Uninitialized -> Jsonl))
+  match !backend_state with
+  | Active backend -> backend
+  | Uninitialized ->
+      backend_state := Active Jsonl;
+      Log.Task.info "JSONL backend initialized (using Room.* functions).";
+      Jsonl
 
 (** Check if PostgreSQL backend is active *)
 let is_postgres () =
@@ -81,10 +71,9 @@ let is_postgres () =
 
 (** Get PostgreSQL pool if available *)
 let get_pg_pool () =
-  with_task_ro (fun () ->
-    match !backend_state with
-    | Active (Postgres t) -> Some (Task_pg.get_pool t)
-    | _ -> None)
+  match !backend_state with
+  | Active (Postgres t) -> Some (Task_pg.get_pool t)
+  | _ -> None
 
 (** {1 Dispatch Functions} *)
 

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -21,8 +21,6 @@ type call_stats = {
 
 (** Global registry - process-lifetime, protected by mutex for fiber safety *)
 let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
-let registry_mutex = Eio.Mutex.create ()
-
 let known_tool_names : (string, unit) Hashtbl.t Eio.Lazy.t =
   Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let tbl = Hashtbl.create 256 in
@@ -36,28 +34,27 @@ let is_known_tool tool_name =
 
 (** Record a tool call. Called from handle_call_tool_eio after execution. *)
 let record_call ~tool_name ~success ~duration_ms =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      let stats =
-        match Hashtbl.find_opt registry tool_name with
-        | Some s -> s
-        | None ->
-            let s = {
-              call_count = 0;
-              success_count = 0;
-              failure_count = 0;
-              last_called_at = 0.0;
-              total_duration_ms = 0;
-            } in
-            Hashtbl.replace registry tool_name s;
-            s
-      in
-      stats.call_count <- stats.call_count + 1;
-      if success then
-        stats.success_count <- stats.success_count + 1
-      else
-        stats.failure_count <- stats.failure_count + 1;
-      stats.last_called_at <- Time_compat.now ();
-      stats.total_duration_ms <- stats.total_duration_ms + duration_ms)
+  let stats =
+    match Hashtbl.find_opt registry tool_name with
+    | Some s -> s
+    | None ->
+        let s = {
+          call_count = 0;
+          success_count = 0;
+          failure_count = 0;
+          last_called_at = 0.0;
+          total_duration_ms = 0;
+        } in
+        Hashtbl.replace registry tool_name s;
+        s
+  in
+  stats.call_count <- stats.call_count + 1;
+  if success then
+    stats.success_count <- stats.success_count + 1
+  else
+    stats.failure_count <- stats.failure_count + 1;
+  stats.last_called_at <- Time_compat.now ();
+  stats.total_duration_ms <- stats.total_duration_ms + duration_ms
 
 let record_call_if_known ~tool_name ~success ~duration_ms =
   if is_known_tool tool_name then
@@ -65,9 +62,8 @@ let record_call_if_known ~tool_name ~success ~duration_ms =
 
 (** Get all stats as a sorted list (by call_count descending) *)
 let get_stats () : (string * call_stats) list =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.fold (fun name stats acc -> (name, stats) :: acc) registry []
-      |> List.sort (fun (_, a) (_, b) -> compare b.call_count a.call_count))
+  Hashtbl.fold (fun name stats acc -> (name, stats) :: acc) registry []
+  |> List.sort (fun (_, a) (_, b) -> compare b.call_count a.call_count)
 
 (** Get top N tools by call count *)
 let get_top_n n : (string * call_stats) list =
@@ -83,30 +79,27 @@ let get_top_n n : (string * call_stats) list =
     Only includes tools that are registered (have been called at least once)
     but not recently. *)
 let get_unused_since (cutoff : float) : string list =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.fold
-        (fun name stats acc ->
-          if stats.last_called_at < cutoff then name :: acc else acc)
-        registry []
-      |> List.sort String.compare)
+  Hashtbl.fold
+    (fun name stats acc ->
+      if stats.last_called_at < cutoff then name :: acc else acc)
+    registry []
+  |> List.sort String.compare
 
 (** Get tools that have never been called (not in registry at all)
     compared against a list of all known tool names *)
 let get_never_called (all_tool_names : string list) : string list =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      List.filter
-        (fun name -> not (Hashtbl.mem registry name))
-        all_tool_names
-      |> List.sort String.compare)
+  List.filter
+    (fun name -> not (Hashtbl.mem registry name))
+    all_tool_names
+  |> List.sort String.compare
 
 (** Total calls across all tools *)
 let total_calls () : int =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.fold (fun _ stats acc -> acc + stats.call_count) registry 0)
+  Hashtbl.fold (fun _ stats acc -> acc + stats.call_count) registry 0
 
 (** Number of distinct tools that have been called *)
 let distinct_tools_called () : int =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.length registry)
+  Hashtbl.length registry
 
 (** Convert call_stats to JSON *)
 let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
@@ -145,26 +138,24 @@ let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
 (** Warm up registry from telemetry summary.
     Called once at server startup to restore persistent metrics. *)
 let warm_up (summary : Telemetry_eio.tool_usage_summary) : int =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      let count = ref 0 in
-      Hashtbl.iter
-        (fun tool_name (stats : Telemetry_eio.tool_usage_stats) ->
-          if not (Hashtbl.mem registry tool_name) then (
-            Hashtbl.replace registry tool_name
-              {
-                call_count = stats.count;
-                success_count = stats.success_count;
-                failure_count = stats.failure_count;
-                last_called_at =
-                  (match stats.last_used_at with
-                  | Some t -> t
-                  | None -> 0.0);
-                total_duration_ms = 0;
-              };
-            incr count))
-        summary.stats_by_tool;
-      !count)
+  let count = ref 0 in
+  Hashtbl.iter
+    (fun tool_name (stats : Telemetry_eio.tool_usage_stats) ->
+      if not (Hashtbl.mem registry tool_name) then (
+        Hashtbl.replace registry tool_name
+          {
+            call_count = stats.count;
+            success_count = stats.success_count;
+            failure_count = stats.failure_count;
+            last_called_at =
+              (match stats.last_used_at with
+              | Some t -> t
+              | None -> 0.0);
+            total_duration_ms = 0;
+          };
+        incr count))
+    summary.stats_by_tool;
+  !count
 
 (** Reset all counters (for testing) *)
-let reset () =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)
+let reset () = Hashtbl.clear registry


### PR DESCRIPTION
## Summary
- core leaf 모듈에서 불필요한 Eio.Mutex 6개 제거 (6개 파일, -60줄)
- 모든 보호 대상 연산이 non-yielding — single-domain Eio에서 원자적

## 제거 대상
| 파일 | mutex | 근거 |
|------|-------|------|
| tool_registry.ml | registry_mutex | Hashtbl call counters |
| agent_card.ml | card_mu | ref cache + generation int |
| oas_worker.ml | cascade_counters_mu | Hashtbl mutable counters |
| task_dispatch.ml | task_mu | backend_state ref read/write |
| prometheus.ml | metrics_mutex | Hashtbl metric store |
| mcp_server.ml | mitosis_mutex | cell/pool ref read/write |

## 누적 진척 (#3181)
| Batch | PR | Mutex 제거 | 상태 |
|-------|-----|-----------|------|
| 1 | #3533 | 2 + trace.ml dead code | Merged |
| 2 | #3540 | 8 (chain/) | Merged |
| 3a | this | 6 (core leaf) | Draft |
| **Total** | | **16 removed** | |

## Test plan
- [x] `dune build` 성공
- [ ] CI 전체 통과

Refs: #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)