### PR TITLE
fix(test): add Eio runtime to test_bounded for retry backoff sleep

### DIFF
--- a/test/test_bounded.ml
+++ b/test/test_bounded.ml
@@ -355,6 +355,8 @@ let serialization_tests = [
 ]
 
 let () =
+  Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   run "Bounded" [
     "constraints", constraint_tests;
     "goal_parsing", goal_parsing_tests;


### PR DESCRIPTION
## Summary
- `Bounded.bounded_run`이 내부에서 `Time_compat.sleep`을 사용하여 retry backoff을 구현
- `test_bounded.ml`이 Eio 환경 없이 실행되어 `Time_compat.sleep: no Eio clock set` 에러 발생
- `Eio_main.run` + `Time_compat.set_clock`을 테스트 entry point에 추가하여 수정

## Context
PR #3513 (storage hardening) 머지 시 포함되지 못한 마지막 flaky test fix.
main에서 `retry success after failures`와 `retry exhausted` 테스트가 실패하는 문제를 해결.

## Test plan
- [x] `test_bounded.exe` — 25 tests passed (retry 2, 3 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)