### PR TITLE
feat(dashboard): surface CDAL proof in keeper metrics

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -166,6 +166,22 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
          match handoff_json with
          | Some value -> value
          | None -> `Assoc [ ("performed", `Bool false) ]);
+        ("cdal_proof",
+         match result.proof with
+         | Some p ->
+           `Assoc [
+             ("run_id", `String p.Agent_sdk.Cdal_proof.run_id);
+             ("effective_mode",
+              Agent_sdk.Execution_mode.to_yojson p.effective_execution_mode);
+             ("result_status",
+              Agent_sdk.Cdal_proof.result_status_to_yojson p.result_status);
+             ("violation_count",
+              `Int (List.length p.raw_evidence_refs));
+             ("tool_trace_count",
+              `Int (List.length p.tool_trace_refs));
+             ("mode_source", `String p.mode_decision_source);
+           ]
+         | None -> `Null);
       ]
   in
   Dated_jsonl.append metrics_store snapshot


### PR DESCRIPTION
## Summary

Keeper turn metrics snapshot에 `cdal_proof` 필드 추가 (+16 lines, 1 file).

매 keeper turn 후 `Dated_jsonl`에 저장되는 snapshot에 CDAL proof summary 포함:
```json
{
  "cdal_proof": {
    "run_id": "cdal-1711594800000-abc123",
    "effective_mode": "draft",
    "result_status": "completed",
    "violation_count": 0,
    "tool_trace_count": 3,
    "mode_source": "passthrough"
  }
}
```

proof가 없으면 `"cdal_proof": null`.

Dashboard HTTP endpoint가 이 metrics store를 읽으므로, keeper dashboard에 자동 반영.

## Test plan

- [x] `dune build` success
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)