### PR TITLE
fix(dashboard): remove redundant type modifier in store.ts

### DIFF
--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -20,7 +20,7 @@ import type {
   DashboardExecutionOperationBrief,
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
-  type DashboardExecutionResponse,
+  DashboardExecutionResponse,
 } from './types'
 import {
   fetchDashboardExecution,


### PR DESCRIPTION
One-line fix: `import type { ..., type DashboardExecutionResponse }` → remove inner `type`.

Fixes tsc build error: `TS2206: The 'type' modifier cannot be used on a named import when 'import type' is used`.

Generated with [Claude Code](https://claude.com/claude-code)