### PR TITLE
CI: streamline required gates and shared bootstrap

### DIFF
--- a/.github/actions/setup-ocaml-env/action.yml
+++ b/.github/actions/setup-ocaml-env/action.yml
@@ -1,0 +1,83 @@
+name: Setup OCaml Environment
+description: Setup OCaml, pin external opam deps, optionally install apt packages, and install opam dependencies with retries.
+
+inputs:
+  ocaml-compiler:
+    description: OCaml compiler version for ocaml/setup-ocaml
+    required: false
+    default: 5.4.x
+  dune-cache:
+    description: Whether dune cache should be enabled
+    required: false
+    default: "true"
+  cache-prefix:
+    description: Optional ocaml/setup-ocaml cache prefix
+    required: false
+    default: ""
+  pin-extra-args:
+    description: Extra arguments forwarded to scripts/opam-pin-external-deps.sh
+    required: false
+    default: ""
+  apt-packages:
+    description: Space-delimited apt packages to install on Linux runners
+    required: false
+    default: ""
+  opam-install-args:
+    description: Extra arguments appended after `opam install .`
+    required: false
+    default: "--deps-only --yes"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup OCaml
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: ${{ inputs.ocaml-compiler }}
+        dune-cache: ${{ inputs.dune-cache }}
+        cache-prefix: ${{ inputs.cache-prefix }}
+
+    - name: Pin external dependencies
+      shell: bash
+      env:
+        PIN_EXTRA_ARGS: ${{ inputs.pin-extra-args }}
+      run: |
+        set -euo pipefail
+        chmod +x scripts/opam-pin-external-deps.sh
+        if [ -n "${PIN_EXTRA_ARGS}" ]; then
+          set -- ${PIN_EXTRA_ARGS}
+          scripts/opam-pin-external-deps.sh "$@"
+        else
+          scripts/opam-pin-external-deps.sh
+        fi
+
+    - name: Refresh system package index
+      if: runner.os == 'Linux' && inputs.apt-packages != ''
+      shell: bash
+      run: sudo apt-get update -qq
+
+    - name: Install OS dependencies
+      if: runner.os == 'Linux' && inputs.apt-packages != ''
+      shell: bash
+      env:
+        APT_PACKAGES: ${{ inputs.apt-packages }}
+      run: |
+        set -euo pipefail
+        sudo apt-get install -y ${APT_PACKAGES}
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        OPAM_INSTALL_ARGS: ${{ inputs.opam-install-args }}
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          set -- ${OPAM_INSTALL_ARGS}
+          opam install . "$@" && break
+          if [ "$attempt" -eq 3 ]; then
+            echo "opam install failed after ${attempt} attempts"
+            exit 1
+          fi
+          echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+          sleep 15
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
           ME_ROOT: /tmp/me
           CI_TEST_TIMEOUT_SEC: 900
           CI_TEST_HEARTBEAT_SEC: 15
+          MASC_MAIN_EIO_EXE: .ci_build/default/bin/main_eio.exe
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      ci_shared: ${{ steps.filter.outputs.ci_shared }}
+      dashboard: ${{ steps.filter.outputs.dashboard }}
+      ocaml_ci: ${{ steps.filter.outputs.ocaml_ci }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ci_shared:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            dashboard:
+              - 'dashboard/**'
+            ocaml_ci:
+              - '**/*'
+              - '!dashboard/**'
+              - '!docs/**'
+              - '!**/*.md'
+
   health:
     name: Health
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.ocaml_ci == 'true'
     timeout-minutes: 20
 
     steps:
@@ -45,35 +77,13 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
         with:
-          ocaml-compiler: 5.4.x
-          dune-cache: true
           cache-prefix: oas-otel-02
-
-      - name: Pin external dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh --with-bisect
-
-      - name: Refresh system package index
-        run: sudo apt-get update -qq
-
-      - name: Install OS dependencies
-        run: sudo apt-get install -y ripgrep bc
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only --with-test --yes && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
+          pin-extra-args: --with-bisect
+          apt-packages: ripgrep bc
+          opam-install-args: --deps-only --with-test --yes
 
       - name: Fetch base branch for health ratchet
         if: github.event_name == 'pull_request'
@@ -142,7 +152,12 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.ocaml_ci == 'true'
     timeout-minutes: 60
+    env:
+      CI_CONTRACT_HARNESS_ENABLED: "0"
+      DUNE_BUILD_DIR: .ci_build
 
     steps:
       - name: Checkout
@@ -161,45 +176,23 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
         with:
-          ocaml-compiler: 5.4.x
-          dune-cache: true
           cache-prefix: oas-otel-02
-
-      - name: Pin external dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh --with-bisect
-
-      - name: Refresh system package index
-        run: sudo apt-get update -qq
+          pin-extra-args: --with-bisect
+          apt-packages: jq
+          opam-install-args: --deps-only --with-test --yes
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
 
-      - name: Install transport harness OS dependencies
-        run: sudo apt-get install -y jq
-
       - name: Install grpcurl
         run: |
           GOBIN="$HOME/go/bin" go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only --with-test --yes && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
 
       - name: Build
         run: |
@@ -252,13 +245,19 @@ jobs:
 
       - name: Verification matrix summary
         run: |
-          echo "::notice::Required CI gates: dune test, test_sse_storm_e2e, transport harness suite, contract harness suite"
+          echo "::notice::Required CI gates in this job: dune test, test_sse_storm_e2e, transport harness suite"
+          echo "::notice::Dedicated required CI job: contract harness suite"
           echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN/TURN/browser interop, viewer-local-e2e-check, swarm/team-session workload harnesses"
 
   contract:
     name: Contract Harness
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.ocaml_ci == 'true'
     timeout-minutes: 30
+    env:
+      CI_CONTRACT_HARNESS_ENABLED: "0"
+      DUNE_BUILD_DIR: .ci_build
 
     steps:
       - name: Checkout
@@ -277,32 +276,11 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
         with:
-          ocaml-compiler: 5.4.x
-          dune-cache: true
           cache-prefix: oas-otel-02
-
-      - name: Pin external dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh
-
-      - name: Refresh system package index
-        run: sudo apt-get update -qq
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only --yes && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
+          opam-install-args: --deps-only --yes
 
       - name: Build server executable
         run: |
@@ -322,12 +300,15 @@ jobs:
 
       - name: Verification matrix summary
         run: |
-          echo "::notice::Required CI gates: contract harness suite"
+          echo "::notice::Required CI gate in this job: contract harness suite"
+          echo "::notice::Contract harness runs once here via an explicit wrapped command"
           echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN, viewer-local-e2e-check, swarm/team-session workload harnesses"
 
-  lint:
-    name: Lint
+  dashboard:
+    name: Dashboard Validation
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.dashboard == 'true' || needs.changes.outputs.ci_shared == 'true'
     timeout-minutes: 20
 
     steps:
@@ -347,35 +328,62 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --expected-head-sha "$PR_HEAD_SHA"
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
-          ocaml-compiler: 5.4.x
-          dune-cache: true
+          version: 10.31.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+
+      - name: Install dashboard dependencies
+        run: pnpm --dir dashboard install --frozen-lockfile
+
+      - name: Typecheck dashboard
+        run: pnpm --dir dashboard exec tsc --noEmit --pretty false
+
+      - name: Run dashboard unit tests
+        run: pnpm --dir dashboard exec vitest run
+
+      - name: Verification matrix summary
+        run: |
+          echo "::notice::Required CI gates in this job: dashboard typecheck, dashboard unit tests"
+          echo "::notice::Dashboard-only changes skip OCaml transport jobs unless shared CI files changed"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.ocaml_ci == 'true'
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify PR sync
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          chmod +x scripts/check-pr-sync.sh
+          scripts/check-pr-sync.sh \
+            --head-branch "$PR_HEAD_REF" \
+            --pr-number "$PR_NUMBER" \
+            --expected-head-sha "$PR_HEAD_SHA"
+
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
+        with:
           cache-prefix: oas-otel-02
-
-      - name: Pin external dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh
-
-      - name: Refresh system package index
-        run: sudo apt-get update -qq
-
-      - name: Install OS dependencies
-        run: sudo apt-get install -y ripgrep
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only --yes && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
+          apt-packages: ripgrep
+          opam-install-args: --deps-only --yes
 
       - name: Check Eio conventions
         run: |
@@ -404,32 +412,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
         with:
-          ocaml-compiler: 5.4.x
-          dune-cache: true
           cache-prefix: oas-otel-02
+          opam-install-args: --deps-only --with-doc --yes
 
-      - name: Pin external dependencies
+      - name: Install odoc
         run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh
-
-      - name: Refresh system package index
-        run: sudo apt-get update -qq
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only --with-doc --yes && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install --with-doc failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install --with-doc failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
           for attempt in 1 2 3; do
             opam install odoc --yes && break
             if [ "$attempt" -eq 3 ]; then

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -15,31 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
         with:
-          ocaml-compiler: 5.4.x
-
-      - name: Pin private dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh --with-compact-protocol
-
-
-      - name: Refresh apt index
-        run: sudo apt-get update
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only -y && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
+          dune-cache: "false"
+          pin-extra-args: --with-compact-protocol
+          opam-install-args: --deps-only --yes
 
       - name: Build release binary
         run: opam exec -- dune build --release bin/main_eio.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,17 +38,6 @@ jobs:
             scripts/check-version-truth.sh
           fi
 
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 5.4.x
-
-      - name: Pin private dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh --with-compact-protocol
-
-
       - name: Install libpq (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -56,21 +45,12 @@ jobs:
           echo "$(brew --prefix libpq)/bin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=$(brew --prefix libpq)/lib/pkgconfig" >> "$GITHUB_ENV"
 
-      - name: Refresh apt index
-        if: runner.os == 'Linux'
-        run: sudo apt-get update -qq
-
-      - name: Install dependencies
-        run: |
-          for attempt in 1 2 3; do
-            opam install . --deps-only -y && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "opam install failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
-            sleep 15
-          done
+      - name: Setup OCaml environment
+        uses: ./.github/actions/setup-ocaml-env
+        with:
+          dune-cache: "false"
+          pin-extra-args: --with-compact-protocol
+          opam-install-args: --deps-only --yes
 
       - name: Build
         run: opam exec -- dune build --release bin/main_eio.exe

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -13,13 +13,15 @@ describe('lab navigation', () => {
       'experiments',
       'autoresearch',
       'harness',
+      'config',
     ])
 
     expect(labSections.map(item => item.label)).toEqual([
       '도구',
       '실험',
       '오토리서치',
-      '하네스 헬스',
+      '세이프티 하네스',
+      '서버 설정',
     ])
   })
 })

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -28,7 +28,10 @@ CI_TEST_RPC_RETRY_DONE=0
 CI_TEST_ALLOW_FLAKY_RETRY="${CI_TEST_ALLOW_FLAKY_RETRY:-1}"
 CI_TEST_FLAKY_RETRY_DONE=0
 CI_TEST_ISOLATED_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR:-.ci_build}"
-CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-1}"
+# Post-test contract harness execution is opt-in. Required CI runs the
+# dedicated contract harness suite explicitly instead of relying on this
+# wrapper's implicit post-hook.
+CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-0}"
 CI_CONTRACT_HARNESS_CMD="${CI_CONTRACT_HARNESS_CMD:-scripts/harness/contract/run_all.sh}"
 CI_CONTRACT_HARNESS_TIMEOUT_SEC="${CI_CONTRACT_HARNESS_TIMEOUT_SEC:-900}"
 ACTIVE_TEST_BUILD_DIR="${DUNE_BUILD_DIR:-_build}"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -52,6 +52,57 @@ let test_health_and_ci_runner_diagnostics () =
   check bool "ci runner tracks active build dir for diagnostics" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR")
 
+let test_ci_contract_harness_topology () =
+  check bool "ci runner defaults contract harness post hook to opt in" true
+    (file_contains_pattern "scripts/ci-run-tests.sh"
+       {|CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-0}"|});
+  check bool "ci workflow disables implicit contract post hook" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|CI_CONTRACT_HARNESS_ENABLED: "0"|});
+  check bool "build summary points at dedicated contract job" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "Dedicated required CI job: contract harness suite");
+  check bool "contract summary documents single explicit wrapped run" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "Contract harness runs once here via an explicit wrapped command")
+
+let test_ci_dashboard_validation_topology () =
+  check bool "ci workflow detects changed paths with dorny filter" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "uses: dorny/paths-filter@v3");
+  check bool "ci workflow defines dashboard validation job" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "name: Dashboard Validation");
+  check bool "ci workflow typechecks dashboard in required job" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "pnpm --dir dashboard exec tsc --noEmit --pretty false");
+  check bool "ci workflow runs dashboard unit tests in required job" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "pnpm --dir dashboard exec vitest run");
+  check bool "ci workflow skips ocaml jobs for dashboard only changes" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "Dashboard-only changes skip OCaml transport jobs unless shared CI files changed")
+
+let test_ci_bootstrap_and_isolated_build_dir_topology () =
+  check bool "shared ocaml bootstrap action exists" true
+    (file_contains_pattern ".github/actions/setup-ocaml-env/action.yml"
+       "uses: ocaml/setup-ocaml@v3");
+  check bool "ci workflow consumes shared ocaml bootstrap action" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "uses: ./.github/actions/setup-ocaml-env");
+  check bool "release workflow consumes shared ocaml bootstrap action" true
+    (file_contains_pattern ".github/workflows/release.yml"
+       "uses: ./.github/actions/setup-ocaml-env");
+  check bool "deploy workflow consumes shared ocaml bootstrap action" true
+    (file_contains_pattern ".github/workflows/deploy-railway.yml"
+       "uses: ./.github/actions/setup-ocaml-env");
+  check bool "build job defaults dune build dir to ci_build" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       {|DUNE_BUILD_DIR: .ci_build|});
+  check bool "build job summary preserves dedicated contract topology" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "Dedicated required CI job: contract harness suite")
+
 let test_contract_harness_and_team_session_authz_contracts () =
   check bool "contract harness exposes extract_text helper" true
     (file_contains_pattern "scripts/harness/lib/test_framework.sh"
@@ -530,6 +581,12 @@ let () =
            test_case "contract harness and team session authz contracts" `Quick
              test_contract_harness_and_team_session_authz_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
+           test_case "ci contract harness topology" `Quick
+             test_ci_contract_harness_topology;
+           test_case "ci dashboard validation topology" `Quick
+             test_ci_dashboard_validation_topology;
+           test_case "ci bootstrap and isolated build dir topology" `Quick
+             test_ci_bootstrap_and_isolated_build_dir_topology;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
            test_case "keeper direct reply contracts" `Quick

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -98,6 +98,81 @@ exit 0
   Unix.chmod dune_path 0o755;
   bin_dir
 
+let make_fake_script path body =
+  write_file path
+    (Printf.sprintf {|#!/bin/sh
+set -eu
+%s
+|} body);
+  Unix.chmod path 0o755
+
+let test_contract_harness_is_opt_in_by_default () =
+  with_temp_dir "ci-run-tests-contract-default" (fun dir ->
+      let test_log = Filename.concat dir "test.log" in
+      let contract_log = Filename.concat dir "contract.log" in
+      let test_script = Filename.concat dir "test.sh" in
+      let contract_script = Filename.concat dir "contract.sh" in
+      make_fake_script test_script {|printf 'test\n' >> "${FAKE_TEST_LOG:?}"|};
+      make_fake_script contract_script
+        {|printf 'contract\n' >> "${FAKE_CONTRACT_LOG:?}"|};
+      let env =
+        [
+          ("FAKE_TEST_LOG", test_log);
+          ("FAKE_CONTRACT_LOG", contract_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_CONTRACT_HARNESS_CMD", contract_script);
+        ]
+      in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env
+          (Printf.sprintf "%s %s" (quote (script_path ())) (quote test_script))
+      in
+      if code <> 0 then
+        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check string "test command ran once" "test\n" (read_file test_log);
+      check bool "contract harness skipped by default" false
+        (Sys.file_exists contract_log);
+      let observed_output = String.concat "\n" [ stdout; stderr ] in
+      check bool "default skip logged" true
+        (contains_substring observed_output
+           "contract harness skipped (CI_CONTRACT_HARNESS_ENABLED=0)"))
+
+let test_contract_harness_runs_once_when_explicitly_enabled () =
+  with_temp_dir "ci-run-tests-contract-enabled" (fun dir ->
+      let test_log = Filename.concat dir "test.log" in
+      let contract_log = Filename.concat dir "contract.log" in
+      let test_script = Filename.concat dir "test.sh" in
+      let contract_script = Filename.concat dir "contract.sh" in
+      make_fake_script test_script {|printf 'test\n' >> "${FAKE_TEST_LOG:?}"|};
+      make_fake_script contract_script
+        {|printf 'contract\n' >> "${FAKE_CONTRACT_LOG:?}"|};
+      let env =
+        [
+          ("FAKE_TEST_LOG", test_log);
+          ("FAKE_CONTRACT_LOG", contract_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_CONTRACT_HARNESS_ENABLED", "1");
+          ("CI_CONTRACT_HARNESS_CMD", contract_script);
+        ]
+      in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env
+          (Printf.sprintf "%s %s" (quote (script_path ())) (quote test_script))
+      in
+      if code <> 0 then
+        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check string "test command ran once" "test\n" (read_file test_log);
+      check string "contract harness ran once" "contract\n"
+        (read_file contract_log);
+      let observed_output = String.concat "\n" [ stdout; stderr ] in
+      check bool "explicit contract completion logged" true
+        (contains_substring observed_output
+           "contract harness completed successfully"))
+
 let test_rpc_retry_uses_isolated_build_dir () =
   with_temp_dir "ci-run-tests-retry" (fun dir ->
       let fake_log = Filename.concat dir "fake-dune.log" in
@@ -158,6 +233,10 @@ let () =
     [
       ( "script",
         [
+          test_case "contract harness is opt-in by default" `Quick
+            test_contract_harness_is_opt_in_by_default;
+          test_case "contract harness runs once when explicitly enabled" `Quick
+            test_contract_harness_runs_once_when_explicitly_enabled;
           test_case "rpc retry uses isolated build dir" `Quick
             test_rpc_retry_uses_isolated_build_dir;
         ] );

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -136,11 +136,26 @@ let find_main_eio_exe () =
     match env_override with
     | Some p -> [p]
     | None ->
+        let build_dir =
+          match Sys.getenv_opt "DUNE_BUILD_DIR" with
+          | Some d -> d
+          | None -> "_build"
+        in
         let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
         let build_candidates =
           List.map
-            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
+            (fun root ->
+              Filename.concat root
+                (Filename.concat build_dir "default/bin/main_eio.exe"))
             build_roots
+        in
+        let fallback_candidates =
+          if build_dir <> "_build" then
+            List.map
+              (fun root ->
+                Filename.concat root "_build/default/bin/main_eio.exe")
+              build_roots
+          else []
         in
         [
           "./bin/main_eio.exe";
@@ -148,7 +163,8 @@ let find_main_eio_exe () =
           "../../bin/main_eio.exe";
           "../../../bin/main_eio.exe";
           "../../../../bin/main_eio.exe";
-        ] @ build_candidates
+        ]
+        @ build_candidates @ fallback_candidates
   in
   match List.find_opt Sys.file_exists candidates with
   | Some path -> path


### PR DESCRIPTION
## Summary
- remove implicit contract harness duplication from the CI wrapper path
- add dashboard validation plus changed-path routing for required CI
- extract shared OCaml bootstrap and default CI wrapped test jobs to .ci_build

## Testing
- env DUNE_BUILD_DIR=.ci_build opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/ci-3552-contract-dedupe test/test_ci_run_tests_script.exe test/test_ci_hardening_source.exe
- ./.ci_build/default/test/test_ci_run_tests_script.exe
- ./.ci_build/default/test/test_ci_hardening_source.exe
- ruby -e "require 'yaml'; ARGV.each { |path| YAML.load_file(path) }" .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/deploy-railway.yml .github/actions/setup-ocaml-env/action.yml

Refs #3551
Closes #3552
Closes #3553
Closes #3554