### PR TITLE
feat(keeper): bidi gRPC heartbeat + directive dispatch (P2/P3) #2880

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -220,6 +220,49 @@ let active_heartbeat_streams = Atomic.make 0
 (** Active subscribe stream count (atomic for signal safety). *)
 let active_subscribe_streams = Atomic.make 0
 
+(** Compute directives for a keeper based on current room state.
+    Returns a list of string directives to include in HeartbeatAck.
+    Reads agent paused state and unclaimed tasks from the filesystem. *)
+let compute_directives
+    ~(room_config : Room_utils_backend_setup.config)
+    ~(agent_name : string) : string list =
+  let masc_dir = Filename.concat room_config.base_path ".masc" in
+  let directives = ref [] in
+  (* 1. Pause directive: check if agent is marked paused *)
+  let agent_file =
+    Filename.concat
+      (Filename.concat masc_dir "agents")
+      (safe_filename agent_name ^ ".json")
+  in
+  (if Sys.file_exists agent_file then
+    try
+      let json = Yojson.Safe.from_string (read_file_safe agent_file) in
+      (match Yojson.Safe.Util.member "paused" json with
+       | `Bool true -> directives := "pause" :: !directives
+       | _ -> ())
+    with _ -> ());
+  (* 2. Task assignment: find first unclaimed task for idle agent *)
+  let tasks_dir = Filename.concat masc_dir "tasks" in
+  (if Sys.file_exists tasks_dir then
+    let unclaimed =
+      Sys.readdir tasks_dir
+      |> Array.to_list
+      |> List.filter_map (fun f ->
+          if Filename.check_suffix f ".json" then
+            try
+              let path = Filename.concat tasks_dir f in
+              let task_json = Yojson.Safe.from_string (read_file_safe path) in
+              (match Yojson.Safe.Util.member "status" task_json with
+               | `String "todo" -> Some (Filename.chop_suffix f ".json")
+               | _ -> None)
+            with _ -> None
+          else None)
+    in
+    match unclaimed with
+    | task_id :: _ -> directives := ("claim:" ^ task_id) :: !directives
+    | [] -> ());
+  List.rev !directives
+
 (** Heartbeat bidi handler: receive pings, respond with acks. *)
 let handle_heartbeat
     (room_config : Room_utils_backend_setup.config)
@@ -280,11 +323,14 @@ let handle_heartbeat
             |> List.length
           else 0
         in
+        let directives =
+          compute_directives ~room_config ~agent_name:ping.agent_name
+        in
         let ack = T.HeartbeatAck.{
           timestamp_ms = now_ms ();
           active_agent_count = agent_count;
           pending_task_count = pending_count;
-          directives = [];
+          directives;
         } in
         Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
         (* Record heartbeat latency *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -504,13 +504,57 @@ let run_heartbeat_loop ~proactive_warmup_sec (ctx : _ context)
   in
   loop ()
 
+(** Process a single directive received from a gRPC HeartbeatAck.
+    Directives are string commands: "pause", "resume", "wakeup",
+    "claim:<task_id>". Unknown directives are logged and ignored. *)
+let process_directive ~agent_name directive =
+  match directive with
+  | "pause" ->
+    Log.Keeper.info "directive: pausing keeper %s" agent_name;
+    (match Keeper_registry.find_by_agent_name agent_name with
+     | Some entry ->
+       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
+         { entry.meta with paused = true }
+     | None ->
+       Log.Keeper.warn "directive pause: agent %s not in registry" agent_name)
+  | "resume" ->
+    Log.Keeper.info "directive: resuming keeper %s" agent_name;
+    (match Keeper_registry.find_by_agent_name agent_name with
+     | Some entry ->
+       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
+         { entry.meta with paused = false }
+     | None ->
+       Log.Keeper.warn "directive resume: agent %s not in registry" agent_name)
+  | "wakeup" ->
+    Log.Keeper.debug "directive: waking up %s" agent_name;
+    (match Keeper_registry.find_by_agent_name agent_name with
+     | Some entry -> wakeup_keeper entry.name
+     | None ->
+       Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
+  | s when String.length s > 6 && String.sub s 0 6 = "claim:" ->
+    let task_id = String.sub s 6 (String.length s - 6) in
+    Log.Keeper.info "directive: server assigned task %s to %s" task_id agent_name;
+    (match Keeper_registry.find_by_agent_name agent_name with
+     | Some entry ->
+       Keeper_registry.update_meta ~base_path:entry.base_path entry.name
+         { entry.meta with current_task_id = Some task_id };
+       wakeup_keeper entry.name
+     | None ->
+       Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
+  | unknown ->
+    Log.Keeper.warn "unknown gRPC directive for %s: %s" agent_name unknown
+
 (** Run a gRPC heartbeat sender in a background fiber.
-    Sends [HeartbeatPing] messages at the same interval as the
-    file-based loop. Reads [HeartbeatAck] responses and logs
-    agent/task counts. Stops when [stop] is set.
+    Opens a bidirectional [Heartbeat] stream and sends [HeartbeatPing]
+    messages at the configured interval. Reads [HeartbeatAck] responses,
+    logs agent/task counts, and dispatches directives. Reconnects on
+    stream failure up to 5 times. Stops when [stop] is set.
 
     Requires [grpc_client_ref] to be set (via [set_grpc_client])
     and Eio switch/env to be available in [Eio_context]. *)
+let max_reconnect_attempts = 5
+let reconnect_backoff_sec = 5.0
+
 let run_grpc_heartbeat_fiber ~sw ~stop
     ~(grpc_client : Masc_grpc_client.t)
     ~(agent_name : string) ~(session_id : string)
@@ -520,32 +564,80 @@ let run_grpc_heartbeat_fiber ~sw ~stop
     Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
     None
   | Some grpc_sw, Some env ->
-  (* Periodic unary gRPC get_status as heartbeat signal.
-     Bidi streaming deferred to P2 (requires env threading). *)
-  ignore session_id;
   let close_ref = ref false in
   Eio.Fiber.fork ~sw (fun () ->
-    let rec loop () =
-      if Atomic.get stop || !close_ref then ()
-      else (
-        (try
-          let no_wakeup = Atomic.make false in
-          interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
-          if not (Atomic.get stop || !close_ref) then
-            match Masc_grpc_client.get_status grpc_client ~sw:grpc_sw ~env with
-            | Ok status ->
-                Log.Keeper.debug "gRPC heartbeat: agent=%s agents=%d tasks=%d"
-                  agent_name (List.length status.agents) (List.length status.tasks)
-            | Error err ->
-                Log.Keeper.warn "gRPC heartbeat failed: %s" err
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Keeper.error "gRPC heartbeat tick error: %s"
-            (Printexc.to_string exn));
-        if not (Atomic.get stop) then loop ())
+    let make_ping () =
+      let current_task_id =
+        match Keeper_registry.find_by_agent_name agent_name with
+        | Some e -> Option.value ~default:"" e.meta.current_task_id
+        | None -> ""
+      in
+      Masc_grpc_types.HeartbeatPing.{
+        agent_name;
+        session_id;
+        timestamp_ms = Int64.of_float (Time_compat.now () *. 1000.0);
+        current_task_id;
+      }
     in
-    loop ());
+    (* Inner loop: send ping → recv ack → sleep → repeat on one stream *)
+    let run_stream send recv =
+      let rec tick () =
+        if Atomic.get stop || !close_ref then ()
+        else (
+          (try
+            send (make_ping ());
+            (match recv () with
+             | Ok (ack : Masc_grpc_types.HeartbeatAck.t) ->
+               Log.Keeper.debug
+                 "gRPC bidi heartbeat: agent=%s agents=%d tasks=%d directives=%d"
+                 agent_name ack.active_agent_count ack.pending_task_count
+                 (List.length ack.directives);
+               List.iter (process_directive ~agent_name) ack.directives
+             | Error err ->
+               Log.Keeper.warn "gRPC heartbeat recv: %s" err)
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | End_of_file -> raise End_of_file
+          | exn ->
+            Log.Keeper.error "gRPC heartbeat tick error: %s"
+              (Printexc.to_string exn));
+          if not (Atomic.get stop || !close_ref) then (
+            let no_wakeup = Atomic.make false in
+            interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
+            tick ()))
+      in
+      tick ()
+    in
+    (* Outer loop: reconnect on stream failure *)
+    let rec connect_loop attempts =
+      if Atomic.get stop || !close_ref then ()
+      else if attempts >= max_reconnect_attempts then
+        Log.Keeper.error
+          "gRPC heartbeat: exceeded %d reconnect attempts for %s, stopping"
+          max_reconnect_attempts agent_name
+      else (
+        let send, recv, close_stream =
+          Masc_grpc_client.heartbeat_stream grpc_client ~sw:grpc_sw ~env
+        in
+        (try run_stream send recv
+         with
+         | Eio.Cancel.Cancelled _ as e -> close_stream (); raise e
+         | End_of_file ->
+           Log.Keeper.warn
+             "gRPC heartbeat stream closed for %s (attempt %d/%d)"
+             agent_name (attempts + 1) max_reconnect_attempts;
+           close_stream ()
+         | exn ->
+           Log.Keeper.warn
+             "gRPC heartbeat stream error for %s: %s (attempt %d/%d)"
+             agent_name (Printexc.to_string exn)
+             (attempts + 1) max_reconnect_attempts;
+           close_stream ());
+        if not (Atomic.get stop || !close_ref) then (
+          Eio.Time.sleep clock reconnect_backoff_sec;
+          connect_loop (attempts + 1)))
+    in
+    connect_loop 0);
   Some (fun () -> close_ref := true)
 
 let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -6,10 +6,15 @@ val set_bus : Agent_sdk.Event_bus.t -> unit
 (** Retrieve the shared Event_bus, if set. *)
 val get_bus : unit -> Agent_sdk.Event_bus.t option
 
-(** Inject a gRPC client for heartbeat streaming.
-    When set and [MASC_AGENT_TRANSPORT=grpc], keepalive will also
-    send heartbeat pings over gRPC unary RPC. *)
+(** Inject a gRPC client for bidirectional heartbeat streaming.
+    When set and [MASC_AGENT_TRANSPORT=grpc], keepalive opens a
+    persistent bidi [Heartbeat] stream, sends [HeartbeatPing] at
+    each interval, and processes [HeartbeatAck] directives. *)
 val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
+
+(** Process a single directive string from a gRPC HeartbeatAck.
+    Supported: "pause", "resume", "wakeup", "claim:<task_id>". *)
+val process_directive : agent_name:string -> string -> unit
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -355,6 +355,16 @@ let find_by_name name =
         | None -> if String.equal v.name name then Some v else None)
       !registry None)
 
+let find_by_agent_name agent_name =
+  with_lock_ro (fun () ->
+    StringMap.fold
+      (fun _k v acc ->
+        match acc with
+        | Some _ -> acc
+        | None ->
+          if String.equal v.meta.agent_name agent_name then Some v else None)
+      !registry None)
+
 let tool_usage_of_by_name name =
   with_lock_ro (fun () ->
     match find_by_name name with

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -140,6 +140,9 @@ val tool_usage_of : base_path:string -> string ->
 (** Look up a keeper by name across all base_paths (O(n) scan). *)
 val find_by_name : string -> registry_entry option
 
+(** Look up a keeper by agent_name across all base_paths (O(n) scan). *)
+val find_by_agent_name : string -> registry_entry option
+
 (** Get tool usage by keeper name (scans all base_paths). *)
 val tool_usage_of_by_name : string ->
   (string * Keeper_types.tool_call_entry) list

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -186,6 +186,29 @@ let test_subscribe_request_serde () =
   Alcotest.(check (list string)) "types" req.event_types decoded.event_types;
   Alcotest.(check int64) "seq" req.since_seq decoded.since_seq
 
+let test_heartbeat_ack_directive_types () =
+  let ack = T.HeartbeatAck.{
+    timestamp_ms = 1700000002000L;
+    active_agent_count = 2;
+    pending_task_count = 1;
+    directives = ["pause"; "claim:T-42"; "wakeup"; "resume"];
+  } in
+  let bytes = T.HeartbeatAck.to_bytes ack in
+  let decoded = T.HeartbeatAck.of_bytes bytes in
+  Alcotest.(check (list string)) "P3 directives roundtrip"
+    ["pause"; "claim:T-42"; "wakeup"; "resume"] decoded.directives
+
+let test_heartbeat_ack_empty_directives () =
+  let ack = T.HeartbeatAck.{
+    timestamp_ms = 1700000003000L;
+    active_agent_count = 0;
+    pending_task_count = 0;
+    directives = [];
+  } in
+  let bytes = T.HeartbeatAck.to_bytes ack in
+  let decoded = T.HeartbeatAck.of_bytes bytes in
+  Alcotest.(check (list string)) "empty directives" [] decoded.directives
+
 (* ====== Test runner ====== *)
 
 let () =
@@ -202,6 +225,10 @@ let () =
       Alcotest.test_case "event roundtrip" `Quick test_event_roundtrip;
       Alcotest.test_case "status response roundtrip" `Quick test_status_response_roundtrip;
       Alcotest.test_case "subscribe request serde" `Quick test_subscribe_request_serde;
+    ];
+    "directives", [
+      Alcotest.test_case "P3 directive types roundtrip" `Quick test_heartbeat_ack_directive_types;
+      Alcotest.test_case "empty directives roundtrip" `Quick test_heartbeat_ack_empty_directives;
     ];
     "transport", [
       Alcotest.test_case "default is local" `Quick test_transport_from_env_default;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -284,6 +284,60 @@ let test_cleanup_tracking () =
   let allowed = R.board_wakeup_allowed ~base_path:bp "ct1" ~post_id:"x" ~debounce_sec:60.0 in
   check bool "wakeup allowed after cleanup" true allowed
 
+let test_find_by_agent_name () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "fn1" (make_meta "fn1") in
+  let _entry2 = R.register ~base_path:bp "fn2" (make_meta "fn2") in
+  (match R.find_by_agent_name "agent-fn2" with
+   | Some e -> check string "found by agent_name" "fn2" e.name
+   | None -> fail "expected fn2 via agent_name");
+  check bool "not found returns None" true
+    (Option.is_none (R.find_by_agent_name "agent-nonexistent"))
+
+(* ── Directive processing tests ─────────────────────────── *)
+
+module KK = Masc_mcp.Keeper_keepalive
+
+let test_directive_pause () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "dp1" (make_meta "dp1") in
+  KK.process_directive ~agent_name:"agent-dp1" "pause";
+  match R.get ~base_path:bp "dp1" with
+  | Some e -> check bool "paused after directive" true e.meta.paused
+  | None -> fail "expected dp1"
+
+let test_directive_resume () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "dr1" (make_meta "dr1") in
+  KK.process_directive ~agent_name:"agent-dr1" "pause";
+  KK.process_directive ~agent_name:"agent-dr1" "resume";
+  match R.get ~base_path:bp "dr1" with
+  | Some e -> check bool "resumed after directive" false e.meta.paused
+  | None -> fail "expected dr1"
+
+let test_directive_claim () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "dc1" (make_meta "dc1") in
+  KK.process_directive ~agent_name:"agent-dc1" "claim:T-42";
+  match R.get ~base_path:bp "dc1" with
+  | Some e ->
+    (match e.meta.current_task_id with
+     | Some tid -> check string "task assigned" "T-42" tid
+     | None -> fail "expected current_task_id set")
+  | None -> fail "expected dc1"
+
+let test_directive_unknown_no_crash () =
+  R.clear ();
+  let _entry = R.register ~base_path:bp "du1" (make_meta "du1") in
+  KK.process_directive ~agent_name:"agent-du1" "unknown-directive";
+  check bool "still running after unknown directive" true
+    (R.is_running ~base_path:bp "du1")
+
+let test_directive_nonexistent_agent () =
+  R.clear ();
+  KK.process_directive ~agent_name:"ghost-agent" "pause";
+  check bool "no crash on missing agent" true true
+
 let () =
   run "Keeper_registry"
     [
@@ -323,5 +377,17 @@ let () =
           eio_test "board wakeup debounce" test_board_wakeup_debounce;
           eio_test "board wakeup different post" test_board_wakeup_different_post;
           eio_test "cleanup_tracking resets" test_cleanup_tracking;
+        ] );
+      ( "agent_name_lookup",
+        [
+          eio_test "find_by_agent_name" test_find_by_agent_name;
+        ] );
+      ( "directives",
+        [
+          eio_test "pause directive" test_directive_pause;
+          eio_test "resume directive" test_directive_resume;
+          eio_test "claim directive" test_directive_claim;
+          eio_test "unknown directive no crash" test_directive_unknown_no_crash;
+          eio_test "nonexistent agent no crash" test_directive_nonexistent_agent;
         ] );
     ]


### PR DESCRIPTION
## Summary

- **P2**: Replace unary `get_status` polling with persistent bidirectional `Heartbeat` stream in keeper keepalive
- **P3**: Server-side `compute_directives` generates directives from room state (paused agents, unclaimed tasks)
- **P3**: Keeper-side `process_directive` handles: `pause`, `resume`, `wakeup`, `claim:<task_id>`
- `Keeper_registry.find_by_agent_name` added for agent_name-based lookup
- Reconnect outer loop (5 attempts, 5s backoff) for stream failure recovery

## Changed files

| File | Change |
|------|--------|
| `lib/keeper/keeper_keepalive.ml` | Bidi stream loop + `process_directive` handler |
| `lib/keeper/keeper_keepalive.mli` | Updated docstring + exposed `process_directive` |
| `lib/grpc/masc_grpc_service.ml` | `compute_directives` + wired into `handle_heartbeat` |
| `lib/keeper/keeper_registry.ml` | `find_by_agent_name` |
| `lib/keeper/keeper_registry.mli` | Signature |
| `test/test_grpc_client.ml` | Directive roundtrip tests |
| `test/test_keeper_registry.ml` | find_by_agent_name + 5 directive handler tests |

## Test plan

- [x] `test_keeper_registry` — 34 tests pass (including 5 new directive tests + find_by_agent_name)
- [x] `test_grpc_client` — 15 tests pass (including 2 new directive roundtrip tests)
- [x] `test_ci_hardening_source` — 23 source guard contracts pass
- [ ] CI green on PR

Closes #2880 P2/P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)