### PR TITLE
fix(keeper): with_lock_ro → with_lock in find_by_agent_name

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -361,7 +361,7 @@ let find_by_name name =
       !registry None)
 
 let find_by_agent_name agent_name =
-  with_lock_ro (fun () ->
+  with_lock (fun () ->
     StringMap.fold
       (fun _k v acc ->
         match acc with


### PR DESCRIPTION
## Summary

- One-line fix: `with_lock_ro` → `with_lock` in `find_by_agent_name`
- `with_lock_ro` was removed by a concurrent Phase 3 Eio.Mutex cleanup (#3540), but the P2/P3 merge (#3558) still referenced it
- Build failure on main

## Test plan

- [x] `test_keeper_registry` — 34 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)