### PR TITLE
fix(build): replace with_lock_ro in keeper_registry

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -361,7 +361,7 @@ let find_by_name name =
       !registry None)
 
 let find_by_agent_name agent_name =
-  with_lock_ro (fun () ->
+  with_lock (fun () ->
     StringMap.fold
       (fun _k v acc ->
         match acc with


### PR DESCRIPTION
## Summary

`#3558` merged `find_by_agent_name` using `with_lock_ro`, but `#3541` had already replaced all lock helpers with a single `with_lock` (Stdlib.Mutex). 1-line fix.

## Test plan

- [x] `dune build` success