### PR TITLE
chore: purge all remaining lodge references

### DIFF
--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -140,7 +140,7 @@ repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `~/.masc
 | `MASC_CLAUDE_DEFAULT_MODEL` | string | `"claude-sonnet-4-6"` | Claude 기본 모델 |
 | `MASC_OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | OpenAI 기본 모델 |
 
-**Keeper Autonomy (자율 에이전트)**: `MASC_AUTONOMY_*` prefix (deprecated: `MASC_LODGE_*`).
+**Keeper Autonomy (자율 에이전트)**: `MASC_AUTONOMY_*` prefix.
 
 | 환경변수 | 타입 | 기본값 | 설명 |
 |----------|------|--------|------|
@@ -156,7 +156,7 @@ repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `~/.masc
 | `MASC_AUTONOMY_QUIET_END` | int | 7 | 조용한 시간대 종료 (KST) |
 | `MASC_DELEGATE_INFERENCE` | bool | false | Worker 위임 모드 (Soul+Body) |
 
-> **Deprecated**: `MASC_LODGE_*` env vars are still accepted as fallback but will be removed in a future release.
+> `MASC_LODGE_*` env vars are no longer supported. Use `MASC_AUTONOMY_*` exclusively.
 
 **Thompson Sampling** (`MASC_AUTONOMY_*` prefix):
 

--- a/docs/spec/B-migration-targets.md
+++ b/docs/spec/B-migration-targets.md
@@ -113,7 +113,7 @@ Source: `ROADMAP.md` Mid-term
 | Environment variables -> config file | ARCHITECTURE-COMPLEXITY Phase 3 | 50+ env vars 통합 |
 | Binary distribution (brew/npm) | IDEAS #6 | Owner 없음 |
 | Worktree diff broadcast | IDEAS #7 | Owner 없음 |
-| Keeper Autonomy identity v2 Tier 1 | docs/lodge-identity-v2/ | 설계 완료, 구현 미착수 |
+| Keeper Autonomy identity v2 Tier 1 | docs/archive/lodge-identity-v2/ | 설계 완료, 구현 미착수 |
 
 ### Historical Mode/Profile Proposal
 
@@ -136,7 +136,7 @@ Source: `ROADMAP.md` Long-term
 
 | Direction | Trigger | Source |
 |-----------|---------|--------|
-| Keeper Autonomy identity v2 Tier 2-3 (ToM, archetypes) | Tier 1이 가치 증명 | docs/lodge-identity-v2/ |
+| Keeper Autonomy identity v2 Tier 2-3 (ToM, archetypes) | Tier 1이 가치 증명 | docs/archive/lodge-identity-v2/ |
 | Figma-MCP 통합 (visual heartbeat) | figma-mcp 안정화 | docs/archive/EVOLUTION-PLAN-FIGMA-MCP.md |
 | Cluster mode / multi-node HA | 단일 노드 한계 도달 | IMMORTAL-SERVER-ROADMAP Phase 3 |
 | Chaos engineering framework | Production 장애 패턴 확인 | IMMORTAL-SERVER-ROADMAP Phase 3 |
@@ -261,7 +261,7 @@ docs/spec/ 체계에서 아직 다루지 않는 영역.
 | **Memory system** | AGENT-MEMORY-SYSTEM.md (design phase, 811 lines) | Memory tier 계약 (OAS 5-tier 포함) |
 | **TRPG subsystem** | 7개 docs, 미통합 | 분리 패키지 후 자체 spec |
 | **Transport protocol detail** | TRANSPORT-VERIFICATION-CHECKLIST (401 lines) | 09-server-transport.md에 부분 포함, WebRTC/WS 미상세 |
-| **Keeper Autonomy identity** | lodge-identity-v2/ (3 files) | 구현 후 spec 추가 |
+| **Keeper Autonomy identity** | docs/archive/lodge-identity-v2/ (3 files) | 구현 후 spec 추가 |
 | **OAS integration contract** | OAS-MASC-BOUNDARY.md (55 lines), oas-masc-state-boundary (278 lines) | OAS delegation 범위 상세화 |
 | **Operational runbook** | COMMAND-PLANE-RUNBOOK, BENCHMARK-RUNBOOK | 운영 절차 통합 spec |
 | **Config reference** | 없음 (env var 50+ 산재) | 환경변수/설정 SSOT |

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -585,7 +585,7 @@ let notify_event ~(event_type : event_type) ~(agent : string) ~(data : Yojson.Sa
 
 (** {1 Heartbeat Task Events — Soul + Tool Loop Pattern}
 
-    MASC emits heartbeat_task events when an external worker should act as a Lodge
+    MASC emits heartbeat_task events when an external worker should act as a Keeper
     agent through the MCP tool loop. The payload carries the goal, context, and
     allowed tools. The worker performs tools directly, then reports completion
     evidence back to MASC.

--- a/lib/agent_health.ml
+++ b/lib/agent_health.ml
@@ -1,6 +1,6 @@
-(** Agent Health — Lodge-specific health gate over Circuit Breaker.
+(** Agent Health — Autonomy-specific health gate over Circuit Breaker.
 
-    Wraps Circuit_breaker with agent-name semantics for Lodge Heartbeat.
+    Wraps Circuit_breaker with agent-name semantics for Keeper Heartbeat.
     Agents with open circuit breakers are skipped during tick selection,
     preventing cascading failures from repeatedly invoking failing agents.
 

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -135,7 +135,7 @@ type post = {
   votes_up: int;
   votes_down: int;
   reply_count: int;
-  hearth: string option;     (* Topic category within the Lodge *)
+  hearth: string option;     (* Topic category within the Board *)
   thread_id: string option;  (* Linked Conversation thread *)
 }
 

--- a/lib/env_config_governance.ml
+++ b/lib/env_config_governance.ml
@@ -113,131 +113,81 @@ module RateLimit = struct
 end
 
 (** {1 Agent Autonomy Configuration}
-    Primary env vars: MASC_AUTONOMY_*.
-    Deprecated fallback: MASC_LODGE_* (will be removed in a future release). *)
+    Primary env vars: MASC_AUTONOMY_*. *)
 
 module Autonomy = struct
   let tick_interval_seconds =
-    get_float_deprecated ~default:2700.0
-      ~primary:"MASC_AUTONOMY_TICK_INTERVAL_SEC"
-      ~deprecated:"MASC_LODGE_TICK_INTERVAL_SEC"
+    get_float ~default:2700.0 "MASC_AUTONOMY_TICK_INTERVAL_SEC"
 
   let agents_per_tick =
-    get_int_deprecated ~default:3
-      ~primary:"MASC_AUTONOMY_AGENTS_PER_TICK"
-      ~deprecated:"MASC_LODGE_AGENTS_PER_TICK"
+    get_int ~default:3 "MASC_AUTONOMY_AGENTS_PER_TICK"
 
   let max_posts_per_tick =
-    get_int_deprecated ~default:1
-      ~primary:"MASC_AUTONOMY_MAX_POSTS_PER_TICK"
-      ~deprecated:"MASC_LODGE_MAX_POSTS_PER_TICK"
+    get_int ~default:1 "MASC_AUTONOMY_MAX_POSTS_PER_TICK"
 
   let max_comments_per_tick =
-    get_int_deprecated ~default:3
-      ~primary:"MASC_AUTONOMY_MAX_COMMENTS_PER_TICK"
-      ~deprecated:"MASC_LODGE_MAX_COMMENTS_PER_TICK"
+    get_int ~default:3 "MASC_AUTONOMY_MAX_COMMENTS_PER_TICK"
 
   let max_daily_actions =
-    get_int_deprecated ~default:10
-      ~primary:"MASC_AUTONOMY_MAX_DAILY_ACTIONS"
-      ~deprecated:"MASC_LODGE_MAX_DAILY_ACTIONS"
+    get_int ~default:10 "MASC_AUTONOMY_MAX_DAILY_ACTIONS"
 
   let reflection_threshold =
-    get_int_deprecated ~default:100
-      ~primary:"MASC_AUTONOMY_REFLECTION_THRESHOLD"
-      ~deprecated:"MASC_LODGE_REFLECTION_THRESHOLD"
+    get_int ~default:100 "MASC_AUTONOMY_REFLECTION_THRESHOLD"
 
   let use_planner =
-    get_bool_deprecated ~default:true
-      ~primary:"MASC_AUTONOMY_USE_PLANNER"
-      ~deprecated:"MASC_LODGE_USE_PLANNER"
+    get_bool ~default:true "MASC_AUTONOMY_USE_PLANNER"
 
   let enabled =
-    get_bool_deprecated ~default:true
-      ~primary:"MASC_AUTONOMY_ENABLED"
-      ~deprecated:"MASC_LODGE_ENABLED"
+    get_bool ~default:true "MASC_AUTONOMY_ENABLED"
 
   let quiet_start =
-    get_int_deprecated ~default:3
-      ~primary:"MASC_AUTONOMY_QUIET_START"
-      ~deprecated:"MASC_LODGE_QUIET_START"
+    get_int ~default:3 "MASC_AUTONOMY_QUIET_START"
 
   let quiet_end =
-    get_int_deprecated ~default:7
-      ~primary:"MASC_AUTONOMY_QUIET_END"
-      ~deprecated:"MASC_LODGE_QUIET_END"
+    get_int ~default:7 "MASC_AUTONOMY_QUIET_END"
 
   let min_checkin_gap_seconds =
-    get_float_deprecated ~default:1800.0
-      ~primary:"MASC_AUTONOMY_MIN_CHECKIN_GAP"
-      ~deprecated:"MASC_LODGE_MIN_CHECKIN_GAP"
+    get_float ~default:1800.0 "MASC_AUTONOMY_MIN_CHECKIN_GAP"
 
   let min_post_gap_seconds =
-    get_float_deprecated ~default:600.0
-      ~primary:"MASC_AUTONOMY_MIN_POST_GAP"
-      ~deprecated:"MASC_LODGE_MIN_POST_GAP"
+    get_float ~default:600.0 "MASC_AUTONOMY_MIN_POST_GAP"
 
   let min_comment_gap_seconds =
-    get_float_deprecated ~default:8.0
-      ~primary:"MASC_AUTONOMY_MIN_COMMENT_GAP"
-      ~deprecated:"MASC_LODGE_MIN_COMMENT_GAP"
+    get_float ~default:8.0 "MASC_AUTONOMY_MIN_COMMENT_GAP"
 
   let max_posts_per_day =
-    get_int_deprecated ~default:8
-      ~primary:"MASC_AUTONOMY_MAX_POSTS_PER_DAY"
-      ~deprecated:"MASC_LODGE_MAX_POSTS_PER_DAY"
+    get_int ~default:8 "MASC_AUTONOMY_MAX_POSTS_PER_DAY"
 
   let max_comments_per_day =
-    get_int_deprecated ~default:40
-      ~primary:"MASC_AUTONOMY_MAX_COMMENTS_PER_DAY"
-      ~deprecated:"MASC_LODGE_MAX_COMMENTS_PER_DAY"
+    get_int ~default:40 "MASC_AUTONOMY_MAX_COMMENTS_PER_DAY"
 
   (** Delegate MODEL calls to external Workers (Soul + Body pattern). *)
   let delegate_inference =
     get_bool ~default:false "MASC_DELEGATE_INFERENCE"
 end
 
-(** Backward-compatible alias. Will be removed in a future release. *)
-module LodgeV2 = Autonomy
-
 (** {1 Thompson Sampling / Agent Selection Configuration}
-    Primary env vars: MASC_AUTONOMY_*.
-    Deprecated fallback: MASC_LODGE_* (will be removed in a future release). *)
+    Primary env vars: MASC_AUTONOMY_*. *)
 
 module AgentSelection = struct
   let max_starvation_ticks =
-    get_int_deprecated ~default:12
-      ~primary:"MASC_AUTONOMY_MAX_STARVATION_TICKS"
-      ~deprecated:"MASC_LODGE_MAX_STARVATION_TICKS"
+    get_int ~default:12 "MASC_AUTONOMY_MAX_STARVATION_TICKS"
 
   let starvation_bonus_coefficient =
-    get_float_deprecated ~default:0.15
-      ~primary:"MASC_AUTONOMY_STARVATION_BONUS_COEF"
-      ~deprecated:"MASC_LODGE_STARVATION_BONUS_COEF"
+    get_float ~default:0.15 "MASC_AUTONOMY_STARVATION_BONUS_COEF"
 
   let thompson_weight =
-    get_float_deprecated ~default:0.7
-      ~primary:"MASC_AUTONOMY_THOMPSON_WEIGHT"
-      ~deprecated:"MASC_LODGE_THOMPSON_WEIGHT"
+    get_float ~default:0.7 "MASC_AUTONOMY_THOMPSON_WEIGHT"
 
   let use_model_selection =
-    get_bool_deprecated ~default:false
-      ~primary:"MASC_AUTONOMY_MODEL_SELECTION"
-      ~deprecated:"MASC_LODGE_MODEL_SELECTION"
+    get_bool ~default:false "MASC_AUTONOMY_MODEL_SELECTION"
 
   let stats_persist_interval_s =
-    get_float_deprecated ~default:300.0
-      ~primary:"MASC_AUTONOMY_STATS_PERSIST_INTERVAL"
-      ~deprecated:"MASC_LODGE_STATS_PERSIST_INTERVAL"
+    get_float ~default:300.0 "MASC_AUTONOMY_STATS_PERSIST_INTERVAL"
 
   let vote_decay_factor =
-    get_float_deprecated ~default:0.95
-      ~primary:"MASC_AUTONOMY_VOTE_DECAY_FACTOR"
-      ~deprecated:"MASC_LODGE_VOTE_DECAY_FACTOR"
+    get_float ~default:0.95 "MASC_AUTONOMY_VOTE_DECAY_FACTOR"
 end
-
-(** Backward-compatible alias. Will be removed in a future release. *)
-module LodgeSelection = AgentSelection
 
 (** {1 Timeouts & Buffer Sizes} *)
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -10,7 +10,7 @@
     When fs is not set (non-Eio contexts), falls back to blocking Unix I/O.
     This allows incremental migration without changing all call sites at once.
 
-    @since 2026-02 - Lodge Emergent Identity v2.0
+    @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
 (** Global fs reference - set at Eio_main.run startup *)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -1,6 +1,6 @@
 (** Filesystem Compatibility Layer - Eio-native I/O with fallback
 
-    @since 2026-02 - Lodge Emergent Identity v2.0
+    @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
 val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -623,7 +623,7 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
 (** {1 Lightweight JSONL Episode Recording (No Eio Required)}
 
     Append-only episode log for contexts that don't have Eio fs.
-    Used by Lodge heartbeat, keeper decisions, etc.
+    Used by Keeper heartbeat, keeper decisions, etc.
     Storage: .masc/institution_episodes.jsonl *)
 
 let episodes_jsonl_path () =
@@ -631,7 +631,7 @@ let episodes_jsonl_path () =
   Filename.concat me_root ".masc/institution_episodes.jsonl"
 
 (** Record an episode to JSONL without Eio context.
-    This is the primary entry point for Lodge/Keeper integration. *)
+    This is the primary entry point for Keeper autonomy integration. *)
 let record_episode_jsonl ~event_type ~summary ~participants ~outcome ~learnings =
   let episode : episode = {
     id = Printf.sprintf "ep-%d-%06d"

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -51,7 +51,6 @@ let canonical_keeper_skill_token (raw : string) : string option =
   | "masc-keeper-autonomy"
   | "masc_keeper_autonomy"
   | "keeper-autonomy"
-  | "lodge"  (* backward compat *)
   | "social"
   | "keeper"
   | "autonomy" ->
@@ -91,7 +90,7 @@ let route_keeper_skill ~(soul_profile : string) ~(message : string) : keeper_ski
   ] in
   let autonomy_keywords = [
     "keeper"; "handoff"; "compaction"; "context"; "generation"; "trace"; "memory";
-    "board"; "post"; "comment"; "feed"; "social"; "lodge"; "k2k";
+    "board"; "post"; "comment"; "feed"; "social"; "k2k";
     "키퍼"; "승계"; "핸드오프"; "컴팩팅"; "컨텍스트"; "세대"; "메모리";
     "보드"; "포스트"; "댓글"; "피드"; "활동"; "소셜";
   ] in

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -509,7 +509,7 @@ let execute_action (ctx : 'a context) (request : action_request) :
 
 let validate_request request =
   match request.action_type with
-  | "broadcast" | "room_pause" | "room_resume" | "social_sweep" | "lodge_tick"
+  | "broadcast" | "room_pause" | "room_resume" | "social_sweep"
   | "autonomy_tick" | "team_turn" | "team_note"
   | "team_broadcast" | "team_task_inject" | "team_worker_spawn_batch"
   | "team_stop"

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -121,8 +121,6 @@ type action_request = {
 
 let canonical_action_type action_type =
   match action_type with
-  | "lodge_poke" -> "social_sweep"
-  | "lodge_tick" -> "social_sweep"
   | "autonomy_tick" -> "social_sweep"
   | "social_sweep" -> "social_sweep"
   | "team_turn" -> "team_turn"

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -11,7 +11,7 @@ let high_risk_actions =
   [ "room_pause"; "team_stop"; "team_task_inject"; "team_worker_spawn_batch" ]
 
 let allowed_actions =
-  [ "broadcast"; "room_pause"; "room_resume"; "social_sweep"; "lodge_tick";
+  [ "broadcast"; "room_pause"; "room_resume"; "social_sweep";
     "autonomy_tick";
     "team_note"; "team_broadcast"; "team_task_inject";
     "team_worker_spawn_batch"; "team_stop";

--- a/lib/pulse.mli
+++ b/lib/pulse.mli
@@ -1,7 +1,7 @@
 (** Pulse — the beating heart of any Space.
 
     A Space is an abstracted environment where agents exist and act.
-    Lodge (perpetual, no end) and TRPG (bounded, session ends) are both Spaces.
+    Keeper Autonomy (perpetual, no end) and TRPG (bounded, session ends) are both Spaces.
     The only axis of variation is lifecycle: when does the heart stop?
 
     The Pulse is a tick engine driven by two forces:
@@ -41,7 +41,7 @@ type rhythm = {
 
 (** Space lifecycle. The only difference between spaces. *)
 type lifecycle =
-  | Perpetual             (** Never stops (Lodge). Runs until explicit shutdown. *)
+  | Perpetual             (** Never stops (Keeper Autonomy). Runs until explicit shutdown. *)
   | Bounded of (beat -> bool)
     (** Stops when predicate returns true (TRPG session end, time limit, etc.) *)
 

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -74,13 +74,6 @@ let stats_path () =
   in
   let masc_dir = Filename.concat base ".masc" in
   Fs_compat.mkdir_p masc_dir;
-  (* Migrate legacy file name; ignore race if another process already renamed *)
-  let () =
-    let legacy = Filename.concat masc_dir "lodge_stats.jsonl" in
-    let current = Filename.concat masc_dir "autonomy_stats.jsonl" in
-    if (not (Sys.file_exists current)) && Sys.file_exists legacy then
-      (try Sys.rename legacy current with Sys_error _ -> ())
-  in
   Filename.concat masc_dir "autonomy_stats.jsonl"
 
 (** {1 Beta Distribution Sampling} *)

--- a/lib/thompson_sampling.mli
+++ b/lib/thompson_sampling.mli
@@ -120,7 +120,7 @@ val record_quality_signal :
 
 (** {1 Persistence} *)
 
-(** Load stats from persistent storage (.masc/lodge_stats.jsonl for backward compat) *)
+(** Load stats from persistent storage (.masc/autonomy_stats.jsonl) *)
 val load_stats : unit -> unit
 
 (** Save stats to persistent storage *)

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -32,7 +32,6 @@ let strict_action_enums =
 
 let legacy_action_alias_enums =
   [ `String "team_turn"; `String "keeper_msg"; `String "task_inject";
-    `String "lodge_tick"; `String "lodge_poke";
     `String "autonomy_tick" ]
 
 let target_type_enums =

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarize Lodge decision/action stats from trace JSONL files."""
+"""Summarize Autonomy decision/action stats from trace JSONL files."""
 
 from __future__ import annotations
 
@@ -100,7 +100,7 @@ def pct(n: int, d: int) -> str:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Lodge action/decision stats from traces")
+    parser = argparse.ArgumentParser(description="Autonomy action/decision stats from traces")
     parser.add_argument("--days", type=int, default=1, help="Look back N days (default: 1)")
     parser.add_argument("--since", type=str, default=None, help="Start date (YYYY-MM-DD)")
     parser.add_argument("--until", type=str, default=None, help="End date (YYYY-MM-DD, inclusive)")
@@ -183,7 +183,7 @@ def main() -> int:
     start_s = dt.datetime.fromtimestamp(start_ts).strftime("%Y-%m-%d %H:%M")
     end_s = dt.datetime.fromtimestamp(end_ts).strftime("%Y-%m-%d %H:%M")
 
-    print("Lodge Decision Stats")
+    print("Autonomy Decision Stats")
     print(f"Period: {start_s} ~ {end_s}")
     if args.agent:
         print(f"Agent: {args.agent}")

--- a/scripts/migration-audit.sh
+++ b/scripts/migration-audit.sh
@@ -91,7 +91,7 @@ for ml_file in "$LIB_DIR"/*.ml; do
     *_types*|*_enums*) category="types" ;;
     masc_pb) category="generated" ;;
     cp_*) category="command_plane" ;;
-    lodge_*) category="autonomy" ;;
+    autonomy_*) category="autonomy" ;;
     voice_*) category="voice" ;;
     trpg_*) category="trpg" ;;
     a2a_*) category="a2a" ;;

--- a/scripts/test_emergent_identity.sh
+++ b/scripts/test_emergent_identity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Lodge Emergent Identity System - Integration Test
+# Keeper Emergent Identity System - Integration Test
 #
 # Runs 3 agents for a specified duration and measures:
 # - Upvote ratio (target: >20% vs current ~0%)
@@ -20,7 +20,7 @@ METRICS_FILE="$LOG_DIR/metrics_$(date +%Y%m%d_%H%M%S).json"
 mkdir -p "$LOG_DIR"
 
 echo "=============================================="
-echo "Lodge Emergent Identity System - Integration Test"
+echo "Keeper Emergent Identity System - Integration Test"
 echo "=============================================="
 echo "Duration: ${DURATION_HOURS}h (${DURATION_SECS}s)"
 echo "Agents: ${TEST_AGENTS[*]}"


### PR DESCRIPTION
## Summary
#3544 이후 남아있던 lodge 흔적을 전부 제거.

**Breaking**: `MASC_LODGE_*` env vars 더 이상 지원하지 않음. `MASC_AUTONOMY_*` 사용 필수.

## Changes (20 files, -61 net)
- `env_config_governance.ml` — deprecated fallback 20개 제거, `LodgeV2`/`LodgeSelection` alias 삭제
- `operator_control_action.ml` — `lodge_poke/tick` backward compat 제거
- `operator_control.ml`, `operator_approval.ml`, `tool_operator.ml` — `lodge_tick` 제거
- `keeper_skill_routing.ml` — `"lodge"` routing keyword 제거
- `thompson_sampling.ml/mli` — legacy file migration 로직 제거
- Comments/docstrings 9파일, scripts 3파일, docs 2파일

## Verification
- `dune build` 통과
- `rg -i lodge lib/ test/ dashboard/src/ config/ scripts/` = **0건**

🤖 Generated with [Claude Code](https://claude.com/claude-code)